### PR TITLE
[Export] Add runtime assert to non-strict export

### DIFF
--- a/docs/source/fx.rst
+++ b/docs/source/fx.rst
@@ -1183,6 +1183,7 @@ API Reference
 .. py:module:: torch.fx.passes.param_fetch
 .. py:module:: torch.fx.passes.pass_manager
 .. py:module:: torch.fx.passes.reinplace
+.. py:module:: torch.fx.passes.runtime_assert
 .. py:module:: torch.fx.passes.shape_prop
 .. py:module:: torch.fx.passes.split_module
 .. py:module:: torch.fx.passes.split_utils

--- a/test/export/test_retraceability.py
+++ b/test/export/test_retraceability.py
@@ -21,14 +21,12 @@ def mocked_retraceability_export(*args, **kwargs):
 
 
 def make_dynamic_cls(cls):
-    suffix = "_retraceability"
-
     cls_prefix = "RetraceExport"
 
     test_class = testing.make_test_cls_with_mocked_export(
         cls,
         cls_prefix,
-        suffix,
+        test_export.RETRACEABILITY_SUFFIX,
         mocked_retraceability_export,
         xfail_prop="_expected_failure_retrace",
     )

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -25,11 +25,9 @@ from torch._guards import GlobalContextCheckpointState, Source, TracingContext
 from torch._utils_internal import signpost_event
 from torch.fx._lazy_graph_module import _make_graph_module  # type: ignore[attr-defined]
 from torch.fx.experimental._backward_state import BackwardState
-from torch.fx.experimental.sym_node import SymNode
 from torch.fx.experimental.symbolic_shapes import free_symbols, is_symbolic, ShapeEnv
+from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
-from torch.utils._sympy.interp import sympy_interp
-from torch.utils._sympy.reference import PythonReferenceAnalysis
 
 from . import config, logging as torchdynamo_logging, variables
 from .backends.registry import CompiledFn, CompilerFn
@@ -1226,8 +1224,11 @@ class OutputGraph:
             {},
         )
         if not config.do_not_emit_runtime_asserts:
-            self.insert_deferred_runtime_asserts(root, name)
-
+            insert_deferred_runtime_asserts(
+                fx.GraphModule(root, self.graph),
+                self.shape_env,
+                name,
+            )
         # NB: deferred runtime asserts can keep graphargs live, so make sure
         # those are inserted before pruning
         self.remove_unused_graphargs()
@@ -1443,203 +1444,6 @@ class OutputGraph:
                 else:
                     # Make sure we delete later occurrences of the same symbol
                     used_symbols.remove(symbol)
-
-    # TODO: this is a generic pass that should live outside of Dynamo
-    def insert_deferred_runtime_asserts(self, root, name) -> None:
-        """
-        During tracing, we may have discovered that some data-dependent values
-        had runtime assert on them; e.g., torch.empty(x.item()) induces a runtime
-        that x.item() >= 0.  This asserts can happen unpredictably during fake
-        tensor propagation, so we cannot conveniently insert them into the FX graph
-        when they occur.  Instead, we accumulate them in the ShapeEnv, and in this
-        pass insert them into the graph as proper tests.
-        """
-        # TODO: Request simplification on runtime asserts before emitting them
-        ras_by_symbol = self.shape_env.deferred_runtime_asserts.copy()
-
-        if not any(ras for ras in ras_by_symbol.values()):
-            return
-
-        gm = fx.GraphModule(root, self.graph)
-        graph_code_log.debug(
-            "%s",
-            lazy_format_graph_code(f"pre insert_deferred_runtime_asserts {name}", gm),
-        )
-
-        # We are going to mutate the dict
-        symbol_to_proxy: Dict[sympy.Symbol, fx.Proxy] = {}
-        placeholders = set()
-        last_placeholder = None
-        for node in self.graph.nodes:
-            if node.op != "placeholder":
-                last_placeholder = node
-                break
-            placeholders.add(node)
-        assert last_placeholder is not None
-
-        # Identify what symbols we need to reify.  This isn't strictly needed
-        # but helps reduce churn on the graph
-        needed_symbols: Set[sympy.Symbol] = set()
-        for ras in ras_by_symbol.values():
-            for ra in ras:
-                needed_symbols.update(free_symbols(ra.expr))
-
-        log.debug("needed_symbols = %s", needed_symbols)
-
-        def add_runtime_asserts(ras):
-            for ra in ras:
-                log.debug("inserting runtime assert %s", ra.expr)
-                # Need to process ALL free symbols, not just unbacked ones
-                fvs = free_symbols(ra.expr)
-                missing = fvs - symbol_to_proxy.keys()
-                if missing:
-                    i1 = sorted(missing, key=lambda x: str(x))[0]
-                    # TODO: Remove relaxing assert on unbacked_symint https://github.com/pytorch/pytorch/issues/119689
-                    # assert self.shape_env.is_unbacked_symint(i1), i1
-                    ras_by_symbol.setdefault(i1, []).append(ra)
-                else:
-                    # Convert the sympy expression into a sequence of FX
-                    # nodes
-                    res = sympy_interp(
-                        PythonReferenceAnalysis, symbol_to_proxy, ra.expr
-                    ).node
-                    self.graph.call_function(
-                        torch.ops.aten._assert_scalar.default,
-                        # TODO: use ra.msg here, but it's pretty
-                        # useless right now
-                        (
-                            res,
-                            f"Deferred runtime assertion failed {ra.expr}",
-                        ),
-                    )
-
-        for node in self.graph.nodes:
-            # Placeholders can match symbols, but when we destructure them
-            # with size we have to make sure we insert the nodes after all
-            # the placeholders
-            with self.graph.inserting_before(
-                node.next if node not in placeholders else last_placeholder.next
-            ):
-                if "example_value" not in node.meta:
-                    continue
-
-                if node not in placeholders:
-                    add_runtime_asserts(ras_by_symbol.pop(None, []))
-
-                defs = []
-
-                # For every new unbacked symbol, we need an fx.Node representing
-                # precisely this value.  There are a few places where the unbacked
-                # symbol could have come from, and we will check them to setup
-                # these nodes.
-                #
-                # For a case like item(), this is trivial (no new node is added.)
-                #
-                # For nonzero(), we need to add something like i0 = out.size(0)
-                #
-                # We could end up with duplicate nodes this way but it is not a
-                # big deal.
-                #
-                # We also do this to setup backed SymInts, but those are all going
-                # to be matched from placeholders
-                def match_symbol(symint, cb):
-                    if (
-                        isinstance(symint, torch.SymInt)
-                        and isinstance(symint.node, SymNode)
-                        and isinstance(s := symint.node.expr, sympy.Symbol)
-                        and s not in symbol_to_proxy
-                        and s in needed_symbols
-                    ):
-                        symbol_to_proxy[s] = fx.Proxy(cb())
-                        log.debug("symbol_to_proxy[%s] = %s", s, symbol_to_proxy[s])
-                        defs.append(s)
-
-                match_symbol(node.meta["example_value"], lambda: node)
-                if isinstance(t := node.meta["example_value"], torch.Tensor):
-                    for i, s in enumerate(t.size()):
-                        match_symbol(
-                            s, lambda: self.graph.call_method("size", (node, i))
-                        )
-                    for i, s in enumerate(t.stride()):
-                        match_symbol(
-                            s, lambda: self.graph.call_method("stride", (node, i))
-                        )
-                    match_symbol(
-                        t.storage_offset(),
-                        lambda: self.graph.call_method("storage_offset", (node,)),
-                    )
-
-                for i0 in defs:
-                    ras = ras_by_symbol.pop(i0, [])
-                    # Before we perform any asserts, first apply range
-                    # refinement.  This is important, because if we are going
-                    # to retrace the graph (and we typically are if we send
-                    # the graph to AOTAutograd), we need to make sure we apply
-                    # range refinement (ala _check_is_size) first, BEFORE we
-                    # run any of the asserts.  Otherwise, we may decide to
-                    # perform substitutions based on the asserts which we then
-                    # can't back out, because value ranges can only be applied
-                    # to asserts.)
-                    #
-                    # A perhaps better long term plan is to avoid this order
-                    # dependence by making it possible to refine ranges on
-                    # arbitrary expressions, not just symbols.  But it is not
-                    # so easy to make use of this information, see
-                    # https://twitter.com/ezyang/status/1745801370299482492
-                    # We actually made an attempt at this in
-                    # https://github.com/pytorch/pytorch/pull/119043
-                    # which didn't work.
-                    #
-                    # Another ideas for how to do this:
-                    # - Have bound_sympy be the source of truth of the ranges of any expression
-                    # - Cache intermediate results for every subexpression of bound_sympy
-                    # - This cache should be possible to edit to refine ranges
-                    #
-                    # One issue with this proposal is that if
-                    # we have a bound on 2x, we are not going to be able to
-                    # apply it for 4x.  Similarly, we may have bounds for an
-                    # equivalent expression that we are not applying because
-                    # it's not a perfect match (e.g. x < y vs y > x)".
-                    #
-                    # The first issue we already have it and it's impossible
-                    # to solve in general, so any implementation on a best
-                    # effort basis should do.
-                    #
-                    # The second issue is a preexisting one. It can be mitigated
-                    # with a normalisation algorithm. In general, it may also
-                    # be on a best effort basis, but since our grammar is not
-                    # terribly difficult, chances are we could even fully
-                    # normalise SymPy expressions... who knows.
-
-                    if i0 in self.shape_env.size_like:
-                        self.graph.call_function(
-                            torch._check_is_size, (symbol_to_proxy[i0].node,)
-                        )
-
-                    vr = self.shape_env.var_to_range[i0]
-                    if not self.shape_env._default_unspecified_value_range().issubset(
-                        vr
-                    ):
-                        # The runtime range is constrained, so add a runtime
-                        # assert and also explicitly refine the range
-                        # (refinement should not be necessary once runtime
-                        # asserts cause refinement, but that's NYI)
-                        def convert(s):
-                            try:
-                                return int(s)
-                            except TypeError:
-                                return None
-
-                        self.graph.call_function(
-                            torch._constrain_as_value,
-                            (
-                                symbol_to_proxy[i0].node,
-                                convert(vr.lower),
-                                convert(vr.upper),
-                            ),
-                        )
-
-                    add_runtime_asserts(ras)
 
     def add_output_instructions(self, prefix: List[Instruction]) -> None:
         """

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -98,6 +98,7 @@ from torch._dispatch.python import enable_python_dispatcher
 from torch._subclasses.meta_utils import is_sparse_compressed
 from torch._utils_internal import log_compilation_event
 
+from torch.fx._utils import _format_graph_code, lazy_format_graph_code
 from torch.nn.modules.lazy import LazyModuleMixin
 from torch.utils._triton import has_triton, has_triton_package
 
@@ -2028,26 +2029,6 @@ def tensor_always_has_static_shape(
     if not is_tensor:
         return True, TensorStaticReason.NOT_TENSOR
     return False, None
-
-
-def lazy_format_graph_code(name, gm, maybe_id=None):
-    def format_name():
-        if maybe_id is not None:
-            return f"{name} {maybe_id}"
-        else:
-            return name
-
-    return LazyString(
-        lambda: _format_graph_code(
-            f"===== {format_name()} =====\n",
-            gm.forward.__code__.co_filename,
-            gm.print_readable(print_output=False),
-        )
-    )
-
-
-def _format_graph_code(name, filename, graph_str):
-    return f"TRACED GRAPH\n {name} {filename} {graph_str}\n"
 
 
 def lazy_format_graph_tabular(fn_name, gm):

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -36,6 +36,7 @@ from torch._guards import detect_fake_mode
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._utils_internal import log_export_usage
 from torch.export.exported_program import OutputKind
+from torch.fx._utils import first_call_function_nn_module_stack
 from torch.fx.experimental.symbolic_shapes import (
     ConstraintViolationError,
     free_unbacked_symbols,
@@ -43,6 +44,7 @@ from torch.fx.experimental.symbolic_shapes import (
     ShapeEnv,
 )
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
+from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
 from torch.utils._pytree import TreeSpec
 from torch.utils._sympy.value_ranges import ValueRangeError
 
@@ -1061,6 +1063,12 @@ def _export(
             ),
             example_inputs=(args, kwargs),
             constants=ep_non_strict.constants,
+        )
+        insert_deferred_runtime_asserts(
+            exported_program.graph_module,
+            fake_mode.shape_env,
+            f"non strict exported program: {first_call_function_nn_module_stack(exported_program.graph)}",
+            export=True,
         )
         return exported_program
 

--- a/torch/fx/_utils.py
+++ b/torch/fx/_utils.py
@@ -1,0 +1,56 @@
+from typing import Dict, Optional
+
+import torch
+
+from torch._logging import LazyString
+
+
+def lazy_format_graph_code(name, gm, maybe_id=None):
+    """
+    Returns a LazyString that formats the graph code.
+    """
+
+    def format_name():
+        if maybe_id is not None:
+            return f"{name} {maybe_id}"
+        else:
+            return name
+
+    return LazyString(
+        lambda: _format_graph_code(
+            f"===== {format_name()} =====\n",
+            gm.forward.__code__.co_filename,
+            gm.print_readable(print_output=False),
+        )
+    )
+
+
+def _format_graph_code(name, filename, graph_str):
+    """
+    Returns a string that formats the graph code.
+    """
+    return f"TRACED GRAPH\n {name} {filename} {graph_str}\n"
+
+
+def first_call_function_nn_module_stack(graph: torch.fx.Graph) -> Optional[Dict]:
+    """
+    Returns the nn_module_stack of the first call_function node.
+    """
+    for node in graph.nodes:
+        if node.op == "call_function" and "nn_module_stack" in node.meta:
+            return node.meta["nn_module_stack"]
+    return None
+
+
+def get_node_context(node, num_nodes=2) -> str:
+    """
+    Returns a string of the last num_nodes nodes in the graph.
+    """
+    node_contexts = []
+    cur = node
+    for i in range(num_nodes):
+        node_contexts.append(cur.format_node())
+        if cur.op == "root":
+            break
+        cur = cur.prev
+    return "\n".join(node_contexts[::-1])

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -358,7 +358,7 @@ def _iterate_exprs(val: Union[SymInt, torch.Tensor]) -> Iterable[sympy.Basic]:
     else:
         raise AssertionError(f"cannot extract sympy expressions from {val} {type(val)}")
 
-def free_symbols(val: Union[SymInt, torch.Tensor]) -> Set[sympy.Symbol]:
+def free_symbols(val: Union[SymInt, sympy.Expr, torch.Tensor]) -> Set[sympy.Symbol]:
     if val is None:
         return set()
     itr = _iterate_exprs(val)

--- a/torch/fx/passes/__init__.py
+++ b/torch/fx/passes/__init__.py
@@ -4,6 +4,7 @@ from . import net_min_base
 from . import operator_support
 from . import param_fetch
 from . import reinplace
+from . import runtime_assert
 from . import shape_prop
 from . import split_module
 from . import split_utils

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -1,0 +1,261 @@
+import logging
+import operator
+from typing import Any, Dict, Optional, Set, TYPE_CHECKING
+
+# Import sympy and ShapeEnv during TYPE_CHECKING since importing sympy is slow
+if TYPE_CHECKING:
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv
+else:
+    ShapeEnv = Any
+
+import torch
+from torch import fx
+from torch.fx._utils import get_node_context, lazy_format_graph_code
+from torch.fx.experimental.sym_node import SymNode
+from torch.fx.graph_module import GraphModule
+
+log = logging.getLogger(__name__)
+graph_code_log = torch._logging.getArtifactLogger(__name__, "graph_code")
+
+
+def get_example_value(node: fx.Node) -> Optional[str]:
+    """
+    Get the example value key for a node, since dynamo uses "example_value"
+    while non-strict export uses "val.
+    """
+    if "example_value" in node.meta:
+        return node.meta["example_value"]
+    elif "val" in node.meta:
+        return node.meta["val"]
+    else:
+        return None
+
+
+def insert_deferred_runtime_asserts(
+    gm: GraphModule,
+    shape_env: ShapeEnv,
+    name: str,
+    export: bool = False,
+) -> None:
+    """
+    During tracing, we may have discovered that some data-dependent values
+    had runtime assert on them; e.g., torch.empty(x.item()) induces a runtime
+    that x.item() >= 0.  This asserts can happen unpredictably during fake
+    tensor propagation, so we cannot conveniently insert them into the FX graph
+    when they occur.  Instead, we accumulate them in the ShapeEnv, and in this
+    pass insert them into the graph as proper tests.
+    """
+    # Import sympy locally
+    import sympy
+
+    from torch.fx.experimental.symbolic_shapes import free_symbols
+    from torch.utils._sympy.interp import sympy_interp
+    from torch.utils._sympy.reference import PythonReferenceAnalysis
+
+    # TODO: Request simplification on runtime asserts before emitting them
+    ras_by_symbol = shape_env.deferred_runtime_asserts.copy()
+    graph = gm.graph
+
+    if not any(ras for ras in ras_by_symbol.values()):
+        return
+
+    graph_code_log.debug(
+        "%s",
+        lazy_format_graph_code(f"pre insert_deferred_runtime_asserts {name}", gm),
+    )
+
+    # We are going to mutate the dict
+    symbol_to_proxy: Dict[sympy.Symbol, fx.Proxy] = {}
+    placeholders = set()
+    last_placeholder = None
+    for node in graph.nodes:
+        if node.op != "placeholder":
+            last_placeholder = node
+            break
+        placeholders.add(node)
+    assert last_placeholder is not None
+
+    # Identify what symbols we need to reify.  This isn't strictly needed
+    # but helps reduce churn on the graph
+    needed_symbols: Set[sympy.Symbol] = set()
+    for ras in ras_by_symbol.values():
+        for ra in ras:
+            needed_symbols.update(free_symbols(ra.expr))
+
+    log.debug("needed_symbols = %s", needed_symbols)
+
+    def add_runtime_asserts(ras):
+        for ra in ras:
+            log.debug("inserting runtime assert %s", ra.expr)
+            # Need to process ALL free symbols, not just unbacked ones
+            fvs = free_symbols(ra.expr)
+            missing = fvs - symbol_to_proxy.keys()
+            if missing:
+                i1 = sorted(missing, key=lambda x: str(x))[0]
+                # TODO: Remove relaxing assert on unbacked_symint https://github.com/pytorch/pytorch/issues/119689
+                # assert shape_env.is_unbacked_symint(i1), i1
+                ras_by_symbol.setdefault(i1, []).append(ra)
+            else:
+                # Convert the sympy expression into a sequence of FX
+                # nodes
+                res = sympy_interp(
+                    PythonReferenceAnalysis, symbol_to_proxy, ra.expr
+                ).node
+                graph.call_function(
+                    torch.ops.aten._assert_scalar.default,
+                    # TODO: use ra.msg here, but it's pretty
+                    # useless right now
+                    (
+                        res,
+                        f"Runtime assertion failed for expression {ra.expr} on node '{res}'\nMore context: {get_node_context(res)}",
+                    ),
+                )
+
+    for node in graph.nodes:
+        # Placeholders can match symbols, but when we destructure them
+        # with size we have to make sure we insert the nodes after all
+        # the placeholders
+        with graph.inserting_before(
+            node.next if node not in placeholders else last_placeholder.next
+        ):
+            example_value = get_example_value(node)
+            if example_value is None:
+                continue
+
+            if node not in placeholders:
+                add_runtime_asserts(ras_by_symbol.pop(None, []))  # type: ignore[call-overload]
+
+            defs = []
+
+            # For every new unbacked symbol, we need an fx.Node representing
+            # precisely this value.  There are a few places where the unbacked
+            # symbol could have come from, and we will check them to setup
+            # these nodes.
+            #
+            # For a case like item(), this is trivial (no new node is added.)
+            #
+            # For nonzero(), we need to add something like i0 = out.size(0)
+            #
+            # We could end up with duplicate nodes this way but it is not a
+            # big deal.
+            #
+            # We also do this to setup backed SymInts, but those are all going
+            # to be matched from placeholders
+            def match_symbol(symint, cb):
+                if (
+                    isinstance(symint, torch.SymInt)
+                    and isinstance(symint.node, SymNode)
+                    and isinstance(s := symint.node.expr, sympy.Symbol)
+                    and s not in symbol_to_proxy
+                    and s in needed_symbols
+                ):
+                    symbol_to_proxy[s] = fx.Proxy(cb())
+                    log.debug("symbol_to_proxy[%s] = %s", s, symbol_to_proxy[s])
+                    defs.append(s)
+
+            match_symbol(example_value, lambda: node)
+            if isinstance(t := example_value, torch.Tensor):
+                for i, s in enumerate(t.size()):
+                    match_symbol(s, lambda: graph.call_method("size", (node, i)))
+                for i, s in enumerate(t.stride()):
+                    match_symbol(s, lambda: graph.call_method("stride", (node, i)))
+                match_symbol(
+                    t.storage_offset(),
+                    lambda: graph.call_method("storage_offset", (node,)),
+                )
+
+            for i0 in defs:
+                ras = ras_by_symbol.pop(i0, [])
+                # Before we perform any asserts, first apply range
+                # refinement.  This is important, because if we are going
+                # to retrace the graph (and we typically are if we send
+                # the graph to AOTAutograd), we need to make sure we apply
+                # range refinement (ala _check_is_size) first, BEFORE we
+                # run any of the asserts.  Otherwise, we may decide to
+                # perform substitutions based on the asserts which we then
+                # can't back out, because value ranges can only be applied
+                # to asserts.)
+                #
+                # A perhaps better long term plan is to avoid this order
+                # dependence by making it possible to refine ranges on
+                # arbitrary expressions, not just symbols.  But it is not
+                # so easy to make use of this information, see
+                # https://twitter.com/ezyang/status/1745801370299482492
+                # We actually made an attempt at this in
+                # https://github.com/pytorch/pytorch/pull/119043
+                # which didn't work.
+                #
+                # Another ideas for how to do this:
+                # - Have bound_sympy be the source of truth of the ranges of any expression
+                # - Cache intermediate results for every subexpression of bound_sympy
+                # - This cache should be possible to edit to refine ranges
+                #
+                # One issue with this proposal is that if
+                # we have a bound on 2x, we are not going to be able to
+                # apply it for 4x.  Similarly, we may have bounds for an
+                # equivalent expression that we are not applying because
+                # it's not a perfect match (e.g. x < y vs y > x)".
+                #
+                # The first issue we already have it and it's impossible
+                # to solve in general, so any implementation on a best
+                # effort basis should do.
+                #
+                # The second issue is a preexisting one. It can be mitigated
+                # with a normalisation algorithm. In general, it may also
+                # be on a best effort basis, but since our grammar is not
+                # terribly difficult, chances are we could even fully
+                # normalise SymPy expressions... who knows.
+
+                if i0 in shape_env.size_like:
+                    if export:
+                        graph.call_function(
+                            torch.ops.aten.sym_constrain_range_for_size,
+                            (symbol_to_proxy[i0].node,),
+                        )
+                    else:
+                        graph.call_function(
+                            torch._check_is_size, (symbol_to_proxy[i0].node,)
+                        )
+
+                vr = shape_env.var_to_range[i0]
+                if not shape_env._default_unspecified_value_range().issubset(vr):
+                    # The runtime range is constrained, so add a runtime
+                    # assert and also explicitly refine the range
+                    # (refinement should not be necessary once runtime
+                    # asserts cause refinement, but that's NYI)
+                    def convert(s):
+                        try:
+                            return int(s)
+                        except TypeError:
+                            return None
+
+                    ge_check = graph.call_function(
+                        operator.ge,
+                        (
+                            symbol_to_proxy[i0].node,
+                            convert(vr.lower),
+                        ),
+                    )
+                    le_check = graph.call_function(
+                        operator.le,
+                        (
+                            symbol_to_proxy[i0].node,
+                            convert(vr.upper),
+                        ),
+                    )
+                    graph.call_function(
+                        torch.ops.aten._assert_scalar.default,
+                        (
+                            ge_check,
+                            f"Runtime assertion failed for {symbol_to_proxy[i0].node} >= {vr.lower}",
+                        ),
+                    )
+                    graph.call_function(
+                        torch.ops.aten._assert_scalar.default,
+                        (
+                            le_check,
+                            f"Runtime assertion failed for {symbol_to_proxy[i0].node} <= {vr.upper}",
+                        ),
+                    )
+
+                add_runtime_asserts(ras)


### PR DESCRIPTION
This PR moves insert_deferred_runtime_asserts from dynamo to torch.fx.passes and uses it to add runtime assertion for non-strict export.

Differential Revision: D55944267

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang