### PR TITLE
[Inductor] Enable VecMask store

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_mask.h
+++ b/aten/src/ATen/cpu/vec/vec_mask.h
@@ -134,6 +134,19 @@ class VecMask {
     return VectorizedN<T, N>(VectorizedN<T, N>::loadu(mask));
   }
 
+  void store(bool* b, int count) {
+    using int_t = int_same_size_t<T>;
+    int size_ = mask_[0].size();
+    TORCH_CHECK(count == size_ * N, "Expect same number of elements in VecMask::store.");
+#pragma unroll(2)
+    for (int i = 0; i < N; i++) {
+      for (int j = 0; j < size_; j++) {
+        b[i * size_ + j] = ((int_t)mask_[i].values[j] == (int_t)0) ? 0x00 : 0x01;
+      }
+    }
+    return;
+  }
+
   template <typename U, int L, std::enable_if_t<L >= 2, int> = 0>
   inline VectorizedN<U, L> to() const {
     return VecMaskTo<U, L, T, N>::apply(*this);

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1825,6 +1825,8 @@ class CPUReproTests(TestCase):
         self.assertEqual(input_grad_aten_eager, input_grad)
         self.assertEqual(input_grad_decomp_eager, input_grad)
         self.assertEqual(input_grad[1, 2, 3, 4], torch.tensor(0.0))
+        # For forward and backward kernel
+        check_metrics_vec_kernel_count(2)
 
     @patch("torch.cuda.is_available", lambda: False)
     def test_scatter_using_atomic_add(self):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2881,6 +2881,7 @@ class CppVecKernelChecker(CppVecKernel):
             torch.int8,
             torch.int32,
             torch.int64,
+            torch.bool,
         ]
 
     def disable_vec(self, msg=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123710
* #123512

**Summary**
Enable the vectorization of store with `bool` dtype. 

**Test Plan**
```
python -u -m pytest -s -v inductor/test_cpu_repro.py -k test_decomposed_fake_quant_per_channel 
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang