### PR TITLE
Fix typo in TorchScript annotate docstring

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -139,7 +139,7 @@ def annotate(the_type, the_value):
 
     Note that `annotate()` does not help in `__init__` method of `torch.nn.Module` subclasses because it
     is executed in eager mode. To annotate types of `torch.nn.Module` attributes,
-    use :meth:`~torch.jit.Annotate` instead.
+    use :meth:`~torch.jit.Attribute` instead.
 
     Example:
 


### PR DESCRIPTION
It's already in the docstring for torch.jit.Attribute to use Attribute in a __init__ method of a Module. However, this was wrong in the `annotate` docstring