### PR TITLE
Add rotary_embedding CPU operation

### DIFF
--- a/aten/src/ATen/native/RotaryEmbedding.cpp
+++ b/aten/src/ATen/native/RotaryEmbedding.cpp
@@ -1,0 +1,39 @@
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+
+Tensor rotate_half(const Tensor& x) {
+    auto half_dim = x.size(-1) / 2;
+    auto x1 = x.narrow(-1, 0, half_dim);
+    auto x2 = x.narrow(-1, half_dim, half_dim);
+    return at::cat({-x2, x1}, -1);
+}
+
+
+std::tuple<Tensor, Tensor> rotary_embedding(const Tensor& q, const Tensor& k, const Tensor& cos, const Tensor& sin, const Tensor& position_ids, int64_t unsqueeze_dim) {
+    TORCH_CHECK(q.dim() == 4, "rotary_embedding: Expected 4-D argument q but got ", q.dim(), "-D");
+    TORCH_CHECK(k.dim() == 4, "rotary_embedding: Expected 4-D argument k but got ", k.dim(), "-D");
+    TORCH_CHECK(cos.dim() == 2, "rotary_embedding: Expected 2-D argument cos but got ", cos.dim(), "-D");
+    TORCH_CHECK(sin.dim() == 2, "rotary_embedding: Expected 2-D argument sin but got ", sin.dim(), "-D");
+    TORCH_CHECK(position_ids.dim() == 1, "rotary_embedding: Expected 1-D argument position_ids but got ", position_ids.dim(), "-D");
+    
+    auto cos_adjusted = cos.index_select(0, position_ids).unsqueeze(unsqueeze_dim);
+    auto sin_adjusted = sin.index_select(0, position_ids).unsqueeze(unsqueeze_dim);
+    
+    cos_adjusted = cos_adjusted.unsqueeze(0);
+    sin_adjusted = sin_adjusted.unsqueeze(0);
+
+    auto q_embed = (q * cos_adjusted) + (rotate_half(q) * sin_adjusted);
+    auto k_embed = (k * cos_adjusted) + (rotate_half(k) * sin_adjusted);
+
+    return std::make_tuple(q_embed, k_embed);
+}
+
+TORCH_LIBRARY_IMPL(aten, CPU, m) {
+    m.impl("rotary_embedding", TORCH_FN(rotary_embedding));
+}
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -15555,3 +15555,7 @@
 # This op is ONLY used by pytorch/XLA in functionalization, and should never show up in vanilla eager mode or in any pytorch tracing contexts.
 - func: _propagate_xla_data(Tensor input, Tensor output) -> ()
   variants: function
+
+- func: rotary_embedding(Tensor q, Tensor k, Tensor cos, Tensor sin, Tensor position_ids, int unsqueeze_dim) -> (Tensor, Tensor)
+  use_const_ref_for_mutable_tensors: True
+  variants: function


### PR DESCRIPTION
**Summary**:
Introduces a new rotary_embedding operation to PyTorch's CPU backend. This operation applies rotary positional embeddings to query and key tensors in attention.  The implementation supports 4D query and key tensors, and uses 2D cosine and sine embeddings for rotation.

**Motivation**:
Rotary positional embeddings have been shown to significantly improve the performance of transformer models by providing a more effective means of encoding positional information compared to traditional positional embeddings. This operation aims to provide PyTorch users with an efficient, native CPU implementation of RoPE, facilitating development in LLMs(NLP) and beyond.

**Technical Details**:
The operation is implemented as a custom ATen operation in C++ for CPU tensors.
Input validation checks (using TORCH_CHECK) ensure tensors are of expected dimensions.


**API Changes**:
Introduces a new function signature to the torch namespace:
```
torch.rotary_embedding(q, k, cos, sin, position_ids, unsqueeze_dim)
```
- q, k: 4D Tensors representing queries and keys. (batch, n_heads, seq_len, head_dim // partial_rotary_factor)
- cos, sin: 2D Tensors for cosine and sine rotational embeddings. (max_seq_len, n_head)
- position_ids: 1D Tensor indicating the position IDs for embeddings. (seq_len)
- unsqueeze_dim: Integer specifying the dimension for unsqueezing.


TODO:
- add tests
- update documentation
- benchmarking with native impl/python impl
- extend to CUDA support

Acknowledgments:
Thanks to the PyTorch community and contributors for feedback and suggestions during the development of this feature.


cc @albanD