### PR TITLE
Fix vec256_half_neon != operator

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_half_neon.h
@@ -565,9 +565,9 @@ class Vectorized<c10::Half> {
   }
 
   Vectorized<c10::Half> operator!=(const Vectorized<c10::Half>& other) const {
-    float32x4_t r0 = vreinterpretq_f16_u16(
+    float16x8_t r0 = vreinterpretq_f16_u16(
         vmvnq_u16(vceqq_f16(values.val[0], other.values.val[0])));
-    float32x4_t r1 = vreinterpretq_f16_u16(
+    float16x8_t r1 = vreinterpretq_f16_u16(
         vmvnq_u16(vceqq_f16(values.val[1], other.values.val[1])));
     return Vectorized<c10::Half>(r0, r1);
   }


### PR DESCRIPTION
Fixes compilation errors introduced in #122918. Reproduced by installing pytorch with spack/GCC on a system with Grace CPUs, cf. logs: 

```
==> Installing py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj [1/1]                                                                         
==> No binary for py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj found: installing from source                                              
==> Ran patch() for py-torch                                                                                                                
==> py-torch: Executing phase: 'install'                                                                                                    
==> Error: ProcessError: Command exited with status 1:                                                                                      
    '/user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/python-3.11.7-tzzpmzrow6jkv2wuv35zg2fqays3ncma/bin/python3.11' '-m' 'pip' '-vvv' 
'--no-input' '--no-cache-dir' '--disable-pip-version-check' 'install' '--no-deps' '--ignore-installed' '--no-build-isolation' '--no-warn-scr
ipt-location' '--no-index' '--prefix=/user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj' '
.'                                                                                                                                          
                                                                                                                                            
5 errors found in build log:                                                                                                                
     5877      [4762/6281] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/register_symbols.cpp.o                 
     5878      [4763/6281] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/interned_strings.cpp.o                 
     5879      [4764/6281] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/class_type.cpp.o                       
     5880      [4765/6281] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/torch/csrc/jit/frontend/error_report.cpp.o                
     5881      [4766/6281] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/core/custom_class.cpp.o                     
     5882      [4767/6281] Building CXX object caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UpSampleBilinear2d.cpp.o             
  >> 5883    FAILED: caffe2/CMakeFiles/torch_cpu.dir/__/aten/src/ATen/native/UpSampleBilinear2d.cpp.o                                       
     5884      /dev/shm/stack-build/ml-base/spack/lib/spack/env/gcc/g++ ... /tmp/lukasd/sp...ack-src/aten/src/ATen/native/UpSampleBilinear2d.cpp
     5885      In file included from /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/
             ATen/cpu/vec/vec256/vec256.h:12,
     5886                       from /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/
             ATen/cpu/vec/vec.h:6,
     5887                       from /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/
             ATen/cpu/vec/functional_base.h:6,
     5888                       from /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/
             ATen/cpu/vec/functional.h:3,
     5889                       from /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/
             ATen/native/UpSample.h:9,
     5890                       from /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/
             ATen/native/UpSampleBilinear2d.cpp:7:
     5891      /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/ATen/cpu/vec/vec256/ve
             c256_half_neon.h: In member function 'at::vec::CPU_CAPABILITY::Vectorized<c10::Half> at::vec::CPU_CAPABILITY::Vectorized<c10::
             Half>::operator!=(const at::vec::CPU_CAPABILITY::Vectorized<c10::Half>&) const':
  >> 5892    /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/ATen/cpu/vec/vec256/vec2
             56_half_neon.h:568:43: error: cannot convert 'float16x8_t' to 'float32x4_t' in initialization
     5893        568 |     float32x4_t r0 = vreinterpretq_f16_u16(
     5894            |                      ~~~~~~~~~~~~~~~~~~~~~^
     5895            |                                           |
     5896            |                                           float16x8_t
     5897        569 |         vmvnq_u16(vceqq_f16(values.val[0], other.values.val[0])));
     5898            |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  >> 5899    /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/ATen/cpu/vec/vec256/vec2
             56_half_neon.h:570:43: error: cannot convert 'float16x8_t' to 'float32x4_t' in initialization
     5900        570 |     float32x4_t r1 = vreinterpretq_f16_u16(
     5901            |                      ~~~~~~~~~~~~~~~~~~~~~^
     5902            |                                           |
     5903            |                                           float16x8_t
     5904        571 |         vmvnq_u16(vceqq_f16(values.val[1], other.values.val[1])));
     5905            |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  >> 5906    /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/ATen/cpu/vec/vec256/vec2
             56_half_neon.h:572:40: error: no matching function for call to 'at::vec::CPU_CAPABILITY::Vectorized<c10::Half>::Vectorized(flo
             at32x4_t&, float32x4_t&)'
     5907        572 |     return Vectorized<c10::Half>(r0, r1);
     5908            |                                        ^
     5909      /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/ATen/cpu/vec/vec256/ve
             c256_half_neon.h:189:3: note: candidate: 'at::vec::CPU_CAPABILITY::Vectorized<c10::Half>::Vectorized(float16x8_t, float16x8_t)
             '
     5910        189 |   Vectorized(float16x8_t val0, float16x8_t val1) : values{val0, val1} {}
     5911            |   ^~~~~~~~~~
     5912      /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src/aten/src/ATen/cpu/vec/vec256/ve
             c256_half_neon.h:189:26: note:   no known conversion for argument 1 from 'float32x4_t' to 'float16x8_t'

     ...

     5965      ╰─> See above for output.
     5966    
     5967      note: This error originates from a subprocess, and is likely not a problem with pip.
     5968      full command: /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/python-3.11.7-tzzpmzrow6jkv2wuv35zg2fqays3ncma/bin/pytho
             n3.11 /user-environment/linux-sles15-neoverse_v2/gcc-12.3.0/py-pip-23.0-uyauk3uhefzkrfq3fkwc5ct6zp7qj7cw/lib/python3.11/site-p
             ackages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpn30r4dk9
     5969      cwd: /tmp/lukasd/spack-stage/spack-stage-py-torch-main-mk5ycetnpfhh5x3fw5wkaz6bt3pkj4bj/spack-src
     5970      Preparing metadata (pyproject.toml): finished with status 'error'
  >> 5971    error: metadata-generation-failed
     5972    
     5973    × Encountered error while generating package metadata.
     5974    ╰─> See above for output.
     5975    
     5976    note: This is an issue with the package mentioned above, not pip.
     5977    hint: See above for details.
```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10