### PR TITLE
Ensure profiler record function callback always increments "record function id". 

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1569,7 +1569,7 @@ class TestProfiler(TestCase):
                         self.assertEqual(args["Input type"], ["TensorList", "Scalar"])
 
                     # check that each op has record function id
-                    self.assertGreaterEqual(
+                    self.assertGreater(
                         args.get("Record function id", -1),
                         0,
                         f"Failed finding record funciont for op = {e}"

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -497,6 +497,7 @@ void pushProfilingCallbacks(const std::unordered_set<at::RecordScope>& scopes) {
           onFunctionEnter<use_global_callback>,
           onFunctionExit<use_global_callback>)
           .needsInputs(registration_state_ptr->config().report_input_shapes)
+          .needsIds(true)
           .scopes(scopes);
 
   if constexpr (use_global_callback) {


### PR DESCRIPTION
Fixes #123640

Each function run that is instrumented using "record function observer" can possibly include a unique "record function id". When we collect Execution Trace and PyTorch Profiler together this ID is incremented, because Execution Trace observer requests for it. If anyone of the observers request for the ID to be incrmented it will be visible to all of them.

In the issue this was not getting incremented for PyTorch profiler. This fix will ensure PyTorch profiler also requests for the unique ID to be incremented :)

## Testing
Original code matmul.py in issue now collects non zero "record function id". 

Updated unit test as well to detect this issue.