### PR TITLE
[PT2][Inductor] Add runtime numeric check for the post grad pass

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -166,6 +166,7 @@ use_mixed_mm = False
 # https://pytorch.org/docs/stable/notes/numerical_accuracy.html#batched-computations-or-slice-computations
 fx_passes_numeric_check: Dict[str, Any] = {
     "pre_grad": False,
+    "post_grad": False,
     "precision": 1e-4,
     "num_iterations": 1,
     "requires_optimizer": True,

--- a/torch/_inductor/fx_passes/numeric_utils.py
+++ b/torch/_inductor/fx_passes/numeric_utils.py
@@ -205,6 +205,6 @@ def numeric_check_if_enabled(
             )
     except Exception as e:
         logger.warning(
-            "Runtime numeric check failed in pre grad fx passes with error: %s", e
+            "Runtime numeric check failed in fx passes with error: %s", e
         )
         traceback.print_exc()

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -124,9 +124,11 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
     """
     if config.pattern_matcher:
         lazy_init()
-        if hasattr(
-            config, "fx_passes_numeric_check"
-        ) and config.fx_passes_numeric_check.get("pre_grad", False):
+        if (
+            hasattr(config, "fx_passes_numeric_check")
+            and config.fx_passes_numeric_check.get("pre_grad", False)
+            and example_inputs is not None
+        ):
             gm_before_fx_passes = gm.__copy__()
         # explicitly run with predispatch atenIR based passes
         if config.is_predispatch:


### PR DESCRIPTION
Summary: Similar to D51838043, we further add post grad runtime numeric check since some graph passes are performed at aten-level.

Test Plan:
# local reproduce
```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "cmf" --flow_id 524546542
```
P1210543145

# How to leverage it to inspect NE issue

### DPA_FIRST has 0.01% NE variance by using batch_fusion
f543613937
### MAI has train_eval NE issue in post_grad fusion
f534040609

# e2e

Differential Revision: D55989055




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang