### PR TITLE
[PT] [FSDP] fix HSDP sharding placement

### DIFF
--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -141,15 +141,15 @@ class TestShardingPlan(ShardedTensorTestBase):
         colwise_sharding_spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:2",
-                "rank:1/cuda:3",
+                "rank:2/cuda:2",
+                "rank:3/cuda:3",
             ],
         )
         rowwise_sharding_spec = ChunkShardingSpec(
             dim=1,
             placements=[
-                "rank:0/cuda:2",
-                "rank:1/cuda:3",
+                "rank:2/cuda:2",
+                "rank:3/cuda:3",
             ],
         )
         sharding_plan = ShardingPlan(

--- a/torch/distributed/_shard/api.py
+++ b/torch/distributed/_shard/api.py
@@ -66,7 +66,7 @@ def _shard_tensor(
                 f'sharding_spec={sharding_spec} on rank: {current_rank} does not '  # type: ignore[index]
                 f'match with sharding_spec={entry[1]} on rank: {idx}')
 
-    st = sharding_spec.shard(tensor, src_rank=src_rank, process_group=process_group)
+    st = sharding_spec.shard(tensor, src_rank=src_rank, process_group=pg)
 
     return st
 

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -57,7 +57,11 @@ def _create_chunk_sharded_tensor(
         else device.type
     )
     placements = [
-        _get_remote_device_str(r, device_type, num_devices_per_node)
+        _get_remote_device_str(
+            dist.get_global_rank(pg, r),
+            device_type,
+            num_devices_per_node,
+        )
         for r in range(len(chunk_sizes))
     ]
     assert len(chunk_sizes) == len(chunk_offsets) == len(placements)


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/123230 formalized the contract for `ShardedTensor` sub group rank placement validation by making sure the placement rank is global rank, to align with general `torch.distributed` convention.

The current HSDP allows for both `ShardedTensor` and `DTensor`. While `DTensor` will eventually will replace `ShardedTensor`, its usage still exists and there's at least one test verifying the state dict with ST output.

This got broken as the test is run periodically only so it didn't block the other PR.
Fixes [#123749](https://github.com/pytorch/pytorch/issues/123749)

Test Plan: CI

Differential Revision: D55991256




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang