### PR TITLE
[WIP][inductor] add metadata on grid functions & filename for profiling purposes

### DIFF
--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -154,6 +154,20 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
             self.assertTrue(event_found)
 
     @unittest.skipIf(not HAS_TRITON, "requires cuda & triton")
+    def test_inductor_profiling_record_shapes(self):
+        @torch.compile
+        def fn(x, y):
+            return (x + y).sin().cos()
+
+        inp = [torch.rand((4, 4), device="cuda") for _ in range(2)]
+
+        fn(*inp)
+        with torch.profiler.profile(record_shapes=True) as prof:
+            fn(*inp)
+
+        self.assertTrue(any(("sin" in evt.name) for evt in prof.events()))
+
+    @unittest.skipIf(not HAS_TRITON, "requires cuda & triton")
     def test_inductor_profiling_triton_hooks(self):
         from triton.compiler import CompiledKernel
 

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -177,7 +177,7 @@ class CachingAutotuner(KernelInterface):
             for c in self.configs:
                 log.debug(c)
 
-        self.launchers = []
+        self.launchers = []  # type: ignore[var-annotated]
         self.lock = threading.Lock()
         if os.getenv("TRITON_CACHE_DIR") is None:
             os.environ["TRITON_CACHE_DIR"] = os.path.join(

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -738,7 +738,9 @@ class CachingAutotuner(KernelInterface):
             # grid can be a tuple of ints or a lambda.
             # if it is a lambda, then it should have metadata associated that can be used
             # to reconstruct the lambda.
-            grid_info = grid if isinstance(grid, tuple) else getattr(grid, "grid_meta", None)
+            grid_info = (
+                grid if isinstance(grid, tuple) else getattr(grid, "grid_args", None)
+            )
             with torch._C._profiler._RecordFunctionFast(
                 self.inductor_meta.get("kernel_name", "triton kernel"),
                 args,
@@ -1612,7 +1614,7 @@ def grid(*numels):
             z_grid,
         )
 
-    grid_fn.grid_meta = ("grid", *numels)
+    grid_fn.grid_args = ("grid", *numels)  # type: ignore[attr-defined]
 
     return grid_fn
 
@@ -1622,6 +1624,6 @@ def split_scan_grid(xnumel, rnumel):
         assert meta.get("XBLOCK", 1) == 1
         return (ceildiv(rnumel, meta.get("RBLOCK", 1)), xnumel, 1)
 
-    grid_fn.grid_meta = ("split_scan_grid", xnumel, rnumel)
+    grid_fn.grid_args = ("split_scan_grid", xnumel, rnumel)  # type: ignore[attr-defined]
 
     return grid_fn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123781

Filename - plumb it through to CachedAutotuner so that we have the information available to the profiler
Grid function - stash the args & function name on the closure, and recover it if we try to profile it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang

Differential Revision: [D55997632](https://our.internmc.facebook.com/intern/diff/D55997632)