### PR TITLE
Enable int4mm for both half and bfloat16

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3479,8 +3479,8 @@ Tensor _weight_int4pack_mm_cpu(
   auto N = B.size(0) * kNTileSize;
   auto K = A.size(1);
 
-  TORCH_CHECK(A.dtype() == kBFloat16,
-      __func__, " : expect A to be bfloat16 tensor.");
+  TORCH_CHECK(A.dtype() == kBFloat16 || A.dtype() == kHalf,
+      __func__, " : expect A to be float16 or bfloat16 tensor.");
   TORCH_CHECK(A.is_contiguous(),
       __func__, " : expect A to be contiguous.");
   TORCH_CHECK(A.dim() == 2,


### PR DESCRIPTION
By making performant kernels a template specialization. This is a prep change for enabling ARM+float16 fast int4 kernel
TODO:
 - Add float32 and some testing

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10