### PR TITLE
[EZ] Pin scipy to 1.12 for Py-3.12

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -231,6 +231,7 @@ scikit-image==0.20.0 ; python_version >= "3.10"
 scipy==1.6.3 ; python_version < "3.10"
 scipy==1.8.1 ; python_version == "3.10"
 scipy==1.10.1 ; python_version == "3.11"
+scipy==1.12.0 ; python_version == "3.12"
 # Pin SciPy because of failing distribution tests (see #60347)
 #Description: scientific python
 #Pinned versions: 1.6.3


### PR DESCRIPTION
This caused false positive failures/reverts for https://github.com/pytorch/pytorch/pull/123689 and https://github.com/pytorch/pytorch/pull/123595

Fixes https://github.com/pytorch/pytorch/issues/123655
