### PR TITLE
Avoid COW materialization in backward ops (3)

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -411,8 +411,8 @@ TORCH_IMPL_FUNC(gelu_backward_out_cpu) (
 auto approximate_type = get_gelutype_enum(approximate);
 #if AT_MKLDNN_ENABLED()
   if (use_mkldnn(self) && (approximate_type == GeluType::None)) {
-    const ideep::tensor& x = itensor_from_tensor(self);
-    ideep::tensor grady = itensor_from_tensor(grad);
+    const ideep::tensor& x = itensor_from_tensor(self, /*from_const_data_ptr*/true);
+    ideep::tensor grady = itensor_from_tensor(grad, /*from_const_data_ptr*/true);
     ideep::tensor gradx = itensor_from_tensor(grad_input);
     ideep::eltwise_backward::compute(x, grady, gradx,
       ideep::algorithm::eltwise_gelu_erf, /*alpha*/ 0.0);
@@ -730,9 +730,9 @@ std::tuple<Tensor, Tensor> _prelu_kernel_backward(const Tensor& grad_out, const 
   auto iter = TensorIteratorConfig()
     .add_output(grad_self)
     .add_output(grad_weight)
-    .add_input(self)
-    .add_input(weight)
-    .add_input(grad_out)
+    .add_const_input(self)
+    .add_const_input(weight)
+    .add_const_input(grad_out)
     .build();
   prelu_backward_stub(iter.device_type(), iter);
   return {grad_self, grad_weight};

--- a/aten/src/ATen/native/ConvolutionMM2d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM2d.cpp
@@ -285,8 +285,8 @@ static void slow_conv2d_update_output_frame(
 template <typename scalar_t>
 void slow_conv2d_backward_update_grad_input_frame(
     TensorAccessor<scalar_t, 3> grad_input,
-    TensorAccessor<scalar_t, 3> grad_output,
-    TensorAccessor<scalar_t, 2> weight,
+    TensorAccessor<const scalar_t, 3> grad_output,
+    TensorAccessor<const scalar_t, 2> weight,
     scalar_t *fgrad_input,
     int64_t kernel_height,
     int64_t kernel_width,
@@ -405,9 +405,9 @@ void slow_conv2d_backward_out_cpu_template(
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kBFloat16, kHalf, input.scalar_type(), "slow_conv2d_cpu_grad_input", [&] {
-    auto grad_output_a = grad_output.accessor<scalar_t, 4>();
+    auto grad_output_a = grad_output.accessor<const scalar_t, 4>();
     auto grad_input_a = grad_input.accessor<scalar_t, 4>();
-    auto weight_a = weight.accessor<scalar_t, 2>();
+    auto weight_a = weight.accessor<const scalar_t, 2>();
 
     at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
       auto fgrad_input = std::make_unique<scalar_t[]>(fgrad_input_size);
@@ -434,8 +434,8 @@ void slow_conv2d_backward_out_cpu_template(
 template <typename scalar_t>
 void slow_conv2d_backward_weight_frame(
     TensorAccessor<scalar_t, 2> grad_weight,
-    TensorAccessor<scalar_t, 3> grad_output,
-    TensorAccessor<scalar_t, 2> finput,
+    TensorAccessor<const scalar_t, 3> grad_output,
+    TensorAccessor<const scalar_t, 2> finput,
     bool is_channels_last) {
   // Compute grad_weight += grad_output.reshape({grad_output.shape(0), -1}) * finput.T
   // Note gemm expects fortran order, so all 3 matrices are transposed.
@@ -519,9 +519,9 @@ static void slow_conv2d_backward_weight_out_cpu_template(
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kBFloat16, kHalf, input.scalar_type(), "slow_conv2d_cpu_grad_weight", [&] {
-    auto grad_output_a = grad_output.accessor<scalar_t, 4>();
+    auto grad_output_a = grad_output.accessor<const scalar_t, 4>();
     auto grad_weight_2d_a = grad_weight_2d.accessor<scalar_t, 2>();
-    auto finput_a = finput.accessor<scalar_t, 3>();
+    auto finput_a = finput.accessor<const scalar_t, 3>();
 
     for (const auto t : c10::irange(batch_size)) {
       auto grad_output_t = grad_output_a[t];

--- a/aten/src/ATen/native/ConvolutionMM3d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM3d.cpp
@@ -311,8 +311,8 @@ static void slow_conv3d_update_output_frame(
 template <typename scalar_t>
 void slow_conv3d_backward_update_grad_input_frame(
     TensorAccessor<scalar_t, 4> grad_input,
-    TensorAccessor<scalar_t, 4> grad_output,
-    TensorAccessor<scalar_t, 2> weight,
+    TensorAccessor<const scalar_t, 4> grad_output,
+    TensorAccessor<const scalar_t, 2> weight,
     TensorAccessor<scalar_t, 2> fgrad_input,
     int64_t kernel_depth,
     int64_t kernel_height,
@@ -431,9 +431,9 @@ void slow_conv3d_backward_out_cpu_template(
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kBFloat16, kHalf, input.scalar_type(), "slow_conv3d_cpu_grad_input", [&] {
     auto grad_input_a = grad_input.accessor<scalar_t, 5>();
-    auto grad_output_a = grad_output_contiguous.accessor<scalar_t, 5>();
+    auto grad_output_a = grad_output_contiguous.accessor<const scalar_t, 5>();
     auto fgrad_input_a = fgrad_input.accessor<scalar_t, 3>();
-    auto weight_2d_a = weight2d.accessor<scalar_t, 2>();
+    auto weight_2d_a = weight2d.accessor<const scalar_t, 2>();
     at::parallel_for(0, batch_size, CONV3D_GRAIN_SALT,
                     [&](int64_t start, int64_t end) {
 
@@ -464,8 +464,8 @@ void slow_conv3d_backward_out_cpu_template(
 template <typename scalar_t>
 void slow_conv3d_backward_weight_frame(
     TensorAccessor<scalar_t, 2> grad_weight,
-    TensorAccessor<scalar_t, 4> grad_output,
-    TensorAccessor<scalar_t, 2> finput,
+    TensorAccessor<const scalar_t, 4> grad_output,
+    TensorAccessor<const scalar_t, 2> finput,
     int64_t groups) {
   // Compute grad_weight += grad_output.reshape({grad_output.shape(0), -1}) * finput.T
   // Note gemm expects fortran order, so all 3 matrices are transposed.
@@ -538,8 +538,8 @@ static void slow_conv3d_backward_parameters_out_cpu_template(
   AT_DISPATCH_FLOATING_TYPES_AND2(
       kBFloat16, kHalf, input.scalar_type(), "slow_conv3d_cpu_grad_weight", [&] {
     auto grad_weight_2d_a = grad_weight_2d.accessor<scalar_t, 2>();
-    auto grad_output_a = grad_output_contiguous.accessor<scalar_t, 5>();
-    auto finput_a = finput.accessor<scalar_t, 3>();
+    auto grad_output_a = grad_output_contiguous.accessor<const scalar_t, 5>();
+    auto finput_a = finput.accessor<const scalar_t, 3>();
     for (const auto t : c10::irange(batch_size)) {
       auto grad_output_t = grad_output_a[t];
       auto finput_t = finput_a[t];

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -124,18 +124,18 @@ Tensor embedding_dense_backward_cpu(
   auto add_iter = TensorIteratorConfig()
     .add_output(grad_weight)
     .add_input(grad_weight)
-    .add_input(grad)
+    .add_const_input(grad)
     .resize_outputs(false)
     .declare_static_shape(grad.sizes(), /*squash_dims=*/0)
     .build();
 
   const auto gW_data = reinterpret_cast<char*>(grad_weight.data_ptr());
-  const auto gO_data = reinterpret_cast<char*>(grad.data_ptr());
+  const auto gO_data = reinterpret_cast<const char*>(grad.const_data_ptr());
   const auto gW_stride = grad_weight.strides()[0] * grad_weight.element_size();
   const auto gO_stride = grad.strides()[0] * grad.element_size();
 
   AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "embedding_dense_backward_cpu", [&] () {
-    auto indices_data = indices_contig.data_ptr<index_t>();
+    auto indices_data = indices_contig.const_data_ptr<index_t>();
 
     // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     std::unique_ptr<index_t[]> counts;
@@ -164,7 +164,7 @@ Tensor embedding_dense_backward_cpu(
             // grad_weight[k].add_(grad[i], scale);
             iter.unsafe_replace_operand(0, gW_data + k * gW_stride);
             iter.unsafe_replace_operand(1, gW_data + k * gW_stride);
-            iter.unsafe_replace_operand(2, gO_data + i * gO_stride);
+            iter.unsafe_replace_operand(2, const_cast<char*>(gO_data + i * gO_stride));
             add_stub(kCPU, iter, scale);
           }
         }

--- a/aten/src/ATen/native/GatedLinearUnit.cpp
+++ b/aten/src/ATen/native/GatedLinearUnit.cpp
@@ -71,9 +71,9 @@ Tensor& glu_backward_cpu_out(const Tensor& grad_output, const Tensor& input,
   // for second gradinput half, can get a better performance by fusion
   auto iter = at::TensorIteratorConfig()
     .add_output(gradInputsecondHalf)
-    .add_input(gradInputfirstHalf)
-    .add_input(firstHalf)
-    .add_input(grad_output)
+    .add_const_input(gradInputfirstHalf)
+    .add_const_input(firstHalf)
+    .add_const_input(grad_output)
     .build();
   glu_backward_stub(iter.device_type(), iter);
   gradInputfirstHalf.mul_(grad_output);
@@ -99,10 +99,10 @@ Tensor glu_jvp(
   auto dglu = at::empty_like(glu);
   auto iter = at::TensorIteratorConfig()
     .add_output(dglu)
-    .add_input(glu)
-    .add_input(b)
-    .add_input(da)
-    .add_input(db)
+    .add_const_input(glu)
+    .add_const_input(b)
+    .add_const_input(da)
+    .add_const_input(db)
     .build();
   glu_jvp_stub(iter.device_type(), iter);
   return dglu;

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -323,9 +323,9 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
 
     auto iter = TensorIteratorConfig()
       .add_output(grad_input_squeezed)
-      .add_owned_input(at::squeeze(grad))
-      .add_owned_input(at::squeeze(input))
-      .add_owned_input(at::squeeze(target))
+      .add_owned_const_input(at::squeeze(grad))
+      .add_owned_const_input(at::squeeze(input))
+      .add_owned_const_input(at::squeeze(target))
       .build();
 
     AT_DISPATCH_FLOATING_TYPES(grad_input.scalar_type(), "binary_cross_entropy_backward", [&] {
@@ -435,9 +435,9 @@ Tensor& smooth_l1_loss_backward_out(const Tensor& grad_output, const Tensor& inp
   auto norm = reduction == Reduction::Mean ? 1. / input.numel() : 1.;
   auto iter = at::TensorIteratorConfig()
     .add_output(grad_input)
-    .add_input(input)
-    .add_input(target)
-    .add_input(grad_output)
+    .add_const_input(input)
+    .add_const_input(target)
+    .add_const_input(grad_output)
     .promote_inputs_to_common_dtype(true)
     .cast_common_dtype_to_outputs(true)
     .enforce_safe_casting_to_output(true)

--- a/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
@@ -356,7 +356,7 @@ void slow_conv_transpose2d_out_cpu_template(
 
         // Unpack columns back into input:
         col2im<scalar_t>(
-            columns_n.data_ptr<scalar_t>(),
+            columns_n.const_data_ptr<scalar_t>(),
             n_output_plane,
             output_height,
             output_width,
@@ -511,7 +511,7 @@ static void slow_conv_transpose2d_backward_out_cpu_template(
           if (need_columns) {
             // Extract columns:
             im2col<scalar_t>(
-                  grad_output_n.data_ptr<scalar_t>(),
+                  grad_output_n.const_data_ptr<scalar_t>(),
                   n_output_plane,
                   output_height,
                   output_width,
@@ -529,8 +529,8 @@ static void slow_conv_transpose2d_backward_out_cpu_template(
                   use_channels_last);
           }
 
-          auto gemm_in_ptr = need_columns ? grad_columns.data_ptr<scalar_t>()
-              : grad_output_n.data_ptr<scalar_t>();
+          auto gemm_in_ptr = need_columns ? grad_columns.const_data_ptr<scalar_t>()
+              : grad_output_n.const_data_ptr<scalar_t>();
 
           if (use_channels_last) {
             int64_t m = n_input_plane;
@@ -709,7 +709,7 @@ void slow_conv_transpose2d_acc_grad_parameters_cpu(
             if (need_columns) {
               // Extract columns:
               im2col<scalar_t>(
-                  grad_output_n.data_ptr<scalar_t>(),
+                  grad_output_n.const_data_ptr<scalar_t>(),
                   n_output_plane,
                   output_height,
                   output_width,
@@ -727,8 +727,8 @@ void slow_conv_transpose2d_acc_grad_parameters_cpu(
                   use_channels_last);
             }
 
-            auto gemm_in_ptr = need_columns ? columns.data_ptr<scalar_t>()
-                : grad_output_n.data_ptr<scalar_t>();
+            auto gemm_in_ptr = need_columns ? columns.const_data_ptr<scalar_t>()
+                : grad_output_n.const_data_ptr<scalar_t>();
 
             if (use_channels_last) {
               int64_t m = kernel_height * kernel_width * n_output_plane;

--- a/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
@@ -329,7 +329,7 @@ void slow_conv_transpose3d_out_cpu_template(
 
           // Unpack columns back into input:
           at::native::col2vol<scalar_t>(
-              columns.data_ptr<scalar_t>(),
+              columns.const_data_ptr<scalar_t>(),
               n_output_plane,
               output_depth,
               output_height,
@@ -562,8 +562,8 @@ void slow_conv_transpose3d_backward_out_cpu_template(
 
           // Do GEMM (note: this is a bit confusing because gemm assumes
           // column-major matrices)
-          auto gemm_in_ptr = need_columns ? grad_columns.data_ptr<scalar_t>()
-              : grad_output_n.data_ptr<scalar_t>();
+          auto gemm_in_ptr = need_columns ? grad_columns.const_data_ptr<scalar_t>()
+              : grad_output_n.const_data_ptr<scalar_t>();
           cpublas::gemm(
               TransposeType::NoTranspose,
               TransposeType::NoTranspose,
@@ -782,8 +782,8 @@ void slow_conv_transpose3d_acc_grad_parameters_cpu(
 
             // Do GEMM (note: this is a bit confusing because gemm assumes
             // column-major matrices)
-            auto gemm_in_ptr = need_columns ? columns.data_ptr<scalar_t>()
-                : grad_output_n.data_ptr<scalar_t>();
+            auto gemm_in_ptr = need_columns ? columns.const_data_ptr<scalar_t>()
+                : grad_output_n.const_data_ptr<scalar_t>();
             cpublas::gemm(
                 TransposeType::Transpose,
                 TransposeType::NoTranspose,

--- a/aten/src/ATen/native/UnfoldBackward.h
+++ b/aten/src/ATen/native/UnfoldBackward.h
@@ -100,8 +100,8 @@ static C10_UNUSED TensorIterator _make_unfold_backward_iter_over_grad_out(
     .check_all_same_dtype(false)
     .resize_outputs(false)
     .add_owned_output(grad_out_restrided)
-    .add_owned_input(grad_in_restrided)
-    .add_owned_input(idx_dim_restrided)
+    .add_owned_const_input(grad_in_restrided)
+    .add_owned_const_input(idx_dim_restrided)
     .build();
 
   return iter;

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -493,15 +493,15 @@ void cpu_flash_attention_backward(
   scalar_t* grad_q_data = grad_q.data_ptr<scalar_t>();
   scalar_t* grad_k_data = grad_k.data_ptr<scalar_t>();
   scalar_t* grad_v_data = grad_v.data_ptr<scalar_t>();
-  scalar_t* grad_out_data = grad_out.data_ptr<scalar_t>();
-  scalar_t* q_data = query.data_ptr<scalar_t>();
-  scalar_t* k_data = key.data_ptr<scalar_t>();
-  scalar_t* v_data = value.data_ptr<scalar_t>();
-  accum_t* mask_data = has_attn_mask
-      ? attn_mask.value().data_ptr<accum_t>()
+  const scalar_t* grad_out_data = grad_out.const_data_ptr<scalar_t>();
+  const scalar_t* q_data = query.const_data_ptr<scalar_t>();
+  const scalar_t* k_data = key.const_data_ptr<scalar_t>();
+  const scalar_t* v_data = value.const_data_ptr<scalar_t>();
+  const accum_t* mask_data = has_attn_mask
+      ? attn_mask.value().const_data_ptr<accum_t>()
       : nullptr;
-  scalar_t* out_data = out.data_ptr<scalar_t>();
-  accum_t* lse_data = logsumexp.data_ptr<accum_t>();
+  const scalar_t* out_data = out.const_data_ptr<scalar_t>();
+  const accum_t* lse_data = logsumexp.const_data_ptr<accum_t>();
   accum_t* buf_data = buf.data_ptr<accum_t>();
   scalar_t* buf_reduced_data = is_reduced_type ? buf_reduced.data_ptr<scalar_t>() : nullptr;
 

--- a/aten/src/ATen/native/cuda/Activation.cpp
+++ b/aten/src/ATen/native/cuda/Activation.cpp
@@ -44,8 +44,8 @@ Tensor& glu_backward_cuda_out(const Tensor& grad_output, const Tensor& input,
 
   const auto iter = at::TensorIteratorConfig()
     .add_output(grad_input)
-    .add_input(input)
-    .add_input(grad_output)
+    .add_const_input(input)
+    .add_const_input(grad_output)
     .resize_outputs(false)
     .declare_static_shape(iter_shape)
     .build();

--- a/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
@@ -103,9 +103,9 @@ __global__ void conv_depthwise2d_forward_kernel(
 
 template <int kSize, int stride, typename scalar_t, typename index_t>
 __global__ void conv_depthwise2d_backward_kernel(
-    const PackedTensorAccessor32<scalar_t, 4, DefaultPtrTraits> grad_output,
+    const PackedTensorAccessor32<const scalar_t, 4, DefaultPtrTraits> grad_output,
     PackedTensorAccessor32<scalar_t, 4, DefaultPtrTraits> grad_input,
-    const PackedTensorAccessor32<scalar_t, 4, DefaultPtrTraits> weight,
+    const PackedTensorAccessor32<const scalar_t, 4, DefaultPtrTraits> weight,
     index_t totalElements,
     const int inputChannels,
     const int depthwiseMultiplier,
@@ -174,8 +174,8 @@ __global__ void conv_depthwise2d_backward_kernel(
 
 template <typename scalar_t, typename index_t=unsigned>
 __global__ void conv_depthwise2d_grad_weight_kernel(
-    const PackedTensorAccessor32<scalar_t, 4, DefaultPtrTraits> grad_output,
-    const PackedTensorAccessor32<scalar_t, 4, DefaultPtrTraits> input,
+    const PackedTensorAccessor32<const scalar_t, 4, DefaultPtrTraits> grad_output,
+    const PackedTensorAccessor32<const scalar_t, 4, DefaultPtrTraits> input,
     PackedTensorAccessor32<scalar_t, 4, DefaultPtrTraits> grad_weight,
     const int batchSize,
     const int inputChannels,
@@ -387,9 +387,9 @@ void conv_depthwise2d_backward_out(
   const auto stream = c10::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, grad_output.scalar_type(),
                                   "conv_depthwise2d_backward_cuda", [&] {
-    auto grad_output_a = grad_output.packed_accessor32<scalar_t, 4>();
+    auto grad_output_a = grad_output.packed_accessor32<const scalar_t, 4>();
     auto grad_input_a = grad_input.packed_accessor32<scalar_t, 4>();
-    auto weight_a = weight.packed_accessor32<scalar_t, 4>();
+    auto weight_a = weight.packed_accessor32<const scalar_t, 4>();
 
     if (kW == 3 && kH == 3) {
       if (dW == 1 && dH == 1){
@@ -501,8 +501,8 @@ void conv_depthwise2d_grad_weight_out(
 
   AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, grad_output.scalar_type(),
                                   "conv_depthwise2d_grad_weight_cuda", [&] {
-    const auto grad_output_a = grad_output.packed_accessor32<scalar_t, 4>();
-    const auto input_a = input.packed_accessor32<scalar_t, 4>();
+    const auto grad_output_a = grad_output.packed_accessor32<const scalar_t, 4>();
+    const auto input_a = input.packed_accessor32<const scalar_t, 4>();
     const auto grad_weight_a = grad_weight.packed_accessor32<scalar_t, 4>();
     using acc_t = at::acc_type<scalar_t, true>;
     int warp_size = at::cuda::warp_size();

--- a/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
@@ -99,9 +99,9 @@ template <typename scalar_t, typename accscalar_t,
     int kKnownStrideT, int kKnownStrideH, int kKnownStrideW>
 __global__ void
 conv_depthwise3d_cuda_backward_input_kernel(
-    const PackedTensorAccessor32<scalar_t, 5> grad_output,
+    const PackedTensorAccessor32<const scalar_t, 5> grad_output,
     PackedTensorAccessor32<scalar_t, 5> grad_input,
-    const PackedTensorAccessor32<scalar_t, 5> kernel,
+    const PackedTensorAccessor32<const scalar_t, 5> kernel,
     int strideT_, int strideH_, int strideW_,
     int paddingT, int paddingH, int paddingW,
     int dilationT_, int dilationH_, int dilationW_) {
@@ -180,8 +180,8 @@ template <typename scalar_t, typename accscalar_t,
     int kKnownStrideH, int kKnownStrideW>
 __global__ void
 conv_depthwise3d_cuda_backward_weight_kernel(
-    const PackedTensorAccessor32<scalar_t, 5> grad_output,
-    const PackedTensorAccessor32<scalar_t, 5> input,
+    const PackedTensorAccessor32<const scalar_t, 5> grad_output,
+    const PackedTensorAccessor32<const scalar_t, 5> input,
     PackedTensorAccessor32<scalar_t, 5> grad_kernel,
     int strideT, int strideH_, int strideW_,
     int paddingT, int paddingH, int paddingW,
@@ -470,9 +470,9 @@ Tensor conv_depthwise3d_cuda(
     conv_depthwise3d_cuda_backward_input_kernel                             \
     <scalar_t, accscalar_t, (kt), (kh), (kw), (dilt), (dilh), (dilw), (dt), (dh), (dw)>  \
       <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(               \
-        grad_output_.packed_accessor32<scalar_t, 5>(),                      \
+        grad_output_.packed_accessor32<const scalar_t, 5>(),                \
         grad_input_.packed_accessor32<scalar_t, 5>(),                       \
-        weight_.packed_accessor32<scalar_t, 5>(),                           \
+        weight_.packed_accessor32<const scalar_t, 5>(),                     \
         stride[0], stride[1], stride[2],                                    \
         padding[0], padding[1], padding[2],                                 \
         dilation[0], dilation[1], dilation[2]);                             \
@@ -485,9 +485,9 @@ Tensor conv_depthwise3d_cuda(
     conv_depthwise3d_cuda_backward_input_kernel                             \
     <scalar_t, accscalar_t, -1, -1, -1, -1, -1, -1, -1, -1, -1>             \
       <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(               \
-        grad_output_.packed_accessor32<scalar_t, 5>(),                      \
+        grad_output_.packed_accessor32<const scalar_t, 5>(),                \
         grad_input_.packed_accessor32<scalar_t, 5>(),                       \
-        weight_.packed_accessor32<scalar_t, 5>(),                           \
+        weight_.packed_accessor32<const scalar_t, 5>(),                     \
         stride[0], stride[1], stride[2],                                    \
         padding[0], padding[1], padding[2],                                 \
         dilation[0], dilation[1], dilation[2]);                             \
@@ -500,8 +500,8 @@ Tensor conv_depthwise3d_cuda(
     conv_depthwise3d_cuda_backward_weight_kernel                            \
     <scalar_t, accscalar_t, (dh), (dw)>                                     \
       <<<grid, block, smem, at::cuda::getCurrentCUDAStream()>>>(            \
-        grad_output_.packed_accessor32<scalar_t, 5>(),                      \
-        input_.packed_accessor32<scalar_t, 5>(),                            \
+        grad_output_.packed_accessor32<const scalar_t, 5>(),                \
+        input_.packed_accessor32<const scalar_t, 5>(),                      \
         grad_weight.packed_accessor32<scalar_t, 5>(),                       \
         stride[0], stride[1], stride[2],                                    \
         padding[0], padding[1], padding[2],                                 \
@@ -515,8 +515,8 @@ Tensor conv_depthwise3d_cuda(
     conv_depthwise3d_cuda_backward_weight_kernel                            \
     <scalar_t, accscalar_t, -1, -1>                                         \
       <<<grid, block, smem, at::cuda::getCurrentCUDAStream()>>>(            \
-        grad_output_.packed_accessor32<scalar_t, 5>(),                      \
-        input_.packed_accessor32<scalar_t, 5>(),                            \
+        grad_output_.packed_accessor32<const scalar_t, 5>(),                \
+        input_.packed_accessor32<const scalar_t, 5>(),                      \
         grad_weight.packed_accessor32<scalar_t, 5>(),                       \
         stride[0], stride[1], stride[2],                                    \
         padding[0], padding[1], padding[2],                                 \

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -376,6 +376,12 @@ void run_conv_plan(
     data_ptrs[0] = x.data_ptr();
     data_ptrs[1] = const_cast<void*>(y.const_data_ptr());
     data_ptrs[2] = const_cast<void*>(w.const_data_ptr());
+  } else if (
+      operation ==
+      CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_FILTER_DESCRIPTOR) {
+    data_ptrs[0] = const_cast<void*>(x.const_data_ptr());
+    data_ptrs[1] = const_cast<void*>(y.const_data_ptr());
+    data_ptrs[2] = w.data_ptr();
   } else {
     data_ptrs[0] = x.data_ptr();
     data_ptrs[1] = y.data_ptr();

--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -825,8 +825,8 @@ Tensor mkldnn_convolution_backward_input(
     bool is_channels_last) {
   auto grad_input = at::empty({0}, grad_output.options());
 
-  auto grad_y = itensor_from_tensor(grad_output);
-  auto w = itensor_view_from_dense(weight);
+  auto grad_y = itensor_from_tensor(grad_output, /*from_const_data_ptr*/true);
+  auto w = itensor_view_from_dense(weight, /*from_const_data_ptr*/true);
 
   ideep::tensor grad_x;
   if (is_channels_last) {
@@ -865,8 +865,8 @@ std::tuple<Tensor, Tensor> mkldnn_convolution_backward_weights(
     int64_t groups,
     bool bias_defined,
     bool is_channels_last) {
-  const ideep::tensor grad_y = itensor_from_tensor(grad_output);
-  const ideep::tensor x = itensor_from_tensor(input);
+  const ideep::tensor grad_y = itensor_from_tensor(grad_output, /*from_const_data_ptr*/true);
+  const ideep::tensor x = itensor_from_tensor(input, /*from_const_data_ptr*/true);
 
   ideep::tensor grad_w, grad_b;
   if (bias_defined) {
@@ -975,8 +975,8 @@ Tensor mkldnn_convolution_transpose_backward_input(
     bool is_channels_last) {
   auto grad_input = at::empty({0}, grad_output.options());
 
-  auto grad_y = itensor_from_tensor(grad_output);
-  auto w = itensor_view_from_dense(weight).transpose_(0, 1);
+  auto grad_y = itensor_from_tensor(grad_output, /*from_const_data_ptr*/true);
+  auto w = itensor_view_from_dense(weight, /*from_const_data_ptr*/true).transpose_(0, 1);
 
   ideep::tensor grad_x;
   if (is_channels_last) {
@@ -1016,8 +1016,8 @@ std::tuple<Tensor,Tensor> mkldnn_convolution_transpose_backward_weights(
     int64_t groups,
     bool bias_defined,
     bool is_channels_last) {
-  auto grad_y = itensor_from_tensor(grad_output);
-  auto x = itensor_from_tensor(input);
+  auto grad_y = itensor_from_tensor(grad_output, /*from_const_data_ptr*/true);
+  auto x = itensor_from_tensor(input, /*from_const_data_ptr*/true);
 
   ideep::tensor grad_w, grad_b;
   if (bias_defined) {

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -341,12 +341,12 @@ _efficient_attention_backward(
     TORCH_INTERNAL_ASSERT(delta.size(2) == M);
 
     typename Kernel::Params p;
-    p.query_ptr = (scalar_t*)query.data_ptr();
-    p.key_ptr = (scalar_t*)key.data_ptr();
-    p.value_ptr = (scalar_t*)value.data_ptr();
-    p.logsumexp_ptr = (typename Kernel::lse_scalar_t*)logsumexp.data_ptr();
-    p.output_ptr = (scalar_t*)out.data_ptr();
-    p.grad_output_ptr = (scalar_t*)grad_out.data_ptr();
+    p.query_ptr = (const scalar_t*)query.const_data_ptr();
+    p.key_ptr = (const scalar_t*)key.const_data_ptr();
+    p.value_ptr = (const scalar_t*)value.const_data_ptr();
+    p.logsumexp_ptr = (typename Kernel::lse_scalar_t const *)logsumexp.const_data_ptr();
+    p.output_ptr = (const scalar_t*)out.const_data_ptr();
+    p.grad_output_ptr = (const scalar_t*)grad_out.const_data_ptr();
     p.grad_query_ptr = (scalar_t*)grad_q.data_ptr();
     p.grad_key_ptr = (scalar_t*)grad_k.data_ptr();
     p.grad_value_ptr = (scalar_t*)grad_v.data_ptr();
@@ -360,8 +360,8 @@ _efficient_attention_backward(
     p.custom_mask_type = custom_mask_type;
     p.scale = sdp::calculate_scale(query, scale).as_float_unchecked();
     if (cu_seqlens_q.has_value()) {
-      p.cu_seqlens_q_ptr = (int32_t*)cu_seqlens_q->data_ptr();
-      p.cu_seqlens_k_ptr = (int32_t*)cu_seqlens_k->data_ptr();
+      p.cu_seqlens_q_ptr = (const int32_t*)cu_seqlens_q->const_data_ptr();
+      p.cu_seqlens_k_ptr = (const int32_t*)cu_seqlens_k->const_data_ptr();
     }
     if (window_size.has_value()) {
       p.window_size = *window_size;

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13409,7 +13409,6 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,
-           supports_cow_input_no_materialize_backward=False,
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            decorators=(
                DecorateInfo(
@@ -13456,7 +13455,6 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,
-           supports_cow_input_no_materialize_backward=False,
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            decorators=[
                DecorateInfo(
@@ -13503,7 +13501,6 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,
-           supports_cow_input_no_materialize_backward=False,
            # Runs very slowly on slow-gradcheck - alternatively reduce input sizes
            gradcheck_fast_mode=True,
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
@@ -13564,7 +13561,6 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,
-           supports_cow_input_no_materialize_backward=False,
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            decorators=(
                DecorateInfo(
@@ -13605,7 +13601,6 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            assert_jit_shape_analysis=True,
-           supports_cow_input_no_materialize_backward=False,
            decorators=(
                DecorateInfo(
                    toleranceOverride({torch.chalf: tol(atol=6e-2, rtol=5e-2)}),
@@ -13637,7 +13632,6 @@ op_db: List[OpInfo] = [
            gradcheck_fast_mode=True,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           supports_cow_input_no_materialize_backward=False,
            decorators=(
                DecorateInfo(
                    toleranceOverride({torch.chalf: tol(atol=6e-2, rtol=5e-2)}),
@@ -14411,7 +14405,6 @@ op_db: List[OpInfo] = [
            dtypes=floating_types_and(torch.bfloat16, torch.float16),
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           supports_cow_input_no_materialize_backward=False,
            supports_out=False),
     UnaryUfuncInfo(
         'nn.functional.elu',
@@ -14453,7 +14446,6 @@ op_db: List[OpInfo] = [
         assert_autodiffed=False,
         supports_gradgrad=True,
         supports_out=False,
-        supports_cow_input_no_materialize_backward=False,
         # test_reference_numerics only tests the case when the weight tensor is a scalar
         sample_kwargs=sample_kwargs_prelu_scalar_weight,
         error_inputs_func=error_inputs_prelu,
@@ -14581,7 +14573,6 @@ op_db: List[OpInfo] = [
         supports_forward_ad=False,
         supports_fwgrad_bwgrad=True,
         check_batched_forward_grad=False,
-        supports_cow_input_no_materialize_backward=False,
         decorators=[DecorateInfo(toleranceOverride(
             {torch.float32: tol(atol=5e-05, rtol=5e-6)}), 'TestCommon',), ],
         skips=(
@@ -14825,7 +14816,6 @@ op_db: List[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         supports_gradgrad=True,
-        supports_cow_input_no_materialize_backward=False,
         # autodiff_nonfusible_nodes=["aten::log_sigmoid"],
         decorators=[
             DecorateInfo(
@@ -14923,7 +14913,6 @@ op_db: List[OpInfo] = [
         assert_autodiffed=False,
         supports_gradgrad=True,
         supports_out=False,
-        supports_cow_input_no_materialize_backward=False,
         sample_kwargs=lambda device, dtype, input: ({'threshold': float.fromhex('0x1.3ap-3'),
                                                     'value': -9},
                                                     {'threshold': float.fromhex('0x1.3ap-3'),
@@ -15062,7 +15051,6 @@ op_db: List[OpInfo] = [
         supports_autograd=True,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
-        supports_cow_input_no_materialize_backward=False,
         decorators=(
             # RuntimeError: expected int at position 0, but got: Tensor
             DecorateInfo(
@@ -15229,7 +15217,6 @@ op_db: List[OpInfo] = [
            supports_gradgrad=True,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           supports_cow_input_no_materialize_backward=False,
            autodiff_nonfusible_nodes=["aten::gelu"],
            skips=(
                # AssertionError: Tensor-likes are not close!
@@ -17798,7 +17785,6 @@ op_db: List[OpInfo] = [
            check_batched_gradgrad=False,
            # See https://github.com/pytorch/pytorch/issues/66357
            check_batched_forward_grad=False,
-           supports_cow_input_no_materialize_backward=False,
            skips=(
                DecorateInfo(unittest.expectedFailure, "TestNormalizeOperators", "test_normalize_operator_exhaustive"),
                # Skip operator schema test because this is a functional and not an operator
@@ -17816,7 +17802,6 @@ op_db: List[OpInfo] = [
            check_batched_gradgrad=False,
            # See https://github.com/pytorch/pytorch/issues/66357
            check_batched_forward_grad=False,
-           supports_cow_input_no_materialize_backward=False,
            sample_inputs_func=sample_inputs_unfold),
     OpInfo('msort',
            dtypes=all_types_and(torch.bool, torch.float16, torch.bfloat16),
@@ -18333,7 +18318,6 @@ op_db: List[OpInfo] = [
            supports_out=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           supports_cow_input_no_materialize_backward=False,
            skips=(
                # RuntimeError: input->type()->kind() == TypeKind::OptionalTypeINTERNAL ASSERT FAILED
                # at "../torch/csrc/jit/passes/utils/check_alias_annotation.cpp":270, please report a bug to PyTorch.
@@ -18892,7 +18876,6 @@ op_db: List[OpInfo] = [
         dtypes=floating_types_and(torch.bfloat16, torch.float16),
         sample_inputs_func=sample_inputs_embedding,
         allow_cow_input_materialize_forward=[0],
-        supports_cow_input_no_materialize_backward=False,
         error_inputs_func=error_inputs_embedding,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #123798
* __->__ #123797

Affected ops:
* conv ops
* glu
* prelu
* scaled_dot_product_attention
* threshold
* logsigmoid
* binary_cross_entropy
* gelu
* unfold
* smooth_l1_loss
* embedding


Part of #97856

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10