### PR TITLE
Fix FSDP1 2D extension checkpoint uneven sharded DTensor

### DIFF
--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -264,6 +264,10 @@ def _chunk_dtensor(
     else:
         tp_placements = tensor.placements
         tp_placement = tp_placements[0]
+        # the 1D DTensor should be global shape, as we first shard the tensor using DTensor where
+        # DTensor preserves the global shape
+        global_shape = tensor.shape
+        global_stride = tensor.stride()
 
         tensor = tensor.to_local()
 
@@ -279,7 +283,7 @@ def _chunk_dtensor(
         shard_placements[-1] = tp_placement  # type: ignore[call-overload]
 
         return DTensor.from_local(
-            tensor, parent_mesh, replicate_placements
+            tensor, parent_mesh, replicate_placements, run_check=False, shape=global_shape, stride=global_stride,
         ).redistribute(
             device_mesh=parent_mesh,
             placements=shard_placements,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123812

as titled, the current behavior get the local shard from DTensor and
re-create a DTensor that includes FSDP dimension, however it lost the
global shape information where DTensor uses to track the uneven
sharding.

This PR fix this issue by reuse the global information from the initial
DTensor

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma