### PR TITLE
[Reland] [Distributed] [2/N] Fix clang-tidy warnings in torch/csrc/distributed/c10d

### DIFF
--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -1,5 +1,3 @@
-#include <shared_mutex>
-
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <c10/core/DispatchKey.h>
@@ -7,6 +5,7 @@
 #include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/RankLocal.hpp>
+#include <utility>
 
 namespace {
 
@@ -14,7 +13,7 @@ class WorkRegistry {
  public:
   void register_work(
       const at::Tensor& tensor,
-      c10::intrusive_ptr<c10d::Work> work) {
+      const c10::intrusive_ptr<c10d::Work>& work) {
     const auto storage = tensor.storage().getWeakStorageImpl();
     std::unique_lock lock(lock_);
     auto [it, inserted] = registry_.emplace(storage, work);
@@ -50,8 +49,8 @@ class WorkRegistry {
           "is invoked on all tensors returned from c10d_functional collective "
           "ops before they are used.");
     }
-    for (auto it = registry_.begin(); it != registry_.end(); ++it) {
-      it->second.release();
+    for (auto& it : registry_) {
+      it.second.release();
     }
   }
 
@@ -67,7 +66,7 @@ static WorkRegistry process_registry;
 
 void register_work(
     const at::Tensor& tensor,
-    c10::intrusive_ptr<c10d::Work> work) {
+    const c10::intrusive_ptr<c10d::Work>& work) {
   if (c10d::get_thread_isolation_mode()) {
     c10d::RankLocal<WorkRegistry>::get().register_work(tensor, work);
   } else {
@@ -167,6 +166,7 @@ std::vector<at::Tensor> all_gather_into_tensor_coalesced(
     int64_t group_size,
     std::string group_name) {
   std::vector<at::Tensor> outputs;
+  outputs.reserve(inputs.size());
   for (const auto& tensor : inputs) {
     outputs.push_back(allocate_all_gather_output(tensor, group_size));
   }
@@ -211,6 +211,7 @@ std::vector<at::Tensor> reduce_scatter_tensor_coalesced(
   c10d::ReduceScatterOptions opts;
   opts.reduceOp = to_reduce_op(reduce_op);
   std::vector<at::Tensor> outputs;
+  outputs.reserve(inputs.size());
   for (const auto& tensor : inputs) {
     outputs.push_back(allocate_reduce_scatter_output(tensor, group_size));
   }
@@ -240,8 +241,8 @@ at::Tensor all_to_all_single(
     std::vector<int64_t> input_split_sizes,
     std::string group_name) {
   std::vector<int64_t> output_sizes = input.sizes().vec();
-  output_sizes[0] =
-      std::accumulate(output_split_sizes.begin(), output_split_sizes.end(), 0);
+  output_sizes[0] = std::accumulate(
+      output_split_sizes.begin(), output_split_sizes.end(), int64_t(0));
   auto output = input.new_empty(output_sizes);
 
   auto group = c10d::resolve_process_group(group_name);

--- a/torch/csrc/distributed/c10d/reducer.hpp
+++ b/torch/csrc/distributed/c10d/reducer.hpp
@@ -51,7 +51,7 @@ class TORCH_API Reducer {
   explicit Reducer(
       std::vector<at::Tensor> params,
       std::vector<std::vector<size_t>> bucket_indices,
-      std::vector<size_t> per_bucket_size_limits,
+      const std::vector<size_t>& per_bucket_size_limits,
       c10::intrusive_ptr<c10d::ProcessGroup> process_group,
       std::vector<bool> expect_sparse_gradients,
       int64_t bucket_bytes_cap,
@@ -303,11 +303,9 @@ class TORCH_API Reducer {
   using GradCallback = std::function<bool(at::Tensor&)>;
 #ifndef _WIN32
   static_assert(
-      std::is_same<
+      std::is_same_v<
           GradCallback,
-          torch::distributed::autograd::DistAutogradContext::GradCallback>::
-          value,
-      "");
+          torch::distributed::autograd::DistAutogradContext::GradCallback>);
 #endif
   void runGradCallbackForVariable(at::Tensor& variable, GradCallback&& cb);
 


### PR DESCRIPTION
Reland of #122892 with problematic changes reverted.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang