### PR TITLE
Add bfloat16 support to binary_cross_entropy for CPU

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -273,8 +273,12 @@ Tensor& binary_cross_entropy_out_cpu(const Tensor& input, const Tensor& target, 
       .add_owned_const_input(at::squeeze(target))
       .build();
 
-    AT_DISPATCH_FLOATING_TYPES_AND(
-        ScalarType::BFloat16, loss.scalar_type(), "binary_cross_entropy", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
+        ScalarType::BFloat16,
+        loss.scalar_type(),
+        "binary_cross_entropy",
+        [&] {
           at::native::cpu_kernel(
               iter, [](scalar_t input_val, scalar_t target_val) {
                 TORCH_CHECK(
@@ -327,7 +331,8 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
       .add_owned_const_input(at::squeeze(target))
       .build();
 
-    AT_DISPATCH_FLOATING_TYPES_AND(
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        ScalarType::Half,
         ScalarType::BFloat16,
         grad_input.scalar_type(),
         "binary_cross_entropy_backward",

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -273,27 +273,26 @@ Tensor& binary_cross_entropy_out_cpu(const Tensor& input, const Tensor& target, 
       .add_owned_const_input(at::squeeze(target))
       .build();
 
-    AT_DISPATCH_FLOATING_TYPES(loss.scalar_type(), "binary_cross_entropy", [&] {
-        at::native::cpu_kernel(
-            iter,
-            [] (scalar_t input_val, scalar_t target_val) {
+    AT_DISPATCH_FLOATING_TYPES_AND(
+        ScalarType::BFloat16, loss.scalar_type(), "binary_cross_entropy", [&] {
+          at::native::cpu_kernel(
+              iter, [](scalar_t input_val, scalar_t target_val) {
                 TORCH_CHECK(
                     (input_val >= 0) && (input_val <= 1),
-                    "all elements of input should be between 0 and 1"
-                );
+                    "all elements of input should be between 0 and 1");
                 TORCH_CHECK(
                     (target_val >= 0) && (target_val <= 1),
-                    "all elements of target should be between 0 and 1"
-                );
+                    "all elements of target should be between 0 and 1");
 
                 // Binary cross entropy tensor is defined by the equation:
                 // L = -w (y ln(x) + (1-y) ln(1-x))
-                return (target_val - scalar_t(1))
-                    * std::max(scalar_t(std::log1p(-input_val)), scalar_t(-100))
-                    - target_val * std::max(scalar_t(std::log(input_val)), scalar_t(-100));
-            }
-        );
-    });
+                return (target_val - scalar_t(1)) *
+                    std::max(scalar_t(std::log1p(-input_val)), scalar_t(-100)) -
+                    target_val *
+                    std::max(scalar_t(std::log(input_val)), scalar_t(-100));
+              });
+        });
+
     if (weight.defined()) {
         loss.mul_(weight);
     }
@@ -328,21 +327,24 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
       .add_owned_const_input(at::squeeze(target))
       .build();
 
-    AT_DISPATCH_FLOATING_TYPES(grad_input.scalar_type(), "binary_cross_entropy_backward", [&] {
-        at::native::cpu_kernel(
-            iter,
-            [] (scalar_t grad_val, scalar_t input_val, scalar_t target_val) {
+    AT_DISPATCH_FLOATING_TYPES_AND(
+        ScalarType::BFloat16,
+        grad_input.scalar_type(),
+        "binary_cross_entropy_backward",
+        [&] {
+          at::native::cpu_kernel(
+              iter,
+              [](scalar_t grad_val, scalar_t input_val, scalar_t target_val) {
                 // The gradient is the partial derivative of BCELoss
                 // with respect to x
                 // d(L)/d(x) = -w (y - x) / (x - x^2)
-                return grad_val * (input_val - target_val)
-                    / (scalar_t(std::max(
+                return grad_val * (input_val - target_val) /
+                    (scalar_t(std::max(
                         (scalar_t(1) - input_val) * input_val,
-                        scalar_t(EPSILON)
-                    )));
-            }
-        );
-    });
+                        scalar_t(EPSILON))));
+              });
+        });
+
     if (weight.defined()) {
         grad_input.mul_(weight);
     }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -171,7 +171,6 @@ def mps_ops_grad_modifier(ops):
         'nn.functional.conv_transpose1d': [torch.float16],
         'nn.functional.conv_transpose2d': [torch.float16],
         'nn.functional.conv_transpose3d': [torch.float16],
-        'nn.functional.binary_cross_entropy': [torch.float16]
     }
 
     MACOS_13_3_XFAILLIST_GRAD = {
@@ -983,6 +982,9 @@ def mps_ops_modifier(ops):
         # Unsupported
         # input types 'tensor<1x3x9x9xf16>' and 'tensor<1xf32>' are not broadcast compatible
         'nn.functional.avg_pool2d': [torch.float16],
+        # input types 'tensor<f32>' and 'tensor<1xf16>' are not broadcast compatible
+        # Refer to the issue please: https://github.com/pytorch/pytorch/issues/124252
+        'nn.functional.binary_cross_entropy': [torch.float16]
     }
 
     def addDecorator(op, d) -> None:

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -171,6 +171,7 @@ def mps_ops_grad_modifier(ops):
         'nn.functional.conv_transpose1d': [torch.float16],
         'nn.functional.conv_transpose2d': [torch.float16],
         'nn.functional.conv_transpose3d': [torch.float16],
+        'nn.functional.binary_cross_entropy': [torch.float16]
     }
 
     MACOS_13_3_XFAILLIST_GRAD = {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15058,7 +15058,7 @@ op_db: List[OpInfo] = [
         "nn.functional.binary_cross_entropy",
         aten_backward_name='binary_cross_entropy_backward',
         sample_inputs_func=sample_inputs_binary_cross_entropy,
-        dtypes=floating_types(),
+        dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
         supports_out=False,
         gradcheck_fast_mode=False,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15058,7 +15058,7 @@ op_db: List[OpInfo] = [
         "nn.functional.binary_cross_entropy",
         aten_backward_name='binary_cross_entropy_backward',
         sample_inputs_func=sample_inputs_binary_cross_entropy,
-        dtypes=floating_types_and(torch.bfloat16),
+        dtypes=floating_types_and(torch.float16, torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
         supports_out=False,
         gradcheck_fast_mode=False,


### PR DESCRIPTION
Fixes #123715

As the title stated.

But, maybe we should pay attention to this https://github.com/pytorch/pytorch/pull/33206, which removed the half support for cpu about 4 years ago.
