### PR TITLE
Support SparseCsrPrivateUse1

### DIFF
--- a/aten/src/ATen/SparseCsrTensorImpl.cpp
+++ b/aten/src/ATen/SparseCsrTensorImpl.cpp
@@ -56,7 +56,8 @@ SparseCsrTensorImpl::SparseCsrTensorImpl(
 
   TORCH_INTERNAL_ASSERT(((key_set.has(DispatchKey::SparseCsrCPU) && device().type() == kCPU)
                          || (key_set.has(DispatchKey::SparseCsrCUDA) && device().type() == kCUDA)
-                         || (key_set.has(DispatchKey::SparseCsrMeta) && device().type() == kMeta)),
+                         || (key_set.has(DispatchKey::SparseCsrMeta) && device().type() == kMeta)
+                         || (key_set.has(DispatchKey::SparseCsrPrivateUse1) && device().type() == kPrivateUse1)),
                         "Inconsistent key_set (=", key_set, ") and device (=", device(), ")");
 
   set_storage_access_should_throw();

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -345,6 +345,9 @@ static SparseCsrTensor new_compressed_tensor(const TensorOptions& options) {
   case kMeta:
     dispatch_key = DispatchKey::SparseCsrMeta;
     break;
+  case kPrivateUse1:
+    dispatch_key = DispatchKey::SparseCsrPrivateUse1;
+    break;
   default:
     TORCH_CHECK_NOT_IMPLEMENTED(false, "Could not run 'new_compressed_tensor' from the '", options.device(), "' device.)");
   }


### PR DESCRIPTION
As in the title, the changes support SparseCsr tensors working on PrivateUse1 devices.