### PR TITLE
Avoid retrieving launch metadata if launch_enter_hook is not installed

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -446,6 +446,7 @@ class CachingAutotuner(KernelInterface):
         # we want to burn None in to the launch args with zero overhead.
         # See https://github.com/pytorch/pytorch/issues/123597
         if binary.launch_enter_hook:
+
             def get_launch_args_with_kernel_launch_metadata(
                 grid,
                 grid_0,
@@ -477,7 +478,9 @@ class CachingAutotuner(KernelInterface):
                     launch_enter_hook,
                     launch_exit_hook,
                 )
+
         else:
+
             def get_launch_args_with_kernel_launch_metadata(
                 grid,
                 grid_0,

--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -440,37 +440,75 @@ class CachingAutotuner(KernelInterface):
                 metadata,
             )
 
-        def get_launch_args_with_kernel_launch_metadata(
-            grid,
-            grid_0,
-            grid_1,
-            grid_2,
-            stream,
-            function,
-            metadata,
-            bin,
-            launch_enter_hook,
-            launch_exit_hook,
-            num_warps,
-            shared,
-            cta_args,
-            args,
-        ):
-            """
-            Construct launch args after CompiledKernel.launch_metadata is added
-            by https://github.com/openai/triton/pull/3492 .
-            """
-            return (
+        # Getting the kernel launch args is extremely perf-sensitive.  Evaluating
+        # `bin.launch_metadata` is relatively expensive, and returns None unless a
+        # `launch_enter_hook` is installed.  So if we don't have that hook installed,
+        # we want to burn None in to the launch args with zero overhead.
+        # See https://github.com/pytorch/pytorch/issues/123597
+        if binary.launch_enter_hook:
+            def get_launch_args_with_kernel_launch_metadata(
+                grid,
                 grid_0,
                 grid_1,
                 grid_2,
                 stream,
                 function,
                 metadata,
-                bin.launch_metadata(grid, stream, *args),
+                bin,
                 launch_enter_hook,
                 launch_exit_hook,
-            )
+                num_warps,
+                shared,
+                cta_args,
+                args,
+            ):
+                """
+                Construct launch args after CompiledKernel.launch_metadata is added
+                by https://github.com/openai/triton/pull/3492 .
+                """
+                return (
+                    grid_0,
+                    grid_1,
+                    grid_2,
+                    stream,
+                    function,
+                    metadata,
+                    bin.launch_metadata(grid, stream, *args),
+                    launch_enter_hook,
+                    launch_exit_hook,
+                )
+        else:
+            def get_launch_args_with_kernel_launch_metadata(
+                grid,
+                grid_0,
+                grid_1,
+                grid_2,
+                stream,
+                function,
+                metadata,
+                bin,
+                launch_enter_hook,
+                launch_exit_hook,
+                num_warps,
+                shared,
+                cta_args,
+                args,
+            ):
+                """
+                Construct launch args after CompiledKernel.launch_metadata is added
+                by https://github.com/openai/triton/pull/3492 .
+                """
+                return (
+                    grid_0,
+                    grid_1,
+                    grid_2,
+                    stream,
+                    function,
+                    metadata,
+                    None,
+                    launch_enter_hook,
+                    launch_exit_hook,
+                )
 
         scope["get_launch_args"] = (
             get_launch_args_with_kernel_launch_metadata


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #123842
* __->__ #123841

Fixes #123597

There's a sizable comment in the PR about why this is needed, but essentially the launch path is really really perf sensitive (running `launch` is ~30 microseconds, and according to the linked issue, regressing it to 33us is worth 6% overall on torchbench).  The `bin.launch_metadata` call doesn't look super expensive, but microseconds matter, and this is only useful when we have a launch hook installed (which seems pretty rare?).  This change is worth about 2us, and when combined with the other diff in the stack seems to completely eliminate the torchbench regression.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang

Differential Revision: [D56046347](https://our.internmc.facebook.com/intern/diff/D56046347)