### PR TITLE
Use packed metadata from triton to reduce launch latency

### DIFF
--- a/torch/_inductor/triton_heuristics.py
+++ b/torch/_inductor/triton_heuristics.py
@@ -385,7 +385,7 @@ class CachingAutotuner(KernelInterface):
             "bin": binary,
             "launch_enter_hook": binary.launch_enter_hook,
             "launch_exit_hook": binary.launch_exit_hook,
-            "metadata": binary.metadata,
+            "metadata": binary.packed_metadata if hasattr(binary, "packed_metadata") else binary.metadata,
             "shared": binary_shared,
         }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123842
* #123841

https://github.com/openai/triton/pull/3633 converts some kernel launch metadata from a namedtuple to a regular tuple, which is faster to parse.  Using it here shaves off a microsecond or so from the apparently extremely-sensitive launch path.

Fixes #123597


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang