### PR TITLE
[BE] migrate import sorter configurations to `pyproject.toml`

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,0 @@
-[settings]
-include_trailing_comma=True
-multi_line_output=3
-skip=third_party
-skip_gitignore=True
-use_parentheses=True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,27 @@ build-backend = "setuptools.build_meta:__legacy__"
 
 
 [tool.black]
-# Uncomment if pyproject.toml worked fine to ensure consistency with flake8
-# line-length = 120
+line-length = 88
 target-version = ["py38", "py39", "py310", "py311"]
+
+
+[tool.isort]
+src_paths = ["caffe2", "torch", "torchgen", "functorch", "tests"]
+extra_standard_library = ["typing_extensions"]
+skip_gitignore = true
+skip_glob = ["third_party/*"]
+atomic = true
+profile = "black"
+indent = 4
+line_length = 88
+lines_after_imports = 2
+multi_line_output = 3
+include_trailing_comma = true
+
+
+[tool.usort.kown]
+first_party = ["caffe2", "torch", "torchgen", "functorch", "tests"]
+standard_library = ["typing_extensions"]
 
 
 [tool.ruff]


### PR DESCRIPTION
Migrate import sorter configurations to `pyproject.toml` and delete `.isort.cfg`. Also, set the line length to 88 (which is the default of `black`).