### PR TITLE
[caffe2] Name the third-pary thread pools

### DIFF
--- a/c10/util/thread_name.cpp
+++ b/c10/util/thread_name.cpp
@@ -1,6 +1,7 @@
 #include <c10/util/thread_name.h>
 
 #include <algorithm>
+#include <array>
 
 #ifndef __GLIBC_PREREQ
 #define __GLIBC_PREREQ(x, y) 0
@@ -11,8 +12,20 @@
 #define C10_HAS_PTHREAD_SETNAME_NP
 #endif
 
+// Android only, prctl is only used when pthread_setname_np
+// and pthread_getname_np are not avilable.
+#if defined(__linux__)
+#define C10_HAS_PRCTL_PR_SET_NAME 1
+#else
+#define C10_HAS_PRCTL_PR_SET_NAME 0
+#endif
+
 #ifdef C10_HAS_PTHREAD_SETNAME_NP
 #include <pthread.h>
+#endif
+
+#if C10_HAS_PRCTL_PR_SET_NAME
+#include <sys/prctl.h>
 #endif
 
 namespace c10 {
@@ -23,7 +36,24 @@ void setThreadName(std::string name) {
   name.resize(std::min(name.size(), kMaxThreadName));
 
   pthread_setname_np(pthread_self(), name.c_str());
+#elif C10_HAS_PRCTL_PR_SET_NAME
+  // for Android prctl is used instead of pthread_setname_np
+  // if Android NDK version is older than API level 9.
+  prctl(PR_SET_NAME, name.c_str(), 0L, 0L, 0L);
 #endif
+}
+
+std::string getThreadName() {
+#ifdef C10_HAS_PTHREAD_SETNAME_NP
+  std::array<char, 16> buf{};
+  pthread_getname_np(pthread_self(), buf.data(), buf.size());
+  return std::string(buf.data());
+#elif C10_HAS_PRCTL_PR_SET_NAME
+  std::array<char, 16> buf{};
+  prctl(PR_GET_NAME, buf.data(), 0L, 0L, 0L);
+  return std::string(buf.data());
+#endif
+  return "";
 }
 
 } // namespace c10

--- a/c10/util/thread_name.h
+++ b/c10/util/thread_name.h
@@ -7,5 +7,6 @@
 namespace c10 {
 
 C10_API void setThreadName(std::string name);
+C10_API std::string getThreadName();
 
 } // namespace c10


### PR DESCRIPTION
Summary:
The caffe2/utils threadpool impl used to set thread name, since D8266344
https://www.internalfb.com/code/fbsource/[3ba3d30d6841]/xplat/caffe2/caffe2/utils/threadpool/WorkersPool.h?lines=271-273

But now we don't use this caffe2's own impl (since D21232894?), but use the third-party threadpool instead, which doesn't set thread name

This diff is to achieve same effect as D8266344, such that we can tell which threads are pytorch threads from perfetto trace.

The idea comes from https://stackoverflow.com/questions/32375034/how-to-obtain-thread-name-in-android-ndk and folly ThreadName
https://www.internalfb.com/code/fbsource/[3ba3d30d6841]/xplat/folly/system/ThreadName.cpp?lines=30-41

I'm not sure if this is the right place to put this change.


BTW, Pytorch thread pool caller thread is worker #0

https://www.internalfb.com/code/fbsource/[3ba3d30d6841281c140db1c8bd2f85ede310a01b]/xplat/third-party/pthreadpool/pthreadpool/src/pthreads.c?lines=289-292

Test Plan:
## Before

```
--num_cpu_threads 2 --num_pytorch_threads -1     # default to size equal to 4 cpu cores
mos:/ $ ps -T -p `pidof transcribe_bin`
USER            PID   TID   PPID     VSZ    RSS WCHAN            ADDR S CMD
shell          8985  8985   8983  118576  47688 hrtimer_n+          0 S transcribe_bin        <-- main thread
shell          8985  8986   8983  118576  47688 0                   0 R transcribe_bin         <-- pytorch thread #1
shell          8985  8987   8983  118576  47688 0                   0 R transcribe_bin         <-- pytorch thread #2
shell          8985  8988   8983  118576  47688 0                   0 R transcribe_bin         <-- pytorch thread #3
shell          8985  8989   8983  118576  47688 0                   0 R CPUThreadPool0
shell          8985  8990   8983  118576  47688 futex_wai+          0 S CPUThreadPool1
shell          8985  8991   8983  118576  47688 ep_poll             0 S IOThreadPool0
shell          8985  8992   8983  118576  47688 futex_wai+          0 S FutureTimekeepr
shell          8985  8993   8983  118576  47688 pipe_wait           0 S snapshot_thread
shell          8985  8994   8983  118576  47688 hrtimer_n+          0 S snapshot_thread
shell          8985  8997   8983  118576  47688 futex_wai+          0 S AsyncDataQueue
```

## After
```
--num_cpu_threads 2 --num_pytorch_threads -1
mos:/ $ ps -T -p `pidof transcribe_bin`
USER            PID   TID   PPID     VSZ    RSS WCHAN            ADDR S CMD
shell         11901 11901  11899  118128  40748 futex_wai+          0 S transcribe_bin         <-- main thread serves as pytorch thread #0
shell         11901 11902  11899  118132  40748 futex_wai+          0 S c10pthreadpool         <-- pytorch thread #1
shell         11901 11903  11899  118132  40748 futex_wai+          0 S c10pthreadpool         <-- pytorch thread #2
shell         11901 11904  11899  118132  40748 futex_wai+          0 S c10pthreadpool         <-- pytorch thread #3
shell         11901 11905  11899  118152  40752 futex_wai+          0 S CPUThreadPool0
shell         11901 11906  11899  118148  40752 0                   0 R CPUThreadPool1
shell         11901 11907  11899  118148  40756 ep_poll             0 S IOThreadPool0
shell         11901 11908  11899  118152  40756 futex_wai+          0 S FutureTimekeepr
shell         11901 11909  11899  118164  40756 pipe_wait           0 S snapshot_thread
shell         11901 11910  11899  118168  40756 hrtimer_n+          0 S snapshot_thread
shell         11901 11913  11899  118160  40760 futex_wai+          0 S AsyncDataQueue
```

Example Perfetto trace:

 {F1483727859} 
Looks like the pytorch thread pool was originally created with 4 thread during ASR loading (`loadTunaFactory`), and later recreated with 3 threads during inference.

Differential Revision: D55990584


