### PR TITLE
[NT] Fix typo in declared strides variable

### DIFF
--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -45,7 +45,7 @@ class NestedTensor(torch.Tensor):
     # For example, a jagged tensor with shape [B, x, D] can be strided in two
     # ways: [xD, D, 1] and [x, 1, sum(x)], where xD represents x multiplied by D
     _size: Tuple[int, ...]
-    _stride: Tuple[int, ...]
+    _strides: Tuple[int, ...]
     # Indicates that the nth dimension is ragged
     _ragged_idx: int
     _metadata_cache: Dict[str, Any]


### PR DESCRIPTION
Summary:
Looks like it's missing an s in the declaration so pyre is throwing an error

{F1484357040}

Test Plan: expect no pyre errors

Differential Revision: D56023743
