### PR TITLE
[ROCm] Add cast to kFloat in amax calculation

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -912,7 +912,7 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
 
 #if defined(USE_ROCM) && ROCM_VERSION >= 60000
   // rocm's hipblaslt does not yet support amax, so calculate separately
-  amax = at::max(at::abs(out));
+  amax = at::max(at::abs(out.to(kFloat)));
 #endif
 
   return {out, amax};


### PR DESCRIPTION
necessary cast to kFloat missed in previous amax PR


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang