### PR TITLE
[export] Serialize rational symint ranges

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -28,7 +28,7 @@ from torch._export.serde.serialize import (
 from torch._higher_order_ops.torchbind import enable_torchbind_tracing
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.export import Dim, export, load, save
-from torch.fx.experimental.symbolic_shapes import is_concrete_int
+from torch.fx.experimental.symbolic_shapes import is_concrete_int, ValueRanges
 from torch.testing._internal.common_utils import (
     find_library_location,
     instantiate_parametrized_tests,
@@ -276,6 +276,29 @@ class TestSerialize(TestCase):
             name = output.as_tensor.name
             self.assertNotIn(name, seen)
             seen.add(name)
+
+    def test_rational_ranges(self) -> None:
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x + x
+
+        ep = torch.export.export(
+            M(), (torch.randn(4),), dynamic_shapes=({0: Dim("temp")},)
+        )
+
+        range_constraints = list(ep.range_constraints.keys())
+        assert len(range_constraints) == 1
+        symint = range_constraints[0]
+
+        import sympy
+
+        upper_range = sympy.Rational(10, 3)
+        lower_range = sympy.Rational(10, 6)
+        ep.range_constraints[symint] = ValueRanges(lower=lower_range, upper=upper_range)
+
+        serialized = ExportedProgramSerializer().serialize(ep)
+        self.assertEqual(serialized.exported_program.range_constraints["s0"].min_val, 2)
+        self.assertEqual(serialized.exported_program.range_constraints["s0"].max_val, 3)
 
     def test_kwargs_default(self) -> None:
         """

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -315,7 +315,7 @@ def deserialize_torch_artifact(serialized: Union[Dict[str, Any], Tuple[Any, ...]
     return artifact
 
 
-def _sympy_int_to_int(val: sympy.Expr):
+def _sympy_int_to_int(val: sympy.Expr, adjust: str):
     # Convert simple sympy Integers into concrete int
     if val == sympy.oo:
         return math.inf
@@ -323,7 +323,20 @@ def _sympy_int_to_int(val: sympy.Expr):
         return -math.inf
     if isinstance(val, sympy.Integer):
         return int(val)
-    raise RuntimeError("Export constraints cannot be non-integer expressions")
+
+    # TODO: Remove this adjustment when Ed gets rid of fractional ranges
+    log.warning(
+        "Export constraints cannot be non-integer expressions. Found "
+        "type %s, and value %s. We will attempt to %s "
+        "this value.", type(val), val, adjust
+    )
+
+    if adjust == "floor":
+        return math.floor(val)
+    elif adjust == "ceil":
+        return math.ceil(val)
+    else:
+        raise RuntimeError(f"Got invalid adjustment {adjust}")
 
 
 def _int_to_sympy_int(val) -> sympy.Expr:
@@ -340,8 +353,8 @@ def serialize_range_constraints(
 ) -> Dict[str, RangeConstraint]:
     return {
         str(k): RangeConstraint(
-            _sympy_int_to_int(v.lower),  # type: ignore[arg-type]
-            _sympy_int_to_int(v.upper),  # type: ignore[arg-type]
+            _sympy_int_to_int(v.lower, "ceil"),  # type: ignore[arg-type]
+            _sympy_int_to_int(v.upper, "floor"),  # type: ignore[arg-type]
         )
         for k, v in range_constraints.items()
     }


### PR DESCRIPTION
Some symints result in rational ranges like 10/3 which runs into an error ([example](https://www.internalfb.com/intern/everpaste/?handle=GMG2AxkeoFUrh-UDAFcE8pKPgjoUbsIXAAAB)).

Ed will eventually get rid(?) of these rational ranges but as a workaround export can just clamp the results during serialization time