### PR TITLE
Don't add non-integer Triton kernel arg 1 to equal_to_1

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1848,7 +1848,8 @@ class AOTInductorTestsTemplate:
         self.check_model(Model(), example_inputs)
 
     @skipIfRocm
-    def test_triton_kernel_equal_to_1_float_arg(self):
+    @common_utils.parametrize("dynamic", [False, True])
+    def test_triton_kernel_equal_to_1_float_arg(self, dynamic):
         if self.device != "cuda":
             raise unittest.SkipTest("requires CUDA")
 
@@ -1856,17 +1857,33 @@ class AOTInductorTestsTemplate:
             def forward(self, x, y):
                 out = torch.empty_like(x)
                 n_elements = x.numel()
+                scaling_factor = (n_elements**0) / 1.0
                 add_kernel_with_scaling[(n_elements,)](
-                    x, y, out, n_elements, 1.0, BLOCK_SIZE=16
+                    x,
+                    y,
+                    out,
+                    n_elements,
+                    scaling_factor,
+                    BLOCK_SIZE=16,
                 )
                 return out
 
+        dynamic_shapes = None
+        if dynamic:
+            dim0_xy = Dim("s0", min=2, max=1024)
+            dynamic_shapes = {
+                "x": {0: dim0_xy, 1: None},
+                "y": {0: dim0_xy, 1: None},
+            }
         example_inputs = (
             torch.randn(2, device=self.device),
             torch.randn(2, device=self.device),
         )
-
-        self.check_model(Model(), example_inputs)
+        self.check_model(
+            Model(),
+            example_inputs,
+            dynamic_shapes=dynamic_shapes,
+        )
 
     def test_shifted_constraint_ranges(self):
         class Model(torch.nn.Module):

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -1015,24 +1015,6 @@ def forward(self, x_1, output_1):
     @requires_cuda
     @skipIfRocm
     def test_triton_kernel_equal_to_1_float_arg(self):
-        @triton.jit
-        def add_kernel_with_scaling(
-            in_ptr0,
-            in_ptr1,
-            out_ptr,
-            n_elements,
-            scaling_factor,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            x = tl.load(in_ptr0 + offsets, mask=mask)
-            y = tl.load(in_ptr1 + offsets, mask=mask)
-            output = (x + y) * scaling_factor
-            tl.store(out_ptr + offsets, output, mask=mask)
-
         def f(x, y):
             out = torch.empty_like(x)
             n_elements = x.numel()

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -1014,21 +1014,31 @@ def forward(self, x_1, output_1):
 
     @requires_cuda
     @skipIfRocm
-    def test_triton_kernel_equal_to_1_float_arg(self):
+    @common_utils.parametrize("dynamic", [False, True])
+    def test_triton_kernel_equal_to_1_float_arg(self, dynamic):
         def f(x, y):
             out = torch.empty_like(x)
             n_elements = x.numel()
+            scaling_factor = (n_elements**0) / 1.0
             add_kernel_with_scaling[(n_elements,)](
-                x, y, out, n_elements, 1.0, BLOCK_SIZE=16
+                x,
+                y,
+                out,
+                n_elements,
+                scaling_factor,
+                BLOCK_SIZE=16,
             )
             return out
 
         x = torch.randn(2, device="cuda")
         y = torch.randn(2, device="cuda")
         eager_out = f(x, y)
-        compiled_out, sources = run_and_get_code(torch.compile(f), x, y)
+        compiled_out, sources = run_and_get_code(
+            torch.compile(f, dynamic=dynamic), x, y
+        )
 
-        # float 1.0 should not be in equal_to_1
+        # float 1.0 (both literal or symbolic)
+        # should not be added to equal_to_1
         self.assertTrue("equal_to_1=()" in sources[0])
         self.assertEqual(compiled_out, eager_out)
 

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -198,6 +198,8 @@ class CppWrapperCuda(CppWrapperCpu):
             var_name = f"var_{next(self.arg_var_id)}"
             if isinstance(arg, (sympy.Integer, sympy.Symbol, SymbolicCallArg)):
                 self.writeline(f"auto {var_name} = {arg};")
+            elif isinstance(arg, sympy.Float):
+                self.writeline(f"float {var_name} = {self.expr_printer(arg)};")
             elif isinstance(arg, sympy.Expr):
                 self.writeline(f"auto {var_name} = {self.expr_printer(arg)};")
             elif is_int(arg):

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -119,8 +119,10 @@ def config_of(
     equal_to_1 = tuple(
         i
         for i, arg in zip(indices, args)
-        if isinstance(arg, SizeArg)
-        and arg.expr is not None
+        if isinstance(arg, SizeArg) and arg.expr is not None
+        # we include sympy.Expr as a possible type of arg.expr to allow
+        # symbolic expressions that are statically_known_equal to int 1
+        # (as checked in the line below)
         and isinstance(arg.expr, (int, sympy.Expr))
         and V.graph.sizevars.statically_known_equals(arg.expr, 1)  # type: ignore[arg-type]
     )

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -119,7 +119,7 @@ def config_of(
     equal_to_1 = tuple(
         i
         for i, arg in zip(indices, args)
-        if isinstance(arg, SizeArg) and arg.expr is not None
+        if isinstance(arg, SizeArg)
         # we include sympy.Expr as a possible type of arg.expr to allow
         # symbolic expressions that are statically_known_equal to int 1
         # (as checked in the line below)

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -120,9 +120,6 @@ def config_of(
         i
         for i, arg in zip(indices, args)
         if isinstance(arg, SizeArg)
-        # we include sympy.Expr as a possible type of arg.expr to allow
-        # symbolic expressions that are statically_known_equal to int 1
-        # (as checked in the line below)
         and isinstance(arg.expr, (int, sympy.Integer))
         and V.graph.sizevars.statically_known_equals(arg.expr, 1)  # type: ignore[arg-type]
     )

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Optional
 
+import sympy
+
 import torch
 
 from .. import config
@@ -119,6 +121,7 @@ def config_of(
         for i, arg in zip(indices, args)
         if isinstance(arg, SizeArg)
         and arg.expr is not None
+        and isinstance(arg.expr, (int, sympy.Expr))
         and V.graph.sizevars.statically_known_equals(arg.expr, 1)  # type: ignore[arg-type]
     )
     # ids_of_folded_args is set from equal_to_1

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -38,7 +38,7 @@ def signature_of(arg: KernelArgType, *, size_dtype: str) -> str:
             # From triton/runtime/jit.py
             # `None` is nullptr.  Implicitly convert to *i8.
             return "*i8"
-        elif isinstance(arg.expr, float):
+        elif isinstance(arg.expr, (float, sympy.Float)):
             return "fp32"
         if size_dtype == "tl.int32":
             return "i32"
@@ -123,7 +123,7 @@ def config_of(
         # we include sympy.Expr as a possible type of arg.expr to allow
         # symbolic expressions that are statically_known_equal to int 1
         # (as checked in the line below)
-        and isinstance(arg.expr, (int, sympy.Expr))
+        and isinstance(arg.expr, (int, sympy.Integer))
         and V.graph.sizevars.statically_known_equals(arg.expr, 1)  # type: ignore[arg-type]
     )
     # ids_of_folded_args is set from equal_to_1

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1065,7 +1065,7 @@ class WrapperCodeGen(CodeGen):
                     signature.append(SizeArg(key, arg))
                     if (
                         arg is not None
-                        and isinstance(arg, (int, sympy.Expr))
+                        and isinstance(arg, (int, sympy.Integer))
                         and V.graph.sizevars.statically_known_equals(
                             arg, 1
                         )  # type: ignore[arg-type]

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1063,13 +1063,11 @@ class WrapperCodeGen(CodeGen):
                     )
                 else:
                     signature.append(SizeArg(key, arg))
-                    if (
-                        arg is not None
-                        and isinstance(arg, (int, sympy.Integer))
-                        and V.graph.sizevars.statically_known_equals(
-                            arg, 1
-                        )  # type: ignore[arg-type]
-                    ):
+                    if isinstance(
+                        arg, (int, sympy.Integer)
+                    ) and V.graph.sizevars.statically_known_equals(
+                        arg, 1
+                    ):  # type: ignore[arg-type]
                         equal_to_1_arg_idx.append(idx)
         index_dtype = "tl.int32"
         triton_meta = {

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1063,7 +1063,13 @@ class WrapperCodeGen(CodeGen):
                     )
                 else:
                     signature.append(SizeArg(key, arg))
-                    if arg is not None and V.graph.sizevars.statically_known_equals(arg, 1):  # type: ignore[arg-type]
+                    if (
+                        arg is not None
+                        and isinstance(arg, (int, sympy.Expr))
+                        and V.graph.sizevars.statically_known_equals(
+                            arg, 1
+                        )  # type: ignore[arg-type]
+                    ):
                         equal_to_1_arg_idx.append(idx)
         index_dtype = "tl.int32"
         triton_meta = {

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1066,8 +1066,8 @@ class WrapperCodeGen(CodeGen):
                     if isinstance(
                         arg, (int, sympy.Integer)
                     ) and V.graph.sizevars.statically_known_equals(
-                        arg, 1
-                    ):  # type: ignore[arg-type]
+                        arg, 1  # type: ignore[arg-type]
+                    ):
                         equal_to_1_arg_idx.append(idx)
         index_dtype = "tl.int32"
         triton_meta = {

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -117,6 +117,24 @@ if HAS_CUDA:
         tl.store(out_ptr + (x1 + (x_elements * y0)), tmp2, xmask & ymask)
 
     @triton.jit
+    def add_kernel_with_scaling(
+        in_ptr0,
+        in_ptr1,
+        out_ptr,
+        n_elements,
+        scaling_factor,
+        BLOCK_SIZE: "tl.constexpr",
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(in_ptr0 + offsets, mask=mask)
+        y = tl.load(in_ptr1 + offsets, mask=mask)
+        output = (x + y) * scaling_factor
+        tl.store(out_ptr + offsets, output, mask=mask)
+
+    @triton.jit
     def mul2_kernel(
         in_ptr0,
         out_ptr,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123886
* #123703

Summary: Triton compiler adds constnat argument 1 to `equal_to_1` [only when it's an int](https://github.com/openai/triton/blob/8c5e33c77ef83e0cb99c744e58842930e602df31/python/triton/runtime/jit.py#L275). Here we restrict Inductor's `equal_to_1` in the same way.

Test Plan:

```
$ python test/inductor/test_triton_kernels.py -k test_triton_kernel_equal_to_1_float_arg
...
----------------------------------------------------------------------
Ran 1 test in 6.528s

OK

$ python test/inductor/test_triton_kernels.py -k test_triton_kernel_equal_to_1_arg
...
----------------------------------------------------------------------
Ran 2 tests in 10.142s

OK
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang