### PR TITLE
fix constant folding with buffer mutation

### DIFF
--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -210,12 +210,30 @@ def constant_fold(gm, constraint_fn: Optional[Callable[[torch.fx.Node], bool]] =
         replace_node_with_constant(gm, node, constant)
 
     erased_params = []
+    # Get all attr users by looking up the graph instead from node.users, because in this case
+    # _tensor_constant0 and _tensor_constant0_1 are actually refereing to the same tensor.
+
+    #     opcode         name                 target            args                         kwargs
+    # -------------  -------------------  ----------------  ---------------------------  --------
+    # placeholder    arg0_1               arg0              ()                           {}
+    # get_attr       _tensor_constant0    state             ()                           {}
+    # call_function  add                  aten.add.Tensor   (arg0_1, _tensor_constant0)  {}
+    # get_attr       _tensor_constant0_1  state             ()                           {}
+    # call_function  add_                 aten.add_.Tensor  (_tensor_constant0_1, 1)     {}
+    # output         output               output            ([add],)                     {}
+
+    get_attr_node_users = {}
+    for node in gm.graph.nodes:
+        if node.op == "get_attr":
+            if node.target in get_attr_node_users:
+                get_attr_node_users[node.target].extend(node.users.keys())
+            else:
+                get_attr_node_users[node.target] = list(node.users.keys())
     for node in gm.graph.find_nodes(op="get_attr"):
-        if len(node.users) == 0:
+        if node.op == "get_attr" and len(get_attr_node_users[node.target]) == 0:
             if hasattr(gm, node.target):
                 delattr(gm, node.target)
             erased_params.append(node)
-
     for node in erased_params:
         gm.graph.erase_node(node)
 


### PR DESCRIPTION
Summary:
For this module is
```
class MutableStateModule(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.register_buffer("state", torch.zeros(1))

    def forward(self, x):
        y = x + self.state
        self.state.add_(1)
        return y
```

The pre dispatch graph is 
```
opcode         name                 target            args                         kwargs
-------------  -------------------  ----------------  ---------------------------  --------
placeholder    arg0_1               arg0              ()                           {}
get_attr       _tensor_constant0    state             ()                           {}
call_function  add                  aten.add.Tensor   (arg0_1, _tensor_constant0)  {}
get_attr       _tensor_constant0_1  state             ()                           {}
call_function  add_                 aten.add_.Tensor  (_tensor_constant0_1, 1)     {}
output         output               output            ([add],)                     {}
```
here we can see two `get_attr` node refer to the same target, and the actual users for `state` is `add` and `add_`. In the current constant folding logic, we try to fold them because `_tensor_constant0` only has one user, and same for `_tensor_constant0_1`, which is not correct.

This diff create a map: the key is the target and the value is the users for the target, in the example, it will be both `add` and `add_`.

Test Plan:
```
 buck test //caffe2/test/inductor:test_aot_inductor
```

Differential Revision: D55930580




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang