### PR TITLE
fix cpp path in torch/_C/_autograd.pyi

### DIFF
--- a/torch/_C/_autograd.pyi
+++ b/torch/_C/_autograd.pyi
@@ -10,7 +10,7 @@ from ._profiler import (
     ProfilerConfig,
 )
 
-# Defined in tools/autograd/init.cpp
+# Defined in torch/csrc/autograd/init.cpp
 
 class DeviceType(Enum):
     CPU = ...


### PR DESCRIPTION
The file `tools/autograd/init.cpp` does not exist, I think the right path is `torch/csrc/autograd/init.cpp`.