### PR TITLE
[TESTING] Don't consider storage changes for incremental fake tensor update

### DIFF
--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -119,16 +119,7 @@ class FakeTensorUpdater:
             if new.device != old.device:
                 return False
 
-            if get_storage(new) == get_storage(old):
-                return True
-
-            # This is the case where it returns a completely fresh storage that's used nowhere else.
-            if (
-                existing_storages[get_storage(old)] == 1
-                and get_storage(new) not in existing_storages
-            ):
-                return True
-            return False
+            return True
 
         def should_process_node(node):
             # node.target for nodes returning true from this function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123940

Let's suppose that we are doing incremental fake tensor update after this optimization:

```
device_put_1: "i64[3]" = torch.ops.prims.device_put.default(primals_21, device(type='cuda', index=0));  primals
_21 = None
convert_element_type_1: "i64[3]" = torch.ops.prims.convert_element_type.default(device_put_1, torch.int64);  
device_put_1 = None  # remove this no-op conversion
```

When we compare the fake tensor of `convert_element_type_1` with `device_put_1`, we find they are identical except that the storages are different (as `convert_element_type` generates a new tensor). The current incremental fake tensor update concludes that repropagation is necessary.

However, it seems like this repropagation is... not necessary? In particular, for Inductor IR with no mutations (not true in reality, but humor me for now), we don't care about the aliasing properties, all the downstream prop would all be the same. This PR is testing if this hypothesis is true, but we also need a more robust correctness argument.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang