### PR TITLE
Add env variable for nvidia pytorch wheel release automation.

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -60,6 +60,15 @@ def get_torch_version(sha: Optional[str] = None) -> str:
         if sha is None:
             sha = get_sha(pytorch_root)
         version += "+git" + sha[:7]
+    if os.getenv("NVIDIA_PYTORCH_VERSION"):
+        # see if it matches YY.MM
+        str_nvidia_pytorch_version = os.getenv("NVIDIA_PYTORCH_VERSION")
+        pattern = re.compile(r'^\d{2}\.\d{2}$')
+        if bool(pattern.match(str_nvidia_pytorch_version)):
+          version += ".nv" + str_nvidia_pytorch_version
+        else:
+          version += ".nvInternal"
+
     return version
 
 

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -60,9 +60,8 @@ def get_torch_version(sha: Optional[str] = None) -> str:
         if sha is None:
             sha = get_sha(pytorch_root)
         version += "+git" + sha[:7]
-    if os.getenv("NVIDIA_PYTORCH_VERSION"):
+    if str_nvidia_pytorch_version := os.getenv("NVIDIA_PYTORCH_VERSION"):
         # see if it matches YY.MM
-        str_nvidia_pytorch_version = os.getenv("NVIDIA_PYTORCH_VERSION")
         pattern = re.compile(r'^\d{2}\.\d{2}$')
         if bool(pattern.match(str_nvidia_pytorch_version)):
           version += ".nv" + str_nvidia_pytorch_version


### PR DESCRIPTION
Background: NVIDIA releases monthly NGC containers based on pytorch, e.g. https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-24-03.html 
This PR is needed to facilitate the above efforts, avoiding the need to cherry pick this change every month. 

cc @malfet @atalman @ptrblck 