### PR TITLE
Remove warning from LazyModuleMixin constructor.

### DIFF
--- a/torch/nn/modules/lazy.py
+++ b/torch/nn/modules/lazy.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 from typing import Protocol, Optional, Type, Any
 
 import torch
@@ -178,8 +177,6 @@ class LazyModuleMixin:
         super().__init__(*args, **kwargs)  # type: ignore[misc]
         self._load_hook = self._register_load_state_dict_pre_hook(self._lazy_load_hook)
         self._initialize_hook = self.register_forward_pre_hook(self._infer_parameters, with_kwargs=True)
-        warnings.warn('Lazy modules are a new feature under heavy development '
-                      'so changes to the API or functionality can happen at any moment.')
 
     def _save_to_state_dict(self: _LazyProtocol, destination, prefix, keep_vars):
         # This should be ideally implemented as a hook,


### PR DESCRIPTION
Remove warning from `LazyModuleMixin` about lazy modules being a new feature under heavy development. The last nontrivial change to the code happened more than three years ago.

Fixes #123928
