### PR TITLE
dynamo: guard on tensor subclass constant metadata

### DIFF
--- a/test/distributed/_tensor/test_dtensor_compile.py
+++ b/test/distributed/_tensor/test_dtensor_compile.py
@@ -12,6 +12,7 @@ import torch._dynamo.testing
 import torch.distributed as dist
 import torch.nn as nn
 from torch._C import FileCheck
+from torch._dynamo.testing import CompileCounter
 from torch._inductor.utils import run_and_get_triton_code
 from torch.distributed._tensor import (
     DeviceMesh,
@@ -360,6 +361,26 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         )
         res = opt_kwargs_fn(x)
         self.assertEqual(res, ref)
+
+    def test_dynamo_dtensor_recompile(self):
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        # test passing in DTensor as inputs/outputs and run some tensor computation
+        def fn(x):
+            return torch.mul(x, x)
+
+        x = DTensor.from_local(torch.rand(2, 2), mesh, [Shard(0)], run_check=False)
+        x2 = DTensor.from_local(torch.rand(2, 2), mesh, [Shard(0)], run_check=False)
+        x3 = DTensor.from_local(torch.rand(2, 2), mesh, [Shard(1)], run_check=False)
+
+        cnt = CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True, dynamic=False)
+        self.assertEqual(fn(x), opt_fn(x))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(fn(x2), opt_fn(x2))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(fn(x3), opt_fn(x3))
+        self.assertEqual(cnt.frame_count, 2)
 
     def test_dtensor_dynamo_device_mesh_attrs(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -196,6 +196,11 @@ def _recompiles_for_inputs(fn, inputs1, inputs2, dynamic=True):
     return compile_count[0] > 1
 
 
+def _check_recompiles(self, fn, inputs1, inputs2, expected_recompiles):
+    actual_recompiles = _recompiles_for_inputs(fn, inputs1, inputs2)
+    self.assertEqual(actual_recompiles, expected_recompiles)
+
+
 class SubclassTests(torch._dynamo.test_case.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -816,6 +821,76 @@ class GraphModule(torch.nn.Module):
             self.assertEqual(ref0, res0)
             self.assertEqual(ref1, res1)
 
+    def test_tensor_subclass_ctx_guards(self):
+        from torch.utils._python_dispatch import return_and_correct_aliasing
+
+        class SubclassTensor(torch.Tensor):
+            @staticmethod
+            def __new__(cls, a, constant):
+                shape = a.shape
+                kwargs = {}
+                kwargs["strides"] = a.stride()
+                kwargs["storage_offset"] = a.storage_offset()
+                kwargs["device"] = a.device
+                kwargs["layout"] = a.layout
+                kwargs["requires_grad"] = a.requires_grad
+                kwargs["dtype"] = a.dtype
+                out = torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)
+                return out
+
+            def __init__(self, a, constant):
+                self.a = a
+                self.constant = constant
+
+            def __repr__(self):
+                a_repr = repr(self.a)
+                return f"SubclassTensor({a_repr})"
+
+            def __tensor_flatten__(self):
+                return ["a"], (self.constant,)
+
+            @staticmethod
+            def __tensor_unflatten__(inner_tensors, meta, sizes, strides):
+                constant = meta[0]
+                a = inner_tensors["a"]
+                return SubclassTensor(a, constant)
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args, kwargs):
+                if kwargs is None:
+                    kwargs = {}
+                biggest_constant = max(
+                    [
+                        x.constant
+                        for x in pytree.tree_flatten(args)[0]
+                        if isinstance(x, SubclassTensor)
+                    ]
+                )
+                args_a = pytree.tree_map(
+                    lambda x: x.a if isinstance(x, SubclassTensor) else x, args
+                )
+                kwargs_a = pytree.tree_map(
+                    lambda x: x.a if isinstance(x, SubclassTensor) else x, kwargs
+                )
+                out_a = func(*args_a, **kwargs_a)
+                out = pytree.tree_map(
+                    lambda x: SubclassTensor(x, biggest_constant)
+                    if isinstance(x, torch.Tensor)
+                    else x,
+                    out_a,
+                )
+
+                if func == torch.ops.aten.mul.Tensor:
+                    out = out + out.constant
+
+                return return_and_correct_aliasing(func, args, kwargs, out)
+
+        x = SubclassTensor(torch.ones(2), 3)
+        x2 = SubclassTensor(torch.ones(2), 3)
+        x3 = SubclassTensor(torch.ones(2), 4)
+        _check_recompiles(self, lambda x: x * x, (x,), (x2,), False)
+        _check_recompiles(self, lambda x: x * x, (x,), (x3,), True)
+
     def test_wrapper_subclass_guards_on_inner_tensor(self):
         # Holds an inner tensor, that has a distinct shape from the outer wrapper tensor.
         # Also adds additional guards on the inner tensor's sizes.
@@ -1230,14 +1305,10 @@ class TestNestedTensor(torch._dynamo.test_case.TestCase):
         )
         return jagged_from_tensor_and_lengths(values_tensor, starts, lengths)
 
-    def _check_recompiles(self, fn, inputs1, inputs2, expected_recompiles):
-        actual_recompiles = _recompiles_for_inputs(fn, inputs1, inputs2)
-        self.assertEqual(actual_recompiles, expected_recompiles)
-
     def test_unary_does_not_recompile(self):
         nt1, _ = self._get_jagged_tensor(((2, 3, 4), 3), None)
         nt2, _ = self._get_jagged_tensor(((3, 4, 5, 6), 4), None)
-        self._check_recompiles(lambda nt1: nt1.sin(), (nt1,), (nt2,), False)
+        _check_recompiles(lambda nt1: nt1.sin(), (nt1,), (nt2,), False)
 
     def test_binary_does_not_recompile(self):
         def binary(nt1, nt2):
@@ -1253,7 +1324,7 @@ class TestNestedTensor(torch._dynamo.test_case.TestCase):
         nt2, _ = self._get_jagged_tensor(((2, 3, 4), 5), offsets)
         nt3, offsets = self._get_jagged_tensor(((3, 4, 5), 4), None)
         nt4, _ = self._get_jagged_tensor(((3, 4, 5), 4), offsets)
-        self._check_recompiles(binary, (nt1, nt2), (nt3, nt4), False)
+        _check_recompiles(binary, (nt1, nt2), (nt3, nt4), False)
 
     def test_binary_recompiles(self):
         def binary(nt1, nt2):
@@ -1266,7 +1337,7 @@ class TestNestedTensor(torch._dynamo.test_case.TestCase):
         nt1, offsets = self._get_jagged_tensor(((2, 3, 4), 5), None)
         nt2, _ = self._get_jagged_tensor(((2, 3, 4), 5), offsets)
         nt3, _ = self._get_jagged_tensor(((2, 3, 4), 5), None)
-        self._check_recompiles(binary, (nt1, nt2), (nt1, nt3), True)
+        _check_recompiles(binary, (nt1, nt2), (nt1, nt3), True)
 
     # TODO: cannot parametrize this test class with device for some reason
     def _test_autograd(self, backend):
@@ -1358,8 +1429,8 @@ class TestNestedTensor(torch._dynamo.test_case.TestCase):
         # length of the offsets is different. (2) we don't recompile if the
         # length of the offsets is the same, even if the size of the constituent
         # tensors are different.
-        self._check_recompiles(fn, (nt,), (nt2,), False)
-        self._check_recompiles(fn, (nt,), (nt3,), True)
+        _check_recompiles(fn, (nt,), (nt2,), False)
+        _check_recompiles(fn, (nt,), (nt3,), True)
 
     def _get_views(self):
         # Test all cases with both an NT base and a dense base

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import builtins
 import collections
+import copy
 import dataclasses
 import enum
 import functools
@@ -50,6 +51,7 @@ from torch.fx.experimental.symbolic_shapes import (
     is_symbolic,
     SYMPY_INTERP,
 )
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from torch.utils._traceback import format_frame, report_compile_source_on_error
 from torch.utils.weak import TensorWeakRef
 
@@ -413,6 +415,7 @@ class GuardBuilder(GuardBuilderBase):
         self.lookup_weakrefs = lookup_weakrefs
         self.scope: Dict[str, Dict[str, object]] = {"L": local_scope, "G": global_scope}
         self.scope["__builtins__"] = builtins.__dict__.copy()
+        self.scope["G"]["___stored_objs_by_id"] = {}
         for (
             name,
             package_module,
@@ -897,9 +900,9 @@ class GuardBuilder(GuardBuilderBase):
             # Increase the scope of ID_MATCH'd objects.
             if isinstance(val, torch.nn.Module):
                 local_name = guard.originating_source.local_name
-                weak_id = self.lookup_weakrefs(val)
-                if weak_id is not None:
-                    self.id_matched_objs[local_name] = weak_id
+                weak_obj = self.lookup_weakrefs(val)
+                if weak_obj is not None:
+                    self.id_matched_objs[local_name] = weak_obj
 
     def NOT_NONE_MATCH(self, guard: Guard, value=None):
         ref = self.arg_ref(guard)
@@ -1437,6 +1440,16 @@ class GuardBuilder(GuardBuilderBase):
                 self.tensor_check_examples.append(value)
                 self.tensor_check_names.append(tensor_name)
                 self.tensor_check_guards.append(guard)
+
+            if is_traceable_wrapper_subclass(value):
+                ctx = value.__tensor_flatten__()[1]  # type: ignore[attr-defined]
+                if ctx is not None:
+                    # Assume that the ctx obeys object equality
+                    obj_store = self.get("G['___stored_objs_by_id']")
+                    obj_store[id(ctx)] = copy.deepcopy(ctx)
+                    code.append(
+                        f"{tensor_name}.__tensor_flatten__()[1] == G['___stored_objs_by_id'][{id(ctx)}]"
+                    )
 
                 if config.enable_cpp_guard_manager:
                     guard_manager = self.get_guard_manager(guard)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/114405

Update from https://github.com/pytorch/pytorch/pull/114469, credit to @jon-chuang for the original PR.

Changes were mostly removing the special case for nested tensor + fixing merge conflicts.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123970
* #118646
* #118645



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @rohan-varma