### PR TITLE
Fix CUDA out of memory error message formatting

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1149,7 +1149,7 @@ class DeviceCachingAllocator {
           "CUDA out of memory. Tried to allocate ",
           format_size(alloc_size),
           ". GPU ",
-          device,
+          std::to_string(device),
           " has a total capacity of ",
           format_size(device_total),
           " of which ",

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1149,7 +1149,7 @@ class DeviceCachingAllocator {
           "CUDA out of memory. Tried to allocate ",
           format_size(alloc_size),
           ". GPU ",
-          std::to_string(device),
+          static_cast<int>(device),
           " has a total capacity of ",
           format_size(device_total),
           " of which ",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123984

We need a string instead of an integer here. With device 0, the
string was getting NULL terminated leading to a truncated
error message