### PR TITLE
[export] kill _process_constraints()

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -28,6 +28,7 @@ from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.exc import UserError, UserErrorType
 from torch._dynamo.source import ConstantSource
 from torch._export.passes.collect_tracepoints_pass import CollectTracepointsPass
+from torch._export.non_strict_utils import make_constraints
 from torch._functorch.aot_autograd import aot_export_module, GraphSignature
 from torch._functorch.eager_transforms import functionalize
 from torch._guards import detect_fake_mode
@@ -39,7 +40,6 @@ from torch._utils_internal import log_export_usage
 from torch.export._tree_utils import reorder_kwargs
 from torch.export._unlift import _create_stateful_graph_module
 from torch.export.dynamic_shapes import (
-    _process_constraints,
     Constraint,
     dims,
     dynamic_dim,
@@ -175,7 +175,12 @@ def capture_pre_autograd_graph(
                 _restore_state_dict(f, m)
 
             flat_args, _ = pytree.tree_flatten((args, kwargs or {}))
-            range_constraints = _process_constraints(fake_mode, m, 0, flat_args)
+            range_constraints = make_constraints(
+                fake_mode,
+                m,
+                dynamic_shapes,
+                0,
+            )
 
             module = _create_stateful_graph_module(
                 m,

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -16,8 +16,7 @@ from torch._guards import Source
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.export import Constraint
 from torch.export.dynamic_shapes import _Dim
-from torch.export.exported_program import InputKind
-from torch.export.graph_signature import CustomObjArgument, InputSpec, TensorArgument
+from torch.export.graph_signature import CustomObjArgument
 from torch.fx.experimental.symbolic_shapes import (
     ConstraintViolationError,
     DimDynamic,
@@ -174,51 +173,47 @@ def make_fake_inputs(nn_module, args, kwargs, dynamic_shapes):
         return fake_mode, fake_args, fake_kwargs, equalities_inputs, original_signature
 
 
-def make_constraints(
+def _flatten_dynamic_shapes(
+    dynamic_shapes: Union[Dict[str, Any], Tuple[Any], List[Any]]
+):
+    def _is_dynamic_shape_leaf(x):
+        if isinstance(x, dict):
+            x = list(x.values())
+        return x is None or all(isinstance(y, (_Dim, int)) or y is None for y in x)
+
+    if isinstance(dynamic_shapes, (list, tuple)):
+        flat_dynamic_shapes = []
+        for item in dynamic_shapes:
+            flat_shapes, _ = tree_flatten(
+                dynamic_shapes, is_leaf=_is_dynamic_shape_leaf
+            )
+            flat_dynamic_shapes += flat_shapes
+    else:
+        flat_dynamic_shapes, _ = tree_flatten(
+            dynamic_shapes, is_leaf=_is_dynamic_shape_leaf
+        )
+    return flat_dynamic_shapes
+
+
+def produce_guards_and_solve_constraints(
     fake_mode: FakeTensorMode,
-    equalities_inputs: EqualityConstraint,
-    dynamic_shapes: Union[Dict[str, Any], Tuple[Any], List[Any]],
-    input_specs: List[InputSpec],
-    original_signature: inspect.Signature,
     gm: torch.fx.GraphModule,
+    equalities_inputs: EqualityConstraint,
+    original_signature: inspect.Signature,
 ):
     """
     Given a fake mode, sources pairs corresponding to equal dynamic shape dimensions,
     and a graph module, produce guards on the fake mode's shape env (raising constraint
-    violations if any), solve (to suggest simplifications or fixes), and return the
-    resulting range constraints and equality constraints.
+    violations if any), solve (to suggest simplifications or fixes).
+    Dynamo already performs this, so this is for non-strict mode.
+
+    Additional inputs:
+        equalities_inputs: the equality constraints to use for guards
+        original_signature: the signature of the forward method
     """
-    # TODO(avik): refactor Dynamo to avoid duplication of the following code
-    # between non-strict and strict.
-    # Specifically, here (non-strict) we do the following post-tracing steps:
-    #   - Produce guards.
-    #   - Solve constraints.
-    #   - Install shape metadata in IR.
-    # In strict, these steps are spread across multiple files:
-    #   - guards.py produces guards.
-    #   - eval_frame.py solves constraints
-    #   - _trace.py installs shape metadata in IR.
-
-    inline_constraints = gm.meta.get("inline_constraints", [])
-    range_constraints = {
-        symbol: inline_constraints[symbol] for symbol in inline_constraints
-    }
-    if dynamic_shapes == []:
-        return range_constraints
-
-    def _is_dynamic_shape_leaf(x):
-        if x is None:
-            return True
-        if isinstance(x, dict):
-            x = list(x.values())
-        return all(isinstance(y, (_Dim, int)) or y is None for y in x)
-
-    flat_dynamic_shapes, _ = tree_flatten(
-        dynamic_shapes, is_leaf=_is_dynamic_shape_leaf
-    )
-
     shape_env = fake_mode.shape_env
     assert shape_env.tracked_fakes is not None
+
     placeholders = [tf.fake for tf in shape_env.tracked_fakes]
     sources = [tf.source for tf in shape_env.tracked_fakes]
     input_contexts = [tf.symbolic_context for tf in shape_env.tracked_fakes]
@@ -255,23 +250,41 @@ def make_constraints(
     if constraint_violation_error:
         raise constraint_violation_error
 
-    user_tensor_input_names = {
-        spec.arg.name
-        for spec in input_specs
-        if spec.kind == InputKind.USER_INPUT and isinstance(spec.arg, TensorArgument)
-    }
 
+def make_constraints(
+    fake_mode: FakeTensorMode,
+    gm: torch.fx.GraphModule,
+    dynamic_shapes: Union[Dict[str, Any], Tuple[Any], List[Any], None],
+    num_lifted_inputs: int,
+):
+    """
+    Given a fake mode's shape env and user-specified dynamic shapes,
+    return the resulting range constraints and equality constraints.
+
+    Additional args:
+        num_lifted_inputs: the number of non-user-input placeholder nodes in the graph
+        (used only to enumerate the user-input nodes)
+    """
+
+    shape_env = fake_mode.shape_env
+    inline_constraints = gm.meta.get("inline_constraints", [])
+    range_constraints = {
+        symbol: inline_constraints[symbol] for symbol in inline_constraints
+    }
+    if not dynamic_shapes:
+        return range_constraints
+
+    flat_dynamic_shapes = _flatten_dynamic_shapes(dynamic_shapes)
     input_dims = defaultdict(list)
     free_symbols = set()
-    input_index = 0
-    for node in gm.graph.nodes:
-        if node.name not in user_tensor_input_names:
+    for input_index, node in enumerate(gm.graph.nodes):
+        if input_index < num_lifted_inputs or node.op != "placeholder":
             continue
         if _is_constant_argument(node.meta["val"]) or isinstance(
             node.meta["val"], CustomObjArgument
         ):
             continue
-        shape_spec = flat_dynamic_shapes[input_index]
+        shape_spec = flat_dynamic_shapes[input_index - num_lifted_inputs]
         for i, d in enumerate(node.meta["val"].shape):
             if isinstance(d, torch.SymInt):
                 # Look up the range constraint for the symbol corresponding to this shape dimension
@@ -290,7 +303,6 @@ def make_constraints(
                     ]
                 input_dims[d.node.expr].append(InputDim(input_name=node.name, dim=i))
                 free_symbols.update(d.node.expr.free_symbols)
-        input_index += 1
 
     for symbol in free_symbols:
         if symbol not in range_constraints:

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -651,8 +651,7 @@ class ExportedProgram:
 
         new_range_constraints = _get_updated_range_constraints(
             gm,
-            self._num_lifted_params_buffers(),
-            pytree.tree_leaves(self.example_inputs),
+            self.range_constraints,
             _is_executorch=False,
         )
 
@@ -764,8 +763,7 @@ class ExportedProgram:
             state_dict=self.state_dict,
             range_constraints=_get_updated_range_constraints(
                 transformed_gm,
-                self._num_lifted_params_buffers(),
-                pytree.tree_leaves(self.example_inputs),
+                self.range_constraints,
                 _is_executorch=False,
             ),
             module_call_graph=copy.deepcopy(self._module_call_graph),
@@ -812,8 +810,7 @@ class ExportedProgram:
 
 def _get_updated_range_constraints(
     gm: torch.fx.GraphModule,
-    num_lifted: Optional[int] = None,
-    example_inputs: Optional[List[Any]] = None,
+    old_range_constraints: "Optional[Dict[sympy.Symbol, Any]]" = None,
     _is_executorch: bool = True,
 ) -> "Dict[sympy.Symbol, Any]":
     def get_shape_env(gm):
@@ -833,8 +830,7 @@ def _get_updated_range_constraints(
 
     # FIXME(tmanlaibaatar) Remove this whole branch once https://github.com/pytorch/pytorch/pull/123764
     if _is_executorch:
-        assert num_lifted is None
-        assert example_inputs is None
+        assert old_range_constraints is None
         shape_env, _ = get_shape_env(gm)
         if shape_env is None:
             return {}
@@ -851,17 +847,13 @@ def _get_updated_range_constraints(
                 range_constraints[k] = v
         return range_constraints
 
-    assert num_lifted is not None
-    assert example_inputs is not None
+    assert old_range_constraints is not None
 
     shape_env, fake_mode = get_shape_env(gm)
     if shape_env is None:
         return {}
 
-    from torch.export.dynamic_shapes import _process_constraints
-
-    range_constraints = _process_constraints(fake_mode, gm, num_lifted, example_inputs)
-
+    range_constraints = copy.copy(old_range_constraints)
     range_constraints = {
         k: v for k, v in range_constraints.items() if k not in shape_env.replacements
     }


### PR DESCRIPTION
The process for populating range_constraints follows separate methods for non-strict (`make_constraints`), and strict (`_process_constraints`). The strict method is somewhat more convoluted, and the analysis that Dynamo performs for strict is already present as part of the non-strict process in make_constraints (produce_guards(), running the export constraint solver).

This PR kills _process_constraints() and replaces calls with make_constraints, without duplicating the work that Dynamo already does.