### PR TITLE
all_gather and reduce_scatter autograd

### DIFF
--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -437,6 +437,119 @@ at::Tensor all_to_all_single_autograd(
       input, output_split_sizes, input_split_sizes, group_name)[0];
 }
 
+class ReduceScatterTensor
+    : public torch::autograd::Function<ReduceScatterTensor> {
+ public:
+  static torch::autograd::Variable forward(
+      torch::autograd::AutogradContext* ctx,
+      const at::Tensor& input,
+      std::string reduce_op,
+      int64_t group_size,
+      std::string group_name) {
+    TORCH_CHECK(reduce_op == "sum", "Only sum reduce op is supported");
+
+    ctx->saved_data["group_size"] = group_size;
+    ctx->saved_data["group_name"] = group_name;
+
+    return c10::Dispatcher::singleton()
+        .findSchemaOrThrow("_c10d_functional::reduce_scatter_tensor", "")
+        .typed<decltype(reduce_scatter_tensor)>()
+        .call(input, reduce_op, group_size, group_name);
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_out_list) {
+    const int64_t group_size = ctx->saved_data["group_size"].toInt();
+    const std::string& group_name = ctx->saved_data["group_name"].toStringRef();
+
+    DCHECK(grad_out_list.size() == 1);
+    auto grad_out = grad_out_list[0];
+
+    auto out =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("_c10d_functional::all_gather_into_tensor", "")
+            .typed<decltype(all_gather_into_tensor)>()
+            .call(grad_out, group_size, group_name);
+
+    // do an explicit wait to avoid cuda stream issues
+    // TODO: track active cuda stream in wait
+    out = c10::Dispatcher::singleton()
+              .findSchemaOrThrow("_c10d_functional::wait_tensor", "")
+              .typed<decltype(wait_tensor)>()
+              .call(out);
+
+    return {
+        out,
+        at::Tensor(),
+        at::Tensor(),
+        at::Tensor(),
+    };
+  }
+};
+
+at::Tensor reduce_scatter_tensor_autograd(
+    const at::Tensor& input,
+    std::string reduce_op,
+    int64_t group_size,
+    std::string group_name) {
+  return ReduceScatterTensor::apply(input, reduce_op, group_size, group_name);
+}
+
+class AllGatherIntoTensor
+    : public torch::autograd::Function<AllGatherIntoTensor> {
+ public:
+  static torch::autograd::Variable forward(
+      torch::autograd::AutogradContext* ctx,
+      const at::Tensor& input,
+      int64_t group_size,
+      std::string group_name) {
+    ctx->saved_data["group_size"] = group_size;
+    ctx->saved_data["group_name"] = group_name;
+
+    return c10::Dispatcher::singleton()
+        .findSchemaOrThrow("_c10d_functional::all_gather_into_tensor", "")
+        .typed<decltype(all_gather_into_tensor)>()
+        .call(input, group_size, group_name);
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext* ctx,
+      torch::autograd::variable_list grad_out_list) {
+    const int64_t group_size = ctx->saved_data["group_size"].toInt();
+    const std::string& group_name = ctx->saved_data["group_name"].toStringRef();
+
+    DCHECK(grad_out_list.size() == 1);
+    auto grad_out = grad_out_list[0];
+
+    auto out =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("_c10d_functional::reduce_scatter_tensor", "")
+            .typed<decltype(reduce_scatter_tensor)>()
+            .call(grad_out, "sum", group_size, group_name);
+
+    // do an explicit wait to avoid cuda stream issues
+    // TODO: track active cuda stream in wait
+    out = c10::Dispatcher::singleton()
+              .findSchemaOrThrow("_c10d_functional::wait_tensor", "")
+              .typed<decltype(wait_tensor)>()
+              .call(out);
+
+    return {
+        out,
+        at::Tensor(),
+        at::Tensor(),
+    };
+  }
+};
+
+at::Tensor all_gather_into_tensor_autograd(
+    const at::Tensor& input,
+    int64_t group_size,
+    std::string group_name) {
+  return AllGatherIntoTensor::apply(input, group_size, group_name);
+}
+
 } // namespace
 
 TORCH_LIBRARY(_c10d_functional_autograd, m) {
@@ -447,5 +560,22 @@ TORCH_LIBRARY(_c10d_functional_autograd, m) {
       "SymInt[] input_split_sizes, "
       "str group_name) -> Tensor",
       torch::dispatch(c10::DispatchKey::Autograd, ::all_to_all_single_autograd),
+      {at::Tag::pt2_compliant_tag});
+  m.def(
+      "reduce_scatter_tensor("
+      "Tensor input, "
+      "str reduce_op, "
+      "int group_size, "
+      "str group_name) -> Tensor",
+      torch::dispatch(
+          c10::DispatchKey::Autograd, ::reduce_scatter_tensor_autograd),
+      {at::Tag::pt2_compliant_tag});
+  m.def(
+      "all_gather_into_tensor("
+      "Tensor input, "
+      "int group_size, "
+      "str group_name) -> Tensor",
+      torch::dispatch(
+          c10::DispatchKey::Autograd, ::all_gather_into_tensor_autograd),
       {at::Tag::pt2_compliant_tag});
 }


### PR DESCRIPTION
This adds `all_gather_tensor_autograd` and `reduce_scatter_tensor_autograd` to the functional_collectives library.

This only supports `sum` mode for `reduce_scatter` but should be easy to extend in the future.

The backwards implementations match the behavior in https://github.com/pytorch/torchrec/blob/main/torchrec/distributed/comm_ops.py

This follows the pattern of #123599 .

Test plan:

```sh
pytest test/distributed/test_functional_api.py -k Autograd
```


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang