### PR TITLE
[export] fix flaky tests memory leak checks by resetting dynamo cache in test

### DIFF
--- a/test/export/test_hop.py
+++ b/test/export/test_hop.py
@@ -84,6 +84,11 @@ class TestHOP(TestCase):
             kwargs = inp.kwargs
             ep = export(model, args, kwargs)
             self._compare(model, ep, args, kwargs)
+        # Mannually resetting dynamo state to avoid memory leak warning.
+        # Note that even though TestCase.tearDown calls reset, the
+        # memory leak checks when PYTORCH_TEST_CUDA_MEM_LEAK_CHECK=1
+        # checks memory leaks before that.
+        torch._dynamo.reset()
 
     @ops(hop_tests, allowed_dtypes=(torch.float,))
     def test_pre_dispatch_export(self, device, dtype, op):
@@ -99,6 +104,7 @@ class TestHOP(TestCase):
             kwargs = inp.kwargs
             ep = _export(model, args, kwargs, pre_dispatch=True)
             self._compare(model, ep, args, kwargs)
+        torch._dynamo.reset()
 
     @ops(hop_tests, allowed_dtypes=(torch.float,))
     def test_retrace_export(self, device, dtype, op):
@@ -115,6 +121,7 @@ class TestHOP(TestCase):
             ep = _export(model, args, kwargs, pre_dispatch=True)
             ep = ep.run_decompositions()
             self._compare(model, ep, args, kwargs)
+        torch._dynamo.reset()
 
     @ops(hop_tests, allowed_dtypes=(torch.float,))
     def test_serialize_export(self, device, dtype, op):
@@ -143,6 +150,7 @@ class TestHOP(TestCase):
                     self._compare(model, ep, args, kwargs)
             else:
                 self._compare(model, ep, args, kwargs)
+        torch._dynamo.reset()
 
 
 instantiate_device_type_tests(TestHOP, globals())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #123999

Should fix #123948, #123946, #123944, #123943,  #123727, #123564, #123563, #123352 , #123449, #123194, #122964, #123095, #123096
This is not necessarily a memory leak in dynamo: dynamo may need to cache the input tensors somewhere but we need to confirm the necessity.

For now, we'll just manually reset dynamo cache before memory leak checks to re-enable the tests on CI to guard against regression.


