### PR TITLE
[FSDP] Move the flattened tensors back to GPU to prevent CPU OOM

### DIFF
--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -688,6 +688,11 @@ def _flatten_optim_state(
                 unflat_param_names,
             )
 
+    # Move the tensors to GPU
+    for k, v in flat_state.items():
+        if isinstance(v, torch.Tensor):
+            flat_state[k] = flat_state[k].to(fsdp_state.compute_device)
+
     return flat_state
 
 


### PR DESCRIPTION
I encountered a CPU OOM issue when resuming from a checkpoint with `FSDP.optim_state_dict_to_load`. See https://github.com/huggingface/accelerate/blob/5ca095a34fede7c988af8c193eb0c0d199750845/src/accelerate/utils/fsdp_utils.py#L208 for details. 

I notice that `_flatten_tensor_optim_state` and `_flatten_zero_dim_tensor_optim_state` will create tensors on CPU, and results in the OOM issue. I have tried creating tensors on GPU directly, but it caused OOM on GPU. 

My solution is to move the flattened tensors back to the device where FSDP is running on. This works well for me with PyTorch 2.1.1. The current main branch doesn't seem to have fixed this issue yet.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @rohan-varma