### PR TITLE
[BE][Ez]: Fix minor potential perf regression from #123960

### DIFF
--- a/torch/amp/grad_scaler.py
+++ b/torch/amp/grad_scaler.py
@@ -426,8 +426,10 @@ class GradScaler:
                 found_inf = cast(
                     torch.Tensor,
                     sum(
-                        t.to(scaler.device, non_blocking=True)
-                        for t in optimizer_state["found_inf_per_device"].values()
+                        [  # noqa: C419
+                            t.to(scaler.device, non_blocking=True)
+                            for t in optimizer_state["found_inf_per_device"].values()
+                        ]
                     ),
                 )
                 optimizer.grad_scale = (  # type: ignore[attr-defined]


### PR DESCRIPTION
The `non_blocking` arg here is useless if the values are all eagerly consumed, so revert the change.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5