### PR TITLE
[Distributed] [4/N] Fix clang-tidy warnings in torch/csrc/distributed/c10d

### DIFF
--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -90,6 +90,7 @@ class Lock {
     flock(operation);
   }
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~Lock() {
     unlock();
   }
@@ -290,6 +291,7 @@ FileStore::FileStore(std::string path, int numWorkers)
   addHelper(refCountKey_, 1);
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 FileStore::~FileStore() {
   // If the file does not exist - exit.
   // This can happen when FileStore is invoked from python language which has

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -105,7 +105,9 @@ c10d::ReduceOp to_reduce_op(const std::string& reduce_op) {
 
 at::Tensor& all_reduce_(
     at::Tensor& input,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string reduce_op,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string group_name) {
   c10d::AllreduceOptions opts;
   opts.reduceOp = to_reduce_op(reduce_op);
@@ -122,12 +124,14 @@ at::Tensor all_reduce(
     std::string reduce_op,
     std::string group_name) {
   auto output = input.clone(at::MemoryFormat::Contiguous);
-  return all_reduce_(output, reduce_op, group_name);
+  return all_reduce_(output, std::move(reduce_op), std::move(group_name));
 }
 
 std::vector<at::Tensor> all_reduce_coalesced_(
     std::vector<at::Tensor> inputs,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string reduce_op,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string group_name) {
   c10d::AllreduceCoalescedOptions opts;
   opts.reduceOp = to_reduce_op(reduce_op);
@@ -141,6 +145,7 @@ std::vector<at::Tensor> all_reduce_coalesced_(
 }
 
 std::vector<at::Tensor> all_reduce_coalesced(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::vector<at::Tensor> inputs,
     std::string reduce_op,
     std::string group_name) {
@@ -149,7 +154,8 @@ std::vector<at::Tensor> all_reduce_coalesced(
   for (const auto& tensor : inputs) {
     outputs.push_back(tensor.clone(at::MemoryFormat::Contiguous));
   }
-  return all_reduce_coalesced_(outputs, reduce_op, group_name);
+  return all_reduce_coalesced_(
+      outputs, std::move(reduce_op), std::move(group_name));
 }
 
 at::Tensor allocate_all_gather_output(
@@ -165,6 +171,7 @@ at::Tensor allocate_all_gather_output(
 std::vector<at::Tensor> all_gather_into_tensor_coalesced(
     std::vector<at::Tensor> inputs,
     int64_t group_size,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string group_name) {
   std::vector<at::Tensor> outputs;
   outputs.reserve(inputs.size());
@@ -173,8 +180,7 @@ std::vector<at::Tensor> all_gather_into_tensor_coalesced(
   }
 
   auto group = c10d::resolve_process_group(group_name);
-  auto work = group->allgather_into_tensor_coalesced(
-      outputs, const_cast<std::vector<at::Tensor>&>(inputs));
+  auto work = group->allgather_into_tensor_coalesced(outputs, inputs);
   for (const auto& tensor : outputs) {
     c10d::RankLocal<WorkRegistry>::get().register_work(tensor, work);
   }
@@ -186,7 +192,8 @@ at::Tensor all_gather_into_tensor(
     int64_t group_size,
     std::string group_name) {
   std::vector<at::Tensor> inputs{input};
-  return all_gather_into_tensor_coalesced(inputs, group_size, group_name)[0];
+  return all_gather_into_tensor_coalesced(
+      inputs, group_size, std::move(group_name))[0];
 }
 
 at::Tensor allocate_reduce_scatter_output(
@@ -206,8 +213,10 @@ at::Tensor allocate_reduce_scatter_output(
 
 std::vector<at::Tensor> reduce_scatter_tensor_coalesced(
     std::vector<at::Tensor> inputs,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string reduce_op,
     int64_t group_size,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string group_name) {
   c10d::ReduceScatterOptions opts;
   opts.reduceOp = to_reduce_op(reduce_op);
@@ -218,8 +227,7 @@ std::vector<at::Tensor> reduce_scatter_tensor_coalesced(
   }
 
   auto group = c10d::resolve_process_group(group_name);
-  auto work = group->reduce_scatter_tensor_coalesced(
-      outputs, const_cast<std::vector<at::Tensor>&>(inputs), opts);
+  auto work = group->reduce_scatter_tensor_coalesced(outputs, inputs, opts);
   for (const auto& tensor : outputs) {
     c10d::RankLocal<WorkRegistry>::get().register_work(tensor, work);
   }
@@ -233,13 +241,14 @@ at::Tensor reduce_scatter_tensor(
     std::string group_name) {
   std::vector<at::Tensor> inputs{input};
   return reduce_scatter_tensor_coalesced(
-      inputs, reduce_op, group_size, group_name)[0];
+      inputs, std::move(reduce_op), group_size, std::move(group_name))[0];
 }
 
 at::Tensor all_to_all_single(
     const at::Tensor& input,
     std::vector<int64_t> output_split_sizes,
     std::vector<int64_t> input_split_sizes,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string group_name) {
   std::vector<int64_t> output_sizes = input.sizes().vec();
   output_sizes[0] = std::accumulate(
@@ -249,6 +258,7 @@ at::Tensor all_to_all_single(
   auto group = c10d::resolve_process_group(group_name);
   auto work = group->alltoall_base(
       output,
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
       const_cast<at::Tensor&>(input),
       output_split_sizes,
       input_split_sizes);
@@ -256,6 +266,7 @@ at::Tensor all_to_all_single(
   return output;
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 at::Tensor& broadcast_(at::Tensor& input, int64_t src, std::string group_name) {
   c10d::BroadcastOptions opts;
   opts.rootRank = src;
@@ -272,7 +283,7 @@ at::Tensor broadcast(
     int64_t src,
     std::string group_name) {
   auto output = input.clone(at::MemoryFormat::Contiguous);
-  return broadcast_(output, src, group_name);
+  return broadcast_(output, src, std::move(group_name));
 }
 
 at::Tensor wait_tensor(const at::Tensor& tensor) {
@@ -371,8 +382,11 @@ class AllToAllSingle : public torch::autograd::Function<AllToAllSingle> {
   static torch::autograd::Variable forward(
       torch::autograd::AutogradContext* ctx,
       const at::Tensor& input,
+      // NOLINTNEXTLINE(performance-unnecessary-value-param)
       std::vector<int64_t> output_split_sizes,
+      // NOLINTNEXTLINE(performance-unnecessary-value-param)
       std::vector<int64_t> input_split_sizes,
+      // NOLINTNEXTLINE(performance-unnecessary-value-param)
       std::string group_name) {
     // swap sizes for backwards pass
     ctx->saved_data["output_split_sizes"] = input_split_sizes;
@@ -416,9 +430,9 @@ class AllToAllSingle : public torch::autograd::Function<AllToAllSingle> {
 
 at::Tensor all_to_all_single_autograd(
     const at::Tensor& input,
-    std::vector<int64_t> output_split_sizes,
-    std::vector<int64_t> input_split_sizes,
-    std::string group_name) {
+    const std::vector<int64_t>& output_split_sizes,
+    const std::vector<int64_t>& input_split_sizes,
+    const std::string& group_name) {
   return AllToAllSingle::apply(
       input, output_split_sizes, input_split_sizes, group_name)[0];
 }

--- a/torch/csrc/distributed/c10d/GroupRegistry.cpp
+++ b/torch/csrc/distributed/c10d/GroupRegistry.cpp
@@ -13,7 +13,7 @@ class GroupRegistry {
       const std::string& group_name,
       c10::intrusive_ptr<c10d::ProcessGroup> group) {
     std::unique_lock write_lock(lock_);
-    auto [_, inserted] = registry_.emplace(group_name, group);
+    auto [_, inserted] = registry_.try_emplace(group_name, std::move(group));
     TORCH_CHECK(
         inserted,
         "A process group is already registered under the name",
@@ -72,9 +72,10 @@ void register_process_group(
     const std::string& group_name,
     c10::intrusive_ptr<c10d::ProcessGroup> group) {
   if (thread_isolation_mode) {
-    RankLocal<::GroupRegistry>::get().register_group(group_name, group);
+    RankLocal<::GroupRegistry>::get().register_group(
+        group_name, std::move(group));
   } else {
-    process_registry.register_group(group_name, group);
+    process_registry.register_group(group_name, std::move(group));
   }
 }
 

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
@@ -85,8 +85,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   at::ScalarType dType_ = at::kByte;
   std::vector<int64_t> inputSplitSizes_;
   std::vector<int64_t> outputSplitSizes_;
-  int globalRankStart_;
-  int globalRankStride_;
+  int globalRankStart_{};
+  int globalRankStride_{};
   std::vector<int64_t> groupRanks_{};
 };
 

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -674,7 +674,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
     std::vector<c10::Device> devices;
     devices.reserve(deviceTypes_.size());
     for (auto& dt : deviceTypes_) {
-      devices.push_back(c10::Device(dt));
+      devices.emplace_back(dt);
     }
     return devices;
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -147,7 +147,7 @@ class TORCH_API ProcessGroupGloo : public Backend {
         const std::vector<std::string>& keys) override {
       std::vector<std::vector<char>> res;
       for (auto& value : store_->multiGet(keys)) {
-        res.emplace_back(std::vector<char>(value.begin(), value.end()));
+        res.emplace_back(value.begin(), value.end());
       }
       return res;
     }
@@ -156,8 +156,9 @@ class TORCH_API ProcessGroupGloo : public Backend {
         const std::vector<std::string>& keys,
         const std::vector<std::vector<char>>& values) override {
       std::vector<std::vector<uint8_t>> u_values;
-      for (auto& value : values) {
-        u_values.emplace_back(std::vector<uint8_t>(value.begin(), value.end()));
+      u_values.reserve(values.size());
+for (auto& value : values) {
+        u_values.emplace_back(value.begin(), value.end());
       }
       store_->multiSet(keys, u_values);
     }

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -157,7 +157,7 @@ class TORCH_API ProcessGroupGloo : public Backend {
         const std::vector<std::vector<char>>& values) override {
       std::vector<std::vector<uint8_t>> u_values;
       u_values.reserve(values.size());
-for (auto& value : values) {
+      for (auto& value : values) {
         u_values.emplace_back(value.begin(), value.end());
       }
       store_->multiSet(keys, u_values);

--- a/torch/csrc/distributed/c10d/UnixSockUtils.hpp
+++ b/torch/csrc/distributed/c10d/UnixSockUtils.hpp
@@ -2,8 +2,7 @@
 
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 
-namespace c10d {
-namespace tcputil {
+namespace c10d::tcputil {
 
 #define CONNECT_SOCKET_OFFSET 2
 
@@ -23,5 +22,4 @@ inline struct ::pollfd getPollfd(int socket, short events) {
   return res;
 }
 
-} // namespace tcputil
-} // namespace c10d
+} // namespace c10d::tcputil

--- a/torch/csrc/distributed/c10d/WinSockUtils.hpp
+++ b/torch/csrc/distributed/c10d/WinSockUtils.hpp
@@ -2,8 +2,7 @@
 
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 
-namespace c10d {
-namespace tcputil {
+namespace c10d::tcputil {
 
 #define CONNECT_SOCKET_OFFSET 1
 
@@ -23,5 +22,4 @@ inline struct ::pollfd getPollfd(int socket, short events) {
   return res;
 }
 
-} // namespace tcputil
-} // namespace c10d
+} // namespace c10d::tcputil

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -85,7 +85,7 @@ static bool registered = registerGilChecker();
 // TODO: move this somewhere more generally useful
 template <typename T>
 class IntrusivePtrNoGilDestructor {
-  c10::intrusive_ptr<T> impl_;
+  c10::intrusive_ptr<T> impl_{};
 
  public:
   IntrusivePtrNoGilDestructor() = default;
@@ -132,9 +132,7 @@ class IntrusivePtrNoGilDestructor {
 
 PYBIND11_DECLARE_HOLDER_TYPE(T, IntrusivePtrNoGilDestructor<T>, true);
 
-namespace torch {
-namespace distributed {
-namespace c10d {
+namespace torch::distributed::c10d {
 
 namespace {
 
@@ -259,7 +257,7 @@ class PythonStore : public ::c10d::Store {
        py::bytes(reinterpret_cast<const char*>(value.data()), value.size()));
   }
 
-  virtual std::vector<std::vector<uint8_t>> multiGet(
+  std::vector<std::vector<uint8_t>> multiGet(
       const std::vector<std::string>& keys) override {
     pybind11::gil_scoped_acquire gil;
     pybind11::function fn = pybind11::get_overload(
@@ -270,15 +268,16 @@ class PythonStore : public ::c10d::Store {
     std::vector<std::string> py_list =
         pybind11::cast<std::vector<std::string>>(fn(keys));
     std::vector<std::vector<uint8_t>> res;
+    res.reserve(py_list.size());
 
     for (auto& str : py_list) {
-      res.emplace_back(std::vector<uint8_t>(str.begin(), str.end()));
+      res.emplace_back(str.begin(), str.end());
     }
 
     return res;
   }
 
-  virtual void multiSet(
+  void multiSet(
       const std::vector<std::string>& keys,
       const std::vector<std::vector<uint8_t>>& values) override {
     pybind11::gil_scoped_acquire gil;
@@ -289,9 +288,10 @@ class PythonStore : public ::c10d::Store {
     }
 
     std::vector<py::bytes> bytes;
+    bytes.reserve(values.size());
     for (auto& value : values) {
       bytes.emplace_back(
-          py::bytes(reinterpret_cast<const char*>(value.data()), value.size()));
+          reinterpret_cast<const char*>(value.data()), value.size());
     }
 
     fn(keys, bytes);
@@ -350,6 +350,7 @@ static PyObject* reduceopmeta___instancecheck__(
   }
   Py_RETURN_FALSE;
 }
+// NOLINTNEXTLINE(*c-arrays)
 static PyMethodDef reduceopmeta_methods[] = {
     {"__instancecheck__",
      (PyCFunction)reduceopmeta___instancecheck__,
@@ -360,6 +361,7 @@ PyTypeObject* GetReduceOpMetaclass() {
   static auto* metaclass = [] {
     PyTypeObject* base_metaclass =
         pybind11::detail::get_internals().default_metaclass;
+    // NOLINTNEXTLINE(*c-arrays)
     PyType_Slot slots[] = {
         {Py_tp_base, base_metaclass},
         {Py_tp_methods, reduceopmeta_methods},
@@ -367,6 +369,7 @@ PyTypeObject* GetReduceOpMetaclass() {
     };
     PyType_Spec spec = {};
     spec.name = "torch._C._distributed_c10d._ReduceOpMeta";
+    // NOLINTNEXTLINE(*-narrowing-conversions)
     spec.basicsize = base_metaclass->tp_basicsize;
     spec.flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
     spec.slots = slots;
@@ -533,7 +536,7 @@ An enum-like class for built-in communication hooks: ``ALLREDUCE`` and ``FP16_CO
             for (const auto& fut : futs) {
               futures.push_back(fut->fut);
             }
-            reducer.install_futures(std::move(futures));
+            reducer.install_futures(futures);
           },
           py::call_guard<py::gil_scoped_release>())
       .def(
@@ -616,7 +619,7 @@ An enum-like class for built-in communication hooks: ``ALLREDUCE`` and ``FP16_CO
       .def(
           "set_logger",
           [](::c10d::Reducer& reducer,
-             const std::shared_ptr<::c10d::Logger> logger) {
+             const std::shared_ptr<::c10d::Logger>& logger) {
             std::weak_ptr<::c10d::Logger> logger_weakref = logger;
             reducer.set_logger(logger_weakref);
           })
@@ -636,7 +639,7 @@ An enum-like class for built-in communication hooks: ``ALLREDUCE`` and ``FP16_CO
           "_update_process_group",
           [](::c10d::Reducer& reducer,
              c10::intrusive_ptr<::c10d::ProcessGroup> new_process_group) {
-            return reducer.update_process_group(new_process_group);
+            return reducer.update_process_group(std::move(new_process_group));
           },
           py::call_guard<py::gil_scoped_release>());
 
@@ -764,6 +767,7 @@ This class does not support ``__members__`` property.)");
           // With the above custom `__eq__`'s, I have to manually support the
           // other types.
           "__eq__",
+          // NOLINTNEXTLINE(performance-unnecessary-value-param)
           [](const ::c10d::ReduceOp& self, py::object) { return false; })
       .def(
           "__hash__",
@@ -794,7 +798,7 @@ This class does not support ``__members__`` property.)");
               return py::make_tuple(r.op_, preMulSupplement->tensor_factor);
             }
           },
-          [](const py::tuple t) {
+          [](const py::tuple& t) {
             // __setstate__
             TORCH_CHECK(t.size() == 2, "Invalid state");
             const auto op =
@@ -856,7 +860,7 @@ This class does not support ``__members__`` property.)");
       "_register_process_group",
       [](const std::string& group_name,
          c10::intrusive_ptr<::c10d::ProcessGroup> group) {
-        ::c10d::register_process_group(group_name, group);
+        ::c10d::register_process_group(group_name, std::move(group));
       },
       py::arg("group_name"),
       py::arg("group"));
@@ -1295,9 +1299,9 @@ Example::
                  const std::vector<std::string>& keys,
                  const std::vector<std::string>& values) {
                 std::vector<std::vector<uint8_t>> vals;
+                vals.reserve(values.size());
                 for (auto& value : values) {
-                  vals.push_back(
-                      std::vector<uint8_t>(value.begin(), value.end()));
+                  vals.emplace_back(value.begin(), value.end());
                 }
                 store.multiSet(keys, vals);
               },
@@ -1534,7 +1538,7 @@ Arguments:
               "allreduce",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  std::vector<at::Tensor>& xs,
-                 ::c10d::ReduceOp op) {
+                 const ::c10d::ReduceOp& op) {
                 ::c10d::AllreduceOptions opts;
                 opts.reduceOp = op;
                 return self->allreduce(xs, opts);
@@ -1547,7 +1551,7 @@ Arguments:
               "allreduce",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  at::Tensor& x,
-                 ::c10d::ReduceOp op) {
+                 const ::c10d::ReduceOp& op) {
                 ::c10d::AllreduceOptions opts;
                 opts.reduceOp = op;
                 std::vector<at::Tensor> xs = {x};
@@ -1575,7 +1579,7 @@ Arguments:
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  at::Tensor& x,
                  int rootRank,
-                 ::c10d::ReduceOp op) {
+                 const ::c10d::ReduceOp& op) {
                 ::c10d::ReduceOptions opts;
                 opts.reduceOp = op;
                 opts.rootRank = rootRank;
@@ -1686,7 +1690,7 @@ Arguments:
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  at::Tensor& output,
                  std::vector<at::Tensor>& input,
-                 ::c10d::ReduceOp op) {
+                 const ::c10d::ReduceOp& op) {
                 std::vector<at::Tensor> outputs = {output};
                 std::vector<std::vector<at::Tensor>> inputs = {input};
                 ::c10d::ReduceScatterOptions opts;
@@ -1826,7 +1830,7 @@ Arguments:
                 self->registerOnCompletionHook(
                     [hookWrapper = ::c10d::PythonOnCompletionHook(std::move(
                          hook))](std::shared_ptr<::c10d::WorkInfo> workInfo) {
-                      hookWrapper(workInfo);
+                      hookWrapper(std::move(workInfo));
                     });
               },
               py::arg("hook"),
@@ -1903,7 +1907,7 @@ Arguments:
           })
           .def_static("unbox", [](py::object obj) {
               auto typePtr = torch::getCustomClass("__torch__.torch.classes.c10d.ProcessGroup");
-              auto ivalue = torch::jit::toIValue(obj, typePtr);
+              auto ivalue = torch::jit::toIValue(std::move(obj), typePtr);
               return ivalue.toCustomClass<::c10d::ProcessGroup>();
           });
 
@@ -1995,7 +1999,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               "allreduce",
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  std::vector<at::Tensor>& xs,
-                 ::c10d::ReduceOp op) {
+                 const ::c10d::ReduceOp& op) {
                 ::c10d::AllreduceOptions opts;
                 opts.reduceOp = op;
                 return self->allreduce(xs, opts);
@@ -2007,7 +2011,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               "allreduce",
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  at::Tensor& x,
-                 ::c10d::ReduceOp op) {
+                 const ::c10d::ReduceOp& op) {
                 ::c10d::AllreduceOptions opts;
                 opts.reduceOp = op;
                 std::vector<at::Tensor> xs = {x};
@@ -2033,7 +2037,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  at::Tensor& x,
                  int rootRank,
-                 ::c10d::ReduceOp op) {
+                 const ::c10d::ReduceOp& op) {
                 ::c10d::ReduceOptions opts;
                 opts.reduceOp = op;
                 opts.rootRank = rootRank;
@@ -2136,7 +2140,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               [](const c10::intrusive_ptr<::c10d::Backend>& self,
                  at::Tensor& output,
                  std::vector<at::Tensor>& input,
-                 ::c10d::ReduceOp op) {
+                 const ::c10d::ReduceOp& op) {
                 std::vector<at::Tensor> outputs = {output};
                 std::vector<std::vector<at::Tensor>> inputs = {input};
                 ::c10d::ReduceScatterOptions opts;
@@ -2258,6 +2262,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
       intrusive_ptr_no_gil_destructor_class_<::c10d::ProcessGroupGloo>(
           module, "ProcessGroupGloo", backend);
 
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   shared_ptr_class_<::gloo::transport::Device>(processGroupGloo, "Device");
 
   intrusive_ptr_class_<::c10d::ProcessGroupGloo::Options>(
@@ -2535,7 +2540,7 @@ Example::
   processGroupMPI.def_static(
       "create",
       [](std::vector<int> ranks) {
-        return ::c10d::ProcessGroupMPI::createProcessGroupMPI(ranks);
+        return ::c10d::ProcessGroupMPI::createProcessGroupMPI(std::move(ranks));
       },
       py::call_guard<py::gil_scoped_release>());
 #endif
@@ -2712,12 +2717,12 @@ such as `dist.all_reduce(tensor, async_op=True)`.
       .def(
           "boxed",
           [](c10::intrusive_ptr<::c10d::Work> self) {
-            return torch::jit::toPyObject(c10::IValue(self));
+            return torch::jit::toPyObject(c10::IValue(std::move(self)));
           })
       .def_static("unbox", [](py::object obj) {
         auto typePtr =
             torch::getCustomClass("__torch__.torch.classes.c10d.Work");
-        auto ivalue = torch::jit::toIValue(obj, typePtr);
+        auto ivalue = torch::jit::toIValue(std::move(obj), typePtr);
         return ivalue.toCustomClass<::c10d::Work>();
       });
 
@@ -2787,12 +2792,11 @@ such as `dist.all_reduce(tensor, async_op=True)`.
       // Define a lambda such that the pybind11 prototype can take a std::vector
       // for the tensor list argument, but still pass it to the underlying
       // function as a c10::ArrayRef.
-      [](c10::intrusive_ptr<::c10d::ProcessGroup> process_group,
-         std::vector<at::Tensor> tensors, // NOLINT
+      [](const c10::intrusive_ptr<::c10d::ProcessGroup>& process_group,
+         const std::vector<at::Tensor>& tensors,
          size_t buffer_size,
          int rank) {
-        broadcast_coalesced(
-            std::move(process_group), tensors, buffer_size, rank);
+        broadcast_coalesced(process_group, tensors, buffer_size, rank);
       },
       py::arg("process_group"),
       py::arg("tensors"),
@@ -2875,7 +2879,7 @@ such as `dist.all_reduce(tensor, async_op=True)`.
 
   module.def(
       "_create_work_from_future",
-      [](std::shared_ptr<jit::PythonFutureWrapper> future) {
+      [](const std::shared_ptr<jit::PythonFutureWrapper>& future) {
         return ::c10d::Work::create_from_future(future->fut);
       },
       py::arg("future"),
@@ -2934,6 +2938,4 @@ PyMethodDef* python_functions() {
   return methods;
 }
 
-} // namespace c10d
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::c10d

--- a/torch/csrc/distributed/c10d/intra_node_comm.cpp
+++ b/torch/csrc/distributed/c10d/intra_node_comm.cpp
@@ -47,9 +47,6 @@ void* initTopoInfo(Topology topology, NvlMesh nvlMesh, size_t rank);
 // Topology Detection
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO: find a better way to determine this
-static constexpr size_t kMaxNvLinks = 20;
-
 static std::ostream& operator<<(std::ostream& os, const NvlMesh& nvlMesh) {
   std::ostringstream oss;
   for (size_t i = 0; i < kMaxDevices; ++i) {
@@ -97,6 +94,9 @@ static NvlMesh getNvlMesh(const std::vector<std::string>& rankToBusId) {
         driverApi->nvmlDeviceGetHandleByPciBusId_v2_(
             rankToBusId[r].c_str(), &devices[r]) == NVML_SUCCESS);
   }
+
+  // TODO: find a better way to determine this
+  constexpr size_t kMaxNvLinks = 20;
 
   // For each device, loop over devices connected to it via NVLink
   for (size_t idx = 0; idx < worldSize; ++idx) {

--- a/torch/csrc/distributed/c10d/intra_node_comm.hpp
+++ b/torch/csrc/distributed/c10d/intra_node_comm.hpp
@@ -9,7 +9,7 @@
 namespace c10d::intra_node_comm {
 
 constexpr size_t kMaxDevices = 8;
-constexpr size_t kDefaultBufferSize = 10 * 1024 * 1024;
+constexpr size_t kDefaultBufferSize = 10ull * 1024 * 1024;
 
 using NvlMesh = std::array<std::array<size_t, kMaxDevices>, kMaxDevices>;
 using HybridCubeMesh = std::array<std::array<int, 4>, kMaxDevices>;

--- a/torch/csrc/distributed/c10d/logger.hpp
+++ b/torch/csrc/distributed/c10d/logger.hpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/distributed/c10d/reducer.hpp>
 
 #include <mutex>
+#include <utility>
 
 namespace c10d {
 
@@ -124,8 +125,8 @@ class TORCH_API C10dLogger {
 
  protected:
   // singletion, hide constructor from the public
-  C10dLogger(const std::string& logDestination)
-      : logDestination_(logDestination) {}
+  C10dLogger(std::string logDestination)
+      : logDestination_(std::move(logDestination)) {}
 
   // the name of the destination this logger should log to
   std::string logDestination_;

--- a/torch/csrc/distributed/c10d/logger.hpp
+++ b/torch/csrc/distributed/c10d/logger.hpp
@@ -124,9 +124,8 @@ class TORCH_API C10dLogger {
 
  protected:
   // singletion, hide constructor from the public
-  C10dLogger(const std::string& logDestination) {
-    logDestination_ = logDestination;
-  }
+  C10dLogger(const std::string& logDestination)
+      : logDestination_(logDestination) {}
 
   // the name of the destination this logger should log to
   std::string logDestination_;


### PR DESCRIPTION
This PR continues to fix some clang-tidy warnings in distributed/c10d code, following https://github.com/pytorch/pytorch/pull/123312.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang