### PR TITLE
Use uv in lintrunner init when it is available.

### DIFF
--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -4,6 +4,7 @@ Initializer script that installs stuff to pip.
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -50,7 +51,12 @@ if __name__ == "__main__":
         stream=sys.stderr,
     )
 
-    pip_args = ["pip3", "install"]
+    uv_available = shutil.which("uv") is not None
+
+    if uv_available:
+        pip_args = ["uv", "pip", "install"]
+    else:
+        pip_args = ["pip", "install"]
 
     # If we are in a global install, use `--user` to install so that you do not
     # need root access in order to initialize linters.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124033

Before, a no-op lintrunner init takes 12s.  After, it takes 1s;
a full order of magnitude improvement.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>