### PR TITLE
[profiler] Log process group name instead of pg uid

### DIFF
--- a/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
@@ -8,9 +8,9 @@
 namespace torch {
 
 ParamCommsDebugInfo::ParamCommsDebugInfo(
-    int pgId,
+    std::tuple<std::string, std::string> pgName,
     int rank,
-    std::string&& colName,
+    std::string&& collName,
     int inNelems,
     int outNelems,
     at::ScalarType dType,
@@ -19,10 +19,10 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
     int globalRankStart,
     int globalRankStride,
     int worldSize)
-    : pgId_(pgId),
+    : pgName_(pgName),
       rank_(rank),
       worldSize_(worldSize),
-      columnName_(colName),
+      collectiveName_(collName),
       inMessageNelems_(inNelems),
       outMessageNelems_(outNelems),
       dType_(dType),

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
@@ -13,9 +13,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
  public:
   ParamCommsDebugInfo() = default;
   ParamCommsDebugInfo(
-      int pgId,
+      std::tuple<std::string, std::string> pgName,
       int rank,
-      std::string&& colName,
+      std::string&& collName,
       int inNelems,
       int outNelems,
       at::ScalarType dType,
@@ -27,8 +27,12 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
 
   ~ParamCommsDebugInfo() override = default;
 
-  int getProcessGroupId() const {
-    return pgId_;
+  const std::string getProcessGroupName() const {
+    return std::get<0>(pgName_);
+  }
+
+  const std::string getProcessGroupDesc() const {
+    return std::get<1>(pgName_);
   }
 
   int getRank() const {
@@ -47,8 +51,8 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     return globalRankStride_;
   }
 
-  const std::string getColumnName() const {
-    return columnName_;
+  const std::string getCollectiveName() const {
+    return collectiveName_;
   }
 
   int getInMessageNelems() const {
@@ -76,10 +80,10 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   }
 
  private:
-  int pgId_{};
+  std::tuple<std::string, std::string> pgName_; // <group_name, group_desc>
   int rank_{};
   int worldSize_{};
-  std::string columnName_;
+  std::string collectiveName_;
   int inMessageNelems_{};
   int outMessageNelems_{};
   at::ScalarType dType_ = at::kByte;
@@ -92,9 +96,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
 
 #define RECORD_PARAM_COMMS(                                                    \
     seq,                                                                       \
-    pgId,                                                                      \
+    pgName,                                                                    \
     rank,                                                                      \
-    colName,                                                                   \
+    collName,                                                                  \
     inNelems,                                                                  \
     outNelems,                                                                 \
     dType,                                                                     \
@@ -104,9 +108,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     globalRankStride,                                                          \
     worldSize)                                                                 \
   auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>(          \
-      pgId,                                                                    \
+      pgName,                                                                  \
       rank,                                                                    \
-      colName,                                                                 \
+      collName,                                                                \
       inNelems,                                                                \
       outNelems,                                                               \
       dType,                                                                   \
@@ -118,9 +122,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   std::initializer_list<const c10::IValue> paramList = {                       \
       c10::IValue(seq),                                                        \
-      pgId,                                                                    \
+      pgName,                                                                  \
       rank,                                                                    \
-      colName,                                                                 \
+      collName,                                                                \
       inSplitSizes,                                                            \
       outSplitSizes,                                                           \
       globalRankStart,                                                         \
@@ -131,11 +135,11 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
 
 #define RECORD_PARAM_COMMS_DATA(                                               \
     seq,                                                                       \
-    pgId,                                                                      \
+    pgName,                                                                    \
     InputTensors,                                                              \
     OutputTensors,                                                             \
     rank,                                                                      \
-    colName,                                                                   \
+    collName,                                                                  \
     inNelems,                                                                  \
     outNelems,                                                                 \
     dType,                                                                     \
@@ -145,9 +149,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
     globalRankStride,                                                          \
     worldSize)                                                                 \
   auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>(          \
-      pgId,                                                                    \
+      pgName,                                                                  \
       rank,                                                                    \
-      colName,                                                                 \
+      collName,                                                                \
       inNelems,                                                                \
       outNelems,                                                               \
       dType,                                                                   \
@@ -160,9 +164,9 @@ class TORCH_API ParamCommsDebugInfo : public c10::DebugInfoBase {
   std::initializer_list<const c10::IValue> paramList = {                       \
       c10::IValue(InputTensors),                                               \
       c10::IValue(seq),                                                        \
-      pgId,                                                                    \
+      pgName,                                                                  \
       rank,                                                                    \
-      colName,                                                                 \
+      collName,                                                                \
       inSplitSizes,                                                            \
       outSplitSizes,                                                           \
       globalRankStart,                                                         \

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -664,9 +664,9 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeInternal(
 bool ProcessGroupNCCL::WorkNCCL::wait(std::chrono::milliseconds timeout) {
   RECORD_PARAM_COMMS(
       static_cast<int>(this->seq_), // seq
-      0, // process group ptr
+      std::make_tuple("", ""), // PG name tuple
       rank_, // rank
-      "wait", // colName
+      "wait", // collective name
       0, // inNelems
       0, // outNelems
       at::kByte, // dType
@@ -864,20 +864,6 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       this->globalRankStride = -1;
     }
   }
-
-  RECORD_PARAM_COMMS(
-      0, // seq
-      static_cast<int>(uid_), // pg id
-      rank, // rank
-      "init", // colName
-      0, // inNelems
-      0, // outNelems
-      at::kByte, // dType
-      std::vector<int64_t>(), // inSplitSizes
-      std::vector<int64_t>(), // outSplitSizes
-      globalRankStart, // globalRankStart
-      globalRankStride, // globalRankStride
-      size_); // worldSize
 
   // Attach hooks to cache allocator to trigger the hooks whenever a traced
   // action is called. In the following hooks, we register a newly allocated
@@ -1934,6 +1920,9 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::getNCCLComm(
   // Create the unique NCCL ID and broadcast it
   ncclUniqueId ncclID;
 
+  // reset log prefix to include group_desc
+  logPrefix_ = createLogPrefix();
+
   // For batch_isend_irecv, ncclGroupStart() would be called upfront
   bool batchP2P = ncclActiveGroupCounter_ > 0;
   bool singleP2POp = isP2POp(opType, batchP2P);
@@ -2057,9 +2046,22 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::getNCCLComm(
   }
 #endif
 
-  logPrefix_ = createLogPrefix(); // reset log prefix to include group_desc
   NCCLTraceBuffer::get()->record_pg_ranks(
       std::make_tuple(pg_name_, pg_desc_), groupRanks());
+
+  RECORD_PARAM_COMMS(
+      0, // seq
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
+      rank, // rank
+      "init", // collective name
+      0, // inNelems
+      0, // outNelems
+      at::kByte, // dType
+      std::vector<int64_t>(), // inSplitSizes
+      std::vector<int64_t>(), // outSplitSizes
+      globalRankStart, // globalRankStart
+      globalRankStride, // globalRankStride
+      size_); // worldSize
 
   LOG(INFO) << logPrefix() << "ProcessGroupNCCL created ncclComm_ "
             << ncclComm->ncclComm_ << " on CUDA device: " << deviceIndex;
@@ -3130,11 +3132,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       tensors, // inputTensors
       tensors, // outputTensors
       rank_, // rank
-      "allreduce", // colName
+      "allreduce", // collective name
       tensor.numel(), // inNelems
       tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
@@ -3157,11 +3159,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce_coalesced(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       tensors, // inputTensors
       tensors, // outputTensors
       rank_, // rank
-      "allreduce_coalesced", // colName
+      "allreduce_coalesced", // collective name
       total_numel, // inNelems
       total_numel, // outNelems
       tensors[0].scalar_type(), // dType
@@ -3210,11 +3212,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::broadcast(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       tensors, // inputTensors
       tensors, // outputTensors
       opts.rootRank, // root rank
-      "broadcast", // colName
+      "broadcast", // collective name
       tensor.numel(), // inNelems
       tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
@@ -3304,11 +3306,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       tensors, // inputTensors
       tensors, // outputTensors
       opts.rootRank, // root rank
-      "reduce", // colName
+      "reduce", // collective name
       tensor.numel(), // inNelems
       tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
@@ -3400,11 +3402,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allgather(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      this->getID(),
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       inputTensors, // inputTensors
       outputTensors, // outputTensors
       rank_, // rank
-      "all_gather", // colName
+      "all_gather", // collective name
       inputTensor.numel(), // inNelems
       inputTensor.numel() * // outNelems
           this->getSize(),
@@ -3528,11 +3530,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce_scatter(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      this->getID(),
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       inputTensors, // inputTensors
       outputTensors, // outputTensors
       rank_, // rank
-      "reduce_scatter", // colName
+      "reduce_scatter", // collective name
       outputTensor.numel() * this->getSize(), // inNelems
       outputTensor.numel(), // outNelems
       outputTensor.scalar_type(), // dType
@@ -3638,11 +3640,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       inputTensor, // inputTensor
       outputTensor, // outputTensor
       rank_, // rank
-      "_reduce_scatter_base", // colName
+      "_reduce_scatter_base", // collective name
       inputTensor.numel(), // inNelems
       tensor.numel(), // outNelems
       tensor.scalar_type(), // dtype
@@ -3726,9 +3728,9 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::barrier(const BarrierOptions& opts) {
   RECORD_PARAM_COMMS(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       rank_, // rank
-      "barrier", // colName
+      "barrier", // collective name
       0, // inNelems
       0, // outNelems
       at::kByte, // dType
@@ -3795,11 +3797,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::alltoall_base(
         static_cast<int>(
             this->getSequenceNumberForGroup() +
             1), // seq + 1 to match collective
-        static_cast<int>(uid_), // pg id
+        std::make_tuple(pg_name_, pg_desc_), // PG name tuple
         inputTensor, // inputTensor
         outputTensor, // outputTensor
         rank_, // rank
-        "all_to_all", // colName
+        "all_to_all", // collective name
         inputTensor.numel(), // inNelems
         outputTensor.numel(), // outNelems
         inputTensor.scalar_type(), // dType
@@ -3837,11 +3839,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::alltoall_base(
         static_cast<int>(
             this->getSequenceNumberForGroup() +
             1), // seq + 1 to match collective
-        static_cast<int>(uid_), // pg id
+        std::make_tuple(pg_name_, pg_desc_), // PG name tuple
         inputTensor, // inputTensor
         outputTensor, // outputTensor
         rank_, // rank
-        "all_to_allv", // colName
+        "all_to_allv", // collective name
         inputTensor.numel(), // inNelems
         outputTensor.numel(), // outNelems
         inputTensor.scalar_type(), // dType
@@ -3915,11 +3917,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::alltoall(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       inputTensors, // inputTensors
       outputTensors, // outputTensors
       rank_, // rank
-      "all_to_all", // colName
+      "all_to_all", // collective name
       total_numel, // inNelems
       total_numel, // outNelems
       inputTensors.front().scalar_type(), // dType
@@ -3967,11 +3969,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::send(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       tensors, // inputTensors
       tensors, // outputTensors
       dstRank, // dst rank
-      "send", // colName
+      "send", // collective name
       tensor.numel(), // inNelems
       tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
@@ -4008,11 +4010,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::recv(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       tensors, // inputTensors
       tensors, // outputTensors
       srcRank, // src rank
-      "recv", // colName
+      "recv", // collective name
       tensor.numel(), // inNelems
       tensor.numel(), // outNelems
       tensor.scalar_type(), // dType
@@ -4108,11 +4110,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::gather(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       inputTensors, // inputTensors
       outputTensors, // outputTensors
       opts.rootRank, // root rank
-      "gather", // colName
+      "gather", // collective name
       inputTensor.numel(), // inNelems
       inputTensor.numel() * this->getSize(), // outNelems
       inputTensor.scalar_type(), // dType
@@ -4195,11 +4197,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::scatter(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       inputTensors, // inputTensors
       outputTensors, // outputTensors
       opts.rootRank, // root rank
-      "scatter", // colName
+      "scatter", // collective name
       outputTensor.numel() * this->getSize(), // inNelems
       outputTensor.numel(), // outNelems
       outputTensor.scalar_type(), // dType
@@ -4265,11 +4267,11 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_allgather_base(
   RECORD_PARAM_COMMS_DATA(
       static_cast<int>(
           this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
-      static_cast<int>(uid_), // pg id
+      std::make_tuple(pg_name_, pg_desc_), // PG name tuple
       input_tensor, // inputTensors
       output_tensor, // outputTensors
       rank_, // rank
-      "_allgather_base", // colName
+      "_allgather_base", // collective name
       input_tensor.numel(), // inNelems
       output_tensor.numel(), // outNelems
       output_tensor.scalar_type(), // dType

--- a/torch/csrc/distributed/c10d/UCCTracing.cpp
+++ b/torch/csrc/distributed/c10d/UCCTracing.cpp
@@ -150,7 +150,7 @@ void CommTraceLogger::recordComms(
   // record the trace to kineto trace if applicable
   RECORD_PARAM_COMMS(
       static_cast<int64_t>(seqnum), // seq
-      0, // process group ptr
+      std::make_tuple("0", ""), // pg_name tuple
       rank,
       commName.c_str(),
       inNelems,

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -326,7 +326,7 @@ static bool initExecutionTraceStart(ExecutionTraceObserver& ob) {
 
   ob.out << fmt::format(
       R"JSON({{
-  "schema": "1.0.2-chakra.0.0.4", "pid": {}, "time": "{}", "start_ts": {},
+  "schema": "1.0.3-chakra.0.0.4", "pid": {}, "time": "{}", "start_ts": {},
   "nodes": [)JSON",
       ob.pid,
       ob.record_time,

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -338,7 +338,7 @@ std::vector<std::string> inputTypes(const at::RecordFunction& fn) {
 // ----------------------------------------------------------------------------
 #ifdef USE_DISTRIBUTED
 #ifdef USE_C10D
-static constexpr auto kCommuName = "Collective name";
+static constexpr auto kCommsName = "Collective name";
 static constexpr auto kDtype = "dtype";
 static constexpr auto kInMsgNelems = "In msg nelems";
 static constexpr auto kOutMsgNelems = "Out msg nelems";
@@ -347,7 +347,8 @@ static constexpr auto kOutSplit = "Out split size";
 static constexpr auto kGlobalRankStart = "Global rank start";
 static constexpr auto kGlobalRankStride = "Global rank stride";
 static constexpr auto kGroupSize = "Group size";
-static constexpr auto kProcessGroupId = "Process Group ID";
+static constexpr auto kProcessGroupName = "Process Group Name";
+static constexpr auto kProcessGroupDesc = "Process Group Description";
 static constexpr auto kGroupRanks = "Process Group Ranks";
 
 static constexpr int32_t kTruncatLength = 30;
@@ -367,7 +368,8 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
     return map;
   }
 
-  map.emplace(kCommuName, fmt::format("\"{}\"", debugInfo->getColumnName()));
+  map.emplace(
+      kCommsName, fmt::format("\"{}\"", debugInfo->getCollectiveName()));
   map.emplace(
       kDtype, fmt::format("\"{}\"", c10::toString(debugInfo->getDType())));
   map.emplace(kInMsgNelems, std::to_string(debugInfo->getInMessageNelems()));
@@ -400,12 +402,23 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
                 outSplitSizes.begin() + kTruncatLength,
                 ", ")));
   }
-  map.emplace(
-      kGlobalRankStart, std::to_string(debugInfo->getGlobalRankStart()));
-  map.emplace(
-      kGlobalRankStride, std::to_string(debugInfo->getGlobalRankStride()));
+  auto globalRankStart = debugInfo->getGlobalRankStart();
+  if (globalRankStart >= 0) {
+    map.emplace(kGlobalRankStart, std::to_string(globalRankStart));
+  }
+  auto globalRankStride = debugInfo->getGlobalRankStride();
+  if (globalRankStride > 0) {
+    map.emplace(kGlobalRankStride, std::to_string(globalRankStride));
+  }
   map.emplace(kGroupSize, std::to_string(debugInfo->getWorldSize()));
-  map.emplace(kProcessGroupId, std::to_string(debugInfo->getProcessGroupId()));
+  auto& group_name = debugInfo->getProcessGroupName();
+  if (!group_name.empty()) {
+    map.emplace(kProcessGroupName, fmt::format("\"{}\"", group_name));
+  }
+  auto& group_desc = debugInfo->getProcessGroupDesc();
+  if (!group_desc.empty()) {
+    map.emplace(kProcessGroupDesc, fmt::format("\"{}\"", group_desc));
+  }
   auto& groupRanks = debugInfo->getGroupRanks();
   if (!groupRanks.empty() && groupRanks.size() <= kTruncatLength) {
     map.emplace(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -562,7 +562,7 @@ class _World:
             config_info.append(
                 {
                     "pg_name": self.pg_names[pg],
-                    "uid": _get_process_group_uid(pg),
+                    "pg_desc": pg.group_desc,
                     "backend_config": self.pg_backend_config[pg],
                     "ranks": list(ranks.keys())
                     if len(ranks) != default_pg_size
@@ -1097,7 +1097,7 @@ def _get_pg_config(group: Optional[ProcessGroup] = None) -> Dict[str, Any]:
         pg = group
     return {
         "pg_name": _get_process_group_name(pg),
-        "uid": _get_process_group_uid(pg),
+        "pg_desc": pg.group_desc,
         "backend_config": get_backend_config(pg),
         "pg_size": _get_group_size(pg),
         "ranks": get_process_group_ranks(pg),


### PR DESCRIPTION
Summary:
As part of the work of unifying process group identifier, log <group_name, group_desc>,  instead of pg uid in profiler.
- group_name remains as the unique identifier, e.g. “0”, "1"
- group_desc will be the user specified name, e.g. "fsdp".

Reviewed By: aaronenyeshi, kwen2501

Differential Revision: D55610682




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang