### PR TITLE
[Distributed] [5/N] Fix clang-tidy warnings in torch/csrc/distributed/c10d

### DIFF
--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <condition_variable>
 #include <memory>
-#include <mutex>
-#include <stdexcept>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -15,9 +15,9 @@ class WorkRegistry {
   void register_work(
       const at::Tensor& tensor,
       const c10::intrusive_ptr<c10d::Work>& work) {
-    const auto storage = tensor.storage().getWeakStorageImpl();
+    auto storage = tensor.storage().getWeakStorageImpl();
     std::unique_lock lock(lock_);
-    auto [it, inserted] = registry_.emplace(storage, work);
+    auto [it, inserted] = registry_.try_emplace(std::move(storage), work);
     TORCH_CHECK(
         inserted || it->second != work,
         "The tensor storage is already associated with another work.");

--- a/torch/csrc/distributed/c10d/HashStore.hpp
+++ b/torch/csrc/distributed/c10d/HashStore.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <sys/types.h>
-
 #include <condition_variable>
 #include <mutex>
 #include <unordered_map>

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -465,7 +465,7 @@ allreduce_sparse_cuda_(
                   ->allreduce_sparse(
                       tensor_vec,
                       AllreduceOptions{
-                          *reduce_op.get(),
+                          *reduce_op,
                           std::chrono::milliseconds(timeout),
                           sparse_indices});
 

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
@@ -22,7 +22,7 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
     : pgName_(pgName),
       rank_(rank),
       worldSize_(worldSize),
-      collectiveName_(collName),
+      collectiveName_(std::move(collName)),
       inMessageNelems_(inNelems),
       outMessageNelems_(outNelems),
       dType_(dType),

--- a/torch/csrc/distributed/c10d/PrefixStore.hpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <torch/csrc/distributed/c10d/Store.hpp>
-#include <memory>
 
 namespace c10d {
 

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
 #include <torch/csrc/distributed/c10d/Backend.hpp>
-#include <condition_variable>
 #include <memory>
-#include <mutex>
-#include <stdexcept>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -6,7 +6,6 @@
 #include <deque>
 #include <mutex>
 #include <thread>
-#include <unordered_map>
 #include <vector>
 
 #include <gloo/algorithm.h>

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -106,7 +106,8 @@ c10::intrusive_ptr<c10::ivalue::Future> ProcessGroupMPI::WorkMPI::getFuture() {
   return future_;
 }
 
-void ProcessGroupMPI::WorkMPI::finishWorkMPIError(std::exception_ptr eptr) {
+void ProcessGroupMPI::WorkMPI::finishWorkMPIError(
+    const std::exception_ptr& eptr) {
   future_->setError(eptr);
   finish(eptr);
 }
@@ -131,7 +132,7 @@ ProcessGroupMPI::AsyncWork::~AsyncWork() {
   if (request_ != MPI_REQUEST_NULL) {
     std::cerr
         << "Attempted destruction of AsyncWork before work has completed, "
-        << "terminating the program." << std::endl;
+        << "terminating the program." << '\n';
     std::terminate();
   }
 }
@@ -209,7 +210,7 @@ std::vector<at::Tensor> ProcessGroupMPI::AsyncWork::result() {
 }
 
 void ProcessGroupMPI::AsyncWork::populateException() {
-  std::array<char, MPI_MAX_ERROR_STRING> buf;
+  std::array<char, MPI_MAX_ERROR_STRING> buf{};
   int len = buf.size();
   MPI_CHECK(MPI_Error_string(status_.MPI_ERROR, buf.data(), &len));
   exception_ =
@@ -266,8 +267,8 @@ c10::intrusive_ptr<ProcessGroupMPI> ProcessGroupMPI::createProcessGroupMPI(
 
     // If no ranks are specified, assume we're creating the root group
     if (!ranks.empty()) {
-      MPI_Group worldGroup;
-      MPI_Group ranksGroup;
+      MPI_Group worldGroup = nullptr;
+      MPI_Group ranksGroup = nullptr;
       MPI_CHECK(MPI_Comm_group(MPI_COMM_WORLD, &worldGroup));
       MPI_CHECK(
           MPI_Group_incl(worldGroup, ranks.size(), ranks.data(), &ranksGroup));
@@ -382,7 +383,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::enqueue(
   auto work =
       c10::make_intrusive<WorkMPI>(entry->dst, profilingTitle, inputTensors);
   std::unique_lock<std::mutex> lock(pgMutex_);
-  queue_.push_back(std::make_tuple(std::move(entry), work));
+  queue_.emplace_back(std::move(entry), work);
   lock.unlock();
   queueProduceCV_.notify_one();
   return work;
@@ -538,7 +539,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::gather(
   checkSingleTensor(inputTensors);
 
   if (rank_ != opts.rootRank) {
-    if (outputTensors.size() > 0) {
+    if (!outputTensors.empty()) {
       TORCH_CHECK(
           false,
           "Gather: number of output tensors should be 0 "
@@ -614,7 +615,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::scatter(
   checkSingleTensor(outputTensors);
 
   if (rank_ != opts.rootRank) {
-    if (inputTensors.size() > 0) {
+    if (!inputTensors.empty()) {
       TORCH_CHECK(
           false,
           "Scatter: number of input tensors should be 0 "
@@ -669,7 +670,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::scatter(
     return enqueue(
         std::move(entry),
         "mpi:scatter",
-        inputTensors.size() > 0
+        !inputTensors.empty()
             ? c10::optional<std::vector<at::Tensor>>(inputTensors[0])
             : c10::nullopt);
   } else {
@@ -678,7 +679,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::scatter(
     return enqueue(
         std::move(entry),
         "mpi:scatter",
-        inputTensors.size() > 0
+        !inputTensors.empty()
             ? c10::optional<std::vector<at::Tensor>>(inputTensors[0])
             : c10::nullopt);
   }
@@ -700,7 +701,7 @@ c10::intrusive_ptr<Work> ProcessGroupMPI::alltoall_base(
   checkSingleTensorHelper(inputTensor);
   checkSingleTensorHelper(outputTensor);
 
-  if (outputSplitSizes.size() == 0 && inputSplitSizes.size() == 0) {
+  if (outputSplitSizes.empty() && inputSplitSizes.empty()) {
     // We can use alltoall
     TORCH_CHECK(
         outputTensor.numel() == inputTensor.numel() &&

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -3,7 +3,6 @@
 #ifdef USE_C10D_MPI
 
 #include <iostream>
-#include <limits>
 #include <map>
 
 #include <c10/core/DeviceGuard.h>

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
@@ -102,7 +102,7 @@ class TORCH_API ProcessGroupMPI : public Backend {
 
    private:
     void finishWorkMPI();
-    void finishWorkMPIError(std::exception_ptr eptr);
+    void finishWorkMPIError(const std::exception_ptr& eptr);
 
     std::vector<at::Tensor> outputTensors_;
     c10::intrusive_ptr<at::ivalue::Future> future_;
@@ -137,7 +137,7 @@ class TORCH_API ProcessGroupMPI : public Backend {
    private:
     const std::vector<at::Tensor> outputTensors_;
     MPI_Request request_;
-    MPI_Status status_;
+    MPI_Status status_{};
   };
 
   // Constructor will spawn up the worker thread loop

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1,13 +1,11 @@
-#include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
-#include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
-#include <fstream>
-#include <mutex>
-#include <sstream>
 
 #ifdef USE_C10D_NCCL
 
 #include <exception>
+#include <fstream>
 #include <map>
+#include <mutex>
+#include <sstream>
 #include <stdexcept>
 #include <tuple>
 #include <unordered_set>
@@ -25,8 +23,10 @@
 #include <c10/util/Optional.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/cuda/nccl.h>
+#include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
 #include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
 #include <torch/csrc/distributed/c10d/TraceUtils.h>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/csrc/distributed/c10d/logger.hpp>

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
+#ifdef USE_C10D_NCCL
+
 #if defined(__linux__)
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 #endif
-
-#ifdef USE_C10D_NCCL
 
 #include <atomic>
 #include <chrono>

--- a/torch/csrc/distributed/c10d/Store.hpp
+++ b/torch/csrc/distributed/c10d/Store.hpp
@@ -2,7 +2,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -5,13 +5,9 @@
 #include <torch/csrc/distributed/c10d/logging.h>
 
 #include <fcntl.h>
-#include <algorithm>
-#include <array>
 #include <chrono>
 #include <fstream>
 #include <random>
-#include <streambuf>
-#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <utility>

--- a/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
+++ b/torch/csrc/distributed/c10d/TCPStoreBackend.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <chrono>
 #include <thread>
-#include <vector>
 
 #include <torch/csrc/distributed/c10d/TCPStore.hpp>
 #include <torch/csrc/distributed/c10d/socket.h>

--- a/torch/csrc/distributed/c10d/Types.hpp
+++ b/torch/csrc/distributed/c10d/Types.hpp
@@ -67,8 +67,10 @@ struct TORCH_API ReduceOp : torch::CustomClassHolder {
   // The heap resource supplement_, if it exists, is managed by a
   // c10::intrusive_ptr, so constructors and operator= can be simple
   ReduceOp(const ReduceOp& other) = default;
-
   ReduceOp& operator=(const ReduceOp& other) = default;
+
+  ReduceOp(ReduceOp&& other) = default;
+  ReduceOp& operator=(ReduceOp&& other) = default;
 
   operator RedOpType() const {
     return op_;

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -21,14 +21,10 @@ typedef SSIZE_T ssize_t;
 
 #include <sys/types.h>
 
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
-#include <limits>
 #include <string>
-#include <system_error>
-#include <tuple>
 #include <vector>
 
 namespace c10d {

--- a/torch/csrc/distributed/c10d/Work.hpp
+++ b/torch/csrc/distributed/c10d/Work.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
-#include <stdexcept>
+#include <mutex>
 #include <vector>
 
 constexpr auto kNoTimeout = std::chrono::milliseconds(0);

--- a/torch/csrc/distributed/c10d/Work.hpp
+++ b/torch/csrc/distributed/c10d/Work.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <chrono>
 #include <mutex>
 #include <vector>
 

--- a/torch/csrc/distributed/c10d/logger.hpp
+++ b/torch/csrc/distributed/c10d/logger.hpp
@@ -1,7 +1,6 @@
 #include <c10/util/Logging.h>
 #include <torch/csrc/distributed/c10d/reducer.hpp>
 
-#include <mutex>
 #include <utility>
 
 namespace c10d {

--- a/torch/csrc/distributed/c10d/logging.cpp
+++ b/torch/csrc/distributed/c10d/logging.cpp
@@ -8,8 +8,7 @@
 
 #include <torch/csrc/distributed/c10d/debug.h>
 
-namespace c10d {
-namespace detail {
+namespace c10d::detail {
 
 bool isLogLevelEnabled(LogLevel level) noexcept {
   // c10 logger does not support debug and trace levels. In order to map higher
@@ -35,5 +34,4 @@ bool isLogLevelEnabled(LogLevel level) noexcept {
   return false;
 }
 
-} // namespace detail
-} // namespace c10d
+} // namespace c10d::detail

--- a/torch/csrc/distributed/c10d/sequence_num.hpp
+++ b/torch/csrc/distributed/c10d/sequence_num.hpp
@@ -3,6 +3,7 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/Optional.h>
 #include <c10/util/irange.h>
+#include <mutex>
 #include <vector>
 
 namespace c10d {


### PR DESCRIPTION
This PR continues to fix some clang-tidy warnings in distributed/c10d code, following https://github.com/pytorch/pytorch/pull/124032.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k