### PR TITLE
[BASE_MODULE] removing base_module for glow/fb/test:test_utils

### DIFF
--- a/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchmatmul_nnpi_fp16.py
@@ -2,12 +2,12 @@
 
 import numpy as np
 import unittest
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import datetime
 from hypothesis import given, settings
 import hypothesis.strategies as st

--- a/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
@@ -1,14 +1,14 @@
 import numpy as np
 import unittest
 
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import caffe2.python.serialized_test.serialized_test_util as serial
 import datetime
 

--- a/caffe2/contrib/fakelowp/test/test_chunking.py
+++ b/caffe2/contrib/fakelowp/test/test_chunking.py
@@ -1,12 +1,12 @@
 # Must happen before importing caffe2.python.*
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 import datetime
 import numpy as np
 from hypothesis import given, settings, example
 from hypothesis import strategies as st
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import caffe2.python.serialized_test.serialized_test_util as serial
 
 # Test that parallel chunks behave the same way as the serial one

--- a/caffe2/contrib/fakelowp/test/test_deq_swish_quant_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_deq_swish_quant_nnpi.py
@@ -1,8 +1,8 @@
 import numpy as np
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import caffe2.python.serialized_test.serialized_test_util as serial
 import datetime
 from hypothesis import settings

--- a/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_fc_nnpi_fp16.py
@@ -1,14 +1,14 @@
 import numpy as np
 import unittest
 
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import datetime
 import caffe2.python.serialized_test.serialized_test_util as serial
 

--- a/caffe2/contrib/fakelowp/test/test_fusions.py
+++ b/caffe2/contrib/fakelowp/test/test_fusions.py
@@ -1,5 +1,5 @@
 # Must happen before importing caffe2.python.*
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 import datetime
 import numpy as np
 from hypothesis import given, settings
@@ -7,7 +7,7 @@ from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import caffe2.python.serialized_test.serialized_test_util as serial
 
 workspace.GlobalInit(

--- a/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_ops_nnpi.py
@@ -1,9 +1,9 @@
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 import numpy as np
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from hypothesis import given, strategies as st, settings
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import caffe2.python.serialized_test.serialized_test_util as serial
 import datetime
 

--- a/caffe2/contrib/fakelowp/test/test_int8_quant.py
+++ b/caffe2/contrib/fakelowp/test/test_int8_quant.py
@@ -1,5 +1,5 @@
 # Must happen before importing caffe2.python.*
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 import datetime
 import numpy as np
 from caffe2.proto import caffe2_pb2

--- a/caffe2/contrib/fakelowp/test/test_layernorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_layernorm_nnpi_fp16.py
@@ -1,10 +1,10 @@
 import numpy as np
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 from hypothesis import given, settings
 from hypothesis import strategies as st
 import caffe2.python.serialized_test.serialized_test_util as serial

--- a/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_op_nnpi_fp16.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 import datetime
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -8,8 +8,8 @@ from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 from caffe2.python import workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
-from caffe2.python.fakelowp.test_utils import compute_ulp_error
+from glow.fb.test.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import compute_ulp_error
 import caffe2.python.serialized_test.serialized_test_util as serial
 
 core.GlobalInit(["caffe2", "--caffe2_log_level=-3", "--glow_global_fp16=1"])

--- a/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_4bit_nnpi_fp16.py
@@ -2,14 +2,14 @@ import numpy as np
 import unittest
 
 # Must happen before importing caffe2.python.*
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import caffe2.python.serialized_test.serialized_test_util as serial
 import datetime
 

--- a/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp16.py
@@ -2,7 +2,7 @@ import unittest
 from typing import Dict, Any
 
 # Must happen before importing caffe2.python.*
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 import datetime
 import numpy as np
 from hypothesis import given, settings
@@ -10,7 +10,7 @@ from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import caffe2.python.serialized_test.serialized_test_util as serial
 
 workspace.GlobalInit(

--- a/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
+++ b/caffe2/contrib/fakelowp/test/test_sls_8bit_nnpi_fp32.py
@@ -1,7 +1,7 @@
 import unittest
 
 # Must happen before importing caffe2.python.*
-import caffe2.python.fakelowp.init_shared_libs  # noqa
+import glow.fb.test.init_shared_libs  # noqa
 import datetime
 import numpy as np
 from hypothesis import given, settings
@@ -9,7 +9,7 @@ from hypothesis import strategies as st
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
-from caffe2.python.fakelowp.test_utils import print_test_debug_info
+from glow.fb.test.test_utils import print_test_debug_info
 import caffe2.python.serialized_test.serialized_test_util as serial
 
 workspace.GlobalInit(


### PR DESCRIPTION
Summary: This is an attempt to reduce the number of buck targets with unnecessary base_module.

Test Plan: CI

Differential Revision: D56139116


