### PR TITLE
Support Triton Kernel in Execution Trace

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -21,6 +21,7 @@ import torch.nn as nn
 import torch.optim
 import torch.utils.data
 import torch.utils.data.datapipes as dp
+from torch import _dynamo as torchdynamo
 from torch.autograd import (
     _record_function_with_args_enter,
     _record_function_with_args_exit,
@@ -53,7 +54,13 @@ from torch.profiler._pattern_matcher import (
     report_all_anti_patterns,
     SynchronizedDataLoaderPattern,
 )
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
+
+from torch.testing._internal.common_cuda import (
+    _get_torch_cuda_version,
+    TEST_CUDA,
+    TEST_MULTIGPU,
+)
+
 from torch.testing._internal.common_device_type import skipCUDAVersionIn
 from torch.testing._internal.common_utils import (
     IS_JETSON,
@@ -69,6 +76,8 @@ from torch.testing._internal.common_utils import (
     TestCase,
     skipIfTorchDynamo,
 )
+
+from torch.utils._triton import has_triton
 
 Json = Dict[str, Any]
 
@@ -484,42 +493,49 @@ class TestExecutionTrace(TestCase):
         assert loop_count == expected_loop_events
 
     @unittest.skipIf(IS_WINDOWS, 'torch.compile does not support WINDOWS')
+    @unittest.skipIf(sys.version_info >= (3, 12), "torch.compile is not supported on python 3.12+")
+    @unittest.skipIf(not TEST_CUDA or not has_triton(), "need CUDA and triton to run")
     def test_execution_trace_with_pt2(self):
 
-        class ConvAndRelu(nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.linear = nn.Linear(4096, 4096)
-                self.relu = nn.ReLU(inplace=True)
+        @torchdynamo.optimize("inductor")
+        def fn(a, b, c):
+            x = torch.nn.functional.linear(a, b)
+            x = x + c
+            return x.cos()
 
-            def forward(self, x: torch.Tensor) -> torch.Tensor:
-                x = self.linear(x)
-                x = self.relu(x)
-                return x
+        a, b, c = (torch.randn(4, 4, requires_grad=True).to("cuda") for _ in range(3))
+
+        inputs = [a, b, c]
+        fn(*inputs)
 
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile('w+t', suffix='.et.json', delete=False)
         fp.close()
 
-        test_module = torch.compile(ConvAndRelu())
-
-        x = torch.rand(128, 4096)
-        et = ExecutionTraceObserver().register_callback(fp.name)
-        et.start()
-        test_module.forward(x)
-        et.stop()
+        et_file = fp.name
+        et = ExecutionTraceObserver()
+        et.register_callback(et_file)
+        with profile(activities=torch.profiler.supported_activities(), record_shapes=True):
+            et.start()
+            fn(*inputs)
+            et.stop()
 
         assert fp.name == et.get_output_file_path()
         et.unregister_callback()
+
         nodes = self.get_execution_trace_root(fp.name)
 
-        found_root_node = False
+        found_captured_triton_kernel_node = False
         for n in nodes:
             assert "name" in n
-            if "[pytorch|profiler|execution_trace|process]" in n["name"]:
-                found_root_node = True
+            if "triton_" in n["name"]:
+                for attr in n['attrs']:
+                    if attr['name'] == 'kernel_file' and attr['value'] != '':
+                        found_captured_triton_kernel_node = True
+                        assert len(n['inputs']['values']) > 0
+                        assert len(n['outputs']['values']) == 0
 
-        assert found_root_node
+        assert found_captured_triton_kernel_node
 
     def test_execution_trace_start_stop(self):
         use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -1,6 +1,7 @@
 import gzip
 import json
 import os
+import shutil
 import tempfile
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -788,6 +789,27 @@ class ExecutionTraceObserver(_ITraceObserver):
         """
         if self._registered:
             self.stop()
+
+            # Save the kernel paths for the generated kernels
+            from torch._inductor.codecache import PyCodeCache as PyCodeCache
+
+            kernel_files = [
+                v.__file__
+                for v in PyCodeCache.cache.values()
+                if getattr(v, "__file__", None) is not None
+            ]
+            work_dir, file_name = os.path.split(self._output_file_path)
+            resource_dir = os.path.join(work_dir, os.path.splitext(file_name)[0] + "_resources")
+            if not os.path.exists(resource_dir):
+                os.mkdir(resource_dir)
+
+            for kernel_file in kernel_files:
+                if kernel_file is None:
+                    continue
+                path, name = os.path.split(kernel_file)
+                dst = os.path.join(resource_dir, name)
+                shutil.copyfile(kernel_file, dst)
+
             _remove_execution_trace_observer()
             self._registered = False
 


### PR DESCRIPTION
Summary: This DIFF is to capture triton kernels in execution trace. The kernel files are copied to (execution trace file name)_resources directory. For example, et file is alextnet_et.json, then the kernels are in alexnet_et_resources.

Test Plan: buck test  mode/dev-nosan caffe2/test:profiler -- test_execution_trace_with_pt2

Differential Revision: D56033769


