### PR TITLE
[CI] Reduce CI_SERIAL_LIST list

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -449,7 +449,7 @@ def parse_reenabled_issues(s: Optional[str]) -> List[str]:
 
 
 def get_reenabled_issues(pr_body: str = "") -> List[str]:
-    default_branch = os.getenv("GIT_DEFAULT_BRANCH", "main")
+    default_branch = os.getenv("GIT_DEFAULT_BRANCH", "origin/main")
     try:
         commit_messages = subprocess.check_output(
             f"git cherry -v {default_branch}".split(" ")

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -449,7 +449,7 @@ def parse_reenabled_issues(s: Optional[str]) -> List[str]:
 
 
 def get_reenabled_issues(pr_body: str = "") -> List[str]:
-    default_branch = os.getenv("GIT_DEFAULT_BRANCH", "origin/main")
+    default_branch = os.getenv("GIT_DEFAULT_BRANCH", "main")
     try:
         commit_messages = subprocess.check_output(
             f"git cherry -v {default_branch}".split(" ")

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,3 +19,6 @@ filterwarnings =
     ignore:Module already imported so cannot be rewritten.*hypothesis:pytest.PytestAssertRewriteWarning
 
 xfail_strict = True
+
+markers =
+    serial: marks tests as needs to be run serially (deselect with '-m "not serial"')

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -70,6 +70,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     IS_X86,
     parametrize,
+    serialTest,
     skipIfRocm,
     subtest,
     TEST_WITH_ASAN,
@@ -9278,6 +9279,7 @@ class CommonTemplate:
     @config.patch(
         "triton.autotune_pointwise", True
     )  # needed to introduce config that exceed max shared memory usage
+    @serialTest()
     def test_large_block_sizes(self):
         """
         Inductor will try triton configs like x = 64 and y = 1024 which will

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1511,7 +1511,6 @@ def run_test_module(
         maybe_set_hip_visible_devies()
 
         test_name = test.name
-        start = time.time()
 
         # Printing the date here can help diagnose which tests are slow
         print_to_stderr(f"Running {str(test)} ... [{datetime.now()}]")
@@ -1520,9 +1519,6 @@ def run_test_module(
         assert isinstance(return_code, int) and not isinstance(
             return_code, bool
         ), f"While running {str(test)} got non integer return code {return_code}"
-        print(
-            f"TIME INFO: Took {time.time() - start:.2f}s to run {str(test)}, expected time {test.time}s"
-        )
         if return_code == 0:
             return None
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1285,6 +1285,7 @@ def must_serial(file: Union[str, ShardedTest]) -> bool:
         or DISTRIBUTED_TEST_PREFIX in file
         or file in CUSTOM_HANDLERS
         or file in RUN_PARALLEL_BLOCKLIST
+        or file in CI_SERIAL_LIST
         or file in JIT_EXECUTOR_TESTS
         or file in ONNX_SERIAL_LIST
         or NUM_PROCS == 1

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -97,6 +97,11 @@ from torch.utils._import_utils import _check_module_exists
 import torch.utils._pytree as pytree
 
 from .composite_compliance import no_dispatch
+try:
+    import pytest
+    has_pytest = True
+except ImportError:
+    has_pytest = False
 
 
 # Class to keep track of test flags configurable by environment variables.
@@ -1384,6 +1389,15 @@ def skipIfTorchInductor(msg="test doesn't currently work with torchinductor",
 
     return decorator
 
+def serialTest(condition=True):
+    """
+    Decorator for running tests serially.  Requires pytest
+    """
+    def decorator(fn):
+        if has_pytest and condition:
+            return pytest.mark.serial(fn)
+        return fn
+    return decorator
 
 def unMarkDynamoStrictTest(cls=None):
     def decorator(cls):


### PR DESCRIPTION
Add serial marker for individual tests so the test file can be removed from the ci serial list
Run serial marked tests first in serial
Run all other tests afterwards in parallel

Slowly reduce list and mark individual tests as serial instead

Hope # of serial tests is small so sharding evenness doesn't get too messed up

Hopefully can do 3 procs for sm86 and cpu?

serial no longer looks like a real word to me


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang