### PR TITLE
Adds LSE output for templated-attention-hop if inputs require grad

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -412,9 +412,8 @@ class BenchmarkRequest:
             input_tensor_meta = [input_tensor_meta]
         self.input_tensor_meta = input_tensor_meta
 
-        if isinstance(output_tensor_meta, (tuple, list)):
-            assert len(output_tensor_meta) == 1
-            output_tensor_meta = output_tensor_meta[0]
+        if isinstance(output_tensor_meta, TensorMeta):
+            output_tensor_meta = [output_tensor_meta]
         self.output_tensor_meta = output_tensor_meta
 
         self.extra_args = extra_args

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1706,12 +1706,15 @@ class KernelTemplate:
         return None
 
     @staticmethod
-    def _fake_get_dtype(fake_out):
+    def _fake_get_dtype(fake_outs):
         _get_dtype_real = V.graph.get_dtype
 
         def get_dtype(name):
-            if name == fake_out.get_name():
-                return fake_out.get_dtype()
+            name_map = {
+                fake_out.get_name(): fake_out.get_dtype() for fake_out in fake_outs
+            }
+            if name in name_map:
+                return name_map[name]
             return _get_dtype_real(name)
 
         return get_dtype

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5543,7 +5543,7 @@ class MultiOutput(ExternKernel):
         ]
 
 
-class MultiOutputAlloc(MultiOutput):
+class MultiOutputOut(MultiOutput):
     def should_allocate(self):
         return True
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5543,6 +5543,11 @@ class MultiOutput(ExternKernel):
         ]
 
 
+class MultiOutputAlloc(MultiOutput):
+    def should_allocate(self):
+        return True
+
+
 def _prepare_convolution_fusion_create(
     cls,
     x: "TensorBox",


### PR DESCRIPTION
# Summary
Prep PR for adding autograd support to templated-attention-hop. The kernel needs to output the LSE during the forward which will be used during backwards. If we are not computing autograd though we don't want to realize this tensor to its full size. This is similar to what is done for torch.nn.fucntional.sdpa




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang