### PR TITLE
[BE] Do not use `using namespace` in mps headers

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -5,6 +5,7 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 
+#include <cstdint>
 
 #ifdef __OBJC__
 #include <Foundation/Foundation.h>
@@ -21,8 +22,6 @@ typedef void* MTLLibrary_t;
 typedef void* MTLComputePipelineState_t;
 typedef void* MTLLibrary_t;
 #endif
-
-using namespace std;
 
 namespace at::mps {
 

--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -5,7 +5,6 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 
-#include <cstdint>
 
 #ifdef __OBJC__
 #include <Foundation/Foundation.h>

--- a/aten/src/ATen/mps/MPSProfiler.h
+++ b/aten/src/ATen/mps/MPSProfiler.h
@@ -9,12 +9,12 @@
 #include <os/signpost.h>
 #include <os/log.h>
 
+#include <atomic>
+#include <ctime>
 #include <sstream>
 #include <string>
-#include <atomic>
 #include <unordered_map>
 #include <utility>
-#include <ctime>
 
 namespace at::mps {
 
@@ -296,7 +296,7 @@ public:
   // during runtime (instead of environment variables).
   // The "mode" could be either "interval", "event", or both "interval,event"
   // for interval-based and/or event-based signpost tracing.
-  void StartTrace(const string& mode, bool waitUntilCompleted);
+  void StartTrace(const std::string& mode, bool waitUntilCompleted);
   void StopTrace();
 
   // convenience functions to indicate whether signpost tracing or

--- a/aten/src/ATen/mps/MPSProfiler.mm
+++ b/aten/src/ATen/mps/MPSProfiler.mm
@@ -195,7 +195,7 @@ void MPSProfiler::initialize() {
   }
 }
 
-void MPSProfiler::StartTrace(const string& mode, bool waitUntilCompleted) {
+void MPSProfiler::StartTrace(const std::string& mode, bool waitUntilCompleted) {
   TORCH_CHECK(m_profile_options == ProfileOptions::OPTIONS_NONE, "Tracing Signposts is already enabled ");
 
   std::stringstream ss(mode);

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -318,8 +318,8 @@ static void impl_func_norm_mps(const Tensor& input_tensor,
 
   auto reciprocal_p = 1 / p;
   bool pIsZero = (p == 0.0);
-  bool pIsPosInf = (p == numeric_limits<double>::infinity());
-  bool pIsNegInf = (p == -numeric_limits<double>::infinity());
+  bool pIsPosInf = (p == std::numeric_limits<double>::infinity());
+  bool pIsNegInf = (p == -std::numeric_limits<double>::infinity());
 
   int64_t num_input_dims = input_shape.size();
   int64_t num_reduce_dims = dim.size();


### PR DESCRIPTION
- Remove `using namespace std` from `MPSDevice.h`
- Add `std::` prefix to 1st argument of `MPSProfiler::StartTrace`
- Do the same in front of `numeric_limits` template instantiation in `ReduceOps.mm`