### PR TITLE
Fix AVX512 int4pack_mm_kernel crash if weighs are unaligned

### DIFF
--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -139,7 +139,7 @@ inline void tinygemm_kernel(
         // when BLOCK_N = 64, handle each row at a time
         // to reduce de-quantize overhead.
         if constexpr (col == 0) {
-          __m256i b4 = _mm256_load_si256((__m256i*)(B + k * ldb));
+          __m256i b4 = _mm256_loadu_si256((__m256i*)(B + k * ldb));
           if (k + PREFETCH_SIZE_K < K) {
             _mm_prefetch(B + (k + PREFETCH_SIZE_K) * ldb, _MM_HINT_T0);
           }


### PR DESCRIPTION
By replacing `_mm256_load_si256` with `_mm256_loadu_si256`, as there are no guarantees that tensor should be aligned

Fixes crash reported in https://github.com/pytorch/pytorch/issues/124034 though I'm unsure about perf implications if tensor are properly aligned



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10