### PR TITLE
improve F.adaptive_avg_pool2d error messages on mps

### DIFF
--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -37,8 +37,9 @@ static void set_kernel_params(int64_t isizeH,
 
   if (isizeH >= osizeH) {
     if (check_avg_pooling) {
-      TORCH_CHECK((isizeH % osizeH == 0 && isizeW % osizeW == 0),
-                  "Adaptive pool MPS: input sizes must be divisible by output sizes. Non-divisible input sizes are not implemented on MPS device yet. For now, you can manually transfer tensor to cpu in this case. Please refer to [this issue](https://github.com/pytorch/pytorch/issues/96056)");
+      TORCH_CHECK(
+          (isizeH % osizeH == 0 && isizeW % osizeW == 0),
+          "Adaptive pool MPS: input sizes must be divisible by output sizes. Non-divisible input sizes are not implemented on MPS device yet. For now, you can manually transfer tensor to cpu in this case. Please refer to [this issue](https://github.com/pytorch/pytorch/issues/96056)");
     }
     strideH = (int64_t)(isizeH / osizeH);
     strideW = (int64_t)(isizeW / osizeW);
@@ -46,8 +47,9 @@ static void set_kernel_params(int64_t isizeH,
     kernel_sizeW = isizeW - (osizeW - 1) * strideW;
   } else {
     if (check_avg_pooling) {
-      TORCH_CHECK((osizeH % isizeH == 0 && osizeW % isizeW == 0),
-                  "Adaptive pool MPS: output sizes must be divisible by input sizes. Non-divisible input sizes are not implemented on MPS device yet. For now, you can manually transfer tensor to cpu in this case. Please refer to [this issue](https://github.com/pytorch/pytorch/issues/96056)");
+      TORCH_CHECK(
+          (osizeH % isizeH == 0 && osizeW % isizeW == 0),
+          "Adaptive pool MPS: output sizes must be divisible by input sizes. Non-divisible input sizes are not implemented on MPS device yet. For now, you can manually transfer tensor to cpu in this case. Please refer to [this issue](https://github.com/pytorch/pytorch/issues/96056)");
     }
     strideH = (int64_t)(osizeH / isizeH);
     strideW = (int64_t)(osizeW / isizeW);

--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -47,7 +47,7 @@ static void set_kernel_params(int64_t isizeH,
   } else {
     if (check_avg_pooling) {
       TORCH_CHECK((osizeH % isizeH == 0 && osizeW % isizeW == 0),
-                  "Adaptive pool MPS: output sizes must be divisible by input sizes.");
+                  "Adaptive pool MPS: output sizes must be divisible by input sizes. Non-divisible input sizes are not implemented on MPS device yet. For now, you can manually transfer tensor to cpu in this case. Please refer to [this issue](https://github.com/pytorch/pytorch/issues/96056)");
     }
     strideH = (int64_t)(osizeH / isizeH);
     strideW = (int64_t)(osizeW / isizeW);

--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -38,7 +38,7 @@ static void set_kernel_params(int64_t isizeH,
   if (isizeH >= osizeH) {
     if (check_avg_pooling) {
       TORCH_CHECK((isizeH % osizeH == 0 && isizeW % osizeW == 0),
-                  "Adaptive pool MPS: input sizes must be divisible by output sizes.");
+                  "Adaptive pool MPS: input sizes must be divisible by output sizes. Non-divisible input sizes are not implemented on MPS device yet. For now, you can manually transfer tensor to cpu in this case. Please refer to [this issue](https://github.com/pytorch/pytorch/issues/96056)");
     }
     strideH = (int64_t)(isizeH / osizeH);
     strideW = (int64_t)(isizeW / osizeW);


### PR DESCRIPTION
Gives better error messages on mps. Partially fixes #123725 in the case of `F.adaptive_avg_pool2d`. This also relates to #96056.