### PR TITLE
[nccl-pg] Pass pg name and desc to NCCL communicator

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1923,6 +1923,12 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::getNCCLComm(
   // reset log prefix to include group_desc
   logPrefix_ = createLogPrefix();
 
+#ifdef NCCL_COMM_DESCRIPTION
+  // Pass process group name and description to NCCL communicator
+  std::string commDesc = pg_desc_ + ':' + pg_name_;
+  options_->config.commDesc = strdup(commDesc.c_str());
+#endif
+
   // For batch_isend_irecv, ncclGroupStart() would be called upfront
   bool batchP2P = ncclActiveGroupCounter_ > 0;
   bool singleP2POp = isP2POp(opType, batchP2P);


### PR DESCRIPTION
Summary:
Pass Process Group Name and Desc to NCCL communicator in order to access pg information in NCCL layer. 
The information is passed as commDesc string(i.e. "<pg_desc>:<pg_name>") 
Function only valid when NCCL_COMM_DESCRIPTION is defined.

Differential Revision: D55703310




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang