### PR TITLE
[AMD] Remove deprecated macro from COnvUtils

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2511,7 +2511,6 @@ exclude_patterns = [
     "aten/src/ATen/Context.cpp",
     "aten/src/ATen/DLConvertor.cpp",
     "aten/src/ATen/core/Array.h",
-    "aten/src/ATen/native/ConvUtils.h",
     "aten/src/ATen/native/quantized/ConvUtils.h",
     "aten/src/ATen/native/sparse/SparseBlasImpl.cpp",  # triton implementation
     "aten/src/ATen/native/transformers/attention.cpp",

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -358,7 +358,6 @@ static inline bool miopen_conv_use_channels_last(const at::Tensor& input, const 
   }
 
   bool can_use_miopen_channels_last_2d = false;
-#if defined(USE_ROCM) && (ROCM_VERSION >= 40300)
   // TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
   // See #64427
   static c10::optional<bool> PYTORCH_MIOPEN_SUGGEST_NHWC = c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC");
@@ -370,7 +369,6 @@ static inline bool miopen_conv_use_channels_last(const at::Tensor& input, const 
             ( (input_memory_format  == at::MemoryFormat::ChannelsLast) ||
             (weight_memory_format == at::MemoryFormat::ChannelsLast) )
         );
-#endif
 
   bool can_use_miopen_channels_last_3d = false;
 


### PR DESCRIPTION
Summary:
This is not great, but our ATen-cpu is not completely GPU agnostic. Previously we have worked on D54453492 (https://github.com/pytorch/pytorch/pull/121082) and D54528255, but there are a few things we haven't resolved, and it's exploding here. So we'll continue to fix them until all are gone. 

This ROCm block is for 4.3 which is very old. I don't think it should be supported any more. So let's just kill this macro

Test Plan: CI

Differential Revision: D56172660


