### PR TITLE
[2/n] Make aten-cpu build gpu agnostic

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2507,8 +2507,6 @@ include_patterns = [
     "aten/src/ATen/native/mkldnn/**/*.h",
 ]
 exclude_patterns = [
-    "aten/src/ATen/Context.h",
-    "aten/src/ATen/Context.cpp",
     "aten/src/ATen/DLConvertor.cpp",
     "aten/src/ATen/core/Array.h",
     "aten/src/ATen/native/ConvUtils.h",

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -189,11 +189,16 @@ void Context::alertCuBLASConfigNotDeterministic() const {
 }
 
 bool Context::benchmarkCuDNN() const {
-  return benchmark_cudnn;
+  if (hasHIP()) {
+    return benchmark_miopen;
+  } else {
+    return benchmark_cudnn;
+  }
 }
 
 void Context::setBenchmarkCuDNN(bool b) {
   benchmark_cudnn = b;
+  benchmark_miopen = b;
 }
 
 int Context::benchmarkLimitCuDNN() const {

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -352,11 +352,10 @@ class TORCH_API Context {
   bool enabled_mem_efficientSDP = true;
   bool enabled_mathSDP = true;
   bool enabled_cudnnSDP = false;
-#ifdef USE_ROCM
-  bool benchmark_cudnn = true;
-#else
+  // miopen's benchmark mode is true by default because it's much
+  // faster than the immediate mode
+  bool benchmark_miopen = true;
   bool benchmark_cudnn = false;
-#endif
   Float32MatmulPrecision float32_matmul_precision =
       c10::utils::check_env("TORCH_ALLOW_TF32_CUBLAS_OVERRIDE") == true
       ? at::Float32MatmulPrecision::HIGH


### PR DESCRIPTION
Summary: Again, it's not ideal to have aten-cpu diverge between cuda and rocm which can cause weird issues. So let's kill them one by one

Test Plan: CI

Differential Revision: D54528255


