### PR TITLE
Simplify amax/amin jvp

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -583,7 +583,7 @@
 
 - name: div.Scalar(Tensor self, Scalar other) -> Tensor
   self: div_tensor_self_backward(grad, other, self.scalar_type())
-  result: self_t / other
+  result: auto_linear
 
 - name: div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor
   self: div_tensor_self_backward(grad, other, self.scalar_type(), rounding_mode)
@@ -1163,11 +1163,11 @@
 
 - name: amax(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
   self: scale_grad_by_count(restore_reduced_dims(grad, dim, keepdim), restore_reduced_dims(result, dim, keepdim) == self, dim)
-  result: amaxamin_jvp(self_p, self_t, result, dim, keepdim)
+  result: auto_linear
 
 - name: amin(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
   self: scale_grad_by_count(restore_reduced_dims(grad, dim, keepdim), restore_reduced_dims(result, dim, keepdim) == self, dim)
-  result: amaxamin_jvp(self_p, self_t, result, dim, keepdim)
+  result: auto_linear
 
 - name: mm(Tensor self, Tensor mat2) -> Tensor
   self: mm_mat1_backward(grad, mat2, self.sym_sizes(), self.sym_strides(), self.layout(), 1)
@@ -1185,7 +1185,7 @@
 
 - name: mul.Scalar(Tensor self, Scalar other) -> Tensor
   self: mul_tensor_backward(grad, other, self.scalar_type())
-  result: self_t * other
+  result: auto_linear
 
 - name: mv(Tensor self, Tensor vec) -> Tensor
   self: grad.ger(vec.conj())

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -206,16 +206,6 @@ Tensor scale_grad_by_count(
   return (grad / mask.sum(dims, true)) * mask;
 }
 
-Tensor amaxamin_jvp(
-    const Tensor& x,
-    const Tensor& dx,
-    const Tensor& result,
-    IntArrayRef dim,
-    bool keepdim) {
-  auto mask = x == restore_reduced_dims(result, dim, keepdim);
-  return at::where(mask, dx, 0.).sum(dim, keepdim) / mask.sum(dim, keepdim);
-}
-
 std::tuple<Tensor, Tensor> _euclidean_dist_backward(
     const Tensor& grad,
     const Tensor& x1,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -782,12 +782,6 @@ std::tuple<Tensor, Tensor> atan2_backward(
     const Tensor& self,
     const Tensor& other,
     std::array<bool, 2> output_mask);
-Tensor amaxamin_jvp(
-    const Tensor& x,
-    const Tensor& dx,
-    const Tensor& result,
-    IntArrayRef dim,
-    bool keepdim);
 std::tuple<Tensor, Tensor, Tensor> layer_norm_double_backward(
     const Tensor& input,
     const c10::optional<Tensor>& gamma,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124174

This is linear, so its JVP is easier than currently implemented (and it
can be fused into just one op).

Same same for multiplying by a constant, only that in this case we don't
get a perf improvement.