### PR TITLE
Fix example_value of map

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1300,10 +1300,22 @@ def forward(self, getitem, const):
         def inner(x):
             return x.sin(), x.cos().T, x.sin().view(-1)
 
+        rand_44 = torch.randn(4, 4)
         inps = [
             torch.randn(3),
             torch.randn(3, 4),
             torch.randn(3, 4, 5, requires_grad=True),
+            torch.randn(3, 4, 5, requires_grad=True).permute((2, 0, 1)),
+            torch.randn(3, 4, 5, requires_grad=True).detach(),
+            torch.randn(3, 4, 5, requires_grad=True).narrow(1, 1, 2),
+            rand_44.T,
+            rand_44[::2],
+            rand_44[::2, ::2],
+            rand_44[1::3, 1::3],
+            rand_44[1::3, 1::2].T,
+            rand_44.unsqueeze(1),
+            rand_44.squeeze(0),
+            rand_44.reshape(2, 8),
         ]
         for x in inps:
             compiled_ret = torch.compile(

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -45,11 +45,11 @@ class TestExperiment(TestCase):
             """\
 def forward(self, b_submodule_buffer1, x):
     sin = torch.ops.aten.sin.default(x)
-    strict_graph_1 = self.strict_graph_1
-    strict_mode_1 = torch.ops.higher_order.strict_mode(strict_graph_1, (sin, b_submodule_buffer1));  strict_graph_1 = sin = b_submodule_buffer1 = None
-    getitem_1 = strict_mode_1[0];  strict_mode_1 = None
+    strict_graph_0 = self.strict_graph_0
+    strict_mode = torch.ops.higher_order.strict_mode(strict_graph_0, (sin, b_submodule_buffer1));  strict_graph_0 = sin = b_submodule_buffer1 = None
+    getitem = strict_mode[0];  strict_mode = None
     add = torch.ops.aten.add.Tensor(x, 3);  x = None
-    return (getitem_1, add)""",
+    return (getitem, add)""",
         )
 
         self.assertExpectedInline(

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -53,7 +53,7 @@ def forward(self, b_submodule_buffer1, x):
         )
 
         self.assertExpectedInline(
-            str(ep.graph_module.strict_graph_1.code.strip()),
+            str(ep.graph_module.strict_graph_0.code.strip()),
             """\
 def forward(self, arg0_1, arg1_1):
     add = torch.ops.aten.add.Tensor(arg0_1, 2)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -971,9 +971,18 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         subgraph_example_value = [
             proxy.node.meta["example_value"] for proxy in body_r.as_proxy()
         ]
-        map_example_out = [
-            t.expand(sample_shape[0], *t.shape) for t in subgraph_example_value
-        ]
+        with tx.output.fake_mode:
+            map_example_out = [
+                torch.empty_strided(
+                    size=(sample_shape[0], *t.size()),
+                    stride=(0, *t.stride()),
+                    dtype=t.dtype,
+                    layout=t.layout,
+                    device=t.device,
+                    requires_grad=t.requires_grad,
+                )
+                for t in subgraph_example_value
+            ]
 
         body_nn_modules = dict(tx.output.nn_modules)
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -88,14 +88,10 @@ def _make_inlined(tx, f):
     return inline_call
 
 
-def _call_function_and_unflatten_output(tx, fn, args, kwargs, ret_vt, ret_treespec):
+def _call_function_and_unflatten_output(
+    tx, fn, args, kwargs, flat_example_value, ret_treespec
+):
     from .builder import wrap_fx_proxy
-
-    flat_example_value = pytree.tree_map_only(
-        torch.fx.Proxy,
-        lambda a: a.node.meta["example_value"],
-        ret_vt.as_proxy(),
-    )
 
     # Store the invocation as a call
     flat_variable = wrap_fx_proxy(
@@ -731,8 +727,19 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
             true_shared + unique_true + unique_false,
         )
 
+        flat_example_value = pytree.tree_map_only(
+            torch.fx.Proxy,
+            lambda a: a.node.meta["example_value"],
+            true_r.as_proxy(),
+        )
+
         return _call_function_and_unflatten_output(
-            tx, torch.ops.higher_order.cond, p_args, {}, true_r, true_treespec
+            tx,
+            torch.ops.higher_order.cond,
+            p_args,
+            {},
+            flat_example_value,
+            true_treespec,
         )
 
 
@@ -885,8 +892,19 @@ class WhileLoopHigherOrderVariable(TorchHigherOrderOperatorVariable):
             ),
         )
 
+        flat_example_value = pytree.tree_map_only(
+            torch.fx.Proxy,
+            lambda a: a.node.meta["example_value"],
+            body_r.as_proxy(),
+        )
+
         return _call_function_and_unflatten_output(
-            tx, torch.ops.higher_order.while_loop, p_args, {}, body_r, body_treespec
+            tx,
+            torch.ops.higher_order.while_loop,
+            p_args,
+            {},
+            flat_example_value,
+            body_treespec,
         )
 
 
@@ -950,6 +968,13 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             should_flatten_outputs=True,
         )
 
+        subgraph_example_value = [
+            proxy.node.meta["example_value"] for proxy in body_r.as_proxy()
+        ]
+        map_example_out = [
+            t.expand(sample_shape[0], *t.shape) for t in subgraph_example_value
+        ]
+
         body_nn_modules = dict(tx.output.nn_modules)
 
         body_name = add_subgraph(
@@ -965,8 +990,9 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             [args[1].as_proxy()],
             [arg.as_proxy() for arg in args[2:]] + list(body_lifted_freevars.keys()),
         )
+
         return _call_function_and_unflatten_output(
-            tx, torch.ops.higher_order.map_impl, p_args, {}, body_r, body_spec
+            tx, torch.ops.higher_order.map_impl, p_args, {}, map_example_out, body_spec
         )
 
 
@@ -1094,8 +1120,14 @@ class WrapHigherOrderVariable(TorchHigherOrderOperatorVariable):
         if len(p_kwargs) > 0:
             unimplemented("kwargs should have been flattened into lifted args")
 
+        flat_example_value = pytree.tree_map_only(
+            torch.fx.Proxy,
+            lambda a: a.node.meta["example_value"],
+            body_r.as_proxy(),
+        )
+
         return _call_function_and_unflatten_output(
-            tx, self.value, tuple(p_args), p_kwargs, body_r, treespec
+            tx, self.value, tuple(p_args), p_kwargs, flat_example_value, treespec
         )
 
 
@@ -1138,8 +1170,6 @@ class StrictModeHigherOrderVariable(TorchHigherOrderOperatorVariable):
     def call_function(
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
-        from .builder import wrap_fx_proxy
-
         callable = args[0]
 
         unpacked_sequence = args[1].unpack_var_sequence(tx)
@@ -1187,20 +1217,13 @@ class StrictModeHigherOrderVariable(TorchHigherOrderOperatorVariable):
             ret_val.as_proxy(),
         )
 
-        # Store the invocation as a call
-        flat_variable = wrap_fx_proxy(
-            tx=tx,
-            proxy=tx.output.create_proxy(
-                "call_function",
-                torch.ops.higher_order.strict_mode,
-                args=tuple(p_args),
-                kwargs={},
-            ),
-            example_value=flat_example_value,
-        )
-
         return _call_function_and_unflatten_output(
-            tx, torch.ops.higher_order.strict_mode, p_args, {}, ret_val, ret_treespec
+            tx,
+            torch.ops.higher_order.strict_mode,
+            p_args,
+            {},
+            flat_example_value,
+            ret_treespec,
         )
 
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -976,7 +976,8 @@ class MapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             # We need to expand the example output from map() so that it has
             # the same first dimension as the mapped input.
             # We also do a clone with contiguous_format. This is to be consistent with
-            # eager semantic of map, which stacks the output and turns the memory layout to contiguous.
+            # eager semantic of map, which stacks the outputs. The result is contiguous
+            # as a result of the stack operation.
             map_example_out = [
                 t.expand(sample_shape[0], *t.size()).clone(
                     memory_format=torch.contiguous_format


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124203


Previously, we didn't expand the shape of example_value of map to the same as inputs (edit: the first mapped dimension). This pr fixes this bug. To make this easier, we change _call_function_and_unflatten_output to accept example_values directly instead of retrieving them from the variable trackers. 

Also remove a redundant call function node in strict_mode higher order op in dynamo.

Test Plan:
existing tests.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang