### PR TITLE
Remove unnecessary FileLock in Fx Graph Cache

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -862,29 +862,25 @@ class FxGraphCache:
         Load a compiled graph from the cache. If a cached entry does not exist,
         compile the graph and save it to the cache.
         """
-        from filelock import FileLock
 
         compiled_graph = None
         try:
             FxGraphCache._check_can_cache()
             key = compiled_fx_graph_hash(gm, example_inputs, fx_kwargs)
 
-            lock_path = os.path.join(get_lock_dir(), key + ".lock")
-            with FileLock(lock_path, timeout=LOCK_TIMEOUT):
-                compiled_graph = FxGraphCache._lookup_graph(key, example_inputs)
-                if compiled_graph is None:
-                    log.debug("fx graph cache miss for key %s", key)
-                    counters["inductor"]["fxgraph_cache_miss"] += 1
-                    compiled_graph = compile_fx_fn(gm, example_inputs, **fx_kwargs)
-                    FxGraphCache._save_graph(key, compiled_graph, example_inputs)
-                else:
-                    log.debug("fx graph cache hit for key %s", key)
-                    counters["inductor"]["fxgraph_cache_hit"] += 1
+            compiled_graph = FxGraphCache._lookup_graph(key, example_inputs)
+            if compiled_graph is None:
+                log.debug("fx graph cache miss for key %s", key)
+                counters["inductor"]["fxgraph_cache_miss"] += 1
+                compiled_graph = compile_fx_fn(gm, example_inputs, **fx_kwargs)
+                FxGraphCache._save_graph(key, compiled_graph, example_inputs)
+            else:
+                log.debug("fx graph cache hit for key %s", key)
+                counters["inductor"]["fxgraph_cache_hit"] += 1
         except BypassFxGraphCache:
             counters["inductor"]["fxgraph_cache_bypass"] += 1
-
-        if not compiled_graph:
-            compiled_graph = compile_fx_fn(gm, example_inputs, **fx_kwargs)
+            if not compiled_graph:
+                compiled_graph = compile_fx_fn(gm, example_inputs, **fx_kwargs)
 
         return compiled_graph
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124212

Writing to file happens via `write_atomic`, there's no need to take a global lock on the file system. This is likely creating unnecessary waits.

Differential Revision: [D56208628](https://our.internmc.facebook.com/intern/diff/D56208628/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang