### PR TITLE
[don't land] Add ability to save TORCH_COMPILE_DEBUG logs for CI failures

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -46,7 +46,7 @@ runs:
       env:
         FILE_SUFFIX: ${{ inputs.file-suffix }}
       run: |
-        # Remove any previous test reports if they exist
+        # Remove any previous usage logs if they exist
         rm -f logs-*.zip
         # this workflow is also run in bazel build test, but we dont generate usage reports for it
         # so check to see if the file exists first
@@ -55,6 +55,18 @@ runs:
         fi
         if ls test/**/*.log 1> /dev/null 2>&1; then
             zip -r "logs-${FILE_SUFFIX}.zip" test -i '*.log'
+        fi
+
+    - name: Zip debugging artifacts for upload
+      if: runner.os != 'Windows' && !inputs.use-gha
+      shell: bash
+      env:
+        FILE_SUFFIX: ${{ inputs.file-suffix }}
+      run: |
+        # Remove any previous debugging artifacts if they exist
+        rm -f debug-*.zip
+        if [ -d 'test/debug' ]; then
+          zip -r "debug-${FILE_SUFFIX}.zip" test/debug
         fi
 
     # Windows zip
@@ -121,6 +133,18 @@ runs:
         if-no-files-found: ignore
         path: logs-*.zip
 
+    - name: Store Debug Artifacts on S3
+      uses: seemethere/upload-artifact-s3@v5
+      if: ${{ !inputs.use-gha }}
+      continue-on-error: true
+      with:
+        s3-bucket: ${{ inputs.s3-bucket }}
+        s3-prefix: |
+          ${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}/artifact
+        retention-days: 14
+        if-no-files-found: ignore
+        path: debug-*.zip
+
     # GHA upload
     - name: Store Test Downloaded JSONs on Github
       uses: actions/upload-artifact@v3
@@ -159,3 +183,15 @@ runs:
         path: |
           usage_log.txt
           test/**/*.log
+
+    - name: Store Debugging Artifacts on Github
+      uses: actions/upload-artifact@v3
+      if: inputs.use-gha
+      continue-on-error: true
+      with:
+        # Add the run attempt, see [Artifact run attempt]
+        name: debug-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
+        retention-days: 14
+        if-no-files-found: ignore
+        path: |
+          test/debug/

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -183,15 +183,3 @@ runs:
         path: |
           usage_log.txt
           test/**/*.log
-
-    - name: Store Debugging Artifacts on Github
-      uses: actions/upload-artifact@v3
-      if: inputs.use-gha
-      continue-on-error: true
-      with:
-        # Add the run attempt, see [Artifact run attempt]
-        name: debug-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
-        retention-days: 14
-        if-no-files-found: ignore
-        path: |
-          test/debug/

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ test/.coverage
 test/.hypothesis/
 test/cpp/api/mnist
 test/custom_operator/model.pt
+test/debug/
 test/jit_hooks/*.pt
 test/data/legacy_modules.t7
 test/data/*.pt

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2575,10 +2575,6 @@ class BenchmarkRunner:
                     accuracy_status = "fail_accuracy"
                 return record_status(accuracy_status, dynamo_start_stats=start_stats)
 
-        # TESTING: delete me
-        if name in CI_PRESERVE_COMPILE_DEBUG:
-            accuracy_status = "fail_accuracy"
-
         return record_status(accuracy_status, dynamo_start_stats=start_stats)
 
     def check_tolerance(
@@ -4031,8 +4027,6 @@ def run(runner, args, original_dir=None):
         if original_dir:
             os.chdir(original_dir)
         model_names = list(runner.iter_model_names(args))
-        # TESTING: delete me
-        model_names = ["mnasnet1_0", "resnet50"]
         nmodels = len(model_names)
         for i, name in enumerate(model_names):
             current_name = name

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -263,7 +263,7 @@ DO_NOT_CAST_INPUTS = {"stable_diffusion"}
 # the result status matches one listed.
 CI_PRESERVE_COMPILE_DEBUG = {
     "mnasnet1_0": ["fail_accuracy"],
-    "resnet50":  ["fail_accuracy"],
+    "resnet50": ["fail_accuracy"],
 }
 
 
@@ -2575,6 +2575,10 @@ class BenchmarkRunner:
                     accuracy_status = "fail_accuracy"
                 return record_status(accuracy_status, dynamo_start_stats=start_stats)
 
+        # TESTING: delete me
+        if name in CI_PRESERVE_COMPILE_DEBUG:
+            accuracy_status = "fail_accuracy"
+
         return record_status(accuracy_status, dynamo_start_stats=start_stats)
 
     def check_tolerance(
@@ -2822,10 +2826,15 @@ class BenchmarkRunner:
             )
 
     def maybe_preserve_compile_debug(self, name, status):
-        if name in CI_PRESERVE_COMPILE_DEBUG and status in CI_PRESERVE_COMPILE_DEBUG[name]:
+        if (
+            name in CI_PRESERVE_COMPILE_DEBUG
+            and status in CI_PRESERVE_COMPILE_DEBUG[name]
+        ):
             src_dir = torch._dynamo.utils.get_debug_dir()
             if os.path.isdir(src_dir):
-                dbg_dir = os.path.join(os.getcwd(), "test", "debug", "torch_compile_debug")
+                dbg_dir = os.path.join(
+                    os.getcwd(), "test", "debug", "torch_compile_debug"
+                )
                 dst_dir = os.path.join(dbg_dir, os.path.basename(src_dir))
                 try:
                     os.makedirs(dbg_dir, exist_ok=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124234

Summary: The idea is that we can enroll certain benchmarks to a) enable TORCH_COMPILE_DEBUG=1, and b) save those logs in test/debug in case of a failure. We can then update action.yml to upload test/debug/ to S3 whenever it exists.

Test Plan:
See artifacts generated when I force a benchmark failure:
https://hud.pytorch.org/pr/124234 (e.g., debug-test-inductor_torchbench-2-2-linux.g5.4xlarge.nvidia.gpu_23904773386.zip)