### PR TITLE
[AOTI] set alignment for aot constant

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1718,6 +1718,7 @@ class AotCodeCompiler:
             cmd = (
                 f"{objcopy_command} --rename-section"
                 " .data=.ldata"
+                " --set-section-alignment .data=64"  # Set the alignment to 64-byte
                 f" {consts_o} {consts_o}"
             )
             log.debug("aot constant rename section command: %s", cmd)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1718,7 +1718,7 @@ class AotCodeCompiler:
             cmd = (
                 f"{objcopy_command} --rename-section"
                 " .data=.ldata"
-                " --set-section-alignment .data=64"  # Set the alignment to 64-byte
+                " --set-section-alignment .data=64"  # following the gAlignment of CPU in c10/core/alignment.h
                 f" {consts_o} {consts_o}"
             )
             log.debug("aot constant rename section command: %s", cmd)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124350
* #124349
* __->__ #124272

GPU copies the constant blob to aligned memory ([RAII_cudaMalloc](https://github.com/pytorch/pytorch/blob/d0211e207c78fafac2edaf2e14954f668e898b4a/torch/csrc/inductor/aoti_runtime/model.h#L46
), [64-alignment](https://github.com/pytorch/pytorch/blob/d0211e207c78fafac2edaf2e14954f668e898b4a/torch/csrc/inductor/aoti_runtime/model.h#L324)) while CPU doesn't have this copy procedure for constant blob, which may result in sub-optimal performance when we want to directly use the constant blob buffer in the computation (for example when these constant blobs are the weight tensor to the oneDNN primitive).

We set the alignment to the `constant.o` directly so that there's no need to copy the data to an aligned memory for CPU (when using `--rename-section`, the original section name would need to be specified for `--set-section-alignment`).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang