### PR TITLE
Skip `deepspeed` and `triton` in dynamo

### DIFF
--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3121,6 +3121,7 @@ BUILTIN_SKIPLIST = (
 # third party libraries skiplist is defined by str, because users may not use these libraries.
 # we should use lazy import & skip in the future.
 THIRDPARTY_SKIPLIST = (
+    "deepspeed",
     "fx2trt_oss",
     "hypothesis",
     "networkx",
@@ -3137,6 +3138,7 @@ THIRDPARTY_SKIPLIST = (
     "torch2trt",
     "tqdm",
     "tree",
+    "triton",
     "tvm",
     "xarray",
 )

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -3138,7 +3138,7 @@ THIRDPARTY_SKIPLIST = (
     "torch2trt",
     "tqdm",
     "tree",
-    "triton",
+    "triton.runtime.jit",
     "tvm",
     "xarray",
 )


### PR DESCRIPTION
Fixes #97079
Fixes #122768

This PR adds two third-party library to `THIRDPARTY_SKIPLIST`: deepspeed and triton, to resolve different issues:
1. Deepspeed now supports dynamo: https://github.com/microsoft/DeepSpeed/pull/4878, but skipping comm op is not completely implemented (https://github.com/huggingface/accelerate/pull/2460). Skip deepspeed in torch can resolve this and does not seem to slowdown anything;
2. In rare cases, triton kernel can be traced by dynamo (#122768), which is not intended. Skip triton can be a fallback for similar situations.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang