### PR TITLE
Assert that TracingContext is available when set_example_value is called

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -58,7 +58,7 @@ from .code_context import code_context
 from .exc import CondOpArgsMismatchError, UserError, UserErrorType
 from .mutation_guard import install_generation_tagging_init
 from .types import CacheEntry, DynamoCallback
-from .utils import common_constant_types, compile_times, set_example_value
+from .utils import common_constant_types, compile_times
 
 log = logging.getLogger(__name__)
 
@@ -773,7 +773,8 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
         if "tensor_dict" in self.current_node.meta:
             arg.node.meta["tensor_dict"] = self.current_node.meta["tensor_dict"]
         if "example_value" in self.current_node.meta:
-            set_example_value(arg.node, self.current_node.meta["example_value"])
+            # NB: intentionally do not use set_example_value
+            arg.node.meta["example_value"] = self.current_node.meta["example_value"]
         return arg
 
     def output(self, target, args, kwargs):
@@ -797,9 +798,10 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
         if "val" in self.current_node.meta:
             result_proxy.node.meta["val"] = self.current_node.meta["val"]
         if "example_value" in self.current_node.meta:
-            set_example_value(
-                result_proxy.node, self.current_node.meta["example_value"]
-            )
+            # NB: intentionally do not use set_example_value
+            result_proxy.node.meta["example_value"] = self.current_node.meta[
+                "example_value"
+            ]
         if self.current_node.op != "output":
             result_proxy.node._rename(
                 getattr(self.current_node, "name", result_proxy.node.name)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -95,12 +95,12 @@ import torch.fx.experimental.symbolic_shapes
 import torch.utils._pytree as pytree
 from torch import fx
 from torch._dispatch.python import enable_python_dispatcher
+from torch._guards import TracingContext
 from torch._subclasses.meta_utils import is_sparse_compressed
 from torch._utils_internal import log_compilation_event
 
 from torch.nn.modules.lazy import LazyModuleMixin
 from torch.utils._triton import has_triton, has_triton_package
-from torch._guards import TracingContext
 
 
 counters: DefaultDict[str, Counter[str]] = collections.defaultdict(collections.Counter)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -100,6 +100,7 @@ from torch._utils_internal import log_compilation_event
 
 from torch.nn.modules.lazy import LazyModuleMixin
 from torch.utils._triton import has_triton, has_triton_package
+from torch._guards import TracingContext
 
 
 counters: DefaultDict[str, Counter[str]] = collections.defaultdict(collections.Counter)
@@ -1151,6 +1152,7 @@ def set_example_value(node, example_value):
     # this to accurately reflect what the state of the value was at the time
     # the program was traced).
     node.meta["example_value"] = example_value
+    assert TracingContext.try_get() is not None
 
 
 def _get_fake_tensor(vt):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124567
* #124394
* #124316
* #124314
* #124310
* #124297
* #124290
* __->__ #124284
* #124283

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang