### PR TITLE
[BE] test_foreach: Parity dtypes testing in test_parity

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -186,6 +186,7 @@ class TestForeach(TestCase):
         + foreach_pointwise_op_db
         + foreach_reduce_op_db
         + foreach_other_op_db,
+        dtypes=all_types_and_complex_and(torch.half, torch.bfloat16),
     )
     @parametrize(
         "noncontiguous,inplace",


### PR DESCRIPTION
Before only parity was checked for only 5 dtypes on CUDA vs 11 on CPU, see below:
```
$ python3 test_foreach.py --discover-tests |grep -v "<"| grep -v "__main__"|grep test_parity__foreach_copy_fastpath_inplace
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_bfloat16
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_complex128
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_complex64
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_float16
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_float32
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_float64
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_int16
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_int32
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_int64
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_int8
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_uint8
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_complex128
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_complex64
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_float16
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_float32
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_float64
```
And after the change:
```
$ python3 test_foreach.py --discover-tests |grep -v "<"| grep -v "__main__"|grep test_parity__foreach_copy_fastpath_inplace
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_bfloat16
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_complex128
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_complex64
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_float16
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_float32
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_float64
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_int16
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_int32
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_int64
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_int8
TestForeachCPU.test_parity__foreach_copy_fastpath_inplace_cpu_uint8
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_bfloat16
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_complex128
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_complex64
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_float16
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_float32
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_float64
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_int16
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_int32
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_int64
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_int8
TestForeachCUDA.test_parity__foreach_copy_fastpath_inplace_cuda_uint8
```

Fixes https://github.com/pytorch/pytorch/issues/124170
