### PR TITLE
[FSDP2] Made `unshard` return type consistent

### DIFF
--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -178,10 +178,10 @@ class FSDP:
             pending unshard op in the pre-forward automatically.
         """
         state = self._get_fsdp_state()
-        if (fsdp_param_group := state._fsdp_param_group) is None:
-            return None
-        fsdp_param_group.lazy_init()
-        fsdp_param_group.unshard(async_op=async_op)
+        fsdp_param_group = state._fsdp_param_group
+        if fsdp_param_group is not None:
+            fsdp_param_group.lazy_init()
+            fsdp_param_group.unshard(async_op=async_op)
         handle = UnshardHandle(fsdp_param_group)
         if async_op:
             return handle
@@ -281,10 +281,12 @@ class UnshardHandle:
     A handle to wait on the unshard op.
 
     Args:
-        fsdp_param_group (FSDPParamGroup): FSDP parameter group to unshard.
+        fsdp_param_group (FSDPParamGroup, optional): FSDP parameter group to
+            unshard. This should be ``None`` iff the FSDP module does not
+            manage any parameters, meaning the unshard is a no-op.
     """
 
-    def __init__(self, fsdp_param_group: FSDPParamGroup):
+    def __init__(self, fsdp_param_group: Optional[FSDPParamGroup]):
         self._fsdp_param_group = fsdp_param_group
 
     def wait(self):
@@ -294,7 +296,7 @@ class UnshardHandle:
         This ensures that the current stream can use the unsharded parameters,
         which are now registered to the module.
         """
-        if hasattr(self, "_fsdp_param_group"):
+        if self._fsdp_param_group is not None:
             self._fsdp_param_group.wait_for_unshard()
             # Avoid keeping a reference
-            delattr(self, "_fsdp_param_group")
+            self._fsdp_param_group = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124319
* #124318
* __->__ #124293
* #120952

We can always return an `UnshardHandle` if `async_op=True` even if the FSDP module does not manage any parameters and hence does not have an `FSDPParamGroup`.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k