### PR TITLE
Adds LSE output for templated-attention-hop if inputs require grad

### DIFF
--- a/test/inductor/test_templated_attention.py
+++ b/test/inductor/test_templated_attention.py
@@ -8,6 +8,9 @@ from unittest import expectedFailure, skipUnless
 from unittest.mock import patch
 
 import torch
+from torch._higher_order_ops.templated_attention import (
+    templated_attention as templated_attention_hop,
+)
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch.nn.attention._templated_attention import _compose, _templated_attention
 from torch.testing._internal import common_utils
@@ -65,7 +68,7 @@ class TestTemplatedSDPA(InductorTestCase):
         else:
             fudge_factor = 1.1
         if compiled_error > ref_error * fudge_factor:
-            msg = f"Compiled error {compiled_error} is greater than ref error {ref_error} by more than 10%."
+            msg = f"Compiled error {compiled_error} is greater than ref error {ref_error} by more than {fudge_factor}X."
             self.assertTrue(False, msg)
 
     @supported_platform
@@ -190,6 +193,52 @@ class TestTemplatedSDPA(InductorTestCase):
             return score * 2
 
         self.run_test(score_mod)
+
+    @supported_platform
+    def test_logsumexp_correctness(self):
+        score_mod = _identity_mod
+
+        @torch.compile
+        def sdpa_hop(q, k, v, score_mod):
+            return templated_attention_hop(q, k, v, score_mod)
+
+        q = torch.randn(
+            (4, 8, 2048, 64), dtype=torch.float32, device="cuda", requires_grad=True
+        )
+        k = torch.randn(
+            (4, 8, 2048, 64), dtype=torch.float32, device="cuda", requires_grad=True
+        )
+        v = torch.randn(
+            (4, 8, 2048, 64), dtype=torch.float32, device="cuda", requires_grad=True
+        )
+        ref_out, ref_lse = templated_attention_hop(
+            q.to(torch.float64), k.to(torch.float64), v.to(torch.float64), score_mod
+        )
+        compiled_out, compiled_lse = sdpa_hop(q, k, v, score_mod)
+
+        # Comparing LSE for the ref and the compiled version
+        # The compiled uses a change of base trick to more efficiently compute the LSE
+        # this means that the base for the LSE computed by ref is e while for the compiled
+        # version it is 2. To compare we use the change of base formula
+        # log_2(x_compiled) = log_e(x_ref) * log_2(e) where
+        # x_ref      = ∑_i e^(scores[i])
+        # x_compiled = ∑_i 2^(log2(e) * scores[i])
+
+        ref_lse = ref_lse * torch.log2(torch.tensor(torch.e))
+
+        tolerance = Tolerances(atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(
+            ref_out.to(dtype=torch.float32),
+            compiled_out.to(dtype=torch.float32),
+            atol=tolerance.atol,
+            rtol=tolerance.rtol,
+        )
+        torch.testing.assert_close(
+            ref_lse.to(dtype=torch.float32),
+            compiled_lse.to(dtype=torch.float32),
+            atol=tolerance.atol,
+            rtol=tolerance.rtol,
+        )
 
 
 common_utils.instantiate_parametrized_tests(TestTemplatedSDPA)

--- a/test/inductor/test_templated_attention.py
+++ b/test/inductor/test_templated_attention.py
@@ -224,6 +224,8 @@ class TestTemplatedSDPA(InductorTestCase):
         # x_ref      = ∑_i e^(scores[i])
         # x_compiled = ∑_i 2^(log2(e) * scores[i])
 
+        self.assertTrue(ref_lse.dtype == torch.float32)
+        self.assertTrue(compiled_lse.dtype == torch.float32)
         ref_lse = ref_lse * torch.log2(torch.tensor(torch.e))
 
         tolerance = Tolerances(atol=2e-2, rtol=2e-2)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1366,7 +1366,12 @@ class TemplatedAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
         def create_scalar():
             return query.call_method(
-                tx, "new_empty", (SourcelessBuilder.create(tx, []),), {}
+                tx,
+                "new_empty",
+                (SourcelessBuilder.create(tx, []),),
+                {
+                    "dtype": SourcelessBuilder.create(tx, torch.int32),
+                },
             )
 
         bhmn = [create_scalar() for _ in range(4)]

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1424,6 +1424,10 @@ class TemplatedAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
         # Norm_kwargs contains the score_function and we dont want to proxy this because
         # Proxying user defined functions is not supported.
         inp_args, _ = proxy_args_kwargs(proxied_args, {})
+
+        # Why is this here? Unlike other HOPs, the subgrpah's output for this hop is unrelated
+        # to what the overall HOP returns, we create the correct output proxy by calling the
+        # hop (self.value) with the example values.
         with torch._guards.TracingContext.try_get().fake_mode:
             example_args = pytree.tree_map_only(
                 torch.fx.Proxy, lambda a: a.node.meta["example_value"], inp_args

--- a/torch/_higher_order_ops/templated_attention.py
+++ b/torch/_higher_order_ops/templated_attention.py
@@ -75,8 +75,7 @@ def math_attention(
 
     scores = score_mod(scores, b, h, m, n, *other_buffers).to(torch.float32)
 
-    # Logsumexp of the scores is needed for the backward pass
-    # TODO For now lets just unconditionally return the logsumexp, we can optimize this later
+    # TODO Unconditionally return logsumexp for backwards
     # if any(t.requires_grad for t in (query, key, value)):
     logsumexp = scores.logsumexp(dim=-1)
 

--- a/torch/_higher_order_ops/templated_attention.py
+++ b/torch/_higher_order_ops/templated_attention.py
@@ -44,7 +44,7 @@ def math_attention(
     value: torch.Tensor,
     score_mod: Callable,
     *other_buffers: torch.Tensor,
-):
+) -> Tuple[torch.Tensor, torch.Tensor]:
     """Eager implementation
 
     This implementation uses vmap to vectorize the score_mod function over the batch, head, m, and n dimensions.
@@ -75,8 +75,14 @@ def math_attention(
 
     scores = score_mod(scores, b, h, m, n, *other_buffers)
 
+    # Logsumexp of the scores is needed for the backward pass
+    # TODO For now lets just unconditionally return the logsumexp, we can optimize this later
+    # if any(t.requires_grad for t in (query, key, value)):
+    logsumexp = scores.logsumexp(dim=-1)
+
     scores = scores.softmax(dim=-1)
-    return scores @ value
+
+    return scores @ value, logsumexp
 
 
 @templated_attention.py_impl(DispatchKey.CompositeExplicitAutograd)
@@ -86,8 +92,10 @@ def sdpa_dense(
     value: torch.Tensor,
     score_mod: Callable,
     *other_buffers: torch.Tensor,
-):
-    return math_attention(query, key, value, score_mod, *other_buffers).contiguous()
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    out, lse = math_attention(query, key, value, score_mod, *other_buffers)
+    out = out.contiguous()
+    return out, lse
 
 
 # TODO We need to implement an autograd function for this, there is some complexity to do this generically
@@ -103,7 +111,7 @@ def trace_templated_attention(
     value: torch.Tensor,
     score_mod: Callable,
     *other_buffers: torch.Tensor,
-):
+) -> Tuple[torch.Tensor, torch.Tensor]:
     """Traces the templated_attention operator with the given score_mod function and other_buffers.
 
     Trace SDPA will call make_fx with "fake" example vals and then trace the score_mod function
@@ -135,7 +143,7 @@ def templated_attention_proxy_torch_dispatch_mode(
     value: torch.Tensor,
     score_mod: Callable,
     *other_buffers: torch.Tensor,
-):
+) -> Tuple[torch.Tensor, torch.Tensor]:
     assert mode is not None, "Mode should always be enabled for python fallback key"
     if mode.enable_tracing:
         return trace_templated_attention(
@@ -153,7 +161,7 @@ def templated_attention_functionalize(
     value: torch.Tensor,
     score_mod: Callable,
     *other_buffers: torch.Tensor,
-):
+) -> Tuple[torch.Tensor, torch.Tensor]:
     """Defines the functionalization rules for the templated_attention operator.
 
     Write now we are unwrapping each tensor and then redispatching to the next, however we want to
@@ -193,7 +201,7 @@ def templated_attention_functionalize(
             functional_score_mod,
             *other_buffers_unwrapped,
         )
-    return ctx.wrap_tensors(out)
+    return ctx.wrap_tensors(out)  # type: ignore[return-value]
 
 
 @templated_attention.py_impl(FakeTensorMode)
@@ -204,6 +212,8 @@ def templated_attention_fake_tensor_mode(
     value: torch.Tensor,
     score_mod: Callable,
     *other_buffers: Tuple[torch.Tensor, ...],
-) -> torch.Tensor:
+) -> Tuple[torch.Tensor, torch.Tensor]:
     with mode:
-        return torch.empty_like(query, memory_format=torch.contiguous_format)
+        batch_size, num_heads, seq_len_q, _ = query.shape
+        logsumexp = query.new_empty(batch_size, num_heads, seq_len_q)
+        return torch.empty_like(query, memory_format=torch.contiguous_format), logsumexp

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3655,6 +3655,12 @@ class TritonTemplateBuffer(TemplateBuffer):
         self.debug_extra = debug_extra
         self.mutated_inputs = mutated_inputs
         if mutated_inputs is not None:
+            # Ensure that the mutated inputs are only allowed for certain nodes
+            allowed_set = {"templated_attention"}
+            current_node = str(V.graph.current_node)
+            assert (
+                current_node in allowed_set
+            ), f"Mutated inputs are only allowed for {allowed_set} but got {current_node}"
             mark_node_as_mutating(self, *mutated_inputs)
 
     def __str__(self):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3634,9 +3634,28 @@ class TemplateBuffer(Buffer):
 
 
 class TritonTemplateBuffer(TemplateBuffer):
-    def __init__(self, layout, inputs, make_kernel_render, debug_extra=None):
+    def __init__(
+        self,
+        layout,
+        inputs,
+        make_kernel_render,
+        debug_extra=None,
+        mutated_inputs: Optional[Iterable[IRNode]] = None,
+    ):
+        """
+        NOTE:[TritonTemplates with multiple outputs]
+        We want the ability for TritonTemplates to output multiple tensors. Triton
+        kernels have no notion of outputs and this is done by creating tensors that
+        are then mutated by the kernel. Currenlty our STORE_OUTPUT codegen doesn't
+        support creating multinode outputs for triton templates.
+        We work around this by creating an extra input buffer during the lowering
+        and we mark them as mutated inputs.
+        """
         super().__init__(layout, inputs, make_kernel_render)
         self.debug_extra = debug_extra
+        self.mutated_inputs = mutated_inputs
+        if mutated_inputs is not None:
+            mark_node_as_mutating(self, *mutated_inputs)
 
     def __str__(self):
         out = f"TritonTemplateBuffer(layout={self.layout}, {self.debug_extra})"
@@ -4668,13 +4687,15 @@ class UserDefinedTritonKernel(ExternKernel):
         return [i.get_name() for i in self.inputs]
 
 
-def mark_node_as_mutating(cur_buffer, *mutated_ops):
+def mark_node_as_mutating(cur_buffer, *mutated_ops: IRNode):
     """
     Allows ops in mutated_ops to be marked as being mutated as well as
     indicates to the scheduler that these ops depend on cur_buffer.
     """
     for op in mutated_ops:
-        assert isinstance(op, IRNode), op
+        assert isinstance(
+            op, IRNode
+        ), f"{op} op is type {type(op)} and is not an IRNode"
         V.graph.mark_buffer_mutated(op.get_name())
         assert hasattr(op, "layout")
         MutationOutput(op.layout, op, cur_buffer)

--- a/torch/_inductor/kernel/templated_attention.py
+++ b/torch/_inductor/kernel/templated_attention.py
@@ -243,7 +243,7 @@ def templated_attention(*args, **kwargs):
                 "The output node for the templated attention subgraph must be a StorageBox, but got: ",
                 type(output_buffer),
             )
-            # Create the ComputedBuffere directly that will be inlined into the modfication block
+            # Create the ComputedBuffer directly that will be inlined into the modification block
             subgraph_buffer = ComputedBuffer(
                 name=None,
                 layout=FlexibleLayout(

--- a/torch/_inductor/kernel/templated_attention.py
+++ b/torch/_inductor/kernel/templated_attention.py
@@ -206,10 +206,10 @@ def templated_attention(*args, **kwargs):
         create_placeholder(name, dtype)
         for name, dtype in [
             ("score", query.get_dtype()),
-            ("b", torch.int64),
-            ("h", torch.int64),
-            ("m", torch.int64),
-            ("n", torch.int64),
+            ("b", torch.int32),
+            ("h", torch.int32),
+            ("m", torch.int32),
+            ("n", torch.int32),
         ]
     ]
     for node in subgraph.graph_module.graph.nodes:
@@ -263,7 +263,7 @@ def templated_attention(*args, **kwargs):
             logsumexp = empty_strided(
                 logsumexp_shape,
                 None,
-                dtype=query.get_dtype(),
+                dtype=torch.float32,  # The logsumexp is always stored in fp32 regardless of the input dtype
                 device=output_buffer.get_device(),
             )
             choices: List[Any] = []

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -517,8 +517,25 @@ class TritonTemplate(KernelTemplate):
         suffix_args=0,
         epilogue_fn=identity,
         subgraphs=None,
+        mutated_inputs=None,
         **kwargs,
     ):
+        """This function generates a TritonTemplateCaller
+
+        Args:
+            input_nodes: List of input nodes
+            layout: Output layout
+            num_stages: Number of stages for triton launch
+            num_warps: Number of warps for triton launch
+            prefix_args: Number of input nodes to be passed as arguments
+            suffix_args: Number of input nodes to be passed as arguments
+            epilogue_fn: Optional epilogue function to be called on the output
+            subgraphs: Optional subgraphs to be passed as arguments, these will be inlined
+                into the triton template string
+            mutated_inputs: Optional list of input nodes that are mutated by the kernel, this is helpful
+                if you need to return multiple outputs. You can pass them as inputs and mark them as
+                being mutated by the kernel.
+        """
         assert self.template, "requires jinja2"
         defines = StringIO()
         for name, val in kwargs.items():
@@ -649,6 +666,7 @@ class TritonTemplate(KernelTemplate):
                 "allow_tf32": str(kwargs.get("ALLOW_TF32", None)),
                 "acc_type": str(kwargs.get("ACC_TYPE", None)),
             },
+            mutated_inputs=mutated_inputs,
         )
 
 
@@ -719,6 +737,7 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
         log_info: Optional[
             Dict[str, Union[PrimitiveInfoType, List[PrimitiveInfoType]]]
         ] = None,
+        mutated_inputs=None,
     ):
         super().__init__(name, input_nodes, layout)
         self.make_kernel_render = make_kernel_render
@@ -735,6 +754,7 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
                 "num_warps": self.bmreq.num_warps,
             }
         )
+        self.mutated_inputs = mutated_inputs
 
     def benchmark(self, *args, out):
         assert self.bmreq is not None
@@ -761,6 +781,7 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
                 inputs=self.input_nodes,
                 make_kernel_render=self.make_kernel_render,
                 debug_extra=self.debug_extra,
+                mutated_inputs=self.mutated_inputs,
             )
         )
 

--- a/torch/nn/attention/_templated_attention.py
+++ b/torch/nn/attention/_templated_attention.py
@@ -1,6 +1,6 @@
 """This module implements the user facing API for templated attention in PyTorch."""
 import functools
-from typing import Callable
+from typing import Callable, Tuple
 
 import torch
 from torch._higher_order_ops.templated_attention import (
@@ -31,7 +31,7 @@ def _templated_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: _score_mod_signature,
-) -> torch.Tensor:
+) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""This function implements scaled dot product attention with an arbitrary attention score modification function.
 
     This function computes the scaled dot product attention between query, key, and value tensors with a user-defined
@@ -86,4 +86,7 @@ def _templated_attention(
         raise ValueError(
             "NYI: The target sequence length (L) of the query tensor must match the source sequence length (S) of the key tensor."
         )
-    return templated_attention_hop(query, key, value, score_mod)
+    out, _ = templated_attention_hop(query, key, value, score_mod)
+
+    # Drop the logsumexp value since this is only needed for backwards
+    return out


### PR DESCRIPTION
Adds LSE output for templated-attention-hop if inputs require grad

Prep PR for adding autograd support to templated-attention-hop. The kernel needs to output the LSE during the forward which will be used during backwards. 


### Output code
https://gist.github.com/drisspg/2aea3ce5db75811e7e143eeecb774d8a


## Before
| Type    |   Speedup |   batch_size |   num_heads |   q_seq_len |   k_seq_len |   head_dim | score_mod     | dtype          |
|---------|-----------|--------------|-------------|-------------|-------------|------------|---------------|----------------|
| Average |     1.159 |              |             |             |             |            |               |                |
| Max     |     1.342 |           16 |          16 |         512 |         512 |         64 | noop          | torch.bfloat16 |
| Min     |     1.016 |            1 |          16 |         512 |         512 |         64 | relative_bias | torch.bfloat16 |

## After
 Type    |   Speedup |   batch_size |   num_heads |   q_seq_len |   k_seq_len |   head_dim | score_mod   | dtype          |
|---------|-----------|--------------|-------------|-------------|-------------|------------|-------------|----------------|
| Average |     1.155 |              |             |             |             |            |             |                |
| Max     |     1.339 |           16 |          16 |         512 |         512 |         64 | noop        | torch.bfloat16 |
| Min     |     1.009 |            1 |          16 |         512 |         512 |         64 | head_bias   | torch.bfloat16 |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang