### PR TITLE
Try to speed up lintrunner in CI

### DIFF
--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -6,7 +6,8 @@ CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
 eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
 conda activate "${CONDA_ENV}"
 
-
+# Use uv to speed up lintrunner init
+python3 -m pip install uv
 
 CACHE_DIRECTORY="/tmp/.lintbin"
 # Try to recover the cached binaries

--- a/.github/scripts/lintrunner.sh
+++ b/.github/scripts/lintrunner.sh
@@ -6,6 +6,8 @@ CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
 eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
 conda activate "${CONDA_ENV}"
 
+
+
 CACHE_DIRECTORY="/tmp/.lintbin"
 # Try to recover the cached binaries
 if [[ -d "${CACHE_DIRECTORY}" ]]; then


### PR DESCRIPTION
Before timing: clang is 19min and noclang is 16min
After timing: clang is 17min and noclang is 15min

This is still crazy slow so most likely more could be done but didn't check the logs in details.