### PR TITLE
[FSDP2] Fixed `set_requires_gradient_sync`'s `recurse` arg

### DIFF
--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -211,7 +211,9 @@ class FSDP:
             recurse (bool): Whether to set for all submodules or just the
                 passed-in module.
         """
-        for module in cast(nn.Module, self).modules():
+        self_module = cast(nn.Module, self)
+        modules = list(self_module.modules()) if recurse else [self_module]
+        for module in modules:
             if isinstance(module, FSDP):
                 state = module._get_fsdp_state()
                 if fsdp_param_group := state._fsdp_param_group:
@@ -227,7 +229,9 @@ class FSDP:
         # TODO: post_reduce_output += fsdp_param.sharded_param.grad
         # after reduce-scatter and before all-reduce
         raise NotImplementedError("requires_all_reduce is not yet supported in HSDP")
-        for module in cast(nn.Module, self).modules():
+        self_module = cast(nn.Module, self)
+        modules = list(self_module.modules()) if recurse else [self_module]
+        for module in modules:
             if isinstance(module, FSDP):
                 state = module._get_fsdp_state()
                 if fsdp_param_group := state._fsdp_param_group:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124319
* __->__ #124318
* #124293
* #120952

The `recurse` argument was not being respected for `set_requires_gradient_sync`. This PR fixes that.

The previous unit test did not have nested FSDP modules with managed parameters, so the `recurse=False` was not being exercised. We augment the unit test to try only disabling gradient sync for the root module and not children.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k