### PR TITLE
[inductor] let coordesc tuner respect max RBLOCK

### DIFF
--- a/test/inductor/test_coordinate_descent_tuner.py
+++ b/test/inductor/test_coordinate_descent_tuner.py
@@ -98,6 +98,18 @@ class TestCoordinateDescentTuner(TestCase):
                 f"Expected:\n{expected}\nActual:\n{actual}",
             )
 
+    def test_value_too_large(self):
+        # Simulate a reduction
+        size_hints = [2**20, 2**20]
+
+        tuner = CoordescTuner(size_hints=size_hints)
+
+        max_block = config.triton.max_block
+        self.assertFalse(tuner.value_too_large("XBLOCK", max_block["X"]))
+        self.assertTrue(tuner.value_too_large("XBLOCK", max_block["X"] * 2))
+        self.assertFalse(tuner.value_too_large("RBLOCK", max_block["R"]))
+        self.assertTrue(tuner.value_too_large("RBLOCK", max_block["R"] * 2))
+
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_CUDA:

--- a/torch/_inductor/coordinate_descent_tuner.py
+++ b/torch/_inductor/coordinate_descent_tuner.py
@@ -70,11 +70,10 @@ class CoordescTuner:
         return zmax
 
     def get_rmax(self):
+        rmax = inductor_config.triton.max_block["R"]
         if self.size_hints and len(self.size_hints) > 0:
-            return self.size_hints[-1]  # the last one is for reduction
-        else:
-            # large enough. We should not pick this large RBLOCK anyway
-            return 2**30
+            rmax = min(rmax, self.size_hints[-1])  # the last one is for reduction
+        return rmax
 
     def get_warpsmax(self):
         # Currently, CUDA has a maximum of 1024 threads, so 32 is the max


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124325

Fix https://github.com/pytorch/pytorch/issues/124251 .

Coordesc tuner need respect max RBLOCK. When rnumel is a multiple of max-RBLOCK, inductor codegen will skip rmask. If coordesc tuner does not consider max-RBLOCK and pick a RBLOCK larger than that, we would get CUDA IMA (illegal memory access) error.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang