### PR TITLE
[DONOTREVIEW][DTenosr][Test] DTensor 2D sharding

### DIFF
--- a/test/distributed/tensor/parallel/test_dtensor_2d.py
+++ b/test/distributed/tensor/parallel/test_dtensor_2d.py
@@ -1,0 +1,30 @@
+import torch
+from torch.distributed._tensor import distribute_tensor, init_device_mesh, Shard
+from torch.distributed._tensor._utils import compute_local_shape_and_global_offset
+from torch.testing._internal.common_utils import run_tests
+
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+
+class TestDTensor2D(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 6
+
+    @with_comms
+    def test_dtensor_2d_uneven(self):
+        global_tensor = torch.arange(8)
+        mesh = init_device_mesh(self.device_type, (3, 2), mesh_dim_names=("dp", "tp"))
+        dtensor = distribute_tensor(global_tensor, mesh, (Shard(0), Shard(0)))
+        # local shards seems wrong
+        print(f"{self.rank=}, {dtensor.to_local().shape=}, {dtensor.to_local()=}")
+
+        shape, offset = compute_local_shape_and_global_offset(global_tensor.shape, mesh, (Shard(0), Shard(0)))
+        # local shape and offsets also seem wrong
+        print(f"compute_local_shape_and_global_offset -- {self.rank=}, {shape=}, {offset=}")
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
world_size = 6
mesh_shape(3, 2)
placements = (Shard(0), Shard(0))

print result:
```
self.rank=0, dtensor.to_local().shape=torch.Size([2]), dtensor.to_local()=tensor([0, 1], device='cuda:0')
self.rank=1, dtensor.to_local().shape=torch.Size([1]), dtensor.to_local()=tensor([2], device='cuda:1')
self.rank=2, dtensor.to_local().shape=torch.Size([2]), dtensor.to_local()=tensor([3, 4], device='cuda:2')
self.rank=3, dtensor.to_local().shape=torch.Size([1]), dtensor.to_local()=tensor([5], device='cuda:3')
self.rank=4, dtensor.to_local().shape=torch.Size([1]), dtensor.to_local()=tensor([6], device='cuda:4')
self.rank=5, dtensor.to_local().shape=torch.Size([1]), dtensor.to_local()=tensor([7], device='cuda:5')
```

Right now, the sharding result is:
```
rank0: [0, 1], rank1: [2]
rank2: [3, 4], rank3: [5]
rank4: [6], rank5: [7] 
```
This result is expected as DTensor don't handle padding right now.

What is expected with padding should be:
```
rank0: [0, 1], rank1: [4, 5]
rank2: [2, 3], rank3: [6, 7]
rank4: [], rank5: [] 
```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @chauhang @d4l3k