### PR TITLE
[AOTI] Enbale mmaped weights when CUDA is used

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1811,9 +1811,7 @@ class AotCodeCompiler:
                 if name not in graph.folded_constants
             )
             # TODO: Fix mmap weights with cuda
-            use_mmap_weights = (
-                not config.is_fbcode() and consts_size > 2_000_000_000
-            )
+            use_mmap_weights = not config.is_fbcode() and consts_size > 2_000_000_000
             if config.aot_inductor.force_mmap_weights:
                 use_mmap_weights = True
             compile_cmd = cpp_compile_command(

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1812,9 +1812,9 @@ class AotCodeCompiler:
             )
             # TODO: Fix mmap weights with cuda
             use_mmap_weights = (
-                not cuda and not config.is_fbcode() and consts_size > 2_000_000_000
+                not config.is_fbcode() and consts_size > 2_000_000_000
             )
-            if config.aot_inductor.force_mmap_weights and not cuda:
+            if config.aot_inductor.force_mmap_weights:
                 use_mmap_weights = True
             compile_cmd = cpp_compile_command(
                 input=input_path,


### PR DESCRIPTION
By refactoring the logic that returns the start to constant pointer into `_get_constants_start()` method and call it from both CUDA and CPU readers

It has no runtime impact, but export time is down from 10m to 3m if mmaped weights are used on AWS p4d.24xlarge



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang