### PR TITLE
remove the redundent '* 1000' to timestamp

### DIFF
--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -956,7 +956,7 @@ class TransferEvents {
         static_cast<int32_t>(activity->resourceId())};
 
     auto event = Result::create(
-        activity->timestamp() * 1000,
+        activity->timestamp(),
         noTID, // Placeholder
         device_and_resource,
         ExtraFields<EventType::Kineto>{


### PR DESCRIPTION
activity->timestamp() already in nanosecond granularity,  no need to multiply by 1000.