### PR TITLE
Update _custom_ops.py to accomodate renaming of impl_abstract

### DIFF
--- a/torch/_custom_ops.py
+++ b/torch/_custom_ops.py
@@ -250,7 +250,7 @@ def impl_abstract(qualname, *, func=None):
     """
     import torch.library
 
-    return torch.library.impl_abstract(qualname, func, _stacklevel=2)
+    return torch.library.register_fake(qualname, func, _stacklevel=2)
 
 
 def impl_save_for_backward(qualname, *, func=None):


### PR DESCRIPTION
Fixes a deprecation warning raised because of #123937 and not fixed in #123938

cc @zou3519 