### PR TITLE
[c10d] abort a communicator at most once

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1591,14 +1591,6 @@ void ProcessGroupNCCL::watchdogHandler() {
           }
         }
 
-        if (SHOULD_CLEAN_UP(asyncErrorHandling_)) {
-          // Abort work and corresponding communicators
-          work.abort();
-          // PG level abort, which would abort all other communicators on this
-          // rank
-          abort();
-        }
-
         // Report desync state in case of timeout
         if (timedOut) {
           LOG(ERROR) << c10::str(
@@ -1627,6 +1619,10 @@ void ProcessGroupNCCL::watchdogHandler() {
                   << " Please file an issue.";
             }
           }
+        }
+        if (SHOULD_CLEAN_UP(asyncErrorHandling_)) {
+          // Abort all communicators
+          abort();
         }
         // Throw exception
         work.handleException(asyncErrorHandling_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124436

Summary:
In our current cleanin up, abort is called at both work and PG level,
which is unecessary. Though we have protection in ncclComm to call abort
twice
Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k