### PR TITLE
[sym_shapes][perf] Skip repetitive check_is_size on same expr

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2029,6 +2029,8 @@ class ShapeEnv:
         # Set that holds "size-like" symbols.  When we perform
         # "size-oblivious" tests, these can be assumed to be >= 2.
         self.size_like: Set[sympy.Symbol] = set()
+        # torch._check_is_size processing could be expensive: memoizing exprs it was already called to skip repetetive calls.
+        self.check_is_size_called: Set[sympy.Expr] = set()
         # Duck-shaping says that if two input tensors have the same size,
         # they get assigned the same symbolic variable
         self.val_to_var: Dict[int, sympy.Expr] = {}

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2165,6 +2165,7 @@ class ShapeEnv:
             "source_name_to_debug_name",
             "_prev_cache_key",
             "_version_counter",
+            "check_is_size_called",
         )
 
         # Mapping of the value of each to-be-compared field into the values that


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124471

torch._check_is_size can be expensive , trying to calculate static value and doing replacements.
Skipping it if it was already called on the same expr in the same ShapeEnv

Differential Revision: [D56352337](https://our.internmc.facebook.com/intern/diff/D56352337)