### PR TITLE
[export] refactor _AddRuntimeAssertionsForInlineConstraintsPass

### DIFF
--- a/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
+++ b/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py
@@ -1,3 +1,4 @@
+import copy
 import math
 import operator
 import traceback
@@ -8,10 +9,11 @@ import sympy
 
 import torch
 import torch.fx
-from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse, ProxyValue, PassResult
 from torch.utils._sympy.value_ranges import ValueRanges
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
-
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
+from torch._subclasses import FakeTensor
+from torch._subclasses.fake_tensor import FakeTensorMode
 
 __all__ = ["InputDim"]
 
@@ -41,7 +43,7 @@ def _convert_range_to_int(range: ValueRanges):
     return min_val, max_val
 
 
-class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBaseDeprecatedDoNotUse):
+class _AddRuntimeAssertionsForInlineConstraintsPass(PassBase):
     def __init__(
         self,
         range_constraints: Dict[sympy.Symbol, ValueRanges],
@@ -50,97 +52,123 @@ class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBaseDeprecatedDoN
         self.range_constraints: Dict[sympy.Symbol, ValueRanges] = range_constraints
         self._asserts_generated_unbacked_symbols: Set[sympy.Symbol] = set()
         self.counter = 0
+        self.fake_tensor_mode = FakeTensorMode(allow_non_fake_inputs=True)
 
-    def _assert_range_constraint(self, proxy, lower, upper, assert_msg):
+    def _create_metadata(self, node, original_meta, val):
+        node.meta = {
+            "stack_trace": "".join(traceback.format_stack(limit=1)),
+            "seq_nr": -1,
+            "tensor_meta": None,
+        }
+        for field in ["nn_module_stack", "source_fn_stack", "from_node", "torch_fn"]:
+            if field in original_meta:
+                node.meta[field] = copy.copy(original_meta[field])
+        node.meta["val"] = val
+
+    def _assert_range_constraint(self, node, lower, upper, assert_msg):
+        last_node = node
         if lower > -math.inf:
-            self._insert_assert_async(operator.ge, proxy, lower, assert_msg)
+            last_node = self._insert_assert_async(last_node, operator.ge, node, lower, assert_msg)
 
         if upper < math.inf:
-            self._insert_assert_async(operator.le, proxy, upper, assert_msg)
+            last_node = self._insert_assert_async(last_node, operator.le, node, upper, assert_msg)
 
-    def _insert_assert_async(self, operator, lower, upper, assert_msg):
+    def _insert_assert_async(self, last_node, op, lower, upper, assert_msg):
         """
         Inserts assert_async call_function nodes in the graph. This function is
         called **during** the interpreter-based pass.
         """
         self.counter += 1
-        cmp = super().call_operator(operator, (lower, upper), {}, self._create_dummy_node_metadata())
-        cmp_tensor = super().call_operator(torch.ops.aten.scalar_tensor.default, (cmp,), {}, self._create_dummy_node_metadata())
-        super().call_operator(
-            torch.ops.aten._assert_async.msg,
-            (cmp_tensor, assert_msg),
-            {},
-            self._create_dummy_node_metadata(),
-        )
+        graph = last_node.graph
+        with graph.inserting_after(last_node):
+            cmp = graph.call_function(op, (lower, upper), {})
+        with graph.inserting_after(cmp):
+            cmp_tensor = graph.call_function(torch.ops.aten.scalar_tensor.default, (cmp,), {})
+        with graph.inserting_after(cmp_tensor):
+            assert_async = graph.call_function(
+                torch.ops.aten._assert_async.msg,
+                (cmp_tensor, assert_msg),
+                {},
+            )
+        # create metadata
+        val = lower.meta["val"]
+        self._create_metadata(cmp, lower.meta, val >= 0 if op == operator.ge else val <= 0)
+        self._create_metadata(cmp_tensor, lower.meta, FakeTensor(
+            self.fake_tensor_mode,
+            torch.empty((), dtype=torch.float32, device="meta"),
+            device="cpu"
+        ))
+        self._create_metadata(assert_async, lower.meta, None)
+        return assert_async
 
-    def call_operator(self, op, args, kwargs, meta) -> ProxyValue:
-        ret = super().call_operator(op, args, kwargs, meta)
-        if "val" not in meta:
-            return ret
-
-        val = meta["val"]
-
-        # In general, we may have to deal the case such as: ret[1].shape[0].
-        # We need first find out what symbols require assertion, then we need to follow the path
-        # from ret to the symbol, construct the proxies along the way and construct the messages
-        # piece-wise at the same time.
-        #
-        # We use post-order traversal to collect all the proxies callbacks needed, construct
-        # the error message callbacks, and at the top-level traversal tree we execute all the callbacks.
-        # We need the callbacks because, in order to call the function to create a proxy for shape[0], we
-        # need the proxy for shape, which further requires the proxy for ret[1], etc.
-        def add_assertions(val):
-            call_backs: List[Callable] = []
-            messages: List[str] = []
-            if isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
-                symbol = val.node.expr
-                if symbol in self.existing_inline_assertions:
-                    return call_backs, messages
-                if isinstance(symbol, sympy.Symbol) and free_unbacked_symbols(symbol):
-                    if symbol in self._asserts_generated_unbacked_symbols:
-                        return call_backs, messages
-                    # We only care about unbacked symints for these inline
-                    # constraints, which are prefixed with 'u'
-                    constraint = self.range_constraints[symbol]
-                    min_val, max_val = _convert_range_to_int(constraint)
-                    assert_msg = f" is outside of inline constraint [{min_val}, {max_val}]."
-                    call_backs.append(
-                        partial(self._assert_range_constraint, lower=min_val, upper=max_val)
-                    )
-                    messages.append(assert_msg)
-                    self._asserts_generated_unbacked_symbols.add(symbol)
-
-            elif isinstance(val, torch.Tensor):
-                for i, sym in enumerate(val.shape):
-                    cbs, msgs = add_assertions(sym)
-                    for cb, msg in zip(cbs, msgs):
-                        def sym_size_cb(proxy, assert_msg, dim):
-                            dim_proxy = super(
-                                _AddRuntimeAssertionsForInlineConstraintsPass,
-                                self
-                            ).call_operator(
-                                torch.ops.aten.sym_size.int,
-                                (proxy, dim),
-                                {},
-                                self._create_dummy_node_metadata(),
-                            )
-                            cb(proxy=dim_proxy, assert_msg=assert_msg)
-                        call_backs.append(partial(sym_size_cb, dim=i))
-                        messages.append(f".shape[{i}]" + msg)
-            return call_backs, messages
-
-        callbacks, messages = add_assertions(val)
-        for cb, msg in zip(callbacks, messages):
-            cb(proxy=ret, assert_msg=f"{ret.node}" + msg)
-        return ret
-
-    def call(self, graph_module):
+    def call(self, graph_module) -> PassResult:
         self.existing_inline_assertions = _get_existing_inline_assertions(
             graph_module, self.range_constraints
         )
 
-        # Add runtime asserts for inline constraints
-        val = super().call(graph_module)
+        for module in graph_module.modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
+            for node in module.graph.nodes:
+                if node.op != "call_function":
+                    continue
+                if "val" not in node.meta:
+                    continue
+
+                val = node.meta["val"]
+                # In general, we may have to deal the case such as: ret[1].shape[0].
+                # We need first find out what symbols require assertion, then we need to follow the path
+                # from ret to the symbol, construct the proxies along the way and construct the messages
+                # piece-wise at the same time.
+                #
+                # We use post-order traversal to collect all the proxies callbacks needed, construct
+                # the error message callbacks, and at the top-level traversal tree we execute all the callbacks.
+                # We need the callbacks because, in order to call the function to create a proxy for shape[0], we
+                # need the proxy for shape, which further requires the proxy for ret[1], etc.
+
+                def add_assertions(val):
+                    call_backs: List[Callable] = []
+                    messages: List[str] = []
+                    if isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+                        symbol = val.node.expr
+                        if symbol in self.existing_inline_assertions:
+                            return call_backs, messages
+                        if isinstance(symbol, sympy.Symbol) and free_unbacked_symbols(symbol):
+                            if symbol in self._asserts_generated_unbacked_symbols:
+                                return call_backs, messages
+                            # We only care about unbacked symints for these inline
+                            # constraints, which are prefixed with 'u'
+                            constraint = self.range_constraints[symbol]
+                            min_val, max_val = _convert_range_to_int(constraint)
+                            assert_msg = f" is outside of inline constraint [{min_val}, {max_val}]."
+                            call_backs.append(
+                                partial(self._assert_range_constraint, lower=min_val, upper=max_val)
+                            )
+                            messages.append(assert_msg)
+                            self._asserts_generated_unbacked_symbols.add(symbol)
+
+                    elif isinstance(val, torch.Tensor):
+                        for i, sym in enumerate(val.shape):
+                            cbs, msgs = add_assertions(sym)
+                            for cb, msg in zip(cbs, msgs):
+                                def sym_size_cb(node, assert_msg, dim):
+                                    with node.graph.inserting_after(node):
+                                        dim_node = module.graph.call_function(
+                                            torch.ops.aten.sym_size.int,
+                                            (node, dim),
+                                            {},
+                                        )
+                                    self._create_metadata(dim_node, node.meta, val.shape[dim])
+                                    cb(node=dim_node, assert_msg=assert_msg)
+                                call_backs.append(partial(sym_size_cb, dim=i))
+                                messages.append(f".shape[{i}]" + msg)
+                    return call_backs, messages
+
+                callbacks, messages = add_assertions(val)
+                for cb, msg in zip(callbacks, messages):
+                    cb(node=node, assert_msg=f"{node}" + msg)
+
+            module.recompile()
 
         # Sometimes this pass would return a wrong graph where we have mismatched
         # node names in signature. Before we fix it, let's just skip it.
@@ -148,11 +176,10 @@ class _AddRuntimeAssertionsForInlineConstraintsPass(_ExportPassBaseDeprecatedDoN
             return PassResult(graph_module, False)
 
         # Populate the stack trace with dummy vals to respect IR
-        for node in val.graph_module.graph.nodes:
+        for node in graph_module.graph.nodes:
             if not node.meta.get("stack_trace", None) and node.op not in ["placeholder", "output"]:
                 node.meta["stack_trace"] = "".join(traceback.format_stack(limit=1))
-
-        return PassResult(val.graph_module, val.modified)
+        return PassResult(graph_module, True)
 
 
 def _get_existing_inline_assertions(

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1254,6 +1254,11 @@ def _export(
         assert res is not None
         gm = res.graph_module
 
+    if len(range_constraints) > 0:
+        res = _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints)(gm)
+        assert res is not None
+        gm = res.graph_module
+
     assert orig_out_spec is not None
     _verify_nn_module_stack(gm)
     _verify_stack_trace(gm)
@@ -1274,10 +1279,5 @@ def _export(
         constants=constants,
     )
     log.debug("Exported program from AOTAutograd:\n%s", exported_program)
-
-    if len(range_constraints) > 0:
-        exported_program = exported_program._transform_do_not_use(
-            _AddRuntimeAssertionsForInlineConstraintsPass(range_constraints)
-        )
 
     return exported_program

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -662,6 +662,14 @@ class ExportedProgram:
             self.constants[k] = v
 
         _replace_sym_size_ops_pass(gm)
+
+        if len(new_range_constraints) > 0:
+            res = _AddRuntimeAssertionsForInlineConstraintsPass(new_range_constraints)(
+                gm
+            )
+            assert res is not None
+            gm = res.graph_module
+
         exported_program = ExportedProgram(
             root=gm,
             graph=gm.graph,
@@ -673,11 +681,6 @@ class ExportedProgram:
             verifier=self.verifier,
             constants=self.constants,
         )
-        if len(new_range_constraints) > 0:
-            exported_program = exported_program._transform_do_not_use(
-                _AddRuntimeAssertionsForInlineConstraintsPass(new_range_constraints)
-            )
-
         return exported_program
 
     def _transform_do_not_use(self, *passes: PassType) -> "ExportedProgram":


### PR DESCRIPTION
Summary:
The current _AddRuntimeAssertionsForInlineConstraintsPass has 2 known issues caused by its use of torch.fx.Interpreter:
1. SymInt-related ops (e.g. item()) are executed, causing new Unbacked SymInts to appear in the graph during the pass.
2. The graph is reconstructed, and node names/indices can be different from before, causing mismatches with `module_call_graph`, and leading to issues during unflattening.

This refactors the pass to use PassBase instead of _ExportPassBaseDeprecatedDoNotUse, only constructing new nodes for assertions.

Test Plan: This pass is called on all strict-mode export calls with range_constraints, test that behavior remains unchanged.

Differential Revision: D56360137
