### PR TITLE
[minimizer] Add exclusion function to minimizer base

### DIFF
--- a/torch/fx/passes/net_min_base.py
+++ b/torch/fx/passes/net_min_base.py
@@ -112,9 +112,12 @@ class _MinimizerBase:
         settings: _MinimizerSettingBase,
         module_exporter: Optional[
             Callable[
-                [List[torch.Tensor], torch.fx.GraphModule, str],
+                [Tensors, torch.fx.GraphModule, str],
                 None
             ]
+        ] = None,
+        exclusion_fn: Optional[
+            Callable[[NodeList, int, int], None]
         ] = None,
     ):
         assert isinstance(module, torch.fx.GraphModule)
@@ -124,6 +127,7 @@ class _MinimizerBase:
         self.compare_fn = compare_fn
         self.module_exporter = module_exporter
         self.settings = settings
+        self.exclusion_fn = exclusion_fn
 
         # Stores outputs of run_a function
         self.a_outputs: Dict[str, Any] = {}
@@ -382,10 +386,10 @@ class _MinimizerBase:
             report.append(f"Result mismatch for {result_key}")
             if self.module_exporter:
                 self.module_exporter(
-                    List[torch.Tensor](a_input), submodule, str(result_key[0]) + "_cpu",
+                    a_input, submodule, str(result_key[0]) + "_cpu",
                 )
                 self.module_exporter(
-                    List[torch.Tensor](b_input), submodule, str(result_key[0]) + "_acc",
+                    b_input, submodule, str(result_key[0]) + "_acc",
                 )
             raise FxNetMinimizerResultMismatchError(f"Result mismatch for {result_key}")
 
@@ -395,26 +399,32 @@ class _MinimizerBase:
         """
         Recursive binary search implementation.
         """
+        culprits: NodeSet = set()
         nodes: NodeList = all_nodes[start_idx:end_idx]
 
         report: List[str] = []
-        self.reports.append(report)
+        if self.exclusion_fn is not None:
+            self.exclusion_fn(nodes, start_idx, end_idx)
+            if len(nodes) == 0:
+                report = ["All nodes are excluded by user"]
+                self.reports.append(report)
+                return culprits
+
+        first_node_name = nodes[0].name
+        output_node_name = nodes[-1].name
         self.iteration += 1
-        report.append(f"Binary search iteration {self.iteration}.")
+        self.reports.append(report)
+        report.append(f"Binary search iteration {self.iteration}")
         report.append(
-            f"From node index {start_idx} to {end_idx-1}. "
+            f"From node index {start_idx}:{first_node_name} to {end_idx-1}:{output_node_name}. "
             f"Size of the interested node list is {len(nodes)}"
         )
-
         cur_nodes: NodeSet = set(nodes)
-
-        for node in nodes:
-            if node in self.fusions:
-                cur_nodes.update(self.fusions[node])
 
         try:
             split_module, submod_name = self._build_submodule(cur_nodes)
-            self._run_and_compare(split_module, submod_name, [])
+            self._run_and_compare(split_module, submod_name, [output_node_name])
+
         except (FxNetMinimizerRunFuncError, FxNetMinimizerResultMismatchError):
 
             if len(nodes) == 1:
@@ -472,6 +482,14 @@ class _MinimizerBase:
             report.append(f"Visit node: {node.name}")
 
             _LOGGER.info("Visit node: %s", node.name)
+            node_list: NodeList = [node]
+            if self.exclusion_fn is not None:
+                self.exclusion_fn(node_list, -1, -1)
+                if len(node_list) == 0:
+                    report.append(f"User exclusion : {node.name}")
+                    self.print_report(report)
+                    return culprits
+
             cur_nodes: NodeSet = {node}
 
             if node in self.fusions:
@@ -501,6 +519,12 @@ class _MinimizerBase:
         run user defined `nodes` and determine if it is a culprit.
         """
         culprits: NodeSet = set()
+        if self.exclusion_fn is not None:
+            self.exclusion_fn(nodes, -1, -1)
+        if len(nodes) == 0:
+            report = ["All nodes are excluded by user"]
+            self.reports.append(report)
+            return culprits
 
         first_node_name = nodes[0].name
         output_node_name = nodes[-1].name
@@ -562,7 +586,14 @@ class _MinimizerBase:
         """
         culprits: NodeSet = set()
         nodes: NodeList = all_nodes[start_idx:end_idx]
-
+        cur_nodes: NodeSet = set(nodes)
+        if self.exclusion_fn is not None:
+            self.exclusion_fn(nodes, start_idx, end_idx)
+            cur_nodes = set(nodes)
+        else:
+            for node in nodes:
+                if node in self.fusions:
+                    cur_nodes.update(self.fusions[node])
         report: List[str] = []
         self.reports.append(report)
         self.iteration += 1
@@ -571,12 +602,6 @@ class _MinimizerBase:
             f"From node index {start_idx} to {end_idx-1}. "
             f"Size of the interested node list is {len(nodes)}"
         )
-
-        cur_nodes: NodeSet = set(nodes)
-
-        for node in nodes:
-            if node in self.fusions:
-                cur_nodes.update(self.fusions[node])
 
         try:
             split_module, submod_name = self._build_submodule(cur_nodes)
@@ -588,7 +613,7 @@ class _MinimizerBase:
             return culprits
         except (FxNetMinimizerRunFuncError):
             culprits.update(cur_nodes)
-            report.append(f"Found culprit from run error: {node}")
+            report.append(f"Found culprit from run error: {cur_nodes}")
             self.print_report(report)
             return culprits
         else:


### PR DESCRIPTION
Summary:
Add exclusion list to minimizer:
1. some operations cannot be lowered when constructing subgraphs; this usually happens when they are isolated from operation group
2. exclude them in search strategies for automation

Reviewed By: jimone1

Differential Revision: D56327289


