### PR TITLE
[do not review] Add API for setting backward stream

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -240,6 +240,9 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
    * they may have different streams.
    */
   c10::optional<c10::Stream> stream() {
+    if (stream_override_.has_value()) {
+      return stream_override_.value();
+    }
     auto opt_device_type = at::getAccelerator();
     if (!opt_device_type.has_value()) {
       return c10::nullopt;
@@ -587,6 +590,10 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
         std::string("apply_with_saved not implemented: ") + name());
   }
 
+  void set_stream_override(c10::Stream stream) {
+    stream_override_ = stream;
+  }
+
  protected:
   /// Performs the `Node`'s actual operation.
   virtual variable_list apply(variable_list&& inputs) = 0;
@@ -674,6 +681,7 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
       retains_grad_hooks_;
   std::vector<std::unique_ptr<FunctionPostHook>> post_hooks_;
   at::SmallVector<InputMetadata, 2> input_metadata_;
+  c10::optional<c10::Stream> stream_override_;
 };
 
 /// See Node::is_traceable() for definition.

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -17,6 +17,7 @@
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/autograd/utils/python_arg_parsing.h>
 
 using namespace torch::autograd;
 
@@ -208,6 +209,21 @@ PyObject* THPCppFunction_set_sequence_nr(
   HANDLE_TH_ERRORS
   auto& fn = *((THPCppFunction*)self)->cdata;
   fn.set_sequence_nr(THPUtils_unpackUInt64(sequence_nr));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THPCppFunction_set_stream_override(PyObject* self, PyObject* args, PyObject* kwargs) {
+  HANDLE_TH_ERRORS;
+  auto cdata = ((THPCppFunction*)self)->cdata;
+
+  static PythonArgParser parser({
+    "set_stream_override()",
+    "set_stream_override(*, int64_t device_id, int64_t stream_id)",
+  });
+  ParsedArgs<2> parsed_args;
+  auto r = parser.parse(self, args, kwargs, parsed_args);
+  cdata->set_stream_override(c10::Stream::unpack3(c10::StreamId(r.toInt64(1)), c10::DeviceIndex(r.toInt64(0)), c10::DeviceType::CUDA));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -7,6 +7,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/utils/object_ptr.h>
+#include <torch/csrc/utils/pycfunction_helpers.h>
 
 namespace torch::autograd {
 
@@ -32,24 +33,27 @@ PyObject* CppFunction_pynew(
   return obj.release();
 }
 
-#define THP_FUNCTION_DEFAULT_METHODS                                           \
-  {(char*)"_register_hook_dict",                                               \
-   THPCppFunction_register_hook_dict,                                          \
-   METH_O,                                                                     \
-   nullptr},                                                                   \
-      {(char*)"register_hook", THPCppFunction_register_hook, METH_O, nullptr}, \
-      {(char*)"register_prehook",                                              \
-       THPCppFunction_register_prehook,                                        \
-       METH_O,                                                                 \
-       nullptr},                                                               \
-      {(char*)"name", THPCppFunction_name, METH_NOARGS, nullptr},              \
-      {(char*)"_sequence_nr",                                                  \
-       THPCppFunction_sequence_nr,                                             \
-       METH_NOARGS,                                                            \
-       nullptr},                                                               \
-  {                                                                            \
-    (char*)"_set_sequence_nr", THPCppFunction_set_sequence_nr, METH_O, nullptr \
-  }
+#define THP_FUNCTION_DEFAULT_METHODS                                                         \
+  {(char*)"_register_hook_dict",                                                             \
+   THPCppFunction_register_hook_dict,                                                        \
+   METH_O,                                                                                   \
+   nullptr},                                                                                 \
+      {(char*)"register_hook", THPCppFunction_register_hook, METH_O, nullptr},               \
+      {(char*)"register_prehook",                                                            \
+       THPCppFunction_register_prehook,                                                      \
+       METH_O,                                                                               \
+       nullptr},                                                                             \
+      {(char*)"name", THPCppFunction_name, METH_NOARGS, nullptr},                            \
+      {(char*)"_sequence_nr",                                                                \
+       THPCppFunction_sequence_nr,                                                           \
+       METH_NOARGS,                                                                          \
+       nullptr},                                                                             \
+  {                                                                                          \
+    (char*)"_set_sequence_nr", THPCppFunction_set_sequence_nr, METH_O, nullptr               \
+  },                                                                                         \
+  {                                                                                          \
+    (char*)"_set_stream_override", castPyCFunctionWithKeywords(THPCppFunction_set_stream_override), METH_VARARGS | METH_KEYWORDS, nullptr \
+  }                                                                                          \
 
 #define THP_FUNCTION_DEFAULT_PROPERTIES                                   \
   {(char*)"next_functions",                                               \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124538

By default backward runs on the same stream that forward runs on. This PR introduces `t.grad_fn._set_stream_override(*, device_id: int, stream_id: int)` to specify that backward runs on a specific stream. Do not use with nodes that save things for backward (to support that we'd need some additional synchronization).

```python
import torch
from torch.profiler import profile, record_function, ProfilerActivity

s = torch.cuda.Stream()

class Func(torch.autograd.Function):
    @staticmethod
    def forward(ctx, x):
        return x.clone()

    @staticmethod
    def backward(ctx, gO):
        return gO.exp().exp()

with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
    a = torch.ones(10, 4096, 4096,  device="cuda", requires_grad=True)

    # first operation performed in the default stream
    # it is linear so nothing is saved for backward
    b = a.mul(2)

    with torch.cuda.stream(s):
       c = a.exp()

    print(type(s.device_index), type(s.stream_id))
    b.grad_fn._set_stream_override(device_id=s.device_index, stream_id=s.stream_id)

    c = Func.apply(b)
    c.grad_fn._set_stream_override(device_id=s.device_index, stream_id=s.stream_id)

    c.sum().backward()


prof.export_chrome_trace("trace.json")
```

<img width="1265" alt="image" src="https://github.com/pytorch/pytorch/assets/13428986/c86520bc-a8a7-410b-b09f-d05146c50a08">

