### PR TITLE
Add meta function for `torch.histc`

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -215,7 +215,7 @@ inductor_expected_failures_single_sample["cpu"] = {
     "complex": {f16},
     "resize_": {b8, f16, f32, f64, i32, i64},
     "resize_as_": {b8, f16, f32, f64, i32, i64},
-    "histc": {f16, i32, i64},
+    "histc": {f16},
     "multinomial": {f16, f32, f64},
     "nn.functional.avg_pool1d": {i64},
     "nn.functional.avg_pool2d": {i64},
@@ -238,7 +238,6 @@ inductor_expected_failures_single_sample["cpu"] = {
 inductor_expected_failures_single_sample["cuda"] = {
     "_upsample_bilinear2d_aa": {f16, f32, f64},
     "cholesky": {f32, f64},
-    "histc": {i32, i64},
     "multinomial": {f16, f32, f64},
     ("normal", "in_place"): {f16, f32, f64},
     ("normal", "number_mean"): {f16, f32, f64},

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -215,7 +215,7 @@ inductor_expected_failures_single_sample["cpu"] = {
     "complex": {f16},
     "resize_": {b8, f16, f32, f64, i32, i64},
     "resize_as_": {b8, f16, f32, f64, i32, i64},
-    "histc": {f16},
+    "histc": {f16, i32, i64},
     "multinomial": {f16, f32, f64},
     "nn.functional.avg_pool1d": {i64},
     "nn.functional.avg_pool2d": {i64},
@@ -238,6 +238,7 @@ inductor_expected_failures_single_sample["cpu"] = {
 inductor_expected_failures_single_sample["cuda"] = {
     "_upsample_bilinear2d_aa": {f16, f32, f64},
     "cholesky": {f32, f64},
+    "histc": {i32, i64},
     "multinomial": {f16, f32, f64},
     ("normal", "in_place"): {f16, f32, f64},
     ("normal", "number_mean"): {f16, f32, f64},

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -664,7 +664,6 @@ meta_function_expected_failures = {
     torch.bincount : {i32, i64, u8, i16, i8},
     torch.functional.unique : {f64, i32, i64, u8, i16, f16, bf16, b8, i8, f32, u16, u32, u64},
     torch.functional.unique_consecutive : {f64, i32, i64, u8, i16, f16, bf16, b8, i8, f32, u16, u32, u64},
-    torch.histc : {f64, f16, bf16, f32},
     torch.histogram : {f64, f32},
     torch.histogramdd : {f64, f32},
     torch.kthvalue : {f64, i32, i64, u8, i16, f16, bf16, i8, f32},
@@ -838,8 +837,6 @@ meta_dispatch_expected_failures = {
     aten._unique2.default : {i8, f64, i64, f16, bf16, f32, i32, b8, i16, u8, u16, u32, u64},
     aten.bincount.default : {i64, i8, i32, i16, u8},
     aten.equal.default : {c64, f16, i8, f64, c128, i64, bf16, f32, i32, b8, i16, u8},
-    aten.histc.default : {bf16, f32, f64},
-    aten.histc.out : {bf16, f32, f64},
     aten.histogram.bin_ct : {f32, f64},
     aten.histogram.bins_tensor : {f32, f64},
     aten.kthvalue.default : {i8, f64, i64, f16, bf16, f32, i32, i16, u8},
@@ -883,8 +880,6 @@ meta_dispatch_device_expected_failures['cpu'] = {
     aten._batch_norm_with_update.default: {bf16, f16},
 
     aten.native_layer_norm.default: {bf16, f16},
-    aten.histc.default: {f16},
-    aten.histc.out: {f16},
 }
 
 meta_dispatch_device_expected_failures['cuda'] = {

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -740,7 +740,6 @@ meta_function_device_expected_failures['cuda'] = {
     torch.functional.unique: {f16},  # aten::_unique2, aten::unique_dim
     torch.functional.unique_consecutive: {f16},  # aten::unique_consecutive
     torch.geqrf: {f32, f64},  # aten::geqrf
-    torch.histc: {i16, i32, i64, i8},  # aten::histc, aten::histc.out
     torch.kthvalue: {f16},  # aten::kthvalue.values
 }
 
@@ -888,8 +887,6 @@ meta_dispatch_device_expected_failures['cuda'] = {
     aten._use_cudnn_ctc_loss.Tensor: {f32, f64},  # aten::_use_cudnn_ctc_loss.Tensor
     aten.cudnn_grid_sampler.default: {f16, f32, f64},  # aten::cudnn_grid_sampler
     aten.geqrf.default: {f32, f64},  # aten::geqrf
-    aten.histc.default: {i16, i32, i64, i8},  # aten::histc
-    aten.histc.out: {i16, i32, i64, i8},  # aten::histc.out
     aten.kthvalue.default: {f16},  # aten::kthvalue.values
     aten.linalg_eigvalsh.out: {f32, f64},  # aten::linalg_eigvalsh.out
     aten.log_sigmoid_forward.default: {bf16, f16, f64, f32},

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1889,7 +1889,6 @@ fake_tensor_failures = {
 symbolic_tensor_failures = {
     xfail('combinations', ''),
     xfail('geqrf', ''),  # aten.geqrf.default - couldn't find symbolic meta function/decomposition
-    xfail('histc', ''),  # Could not run 'aten::histc' with arguments from the 'Meta' backend. This could be because...
     xfail('histogram', ''),  # Could not run 'aten::histogram.bin_ct' with arguments from the 'Meta' backend. This c...
     xfail('histogramdd', ''),  # aten._histogramdd_bin_edges.default - couldn't find symbolic meta function/decomposition
     xfail('kthvalue', ''),  # aten.kthvalue.default - couldn't find symbolic meta function/decomposition

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -21,6 +21,7 @@ from torch._prims_common import (
     ELEMENTWISE_TYPE_PROMOTION_KIND,
     IntLike,
     make_contiguous_strides_for,
+    Number,
     TensorLike,
 )
 
@@ -6086,9 +6087,25 @@ def meta_bucketize(self, boundaries, *, out_int32=False, right=False):
 @register_meta([aten.histc])
 @out_wrapper()
 def meta_histc(input, bins=100, min=0, max=0):
+    fn_name = "histc()"
     torch._check(
-        input.is_floating_point(), lambda: f"input must be float, not {input.dtype}"
+        input.is_floating_point(),
+        lambda: f"{fn_name}: input tensor must have a float dtype, not {input.dtype}",
     )
+    torch._check(
+        isinstance(bins, IntLike),
+        lambda: f"{fn_name}: argument 'bins' must be int, not {type(bins)}",
+    )
+    torch._check(bins > 0, lambda: f"{fn_name}: bins must be > 0, but got {bins}")
+    torch._check(
+        isinstance(min, Number),
+        lambda: f"{fn_name}: argument 'min' must be Number, not {type(min)}",
+    )
+    torch._check(
+        isinstance(max, Number),
+        lambda: f"{fn_name}: argument 'max' must be Number, not {type(max)}",
+    )
+    torch._check(max >= min, lambda: "{fn_name}: max must be larger than min")
     return torch.empty(bins, device=input.device, dtype=input.dtype)
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6088,10 +6088,11 @@ def meta_bucketize(self, boundaries, *, out_int32=False, right=False):
 @out_wrapper()
 def meta_histc(input, bins=100, min=0, max=0):
     fn_name = "histc()"
-    torch._check(
-        input.is_floating_point(),
-        lambda: f"{fn_name}: input tensor must have a float dtype, not {input.dtype}",
-    )
+    if device_hint(input) == "cpu":
+        torch._check(
+            input.is_floating_point(),
+            lambda: f"\"histogram_cpu\" not implemented for '{input.dtype}'",
+        )
     torch._check(
         isinstance(bins, IntLike),
         lambda: f"{fn_name}: argument 'bins' must be int, not {type(bins)}",

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6083,6 +6083,15 @@ def meta_bucketize(self, boundaries, *, out_int32=False, right=False):
     ).contiguous()
 
 
+@register_meta([aten.histc])
+@out_wrapper()
+def meta_histc(input, bins=100, min=0, max=0):
+    torch._check(
+        input.is_floating_point(), lambda: f"input must be float, not {input.dtype}"
+    )
+    return torch.empty(bins, device=input.device, dtype=input.dtype)
+
+
 @register_meta(
     [aten._upsample_bilinear2d_aa.default, aten._upsample_bicubic2d_aa.default]
 )


### PR DESCRIPTION
Registers a meta function for the `aten.histc.default` and `aten.histc.out` ops to support `torch.compile(dynamic=True)`. Fixes #124512.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang