### PR TITLE
Correct error message for aten::_local_scalar_dense on meta tensor

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1724,6 +1724,11 @@ class TestMeta(TestCase):
             out = f()
             self.assertEqual(out.shape, [10, 16])
 
+    def test_local_scalar_dense_call(self):
+        with self.assertRaisesRegex(AssertionError, "aten::\_local\_scalar\_dense operator \(aka Tensor\.item\(\)\) cannot be called on meta tensors\."):
+            meta_tensor = torch.randn(1, device='meta')
+            meta_tensor.item()
+
 instantiate_device_type_tests(TestMeta, globals())
 
 def print_op_str_if_not_supported(op_str):

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1725,7 +1725,7 @@ class TestMeta(TestCase):
             self.assertEqual(out.shape, [10, 16])
 
     def test_local_scalar_dense_call(self):
-        with self.assertRaisesRegex(AssertionError, "aten::\_local\_scalar\_dense operator \(aka Tensor\.item\(\)\) cannot be called on meta tensors\."):
+        with self.assertRaisesRegex(RuntimeError, "cannot be called on meta tensors"):
             meta_tensor = torch.randn(1, device='meta')
             meta_tensor.item()
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6344,6 +6344,15 @@ def meta_channel_shuffle(input, groups):
     )
 
 
+@register_meta(aten._local_scalar_dense)
+def meta_local_scalar_dense(self:Tensor):
+    torch._check(
+        not self.is_meta,
+        lambda: "aten::_local_scalar_dense operator (aka Tensor.item()) cannot be called on meta tensors.",
+    )
+    return torch.empty_like(self)
+
+
 def _create_unary_float_meta_func(func):
     @register_meta(func)
     @out_wrapper()

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6345,12 +6345,8 @@ def meta_channel_shuffle(input, groups):
 
 
 @register_meta(aten._local_scalar_dense)
-def meta_local_scalar_dense(self:Tensor):
-    torch._check(
-        not self.is_meta,
-        lambda: "aten::_local_scalar_dense operator (aka Tensor.item()) cannot be called on meta tensors.",
-    )
-    return torch.empty_like(self)
+def meta_local_scalar_dense(self: Tensor):
+    assert not self.is_meta, "aten::_local_scalar_dense operator (aka Tensor.item()) cannot be called on meta tensors."
 
 
 def _create_unary_float_meta_func(func):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6346,7 +6346,7 @@ def meta_channel_shuffle(input, groups):
 
 @register_meta(aten._local_scalar_dense)
 def meta_local_scalar_dense(self: Tensor):
-    assert not self.is_meta, "aten::_local_scalar_dense operator (aka Tensor.item()) cannot be called on meta tensors."
+    raise RuntimeError("Tensor.item() cannot be called on meta tensors")
 
 
 def _create_unary_float_meta_func(func):


### PR DESCRIPTION

registering a meta for aten::_local_scalar_dense with a different error message.

Fixes pytorch#119588

cc @ezyang @zou3519 