### PR TITLE
Make _mesh_resources global var thread local

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -146,7 +146,12 @@ else:
                 )
             return not_none(device_mesh.mesh_dim_names.index(mesh_dim_name))
 
-    _mesh_resources: _MeshEnv = _MeshEnv()
+    import threading
+    print("making _MeshEnv global var thread local")
+    thread_local = threading.local()
+    thread_local._mr = _MeshEnv()
+    _mesh_resources = thread_local._mr
+
 
     def _get_device_handle(device_type: str = "cuda"):
         """


### PR DESCRIPTION
Test Plan:
```
buck2 test 'fbcode//mode/opt' fbcode//apf/data/tests:data_loader_provider_test -- --exact 'apf/data/tests:data_loader_provider_test - apf.data.tests.data_loader_provider_test.DataLoaderProviderTest: test_full_sync_pipeline_parallel' --run-disabled --jobs 18 --stress-runs 10 --record-results
```

Buck UI: https://www.internalfb.com/buck2/6525515d-d594-466f-ad61-fe7116d8fda2
Test UI: https://www.internalfb.com/intern/testinfra/testrun/14918173795931039

Differential Revision: D56327386




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @tianyu-l @wconstab @yf225 @chauhang @d4l3k