### PR TITLE
use namespacepid:pid as pid in strobelight profiler instead of binary name.

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -28,7 +28,7 @@ import torch
 import torch._logging
 from torch._guards import compile_context, CompileContext, CompileId, tracing
 from torch._logging import structured
-from torch._utils_internal import compiletime_strobelight_meta, signpost_event
+from torch._utils_internal import compile_time_strobelight_meta, signpost_event
 from torch.fx.experimental.symbolic_shapes import (
     ConstraintViolationError,
     GuardOnDataDependentSymNode,
@@ -452,7 +452,7 @@ def register_bytecode_hook(hook: BytecodeHook) -> RemovableHandle:
     return handle
 
 
-@compiletime_strobelight_meta(phase_name="_compile")
+@compile_time_strobelight_meta(phase_name="_compile")
 @_use_lazy_graph_module(config.use_lazy_graph_module)
 @maybe_cprofile
 def _compile(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -36,7 +36,7 @@ from torch._inductor.utils import BoxedBool, count_tangents
 from torch._logging import trace_structured
 from torch._ops import OpOverload
 from torch._subclasses.fake_tensor import FakeTensor
-from torch._utils_internal import compiletime_strobelight_meta
+from torch._utils_internal import compile_time_strobelight_meta
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 
@@ -1349,7 +1349,7 @@ def compile_fx(
             graph, joint_inputs, **kwargs, compiler="inductor"
         )
 
-    @compiletime_strobelight_meta(phase_name="bw_compiler")
+    @compile_time_strobelight_meta(phase_name="bw_compiler")
     @dynamo_utils.dynamo_timed
     @dynamo_utils.maybe_cprofile
     def bw_compiler(model: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -63,15 +63,15 @@ def throw_abstract_impl_not_imported_error(opname, module, context):
 
 
 # Meta only, act as nop otherwise.
-def compiletime_strobelight_meta(phase_name):
-    def compiletime_strobelight_meta_inner(function):
+def compile_time_strobelight_meta(phase_name):
+    def compile_time_strobelight_meta_inner(function):
         @functools.wraps(function)
         def wrapper_function(*args, **kwargs):
             return function(*args, **kwargs)
 
         return wrapper_function
 
-    return compiletime_strobelight_meta_inner
+    return compile_time_strobelight_meta_inner
 
 
 # Meta only, see


### PR DESCRIPTION
Summary:
Binary name by itself is problematic since several binary can have the same name   (pt_main_thread) usually. 
pid had issues in containers like on demand 

the correct way to do is using namespacepid:pid see post:
https://fb.workplace.com/groups/341071063335758/permalink/1504970400279146/

Test Plan: test on on demand server that profiling works correctly./

Reviewed By: oulgen, blaine-rister

Differential Revision: D56330127




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire @chauhang