### PR TITLE
[BE]: TRY002 - Ban raising vanilla exceptions

### DIFF
--- a/.ci/pytorch/perf_test/compare_with_baseline.py
+++ b/.ci/pytorch/perf_test/compare_with_baseline.py
@@ -59,16 +59,16 @@ print("sample mean: ", sample_mean)
 print("sample sigma: ", sample_sigma)
 
 if math.isnan(sample_mean):
-    raise Exception("""Error: sample mean is NaN""")
+    raise Exception("""Error: sample mean is NaN""")  # noqa: TRY002
 elif math.isnan(sample_sigma):
-    raise Exception("""Error: sample sigma is NaN""")
+    raise Exception("""Error: sample sigma is NaN""")  # noqa: TRY002
 
 z_value = (sample_mean - mean) / sigma
 
 print("z-value: ", z_value)
 
 if z_value >= 3:
-    raise Exception(
+    raise Exception(  # noqa: TRY002
         f"""\n
 z-value >= 3, there is high chance of perf regression.\n
 To reproduce this regression, run

--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -18,7 +18,7 @@ ESTIMATED_TOKENS = [0]
 
 TOKEN = os.environ["GITHUB_TOKEN"]
 if not TOKEN:
-    raise Exception("GITHUB_TOKEN is not set")
+    raise Exception("GITHUB_TOKEN is not set")  # noqa: TRY002
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -378,7 +378,9 @@ def main() -> None:
     for template, workflows in template_and_workflows:
         # added Iterable check to appease the mypy gods
         if not isinstance(workflows, Iterable):
-            raise Exception(f"How is workflows not iterable? {workflows}")
+            raise Exception(  # noqa: TRY002
+                f"How is workflows not iterable? {workflows}"
+            )  # noqa: TRY002
         for workflow in workflows:
             workflow.generate_workflow_file(workflow_template=template)
 

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -60,7 +60,7 @@ def rebase_onto(
     repo._run_git("rebase", onto_branch, branch)
 
     if repo.rev_parse(branch) == repo.rev_parse(onto_branch):
-        raise Exception(SAME_SHA_ERROR)
+        raise Exception(SAME_SHA_ERROR)  # noqa: TRY002
 
     if dry_run:
         push_result = repo._run_git("push", "--dry-run", "-f", remote_url, refspec)
@@ -100,7 +100,7 @@ def rebase_ghstack_onto(
     repo._run_git("rebase", onto_branch, orig_ref)
 
     if repo.rev_parse(orig_ref) == repo.rev_parse(onto_branch):
-        raise Exception(SAME_SHA_ERROR)
+        raise Exception(SAME_SHA_ERROR)  # noqa: TRY002
 
     # steal the identity of the committer of the commit on the orig branch
     email = repo._run_git("log", orig_ref, "--pretty=format:%ae", "-1")
@@ -126,7 +126,7 @@ def rebase_ghstack_onto(
         print(push_result)
         if ghstack_result.returncode != 0:
             print(ghstack_result.stderr.decode("utf-8"))
-            raise Exception(f"\n```{push_result}```")
+            raise Exception(f"\n```{push_result}```")  # noqa: TRY002
         # The contents of a successful push result should look like:
         # Summary of changes (ghstack 0.6.0)
 

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -211,7 +211,7 @@ class Benchmark:
                 msg += f", compute {result_dict['compute_workload']:.2f} Gops/s"
             print(msg)
         else:
-            raise Exception("Unknown output_type " + self.output_type)
+            raise Exception("Unknown output_type " + self.output_type)  # noqa: TRY002
 
 
 @contextlib.contextmanager

--- a/ios/TestApp/run_on_aws_devicefarm.py
+++ b/ios/TestApp/run_on_aws_devicefarm.py
@@ -79,14 +79,14 @@ def upload_file(
         print(f"Uploading {filename} to Device Farm as {upload_name}...")
         r = requests.put(upload_url, data=file_stream, headers={"content-type": mime})
         if not r.ok:
-            raise Exception(f"Couldn't upload {filename}: {r.reason}")
+            raise Exception(f"Couldn't upload {filename}: {r.reason}")  # noqa: TRY002
 
     start_time = datetime.datetime.now()
     # Polling AWS till the uploaded file is ready
     while True:
         waiting_time = datetime.datetime.now() - start_time
         if waiting_time > datetime.timedelta(seconds=MAX_UPLOAD_WAIT_IN_SECOND):
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 f"Uploading {filename} is taking longer than {MAX_UPLOAD_WAIT_IN_SECOND} seconds, terminating..."
             )
 
@@ -96,7 +96,7 @@ def upload_file(
         print(f"{filename} is in state {status} after {waiting_time}")
 
         if status == "FAILED":
-            raise Exception(f"Couldn't upload {filename}: {r}")
+            raise Exception(f"Couldn't upload {filename}: {r}")  # noqa: TRY002
         if status == "SUCCEEDED":
             break
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ select = [
     "RUF015", # access first ele in constant time
     "RUF016", # type error non-integer index
     "RUF017",
+    "TRY002", # ban vanilla raise (todo fix NOQAs)
     "TRY200", # TODO: migrate from deprecated alias
     "TRY302",
     "UP",

--- a/scripts/release_notes/common.py
+++ b/scripts/release_notes/common.py
@@ -217,7 +217,7 @@ def run_query(query):
     if request.status_code == 200:
         return request.json()
     else:
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             f"Query failed to run by returning code of {request.status_code}. {request.json()}"
         )
 
@@ -262,7 +262,7 @@ def github_data(pr_number):
         if len(_ERRORS) < _MAX_ERROR_LEN:
             return [], "None", ()
         else:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 f"Got {_MAX_ERROR_LEN} errors: {_ERRORS}, please check if"
                 " there is something wrong"
             )

--- a/test/distributed/elastic/timer/local_timer_test.py
+++ b/test/distributed/elastic/timer/local_timer_test.py
@@ -51,7 +51,7 @@ if not (IS_WINDOWS or IS_MACOS or TEST_WITH_DEV_DBG_ASAN):
         def test_exception_propagation(self):
             with self.assertRaises(Exception, msg="foobar"):
                 with timer.expires(after=1):
-                    raise Exception("foobar")
+                    raise Exception("foobar")  # noqa: TRY002
 
         def test_no_client(self):
             # no timer client configured; exception expected

--- a/test/dynamo/test_skip_non_tensor.py
+++ b/test/dynamo/test_skip_non_tensor.py
@@ -147,10 +147,10 @@ class SkipNonTensorTests(torch._dynamo.test_case.TestCase):
 
         class Foo(list):
             def __iter__(self):
-                raise Exception
+                raise Exception  # noqa: TRY002
 
             def __len__(self):
-                raise Exception
+                raise Exception  # noqa: TRY002
 
         x = Foo()
         x.append(torch.randn(4))

--- a/test/fx/test_fx_param_shape_control_flow.py
+++ b/test/fx/test_fx_param_shape_control_flow.py
@@ -20,7 +20,7 @@ class MyModuleBase(torch.nn.Module):
         return self.param
 
     def no_relu(self):
-        raise Exception("not implemented")
+        raise Exception("not implemented")  # noqa: TRY002
 
 
 class MyModuleParamShape(MyModuleBase):

--- a/test/jit/test_exception.py
+++ b/test/jit/test_exception.py
@@ -86,7 +86,7 @@ class TestException(TestCase):
         @torch.jit.script
         def foo_decl_always_throws():
             # type: () -> Tensor
-            raise Exception("Hi")
+            raise Exception("Hi")  # noqa: TRY002
 
         output_type = next(foo_decl_always_throws.graph.outputs()).type()
         self.assertTrue(str(output_type) == "Tensor")
@@ -104,9 +104,9 @@ class TestException(TestCase):
                 a = 1
             else:
                 if 1 == 1:
-                    raise Exception("Hi")
+                    raise Exception("Hi")  # noqa: TRY002
                 else:
-                    raise Exception("Hi")
+                    raise Exception("Hi")  # noqa: TRY002
             return a
 
         self.assertEqual(foo(), 1)
@@ -150,7 +150,7 @@ class TestException(TestCase):
     def test_python_op_exception(self):
         @torch.jit.ignore
         def python_op(x):
-            raise Exception("bad!")
+            raise Exception("bad!")  # noqa: TRY002
 
         @torch.jit.script
         def fn(x):

--- a/test/jit/test_peephole.py
+++ b/test/jit/test_peephole.py
@@ -274,7 +274,7 @@ class TestPeephole(JitTestCase):
         @torch.jit.script
         def foo(x: List[int], y: List[int]):
             if len(x) != 4 or len(y) != 5:
-                raise Exception("")
+                raise Exception("")  # noqa: TRY002
 
             return len(x) + len(y)
 
@@ -288,7 +288,7 @@ class TestPeephole(JitTestCase):
             if len(x) == 4 and len(y) == 5:
                 pass
             else:
-                raise Exception("hi")
+                raise Exception("hi")  # noqa: TRY002
 
             return len(x) + len(y)
 
@@ -300,15 +300,15 @@ class TestPeephole(JitTestCase):
         @torch.jit.script
         def foo(x: List[int], y: List[int], z: List[int]):
             if len(x) != 4:
-                raise Exception("..")
+                raise Exception("..")  # noqa: TRY002
             else:
                 if len(y) != 8:
-                    raise Exception("...")
+                    raise Exception("...")  # noqa: TRY002
                 else:
                     if len(z) == 3:
                         pass
                     else:
-                        raise Exception("...")
+                        raise Exception("...")  # noqa: TRY002
 
             return len(x) + len(y) * len(z)
 
@@ -458,7 +458,7 @@ class TestPeephole(JitTestCase):
         @torch.jit.script
         def foo(x: int, y: int):
             if x != 4 or y != 5:
-                raise Exception("")
+                raise Exception("")  # noqa: TRY002
 
             return x + y
 
@@ -477,7 +477,7 @@ class TestPeephole(JitTestCase):
             if x == 4 and y == 5:
                 pass
             else:
-                raise Exception("hi")
+                raise Exception("hi")  # noqa: TRY002
 
             return x + y
 
@@ -489,15 +489,15 @@ class TestPeephole(JitTestCase):
         @torch.jit.script
         def foo(x: int, y: int, z: int):
             if x != 4:
-                raise Exception("..")
+                raise Exception("..")  # noqa: TRY002
             else:
                 if y != 8:
-                    raise Exception("...")
+                    raise Exception("...")  # noqa: TRY002
                 else:
                     if z == 3:
                         pass
                     else:
-                        raise Exception("...")
+                        raise Exception("...")  # noqa: TRY002
 
             return x + y * z
 

--- a/test/jit/test_with.py
+++ b/test/jit/test_with.py
@@ -371,7 +371,7 @@ class TestWith(JitTestCase):
 
         @torch.jit.script
         def method_that_raises() -> torch.Tensor:
-            raise Exception("raised exception")
+            raise Exception("raised exception")  # noqa: TRY002
 
         @torch.jit.script
         def test_exception(x: torch.Tensor, c: Context) -> torch.Tensor:

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -12682,7 +12682,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         class M(torch.nn.Module):
             def forward(self, t: Tensor) -> Tuple[Tensor, Tensor]:
                 if float(t) < 0:
-                    raise Exception("Negative input")
+                    raise Exception("Negative input")  # noqa: TRY002
                 else:
                     return torch.zeros(5), torch.zeros(5)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -399,7 +399,7 @@ class TestAutograd(TestCase):
         @staticmethod
         @once_differentiable
         def backward(ctx, input):
-            raise Exception("Simulate error on backward pass")
+            raise Exception("Simulate error on backward pass")  # noqa: TRY002
 
     def test_custom_function_exception(self):
         t1 = torch.rand((3, 3), requires_grad=True)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5866,7 +5866,7 @@ a")
 
     def test_python_frontend_source_range(self):
         def fn():
-            raise Exception("hello")
+            raise Exception("hello")  # noqa: TRY002
         ast = torch.jit.frontend.get_jit_def(fn, fn.__name__)
         FileCheck().check("SourceRange at:") \
                    .check("def fn():") \
@@ -5877,7 +5877,7 @@ a")
 
     def test_python_frontend_py3(self):
         def fn():
-            raise Exception("hello")
+            raise Exception("hello")  # noqa: TRY002
         ast = torch.jit.frontend.get_jit_def(fn, fn.__name__)
         self.assertExpected(str(ast))
 
@@ -16241,7 +16241,7 @@ def normalize_check_ad(check_ad, name):
     elif len(check_ad) == 3:
         check_ad = list(check_ad)
     else:
-        raise Exception('Invalid check_ad, requires (bool, str|List[str], str|List[str])')
+        raise Exception('Invalid check_ad, requires (bool, str|List[str], str|List[str])')  # noqa: TRY002
 
     check_ad = [[t] if isinstance(t, str) else t for t in check_ad]
 

--- a/test/test_native_functions.py
+++ b/test/test_native_functions.py
@@ -96,7 +96,7 @@ class TestNativeFunctions(TestCase):
                 return traced_none(values)
             if const == [5.1, 4.1]:
                 return traced_list(values)
-            raise Exception("Invalid argument")
+            raise Exception("Invalid argument")  # noqa: TRY002
 
         self.do_test_optional_floatlist_with_module(fake_module)
 
@@ -150,7 +150,7 @@ class TestNativeFunctions(TestCase):
                 return traced_none(values)
             if const == [5, 4]:
                 return traced_list(values)
-            raise Exception("Invalid argument")
+            raise Exception("Invalid argument")  # noqa: TRY002
 
         self.do_test_optional_intlist_with_module(fake_module)
 
@@ -217,7 +217,7 @@ class TestNativeFunctions(TestCase):
                 return traced_none(values)
             if const == 10:
                 return traced_int(values)
-            raise Exception("Invalid argument")
+            raise Exception("Invalid argument")  # noqa: TRY002
 
         self.do_test_optional_filled_intlist_with_module(fake_module)
 

--- a/test/test_nnapi.py
+++ b/test/test_nnapi.py
@@ -287,7 +287,7 @@ class TestNNAPI(TestCase):
                             return torch.nn.functional.relu(arg)
                         if op == "sigmoid":
                             return torch.sigmoid(arg)
-                        raise Exception("Bad op")
+                        raise Exception("Bad op")  # noqa: TRY002
                 self.check(UnaryModule(), torch.tensor([-1.0, 1.0]))
                 self.check(
                     UnaryModule(),
@@ -307,7 +307,7 @@ class TestNNAPI(TestCase):
                             return lhs * rhs
                         if op == "div":
                             return lhs / rhs
-                        raise Exception("Bad op")
+                        raise Exception("Bad op")  # noqa: TRY002
 
                 self.check(
                     BinaryModule(),

--- a/test/test_ops_jit.py
+++ b/test/test_ops_jit.py
@@ -117,7 +117,7 @@ class TestJit(JitCommonTestCase):
                         with inputs {sample}:
                     """
                     )
-                    raise Exception(variant_error_info) from e
+                    raise Exception(variant_error_info) from e  # noqa: TRY002
 
         assert tested, "JIT Test does not execute any logic"
 

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -1181,7 +1181,7 @@ class TestCreation(TestCase):
         # Special case where a bad __getitem__ makes us fall back on __iter__:
         class C:
             def __getitem__(self, x):
-                raise Exception
+                raise Exception  # noqa: TRY002
 
             def __iter__(self):
                 return iter(())

--- a/tools/code_analyzer/gen_oplist.py
+++ b/tools/code_analyzer/gen_oplist.py
@@ -34,7 +34,7 @@ def throw_if_any_op_includes_overloads(selective_builder: SelectiveBuilder) -> N
         if op.include_all_overloads:
             ops.append(op_name)
     if ops:
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             (
                 "Operators that include all overloads are "
                 + "not allowed since --allow-include-all-overloads "

--- a/tools/code_coverage/package/tool/clang_coverage.py
+++ b/tools/code_coverage/package/tool/clang_coverage.py
@@ -74,7 +74,9 @@ def export_target(
     platform_type: TestPlatform,
 ) -> None:
     if binary_file is None:
-        raise Exception(f"{merged_file} doesn't have corresponding binary!")
+        raise Exception(  # noqa: TRY002
+            f"{merged_file} doesn't have corresponding binary!"
+        )  # noqa: TRY002
     print_log("start to export: ", merged_file)
     # run export
     cmd_shared_library = (

--- a/tools/code_coverage/package/util/utils.py
+++ b/tools/code_coverage/package/util/utils.py
@@ -116,7 +116,7 @@ def get_test_name_from_whole_path(path: str) -> str:
 def check_compiler_type(cov_type: Optional[CompilerType]) -> None:
     if cov_type is not None and cov_type in [CompilerType.GCC, CompilerType.CLANG]:
         return
-    raise Exception(
+    raise Exception(  # noqa: TRY002
         f"Can't parse compiler type: {cov_type}.",
         " Please set environment variable COMPILER_TYPE as CLANG or GCC",
     )
@@ -125,7 +125,7 @@ def check_compiler_type(cov_type: Optional[CompilerType]) -> None:
 def check_platform_type(platform_type: TestPlatform) -> None:
     if platform_type in [TestPlatform.OSS, TestPlatform.FBCODE]:
         return
-    raise Exception(
+    raise Exception(  # noqa: TRY002
         f"Can't parse platform type: {platform_type}.",
         " Please set environment variable COMPILER_TYPE as OSS or FBCODE",
     )
@@ -134,7 +134,7 @@ def check_platform_type(platform_type: TestPlatform) -> None:
 def check_test_type(test_type: str, target: str) -> None:
     if test_type in [TestType.CPP.value, TestType.PY.value]:
         return
-    raise Exception(
+    raise Exception(  # noqa: TRY002
         f"Can't parse test type: {test_type}.",
         f" Please check the type of buck target: {target}",
     )

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -252,7 +252,7 @@ def sig_for_ops(opname: str) -> List[str]:
             tname = "builtins." + tname
         return [f"def {opname}(self) -> {tname}: ..."]
     else:
-        raise Exception("unknown op", opname)
+        raise Exception("unknown op", opname)  # noqa: TRY002
 
 
 def generate_type_hints(sig_group: PythonSignatureGroup) -> List[str]:

--- a/tools/stats/upload_test_stat_aggregates.py
+++ b/tools/stats/upload_test_stat_aggregates.py
@@ -22,9 +22,11 @@ def get_oncall_from_testfile(testfile: str) -> Union[List[str], None]:
                 if line.startswith("# Owner(s): "):
                     possible_lists = re.findall(r"\[.*\]", line)
                     if len(possible_lists) > 1:
-                        raise Exception("More than one list found")
+                        raise Exception("More than one list found")  # noqa: TRY002
                     elif len(possible_lists) == 0:
-                        raise Exception("No oncalls found or file is badly formatted")
+                        raise Exception(  # noqa: TRY002
+                            "No oncalls found or file is badly formatted"
+                        )  # noqa: TRY002
                     oncalls = ast.literal_eval(possible_lists[0])
                     return list(oncalls)
     except Exception as e:

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -495,7 +495,7 @@ class TestBenchmarkRequest(BenchmarkRequest):
         self, *input_tensors: torch.Tensor, output_tensor: Optional[torch.Tensor] = None
     ) -> float:
         if self.value is None:
-            raise Exception("Failed to run")
+            raise Exception("Failed to run")  # noqa: TRY002
         return self.value
 
 

--- a/torch/_inductor/comm_analysis.py
+++ b/torch/_inductor/comm_analysis.py
@@ -46,7 +46,9 @@ def get_collective_type(node: ir.IRNode) -> NCCL_COLL:
         elif "reduce_scatter" in kernel_name:
             return NCCL_COLL.REDUCE_SCATTER
         else:
-            raise Exception(f"Unsupported collective kernel: {kernel_name}")
+            raise Exception(  # noqa: TRY002
+                f"Unsupported collective kernel: {kernel_name}"
+            )  # noqa: TRY002
 
     if isinstance(node, (ir.AllReduce, ir.AllReduceCoalesced)):
         return NCCL_COLL.ALL_REDUCE
@@ -55,7 +57,7 @@ def get_collective_type(node: ir.IRNode) -> NCCL_COLL:
     elif isinstance(node, (ir.ReduceScatterTensor, ir.ReduceScatterTensorCoalesced)):
         return NCCL_COLL.REDUCE_SCATTER
     else:
-        raise Exception(f"Unsupported collective type: {node}")
+        raise Exception(f"Unsupported collective type: {node}")  # noqa: TRY002
 
 
 def get_collective_input_size_bytes(node: ir.IRNode) -> int:

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -192,7 +192,7 @@ def reorder_compute_for_overlap(
                     all_nodes.remove(node)
                     progress = True
             if not progress:
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     "Unable to find a free node (indeg == 0). This is an impossible state to reach. "
                     "Please report a bug to PyTorch."
                 )
@@ -312,7 +312,7 @@ def visualize_overlap(order):
                 total_est_runtime += estimate_op_runtime(snode)
                 cur_comm_node = snode.node
             elif is_wait(snode.node):
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     "Wait is not expected when there is no collective running"
                 )
             else:  # exposed compute op
@@ -320,7 +320,7 @@ def visualize_overlap(order):
             overlap_log.debug(f"{node_summary(snode)}")  # noqa: G004
         else:  # cur_comm_node is not None
             if is_collective(snode.node):
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     "Found two collectives running at the same time. "
                     "`visualize_overlap` needs to be updated to handle this case"
                 )

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -27,7 +27,7 @@ def val_expressable_in_32_bits(val):
         iinfo = torch.iinfo(torch.int32)
         return val <= iinfo.max and val >= iinfo.min
 
-    raise Exception(f"Unexpected value {val}")
+    raise Exception(f"Unexpected value {val}")  # noqa: TRY002
 
 
 def range_expressable_in_32_bits(range):

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1237,7 +1237,7 @@ def _serialize_pattern(
         return f"{file_template}{formatted_imports}"
 
     if not SERIALIZED_PATTERN_PATH.is_dir():
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             f"Could not find serialized patterns directory at {SERIALIZED_PATTERN_PATH}"
         )
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -981,7 +981,7 @@ def _get_overloaded_methods(method, mod_class):
     mod_class_fileno = get_source_lines_and_file(mod_class)[1]
     mod_end_fileno = mod_class_fileno + len(get_source_lines_and_file(mod_class)[0])
     if not (method_line_no >= mod_class_fileno and method_line_no <= mod_end_fileno):
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             "Overloads are not useable when a module is redeclared within the same file: "
             + str(method)
         )

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1539,14 +1539,14 @@ class FakeTensorMode(TorchDispatchMode):
             if not self.is_our_fake(x):
                 if torch.Tag.inplace_view in func.tags:
                     args, kwargs = pytree.tree_unflatten(flat_args, args_spec)
-                    raise Exception(
+                    raise Exception(  # noqa: TRY002
                         f"Can't call metadata mutating ops on non-Fake Tensor inputs. Found in {render_call(func, args, kwargs)}"
                     )
                 if not self.allow_non_fake_inputs:
                     if isinstance(x, FakeTensor) and x.fake_mode is not self:
                         raise AssertionError("Mixing fake modes NYI")
                     args, kwargs = pytree.tree_unflatten(flat_args, args_spec)
-                    raise Exception(
+                    raise Exception(  # noqa: TRY002
                         f"Please convert all Tensors to FakeTensors first or instantiate FakeTensorMode "
                         f"with 'allow_non_fake_inputs'. Found in {render_call(func, args, kwargs)}"
                     )

--- a/torch/ao/nn/quantized/reference/modules/utils.py
+++ b/torch/ao/nn/quantized/reference/modules/utils.py
@@ -176,7 +176,7 @@ def _quantize_weight_decomposed(
                 weight_quant_max,
                 weight_dtype_)  # type: ignore[arg-type]
             return weight
-    raise Exception(f"Unsupported dtype and qscheme: {weight_dtype}, {weight_qscheme}")
+    raise Exception(f"Unsupported dtype and qscheme: {weight_dtype}, {weight_qscheme}")  # noqa: TRY002
 
 def _dequantize_weight_decomposed(
         weight: torch.Tensor,
@@ -226,7 +226,7 @@ def _dequantize_weight_decomposed(
                 weight_quant_max,
                 weight_dtype_)  # type: ignore[arg-type]
             return weight
-    raise Exception(f"Unsupported dtype and qscheme: {weight_dtype}, {weight_qscheme}")
+    raise Exception(f"Unsupported dtype and qscheme: {weight_dtype}, {weight_qscheme}")  # noqa: TRY002
 
 def _quantize_weight(
         weight: torch.Tensor,
@@ -250,7 +250,7 @@ def _quantize_weight(
                 weight, weight_scale,
                 weight_zero_point, weight_axis_int, weight_dtype)  # type: ignore[arg-type]
             return weight
-    raise Exception(f"Unsupported dtype and qscheme: {weight_dtype}, {weight_qscheme}")
+    raise Exception(f"Unsupported dtype and qscheme: {weight_dtype}, {weight_qscheme}")  # noqa: TRY002
 
 def _quantize_and_dequantize_weight_decomposed(
         weight: torch.Tensor,

--- a/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
+++ b/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
@@ -301,7 +301,7 @@ class BaseStructuredSparsifier(BaseSparsifier):
 
         for module in self.traced.modules():
             if module_contains_param(module, FakeStructuredSparsity):
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     f"Error: {module} still contains FakeStructuredSparsity parametrizations!"
                 )
 

--- a/torch/ao/pruning/_experimental/pruner/lstm_saliency_pruner.py
+++ b/torch/ao/pruning/_experimental/pruner/lstm_saliency_pruner.py
@@ -31,7 +31,7 @@ class LSTMSaliencyPruner(BaseStructuredSparsifier):
 
                 # select weights based on magnitude
                 if weights.dim() <= 1:
-                    raise Exception("Structured pruning can only be applied to a 2+dim weight tensor!")
+                    raise Exception("Structured pruning can only be applied to a 2+dim weight tensor!")  # noqa: TRY002
                 # take norm over all but first dim
                 dims = tuple(range(1, weights.dim()))
                 saliency = weights.norm(dim=dims, p=1)

--- a/torch/ao/pruning/_experimental/pruner/saliency_pruner.py
+++ b/torch/ao/pruning/_experimental/pruner/saliency_pruner.py
@@ -18,7 +18,7 @@ class SaliencyPruner(BaseStructuredSparsifier):
 
         # use negative weights so we can use topk (we prune out the smallest)
         if weights.dim() <= 1:
-            raise Exception("Structured pruning can only be applied to a 2+dim weight tensor!")
+            raise Exception("Structured pruning can only be applied to a 2+dim weight tensor!")  # noqa: TRY002
         saliency = -weights.norm(dim=tuple(range(1, weights.dim())), p=1)
         assert saliency.shape == mask.shape
 

--- a/torch/ao/quantization/fuser_method_mappings.py
+++ b/torch/ao/quantization/fuser_method_mappings.py
@@ -151,7 +151,7 @@ def fuse_convtranspose_bn(is_qat, convt, bn):
         "ConvTranspose and BN both must be in the same mode (train or eval)."
 
     if is_qat:
-        raise Exception("Fusing ConvTranspose+BatchNorm not yet supported in QAT.")
+        raise Exception("Fusing ConvTranspose+BatchNorm not yet supported in QAT.")  # noqa: TRY002
     else:
         return nn.utils.fusion.fuse_conv_bn_eval(convt, bn, transpose=True)
 

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -616,7 +616,7 @@ def choose_qparams_per_token(
         n_bits = 8
         quant_max = 2 ** (n_bits - 1) - 1
     else:
-        raise Exception(f"unsupported dtype in choose_qparams_per_token: {dtype}")
+        raise Exception(f"unsupported dtype in choose_qparams_per_token: {dtype}")  # noqa: TRY002
 
     scales = scales.clamp(min=1e-5).div(quant_max)
     zero_points = torch.zeros_like(scales)

--- a/torch/ao/quantization/fx/_model_report/model_report.py
+++ b/torch/ao/quantization/fx/_model_report/model_report.py
@@ -269,11 +269,11 @@ class ModelReport:
         """
         # if we haven't prepped model for callibration, then we shouldn't generate report yet
         if not self._prepared_flag:
-            raise Exception("Cannot generate report without preparing model for callibration")
+            raise Exception("Cannot generate report without preparing model for callibration")  # noqa: TRY002
 
         # if we already removed the observers, we cannot generate report
         if self._removed_observers:
-            raise Exception("Cannot generate report on model you already removed observers from")
+            raise Exception("Cannot generate report on model you already removed observers from")  # noqa: TRY002
 
         # keep track of all the reports of interest and their outputs
         reports_of_interest = {}
@@ -416,7 +416,7 @@ class ModelReport:
         """
         # check if user has generated reports at least once
         if len(self._generated_reports) == 0:
-            raise Exception("Unable to generate visualizers without first generating reports")
+            raise Exception("Unable to generate visualizers without first generating reports")  # noqa: TRY002
 
         # get the ordered dict mapping modules to their full set of collected features / stats
         module_fqns_to_features: OrderedDict = self._reformat_reports_for_visualizer()
@@ -502,11 +502,11 @@ class ModelReport:
         """
         # if we haven't prepped model for callibration, then we shouldn't generate mapping yet
         if not self._prepared_flag:
-            raise Exception("Cannot generate report without preparing model for callibration")
+            raise Exception("Cannot generate report without preparing model for callibration")  # noqa: TRY002
 
         # if we already removed the observers, we cannot mapping
         if self._removed_observers:
-            raise Exception("Cannot generate report on model you already removed observers from")
+            raise Exception("Cannot generate report on model you already removed observers from")  # noqa: TRY002
 
         # keep track of qconfig info for each module across detectors
         detector_qconfig_info_combined: Dict[str, DetectorQConfigInfo] = {}

--- a/torch/ao/quantization/fx/_model_report/model_report_observer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_observer.py
@@ -260,6 +260,6 @@ class ModelReportObserver(ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             "calculate_qparams should not be called for ModelReportObserver"
         )

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -1099,7 +1099,7 @@ def _maybe_insert_observers_before_graph_output(
         elif maybe_node is None:
             return None
         else:
-            raise Exception("Unhandled type for returned node:", maybe_node)
+            raise Exception("Unhandled type for returned node:", maybe_node)  # noqa: TRY002
 
     new_args = []
     for old_arg in graph_output_node.args:

--- a/torch/ao/quantization/fx/utils.py
+++ b/torch/ao/quantization/fx/utils.py
@@ -137,7 +137,7 @@ def get_linear_prepack_op_for_dtype(dtype):
     elif dtype == torch.qint8:
         return torch.ops.quantized.linear_prepack
     else:
-        raise Exception("can't get linear prepack op for dtype:", dtype)
+        raise Exception("can't get linear prepack op for dtype:", dtype)  # noqa: TRY002
 
 def get_qconv_prepack_op(conv_op: Callable) -> Callable:
     prepack_ops = {

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -1453,7 +1453,7 @@ class PlaceholderObserver(ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             "calculate_qparams should not be called for PlaceholderObserver"
         )
 
@@ -1479,7 +1479,7 @@ class RecordingObserver(ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        raise Exception("calculate_qparams should not be called for RecordingObserver")
+        raise Exception("calculate_qparams should not be called for RecordingObserver")  # noqa: TRY002
 
     @torch.jit.export
     def get_tensor_value(self):
@@ -1510,7 +1510,7 @@ class NoopObserver(ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        raise Exception("calculate_qparams should not be called for NoopObserver")
+        raise Exception("calculate_qparams should not be called for NoopObserver")  # noqa: TRY002
 
 class ReuseInputObserver(ObserverBase):
     r""" This observer is used when we want to reuse the observer from the operator
@@ -1533,7 +1533,7 @@ class ReuseInputObserver(ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        raise Exception("calculate_qparams should not be called for ReuseInputObserver")
+        raise Exception("calculate_qparams should not be called for ReuseInputObserver")  # noqa: TRY002
 
 def _is_observer_script_module(mod, obs_type_name):
     """Returns true if given mod is an instance of Observer script module."""
@@ -1604,10 +1604,10 @@ def load_observer_state_dict(mod, obs_dict):
                 )
     for k in missing_keys:
         if "observer" in k or "activation_post_process" in k:
-            raise Exception(f"Missing keys for observer {k} in state_dict")
+            raise Exception(f"Missing keys for observer {k} in state_dict")  # noqa: TRY002
     for k in unexpected_keys:
         if "observer" in k or "activation_post_process" in k:
-            raise Exception(f"Unexpected keys for observer {k} in state_dict")
+            raise Exception(f"Unexpected keys for observer {k} in state_dict")  # noqa: TRY002
 
 
 # Restrict activations to be in the range (0,127)

--- a/torch/ao/quantization/pt2e/prepare.py
+++ b/torch/ao/quantization/pt2e/prepare.py
@@ -216,7 +216,7 @@ def _get_edge_or_node_to_group_id(edge_or_node_to_qspec: Dict[EdgeOrNode, Quanti
                 # sharing with other users of the producer node
                 # (arg, user)
                 if not isinstance(arg, Node) or not isinstance(n, Node):
-                    raise Exception(f"Expected input_edge to have type Tuple[Node, Node], but got: {arg, n}")
+                    raise Exception(f"Expected input_edge to have type Tuple[Node, Node], but got: {arg, n}")  # noqa: TRY002
                 for user in arg.users:
                     if user is n:
                         continue

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
@@ -971,7 +971,7 @@ def _annotate_cat(
 
         if cat_node.target != torch.ops.aten.cat.default:
             # TODO: change this to AnnotationException
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 f"Expected cat node: torch.ops.aten.cat.default, but found {cat_node.target}"
                 " please check if you are calling the correct capture API"
             )

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -320,7 +320,7 @@ def get_quant_type(qconfig):
         elif activation.dtype == torch.float16:
             return QuantType.STATIC
 
-    raise Exception(f"Unrecognized dtype combination in get_quant_type: activation({activation.dtype}),"
+    raise Exception(f"Unrecognized dtype combination in get_quant_type: activation({activation.dtype}),"  # noqa: TRY002
                     f"weight({weight.dtype})")
 
 def check_min_max_valid(min_val: torch.Tensor, max_val: torch.Tensor) -> bool:

--- a/torch/backends/_nnapi/prepare.py
+++ b/torch/backends/_nnapi/prepare.py
@@ -75,7 +75,7 @@ class NnapiModule(torch.nn.Module):
             elif fmt == 1:
                 fixed_args.append(args[idx].permute(0, 2, 3, 1).contiguous())
             else:
-                raise Exception("Invalid mem_fmt")
+                raise Exception("Invalid mem_fmt")  # noqa: TRY002
         comp.run(fixed_args, outs)
         assert len(outs) == len(self.out_mem_fmts)
         for idx in range(len(self.out_templates)):
@@ -87,7 +87,7 @@ class NnapiModule(torch.nn.Module):
             elif fmt == 1:
                 outs[idx] = outs[idx].permute(0, 3, 1, 2)
             else:
-                raise Exception("Invalid mem_fmt")
+                raise Exception("Invalid mem_fmt")  # noqa: TRY002
         return outs
 
 

--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -228,7 +228,7 @@ class Operand(NamedTuple):
             return True
         if self.dim_order is DimOrder.CHANNELS_LAST:
             return False
-        raise Exception("Unknown dim order")
+        raise Exception("Unknown dim order")  # noqa: TRY002
 
 
 def broadcast_shapes(shape1, shape2):
@@ -241,10 +241,14 @@ def broadcast_shapes(shape1, shape2):
     # don't match between PT and NNAPI, even though semantics match.
     if len(s1) > len(s2):
         # s2 = [1] * (len(s1) - len(s2)) + s2
-        raise Exception("Non-equal-rank broadcast is not supported yet.")
+        raise Exception(  # noqa: TRY002
+            "Non-equal-rank broadcast is not supported yet."
+        )  # noqa: TRY002
     if len(s2) > len(s1):
         # s3 = [1] * (len(s2) - len(s1)) + s1
-        raise Exception("Non-equal-rank broadcast is not supported yet.")
+        raise Exception(  # noqa: TRY002
+            "Non-equal-rank broadcast is not supported yet."
+        )  # noqa: TRY002
     ret = []
     for d1, d2 in zip(s1, s2):
         if d1 == 1:
@@ -254,7 +258,9 @@ def broadcast_shapes(shape1, shape2):
         elif d1 == d2:
             ret.append(d1)
         else:
-            raise Exception(f"Cannot broadcast shapes: {shape1} and {shape2}")
+            raise Exception(  # noqa: TRY002
+                f"Cannot broadcast shapes: {shape1} and {shape2}"
+            )  # noqa: TRY002
     return tuple(ret)
 
 
@@ -263,7 +269,7 @@ def get_conv_pool_shape(image_shape, args, out_ch, transpose):
 
     # TODO: Handle dilation
     if args.dilation_h != 1 or args.dilation_w != 1:
-        raise Exception("Dilation not supported yet.")
+        raise Exception("Dilation not supported yet.")  # noqa: TRY002
 
     if transpose:
         out_h = (in_h - 1) * args.stride_h + args.kernel_h - args.pad_t - args.pad_b
@@ -296,7 +302,7 @@ def fix_shape(shape, dim_order):
     if dim_order is DimOrder.UNKNOWN_CONSTANT:
         # XXX think this through
         return shape
-    raise Exception(f"Bad dim_order: {dim_order!r}.")
+    raise Exception(f"Bad dim_order: {dim_order!r}.")  # noqa: TRY002
 
 
 def reverse_map_dim(dim_order, d):
@@ -348,7 +354,7 @@ class _NnapiSerializer:
     def add_tensor_operand(self, jitval, oper):
         assert isinstance(oper, Operand)
         if jitval in self.jitval_operand_map:
-            raise Exception(f"Duplicate tensor: {jitval!r}")
+            raise Exception(f"Duplicate tensor: {jitval!r}")  # noqa: TRY002
 
         operand_id = self.get_next_operand_id()
         self.operands.append(oper)
@@ -393,16 +399,18 @@ class _NnapiSerializer:
                     scale = tensor.nnapi_scale
                     zero_point = tensor.nnapi_zero_point
                 else:
-                    raise Exception(
+                    raise Exception(  # noqa: TRY002
                         f"`nnapi_type` needs to be one of {op_codes} for `int16`"
                     )
             else:
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     "`int16` isn't supported. If you're trying to represent NNAPI"
                     " qint16 with Pytorch int16, set `use_int16_for_qint16 = True`"
                 )
         else:
-            raise Exception(f"Can't handle input with dtype '{tensor.dtype}'")
+            raise Exception(  # noqa: TRY002
+                f"Can't handle input with dtype '{tensor.dtype}'"
+            )  # noqa: TRY002
         return Operand(
             shape=tuple(tensor.shape),
             op_type=op_type,
@@ -491,7 +499,9 @@ class _NnapiSerializer:
             if s == 0:
                 # TODO: Improve this error message, possibly after converting
                 # many callsites to support flexible size.
-                raise Exception("Flexible size is not supported for this operand.")
+                raise Exception(  # noqa: TRY002
+                    "Flexible size is not supported for this operand."
+                )  # noqa: TRY002
             if s < 0:
                 # runtime flex
                 LOG.warning("Operand %s has runtime flex shape", oper)
@@ -526,10 +536,12 @@ class _NnapiSerializer:
     def get_constant_value(self, jitval, typekind=None):
         record = self.constants.get(jitval)
         if record is None:
-            raise Exception(f"Could not find constant value for '{jitval!r}'.")
+            raise Exception(  # noqa: TRY002
+                f"Could not find constant value for '{jitval!r}'."
+            )  # noqa: TRY002
         ctype, _ = record
         if typekind is not None and ctype.kind() != typekind:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 f"Expected constant value of type {typekind}, but got {ctype.kind()} for value '{jitval!r}'"
             )
         return record
@@ -553,7 +565,9 @@ class _NnapiSerializer:
                 # Runtime flexible shape
                 shape_parts.append("0")
             else:
-                raise Exception("Unknown dim value, dimensions should be >= -1")
+                raise Exception(  # noqa: TRY002
+                    "Unknown dim value, dimensions should be >= -1"
+                )  # noqa: TRY002
             shape_parts.append(",")
         shape_parts.append(")")
         shape_code = "".join(shape_parts)
@@ -574,12 +588,14 @@ class _NnapiSerializer:
             if self.use_int16_for_qint16:
                 return f"torch.zeros({shape_code}, dtype=torch.int16)"
             else:
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     "`int16` isn't supported. If you're trying to represent NNAPI"
                     " qint16 with Pytorch int16, set `use_int16_for_qint16 = True`"
                 )
 
-        raise Exception(f"Unsupported output operand type: {oper.op_type}")
+        raise Exception(  # noqa: TRY002
+            f"Unsupported output operand type: {oper.op_type}"
+        )  # noqa: TRY002
 
     def forward_operand_shape(self, out_op_id, out_dim, in_op_id, in_dim):
         self.compute_operand_shape(out_op_id, out_dim, flex_name(in_op_id, in_dim))
@@ -591,7 +607,9 @@ class _NnapiSerializer:
 
     def transpose_to_nhwc(self, in_id, oper):
         if oper.shape[2:] != (1, 1):
-            raise Exception("Automatic transpose only supported for H,W == 1,1")
+            raise Exception(  # noqa: TRY002
+                "Automatic transpose only supported for H,W == 1,1"
+            )  # noqa: TRY002
 
         out_oper = oper._replace(dim_order=DimOrder.CHANNELS_LAST)
 
@@ -618,7 +636,7 @@ class _NnapiSerializer:
         if orders == (DimOrder.CHANNELS_LAST, DimOrder.PRESUMED_CONTIGUOUS):
             return (in0_id, in0_oper) + self.transpose_to_nhwc(in1_id, in1_oper)
 
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             f"Automatic transpose not supported for dim_orders: {in0_oper.dim_order!r}, {in1_oper.dim_order!r}"
         )
 
@@ -627,7 +645,9 @@ class _NnapiSerializer:
         if ctype.kind() == "ListType":
             assert ctype.getElementType().kind() == "IntType"
             return value
-        raise Exception(f"Can't handle size arg of type '{ctype!r}' for '{jitval!r}'")
+        raise Exception(  # noqa: TRY002
+            f"Can't handle size arg of type '{ctype!r}' for '{jitval!r}'"
+        )  # noqa: TRY002
 
     def get_conv_pool_args_2d_from_pack(self, kernel_size, packed_config):
         pc = [i.item() for i in packed_config]
@@ -714,7 +734,9 @@ class _NnapiSerializer:
             return_values = self.tensor_sequences[retn_input]
             retval_count = len(return_values)
         else:
-            raise Exception(f"Unsupported return type: {retn_input.type()}")
+            raise Exception(  # noqa: TRY002
+                f"Unsupported return type: {retn_input.type()}"
+            )  # noqa: TRY002
 
         if return_shapes is not None:
             assert len(return_shapes) == len(return_values)
@@ -888,7 +910,9 @@ class _NnapiSerializer:
     def add_node(self, node):
         adder = self.ADDER_MAP.get(node.kind())
         if not adder:
-            raise Exception(f"Unsupported node kind ({node.kind()!r}) in node {node!r}")
+            raise Exception(  # noqa: TRY002
+                f"Unsupported node kind ({node.kind()!r}) in node {node!r}"
+            )  # noqa: TRY002
         adder(self, node)
 
     def _identity(self, node):
@@ -939,7 +963,7 @@ class _NnapiSerializer:
         if tensors is not None:
             self.add_tensor_sequence(output, tensors)
         if const_vals is None and tensors is None:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 f"Unable to handle ListConstruct node.  Neither all constants nor all tensors. {node!r}"
             )
 
@@ -989,7 +1013,7 @@ class _NnapiSerializer:
         is_trivial_reshape = len(shape) == 2 and shape[1] == -1
 
         if in_oper.dim_order != DimOrder.PRESUMED_CONTIGUOUS and not is_trivial_reshape:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "Currently, reshape is only supported on NHWC tensors if the target size is [X, -1]."
             )
 
@@ -1022,7 +1046,7 @@ class _NnapiSerializer:
             in_oper.shape[1] == 1 or (in_oper.shape[2] == 1 and in_oper.shape[3] == 1)
         )
         if in_oper.dim_order != DimOrder.PRESUMED_CONTIGUOUS and not is_trivial_flatten:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "Currently, flatten is not supported on NHWC tensors unless C=1 or H=W=1"
             )
 
@@ -1038,10 +1062,12 @@ class _NnapiSerializer:
         )
 
         if any(dim == 0 for dim in in_oper.shape[start_dim : end_dim + 1]):
-            raise Exception("Flattening flexible dims is not supported yet")
+            raise Exception(  # noqa: TRY002
+                "Flattening flexible dims is not supported yet"
+            )  # noqa: TRY002
         non_flattened_dims = in_oper.shape[:start_dim] + in_oper.shape[end_dim + 1 :]
         if non_flattened_dims.count(0) > 1:
-            raise Exception("Only 1 dim can be flexible")
+            raise Exception("Only 1 dim can be flexible")  # noqa: TRY002
 
         out_oper = in_oper._replace(
             shape=out_shape, dim_order=DimOrder.PRESUMED_CONTIGUOUS
@@ -1087,7 +1113,7 @@ class _NnapiSerializer:
             return
 
         if in_oper.shape[dim_value] == 0:
-            raise Exception("Unable to slice with flexible shape")
+            raise Exception("Unable to slice with flexible shape")  # noqa: TRY002
 
         if stop_value < 0:
             stop_value += in_oper.shape[dim_value]
@@ -1095,7 +1121,9 @@ class _NnapiSerializer:
             stop_value = in_oper.shape[dim_value]
 
         if start_value >= stop_value:
-            raise Exception("Slice start value should be less than stop value")
+            raise Exception(  # noqa: TRY002
+                "Slice start value should be less than stop value"
+            )  # noqa: TRY002
 
         out_len = (stop_value - start_value) // step_value
         out_shape = tuple(
@@ -1253,7 +1281,7 @@ class _NnapiSerializer:
 
         in_id, in_oper = self.get_tensor_operand_by_jitval_fixed_size(node.inputsAt(0))
         if in_oper.dim_order != DimOrder.CHANNELS_LAST:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "Most hardware backends prefer NHWC quantized tensors.  "
                 "Try setting `t.nnapi_nhwc = True` on your tensor inputs.  "
             )
@@ -1261,7 +1289,7 @@ class _NnapiSerializer:
         _, zero_point = self.get_constant_value(node.inputsAt(2), "IntType")
         _, scalar_type = self.get_constant_value(node.inputsAt(3), "IntType")
         if scalar_type != TorchScalarTypes.QUINT8.value:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "PyTorch NNAPI export only supports quantized tensors "
                 "with the quint8 dtype."
             )
@@ -1346,7 +1374,9 @@ class _NnapiSerializer:
                 node.inputsAt(0), in1_oper.dim_order
             )
         else:
-            raise Exception(f"Can't do a NNAPI binary op: {opcode} on two constants")
+            raise Exception(  # noqa: TRY002
+                f"Can't do a NNAPI binary op: {opcode} on two constants"
+            )  # noqa: TRY002
 
         assert in0_oper.op_type == in1_oper.op_type
         in0_id, in0_oper, in1_id, in1_oper = self.transpose_for_broadcast(
@@ -1390,7 +1420,9 @@ class _NnapiSerializer:
 
         _, alpha = self.get_constant_value(node.inputsAt(2), "IntType")
         if alpha != 1:
-            raise Exception("NNAPI does not support add/sub with alpha.")
+            raise Exception(  # noqa: TRY002
+                "NNAPI does not support add/sub with alpha."
+            )  # noqa: TRY002
 
         self._do_add_binary(node, opcode, fuse_code)
 
@@ -1440,7 +1472,9 @@ class _NnapiSerializer:
 
         opcode = op_map.get((min_val, max_val))
         if opcode is None:
-            raise Exception("NNAPI only supports hardtanh with args (-1, 1) or (0, 6).")
+            raise Exception(  # noqa: TRY002
+                "NNAPI only supports hardtanh with args (-1, 1) or (0, 6)."
+            )  # noqa: TRY002
 
         inputs = [None] * 1
         inputs[0] = in_id
@@ -1464,7 +1498,7 @@ class _NnapiSerializer:
         if w_oper.shape[0] > 1:
             if in_oper.use_nchw():
                 # TODO: Support this by adding trailing 1 dims.
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     "Per-channel PReLU only supports channels_last right now."
                 )
 
@@ -1473,7 +1507,9 @@ class _NnapiSerializer:
             if size > 0:
                 pass
             elif dim <= 1:
-                raise Exception("PReLU requires fixed size for dim 0 and dim 1.")
+                raise Exception(  # noqa: TRY002
+                    "PReLU requires fixed size for dim 0 and dim 1."
+                )  # noqa: TRY002
             else:
                 self.forward_operand_shape(out_id, dim, in_id, dim)
 
@@ -1499,7 +1535,7 @@ class _NnapiSerializer:
             self.get_size_arg(kernel), stride, padding, dilation
         )
         if args.dilation_h != 1 or args.dilation_w != 1:
-            raise Exception("NNAPI does not support dilated pooling.")
+            raise Exception("NNAPI does not support dilated pooling.")  # noqa: TRY002
 
         image_id, image_oper = self.get_tensor_operand_by_jitval_fixed_size(image)
         assert len(image_oper.shape) == 4
@@ -1545,7 +1581,7 @@ class _NnapiSerializer:
         _, count_include_pad_value = self.get_constant_value(count_include_pad)
         _, divisor_override_value = self.get_constant_value(divisor_override)
         if not count_include_pad_value or divisor_override_value:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "NNAPI doesn't support count_include_pad=False or divisor_override"
             )
 
@@ -1596,7 +1632,7 @@ class _NnapiSerializer:
         assert size_ctype.kind() == "ListType"
         assert size_ctype.getElementType().kind() == "IntType"
         if size_arg != [1, 1]:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "NNAPI only supports adaptive_avg_pool2d with output size (1, 1)."
             )
 
@@ -1651,7 +1687,7 @@ class _NnapiSerializer:
         assert len(image_oper.shape) == 4
 
         if size_ctype.kind() != "NoneType" and scale_ctype.kind() != "NoneType":
-            raise Exception("Size and scale cannot both be non-None.")
+            raise Exception("Size and scale cannot both be non-None.")  # noqa: TRY002
         elif size_ctype.kind() != "NoneType":
             assert size_ctype.kind() == "ListType"
             assert size_ctype.getElementType().kind() == "IntType"
@@ -1683,7 +1719,7 @@ class _NnapiSerializer:
             arg_h = self.add_immediate_float_scalar(scale_arg[0])
             arg_w = self.add_immediate_float_scalar(scale_arg[1])
         else:
-            raise Exception("Size and scale cannot both be None.")
+            raise Exception("Size and scale cannot both be None.")  # noqa: TRY002
 
         out_shape = (image_oper.shape[0], image_oper.shape[1], out_h, out_w)
         use_nchw = image_oper.use_nchw()
@@ -1692,7 +1728,7 @@ class _NnapiSerializer:
         )
 
         if image_oper.shape[0] == 0 or image_oper.shape[1] == 0:
-            raise Exception("Flexible batch or channels not supported")
+            raise Exception("Flexible batch or channels not supported")  # noqa: TRY002
 
         # Handle variable input size
         for dim in (2, 3):  # h, w indices
@@ -1706,7 +1742,9 @@ class _NnapiSerializer:
                         f"int({scale_arg[dim - 2]} * {flex_name(image_id, dim)})",
                     )
                 else:
-                    raise Exception("Size and scale cannot both be None.")
+                    raise Exception(  # noqa: TRY002
+                        "Size and scale cannot both be None."
+                    )  # noqa: TRY002
 
         inputs = [None] * 4
         inputs[0] = image_id
@@ -1728,7 +1766,7 @@ class _NnapiSerializer:
             scale_ctype, scale_value = self.get_constant_value(jitval)
             assert scale_ctype.kind() in ("IntType", "FloatType")
             if scale_value != 1:
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     "NNAPI Fully-Connected does not support alpha and beta."
                 )
 
@@ -1823,7 +1861,7 @@ class _NnapiSerializer:
         multiplier = input_oper.scale * weight_scale / out_scale
         assert multiplier > 0
         if multiplier >= 1:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "Quantized convolution multiplier is greater than 1.  "
                 "This is supported by NNAPI, but not by most hardware backends.  "
                 "Try training a model without quantization-aware training.  "
@@ -2005,7 +2043,7 @@ class _NnapiSerializer:
         multiplier = image_oper.scale * weight_scale / out_scale
         assert multiplier > 0
         if multiplier >= 1:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "Quantized convolution multiplier is greater than 1.  "
                 "This is supported by NNAPI, but not by most hardware backends.  "
                 "Try training a model without quantization-aware training.  "
@@ -2050,7 +2088,7 @@ class _NnapiSerializer:
             depthwise = True
             weight_permutation = (1, 2, 3, 0)
         else:
-            raise Exception("Group convolution not supported yet.")
+            raise Exception("Group convolution not supported yet.")  # noqa: TRY002
 
         # TODO: Transform at load time to share weights with CPU model.
         nnapi_weight_tensor = weight_tensor.permute(*weight_permutation).contiguous()
@@ -2068,7 +2106,9 @@ class _NnapiSerializer:
             assert approx_equal(image_oper.scale * weight_oper.scale, bias_oper.scale)
             assert bias_oper.zero_point == 0
         else:
-            raise Exception(f"Unsupported input type for conv2d: {image_oper.op_type}")
+            raise Exception(  # noqa: TRY002
+                f"Unsupported input type for conv2d: {image_oper.op_type}"
+            )  # noqa: TRY002
 
         assert len(image_oper.shape) == 4
         assert len(weight_oper.shape) == 4
@@ -2139,7 +2179,7 @@ class _NnapiSerializer:
         if batch == 0:
             self.forward_operand_shape(out_id, 0, image_id, 0)
         if in_ch == 0:
-            raise Exception("Input channels can't be flexible")
+            raise Exception("Input channels can't be flexible")  # noqa: TRY002
         # H & W
         if transpose:
             if in_h == 0:

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -18,7 +18,7 @@ def get_cudnn_mode(mode):
     elif mode == "GRU":
         return int(_cudnn.RNNMode.gru)
     else:
-        raise Exception(f"Unknown mode: {mode}")
+        raise Exception(f"Unknown mode: {mode}")  # noqa: TRY002
 
 
 # NB: We don't actually need this class anymore (in fact, we could serialize the

--- a/torch/cuda/jiterator.py
+++ b/torch/cuda/jiterator.py
@@ -38,7 +38,7 @@ class _CodeParser:
         )  # DOTALL for matching multiline
 
         if result is None:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 f"Couldn't parse code, please check correctness:\n {code_string}"
             )
 

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -916,7 +916,7 @@ class SimpleElasticAgent(ElasticAgent):
                     )
                     self._restart_workers(self._worker_group)
             else:
-                raise Exception(f"[{role}] Worker group in {state.name} state")
+                raise Exception(f"[{role}] Worker group in {state.name} state")  # noqa: TRY002
 
     def _exit_barrier(self):
         """

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1290,7 +1290,7 @@ def _is_named_optimizer(optim_state_dict: Dict[str, Any]) -> bool:
     try:
         key = next(iter(state.keys()))
     except Exception as e:
-        raise Exception(optim_state_dict) from e
+        raise Exception(optim_state_dict) from e  # noqa: TRY002
     return isinstance(key, str)
 
 

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -802,7 +802,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
             ranks = set(map(int, args.local_ranks_filter.split(",")))
             assert ranks
         except Exception as e:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "--local_ranks_filter must be a comma-separated list of integers e.g. --local_ranks_filter=0,1,2"
             ) from e
 

--- a/torch/fx/experimental/unification/utils.py
+++ b/torch/fx/experimental/unification/utils.py
@@ -82,7 +82,7 @@ def reverse_dict(d):
 def xfail(func):
     try:
         func()
-        raise Exception("XFailed test passed")  # pragma:nocover
+        raise Exception("XFailed test passed")  # pragma:nocover  # noqa: TRY002
     except Exception:
         pass
 

--- a/torch/fx/passes/infra/pass_manager.py
+++ b/torch/fx/passes/infra/pass_manager.py
@@ -293,7 +293,7 @@ class PassManager:
                         for p in self.passes[:i]
                     ]
                     msg = f"An error occurred when running the '{fn_name}' pass after the following passes: {prev_pass_names}"
-                    raise Exception(msg) from e
+                    raise Exception(msg) from e  # noqa: TRY002
 
             # If the graph no longer changes, then we can stop running these passes
             overall_modified = overall_modified or modified

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -307,7 +307,7 @@ def _check_repo_is_trusted(repo_owner, repo_name, owner_name_branch, trust_repo,
             if is_trusted:
                 print("The repository is already trusted.")
         elif response.lower() in ("n", "no", ""):
-            raise Exception("Untrusted repository.")
+            raise Exception("Untrusted repository.")  # noqa: TRY002
         else:
             raise ValueError(f"Unrecognized response {response}.")
 

--- a/torch/jit/_fuser.py
+++ b/torch/jit/_fuser.py
@@ -65,7 +65,7 @@ def fuser(name):
         torch._C._jit_set_nvfuser_enabled(False)
         torch._C._jit_set_llga_enabled(False)
     else:
-        raise Exception(f"unrecognized fuser option (name: {name})")
+        raise Exception(f"unrecognized fuser option (name: {name})")  # noqa: TRY002
     try:
         yield
     finally:

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -949,7 +949,7 @@ class PackageExporter:
             if _gate_torchscript_serialization and isinstance(
                 obj, torch.jit.RecursiveScriptModule
             ):
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     "Serializing ScriptModules directly into a package is a beta feature. "
                     "To use, set global "
                     "`torch.package.package_exporter._gate_torchscript_serialization` to `False`."

--- a/torch/profiler/_utils.py
+++ b/torch/profiler/_utils.py
@@ -182,7 +182,7 @@ class BasicEvaluation:
                 return event.start_ns()
             if hasattr(event, "start_time_ns"):
                 return event.start_time_ns
-            raise Exception("Unknown Event Type")
+            raise Exception("Unknown Event Type")  # noqa: TRY002
 
         queue_depth_list: List[Interval] = []
         all_events.sort(key=new_old_event_comparator)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -973,7 +973,7 @@ class ops(_TestParametrizer):
                         except Exception as e:
                             tracked_input = get_tracked_input()
                             if PRINT_REPRO_ON_FAILURE and tracked_input is not None:
-                                raise Exception(
+                                raise Exception(  # noqa: TRY002
                                     f"Caused by {tracked_input.type_desc} "
                                     f"at index {tracked_input.index}: "
                                     f"{_serialize_sample(tracked_input.val)}") from e

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -201,7 +201,7 @@ class SimulateBackwardError(Function):
     @once_differentiable
     def backward(ctx, input):
         if SimulateBackwardError._simulate_error:
-            raise Exception("Simulate error on backward pass")
+            raise Exception("Simulate error on backward pass")  # noqa: TRY002
         else:
             return input
 

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -236,11 +236,11 @@ def build_complex_tensors():
 
 def non_cont_test(t_view, t_cont):
     if t_view.is_contiguous():
-        raise Exception('t_view is contiguous!')
+        raise Exception('t_view is contiguous!')  # noqa: TRY002
     if not t_cont.is_contiguous():
-        raise Exception('t_cont is not contiguous!')
+        raise Exception('t_cont is not contiguous!')  # noqa: TRY002
     if not torch.equal(t_view, t_cont):
-        raise Exception('t_view is not equal to t_cont!')
+        raise Exception('t_view is not equal to t_cont!')  # noqa: TRY002
     return t_view
 
 def my_function(a, b, c):

--- a/torch/utils/bundled_inputs.py
+++ b/torch/utils/bundled_inputs.py
@@ -104,7 +104,7 @@ def bundle_inputs(
     Tensors in lists or tuples will not.
     """
     if not isinstance(model, torch.jit.ScriptModule):
-        raise Exception("Only ScriptModule is supported.")
+        raise Exception("Only ScriptModule is supported.")  # noqa: TRY002
 
     ignored_methods, ignored_attrs = _get_bundled_inputs_attributes_and_methods(model)
     clone = torch._C._hack_do_not_use_clone_module_with_class(  # type: ignore[attr-defined]
@@ -162,7 +162,7 @@ def augment_model_with_bundled_inputs(
         of each tuple are the args that make up one input.
     """
     if not isinstance(model, torch.jit.ScriptModule):
-        raise Exception("Only ScriptModule is supported.")
+        raise Exception("Only ScriptModule is supported.")  # noqa: TRY002
 
     forward: Callable = model.forward
 
@@ -235,13 +235,13 @@ def augment_many_model_functions_with_bundled_inputs(
     Tensors in lists or tuples will not.
     """
     if not isinstance(model, torch.jit.ScriptModule):
-        raise Exception("Only ScriptModule is supported.")
+        raise Exception("Only ScriptModule is supported.")  # noqa: TRY002
 
     if not inputs:
-        raise Exception("Please provide inputs for at least 1 function")
+        raise Exception("Please provide inputs for at least 1 function")  # noqa: TRY002
 
     if hasattr(model, "get_all_bundled_inputs") or hasattr(model, "get_bundled_inputs_functions_and_info"):
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             "Models can only be augmented with bundled inputs once. "
             "This Model seems to have already been augmented with "
             "bundled inputs. Please start afresh with one that "
@@ -257,7 +257,7 @@ def augment_many_model_functions_with_bundled_inputs(
             if hasattr(function, "name"):
                 function_name = function.name  # type: ignore[attr-defined]
             else:
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     'At least one of your functions has no attribute name please ensure all have one. m.foo.name = "foo"')
 
 
@@ -270,12 +270,12 @@ def augment_many_model_functions_with_bundled_inputs(
 
         if hasattr(model, "_generate_bundled_inputs_for_" + function_name):
             if input_list is not None:
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     f"inputs[{function_name}] is not None, but _generate_bundled_inputs_for_{function_name} is already defined"
                 )
             # Model author already defined _generate_bundled_inputs_for_<function_name>.
         elif input_list is None or len(input_list) == 0:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 f"inputs for {function_name} must be specified if "
                 f"_generate_bundled_inputs_for_{function_name} is not already defined"
             )
@@ -369,7 +369,7 @@ def _inflate_expr(
     if isinstance(arg, InflatableArg):
         if arg.fmt_fn:
             if arg.fmt not in ["{}", ""]:
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     f"Bundled input argument at position '{ref}' has "
                     f"both arg.fmt_fn => \n{arg.fmt_fn} "
                     f"\n and arg.fmt  => {arg.fmt}. "
@@ -400,7 +400,7 @@ def _inflate_expr(
                         f"{ref}.contiguous(memory_format={fmt})", None)
         # Prevent big tensors from being bundled by default.
         # TODO: Provide more useful diagnostics.
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             f"Bundled input argument at position '{ref}' is "
             f"a tensor with storage size {arg._typed_storage().size()}. "
             f"You probably don't want to bundle this as an input. "

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -26,7 +26,7 @@ class PandasWrapper:
     @classmethod
     def create_dataframe(cls, data, columns):
         if not _with_pandas():
-            raise Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")  # noqa: TRY002
         return _pandas.DataFrame(data, columns=columns)  # type: ignore[union-attr]
 
     @classmethod
@@ -44,31 +44,31 @@ class PandasWrapper:
     @classmethod
     def iterate(cls, data):
         if not _with_pandas():
-            raise Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")  # noqa: TRY002
         yield from data.itertuples(index=False)
 
     @classmethod
     def concat(cls, buffer):
         if not _with_pandas():
-            raise Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")  # noqa: TRY002
         return _pandas.concat(buffer)  # type: ignore[union-attr]
 
     @classmethod
     def get_item(cls, data, idx):
         if not _with_pandas():
-            raise Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")  # noqa: TRY002
         return data[idx: idx + 1]
 
     @classmethod
     def get_len(cls, df):
         if not _with_pandas():
-            raise Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")  # noqa: TRY002
         return len(df.index)
 
     @classmethod
     def get_columns(cls, df):
         if not _with_pandas():
-            raise Exception("DataFrames prototype requires pandas to function")
+            raise Exception("DataFrames prototype requires pandas to function")  # noqa: TRY002
         return list(df.columns.values.tolist())
 
 

--- a/torch/utils/data/datapipes/dataframe/dataframes.py
+++ b/torch/utils/data/datapipes/dataframe/dataframes.py
@@ -90,7 +90,7 @@ class Capture:
 
     def __getattr__(self, attrname):
         if attrname == 'kwarg' or attrname == 'kwargs':
-            raise Exception('no kwargs!')
+            raise Exception('no kwargs!')  # noqa: TRY002
         if attrname in ['__deepcopy__']:
             raise AttributeError
         result = CaptureGetAttr(self, attrname, ctx=self.ctx)
@@ -244,7 +244,7 @@ class CaptureVariable(Capture):
 
     def __init__(self, value, ctx):
         if CaptureControl.disabled:
-            raise Exception('Attempting to create capture variable with capture off')
+            raise Exception('Attempting to create capture variable with capture off')  # noqa: TRY002
         self.ctx = ctx
         self.value = value
         self.name = f'var_{CaptureVariable.names_idx}'
@@ -404,7 +404,7 @@ class CaptureDataFrameWithDataPipeOps(CaptureDataFrame):
         return self._dataframes_filter(*args, **kwargs)
 
     def collate(self, *args, **kwargs):
-        raise Exception("Can't collate unbatched DataFrames stream")
+        raise Exception("Can't collate unbatched DataFrames stream")  # noqa: TRY002
 
     def __getattr__(self, attrname):  # ?
         if attrname in UNIMPLEMENTED_ATTR:

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -132,7 +132,7 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
     @classmethod
     def register_datapipe_as_function(cls, function_name, cls_to_register, enable_df_api_tracing=False):
         if function_name in cls.functions:
-            raise Exception(f"Unable to add DataPipe function name {function_name} as it is already taken")
+            raise Exception(f"Unable to add DataPipe function name {function_name} as it is already taken")  # noqa: TRY002
 
         def class_function(cls, enable_df_api_tracing, source_dp, *args, **kwargs):
             result_pipe = cls(source_dp, *args, **kwargs)
@@ -174,13 +174,13 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
     @classmethod
     def set_getstate_hook(cls, hook_fn):
         if IterDataPipe.getstate_hook is not None and hook_fn is not None:
-            raise Exception("Attempt to override existing getstate_hook")
+            raise Exception("Attempt to override existing getstate_hook")  # noqa: TRY002
         IterDataPipe.getstate_hook = hook_fn
 
     @classmethod
     def set_reduce_ex_hook(cls, hook_fn):
         if IterDataPipe.reduce_ex_hook is not None and hook_fn is not None:
-            raise Exception("Attempt to override existing reduce_ex_hook")
+            raise Exception("Attempt to override existing reduce_ex_hook")  # noqa: TRY002
         IterDataPipe.reduce_ex_hook = hook_fn
 
     def __repr__(self):
@@ -275,7 +275,7 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
     @classmethod
     def register_datapipe_as_function(cls, function_name, cls_to_register):
         if function_name in cls.functions:
-            raise Exception(f"Unable to add DataPipe function name {function_name} as it is already taken")
+            raise Exception(f"Unable to add DataPipe function name {function_name} as it is already taken")  # noqa: TRY002
 
         def class_function(cls, source_dp, *args, **kwargs):
             result_pipe = cls(source_dp, *args, **kwargs)
@@ -310,13 +310,13 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
     @classmethod
     def set_getstate_hook(cls, hook_fn):
         if MapDataPipe.getstate_hook is not None and hook_fn is not None:
-            raise Exception("Attempt to override existing getstate_hook")
+            raise Exception("Attempt to override existing getstate_hook")  # noqa: TRY002
         MapDataPipe.getstate_hook = hook_fn
 
     @classmethod
     def set_reduce_ex_hook(cls, hook_fn):
         if MapDataPipe.reduce_ex_hook is not None and hook_fn is not None:
-            raise Exception("Attempt to override existing reduce_ex_hook")
+            raise Exception("Attempt to override existing reduce_ex_hook")  # noqa: TRY002
         MapDataPipe.reduce_ex_hook = hook_fn
 
     def __repr__(self):

--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -136,7 +136,7 @@ def _collate_helper(conversion, item):
     # TODO(VitalyFedyunin): Verify that item is any sort of batch
     if len(item.items) > 1:
         # TODO(VitalyFedyunin): Compact all batch dataframes into one
-        raise Exception("Only supports one DataFrame per batch")
+        raise Exception("Only supports one DataFrame per batch")  # noqa: TRY002
     df = item[0]
     columns_name = df_wrapper.get_columns(df)
     tuple_names: List = []
@@ -144,12 +144,12 @@ def _collate_helper(conversion, item):
 
     for name in conversion.keys():
         if name not in columns_name:
-            raise Exception("Conversion keys missmatch")
+            raise Exception("Conversion keys missmatch")  # noqa: TRY002
 
     for name in columns_name:
         if name in conversion:
             if not callable(conversion[name]):
-                raise Exception('Collate (DF)DataPipe requires callable as dict values')
+                raise Exception('Collate (DF)DataPipe requires callable as dict values')  # noqa: TRY002
             collation_fn = conversion[name]
         else:
             # TODO(VitalyFedyunin): Add default collation into df_wrapper
@@ -157,7 +157,7 @@ def _collate_helper(conversion, item):
                 import torcharrow.pytorch as tap  # type: ignore[import]
                 collation_fn = tap.rec.Default()
             except Exception as e:
-                raise Exception("unable to import default collation function from the TorchArrow") from e
+                raise Exception("unable to import default collation function from the TorchArrow") from e  # noqa: TRY002
 
         tuple_names.append(str(name))
         value = collation_fn(df[name])

--- a/torch/utils/data/datapipes/iter/sharding.py
+++ b/torch/utils/data/datapipes/iter/sharding.py
@@ -50,10 +50,10 @@ class ShardingFilterIterDataPipe(_ShardingIterDataPipe):
             raise ValueError(f"instance_id({instance_id}) should be smaller than num_of_instances({num_of_instances})")
         if sharding_group == SHARDING_PRIORITIES.DEFAULT:
             if len(self.groups) and SHARDING_PRIORITIES.DEFAULT not in self.groups:
-                raise Exception('ShardingFilter cannot mix DEFAULT and non DEFAULT groups')
+                raise Exception('ShardingFilter cannot mix DEFAULT and non DEFAULT groups')  # noqa: TRY002
         else:
             if SHARDING_PRIORITIES.DEFAULT in self.groups:
-                raise Exception('ShardingFilter cannot mix DEFAULT and non DEFAULT groups')
+                raise Exception('ShardingFilter cannot mix DEFAULT and non DEFAULT groups')  # noqa: TRY002
         self.groups[sharding_group] = (num_of_instances, instance_id)
         self._update_num_of_instances()
 

--- a/torch/utils/model_dump/__init__.py
+++ b/torch/utils/model_dump/__init__.py
@@ -181,8 +181,8 @@ def hierarchical_pickle(data):
                 "__module_type__": typename,
                 "state": hierarchical_pickle((msg,)),
             }
-        raise Exception(f"Can't prepare fake object of type for JS: {typename}")
-    raise Exception(f"Can't prepare data of type for JS: {type(data)}")
+        raise Exception(f"Can't prepare fake object of type for JS: {typename}")  # noqa: TRY002
+    raise Exception(f"Can't prepare data of type for JS: {type(data)}")  # noqa: TRY002
 
 
 def get_model_info(
@@ -217,7 +217,7 @@ def get_model_info(
             if path_prefix is None:
                 path_prefix = prefix
             elif prefix != path_prefix:
-                raise Exception(f"Mismatched prefixes: {path_prefix} != {prefix}")
+                raise Exception(f"Mismatched prefixes: {path_prefix} != {prefix}")  # noqa: TRY002
             zip_files.append(dict(
                 filename=zi.filename,
                 compression=zi.compress_type,
@@ -411,4 +411,4 @@ def main(argv, *, stdout=None):
         page = burn_in_info(skeleton, info)
         output.write(page)
     else:
-        raise Exception("Invalid style")
+        raise Exception("Invalid style")  # noqa: TRY002

--- a/torch/utils/show_pickle.py
+++ b/torch/utils/show_pickle.py
@@ -40,7 +40,7 @@ class FakeObject:
             printer._format(obj.state, stream, indent, allowance + 1, context, level + 1)
             stream.write(")")
             return
-        raise Exception("Need to implement")
+        raise Exception("Need to implement")  # noqa: TRY002
 
 
 class FakeClass:
@@ -84,7 +84,7 @@ class DumpUnpickler(pickle._Unpickler):  # type: ignore[name-defined]
     def load_binunicode(self):
         strlen, = struct.unpack("<I", self.read(4))  # type: ignore[attr-defined]
         if strlen > sys.maxsize:
-            raise Exception("String too long.")
+            raise Exception("String too long.")  # noqa: TRY002
         str_bytes = self.read(strlen)  # type: ignore[attr-defined]
         obj: Any
         try:
@@ -107,7 +107,7 @@ def main(argv, output_stream=None):
     if len(argv) != 2:
         # Don't spam stderr if not using stdout.
         if output_stream is not None:
-            raise Exception("Pass argv of length 2.")
+            raise Exception("Pass argv of length 2.")  # noqa: TRY002
         sys.stderr.write("usage: show_pickle PICKLE_FILE\n")
         sys.stderr.write("  PICKLE_FILE can be any of:\n")
         sys.stderr.write("    path to a pickle file\n")
@@ -137,7 +137,7 @@ def main(argv, output_stream=None):
                         found = True
                         break
                 if not found:
-                    raise Exception(f"Could not find member matching {mname} in {zfname}")
+                    raise Exception(f"Could not find member matching {mname} in {zfname}")  # noqa: TRY002
 
 
 if __name__ == "__main__":

--- a/torch/utils/tensorboard/_caffe2_graph.py
+++ b/torch/utils/tensorboard/_caffe2_graph.py
@@ -320,7 +320,7 @@ def _tf_device(device_option):
         return "/cpu:*"
     if device_option.device_type == caffe2_pb2.CUDA:
         return f"/gpu:{device_option.device_id}"
-    raise Exception("Unhandled device", device_option)
+    raise Exception("Unhandled device", device_option)  # noqa: TRY002
 
 
 def _add_tf_shape(attr_dict, ints):

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -986,7 +986,7 @@ class SummaryWriter:
                     "warning: Embedding dir exists, did you set global_step for add_embedding()?"
                 )
             else:
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     f"Path: `{save_path}` exists, but is a file. Cannot proceed."
                 )
         else:

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -132,7 +132,7 @@ def _lazy_init():
                         f"XPU call failed lazily at initialization with error: {str(e)}\n\n"
                         f"XPU call was originally invoked at:\n\n{''.join(orig_traceback)}"
                     )
-                    raise Exception(msg) from e
+                    raise Exception(msg) from e  # noqa: TRY002
         finally:
             delattr(_tls, "is_initializing")
         _initialized = True

--- a/torchgen/api/unboxing.py
+++ b/torchgen/api/unboxing.py
@@ -117,7 +117,7 @@ def convert_arguments(f: NativeFunction) -> Tuple[List[Binding], List[str]]:
     for arg in args:
         # expecting only Argument
         if not isinstance(arg.argument, Argument):
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 f"Unexpected argument type, expecting `Argument` but got {arg}"
             )
         argument: Argument = arg.argument
@@ -165,7 +165,7 @@ def argumenttype_ivalue_convert(
             ctype=ctype,
         )
     else:
-        raise Exception(f"Cannot handle type {t}. arg_name: {arg_name}")
+        raise Exception(f"Cannot handle type {t}. arg_name: {arg_name}")  # noqa: TRY002
     return out_name, ctype, code, decl
 
 

--- a/torchgen/executorch/api/custom_ops.py
+++ b/torchgen/executorch/api/custom_ops.py
@@ -47,7 +47,9 @@ class ComputeNativeFunctionStub:
                     # Returns an empty tensor
                     ret_name = "at::Tensor()"
                 else:
-                    raise Exception(f"Can't handle this return type {f.func}")
+                    raise Exception(  # noqa: TRY002
+                        f"Can't handle this return type {f.func}"
+                    )  # noqa: TRY002
         elif len(f.func.arguments.out) == len(f.func.returns):
             # Returns a tuple of out arguments
             tensor_type = "at::Tensor &"

--- a/torchgen/executorch/api/unboxing.py
+++ b/torchgen/executorch/api/unboxing.py
@@ -57,7 +57,7 @@ class Unboxing:
         for arg in args:
             # expecting only Argument
             if not isinstance(arg.argument, Argument):
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     f"Unexpected argument type, expecting `Argument` but got {arg}"
                 )
             argument: Argument = arg.argument
@@ -99,7 +99,9 @@ class Unboxing:
                 arg_name=arg_name, out_name=out_name, t=t, ctype=ctype
             )
         else:
-            raise Exception(f"Cannot handle type {t}. arg_name: {arg_name}")
+            raise Exception(  # noqa: TRY002
+                f"Cannot handle type {t}. arg_name: {arg_name}"
+            )  # noqa: TRY002
         return out_name, ctype, code, decl
 
     def _gen_code_base_type(

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -132,7 +132,7 @@ class ComputeFunction:
 
         # only valid remaining case is only function is in f.variants
         elif not (Variant.function in f.variants and Variant.method not in f.variants):
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 f"Can't handle native function {f.func} with the following variant specification {f.variants}."
             )
 
@@ -228,7 +228,7 @@ class ComputeCodegenUnboxedKernels:
 
         if len(f.func.returns) == 0:
             if len(f.func.arguments.out) == 0:
-                raise Exception(
+                raise Exception(  # noqa: TRY002
                     f"Can't handle native function {f.func} with no returns and no out yet."
                 )
             out = f.func.arguments.out[0]

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -138,7 +138,7 @@ def validate_shape_inference_header(
         decl for decl in expected_shape_infr_decls if decl not in shape_infr_decl_lines
     ]
     if missing_decls:
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             f"""Missing shape inference function.\n
 Please add declare this function in {shape_inference_hdr}:\n
 and implement it in the corresponding shape_inference.cpp file.\n

--- a/torchgen/selective_build/operator.py
+++ b/torchgen/selective_build/operator.py
@@ -61,7 +61,7 @@ class SelectiveBuildOperator:
         }
 
         if len(set(op_info.keys()) - allowed_keys) > 0:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "Got unexpected top level keys: {}".format(
                     ",".join(set(op_info.keys()) - allowed_keys),
                 )
@@ -132,7 +132,7 @@ def combine_operators(
     lhs: "SelectiveBuildOperator", rhs: "SelectiveBuildOperator"
 ) -> "SelectiveBuildOperator":
     if str(lhs.name) != str(rhs.name):
-        raise Exception(
+        raise Exception(  # noqa: TRY002
             f"Expected both arguments to have the same name, but got '{str(lhs.name)}' and '{str(rhs.name)}' instead"
         )
 

--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -80,7 +80,7 @@ class SelectiveBuilder:
         }
         top_level_keys = set(data.keys())
         if len(top_level_keys - valid_top_level_keys) > 0:
-            raise Exception(
+            raise Exception(  # noqa: TRY002
                 "Got unexpected top level keys: {}".format(
                     ",".join(top_level_keys - valid_top_level_keys),
                 )
@@ -255,7 +255,7 @@ class SelectiveBuilder:
                     break
             if not key_found:
                 if "default" not in kernel_key:
-                    raise Exception("Missing kernel for the model")
+                    raise Exception("Missing kernel for the model")  # noqa: TRY002
                 else:
                     result_set.add("default")
 

--- a/torchgen/shape_functions/gen_jit_shape_functions.py
+++ b/torchgen/shape_functions/gen_jit_shape_functions.py
@@ -16,7 +16,7 @@ module_name = "torch.jit._shape_functions"
 err_msg = """Could not find shape functions file, please make sure
 you are in the root directory of the Pytorch git repo"""
 if not file_path.exists():
-    raise Exception(err_msg)
+    raise Exception(err_msg)  # noqa: TRY002
 
 spec = importlib.util.spec_from_file_location(module_name, file_path)
 assert spec is not None


### PR DESCRIPTION
Adds a ruff lint rule to ban raising raw exceptions. Most of these should at the very least be runtime exception, value errors, type errors or some other errors. There are hundreds of instance of these bad exception types already in the codebase, so I have noqa'd most of them. Hopefully this error code will get commiters to rethink what exception type they should raise when they submit a PR.

I also encourage people to gradually go and fix all the existing noqas that have been added so they can be removed overtime and our exception typing can be improved.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @aakhundov @ColinPeppler @amjames @desertfire