### PR TITLE
[Inductor Cutlass backend] Set INDUCTOR_TEST_DISABLE_FRESH_CACHE in test setup

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -44,6 +44,12 @@ def _get_path_without_sccache() -> str:
 @instantiate_parametrized_tests
 class TestCutlassBackend(TestCase):
     def setUp(self):
+        # The new inductor cache refresh mechanism
+        # introduced with https://github.com/pytorch/pytorch/pull/122661
+        # interacts badly with persistent subprocesses during
+        # autotuning. So we need to disable automatic cache refresh
+        # before calling setUp() on the parent class.
+        os.environ["INDUCTOR_TEST_DISABLE_FRESH_CACHE"] = "1"
         super().setUp()
         torch.random.manual_seed(1234)
 

--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -49,8 +49,16 @@ class TestCutlassBackend(TestCase):
         # interacts badly with persistent subprocesses during
         # autotuning. So we need to disable automatic cache refresh
         # before calling setUp() on the parent class.
-        os.environ["INDUCTOR_TEST_DISABLE_FRESH_CACHE"] = "1"
-        super().setUp()
+        old_disable_fresh_cache_envvar = os.environ.get(
+            "INDUCTOR_TEST_DISABLE_FRESH_CACHE", ""
+        )
+        try:
+            os.environ["INDUCTOR_TEST_DISABLE_FRESH_CACHE"] = "1"
+            super().setUp()
+        finally:
+            os.environ[
+                "INDUCTOR_TEST_DISABLE_FRESH_CACHE"
+            ] = old_disable_fresh_cache_envvar
         torch.random.manual_seed(1234)
 
     @unittest.skipIf(not SM75OrLater, "need sm_75")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #121492
* #124577
* #124576
* #124575
* __->__ #124574
* #124107
* #121734

The diff https://github.com/pytorch/pytorch/pull/122661 introduces a new automatic cache refresh mechanism during all inductor-derived test cases.

But this refresh mechanism seems not to work properly across process boundaries, specifically when using  autotune_in_subproc, which many tests in test_cutlass_backend.py rely on.

Solution: Set the env var INDUCTOR_TEST_DISABLE_FRESH_CACHE=1
early during test setup within test_cutlass_backend.py

Test Plan:
This is a change to unit tests only.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @muchulee8 @ColinPeppler @amjames @desertfire @chauhang