### PR TITLE
[Inductor Cutlass backend] clean up CUTLASSGemmTemplate.add_cutlass_gemm_choices

### DIFF
--- a/torch/_inductor/codegen/cuda/gemm_template.py
+++ b/torch/_inductor/codegen/cuda/gemm_template.py
@@ -1,10 +1,11 @@
 import copy
 import logging
 import re
-from typing import cast, Dict, List, Optional, Tuple
+from typing import cast, Dict, List, Optional, Tuple, Union
 
+from ... import ir
 from ...config import cuda as inductor_cuda_config
-from ...ir import Buffer, CUDATemplateBuffer, FixedLayout, IRNode, Layout
+from ...ir import Buffer, ChoiceCaller, CUDATemplateBuffer, FixedLayout, IRNode, Layout
 from ..common import IndentedBuffer
 
 from . import cutlass_utils
@@ -186,60 +187,52 @@ class CUTLASSGemmTemplate(CUTLASSTemplate):
 
     @staticmethod
     def add_cutlass_gemm_choices(
-        choices,
-        layout,
-        input_nodes,
-        alpha=1,
-        beta=0,
-        input_reorder=None,
-        fuseable=True,
-        non_fuseable=True,
-    ):
-        if non_fuseable:
-            if fuseable:
-                # list both fuseable and non-fuseable ops, and treat them all as non-fuseable
-                can_fuse_epilogue = False
-            else:
-                can_fuse_epilogue = None
+        choices: List[ChoiceCaller],
+        layout: ir.Layout,
+        input_nodes: List[ir.IRNode],
+        alpha: Union[float, int] = 1,
+        beta: Union[float, int] = 0,
+        input_reorder: Optional[List[int]] = None,
+        **extra_kwargs,
+    ) -> None:
+        """
+        Adds Cutlass GEMM configurations choices to the auto-tuning list.
 
-            cutlass_template = CUTLASSGemmTemplate(
-                input_nodes,
-                layout,
-                alpha=alpha,
-                beta=beta,
-                input_reorder=input_reorder,
-                can_fuse_epilogue=can_fuse_epilogue,
+        This function mutates the passed list of choices by appending the choices for Cutlass GEMM configs to it.
+
+        Args:
+            choices (list): The list to which choices are appended.
+            layout (ir.Layout): The layout configuration.
+            input_nodes (list): The list of input nodes.
+            alpha (float,int): Scaling factor, defaults to 1.
+            beta (float,int): Offset, defaults to 0.
+            input_reorder (list, optional): Order of the inputs, defaults to None.
+            **extra_kwargs: Additional keyword arguments.
+
+        """
+
+        cutlass_template = CUTLASSGemmTemplate(
+            input_nodes,  # type: ignore[arg-type]
+            layout,
+            alpha=alpha,
+            beta=beta,
+            input_reorder=input_reorder,
+        )
+        ops = cutlass_template.gen_ops()
+        for op in ops:
+            cutlass_template.maybe_append_choice(
+                choices,
+                op=op,
             )
-            ops = cutlass_template.gen_ops()
-            for op in ops:
-                cutlass_template.maybe_append_choice(
-                    choices,
-                    op=op,
-                )
-        else:
-            ops = []
-        if fuseable:
-            cutlass_template_evt = CUTLASSGemmTemplate(
-                input_nodes,
-                layout,
-                alpha=alpha,
-                beta=beta,
-                input_reorder=input_reorder,
-                can_fuse_epilogue=True,
-            )
-            # This will list only ops capable of EVT fusion
-            ops_evt = cutlass_template_evt.gen_ops()
-            for op in ops_evt:
-                cutlass_template_evt.maybe_append_choice(
-                    choices,
-                    op=op,
-                )
-        else:
-            ops_evt = []
+        if len(ops) == 0:
+            input_layouts = [node.get_layout() for node in input_nodes]
+            input_strides = [node.get_stride() for node in input_nodes]
+            output_layout = layout
+            warning_msg = f"No suitable Cutlass GEMM configs found, fallbacks used ( {len(ops)=}, {output_layout=}, {input_layouts=}, {input_strides=} )"  # noqa: B950
+            log.warning(warning_msg)
         log.debug(
-            "Added %d cutlass gemm configs and %d fuseable gemm configs.",
+            "Added %d Cutlass gemm configs.",
             len(ops),
-            len(ops_evt),
         )
 
     def header(self) -> IndentedBuffer:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #121492
* #124577
* #124576
* __->__ #124575
* #124574
* #124107
* #121734

Clean up CUTLASSGemmTemplate.add_cutlass_gemm_choices, removing code that became unneccessary by removing EVT-based epilogue fusion.

Test Plan:
Already covered by test_cutlass_backend.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @muchulee8 @ColinPeppler @amjames @desertfire @chauhang