### PR TITLE
[nn modules] Make _parameters, _buffers and _modules regular dicts

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -445,8 +445,8 @@ class Module:
         super().__setattr__ for all other attributes.
         """
         super().__setattr__('training', True)
-        super().__setattr__('_parameters', OrderedDict())
-        super().__setattr__('_buffers', OrderedDict())
+        super().__setattr__('_parameters', dict())
+        super().__setattr__('_buffers', dict())
         super().__setattr__('_non_persistent_buffers_set', set())
         super().__setattr__('_backward_pre_hooks', OrderedDict())
         super().__setattr__('_backward_hooks', OrderedDict())
@@ -460,7 +460,7 @@ class Module:
         super().__setattr__('_state_dict_pre_hooks', OrderedDict())
         super().__setattr__('_load_state_dict_pre_hooks', OrderedDict())
         super().__setattr__('_load_state_dict_post_hooks', OrderedDict())
-        super().__setattr__('_modules', OrderedDict())
+        super().__setattr__('_modules', dict())
 
         if self.call_super_init:
             super().__init__(*args, **kwargs)
@@ -2560,7 +2560,7 @@ class Module:
 
         # replicas do not have parameters themselves, the replicas reference the original
         # module.
-        replica._parameters = OrderedDict()
+        replica._parameters = dict()
         replica._buffers = replica._buffers.copy()
         replica._modules = replica._modules.copy()
         replica._is_replica = True  # type: ignore[assignment]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124578
* #124522
* #124627

Regular dicts are completely implemented in C. OrderedDict have some key ordering infra completely in python, and it overrides the `keys` method of regular dicts.

Since regular dicts are in C, TorchDynamo can use a really fast CPP guard relying on PyDict_Next. But with OrderedDict, TorchDynamo has to call OrderedDict `keys` method to get the correct key ordering. Some more details here - https://github.com/pytorch/pytorch/blob/main/torch/csrc/dynamo/guards.cpp#L2304-L2325

This PR Speeds up nn module guards on TorchDynamo for MobileBert model from ~38000 units to ~25000 units, just because it can rely on PyDict_Next.

I am not sure if change is ok wrt BC etc. If this requires more discussion, I can open an issue. Let me know.
