### PR TITLE
[inductor] remove dtype constrain for test_tmp_not_defined_issue2

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7586,8 +7586,7 @@ class CommonTemplate:
             sum_default_7 = torch.ops.aten.sum.default(mul_tensor_24)
             return (new_zeros_default_4, sum_default_7)
 
-        # TODO: Remove once https://github.com/pytorch/pytorch/issues/94017 is resolved
-        dtype = torch.float64 if self.device == "cpu" else torch.float32
+        dtype = torch.float32
         args = [
             ((1, 88, 40, 40), (140800, 1600, 40, 1), dtype),
             ((), (), dtype),


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/94017.
Same root cause with https://github.com/pytorch/pytorch/pull/122289. Do not need use double for cpu test now.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124584



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang