### PR TITLE
is_any_autocast_enabled support privateuseone.

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -503,7 +503,8 @@ static PyObject* is_any_autocast_enabled(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   if (at::autocast::is_enabled() || at::autocast::is_cpu_enabled() ||
       at::autocast::is_xpu_enabled() || at::autocast::is_ipu_enabled() ||
-      at::autocast::is_xla_enabled() || at::autocast::is_hpu_enabled()) {
+      at::autocast::is_xla_enabled() || at::autocast::is_hpu_enabled() ||
+      at::autocast::is_privateuseone_enabled()) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;


### PR DESCRIPTION
if we add a custom device for autocast and set it enabled, the is_any_autocast_enabled return false instead of true.