### PR TITLE
[Profiler] iterate frontend function events for profiler post processing

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -467,8 +467,13 @@ class profile:
                 else 0
             )
 
-        # Create and return FunctionEvent list
-        function_events = []
+        # Create and return FunctionEvent list, which contains all function events
+        # Here 2 function events are created:
+        # all_function_events contains all events associated with each kineto event from result
+        all_function_events = []
+        # frontend_function_events contains the events in aten or torch frontend level,
+        # whose correlation id is 0
+        frontend_function_events = []
         device_corr_map: Dict[int, List[FunctionEvent]] = {}
         max_evt_id = 0
         for kineto_event in result.events():
@@ -532,15 +537,21 @@ class profile:
                     if cuda_time > 0:
                         fe.append_kernel(fe.name, fe.device_index, cuda_time)
                         fe.is_legacy = True
-            function_events.append(fe)
+            all_function_events.append(fe)
             corr_id = kineto_event.linked_correlation_id()
             if corr_id > 0:
                 if corr_id not in device_corr_map:
                     device_corr_map[corr_id] = []
                 device_corr_map[corr_id].append(fe)
+            elif corr_id == 0:
+                frontend_function_events.append(fe)
+            else:
+                raise RuntimeError(
+                    f"Got negative correlation id {corr_id} in profiler post processing"
+                )
 
         # associate device kernels and device runtime (CPU) with CPU events
-        for fe in function_events:
+        for fe in frontend_function_events:
             if (
                 fe.device_type == DeviceType.CPU
                 and not fe.is_async
@@ -587,17 +598,17 @@ class profile:
             if not mem_record[1]:
                 max_evt_id += 1
                 fe = createFunctionEventForMemoryEvents(mem_record[0])
-                function_events.append(fe)
+                all_function_events.append(fe)
 
         for oom_record in oom_records:
             max_evt_id += 1
             fe = createFunctionEventForMemoryEvents(oom_record)
-            function_events.append(fe)
+            all_function_events.append(fe)
 
-        function_events.sort(
+        all_function_events.sort(
             key=lambda evt: [evt.time_range.start, -evt.time_range.end]
         )
-        return function_events
+        return all_function_events
 
 
 class record_function(_ContextDecorator):


### PR DESCRIPTION
The `function_events` in `_parse_kineto_results` is used to contain all function events from the result. It contains 2 kinds of events. One is frontend function events whose correlation id is 0, for example, `aten::add`, `aten::mul`. They are on the top level of the profile results. The other is the backend events, which are associated with the frontend events and its correlation id is > 0, for example, `at::native::vectorized_elementwise_kernel`, it should be the backend event of a frontend element-wise op. They have the device execution duration for the related frontend op.

In the following post processing code, the **frontend function events** should be iterated to find its correlated backend events in `device_corr_map`, instead of iterating all function events, because `device_corr_map` is designed as a dict, whose key is the id of the frontend function event.
https://github.com/pytorch/pytorch/blob/3af12447f85dfede191a113c052e58fa7b21a8b3/torch/autograd/profiler.py#L543-L560

https://github.com/pytorch/pytorch/blob/3af12447f85dfede191a113c052e58fa7b21a8b3/torch/autograd/profiler.py#L537-L540