### PR TITLE
Make numel equal test size oblivious in reshape_symint

### DIFF
--- a/aten/src/ATen/InferSize.h
+++ b/aten/src/ATen/InferSize.h
@@ -37,7 +37,7 @@ inline void infer_size_impl(
     }
   }
 
-  if (numel == newsize || (infer_dim && newsize > 0 && numel % newsize == 0)) {
+  if (TORCH_GUARD_SIZE_OBLIVIOUS(sym_eq(numel, newsize)) || (infer_dim && newsize > 0 && numel % newsize == 0)) {
     if (infer_dim) {
       // We have a degree of freedom here to select the dimension size; follow
       // NumPy semantics and just bail.  However, a nice error message is needed

--- a/aten/src/ATen/InferSize.h
+++ b/aten/src/ATen/InferSize.h
@@ -37,7 +37,8 @@ inline void infer_size_impl(
     }
   }
 
-  if (TORCH_GUARD_SIZE_OBLIVIOUS(sym_eq(numel, newsize)) || (infer_dim && newsize > 0 && numel % newsize == 0)) {
+  if (TORCH_GUARD_SIZE_OBLIVIOUS(sym_eq(numel, newsize)) ||
+      (infer_dim && newsize > 0 && numel % newsize == 0)) {
     if (infer_dim) {
       // We have a degree of freedom here to select the dimension size; follow
       // NumPy semantics and just bail.  However, a nice error message is needed

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1406,6 +1406,14 @@ def forward(self, x_1, y_1):
     add = torch.ops.aten.add.Tensor(zeros, y_1);  zeros = y_1 = None
     return add""")  # noqa: B950
 
+    def test_reshape_divisibility_unbacked(self):
+        def f(x):
+            i0 = x.item()
+            r = torch.zeros(i0, 4, 20)
+            r = r.transpose(2, 1)
+            return r.reshape(-1, 80)
+        make_fx(f, tracing_mode="symbolic")(torch.tensor(24))
+
     def test_view_divisibility_unbacked(self):
         def f(x):
             i0 = x.item()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124611

Fixes https://github.com/pytorch/pytorch/issues/124581

Signed-off-by: Edward Z. Yang <ezyang@meta.com>