### PR TITLE
[EZ]  Update pillow to 10.3.0

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -147,9 +147,9 @@ optree==0.11.0
 #test_pointwise_ops.py, test_dtensor_ops.py, test_torchinductor.py, test_fx.py,
 #test_fake_tensor.py, test_mps.py
 
-pillow==10.2.0
+pillow==10.3.0
 #Description:  Python Imaging Library fork
-#Pinned versions: 10.2.0
+#Pinned versions: 10.3.0
 #test that import:
 
 protobuf==3.20.2

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -142,7 +142,8 @@ def _draw_single_box(
     if display_str:
         text_bottom = bottom
         # Reverse list and print from bottom to top.
-        text_width, text_height = font.getsize(display_str)
+        _left, _top, _right, _bottom = font.getbbox(display_str)
+        text_width, text_height = _right - _left, _bottom - _top
         margin = np.ceil(0.05 * text_height)
         draw.rectangle(
             [
@@ -620,10 +621,7 @@ def make_image(tensor, rescale=1, rois=None, labels=None):
     image = Image.fromarray(tensor)
     if rois is not None:
         image = draw_boxes(image, rois, labels=labels)
-    try:
-        ANTIALIAS = Image.Resampling.LANCZOS
-    except AttributeError:
-        ANTIALIAS = Image.ANTIALIAS
+    ANTIALIAS = Image.Resampling.LANCZOS
     image = image.resize((scaled_width, scaled_height), ANTIALIAS)
     import io
 


### PR DESCRIPTION
As older versions as subject to [CVE-2024-28219](https://nvd.nist.gov/vuln/detail/CVE-2024-28219), although it's not super important from CI PoV


Modernize `torch/utils/tensorboard/summary.py` to use Pillow-9+ APIs (is this file even used for anything anymore?)