### PR TITLE
[caffe2] Add build configuration for linux-arm64

### DIFF
--- a/c10/ovrsource_defs.bzl
+++ b/c10/ovrsource_defs.bzl
@@ -8,6 +8,7 @@ cpu_supported_platforms = [
     "ovr_config//os:macos",
     "ovr_config//os:windows-x86_64",
     "ovr_config//runtime:arm64-linux-ubuntu-neon",
+    "ovr_config//os:linux-arm64",
 ]
 
 cuda_supported_platforms = [


### PR DESCRIPTION
Summary: This diff adds a new build configuration that works on linux-arm64.

Test Plan:
Before:
```
$ buck2 build @//arvr/mode/linux/jetson/opt :c10_ovrsource
BUILD FAILED
fbsource//xplat/caffe2/c10:c10_ovrsource is incompatible with cfg:linux-arm64-fbcode-platform010-aarch64-no-san#d47c4385e5d19fe0 (ovr_config//os:android unsatisfied), check the target's compatibility attributes
```

After:
```
$ buck2 build @//arvr/mode/linux/jetson/opt :c10_ovrsource
BUILD SUCCEEDED
```

Differential Revision: D56088211
