### PR TITLE
Don't clean up fresh inductor cache on error

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -685,7 +685,7 @@ def fresh_inductor_cache(cache_entries=None):
                             }
                         )
         shutil.rmtree(inductor_cache_dir)
-    except:
+    except Exception:
         log.warning("on error, temporary cache dir kept at %s", inductor_cache_dir)
         raise
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -665,7 +665,8 @@ def fresh_inductor_cache(cache_entries=None):
     for obj in _registered_caches:
         obj.cache_clear()
 
-    with tempfile.TemporaryDirectory() as inductor_cache_dir:
+    inductor_cache_dir = tempfile.mkdtemp()
+    try:
         with mock.patch.dict(
             os.environ, {"TORCHINDUCTOR_CACHE_DIR": inductor_cache_dir}
         ):
@@ -683,6 +684,10 @@ def fresh_inductor_cache(cache_entries=None):
                                 if ".lock" not in f
                             }
                         )
+        shutil.rmtree(inductor_cache_dir)
+    except:
+        log.warning("on error, temporary cache dir kept at %s", inductor_cache_dir)
+        raise
 
 
 def argsort(seq) -> List[int]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124620

Useful for local debugging.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang