### PR TITLE
[NJT] Allow construction of NJT within graph using offsets from inputs

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -578,6 +578,7 @@ class FakeTensorTest(TestCase):
         self.assertIs(t2.size(0).node.shape_env, t1.size(0).node.shape_env)
         self.assertEqual(str(t2.size(0)), str(t1.size(0)))
 
+    @unittest.skipIf(TEST_WITH_TORCHDYNAMO, "creating NJT in the middle of graph fails in some cases")
     def test_jagged_fake_to_fake_preserved(self):
         from torch.nested._internal.nested_tensor import jagged_from_list
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3787,7 +3787,6 @@ class TestNestedTensorSubclass(TestCase):
             for i, t in enumerate(out):
                 self.assertEqual(t, tensor_list[i])
 
-    @xfailIfTorchDynamo
     def test_layer_norm_2(self, device):
         test_tensor_list = self._get_list_for_jagged_tensor(
             ((2, 3, 4), 3), device=device, requires_grad=True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124624
* #124634
* #124343

Creating symbolic nested ints within the graph is difficult. Using unbacked symints should solve the most important(?) cases in the mean time.

See https://github.com/pytorch/pytorch/issues/118446

Known gaps:
- creating NJT from intermediate offsets (offsets created within the graph, as opposed to being offsets passed in as inputs)
- when the same offsets is also passed in as a input to the graph. We are not smart enough to realize that the offsets from that input is the same and therefore would fail when  the sizes are compare ("s0 cannot be compared with u0")



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames