### PR TITLE
Restore CompileContext as well in backwards

### DIFF
--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -750,7 +750,7 @@ class TracingContext:
 
 
 @contextmanager
-def compile_context(context: CompileContext):
+def compile_context(context: Optional[CompileContext]):
     old_context = getattr(_TLS, "compile_context", None)
     _TLS.compile_context = context
     try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124648
* __->__ #124626

This should fix many of the unknown compile id problems currently
afflicting tlparse backwards analysis.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>