### PR TITLE
Skip fx passes for split-cat with Node dims

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -292,6 +292,15 @@ class TestSplitCatFxPasses(TestCase):
         def simple_split_cat_argspec4(x):
             return torch.cat(tensors=torch.split(x, 4, dim=1), dim=-2)
 
+        def simple_split_cat_node_dim_cat(x):
+            return torch.cat(torch.split(x, 4, dim=1), torch.tensor(1))
+
+        def simple_split_cat_node_dim_split(x):
+            return torch.cat(torch.split(x, 4, dim=torch.tensor(1)), 1)
+
+        def simple_split_cat_node_dim_both(x):
+            return torch.cat(torch.split(x, 4, dim=torch.tensor(1)), torch.tensor(1))
+
         def simple_split_stack(x):
             return torch.stack(torch.split(x, 4, dim=1), dim=1)
 
@@ -558,6 +567,9 @@ class TestSplitCatFxPasses(TestCase):
             (simple_split_cat_argspec2, 0, 0, 0, 0, 0, default_args),
             (simple_split_cat_argspec3, 0, 1, 0, 1, 7, default_args),
             (simple_split_cat_argspec4, 0, 1, 0, 1, 7, default_args),
+            (simple_split_cat_node_dim_cat, 0, 0, 0, 0, 0, default_args),
+            (simple_split_cat_node_dim_split, 0, 0, 0, 0, 0, default_args),
+            (simple_split_cat_node_dim_both, 0, 0, 0, 0, 0, default_args),
             (simple_split_stack, 0, 1, 0, 1, 7, default_args),
             (simple_split_stack_argspec1, 0, 1, 0, 1, 7, default_args),
             (simple_split_stack_argspec2, 0, 1, 0, 1, 7, default_args),

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -179,6 +179,9 @@ def normalize_split_base(
     if split_input is None or split_dim is None or split_size is None:
         log.debug("couldn't find split args")
         return
+    if isinstance(split_dim, torch.fx.Node):
+        log.debug("nodes as dim is not supported")
+        return
     if "example_value" not in split_node.meta:
         log.debug("example value absent for node: %s", split_node)
         return
@@ -242,6 +245,9 @@ def remove_split_with_size_one(match: Match, *args, **kwargs):
     split_input, split_size, split_dim = _get_split_args_default(split_node)
     if split_input is None or split_dim is None or split_size is None:
         log.debug("couldn't find split args")
+        return
+    if isinstance(split_dim, torch.fx.Node):
+        log.debug("nodes as dim is not supported")
         return
     if "example_value" not in split_node.meta:
         log.debug("example value absent for node: %s", split_node)
@@ -328,6 +334,9 @@ def normalize_cat_default(match: Match, *args, **kwargs):
             cat_dim = 0
     if tensors is None or cat_dim is None:
         log.debug("couldn't find cat args")
+        return
+    if isinstance(cat_dim, torch.fx.Node):
+        log.debug("nodes as dim is not supported")
         return
     assert isinstance(tensors, (list, tuple))
     for tensor in itertools.chain([cat_node], tensors):
@@ -957,6 +966,7 @@ class SplitCatSimplifier:
             if (
                 user_node.target == torch.cat
                 and split_dim != cat_dim
+                and type(split_dim) is type(cat_dim)
                 and split_node.target == torch.split
             ):
                 with graph.inserting_after(new_cat_node):


### PR DESCRIPTION
Fixes this error:

```python
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/executors/torch_compile.py", line 92, in compiled_func_wrapper
    return compiled_func(*args)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 410, in _fn
    return fn(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 976, in catch_errors
    return callback(frame, cache_entry, hooks, frame_state, skip=1)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 411, in _convert_frame_assert
    return _compile(
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_utils_internal.py", line 70, in wrapper_function
    return function(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 698, in _compile
    guarded_code = compile_inner(code, one_graph, hooks, transform)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 265, in time_wrapper
    r = func(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 553, in compile_inner
    out_code = transform_code_object(code, transform)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/bytecode_transformation.py", line 1113, in transform_code_object
    transformations(instructions, code_options)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 173, in _fn
    return fn(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 515, in transform
    tracer.run()
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 2201, in run
    super().run()
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 857, in run
    while self.step():
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 767, in step
    self.dispatch_table[inst.opcode](self, inst)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 2337, in RETURN_VALUE
    self._return(inst)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 2322, in _return
    self.output.compile_subgraph(
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/output_graph.py", line 1009, in compile_subgraph
    self.compile_and_call_fx_graph(tx, pass2.graph_output_vars(), root)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/output_graph.py", line 1198, in compile_and_call_fx_graph
    compiled_fn = self.call_user_compiler(gm)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 265, in time_wrapper
    r = func(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/output_graph.py", line 1265, in call_user_compiler
    raise BackendCompilerFailed(self.compiler_fn, e).with_traceback(
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/output_graph.py", line 1246, in call_user_compiler
    compiled_fn = compiler_fn(gm, self.example_inputs())
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/repro/after_dynamo.py", line 127, in debug_wrapper
    compiled_gm = compiler_fn(gm, example_inputs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_dynamo/repro/after_dynamo.py", line 127, in debug_wrapper
    compiled_gm = compiler_fn(gm, example_inputs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/__init__.py", line 1739, in __call__
    return compile_fx(model_, inputs_, config_patches=self.config)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_inductor/compile_fx.py", line 1225, in compile_fx
    model_ = _recursive_pre_grad_passes(model_, example_inputs_)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_inductor/compile_fx.py", line 232, in _recursive_pre_grad_passes
    return pre_grad_passes(gm, example_inputs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_inductor/fx_passes/pre_grad.py", line 212, in pre_grad_passes
    pattern_matcher_pass.apply(gm.graph)  # type: ignore[arg-type]
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_inductor/pattern_matcher.py", line 1500, in apply
    entry.apply(m, graph, node)  # type: ignore[arg-type]
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_inductor/pattern_matcher.py", line 848, in apply
    self.handler(match, *match.args, **match.kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/_inductor/fx_passes/split_cat.py", line 349, in normalize_cat_default
    if cat_dim < 0:  # Normalize cat dim
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/fx/node.py", line 309, in __lt__
    return self._sort_key < other._sort_key
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
AttributeError: 'int' object has no attribute '_sort_key'
```

Simple tryout script:

```python
import torch

def fn(x):
    return torch.cat(torch.split(x, 4, 1), torch.tensor(1))

x = torch.randn(2, 32, 32, 16)
fn = torch.compile(fn, fullgraph=True)
out = fn(x)
print(out.shape)
```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @mcarilli @ptrblck @leslie-fang-intel @ezyang @msaroufim @bdhirsh @anijain2305 @voznesenskym @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @LucasLLC