### PR TITLE
[MPS] Fix large copy

### DIFF
--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -180,14 +180,14 @@ void MPSStream::copy(id<MTLBuffer> srcBuffer,
       size_t bytes_copied = 0;
       size_t bytes_remains = length;
       while (bytes_remains > 0) {
-          NSUInteger bytes_to_copy = std::min(max_copy_size, bytes_remains);
-          [blitEncoder copyFromBuffer:srcBuffer
-                         sourceOffset:(NSUInteger)srcOffset + bytes_copied
-                             toBuffer:dstBuffer
-                    destinationOffset:(NSUInteger)dstOffset + bytes_copied
-                                 size:bytes_to_copy];
-          bytes_copied += bytes_to_copy;
-          bytes_remains -= bytes_to_copy;
+        NSUInteger bytes_to_copy = std::min(max_copy_size, bytes_remains);
+        [blitEncoder copyFromBuffer:srcBuffer
+                       sourceOffset:(NSUInteger)srcOffset + bytes_copied
+                           toBuffer:dstBuffer
+                  destinationOffset:(NSUInteger)dstOffset + bytes_copied
+                               size:bytes_to_copy];
+        bytes_copied += bytes_to_copy;
+        bytes_remains -= bytes_to_copy;
       }
       [blitEncoder endEncoding];
 

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -173,11 +173,22 @@ void MPSStream::copy(id<MTLBuffer> srcBuffer,
       endKernelCoalescing();
       id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer() blitCommandEncoder];
 
-      [blitEncoder copyFromBuffer:srcBuffer
-                     sourceOffset:(NSUInteger)srcOffset
-                         toBuffer:dstBuffer
-                destinationOffset:(NSUInteger)dstOffset
-                             size:(NSUInteger)length];
+      // For some reason copyFromBuffer for 4Gb fails without returning an error
+      // See https://github.com/pytorch/pytorch/issues/124335
+      // Workaround by batching copy commands into 2Gb chunks
+      constexpr size_t max_copy_size = 0x80000000; // 2GB
+      size_t bytes_copied = 0;
+      size_t bytes_remains = length;
+      while (bytes_remains > 0) {
+          NSUInteger bytes_to_copy = std::min(max_copy_size, bytes_remains);
+          [blitEncoder copyFromBuffer:srcBuffer
+                         sourceOffset:(NSUInteger)srcOffset + bytes_copied
+                             toBuffer:dstBuffer
+                    destinationOffset:(NSUInteger)dstOffset + bytes_copied
+                                 size:bytes_to_copy];
+          bytes_copied += bytes_to_copy;
+          bytes_remains -= bytes_to_copy;
+      }
       [blitEncoder endEncoding];
 
       // profilerId has a value only if copy profiling is enabled

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1089,6 +1089,7 @@ if not torch.backends.mps.is_available():
     NNTestCase = NoTest  # noqa: F811
 
 product_version = float('.'.join(platform.mac_ver()[0].split('.')[:2]) or -1)
+total_memory = int(subprocess.check_output(["sysctl", "-n", "hw.memsize"]))
 
 # Determine whether to enable MPS memory leak check (uses same code as CUDA).
 TEST_MPS_MEM_LEAK_CHECK = os.getenv('PYTORCH_TEST_MPS_MEM_LEAK_CHECK', '0') == '1'
@@ -6952,6 +6953,7 @@ class TestMPS(TestCaseMPS):
             # Test bfloat16 mm
             compare_mm(1024, 1, 32769, torch.bfloat16)
 
+    @unittest.skipIf(total_memory < 12_000_000_000, "Needs at least 12Gb RAM to run the test")
     def test_copy_large(self):
         """ Test that copy of 4Gb+ tensors works """
         x = torch.ones((2**30 + 11,), dtype=torch.float32)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6952,6 +6952,14 @@ class TestMPS(TestCaseMPS):
             # Test bfloat16 mm
             compare_mm(1024, 1, 32769, torch.bfloat16)
 
+    def test_copy_large(self):
+        """ Test that copy of 4Gb+ tensors works """
+        x = torch.ones((2**30 + 11,), dtype=torch.float32)
+        y = x.to(device="mps")
+        self.assertTrue(torch.all(y == torch.tensor(1.0, device="mps")))
+        del y
+        del x
+
     # Test flip
     def test_flip(self):
         def helper(shape, dims):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6954,6 +6954,7 @@ class TestMPS(TestCaseMPS):
             compare_mm(1024, 1, 32769, torch.bfloat16)
 
     @unittest.skipIf(total_memory < 12_000_000_000, "Needs at least 12Gb RAM to run the test")
+    @unittest.skipIf(product_version < 14.0, "Can't allocate 4Gb tensor on MacOS 13")
     def test_copy_large(self):
         """ Test that copy of 4Gb+ tensors works """
         x = torch.ones((2**30 + 11,), dtype=torch.float32)


### PR DESCRIPTION
By slicing `copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:` into 2Gb chunks

Add regression test, but limit it to machines with 12Gb of RAM or more, and MacOS 14+, as on MacOS 13 attempt to alloc 4Gb tensor fails with:
```
/AppleInternal/Library/BuildRoots/c651a45f-806e-11ed-a221-7ef33c48bc85/Library/Caches/com.apple.xbs/Sources/MetalPerformanceShaders/MPSCore/Types/MPSNDArray.mm:724: failed assertion `[MPSNDArray initWithDevice:descriptor:] Error: total bytes of NDArray > 2**32'
```

Fixes https://github.com/pytorch/pytorch/issues/124335

