### PR TITLE
[custom_op] register_autograd raises NYI on kwarg-only args

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2662,6 +2662,15 @@ Please use `add.register_fake` to add an fake impl.""",
             y.sum().backward()
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_register_autograd_kwargonly(self):
+        @torch.library.custom_op("_torch_testing::g", mutates_args=())
+        def g(*, x: Tensor) -> Tensor:
+            return x.sin()
+
+        with self.assertRaisesRegex(NotImplementedError, "with kwarg-only args"):
+            g.register_autograd(lambda x: x)
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_replacement(self):
         @torch.library.custom_op("_torch_testing::f", mutates_args=())
         def f(x: Tensor) -> Tensor:

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2662,13 +2662,22 @@ Please use `add.register_fake` to add an fake impl.""",
             y.sum().backward()
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
-    def test_register_autograd_kwargonly(self):
+    def test_kwargonly(self):
         @torch.library.custom_op("_torch_testing::g", mutates_args=())
         def g(*, x: Tensor) -> Tensor:
             return x.sin()
 
         with self.assertRaisesRegex(NotImplementedError, "with kwarg-only args"):
             g.register_autograd(lambda x: x)
+
+        @torch.library.custom_op("_torch_testing::h", mutates_args=())
+        def h(*, x: Tensor, y: int) -> Tensor:
+            return x.sin() * y
+
+        x = torch.randn(3, requires_grad=True)
+        y = 314
+        z = h(x=x, y=y)
+        self.assertEqual(z, x.sin() * y)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_replacement(self):

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -401,14 +401,7 @@ class CustomOpDef:
             >>> assert torch.allclose(grad_x, x.cos())
 
         """
-        schema = self._opoverload._schema
-        if not _library.utils.is_functional_schema(schema):
-            raise RuntimeError(
-                f"Cannot register autograd formula for non-functional operator "
-                f"{self} with schema {schema}. Please create "
-                f"a functional operator and register an autograd formula for that."
-            )
-
+        _library.autograd.check_can_register_autograd(self._opoverload)
         self._backward_fn = backward
         self._setup_context_fn = setup_context
 

--- a/torch/library.py
+++ b/torch/library.py
@@ -668,13 +668,7 @@ def register_autograd(op: _op_identifier, backward: Callable, /, *, setup_contex
     assert isinstance(op, str)
     qualname = op
     op = torch._library.utils.lookup_op(qualname)
-    schema = op._schema
-    if not _library.utils.is_functional_schema(schema):
-        raise RuntimeError(
-            f"Cannot register autograd formula for non-functional operator "
-            f"{op} with schema {schema}. Please create "
-            f"a functional operator and register an autograd formula for that."
-        )
+    torch._library.autograd.check_can_register_autograd(op)
 
     info = _library.autograd.Info(backward, setup_context)
     autograd_kernel = _library.autograd.make_autograd_impl(op, info)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124638
* #124637

It's unclear how to actually handle kwarg-only args, so we raise NYI for
now and hope that there aren't too many use cases for this.

Also, an autograd impl (that raises error on backward) gets unconditionally
registered for the op. We fix that to handle kwarg-only args (assuming the user
did not call register_autograd) by flattening the kwarg-only args and
sending them through the autograd.Function.

Test Plan:
- new tests