### PR TITLE
Record structured log for overall AOTAutograd backwards compilation

### DIFF
--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -925,9 +925,7 @@ Got grad_output types: {str(grad_output_types)}"""
                 ), "BackwardState requires CompiledAutograd"
                 ctx.maybe_clear_saved_tensors()
                 if CompiledFunction.compiled_bw is None:
-                    context = (
-                        torch._C._DisableAutocast if disable_amp else nullcontext
-                    )
+                    context = torch._C._DisableAutocast if disable_amp else nullcontext
                     with tracing(saved_context), compile_context(
                         saved_compile_context
                     ), context(), track_graph_compiling(aot_config, "backward"):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124761
* #124760
* __->__ #124648

It's sort of similar to CompilationMetrics but also not quite the same, quite open to bikeshedding.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>