### PR TITLE
[ez][CI] Move test_cuda off CI_SERIAL_LIST

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -214,8 +214,6 @@ CI_SERIAL_LIST = [
     "test_fake_tensor",
     "test_cpp_api_parity",
     "test_reductions",
-    "test_cuda",
-    "test_cuda_expandable_segments",
     "test_fx_backends",
     "test_linalg",
     "test_cpp_extensions_jit",


### PR DESCRIPTION
Tag test cases with large tensor with serial, also tag a few more that failed on a previous iteration of this PR

Move test_cuda and test_cuda_expandable_segments off the serial list