### PR TITLE
[CUDA] Fix 64-bit indexing in `vol2col` in conv3d

### DIFF
--- a/aten/src/ATen/native/cuda/vol2col.cuh
+++ b/aten/src/ATen/native/cuda/vol2col.cuh
@@ -36,7 +36,7 @@ __global__ void vol2col_kernel(
     const int height_col,
     const int width_col,
     T* data_col) {
-  CUDA_KERNEL_LOOP(index, n) {
+  CUDA_KERNEL_LOOP_TYPE(index, n, int64_t) {
     auto w_out = index % width_col;
     index /= width_col;
     auto h_out = index % height_col;

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -3184,6 +3184,16 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(output.cpu().float(), output_cpu, atol=1e-3, rtol=1e-3)
 
     @onlyCUDA
+    @largeTensorTest("24GB", "cpu")
+    @largeTensorTest("20GB", "cuda")
+    def test_conv3d_large_batch_1(self, device):
+        x = torch.rand(1, 32, 512, 512, 256)
+        m = torch.nn.Conv3d(32, 1, kernel_size=1, padding=0, stride=1, bias=False)
+        yref = m(x)
+        y = m.to(device=device)(x.to(device=device))
+        self.assertEqual(yref, y.cpu())
+
+    @onlyCUDA
     @skipCUDAIfNoCudnn
     def test_contig_wrong_stride_cudnn(self, device):
         # x has to have batch_size 1 to test contiguous checks

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -3184,6 +3184,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(output.cpu().float(), output_cpu, atol=1e-3, rtol=1e-3)
 
     @onlyCUDA
+    @skipCUDAIfRocm
     @largeTensorTest("24GB", "cpu")
     @largeTensorTest("20GB", "cuda")
     def test_conv3d_large_batch_1(self, device):


### PR DESCRIPTION
Similar to #118005, fixes sometimes silent IMAs that occur

CC @atalman @malfet 

cc @ptrblck