### PR TITLE
Fix test_max_autotune_remote_caching

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -250,13 +250,13 @@ class TestMaxAutotune(TestCase):
             def __init__(self, key, is_autotune=False):
                 pass
 
-            def get(self, filenames):
+            def get(self, filename):
                 nonlocal cache
                 nonlocal num_get
-                ret = {
-                    file: json.loads(cache[file]) for file in filenames if file in cache
-                }
-                num_get += len(ret)
+                if filename not in cache:
+                    return None
+                ret = json.loads(cache[filename])
+                num_get += 1
                 return ret
 
             def put(self, filename, data):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124669
* __->__ #124655

D55206000 broke this test. It is not clear why it did not run in the CI but here's the fix.

Differential Revision: [D56439213](https://our.internmc.facebook.com/intern/diff/D56439213/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang