### PR TITLE
[FX] Update opinfo tests (flattened diff)

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -26,7 +26,7 @@ from typing import (
 import sympy
 
 import torch
-from torch._dynamo.utils import dynamo_timed
+from torch._dynamo.utils import counters, dynamo_timed
 from torch._inductor.metrics import get_metric_table, is_metric_table_enabled
 from torch.utils._triton import has_triton
 
@@ -2381,6 +2381,7 @@ class Scheduler:
         # the current kernel from where 'allocate' retrieve those decisions.
         # We have to make sure there is a non-NULL kernel handler to store
         # those inplace update decisions.
+        counters["inductor"]["extern_calls"] += 1
         with V.set_kernel_handler(Kernel(increase_kernel_count=False)):
             scheduler_node.decide_inplace_update()
             scheduler_node.allocate()


### PR DESCRIPTION
Summary:
This diff updates opinfo tests to compute more statistics. The results are described in this post:
https://fb.workplace.com/groups/ai.acceleration.team/permalink/825131926110067/

New features:
  - Optionally dump kernels to a directory
  - Optionally disable block pointers
  - Impose a time limit (2 min) on individual tests
  - Report a variety of specific error codes when a fails:
       - MIXED
       - FALLBACK
       - EXPORT_ERROR
       - COMPILE_ERROR
       - MULTIPLE_KERNELS
       - MISSING_KERNELS
       - TIMEOUT
   - Disable setting the RNG seed inside of opinfo, since Dynamo doesn't like this and it caused a lot of tests to fail which otherwise would be able to generate Triton.
   - Check each test's `(op,dtype)` pair against {HuggingFace, TIMM, TorchBench} benchmark logs, to see whether tests are representative of real-world usage.

Test Plan:
`buck2 test @//mode/{dev-nosan,mtia} fbcode//triton_mtia/python/test:` passed locally. This code is also exercised by the CI.

Added a bunch of new unit tests:
 - Dumping kernels to a directory
 - Disabling block pointers
 - Mocking various error conditions in inductor
   - No kernels
   - Multiple kernels
   - ATen fallback
   - Partial ATen fallback (mixed Triton + ATen)
   - `torch.export` raised exception
   - `torch.inductor._compile` raised exception
   - Timeout while running test
   - Test harness raised uncaught exception
   - Check that return code == Success when exceptions were raised
  - Checking whether various (op,dtype) combos are in benchmarks
     - Check that `aten.add.Tensor` IS in the benchmarks
     - Check that a made up op is NOT in them

Differential Revision: D56336160


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang