### PR TITLE
Some fixups

### DIFF
--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -462,7 +462,7 @@ inline Tensor _sum_to(
     reduce_dims.push_back(i);
   }
   for (int64_t i = leading_dims; i < static_cast<int64_t>(sizes.size()); ++i) {
-    if (shape[i - leading_dims] == 1 && sizes[i] != 1) {
+    if (shape[i - leading_dims] == 1 && TORCH_GUARD_SIZE_OBLIVIOUS(sym_eq(sizes[i], 1))) {
       reduce_dims.push_back(i);
     }
   }

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -462,7 +462,8 @@ inline Tensor _sum_to(
     reduce_dims.push_back(i);
   }
   for (int64_t i = leading_dims; i < static_cast<int64_t>(sizes.size()); ++i) {
-    if (shape[i - leading_dims] == 1 && TORCH_GUARD_SIZE_OBLIVIOUS(sym_eq(sizes[i], 1))) {
+    if (shape[i - leading_dims] == 1 &&
+        TORCH_GUARD_SIZE_OBLIVIOUS(sym_ne(sizes[i], 1))) {
       reduce_dims.push_back(i);
     }
   }

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -278,6 +278,10 @@ def rebind_unbacked(shape_env, n: torch.fx.Node, result):
     """
     from torch._dynamo.tensor_version_op import _tensor_version
 
+    # Inputs never need rebinding
+    if n.op == "placeholder":
+        return
+
     if bindings := n.meta.get("unbacked_bindings"):
         for raw_u0, path in bindings.items():
             u1 = pytree.key_get(result, path)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124785
* #124782
* #124740
* #124739
* __->__ #124658
* #124394
* #124316
* #124314
* #124310
* #124297
* #124290

I can absorb this into the next or previous PRs if you want. But it's some small bug fixes: (1) one more guard size oblivious, and (2) don't rebind unbacked SymInts if they came from an input placeholder. The test that exercises this is in the next PR.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>