### PR TITLE
[BE] Update older scipy used in CI to 1.8.1

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -228,8 +228,7 @@ scikit-image==0.20.0 ; python_version >= "3.10"
 #Pinned versions: 0.20.3
 #test that import:
 
-scipy==1.6.3 ; python_version < "3.10"
-scipy==1.8.1 ; python_version == "3.10"
+scipy==1.8.1 ; python_version <= "3.10"
 scipy==1.10.1 ; python_version == "3.11"
 scipy==1.12.0 ; python_version == "3.12"
 # Pin SciPy because of failing distribution tests (see #60347)


### PR DESCRIPTION
As older scipy are affected by CVE-2023-29824

