### PR TITLE
Conform torch.mps to device module interface

### DIFF
--- a/docs/source/mps.rst
+++ b/docs/source/mps.rst
@@ -7,6 +7,7 @@ torch.mps
     :toctree: generated
     :nosignatures:
 
+    device_count
     synchronize
     get_rng_state
     set_rng_state

--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -32,7 +32,12 @@ def synchronize() -> None:
 
 
 def get_rng_state(device: Union[int, str, torch.device] = "mps") -> Tensor:
-    r"""Returns the random number generator state as a ByteTensor."""
+    r"""Returns the random number generator state as a ByteTensor.
+
+    Args:
+        device (torch.device or int, optional): The device to return the RNG state of.
+            Default: ``'mps'`` (i.e., ``torch.device('mps')``, the current MPS device).
+    """
     return _get_default_mps_generator().get_state()
 
 
@@ -43,6 +48,8 @@ def set_rng_state(
 
     Args:
         new_state (torch.ByteTensor): The desired state
+        device (torch.device or int, optional): The device to set the RNG state.
+            Default: ``'mps'`` (i.e., ``torch.device('mps')``, the current MPS device).
     """
     new_state_copy = new_state.clone(memory_format=torch.contiguous_format)
     _get_default_mps_generator().set_state(new_state_copy)

--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -19,6 +19,11 @@ def _get_default_mps_generator() -> torch._C.Generator:
     return _default_mps_generator
 
 
+def device_count() -> int:
+    r"""Return the number of available MPS devices."""
+    return int(torch._C._has_mps and torch._C._mps_is_available())
+
+
 def synchronize() -> None:
     r"""Waits for all kernels in all streams on a MPS device to complete."""
     return torch._C._mps_deviceSynchronize()
@@ -116,6 +121,7 @@ from . import profiler
 from .event import Event
 
 __all__ = [
+    "device_count",
     "get_rng_state",
     "manual_seed",
     "seed",

--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -4,6 +4,8 @@ Metal is Apple's API for programming metal GPU (graphics processor unit). Using 
 performance can be achieved, by running work on the metal GPU(s).
 See https://developer.apple.com/documentation/metalperformanceshaders for more details.
 """
+from typing import Union
+
 import torch
 from .. import Tensor
 
@@ -20,7 +22,7 @@ def _get_default_mps_generator() -> torch._C.Generator:
 
 
 def device_count() -> int:
-    r"""Return the number of available MPS devices."""
+    r"""Returns the number of available MPS devices."""
     return int(torch._C._has_mps and torch._C._mps_is_available())
 
 
@@ -29,12 +31,14 @@ def synchronize() -> None:
     return torch._C._mps_deviceSynchronize()
 
 
-def get_rng_state() -> Tensor:
+def get_rng_state(device: Union[int, str, torch.device] = "mps") -> Tensor:
     r"""Returns the random number generator state as a ByteTensor."""
     return _get_default_mps_generator().get_state()
 
 
-def set_rng_state(new_state: Tensor) -> None:
+def set_rng_state(
+    new_state: Tensor, device: Union[int, str, torch.device] = "mps"
+) -> None:
     r"""Sets the random number generator state.
 
     Args:


### PR DESCRIPTION
Right now `torch.fork_rng()` doesn't support MPS. MPS' device module functions don't line up with the others'. There is a step of `fork_rng` to call `device_count()`:

https://github.com/pytorch/pytorch/blob/302d7e9a6ecc0d8e162f6d4ff8d067d7ba5bf4eb/torch/random.py#L146

It is pretty simple to know the MPS device count, based on whether it is built and available.

Also:

https://github.com/pytorch/pytorch/blob/302d7e9a6ecc0d8e162f6d4ff8d067d7ba5bf4eb/torch/random.py#L168

https://github.com/pytorch/pytorch/blob/302d7e9a6ecc0d8e162f6d4ff8d067d7ba5bf4eb/torch/random.py#L175

`get_rng_state` and `set_rng_state` are expected to be able to accept a `device` parameter.

@ezyang 