### PR TITLE
Ensure only builtins functions are wrapped in new frame for torch.compile

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -364,6 +364,7 @@ class _TorchDynamoContext:
                 not in ["_call_impl", "_wrapped_call_impl", "_lazy_forward"]
             )
             and filename not in DONT_WRAP_FILES
+            and isinstance(fn, types.BuiltinFunctionType)
         ):
             # call to a builtin without a frame for us to capture
             fn = external_utils.wrap_inline(fn)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -357,11 +357,6 @@ class _TorchDynamoContext:
             filename = inspect.getsourcefile(fn)
         except TypeError:
             filename = None
-        was_created_in_exec_eval = (
-            hasattr(fn, "__code__")
-            and fn.__code__.co_filename == "<string>"
-            and fn.__code__.f_globals.get("__compile_source__") is not None
-        )
         if (
             (filename is None or trace_rules.check(fn))
             and (
@@ -369,7 +364,7 @@ class _TorchDynamoContext:
                 not in ["_call_impl", "_wrapped_call_impl", "_lazy_forward"]
             )
             and filename not in DONT_WRAP_FILES
-            and not was_created_in_exec_eval
+            and not (hasattr(fn, "__code__") and fn.__code__.co_filename == "<string>")
         ):
             # call to a builtin without a frame for us to capture
             fn = external_utils.wrap_inline(fn)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -357,6 +357,11 @@ class _TorchDynamoContext:
             filename = inspect.getsourcefile(fn)
         except TypeError:
             filename = None
+        was_created_in_exec_eval = (
+            hasattr(fn, "__code__")
+            and fn.__code__.co_filename == "<string>"
+            and fn.__code__.f_globals.get("__compile_source__") is not None
+        )
         if (
             (filename is None or trace_rules.check(fn))
             and (
@@ -364,7 +369,7 @@ class _TorchDynamoContext:
                 not in ["_call_impl", "_wrapped_call_impl", "_lazy_forward"]
             )
             and filename not in DONT_WRAP_FILES
-            and isinstance(fn, types.BuiltinFunctionType)
+            and not was_created_in_exec_eval
         ):
             # call to a builtin without a frame for us to capture
             fn = external_utils.wrap_inline(fn)


### PR DESCRIPTION
Fixes #124269

I'm not sure which cases the existing check via `filename` is supposed to handle, but if the comment is right and `external_utils.wrap_inline` is supposed to be applied only on builtin functions, a check for `types.BuiltinFunctionType` should be sufficient.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang