### PR TITLE
Prevent cuda:0 context initialization when working on another cuda device

### DIFF
--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -437,14 +437,17 @@ def pad_bmm(
 
 
 @functools.lru_cache(None)
-def _pad_mm_init():
+def _pad_mm_init(input_device: Optional[torch.device] = None):
     from .joint_graph import patterns
 
-    if torch.cuda.is_available():
-        # workaround https://github.com/pytorch/pytorch/issues/97894
-        device = "cuda"
+    if input_device is None:
+        if torch.cuda.is_available():
+            # workaround https://github.com/pytorch/pytorch/issues/97894
+            device = "cuda"
+        else:
+            device = "cpu"
     else:
-        device = "cpu"
+        device = str(input_device)
 
     # sizes/values dont actually matter for initial trace
     # once we get a possible match we re-trace with the actual values and verify the match still holds

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -126,7 +126,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
 
 @init_once_fakemode
-def lazy_init():
+def lazy_init(input_device: Optional[torch.device] = None):
     if torch._C._has_mkldnn:
         from . import decompose_mem_bound_mm  # noqa: F401
         from .mkldnn_fusion import _mkldnn_fusion_init

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -103,7 +103,7 @@ pattern_matcher_passes_aten: List[PatternMatcherPass] = [
 
 
 @init_once_fakemode
-def lazy_init():
+def lazy_init(input_device: Optional[torch.device] = None):
     from . import efficient_conv_bn_eval, split_cat  # noqa: F401  # noqa: F401
 
     if config.is_fbcode():

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1693,13 +1693,13 @@ def init_once_fakemode(fn: Callable[..., Any]):
 
     @functools.lru_cache(None)
     @functools.wraps(fn)
-    def lazy_init():
+    def lazy_init(input_device: Optional[torch.device] = None):
         counters_ref = counters["inductor"].copy()
 
         with torch._guards.tracing(
             None
         ), maybe_disable_fake_tensor_mode(), FakeTensorMode():
-            result = fn()
+            result = fn(input_device=input_device)
 
         # clear view matches encountered during tracing
         counters["inductor"] = counters_ref

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -321,11 +321,13 @@ class FakeTensorConverter:
 
 
 @functools.lru_cache(None)
-def init_cuda_context():
+def init_cuda_context(device_index=0):
     # Backward will error with cuda Fake Tensors if no cuda tensors have been initialized first
     if torch.cuda.is_available():
-        torch.empty(1, device="cuda") if torch.version.hip is None else torch.zeros(
-            1, device="cuda"
+        torch.empty(
+            1, device=f"cuda:{device_index}"
+        ) if torch.version.hip is None else torch.zeros(
+            1, device=f"cuda:{device_index}"
         )
 
 
@@ -478,7 +480,9 @@ class FakeTensor(torch.Tensor):
             assert device.type != "meta"
         # normalize device.
         if device.type == "cuda":
-            init_cuda_context()
+            init_cuda_context(
+                device_index=device.index if device.index is not None else 0
+            )
 
         if (
             device.type


### PR DESCRIPTION
## Description

**Issue description**.  When user works with "cuda:1" device and compile a model, there is cuda context initialization for device "cuda:0", which can be surprising to the user seeing with nvidia-smi the device 0 utilisation.

**Reproduction code:**
```python
import torch
from torchvision.models import resnet18

def print_memory_usage():
    for d in [0, 1]:
        stats = torch.cuda.memory_stats(device=d)
        m = stats["allocated_bytes.all.allocated"] + stats["inactive_split_bytes.all.allocated"] + stats["reserved_bytes.all.allocated"]
        print(f"\t- CUDA Device: {d}, allocated + reserved + non-released in MB: {m / 1024 / 1024}")

device = "cuda:1"
model = resnet18()
compiled_model = torch.compile(model)

print("--- Before compiled model to device")
print_memory_usage()

compiled_model.to(device)
x = torch.rand(16, 3, 320, 320, device=device)

print("--- Before compiled model forward")
print_memory_usage()

y = compiled_model(x)

print("--- Before compiled model backward")
print_memory_usage()

y.sum().backward()

print("--- After compiled model backward")
print_memory_usage()
```
Output:
```
--- Before compiled model to device
        - CUDA Device: 0, allocated + reserved + non-released in MB: 0.0
        - CUDA Device: 1, allocated + reserved + non-released in MB: 0.0
--- Before compiled model forward
        - CUDA Device: 0, allocated + reserved + non-released in MB: 0.0
        - CUDA Device: 1, allocated + reserved + non-released in MB: 192.966796875
--- Before compiled model backward
        - CUDA Device: 0, allocated + reserved + non-released in MB: 8.044921875    # <--- this should be zero
        - CUDA Device: 1, allocated + reserved + non-released in MB: 2054.27197265625
--- After compiled model backward
        - CUDA Device: 0, allocated + reserved + non-released in MB: 8.044921875    # <--- this should be zero
        - CUDA Device: 1, allocated + reserved + non-released in MB: 5654.61962890625
```

**This PR** fixes cuda context initialization `init_cuda_context` on FakeTensor creation, lazy_init and pattern registrations.


```
--- Before compiled model to device
        - CUDA Device: 0, allocated + reserved + non-released in MB: 0.0
        - CUDA Device: 1, allocated + reserved + non-released in MB: 0.0
--- Before compiled model forward
        - CUDA Device: 0, allocated + reserved + non-released in MB: 0.0
        - CUDA Device: 1, allocated + reserved + non-released in MB: 192.966796875
--- Before compiled model backward
        - CUDA Device: 0, allocated + reserved + non-released in MB: 0.0
        - CUDA Device: 1, allocated + reserved + non-released in MB: 2054.31982421875
--- After compiled model backward
        - CUDA Device: 0, allocated + reserved + non-released in MB: 0.0
        - CUDA Device: 1, allocated + reserved + non-released in MB: 5654.66748046875
```



- [x] Fix the issue
- [ ] Add tests





cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang