### PR TITLE
[CI] Add retry mechanism to check if the Docker daemon is running

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -117,22 +117,16 @@ runs:
         delay=10
         attempt=1
 
-        while true; do
+        for attempt in $(seq 1 $max_attempts); do
           echo "Attempt $attempt of $max_attempts: Checking if Docker daemon is running..."
-
           if docker info > /dev/null 2>&1; then
             echo "Docker is running. Proceeding with the next steps"
-            break
+            exit 0
           else
             echo "Docker is not running yet."
-
-            if [ $attempt -ge $max_attempts ]; then
-              echo "Reached maximum attempts to connect to Docker. Exiting."
-              exit 1
-            else
-              echo "Retrying in $delay seconds..."
-              sleep $delay
-              ((attempt++))
-            fi
+            echo "Retrying in $delay seconds..."
+            sleep $delay
           fi
         done
+        echo "Reached maximum attempts to connect to Docker. Exiting."
+        exit 1

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -66,6 +66,7 @@ runs:
         env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
 
     - name: Kill any existing containers, clean up images
+      if: ${{ steps.check_arc_runner.outputs.IN_ARC_RUNNER == 'false' }}
       shell: bash
       run: |
         # ignore expansion of "docker ps -q" since it could be empty

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -121,7 +121,7 @@ runs:
           echo "Attempt $attempt of $max_attempts: Checking if Docker daemon is running..."
 
           if docker info > /dev/null 2>&1; then
-            echo "Docker is running. Proceeding with the next steps."
+            echo "Docker is running. Proceeding with the next steps"
             break
           else
             echo "Docker is not running yet."

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -105,3 +105,34 @@ runs:
 
         echo "${RESOLVED_IP} ${PT_DOMAIN}" | sudo tee -a /etc/hosts
         cat /etc/hosts
+
+    - name: Check that the docker daemon is running
+      shell: bash
+      continue-on-error: true
+      if: ${{ steps.check_arc_runner.outputs.IN_ARC_RUNNER == 'true' }}
+      run: |
+        set +x
+
+        max_attempts=6
+        delay=10
+        attempt=1
+
+        while true; do
+          echo "Attempt $attempt of $max_attempts: Checking if Docker daemon is running..."
+
+          if docker info > /dev/null 2>&1; then
+            echo "Docker is running. Proceeding with the next steps."
+            break
+          else
+            echo "Docker is not running yet."
+
+            if [ $attempt -ge $max_attempts ]; then
+              echo "Reached maximum attempts to connect to Docker. Exiting."
+              exit 1
+            else
+              echo "Retrying in $delay seconds..."
+              sleep $delay
+              ((attempt++))
+            fi
+          fi
+        done

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -113,7 +113,7 @@ runs:
       run: |
         set +x
 
-        max_attempts=6
+        max_attempts=30
         delay=10
         attempt=1
 


### PR DESCRIPTION
What is done:
* Skipped the 'Kill existing containers' step - ARC runners are always ephemeral.
* Added a retry mechanism to check if the Docker daemon is running.