### PR TITLE
[easy][test_profiler.py] if tqdm is not available, pass instead of None

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -11,7 +11,7 @@ try:
 
     tqdm.tqdm.monitor_interval = 0
 except ImportError:
-    None
+    pass
 
 import collections
 import gc


### PR DESCRIPTION
Change the try exception to pass when it cannot import tqdm.

To address comment: https://github.com/pytorch/pytorch/pull/124409#discussion_r1576327365
