### PR TITLE
[Profiler] Temporarily disable test_execution_trace_with_pt2 due to timeout issues

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -531,6 +531,8 @@ class TestExecutionTrace(TestCase):
         assert found_root_node
         assert loop_count == expected_loop_events
 
+    # TODO: Investigate why this pt2 test is causing timeouts >30mins for others.
+    @unittest.skipIf(True, "this test may be causing other tests to fail or timeout")
     @unittest.skipIf(IS_WINDOWS, "torch.compile does not support WINDOWS")
     def test_execution_trace_with_pt2(self):
         class ConvAndRelu(nn.Module):


### PR DESCRIPTION
Summary: test_execution_trace_with_pt2 is causing issues in other unit tests in test_profiler.py, and causes a timeout in PyTorch CI. Let's disable it while we investigate the issue.

https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=noGPU_AVX512
https://github.com/pytorch/pytorch/actions/runs/8795833563/job/24146458559

Test Plan: CI and Github CI.

Differential Revision: D56478988


