### PR TITLE
[inductor] Keep inductor cache for tests when TORCH_COMPILE_DEBUG is specified

### DIFF
--- a/torch/_inductor/test_case.py
+++ b/torch/_inductor/test_case.py
@@ -24,7 +24,7 @@ class TestCase(DynamoTestCase):
         super().setUp()
         self._inductor_test_stack = contextlib.ExitStack()
         self._inductor_test_stack.enter_context(config.patch({"fx_graph_cache": True}))
-        if os.environ.get("INDUCTOR_TEST_DISABLE_FRESH_CACHE") != "1":
+        if os.environ.get("INDUCTOR_TEST_DISABLE_FRESH_CACHE") != "1" and os.environ.get("TORCH_COMPILE_DEBUG") != "1":
             self._inductor_test_stack.enter_context(fresh_inductor_cache())
 
     def tearDown(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124755



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang