### PR TITLE
[DeviceMesh] Added `DeviceMesh.from_group()`

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
+import copy
 import itertools
 import unittest
 from typing import List
@@ -662,6 +663,65 @@ class TestFullyShardMetaDeviceInit(FSDPTestMultiThread):
         ref_loss.backward()
         self.assertEqual(loss, ref_loss)
         for param, ref_param in zip(model.parameters(), ref_model.parameters()):
+            self.assertEqual(param.grad, ref_param.grad)
+
+
+class TestFullyShardProcessGroupInit(FSDPTestMultiThread):
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_process_group_init(self):
+        assert self.world_size == 4, f"{self.world_size}"
+        # For convenience, use device mesh's infra to construct the DP PG
+        # (in practice, the trainer would do it manually via `new_group()`)
+        dp_size = 2
+        global_mesh = init_device_mesh(
+            "cuda", (dp_size, self.world_size // dp_size), mesh_dim_names=("dp", "tp")
+        )
+        ref_dp_mesh, tp_mesh = global_mesh["dp"], global_mesh["tp"]
+        dp_pg = ref_dp_mesh.get_group(0)
+
+        # Check the `from_group()` API for correctness
+        dp_mesh = DeviceMesh.from_group(dp_pg, "cuda")
+        self.assertEqual(dp_mesh.mesh, ref_dp_mesh.mesh)
+        self.assertEqual(dp_mesh, ref_dp_mesh)
+        # self.assertFalse(hasattr(dp_mesh, "_coordinate_on_dim"))
+        self.assertEqual(dp_mesh._coordinate_on_dim, ref_dp_mesh._coordinate_on_dim)
+        self.assertEqual(dp_mesh._dim_group_infos, ref_dp_mesh._dim_group_infos)
+
+        # Check 1D FSDP forward/backward parity over the DP mesh
+        # NOTE: We cannot use 2D DTensor-based training here because the DP
+        # mesh from `from_group` does not respect the parent mesh.
+        torch.manual_seed(42)
+        mlp_dim = 8
+        ref_model = MLP(mlp_dim)
+        for param in ref_model.parameters():
+            dist.broadcast(param.detach(), src=0)
+        model = copy.deepcopy(ref_model)
+
+        # Parallelize the test model with the ref DP mesh
+        for module in (ref_model.in_proj, ref_model.out_proj, ref_model):
+            fully_shard(module, mesh=ref_dp_mesh)
+        # Parallelize the test model with the new DP mesh from the PG
+        for module in (model.in_proj, model.out_proj, model):
+            fully_shard(module, mesh=dp_mesh)
+
+        # Ensure that TP ranks have the same input
+        inp = torch.randn((4, mlp_dim), device="cuda")
+        if self.rank in (0, 1):
+            dist.broadcast(inp, src=0, group=tp_mesh.get_group(0))
+        elif self.rank in (2, 3):
+            dist.broadcast(inp, src=2, group=tp_mesh.get_group(0))
+
+        ref_loss = ref_model(inp).sum()
+        ref_loss.backward()
+        loss = model(inp).sum()
+        loss.backward()
+        self.assertEqual(loss, ref_loss)
+        for param, ref_param in zip(model.parameters(), ref_model.parameters()):
+            self.assertEqual(param, ref_param)
             self.assertEqual(param.grad, ref_param.grad)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124787
* #124780
* #124768
* #124767
* #124741
* #124651

This PR adds a `DeviceMesh.from_group()` static method to convert an existing process group to a device mesh.

Motivation: We need `DeviceMesh.from_group()` to allow FSDP2 to interoperate with distributed libraries that do not use `DeviceMesh` for all parallelisms.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k