### PR TITLE
Fix layer norm in static runtime when input is non-contiguous

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -2122,7 +2122,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::layer_norm, aten_layer_norm, [](Node* n) -> SROp
           p_node->Output(0).toTensor(), X->sizes(), c10::nullopt);
     }
     at::Tensor& output = p_node->Output(0).toTensor();
-    at::native::layer_norm_cpu_out(output, input, *gamma, *beta, eps, M, N);
+    at::native::layer_norm_cpu_out(output, *X, *gamma, *beta, eps, M, N);
   };
 });
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124789

Test: The added unit test fails before this fix. But it passes now after the fix. 

The fix is coming from @swolchok in D56087067.

