### PR TITLE
[ROCm][Inductor] Disable conv cache emptying with hipgraphs

### DIFF
--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -599,7 +599,6 @@ void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
   cache.insert(args.params, *algo);
   wsscache.insert(args.params, perfResults.memory);
 
-  c10::hip::HIPCachingAllocator::emptyCache();
 }
 
 template<typename algo_t>

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -598,7 +598,7 @@ void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
 
   cache.insert(args.params, *algo);
   wsscache.insert(args.params, perfResults.memory);
-    
+
   if (at::native::_cudnn_get_conv_benchmark_empty_cache()) {
       c10::hip::HIPCachingAllocator::emptyCache();
   }

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -598,6 +598,10 @@ void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
 
   cache.insert(args.params, *algo);
   wsscache.insert(args.params, perfResults.memory);
+    
+  if (at::native::_cudnn_get_conv_benchmark_empty_cache()) {
+      c10::hip::HIPCachingAllocator::emptyCache();
+  }
 
 }
 


### PR DESCRIPTION
When we warmup hipgraphs, we use cudagraph memory pool to allocate a large part of the memory. We don't necessarily execute the kernels on the GPUs. Therefore, we don't want to free up this allocated memory. However, this is conflicting with emptyCache call happening inside findAlgorithm where convolution algorithm benchmarking is happening. For benchmarking, we might use large memory allocations to cache algorithm results. As a fix, we just disable the emptyCache() call during cudagraph warmup. 

As per this cuDNN PR which did the same thing for CUDA, we did not have a significant affect on memory footprint. https://github.com/pytorch/pytorch/commit/a8ff647e4233625d5f5840d46c93b00471c18fe8


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang