### PR TITLE
Attach stack traces to plain callables when using aot_export_joint_simple

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -24,9 +24,7 @@ import inspect
 from dataclasses import dataclass
 import weakref
 import operator
-import traceback
 from torch.utils._stats import count
-from torch.utils._traceback import CapturedTraceback
 import logging
 from torch._library.fake_class_registry import FakeScriptObject
 
@@ -1102,28 +1100,6 @@ class _ModuleStackTracer(PythonKeyTracer):
                 f"{self.torch_fn_metadata.__name__}_{self.torch_fn_counts[self.torch_fn_metadata]}",
                 f"{self.torch_fn_metadata.__class__.__name__}.{self.torch_fn_metadata.__name__}"
             )
-
-        # stack_trace
-        if 'stack_trace' not in node.meta and node.op not in ["placeholder", "output"]:
-            user_frame_summary = CapturedTraceback.extract().summary()
-            if user_frame_summary:
-                # we retain frames from forward() calls, or ops
-                # located in torch/__init__.py (e.g. sym_int, sym_constrain_range, vmap)
-                stack_trace = [frame for frame in user_frame_summary if (
-                    frame.name == 'forward'
-                    or frame.filename.endswith('torch/__init__.py')
-                )]
-                # filter out forward() frames from fx/_symbolic_trace.py, export/_trace.py
-                # this is hardcoded, but leads to a much cleaner stack trace
-                stack_trace = [
-                    frame for frame in stack_trace if not (
-                        frame.filename.endswith('fx/_symbolic_trace.py')
-                        or frame.filename.endswith('export/_trace.py')
-                    )
-                ]
-                if stack_trace:  # empty list for strict mode, dynamo should handle stack_trace
-                    stack_trace = traceback.StackSummary.from_list(stack_trace)
-                    node.meta["stack_trace"] = ''.join(stack_trace.format()).strip()
 
         return node
 


### PR DESCRIPTION
Fixes #102205

Moves the logic for stack_trace building out of the module specific `_ModuleStackTracer` subclass into it's parent class `PythonKeyTracer`. This allows the code the be reused when creating nodes from plain callables.

This is not ready to merge, I'm looking for some guidance on how to handle this case: https://github.com/pytorch/pytorch/pull/124792/files#r1576970878

cc @tugsbayasgalan