### PR TITLE
[rfc]: vendor in open-telemetry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -149,6 +149,3 @@
 [submodule "third_party/mimalloc"]
 	path = third_party/mimalloc
 	url = https://github.com/microsoft/mimalloc.git
-[submodule "third_party/opentelemetry-cpp"]
-	path = third_party/opentelemetry-cpp
-	url = https://github.com/open-telemetry/opentelemetry-cpp.git

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,13 +71,6 @@ http_archive(
     ],
 )
 
-http_archive(
-    name = "com_github_opentelemetry-cpp",
-    urls = [
-        "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.14.2.tar.gz",
-    ],
-)
-
 new_local_repository(
     name = "gloo",
     build_file = "//third_party:gloo.BUILD",

--- a/third_party/LICENSES_BUNDLED.txt
+++ b/third_party/LICENSES_BUNDLED.txt
@@ -41,28 +41,11 @@ License: Apache-2.0
 Files: third_party/benchmark,
      third_party/onnx/third_party/benchmark,
      third_party/onnx-tensorrt/third_party/onnx/third_party/benchmark,
-     third_party/protobuf/third_party/benchmark,
-     third_party/opentelemetry-cpp/third_party/benchmark
+     third_party/protobuf/third_party/benchmark
   For details, see: third_party/benchmark/LICENSE,
      third_party/onnx/third_party/benchmark/LICENSE,
      third_party/onnx-tensorrt/third_party/onnx/third_party/benchmark/LICENSE,
-     third_party/protobuf/third_party/benchmark/LICENSE,
-     third_party/opentelemetry-cpp/third_party/benchmark/LICENSE
-
-Name: boost-vcpkg-helpers
-License: MIT
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/boost-vcpkg-helpers
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/boost-vcpkg-helpers/LICENSE.txt
-
-Name: cJSON
-License: MIT
-Files: third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb/examples/rest/cJSON
-  For details, see: third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb/examples/rest/cJSON/LICENSE
-
-Name: catch2
-License: BSL-1.0
-Files: third_party/opentelemetry-cpp/third_party/opentracing-cpp/3rd_party/include/opentracing/catch2
-  For details, see: third_party/opentelemetry-cpp/third_party/opentracing-cpp/3rd_party/include/opentracing/catch2/LICENSE.txt
+     third_party/protobuf/third_party/benchmark/LICENSE
 
 Name: clog
 License: BSD-2-Clause
@@ -121,16 +104,6 @@ Files: third_party/kineto/libkineto/third_party/dynolog/third_party/json/test/th
   For details, see: third_party/kineto/libkineto/third_party/dynolog/third_party/json/test/thirdparty/doctest/LICENSE.txt,
      third_party/nlohmann/tests/thirdparty/doctest/LICENSE.txt
 
-Name: duktape-1.5.2
-License: MIT
-Files: third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb/src/third_party/duktape-1.5.2
-  For details, see: third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb/src/third_party/duktape-1.5.2/LICENSE.txt
-
-Name: duktape-1.8.0
-License: MIT
-Files: third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb/src/third_party/duktape-1.8.0
-  For details, see: third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb/src/third_party/duktape-1.8.0/LICENSE.txt
-
 Name: dynolog
 License: MIT
 Files: third_party/kineto/libkineto/third_party/dynolog
@@ -141,25 +114,10 @@ License: BSD-3-Clause
 Files: third_party/eigen
   For details, see: third_party/eigen/COPYING.BSD
 
-Name: etw
-License: MIT
-Files: third_party/opentelemetry-cpp/exporters/etw/include/opentelemetry/exporters/etw
-  For details, see: third_party/opentelemetry-cpp/exporters/etw/include/opentelemetry/exporters/etw/LICENSE
-
-Name: expected
-License: MIT
-Files: third_party/opentelemetry-cpp/third_party/opentracing-cpp/3rd_party/include/opentracing/expected
-  For details, see: third_party/opentelemetry-cpp/third_party/opentracing-cpp/3rd_party/include/opentracing/expected/LICENSE
-
 Name: fbgemm
 License: BSD-3-Clause
 Files: third_party/fbgemm
   For details, see: third_party/fbgemm/LICENSE
-
-Name: ffnvcodec
-License: MIT with exception
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/ffnvcodec
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/ffnvcodec/LICENSE.txt
 
 Name: flatbuffers
 License: Apache-2.0
@@ -191,19 +149,12 @@ Files: third_party/fbgemm/third_party/googletest/googlemock/scripts/generator,
      third_party/googletest/googlemock/scripts/generator,
      third_party/kineto/libkineto/third_party/googletest/googlemock/scripts/generator,
      third_party/protobuf/third_party/googletest/googlemock/scripts/generator,
-     third_party/tensorpipe/third_party/googletest/googlemock/scripts/generator,
-     third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/googletest/googlemock/scripts/generator
+     third_party/tensorpipe/third_party/googletest/googlemock/scripts/generator
   For details, see: third_party/fbgemm/third_party/googletest/googlemock/scripts/generator/LICENSE,
      third_party/googletest/googlemock/scripts/generator/LICENSE,
      third_party/kineto/libkineto/third_party/googletest/googlemock/scripts/generator/LICENSE,
      third_party/protobuf/third_party/googletest/googlemock/scripts/generator/LICENSE,
-     third_party/tensorpipe/third_party/googletest/googlemock/scripts/generator/LICENSE,
-     third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/googletest/googlemock/scripts/generator/LICENSE
-
-Name: gettimeofday
-License: Apache-2.0
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/gettimeofday
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/gettimeofday/LICENSE
+     third_party/tensorpipe/third_party/googletest/googlemock/scripts/generator/LICENSE
 
 Name: gloo
 License: BSD-3-Clause
@@ -232,9 +183,7 @@ Files: third_party/fbgemm/third_party/googletest,
      third_party/protobuf/third_party/googletest,
      third_party/protobuf/third_party/googletest/googletest,
      third_party/tensorpipe/third_party/googletest,
-     third_party/tensorpipe/third_party/googletest/googletest,
-     third_party/opentelemetry-cpp/third_party/googletest,
-     third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/googletest
+     third_party/tensorpipe/third_party/googletest/googletest
   For details, see: third_party/fbgemm/third_party/googletest/LICENSE,
      third_party/fbgemm/third_party/googletest/googletest/LICENSE,
      third_party/googletest/LICENSE,
@@ -244,9 +193,7 @@ Files: third_party/fbgemm/third_party/googletest,
      third_party/protobuf/third_party/googletest/LICENSE,
      third_party/protobuf/third_party/googletest/googletest/LICENSE,
      third_party/tensorpipe/third_party/googletest/LICENSE,
-     third_party/tensorpipe/third_party/googletest/googletest/LICENSE,
-     third_party/opentelemetry-cpp/third_party/googletest/LICENSE,
-     third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/googletest/LICENSE
+     third_party/tensorpipe/third_party/googletest/googletest/LICENSE
 
 Name: gtest
 License: BSD-3-Clause
@@ -258,11 +205,6 @@ License: MIT
 Files: third_party/fbgemm/third_party/hipify_torch
   For details, see: third_party/fbgemm/third_party/hipify_torch/LICENSE.txt
 
-Name: hungarian
-License: Apache-2.0
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/hungarian
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/hungarian/LICENSE.txt
-
 Name: ideep
 License: MIT
 Files: third_party/ideep
@@ -273,11 +215,6 @@ License: BSD-3-Clause
 Files: third_party/ios-cmake
   For details, see: third_party/ios-cmake/LICENSE
 
-Name: irrlicht
-License: MIT
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/irrlicht
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/irrlicht/LICENSE.txt
-
 Name: kineto
 License: BSD-3-Clause
 Files: third_party/kineto
@@ -287,11 +224,6 @@ Name: libnop
 License: Apache-2.0
 Files: third_party/tensorpipe/third_party/libnop
   For details, see: third_party/tensorpipe/third_party/libnop/LICENSE
-
-Name: libstemmer
-License: BSD-3-Clause
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/libstemmer
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/libstemmer/LICENSE
 
 Name: libuv
 License: MIT
@@ -312,11 +244,6 @@ Name: mkl-dnn
 License: Apache-2.0
 Files: third_party/ideep/mkl-dnn
   For details, see: third_party/ideep/mkl-dnn/LICENSE
-
-Name: ms-gsl
-License: MIT
-Files: third_party/opentelemetry-cpp/third_party/ms-gsl
-  For details, see: third_party/opentelemetry-cpp/third_party/ms-gsl/LICENSE
 
 Name: nccl
 License: BSD-3-Clause
@@ -343,45 +270,10 @@ License: MIT
 Files: third_party/onnx-tensorrt
   For details, see: third_party/onnx-tensorrt/LICENSE
 
-Name: opentelemetry-cpp
-License: Apache-2.0
-Files: third_party/opentelemetry-cpp
-  For details, see: third_party/opentelemetry-cpp/LICENSE
-
-Name: opentelemetry-proto
-License: Apache-2.0
-Files: third_party/opentelemetry-cpp/third_party/opentelemetry-proto
-  For details, see: third_party/opentelemetry-cpp/third_party/opentelemetry-proto/LICENSE
-
-Name: opentracing-cpp
-License: Apache-2.0
-Files: third_party/opentelemetry-cpp/third_party/opentracing-cpp
-  For details, see: third_party/opentelemetry-cpp/third_party/opentracing-cpp/LICENSE
-
-Name: pdcurses
-License: Apache-2.0
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/pdcurses
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/pdcurses/LICENSE
-
 Name: pfs
 License: Apache-2.0
 Files: third_party/kineto/libkineto/third_party/dynolog/third_party/pfs
   For details, see: third_party/kineto/libkineto/third_party/dynolog/third_party/pfs/LICENSE
-
-Name: physac
-License: MIT
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/physac
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/physac/LICENSE
-
-Name: pqp
-License: Apache-2.0
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/pqp
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/pqp/LICENSE
-
-Name: prometheus-cpp
-License: MIT
-Files: third_party/opentelemetry-cpp/third_party/prometheus-cpp
-  For details, see: third_party/opentelemetry-cpp/third_party/prometheus-cpp/LICENSE
 
 Name: protobuf
 License: BSD-3-Clause
@@ -419,11 +311,6 @@ License: BSD-2-Clause
 Files: third_party/python-peachpy
   For details, see: third_party/python-peachpy/LICENSE.rst
 
-Name: sigslot
-License: Apache-2.0
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/sigslot
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/sigslot/LICENSE
-
 Name: sleef
 License: BSL-1.0
 Files: third_party/sleef
@@ -444,11 +331,6 @@ License: Apache-2.0
 Files: third_party/tbb
   For details, see: third_party/tbb/LICENSE
 
-Name: tensorflow-common
-License: MIT
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/tensorflow-common
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/tensorflow-common/LICENSE.txt
-
 Name: tensorpipe
 License: BSD-3-Clause
 Files: third_party/tensorpipe
@@ -458,21 +340,6 @@ Name: test
 License: MIT with exception
 Files: third_party/kineto/libkineto/third_party/dynolog/third_party/cpr/test
   For details, see: third_party/kineto/libkineto/third_party/dynolog/third_party/cpr/test/LICENSE
-
-Name: variant
-License: BSD-3-Clause
-Files: third_party/opentelemetry-cpp/third_party/opentracing-cpp/3rd_party/include/opentracing/variant
-  For details, see: third_party/opentelemetry-cpp/third_party/opentracing-cpp/3rd_party/include/opentracing/variant/LICENSE
-
-Name: vcpkg
-License: MIT
-Files: third_party/opentelemetry-cpp/tools/vcpkg
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/LICENSE.txt
-
-Name: vulkan
-License: Apache-2.0 with exception
-Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/vulkan
-  For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/vulkan/LICENSE.txt
 
 Name: zstd
 License: BSD-3-Clause

--- a/third_party/build_bundled.py
+++ b/third_party/build_bundled.py
@@ -102,21 +102,6 @@ def identify_license(f, exception=''):
         elif 'BoostSoftwareLicense-Version1.0' in txt:
             # Hmm, do we need to check the text?
             return 'BSL-1.0'
-        elif 'gettimeofday' in txt:
-            # Used in opentelemetry-cpp/tools/vcpkg/ports/gettimeofday
-            return 'Apache-2.0'
-        elif 'libhungarian' in txt:
-            # Used in opentelemetry-cpp/tools/vcpkg/ports/hungarian
-            return 'Apache-2.0'
-        elif 'PDCurses' in txt:
-            # Used in opentelemetry-cpp/tools/vcpkg/ports/pdcurses
-            return 'Apache-2.0'
-        elif 'Copyright1999UniversityofNorthCarolina' in txt:
-            # Used in opentelemetry-cpp/tools/vcpkg/ports/pqp
-            return 'Apache-2.0'
-        elif 'sigslot' in txt:
-            # Used in opentelemetry-cpp/tools/vcpkg/ports/sigslot
-            return 'Apache-2.0'
         elif squeeze("Clarified Artistic License") in txt:
             return 'Clarified Artistic License'
         elif all([squeeze(m) in txt.lower() for m in bsd3_txt]):

--- a/third_party/opentelemetry-cpp/README.md
+++ b/third_party/opentelemetry-cpp/README.md
@@ -1,0 +1,14 @@
+This folder contains vendored copy of opentelemetry-cpp API folder.
+PyTorch depends just on opentelemetry-cpp API.
+We took a dependency on version v1.14.2 of the API.
+To update to a newer version:
+```
+cd /tmp
+git clone https://github.com/open-telemetry/opentelemetry-cpp.git
+cd opentelemetry-cpp
+git checkout <new opentelemetry-cpp tag>
+cd <pytorch checkout dir>
+cp -R /tmp/opentelemetry-cpp/api/ third_party/opentelemetry-cpp
+git add third_party/opentelemetry-cpp
+git commit
+```

--- a/third_party/opentelemetry-cpp/api/BUILD
+++ b/third_party/opentelemetry-cpp/api/BUILD
@@ -1,0 +1,73 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+bool_flag(
+    name = "with_abseil",
+    build_setting_default = False,
+)
+
+CPP_STDLIBS = [
+    "none",
+    "best",
+    "2014",
+    "2017",
+    "2020",
+    "2023",
+]
+
+string_flag(
+    name = "with_cxx_stdlib",
+    build_setting_default = "best",
+    values = CPP_STDLIBS,
+)
+
+cc_library(
+    name = "api",
+    hdrs = glob(["include/**/*.h"]),
+    defines = select({
+        ":with_external_abseil": ["HAVE_ABSEIL"],
+        "//conditions:default": [],
+    }) + select({
+        ":set_cxx_stdlib_none": [],
+        ### automatic selection
+        ":set_cxx_stdlib_best": ["OPENTELEMETRY_STL_VERSION=(__cplusplus/100)"],
+        # See https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus
+        ":set_cxx_stdlib_best_and_msvc": ["OPENTELEMETRY_STL_VERSION=(_MSVC_LANG/100)"],
+        ### manual selection
+        ":set_cxx_stdlib_2014": ["OPENTELEMETRY_STL_VERSION=2014"],
+        ":set_cxx_stdlib_2017": ["OPENTELEMETRY_STL_VERSION=2017"],
+        ":set_cxx_stdlib_2020": ["OPENTELEMETRY_STL_VERSION=2020"],
+        ":set_cxx_stdlib_2023": ["OPENTELEMETRY_STL_VERSION=2023"],
+        "//conditions:default": [],
+    }),
+    strip_include_prefix = "include",
+    tags = ["api"],
+    deps = select({
+        ":with_external_abseil": [
+            "@com_google_absl//absl/base",
+            "@com_google_absl//absl/strings",
+            "@com_google_absl//absl/types:variant",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+config_setting(
+    name = "with_external_abseil",
+    flag_values = {":with_abseil": "true"},
+)
+
+[config_setting(
+    name = "set_cxx_stdlib_%s" % v,
+    flag_values = {":with_cxx_stdlib": v},
+) for v in CPP_STDLIBS]
+
+config_setting(
+    name = "set_cxx_stdlib_best_and_msvc",
+    constraint_values = ["@bazel_tools//tools/cpp:msvc"],
+    flag_values = {":with_cxx_stdlib": "best"},
+)

--- a/third_party/opentelemetry-cpp/api/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/CMakeLists.txt
@@ -1,0 +1,130 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(opentelemetry_api INTERFACE)
+target_include_directories(
+  opentelemetry_api
+  INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+            "$<INSTALL_INTERFACE:include>")
+
+set_target_properties(opentelemetry_api PROPERTIES EXPORT_NAME api)
+
+if(OPENTELEMETRY_INSTALL)
+  install(
+    TARGETS opentelemetry_api
+    EXPORT "${PROJECT_NAME}-target"
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+  install(
+    DIRECTORY include/opentelemetry
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.h")
+
+  unset(TARGET_DEPS)
+endif()
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
+if(WITH_NO_DEPRECATED_CODE)
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE OPENTELEMETRY_NO_DEPRECATED_CODE)
+endif()
+
+if(WITH_ABSEIL)
+  target_compile_definitions(opentelemetry_api INTERFACE HAVE_ABSEIL)
+  target_link_libraries(
+    opentelemetry_api INTERFACE absl::bad_variant_access absl::any absl::base
+                                absl::bits absl::city)
+  list(APPEND TARGET_DEPS "absl_bad_variant_access" "absl_any absl_base"
+       "absl_bits" "absl_city")
+endif()
+
+if(WITH_STL STREQUAL "OFF")
+  message(STATUS "Building WITH_STL=OFF")
+elseif(WITH_STL STREQUAL "CXX11")
+  message(STATUS "Building WITH_STL=CXX11")
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE OPENTELEMETRY_STL_VERSION=2011)
+elseif(WITH_STL STREQUAL "CXX14")
+  message(STATUS "Building WITH_STL=CXX14")
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE OPENTELEMETRY_STL_VERSION=2014)
+elseif(WITH_STL STREQUAL "CXX17")
+  message(STATUS "Building WITH_STL=CXX17")
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE OPENTELEMETRY_STL_VERSION=2017)
+elseif(WITH_STL STREQUAL "CXX20")
+  message(STATUS "Building WITH_STL=CXX20")
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE OPENTELEMETRY_STL_VERSION=2020)
+elseif(WITH_STL STREQUAL "CXX23")
+  message(STATUS "Building WITH_STL=CXX23")
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE OPENTELEMETRY_STL_VERSION=2023)
+elseif(WITH_STL STREQUAL "ON")
+  message(STATUS "Building WITH_STL=ON")
+  # "ON" corresponds to "CXX23" at this time.
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE OPENTELEMETRY_STL_VERSION=2023)
+else()
+  message(
+    FATAL_ERROR "WITH_STL must be ON, OFF, CXX11, CXX14, CXX17, CXX20 or CXX23")
+endif()
+
+if(WITH_GSL)
+  target_compile_definitions(opentelemetry_api INTERFACE HAVE_GSL)
+
+  # Guidelines Support Library path. Used if we are not on not get C++20.
+  #
+  find_package(Microsoft.GSL QUIET)
+  if(TARGET Microsoft.GSL::GSL)
+    target_link_libraries(opentelemetry_api INTERFACE Microsoft.GSL::GSL)
+    list(APPEND TARGET_DEPS "gsl")
+  else()
+    set(GSL_DIR third_party/ms-gsl)
+    target_include_directories(
+      opentelemetry_api INTERFACE "$<BUILD_INTERFACE:${GSL_DIR}/include>")
+  endif()
+endif()
+
+if(WITH_NO_GETENV)
+  target_compile_definitions(opentelemetry_api INTERFACE NO_GETENV)
+endif()
+
+if(WIN32)
+  if(WITH_ETW)
+    target_compile_definitions(opentelemetry_api INTERFACE HAVE_MSGPACK)
+  endif()
+endif()
+
+if(WITH_ASYNC_EXPORT_PREVIEW)
+  target_compile_definitions(opentelemetry_api INTERFACE ENABLE_ASYNC_EXPORT)
+endif()
+
+target_compile_definitions(
+  opentelemetry_api
+  INTERFACE OPENTELEMETRY_ABI_VERSION_NO=${OPENTELEMETRY_ABI_VERSION_NO})
+
+if(WITH_OTLP_GRPC_SSL_MTLS_PREVIEW)
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW)
+endif()
+
+if(WITH_METRICS_EXEMPLAR_PREVIEW)
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE ENABLE_METRICS_EXEMPLAR_PREVIEW)
+endif()
+
+include(${PROJECT_SOURCE_DIR}/cmake/pkgconfig.cmake)
+
+if(OPENTELEMETRY_INSTALL)
+  opentelemetry_add_pkgconfig(
+    api "OpenTelemetry API"
+    "A header-only library to support instrumentation with OpenTelemetry."
+    "${TARGET_DEPS}")
+endif()

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/baggage/baggage.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/baggage/baggage.h
@@ -1,0 +1,299 @@
+﻿// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cctype>
+
+#include "opentelemetry/common/kv_properties.h"
+#include "opentelemetry/common/macros.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+
+namespace baggage
+{
+
+class OPENTELEMETRY_EXPORT Baggage
+{
+public:
+  static constexpr size_t kMaxKeyValuePairs = 180;
+  static constexpr size_t kMaxKeyValueSize  = 4096;
+  static constexpr size_t kMaxSize          = 8192;
+  static constexpr char kKeyValueSeparator  = '=';
+  static constexpr char kMembersSeparator   = ',';
+  static constexpr char kMetadataSeparator  = ';';
+
+  Baggage() noexcept : kv_properties_(new common::KeyValueProperties()) {}
+  Baggage(size_t size) noexcept : kv_properties_(new common::KeyValueProperties(size)) {}
+
+  template <class T>
+  Baggage(const T &keys_and_values) noexcept
+      : kv_properties_(new common::KeyValueProperties(keys_and_values))
+  {}
+
+  OPENTELEMETRY_API_SINGLETON static nostd::shared_ptr<Baggage> GetDefault()
+  {
+    static nostd::shared_ptr<Baggage> baggage{new Baggage()};
+    return baggage;
+  }
+
+  /* Get value for key in the baggage
+     @returns true if key is found, false otherwise
+  */
+  bool GetValue(nostd::string_view key, std::string &value) const noexcept
+  {
+    return kv_properties_->GetValue(key, value);
+  }
+
+  /* Returns shared_ptr of new baggage object which contains new key-value pair. If key or value is
+     invalid, copy of current baggage is returned
+  */
+  nostd::shared_ptr<Baggage> Set(const nostd::string_view &key,
+                                 const nostd::string_view &value) noexcept
+  {
+
+    nostd::shared_ptr<Baggage> baggage(new Baggage(kv_properties_->Size() + 1));
+    const bool valid_kv = IsValidKey(key) && IsValidValue(value);
+
+    if (valid_kv)
+    {
+      baggage->kv_properties_->AddEntry(key, value);
+    }
+
+    // add rest of the fields.
+    kv_properties_->GetAllEntries(
+        [&baggage, &key, &valid_kv](nostd::string_view e_key, nostd::string_view e_value) {
+          // if key or value was not valid, add all the entries. Add only remaining entries
+          // otherwise.
+          if (!valid_kv || key != e_key)
+          {
+            baggage->kv_properties_->AddEntry(e_key, e_value);
+          }
+
+          return true;
+        });
+
+    return baggage;
+  }
+
+  // @return all key-values entries by repeatedly invoking the function reference passed as argument
+  // for each entry
+  bool GetAllEntries(
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)> callback) const noexcept
+  {
+    return kv_properties_->GetAllEntries(callback);
+  }
+
+  // delete key from the baggage if it exists. Returns shared_ptr of new baggage object.
+  // if key does not exist, copy of current baggage is returned.
+  // Validity of key is not checked as invalid keys should never be populated in baggage in the
+  // first place.
+  nostd::shared_ptr<Baggage> Delete(nostd::string_view key) noexcept
+  {
+    // keeping size of baggage same as key might not be found in it
+    nostd::shared_ptr<Baggage> baggage(new Baggage(kv_properties_->Size()));
+    kv_properties_->GetAllEntries(
+        [&baggage, &key](nostd::string_view e_key, nostd::string_view e_value) {
+          if (key != e_key)
+            baggage->kv_properties_->AddEntry(e_key, e_value);
+          return true;
+        });
+    return baggage;
+  }
+
+  // Returns shared_ptr of baggage after extracting key-value pairs from header
+  static nostd::shared_ptr<Baggage> FromHeader(nostd::string_view header) noexcept
+  {
+    if (header.size() > kMaxSize)
+    {
+      // header size exceeds maximum threshold, return empty baggage
+      return GetDefault();
+    }
+
+    common::KeyValueStringTokenizer kv_str_tokenizer(header);
+    size_t cnt = kv_str_tokenizer.NumTokens();  // upper bound on number of kv pairs
+    if (cnt > kMaxKeyValuePairs)
+    {
+      cnt = kMaxKeyValuePairs;
+    }
+
+    nostd::shared_ptr<Baggage> baggage(new Baggage(cnt));
+    bool kv_valid;
+    nostd::string_view key, value;
+
+    while (kv_str_tokenizer.next(kv_valid, key, value) && baggage->kv_properties_->Size() < cnt)
+    {
+      if (!kv_valid || (key.size() + value.size() > kMaxKeyValueSize))
+      {
+        // if kv pair is not valid, skip it
+        continue;
+      }
+
+      // NOTE : metadata is kept as part of value only as it does not have any semantic meaning.
+      // but, we need to extract it (else Decode on value will return error)
+      nostd::string_view metadata;
+      auto metadata_separator = value.find(kMetadataSeparator);
+      if (metadata_separator != std::string::npos)
+      {
+        metadata = value.substr(metadata_separator);
+        value    = value.substr(0, metadata_separator);
+      }
+
+      bool err       = 0;
+      auto key_str   = UrlDecode(common::StringUtil::Trim(key), err);
+      auto value_str = UrlDecode(common::StringUtil::Trim(value), err);
+
+      if (err == false && IsValidKey(key_str) && IsValidValue(value_str))
+      {
+        if (!metadata.empty())
+        {
+          value_str.append(metadata.data(), metadata.size());
+        }
+        baggage->kv_properties_->AddEntry(key_str, value_str);
+      }
+    }
+
+    return baggage;
+  }
+
+  // Creates string from baggage object.
+  std::string ToHeader() const noexcept
+  {
+    std::string header_s;
+    bool first = true;
+    kv_properties_->GetAllEntries([&](nostd::string_view key, nostd::string_view value) {
+      if (!first)
+      {
+        header_s.push_back(kMembersSeparator);
+      }
+      else
+      {
+        first = false;
+      }
+      header_s.append(UrlEncode(key));
+      header_s.push_back(kKeyValueSeparator);
+
+      // extracting metadata from value. We do not encode metadata
+      auto metadata_separator = value.find(kMetadataSeparator);
+      if (metadata_separator != std::string::npos)
+      {
+        header_s.append(UrlEncode(value.substr(0, metadata_separator)));
+        auto metadata = value.substr(metadata_separator);
+        header_s.append(std::string(metadata.data(), metadata.size()));
+      }
+      else
+      {
+        header_s.append(UrlEncode(value));
+      }
+      return true;
+    });
+    return header_s;
+  }
+
+private:
+  static bool IsPrintableString(nostd::string_view str)
+  {
+    for (const auto ch : str)
+    {
+      if (ch < ' ' || ch > '~')
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  static bool IsValidKey(nostd::string_view key) { return key.size() && IsPrintableString(key); }
+
+  static bool IsValidValue(nostd::string_view value) { return IsPrintableString(value); }
+
+  // Uri encode key value pairs before injecting into header
+  // Implementation inspired from : https://golang.org/src/net/url/url.go?s=7851:7884#L264
+  static std::string UrlEncode(nostd::string_view str)
+  {
+    auto to_hex = [](char c) -> char {
+      static const char *hex = "0123456789ABCDEF";
+      return hex[c & 15];
+    };
+
+    std::string ret;
+
+    for (auto c : str)
+    {
+      if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+      {
+        ret.push_back(c);
+      }
+      else if (c == ' ')
+      {
+        ret.push_back('+');
+      }
+      else
+      {
+        ret.push_back('%');
+        ret.push_back(to_hex(c >> 4));
+        ret.push_back(to_hex(c & 15));
+      }
+    }
+
+    return ret;
+  }
+
+  // Uri decode key value pairs after extracting from header
+  static std::string UrlDecode(nostd::string_view str, bool &err)
+  {
+    auto IsHex = [](char c) {
+      return std::isdigit(c) || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+    };
+
+    auto from_hex = [](char c) -> char {
+      // c - '0' produces integer type which could trigger error/warning when casting to char,
+      // but the cast is safe here.
+      return static_cast<char>(std::isdigit(c) ? c - '0' : std::toupper(c) - 'A' + 10);
+    };
+
+    std::string ret;
+
+    for (size_t i = 0; i < str.size(); i++)
+    {
+      if (str[i] == '%')
+      {
+        if (i + 2 >= str.size() || !IsHex(str[i + 1]) || !IsHex(str[i + 2]))
+        {
+          err = 1;
+          return "";
+        }
+        ret.push_back(from_hex(str[i + 1]) << 4 | from_hex(str[i + 2]));
+        i += 2;
+      }
+      else if (str[i] == '+')
+      {
+        ret.push_back(' ');
+      }
+      else if (std::isalnum(str[i]) || str[i] == '-' || str[i] == '_' || str[i] == '.' ||
+               str[i] == '~')
+      {
+        ret.push_back(str[i]);
+      }
+      else
+      {
+        err = 1;
+        return "";
+      }
+    }
+
+    return ret;
+  }
+
+private:
+  // Store entries in a C-style array to avoid using std::array or std::vector.
+  nostd::unique_ptr<common::KeyValueProperties> kv_properties_;
+};
+
+}  // namespace baggage
+
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/baggage/baggage_context.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/baggage/baggage_context.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/baggage/baggage.h"
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+
+namespace baggage
+{
+
+static const std::string kBaggageHeader = "baggage";
+
+inline nostd::shared_ptr<Baggage> GetBaggage(const context::Context &context) noexcept
+{
+  context::ContextValue context_value = context.GetValue(kBaggageHeader);
+  if (nostd::holds_alternative<nostd::shared_ptr<Baggage>>(context_value))
+  {
+    return nostd::get<nostd::shared_ptr<Baggage>>(context_value);
+  }
+  static nostd::shared_ptr<Baggage> empty_baggage{new Baggage()};
+  return empty_baggage;
+}
+
+inline context::Context SetBaggage(context::Context &context,
+                                   nostd::shared_ptr<Baggage> baggage) noexcept
+{
+  return context.SetValue(kBaggageHeader, baggage);
+}
+
+}  // namespace baggage
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/baggage/propagation/baggage_propagator.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/baggage/propagation/baggage_propagator.h
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/baggage/baggage.h"
+#include "opentelemetry/baggage/baggage_context.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace baggage
+{
+namespace propagation
+{
+
+class BaggagePropagator : public context::propagation::TextMapPropagator
+{
+public:
+  void Inject(context::propagation::TextMapCarrier &carrier,
+              const context::Context &context) noexcept override
+  {
+    auto baggage = baggage::GetBaggage(context);
+    auto header  = baggage->ToHeader();
+    if (header.size())
+    {
+      carrier.Set(kBaggageHeader, header);
+    }
+  }
+
+  context::Context Extract(const context::propagation::TextMapCarrier &carrier,
+                           context::Context &context) noexcept override
+  {
+    nostd::string_view baggage_str = carrier.Get(baggage::kBaggageHeader);
+    auto baggage                   = baggage::Baggage::FromHeader(baggage_str);
+
+    if (baggage->ToHeader().size())
+    {
+      return baggage::SetBaggage(context, baggage);
+    }
+    else
+    {
+      return context;
+    }
+  }
+
+  bool Fields(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept override
+  {
+    return callback(kBaggageHeader);
+  }
+};
+}  // namespace propagation
+}  // namespace baggage
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/common/attribute_value.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/common/attribute_value.h
@@ -1,0 +1,82 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/variant.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+/// OpenTelemetry signals can be enriched by adding attributes. The
+/// \c AttributeValue type is defined as a variant of all attribute value
+/// types the OpenTelemetry C++ API supports.
+///
+/// The following attribute value types are supported by the OpenTelemetry
+/// specification:
+///  - Primitive types: string, boolean, double precision floating point
+///    (IEEE 754-1985) or signed 64 bit integer.
+///  - Homogenous arrays of primitive type values.
+///
+/// \warning
+/// \parblock The OpenTelemetry C++ API currently supports several attribute
+/// value types that are not covered by the OpenTelemetry specification:
+///  - \c uint64_t
+///  - \c nostd::span<const uint64_t>
+///  - \c nostd::span<uint8_t>
+///
+/// Those types are reserved for future use and currently should not be
+/// used. There are no guarantees around how those values are handled by
+/// exporters.
+/// \endparblock
+using AttributeValue =
+    nostd::variant<bool,
+                   int32_t,
+                   int64_t,
+                   uint32_t,
+                   double,
+                   const char *,
+                   nostd::string_view,
+                   nostd::span<const bool>,
+                   nostd::span<const int32_t>,
+                   nostd::span<const int64_t>,
+                   nostd::span<const uint32_t>,
+                   nostd::span<const double>,
+                   nostd::span<const nostd::string_view>,
+                   // Not currently supported by the specification, but reserved for future use.
+                   // Added to provide support for all primitive C++ types.
+                   uint64_t,
+                   // Not currently supported by the specification, but reserved for future use.
+                   // Added to provide support for all primitive C++ types.
+                   nostd::span<const uint64_t>,
+                   // Not currently supported by the specification, but reserved for future use.
+                   // See https://github.com/open-telemetry/opentelemetry-specification/issues/780
+                   nostd::span<const uint8_t>>;
+
+enum AttributeType
+{
+  kTypeBool,
+  kTypeInt,
+  kTypeInt64,
+  kTypeUInt,
+  kTypeDouble,
+  kTypeCString,
+  kTypeString,
+  kTypeSpanBool,
+  kTypeSpanInt,
+  kTypeSpanInt64,
+  kTypeSpanUInt,
+  kTypeSpanDouble,
+  kTypeSpanString,
+  kTypeUInt64,
+  kTypeSpanUInt64,
+  kTypeSpanByte
+};
+
+}  // namespace common
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/common/key_value_iterable.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/common/key_value_iterable.h
@@ -1,0 +1,64 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+/**
+ * Supports internal iteration over a collection of key-value pairs.
+ */
+class KeyValueIterable
+{
+public:
+  virtual ~KeyValueIterable() = default;
+
+  /**
+   * Iterate over key-value pairs
+   * @param callback a callback to invoke for each key-value. If the callback returns false,
+   * the iteration is aborted.
+   * @return true if every key-value pair was iterated over
+   */
+  virtual bool ForEachKeyValue(nostd::function_ref<bool(nostd::string_view, common::AttributeValue)>
+                                   callback) const noexcept = 0;
+
+  /**
+   * @return the number of key-value pairs
+   */
+  virtual size_t size() const noexcept = 0;
+};
+
+/**
+ * Supports internal iteration over a collection of key-value pairs.
+ */
+class NoopKeyValueIterable : public KeyValueIterable
+{
+public:
+  ~NoopKeyValueIterable() override = default;
+
+  /**
+   * Iterate over key-value pairs
+   * @param callback a callback to invoke for each key-value. If the callback returns false,
+   * the iteration is aborted.
+   * @return true if every key-value pair was iterated over
+   */
+  bool ForEachKeyValue(
+      nostd::function_ref<bool(nostd::string_view, common::AttributeValue)>) const noexcept override
+  {
+    return true;
+  }
+
+  /**
+   * @return the number of key-value pairs
+   */
+  size_t size() const noexcept override { return 0; }
+};
+
+}  // namespace common
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/common/key_value_iterable_view.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/common/key_value_iterable_view.h
@@ -1,0 +1,141 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <iterator>
+#include <utility>
+
+#include "opentelemetry/common/key_value_iterable.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/type_traits.h"
+#include "opentelemetry/nostd/utility.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+// NOTE - code within `detail` namespace implements internal details, and not part
+// of the public interface.
+namespace detail
+{
+inline void take_key_value(nostd::string_view, common::AttributeValue) {}
+
+template <class T>
+auto is_key_value_iterable_impl(T iterable)
+    -> decltype(take_key_value(std::begin(iterable)->first, std::begin(iterable)->second),
+                nostd::size(iterable),
+                std::true_type{});
+
+std::false_type is_key_value_iterable_impl(...);
+
+template <class T>
+struct is_key_value_iterable
+{
+  static const bool value = decltype(detail::is_key_value_iterable_impl(std::declval<T>()))::value;
+};
+}  // namespace detail
+
+/**
+ * @brief Container for key-value pairs that can transform every value in it to one of types
+ * listed in common::AttributeValue. It may contain value types that are not directly map'able
+ * to primitive value types. In that case the `ForEachKeyValue` method acts as a transform to
+ * convert the value type to one listed under AtributeValue (bool, int32_t, int64_t, uint32_t,
+ * uint64_t, double, nostd::string_view, or arrays of primite types). For example, if UUID,
+ * GUID, or UTF-16 string type is passed as one of values stored inside this container, the
+ * container itself may provide a custom implementation of `ForEachKeyValue` to transform the
+ * 'non-standard' type to one of the standard types.
+ */
+template <class T>
+class KeyValueIterableView final : public KeyValueIterable
+{
+
+public:
+  explicit KeyValueIterableView(const T &container) noexcept : container_{&container} {}
+
+  // KeyValueIterable
+  bool ForEachKeyValue(nostd::function_ref<bool(nostd::string_view, common::AttributeValue)>
+                           callback) const noexcept override
+  {
+    auto iter = std::begin(*container_);
+    auto last = std::end(*container_);
+    for (; iter != last; ++iter)
+    {
+      if (!callback(iter->first, iter->second))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  size_t size() const noexcept override { return nostd::size(*container_); }
+
+private:
+  const T *container_;
+};
+
+template <class T, nostd::enable_if_t<detail::is_key_value_iterable<T>::value> * = nullptr>
+KeyValueIterableView<T> MakeKeyValueIterableView(const T &container) noexcept
+{
+  return KeyValueIterableView<T>(container);
+}
+
+/**
+ * Utility function to help to make a attribute view from initializer_list
+ *
+ * @param attributes
+ * @return nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>
+ */
+inline static nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>
+MakeAttributes(std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>
+                   attributes) noexcept
+{
+  return nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+      attributes.begin(), attributes.end()};
+}
+
+/**
+ * Utility function to help to make a attribute view from a span
+ *
+ * @param attributes
+ * @return nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>
+ */
+inline static nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>
+MakeAttributes(
+    nostd::span<const std::pair<nostd::string_view, common::AttributeValue>> attributes) noexcept
+{
+  return attributes;
+}
+
+/**
+ * Utility function to help to make a attribute view from a KeyValueIterable
+ *
+ * @param attributes
+ * @return common::KeyValueIterable
+ */
+inline static const common::KeyValueIterable &MakeAttributes(
+    const common::KeyValueIterable &attributes) noexcept
+{
+  return attributes;
+}
+
+/**
+ * Utility function to help to make a attribute view from a key-value iterable object
+ *
+ * @param attributes
+ * @return nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>
+ */
+template <
+    class ArgumentType,
+    nostd::enable_if_t<common::detail::is_key_value_iterable<ArgumentType>::value> * = nullptr>
+inline static common::KeyValueIterableView<ArgumentType> MakeAttributes(
+    const ArgumentType &arg) noexcept
+{
+  return common::KeyValueIterableView<ArgumentType>(arg);
+}
+
+}  // namespace common
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/common/kv_properties.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/common/kv_properties.h
@@ -1,0 +1,272 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/common/string_util.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/version.h"
+
+#include <cstring>
+#include <string>
+#include <type_traits>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+
+// Constructor parameter for KeyValueStringTokenizer
+struct KeyValueStringTokenizerOptions
+{
+  char member_separator     = ',';
+  char key_value_separator  = '=';
+  bool ignore_empty_members = true;
+};
+
+// Tokenizer for key-value headers
+class KeyValueStringTokenizer
+{
+public:
+  KeyValueStringTokenizer(
+      nostd::string_view str,
+      const KeyValueStringTokenizerOptions &opts = KeyValueStringTokenizerOptions()) noexcept
+      : str_(str), opts_(opts), index_(0)
+  {}
+
+  static nostd::string_view GetDefaultKeyOrValue()
+  {
+    static std::string default_str = "";
+    return default_str;
+  }
+
+  // Returns next key value in the string header
+  // @param valid_kv : if the found kv pair is valid or not
+  // @param key : key in kv pair
+  // @param key : value in kv pair
+  // @returns true if next kv pair was found, false otherwise.
+  bool next(bool &valid_kv, nostd::string_view &key, nostd::string_view &value) noexcept
+  {
+    valid_kv = true;
+    while (index_ < str_.size())
+    {
+      bool is_empty_pair = false;
+      size_t end         = str_.find(opts_.member_separator, index_);
+      if (end == std::string::npos)
+      {
+        end = str_.size() - 1;
+      }
+      else if (end == index_)  // empty pair. do not update end
+      {
+        is_empty_pair = true;
+      }
+      else
+      {
+        end--;
+      }
+
+      auto list_member = StringUtil::Trim(str_, index_, end);
+      if (list_member.size() == 0 || is_empty_pair)
+      {
+        // empty list member
+        index_ = end + 2 - is_empty_pair;
+        if (opts_.ignore_empty_members)
+        {
+          continue;
+        }
+
+        valid_kv = true;
+        key      = GetDefaultKeyOrValue();
+        value    = GetDefaultKeyOrValue();
+        return true;
+      }
+
+      auto key_end_pos = list_member.find(opts_.key_value_separator);
+      if (key_end_pos == std::string::npos)
+      {
+        // invalid member
+        valid_kv = false;
+      }
+      else
+      {
+        key   = list_member.substr(0, key_end_pos);
+        value = list_member.substr(key_end_pos + 1);
+      }
+
+      index_ = end + 2;
+
+      return true;
+    }
+
+    // no more entries remaining
+    return false;
+  }
+
+  // Returns total number of tokens in header string
+  size_t NumTokens() const noexcept
+  {
+    size_t cnt = 0, begin = 0;
+    while (begin < str_.size())
+    {
+      ++cnt;
+      size_t end = str_.find(opts_.member_separator, begin);
+      if (end == std::string::npos)
+      {
+        break;
+      }
+
+      begin = end + 1;
+    }
+
+    return cnt;
+  }
+
+  // Resets the iterator
+  void reset() noexcept { index_ = 0; }
+
+private:
+  nostd::string_view str_;
+  KeyValueStringTokenizerOptions opts_;
+  size_t index_;
+};
+
+// Class to store fixed size array of key-value pairs of string type
+class KeyValueProperties
+{
+  // Class to store key-value pairs of string types
+public:
+  class Entry
+  {
+  public:
+    Entry() : key_(nullptr), value_(nullptr) {}
+
+    // Copy constructor
+    Entry(const Entry &copy)
+    {
+      key_   = CopyStringToPointer(copy.key_.get());
+      value_ = CopyStringToPointer(copy.value_.get());
+    }
+
+    // Copy assignment operator
+    Entry &operator=(Entry &other)
+    {
+      key_   = CopyStringToPointer(other.key_.get());
+      value_ = CopyStringToPointer(other.value_.get());
+      return *this;
+    }
+
+    // Move contructor and assignment operator
+    Entry(Entry &&other) = default;
+    Entry &operator=(Entry &&other) = default;
+
+    // Creates an Entry for a given key-value pair.
+    Entry(nostd::string_view key, nostd::string_view value)
+    {
+      key_   = CopyStringToPointer(key);
+      value_ = CopyStringToPointer(value);
+    }
+
+    // Gets the key associated with this entry.
+    nostd::string_view GetKey() const noexcept { return key_.get(); }
+
+    // Gets the value associated with this entry.
+    nostd::string_view GetValue() const noexcept { return value_.get(); }
+
+    // Sets the value for this entry. This overrides the previous value.
+    void SetValue(nostd::string_view value) noexcept { value_ = CopyStringToPointer(value); }
+
+  private:
+    // Store key and value as raw char pointers to avoid using std::string.
+    nostd::unique_ptr<const char[]> key_;
+    nostd::unique_ptr<const char[]> value_;
+
+    // Copies string into a buffer and returns a unique_ptr to the buffer.
+    // This is a workaround for the fact that memcpy doesn't accept a const destination.
+    nostd::unique_ptr<const char[]> CopyStringToPointer(nostd::string_view str)
+    {
+      char *temp = new char[str.size() + 1];
+      memcpy(temp, str.data(), str.size());
+      temp[str.size()] = '\0';
+      return nostd::unique_ptr<const char[]>(temp);
+    }
+  };
+
+  // Maintain the number of entries in entries_.
+  size_t num_entries_;
+
+  // Max size of allocated array
+  size_t max_num_entries_;
+
+  // Store entries in a C-style array to avoid using std::array or std::vector.
+  nostd::unique_ptr<Entry[]> entries_;
+
+public:
+  // Create Key-value list of given size
+  // @param size : Size of list.
+  KeyValueProperties(size_t size) noexcept
+      : num_entries_(0), max_num_entries_(size), entries_(new Entry[size])
+  {}
+
+  // Create Empty Key-Value list
+  KeyValueProperties() noexcept : num_entries_(0), max_num_entries_(0), entries_(nullptr) {}
+
+  template <class T, class = typename std::enable_if<detail::is_key_value_iterable<T>::value>::type>
+  KeyValueProperties(const T &keys_and_values) noexcept
+      : num_entries_(0),
+        max_num_entries_(keys_and_values.size()),
+        entries_(new Entry[max_num_entries_])
+  {
+    for (auto &e : keys_and_values)
+    {
+      Entry entry(e.first, e.second);
+      (entries_.get())[num_entries_++] = std::move(entry);
+    }
+  }
+
+  // Adds new kv pair into kv properties
+  void AddEntry(nostd::string_view key, nostd::string_view value) noexcept
+  {
+    if (num_entries_ < max_num_entries_)
+    {
+      Entry entry(key, value);
+      (entries_.get())[num_entries_++] = std::move(entry);
+    }
+  }
+
+  // Returns all kv pair entries
+  bool GetAllEntries(
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)> callback) const noexcept
+  {
+    for (size_t i = 0; i < num_entries_; i++)
+    {
+      auto &entry = (entries_.get())[i];
+      if (!callback(entry.GetKey(), entry.GetValue()))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Return value for key if exists, return false otherwise
+  bool GetValue(nostd::string_view key, std::string &value) const noexcept
+  {
+    for (size_t i = 0; i < num_entries_; i++)
+    {
+      auto &entry = (entries_.get())[i];
+      if (entry.GetKey() == key)
+      {
+        const auto &entry_value = entry.GetValue();
+        value                   = std::string(entry_value.data(), entry_value.size());
+        return true;
+      }
+    }
+    return false;
+  }
+
+  size_t Size() const noexcept { return num_entries_; }
+};
+}  // namespace common
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/common/macros.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/common/macros.h
@@ -1,0 +1,231 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if !defined(OPENTELEMETRY_LIKELY_IF) && defined(__cplusplus)
+// GCC 9 has likely attribute but do not support declare it at the beginning of statement
+#  if defined(__has_cpp_attribute) && (defined(__clang__) || !defined(__GNUC__) || __GNUC__ > 9)
+#    if __has_cpp_attribute(likely)
+#      define OPENTELEMETRY_LIKELY_IF(...) \
+        if (__VA_ARGS__)                   \
+        [[likely]]
+
+#    endif
+#  endif
+#endif
+#if !defined(OPENTELEMETRY_LIKELY_IF) && (defined(__clang__) || defined(__GNUC__))
+#  define OPENTELEMETRY_LIKELY_IF(...) if (__builtin_expect(!!(__VA_ARGS__), true))
+#endif
+#ifndef OPENTELEMETRY_LIKELY_IF
+#  define OPENTELEMETRY_LIKELY_IF(...) if (__VA_ARGS__)
+#endif
+
+/// \brief Declare variable as maybe unused
+/// usage:
+///   OPENTELEMETRY_MAYBE_UNUSED int a;
+///   class OPENTELEMETRY_MAYBE_UNUSED a;
+///   OPENTELEMETRY_MAYBE_UNUSED int a();
+///
+#if defined(__cplusplus) && __cplusplus >= 201703L
+#  define OPENTELEMETRY_MAYBE_UNUSED [[maybe_unused]]
+#elif defined(__clang__)
+#  define OPENTELEMETRY_MAYBE_UNUSED __attribute__((unused))
+#elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
+#  define OPENTELEMETRY_MAYBE_UNUSED __attribute__((unused))
+#elif (defined(_MSC_VER) && _MSC_VER >= 1910) && (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#  define OPENTELEMETRY_MAYBE_UNUSED [[maybe_unused]]
+#else
+#  define OPENTELEMETRY_MAYBE_UNUSED
+#endif
+
+#ifndef OPENTELEMETRY_RTTI_ENABLED
+#  if defined(__clang__)
+#    if __has_feature(cxx_rtti)
+#      define OPENTELEMETRY_RTTI_ENABLED
+#    endif
+#  elif defined(__GNUG__)
+#    if defined(__GXX_RTTI)
+#      define OPENTELEMETRY_RTTI_ENABLED
+#    endif
+#  elif defined(_MSC_VER)
+#    if defined(_CPPRTTI)
+#      define OPENTELEMETRY_RTTI_ENABLED
+#    endif
+#  endif
+#endif
+
+#if defined(__cplusplus) && __cplusplus >= 201402L
+#  define OPENTELEMETRY_DEPRECATED [[deprecated]]
+#elif defined(__clang__)
+#  define OPENTELEMETRY_DEPRECATED __attribute__((deprecated))
+#elif defined(__GNUC__)
+#  define OPENTELEMETRY_DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
+#    define OPENTELEMETRY_DEPRECATED [[deprecated]]
+#  else
+#    define OPENTELEMETRY_DEPRECATED __declspec(deprecated)
+#  endif
+#else
+#  define OPENTELEMETRY_DEPRECATED
+#endif
+
+#if defined(__cplusplus) && __cplusplus >= 201402L
+#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) [[deprecated(msg)]]
+#elif defined(__clang__)
+#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) __attribute__((deprecated(msg)))
+#elif defined(__GNUC__)
+#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
+#    define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) [[deprecated(msg)]]
+#  else
+#    define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) __declspec(deprecated(msg))
+#  endif
+#else
+#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg)
+#endif
+
+// Regex support
+#if (__GNUC__ == 4 && (__GNUC_MINOR__ == 8 || __GNUC_MINOR__ == 9))
+#  define OPENTELEMETRY_HAVE_WORKING_REGEX 0
+#else
+#  define OPENTELEMETRY_HAVE_WORKING_REGEX 1
+#endif
+
+/* clang-format off */
+
+/**
+  @page HEADER_ONLY_SINGLETON Header only singleton.
+
+  @section ELF_SINGLETON
+
+  For clang and gcc, the desired coding pattern is as follows.
+
+  @verbatim
+  class Foo
+  {
+    // (a)
+    __attribute__((visibility("default")))
+    // (b)
+    T& get_singleton()
+    {
+      // (c)
+      static T singleton;
+      return singleton;
+    }
+  };
+  @endverbatim
+
+  (a) is needed when the code is build with
+  @code -fvisibility="hidden" @endcode
+  to ensure that all instances of (b) are visible to the linker.
+
+  What is duplicated in the binary is @em code, in (b).
+
+  The linker will make sure only one instance
+  of all the (b) methods is used.
+
+  (c) is a singleton implemented inside a method.
+
+  This is very desirable, because:
+
+  - the C++ compiler guarantees that construction
+    of the variable (c) is thread safe.
+
+  - constructors for (c) singletons are executed in code path order,
+    or not at all if the singleton is never used.
+
+  @section OTHER_SINGLETON
+
+  For other platforms, header only singletons are not supported at this
+point.
+
+  @section CODING_PATTERN
+
+  The coding pattern to use in the source code is as follows
+
+  @verbatim
+  class Foo
+  {
+    OPENTELEMETRY_API_SINGLETON
+    T& get_singleton()
+    {
+      static T singleton;
+      return singleton;
+    }
+  };
+  @endverbatim
+*/
+
+/* clang-format on */
+
+#if defined(__clang__)
+
+#  define OPENTELEMETRY_API_SINGLETON __attribute__((visibility("default")))
+#  define OPENTELEMETRY_LOCAL_SYMBOL __attribute__((visibility("hidden")))
+
+#elif defined(__GNUC__)
+
+#  define OPENTELEMETRY_API_SINGLETON __attribute__((visibility("default")))
+#  define OPENTELEMETRY_LOCAL_SYMBOL __attribute__((visibility("hidden")))
+
+#else
+
+/* Add support for other compilers here. */
+
+#  define OPENTELEMETRY_API_SINGLETON
+#  define OPENTELEMETRY_LOCAL_SYMBOL
+
+#endif
+
+//
+// Atomic wrappers based on compiler intrinsics for memory read/write.
+// The tailing number is read/write length in bits.
+//
+// N.B. Compiler instrinsic is used because the usage of C++ standard library is restricted in the
+// OpenTelemetry C++ API.
+//
+#if defined(__GNUC__)
+
+#  define OPENTELEMETRY_ATOMIC_READ_8(ptr) __atomic_load_n(ptr, __ATOMIC_SEQ_CST)
+#  define OPENTELEMETRY_ATOMIC_WRITE_8(ptr, value) __atomic_store_n(ptr, value, __ATOMIC_SEQ_CST)
+
+#elif defined(_MSC_VER)
+
+#  include <intrin.h>
+
+#  define OPENTELEMETRY_ATOMIC_READ_8(ptr) \
+    static_cast<uint8_t>(_InterlockedCompareExchange8(reinterpret_cast<char *>(ptr), 0, 0))
+#  define OPENTELEMETRY_ATOMIC_WRITE_8(ptr, value) \
+    _InterlockedExchange8(reinterpret_cast<char *>(ptr), static_cast<char>(value))
+
+#else
+#  error port atomics read/write for the current platform
+#endif
+
+/* clang-format on */
+//
+// The if/elif order matters here. If both OPENTELEMETRY_BUILD_IMPORT_DLL and
+// OPENTELEMETRY_BUILD_EXPORT_DLL are defined, the former takes precedence.
+//
+// TODO: consider define OPENTELEMETRY_EXPORT for cygwin/gcc, see below link.
+// https://gcc.gnu.org/wiki/Visibility#How_to_use_the_new_C.2B-.2B-_visibility_support
+//
+#if defined(_MSC_VER) && defined(OPENTELEMETRY_BUILD_IMPORT_DLL)
+
+#  define OPENTELEMETRY_EXPORT __declspec(dllimport)
+
+#elif defined(_MSC_VER) && defined(OPENTELEMETRY_BUILD_EXPORT_DLL)
+
+#  define OPENTELEMETRY_EXPORT __declspec(dllexport)
+
+#else
+
+//
+// build OpenTelemetry as static library or not on Windows.
+//
+#  define OPENTELEMETRY_EXPORT
+
+#endif

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -1,0 +1,131 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "opentelemetry/version.h"
+
+#if defined(_MSC_VER)
+#  define _WINSOCKAPI_  // stops including winsock.h
+#  include <windows.h>
+#elif defined(__i386__) || defined(__x86_64__)
+#  if defined(__clang__)
+#    include <emmintrin.h>
+#  elif defined(__INTEL_COMPILER)
+#    include <immintrin.h>
+#  endif
+#endif
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+
+constexpr int SPINLOCK_FAST_ITERATIONS = 100;
+constexpr int SPINLOCK_SLEEP_MS        = 1;
+
+/**
+ * A Mutex which uses atomic flags and spin-locks instead of halting threads.
+ *
+ * This mutex uses an incremental back-off strategy with the following phases:
+ * 1. A tight spin-lock loop (pending: using hardware PAUSE/YIELD instructions)
+ * 2. A loop where the current thread yields control after checking the lock.
+ * 3. Issuing a thread-sleep call before starting back in phase 1.
+ *
+ * This is meant to give a good balance of perofrmance and CPU consumption in
+ * practice.
+ *
+ * This mutex uses an incremental back-off strategy with the following phases:
+ * 1. A tight spin-lock loop (pending: using hardware PAUSE/YIELD instructions)
+ * 2. A loop where the current thread yields control after checking the lock.
+ * 3. Issuing a thread-sleep call before starting back in phase 1.
+ *
+ * This is meant to give a good balance of perofrmance and CPU consumption in
+ * practice.
+ *
+ * This class implements the `BasicLockable` specification:
+ * https://en.cppreference.com/w/cpp/named_req/BasicLockable
+ */
+class SpinLockMutex
+{
+public:
+  SpinLockMutex() noexcept {}
+  ~SpinLockMutex() noexcept            = default;
+  SpinLockMutex(const SpinLockMutex &) = delete;
+  SpinLockMutex &operator=(const SpinLockMutex &) = delete;
+
+  static inline void fast_yield() noexcept
+  {
+// Issue a Pause/Yield instruction while spinning.
+#if defined(_MSC_VER)
+    YieldProcessor();
+#elif defined(__i386__) || defined(__x86_64__)
+#  if defined(__clang__) || defined(__INTEL_COMPILER)
+    _mm_pause();
+#  else
+    __builtin_ia32_pause();
+#  endif
+#elif defined(__arm__)
+    __asm__ volatile("yield" ::: "memory");
+#else
+    // TODO: Issue PAGE/YIELD on other architectures.
+#endif
+  }
+
+  /**
+   * Attempts to lock the mutex.  Return immediately with `true` (success) or `false` (failure).
+   */
+  bool try_lock() noexcept
+  {
+    return !flag_.load(std::memory_order_relaxed) &&
+           !flag_.exchange(true, std::memory_order_acquire);
+  }
+
+  /**
+   * Blocks until a lock can be obtained for the current thread.
+   *
+   * This mutex will spin the current CPU waiting for the lock to be available.  This can have
+   * decent performance in scenarios where there is low lock contention and lock-holders achieve
+   * their work quickly.  It degrades in scenarios where locked tasks take a long time.
+   */
+  void lock() noexcept
+  {
+    for (;;)
+    {
+      // Try once
+      if (!flag_.exchange(true, std::memory_order_acquire))
+      {
+        return;
+      }
+      // Spin-Fast (goal ~10ns)
+      for (std::size_t i = 0; i < SPINLOCK_FAST_ITERATIONS; ++i)
+      {
+        if (try_lock())
+        {
+          return;
+        }
+        fast_yield();
+      }
+      // Yield then try again (goal ~100ns)
+      std::this_thread::yield();
+      if (try_lock())
+      {
+        return;
+      }
+      // Sleep and then start the whole process again. (goal ~1000ns)
+      std::this_thread::sleep_for(std::chrono::milliseconds(SPINLOCK_SLEEP_MS));
+    }
+    return;
+  }
+  /** Releases the lock held by the execution agent. Throws no exceptions. */
+  void unlock() noexcept { flag_.store(false, std::memory_order_release); }
+
+private:
+  std::atomic<bool> flag_{false};
+};
+
+}  // namespace common
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/common/string_util.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/common/string_util.h
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+
+class StringUtil
+{
+public:
+  static nostd::string_view Trim(nostd::string_view str, size_t left, size_t right) noexcept
+  {
+    while (left <= right && str[static_cast<std::size_t>(left)] == ' ')
+    {
+      left++;
+    }
+    while (left <= right && str[static_cast<std::size_t>(right)] == ' ')
+    {
+      right--;
+    }
+    return str.substr(left, 1 + right - left);
+  }
+
+  static nostd::string_view Trim(nostd::string_view str) noexcept
+  {
+    if (str.empty())
+    {
+      return str;
+    }
+
+    return Trim(str, 0, str.size() - 1);
+  }
+};
+
+}  // namespace common
+
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/common/timestamp.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/common/timestamp.h
@@ -1,0 +1,206 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+/**
+ * @brief A timepoint relative to the system clock epoch.
+ *
+ * This is used for marking the beginning and end of an operation.
+ */
+class SystemTimestamp
+{
+public:
+  /**
+   * @brief Initializes a system timestamp pointing to the start of the epoch.
+   */
+  SystemTimestamp() noexcept : nanos_since_epoch_{0} {}
+
+  /**
+   * @brief Initializes a system timestamp from a duration.
+   *
+   * @param time_since_epoch Time elapsed since the beginning of the epoch.
+   */
+  template <class Rep, class Period>
+  explicit SystemTimestamp(const std::chrono::duration<Rep, Period> &time_since_epoch) noexcept
+      : nanos_since_epoch_{static_cast<int64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(time_since_epoch).count())}
+  {}
+
+  /**
+   * @brief Initializes a system timestamp based on a point in time.
+   *
+   * @param time_point A point in time.
+   */
+  /*implicit*/ SystemTimestamp(const std::chrono::system_clock::time_point &time_point) noexcept
+      : SystemTimestamp{time_point.time_since_epoch()}
+  {}
+
+  /**
+   * @brief Returns a time point for the time stamp.
+   *
+   * @return A time point corresponding to the time stamp.
+   */
+  operator std::chrono::system_clock::time_point() const noexcept
+  {
+    return std::chrono::system_clock::time_point{
+        std::chrono::duration_cast<std::chrono::system_clock::duration>(
+            std::chrono::nanoseconds{nanos_since_epoch_})};
+  }
+
+  /**
+   * @brief Returns the nanoseconds since the beginning of the epoch.
+   *
+   * @return Elapsed nanoseconds since the beginning of the epoch for this timestamp.
+   */
+  std::chrono::nanoseconds time_since_epoch() const noexcept
+  {
+    return std::chrono::nanoseconds{nanos_since_epoch_};
+  }
+
+  /**
+   * @brief Compare two steady time stamps.
+   *
+   * @return true if the two time stamps are equal.
+   */
+  bool operator==(const SystemTimestamp &other) const noexcept
+  {
+    return nanos_since_epoch_ == other.nanos_since_epoch_;
+  }
+
+  /**
+   * @brief Compare two steady time stamps for inequality.
+   *
+   * @return true if the two time stamps are not equal.
+   */
+  bool operator!=(const SystemTimestamp &other) const noexcept
+  {
+    return nanos_since_epoch_ != other.nanos_since_epoch_;
+  }
+
+private:
+  int64_t nanos_since_epoch_;
+};
+
+/**
+ * @brief A timepoint relative to the monotonic clock epoch
+ *
+ * This is used for calculating the duration of an operation.
+ */
+class SteadyTimestamp
+{
+public:
+  /**
+   * @brief Initializes a monotonic timestamp pointing to the start of the epoch.
+   */
+  SteadyTimestamp() noexcept : nanos_since_epoch_{0} {}
+
+  /**
+   * @brief Initializes a monotonic timestamp from a duration.
+   *
+   * @param time_since_epoch Time elapsed since the beginning of the epoch.
+   */
+  template <class Rep, class Period>
+  explicit SteadyTimestamp(const std::chrono::duration<Rep, Period> &time_since_epoch) noexcept
+      : nanos_since_epoch_{static_cast<int64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(time_since_epoch).count())}
+  {}
+
+  /**
+   * @brief Initializes a monotonic timestamp based on a point in time.
+   *
+   * @param time_point A point in time.
+   */
+  /*implicit*/ SteadyTimestamp(const std::chrono::steady_clock::time_point &time_point) noexcept
+      : SteadyTimestamp{time_point.time_since_epoch()}
+  {}
+
+  /**
+   * @brief Returns a time point for the time stamp.
+   *
+   * @return A time point corresponding to the time stamp.
+   */
+  operator std::chrono::steady_clock::time_point() const noexcept
+  {
+    return std::chrono::steady_clock::time_point{
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::nanoseconds{nanos_since_epoch_})};
+  }
+
+  /**
+   * @brief Returns the nanoseconds since the beginning of the epoch.
+   *
+   * @return Elapsed nanoseconds since the beginning of the epoch for this timestamp.
+   */
+  std::chrono::nanoseconds time_since_epoch() const noexcept
+  {
+    return std::chrono::nanoseconds{nanos_since_epoch_};
+  }
+
+  /**
+   * @brief Compare two steady time stamps.
+   *
+   * @return true if the two time stamps are equal.
+   */
+  bool operator==(const SteadyTimestamp &other) const noexcept
+  {
+    return nanos_since_epoch_ == other.nanos_since_epoch_;
+  }
+
+  /**
+   * @brief Compare two steady time stamps for inequality.
+   *
+   * @return true if the two time stamps are not equal.
+   */
+  bool operator!=(const SteadyTimestamp &other) const noexcept
+  {
+    return nanos_since_epoch_ != other.nanos_since_epoch_;
+  }
+
+private:
+  int64_t nanos_since_epoch_;
+};
+
+class DurationUtil
+{
+public:
+  template <class Rep, class Period>
+  static std::chrono::duration<Rep, Period> AdjustWaitForTimeout(
+      std::chrono::duration<Rep, Period> timeout,
+      std::chrono::duration<Rep, Period> indefinite_value) noexcept
+  {
+    // Do not call now() when this duration is max value, now() may have a expensive cost.
+    if (timeout == (std::chrono::duration<Rep, Period>::max)())
+    {
+      return indefinite_value;
+    }
+
+    // std::future<T>::wait_for, std::this_thread::sleep_for, and std::condition_variable::wait_for
+    // may use steady_clock or system_clock.We need make sure now() + timeout do not overflow.
+    auto max_timeout = std::chrono::duration_cast<std::chrono::duration<Rep, Period>>(
+        (std::chrono::steady_clock::time_point::max)() - std::chrono::steady_clock::now());
+    if (timeout >= max_timeout)
+    {
+      return indefinite_value;
+    }
+    max_timeout = std::chrono::duration_cast<std::chrono::duration<Rep, Period>>(
+        (std::chrono::system_clock::time_point::max)() - std::chrono::system_clock::now());
+    if (timeout >= max_timeout)
+    {
+      return indefinite_value;
+    }
+
+    return timeout;
+  }
+};
+
+}  // namespace common
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/config.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/config.h
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifndef __has_include
+#  define OPENTELEMETRY_HAS_INCLUDE(x) 0
+#else
+#  define OPENTELEMETRY_HAS_INCLUDE(x) __has_include(x)
+#endif
+
+#if !defined(__GLIBCXX__) || OPENTELEMETRY_HAS_INCLUDE(<codecvt>)  // >= libstdc++-5
+#  define OPENTELEMETRY_TRIVIALITY_TYPE_TRAITS
+#endif

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/context/context.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/context/context.h
@@ -1,0 +1,162 @@
+﻿// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstring>
+#include "opentelemetry/context/context_value.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace context
+{
+
+// The context class provides a context identifier. Is built as a linked list
+// of DataList nodes and each context holds a shared_ptr to a place within
+// the list that determines which keys and values it has access to. All that
+// come before and none that come after.
+class Context
+{
+
+public:
+  Context() = default;
+  // Creates a context object from a map of keys and identifiers, this will
+  // hold a shared_ptr to the head of the DataList linked list
+  template <class T>
+  Context(const T &keys_and_values) noexcept
+  {
+    head_ = nostd::shared_ptr<DataList>{new DataList(keys_and_values)};
+  }
+
+  // Creates a context object from a key and value, this will
+  // hold a shared_ptr to the head of the DataList linked list
+  Context(nostd::string_view key, ContextValue value) noexcept
+  {
+    head_ = nostd::shared_ptr<DataList>{new DataList(key, value)};
+  }
+
+  // Accepts a new iterable and then returns a new context that
+  // contains the new key and value data. It attaches the
+  // exisiting list to the end of the new list.
+  template <class T>
+  Context SetValues(T &values) noexcept
+  {
+    Context context                  = Context(values);
+    nostd::shared_ptr<DataList> last = context.head_;
+    while (last->next_ != nullptr)
+    {
+      last = last->next_;
+    }
+    last->next_ = head_;
+    return context;
+  }
+
+  // Accepts a new iterable and then returns a new context that
+  // contains the new key and value data. It attaches the
+  // exisiting list to the end of the new list.
+  Context SetValue(nostd::string_view key, ContextValue value) noexcept
+  {
+    Context context      = Context(key, value);
+    context.head_->next_ = head_;
+    return context;
+  }
+
+  // Returns the value associated with the passed in key.
+  context::ContextValue GetValue(const nostd::string_view key) const noexcept
+  {
+    for (DataList *data = head_.get(); data != nullptr; data = data->next_.get())
+    {
+      if (key.size() == data->key_length_)
+      {
+        if (std::memcmp(key.data(), data->key_, data->key_length_) == 0)
+        {
+          return data->value_;
+        }
+      }
+    }
+    return ContextValue{};
+  }
+
+  // Checks for key and returns true if found
+  bool HasKey(const nostd::string_view key) const noexcept
+  {
+    return !nostd::holds_alternative<nostd::monostate>(GetValue(key));
+  }
+
+  bool operator==(const Context &other) const noexcept { return (head_ == other.head_); }
+
+private:
+  // A linked list to contain the keys and values of this context node
+  class DataList
+  {
+  public:
+    char *key_;
+
+    nostd::shared_ptr<DataList> next_;
+
+    size_t key_length_;
+
+    ContextValue value_;
+
+    DataList() { next_ = nullptr; }
+
+    // Builds a data list off of a key and value iterable and returns the head
+    template <class T>
+    DataList(const T &keys_and_vals) : key_{nullptr}, next_(nostd::shared_ptr<DataList>{nullptr})
+    {
+      bool first = true;
+      auto *node = this;
+      for (auto &iter : keys_and_vals)
+      {
+        if (first)
+        {
+          *node = DataList(iter.first, iter.second);
+          first = false;
+        }
+        else
+        {
+          node->next_ = nostd::shared_ptr<DataList>(new DataList(iter.first, iter.second));
+          node        = node->next_.get();
+        }
+      }
+    }
+
+    // Builds a data list with just a key and value, so it will just be the head
+    // and returns that head.
+    DataList(nostd::string_view key, const ContextValue &value)
+    {
+      key_        = new char[key.size()];
+      key_length_ = key.size();
+      memcpy(key_, key.data(), key.size() * sizeof(char));
+      value_ = value;
+      next_  = nostd::shared_ptr<DataList>{nullptr};
+    }
+
+    DataList &operator=(DataList &&other) noexcept
+    {
+      key_length_ = other.key_length_;
+      value_      = std::move(other.value_);
+      next_       = std::move(other.next_);
+
+      key_       = other.key_;
+      other.key_ = nullptr;
+
+      return *this;
+    }
+
+    ~DataList()
+    {
+      if (key_ != nullptr)
+      {
+        delete[] key_;
+      }
+    }
+  };
+
+  // Head of the list which holds the keys and values of this context
+  nostd::shared_ptr<DataList> head_;
+};
+}  // namespace context
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/context/context_value.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/context/context_value.h
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/variant.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace baggage
+{
+class Baggage;
+}  // namespace baggage
+
+namespace trace
+{
+class Span;
+class SpanContext;
+}  // namespace trace
+
+namespace context
+{
+using ContextValue = nostd::variant<nostd::monostate,
+                                    bool,
+                                    int64_t,
+                                    uint64_t,
+                                    double,
+                                    nostd::shared_ptr<trace::Span>,
+                                    nostd::shared_ptr<trace::SpanContext>,
+                                    nostd::shared_ptr<baggage::Baggage>>;
+}  // namespace context
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/context/propagation/composite_propagator.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/context/propagation/composite_propagator.h
@@ -1,0 +1,93 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace context
+{
+namespace propagation
+{
+
+class CompositePropagator : public TextMapPropagator
+{
+public:
+  CompositePropagator(std::vector<std::unique_ptr<TextMapPropagator>> propagators)
+      : propagators_(std::move(propagators))
+  {}
+
+  /**
+   * Run each of the configured propagators with the given context and carrier.
+   * Propagators are run in the order they are configured, so if multiple
+   * propagators write the same carrier key, the propagator later in the list
+   * will "win".
+   *
+   * @param carrier Carrier into which context will be injected
+   * @param context Context to inject
+   *
+   */
+
+  void Inject(TextMapCarrier &carrier, const context::Context &context) noexcept override
+  {
+    for (auto &p : propagators_)
+    {
+      p->Inject(carrier, context);
+    }
+  }
+
+  /**
+   * Run each of the configured propagators with the given context and carrier.
+   * Propagators are run in the order they are configured, so if multiple
+   * propagators write the same context key, the propagator later in the list
+   * will "win".
+   *
+   * @param carrier Carrier from which to extract context
+   * @param context Context to add values to
+   */
+  context::Context Extract(const TextMapCarrier &carrier,
+                           context::Context &context) noexcept override
+  {
+    auto first = true;
+    context::Context tmp_context;
+    for (auto &p : propagators_)
+    {
+      if (first)
+      {
+        tmp_context = p->Extract(carrier, context);
+        first       = false;
+      }
+      else
+      {
+        tmp_context = p->Extract(carrier, tmp_context);
+      }
+    }
+    return propagators_.size() ? tmp_context : context;
+  }
+
+  /**
+   * Invoke callback with  fields set to carrier by `inject` method for all the
+   * configured propagators
+   * Returns true if all invocation return true
+   */
+  bool Fields(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept override
+  {
+    bool status = true;
+    for (auto &p : propagators_)
+    {
+      status = status && p->Fields(callback);
+    }
+    return status;
+  }
+
+private:
+  std::vector<std::unique_ptr<TextMapPropagator>> propagators_;
+};
+}  // namespace propagation
+}  // namespace context
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/context/propagation/global_propagator.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/context/propagation/global_propagator.h
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mutex>
+
+#include "opentelemetry/context/propagation/noop_propagator.h"
+
+#include "opentelemetry/common/macros.h"
+#include "opentelemetry/common/spin_lock_mutex.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace context
+{
+namespace propagation
+{
+
+class TextMapPropagator;
+
+/* Stores the singleton TextMapPropagator */
+
+class OPENTELEMETRY_EXPORT GlobalTextMapPropagator
+{
+public:
+  static nostd::shared_ptr<TextMapPropagator> GetGlobalPropagator() noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    return nostd::shared_ptr<TextMapPropagator>(GetPropagator());
+  }
+
+  static void SetGlobalPropagator(nostd::shared_ptr<TextMapPropagator> prop) noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    GetPropagator() = prop;
+  }
+
+private:
+  OPENTELEMETRY_API_SINGLETON static nostd::shared_ptr<TextMapPropagator> &GetPropagator() noexcept
+  {
+    static nostd::shared_ptr<TextMapPropagator> propagator(new NoOpPropagator());
+    return propagator;
+  }
+
+  OPENTELEMETRY_API_SINGLETON static common::SpinLockMutex &GetLock() noexcept
+  {
+    static common::SpinLockMutex lock;
+    return lock;
+  }
+};
+
+}  // namespace propagation
+}  // namespace context
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/context/propagation/noop_propagator.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/context/propagation/noop_propagator.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace context
+{
+namespace propagation
+{
+
+/**
+ * No-op implementation TextMapPropagator
+ */
+class NoOpPropagator : public TextMapPropagator
+{
+public:
+  /** Noop extract function does nothing and returns the input context */
+  context::Context Extract(const TextMapCarrier & /*carrier*/,
+                           context::Context &context) noexcept override
+  {
+    return context;
+  }
+
+  /** Noop inject function does nothing */
+  void Inject(TextMapCarrier & /*carrier*/,
+              const context::Context & /* context */) noexcept override
+  {}
+
+  bool Fields(nostd::function_ref<bool(nostd::string_view)> /* callback */) const noexcept override
+  {
+    return true;
+  }
+};
+}  // namespace propagation
+}  // namespace context
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/context/propagation/text_map_propagator.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/context/propagation/text_map_propagator.h
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace context
+{
+namespace propagation
+{
+
+// TextMapCarrier is the storage medium used by TextMapPropagator.
+class TextMapCarrier
+{
+public:
+  // returns the value associated with the passed key.
+  virtual nostd::string_view Get(nostd::string_view key) const noexcept = 0;
+
+  // stores the key-value pair.
+  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept = 0;
+
+  /* list of all the keys in the carrier.
+   By default, it returns true without invoking callback */
+  virtual bool Keys(nostd::function_ref<bool(nostd::string_view)> /* callback */) const noexcept
+  {
+    return true;
+  }
+  virtual ~TextMapCarrier() = default;
+};
+
+// The TextMapPropagator class provides an interface that enables extracting and injecting
+// context into carriers that travel in-band across process boundaries. HTTP frameworks and clients
+// can integrate with TextMapPropagator by providing the object containing the
+// headers, and a getter and setter function for the extraction and
+// injection of values, respectively.
+
+class TextMapPropagator
+{
+public:
+  // Returns the context that is stored in the carrier with the TextMapCarrier as extractor.
+  virtual context::Context Extract(const TextMapCarrier &carrier,
+                                   context::Context &context) noexcept = 0;
+
+  // Sets the context for carrier with self defined rules.
+  virtual void Inject(TextMapCarrier &carrier, const context::Context &context) noexcept = 0;
+
+  // Gets the fields set in the carrier by the `inject` method
+  virtual bool Fields(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept = 0;
+
+  virtual ~TextMapPropagator() = default;
+};
+}  // namespace propagation
+}  // namespace context
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/context/runtime_context.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/context/runtime_context.h
@@ -1,0 +1,335 @@
+﻿// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/macros.h"
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace context
+{
+// The Token object provides is returned when attaching objects to the
+// RuntimeContext object and is associated with a context object, and
+// can be provided to the RuntimeContext Detach method to remove the
+// associated context from the RuntimeContext.
+class Token
+{
+public:
+  bool operator==(const Context &other) const noexcept { return context_ == other; }
+
+  ~Token() noexcept;
+
+private:
+  friend class RuntimeContextStorage;
+
+  // A constructor that sets the token's Context object to the
+  // one that was passed in.
+  Token(const Context &context) : context_(context) {}
+
+  const Context context_;
+};
+
+/**
+ * RuntimeContextStorage is used by RuntimeContext to store Context frames.
+ *
+ * Custom context management strategies can be implemented by deriving from
+ * this class and passing an initialized RuntimeContextStorage object to
+ * RuntimeContext::SetRuntimeContextStorage.
+ */
+class OPENTELEMETRY_EXPORT RuntimeContextStorage
+{
+public:
+  /**
+   * Return the current context.
+   * @return the current context
+   */
+  virtual Context GetCurrent() noexcept = 0;
+
+  /**
+   * Set the current context.
+   * @param the new current context
+   * @return a token for the new current context. This never returns a nullptr.
+   */
+  virtual nostd::unique_ptr<Token> Attach(const Context &context) noexcept = 0;
+
+  /**
+   * Detach the context related to the given token.
+   * @param token a token related to a context
+   * @return true if the context could be detached
+   */
+  virtual bool Detach(Token &token) noexcept = 0;
+
+  virtual ~RuntimeContextStorage() {}
+
+protected:
+  nostd::unique_ptr<Token> CreateToken(const Context &context) noexcept
+  {
+    return nostd::unique_ptr<Token>(new Token(context));
+  }
+};
+
+/**
+ * Construct and return the default RuntimeContextStorage
+ * @return a ThreadLocalContextStorage
+ */
+static RuntimeContextStorage *GetDefaultStorage() noexcept;
+
+// Provides a wrapper for propagating the context object globally.
+//
+// By default, a thread-local runtime context storage is used.
+class OPENTELEMETRY_EXPORT RuntimeContext
+{
+public:
+  // Return the current context.
+  static Context GetCurrent() noexcept { return GetRuntimeContextStorage()->GetCurrent(); }
+
+  // Sets the current 'Context' object. Returns a token
+  // that can be used to reset to the previous Context.
+  static nostd::unique_ptr<Token> Attach(const Context &context) noexcept
+  {
+    return GetRuntimeContextStorage()->Attach(context);
+  }
+
+  // Resets the context to a previous value stored in the
+  // passed in token. Returns true if successful, false otherwise
+  static bool Detach(Token &token) noexcept { return GetRuntimeContextStorage()->Detach(token); }
+
+  // Sets the Key and Value into the passed in context or if a context is not
+  // passed in, the RuntimeContext.
+  // Should be used to SetValues to the current RuntimeContext, is essentially
+  // equivalent to RuntimeContext::GetCurrent().SetValue(key,value). Keep in
+  // mind that the current RuntimeContext will not be changed, and the new
+  // context will be returned.
+  static Context SetValue(nostd::string_view key,
+                          const ContextValue &value,
+                          Context *context = nullptr) noexcept
+  {
+    Context temp_context;
+    if (context == nullptr)
+    {
+      temp_context = GetCurrent();
+    }
+    else
+    {
+      temp_context = *context;
+    }
+    return temp_context.SetValue(key, value);
+  }
+
+  // Returns the value associated with the passed in key and either the
+  // passed in context* or the runtime context if a context is not passed in.
+  // Should be used to get values from the current RuntimeContext, is
+  // essentially equivalent to RuntimeContext::GetCurrent().GetValue(key).
+  static ContextValue GetValue(nostd::string_view key, Context *context = nullptr) noexcept
+  {
+    Context temp_context;
+    if (context == nullptr)
+    {
+      temp_context = GetCurrent();
+    }
+    else
+    {
+      temp_context = *context;
+    }
+    return temp_context.GetValue(key);
+  }
+
+  /**
+   * Provide a custom runtime context storage.
+   *
+   * This provides a possibility to override the default thread-local runtime
+   * context storage. This has to be set before any spans are created by the
+   * application, otherwise the behavior is undefined.
+   *
+   * @param storage a custom runtime context storage
+   */
+  static void SetRuntimeContextStorage(nostd::shared_ptr<RuntimeContextStorage> storage) noexcept
+  {
+    GetStorage() = storage;
+  }
+
+  /**
+   * Provide a pointer to const runtime context storage.
+   *
+   * The returned pointer can only be used for extending the lifetime of the runtime context
+   * storage.
+   *
+   */
+  static nostd::shared_ptr<const RuntimeContextStorage> GetConstRuntimeContextStorage() noexcept
+  {
+    return GetRuntimeContextStorage();
+  }
+
+private:
+  static nostd::shared_ptr<RuntimeContextStorage> GetRuntimeContextStorage() noexcept
+  {
+    return GetStorage();
+  }
+
+  OPENTELEMETRY_API_SINGLETON static nostd::shared_ptr<RuntimeContextStorage> &GetStorage() noexcept
+  {
+    static nostd::shared_ptr<RuntimeContextStorage> context(GetDefaultStorage());
+    return context;
+  }
+};
+
+inline Token::~Token() noexcept
+{
+  context::RuntimeContext::Detach(*this);
+}
+
+// The ThreadLocalContextStorage class is a derived class from
+// RuntimeContextStorage and provides a wrapper for propagating context through
+// cpp thread locally. This file must be included to use the RuntimeContext
+// class if another implementation has not been registered.
+class ThreadLocalContextStorage : public RuntimeContextStorage
+{
+public:
+  ThreadLocalContextStorage() noexcept = default;
+
+  // Return the current context.
+  Context GetCurrent() noexcept override { return GetStack().Top(); }
+
+  // Resets the context to the value previous to the passed in token. This will
+  // also detach all child contexts of the passed in token.
+  // Returns true if successful, false otherwise.
+  bool Detach(Token &token) noexcept override
+  {
+    // In most cases, the context to be detached is on the top of the stack.
+    if (token == GetStack().Top())
+    {
+      GetStack().Pop();
+      return true;
+    }
+
+    if (!GetStack().Contains(token))
+    {
+      return false;
+    }
+
+    while (!(token == GetStack().Top()))
+    {
+      GetStack().Pop();
+    }
+
+    GetStack().Pop();
+
+    return true;
+  }
+
+  // Sets the current 'Context' object. Returns a token
+  // that can be used to reset to the previous Context.
+  nostd::unique_ptr<Token> Attach(const Context &context) noexcept override
+  {
+    GetStack().Push(context);
+    return CreateToken(context);
+  }
+
+private:
+  // A nested class to store the attached contexts in a stack.
+  class Stack
+  {
+    friend class ThreadLocalContextStorage;
+
+    Stack() noexcept : size_(0), capacity_(0), base_(nullptr) {}
+
+    // Pops the top Context off the stack.
+    void Pop() noexcept
+    {
+      if (size_ == 0)
+      {
+        return;
+      }
+      // Store empty Context before decrementing `size`, to ensure
+      // the shared_ptr object (if stored in prev context object ) are released.
+      // The stack is not resized, and the unused memory would be reutilised
+      // for subsequent context storage.
+      base_[size_ - 1] = Context();
+      size_ -= 1;
+    }
+
+    bool Contains(const Token &token) const noexcept
+    {
+      for (size_t pos = size_; pos > 0; --pos)
+      {
+        if (token == base_[pos - 1])
+        {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    // Returns the Context at the top of the stack.
+    Context Top() const noexcept
+    {
+      if (size_ == 0)
+      {
+        return Context();
+      }
+      return base_[size_ - 1];
+    }
+
+    // Pushes the passed in context pointer to the top of the stack
+    // and resizes if necessary.
+    void Push(const Context &context) noexcept
+    {
+      size_++;
+      if (size_ > capacity_)
+      {
+        Resize(size_ * 2);
+      }
+      base_[size_ - 1] = context;
+    }
+
+    // Reallocates the storage array to the pass in new capacity size.
+    void Resize(size_t new_capacity) noexcept
+    {
+      size_t old_size = size_ - 1;
+      if (new_capacity == 0)
+      {
+        new_capacity = 2;
+      }
+      Context *temp = new Context[new_capacity];
+      if (base_ != nullptr)
+      {
+        // vs2015 does not like this construct considering it unsafe:
+        // - std::copy(base_, base_ + old_size, temp);
+        // Ref.
+        // https://stackoverflow.com/questions/12270224/xutility2227-warning-c4996-std-copy-impl
+        for (size_t i = 0; i < (std::min)(old_size, new_capacity); i++)
+        {
+          temp[i] = base_[i];
+        }
+        delete[] base_;
+      }
+      base_     = temp;
+      capacity_ = new_capacity;
+    }
+
+    ~Stack() noexcept { delete[] base_; }
+
+    size_t size_;
+    size_t capacity_;
+    Context *base_;
+  };
+
+  OPENTELEMETRY_API_SINGLETON Stack &GetStack()
+  {
+    static thread_local Stack stack_ = Stack();
+    return stack_;
+  }
+};
+
+static RuntimeContextStorage *GetDefaultStorage() noexcept
+{
+  return new ThreadLocalContextStorage();
+}
+}  // namespace context
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/detail/preprocessor.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/detail/preprocessor.h
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// NOTE - code within detail namespace implements internal details, and not part
+// of the public interface.
+
+#pragma once
+
+#define OPENTELEMETRY_STRINGIFY(S) OPENTELEMETRY_STRINGIFY_(S)
+#define OPENTELEMETRY_STRINGIFY_(S) #S
+
+#define OPENTELEMETRY_CONCAT(A, B) OPENTELEMETRY_CONCAT_(A, B)
+#define OPENTELEMETRY_CONCAT_(A, B) A##B

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/event_id.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/event_id.h
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace logs
+{
+
+/**
+ * EventId class which acts the Id of the event with an optional name.
+ */
+class EventId
+{
+public:
+  EventId(int64_t id, nostd::string_view name) noexcept : id_{id}
+  {
+    name_ = nostd::unique_ptr<char[]>{new char[name.length() + 1]};
+    std::copy(name.begin(), name.end(), name_.get());
+    name_.get()[name.length()] = 0;
+  }
+
+  EventId(int64_t id) noexcept : id_{id}, name_{nullptr} {}
+
+public:
+  int64_t id_;
+  nostd::unique_ptr<char[]> name_;
+};
+
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/event_logger.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/event_logger.h
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/logs/log_record.h"
+#include "opentelemetry/logs/logger.h"
+#include "opentelemetry/logs/logger_type_traits.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace logs
+{
+/**
+ * Handles event log record creation.
+ **/
+class EventLogger
+{
+public:
+  virtual ~EventLogger() = default;
+
+  /* Returns the name of the logger */
+  virtual const nostd::string_view GetName() noexcept = 0;
+
+  /* Returns the delegate logger of this event logger */
+  virtual nostd::shared_ptr<Logger> GetDelegateLogger() noexcept = 0;
+
+  /**
+   * Emit a event Log Record object
+   *
+   * @param event_name Event name
+   * @param log_record Log record
+   */
+  virtual void EmitEvent(nostd::string_view event_name,
+                         nostd::unique_ptr<LogRecord> &&log_record) noexcept = 0;
+
+  /**
+   * Emit a event Log Record object with arguments
+   *
+   * @param event_name Event name
+   * @tparam args Arguments which can be used to set data of log record by type.
+   *  Severity                                -> severity, severity_text
+   *  string_view                             -> body
+   *  AttributeValue                          -> body
+   *  SpanContext                             -> span_id,tace_id and trace_flags
+   *  SpanId                                  -> span_id
+   *  TraceId                                 -> tace_id
+   *  TraceFlags                              -> trace_flags
+   *  SystemTimestamp                         -> timestamp
+   *  system_clock::time_point                -> timestamp
+   *  KeyValueIterable                        -> attributes
+   *  Key value iterable container            -> attributes
+   *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
+   */
+  template <class... ArgumentType>
+  void EmitEvent(nostd::string_view event_name, ArgumentType &&... args)
+  {
+    nostd::shared_ptr<Logger> delegate_logger = GetDelegateLogger();
+    if (!delegate_logger)
+    {
+      return;
+    }
+    nostd::unique_ptr<LogRecord> log_record = delegate_logger->CreateLogRecord();
+    if (!log_record)
+    {
+      return;
+    }
+
+    IgnoreTraitResult(
+        detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::template Set(
+            log_record.get(), std::forward<ArgumentType>(args))...);
+
+    EmitEvent(event_name, std::move(log_record));
+  }
+
+private:
+  template <class... ValueType>
+  void IgnoreTraitResult(ValueType &&...)
+  {}
+};
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/event_logger_provider.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/event_logger_provider.h
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace logs
+{
+
+class EventLogger;
+class Logger;
+
+/**
+ * Creates new EventLogger instances.
+ */
+class EventLoggerProvider
+{
+public:
+  virtual ~EventLoggerProvider() = default;
+
+  /**
+   * Creates a named EventLogger instance.
+   *
+   */
+
+  virtual nostd::shared_ptr<EventLogger> CreateEventLogger(
+      nostd::shared_ptr<Logger> delegate_logger,
+      nostd::string_view event_domain) noexcept = 0;
+};
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/log_record.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/log_record.h
@@ -1,0 +1,92 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/timestamp.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+class SpanId;
+class TraceId;
+class TraceFlags;
+}  // namespace trace
+
+namespace logs
+{
+
+enum class Severity : uint8_t;
+
+/**
+ * Maintains a representation of a log in a format that can be processed by a recorder.
+ *
+ * This class is thread-compatible.
+ */
+class LogRecord
+{
+public:
+  virtual ~LogRecord() = default;
+
+  /**
+   * Set the timestamp for this log.
+   * @param timestamp the timestamp to set
+   */
+  virtual void SetTimestamp(common::SystemTimestamp timestamp) noexcept = 0;
+
+  /**
+   * Set the observed timestamp for this log.
+   * @param timestamp the timestamp to set
+   */
+  virtual void SetObservedTimestamp(common::SystemTimestamp timestamp) noexcept = 0;
+
+  /**
+   * Set the severity for this log.
+   * @param severity the severity of the event
+   */
+  virtual void SetSeverity(logs::Severity severity) noexcept = 0;
+
+  /**
+   * Set body field for this log.
+   * @param message the body to set
+   */
+  virtual void SetBody(const common::AttributeValue &message) noexcept = 0;
+
+  /**
+   * Set an attribute of a log.
+   * @param key the name of the attribute
+   * @param value the attribute value
+   */
+  virtual void SetAttribute(nostd::string_view key,
+                            const common::AttributeValue &value) noexcept = 0;
+
+  /**
+   * Set the Event Id.
+   * @param id The event id to set
+   * @param name Optional event name to set
+   */
+  // TODO: mark this as pure virtual once all exporters have been updated
+  virtual void SetEventId(int64_t id, nostd::string_view name = {}) noexcept = 0;
+
+  /**
+   * Set the trace id for this log.
+   * @param trace_id the trace id to set
+   */
+  virtual void SetTraceId(const trace::TraceId &trace_id) noexcept = 0;
+
+  /**
+   * Set the span id for this log.
+   * @param span_id the span id to set
+   */
+  virtual void SetSpanId(const trace::SpanId &span_id) noexcept = 0;
+
+  /**
+   * Inject trace_flags for this log.
+   * @param trace_flags the trace flags to set
+   */
+  virtual void SetTraceFlags(const trace::TraceFlags &trace_flags) noexcept = 0;
+};
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/logger.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/logger.h
@@ -1,0 +1,476 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/logs/logger_type_traits.h"
+#include "opentelemetry/logs/severity.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+class KeyValueIterable;
+}  // namespace common
+
+namespace logs
+{
+
+class EventId;
+class LogRecord;
+
+/**
+ * Handles log record creation.
+ **/
+class Logger
+{
+public:
+  virtual ~Logger() = default;
+
+  /* Returns the name of the logger */
+  virtual const nostd::string_view GetName() noexcept = 0;
+
+  /**
+   * Create a Log Record object
+   *
+   * @return nostd::unique_ptr<LogRecord>
+   */
+  virtual nostd::unique_ptr<LogRecord> CreateLogRecord() noexcept = 0;
+
+  /**
+   * Emit a Log Record object
+   *
+   * @param log_record
+   */
+  virtual void EmitLogRecord(nostd::unique_ptr<LogRecord> &&log_record) noexcept = 0;
+
+  /**
+   * Emit a Log Record object with arguments
+   *
+   * @param log_record Log record
+   * @tparam args Arguments which can be used to set data of log record by type.
+   *  Severity                                -> severity, severity_text
+   *  string_view                             -> body
+   *  AttributeValue                          -> body
+   *  SpanContext                             -> span_id,tace_id and trace_flags
+   *  SpanId                                  -> span_id
+   *  TraceId                                 -> tace_id
+   *  TraceFlags                              -> trace_flags
+   *  SystemTimestamp                         -> timestamp
+   *  system_clock::time_point                -> timestamp
+   *  KeyValueIterable                        -> attributes
+   *  Key value iterable container            -> attributes
+   *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
+   */
+  template <class... ArgumentType>
+  void EmitLogRecord(nostd::unique_ptr<LogRecord> &&log_record, ArgumentType &&... args)
+  {
+    if (!log_record)
+    {
+      return;
+    }
+
+    IgnoreTraitResult(
+        detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::template Set(
+            log_record.get(), std::forward<ArgumentType>(args))...);
+
+    EmitLogRecord(std::move(log_record));
+  }
+
+  /**
+   * Emit a Log Record object with arguments
+   *
+   * @tparam args Arguments which can be used to set data of log record by type.
+   *  Severity                                -> severity, severity_text
+   *  string_view                             -> body
+   *  AttributeValue                          -> body
+   *  SpanContext                             -> span_id,tace_id and trace_flags
+   *  SpanId                                  -> span_id
+   *  TraceId                                 -> tace_id
+   *  TraceFlags                              -> trace_flags
+   *  SystemTimestamp                         -> timestamp
+   *  system_clock::time_point                -> timestamp
+   *  KeyValueIterable                        -> attributes
+   *  Key value iterable container            -> attributes
+   *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
+   */
+  template <class... ArgumentType>
+  void EmitLogRecord(ArgumentType &&... args)
+  {
+    nostd::unique_ptr<LogRecord> log_record = CreateLogRecord();
+    if (!log_record)
+    {
+      return;
+    }
+
+    EmitLogRecord(std::move(log_record), std::forward<ArgumentType>(args)...);
+  }
+
+  /**
+   * Writes a log with a severity of trace.
+   * @tparam args Arguments which can be used to set data of log record by type.
+   *  string_view                             -> body
+   *  AttributeValue                          -> body
+   *  SpanContext                             -> span_id,tace_id and trace_flags
+   *  SpanId                                  -> span_id
+   *  TraceId                                 -> tace_id
+   *  TraceFlags                              -> trace_flags
+   *  SystemTimestamp                         -> timestamp
+   *  system_clock::time_point                -> timestamp
+   *  KeyValueIterable                        -> attributes
+   *  Key value iterable container            -> attributes
+   *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
+   */
+  template <class... ArgumentType>
+  void Trace(ArgumentType &&... args) noexcept
+  {
+    static_assert(
+        !detail::LogRecordHasType<Severity, typename std::decay<ArgumentType>::type...>::value,
+        "Severity is already set.");
+    this->EmitLogRecord(Severity::kTrace, std::forward<ArgumentType>(args)...);
+  }
+
+  /**
+   * Writes a log with a severity of debug.
+   * @tparam args Arguments which can be used to set data of log record by type.
+   *  string_view                             -> body
+   *  AttributeValue                          -> body
+   *  SpanContext                             -> span_id,tace_id and trace_flags
+   *  SpanId                                  -> span_id
+   *  TraceId                                 -> tace_id
+   *  TraceFlags                              -> trace_flags
+   *  SystemTimestamp                         -> timestamp
+   *  system_clock::time_point                -> timestamp
+   *  KeyValueIterable                        -> attributes
+   *  Key value iterable container            -> attributes
+   *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
+   */
+  template <class... ArgumentType>
+  void Debug(ArgumentType &&... args) noexcept
+  {
+    static_assert(
+        !detail::LogRecordHasType<Severity, typename std::decay<ArgumentType>::type...>::value,
+        "Severity is already set.");
+    this->EmitLogRecord(Severity::kDebug, std::forward<ArgumentType>(args)...);
+  }
+
+  /**
+   * Writes a log with a severity of info.
+   * @tparam args Arguments which can be used to set data of log record by type.
+   *  string_view                             -> body
+   *  AttributeValue                          -> body
+   *  SpanContext                             -> span_id,tace_id and trace_flags
+   *  SpanId                                  -> span_id
+   *  TraceId                                 -> tace_id
+   *  TraceFlags                              -> trace_flags
+   *  SystemTimestamp                         -> timestamp
+   *  system_clock::time_point                -> timestamp
+   *  KeyValueIterable                        -> attributes
+   *  Key value iterable container            -> attributes
+   *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
+   */
+  template <class... ArgumentType>
+  void Info(ArgumentType &&... args) noexcept
+  {
+    static_assert(
+        !detail::LogRecordHasType<Severity, typename std::decay<ArgumentType>::type...>::value,
+        "Severity is already set.");
+    this->EmitLogRecord(Severity::kInfo, std::forward<ArgumentType>(args)...);
+  }
+
+  /**
+   * Writes a log with a severity of warn.
+   * @tparam args Arguments which can be used to set data of log record by type.
+   *  string_view                             -> body
+   *  AttributeValue                          -> body
+   *  SpanContext                             -> span_id,tace_id and trace_flags
+   *  SpanId                                  -> span_id
+   *  TraceId                                 -> tace_id
+   *  TraceFlags                              -> trace_flags
+   *  SystemTimestamp                         -> timestamp
+   *  system_clock::time_point                -> timestamp
+   *  KeyValueIterable                        -> attributes
+   *  Key value iterable container            -> attributes
+   *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
+   */
+  template <class... ArgumentType>
+  void Warn(ArgumentType &&... args) noexcept
+  {
+    static_assert(
+        !detail::LogRecordHasType<Severity, typename std::decay<ArgumentType>::type...>::value,
+        "Severity is already set.");
+    this->EmitLogRecord(Severity::kWarn, std::forward<ArgumentType>(args)...);
+  }
+
+  /**
+   * Writes a log with a severity of error.
+   * @tparam args Arguments which can be used to set data of log record by type.
+   *  string_view                             -> body
+   *  AttributeValue                          -> body
+   *  SpanContext                             -> span_id,tace_id and trace_flags
+   *  SpanId                                  -> span_id
+   *  TraceId                                 -> tace_id
+   *  TraceFlags                              -> trace_flags
+   *  SystemTimestamp                         -> timestamp
+   *  system_clock::time_point                -> timestamp
+   *  KeyValueIterable                        -> attributes
+   *  Key value iterable container            -> attributes
+   *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
+   */
+  template <class... ArgumentType>
+  void Error(ArgumentType &&... args) noexcept
+  {
+    static_assert(
+        !detail::LogRecordHasType<Severity, typename std::decay<ArgumentType>::type...>::value,
+        "Severity is already set.");
+    this->EmitLogRecord(Severity::kError, std::forward<ArgumentType>(args)...);
+  }
+
+  /**
+   * Writes a log with a severity of fatal.
+   * @tparam args Arguments which can be used to set data of log record by type.
+   *  string_view                             -> body
+   *  AttributeValue                          -> body
+   *  SpanContext                             -> span_id,tace_id and trace_flags
+   *  SpanId                                  -> span_id
+   *  TraceId                                 -> tace_id
+   *  TraceFlags                              -> trace_flags
+   *  SystemTimestamp                         -> timestamp
+   *  system_clock::time_point                -> timestamp
+   *  KeyValueIterable                        -> attributes
+   *  Key value iterable container            -> attributes
+   *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
+   */
+  template <class... ArgumentType>
+  void Fatal(ArgumentType &&... args) noexcept
+  {
+    static_assert(
+        !detail::LogRecordHasType<Severity, typename std::decay<ArgumentType>::type...>::value,
+        "Severity is already set.");
+    this->EmitLogRecord(Severity::kFatal, std::forward<ArgumentType>(args)...);
+  }
+
+  //
+  // OpenTelemetry C++ user-facing Logs API
+  //
+
+  inline bool Enabled(Severity severity, const EventId &event_id) const noexcept
+  {
+    OPENTELEMETRY_LIKELY_IF(Enabled(severity) == false) { return false; }
+    return EnabledImplementation(severity, event_id);
+  }
+
+  inline bool Enabled(Severity severity, int64_t event_id) const noexcept
+  {
+    OPENTELEMETRY_LIKELY_IF(Enabled(severity) == false) { return false; }
+    return EnabledImplementation(severity, event_id);
+  }
+
+  inline bool Enabled(Severity severity) const noexcept
+  {
+    return static_cast<uint8_t>(severity) >= OPENTELEMETRY_ATOMIC_READ_8(&minimum_severity_);
+  }
+
+  /**
+   * Log an event
+   *
+   * @severity severity of the log
+   * @event_id event identifier of the log
+   * @format an utf-8 string following https://messagetemplates.org/
+   * @attributes key value pairs of the log
+   */
+  virtual void Log(Severity severity,
+                   const EventId &event_id,
+                   nostd::string_view format,
+                   const common::KeyValueIterable &attributes) noexcept
+  {
+    this->EmitLogRecord(severity, event_id, format, attributes);
+  }
+
+  virtual void Log(Severity severity,
+                   int64_t event_id,
+                   nostd::string_view format,
+                   const common::KeyValueIterable &attributes) noexcept
+  {
+    this->EmitLogRecord(severity, EventId{event_id}, format, attributes);
+  }
+
+  virtual void Log(Severity severity,
+                   nostd::string_view format,
+                   const common::KeyValueIterable &attributes) noexcept
+  {
+    this->EmitLogRecord(severity, format, attributes);
+  }
+
+  virtual void Log(Severity severity, nostd::string_view message) noexcept
+  {
+    this->EmitLogRecord(severity, message);
+  }
+
+  // Convenient wrappers based on virtual methods Log().
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-severitynumber
+
+  inline void Trace(const EventId &event_id,
+                    nostd::string_view format,
+                    const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kTrace, event_id, format, attributes);
+  }
+
+  inline void Trace(int64_t event_id,
+                    nostd::string_view format,
+                    const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kTrace, EventId{event_id}, format, attributes);
+  }
+
+  inline void Trace(nostd::string_view format, const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kTrace, format, attributes);
+  }
+
+  inline void Trace(nostd::string_view message) noexcept { this->Log(Severity::kTrace, message); }
+
+  inline void Debug(const EventId &event_id,
+                    nostd::string_view format,
+                    const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kDebug, event_id, format, attributes);
+  }
+
+  inline void Debug(int64_t event_id,
+                    nostd::string_view format,
+                    const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kDebug, EventId{event_id}, format, attributes);
+  }
+
+  inline void Debug(nostd::string_view format, const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kDebug, format, attributes);
+  }
+
+  inline void Debug(nostd::string_view message) noexcept { this->Log(Severity::kDebug, message); }
+
+  inline void Info(const EventId &event_id,
+                   nostd::string_view format,
+                   const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kInfo, event_id, format, attributes);
+  }
+
+  inline void Info(int64_t event_id,
+                   nostd::string_view format,
+                   const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kInfo, EventId{event_id}, format, attributes);
+  }
+
+  inline void Info(nostd::string_view format, const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kInfo, format, attributes);
+  }
+
+  inline void Info(nostd::string_view message) noexcept { this->Log(Severity::kInfo, message); }
+
+  inline void Warn(const EventId &event_id,
+                   nostd::string_view format,
+                   const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kWarn, event_id, format, attributes);
+  }
+
+  inline void Warn(int64_t event_id,
+                   nostd::string_view format,
+                   const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kWarn, EventId{event_id}, format, attributes);
+  }
+
+  inline void Warn(nostd::string_view format, const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kWarn, format, attributes);
+  }
+
+  inline void Warn(nostd::string_view message) noexcept { this->Log(Severity::kWarn, message); }
+
+  inline void Error(const EventId &event_id,
+                    nostd::string_view format,
+                    const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kError, event_id, format, attributes);
+  }
+
+  inline void Error(int64_t event_id,
+                    nostd::string_view format,
+                    const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kError, EventId{event_id}, format, attributes);
+  }
+
+  inline void Error(nostd::string_view format, const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kError, format, attributes);
+  }
+
+  inline void Error(nostd::string_view message) noexcept { this->Log(Severity::kError, message); }
+
+  inline void Fatal(const EventId &event_id,
+                    nostd::string_view format,
+                    const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kFatal, event_id, format, attributes);
+  }
+
+  inline void Fatal(int64_t event_id,
+                    nostd::string_view format,
+                    const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kFatal, EventId{event_id}, format, attributes);
+  }
+
+  inline void Fatal(nostd::string_view format, const common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(Severity::kFatal, format, attributes);
+  }
+
+  inline void Fatal(nostd::string_view message) noexcept { this->Log(Severity::kFatal, message); }
+
+  //
+  // End of OpenTelemetry C++ user-facing Log API.
+  //
+
+protected:
+  // TODO: discuss with community about naming for internal methods.
+  virtual bool EnabledImplementation(Severity /*severity*/,
+                                     const EventId & /*event_id*/) const noexcept
+  {
+    return false;
+  }
+
+  virtual bool EnabledImplementation(Severity /*severity*/, int64_t /*event_id*/) const noexcept
+  {
+    return false;
+  }
+
+  void SetMinimumSeverity(uint8_t severity_or_max) noexcept
+  {
+    OPENTELEMETRY_ATOMIC_WRITE_8(&minimum_severity_, severity_or_max);
+  }
+
+private:
+  template <class... ValueType>
+  void IgnoreTraitResult(ValueType &&...)
+  {}
+
+  //
+  // minimum_severity_ can be updated concurrently by multiple threads/cores, so race condition on
+  // read/write should be handled. And std::atomic can not be used here because it is not ABI
+  // compatible for OpenTelemetry C++ API.
+  //
+  mutable uint8_t minimum_severity_{kMaxSeverity};
+};
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/logger_provider.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/logger_provider.h
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/key_value_iterable.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/type_traits.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace logs
+{
+
+class Logger;
+
+/**
+ * Creates new Logger instances.
+ */
+class OPENTELEMETRY_EXPORT LoggerProvider
+{
+public:
+  virtual ~LoggerProvider() = default;
+
+  /**
+   * Gets or creates a named Logger instance.
+   *
+   * Optionally a version can be passed to create a named and versioned Logger
+   * instance.
+   *
+   * Optionally a configuration file name can be passed to create a configuration for
+   * the Logger instance.
+   *
+   */
+
+  virtual nostd::shared_ptr<Logger> GetLogger(
+      nostd::string_view logger_name,
+      nostd::string_view library_name            = "",
+      nostd::string_view library_version         = "",
+      nostd::string_view schema_url              = "",
+      const common::KeyValueIterable &attributes = common::NoopKeyValueIterable()) = 0;
+
+  nostd::shared_ptr<Logger> GetLogger(
+      nostd::string_view logger_name,
+      nostd::string_view library_name,
+      nostd::string_view library_version,
+      nostd::string_view schema_url,
+      std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes)
+  {
+    return GetLogger(logger_name, library_name, library_version, schema_url,
+                     nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                         attributes.begin(), attributes.end()});
+  }
+
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+  nostd::shared_ptr<Logger> GetLogger(nostd::string_view logger_name,
+                                      nostd::string_view library_name,
+                                      nostd::string_view library_version,
+                                      nostd::string_view schema_url,
+                                      const T &attributes)
+  {
+    return GetLogger(logger_name, library_name, library_version, schema_url,
+                     common::KeyValueIterableView<T>(attributes));
+  }
+};
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/logger_type_traits.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/logger_type_traits.h
@@ -1,0 +1,199 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <chrono>
+#include <type_traits>
+
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/key_value_iterable.h"
+#include "opentelemetry/common/timestamp.h"
+#include "opentelemetry/logs/event_id.h"
+#include "opentelemetry/logs/log_record.h"
+#include "opentelemetry/logs/severity.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/type_traits.h"
+#include "opentelemetry/trace/span_context.h"
+#include "opentelemetry/trace/span_id.h"
+#include "opentelemetry/trace/trace_flags.h"
+#include "opentelemetry/trace/trace_id.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace logs
+{
+namespace detail
+{
+template <class ValueType>
+struct LogRecordSetterTrait;
+
+template <>
+struct LogRecordSetterTrait<Severity>
+{
+  template <class ArgumentType>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    log_record->SetSeverity(std::forward<ArgumentType>(arg));
+
+    return log_record;
+  }
+};
+
+template <>
+struct LogRecordSetterTrait<EventId>
+{
+  template <class ArgumentType>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    log_record->SetEventId(arg.id_, nostd::string_view{arg.name_.get()});
+
+    return log_record;
+  }
+};
+
+template <>
+struct LogRecordSetterTrait<trace::SpanContext>
+{
+  template <class ArgumentType>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    log_record->SetSpanId(arg.span_id());
+    log_record->SetTraceId(arg.trace_id());
+    log_record->SetTraceFlags(arg.trace_flags());
+
+    return log_record;
+  }
+};
+
+template <>
+struct LogRecordSetterTrait<trace::SpanId>
+{
+  template <class ArgumentType>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    log_record->SetSpanId(std::forward<ArgumentType>(arg));
+
+    return log_record;
+  }
+};
+
+template <>
+struct LogRecordSetterTrait<trace::TraceId>
+{
+  template <class ArgumentType>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    log_record->SetTraceId(std::forward<ArgumentType>(arg));
+
+    return log_record;
+  }
+};
+
+template <>
+struct LogRecordSetterTrait<trace::TraceFlags>
+{
+  template <class ArgumentType>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    log_record->SetTraceFlags(std::forward<ArgumentType>(arg));
+
+    return log_record;
+  }
+};
+
+template <>
+struct LogRecordSetterTrait<common::SystemTimestamp>
+{
+  template <class ArgumentType>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    log_record->SetTimestamp(std::forward<ArgumentType>(arg));
+
+    return log_record;
+  }
+};
+
+template <>
+struct LogRecordSetterTrait<std::chrono::system_clock::time_point>
+{
+  template <class ArgumentType>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    log_record->SetTimestamp(common::SystemTimestamp(std::forward<ArgumentType>(arg)));
+
+    return log_record;
+  }
+};
+
+template <>
+struct LogRecordSetterTrait<common::KeyValueIterable>
+{
+  template <class ArgumentType>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    arg.ForEachKeyValue(
+        [&log_record](nostd::string_view key, common::AttributeValue value) noexcept {
+          log_record->SetAttribute(key, value);
+          return true;
+        });
+
+    return log_record;
+  }
+};
+
+template <class ValueType>
+struct LogRecordSetterTrait
+{
+  template <class ArgumentType,
+            nostd::enable_if_t<std::is_convertible<ArgumentType, nostd::string_view>::value ||
+                                   std::is_convertible<ArgumentType, common::AttributeValue>::value,
+                               void> * = nullptr>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    log_record->SetBody(std::forward<ArgumentType>(arg));
+
+    return log_record;
+  }
+
+  template <class ArgumentType,
+            nostd::enable_if_t<std::is_base_of<common::KeyValueIterable, ArgumentType>::value, bool>
+                * = nullptr>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    return LogRecordSetterTrait<common::KeyValueIterable>::template Set(
+        log_record, std::forward<ArgumentType>(arg));
+  }
+
+  template <class ArgumentType,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<ArgumentType>::value, int> * =
+                nullptr>
+  inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+  {
+    for (auto &argv : arg)
+    {
+      log_record->SetAttribute(argv.first, argv.second);
+    }
+
+    return log_record;
+  }
+};
+
+template <class ValueType, class... ArgumentType>
+struct LogRecordHasType;
+
+template <class ValueType>
+struct LogRecordHasType<ValueType> : public std::false_type
+{};
+
+template <class ValueType, class TargetType, class... ArgumentType>
+struct LogRecordHasType<ValueType, TargetType, ArgumentType...>
+    : public std::conditional<std::is_same<ValueType, TargetType>::value,
+                              std::true_type,
+                              LogRecordHasType<ValueType, ArgumentType...>>::type
+{};
+
+}  // namespace detail
+
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/noop.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/noop.h
@@ -1,0 +1,101 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Please refer to provider.h for documentation on how to obtain a Logger object.
+//
+// This file is part of the internal implementation of OpenTelemetry. Nothing in this file should be
+// used directly. Please refer to logger.h for documentation on these interfaces.
+
+#include "opentelemetry/logs/event_logger.h"
+#include "opentelemetry/logs/event_logger_provider.h"
+#include "opentelemetry/logs/logger.h"
+#include "opentelemetry/logs/logger_provider.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+class KeyValueIterable;
+}  // namespace common
+
+namespace logs
+{
+/**
+ * No-op implementation of Logger. This class should not be used directly. It should only be
+ * instantiated using a LoggerProvider's GetLogger() call.
+ */
+class NoopLogger final : public Logger
+{
+public:
+  const nostd::string_view GetName() noexcept override { return "noop logger"; }
+
+  nostd::unique_ptr<LogRecord> CreateLogRecord() noexcept override { return nullptr; }
+
+  using Logger::EmitLogRecord;
+
+  void EmitLogRecord(nostd::unique_ptr<LogRecord> &&) noexcept override {}
+};
+
+/**
+ * No-op implementation of a LoggerProvider.
+ */
+class NoopLoggerProvider final : public LoggerProvider
+{
+public:
+  NoopLoggerProvider() : logger_{nostd::shared_ptr<NoopLogger>(new NoopLogger())} {}
+
+  nostd::shared_ptr<Logger> GetLogger(nostd::string_view /* logger_name */,
+                                      nostd::string_view /* library_name */,
+                                      nostd::string_view /* library_version */,
+                                      nostd::string_view /* schema_url */,
+                                      const common::KeyValueIterable & /* attributes */) override
+  {
+    return logger_;
+  }
+
+private:
+  nostd::shared_ptr<Logger> logger_;
+};
+
+class NoopEventLogger final : public EventLogger
+{
+public:
+  NoopEventLogger() : logger_{nostd::shared_ptr<NoopLogger>(new NoopLogger())} {}
+
+  const nostd::string_view GetName() noexcept override { return "noop event logger"; }
+
+  nostd::shared_ptr<Logger> GetDelegateLogger() noexcept override { return logger_; }
+
+  void EmitEvent(nostd::string_view, nostd::unique_ptr<LogRecord> &&) noexcept override {}
+
+private:
+  nostd::shared_ptr<Logger> logger_;
+};
+
+/**
+ * No-op implementation of a EventLoggerProvider.
+ */
+class NoopEventLoggerProvider final : public EventLoggerProvider
+{
+public:
+  NoopEventLoggerProvider() : event_logger_{nostd::shared_ptr<EventLogger>(new NoopEventLogger())}
+  {}
+
+  nostd::shared_ptr<EventLogger> CreateEventLogger(
+      nostd::shared_ptr<Logger> /*delegate_logger*/,
+      nostd::string_view /*event_domain*/) noexcept override
+  {
+    return event_logger_;
+  }
+
+private:
+  nostd::shared_ptr<EventLogger> event_logger_;
+};
+
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/provider.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/provider.h
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mutex>
+
+#include "opentelemetry/common/macros.h"
+#include "opentelemetry/common/spin_lock_mutex.h"
+#include "opentelemetry/logs/noop.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace logs
+{
+
+class EventLoggerProvider;
+class LoggerProvider;
+
+/**
+ * Stores the singleton global LoggerProvider.
+ */
+class OPENTELEMETRY_EXPORT Provider
+{
+public:
+  /**
+   * Returns the singleton LoggerProvider.
+   *
+   * By default, a no-op LoggerProvider is returned. This will never return a
+   * nullptr LoggerProvider.
+   */
+  static nostd::shared_ptr<LoggerProvider> GetLoggerProvider() noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    return nostd::shared_ptr<LoggerProvider>(GetProvider());
+  }
+
+  /**
+   * Changes the singleton LoggerProvider.
+   */
+  static void SetLoggerProvider(nostd::shared_ptr<LoggerProvider> tp) noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    GetProvider() = tp;
+  }
+
+  /**
+   * Returns the singleton EventLoggerProvider.
+   *
+   * By default, a no-op EventLoggerProvider is returned. This will never return a
+   * nullptr EventLoggerProvider.
+   */
+  static nostd::shared_ptr<EventLoggerProvider> GetEventLoggerProvider() noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    return nostd::shared_ptr<EventLoggerProvider>(GetEventProvider());
+  }
+
+  /**
+   * Changes the singleton EventLoggerProvider.
+   */
+  static void SetEventLoggerProvider(nostd::shared_ptr<EventLoggerProvider> tp) noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    GetEventProvider() = tp;
+  }
+
+private:
+  OPENTELEMETRY_API_SINGLETON static nostd::shared_ptr<LoggerProvider> &GetProvider() noexcept
+  {
+    static nostd::shared_ptr<LoggerProvider> provider(new NoopLoggerProvider);
+    return provider;
+  }
+
+  OPENTELEMETRY_API_SINGLETON static nostd::shared_ptr<EventLoggerProvider>
+      &GetEventProvider() noexcept
+  {
+    static nostd::shared_ptr<EventLoggerProvider> provider(new NoopEventLoggerProvider);
+    return provider;
+  }
+
+  OPENTELEMETRY_API_SINGLETON static common::SpinLockMutex &GetLock() noexcept
+  {
+    static common::SpinLockMutex lock;
+    return lock;
+  }
+};
+
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/severity.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/logs/severity.h
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace logs
+{
+
+/**
+ * Severity Levels assigned to log events, based on Log Data Model,
+ * with the addition of kInvalid (mapped to a severity number of 0).
+ *
+ * See
+ * https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-severitynumber
+ */
+enum class Severity : uint8_t
+{
+  kInvalid = 0,
+  kTrace   = 1,
+  kTrace2  = 2,
+  kTrace3  = 3,
+  kTrace4  = 4,
+  kDebug   = 5,
+  kDebug2  = 6,
+  kDebug3  = 7,
+  kDebug4  = 8,
+  kInfo    = 9,
+  kInfo2   = 10,
+  kInfo3   = 11,
+  kInfo4   = 12,
+  kWarn    = 13,
+  kWarn2   = 14,
+  kWarn3   = 15,
+  kWarn4   = 16,
+  kError   = 17,
+  kError2  = 18,
+  kError3  = 19,
+  kError4  = 20,
+  kFatal   = 21,
+  kFatal2  = 22,
+  kFatal3  = 23,
+  kFatal4  = 24
+};
+
+const uint8_t kMaxSeverity = 255;
+
+/**
+ * Mapping of the severity enum above, to a severity text string (in all caps).
+ * This severity text can be printed out by exporters. Capital letters follow the
+ * spec naming convention.
+ *
+ * Included to follow the specification's recommendation to print both
+ * severity number and text in each log record.
+ */
+const nostd::string_view SeverityNumToText[25] = {
+    "INVALID", "TRACE",  "TRACE2", "TRACE3", "TRACE4", "DEBUG",  "DEBUG2", "DEBUG3", "DEBUG4",
+    "INFO",    "INFO2",  "INFO3",  "INFO4",  "WARN",   "WARN2",  "WARN3",  "WARN4",  "ERROR",
+    "ERROR2",  "ERROR3", "ERROR4", "FATAL",  "FATAL2", "FATAL3", "FATAL4"};
+
+}  // namespace logs
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/async_instruments.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/async_instruments.h
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/metrics/observer_result.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace metrics
+{
+
+using ObservableCallbackPtr = void (*)(ObserverResult, void *);
+
+class ObservableInstrument
+{
+public:
+  ObservableInstrument()          = default;
+  virtual ~ObservableInstrument() = default;
+
+  /**
+   * Sets up a function that will be called whenever a metric collection is initiated.
+   */
+  virtual void AddCallback(ObservableCallbackPtr, void *state) noexcept = 0;
+
+  /**
+   * Remove a function that was configured to be called whenever a metric collection is initiated.
+   */
+  virtual void RemoveCallback(ObservableCallbackPtr, void *state) noexcept = 0;
+};
+
+}  // namespace metrics
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/meter.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/meter.h
@@ -1,0 +1,150 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace metrics
+{
+
+template <typename T>
+class Counter;
+
+template <typename T>
+class Histogram;
+
+template <typename T>
+class UpDownCounter;
+
+class ObservableInstrument;
+
+/**
+ * Handles instrument creation and provides a facility for batch recording.
+ *
+ * This class provides methods to create new metric instruments, record a
+ * batch of values to a specified set of instruments, and collect
+ * measurements from all instruments.
+ *
+ */
+class Meter
+{
+public:
+  virtual ~Meter() = default;
+
+  /**
+   * Creates a Counter with the passed characteristics and returns a unique_ptr to that Counter.
+   *
+   * @param name the name of the new Counter.
+   * @param description a brief description of what the Counter is used for.
+   * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
+   * @return a shared pointer to the created Counter.
+   */
+
+  virtual nostd::unique_ptr<Counter<uint64_t>> CreateUInt64Counter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  virtual nostd::unique_ptr<Counter<double>> CreateDoubleCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  /**
+   * Creates a Asynchronous (Observable) counter with the passed characteristics and returns a
+   * shared_ptr to that Observable Counter
+   *
+   * @param name the name of the new Observable Counter.
+   * @param description a brief description of what the Observable Counter is used for.
+   * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
+   */
+  virtual nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  virtual nostd::shared_ptr<ObservableInstrument> CreateDoubleObservableCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  /**
+   * Creates a Histogram with the passed characteristics and returns a unique_ptr to that Histogram.
+   *
+   * @param name the name of the new Histogram.
+   * @param description a brief description of what the Histogram is used for.
+   * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
+   * @return a shared pointer to the created Histogram.
+   */
+  virtual nostd::unique_ptr<Histogram<uint64_t>> CreateUInt64Histogram(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  virtual nostd::unique_ptr<Histogram<double>> CreateDoubleHistogram(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  /**
+   * Creates a Asynchronouse (Observable) Gauge with the passed characteristics and returns a
+   * shared_ptr to that Observable Gauge
+   *
+   * @param name the name of the new Observable Gauge.
+   * @param description a brief description of what the Observable Gauge is used for.
+   * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
+   */
+  virtual nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableGauge(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  virtual nostd::shared_ptr<ObservableInstrument> CreateDoubleObservableGauge(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  /**
+   * Creates an UpDownCounter with the passed characteristics and returns a unique_ptr to that
+   * UpDownCounter.
+   *
+   * @param name the name of the new UpDownCounter.
+   * @param description a brief description of what the UpDownCounter is used for.
+   * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
+   * @return a shared pointer to the created UpDownCounter.
+   */
+  virtual nostd::unique_ptr<UpDownCounter<int64_t>> CreateInt64UpDownCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  virtual nostd::unique_ptr<UpDownCounter<double>> CreateDoubleUpDownCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  /**
+   * Creates a Asynchronouse (Observable) UpDownCounter with the passed characteristics and returns
+   * a shared_ptr to that Observable UpDownCounter
+   *
+   * @param name the name of the new Observable UpDownCounter.
+   * @param description a brief description of what the Observable UpDownCounter is used for.
+   * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
+   */
+  virtual nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableUpDownCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+
+  virtual nostd::shared_ptr<ObservableInstrument> CreateDoubleObservableUpDownCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept = 0;
+};
+}  // namespace metrics
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/meter_provider.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/meter_provider.h
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/key_value_iterable.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/type_traits.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace metrics
+{
+
+class Meter;
+
+/**
+ * Creates new Meter instances.
+ */
+class MeterProvider
+{
+public:
+  virtual ~MeterProvider() = default;
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+
+  /**
+   * Gets or creates a named Meter instance (ABI).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Meter instrumentation scope
+   * @param[in] version Instrumentation scope version
+   * @param[in] schema_url Instrumentation scope schema URL
+   * @param[in] attributes Instrumentation scope attributes (optional, may be nullptr)
+   */
+  virtual nostd::shared_ptr<Meter> GetMeter(
+      nostd::string_view name,
+      nostd::string_view version,
+      nostd::string_view schema_url,
+      const common::KeyValueIterable *attributes) noexcept = 0;
+
+  /**
+   * Gets or creates a named Meter instance (API helper).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Meter instrumentation scope
+   * @param[in] version Instrumentation scope version, optional
+   * @param[in] schema_url Instrumentation scope schema URL, optional
+   */
+  nostd::shared_ptr<Meter> GetMeter(nostd::string_view name,
+                                    nostd::string_view version    = "",
+                                    nostd::string_view schema_url = "")
+  {
+    return GetMeter(name, version, schema_url, nullptr);
+  }
+
+  /**
+   * Gets or creates a named Meter instance (API helper).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Meter instrumentation scope
+   * @param[in] version Instrumentation scope version
+   * @param[in] schema_url Instrumentation scope schema URL
+   * @param[in] attributes Instrumentation scope attributes
+   */
+  nostd::shared_ptr<Meter> GetMeter(
+      nostd::string_view name,
+      nostd::string_view version,
+      nostd::string_view schema_url,
+      std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes)
+  {
+    /* Build a container from std::initializer_list. */
+    nostd::span<const std::pair<nostd::string_view, common::AttributeValue>> attributes_span{
+        attributes.begin(), attributes.end()};
+
+    /* Build a view on the container. */
+    common::KeyValueIterableView<
+        nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>>
+        iterable_attributes{attributes_span};
+
+    /* Add attributes using the view. */
+    return GetMeter(name, version, schema_url, &iterable_attributes);
+  }
+
+  /**
+   * Gets or creates a named Meter instance (API helper).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Meter instrumentation scope
+   * @param[in] version Instrumentation scope version
+   * @param[in] schema_url Instrumentation scope schema URL
+   * @param[in] attributes Instrumentation scope attributes container
+   */
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+  nostd::shared_ptr<Meter> GetMeter(nostd::string_view name,
+                                    nostd::string_view version,
+                                    nostd::string_view schema_url,
+                                    const T &attributes)
+  {
+    /* Build a view on the container. */
+    common::KeyValueIterableView<T> iterable_attributes(attributes);
+
+    /* Add attributes using the view. */
+    return GetMeter(name, version, schema_url, &iterable_attributes);
+  }
+
+#else
+  /**
+   * Gets or creates a named Meter instance (ABI)
+   *
+   * @since ABI_VERSION 1
+   *
+   * @param[in] name Meter instrumentation scope
+   * @param[in] version Instrumentation scope version, optional
+   * @param[in] schema_url Instrumentation scope schema URL, optional
+   */
+  virtual nostd::shared_ptr<Meter> GetMeter(nostd::string_view name,
+                                            nostd::string_view version    = "",
+                                            nostd::string_view schema_url = "") noexcept = 0;
+#endif
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  /**
+   * Remove a named Meter instance (ABI).
+   *
+   * This API is experimental, see
+   * https://github.com/open-telemetry/opentelemetry-specification/issues/2232
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Meter instrumentation scope
+   * @param[in] version Instrumentation scope version, optional
+   * @param[in] schema_url Instrumentation scope schema URL, optional
+   */
+  virtual void RemoveMeter(nostd::string_view name,
+                           nostd::string_view version    = "",
+                           nostd::string_view schema_url = "") noexcept = 0;
+#endif
+};
+}  // namespace metrics
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/noop.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/noop.h
@@ -1,0 +1,235 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/metrics/async_instruments.h"
+#include "opentelemetry/metrics/meter.h"
+#include "opentelemetry/metrics/meter_provider.h"
+#include "opentelemetry/metrics/observer_result.h"
+#include "opentelemetry/metrics/sync_instruments.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace metrics
+{
+
+template <class T>
+class NoopCounter : public Counter<T>
+{
+public:
+  NoopCounter(nostd::string_view /* name */,
+              nostd::string_view /* description */,
+              nostd::string_view /* unit */) noexcept
+  {}
+  void Add(T /* value */) noexcept override {}
+  void Add(T /* value */, const context::Context & /* context */) noexcept override {}
+  void Add(T /* value */, const common::KeyValueIterable & /* attributes */) noexcept override {}
+  void Add(T /* value */,
+           const common::KeyValueIterable & /* attributes */,
+           const context::Context & /* context */) noexcept override
+  {}
+};
+
+template <class T>
+class NoopHistogram : public Histogram<T>
+{
+public:
+  NoopHistogram(nostd::string_view /* name */,
+                nostd::string_view /* description */,
+                nostd::string_view /* unit */) noexcept
+  {}
+  void Record(T /* value */, const context::Context & /* context */) noexcept override {}
+  void Record(T /* value */,
+              const common::KeyValueIterable & /* attributes */,
+              const context::Context & /* context */) noexcept override
+  {}
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  void Record(T /*value*/,
+              const opentelemetry::common::KeyValueIterable & /*attributes*/) noexcept override
+  {}
+
+  void Record(T /*value*/) noexcept override {}
+#endif
+};
+
+template <class T>
+class NoopUpDownCounter : public UpDownCounter<T>
+{
+public:
+  NoopUpDownCounter(nostd::string_view /* name */,
+                    nostd::string_view /* description */,
+                    nostd::string_view /* unit */) noexcept
+  {}
+  ~NoopUpDownCounter() override = default;
+  void Add(T /* value */) noexcept override {}
+  void Add(T /* value */, const context::Context & /* context */) noexcept override {}
+  void Add(T /* value */, const common::KeyValueIterable & /* attributes */) noexcept override {}
+  void Add(T /* value */,
+           const common::KeyValueIterable & /* attributes */,
+           const context::Context & /* context */) noexcept override
+  {}
+};
+
+class NoopObservableInstrument : public ObservableInstrument
+{
+public:
+  NoopObservableInstrument(nostd::string_view /* name */,
+                           nostd::string_view /* description */,
+                           nostd::string_view /* unit */) noexcept
+  {}
+
+  void AddCallback(ObservableCallbackPtr, void * /* state */) noexcept override {}
+  void RemoveCallback(ObservableCallbackPtr, void * /* state */) noexcept override {}
+};
+
+/**
+ * No-op implementation of Meter.
+ */
+class NoopMeter final : public Meter
+{
+public:
+  nostd::unique_ptr<Counter<uint64_t>> CreateUInt64Counter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::unique_ptr<Counter<uint64_t>>{new NoopCounter<uint64_t>(name, description, unit)};
+  }
+
+  nostd::unique_ptr<Counter<double>> CreateDoubleCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::unique_ptr<Counter<double>>{new NoopCounter<double>(name, description, unit)};
+  }
+
+  nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::shared_ptr<ObservableInstrument>(
+        new NoopObservableInstrument(name, description, unit));
+  }
+
+  nostd::shared_ptr<ObservableInstrument> CreateDoubleObservableCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::shared_ptr<ObservableInstrument>(
+        new NoopObservableInstrument(name, description, unit));
+  }
+
+  nostd::unique_ptr<Histogram<uint64_t>> CreateUInt64Histogram(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::unique_ptr<Histogram<uint64_t>>{
+        new NoopHistogram<uint64_t>(name, description, unit)};
+  }
+
+  nostd::unique_ptr<Histogram<double>> CreateDoubleHistogram(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::unique_ptr<Histogram<double>>{new NoopHistogram<double>(name, description, unit)};
+  }
+
+  nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableGauge(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::shared_ptr<ObservableInstrument>(
+        new NoopObservableInstrument(name, description, unit));
+  }
+
+  nostd::shared_ptr<ObservableInstrument> CreateDoubleObservableGauge(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::shared_ptr<ObservableInstrument>(
+        new NoopObservableInstrument(name, description, unit));
+  }
+
+  nostd::unique_ptr<UpDownCounter<int64_t>> CreateInt64UpDownCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::unique_ptr<UpDownCounter<int64_t>>{
+        new NoopUpDownCounter<int64_t>(name, description, unit)};
+  }
+
+  nostd::unique_ptr<UpDownCounter<double>> CreateDoubleUpDownCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::unique_ptr<UpDownCounter<double>>{
+        new NoopUpDownCounter<double>(name, description, unit)};
+  }
+
+  nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableUpDownCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::shared_ptr<ObservableInstrument>(
+        new NoopObservableInstrument(name, description, unit));
+  }
+
+  nostd::shared_ptr<ObservableInstrument> CreateDoubleObservableUpDownCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
+  {
+    return nostd::shared_ptr<ObservableInstrument>(
+        new NoopObservableInstrument(name, description, unit));
+  }
+};
+
+/**
+ * No-op implementation of a MeterProvider.
+ */
+class NoopMeterProvider final : public MeterProvider
+{
+public:
+  NoopMeterProvider() : meter_{nostd::shared_ptr<Meter>(new NoopMeter)} {}
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  nostd::shared_ptr<Meter> GetMeter(
+      nostd::string_view /* name */,
+      nostd::string_view /* version */,
+      nostd::string_view /* schema_url */,
+      const common::KeyValueIterable * /* attributes */) noexcept override
+  {
+    return meter_;
+  }
+#else
+  nostd::shared_ptr<Meter> GetMeter(nostd::string_view /* name */,
+                                    nostd::string_view /* version */,
+                                    nostd::string_view /* schema_url */) noexcept override
+  {
+    return meter_;
+  }
+#endif
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  void RemoveMeter(nostd::string_view /* name */,
+                   nostd::string_view /* version */,
+                   nostd::string_view /* schema_url */) noexcept override
+  {}
+#endif
+
+private:
+  nostd::shared_ptr<Meter> meter_;
+};
+}  // namespace metrics
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/observer_result.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/observer_result.h
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/type_traits.h"
+#include "opentelemetry/nostd/variant.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace metrics
+{
+
+/**
+ * ObserverResultT class is necessary for the callback recording asynchronous
+ * instrument use.
+ */
+template <class T>
+class ObserverResultT
+{
+
+public:
+  virtual ~ObserverResultT() = default;
+
+  virtual void Observe(T value) noexcept = 0;
+
+  virtual void Observe(T value, const common::KeyValueIterable &attributes) noexcept = 0;
+
+  template <class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
+  void Observe(T value, const U &attributes) noexcept
+  {
+    this->Observe(value, common::KeyValueIterableView<U>{attributes});
+  }
+
+  void Observe(T value,
+               std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>
+                   attributes) noexcept
+  {
+    this->Observe(value, nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                             attributes.begin(), attributes.end()});
+  }
+};
+
+using ObserverResult = nostd::variant<nostd::shared_ptr<ObserverResultT<int64_t>>,
+                                      nostd::shared_ptr<ObserverResultT<double>>>;
+
+}  // namespace metrics
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/provider.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/provider.h
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mutex>
+
+#include "opentelemetry/common/macros.h"
+#include "opentelemetry/common/spin_lock_mutex.h"
+#include "opentelemetry/metrics/noop.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace metrics
+{
+
+class MeterProvider;
+
+/**
+ * Stores the singleton global MeterProvider.
+ */
+class Provider
+{
+public:
+  /**
+   * Returns the singleton MeterProvider.
+   *
+   * By default, a no-op MeterProvider is returned. This will never return a
+   * nullptr MeterProvider.
+   */
+  static nostd::shared_ptr<MeterProvider> GetMeterProvider() noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    return nostd::shared_ptr<MeterProvider>(GetProvider());
+  }
+
+  /**
+   * Changes the singleton MeterProvider.
+   */
+  static void SetMeterProvider(nostd::shared_ptr<MeterProvider> tp) noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    GetProvider() = tp;
+  }
+
+private:
+  OPENTELEMETRY_API_SINGLETON static nostd::shared_ptr<MeterProvider> &GetProvider() noexcept
+  {
+    static nostd::shared_ptr<MeterProvider> provider(new NoopMeterProvider);
+    return provider;
+  }
+
+  OPENTELEMETRY_API_SINGLETON static common::SpinLockMutex &GetLock() noexcept
+  {
+    static common::SpinLockMutex lock;
+    return lock;
+  }
+};
+
+}  // namespace metrics
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/sync_instruments.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/metrics/sync_instruments.h
@@ -1,0 +1,251 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/type_traits.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace metrics
+{
+
+class SynchronousInstrument
+{
+public:
+  SynchronousInstrument()          = default;
+  virtual ~SynchronousInstrument() = default;
+};
+
+/* A Counter instrument that adds values. */
+template <class T>
+class Counter : public SynchronousInstrument
+{
+
+public:
+  /**
+   * Record a value
+   *
+   * @param value The increment amount. MUST be non-negative.
+   */
+  virtual void Add(T value) noexcept = 0;
+
+  /**
+   * Record a value
+   *
+   * @param value The increment amount. MUST be non-negative.
+   * @param context The explicit context to associate with this measurement.
+   */
+  virtual void Add(T value, const context::Context &context) noexcept = 0;
+
+  /**
+   * Record a value with a set of attributes.
+   *
+   * @param value The increment amount. MUST be non-negative.
+   * @param attributes A set of attributes to associate with the value.
+   */
+
+  virtual void Add(T value, const common::KeyValueIterable &attributes) noexcept = 0;
+
+  /**
+   * Record a value with a set of attributes.
+   *
+   * @param value The increment amount. MUST be non-negative.
+   * @param attributes A set of attributes to associate with the value.
+   * @param context The explicit context to associate with this measurement.
+   */
+  virtual void Add(T value,
+                   const common::KeyValueIterable &attributes,
+                   const context::Context &context) noexcept = 0;
+
+  template <class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
+  void Add(T value, const U &attributes) noexcept
+  {
+    this->Add(value, common::KeyValueIterableView<U>{attributes});
+  }
+
+  template <class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
+  void Add(T value, const U &attributes, const context::Context &context) noexcept
+  {
+    this->Add(value, common::KeyValueIterableView<U>{attributes}, context);
+  }
+
+  void Add(T value,
+           std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>
+               attributes) noexcept
+  {
+    this->Add(value, nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                         attributes.begin(), attributes.end()});
+  }
+
+  void Add(T value,
+           std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes,
+           const context::Context &context) noexcept
+  {
+    this->Add(value,
+              nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                  attributes.begin(), attributes.end()},
+              context);
+  }
+};
+
+/** A histogram instrument that records values. */
+
+template <class T>
+class Histogram : public SynchronousInstrument
+{
+public:
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  /**
+   * @since ABI_VERSION 2
+   * Records a value.
+   *
+   * @param value The measurement value. MUST be non-negative.
+   */
+  virtual void Record(T value) noexcept = 0;
+
+  /**
+   * @since ABI_VERSION 2
+   * Records a value with a set of attributes.
+   *
+   * @param value The measurement value. MUST be non-negative.
+   * @param attribute A set of attributes to associate with the value.
+   */
+  virtual void Record(T value, const common::KeyValueIterable &attribute) noexcept = 0;
+
+  template <class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
+  void Record(T value, const U &attributes) noexcept
+  {
+    this->Record(value, common::KeyValueIterableView<U>{attributes});
+  }
+
+  void Record(T value,
+              std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>
+                  attributes) noexcept
+  {
+    this->Record(value, nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                            attributes.begin(), attributes.end()});
+  }
+#endif
+
+  /**
+   * Records a value.
+   *
+   * @param value The measurement value. MUST be non-negative.
+   * @param context The explicit context to associate with this measurement.
+   */
+  virtual void Record(T value, const context::Context &context) noexcept = 0;
+
+  /**
+   * Records a value with a set of attributes.
+   *
+   * @param value The measurement value. MUST be non-negative.
+   * @param attributes A set of attributes to associate with the value..
+   * @param context The explicit context to associate with this measurement.
+   */
+  virtual void Record(T value,
+                      const common::KeyValueIterable &attributes,
+                      const context::Context &context) noexcept = 0;
+
+  template <class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
+  void Record(T value, const U &attributes, const context::Context &context) noexcept
+  {
+    this->Record(value, common::KeyValueIterableView<U>{attributes}, context);
+  }
+
+  void Record(
+      T value,
+      std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes,
+      const context::Context &context) noexcept
+  {
+    this->Record(value,
+                 nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                     attributes.begin(), attributes.end()},
+                 context);
+  }
+};
+
+/** An up-down-counter instrument that adds or reduce values. */
+
+template <class T>
+class UpDownCounter : public SynchronousInstrument
+{
+public:
+  /**
+   * Record a value.
+   *
+   * @param value The increment amount. May be positive, negative or zero.
+   */
+  virtual void Add(T value) noexcept = 0;
+
+  /**
+   * Record a value.
+   *
+   * @param value The increment amount. May be positive, negative or zero.
+   * @param context The explicit context to associate with this measurement.
+   */
+  virtual void Add(T value, const context::Context &context) noexcept = 0;
+
+  /**
+   * Record a value with a set of attributes.
+   *
+   * @param value The increment amount. May be positive, negative or zero.
+   * @param attributes A set of attributes to associate with the count.
+   */
+  virtual void Add(T value, const common::KeyValueIterable &attributes) noexcept = 0;
+
+  /**
+   * Record a value with a set of attributes.
+   *
+   * @param value The increment amount. May be positive, negative or zero.
+   * @param attributes A set of attributes to associate with the count.
+   * @param context The explicit context to associate with this measurement.
+   */
+  virtual void Add(T value,
+                   const common::KeyValueIterable &attributes,
+                   const context::Context &context) noexcept = 0;
+
+  template <class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
+  void Add(T value, const U &attributes) noexcept
+  {
+    this->Add(value, common::KeyValueIterableView<U>{attributes});
+  }
+
+  template <class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
+  void Add(T value, const U &attributes, const context::Context &context) noexcept
+  {
+    this->Add(value, common::KeyValueIterableView<U>{attributes}, context);
+  }
+
+  void Add(T value,
+           std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>
+               attributes) noexcept
+  {
+    this->Add(value, nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                         attributes.begin(), attributes.end()});
+  }
+
+  void Add(T value,
+           std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes,
+           const context::Context &context) noexcept
+  {
+    this->Add(value,
+              nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                  attributes.begin(), attributes.end()},
+              context);
+  }
+};
+
+}  // namespace metrics
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/all.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/all.h
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+
+#include "opentelemetry/nostd/utility.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+namespace detail
+{
+template <bool... Bs>
+using all = std::is_same<integer_sequence<bool, true, Bs...>, integer_sequence<bool, Bs..., true>>;
+
+}  // namespace detail
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/decay.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/decay.h
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+template <class T>
+using decay_t = typename std::decay<T>::type;
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/dependent_type.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/dependent_type.h
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+namespace detail
+{
+template <typename T, bool>
+struct dependent_type : T
+{};
+}  // namespace detail
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/functional.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/functional.h
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <utility>
+
+#include "opentelemetry/version.h"
+
+#define OPENTELEMETRY_RETURN(...) \
+  noexcept(noexcept(__VA_ARGS__))->decltype(__VA_ARGS__) { return __VA_ARGS__; }
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+namespace detail
+{
+struct equal_to
+{
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+      OPENTELEMETRY_RETURN(std::forward<Lhs>(lhs) == std::forward<Rhs>(rhs))
+};
+
+struct not_equal_to
+{
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+      OPENTELEMETRY_RETURN(std::forward<Lhs>(lhs) != std::forward<Rhs>(rhs))
+};
+
+struct less
+{
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+      OPENTELEMETRY_RETURN(std::forward<Lhs>(lhs) < std::forward<Rhs>(rhs))
+};
+
+struct greater
+{
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+      OPENTELEMETRY_RETURN(std::forward<Lhs>(lhs) > std::forward<Rhs>(rhs))
+};
+
+struct less_equal
+{
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+      OPENTELEMETRY_RETURN(std::forward<Lhs>(lhs) <= std::forward<Rhs>(rhs))
+};
+
+struct greater_equal
+{
+  template <typename Lhs, typename Rhs>
+  inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+      OPENTELEMETRY_RETURN(std::forward<Lhs>(lhs) >= std::forward<Rhs>(rhs))
+};
+}  // namespace detail
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+
+#undef OPENTELEMETRY_RETURN

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/invoke.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/invoke.h
@@ -1,0 +1,159 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "opentelemetry/nostd/detail/decay.h"
+#include "opentelemetry/nostd/detail/void.h"
+#include "opentelemetry/version.h"
+
+#define OPENTELEMETRY_RETURN(...) \
+  noexcept(noexcept(__VA_ARGS__))->decltype(__VA_ARGS__) { return __VA_ARGS__; }
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+namespace detail
+{
+
+template <typename T>
+struct is_reference_wrapper : std::false_type
+{};
+
+template <typename T>
+struct is_reference_wrapper<std::reference_wrapper<T>> : std::true_type
+{};
+
+template <bool, int>
+struct Invoke;
+
+template <>
+struct Invoke<true /* pmf */, 0 /* is_base_of */>
+{
+  template <typename R, typename T, typename Arg, typename... Args>
+  inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+      OPENTELEMETRY_RETURN((std::forward<Arg>(arg).*pmf)(std::forward<Args>(args)...))
+};
+
+template <>
+struct Invoke<true /* pmf */, 1 /* is_reference_wrapper */>
+{
+  template <typename R, typename T, typename Arg, typename... Args>
+  inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+      OPENTELEMETRY_RETURN((std::forward<Arg>(arg).get().*pmf)(std::forward<Args>(args)...))
+};
+
+template <>
+struct Invoke<true /* pmf */, 2 /* otherwise */>
+{
+  template <typename R, typename T, typename Arg, typename... Args>
+  inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+      OPENTELEMETRY_RETURN(((*std::forward<Arg>(arg)).*pmf)(std::forward<Args>(args)...))
+};
+
+template <>
+struct Invoke<false /* pmo */, 0 /* is_base_of */>
+{
+  template <typename R, typename T, typename Arg>
+  inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+      OPENTELEMETRY_RETURN(std::forward<Arg>(arg).*pmo)
+};
+
+template <>
+struct Invoke<false /* pmo */, 1 /* is_reference_wrapper */>
+{
+  template <typename R, typename T, typename Arg>
+  inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+      OPENTELEMETRY_RETURN(std::forward<Arg>(arg).get().*pmo)
+};
+
+template <>
+struct Invoke<false /* pmo */, 2 /* otherwise */>
+{
+  template <typename R, typename T, typename Arg>
+  inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+      OPENTELEMETRY_RETURN((*std::forward<Arg>(arg)).*pmo)
+};
+
+template <typename R, typename T, typename Arg, typename... Args>
+inline constexpr auto invoke_impl(R T::*f, Arg &&arg, Args &&... args)
+    OPENTELEMETRY_RETURN(Invoke<std::is_function<R>::value,
+                                (std::is_base_of<T, decay_t<Arg>>::value
+                                     ? 0
+                                     : is_reference_wrapper<decay_t<Arg>>::value ? 1 : 2)>::
+                             invoke(f, std::forward<Arg>(arg), std::forward<Args>(args)...))
+
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable : 4100)
+#endif
+        template <typename F, typename... Args>
+        inline constexpr auto invoke_impl(F &&f, Args &&... args)
+            OPENTELEMETRY_RETURN(std::forward<F>(f)(std::forward<Args>(args)...))
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
+}  // namespace detail
+
+/* clang-format off */
+template <typename F, typename... Args>
+inline constexpr auto invoke(F &&f, Args &&... args)
+    OPENTELEMETRY_RETURN(detail::invoke_impl(std::forward<F>(f), std::forward<Args>(args)...))
+
+namespace detail
+/* clang-format on */
+{
+
+  template <typename Void, typename, typename...>
+  struct invoke_result
+  {};
+
+  template <typename F, typename... Args>
+  struct invoke_result<void_t<decltype(nostd::invoke(std::declval<F>(), std::declval<Args>()...))>,
+                       F, Args...>
+  {
+    using type = decltype(nostd::invoke(std::declval<F>(), std::declval<Args>()...));
+  };
+
+}  // namespace detail
+
+template <typename F, typename... Args>
+using invoke_result = detail::invoke_result<void, F, Args...>;
+
+template <typename F, typename... Args>
+using invoke_result_t = typename invoke_result<F, Args...>::type;
+
+namespace detail
+{
+
+template <typename Void, typename, typename...>
+struct is_invocable : std::false_type
+{};
+
+template <typename F, typename... Args>
+struct is_invocable<void_t<invoke_result_t<F, Args...>>, F, Args...> : std::true_type
+{};
+
+template <typename Void, typename, typename, typename...>
+struct is_invocable_r : std::false_type
+{};
+
+template <typename R, typename F, typename... Args>
+struct is_invocable_r<void_t<invoke_result_t<F, Args...>>, R, F, Args...>
+    : std::is_convertible<invoke_result_t<F, Args...>, R>
+{};
+
+}  // namespace detail
+
+template <typename F, typename... Args>
+using is_invocable = detail::is_invocable<void, F, Args...>;
+
+template <typename R, typename F, typename... Args>
+using is_invocable_r = detail::is_invocable_r<void, R, F, Args...>;
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+
+#undef OPENTELEMETRY_RETURN

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/trait.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/trait.h
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+
+#include "opentelemetry/nostd/type_traits.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+namespace detail
+{
+enum class Trait
+{
+  TriviallyAvailable,
+  Available,
+  Unavailable
+};
+
+template <typename T,
+          template <typename>
+          class IsTriviallyAvailable,
+          template <typename>
+          class IsAvailable>
+inline constexpr Trait trait()
+{
+  return IsTriviallyAvailable<T>::value
+             ? Trait::TriviallyAvailable
+             : IsAvailable<T>::value ? Trait::Available : Trait::Unavailable;
+}
+
+inline constexpr Trait common_trait_impl(Trait result)
+{
+  return result;
+}
+
+template <typename... Traits>
+inline constexpr Trait common_trait_impl(Trait result, Trait t, Traits... ts)
+{
+  return static_cast<int>(t) > static_cast<int>(result) ? common_trait_impl(t, ts...)
+                                                        : common_trait_impl(result, ts...);
+}
+
+template <typename... Traits>
+inline constexpr Trait common_trait(Traits... ts)
+{
+  return common_trait_impl(Trait::TriviallyAvailable, ts...);
+}
+
+template <typename... Ts>
+struct traits
+{
+  static constexpr Trait copy_constructible_trait =
+      common_trait(trait<Ts, is_trivially_copy_constructible, std::is_copy_constructible>()...);
+
+  static constexpr Trait move_constructible_trait =
+      common_trait(trait<Ts, is_trivially_move_constructible, std::is_move_constructible>()...);
+
+  static constexpr Trait copy_assignable_trait =
+      common_trait(copy_constructible_trait,
+                   trait<Ts, is_trivially_copy_assignable, std::is_copy_assignable>()...);
+
+  static constexpr Trait move_assignable_trait =
+      common_trait(move_constructible_trait,
+                   trait<Ts, is_trivially_move_assignable, std::is_move_assignable>()...);
+
+  static constexpr Trait destructible_trait =
+      common_trait(trait<Ts, std::is_trivially_destructible, std::is_destructible>()...);
+};
+}  // namespace detail
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/type_pack_element.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/type_pack_element.h
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "opentelemetry/nostd/utility.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+namespace detail
+{
+template <std::size_t N>
+using size_constant = std::integral_constant<std::size_t, N>;
+
+template <std::size_t I, typename T>
+struct indexed_type : size_constant<I>
+{
+  using type = T;
+};
+
+template <std::size_t I, typename... Ts>
+struct type_pack_element_impl
+{
+private:
+  template <typename>
+  struct set;
+
+  template <std::size_t... Is>
+  struct set<index_sequence<Is...>> : indexed_type<Is, Ts>...
+  {};
+
+  template <typename T>
+  inline static std::enable_if<true, T> impl(indexed_type<I, T>);
+
+  inline static std::enable_if<false> impl(...);
+
+public:
+  using type = decltype(impl(set<index_sequence_for<Ts...>>{}));
+};
+
+template <std::size_t I, typename... Ts>
+using type_pack_element = typename type_pack_element_impl<I, Ts...>::type;
+
+template <std::size_t I, typename... Ts>
+using type_pack_element_t = typename type_pack_element<I, Ts...>::type;
+}  // namespace detail
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/valueless.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/valueless.h
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+struct valueless_t
+{};
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/variant_alternative.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/variant_alternative.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+
+#include "opentelemetry/nostd/detail/type_pack_element.h"
+#include "opentelemetry/nostd/detail/variant_fwd.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+template <std::size_t I, typename T>
+struct variant_alternative;
+
+template <std::size_t I, typename T>
+using variant_alternative_t = typename variant_alternative<I, T>::type;
+
+template <std::size_t I, typename T>
+struct variant_alternative<I, const T> : std::add_const<variant_alternative_t<I, T>>
+{};
+
+template <std::size_t I, typename T>
+struct variant_alternative<I, volatile T> : std::add_volatile<variant_alternative_t<I, T>>
+{};
+
+template <std::size_t I, typename T>
+struct variant_alternative<I, const volatile T> : std::add_cv<variant_alternative_t<I, T>>
+{};
+
+template <std::size_t I, typename... Ts>
+struct variant_alternative<I, variant<Ts...>>
+{
+  static_assert(I < sizeof...(Ts), "index out of bounds in `std::variant_alternative<>`");
+  using type = detail::type_pack_element_t<I, Ts...>;
+};
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/variant_fwd.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/variant_fwd.h
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+template <typename... Ts>
+class variant;
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/variant_size.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/variant_size.h
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+
+#include "opentelemetry/nostd/detail/variant_fwd.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+template <typename T>
+struct variant_size;
+
+template <typename T>
+struct variant_size<const T> : variant_size<T>
+{};
+
+template <typename T>
+struct variant_size<volatile T> : variant_size<T>
+{};
+
+template <typename T>
+struct variant_size<const volatile T> : variant_size<T>
+{};
+
+template <typename... Ts>
+struct variant_size<variant<Ts...>> : std::integral_constant<size_t, sizeof...(Ts)>
+{};
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/void.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/detail/void.h
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+namespace detail
+{
+template <class...>
+struct voider
+{
+  using type = void;
+};
+}  // namespace detail
+
+/**
+ * Back port of std::void_t
+ *
+ * Note: voider workaround is required for gcc-4.8 to make SFINAE work
+ */
+template <class... Tx>
+using void_t = typename detail::voider<Tx...>::type;
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/function_ref.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/function_ref.h
@@ -1,0 +1,92 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+template <class Sig>
+class function_ref;
+
+/**
+ * Non-owning function reference that can be used as a more performant
+ * replacement for std::function when ownership sematics aren't needed.
+ *
+ * See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0792r0.html
+ *
+ * Based off of https://stackoverflow.com/a/39087660/4447365
+ */
+template <class R, class... Args>
+class function_ref<R(Args...)>
+{
+  void *callable_                = nullptr;
+  R (*invoker_)(void *, Args...) = nullptr;
+
+  template <class F>
+  using FunctionPointer = decltype(std::addressof(std::declval<F &>()));
+
+  template <class F>
+  void BindTo(F &f) noexcept
+  {
+    callable_ = static_cast<void *>(std::addressof(f));
+    invoker_  = [](void *callable, Args... args) -> R {
+      return (*static_cast<FunctionPointer<F>>(callable))(std::forward<Args>(args)...);
+    };
+  }
+
+  template <class R_in, class... Args_in>
+  void BindTo(R_in (*f)(Args_in...)) noexcept
+  {
+    using F = decltype(f);
+    if (f == nullptr)
+    {
+      return BindTo(nullptr);
+    }
+    callable_ = reinterpret_cast<void *>(f);
+    invoker_  = [](void *callable, Args... args) -> R {
+      return (F(callable))(std::forward<Args>(args)...);
+    };
+  }
+
+  void BindTo(std::nullptr_t) noexcept
+  {
+    callable_ = nullptr;
+    invoker_  = nullptr;
+  }
+
+public:
+  template <
+      class F,
+      typename std::enable_if<!std::is_same<function_ref, typename std::decay<F>::type>::value,
+                              int>::type = 0,
+      typename std::enable_if<
+#if (__cplusplus >= 201703L) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201402))
+          // std::result_of deprecated in C++17, removed in C++20
+          std::is_convertible<typename std::invoke_result<F, Args...>::type, R>::value,
+#else
+          // std::result_of since C++11
+          std::is_convertible<typename std::result_of<F &(Args...)>::type, R>::value,
+#endif
+          int>::type = 0>
+  function_ref(F &&f)
+  {
+    BindTo(f);  // not forward
+  }
+
+  function_ref(std::nullptr_t) {}
+
+  function_ref(const function_ref &) noexcept = default;
+  function_ref(function_ref &&) noexcept      = default;
+
+  R operator()(Args... args) const { return invoker_(callable_, std::forward<Args>(args)...); }
+
+  explicit operator bool() const { return invoker_; }
+};
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/.clang-format
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/.clang-format
@@ -1,0 +1,3 @@
+# Disable formatting for Google Abseil library snapshot
+DisableFormat: true
+SortIncludes: false

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/README.md
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/README.md
@@ -1,0 +1,4 @@
+# Notes on Abseil Variant implementation
+
+This is a snapshot of Abseil Variant `absl::variant` from Abseil
+`v2020-03-03#8`.

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/attributes.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/attributes.h
@@ -1,0 +1,621 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This header file defines macros for declaring attributes for functions,
+// types, and variables.
+//
+// These macros are used within Abseil and allow the compiler to optimize, where
+// applicable, certain function calls.
+//
+// This file is used for both C and C++!
+//
+// Most macros here are exposing GCC or Clang features, and are stubbed out for
+// other compilers.
+//
+// GCC attributes documentation:
+//   https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Function-Attributes.html
+//   https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Variable-Attributes.html
+//   https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Type-Attributes.html
+//
+// Most attributes in this file are already supported by GCC 4.7. However, some
+// of them are not supported in older version of Clang. Thus, we check
+// `__has_attribute()` first. If the check fails, we check if we are on GCC and
+// assume the attribute exists on GCC (which is verified on GCC 4.7).
+//
+// -----------------------------------------------------------------------------
+// Sanitizer Attributes
+// -----------------------------------------------------------------------------
+//
+// Sanitizer-related attributes are not "defined" in this file (and indeed
+// are not defined as such in any file). To utilize the following
+// sanitizer-related attributes within your builds, define the following macros
+// within your build using a `-D` flag, along with the given value for
+// `-fsanitize`:
+//
+//   * `ADDRESS_SANITIZER` + `-fsanitize=address` (Clang, GCC 4.8)
+//   * `MEMORY_SANITIZER` + `-fsanitize=memory` (Clang-only)
+//   * `THREAD_SANITIZER + `-fsanitize=thread` (Clang, GCC 4.8+)
+//   * `UNDEFINED_BEHAVIOR_SANITIZER` + `-fsanitize=undefined` (Clang, GCC 4.9+)
+//   * `CONTROL_FLOW_INTEGRITY` + -fsanitize=cfi (Clang-only)
+//
+// Example:
+//
+//   // Enable branches in the Abseil code that are tagged for ASan:
+//   $ bazel build --copt=-DADDRESS_SANITIZER --copt=-fsanitize=address
+//     --linkopt=-fsanitize=address *target*
+//
+// Since these macro names are only supported by GCC and Clang, we only check
+// for `__GNUC__` (GCC or Clang) and the above macros.
+#ifndef OTABSL_BASE_ATTRIBUTES_H_
+#define OTABSL_BASE_ATTRIBUTES_H_
+
+// OTABSL_HAVE_ATTRIBUTE
+//
+// A function-like feature checking macro that is a wrapper around
+// `__has_attribute`, which is defined by GCC 5+ and Clang and evaluates to a
+// nonzero constant integer if the attribute is supported or 0 if not.
+//
+// It evaluates to zero if `__has_attribute` is not defined by the compiler.
+//
+// GCC: https://gcc.gnu.org/gcc-5/changes.html
+// Clang: https://clang.llvm.org/docs/LanguageExtensions.html
+#ifdef __has_attribute
+#define OTABSL_HAVE_ATTRIBUTE(x) __has_attribute(x)
+#else
+#define OTABSL_HAVE_ATTRIBUTE(x) 0
+#endif
+
+// OTABSL_HAVE_CPP_ATTRIBUTE
+//
+// A function-like feature checking macro that accepts C++11 style attributes.
+// It's a wrapper around `__has_cpp_attribute`, defined by ISO C++ SD-6
+// (https://en.cppreference.com/w/cpp/experimental/feature_test). If we don't
+// find `__has_cpp_attribute`, will evaluate to 0.
+#if defined(__cplusplus) && defined(__has_cpp_attribute)
+// NOTE: requiring __cplusplus above should not be necessary, but
+// works around https://bugs.llvm.org/show_bug.cgi?id=23435.
+#define OTABSL_HAVE_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+#define OTABSL_HAVE_CPP_ATTRIBUTE(x) 0
+#endif
+
+// -----------------------------------------------------------------------------
+// Function Attributes
+// -----------------------------------------------------------------------------
+//
+// GCC: https://gcc.gnu.org/onlinedocs/gcc/Function-Attributes.html
+// Clang: https://clang.llvm.org/docs/AttributeReference.html
+
+// OTABSL_PRINTF_ATTRIBUTE
+// OTABSL_SCANF_ATTRIBUTE
+//
+// Tells the compiler to perform `printf` format string checking if the
+// compiler supports it; see the 'format' attribute in
+// <https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Function-Attributes.html>.
+//
+// Note: As the GCC manual states, "[s]ince non-static C++ methods
+// have an implicit 'this' argument, the arguments of such methods
+// should be counted from two, not one."
+#if OTABSL_HAVE_ATTRIBUTE(format) || (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_PRINTF_ATTRIBUTE(string_index, first_to_check) \
+  __attribute__((__format__(__printf__, string_index, first_to_check)))
+#define OTABSL_SCANF_ATTRIBUTE(string_index, first_to_check) \
+  __attribute__((__format__(__scanf__, string_index, first_to_check)))
+#else
+#define OTABSL_PRINTF_ATTRIBUTE(string_index, first_to_check)
+#define OTABSL_SCANF_ATTRIBUTE(string_index, first_to_check)
+#endif
+
+// OTABSL_ATTRIBUTE_ALWAYS_INLINE
+// OTABSL_ATTRIBUTE_NOINLINE
+//
+// Forces functions to either inline or not inline. Introduced in gcc 3.1.
+#if OTABSL_HAVE_ATTRIBUTE(always_inline) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+#define OTABSL_HAVE_ATTRIBUTE_ALWAYS_INLINE 1
+#else
+#define OTABSL_ATTRIBUTE_ALWAYS_INLINE
+#endif
+
+#if OTABSL_HAVE_ATTRIBUTE(noinline) || (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_ATTRIBUTE_NOINLINE __attribute__((noinline))
+#define OTABSL_HAVE_ATTRIBUTE_NOINLINE 1
+#else
+#define OTABSL_ATTRIBUTE_NOINLINE
+#endif
+
+// OTABSL_ATTRIBUTE_NO_TAIL_CALL
+//
+// Prevents the compiler from optimizing away stack frames for functions which
+// end in a call to another function.
+#if OTABSL_HAVE_ATTRIBUTE(disable_tail_calls)
+#define OTABSL_HAVE_ATTRIBUTE_NO_TAIL_CALL 1
+#define OTABSL_ATTRIBUTE_NO_TAIL_CALL __attribute__((disable_tail_calls))
+#elif defined(__GNUC__) && !defined(__clang__)
+#define OTABSL_HAVE_ATTRIBUTE_NO_TAIL_CALL 1
+#define OTABSL_ATTRIBUTE_NO_TAIL_CALL \
+  __attribute__((optimize("no-optimize-sibling-calls")))
+#else
+#define OTABSL_ATTRIBUTE_NO_TAIL_CALL
+#define OTABSL_HAVE_ATTRIBUTE_NO_TAIL_CALL 0
+#endif
+
+// OTABSL_ATTRIBUTE_WEAK
+//
+// Tags a function as weak for the purposes of compilation and linking.
+// Weak attributes currently do not work properly in LLVM's Windows backend,
+// so disable them there. See https://bugs.llvm.org/show_bug.cgi?id=37598
+// for further information.
+// The MinGW compiler doesn't complain about the weak attribute until the link
+// step, presumably because Windows doesn't use ELF binaries.
+#if (OTABSL_HAVE_ATTRIBUTE(weak) ||                   \
+     (defined(__GNUC__) && !defined(__clang__))) && \
+    !(defined(__llvm__) && defined(_WIN32)) && !defined(__MINGW32__)
+#undef OTABSL_ATTRIBUTE_WEAK
+#define OTABSL_ATTRIBUTE_WEAK __attribute__((weak))
+#define OTABSL_HAVE_ATTRIBUTE_WEAK 1
+#else
+#define OTABSL_ATTRIBUTE_WEAK
+#define OTABSL_HAVE_ATTRIBUTE_WEAK 0
+#endif
+
+// OTABSL_ATTRIBUTE_NONNULL
+//
+// Tells the compiler either (a) that a particular function parameter
+// should be a non-null pointer, or (b) that all pointer arguments should
+// be non-null.
+//
+// Note: As the GCC manual states, "[s]ince non-static C++ methods
+// have an implicit 'this' argument, the arguments of such methods
+// should be counted from two, not one."
+//
+// Args are indexed starting at 1.
+//
+// For non-static class member functions, the implicit `this` argument
+// is arg 1, and the first explicit argument is arg 2. For static class member
+// functions, there is no implicit `this`, and the first explicit argument is
+// arg 1.
+//
+// Example:
+//
+//   /* arg_a cannot be null, but arg_b can */
+//   void Function(void* arg_a, void* arg_b) OTABSL_ATTRIBUTE_NONNULL(1);
+//
+//   class C {
+//     /* arg_a cannot be null, but arg_b can */
+//     void Method(void* arg_a, void* arg_b) OTABSL_ATTRIBUTE_NONNULL(2);
+//
+//     /* arg_a cannot be null, but arg_b can */
+//     static void StaticMethod(void* arg_a, void* arg_b)
+//     OTABSL_ATTRIBUTE_NONNULL(1);
+//   };
+//
+// If no arguments are provided, then all pointer arguments should be non-null.
+//
+//  /* No pointer arguments may be null. */
+//  void Function(void* arg_a, void* arg_b, int arg_c) OTABSL_ATTRIBUTE_NONNULL();
+//
+// NOTE: The GCC nonnull attribute actually accepts a list of arguments, but
+// OTABSL_ATTRIBUTE_NONNULL does not.
+#if OTABSL_HAVE_ATTRIBUTE(nonnull) || (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_ATTRIBUTE_NONNULL(arg_index) __attribute__((nonnull(arg_index)))
+#else
+#define OTABSL_ATTRIBUTE_NONNULL(...)
+#endif
+
+// OTABSL_ATTRIBUTE_NORETURN
+//
+// Tells the compiler that a given function never returns.
+#if OTABSL_HAVE_ATTRIBUTE(noreturn) || (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_ATTRIBUTE_NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define OTABSL_ATTRIBUTE_NORETURN __declspec(noreturn)
+#else
+#define OTABSL_ATTRIBUTE_NORETURN
+#endif
+
+// OTABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS
+//
+// Tells the AddressSanitizer (or other memory testing tools) to ignore a given
+// function. Useful for cases when a function reads random locations on stack,
+// calls _exit from a cloned subprocess, deliberately accesses buffer
+// out of bounds or does other scary things with memory.
+// NOTE: GCC supports AddressSanitizer(asan) since 4.8.
+// https://gcc.gnu.org/gcc-4.8/changes.html
+#if defined(__GNUC__)
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS
+#endif
+
+// OTABSL_ATTRIBUTE_NO_SANITIZE_MEMORY
+//
+// Tells the  MemorySanitizer to relax the handling of a given function. All
+// "Use of uninitialized value" warnings from such functions will be suppressed,
+// and all values loaded from memory will be considered fully initialized.
+// This attribute is similar to the ADDRESS_SANITIZER attribute above, but deals
+// with initialized-ness rather than addressability issues.
+// NOTE: MemorySanitizer(msan) is supported by Clang but not GCC.
+#if defined(__clang__)
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_MEMORY __attribute__((no_sanitize_memory))
+#else
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_MEMORY
+#endif
+
+// OTABSL_ATTRIBUTE_NO_SANITIZE_THREAD
+//
+// Tells the ThreadSanitizer to not instrument a given function.
+// NOTE: GCC supports ThreadSanitizer(tsan) since 4.8.
+// https://gcc.gnu.org/gcc-4.8/changes.html
+#if defined(__GNUC__)
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_THREAD __attribute__((no_sanitize_thread))
+#else
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_THREAD
+#endif
+
+// OTABSL_ATTRIBUTE_NO_SANITIZE_UNDEFINED
+//
+// Tells the UndefinedSanitizer to ignore a given function. Useful for cases
+// where certain behavior (eg. division by zero) is being used intentionally.
+// NOTE: GCC supports UndefinedBehaviorSanitizer(ubsan) since 4.9.
+// https://gcc.gnu.org/gcc-4.9/changes.html
+#if defined(__GNUC__) && \
+    (defined(UNDEFINED_BEHAVIOR_SANITIZER) || defined(ADDRESS_SANITIZER))
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_UNDEFINED \
+  __attribute__((no_sanitize("undefined")))
+#else
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_UNDEFINED
+#endif
+
+// OTABSL_ATTRIBUTE_NO_SANITIZE_CFI
+//
+// Tells the ControlFlowIntegrity sanitizer to not instrument a given function.
+// See https://clang.llvm.org/docs/ControlFlowIntegrity.html for details.
+#if defined(__GNUC__) && defined(CONTROL_FLOW_INTEGRITY)
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_CFI __attribute__((no_sanitize("cfi")))
+#else
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_CFI
+#endif
+
+// OTABSL_ATTRIBUTE_NO_SANITIZE_SAFESTACK
+//
+// Tells the SafeStack to not instrument a given function.
+// See https://clang.llvm.org/docs/SafeStack.html for details.
+#if defined(__GNUC__) && defined(SAFESTACK_SANITIZER)
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_SAFESTACK \
+  __attribute__((no_sanitize("safe-stack")))
+#else
+#define OTABSL_ATTRIBUTE_NO_SANITIZE_SAFESTACK
+#endif
+
+// OTABSL_ATTRIBUTE_RETURNS_NONNULL
+//
+// Tells the compiler that a particular function never returns a null pointer.
+#if OTABSL_HAVE_ATTRIBUTE(returns_nonnull) || \
+    (defined(__GNUC__) && \
+     (__GNUC__ > 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)) && \
+     !defined(__clang__))
+#define OTABSL_ATTRIBUTE_RETURNS_NONNULL __attribute__((returns_nonnull))
+#else
+#define OTABSL_ATTRIBUTE_RETURNS_NONNULL
+#endif
+
+// OTABSL_HAVE_ATTRIBUTE_SECTION
+//
+// Indicates whether labeled sections are supported. Weak symbol support is
+// a prerequisite. Labeled sections are not supported on Darwin/iOS.
+#ifdef OTABSL_HAVE_ATTRIBUTE_SECTION
+#error OTABSL_HAVE_ATTRIBUTE_SECTION cannot be directly set
+#elif (OTABSL_HAVE_ATTRIBUTE(section) ||                \
+       (defined(__GNUC__) && !defined(__clang__))) && \
+    !defined(__APPLE__) && OTABSL_HAVE_ATTRIBUTE_WEAK
+#define OTABSL_HAVE_ATTRIBUTE_SECTION 1
+
+// OTABSL_ATTRIBUTE_SECTION
+//
+// Tells the compiler/linker to put a given function into a section and define
+// `__start_ ## name` and `__stop_ ## name` symbols to bracket the section.
+// This functionality is supported by GNU linker.  Any function annotated with
+// `OTABSL_ATTRIBUTE_SECTION` must not be inlined, or it will be placed into
+// whatever section its caller is placed into.
+//
+#ifndef OTABSL_ATTRIBUTE_SECTION
+#define OTABSL_ATTRIBUTE_SECTION(name) \
+  __attribute__((section(#name))) __attribute__((noinline))
+#endif
+
+
+// OTABSL_ATTRIBUTE_SECTION_VARIABLE
+//
+// Tells the compiler/linker to put a given variable into a section and define
+// `__start_ ## name` and `__stop_ ## name` symbols to bracket the section.
+// This functionality is supported by GNU linker.
+#ifndef OTABSL_ATTRIBUTE_SECTION_VARIABLE
+#define OTABSL_ATTRIBUTE_SECTION_VARIABLE(name) __attribute__((section(#name)))
+#endif
+
+// OTABSL_DECLARE_ATTRIBUTE_SECTION_VARS
+//
+// A weak section declaration to be used as a global declaration
+// for OTABSL_ATTRIBUTE_SECTION_START|STOP(name) to compile and link
+// even without functions with OTABSL_ATTRIBUTE_SECTION(name).
+// OTABSL_DEFINE_ATTRIBUTE_SECTION should be in the exactly one file; it's
+// a no-op on ELF but not on Mach-O.
+//
+#ifndef OTABSL_DECLARE_ATTRIBUTE_SECTION_VARS
+#define OTABSL_DECLARE_ATTRIBUTE_SECTION_VARS(name) \
+  extern char __start_##name[] OTABSL_ATTRIBUTE_WEAK;    \
+  extern char __stop_##name[] OTABSL_ATTRIBUTE_WEAK
+#endif
+#ifndef OTABSL_DEFINE_ATTRIBUTE_SECTION_VARS
+#define OTABSL_INIT_ATTRIBUTE_SECTION_VARS(name)
+#define OTABSL_DEFINE_ATTRIBUTE_SECTION_VARS(name)
+#endif
+
+// OTABSL_ATTRIBUTE_SECTION_START
+//
+// Returns `void*` pointers to start/end of a section of code with
+// functions having OTABSL_ATTRIBUTE_SECTION(name).
+// Returns 0 if no such functions exist.
+// One must OTABSL_DECLARE_ATTRIBUTE_SECTION_VARS(name) for this to compile and
+// link.
+//
+#define OTABSL_ATTRIBUTE_SECTION_START(name) \
+  (reinterpret_cast<void *>(__start_##name))
+#define OTABSL_ATTRIBUTE_SECTION_STOP(name) \
+  (reinterpret_cast<void *>(__stop_##name))
+
+#else  // !OTABSL_HAVE_ATTRIBUTE_SECTION
+
+#define OTABSL_HAVE_ATTRIBUTE_SECTION 0
+
+// provide dummy definitions
+#define OTABSL_ATTRIBUTE_SECTION(name)
+#define OTABSL_ATTRIBUTE_SECTION_VARIABLE(name)
+#define OTABSL_INIT_ATTRIBUTE_SECTION_VARS(name)
+#define OTABSL_DEFINE_ATTRIBUTE_SECTION_VARS(name)
+#define OTABSL_DECLARE_ATTRIBUTE_SECTION_VARS(name)
+#define OTABSL_ATTRIBUTE_SECTION_START(name) (reinterpret_cast<void *>(0))
+#define OTABSL_ATTRIBUTE_SECTION_STOP(name) (reinterpret_cast<void *>(0))
+
+#endif  // OTABSL_ATTRIBUTE_SECTION
+
+// OTABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC
+//
+// Support for aligning the stack on 32-bit x86.
+#if OTABSL_HAVE_ATTRIBUTE(force_align_arg_pointer) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#if defined(__i386__)
+#define OTABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC \
+  __attribute__((force_align_arg_pointer))
+#define OTABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE (0)
+#elif defined(__x86_64__)
+#define OTABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE (1)
+#define OTABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC
+#else  // !__i386__ && !__x86_64
+#define OTABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE (0)
+#define OTABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC
+#endif  // __i386__
+#else
+#define OTABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC
+#define OTABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE (0)
+#endif
+
+// OTABSL_MUST_USE_RESULT
+//
+// Tells the compiler to warn about unused results.
+//
+// When annotating a function, it must appear as the first part of the
+// declaration or definition. The compiler will warn if the return value from
+// such a function is unused:
+//
+//   OTABSL_MUST_USE_RESULT Sprocket* AllocateSprocket();
+//   AllocateSprocket();  // Triggers a warning.
+//
+// When annotating a class, it is equivalent to annotating every function which
+// returns an instance.
+//
+//   class OTABSL_MUST_USE_RESULT Sprocket {};
+//   Sprocket();  // Triggers a warning.
+//
+//   Sprocket MakeSprocket();
+//   MakeSprocket();  // Triggers a warning.
+//
+// Note that references and pointers are not instances:
+//
+//   Sprocket* SprocketPointer();
+//   SprocketPointer();  // Does *not* trigger a warning.
+//
+// OTABSL_MUST_USE_RESULT allows using cast-to-void to suppress the unused result
+// warning. For that, warn_unused_result is used only for clang but not for gcc.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425
+//
+// Note: past advice was to place the macro after the argument list.
+#if OTABSL_HAVE_ATTRIBUTE(nodiscard)
+#define OTABSL_MUST_USE_RESULT [[nodiscard]]
+#elif defined(__clang__) && OTABSL_HAVE_ATTRIBUTE(warn_unused_result)
+#define OTABSL_MUST_USE_RESULT __attribute__((warn_unused_result))
+#else
+#define OTABSL_MUST_USE_RESULT
+#endif
+
+// OTABSL_ATTRIBUTE_HOT, OTABSL_ATTRIBUTE_COLD
+//
+// Tells GCC that a function is hot or cold. GCC can use this information to
+// improve static analysis, i.e. a conditional branch to a cold function
+// is likely to be not-taken.
+// This annotation is used for function declarations.
+//
+// Example:
+//
+//   int foo() OTABSL_ATTRIBUTE_HOT;
+#if OTABSL_HAVE_ATTRIBUTE(hot) || (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_ATTRIBUTE_HOT __attribute__((hot))
+#else
+#define OTABSL_ATTRIBUTE_HOT
+#endif
+
+#if OTABSL_HAVE_ATTRIBUTE(cold) || (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_ATTRIBUTE_COLD __attribute__((cold))
+#else
+#define OTABSL_ATTRIBUTE_COLD
+#endif
+
+// OTABSL_XRAY_ALWAYS_INSTRUMENT, OTABSL_XRAY_NEVER_INSTRUMENT, OTABSL_XRAY_LOG_ARGS
+//
+// We define the OTABSL_XRAY_ALWAYS_INSTRUMENT and OTABSL_XRAY_NEVER_INSTRUMENT
+// macro used as an attribute to mark functions that must always or never be
+// instrumented by XRay. Currently, this is only supported in Clang/LLVM.
+//
+// For reference on the LLVM XRay instrumentation, see
+// http://llvm.org/docs/XRay.html.
+//
+// A function with the XRAY_ALWAYS_INSTRUMENT macro attribute in its declaration
+// will always get the XRay instrumentation sleds. These sleds may introduce
+// some binary size and runtime overhead and must be used sparingly.
+//
+// These attributes only take effect when the following conditions are met:
+//
+//   * The file/target is built in at least C++11 mode, with a Clang compiler
+//     that supports XRay attributes.
+//   * The file/target is built with the -fxray-instrument flag set for the
+//     Clang/LLVM compiler.
+//   * The function is defined in the translation unit (the compiler honors the
+//     attribute in either the definition or the declaration, and must match).
+//
+// There are cases when, even when building with XRay instrumentation, users
+// might want to control specifically which functions are instrumented for a
+// particular build using special-case lists provided to the compiler. These
+// special case lists are provided to Clang via the
+// -fxray-always-instrument=... and -fxray-never-instrument=... flags. The
+// attributes in source take precedence over these special-case lists.
+//
+// To disable the XRay attributes at build-time, users may define
+// OTABSL_NO_XRAY_ATTRIBUTES. Do NOT define OTABSL_NO_XRAY_ATTRIBUTES on specific
+// packages/targets, as this may lead to conflicting definitions of functions at
+// link-time.
+//
+#if OTABSL_HAVE_CPP_ATTRIBUTE(clang::xray_always_instrument) && \
+    !defined(OTABSL_NO_XRAY_ATTRIBUTES)
+#define OTABSL_XRAY_ALWAYS_INSTRUMENT [[clang::xray_always_instrument]]
+#define OTABSL_XRAY_NEVER_INSTRUMENT [[clang::xray_never_instrument]]
+#if OTABSL_HAVE_CPP_ATTRIBUTE(clang::xray_log_args)
+#define OTABSL_XRAY_LOG_ARGS(N) \
+    [[clang::xray_always_instrument, clang::xray_log_args(N)]]
+#else
+#define OTABSL_XRAY_LOG_ARGS(N) [[clang::xray_always_instrument]]
+#endif
+#else
+#define OTABSL_XRAY_ALWAYS_INSTRUMENT
+#define OTABSL_XRAY_NEVER_INSTRUMENT
+#define OTABSL_XRAY_LOG_ARGS(N)
+#endif
+
+// OTABSL_ATTRIBUTE_REINITIALIZES
+//
+// Indicates that a member function reinitializes the entire object to a known
+// state, independent of the previous state of the object.
+//
+// The clang-tidy check bugprone-use-after-move allows member functions marked
+// with this attribute to be called on objects that have been moved from;
+// without the attribute, this would result in a use-after-move warning.
+#if OTABSL_HAVE_CPP_ATTRIBUTE(clang::reinitializes)
+#define OTABSL_ATTRIBUTE_REINITIALIZES [[clang::reinitializes]]
+#else
+#define OTABSL_ATTRIBUTE_REINITIALIZES
+#endif
+
+// -----------------------------------------------------------------------------
+// Variable Attributes
+// -----------------------------------------------------------------------------
+
+// OTABSL_ATTRIBUTE_UNUSED
+//
+// Prevents the compiler from complaining about variables that appear unused.
+#if OTABSL_HAVE_ATTRIBUTE(unused) || (defined(__GNUC__) && !defined(__clang__))
+#undef OTABSL_ATTRIBUTE_UNUSED
+#define OTABSL_ATTRIBUTE_UNUSED __attribute__((__unused__))
+#else
+#define OTABSL_ATTRIBUTE_UNUSED
+#endif
+
+// OTABSL_ATTRIBUTE_INITIAL_EXEC
+//
+// Tells the compiler to use "initial-exec" mode for a thread-local variable.
+// See http://people.redhat.com/drepper/tls.pdf for the gory details.
+#if OTABSL_HAVE_ATTRIBUTE(tls_model) || (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_ATTRIBUTE_INITIAL_EXEC __attribute__((tls_model("initial-exec")))
+#else
+#define OTABSL_ATTRIBUTE_INITIAL_EXEC
+#endif
+
+// OTABSL_ATTRIBUTE_PACKED
+//
+// Instructs the compiler not to use natural alignment for a tagged data
+// structure, but instead to reduce its alignment to 1. This attribute can
+// either be applied to members of a structure or to a structure in its
+// entirety. Applying this attribute (judiciously) to a structure in its
+// entirety to optimize the memory footprint of very commonly-used structs is
+// fine. Do not apply this attribute to a structure in its entirety if the
+// purpose is to control the offsets of the members in the structure. Instead,
+// apply this attribute only to structure members that need it.
+//
+// When applying OTABSL_ATTRIBUTE_PACKED only to specific structure members the
+// natural alignment of structure members not annotated is preserved. Aligned
+// member accesses are faster than non-aligned member accesses even if the
+// targeted microprocessor supports non-aligned accesses.
+#if OTABSL_HAVE_ATTRIBUTE(packed) || (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_ATTRIBUTE_PACKED __attribute__((__packed__))
+#else
+#define OTABSL_ATTRIBUTE_PACKED
+#endif
+
+// OTABSL_ATTRIBUTE_FUNC_ALIGN
+//
+// Tells the compiler to align the function start at least to certain
+// alignment boundary
+#if OTABSL_HAVE_ATTRIBUTE(aligned) || (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_ATTRIBUTE_FUNC_ALIGN(bytes) __attribute__((aligned(bytes)))
+#else
+#define OTABSL_ATTRIBUTE_FUNC_ALIGN(bytes)
+#endif
+
+// OTABSL_CONST_INIT
+//
+// A variable declaration annotated with the `OTABSL_CONST_INIT` attribute will
+// not compile (on supported platforms) unless the variable has a constant
+// initializer. This is useful for variables with static and thread storage
+// duration, because it guarantees that they will not suffer from the so-called
+// "static init order fiasco".  Prefer to put this attribute on the most visible
+// declaration of the variable, if there's more than one, because code that
+// accesses the variable can then use the attribute for optimization.
+//
+// Example:
+//
+//   class MyClass {
+//    public:
+//     OTABSL_CONST_INIT static MyType my_var;
+//   };
+//
+//   MyType MyClass::my_var = MakeMyType(...);
+//
+// Note that this attribute is redundant if the variable is declared constexpr.
+#if OTABSL_HAVE_CPP_ATTRIBUTE(clang::require_constant_initialization)
+#define OTABSL_CONST_INIT [[clang::require_constant_initialization]]
+#else
+#define OTABSL_CONST_INIT
+#endif  // OTABSL_HAVE_CPP_ATTRIBUTE(clang::require_constant_initialization)
+
+#endif  // OTABSL_BASE_ATTRIBUTES_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/config.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/config.h
@@ -1,0 +1,684 @@
+//
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: config.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines a set of macros for checking the presence of
+// important compiler and platform features. Such macros can be used to
+// produce portable code by parameterizing compilation based on the presence or
+// lack of a given feature.
+//
+// We define a "feature" as some interface we wish to program to: for example,
+// a library function or system call. A value of `1` indicates support for
+// that feature; any other value indicates the feature support is undefined.
+//
+// Example:
+//
+// Suppose a programmer wants to write a program that uses the 'mmap()' system
+// call. The Abseil macro for that feature (`OTABSL_HAVE_MMAP`) allows you to
+// selectively include the `mmap.h` header and bracket code using that feature
+// in the macro:
+//
+//   #include "absl/base/config.h"
+//
+//   #ifdef OTABSL_HAVE_MMAP
+//   #include "sys/mman.h"
+//   #endif  //OTABSL_HAVE_MMAP
+//
+//   ...
+//   #ifdef OTABSL_HAVE_MMAP
+//   void *ptr = mmap(...);
+//   ...
+//   #endif  // OTABSL_HAVE_MMAP
+
+#ifndef OTABSL_BASE_CONFIG_H_
+#define OTABSL_BASE_CONFIG_H_
+
+// Included for the __GLIBC__ macro (or similar macros on other systems).
+#include <limits.h>
+
+#ifdef __cplusplus
+// Included for __GLIBCXX__, _LIBCPP_VERSION
+#include <cstddef>
+#endif  // __cplusplus
+
+#if defined(__APPLE__)
+// Included for TARGET_OS_IPHONE, __IPHONE_OS_VERSION_MIN_REQUIRED,
+// __IPHONE_8_0.
+#include <Availability.h>
+#include <TargetConditionals.h>
+#endif
+
+#include "options.h"
+#include "policy_checks.h"
+
+// Helper macro to convert a CPP variable to a string literal.
+#define OTABSL_INTERNAL_DO_TOKEN_STR(x) #x
+#define OTABSL_INTERNAL_TOKEN_STR(x) OTABSL_INTERNAL_DO_TOKEN_STR(x)
+
+// -----------------------------------------------------------------------------
+// Abseil namespace annotations
+// -----------------------------------------------------------------------------
+
+// OTABSL_NAMESPACE_BEGIN/OTABSL_NAMESPACE_END
+//
+// An annotation placed at the beginning/end of each `namespace absl` scope.
+// This is used to inject an inline namespace.
+//
+// The proper way to write Abseil code in the `absl` namespace is:
+//
+// namespace absl {
+// OTABSL_NAMESPACE_BEGIN
+//
+// void Foo();  // absl::Foo().
+//
+// OTABSL_NAMESPACE_END
+// }  // namespace absl
+//
+// Users of Abseil should not use these macros, because users of Abseil should
+// not write `namespace absl {` in their own code for any reason.  (Abseil does
+// not support forward declarations of its own types, nor does it support
+// user-provided specialization of Abseil templates.  Code that violates these
+// rules may be broken without warning.)
+#if !defined(OTABSL_OPTION_USE_INLINE_NAMESPACE) || \
+    !defined(OTABSL_OPTION_INLINE_NAMESPACE_NAME)
+#error options.h is misconfigured.
+#endif
+
+// Check that OTABSL_OPTION_INLINE_NAMESPACE_NAME is neither "head" nor ""
+#if defined(__cplusplus) && OTABSL_OPTION_USE_INLINE_NAMESPACE == 1
+
+#define OTABSL_INTERNAL_INLINE_NAMESPACE_STR \
+  OTABSL_INTERNAL_TOKEN_STR(OTABSL_OPTION_INLINE_NAMESPACE_NAME)
+
+static_assert(OTABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != '\0',
+              "options.h misconfigured: OTABSL_OPTION_INLINE_NAMESPACE_NAME must "
+              "not be empty.");
+static_assert(OTABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
+                  OTABSL_INTERNAL_INLINE_NAMESPACE_STR[1] != 'e' ||
+                  OTABSL_INTERNAL_INLINE_NAMESPACE_STR[2] != 'a' ||
+                  OTABSL_INTERNAL_INLINE_NAMESPACE_STR[3] != 'd' ||
+                  OTABSL_INTERNAL_INLINE_NAMESPACE_STR[4] != '\0',
+              "options.h misconfigured: OTABSL_OPTION_INLINE_NAMESPACE_NAME must "
+              "be changed to a new, unique identifier name.");
+
+#endif
+
+#if OTABSL_OPTION_USE_INLINE_NAMESPACE == 0
+#define OTABSL_NAMESPACE_BEGIN
+#define OTABSL_NAMESPACE_END
+#elif OTABSL_OPTION_USE_INLINE_NAMESPACE == 1
+#define OTABSL_NAMESPACE_BEGIN \
+  inline namespace OTABSL_OPTION_INLINE_NAMESPACE_NAME {
+#define OTABSL_NAMESPACE_END }
+#else
+#error options.h is misconfigured.
+#endif
+
+// -----------------------------------------------------------------------------
+// Compiler Feature Checks
+// -----------------------------------------------------------------------------
+
+// OTABSL_HAVE_BUILTIN()
+//
+// Checks whether the compiler supports a Clang Feature Checking Macro, and if
+// so, checks whether it supports the provided builtin function "x" where x
+// is one of the functions noted in
+// https://clang.llvm.org/docs/LanguageExtensions.html
+//
+// Note: Use this macro to avoid an extra level of #ifdef __has_builtin check.
+// http://releases.llvm.org/3.3/tools/clang/docs/LanguageExtensions.html
+#ifdef __has_builtin
+#define OTABSL_HAVE_BUILTIN(x) __has_builtin(x)
+#else
+#define OTABSL_HAVE_BUILTIN(x) 0
+#endif
+
+#if defined(__is_identifier)
+#define OTABSL_INTERNAL_HAS_KEYWORD(x) !(__is_identifier(x))
+#else
+#define OTABSL_INTERNAL_HAS_KEYWORD(x) 0
+#endif
+
+// OTABSL_HAVE_TLS is defined to 1 when __thread should be supported.
+// We assume __thread is supported on Linux when compiled with Clang or compiled
+// against libstdc++ with _GLIBCXX_HAVE_TLS defined.
+#ifdef OTABSL_HAVE_TLS
+#error OTABSL_HAVE_TLS cannot be directly set
+#elif defined(__linux__) && (defined(__clang__) || defined(_GLIBCXX_HAVE_TLS))
+#define OTABSL_HAVE_TLS 1
+#endif
+
+// OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
+//
+// Checks whether `std::is_trivially_destructible<T>` is supported.
+//
+// Notes: All supported compilers using libc++ support this feature, as does
+// gcc >= 4.8.1 using libstdc++, and Visual Studio.
+#ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
+#error OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE cannot be directly set
+#elif defined(_LIBCPP_VERSION) ||                                        \
+    (defined(__clang__) && __clang_major__ >= 15) ||                     \
+    (!defined(__clang__) && defined(__GNUC__) && defined(__GLIBCXX__) && \
+     (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))) ||        \
+    defined(_MSC_VER)
+#define OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE 1
+#endif
+
+// OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE
+//
+// Checks whether `std::is_trivially_default_constructible<T>` and
+// `std::is_trivially_copy_constructible<T>` are supported.
+
+// OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
+//
+// Checks whether `std::is_trivially_copy_assignable<T>` is supported.
+
+// Notes: Clang with libc++ supports these features, as does gcc >= 5.1 with
+// either libc++ or libstdc++, and Visual Studio (but not NVCC).
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE)
+#error OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE cannot be directly set
+#elif defined(OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE)
+#error OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE cannot directly set
+#elif (defined(__clang__) && defined(_LIBCPP_VERSION)) ||        \
+    (defined(__clang__) && __clang_major__ >= 15) ||             \
+    (!defined(__clang__) && defined(__GNUC__) &&                 \
+     (__GNUC__ > 7 || (__GNUC__ == 7 && __GNUC_MINOR__ >= 4)) && \
+     (defined(_LIBCPP_VERSION) || defined(__GLIBCXX__))) ||      \
+    (defined(_MSC_VER) && !defined(__NVCC__))
+#define OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE 1
+#define OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE 1
+#endif
+
+// OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE
+//
+// Checks whether `std::is_trivially_copyable<T>` is supported.
+//
+// Notes: Clang 15+ with libc++ supports these features, GCC hasn't been tested.
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE)
+#error OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE cannot be directly set
+#elif defined(__clang__) && (__clang_major__ >= 15)
+#define OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE 1
+#endif
+
+// OTABSL_HAVE_SOURCE_LOCATION_CURRENT
+//
+// Indicates whether `absl::SourceLocation::current()` will return useful
+// information in some contexts.
+#ifndef OTABSL_HAVE_SOURCE_LOCATION_CURRENT
+#if OTABSL_INTERNAL_HAS_KEYWORD(__builtin_LINE) && \
+    OTABSL_INTERNAL_HAS_KEYWORD(__builtin_FILE)
+#define OTABSL_HAVE_SOURCE_LOCATION_CURRENT 1
+#endif
+#endif
+
+// OTABSL_HAVE_THREAD_LOCAL
+//
+// Checks whether C++11's `thread_local` storage duration specifier is
+// supported.
+#ifdef OTABSL_HAVE_THREAD_LOCAL
+#error OTABSL_HAVE_THREAD_LOCAL cannot be directly set
+#elif defined(__APPLE__)
+// Notes:
+// * Xcode's clang did not support `thread_local` until version 8, and
+//   even then not for all iOS < 9.0.
+// * Xcode 9.3 started disallowing `thread_local` for 32-bit iOS simulator
+//   targeting iOS 9.x.
+// * Xcode 10 moves the deployment target check for iOS < 9.0 to link time
+//   making __has_feature unreliable there.
+//
+// Otherwise, `__has_feature` is only supported by Clang so it has be inside
+// `defined(__APPLE__)` check.
+#if __has_feature(cxx_thread_local) && \
+    !(TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)
+#define OTABSL_HAVE_THREAD_LOCAL 1
+#endif
+#else  // !defined(__APPLE__)
+#define OTABSL_HAVE_THREAD_LOCAL 1
+#endif
+
+// There are platforms for which TLS should not be used even though the compiler
+// makes it seem like it's supported (Android NDK < r12b for example).
+// This is primarily because of linker problems and toolchain misconfiguration:
+// Abseil does not intend to support this indefinitely. Currently, the newest
+// toolchain that we intend to support that requires this behavior is the
+// r11 NDK - allowing for a 5 year support window on that means this option
+// is likely to be removed around June of 2021.
+// TLS isn't supported until NDK r12b per
+// https://developer.android.com/ndk/downloads/revision_history.html
+// Since NDK r16, `__NDK_MAJOR__` and `__NDK_MINOR__` are defined in
+// <android/ndk-version.h>. For NDK < r16, users should define these macros,
+// e.g. `-D__NDK_MAJOR__=11 -D__NKD_MINOR__=0` for NDK r11.
+#if defined(__ANDROID__) && defined(__clang__)
+#if __has_include(<android/ndk-version.h>)
+#include <android/ndk-version.h>
+#endif  // __has_include(<android/ndk-version.h>)
+#if defined(__ANDROID__) && defined(__clang__) && defined(__NDK_MAJOR__) && \
+    defined(__NDK_MINOR__) &&                                               \
+    ((__NDK_MAJOR__ < 12) || ((__NDK_MAJOR__ == 12) && (__NDK_MINOR__ < 1)))
+#undef OTABSL_HAVE_TLS
+#undef OTABSL_HAVE_THREAD_LOCAL
+#endif
+#endif  // defined(__ANDROID__) && defined(__clang__)
+
+// Emscripten doesn't yet support `thread_local` or `__thread`.
+// https://github.com/emscripten-core/emscripten/issues/3502
+#if defined(__EMSCRIPTEN__)
+#undef OTABSL_HAVE_TLS
+#undef OTABSL_HAVE_THREAD_LOCAL
+#endif  // defined(__EMSCRIPTEN__)
+
+// OTABSL_HAVE_INTRINSIC_INT128
+//
+// Checks whether the __int128 compiler extension for a 128-bit integral type is
+// supported.
+//
+// Note: __SIZEOF_INT128__ is defined by Clang and GCC when __int128 is
+// supported, but we avoid using it in certain cases:
+// * On Clang:
+//   * Building using Clang for Windows, where the Clang runtime library has
+//     128-bit support only on LP64 architectures, but Windows is LLP64.
+// * On Nvidia's nvcc:
+//   * nvcc also defines __GNUC__ and __SIZEOF_INT128__, but not all versions
+//     actually support __int128.
+#ifdef OTABSL_HAVE_INTRINSIC_INT128
+#error OTABSL_HAVE_INTRINSIC_INT128 cannot be directly set
+#elif defined(__SIZEOF_INT128__)
+#if (defined(__clang__) && !defined(_WIN32)) || \
+    (defined(__CUDACC__) && __CUDACC_VER_MAJOR__ >= 9) ||                \
+    (defined(__GNUC__) && !defined(__clang__) && !defined(__CUDACC__))
+#define OTABSL_HAVE_INTRINSIC_INT128 1
+#elif defined(__CUDACC__)
+// __CUDACC_VER__ is a full version number before CUDA 9, and is defined to a
+// string explaining that it has been removed starting with CUDA 9. We use
+// nested #ifs because there is no short-circuiting in the preprocessor.
+// NOTE: `__CUDACC__` could be undefined while `__CUDACC_VER__` is defined.
+#if __CUDACC_VER__ >= 70000
+#define OTABSL_HAVE_INTRINSIC_INT128 1
+#endif  // __CUDACC_VER__ >= 70000
+#endif  // defined(__CUDACC__)
+#endif  // OTABSL_HAVE_INTRINSIC_INT128
+
+// OTABSL_HAVE_EXCEPTIONS
+//
+// Checks whether the compiler both supports and enables exceptions. Many
+// compilers support a "no exceptions" mode that disables exceptions.
+//
+// Generally, when OTABSL_HAVE_EXCEPTIONS is not defined:
+//
+// * Code using `throw` and `try` may not compile.
+// * The `noexcept` specifier will still compile and behave as normal.
+// * The `noexcept` operator may still return `false`.
+//
+// For further details, consult the compiler's documentation.
+#ifdef OTABSL_HAVE_EXCEPTIONS
+#error OTABSL_HAVE_EXCEPTIONS cannot be directly set.
+
+#elif defined(__clang__)
+
+#if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6)
+// Clang >= 3.6
+#if __has_feature(cxx_exceptions)
+#define OTABSL_HAVE_EXCEPTIONS 1
+#endif  // __has_feature(cxx_exceptions)
+#else
+// Clang < 3.6
+// http://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html#the-exceptions-macro
+#if defined(__EXCEPTIONS) && __has_feature(cxx_exceptions)
+#define OTABSL_HAVE_EXCEPTIONS 1
+#endif  // defined(__EXCEPTIONS) && __has_feature(cxx_exceptions)
+#endif  // __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6)
+
+// Handle remaining special cases and default to exceptions being supported.
+#elif !(defined(__GNUC__) && (__GNUC__ < 5) && !defined(__EXCEPTIONS)) &&    \
+    !(defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__cpp_exceptions)) && \
+    !(defined(_MSC_VER) && !defined(_CPPUNWIND))
+#define OTABSL_HAVE_EXCEPTIONS 1
+#endif
+
+// -----------------------------------------------------------------------------
+// Platform Feature Checks
+// -----------------------------------------------------------------------------
+
+// Currently supported operating systems and associated preprocessor
+// symbols:
+//
+//   Linux and Linux-derived           __linux__
+//   Android                           __ANDROID__ (implies __linux__)
+//   Linux (non-Android)               __linux__ && !__ANDROID__
+//   Darwin (macOS and iOS)            __APPLE__
+//   Akaros (http://akaros.org)        __ros__
+//   Windows                           _WIN32
+//   NaCL                              __native_client__
+//   AsmJS                             __asmjs__
+//   WebAssembly                       __wasm__
+//   Fuchsia                           __Fuchsia__
+//
+// Note that since Android defines both __ANDROID__ and __linux__, one
+// may probe for either Linux or Android by simply testing for __linux__.
+
+// OTABSL_HAVE_MMAP
+//
+// Checks whether the platform has an mmap(2) implementation as defined in
+// POSIX.1-2001.
+#ifdef OTABSL_HAVE_MMAP
+#error OTABSL_HAVE_MMAP cannot be directly set
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) ||   \
+    defined(__ros__) || defined(__native_client__) || defined(__asmjs__) || \
+    defined(__wasm__) || defined(__Fuchsia__) || defined(__sun) || \
+    defined(__ASYLO__)
+#define OTABSL_HAVE_MMAP 1
+#endif
+
+// OTABSL_HAVE_PTHREAD_GETSCHEDPARAM
+//
+// Checks whether the platform implements the pthread_(get|set)schedparam(3)
+// functions as defined in POSIX.1-2001.
+#ifdef OTABSL_HAVE_PTHREAD_GETSCHEDPARAM
+#error OTABSL_HAVE_PTHREAD_GETSCHEDPARAM cannot be directly set
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || \
+    defined(__ros__)
+#define OTABSL_HAVE_PTHREAD_GETSCHEDPARAM 1
+#endif
+
+// OTABSL_HAVE_SCHED_YIELD
+//
+// Checks whether the platform implements sched_yield(2) as defined in
+// POSIX.1-2001.
+#ifdef OTABSL_HAVE_SCHED_YIELD
+#error OTABSL_HAVE_SCHED_YIELD cannot be directly set
+#elif defined(__linux__) || defined(__ros__) || defined(__native_client__)
+#define OTABSL_HAVE_SCHED_YIELD 1
+#endif
+
+// OTABSL_HAVE_SEMAPHORE_H
+//
+// Checks whether the platform supports the <semaphore.h> header and sem_init(3)
+// family of functions as standardized in POSIX.1-2001.
+//
+// Note: While Apple provides <semaphore.h> for both iOS and macOS, it is
+// explicitly deprecated and will cause build failures if enabled for those
+// platforms.  We side-step the issue by not defining it here for Apple
+// platforms.
+#ifdef OTABSL_HAVE_SEMAPHORE_H
+#error OTABSL_HAVE_SEMAPHORE_H cannot be directly set
+#elif defined(__linux__) || defined(__ros__)
+#define OTABSL_HAVE_SEMAPHORE_H 1
+#endif
+
+// OTABSL_HAVE_ALARM
+//
+// Checks whether the platform supports the <signal.h> header and alarm(2)
+// function as standardized in POSIX.1-2001.
+#ifdef OTABSL_HAVE_ALARM
+#error OTABSL_HAVE_ALARM cannot be directly set
+#elif defined(__GOOGLE_GRTE_VERSION__)
+// feature tests for Google's GRTE
+#define OTABSL_HAVE_ALARM 1
+#elif defined(__GLIBC__)
+// feature test for glibc
+#define OTABSL_HAVE_ALARM 1
+#elif defined(_MSC_VER)
+// feature tests for Microsoft's library
+#elif defined(__MINGW32__)
+// mingw32 doesn't provide alarm(2):
+// https://osdn.net/projects/mingw/scm/git/mingw-org-wsl/blobs/5.2-trunk/mingwrt/include/unistd.h
+// mingw-w64 provides a no-op implementation:
+// https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-crt/misc/alarm.c
+#elif defined(__EMSCRIPTEN__)
+// emscripten doesn't support signals
+#elif defined(__Fuchsia__)
+// Signals don't exist on fuchsia.
+#elif defined(__native_client__)
+#else
+// other standard libraries
+#define OTABSL_HAVE_ALARM 1
+#endif
+
+// OTABSL_IS_LITTLE_ENDIAN
+// OTABSL_IS_BIG_ENDIAN
+//
+// Checks the endianness of the platform.
+//
+// Notes: uses the built in endian macros provided by GCC (since 4.6) and
+// Clang (since 3.2); see
+// https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html.
+// Otherwise, if _WIN32, assume little endian. Otherwise, bail with an error.
+#if defined(OTABSL_IS_BIG_ENDIAN)
+#error "OTABSL_IS_BIG_ENDIAN cannot be directly set."
+#endif
+#if defined(OTABSL_IS_LITTLE_ENDIAN)
+#error "OTABSL_IS_LITTLE_ENDIAN cannot be directly set."
+#endif
+
+#if (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+     __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define OTABSL_IS_LITTLE_ENDIAN 1
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define OTABSL_IS_BIG_ENDIAN 1
+#elif defined(_WIN32)
+#define OTABSL_IS_LITTLE_ENDIAN 1
+#else
+#error "absl endian detection needs to be set up for your compiler"
+#endif
+
+// macOS 10.13 and iOS 10.11 don't let you use <any>, <optional>, or <variant>
+// even though the headers exist and are publicly noted to work.  See
+// https://github.com/abseil/abseil-cpp/issues/207 and
+// https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes
+// libc++ spells out the availability requirements in the file
+// llvm-project/libcxx/include/__config via the #define
+// _LIBCPP_AVAILABILITY_BAD_OPTIONAL_ACCESS.
+#if defined(__APPLE__) && defined(_LIBCPP_VERSION) && \
+  ((defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && \
+   __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101400) || \
+  (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && \
+   __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 120000) || \
+  (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && \
+   __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 120000) || \
+  (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && \
+   __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 50000))
+#define OTABSL_INTERNAL_APPLE_CXX17_TYPES_UNAVAILABLE 1
+#else
+#define OTABSL_INTERNAL_APPLE_CXX17_TYPES_UNAVAILABLE 0
+#endif
+
+// OTABSL_HAVE_STD_ANY
+//
+// Checks whether C++17 std::any is available by checking whether <any> exists.
+#ifdef OTABSL_HAVE_STD_ANY
+#error "OTABSL_HAVE_STD_ANY cannot be directly set."
+#endif
+
+#ifdef __has_include
+#if __has_include(<any>) && __cplusplus >= 201703L && \
+    !OTABSL_INTERNAL_APPLE_CXX17_TYPES_UNAVAILABLE
+#define OTABSL_HAVE_STD_ANY 1
+#endif
+#endif
+
+// OTABSL_HAVE_STD_OPTIONAL
+//
+// Checks whether C++17 std::optional is available.
+#ifdef OTABSL_HAVE_STD_OPTIONAL
+#error "OTABSL_HAVE_STD_OPTIONAL cannot be directly set."
+#endif
+
+#ifdef __has_include
+#if __has_include(<optional>) && __cplusplus >= 201703L && \
+    !OTABSL_INTERNAL_APPLE_CXX17_TYPES_UNAVAILABLE
+#define OTABSL_HAVE_STD_OPTIONAL 1
+#endif
+#endif
+
+// OTABSL_HAVE_STD_VARIANT
+//
+// Checks whether C++17 std::variant is available.
+#ifdef OTABSL_HAVE_STD_VARIANT
+#error "OTABSL_HAVE_STD_VARIANT cannot be directly set."
+#endif
+
+#ifdef __has_include
+#if __has_include(<variant>) && __cplusplus >= 201703L && \
+    !OTABSL_INTERNAL_APPLE_CXX17_TYPES_UNAVAILABLE
+#define OTABSL_HAVE_STD_VARIANT 1
+#endif
+#endif
+
+// OTABSL_HAVE_STD_STRING_VIEW
+//
+// Checks whether C++17 std::string_view is available.
+#ifdef OTABSL_HAVE_STD_STRING_VIEW
+#error "OTABSL_HAVE_STD_STRING_VIEW cannot be directly set."
+#endif
+
+#ifdef __has_include
+#if __has_include(<string_view>) && __cplusplus >= 201703L
+#define OTABSL_HAVE_STD_STRING_VIEW 1
+#endif
+#endif
+
+// For MSVC, `__has_include` is supported in VS 2017 15.3, which is later than
+// the support for <optional>, <any>, <string_view>, <variant>. So we use
+// _MSC_VER to check whether we have VS 2017 RTM (when <optional>, <any>,
+// <string_view>, <variant> is implemented) or higher. Also, `__cplusplus` is
+// not correctly set by MSVC, so we use `_MSVC_LANG` to check the language
+// version.
+// TODO(zhangxy): fix tests before enabling aliasing for `std::any`.
+#if defined(_MSC_VER) && _MSC_VER >= 1910 && \
+    ((defined(_MSVC_LANG) && _MSVC_LANG > 201402) || __cplusplus > 201402)
+// #define OTABSL_HAVE_STD_ANY 1
+#define OTABSL_HAVE_STD_OPTIONAL 1
+#define OTABSL_HAVE_STD_VARIANT 1
+#define OTABSL_HAVE_STD_STRING_VIEW 1
+#endif
+
+// OTABSL_USES_STD_ANY
+//
+// Indicates whether absl::any is an alias for std::any.
+#if !defined(OTABSL_OPTION_USE_STD_ANY)
+#error options.h is misconfigured.
+#elif OTABSL_OPTION_USE_STD_ANY == 0 || \
+    (OTABSL_OPTION_USE_STD_ANY == 2 && !defined(OTABSL_HAVE_STD_ANY))
+#undef OTABSL_USES_STD_ANY
+#elif OTABSL_OPTION_USE_STD_ANY == 1 || \
+    (OTABSL_OPTION_USE_STD_ANY == 2 && defined(OTABSL_HAVE_STD_ANY))
+#define OTABSL_USES_STD_ANY 1
+#else
+#error options.h is misconfigured.
+#endif
+
+// OTABSL_USES_STD_OPTIONAL
+//
+// Indicates whether absl::optional is an alias for std::optional.
+#if !defined(OTABSL_OPTION_USE_STD_OPTIONAL)
+#error options.h is misconfigured.
+#elif OTABSL_OPTION_USE_STD_OPTIONAL == 0 || \
+    (OTABSL_OPTION_USE_STD_OPTIONAL == 2 && !defined(OTABSL_HAVE_STD_OPTIONAL))
+#undef OTABSL_USES_STD_OPTIONAL
+#elif OTABSL_OPTION_USE_STD_OPTIONAL == 1 || \
+    (OTABSL_OPTION_USE_STD_OPTIONAL == 2 && defined(OTABSL_HAVE_STD_OPTIONAL))
+#define OTABSL_USES_STD_OPTIONAL 1
+#else
+#error options.h is misconfigured.
+#endif
+
+// OTABSL_USES_STD_VARIANT
+//
+// Indicates whether absl::variant is an alias for std::variant.
+#if !defined(OTABSL_OPTION_USE_STD_VARIANT)
+#error options.h is misconfigured.
+#elif OTABSL_OPTION_USE_STD_VARIANT == 0 || \
+    (OTABSL_OPTION_USE_STD_VARIANT == 2 && !defined(OTABSL_HAVE_STD_VARIANT))
+#undef OTABSL_USES_STD_VARIANT
+#elif OTABSL_OPTION_USE_STD_VARIANT == 1 || \
+    (OTABSL_OPTION_USE_STD_VARIANT == 2 && defined(OTABSL_HAVE_STD_VARIANT))
+#define OTABSL_USES_STD_VARIANT 1
+#else
+#error options.h is misconfigured.
+#endif
+
+// OTABSL_USES_STD_STRING_VIEW
+//
+// Indicates whether absl::string_view is an alias for std::string_view.
+#if !defined(OTABSL_OPTION_USE_STD_STRING_VIEW)
+#error options.h is misconfigured.
+#elif OTABSL_OPTION_USE_STD_STRING_VIEW == 0 || \
+    (OTABSL_OPTION_USE_STD_STRING_VIEW == 2 &&  \
+     !defined(OTABSL_HAVE_STD_STRING_VIEW))
+#undef OTABSL_USES_STD_STRING_VIEW
+#elif OTABSL_OPTION_USE_STD_STRING_VIEW == 1 || \
+    (OTABSL_OPTION_USE_STD_STRING_VIEW == 2 &&  \
+     defined(OTABSL_HAVE_STD_STRING_VIEW))
+#define OTABSL_USES_STD_STRING_VIEW 1
+#else
+#error options.h is misconfigured.
+#endif
+
+// In debug mode, MSVC 2017's std::variant throws a EXCEPTION_ACCESS_VIOLATION
+// SEH exception from emplace for variant<SomeStruct> when constructing the
+// struct can throw. This defeats some of variant_test and
+// variant_exception_safety_test.
+#if defined(_MSC_VER) && _MSC_VER >= 1700 && defined(_DEBUG)
+#define OTABSL_INTERNAL_MSVC_2017_DBG_MODE
+#endif
+
+// OTABSL_INTERNAL_MANGLED_NS
+// OTABSL_INTERNAL_MANGLED_BACKREFERENCE
+//
+// Internal macros for building up mangled names in our internal fork of CCTZ.
+// This implementation detail is only needed and provided for the MSVC build.
+//
+// These macros both expand to string literals.  OTABSL_INTERNAL_MANGLED_NS is
+// the mangled spelling of the `absl` namespace, and
+// OTABSL_INTERNAL_MANGLED_BACKREFERENCE is a back-reference integer representing
+// the proper count to skip past the CCTZ fork namespace names.  (This number
+// is one larger when there is an inline namespace name to skip.)
+#if defined(_MSC_VER)
+#if OTABSL_OPTION_USE_INLINE_NAMESPACE == 0
+#define OTABSL_INTERNAL_MANGLED_NS "absl"
+#define OTABSL_INTERNAL_MANGLED_BACKREFERENCE "5"
+#else
+#define OTABSL_INTERNAL_MANGLED_NS \
+  OTABSL_INTERNAL_TOKEN_STR(OTABSL_OPTION_INLINE_NAMESPACE_NAME) "@absl"
+#define OTABSL_INTERNAL_MANGLED_BACKREFERENCE "6"
+#endif
+#endif
+
+#undef OTABSL_INTERNAL_HAS_KEYWORD
+
+// OTABSL_DLL
+//
+// When building Abseil as a DLL, this macro expands to `__declspec(dllexport)`
+// so we can annotate symbols appropriately as being exported. When used in
+// headers consuming a DLL, this macro expands to `__declspec(dllimport)` so
+// that consumers know the symbol is defined inside the DLL. In all other cases,
+// the macro expands to nothing.
+#if defined(_MSC_VER)
+#if defined(OTABSL_BUILD_DLL)
+#define OTABSL_DLL __declspec(dllexport)
+#elif 1
+#define OTABSL_DLL __declspec(dllimport)
+#else
+#define OTABSL_DLL
+#endif
+#else
+#define OTABSL_DLL
+#endif  // defined(_MSC_VER)
+
+#endif  // OTABSL_BASE_CONFIG_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/internal/identity.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/internal/identity.h
@@ -1,0 +1,37 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef OTABSL_BASE_INTERNAL_IDENTITY_H_
+#define OTABSL_BASE_INTERNAL_IDENTITY_H_
+
+#include "../config.h"
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+namespace internal {
+
+template <typename T>
+struct identity {
+  typedef T type;
+};
+
+template <typename T>
+using identity_t = typename identity<T>::type;
+
+}  // namespace internal
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // OTABSL_BASE_INTERNAL_IDENTITY_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/internal/inline_variable.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/internal/inline_variable.h
@@ -1,0 +1,107 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OTABSL_BASE_INTERNAL_INLINE_VARIABLE_EMULATION_H_
+#define OTABSL_BASE_INTERNAL_INLINE_VARIABLE_EMULATION_H_
+
+#include <type_traits>
+
+#include "identity.h"
+
+// File:
+//   This file define a macro that allows the creation of or emulation of C++17
+//   inline variables based on whether or not the feature is supported.
+
+////////////////////////////////////////////////////////////////////////////////
+// Macro: OTABSL_INTERNAL_INLINE_CONSTEXPR(type, name, init)
+//
+// Description:
+//   Expands to the equivalent of an inline constexpr instance of the specified
+//   `type` and `name`, initialized to the value `init`. If the compiler being
+//   used is detected as supporting actual inline variables as a language
+//   feature, then the macro expands to an actual inline variable definition.
+//
+// Requires:
+//   `type` is a type that is usable in an extern variable declaration.
+//
+// Requires: `name` is a valid identifier
+//
+// Requires:
+//   `init` is an expression that can be used in the following definition:
+//     constexpr type name = init;
+//
+// Usage:
+//
+//   // Equivalent to: `inline constexpr size_t variant_npos = -1;`
+//   OTABSL_INTERNAL_INLINE_CONSTEXPR(size_t, variant_npos, -1);
+//
+// Differences in implementation:
+//   For a direct, language-level inline variable, decltype(name) will be the
+//   type that was specified along with const qualification, whereas for
+//   emulated inline variables, decltype(name) may be different (in practice
+//   it will likely be a reference type).
+////////////////////////////////////////////////////////////////////////////////
+
+#ifdef __cpp_inline_variables
+
+// Clang's -Wmissing-variable-declarations option erroneously warned that
+// inline constexpr objects need to be pre-declared. This has now been fixed,
+// but we will need to support this workaround for people building with older
+// versions of clang.
+//
+// Bug: https://bugs.llvm.org/show_bug.cgi?id=35862
+//
+// Note:
+//   identity_t is used here so that the const and name are in the
+//   appropriate place for pointer types, reference types, function pointer
+//   types, etc..
+#if defined(__clang__)
+#define OTABSL_INTERNAL_EXTERN_DECL(type, name) \
+  extern const ::absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::internal::identity_t<type> name;
+#else  // Otherwise, just define the macro to do nothing.
+#define OTABSL_INTERNAL_EXTERN_DECL(type, name)
+#endif  // defined(__clang__)
+
+// See above comment at top of file for details.
+#define OTABSL_INTERNAL_INLINE_CONSTEXPR(type, name, init) \
+  OTABSL_INTERNAL_EXTERN_DECL(type, name)                  \
+  inline constexpr ::absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::internal::identity_t<type> name = init
+
+#else
+
+// See above comment at top of file for details.
+//
+// Note:
+//   identity_t is used here so that the const and name are in the
+//   appropriate place for pointer types, reference types, function pointer
+//   types, etc..
+#define OTABSL_INTERNAL_INLINE_CONSTEXPR(var_type, name, init)                  \
+  template <class /*AbslInternalDummy*/ = void>                               \
+  struct AbslInternalInlineVariableHolder##name {                             \
+    static constexpr ::absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::internal::identity_t<var_type> kInstance = init; \
+  };                                                                          \
+                                                                              \
+  template <class AbslInternalDummy>                                          \
+  constexpr ::absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::internal::identity_t<var_type>                            \
+      AbslInternalInlineVariableHolder##name<AbslInternalDummy>::kInstance;   \
+                                                                              \
+  static constexpr const ::absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::internal::identity_t<var_type>&              \
+      name = /* NOLINT */                                                     \
+      AbslInternalInlineVariableHolder##name<>::kInstance;                    \
+  static_assert(sizeof(void (*)(decltype(name))) != 0,                        \
+                "Silence unused variable warnings.")
+
+#endif  // __cpp_inline_variables
+
+#endif  // OTABSL_BASE_INTERNAL_INLINE_VARIABLE_EMULATION_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/internal/invoke.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/internal/invoke.h
@@ -1,0 +1,188 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// absl::base_internal::Invoke(f, args...) is an implementation of
+// INVOKE(f, args...) from section [func.require] of the C++ standard.
+//
+// [func.require]
+// Define INVOKE (f, t1, t2, ..., tN) as follows:
+// 1. (t1.*f)(t2, ..., tN) when f is a pointer to a member function of a class T
+//    and t1 is an object of type T or a reference to an object of type T or a
+//    reference to an object of a type derived from T;
+// 2. ((*t1).*f)(t2, ..., tN) when f is a pointer to a member function of a
+//    class T and t1 is not one of the types described in the previous item;
+// 3. t1.*f when N == 1 and f is a pointer to member data of a class T and t1 is
+//    an object of type T or a reference to an object of type T or a reference
+//    to an object of a type derived from T;
+// 4. (*t1).*f when N == 1 and f is a pointer to member data of a class T and t1
+//    is not one of the types described in the previous item;
+// 5. f(t1, t2, ..., tN) in all other cases.
+//
+// The implementation is SFINAE-friendly: substitution failure within Invoke()
+// isn't an error.
+
+#ifndef OTABSL_BASE_INTERNAL_INVOKE_H_
+#define OTABSL_BASE_INTERNAL_INVOKE_H_
+
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+
+#include "../../meta/type_traits.h"
+
+// The following code is internal implementation detail.  See the comment at the
+// top of this file for the API documentation.
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+namespace base_internal {
+
+// The five classes below each implement one of the clauses from the definition
+// of INVOKE. The inner class template Accept<F, Args...> checks whether the
+// clause is applicable; static function template Invoke(f, args...) does the
+// invocation.
+//
+// By separating the clause selection logic from invocation we make sure that
+// Invoke() does exactly what the standard says.
+
+template <typename Derived>
+struct StrippedAccept {
+  template <typename... Args>
+  struct Accept : Derived::template AcceptImpl<typename std::remove_cv<
+                      typename std::remove_reference<Args>::type>::type...> {};
+};
+
+// (t1.*f)(t2, ..., tN) when f is a pointer to a member function of a class T
+// and t1 is an object of type T or a reference to an object of type T or a
+// reference to an object of a type derived from T.
+struct MemFunAndRef : StrippedAccept<MemFunAndRef> {
+  template <typename... Args>
+  struct AcceptImpl : std::false_type {};
+
+  template <typename MemFunType, typename C, typename Obj, typename... Args>
+  struct AcceptImpl<MemFunType C::*, Obj, Args...>
+      : std::integral_constant<bool, std::is_base_of<C, Obj>::value &&
+                                         absl::is_function<MemFunType>::value> {
+  };
+
+  template <typename MemFun, typename Obj, typename... Args>
+  static decltype((std::declval<Obj>().*
+                   std::declval<MemFun>())(std::declval<Args>()...))
+  Invoke(MemFun&& mem_fun, Obj&& obj, Args&&... args) {
+    return (std::forward<Obj>(obj).*
+            std::forward<MemFun>(mem_fun))(std::forward<Args>(args)...);
+  }
+};
+
+// ((*t1).*f)(t2, ..., tN) when f is a pointer to a member function of a
+// class T and t1 is not one of the types described in the previous item.
+struct MemFunAndPtr : StrippedAccept<MemFunAndPtr> {
+  template <typename... Args>
+  struct AcceptImpl : std::false_type {};
+
+  template <typename MemFunType, typename C, typename Ptr, typename... Args>
+  struct AcceptImpl<MemFunType C::*, Ptr, Args...>
+      : std::integral_constant<bool, !std::is_base_of<C, Ptr>::value &&
+                                         absl::is_function<MemFunType>::value> {
+  };
+
+  template <typename MemFun, typename Ptr, typename... Args>
+  static decltype(((*std::declval<Ptr>()).*
+                   std::declval<MemFun>())(std::declval<Args>()...))
+  Invoke(MemFun&& mem_fun, Ptr&& ptr, Args&&... args) {
+    return ((*std::forward<Ptr>(ptr)).*
+            std::forward<MemFun>(mem_fun))(std::forward<Args>(args)...);
+  }
+};
+
+// t1.*f when N == 1 and f is a pointer to member data of a class T and t1 is
+// an object of type T or a reference to an object of type T or a reference
+// to an object of a type derived from T.
+struct DataMemAndRef : StrippedAccept<DataMemAndRef> {
+  template <typename... Args>
+  struct AcceptImpl : std::false_type {};
+
+  template <typename R, typename C, typename Obj>
+  struct AcceptImpl<R C::*, Obj>
+      : std::integral_constant<bool, std::is_base_of<C, Obj>::value &&
+                                         !absl::is_function<R>::value> {};
+
+  template <typename DataMem, typename Ref>
+  static decltype(std::declval<Ref>().*std::declval<DataMem>()) Invoke(
+      DataMem&& data_mem, Ref&& ref) {
+    return std::forward<Ref>(ref).*std::forward<DataMem>(data_mem);
+  }
+};
+
+// (*t1).*f when N == 1 and f is a pointer to member data of a class T and t1
+// is not one of the types described in the previous item.
+struct DataMemAndPtr : StrippedAccept<DataMemAndPtr> {
+  template <typename... Args>
+  struct AcceptImpl : std::false_type {};
+
+  template <typename R, typename C, typename Ptr>
+  struct AcceptImpl<R C::*, Ptr>
+      : std::integral_constant<bool, !std::is_base_of<C, Ptr>::value &&
+                                         !absl::is_function<R>::value> {};
+
+  template <typename DataMem, typename Ptr>
+  static decltype((*std::declval<Ptr>()).*std::declval<DataMem>()) Invoke(
+      DataMem&& data_mem, Ptr&& ptr) {
+    return (*std::forward<Ptr>(ptr)).*std::forward<DataMem>(data_mem);
+  }
+};
+
+// f(t1, t2, ..., tN) in all other cases.
+struct Callable {
+  // Callable doesn't have Accept because it's the last clause that gets picked
+  // when none of the previous clauses are applicable.
+  template <typename F, typename... Args>
+  static decltype(std::declval<F>()(std::declval<Args>()...)) Invoke(
+      F&& f, Args&&... args) {
+    return std::forward<F>(f)(std::forward<Args>(args)...);
+  }
+};
+
+// Resolves to the first matching clause.
+template <typename... Args>
+struct Invoker {
+  typedef typename std::conditional<
+      MemFunAndRef::Accept<Args...>::value, MemFunAndRef,
+      typename std::conditional<
+          MemFunAndPtr::Accept<Args...>::value, MemFunAndPtr,
+          typename std::conditional<
+              DataMemAndRef::Accept<Args...>::value, DataMemAndRef,
+              typename std::conditional<DataMemAndPtr::Accept<Args...>::value,
+                                        DataMemAndPtr, Callable>::type>::type>::
+          type>::type type;
+};
+
+// The result type of Invoke<F, Args...>.
+template <typename F, typename... Args>
+using InvokeT = decltype(Invoker<F, Args...>::type::Invoke(
+    std::declval<F>(), std::declval<Args>()...));
+
+// Invoke(f, args...) is an implementation of INVOKE(f, args...) from section
+// [func.require] of the C++ standard.
+template <typename F, typename... Args>
+InvokeT<F, Args...> Invoke(F&& f, Args&&... args) {
+  return Invoker<F, Args...>::type::Invoke(std::forward<F>(f),
+                                           std::forward<Args>(args)...);
+}
+
+}  // namespace base_internal
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // OTABSL_BASE_INTERNAL_INVOKE_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/macros.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/macros.h
@@ -1,0 +1,220 @@
+//
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: macros.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines the set of language macros used within Abseil code.
+// For the set of macros used to determine supported compilers and platforms,
+// see absl/base/config.h instead.
+//
+// This code is compiled directly on many platforms, including client
+// platforms like Windows, Mac, and embedded systems.  Before making
+// any changes here, make sure that you're not breaking any platforms.
+
+#ifndef OTABSL_BASE_MACROS_H_
+#define OTABSL_BASE_MACROS_H_
+
+#include <cassert>
+#include <cstddef>
+
+#include "attributes.h"
+#include "optimization.h"
+#include "port.h"
+
+// OTABSL_ARRAYSIZE()
+//
+// Returns the number of elements in an array as a compile-time constant, which
+// can be used in defining new arrays. If you use this macro on a pointer by
+// mistake, you will get a compile-time error.
+#define OTABSL_ARRAYSIZE(array) \
+  (sizeof(::absl::macros_internal::ArraySizeHelper(array)))
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+namespace macros_internal {
+// Note: this internal template function declaration is used by OTABSL_ARRAYSIZE.
+// The function doesn't need a definition, as we only use its type.
+template <typename T, size_t N>
+auto ArraySizeHelper(const T (&array)[N]) -> char (&)[N];
+}  // namespace macros_internal
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+// kLinkerInitialized
+//
+// An enum used only as a constructor argument to indicate that a variable has
+// static storage duration, and that the constructor should do nothing to its
+// state. Use of this macro indicates to the reader that it is legal to
+// declare a static instance of the class, provided the constructor is given
+// the absl::base_internal::kLinkerInitialized argument.
+//
+// Normally, it is unsafe to declare a static variable that has a constructor or
+// a destructor because invocation order is undefined. However, if the type can
+// be zero-initialized (which the loader does for static variables) into a valid
+// state and the type's destructor does not affect storage, then a constructor
+// for static initialization can be declared.
+//
+// Example:
+//       // Declaration
+//       explicit MyClass(absl::base_internal:LinkerInitialized x) {}
+//
+//       // Invocation
+//       static MyClass my_global(absl::base_internal::kLinkerInitialized);
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+namespace base_internal {
+enum LinkerInitialized {
+  kLinkerInitialized = 0,
+};
+}  // namespace base_internal
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+// OTABSL_FALLTHROUGH_INTENDED
+//
+// Annotates implicit fall-through between switch labels, allowing a case to
+// indicate intentional fallthrough and turn off warnings about any lack of a
+// `break` statement. The OTABSL_FALLTHROUGH_INTENDED macro should be followed by
+// a semicolon and can be used in most places where `break` can, provided that
+// no statements exist between it and the next switch label.
+//
+// Example:
+//
+//  switch (x) {
+//    case 40:
+//    case 41:
+//      if (truth_is_out_there) {
+//        ++x;
+//        OTABSL_FALLTHROUGH_INTENDED;  // Use instead of/along with annotations
+//                                    // in comments
+//      } else {
+//        return x;
+//      }
+//    case 42:
+//      ...
+//
+// Notes: when compiled with clang in C++11 mode, the OTABSL_FALLTHROUGH_INTENDED
+// macro is expanded to the [[clang::fallthrough]] attribute, which is analysed
+// when  performing switch labels fall-through diagnostic
+// (`-Wimplicit-fallthrough`). See clang documentation on language extensions
+// for details:
+// https://clang.llvm.org/docs/AttributeReference.html#fallthrough-clang-fallthrough
+//
+// When used with unsupported compilers, the OTABSL_FALLTHROUGH_INTENDED macro
+// has no effect on diagnostics. In any case this macro has no effect on runtime
+// behavior and performance of code.
+#ifdef OTABSL_FALLTHROUGH_INTENDED
+#error "OTABSL_FALLTHROUGH_INTENDED should not be defined."
+#endif
+
+// TODO(zhangxy): Use c++17 standard [[fallthrough]] macro, when supported.
+#if defined(__clang__) && defined(__has_warning)
+#if __has_feature(cxx_attributes) && __has_warning("-Wimplicit-fallthrough")
+#define OTABSL_FALLTHROUGH_INTENDED [[clang::fallthrough]]
+#endif
+#elif defined(__GNUC__) && __GNUC__ >= 7
+#define OTABSL_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
+#endif
+
+#ifndef OTABSL_FALLTHROUGH_INTENDED
+#define OTABSL_FALLTHROUGH_INTENDED \
+  do {                            \
+  } while (0)
+#endif
+
+// OTABSL_DEPRECATED()
+//
+// Marks a deprecated class, struct, enum, function, method and variable
+// declarations. The macro argument is used as a custom diagnostic message (e.g.
+// suggestion of a better alternative).
+//
+// Examples:
+//
+//   class OTABSL_DEPRECATED("Use Bar instead") Foo {...};
+//
+//   OTABSL_DEPRECATED("Use Baz() instead") void Bar() {...}
+//
+//   template <typename T>
+//   OTABSL_DEPRECATED("Use DoThat() instead")
+//   void DoThis();
+//
+// Every usage of a deprecated entity will trigger a warning when compiled with
+// clang's `-Wdeprecated-declarations` option. This option is turned off by
+// default, but the warnings will be reported by clang-tidy.
+#if defined(__clang__) && __cplusplus >= 201103L
+#define OTABSL_DEPRECATED(message) __attribute__((deprecated(message)))
+#endif
+
+#ifndef OTABSL_DEPRECATED
+#define OTABSL_DEPRECATED(message)
+#endif
+
+// OTABSL_BAD_CALL_IF()
+//
+// Used on a function overload to trap bad calls: any call that matches the
+// overload will cause a compile-time error. This macro uses a clang-specific
+// "enable_if" attribute, as described at
+// https://clang.llvm.org/docs/AttributeReference.html#enable-if
+//
+// Overloads which use this macro should be bracketed by
+// `#ifdef OTABSL_BAD_CALL_IF`.
+//
+// Example:
+//
+//   int isdigit(int c);
+//   #ifdef OTABSL_BAD_CALL_IF
+//   int isdigit(int c)
+//     OTABSL_BAD_CALL_IF(c <= -1 || c > 255,
+//                       "'c' must have the value of an unsigned char or EOF");
+//   #endif // OTABSL_BAD_CALL_IF
+#if OTABSL_HAVE_ATTRIBUTE(enable_if)
+#define OTABSL_BAD_CALL_IF(expr, msg) \
+  __attribute__((enable_if(expr, "Bad call trap"), unavailable(msg)))
+#endif
+
+// OTABSL_ASSERT()
+//
+// In C++11, `assert` can't be used portably within constexpr functions.
+// OTABSL_ASSERT functions as a runtime assert but works in C++11 constexpr
+// functions.  Example:
+//
+// constexpr double Divide(double a, double b) {
+//   return OTABSL_ASSERT(b != 0), a / b;
+// }
+//
+// This macro is inspired by
+// https://akrzemi1.wordpress.com/2017/05/18/asserts-in-constexpr-functions/
+#if defined(NDEBUG)
+#define OTABSL_ASSERT(expr) \
+  (false ? static_cast<void>(expr) : static_cast<void>(0))
+#else
+#define OTABSL_ASSERT(expr)                           \
+  (OTABSL_PREDICT_TRUE((expr)) ? static_cast<void>(0) \
+                             : [] { assert(false && #expr); }())  // NOLINT
+#endif
+
+#ifdef OTABSL_HAVE_EXCEPTIONS
+#define OTABSL_INTERNAL_TRY try
+#define OTABSL_INTERNAL_CATCH_ANY catch (...)
+#define OTABSL_INTERNAL_RETHROW do { throw; } while (false)
+#else  // OTABSL_HAVE_EXCEPTIONS
+#define OTABSL_INTERNAL_TRY if (true)
+#define OTABSL_INTERNAL_CATCH_ANY else if (false)
+#define OTABSL_INTERNAL_RETHROW do {} while (false)
+#endif  // OTABSL_HAVE_EXCEPTIONS
+
+#endif  // OTABSL_BASE_MACROS_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/optimization.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/optimization.h
@@ -1,0 +1,181 @@
+//
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: optimization.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines portable macros for performance optimization.
+
+#ifndef OTABSL_BASE_OPTIMIZATION_H_
+#define OTABSL_BASE_OPTIMIZATION_H_
+
+#include "config.h"
+
+// OTABSL_BLOCK_TAIL_CALL_OPTIMIZATION
+//
+// Instructs the compiler to avoid optimizing tail-call recursion. Use of this
+// macro is useful when you wish to preserve the existing function order within
+// a stack trace for logging, debugging, or profiling purposes.
+//
+// Example:
+//
+//   int f() {
+//     int result = g();
+//     OTABSL_BLOCK_TAIL_CALL_OPTIMIZATION();
+//     return result;
+//   }
+#if defined(__pnacl__)
+#define OTABSL_BLOCK_TAIL_CALL_OPTIMIZATION() if (volatile int x = 0) { (void)x; }
+#elif defined(__clang__)
+// Clang will not tail call given inline volatile assembly.
+#define OTABSL_BLOCK_TAIL_CALL_OPTIMIZATION() __asm__ __volatile__("")
+#elif defined(__GNUC__)
+// GCC will not tail call given inline volatile assembly.
+#define OTABSL_BLOCK_TAIL_CALL_OPTIMIZATION() __asm__ __volatile__("")
+#elif defined(_MSC_VER)
+#include <intrin.h>
+// The __nop() intrinsic blocks the optimisation.
+#define OTABSL_BLOCK_TAIL_CALL_OPTIMIZATION() __nop()
+#else
+#define OTABSL_BLOCK_TAIL_CALL_OPTIMIZATION() if (volatile int x = 0) { (void)x; }
+#endif
+
+// OTABSL_CACHELINE_SIZE
+//
+// Explicitly defines the size of the L1 cache for purposes of alignment.
+// Setting the cacheline size allows you to specify that certain objects be
+// aligned on a cacheline boundary with `OTABSL_CACHELINE_ALIGNED` declarations.
+// (See below.)
+//
+// NOTE: this macro should be replaced with the following C++17 features, when
+// those are generally available:
+//
+//   * `std::hardware_constructive_interference_size`
+//   * `std::hardware_destructive_interference_size`
+//
+// See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0154r1.html
+// for more information.
+#if defined(__GNUC__)
+// Cache line alignment
+#if defined(__i386__) || defined(__x86_64__)
+#define OTABSL_CACHELINE_SIZE 64
+#elif defined(__powerpc64__)
+#define OTABSL_CACHELINE_SIZE 128
+#elif defined(__aarch64__)
+// We would need to read special register ctr_el0 to find out L1 dcache size.
+// This value is a good estimate based on a real aarch64 machine.
+#define OTABSL_CACHELINE_SIZE 64
+#elif defined(__arm__)
+// Cache line sizes for ARM: These values are not strictly correct since
+// cache line sizes depend on implementations, not architectures.  There
+// are even implementations with cache line sizes configurable at boot
+// time.
+#if defined(__ARM_ARCH_5T__)
+#define OTABSL_CACHELINE_SIZE 32
+#elif defined(__ARM_ARCH_7A__)
+#define OTABSL_CACHELINE_SIZE 64
+#endif
+#endif
+
+#ifndef OTABSL_CACHELINE_SIZE
+// A reasonable default guess.  Note that overestimates tend to waste more
+// space, while underestimates tend to waste more time.
+#define OTABSL_CACHELINE_SIZE 64
+#endif
+
+// OTABSL_CACHELINE_ALIGNED
+//
+// Indicates that the declared object be cache aligned using
+// `OTABSL_CACHELINE_SIZE` (see above). Cacheline aligning objects allows you to
+// load a set of related objects in the L1 cache for performance improvements.
+// Cacheline aligning objects properly allows constructive memory sharing and
+// prevents destructive (or "false") memory sharing.
+//
+// NOTE: this macro should be replaced with usage of `alignas()` using
+// `std::hardware_constructive_interference_size` and/or
+// `std::hardware_destructive_interference_size` when available within C++17.
+//
+// See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0154r1.html
+// for more information.
+//
+// On some compilers, `OTABSL_CACHELINE_ALIGNED` expands to an `__attribute__`
+// or `__declspec` attribute. For compilers where this is not known to work,
+// the macro expands to nothing.
+//
+// No further guarantees are made here. The result of applying the macro
+// to variables and types is always implementation-defined.
+//
+// WARNING: It is easy to use this attribute incorrectly, even to the point
+// of causing bugs that are difficult to diagnose, crash, etc. It does not
+// of itself guarantee that objects are aligned to a cache line.
+//
+// NOTE: Some compilers are picky about the locations of annotations such as
+// this attribute, so prefer to put it at the beginning of your declaration.
+// For example,
+//
+//   OTABSL_CACHELINE_ALIGNED static Foo* foo = ...
+//
+//   class OTABSL_CACHELINE_ALIGNED Bar { ...
+//
+// Recommendations:
+//
+// 1) Consult compiler documentation; this comment is not kept in sync as
+//    toolchains evolve.
+// 2) Verify your use has the intended effect. This often requires inspecting
+//    the generated machine code.
+// 3) Prefer applying this attribute to individual variables. Avoid
+//    applying it to types. This tends to localize the effect.
+#define OTABSL_CACHELINE_ALIGNED __attribute__((aligned(OTABSL_CACHELINE_SIZE)))
+#elif defined(_MSC_VER)
+#define OTABSL_CACHELINE_SIZE 64
+#define OTABSL_CACHELINE_ALIGNED __declspec(align(OTABSL_CACHELINE_SIZE))
+#else
+#define OTABSL_CACHELINE_SIZE 64
+#define OTABSL_CACHELINE_ALIGNED
+#endif
+
+// OTABSL_PREDICT_TRUE, OTABSL_PREDICT_FALSE
+//
+// Enables the compiler to prioritize compilation using static analysis for
+// likely paths within a boolean branch.
+//
+// Example:
+//
+//   if (OTABSL_PREDICT_TRUE(expression)) {
+//     return result;                        // Faster if more likely
+//   } else {
+//     return 0;
+//   }
+//
+// Compilers can use the information that a certain branch is not likely to be
+// taken (for instance, a CHECK failure) to optimize for the common case in
+// the absence of better information (ie. compiling gcc with `-fprofile-arcs`).
+//
+// Recommendation: Modern CPUs dynamically predict branch execution paths,
+// typically with accuracy greater than 97%. As a result, annotating every
+// branch in a codebase is likely counterproductive; however, annotating
+// specific branches that are both hot and consistently mispredicted is likely
+// to yield performance improvements.
+#if OTABSL_HAVE_BUILTIN(__builtin_expect) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#define OTABSL_PREDICT_FALSE(x) (__builtin_expect(x, 0))
+#define OTABSL_PREDICT_TRUE(x) (__builtin_expect(false || (x), true))
+#else
+#define OTABSL_PREDICT_FALSE(x) (x)
+#define OTABSL_PREDICT_TRUE(x) (x)
+#endif
+
+#endif  // OTABSL_BASE_OPTIMIZATION_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/options.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/options.h
@@ -1,0 +1,211 @@
+#ifndef OTABSL_BASE_OPTIONS_H_
+#define OTABSL_BASE_OPTIONS_H_
+
+// Copyright 2019 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: options.h
+// -----------------------------------------------------------------------------
+//
+// This file contains Abseil configuration options for setting specific
+// implementations instead of letting Abseil determine which implementation to
+// use at compile-time. Setting these options may be useful for package or build
+// managers who wish to guarantee ABI stability within binary builds (which are
+// otherwise difficult to enforce).
+//
+// *** IMPORTANT NOTICE FOR PACKAGE MANAGERS:  It is important that
+// maintainers of package managers who wish to package Abseil read and
+// understand this file! ***
+//
+// Abseil contains a number of possible configuration endpoints, based on
+// parameters such as the detected platform, language version, or command-line
+// flags used to invoke the underlying binary. As is the case with all
+// libraries, binaries which contain Abseil code must ensure that separate
+// packages use the same compiled copy of Abseil to avoid a diamond dependency
+// problem, which can occur if two packages built with different Abseil
+// configuration settings are linked together. Diamond dependency problems in
+// C++ may manifest as violations to the One Definition Rule (ODR) (resulting in
+// linker errors), or undefined behavior (resulting in crashes).
+//
+// Diamond dependency problems can be avoided if all packages utilize the same
+// exact version of Abseil. Building from source code with the same compilation
+// parameters is the easiest way to avoid such dependency problems. However, for
+// package managers who cannot control such compilation parameters, we are
+// providing the file to allow you to inject ABI (Application Binary Interface)
+// stability across builds. Settings options in this file will neither change
+// API nor ABI, providing a stable copy of Abseil between packages.
+//
+// Care must be taken to keep options within these configurations isolated
+// from any other dynamic settings, such as command-line flags which could alter
+// these options. This file is provided specifically to help build and package
+// managers provide a stable copy of Abseil within their libraries and binaries;
+// other developers should not have need to alter the contents of this file.
+//
+// -----------------------------------------------------------------------------
+// Usage
+// -----------------------------------------------------------------------------
+//
+// For any particular package release, set the appropriate definitions within
+// this file to whatever value makes the most sense for your package(s). Note
+// that, by default, most of these options, at the moment, affect the
+// implementation of types; future options may affect other implementation
+// details.
+//
+// NOTE: the defaults within this file all assume that Abseil can select the
+// proper Abseil implementation at compile-time, which will not be sufficient
+// to guarantee ABI stability to package managers.
+
+// Include a standard library header to allow configuration based on the
+// standard library in use.
+#ifdef __cplusplus
+#include <ciso646>
+#endif
+
+// -----------------------------------------------------------------------------
+// Type Compatibility Options
+// -----------------------------------------------------------------------------
+//
+// OTABSL_OPTION_USE_STD_ANY
+//
+// This option controls whether absl::any is implemented as an alias to
+// std::any, or as an independent implementation.
+//
+// A value of 0 means to use Abseil's implementation.  This requires only C++11
+// support, and is expected to work on every toolchain we support.
+//
+// A value of 1 means to use an alias to std::any.  This requires that all code
+// using Abseil is built in C++17 mode or later.
+//
+// A value of 2 means to detect the C++ version being used to compile Abseil,
+// and use an alias only if a working std::any is available.  This option is
+// useful when you are building your entire program, including all of its
+// dependencies, from source.  It should not be used otherwise -- for example,
+// if you are distributing Abseil in a binary package manager -- since in
+// mode 2, absl::any will name a different type, with a different mangled name
+// and binary layout, depending on the compiler flags passed by the end user.
+// For more info, see https://abseil.io/about/design/dropin-types.
+//
+// User code should not inspect this macro.  To check in the preprocessor if
+// absl::any is a typedef of std::any, use the feature macro OTABSL_USES_STD_ANY.
+
+#define OTABSL_OPTION_USE_STD_ANY 0
+
+
+// OTABSL_OPTION_USE_STD_OPTIONAL
+//
+// This option controls whether absl::optional is implemented as an alias to
+// std::optional, or as an independent implementation.
+//
+// A value of 0 means to use Abseil's implementation.  This requires only C++11
+// support, and is expected to work on every toolchain we support.
+//
+// A value of 1 means to use an alias to std::optional.  This requires that all
+// code using Abseil is built in C++17 mode or later.
+//
+// A value of 2 means to detect the C++ version being used to compile Abseil,
+// and use an alias only if a working std::optional is available.  This option
+// is useful when you are building your program from source.  It should not be
+// used otherwise -- for example, if you are distributing Abseil in a binary
+// package manager -- since in mode 2, absl::optional will name a different
+// type, with a different mangled name and binary layout, depending on the
+// compiler flags passed by the end user.  For more info, see
+// https://abseil.io/about/design/dropin-types.
+
+// User code should not inspect this macro.  To check in the preprocessor if
+// absl::optional is a typedef of std::optional, use the feature macro
+// OTABSL_USES_STD_OPTIONAL.
+
+#define OTABSL_OPTION_USE_STD_OPTIONAL 0
+
+
+// OTABSL_OPTION_USE_STD_STRING_VIEW
+//
+// This option controls whether absl::string_view is implemented as an alias to
+// std::string_view, or as an independent implementation.
+//
+// A value of 0 means to use Abseil's implementation.  This requires only C++11
+// support, and is expected to work on every toolchain we support.
+//
+// A value of 1 means to use an alias to std::string_view.  This requires that
+// all code using Abseil is built in C++17 mode or later.
+//
+// A value of 2 means to detect the C++ version being used to compile Abseil,
+// and use an alias only if a working std::string_view is available.  This
+// option is useful when you are building your program from source.  It should
+// not be used otherwise -- for example, if you are distributing Abseil in a
+// binary package manager -- since in mode 2, absl::string_view will name a
+// different type, with a different mangled name and binary layout, depending on
+// the compiler flags passed by the end user.  For more info, see
+// https://abseil.io/about/design/dropin-types.
+//
+// User code should not inspect this macro.  To check in the preprocessor if
+// absl::string_view is a typedef of std::string_view, use the feature macro
+// OTABSL_USES_STD_STRING_VIEW.
+
+#define OTABSL_OPTION_USE_STD_STRING_VIEW 0
+
+// OTABSL_OPTION_USE_STD_VARIANT
+//
+// This option controls whether absl::variant is implemented as an alias to
+// std::variant, or as an independent implementation.
+//
+// A value of 0 means to use Abseil's implementation.  This requires only C++11
+// support, and is expected to work on every toolchain we support.
+//
+// A value of 1 means to use an alias to std::variant.  This requires that all
+// code using Abseil is built in C++17 mode or later.
+//
+// A value of 2 means to detect the C++ version being used to compile Abseil,
+// and use an alias only if a working std::variant is available.  This option
+// is useful when you are building your program from source.  It should not be
+// used otherwise -- for example, if you are distributing Abseil in a binary
+// package manager -- since in mode 2, absl::variant will name a different
+// type, with a different mangled name and binary layout, depending on the
+// compiler flags passed by the end user.  For more info, see
+// https://abseil.io/about/design/dropin-types.
+//
+// User code should not inspect this macro.  To check in the preprocessor if
+// absl::variant is a typedef of std::variant, use the feature macro
+// OTABSL_USES_STD_VARIANT.
+
+#define OTABSL_OPTION_USE_STD_VARIANT 0
+
+
+// OTABSL_OPTION_USE_INLINE_NAMESPACE
+// OTABSL_OPTION_INLINE_NAMESPACE_NAME
+//
+// These options controls whether all entities in the absl namespace are
+// contained within an inner inline namespace.  This does not affect the
+// user-visible API of Abseil, but it changes the mangled names of all symbols.
+//
+// This can be useful as a version tag if you are distributing Abseil in
+// precompiled form.  This will prevent a binary library build of Abseil with
+// one inline namespace being used with headers configured with a different
+// inline namespace name.  Binary packagers are reminded that Abseil does not
+// guarantee any ABI stability in Abseil, so any update of Abseil or
+// configuration change in such a binary package should be combined with a
+// new, unique value for the inline namespace name.
+//
+// A value of 0 means not to use inline namespaces.
+//
+// A value of 1 means to use an inline namespace with the given name inside
+// namespace absl.  If this is set, OTABSL_OPTION_INLINE_NAMESPACE_NAME must also
+// be changed to a new, unique identifier name.  In particular "head" is not
+// allowed.
+
+#define OTABSL_OPTION_USE_INLINE_NAMESPACE 1
+#define OTABSL_OPTION_INLINE_NAMESPACE_NAME otel_v1
+
+#endif  // OTABSL_BASE_OPTIONS_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/policy_checks.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/policy_checks.h
@@ -1,0 +1,115 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: policy_checks.h
+// -----------------------------------------------------------------------------
+//
+// This header enforces a minimum set of policies at build time, such as the
+// supported compiler and library versions. Unsupported configurations are
+// reported with `#error`. This enforcement is best effort, so successfully
+// compiling this header does not guarantee a supported configuration.
+
+#ifndef OTABSL_BASE_POLICY_CHECKS_H_
+#define OTABSL_BASE_POLICY_CHECKS_H_
+
+// Included for the __GLIBC_PREREQ macro used below.
+#include <limits.h>
+
+// Included for the _STLPORT_VERSION macro used below.
+#if defined(__cplusplus)
+#include <cstddef>
+#endif
+
+// -----------------------------------------------------------------------------
+// Operating System Check
+// -----------------------------------------------------------------------------
+
+#if defined(__CYGWIN__)
+#error "Cygwin is not supported."
+#endif
+
+// -----------------------------------------------------------------------------
+// Compiler Check
+// -----------------------------------------------------------------------------
+
+#if 0 /* FIXME: MG */
+// We support MSVC++ 14.0 update 2 and later.
+// This minimum will go up.
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER < 190023918 && !defined(__clang__)
+#error "This package requires Visual Studio 2015 Update 2 or higher."
+#endif
+#endif
+
+// We support gcc 4.7 and later.
+// This minimum will go up.
+#if defined(__GNUC__) && !defined(__clang__)
+#if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 7)
+#error "This package requires gcc 4.7 or higher."
+#endif
+#endif
+
+// We support Apple Xcode clang 4.2.1 (version 421.11.65) and later.
+// This corresponds to Apple Xcode version 4.5.
+// This minimum will go up.
+#if defined(__apple_build_version__) && __apple_build_version__ < 4211165
+#error "This package requires __apple_build_version__ of 4211165 or higher."
+#endif
+
+// -----------------------------------------------------------------------------
+// C++ Version Check
+// -----------------------------------------------------------------------------
+
+// Enforce C++11 as the minimum.
+#if defined(_MSVC_LANG)
+#if _MSVC_LANG < 201103L
+#error "C++ versions less than C++11 are not supported."
+#endif  // _MSVC_LANG < 201103L
+#elif defined(__cplusplus)
+#if __cplusplus < 201103L
+#error "C++ versions less than C++11 are not supported."
+#endif  // __cplusplus < 201103L
+#endif
+
+// -----------------------------------------------------------------------------
+// Standard Library Check
+// -----------------------------------------------------------------------------
+
+#if defined(_STLPORT_VERSION)
+#error "STLPort is not supported."
+#endif
+
+// -----------------------------------------------------------------------------
+// `char` Size Check
+// -----------------------------------------------------------------------------
+
+// Abseil currently assumes CHAR_BIT == 8. If you would like to use Abseil on a
+// platform where this is not the case, please provide us with the details about
+// your platform so we can consider relaxing this requirement.
+#if CHAR_BIT != 8
+#error "Abseil assumes CHAR_BIT == 8."
+#endif
+
+// -----------------------------------------------------------------------------
+// `int` Size Check
+// -----------------------------------------------------------------------------
+
+// Abseil currently assumes that an int is 4 bytes. If you would like to use
+// Abseil on a platform where this is not the case, please provide us with the
+// details about your platform so we can consider relaxing this requirement.
+#if INT_MAX < 2147483647
+#error "Abseil assumes that int is at least 4 bytes. "
+#endif
+
+#endif  // OTABSL_BASE_POLICY_CHECKS_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/port.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/base/port.h
@@ -1,0 +1,26 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This files is a forwarding header for other headers containing various
+// portability macros and functions.
+// This file is used for both C and C++!
+
+#ifndef OTABSL_BASE_PORT_H_
+#define OTABSL_BASE_PORT_H_
+
+#include "attributes.h"
+#include "config.h"
+#include "optimization.h"
+
+#endif  // OTABSL_BASE_PORT_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
@@ -1,0 +1,795 @@
+//
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// type_traits.h
+// -----------------------------------------------------------------------------
+//
+// This file contains C++11-compatible versions of standard <type_traits> API
+// functions for determining the characteristics of types. Such traits can
+// support type inference, classification, and transformation, as well as
+// make it easier to write templates based on generic type behavior.
+//
+// See https://en.cppreference.com/w/cpp/header/type_traits
+//
+// WARNING: use of many of the constructs in this header will count as "complex
+// template metaprogramming", so before proceeding, please carefully consider
+// https://google.github.io/styleguide/cppguide.html#Template_metaprogramming
+//
+// WARNING: using template metaprogramming to detect or depend on API
+// features is brittle and not guaranteed. Neither the standard library nor
+// Abseil provides any guarantee that APIs are stable in the face of template
+// metaprogramming. Use with caution.
+#ifndef OTABSL_META_TYPE_TRAITS_H_
+#define OTABSL_META_TYPE_TRAITS_H_
+
+#include <stddef.h>
+#include <functional>
+#include <type_traits>
+
+#include "../base/config.h"
+
+// MSVC constructibility traits do not detect destructor properties and so our
+// implementations should not use them as a source-of-truth.
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__)
+#define OTABSL_META_INTERNAL_STD_CONSTRUCTION_TRAITS_DONT_CHECK_DESTRUCTION 1
+#endif
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+
+// Defined and documented later on in this file.
+template <typename T>
+struct is_trivially_destructible;
+
+// Defined and documented later on in this file.
+template <typename T>
+struct is_trivially_move_assignable;
+
+namespace type_traits_internal {
+
+// Silence MSVC warnings about the destructor being defined as deleted.
+#if defined(_MSC_VER) && !defined(__GNUC__)
+#pragma warning(push)
+#pragma warning(disable : 4624)
+#endif  // defined(_MSC_VER) && !defined(__GNUC__)
+
+template <class T>
+union SingleMemberUnion {
+  T t;
+};
+
+// Restore the state of the destructor warning that was silenced above.
+#if defined(_MSC_VER) && !defined(__GNUC__)
+#pragma warning(pop)
+#endif  // defined(_MSC_VER) && !defined(__GNUC__)
+
+template <class T>
+struct IsTriviallyMoveConstructibleObject
+    : std::integral_constant<
+          bool, std::is_move_constructible<
+                    type_traits_internal::SingleMemberUnion<T>>::value &&
+                    absl::is_trivially_destructible<T>::value> {};
+
+template <class T>
+struct IsTriviallyCopyConstructibleObject
+    : std::integral_constant<
+          bool, std::is_copy_constructible<
+                    type_traits_internal::SingleMemberUnion<T>>::value &&
+                    absl::is_trivially_destructible<T>::value> {};
+
+template <class T>
+struct IsTriviallyMoveAssignableReference : std::false_type {};
+
+template <class T>
+struct IsTriviallyMoveAssignableReference<T&>
+    : absl::is_trivially_move_assignable<T>::type {};
+
+template <class T>
+struct IsTriviallyMoveAssignableReference<T&&>
+    : absl::is_trivially_move_assignable<T>::type {};
+
+template <typename... Ts>
+struct VoidTImpl {
+  using type = void;
+};
+
+// This trick to retrieve a default alignment is necessary for our
+// implementation of aligned_storage_t to be consistent with any implementation
+// of std::aligned_storage.
+template <size_t Len, typename T = std::aligned_storage<Len>>
+struct default_alignment_of_aligned_storage;
+
+template <size_t Len, size_t Align>
+struct default_alignment_of_aligned_storage<Len,
+                                            std::aligned_storage<Len, Align>> {
+  static constexpr size_t value = Align;
+};
+
+////////////////////////////////
+// Library Fundamentals V2 TS //
+////////////////////////////////
+
+// NOTE: The `is_detected` family of templates here differ from the library
+// fundamentals specification in that for library fundamentals, `Op<Args...>` is
+// evaluated as soon as the type `is_detected<Op, Args...>` undergoes
+// substitution, regardless of whether or not the `::value` is accessed. That
+// is inconsistent with all other standard traits and prevents lazy evaluation
+// in larger contexts (such as if the `is_detected` check is a trailing argument
+// of a `conjunction`. This implementation opts to instead be lazy in the same
+// way that the standard traits are (this "defect" of the detection idiom
+// specifications has been reported).
+
+template <class Enabler, template <class...> class Op, class... Args>
+struct is_detected_impl {
+  using type = std::false_type;
+};
+
+template <template <class...> class Op, class... Args>
+struct is_detected_impl<typename VoidTImpl<Op<Args...>>::type, Op, Args...> {
+  using type = std::true_type;
+};
+
+template <template <class...> class Op, class... Args>
+struct is_detected : is_detected_impl<void, Op, Args...>::type {};
+
+template <class Enabler, class To, template <class...> class Op, class... Args>
+struct is_detected_convertible_impl {
+  using type = std::false_type;
+};
+
+template <class To, template <class...> class Op, class... Args>
+struct is_detected_convertible_impl<
+    typename std::enable_if<std::is_convertible<Op<Args...>, To>::value>::type,
+    To, Op, Args...> {
+  using type = std::true_type;
+};
+
+template <class To, template <class...> class Op, class... Args>
+struct is_detected_convertible
+    : is_detected_convertible_impl<void, To, Op, Args...>::type {};
+
+template <typename T>
+using IsCopyAssignableImpl =
+    decltype(std::declval<T&>() = std::declval<const T&>());
+
+template <typename T>
+using IsMoveAssignableImpl = decltype(std::declval<T&>() = std::declval<T&&>());
+
+}  // namespace type_traits_internal
+
+// MSVC 19.10 and higher have a regression that causes our workarounds to fail, but their
+// std forms now appear to be compliant.
+#if defined(_MSC_VER) && !defined(__clang__) && (_MSC_VER >= 1910)
+
+template <typename T>
+using is_copy_assignable = std::is_copy_assignable<T>;
+
+template <typename T>
+using is_move_assignable = std::is_move_assignable<T>;
+
+#else
+
+template <typename T>
+struct is_copy_assignable : type_traits_internal::is_detected<
+                                type_traits_internal::IsCopyAssignableImpl, T> {
+};
+
+template <typename T>
+struct is_move_assignable : type_traits_internal::is_detected<
+                                type_traits_internal::IsMoveAssignableImpl, T> {
+};
+
+#endif
+
+// void_t()
+//
+// Ignores the type of any its arguments and returns `void`. In general, this
+// metafunction allows you to create a general case that maps to `void` while
+// allowing specializations that map to specific types.
+//
+// This metafunction is designed to be a drop-in replacement for the C++17
+// `std::void_t` metafunction.
+//
+// NOTE: `absl::void_t` does not use the standard-specified implementation so
+// that it can remain compatible with gcc < 5.1. This can introduce slightly
+// different behavior, such as when ordering partial specializations.
+template <typename... Ts>
+using void_t = typename type_traits_internal::VoidTImpl<Ts...>::type;
+
+// conjunction
+//
+// Performs a compile-time logical AND operation on the passed types (which
+// must have  `::value` members convertible to `bool`. Short-circuits if it
+// encounters any `false` members (and does not compare the `::value` members
+// of any remaining arguments).
+//
+// This metafunction is designed to be a drop-in replacement for the C++17
+// `std::conjunction` metafunction.
+template <typename... Ts>
+struct conjunction;
+
+template <typename T, typename... Ts>
+struct conjunction<T, Ts...>
+    : std::conditional<T::value, conjunction<Ts...>, T>::type {};
+
+template <typename T>
+struct conjunction<T> : T {};
+
+template <>
+struct conjunction<> : std::true_type {};
+
+// disjunction
+//
+// Performs a compile-time logical OR operation on the passed types (which
+// must have  `::value` members convertible to `bool`. Short-circuits if it
+// encounters any `true` members (and does not compare the `::value` members
+// of any remaining arguments).
+//
+// This metafunction is designed to be a drop-in replacement for the C++17
+// `std::disjunction` metafunction.
+template <typename... Ts>
+struct disjunction;
+
+template <typename T, typename... Ts>
+struct disjunction<T, Ts...> :
+      std::conditional<T::value, T, disjunction<Ts...>>::type {};
+
+template <typename T>
+struct disjunction<T> : T {};
+
+template <>
+struct disjunction<> : std::false_type {};
+
+// negation
+//
+// Performs a compile-time logical NOT operation on the passed type (which
+// must have  `::value` members convertible to `bool`.
+//
+// This metafunction is designed to be a drop-in replacement for the C++17
+// `std::negation` metafunction.
+template <typename T>
+struct negation : std::integral_constant<bool, !T::value> {};
+
+// is_function()
+//
+// Determines whether the passed type `T` is a function type.
+//
+// This metafunction is designed to be a drop-in replacement for the C++11
+// `std::is_function()` metafunction for platforms that have incomplete C++11
+// support (such as libstdc++ 4.x).
+//
+// This metafunction works because appending `const` to a type does nothing to
+// function types and reference types (and forms a const-qualified type
+// otherwise).
+template <typename T>
+struct is_function
+    : std::integral_constant<
+          bool, !(std::is_reference<T>::value ||
+                  std::is_const<typename std::add_const<T>::type>::value)> {};
+
+// is_trivially_destructible()
+//
+// Determines whether the passed type `T` is trivially destructible.
+//
+// This metafunction is designed to be a drop-in replacement for the C++11
+// `std::is_trivially_destructible()` metafunction for platforms that have
+// incomplete C++11 support (such as libstdc++ 4.x). On any platforms that do
+// fully support C++11, we check whether this yields the same result as the std
+// implementation.
+//
+// NOTE: the extensions (__has_trivial_xxx) are implemented in gcc (version >=
+// 4.3) and clang. Since we are supporting libstdc++ > 4.7, they should always
+// be present. These  extensions are documented at
+// https://gcc.gnu.org/onlinedocs/gcc/Type-Traits.html#Type-Traits.
+template <typename T>
+struct is_trivially_destructible
+#ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
+    : std::is_trivially_destructible<T> {
+#else
+    : std::integral_constant<bool, __has_trivial_destructor(T) &&
+                                   std::is_destructible<T>::value> {
+#endif
+#ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
+ private:
+  static constexpr bool compliant = std::is_trivially_destructible<T>::value ==
+                                    is_trivially_destructible::value;
+  static_assert(compliant || std::is_trivially_destructible<T>::value,
+                "Not compliant with std::is_trivially_destructible; "
+                "Standard: false, Implementation: true");
+  static_assert(compliant || !std::is_trivially_destructible<T>::value,
+                "Not compliant with std::is_trivially_destructible; "
+                "Standard: true, Implementation: false");
+#endif  // OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
+};
+
+// is_trivially_default_constructible()
+//
+// Determines whether the passed type `T` is trivially default constructible.
+//
+// This metafunction is designed to be a drop-in replacement for the C++11
+// `std::is_trivially_default_constructible()` metafunction for platforms that
+// have incomplete C++11 support (such as libstdc++ 4.x). On any platforms that
+// do fully support C++11, we check whether this yields the same result as the
+// std implementation.
+//
+// NOTE: according to the C++ standard, Section: 20.15.4.3 [meta.unary.prop]
+// "The predicate condition for a template specialization is_constructible<T,
+// Args...> shall be satisfied if and only if the following variable
+// definition would be well-formed for some invented variable t:
+//
+// T t(declval<Args>()...);
+//
+// is_trivially_constructible<T, Args...> additionally requires that the
+// variable definition does not call any operation that is not trivial.
+// For the purposes of this check, the call to std::declval is considered
+// trivial."
+//
+// Notes from https://en.cppreference.com/w/cpp/types/is_constructible:
+// In many implementations, is_nothrow_constructible also checks if the
+// destructor throws because it is effectively noexcept(T(arg)). Same
+// applies to is_trivially_constructible, which, in these implementations, also
+// requires that the destructor is trivial.
+// GCC bug 51452: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51452
+// LWG issue 2116: http://cplusplus.github.io/LWG/lwg-active.html#2116.
+//
+// "T obj();" need to be well-formed and not call any nontrivial operation.
+// Nontrivially destructible types will cause the expression to be nontrivial.
+template <typename T>
+struct is_trivially_default_constructible
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE)
+    : std::is_trivially_default_constructible<T> {
+#else
+    : std::integral_constant<bool, __has_trivial_constructor(T) &&
+                                   std::is_default_constructible<T>::value &&
+                                   is_trivially_destructible<T>::value> {
+#endif
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE) && \
+    !defined(                                            \
+        OTABSL_META_INTERNAL_STD_CONSTRUCTION_TRAITS_DONT_CHECK_DESTRUCTION)
+ private:
+  static constexpr bool compliant =
+      std::is_trivially_default_constructible<T>::value ==
+      is_trivially_default_constructible::value;
+  static_assert(compliant || std::is_trivially_default_constructible<T>::value,
+                "Not compliant with std::is_trivially_default_constructible; "
+                "Standard: false, Implementation: true");
+  static_assert(compliant || !std::is_trivially_default_constructible<T>::value,
+                "Not compliant with std::is_trivially_default_constructible; "
+                "Standard: true, Implementation: false");
+#endif  // OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE
+};
+
+// is_trivially_move_constructible()
+//
+// Determines whether the passed type `T` is trivially move constructible.
+//
+// This metafunction is designed to be a drop-in replacement for the C++11
+// `std::is_trivially_move_constructible()` metafunction for platforms that have
+// incomplete C++11 support (such as libstdc++ 4.x). On any platforms that do
+// fully support C++11, we check whether this yields the same result as the std
+// implementation.
+//
+// NOTE: `T obj(declval<T>());` needs to be well-formed and not call any
+// nontrivial operation.  Nontrivially destructible types will cause the
+// expression to be nontrivial.
+template <typename T>
+struct is_trivially_move_constructible
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE)
+    : std::is_trivially_move_constructible<T> {
+#else
+    : std::conditional<
+          std::is_object<T>::value && !std::is_array<T>::value,
+          type_traits_internal::IsTriviallyMoveConstructibleObject<T>,
+          std::is_reference<T>>::type::type {
+#endif
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE) && \
+    !defined(                                            \
+        OTABSL_META_INTERNAL_STD_CONSTRUCTION_TRAITS_DONT_CHECK_DESTRUCTION)
+ private:
+  static constexpr bool compliant =
+      std::is_trivially_move_constructible<T>::value ==
+      is_trivially_move_constructible::value;
+  static_assert(compliant || std::is_trivially_move_constructible<T>::value,
+                "Not compliant with std::is_trivially_move_constructible; "
+                "Standard: false, Implementation: true");
+  static_assert(compliant || !std::is_trivially_move_constructible<T>::value,
+                "Not compliant with std::is_trivially_move_constructible; "
+                "Standard: true, Implementation: false");
+#endif  // OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE
+};
+
+// is_trivially_copy_constructible()
+//
+// Determines whether the passed type `T` is trivially copy constructible.
+//
+// This metafunction is designed to be a drop-in replacement for the C++11
+// `std::is_trivially_copy_constructible()` metafunction for platforms that have
+// incomplete C++11 support (such as libstdc++ 4.x). On any platforms that do
+// fully support C++11, we check whether this yields the same result as the std
+// implementation.
+//
+// NOTE: `T obj(declval<const T&>());` needs to be well-formed and not call any
+// nontrivial operation.  Nontrivially destructible types will cause the
+// expression to be nontrivial.
+template <typename T>
+struct is_trivially_copy_constructible
+    : std::conditional<
+          std::is_object<T>::value && !std::is_array<T>::value,
+          type_traits_internal::IsTriviallyCopyConstructibleObject<T>,
+          std::is_lvalue_reference<T>>::type::type {
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE) && \
+    !defined(                                            \
+        OTABSL_META_INTERNAL_STD_CONSTRUCTION_TRAITS_DONT_CHECK_DESTRUCTION)
+ private:
+  static constexpr bool compliant =
+      std::is_trivially_copy_constructible<T>::value ==
+      is_trivially_copy_constructible::value;
+  static_assert(compliant || std::is_trivially_copy_constructible<T>::value,
+                "Not compliant with std::is_trivially_copy_constructible; "
+                "Standard: false, Implementation: true");
+  static_assert(compliant || !std::is_trivially_copy_constructible<T>::value,
+                "Not compliant with std::is_trivially_copy_constructible; "
+                "Standard: true, Implementation: false");
+#endif  // OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE
+};
+
+// is_trivially_move_assignable()
+//
+// Determines whether the passed type `T` is trivially move assignable.
+//
+// This metafunction is designed to be a drop-in replacement for the C++11
+// `std::is_trivially_move_assignable()` metafunction for platforms that have
+// incomplete C++11 support (such as libstdc++ 4.x). On any platforms that do
+// fully support C++11, we check whether this yields the same result as the std
+// implementation.
+//
+// NOTE: `is_assignable<T, U>::value` is `true` if the expression
+// `declval<T>() = declval<U>()` is well-formed when treated as an unevaluated
+// operand. `is_trivially_assignable<T, U>` requires the assignment to call no
+// operation that is not trivial. `is_trivially_copy_assignable<T>` is simply
+// `is_trivially_assignable<T&, T>`.
+template <typename T>
+struct is_trivially_move_assignable
+    : std::conditional<
+          std::is_object<T>::value && !std::is_array<T>::value &&
+              std::is_move_assignable<T>::value,
+          std::is_move_assignable<type_traits_internal::SingleMemberUnion<T>>,
+          type_traits_internal::IsTriviallyMoveAssignableReference<T>>::type::
+          type {
+#ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
+ private:
+  static constexpr bool compliant =
+      std::is_trivially_move_assignable<T>::value ==
+      is_trivially_move_assignable::value;
+  static_assert(compliant || std::is_trivially_move_assignable<T>::value,
+                "Not compliant with std::is_trivially_move_assignable; "
+                "Standard: false, Implementation: true");
+  static_assert(compliant || !std::is_trivially_move_assignable<T>::value,
+                "Not compliant with std::is_trivially_move_assignable; "
+                "Standard: true, Implementation: false");
+#endif  // OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
+};
+
+// is_trivially_copy_assignable()
+//
+// Determines whether the passed type `T` is trivially copy assignable.
+//
+// This metafunction is designed to be a drop-in replacement for the C++11
+// `std::is_trivially_copy_assignable()` metafunction for platforms that have
+// incomplete C++11 support (such as libstdc++ 4.x). On any platforms that do
+// fully support C++11, we check whether this yields the same result as the std
+// implementation.
+//
+// NOTE: `is_assignable<T, U>::value` is `true` if the expression
+// `declval<T>() = declval<U>()` is well-formed when treated as an unevaluated
+// operand. `is_trivially_assignable<T, U>` requires the assignment to call no
+// operation that is not trivial. `is_trivially_copy_assignable<T>` is simply
+// `is_trivially_assignable<T&, const T&>`.
+template <typename T>
+struct is_trivially_copy_assignable
+#ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
+    : std::is_trivially_copy_assignable<T> {
+#else
+    : std::integral_constant<
+          bool, __has_trivial_assign(typename std::remove_reference<T>::type) &&
+                    absl::is_copy_assignable<T>::value> {
+#endif
+#ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
+ private:
+  static constexpr bool compliant =
+      std::is_trivially_copy_assignable<T>::value ==
+      is_trivially_copy_assignable::value;
+  static_assert(compliant || std::is_trivially_copy_assignable<T>::value,
+                "Not compliant with std::is_trivially_copy_assignable; "
+                "Standard: false, Implementation: true");
+  static_assert(compliant || !std::is_trivially_copy_assignable<T>::value,
+                "Not compliant with std::is_trivially_copy_assignable; "
+                "Standard: true, Implementation: false");
+#endif  // OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
+};
+
+namespace type_traits_internal {
+// is_trivially_copyable()
+//
+// Determines whether the passed type `T` is trivially copyable.
+//
+// This metafunction is designed to be a drop-in replacement for the C++11
+// `std::is_trivially_copyable()` metafunction for platforms that have
+// incomplete C++11 support (such as libstdc++ 4.x). We use the C++17 definition
+// of TriviallyCopyable.
+//
+// NOTE: `is_trivially_copyable<T>::value` is `true` if all of T's copy/move
+// constructors/assignment operators are trivial or deleted, T has at least
+// one non-deleted copy/move constructor/assignment operator, and T is trivially
+// destructible. Arrays of trivially copyable types are trivially copyable.
+//
+// We expose this metafunction only for internal use within absl.
+
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE)
+template <typename T>
+struct is_trivially_copyable : std::is_trivially_copyable<T> {};
+#else
+template <typename T>
+class is_trivially_copyable_impl {
+  using ExtentsRemoved = typename std::remove_all_extents<T>::type;
+  static constexpr bool kIsCopyOrMoveConstructible =
+      std::is_copy_constructible<ExtentsRemoved>::value ||
+      std::is_move_constructible<ExtentsRemoved>::value;
+  static constexpr bool kIsCopyOrMoveAssignable =
+      absl::is_copy_assignable<ExtentsRemoved>::value ||
+      absl::is_move_assignable<ExtentsRemoved>::value;
+
+ public:
+  static constexpr bool kValue =
+      (__has_trivial_copy(ExtentsRemoved) || !kIsCopyOrMoveConstructible) &&
+      (__has_trivial_assign(ExtentsRemoved) || !kIsCopyOrMoveAssignable) &&
+      (kIsCopyOrMoveConstructible || kIsCopyOrMoveAssignable) &&
+      is_trivially_destructible<ExtentsRemoved>::value &&
+      // We need to check for this explicitly because otherwise we'll say
+      // references are trivial copyable when compiled by MSVC.
+      !std::is_reference<ExtentsRemoved>::value;
+};
+
+template <typename T>
+struct is_trivially_copyable
+    : std::integral_constant<
+          bool, type_traits_internal::is_trivially_copyable_impl<T>::kValue> {};
+#endif
+}  // namespace type_traits_internal
+
+// -----------------------------------------------------------------------------
+// C++14 "_t" trait aliases
+// -----------------------------------------------------------------------------
+
+template <typename T>
+using remove_cv_t = typename std::remove_cv<T>::type;
+
+template <typename T>
+using remove_const_t = typename std::remove_const<T>::type;
+
+template <typename T>
+using remove_volatile_t = typename std::remove_volatile<T>::type;
+
+template <typename T>
+using add_cv_t = typename std::add_cv<T>::type;
+
+template <typename T>
+using add_const_t = typename std::add_const<T>::type;
+
+template <typename T>
+using add_volatile_t = typename std::add_volatile<T>::type;
+
+template <typename T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+
+template <typename T>
+using add_lvalue_reference_t = typename std::add_lvalue_reference<T>::type;
+
+template <typename T>
+using add_rvalue_reference_t = typename std::add_rvalue_reference<T>::type;
+
+template <typename T>
+using remove_pointer_t = typename std::remove_pointer<T>::type;
+
+template <typename T>
+using add_pointer_t = typename std::add_pointer<T>::type;
+
+template <typename T>
+using make_signed_t = typename std::make_signed<T>::type;
+
+template <typename T>
+using make_unsigned_t = typename std::make_unsigned<T>::type;
+
+template <typename T>
+using remove_extent_t = typename std::remove_extent<T>::type;
+
+template <typename T>
+using remove_all_extents_t = typename std::remove_all_extents<T>::type;
+
+template <size_t Len, size_t Align = type_traits_internal::
+                          default_alignment_of_aligned_storage<Len>::value>
+using aligned_storage_t = typename std::aligned_storage<Len, Align>::type;
+
+template <typename T>
+using decay_t = typename std::decay<T>::type;
+
+template <bool B, typename T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+template <bool B, typename T, typename F>
+using conditional_t = typename std::conditional<B, T, F>::type;
+
+template <typename... T>
+using common_type_t = typename std::common_type<T...>::type;
+
+template <typename T>
+using underlying_type_t = typename std::underlying_type<T>::type;
+
+namespace type_traits_internal {
+
+#if (!defined(_MSVC_LANG) && (__cplusplus >= 201703L)) || \
+    (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L))
+// std::result_of is deprecated (C++17) or removed (C++20)
+template<typename> struct result_of;
+template<typename F, typename... Args>
+struct result_of<F(Args...)> : std::invoke_result<F, Args...> {};
+#else
+template<typename F> using result_of = std::result_of<F>;
+#endif
+
+}  // namespace type_traits_internal
+
+template<typename F>
+using result_of_t = typename type_traits_internal::result_of<F>::type;
+
+namespace type_traits_internal {
+// In MSVC we can't probe std::hash or stdext::hash because it triggers a
+// static_assert instead of failing substitution. Libc++ prior to 4.0
+// also used a static_assert.
+//
+#if defined(_MSC_VER) || (defined(_LIBCPP_VERSION) && \
+                          _LIBCPP_VERSION < 4000 && _LIBCPP_STD_VER > 11)
+#define OTABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_ 0
+#else
+#define OTABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_ 1
+#endif
+
+#if !OTABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_
+template <typename Key, typename = size_t>
+struct IsHashable : std::true_type {};
+#else   // OTABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_
+template <typename Key, typename = void>
+struct IsHashable : std::false_type {};
+
+template <typename Key>
+struct IsHashable<
+    Key,
+    absl::enable_if_t<std::is_convertible<
+        decltype(std::declval<std::hash<Key>&>()(std::declval<Key const&>())),
+        std::size_t>::value>> : std::true_type {};
+#endif  // !OTABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_
+
+struct AssertHashEnabledHelper {
+ private:
+  static void Sink(...) {}
+  struct NAT {};
+
+  template <class Key>
+  static auto GetReturnType(int)
+      -> decltype(std::declval<std::hash<Key>>()(std::declval<Key const&>()));
+  template <class Key>
+  static NAT GetReturnType(...);
+
+  template <class Key>
+  static std::nullptr_t DoIt() {
+    static_assert(IsHashable<Key>::value,
+                  "std::hash<Key> does not provide a call operator");
+    static_assert(
+        std::is_default_constructible<std::hash<Key>>::value,
+        "std::hash<Key> must be default constructible when it is enabled");
+    static_assert(
+        std::is_copy_constructible<std::hash<Key>>::value,
+        "std::hash<Key> must be copy constructible when it is enabled");
+    static_assert(absl::is_copy_assignable<std::hash<Key>>::value,
+                  "std::hash<Key> must be copy assignable when it is enabled");
+    // is_destructible is unchecked as it's implied by each of the
+    // is_constructible checks.
+    using ReturnType = decltype(GetReturnType<Key>(0));
+    static_assert(std::is_same<ReturnType, NAT>::value ||
+                      std::is_same<ReturnType, size_t>::value,
+                  "std::hash<Key> must return size_t");
+    return nullptr;
+  }
+
+  template <class... Ts>
+  friend void AssertHashEnabled();
+};
+
+template <class... Ts>
+inline void AssertHashEnabled() {
+  using Helper = AssertHashEnabledHelper;
+  Helper::Sink(Helper::DoIt<Ts>()...);
+}
+
+}  // namespace type_traits_internal
+
+// An internal namespace that is required to implement the C++17 swap traits.
+// It is not further nested in type_traits_internal to avoid long symbol names.
+namespace swap_internal {
+
+// Necessary for the traits.
+using std::swap;
+
+// This declaration prevents global `swap` and `absl::swap` overloads from being
+// considered unless ADL picks them up.
+void swap();
+
+template <class T>
+using IsSwappableImpl = decltype(swap(std::declval<T&>(), std::declval<T&>()));
+
+// NOTE: This dance with the default template parameter is for MSVC.
+template <class T,
+          class IsNoexcept = std::integral_constant<
+              bool, noexcept(swap(std::declval<T&>(), std::declval<T&>()))>>
+using IsNothrowSwappableImpl = typename std::enable_if<IsNoexcept::value>::type;
+
+// IsSwappable
+//
+// Determines whether the standard swap idiom is a valid expression for
+// arguments of type `T`.
+template <class T>
+struct IsSwappable
+    : absl::type_traits_internal::is_detected<IsSwappableImpl, T> {};
+
+// IsNothrowSwappable
+//
+// Determines whether the standard swap idiom is a valid expression for
+// arguments of type `T` and is noexcept.
+template <class T>
+struct IsNothrowSwappable
+    : absl::type_traits_internal::is_detected<IsNothrowSwappableImpl, T> {};
+
+// Swap()
+//
+// Performs the swap idiom from a namespace where valid candidates may only be
+// found in `std` or via ADL.
+template <class T, absl::enable_if_t<IsSwappable<T>::value, int> = 0>
+void Swap(T& lhs, T& rhs) noexcept(IsNothrowSwappable<T>::value) {
+  swap(lhs, rhs);
+}
+
+// StdSwapIsUnconstrained
+//
+// Some standard library implementations are broken in that they do not
+// constrain `std::swap`. This will effectively tell us if we are dealing with
+// one of those implementations.
+using StdSwapIsUnconstrained = IsSwappable<void()>;
+
+}  // namespace swap_internal
+
+namespace type_traits_internal {
+
+// Make the swap-related traits/function accessible from this namespace.
+using swap_internal::IsNothrowSwappable;
+using swap_internal::IsSwappable;
+using swap_internal::Swap;
+using swap_internal::StdSwapIsUnconstrained;
+
+}  // namespace type_traits_internal
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // OTABSL_META_TYPE_TRAITS_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/types/bad_variant_access.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/types/bad_variant_access.h
@@ -1,0 +1,94 @@
+// Copyright 2018 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// bad_variant_access.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines the `absl::bad_variant_access` type.
+
+#ifndef OTABSL_TYPES_BAD_VARIANT_ACCESS_H_
+#define OTABSL_TYPES_BAD_VARIANT_ACCESS_H_
+
+#include <stdexcept>
+
+#include "../base/config.h"
+
+#ifdef OTABSL_USES_STD_VARIANT
+
+#include <variant>
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+using std::bad_variant_access;
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+#else  // OTABSL_USES_STD_VARIANT
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+
+// -----------------------------------------------------------------------------
+// bad_variant_access
+// -----------------------------------------------------------------------------
+//
+// An `absl::bad_variant_access` type is an exception type that is thrown in
+// the following cases:
+//
+//   * Calling `absl::get(absl::variant) with an index or type that does not
+//     match the currently selected alternative type
+//   * Calling `absl::visit on an `absl::variant` that is in the
+//     `variant::valueless_by_exception` state.
+//
+// Example:
+//
+//   absl::variant<int, std::string> v;
+//   v = 1;
+//   try {
+//     absl::get<std::string>(v);
+//   } catch(const absl::bad_variant_access& e) {
+//     std::cout << "Bad variant access: " << e.what() << '\n';
+//   }
+class bad_variant_access : public std::exception {
+ public:
+  bad_variant_access() noexcept = default;
+  ~bad_variant_access() override;
+  const char* what() const noexcept override;
+};
+
+namespace variant_internal {
+#ifdef THROW_BAD_VARIANT_ACCESS
+// Header-only implementation with static throw implementation.
+// No need to link against Abseil library.
+[[noreturn]] static inline void ThrowBadVariantAccess()
+{
+  THROW_BAD_VARIANT_ACCESS;
+}
+//[[noreturn]] static inline void Rethrow()
+//{
+//  THROW_BAD_VARIANT_ACCESS; // Unused!
+//};
+#else
+// Original implementation requires linking Abseil library!
+[[noreturn]] void ThrowBadVariantAccess();
+[[noreturn]] void Rethrow();
+#endif
+}  // namespace variant_internal
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // OTABSL_USES_STD_VARIANT
+
+#endif  // OTABSL_TYPES_BAD_VARIANT_ACCESS_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/types/internal/variant.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/types/internal/variant.h
@@ -1,0 +1,1646 @@
+// Copyright 2018 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Implementation details of absl/types/variant.h, pulled into a
+// separate file to avoid cluttering the top of the API header with
+// implementation details.
+
+#ifndef OTABSL_TYPES_variant_internal_H_
+#define OTABSL_TYPES_variant_internal_H_
+
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+
+#include "../../base/config.h"
+#include "../../base/internal/identity.h"
+#include "../../base/internal/inline_variable.h"
+#include "../../base/internal/invoke.h"
+#include "../../base/macros.h"
+#include "../../base/optimization.h"
+#include "../../meta/type_traits.h"
+#include "../../types/bad_variant_access.h"
+#include "../../utility/utility.h"
+
+#if !defined(OTABSL_USES_STD_VARIANT)
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+
+template <class... Types>
+class variant;
+
+OTABSL_INTERNAL_INLINE_CONSTEXPR(size_t, variant_npos, -1);
+
+template <class T>
+struct variant_size;
+
+template <std::size_t I, class T>
+struct variant_alternative;
+
+namespace variant_internal {
+
+// NOTE: See specializations below for details.
+template <std::size_t I, class T>
+struct VariantAlternativeSfinae {};
+
+// Requires: I < variant_size_v<T>.
+//
+// Value: The Ith type of Types...
+template <std::size_t I, class T0, class... Tn>
+struct VariantAlternativeSfinae<I, variant<T0, Tn...>>
+    : VariantAlternativeSfinae<I - 1, variant<Tn...>> {};
+
+// Value: T0
+template <class T0, class... Ts>
+struct VariantAlternativeSfinae<0, variant<T0, Ts...>> {
+  using type = T0;
+};
+
+template <std::size_t I, class T>
+using VariantAlternativeSfinaeT = typename VariantAlternativeSfinae<I, T>::type;
+
+// NOTE: Requires T to be a reference type.
+template <class T, class U>
+struct GiveQualsTo;
+
+template <class T, class U>
+struct GiveQualsTo<T&, U> {
+  using type = U&;
+};
+
+template <class T, class U>
+struct GiveQualsTo<T&&, U> {
+  using type = U&&;
+};
+
+template <class T, class U>
+struct GiveQualsTo<const T&, U> {
+  using type = const U&;
+};
+
+template <class T, class U>
+struct GiveQualsTo<const T&&, U> {
+  using type = const U&&;
+};
+
+template <class T, class U>
+struct GiveQualsTo<volatile T&, U> {
+  using type = volatile U&;
+};
+
+template <class T, class U>
+struct GiveQualsTo<volatile T&&, U> {
+  using type = volatile U&&;
+};
+
+template <class T, class U>
+struct GiveQualsTo<volatile const T&, U> {
+  using type = volatile const U&;
+};
+
+template <class T, class U>
+struct GiveQualsTo<volatile const T&&, U> {
+  using type = volatile const U&&;
+};
+
+template <class T, class U>
+using GiveQualsToT = typename GiveQualsTo<T, U>::type;
+
+// Convenience alias, since size_t integral_constant is used a lot in this file.
+template <std::size_t I>
+using SizeT = std::integral_constant<std::size_t, I>;
+
+using NPos = SizeT<variant_npos>;
+
+template <class Variant, class T, class = void>
+struct IndexOfConstructedType {};
+
+template <std::size_t I, class Variant>
+struct VariantAccessResultImpl;
+
+template <std::size_t I, template <class...> class Variantemplate, class... T>
+struct VariantAccessResultImpl<I, Variantemplate<T...>&> {
+  using type = typename absl::variant_alternative<I, variant<T...>>::type&;
+};
+
+template <std::size_t I, template <class...> class Variantemplate, class... T>
+struct VariantAccessResultImpl<I, const Variantemplate<T...>&> {
+  using type =
+      const typename absl::variant_alternative<I, variant<T...>>::type&;
+};
+
+template <std::size_t I, template <class...> class Variantemplate, class... T>
+struct VariantAccessResultImpl<I, Variantemplate<T...>&&> {
+  using type = typename absl::variant_alternative<I, variant<T...>>::type&&;
+};
+
+template <std::size_t I, template <class...> class Variantemplate, class... T>
+struct VariantAccessResultImpl<I, const Variantemplate<T...>&&> {
+  using type =
+      const typename absl::variant_alternative<I, variant<T...>>::type&&;
+};
+
+template <std::size_t I, class Variant>
+using VariantAccessResult =
+    typename VariantAccessResultImpl<I, Variant&&>::type;
+
+// NOTE: This is used instead of std::array to reduce instantiation overhead.
+template <class T, std::size_t Size>
+struct SimpleArray {
+  static_assert(Size != 0, "");
+  T value[Size];
+};
+
+template <class T>
+struct AccessedType {
+  using type = T;
+};
+
+template <class T>
+using AccessedTypeT = typename AccessedType<T>::type;
+
+template <class T, std::size_t Size>
+struct AccessedType<SimpleArray<T, Size>> {
+  using type = AccessedTypeT<T>;
+};
+
+template <class T>
+constexpr T AccessSimpleArray(const T& value) {
+  return value;
+}
+
+template <class T, std::size_t Size, class... SizeT>
+constexpr AccessedTypeT<T> AccessSimpleArray(const SimpleArray<T, Size>& table,
+                                             std::size_t head_index,
+                                             SizeT... tail_indices) {
+  return AccessSimpleArray(table.value[head_index], tail_indices...);
+}
+
+// Note: Intentionally is an alias.
+template <class T>
+using AlwaysZero = SizeT<0>;
+
+template <class Op, class... Vs>
+struct VisitIndicesResultImpl {
+  using type = absl::result_of_t<Op(AlwaysZero<Vs>...)>;
+};
+
+template <class Op, class... Vs>
+using VisitIndicesResultT = typename VisitIndicesResultImpl<Op, Vs...>::type;
+
+template <class ReturnType, class FunctionObject, class EndIndices,
+          class BoundIndices>
+struct MakeVisitationMatrix;
+
+template <class ReturnType, class FunctionObject, std::size_t... Indices>
+constexpr ReturnType call_with_indices(FunctionObject&& function) {
+  static_assert(
+      std::is_same<ReturnType, decltype(std::declval<FunctionObject>()(
+                                   SizeT<Indices>()...))>::value,
+      "Not all visitation overloads have the same return type.");
+  return absl::forward<FunctionObject>(function)(SizeT<Indices>()...);
+}
+
+template <class ReturnType, class FunctionObject, std::size_t... BoundIndices>
+struct MakeVisitationMatrix<ReturnType, FunctionObject, index_sequence<>,
+                            index_sequence<BoundIndices...>> {
+  using ResultType = ReturnType (*)(FunctionObject&&);
+  static constexpr ResultType Run() {
+    return &call_with_indices<ReturnType, FunctionObject,
+                              (BoundIndices - 1)...>;
+  }
+};
+
+template <typename Is, std::size_t J>
+struct AppendToIndexSequence;
+
+template <typename Is, std::size_t J>
+using AppendToIndexSequenceT = typename AppendToIndexSequence<Is, J>::type;
+
+template <std::size_t... Is, std::size_t J>
+struct AppendToIndexSequence<index_sequence<Is...>, J> {
+  using type = index_sequence<Is..., J>;
+};
+
+template <class ReturnType, class FunctionObject, class EndIndices,
+          class CurrIndices, class BoundIndices>
+struct MakeVisitationMatrixImpl;
+
+template <class ReturnType, class FunctionObject, class EndIndices,
+          std::size_t... CurrIndices, class BoundIndices>
+struct MakeVisitationMatrixImpl<ReturnType, FunctionObject, EndIndices,
+                                index_sequence<CurrIndices...>, BoundIndices> {
+  using ResultType = SimpleArray<
+      typename MakeVisitationMatrix<ReturnType, FunctionObject, EndIndices,
+                                    index_sequence<>>::ResultType,
+      sizeof...(CurrIndices)>;
+
+  static constexpr ResultType Run() {
+    return {{MakeVisitationMatrix<
+        ReturnType, FunctionObject, EndIndices,
+        AppendToIndexSequenceT<BoundIndices, CurrIndices>>::Run()...}};
+  }
+};
+
+template <class ReturnType, class FunctionObject, std::size_t HeadEndIndex,
+          std::size_t... TailEndIndices, std::size_t... BoundIndices>
+struct MakeVisitationMatrix<ReturnType, FunctionObject,
+                            index_sequence<HeadEndIndex, TailEndIndices...>,
+                            index_sequence<BoundIndices...>>
+    : MakeVisitationMatrixImpl<ReturnType, FunctionObject,
+                               index_sequence<TailEndIndices...>,
+                               absl::make_index_sequence<HeadEndIndex>,
+                               index_sequence<BoundIndices...>> {};
+
+struct UnreachableSwitchCase {
+  template <class Op>
+  [[noreturn]] static VisitIndicesResultT<Op, std::size_t> Run(
+      Op&& /*ignored*/) {
+#if OTABSL_HAVE_BUILTIN(__builtin_unreachable) || \
+    (defined(__GNUC__) && !defined(__clang__))
+    __builtin_unreachable();
+#elif defined(_MSC_VER)
+    __assume(false);
+#else
+    // Try to use assert of false being identified as an unreachable intrinsic.
+    // NOTE: We use assert directly to increase chances of exploiting an assume
+    //       intrinsic.
+    assert(false);  // NOLINT
+
+    // Hack to silence potential no return warning -- cause an infinite loop.
+    return Run(absl::forward<Op>(op));
+#endif  // Checks for __builtin_unreachable
+  }
+};
+
+template <class Op, std::size_t I>
+struct ReachableSwitchCase {
+  static VisitIndicesResultT<Op, std::size_t> Run(Op&& op) {
+    return absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::base_internal::Invoke(absl::forward<Op>(op), SizeT<I>());
+  }
+};
+
+// The number 33 is just a guess at a reasonable maximum to our switch. It is
+// not based on any analysis. The reason it is a power of 2 plus 1 instead of a
+// power of 2 is because the number was picked to correspond to a power of 2
+// amount of "normal" alternatives, plus one for the possibility of the user
+// providing "monostate" in addition to the more natural alternatives.
+OTABSL_INTERNAL_INLINE_CONSTEXPR(std::size_t, MaxUnrolledVisitCases, 33);
+
+// Note: The default-definition is for unreachable cases.
+template <bool IsReachable>
+struct PickCaseImpl {
+  template <class Op, std::size_t I>
+  using Apply = UnreachableSwitchCase;
+};
+
+template <>
+struct PickCaseImpl</*IsReachable =*/true> {
+  template <class Op, std::size_t I>
+  using Apply = ReachableSwitchCase<Op, I>;
+};
+
+// Note: This form of dance with template aliases is to make sure that we
+//       instantiate a number of templates proportional to the number of variant
+//       alternatives rather than a number of templates proportional to our
+//       maximum unrolled amount of visitation cases (aliases are effectively
+//       "free" whereas other template instantiations are costly).
+template <class Op, std::size_t I, std::size_t EndIndex>
+using PickCase = typename PickCaseImpl<(I < EndIndex)>::template Apply<Op, I>;
+
+template <class ReturnType>
+[[noreturn]] ReturnType TypedThrowBadVariantAccess() {
+  absl::variant_internal::ThrowBadVariantAccess();
+}
+
+// Given N variant sizes, determine the number of cases there would need to be
+// in a single switch-statement that would cover every possibility in the
+// corresponding N-ary visit operation.
+template <std::size_t... NumAlternatives>
+struct NumCasesOfSwitch;
+
+template <std::size_t HeadNumAlternatives, std::size_t... TailNumAlternatives>
+struct NumCasesOfSwitch<HeadNumAlternatives, TailNumAlternatives...> {
+  static constexpr std::size_t value =
+      (HeadNumAlternatives + 1) *
+      NumCasesOfSwitch<TailNumAlternatives...>::value;
+};
+
+template <>
+struct NumCasesOfSwitch<> {
+  static constexpr std::size_t value = 1;
+};
+
+// A switch statement optimizes better than the table of function pointers.
+template <std::size_t EndIndex>
+struct VisitIndicesSwitch {
+  static_assert(EndIndex <= MaxUnrolledVisitCases,
+                "Maximum unrolled switch size exceeded.");
+
+  template <class Op>
+  static VisitIndicesResultT<Op, std::size_t> Run(Op&& op, std::size_t i) {
+    switch (i) {
+      case 0:
+        return PickCase<Op, 0, EndIndex>::Run(absl::forward<Op>(op));
+      case 1:
+        return PickCase<Op, 1, EndIndex>::Run(absl::forward<Op>(op));
+      case 2:
+        return PickCase<Op, 2, EndIndex>::Run(absl::forward<Op>(op));
+      case 3:
+        return PickCase<Op, 3, EndIndex>::Run(absl::forward<Op>(op));
+      case 4:
+        return PickCase<Op, 4, EndIndex>::Run(absl::forward<Op>(op));
+      case 5:
+        return PickCase<Op, 5, EndIndex>::Run(absl::forward<Op>(op));
+      case 6:
+        return PickCase<Op, 6, EndIndex>::Run(absl::forward<Op>(op));
+      case 7:
+        return PickCase<Op, 7, EndIndex>::Run(absl::forward<Op>(op));
+      case 8:
+        return PickCase<Op, 8, EndIndex>::Run(absl::forward<Op>(op));
+      case 9:
+        return PickCase<Op, 9, EndIndex>::Run(absl::forward<Op>(op));
+      case 10:
+        return PickCase<Op, 10, EndIndex>::Run(absl::forward<Op>(op));
+      case 11:
+        return PickCase<Op, 11, EndIndex>::Run(absl::forward<Op>(op));
+      case 12:
+        return PickCase<Op, 12, EndIndex>::Run(absl::forward<Op>(op));
+      case 13:
+        return PickCase<Op, 13, EndIndex>::Run(absl::forward<Op>(op));
+      case 14:
+        return PickCase<Op, 14, EndIndex>::Run(absl::forward<Op>(op));
+      case 15:
+        return PickCase<Op, 15, EndIndex>::Run(absl::forward<Op>(op));
+      case 16:
+        return PickCase<Op, 16, EndIndex>::Run(absl::forward<Op>(op));
+      case 17:
+        return PickCase<Op, 17, EndIndex>::Run(absl::forward<Op>(op));
+      case 18:
+        return PickCase<Op, 18, EndIndex>::Run(absl::forward<Op>(op));
+      case 19:
+        return PickCase<Op, 19, EndIndex>::Run(absl::forward<Op>(op));
+      case 20:
+        return PickCase<Op, 20, EndIndex>::Run(absl::forward<Op>(op));
+      case 21:
+        return PickCase<Op, 21, EndIndex>::Run(absl::forward<Op>(op));
+      case 22:
+        return PickCase<Op, 22, EndIndex>::Run(absl::forward<Op>(op));
+      case 23:
+        return PickCase<Op, 23, EndIndex>::Run(absl::forward<Op>(op));
+      case 24:
+        return PickCase<Op, 24, EndIndex>::Run(absl::forward<Op>(op));
+      case 25:
+        return PickCase<Op, 25, EndIndex>::Run(absl::forward<Op>(op));
+      case 26:
+        return PickCase<Op, 26, EndIndex>::Run(absl::forward<Op>(op));
+      case 27:
+        return PickCase<Op, 27, EndIndex>::Run(absl::forward<Op>(op));
+      case 28:
+        return PickCase<Op, 28, EndIndex>::Run(absl::forward<Op>(op));
+      case 29:
+        return PickCase<Op, 29, EndIndex>::Run(absl::forward<Op>(op));
+      case 30:
+        return PickCase<Op, 30, EndIndex>::Run(absl::forward<Op>(op));
+      case 31:
+        return PickCase<Op, 31, EndIndex>::Run(absl::forward<Op>(op));
+      case 32:
+        return PickCase<Op, 32, EndIndex>::Run(absl::forward<Op>(op));
+      default:
+        OTABSL_ASSERT(i == variant_npos);
+        return absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::base_internal::Invoke(absl::forward<Op>(op), NPos());
+    }
+  }
+};
+
+template <std::size_t... EndIndices>
+struct VisitIndicesFallback {
+  template <class Op, class... SizeT>
+  static VisitIndicesResultT<Op, SizeT...> Run(Op&& op, SizeT... indices) {
+    return AccessSimpleArray(
+        MakeVisitationMatrix<VisitIndicesResultT<Op, SizeT...>, Op,
+                             index_sequence<(EndIndices + 1)...>,
+                             index_sequence<>>::Run(),
+        (indices + 1)...)(absl::forward<Op>(op));
+  }
+};
+
+// Take an N-dimensional series of indices and convert them into a single index
+// without loss of information. The purpose of this is to be able to convert an
+// N-ary visit operation into a single switch statement.
+template <std::size_t...>
+struct FlattenIndices;
+
+template <std::size_t HeadSize, std::size_t... TailSize>
+struct FlattenIndices<HeadSize, TailSize...> {
+  template<class... SizeType>
+  static constexpr std::size_t Run(std::size_t head, SizeType... tail) {
+    return head + HeadSize * FlattenIndices<TailSize...>::Run(tail...);
+  }
+};
+
+template <>
+struct FlattenIndices<> {
+  static constexpr std::size_t Run() { return 0; }
+};
+
+// Take a single "flattened" index (flattened by FlattenIndices) and determine
+// the value of the index of one of the logically represented dimensions.
+template <std::size_t I, std::size_t IndexToGet, std::size_t HeadSize,
+          std::size_t... TailSize>
+struct UnflattenIndex {
+  static constexpr std::size_t value =
+      UnflattenIndex<I / HeadSize, IndexToGet - 1, TailSize...>::value;
+};
+
+template <std::size_t I, std::size_t HeadSize, std::size_t... TailSize>
+struct UnflattenIndex<I, 0, HeadSize, TailSize...> {
+  static constexpr std::size_t value = (I % HeadSize);
+};
+
+// The backend for converting an N-ary visit operation into a unary visit.
+template <class IndexSequence, std::size_t... EndIndices>
+struct VisitIndicesVariadicImpl;
+
+template <std::size_t... N, std::size_t... EndIndices>
+struct VisitIndicesVariadicImpl<absl::index_sequence<N...>, EndIndices...> {
+  // A type that can take an N-ary function object and converts it to a unary
+  // function object that takes a single, flattened index, and "unflattens" it
+  // into its individual dimensions when forwarding to the wrapped object.
+  template <class Op>
+  struct FlattenedOp {
+    template <std::size_t I>
+    VisitIndicesResultT<Op, decltype(EndIndices)...> operator()(
+        SizeT<I> /*index*/) && {
+      return OTABSL_OPTION_INLINE_NAMESPACE_NAME::base_internal::Invoke(
+          absl::forward<Op>(op),
+          SizeT<UnflattenIndex<I, N, (EndIndices + 1)...>::value -
+                std::size_t{1}>()...);
+    }
+
+    Op&& op;
+  };
+
+  template <class Op, class... SizeType>
+  static VisitIndicesResultT<Op, decltype(EndIndices)...> Run(
+      Op&& op, SizeType... i) {
+    return VisitIndicesSwitch<NumCasesOfSwitch<EndIndices...>::value>::Run(
+        FlattenedOp<Op>{absl::forward<Op>(op)},
+        FlattenIndices<(EndIndices + std::size_t{1})...>::Run(
+            (i + std::size_t{1})...));
+  }
+};
+
+template <std::size_t... EndIndices>
+struct VisitIndicesVariadic
+    : VisitIndicesVariadicImpl<absl::make_index_sequence<sizeof...(EndIndices)>,
+                               EndIndices...> {};
+
+// This implementation will flatten N-ary visit operations into a single switch
+// statement when the number of cases would be less than our maximum specified
+// switch-statement size.
+// TODO(calabrese)
+//   Based on benchmarks, determine whether the function table approach actually
+//   does optimize better than a chain of switch statements and possibly update
+//   the implementation accordingly. Also consider increasing the maximum switch
+//   size.
+template <std::size_t... EndIndices>
+struct VisitIndices
+    : absl::conditional_t<(NumCasesOfSwitch<EndIndices...>::value <=
+                           MaxUnrolledVisitCases),
+                          VisitIndicesVariadic<EndIndices...>,
+                          VisitIndicesFallback<EndIndices...>> {};
+
+template <std::size_t EndIndex>
+struct VisitIndices<EndIndex>
+    : absl::conditional_t<(EndIndex <= MaxUnrolledVisitCases),
+                          VisitIndicesSwitch<EndIndex>,
+                          VisitIndicesFallback<EndIndex>> {};
+
+// Suppress bogus warning on MSVC: MSVC complains that the `reinterpret_cast`
+// below is returning the address of a temporary or local object.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4172)
+#endif  // _MSC_VER
+
+// TODO(calabrese) std::launder
+// TODO(calabrese) constexpr
+// NOTE: DO NOT REMOVE the `inline` keyword as it is necessary to work around a
+// MSVC bug. See https://github.com/abseil/abseil-cpp/issues/129 for details.
+template <class Self, std::size_t I>
+inline VariantAccessResult<I, Self> AccessUnion(Self&& self, SizeT<I> /*i*/) {
+  return reinterpret_cast<VariantAccessResult<I, Self>>(self);
+}
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
+
+template <class T>
+void DeducedDestroy(T& self) {  // NOLINT
+  self.~T();
+}
+
+// NOTE: This type exists as a single entity for variant and its bases to
+// befriend. It contains helper functionality that manipulates the state of the
+// variant, such as the implementation of things like assignment and emplace
+// operations.
+struct VariantCoreAccess {
+  template <class VariantType>
+  static typename VariantType::Variant& Derived(VariantType& self) {  // NOLINT
+    return static_cast<typename VariantType::Variant&>(self);
+  }
+
+  template <class VariantType>
+  static const typename VariantType::Variant& Derived(
+      const VariantType& self) {  // NOLINT
+    return static_cast<const typename VariantType::Variant&>(self);
+  }
+
+  template <class VariantType>
+  static void Destroy(VariantType& self) {  // NOLINT
+    Derived(self).destroy();
+    self.index_ = absl::variant_npos;
+  }
+
+  template <class Variant>
+  static void SetIndex(Variant& self, std::size_t i) {  // NOLINT
+    self.index_ = i;
+  }
+
+  template <class Variant>
+  static void InitFrom(Variant& self, Variant&& other) {  // NOLINT
+    VisitIndices<absl::variant_size<Variant>::value>::Run(
+        InitFromVisitor<Variant, Variant&&>{&self,
+                                            std::forward<Variant>(other)},
+        other.index());
+    self.index_ = other.index();
+  }
+
+  // Access a variant alternative, assuming the index is correct.
+  template <std::size_t I, class Variant>
+  static VariantAccessResult<I, Variant> Access(Variant&& self) {
+    // This cast instead of invocation of AccessUnion with an rvalue is a
+    // workaround for msvc. Without this there is a runtime failure when dealing
+    // with rvalues.
+    // TODO(calabrese) Reduce test case and find a simpler workaround.
+    return static_cast<VariantAccessResult<I, Variant>>(
+        variant_internal::AccessUnion(self.state_, SizeT<I>()));
+  }
+
+  // Access a variant alternative, throwing if the index is incorrect.
+  template <std::size_t I, class Variant>
+  static VariantAccessResult<I, Variant> CheckedAccess(Variant&& self) {
+    if (OTABSL_PREDICT_FALSE(self.index_ != I)) {
+      TypedThrowBadVariantAccess<VariantAccessResult<I, Variant>>();
+    }
+
+    return Access<I>(absl::forward<Variant>(self));
+  }
+
+  // The implementation of the move-assignment operation for a variant.
+  template <class VType>
+  struct MoveAssignVisitor {
+    using DerivedType = typename VType::Variant;
+    template <std::size_t NewIndex>
+    void operator()(SizeT<NewIndex> /*new_i*/) const {
+      if (left->index_ == NewIndex) {
+        Access<NewIndex>(*left) = std::move(Access<NewIndex>(*right));
+      } else {
+        Derived(*left).template emplace<NewIndex>(
+            std::move(Access<NewIndex>(*right)));
+      }
+    }
+
+    void operator()(SizeT<absl::variant_npos> /*new_i*/) const {
+      Destroy(*left);
+    }
+
+    VType* left;
+    VType* right;
+  };
+
+  template <class VType>
+  static MoveAssignVisitor<VType> MakeMoveAssignVisitor(VType* left,
+                                                        VType* other) {
+    return {left, other};
+  }
+
+  // The implementation of the assignment operation for a variant.
+  template <class VType>
+  struct CopyAssignVisitor {
+    using DerivedType = typename VType::Variant;
+    template <std::size_t NewIndex>
+    void operator()(SizeT<NewIndex> /*new_i*/) const {
+      using New =
+          typename absl::variant_alternative<NewIndex, DerivedType>::type;
+
+      if (left->index_ == NewIndex) {
+        Access<NewIndex>(*left) = Access<NewIndex>(*right);
+      } else if (std::is_nothrow_copy_constructible<New>::value ||
+                 !std::is_nothrow_move_constructible<New>::value) {
+        Derived(*left).template emplace<NewIndex>(Access<NewIndex>(*right));
+      } else {
+        Derived(*left) = DerivedType(Derived(*right));
+      }
+    }
+
+    void operator()(SizeT<absl::variant_npos> /*new_i*/) const {
+      Destroy(*left);
+    }
+
+    VType* left;
+    const VType* right;
+  };
+
+  template <class VType>
+  static CopyAssignVisitor<VType> MakeCopyAssignVisitor(VType* left,
+                                                        const VType& other) {
+    return {left, &other};
+  }
+
+  // The implementation of conversion-assignment operations for variant.
+  template <class Left, class QualifiedNew>
+  struct ConversionAssignVisitor {
+    using NewIndex =
+        variant_internal::IndexOfConstructedType<Left, QualifiedNew>;
+
+    void operator()(SizeT<NewIndex::value> /*old_i*/
+                    ) const {
+      Access<NewIndex::value>(*left) = absl::forward<QualifiedNew>(other);
+    }
+
+    template <std::size_t OldIndex>
+    void operator()(SizeT<OldIndex> /*old_i*/
+                    ) const {
+      using New =
+          typename absl::variant_alternative<NewIndex::value, Left>::type;
+      if (std::is_nothrow_constructible<New, QualifiedNew>::value ||
+          !std::is_nothrow_move_constructible<New>::value) {
+        left->template emplace<NewIndex::value>(
+            absl::forward<QualifiedNew>(other));
+      } else {
+        // the standard says "equivalent to
+        // operator=(variant(std::forward<T>(t)))", but we use `emplace` here
+        // because the variant's move assignment operator could be deleted.
+        left->template emplace<NewIndex::value>(
+            New(absl::forward<QualifiedNew>(other)));
+      }
+    }
+
+    Left* left;
+    QualifiedNew&& other;
+  };
+
+  template <class Left, class QualifiedNew>
+  static ConversionAssignVisitor<Left, QualifiedNew>
+  MakeConversionAssignVisitor(Left* left, QualifiedNew&& qual) {
+    return {left, absl::forward<QualifiedNew>(qual)};
+  }
+
+  // Backend for operations for `emplace()` which destructs `*self` then
+  // construct a new alternative with `Args...`.
+  template <std::size_t NewIndex, class Self, class... Args>
+  static typename absl::variant_alternative<NewIndex, Self>::type& Replace(
+      Self* self, Args&&... args) {
+    Destroy(*self);
+    using New = typename absl::variant_alternative<NewIndex, Self>::type;
+    New* const result = ::new (static_cast<void*>(&self->state_))
+        New(absl::forward<Args>(args)...);
+    self->index_ = NewIndex;
+    return *result;
+  }
+
+  template <class LeftVariant, class QualifiedRightVariant>
+  struct InitFromVisitor {
+    template <std::size_t NewIndex>
+    void operator()(SizeT<NewIndex> /*new_i*/) const {
+      using Alternative =
+          typename variant_alternative<NewIndex, LeftVariant>::type;
+      ::new (static_cast<void*>(&left->state_)) Alternative(
+          Access<NewIndex>(std::forward<QualifiedRightVariant>(right)));
+    }
+
+    void operator()(SizeT<absl::variant_npos> /*new_i*/) const {
+      // This space intentionally left blank.
+    }
+    LeftVariant* left;
+    QualifiedRightVariant&& right;
+  };
+};
+
+template <class Expected, class... T>
+struct IndexOfImpl;
+
+template <class Expected>
+struct IndexOfImpl<Expected> {
+  using IndexFromEnd = SizeT<0>;
+  using MatchedIndexFromEnd = IndexFromEnd;
+  using MultipleMatches = std::false_type;
+};
+
+template <class Expected, class Head, class... Tail>
+struct IndexOfImpl<Expected, Head, Tail...> : IndexOfImpl<Expected, Tail...> {
+  using IndexFromEnd =
+      SizeT<IndexOfImpl<Expected, Tail...>::IndexFromEnd::value + 1>;
+};
+
+template <class Expected, class... Tail>
+struct IndexOfImpl<Expected, Expected, Tail...>
+    : IndexOfImpl<Expected, Tail...> {
+  using IndexFromEnd =
+      SizeT<IndexOfImpl<Expected, Tail...>::IndexFromEnd::value + 1>;
+  using MatchedIndexFromEnd = IndexFromEnd;
+  using MultipleMatches = std::integral_constant<
+      bool, IndexOfImpl<Expected, Tail...>::MatchedIndexFromEnd::value != 0>;
+};
+
+template <class Expected, class... Types>
+struct IndexOfMeta {
+  using Results = IndexOfImpl<Expected, Types...>;
+  static_assert(!Results::MultipleMatches::value,
+                "Attempted to access a variant by specifying a type that "
+                "matches more than one alternative.");
+  static_assert(Results::MatchedIndexFromEnd::value != 0,
+                "Attempted to access a variant by specifying a type that does "
+                "not match any alternative.");
+  using type = SizeT<sizeof...(Types) - Results::MatchedIndexFromEnd::value>;
+};
+
+template <class Expected, class... Types>
+using IndexOf = typename IndexOfMeta<Expected, Types...>::type;
+
+template <class Variant, class T, std::size_t CurrIndex>
+struct UnambiguousIndexOfImpl;
+
+// Terminating case encountered once we've checked all of the alternatives
+template <class T, std::size_t CurrIndex>
+struct UnambiguousIndexOfImpl<variant<>, T, CurrIndex> : SizeT<CurrIndex> {};
+
+// Case where T is not Head
+template <class Head, class... Tail, class T, std::size_t CurrIndex>
+struct UnambiguousIndexOfImpl<variant<Head, Tail...>, T, CurrIndex>
+    : UnambiguousIndexOfImpl<variant<Tail...>, T, CurrIndex + 1>::type {};
+
+// Case where T is Head
+template <class Head, class... Tail, std::size_t CurrIndex>
+struct UnambiguousIndexOfImpl<variant<Head, Tail...>, Head, CurrIndex>
+    : SizeT<UnambiguousIndexOfImpl<variant<Tail...>, Head, 0>::value ==
+                    sizeof...(Tail)
+                ? CurrIndex
+                : CurrIndex + sizeof...(Tail) + 1> {};
+
+template <class Variant, class T>
+struct UnambiguousIndexOf;
+
+struct NoMatch {
+  struct type {};
+};
+
+template <class... Alts, class T>
+struct UnambiguousIndexOf<variant<Alts...>, T>
+    : std::conditional<UnambiguousIndexOfImpl<variant<Alts...>, T, 0>::value !=
+                           sizeof...(Alts),
+                       UnambiguousIndexOfImpl<variant<Alts...>, T, 0>,
+                       NoMatch>::type::type {};
+
+template <class T, std::size_t /*Dummy*/>
+using UnambiguousTypeOfImpl = T;
+
+template <class Variant, class T>
+using UnambiguousTypeOfT =
+    UnambiguousTypeOfImpl<T, UnambiguousIndexOf<Variant, T>::value>;
+
+template <class H, class... T>
+class VariantStateBase;
+
+// This is an implementation of the "imaginary function" that is described in
+// [variant.ctor]
+// It is used in order to determine which alternative to construct during
+// initialization from some type T.
+template <class Variant, std::size_t I = 0>
+struct ImaginaryFun;
+
+template <std::size_t I>
+struct ImaginaryFun<variant<>, I> {
+  static void Run() = delete;
+};
+
+template <class H, class... T, std::size_t I>
+struct ImaginaryFun<variant<H, T...>, I> : ImaginaryFun<variant<T...>, I + 1> {
+  using ImaginaryFun<variant<T...>, I + 1>::Run;
+
+  // NOTE: const& and && are used instead of by-value due to lack of guaranteed
+  // move elision of C++17. This may have other minor differences, but tests
+  // pass.
+  static SizeT<I> Run(const H&, SizeT<I>);
+  static SizeT<I> Run(H&&, SizeT<I>);
+};
+
+// The following metafunctions are used in constructor and assignment
+// constraints.
+template <class Self, class T>
+struct IsNeitherSelfNorInPlace : std::true_type {};
+
+template <class Self>
+struct IsNeitherSelfNorInPlace<Self, Self> : std::false_type {};
+
+template <class Self, class T>
+struct IsNeitherSelfNorInPlace<Self, in_place_type_t<T>> : std::false_type {};
+
+template <class Self, std::size_t I>
+struct IsNeitherSelfNorInPlace<Self, in_place_index_t<I>> : std::false_type {};
+
+template <class Variant, class T, class = void>
+struct ConversionIsPossibleImpl : std::false_type {};
+
+template <class Variant, class T>
+struct ConversionIsPossibleImpl<
+    Variant, T,
+    void_t<decltype(ImaginaryFun<Variant>::Run(std::declval<T>(), {}))>>
+    : std::true_type {};
+
+template <class Variant, class T>
+struct ConversionIsPossible : ConversionIsPossibleImpl<Variant, T>::type {};
+
+template <class Variant, class T>
+struct IndexOfConstructedType<
+    Variant, T,
+    void_t<decltype(ImaginaryFun<Variant>::Run(std::declval<T>(), {}))>>
+    : decltype(ImaginaryFun<Variant>::Run(std::declval<T>(), {})) {};
+
+template <std::size_t... Is>
+struct ContainsVariantNPos
+    : absl::negation<std::is_same<  // NOLINT
+          absl::integer_sequence<bool, 0 <= Is...>,
+          absl::integer_sequence<bool, Is != absl::variant_npos...>>> {};
+
+template <class Op, class... QualifiedVariants>
+using RawVisitResult =
+    absl::result_of_t<Op(VariantAccessResult<0, QualifiedVariants>...)>;
+
+// NOTE: The spec requires that all return-paths yield the same type and is not
+// SFINAE-friendly, so we can deduce the return type by examining the first
+// result. If it's not callable, then we get an error, but are compliant and
+// fast to compile.
+// TODO(calabrese) Possibly rewrite in a way that yields better compile errors
+// at the cost of longer compile-times.
+template <class Op, class... QualifiedVariants>
+struct VisitResultImpl {
+  using type =
+      absl::result_of_t<Op(VariantAccessResult<0, QualifiedVariants>...)>;
+};
+
+// Done in two steps intentionally so that we don't cause substitution to fail.
+template <class Op, class... QualifiedVariants>
+using VisitResult = typename VisitResultImpl<Op, QualifiedVariants...>::type;
+
+template <class Op, class... QualifiedVariants>
+struct PerformVisitation {
+  using ReturnType = VisitResult<Op, QualifiedVariants...>;
+
+  template <std::size_t... Is>
+  constexpr ReturnType operator()(SizeT<Is>... indices) const {
+    return Run(typename ContainsVariantNPos<Is...>::type{},
+               absl::index_sequence_for<QualifiedVariants...>(), indices...);
+  }
+
+  template <std::size_t... TupIs, std::size_t... Is>
+  constexpr ReturnType Run(std::false_type /*has_valueless*/,
+                           index_sequence<TupIs...>, SizeT<Is>...) const {
+    static_assert(
+        std::is_same<ReturnType,
+                     absl::result_of_t<Op(VariantAccessResult<
+                                          Is, QualifiedVariants>...)>>::value,
+        "All visitation overloads must have the same return type.");
+    return absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::base_internal::Invoke(
+        absl::forward<Op>(op),
+        VariantCoreAccess::Access<Is>(
+            absl::forward<QualifiedVariants>(std::get<TupIs>(variant_tup)))...);
+  }
+
+  template <std::size_t... TupIs, std::size_t... Is>
+  [[noreturn]] ReturnType Run(std::true_type /*has_valueless*/,
+                              index_sequence<TupIs...>, SizeT<Is>...) const {
+    absl::variant_internal::ThrowBadVariantAccess();
+  }
+
+  // TODO(calabrese) Avoid using a tuple, which causes lots of instantiations
+  // Attempts using lambda variadic captures fail on current GCC.
+  std::tuple<QualifiedVariants&&...> variant_tup;
+  Op&& op;
+};
+
+template <class... T>
+union Union;
+
+// We want to allow for variant<> to be trivial. For that, we need the default
+// constructor to be trivial, which means we can't define it ourselves.
+// Instead, we use a non-default constructor that takes NoopConstructorTag
+// that doesn't affect the triviality of the types.
+struct NoopConstructorTag {};
+
+template <std::size_t I>
+struct EmplaceTag {};
+
+template <>
+union Union<> {
+  constexpr explicit Union(NoopConstructorTag) noexcept {}
+};
+
+// Suppress bogus warning on MSVC: MSVC complains that Union<T...> has a defined
+// deleted destructor from the `std::is_destructible` check below.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4624)
+#endif  // _MSC_VER
+
+template <class Head, class... Tail>
+union Union<Head, Tail...> {
+  using TailUnion = Union<Tail...>;
+
+  explicit constexpr Union(NoopConstructorTag /*tag*/) noexcept
+      : tail(NoopConstructorTag()) {}
+
+  template <class... P>
+  explicit constexpr Union(EmplaceTag<0>, P&&... args)
+      : head(absl::forward<P>(args)...) {}
+
+  template <std::size_t I, class... P>
+  explicit constexpr Union(EmplaceTag<I>, P&&... args)
+      : tail(EmplaceTag<I - 1>{}, absl::forward<P>(args)...) {}
+
+  Head head;
+  TailUnion tail;
+};
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
+
+// TODO(calabrese) Just contain a Union in this union (certain configs fail).
+template <class... T>
+union DestructibleUnionImpl;
+
+template <>
+union DestructibleUnionImpl<> {
+  constexpr explicit DestructibleUnionImpl(NoopConstructorTag) noexcept {}
+};
+
+template <class Head, class... Tail>
+union DestructibleUnionImpl<Head, Tail...> {
+  using TailUnion = DestructibleUnionImpl<Tail...>;
+
+  explicit constexpr DestructibleUnionImpl(NoopConstructorTag /*tag*/) noexcept
+      : tail(NoopConstructorTag()) {}
+
+  template <class... P>
+  explicit constexpr DestructibleUnionImpl(EmplaceTag<0>, P&&... args)
+      : head(absl::forward<P>(args)...) {}
+
+  template <std::size_t I, class... P>
+  explicit constexpr DestructibleUnionImpl(EmplaceTag<I>, P&&... args)
+      : tail(EmplaceTag<I - 1>{}, absl::forward<P>(args)...) {}
+
+  ~DestructibleUnionImpl() {}
+
+  Head head;
+  TailUnion tail;
+};
+
+// This union type is destructible even if one or more T are not trivially
+// destructible. In the case that all T are trivially destructible, then so is
+// this resultant type.
+template <class... T>
+using DestructibleUnion =
+    absl::conditional_t<std::is_destructible<Union<T...>>::value, Union<T...>,
+                        DestructibleUnionImpl<T...>>;
+
+// Deepest base, containing the actual union and the discriminator
+template <class H, class... T>
+class VariantStateBase {
+ protected:
+  using Variant = variant<H, T...>;
+
+  template <class LazyH = H,
+            class ConstructibleH = absl::enable_if_t<
+                std::is_default_constructible<LazyH>::value, LazyH>>
+  constexpr VariantStateBase() noexcept(
+      std::is_nothrow_default_constructible<ConstructibleH>::value)
+      : state_(EmplaceTag<0>()), index_(0) {}
+
+  template <std::size_t I, class... P>
+  explicit constexpr VariantStateBase(EmplaceTag<I> tag, P&&... args)
+      : state_(tag, absl::forward<P>(args)...), index_(I) {}
+
+  explicit constexpr VariantStateBase(NoopConstructorTag)
+      : state_(NoopConstructorTag()), index_(variant_npos) {}
+
+  void destroy() {}  // Does nothing (shadowed in child if non-trivial)
+
+  DestructibleUnion<H, T...> state_;
+  std::size_t index_;
+};
+
+using absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::internal::identity;
+
+// OverloadSet::Overload() is a unary function which is overloaded to
+// take any of the element types of the variant, by reference-to-const.
+// The return type of the overload on T is identity<T>, so that you
+// can statically determine which overload was called.
+//
+// Overload() is not defined, so it can only be called in unevaluated
+// contexts.
+template <typename... Ts>
+struct OverloadSet;
+
+template <typename T, typename... Ts>
+struct OverloadSet<T, Ts...> : OverloadSet<Ts...> {
+  using Base = OverloadSet<Ts...>;
+  static identity<T> Overload(const T&);
+  using Base::Overload;
+};
+
+template <>
+struct OverloadSet<> {
+  // For any case not handled above.
+  static void Overload(...);
+};
+
+template <class T>
+using LessThanResult = decltype(std::declval<T>() < std::declval<T>());
+
+template <class T>
+using GreaterThanResult = decltype(std::declval<T>() > std::declval<T>());
+
+template <class T>
+using LessThanOrEqualResult = decltype(std::declval<T>() <= std::declval<T>());
+
+template <class T>
+using GreaterThanOrEqualResult =
+    decltype(std::declval<T>() >= std::declval<T>());
+
+template <class T>
+using EqualResult = decltype(std::declval<T>() == std::declval<T>());
+
+template <class T>
+using NotEqualResult = decltype(std::declval<T>() != std::declval<T>());
+
+using type_traits_internal::is_detected_convertible;
+
+template <class... T>
+using RequireAllHaveEqualT = absl::enable_if_t<
+    absl::conjunction<is_detected_convertible<bool, EqualResult, T>...>::value,
+    bool>;
+
+template <class... T>
+using RequireAllHaveNotEqualT =
+    absl::enable_if_t<absl::conjunction<is_detected_convertible<
+                          bool, NotEqualResult, T>...>::value,
+                      bool>;
+
+template <class... T>
+using RequireAllHaveLessThanT =
+    absl::enable_if_t<absl::conjunction<is_detected_convertible<
+                          bool, LessThanResult, T>...>::value,
+                      bool>;
+
+template <class... T>
+using RequireAllHaveLessThanOrEqualT =
+    absl::enable_if_t<absl::conjunction<is_detected_convertible<
+                          bool, LessThanOrEqualResult, T>...>::value,
+                      bool>;
+
+template <class... T>
+using RequireAllHaveGreaterThanOrEqualT =
+    absl::enable_if_t<absl::conjunction<is_detected_convertible<
+                          bool, GreaterThanOrEqualResult, T>...>::value,
+                      bool>;
+
+template <class... T>
+using RequireAllHaveGreaterThanT =
+    absl::enable_if_t<absl::conjunction<is_detected_convertible<
+                          bool, GreaterThanResult, T>...>::value,
+                      bool>;
+
+// Helper template containing implementations details of variant that can't go
+// in the private section. For convenience, this takes the variant type as a
+// single template parameter.
+template <typename T>
+struct VariantHelper;
+
+template <typename... Ts>
+struct VariantHelper<variant<Ts...>> {
+  // Type metafunction which returns the element type selected if
+  // OverloadSet::Overload() is well-formed when called with argument type U.
+  template <typename U>
+  using BestMatch = decltype(
+      variant_internal::OverloadSet<Ts...>::Overload(std::declval<U>()));
+
+  // Type metafunction which returns true if OverloadSet::Overload() is
+  // well-formed when called with argument type U.
+  // CanAccept can't be just an alias because there is a MSVC bug on parameter
+  // pack expansion involving decltype.
+  template <typename U>
+  struct CanAccept :
+      std::integral_constant<bool, !std::is_void<BestMatch<U>>::value> {};
+
+  // Type metafunction which returns true if Other is an instantiation of
+  // variant, and variants's converting constructor from Other will be
+  // well-formed. We will use this to remove constructors that would be
+  // ill-formed from the overload set.
+  template <typename Other>
+  struct CanConvertFrom;
+
+  template <typename... Us>
+  struct CanConvertFrom<variant<Us...>>
+      : public absl::conjunction<CanAccept<Us>...> {};
+};
+
+// A type with nontrivial copy ctor and trivial move ctor.
+struct TrivialMoveOnly {
+  TrivialMoveOnly(TrivialMoveOnly&&) = default;
+};
+
+// Trait class to detect whether a type is trivially move constructible.
+// A union's defaulted copy/move constructor is deleted if any variant member's
+// copy/move constructor is nontrivial.
+template <typename T>
+struct IsTriviallyMoveConstructible:
+  std::is_move_constructible<Union<T, TrivialMoveOnly>> {};
+
+// To guarantee triviality of all special-member functions that can be trivial,
+// we use a chain of conditional bases for each one.
+// The order of inheritance of bases from child to base are logically:
+//
+// variant
+// VariantCopyAssignBase
+// VariantMoveAssignBase
+// VariantCopyBase
+// VariantMoveBase
+// VariantStateBaseDestructor
+// VariantStateBase
+//
+// Note that there is a separate branch at each base that is dependent on
+// whether or not that corresponding special-member-function can be trivial in
+// the resultant variant type.
+
+template <class... T>
+class VariantStateBaseDestructorNontrivial;
+
+template <class... T>
+class VariantMoveBaseNontrivial;
+
+template <class... T>
+class VariantCopyBaseNontrivial;
+
+template <class... T>
+class VariantMoveAssignBaseNontrivial;
+
+template <class... T>
+class VariantCopyAssignBaseNontrivial;
+
+// Base that is dependent on whether or not the destructor can be trivial.
+template <class... T>
+using VariantStateBaseDestructor =
+    absl::conditional_t<std::is_destructible<Union<T...>>::value,
+                        VariantStateBase<T...>,
+                        VariantStateBaseDestructorNontrivial<T...>>;
+
+// Base that is dependent on whether or not the move-constructor can be
+// implicitly generated by the compiler (trivial or deleted).
+// Previously we were using `std::is_move_constructible<Union<T...>>` to check
+// whether all Ts have trivial move constructor, but it ran into a GCC bug:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84866
+// So we have to use a different approach (i.e. `HasTrivialMoveConstructor`) to
+// work around the bug.
+template <class... T>
+using VariantMoveBase = absl::conditional_t<
+    absl::disjunction<
+        absl::negation<absl::conjunction<std::is_move_constructible<T>...>>,
+        absl::conjunction<IsTriviallyMoveConstructible<T>...>>::value,
+    VariantStateBaseDestructor<T...>, VariantMoveBaseNontrivial<T...>>;
+
+// Base that is dependent on whether or not the copy-constructor can be trivial.
+template <class... T>
+using VariantCopyBase = absl::conditional_t<
+    absl::disjunction<
+        absl::negation<absl::conjunction<std::is_copy_constructible<T>...>>,
+        std::is_copy_constructible<Union<T...>>>::value,
+    VariantMoveBase<T...>, VariantCopyBaseNontrivial<T...>>;
+
+// Base that is dependent on whether or not the move-assign can be trivial.
+template <class... T>
+using VariantMoveAssignBase = absl::conditional_t<
+    absl::disjunction<
+        absl::conjunction<absl::is_move_assignable<Union<T...>>,
+                          std::is_move_constructible<Union<T...>>,
+                          std::is_destructible<Union<T...>>>,
+        absl::negation<absl::conjunction<std::is_move_constructible<T>...,
+                                         // Note: We're not qualifying this with
+                                         // absl:: because it doesn't compile
+                                         // under MSVC.
+                                         is_move_assignable<T>...>>>::value,
+    VariantCopyBase<T...>, VariantMoveAssignBaseNontrivial<T...>>;
+
+// Base that is dependent on whether or not the copy-assign can be trivial.
+template <class... T>
+using VariantCopyAssignBase = absl::conditional_t<
+    absl::disjunction<
+        absl::conjunction<absl::is_copy_assignable<Union<T...>>,
+                          std::is_copy_constructible<Union<T...>>,
+                          std::is_destructible<Union<T...>>>,
+        absl::negation<absl::conjunction<std::is_copy_constructible<T>...,
+                                         // Note: We're not qualifying this with
+                                         // absl:: because it doesn't compile
+                                         // under MSVC.
+                                         is_copy_assignable<T>...>>>::value,
+    VariantMoveAssignBase<T...>, VariantCopyAssignBaseNontrivial<T...>>;
+
+template <class... T>
+using VariantBase = VariantCopyAssignBase<T...>;
+
+template <class... T>
+class VariantStateBaseDestructorNontrivial : protected VariantStateBase<T...> {
+ private:
+  using Base = VariantStateBase<T...>;
+
+ protected:
+  using Base::Base;
+
+  VariantStateBaseDestructorNontrivial() = default;
+  VariantStateBaseDestructorNontrivial(VariantStateBaseDestructorNontrivial&&) =
+      default;
+  VariantStateBaseDestructorNontrivial(
+      const VariantStateBaseDestructorNontrivial&) = default;
+  VariantStateBaseDestructorNontrivial& operator=(
+      VariantStateBaseDestructorNontrivial&&) = default;
+  VariantStateBaseDestructorNontrivial& operator=(
+      const VariantStateBaseDestructorNontrivial&) = default;
+
+  struct Destroyer {
+    template <std::size_t I>
+    void operator()(SizeT<I> i) const {
+      using Alternative =
+          typename absl::variant_alternative<I, variant<T...>>::type;
+      variant_internal::AccessUnion(self->state_, i).~Alternative();
+    }
+
+    void operator()(SizeT<absl::variant_npos> /*i*/) const {
+      // This space intentionally left blank
+    }
+
+    VariantStateBaseDestructorNontrivial* self;
+  };
+
+  void destroy() { VisitIndices<sizeof...(T)>::Run(Destroyer{this}, index_); }
+
+  ~VariantStateBaseDestructorNontrivial() { destroy(); }
+
+ protected:
+  using Base::index_;
+  using Base::state_;
+};
+
+template <class... T>
+class VariantMoveBaseNontrivial : protected VariantStateBaseDestructor<T...> {
+ private:
+  using Base = VariantStateBaseDestructor<T...>;
+
+ protected:
+  using Base::Base;
+
+  struct Construct {
+    template <std::size_t I>
+    void operator()(SizeT<I> i) const {
+      using Alternative =
+          typename absl::variant_alternative<I, variant<T...>>::type;
+      ::new (static_cast<void*>(&self->state_)) Alternative(
+          variant_internal::AccessUnion(absl::move(other->state_), i));
+    }
+
+    void operator()(SizeT<absl::variant_npos> /*i*/) const {}
+
+    VariantMoveBaseNontrivial* self;
+    VariantMoveBaseNontrivial* other;
+  };
+
+  VariantMoveBaseNontrivial() = default;
+  VariantMoveBaseNontrivial(VariantMoveBaseNontrivial&& other) noexcept(
+      absl::conjunction<std::is_nothrow_move_constructible<T>...>::value)
+      : Base(NoopConstructorTag()) {
+    VisitIndices<sizeof...(T)>::Run(Construct{this, &other}, other.index_);
+    index_ = other.index_;
+  }
+
+  VariantMoveBaseNontrivial(VariantMoveBaseNontrivial const&) = default;
+
+  VariantMoveBaseNontrivial& operator=(VariantMoveBaseNontrivial&&) = default;
+  VariantMoveBaseNontrivial& operator=(VariantMoveBaseNontrivial const&) =
+      default;
+
+ protected:
+  using Base::index_;
+  using Base::state_;
+};
+
+template <class... T>
+class VariantCopyBaseNontrivial : protected VariantMoveBase<T...> {
+ private:
+  using Base = VariantMoveBase<T...>;
+
+ protected:
+  using Base::Base;
+
+  VariantCopyBaseNontrivial() = default;
+  VariantCopyBaseNontrivial(VariantCopyBaseNontrivial&&) = default;
+
+  struct Construct {
+    template <std::size_t I>
+    void operator()(SizeT<I> i) const {
+      using Alternative =
+          typename absl::variant_alternative<I, variant<T...>>::type;
+      ::new (static_cast<void*>(&self->state_))
+          Alternative(variant_internal::AccessUnion(other->state_, i));
+    }
+
+    void operator()(SizeT<absl::variant_npos> /*i*/) const {}
+
+    VariantCopyBaseNontrivial* self;
+    const VariantCopyBaseNontrivial* other;
+  };
+
+  VariantCopyBaseNontrivial(VariantCopyBaseNontrivial const& other)
+      : Base(NoopConstructorTag()) {
+    VisitIndices<sizeof...(T)>::Run(Construct{this, &other}, other.index_);
+    index_ = other.index_;
+  }
+
+  VariantCopyBaseNontrivial& operator=(VariantCopyBaseNontrivial&&) = default;
+  VariantCopyBaseNontrivial& operator=(VariantCopyBaseNontrivial const&) =
+      default;
+
+ protected:
+  using Base::index_;
+  using Base::state_;
+};
+
+template <class... T>
+class VariantMoveAssignBaseNontrivial : protected VariantCopyBase<T...> {
+  friend struct VariantCoreAccess;
+
+ private:
+  using Base = VariantCopyBase<T...>;
+
+ protected:
+  using Base::Base;
+
+  VariantMoveAssignBaseNontrivial() = default;
+  VariantMoveAssignBaseNontrivial(VariantMoveAssignBaseNontrivial&&) = default;
+  VariantMoveAssignBaseNontrivial(const VariantMoveAssignBaseNontrivial&) =
+      default;
+  VariantMoveAssignBaseNontrivial& operator=(
+      VariantMoveAssignBaseNontrivial const&) = default;
+
+    VariantMoveAssignBaseNontrivial&
+    operator=(VariantMoveAssignBaseNontrivial&& other) noexcept(
+        absl::conjunction<std::is_nothrow_move_constructible<T>...,
+                          std::is_nothrow_move_assignable<T>...>::value) {
+      VisitIndices<sizeof...(T)>::Run(
+          VariantCoreAccess::MakeMoveAssignVisitor(this, &other), other.index_);
+      return *this;
+    }
+
+ protected:
+  using Base::index_;
+  using Base::state_;
+};
+
+template <class... T>
+class VariantCopyAssignBaseNontrivial : protected VariantMoveAssignBase<T...> {
+  friend struct VariantCoreAccess;
+
+ private:
+  using Base = VariantMoveAssignBase<T...>;
+
+ protected:
+  using Base::Base;
+
+  VariantCopyAssignBaseNontrivial() = default;
+  VariantCopyAssignBaseNontrivial(VariantCopyAssignBaseNontrivial&&) = default;
+  VariantCopyAssignBaseNontrivial(const VariantCopyAssignBaseNontrivial&) =
+      default;
+  VariantCopyAssignBaseNontrivial& operator=(
+      VariantCopyAssignBaseNontrivial&&) = default;
+
+    VariantCopyAssignBaseNontrivial& operator=(
+        const VariantCopyAssignBaseNontrivial& other) {
+      VisitIndices<sizeof...(T)>::Run(
+          VariantCoreAccess::MakeCopyAssignVisitor(this, other), other.index_);
+      return *this;
+    }
+
+ protected:
+  using Base::index_;
+  using Base::state_;
+};
+
+////////////////////////////////////////
+// Visitors for Comparison Operations //
+////////////////////////////////////////
+
+template <class... Types>
+struct EqualsOp {
+  const variant<Types...>* v;
+  const variant<Types...>* w;
+
+  constexpr bool operator()(SizeT<absl::variant_npos> /*v_i*/) const {
+    return true;
+  }
+
+  template <std::size_t I>
+  constexpr bool operator()(SizeT<I> /*v_i*/) const {
+    return VariantCoreAccess::Access<I>(*v) == VariantCoreAccess::Access<I>(*w);
+  }
+};
+
+template <class... Types>
+struct NotEqualsOp {
+  const variant<Types...>* v;
+  const variant<Types...>* w;
+
+  constexpr bool operator()(SizeT<absl::variant_npos> /*v_i*/) const {
+    return false;
+  }
+
+  template <std::size_t I>
+  constexpr bool operator()(SizeT<I> /*v_i*/) const {
+    return VariantCoreAccess::Access<I>(*v) != VariantCoreAccess::Access<I>(*w);
+  }
+};
+
+template <class... Types>
+struct LessThanOp {
+  const variant<Types...>* v;
+  const variant<Types...>* w;
+
+  constexpr bool operator()(SizeT<absl::variant_npos> /*v_i*/) const {
+    return false;
+  }
+
+  template <std::size_t I>
+  constexpr bool operator()(SizeT<I> /*v_i*/) const {
+    return VariantCoreAccess::Access<I>(*v) < VariantCoreAccess::Access<I>(*w);
+  }
+};
+
+template <class... Types>
+struct GreaterThanOp {
+  const variant<Types...>* v;
+  const variant<Types...>* w;
+
+  constexpr bool operator()(SizeT<absl::variant_npos> /*v_i*/) const {
+    return false;
+  }
+
+  template <std::size_t I>
+  constexpr bool operator()(SizeT<I> /*v_i*/) const {
+    return VariantCoreAccess::Access<I>(*v) > VariantCoreAccess::Access<I>(*w);
+  }
+};
+
+template <class... Types>
+struct LessThanOrEqualsOp {
+  const variant<Types...>* v;
+  const variant<Types...>* w;
+
+  constexpr bool operator()(SizeT<absl::variant_npos> /*v_i*/) const {
+    return true;
+  }
+
+  template <std::size_t I>
+  constexpr bool operator()(SizeT<I> /*v_i*/) const {
+    return VariantCoreAccess::Access<I>(*v) <= VariantCoreAccess::Access<I>(*w);
+  }
+};
+
+template <class... Types>
+struct GreaterThanOrEqualsOp {
+  const variant<Types...>* v;
+  const variant<Types...>* w;
+
+  constexpr bool operator()(SizeT<absl::variant_npos> /*v_i*/) const {
+    return true;
+  }
+
+  template <std::size_t I>
+  constexpr bool operator()(SizeT<I> /*v_i*/) const {
+    return VariantCoreAccess::Access<I>(*v) >= VariantCoreAccess::Access<I>(*w);
+  }
+};
+
+// Precondition: v.index() == w.index();
+template <class... Types>
+struct SwapSameIndex {
+  variant<Types...>* v;
+  variant<Types...>* w;
+  template <std::size_t I>
+  void operator()(SizeT<I>) const {
+    type_traits_internal::Swap(VariantCoreAccess::Access<I>(*v),
+                               VariantCoreAccess::Access<I>(*w));
+  }
+
+  void operator()(SizeT<variant_npos>) const {}
+};
+
+// TODO(calabrese) do this from a different namespace for proper adl usage
+template <class... Types>
+struct Swap {
+  variant<Types...>* v;
+  variant<Types...>* w;
+
+  void generic_swap() const {
+    variant<Types...> tmp(std::move(*w));
+    VariantCoreAccess::Destroy(*w);
+    VariantCoreAccess::InitFrom(*w, std::move(*v));
+    VariantCoreAccess::Destroy(*v);
+    VariantCoreAccess::InitFrom(*v, std::move(tmp));
+  }
+
+  void operator()(SizeT<absl::variant_npos> /*w_i*/) const {
+    if (!v->valueless_by_exception()) {
+      generic_swap();
+    }
+  }
+
+  template <std::size_t Wi>
+  void operator()(SizeT<Wi> /*w_i*/) {
+    if (v->index() == Wi) {
+      VisitIndices<sizeof...(Types)>::Run(SwapSameIndex<Types...>{v, w}, Wi);
+    } else {
+      generic_swap();
+    }
+  }
+};
+
+template <typename Variant, typename = void, typename... Ts>
+struct VariantHashBase {
+  VariantHashBase() = delete;
+  VariantHashBase(const VariantHashBase&) = delete;
+  VariantHashBase(VariantHashBase&&) = delete;
+  VariantHashBase& operator=(const VariantHashBase&) = delete;
+  VariantHashBase& operator=(VariantHashBase&&) = delete;
+};
+
+struct VariantHashVisitor {
+  template <typename T>
+  size_t operator()(const T& t) {
+    return std::hash<T>{}(t);
+  }
+};
+
+template <typename Variant, typename... Ts>
+struct VariantHashBase<Variant,
+                       absl::enable_if_t<absl::conjunction<
+                           type_traits_internal::IsHashable<Ts>...>::value>,
+                       Ts...> {
+  using argument_type = Variant;
+  using result_type = size_t;
+  size_t operator()(const Variant& var) const {
+    type_traits_internal::AssertHashEnabled<Ts...>();
+    if (var.valueless_by_exception()) {
+      return 239799884;
+    }
+    size_t result = VisitIndices<variant_size<Variant>::value>::Run(
+        PerformVisitation<VariantHashVisitor, const Variant&>{
+            std::forward_as_tuple(var), VariantHashVisitor{}},
+        var.index());
+    // Combine the index and the hash result in order to distinguish
+    // std::variant<int, int> holding the same value as different alternative.
+    return result ^ var.index();
+  }
+};
+
+}  // namespace variant_internal
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // !defined(OTABSL_USES_STD_VARIANT)
+#endif  // OTABSL_TYPES_variant_internal_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/types/variant.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/types/variant.h
@@ -1,0 +1,866 @@
+// Copyright 2018 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// variant.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines an `absl::variant` type for holding a type-safe
+// value of some prescribed set of types (noted as alternative types), and
+// associated functions for managing variants.
+//
+// The `absl::variant` type is a form of type-safe union. An `absl::variant`
+// should always hold a value of one of its alternative types (except in the
+// "valueless by exception state" -- see below). A default-constructed
+// `absl::variant` will hold the value of its first alternative type, provided
+// it is default-constructible.
+//
+// In exceptional cases due to error, an `absl::variant` can hold no
+// value (known as a "valueless by exception" state), though this is not the
+// norm.
+//
+// As with `absl::optional`, an `absl::variant` -- when it holds a value --
+// allocates a value of that type directly within the `variant` itself; it
+// cannot hold a reference, array, or the type `void`; it can, however, hold a
+// pointer to externally managed memory.
+//
+// `absl::variant` is a C++11 compatible version of the C++17 `std::variant`
+// abstraction and is designed to be a drop-in replacement for code compliant
+// with C++17.
+
+#ifndef OTABSL_TYPES_VARIANT_H_
+#define OTABSL_TYPES_VARIANT_H_
+
+#include "../base/config.h"
+#include "../utility/utility.h"
+
+#ifdef OTABSL_USES_STD_VARIANT
+
+#include <variant>  // IWYU pragma: export
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+using std::bad_variant_access;
+using std::get;
+using std::get_if;
+using std::holds_alternative;
+using std::monostate;
+using std::variant;
+using std::variant_alternative;
+using std::variant_alternative_t;
+using std::variant_npos;
+using std::variant_size;
+using std::variant_size_v;
+using std::visit;
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+#else  // OTABSL_USES_STD_VARIANT
+
+#include <functional>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+#include "../base/macros.h"
+#include "../base/port.h"
+#include "../meta/type_traits.h"
+#include "../types/internal/variant.h"
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+
+// -----------------------------------------------------------------------------
+// absl::variant
+// -----------------------------------------------------------------------------
+//
+// An `absl::variant` type is a form of type-safe union. An `absl::variant` --
+// except in exceptional cases -- always holds a value of one of its alternative
+// types.
+//
+// Example:
+//
+//   // Construct a variant that holds either an integer or a std::string and
+//   // assign it to a std::string.
+//   absl::variant<int, std::string> v = std::string("abc");
+//
+//   // A default-constructed variant will hold a value-initialized value of
+//   // the first alternative type.
+//   auto a = absl::variant<int, std::string>();   // Holds an int of value '0'.
+//
+//   // variants are assignable.
+//
+//   // copy assignment
+//   auto v1 = absl::variant<int, std::string>("abc");
+//   auto v2 = absl::variant<int, std::string>(10);
+//   v2 = v1;  // copy assign
+//
+//   // move assignment
+//   auto v1 = absl::variant<int, std::string>("abc");
+//   v1 = absl::variant<int, std::string>(10);
+//
+//   // assignment through type conversion
+//   a = 128;         // variant contains int
+//   a = "128";       // variant contains std::string
+//
+// An `absl::variant` holding a value of one of its alternative types `T` holds
+// an allocation of `T` directly within the variant itself. An `absl::variant`
+// is not allowed to allocate additional storage, such as dynamic memory, to
+// allocate the contained value. The contained value shall be allocated in a
+// region of the variant storage suitably aligned for all alternative types.
+template <typename... Ts>
+class variant;
+
+// swap()
+//
+// Swaps two `absl::variant` values. This function is equivalent to `v.swap(w)`
+// where `v` and `w` are `absl::variant` types.
+//
+// Note that this function requires all alternative types to be both swappable
+// and move-constructible, because any two variants may refer to either the same
+// type (in which case, they will be swapped) or to two different types (in
+// which case the values will need to be moved).
+//
+template <
+    typename... Ts,
+    absl::enable_if_t<
+        absl::conjunction<std::is_move_constructible<Ts>...,
+                          type_traits_internal::IsSwappable<Ts>...>::value,
+        int> = 0>
+void swap(variant<Ts...>& v, variant<Ts...>& w) noexcept(noexcept(v.swap(w))) {
+  v.swap(w);
+}
+
+// variant_size
+//
+// Returns the number of alternative types available for a given `absl::variant`
+// type as a compile-time constant expression. As this is a class template, it
+// is not generally useful for accessing the number of alternative types of
+// any given `absl::variant` instance.
+//
+// Example:
+//
+//   auto a = absl::variant<int, std::string>;
+//   constexpr int num_types =
+//       absl::variant_size<absl::variant<int, std::string>>();
+//
+//   // You can also use the member constant `value`.
+//   constexpr int num_types =
+//       absl::variant_size<absl::variant<int, std::string>>::value;
+//
+//   // `absl::variant_size` is more valuable for use in generic code:
+//   template <typename Variant>
+//   constexpr bool IsVariantMultivalue() {
+//       return absl::variant_size<Variant>() > 1;
+//   }
+//
+// Note that the set of cv-qualified specializations of `variant_size` are
+// provided to ensure that those specializations compile (especially when passed
+// within template logic).
+template <class T>
+struct variant_size;
+
+template <class... Ts>
+struct variant_size<variant<Ts...>>
+    : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+
+// Specialization of `variant_size` for const qualified variants.
+template <class T>
+struct variant_size<const T> : variant_size<T>::type {};
+
+// Specialization of `variant_size` for volatile qualified variants.
+template <class T>
+struct variant_size<volatile T> : variant_size<T>::type {};
+
+// Specialization of `variant_size` for const volatile qualified variants.
+template <class T>
+struct variant_size<const volatile T> : variant_size<T>::type {};
+
+// variant_alternative
+//
+// Returns the alternative type for a given `absl::variant` at the passed
+// index value as a compile-time constant expression. As this is a class
+// template resulting in a type, it is not useful for access of the run-time
+// value of any given `absl::variant` variable.
+//
+// Example:
+//
+//   // The type of the 0th alternative is "int".
+//   using alternative_type_0
+//     = absl::variant_alternative<0, absl::variant<int, std::string>>::type;
+//
+//   static_assert(std::is_same<alternative_type_0, int>::value, "");
+//
+//   // `absl::variant_alternative` is more valuable for use in generic code:
+//   template <typename Variant>
+//   constexpr bool IsFirstElementTrivial() {
+//       return std::is_trivial_v<variant_alternative<0, Variant>::type>;
+//   }
+//
+// Note that the set of cv-qualified specializations of `variant_alternative`
+// are provided to ensure that those specializations compile (especially when
+// passed within template logic).
+template <std::size_t I, class T>
+struct variant_alternative;
+
+template <std::size_t I, class... Types>
+struct variant_alternative<I, variant<Types...>> {
+  using type =
+      variant_internal::VariantAlternativeSfinaeT<I, variant<Types...>>;
+};
+
+// Specialization of `variant_alternative` for const qualified variants.
+template <std::size_t I, class T>
+struct variant_alternative<I, const T> {
+  using type = const typename variant_alternative<I, T>::type;
+};
+
+// Specialization of `variant_alternative` for volatile qualified variants.
+template <std::size_t I, class T>
+struct variant_alternative<I, volatile T> {
+  using type = volatile typename variant_alternative<I, T>::type;
+};
+
+// Specialization of `variant_alternative` for const volatile qualified
+// variants.
+template <std::size_t I, class T>
+struct variant_alternative<I, const volatile T> {
+  using type = const volatile typename variant_alternative<I, T>::type;
+};
+
+// Template type alias for variant_alternative<I, T>::type.
+//
+// Example:
+//
+//   using alternative_type_0
+//     = absl::variant_alternative_t<0, absl::variant<int, std::string>>;
+//   static_assert(std::is_same<alternative_type_0, int>::value, "");
+template <std::size_t I, class T>
+using variant_alternative_t = typename variant_alternative<I, T>::type;
+
+// holds_alternative()
+//
+// Checks whether the given variant currently holds a given alternative type,
+// returning `true` if so.
+//
+// Example:
+//
+//   absl::variant<int, std::string> foo = 42;
+//   if (absl::holds_alternative<int>(foo)) {
+//       std::cout << "The variant holds an integer";
+//   }
+template <class T, class... Types>
+constexpr bool holds_alternative(const variant<Types...>& v) noexcept {
+  static_assert(
+      variant_internal::UnambiguousIndexOfImpl<variant<Types...>, T,
+                                               0>::value != sizeof...(Types),
+      "The type T must occur exactly once in Types...");
+  return v.index() ==
+         variant_internal::UnambiguousIndexOf<variant<Types...>, T>::value;
+}
+
+// get()
+//
+// Returns a reference to the value currently within a given variant, using
+// either a unique alternative type amongst the variant's set of alternative
+// types, or the variant's index value. Attempting to get a variant's value
+// using a type that is not unique within the variant's set of alternative types
+// is a compile-time error. If the index of the alternative being specified is
+// different from the index of the alternative that is currently stored, throws
+// `absl::bad_variant_access`.
+//
+// Example:
+//
+//   auto a = absl::variant<int, std::string>;
+//
+//   // Get the value by type (if unique).
+//   int i = absl::get<int>(a);
+//
+//   auto b = absl::variant<int, int>;
+//
+//   // Getting the value by a type that is not unique is ill-formed.
+//   int j = absl::get<int>(b);     // Compile Error!
+//
+//   // Getting value by index not ambiguous and allowed.
+//   int k = absl::get<1>(b);
+
+// Overload for getting a variant's lvalue by type.
+template <class T, class... Types>
+constexpr T& get(variant<Types...>& v) {  // NOLINT
+  return variant_internal::VariantCoreAccess::CheckedAccess<
+      variant_internal::IndexOf<T, Types...>::value>(v);
+}
+
+// Overload for getting a variant's rvalue by type.
+// Note: `absl::move()` is required to allow use of constexpr in C++11.
+template <class T, class... Types>
+constexpr T&& get(variant<Types...>&& v) {
+  return variant_internal::VariantCoreAccess::CheckedAccess<
+      variant_internal::IndexOf<T, Types...>::value>(absl::move(v));
+}
+
+// Overload for getting a variant's const lvalue by type.
+template <class T, class... Types>
+constexpr const T& get(const variant<Types...>& v) {
+  return variant_internal::VariantCoreAccess::CheckedAccess<
+      variant_internal::IndexOf<T, Types...>::value>(v);
+}
+
+// Overload for getting a variant's const rvalue by type.
+// Note: `absl::move()` is required to allow use of constexpr in C++11.
+template <class T, class... Types>
+constexpr const T&& get(const variant<Types...>&& v) {
+  return variant_internal::VariantCoreAccess::CheckedAccess<
+      variant_internal::IndexOf<T, Types...>::value>(absl::move(v));
+}
+
+// Overload for getting a variant's lvalue by index.
+template <std::size_t I, class... Types>
+constexpr variant_alternative_t<I, variant<Types...>>& get(
+    variant<Types...>& v) {  // NOLINT
+  return variant_internal::VariantCoreAccess::CheckedAccess<I>(v);
+}
+
+// Overload for getting a variant's rvalue by index.
+// Note: `absl::move()` is required to allow use of constexpr in C++11.
+template <std::size_t I, class... Types>
+constexpr variant_alternative_t<I, variant<Types...>>&& get(
+    variant<Types...>&& v) {
+  return variant_internal::VariantCoreAccess::CheckedAccess<I>(absl::move(v));
+}
+
+// Overload for getting a variant's const lvalue by index.
+template <std::size_t I, class... Types>
+constexpr const variant_alternative_t<I, variant<Types...>>& get(
+    const variant<Types...>& v) {
+  return variant_internal::VariantCoreAccess::CheckedAccess<I>(v);
+}
+
+// Overload for getting a variant's const rvalue by index.
+// Note: `absl::move()` is required to allow use of constexpr in C++11.
+template <std::size_t I, class... Types>
+constexpr const variant_alternative_t<I, variant<Types...>>&& get(
+    const variant<Types...>&& v) {
+  return variant_internal::VariantCoreAccess::CheckedAccess<I>(absl::move(v));
+}
+
+// get_if()
+//
+// Returns a pointer to the value currently stored within a given variant, if
+// present, using either a unique alternative type amongst the variant's set of
+// alternative types, or the variant's index value. If such a value does not
+// exist, returns `nullptr`.
+//
+// As with `get`, attempting to get a variant's value using a type that is not
+// unique within the variant's set of alternative types is a compile-time error.
+
+// Overload for getting a pointer to the value stored in the given variant by
+// index.
+template <std::size_t I, class... Types>
+constexpr absl::add_pointer_t<variant_alternative_t<I, variant<Types...>>>
+get_if(variant<Types...>* v) noexcept {
+  return (v != nullptr && v->index() == I)
+             ? std::addressof(
+                   variant_internal::VariantCoreAccess::Access<I>(*v))
+             : nullptr;
+}
+
+// Overload for getting a pointer to the const value stored in the given
+// variant by index.
+template <std::size_t I, class... Types>
+constexpr absl::add_pointer_t<const variant_alternative_t<I, variant<Types...>>>
+get_if(const variant<Types...>* v) noexcept {
+  return (v != nullptr && v->index() == I)
+             ? std::addressof(
+                   variant_internal::VariantCoreAccess::Access<I>(*v))
+             : nullptr;
+}
+
+// Overload for getting a pointer to the value stored in the given variant by
+// type.
+template <class T, class... Types>
+constexpr absl::add_pointer_t<T> get_if(variant<Types...>* v) noexcept {
+  return absl::get_if<variant_internal::IndexOf<T, Types...>::value>(v);
+}
+
+// Overload for getting a pointer to the const value stored in the given variant
+// by type.
+template <class T, class... Types>
+constexpr absl::add_pointer_t<const T> get_if(
+    const variant<Types...>* v) noexcept {
+  return absl::get_if<variant_internal::IndexOf<T, Types...>::value>(v);
+}
+
+// visit()
+//
+// Calls a provided functor on a given set of variants. `absl::visit()` is
+// commonly used to conditionally inspect the state of a given variant (or set
+// of variants).
+//
+// The functor must return the same type when called with any of the variants'
+// alternatives.
+//
+// Example:
+//
+//   // Define a visitor functor
+//   struct GetVariant {
+//       template<typename T>
+//       void operator()(const T& i) const {
+//         std::cout << "The variant's value is: " << i;
+//       }
+//   };
+//
+//   // Declare our variant, and call `absl::visit()` on it.
+//   // Note that `GetVariant()` returns void in either case.
+//   absl::variant<int, std::string> foo = std::string("foo");
+//   GetVariant visitor;
+//   absl::visit(visitor, foo);  // Prints `The variant's value is: foo'
+template <typename Visitor, typename... Variants>
+variant_internal::VisitResult<Visitor, Variants...> visit(Visitor&& vis,
+                                                          Variants&&... vars) {
+  return variant_internal::
+      VisitIndices<variant_size<absl::decay_t<Variants> >::value...>::Run(
+          variant_internal::PerformVisitation<Visitor, Variants...>{
+              std::forward_as_tuple(absl::forward<Variants>(vars)...),
+              absl::forward<Visitor>(vis)},
+          vars.index()...);
+}
+
+// monostate
+//
+// The monostate class serves as a first alternative type for a variant for
+// which the first variant type is otherwise not default-constructible.
+struct monostate {};
+
+// `absl::monostate` Relational Operators
+
+constexpr bool operator<(monostate, monostate) noexcept { return false; }
+constexpr bool operator>(monostate, monostate) noexcept { return false; }
+constexpr bool operator<=(monostate, monostate) noexcept { return true; }
+constexpr bool operator>=(monostate, monostate) noexcept { return true; }
+constexpr bool operator==(monostate, monostate) noexcept { return true; }
+constexpr bool operator!=(monostate, monostate) noexcept { return false; }
+
+
+//------------------------------------------------------------------------------
+// `absl::variant` Template Definition
+//------------------------------------------------------------------------------
+template <typename T0, typename... Tn>
+class variant<T0, Tn...> : private variant_internal::VariantBase<T0, Tn...> {
+  static_assert(absl::conjunction<std::is_object<T0>,
+                                  std::is_object<Tn>...>::value,
+                "Attempted to instantiate a variant containing a non-object "
+                "type.");
+  // Intentionally not qualifying `negation` with `absl::` to work around a bug
+  // in MSVC 2015 with inline namespace and variadic template.
+  static_assert(absl::conjunction<negation<std::is_array<T0> >,
+                                  negation<std::is_array<Tn> >...>::value,
+                "Attempted to instantiate a variant containing an array type.");
+  static_assert(absl::conjunction<std::is_nothrow_destructible<T0>,
+                                  std::is_nothrow_destructible<Tn>...>::value,
+                "Attempted to instantiate a variant containing a non-nothrow "
+                "destructible type.");
+
+  friend struct variant_internal::VariantCoreAccess;
+
+ private:
+  using Base = variant_internal::VariantBase<T0, Tn...>;
+
+ public:
+  // Constructors
+
+  // Constructs a variant holding a default-initialized value of the first
+  // alternative type.
+  constexpr variant() /*noexcept(see 111above)*/ = default;
+
+  // Copy constructor, standard semantics
+  variant(const variant& other) = default;
+
+  // Move constructor, standard semantics
+  variant(variant&& other) /*noexcept(see above)*/ = default;
+
+  // Constructs a variant of an alternative type specified by overload
+  // resolution of the provided forwarding arguments through
+  // direct-initialization.
+  //
+  // Note: If the selected constructor is a constexpr constructor, this
+  // constructor shall be a constexpr constructor.
+  //
+  // NOTE: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0608r1.html
+  // has been voted passed the design phase in the C++ standard meeting in Mar
+  // 2018. It will be implemented and integrated into `absl::variant`.
+  template <
+      class T,
+      std::size_t I = std::enable_if<
+          variant_internal::IsNeitherSelfNorInPlace<variant,
+                                                    absl::decay_t<T>>::value,
+          variant_internal::IndexOfConstructedType<variant, T>>::type::value,
+      class Tj = absl::variant_alternative_t<I, variant>,
+      absl::enable_if_t<std::is_constructible<Tj, T>::value>* =
+          nullptr>
+  constexpr variant(T&& t) noexcept(std::is_nothrow_constructible<Tj, T>::value)
+      : Base(variant_internal::EmplaceTag<I>(), absl::forward<T>(t)) {}
+
+  // Constructs a variant of an alternative type from the arguments through
+  // direct-initialization.
+  //
+  // Note: If the selected constructor is a constexpr constructor, this
+  // constructor shall be a constexpr constructor.
+  template <class T, class... Args,
+            typename std::enable_if<std::is_constructible<
+                variant_internal::UnambiguousTypeOfT<variant, T>,
+                Args...>::value>::type* = nullptr>
+  constexpr explicit variant(in_place_type_t<T>, Args&&... args)
+      : Base(variant_internal::EmplaceTag<
+                 variant_internal::UnambiguousIndexOf<variant, T>::value>(),
+             absl::forward<Args>(args)...) {}
+
+  // Constructs a variant of an alternative type from an initializer list
+  // and other arguments through direct-initialization.
+  //
+  // Note: If the selected constructor is a constexpr constructor, this
+  // constructor shall be a constexpr constructor.
+  template <class T, class U, class... Args,
+            typename std::enable_if<std::is_constructible<
+                variant_internal::UnambiguousTypeOfT<variant, T>,
+                std::initializer_list<U>&, Args...>::value>::type* = nullptr>
+  constexpr explicit variant(in_place_type_t<T>, std::initializer_list<U> il,
+                             Args&&... args)
+      : Base(variant_internal::EmplaceTag<
+                 variant_internal::UnambiguousIndexOf<variant, T>::value>(),
+             il, absl::forward<Args>(args)...) {}
+
+  // Constructs a variant of an alternative type from a provided index,
+  // through value-initialization using the provided forwarded arguments.
+  template <std::size_t I, class... Args,
+            typename std::enable_if<std::is_constructible<
+                variant_internal::VariantAlternativeSfinaeT<I, variant>,
+                Args...>::value>::type* = nullptr>
+  constexpr explicit variant(in_place_index_t<I>, Args&&... args)
+      : Base(variant_internal::EmplaceTag<I>(), absl::forward<Args>(args)...) {}
+
+  // Constructs a variant of an alternative type from a provided index,
+  // through value-initialization of an initializer list and the provided
+  // forwarded arguments.
+  template <std::size_t I, class U, class... Args,
+            typename std::enable_if<std::is_constructible<
+                variant_internal::VariantAlternativeSfinaeT<I, variant>,
+                std::initializer_list<U>&, Args...>::value>::type* = nullptr>
+  constexpr explicit variant(in_place_index_t<I>, std::initializer_list<U> il,
+                             Args&&... args)
+      : Base(variant_internal::EmplaceTag<I>(), il,
+             absl::forward<Args>(args)...) {}
+
+  // Destructors
+
+  // Destroys the variant's currently contained value, provided that
+  // `absl::valueless_by_exception()` is false.
+  ~variant() = default;
+
+  // Assignment Operators
+
+  // Copy assignment operator
+  variant& operator=(const variant& other) = default;
+
+  // Move assignment operator
+  variant& operator=(variant&& other) /*noexcept(see above)*/ = default;
+
+  // Converting assignment operator
+  //
+  // NOTE: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0608r1.html
+  // has been voted passed the design phase in the C++ standard meeting in Mar
+  // 2018. It will be implemented and integrated into `absl::variant`.
+  template <
+      class T,
+      std::size_t I = std::enable_if<
+          !std::is_same<absl::decay_t<T>, variant>::value,
+          variant_internal::IndexOfConstructedType<variant, T>>::type::value,
+      class Tj = absl::variant_alternative_t<I, variant>,
+      typename std::enable_if<std::is_assignable<Tj&, T>::value &&
+                              std::is_constructible<Tj, T>::value>::type* =
+          nullptr>
+  variant& operator=(T&& t) noexcept(
+      std::is_nothrow_assignable<Tj&, T>::value&&
+          std::is_nothrow_constructible<Tj, T>::value) {
+    variant_internal::VisitIndices<sizeof...(Tn) + 1>::Run(
+        variant_internal::VariantCoreAccess::MakeConversionAssignVisitor(
+            this, absl::forward<T>(t)),
+        index());
+
+    return *this;
+  }
+
+
+  // emplace() Functions
+
+  // Constructs a value of the given alternative type T within the variant. The
+  // existing value of the variant is destroyed first (provided that
+  // `absl::valueless_by_exception()` is false). Requires that T is unambiguous
+  // in the variant.
+  //
+  // Example:
+  //
+  //   absl::variant<std::vector<int>, int, std::string> v;
+  //   v.emplace<int>(99);
+  //   v.emplace<std::string>("abc");
+  template <
+      class T, class... Args,
+      typename std::enable_if<std::is_constructible<
+          absl::variant_alternative_t<
+              variant_internal::UnambiguousIndexOf<variant, T>::value, variant>,
+          Args...>::value>::type* = nullptr>
+  T& emplace(Args&&... args) {
+    return variant_internal::VariantCoreAccess::Replace<
+        variant_internal::UnambiguousIndexOf<variant, T>::value>(
+        this, absl::forward<Args>(args)...);
+  }
+
+  // Constructs a value of the given alternative type T within the variant using
+  // an initializer list. The existing value of the variant is destroyed first
+  // (provided that `absl::valueless_by_exception()` is false). Requires that T
+  // is unambiguous in the variant.
+  //
+  // Example:
+  //
+  //   absl::variant<std::vector<int>, int, std::string> v;
+  //   v.emplace<std::vector<int>>({0, 1, 2});
+  template <
+      class T, class U, class... Args,
+      typename std::enable_if<std::is_constructible<
+          absl::variant_alternative_t<
+              variant_internal::UnambiguousIndexOf<variant, T>::value, variant>,
+          std::initializer_list<U>&, Args...>::value>::type* = nullptr>
+  T& emplace(std::initializer_list<U> il, Args&&... args) {
+    return variant_internal::VariantCoreAccess::Replace<
+        variant_internal::UnambiguousIndexOf<variant, T>::value>(
+        this, il, absl::forward<Args>(args)...);
+  }
+
+  // Destroys the current value of the variant (provided that
+  // `absl::valueless_by_exception()` is false) and constructs a new value at
+  // the given index.
+  //
+  // Example:
+  //
+  //   absl::variant<std::vector<int>, int, int> v;
+  //   v.emplace<1>(99);
+  //   v.emplace<2>(98);
+  //   v.emplace<int>(99);  // Won't compile. 'int' isn't a unique type.
+  template <std::size_t I, class... Args,
+            typename std::enable_if<
+                std::is_constructible<absl::variant_alternative_t<I, variant>,
+                                      Args...>::value>::type* = nullptr>
+  absl::variant_alternative_t<I, variant>& emplace(Args&&... args) {
+    return variant_internal::VariantCoreAccess::Replace<I>(
+        this, absl::forward<Args>(args)...);
+  }
+
+  // Destroys the current value of the variant (provided that
+  // `absl::valueless_by_exception()` is false) and constructs a new value at
+  // the given index using an initializer list and the provided arguments.
+  //
+  // Example:
+  //
+  //   absl::variant<std::vector<int>, int, int> v;
+  //   v.emplace<0>({0, 1, 2});
+  template <std::size_t I, class U, class... Args,
+            typename std::enable_if<std::is_constructible<
+                absl::variant_alternative_t<I, variant>,
+                std::initializer_list<U>&, Args...>::value>::type* = nullptr>
+  absl::variant_alternative_t<I, variant>& emplace(std::initializer_list<U> il,
+                                                   Args&&... args) {
+    return variant_internal::VariantCoreAccess::Replace<I>(
+        this, il, absl::forward<Args>(args)...);
+  }
+
+  // variant::valueless_by_exception()
+  //
+  // Returns false if and only if the variant currently holds a valid value.
+  constexpr bool valueless_by_exception() const noexcept {
+    return this->index_ == absl::variant_npos;
+  }
+
+  // variant::index()
+  //
+  // Returns the index value of the variant's currently selected alternative
+  // type.
+  constexpr std::size_t index() const noexcept { return this->index_; }
+
+  // variant::swap()
+  //
+  // Swaps the values of two variant objects.
+  //
+  void swap(variant& rhs) noexcept(
+      absl::conjunction<
+          std::is_nothrow_move_constructible<T0>,
+          std::is_nothrow_move_constructible<Tn>...,
+          type_traits_internal::IsNothrowSwappable<T0>,
+          type_traits_internal::IsNothrowSwappable<Tn>...>::value) {
+    return variant_internal::VisitIndices<sizeof...(Tn) + 1>::Run(
+        variant_internal::Swap<T0, Tn...>{this, &rhs}, rhs.index());
+  }
+};
+
+// We need a valid declaration of variant<> for SFINAE and overload resolution
+// to work properly above, but we don't need a full declaration since this type
+// will never be constructed. This declaration, though incomplete, suffices.
+template <>
+class variant<>;
+
+//------------------------------------------------------------------------------
+// Relational Operators
+//------------------------------------------------------------------------------
+//
+// If neither operand is in the `variant::valueless_by_exception` state:
+//
+//   * If the index of both variants is the same, the relational operator
+//     returns the result of the corresponding relational operator for the
+//     corresponding alternative type.
+//   * If the index of both variants is not the same, the relational operator
+//     returns the result of that operation applied to the value of the left
+//     operand's index and the value of the right operand's index.
+//   * If at least one operand is in the valueless_by_exception state:
+//     - A variant in the valueless_by_exception state is only considered equal
+//       to another variant in the valueless_by_exception state.
+//     - If exactly one operand is in the valueless_by_exception state, the
+//       variant in the valueless_by_exception state is less than the variant
+//       that is not in the valueless_by_exception state.
+//
+// Note: The value 1 is added to each index in the relational comparisons such
+// that the index corresponding to the valueless_by_exception state wraps around
+// to 0 (the lowest value for the index type), and the remaining indices stay in
+// the same relative order.
+
+// Equal-to operator
+template <typename... Types>
+constexpr variant_internal::RequireAllHaveEqualT<Types...> operator==(
+    const variant<Types...>& a, const variant<Types...>& b) {
+  return (a.index() == b.index()) &&
+         variant_internal::VisitIndices<sizeof...(Types)>::Run(
+             variant_internal::EqualsOp<Types...>{&a, &b}, a.index());
+}
+
+// Not equal operator
+template <typename... Types>
+constexpr variant_internal::RequireAllHaveNotEqualT<Types...> operator!=(
+    const variant<Types...>& a, const variant<Types...>& b) {
+  return (a.index() != b.index()) ||
+         variant_internal::VisitIndices<sizeof...(Types)>::Run(
+             variant_internal::NotEqualsOp<Types...>{&a, &b}, a.index());
+}
+
+// Less-than operator
+template <typename... Types>
+constexpr variant_internal::RequireAllHaveLessThanT<Types...> operator<(
+    const variant<Types...>& a, const variant<Types...>& b) {
+  return (a.index() != b.index())
+             ? (a.index() + 1) < (b.index() + 1)
+             : variant_internal::VisitIndices<sizeof...(Types)>::Run(
+                   variant_internal::LessThanOp<Types...>{&a, &b}, a.index());
+}
+
+// Greater-than operator
+template <typename... Types>
+constexpr variant_internal::RequireAllHaveGreaterThanT<Types...> operator>(
+    const variant<Types...>& a, const variant<Types...>& b) {
+  return (a.index() != b.index())
+             ? (a.index() + 1) > (b.index() + 1)
+             : variant_internal::VisitIndices<sizeof...(Types)>::Run(
+                   variant_internal::GreaterThanOp<Types...>{&a, &b},
+                   a.index());
+}
+
+// Less-than or equal-to operator
+template <typename... Types>
+constexpr variant_internal::RequireAllHaveLessThanOrEqualT<Types...> operator<=(
+    const variant<Types...>& a, const variant<Types...>& b) {
+  return (a.index() != b.index())
+             ? (a.index() + 1) < (b.index() + 1)
+             : variant_internal::VisitIndices<sizeof...(Types)>::Run(
+                   variant_internal::LessThanOrEqualsOp<Types...>{&a, &b},
+                   a.index());
+}
+
+// Greater-than or equal-to operator
+template <typename... Types>
+constexpr variant_internal::RequireAllHaveGreaterThanOrEqualT<Types...>
+operator>=(const variant<Types...>& a, const variant<Types...>& b) {
+  return (a.index() != b.index())
+             ? (a.index() + 1) > (b.index() + 1)
+             : variant_internal::VisitIndices<sizeof...(Types)>::Run(
+                   variant_internal::GreaterThanOrEqualsOp<Types...>{&a, &b},
+                   a.index());
+}
+
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+namespace std {
+
+// hash()
+template <>  // NOLINT
+struct hash<absl::monostate> {
+  std::size_t operator()(absl::monostate) const { return 0; }
+};
+
+template <class... T>  // NOLINT
+struct hash<absl::variant<T...>>
+    : absl::variant_internal::VariantHashBase<absl::variant<T...>, void,
+                                              absl::remove_const_t<T>...> {};
+
+}  // namespace std
+
+#endif  // OTABSL_USES_STD_VARIANT
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+namespace variant_internal {
+
+// Helper visitor for converting a variant<Ts...>` into another type (mostly
+// variant) that can be constructed from any type.
+template <typename To>
+struct ConversionVisitor {
+  template <typename T>
+  To operator()(T&& v) const {
+    return To(std::forward<T>(v));
+  }
+};
+
+}  // namespace variant_internal
+
+// ConvertVariantTo()
+//
+// Helper functions to convert an `absl::variant` to a variant of another set of
+// types, provided that the alternative type of the new variant type can be
+// converted from any type in the source variant.
+//
+// Example:
+//
+//   absl::variant<name1, name2, float> InternalReq(const Req&);
+//
+//   // name1 and name2 are convertible to name
+//   absl::variant<name, float> ExternalReq(const Req& req) {
+//     return absl::ConvertVariantTo<absl::variant<name, float>>(
+//              InternalReq(req));
+//   }
+template <typename To, typename Variant>
+To ConvertVariantTo(Variant&& variant) {
+  return absl::visit(variant_internal::ConversionVisitor<To>{},
+                     std::forward<Variant>(variant));
+}
+
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // OTABSL_TYPES_VARIANT_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/utility/utility.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/internal/absl/utility/utility.h
@@ -1,0 +1,350 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This header file contains C++11 versions of standard <utility> header
+// abstractions available within C++14 and C++17, and are designed to be drop-in
+// replacement for code compliant with C++14 and C++17.
+//
+// The following abstractions are defined:
+//
+//   * integer_sequence<T, Ints...>  == std::integer_sequence<T, Ints...>
+//   * index_sequence<Ints...>       == std::index_sequence<Ints...>
+//   * make_integer_sequence<T, N>   == std::make_integer_sequence<T, N>
+//   * make_index_sequence<N>        == std::make_index_sequence<N>
+//   * index_sequence_for<Ts...>     == std::index_sequence_for<Ts...>
+//   * apply<Functor, Tuple>         == std::apply<Functor, Tuple>
+//   * exchange<T>                   == std::exchange<T>
+//   * make_from_tuple<T>            == std::make_from_tuple<T>
+//
+// This header file also provides the tag types `in_place_t`, `in_place_type_t`,
+// and `in_place_index_t`, as well as the constant `in_place`, and
+// `constexpr` `std::move()` and `std::forward()` implementations in C++11.
+//
+// References:
+//
+//  https://en.cppreference.com/w/cpp/utility/integer_sequence
+//  https://en.cppreference.com/w/cpp/utility/apply
+//  http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3658.html
+
+#ifndef OTABSL_UTILITY_UTILITY_H_
+#define OTABSL_UTILITY_UTILITY_H_
+
+#include <cstddef>
+#include <cstdlib>
+#include <tuple>
+#include <utility>
+
+#include "../base/config.h"
+#include "../base/internal/inline_variable.h"
+#include "../base/internal/invoke.h"
+#include "../meta/type_traits.h"
+
+namespace absl {
+OTABSL_NAMESPACE_BEGIN
+
+// integer_sequence
+//
+// Class template representing a compile-time integer sequence. An instantiation
+// of `integer_sequence<T, Ints...>` has a sequence of integers encoded in its
+// type through its template arguments (which is a common need when
+// working with C++11 variadic templates). `absl::integer_sequence` is designed
+// to be a drop-in replacement for C++14's `std::integer_sequence`.
+//
+// Example:
+//
+//   template< class T, T... Ints >
+//   void user_function(integer_sequence<T, Ints...>);
+//
+//   int main()
+//   {
+//     // user_function's `T` will be deduced to `int` and `Ints...`
+//     // will be deduced to `0, 1, 2, 3, 4`.
+//     user_function(make_integer_sequence<int, 5>());
+//   }
+template <typename T, T... Ints>
+struct integer_sequence {
+  using value_type = T;
+  static constexpr size_t size() noexcept { return sizeof...(Ints); }
+};
+
+// index_sequence
+//
+// A helper template for an `integer_sequence` of `size_t`,
+// `absl::index_sequence` is designed to be a drop-in replacement for C++14's
+// `std::index_sequence`.
+template <size_t... Ints>
+using index_sequence = integer_sequence<size_t, Ints...>;
+
+namespace utility_internal {
+
+template <typename Seq, size_t SeqSize, size_t Rem>
+struct Extend;
+
+// Note that SeqSize == sizeof...(Ints). It's passed explicitly for efficiency.
+template <typename T, T... Ints, size_t SeqSize>
+struct Extend<integer_sequence<T, Ints...>, SeqSize, 0> {
+  using type = integer_sequence<T, Ints..., (Ints + SeqSize)...>;
+};
+
+template <typename T, T... Ints, size_t SeqSize>
+struct Extend<integer_sequence<T, Ints...>, SeqSize, 1> {
+  using type = integer_sequence<T, Ints..., (Ints + SeqSize)..., 2 * SeqSize>;
+};
+
+// Recursion helper for 'make_integer_sequence<T, N>'.
+// 'Gen<T, N>::type' is an alias for 'integer_sequence<T, 0, 1, ... N-1>'.
+template <typename T, size_t N>
+struct Gen {
+  using type =
+      typename Extend<typename Gen<T, N / 2>::type, N / 2, N % 2>::type;
+};
+
+template <typename T>
+struct Gen<T, 0> {
+  using type = integer_sequence<T>;
+};
+
+template <typename T>
+struct InPlaceTypeTag {
+  explicit InPlaceTypeTag() = delete;
+  InPlaceTypeTag(const InPlaceTypeTag&) = delete;
+  InPlaceTypeTag& operator=(const InPlaceTypeTag&) = delete;
+};
+
+template <size_t I>
+struct InPlaceIndexTag {
+  explicit InPlaceIndexTag() = delete;
+  InPlaceIndexTag(const InPlaceIndexTag&) = delete;
+  InPlaceIndexTag& operator=(const InPlaceIndexTag&) = delete;
+};
+
+}  // namespace utility_internal
+
+// Compile-time sequences of integers
+
+// make_integer_sequence
+//
+// This template alias is equivalent to
+// `integer_sequence<int, 0, 1, ..., N-1>`, and is designed to be a drop-in
+// replacement for C++14's `std::make_integer_sequence`.
+template <typename T, T N>
+using make_integer_sequence = typename utility_internal::Gen<T, N>::type;
+
+// make_index_sequence
+//
+// This template alias is equivalent to `index_sequence<0, 1, ..., N-1>`,
+// and is designed to be a drop-in replacement for C++14's
+// `std::make_index_sequence`.
+template <size_t N>
+using make_index_sequence = make_integer_sequence<size_t, N>;
+
+// index_sequence_for
+//
+// Converts a typename pack into an index sequence of the same length, and
+// is designed to be a drop-in replacement for C++14's
+// `std::index_sequence_for()`
+template <typename... Ts>
+using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+
+// Tag types
+
+#ifdef OTABSL_USES_STD_OPTIONAL
+
+using std::in_place_t;
+using std::in_place;
+
+#else  // OTABSL_USES_STD_OPTIONAL
+
+// in_place_t
+//
+// Tag type used to specify in-place construction, such as with
+// `absl::optional`, designed to be a drop-in replacement for C++17's
+// `std::in_place_t`.
+struct in_place_t {};
+
+OTABSL_INTERNAL_INLINE_CONSTEXPR(in_place_t, in_place, {});
+
+#endif  // OTABSL_USES_STD_OPTIONAL
+
+#if defined(OTABSL_USES_STD_ANY) || defined(OTABSL_USES_STD_VARIANT)
+using std::in_place_type;
+using std::in_place_type_t;
+#else
+
+// in_place_type_t
+//
+// Tag type used for in-place construction when the type to construct needs to
+// be specified, such as with `absl::any`, designed to be a drop-in replacement
+// for C++17's `std::in_place_type_t`.
+template <typename T>
+using in_place_type_t = void (*)(utility_internal::InPlaceTypeTag<T>);
+
+template <typename T>
+void in_place_type(utility_internal::InPlaceTypeTag<T>) {}
+#endif  // OTABSL_USES_STD_ANY || OTABSL_USES_STD_VARIANT
+
+#ifdef OTABSL_USES_STD_VARIANT
+using std::in_place_index;
+using std::in_place_index_t;
+#else
+
+// in_place_index_t
+//
+// Tag type used for in-place construction when the type to construct needs to
+// be specified, such as with `absl::any`, designed to be a drop-in replacement
+// for C++17's `std::in_place_index_t`.
+template <size_t I>
+using in_place_index_t = void (*)(utility_internal::InPlaceIndexTag<I>);
+
+template <size_t I>
+void in_place_index(utility_internal::InPlaceIndexTag<I>) {}
+#endif  // OTABSL_USES_STD_VARIANT
+
+// Constexpr move and forward
+
+// move()
+//
+// A constexpr version of `std::move()`, designed to be a drop-in replacement
+// for C++14's `std::move()`.
+template <typename T>
+constexpr absl::remove_reference_t<T>&& move(T&& t) noexcept {
+  return static_cast<absl::remove_reference_t<T>&&>(t);
+}
+
+// forward()
+//
+// A constexpr version of `std::forward()`, designed to be a drop-in replacement
+// for C++14's `std::forward()`.
+template <typename T>
+constexpr T&& forward(
+    absl::remove_reference_t<T>& t) noexcept {  // NOLINT(runtime/references)
+  return static_cast<T&&>(t);
+}
+
+namespace utility_internal {
+// Helper method for expanding tuple into a called method.
+template <typename Functor, typename Tuple, std::size_t... Indexes>
+auto apply_helper(Functor&& functor, Tuple&& t, index_sequence<Indexes...>)
+    -> decltype(absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::base_internal::Invoke(
+        absl::forward<Functor>(functor),
+        std::get<Indexes>(absl::forward<Tuple>(t))...)) {
+  return absl::OTABSL_OPTION_INLINE_NAMESPACE_NAME::base_internal::Invoke(
+      absl::forward<Functor>(functor),
+      std::get<Indexes>(absl::forward<Tuple>(t))...);
+}
+
+}  // namespace utility_internal
+
+// apply
+//
+// Invokes a Callable using elements of a tuple as its arguments.
+// Each element of the tuple corresponds to an argument of the call (in order).
+// Both the Callable argument and the tuple argument are perfect-forwarded.
+// For member-function Callables, the first tuple element acts as the `this`
+// pointer. `absl::apply` is designed to be a drop-in replacement for C++17's
+// `std::apply`. Unlike C++17's `std::apply`, this is not currently `constexpr`.
+//
+// Example:
+//
+//   class Foo {
+//    public:
+//     void Bar(int);
+//   };
+//   void user_function1(int, std::string);
+//   void user_function2(std::unique_ptr<Foo>);
+//   auto user_lambda = [](int, int) {};
+//
+//   int main()
+//   {
+//       std::tuple<int, std::string> tuple1(42, "bar");
+//       // Invokes the first user function on int, std::string.
+//       absl::apply(&user_function1, tuple1);
+//
+//       std::tuple<std::unique_ptr<Foo>> tuple2(absl::make_unique<Foo>());
+//       // Invokes the user function that takes ownership of the unique
+//       // pointer.
+//       absl::apply(&user_function2, std::move(tuple2));
+//
+//       auto foo = absl::make_unique<Foo>();
+//       std::tuple<Foo*, int> tuple3(foo.get(), 42);
+//       // Invokes the method Bar on foo with one argument, 42.
+//       absl::apply(&Foo::Bar, tuple3);
+//
+//       std::tuple<int, int> tuple4(8, 9);
+//       // Invokes a lambda.
+//       absl::apply(user_lambda, tuple4);
+//   }
+template <typename Functor, typename Tuple>
+auto apply(Functor&& functor, Tuple&& t)
+    -> decltype(utility_internal::apply_helper(
+        absl::forward<Functor>(functor), absl::forward<Tuple>(t),
+        absl::make_index_sequence<std::tuple_size<
+            typename std::remove_reference<Tuple>::type>::value>{})) {
+  return utility_internal::apply_helper(
+      absl::forward<Functor>(functor), absl::forward<Tuple>(t),
+      absl::make_index_sequence<std::tuple_size<
+          typename std::remove_reference<Tuple>::type>::value>{});
+}
+
+// exchange
+//
+// Replaces the value of `obj` with `new_value` and returns the old value of
+// `obj`.  `absl::exchange` is designed to be a drop-in replacement for C++14's
+// `std::exchange`.
+//
+// Example:
+//
+//   Foo& operator=(Foo&& other) {
+//     ptr1_ = absl::exchange(other.ptr1_, nullptr);
+//     int1_ = absl::exchange(other.int1_, -1);
+//     return *this;
+//   }
+template <typename T, typename U = T>
+T exchange(T& obj, U&& new_value) {
+  T old_value = absl::move(obj);
+  obj = absl::forward<U>(new_value);
+  return old_value;
+}
+
+namespace utility_internal {
+template <typename T, typename Tuple, size_t... I>
+T make_from_tuple_impl(Tuple&& tup, absl::index_sequence<I...>) {
+  return T(std::get<I>(std::forward<Tuple>(tup))...);
+}
+}  // namespace utility_internal
+
+// make_from_tuple
+//
+// Given the template parameter type `T` and a tuple of arguments
+// `std::tuple(arg0, arg1, ..., argN)` constructs an object of type `T` as if by
+// calling `T(arg0, arg1, ..., argN)`.
+//
+// Example:
+//
+//   std::tuple<const char*, size_t> args("hello world", 5);
+//   auto s = absl::make_from_tuple<std::string>(args);
+//   assert(s == "hello");
+//
+template <typename T, typename Tuple>
+constexpr T make_from_tuple(Tuple&& tup) {
+  return utility_internal::make_from_tuple_impl<T>(
+      std::forward<Tuple>(tup),
+      absl::make_index_sequence<
+          std::tuple_size<absl::decay_t<Tuple>>::value>{});
+}
+
+OTABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // OTABSL_UTILITY_UTILITY_H_

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/shared_ptr.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/shared_ptr.h
@@ -1,0 +1,210 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(OPENTELEMETRY_STL_VERSION)
+#  if OPENTELEMETRY_STL_VERSION >= 2011
+#    include "opentelemetry/std/shared_ptr.h"
+#    define OPENTELEMETRY_HAVE_STD_SHARED_PTR
+#  endif
+#endif
+
+#if !defined(OPENTELEMETRY_HAVE_STD_SHARED_PTR)
+#  include <cstdlib>
+#  include <memory>
+#  include <utility>
+
+#  include "opentelemetry/nostd/unique_ptr.h"
+#  include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+/**
+ * Provide a type-erased version of std::shared_ptr that has ABI stability.
+ */
+template <class T>
+class shared_ptr
+{
+public:
+  using element_type = T;
+  using pointer      = element_type *;
+
+private:
+  static constexpr size_t kMaxSize   = 32;
+  static constexpr size_t kAlignment = 8;
+
+  struct alignas(kAlignment) PlacementBuffer
+  {
+    char data[kMaxSize];
+  };
+
+  class shared_ptr_wrapper
+  {
+  public:
+    shared_ptr_wrapper() noexcept = default;
+
+    shared_ptr_wrapper(std::shared_ptr<T> &&ptr) noexcept : ptr_{std::move(ptr)} {}
+
+    virtual ~shared_ptr_wrapper() {}
+
+    virtual void CopyTo(PlacementBuffer &buffer) const noexcept
+    {
+      new (buffer.data) shared_ptr_wrapper{*this};
+    }
+
+    virtual void MoveTo(PlacementBuffer &buffer) noexcept
+    {
+      new (buffer.data) shared_ptr_wrapper{std::move(this->ptr_)};
+    }
+
+    template <class U,
+              typename std::enable_if<std::is_convertible<pointer, U *>::value>::type * = nullptr>
+    void MoveTo(typename shared_ptr<U>::PlacementBuffer &buffer) noexcept
+    {
+      using other_shared_ptr_wrapper = typename shared_ptr<U>::shared_ptr_wrapper;
+      new (buffer.data) other_shared_ptr_wrapper{std::move(this->ptr_)};
+    }
+
+    virtual pointer Get() const noexcept { return ptr_.get(); }
+
+    virtual void Reset() noexcept { ptr_.reset(); }
+
+  private:
+    std::shared_ptr<T> ptr_;
+  };
+
+  static_assert(sizeof(shared_ptr_wrapper) <= kMaxSize, "Placement buffer is too small");
+  static_assert(alignof(shared_ptr_wrapper) <= kAlignment, "Placement buffer not properly aligned");
+
+public:
+  shared_ptr() noexcept { new (buffer_.data) shared_ptr_wrapper{}; }
+
+  explicit shared_ptr(pointer ptr)
+  {
+    std::shared_ptr<T> ptr_(ptr);
+    new (buffer_.data) shared_ptr_wrapper{std::move(ptr_)};
+  }
+
+  shared_ptr(std::shared_ptr<T> ptr) noexcept
+  {
+    new (buffer_.data) shared_ptr_wrapper{std::move(ptr)};
+  }
+
+  shared_ptr(shared_ptr &&other) noexcept { other.wrapper().MoveTo(buffer_); }
+
+  template <class U,
+            typename std::enable_if<std::is_convertible<U *, pointer>::value>::type * = nullptr>
+  shared_ptr(shared_ptr<U> &&other) noexcept
+  {
+    other.wrapper().template MoveTo<T>(buffer_);
+  }
+
+  shared_ptr(const shared_ptr &other) noexcept { other.wrapper().CopyTo(buffer_); }
+
+  shared_ptr(unique_ptr<T> &&other) noexcept
+  {
+    std::shared_ptr<T> ptr_(other.release());
+    new (buffer_.data) shared_ptr_wrapper{std::move(ptr_)};
+  }
+
+  shared_ptr(std::unique_ptr<T> &&other) noexcept
+  {
+    std::shared_ptr<T> ptr_(other.release());
+    new (buffer_.data) shared_ptr_wrapper{std::move(ptr_)};
+  }
+
+  ~shared_ptr() { wrapper().~shared_ptr_wrapper(); }
+
+  shared_ptr &operator=(shared_ptr &&other) noexcept
+  {
+    wrapper().~shared_ptr_wrapper();
+    other.wrapper().MoveTo(buffer_);
+    return *this;
+  }
+
+  shared_ptr &operator=(std::nullptr_t) noexcept
+  {
+    wrapper().Reset();
+    return *this;
+  }
+
+  shared_ptr &operator=(const shared_ptr &other) noexcept
+  {
+    wrapper().~shared_ptr_wrapper();
+    other.wrapper().CopyTo(buffer_);
+    return *this;
+  }
+
+  element_type &operator*() const noexcept { return *wrapper().Get(); }
+
+  pointer operator->() const noexcept { return wrapper().Get(); }
+
+  operator bool() const noexcept { return wrapper().Get() != nullptr; }
+
+  pointer get() const noexcept { return wrapper().Get(); }
+
+  void swap(shared_ptr<T> &other) noexcept
+  {
+    shared_ptr<T> tmp{std::move(other)};
+
+    wrapper().MoveTo(other.buffer_);
+    tmp.wrapper().MoveTo(buffer_);
+  }
+
+  template <typename U>
+  friend class shared_ptr;
+
+private:
+  PlacementBuffer buffer_;
+
+  shared_ptr_wrapper &wrapper() noexcept
+  {
+    return *reinterpret_cast<shared_ptr_wrapper *>(buffer_.data);
+  }
+
+  const shared_ptr_wrapper &wrapper() const noexcept
+  {
+    return *reinterpret_cast<const shared_ptr_wrapper *>(buffer_.data);
+  }
+};
+
+template <class T1, class T2>
+bool operator!=(const shared_ptr<T1> &lhs, const shared_ptr<T2> &rhs) noexcept
+{
+  return lhs.get() != rhs.get();
+}
+
+template <class T1, class T2>
+bool operator==(const shared_ptr<T1> &lhs, const shared_ptr<T2> &rhs) noexcept
+{
+  return lhs.get() == rhs.get();
+}
+
+template <class T>
+inline bool operator==(const shared_ptr<T> &lhs, std::nullptr_t) noexcept
+{
+  return lhs.get() == nullptr;
+}
+
+template <class T>
+inline bool operator==(std::nullptr_t, const shared_ptr<T> &rhs) noexcept
+{
+  return nullptr == rhs.get();
+}
+
+template <class T>
+inline bool operator!=(const shared_ptr<T> &lhs, std::nullptr_t) noexcept
+{
+  return lhs.get() != nullptr;
+}
+
+template <class T>
+inline bool operator!=(std::nullptr_t, const shared_ptr<T> &rhs) noexcept
+{
+  return nullptr != rhs.get();
+}
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+#endif /* OPENTELEMETRY_HAVE_STD_SHARED_PTR */

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/span.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/span.h
@@ -1,0 +1,274 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Try to use either `std::span` or `gsl::span`
+#if defined(OPENTELEMETRY_STL_VERSION)
+#  if OPENTELEMETRY_STL_VERSION >= 2020
+#    include <array>
+#    include <cstddef>
+#    include <iterator>
+#    include <type_traits>
+
+/**
+ * @brief Clang 14.0.0 with libc++ do not support implicitly construct a span
+ * for a range. We just use our fallback version.
+ *
+ */
+#    if !defined(OPENTELEMETRY_OPTION_USE_STD_SPAN) && defined(_LIBCPP_VERSION)
+#      if _LIBCPP_VERSION <= 14000
+#        define OPENTELEMETRY_OPTION_USE_STD_SPAN 0
+#      endif
+#    endif
+#    ifndef OPENTELEMETRY_OPTION_USE_STD_SPAN
+#      define OPENTELEMETRY_OPTION_USE_STD_SPAN 1
+#    endif
+#    if OPENTELEMETRY_OPTION_USE_STD_SPAN
+#      include "opentelemetry/std/span.h"
+#    endif
+#  endif /* OPENTELEMETRY_STL_VERSION >= 2020 */
+#endif   /* OPENTELEMETRY_STL_VERSION */
+
+// Fallback to `nostd::span` if necessary
+#if !defined(OPENTELEMETRY_HAVE_SPAN)
+#  include <array>
+#  include <cassert>
+#  include <cstddef>
+#  include <exception>
+#  include <iterator>
+#  include <type_traits>
+
+#  include "opentelemetry/nostd/utility.h"
+#  include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+constexpr size_t dynamic_extent = static_cast<size_t>(-1);
+
+template <class T, size_t Extent = dynamic_extent>
+class span;
+
+namespace detail
+{
+/**
+ * Helper class to resolve overloaded constructors
+ */
+template <class T>
+struct is_specialized_span_convertible : std::false_type
+{};
+
+template <class T, size_t N>
+struct is_specialized_span_convertible<std::array<T, N>> : std::true_type
+{};
+
+template <class T, size_t N>
+struct is_specialized_span_convertible<T[N]> : std::true_type
+{};
+
+template <class T, size_t Extent>
+struct is_specialized_span_convertible<span<T, Extent>> : std::true_type
+{};
+}  // namespace detail
+
+/**
+ * Back port of std::span.
+ *
+ * See https://en.cppreference.com/w/cpp/container/span for interface documentation.
+ *
+ * Note: This provides a subset of the methods available on std::span.
+ *
+ * Note: The std::span API specifies error cases to have undefined behavior, so this implementation
+ * chooses to terminate or assert rather than throw exceptions.
+ */
+template <class T, size_t Extent>
+class span
+{
+public:
+  static constexpr size_t extent = Extent;
+
+  // This arcane code is how we make default-construction result in an SFINAE error
+  // with C++11 when Extent != 0 as specified by the std::span API.
+  //
+  // See https://stackoverflow.com/a/10309720/4447365
+  template <bool B = Extent == 0, typename std::enable_if<B>::type * = nullptr>
+  span() noexcept : data_{nullptr}
+  {}
+
+  span(T *data, size_t count) noexcept : data_{data}
+  {
+    if (count != Extent)
+    {
+      std::terminate();
+    }
+  }
+
+  span(T *first, T *last) noexcept : data_{first}
+  {
+    if (std::distance(first, last) != Extent)
+    {
+      std::terminate();
+    }
+  }
+
+  template <size_t N, typename std::enable_if<Extent == N>::type * = nullptr>
+  span(T (&array)[N]) noexcept : data_{array}
+  {}
+
+  template <size_t N, typename std::enable_if<Extent == N>::type * = nullptr>
+  span(std::array<T, N> &array) noexcept : data_{array.data()}
+  {}
+
+  template <size_t N, typename std::enable_if<Extent == N>::type * = nullptr>
+  span(const std::array<T, N> &array) noexcept : data_{array.data()}
+  {}
+
+  template <
+      class C,
+      typename std::enable_if<!detail::is_specialized_span_convertible<C>::value &&
+                              std::is_convertible<typename std::remove_pointer<decltype(nostd::data(
+                                                      std::declval<C &>()))>::type (*)[],
+                                                  T (*)[]>::value &&
+                              std::is_convertible<decltype(nostd::size(std::declval<const C &>())),
+                                                  size_t>::value>::type * = nullptr>
+  span(C &c) noexcept(noexcept(nostd::data(c), nostd::size(c))) : data_{nostd::data(c)}
+  {
+    if (nostd::size(c) != Extent)
+    {
+      std::terminate();
+    }
+  }
+
+  template <
+      class C,
+      typename std::enable_if<!detail::is_specialized_span_convertible<C>::value &&
+                              std::is_convertible<typename std::remove_pointer<decltype(nostd::data(
+                                                      std::declval<const C &>()))>::type (*)[],
+                                                  T (*)[]>::value &&
+                              std::is_convertible<decltype(nostd::size(std::declval<const C &>())),
+                                                  size_t>::value>::type * = nullptr>
+  span(const C &c) noexcept(noexcept(nostd::data(c), nostd::size(c))) : data_{nostd::data(c)}
+  {
+    if (nostd::size(c) != Extent)
+    {
+      std::terminate();
+    }
+  }
+
+  template <class U,
+            size_t N,
+            typename std::enable_if<N == Extent &&
+                                    std::is_convertible<U (*)[], T (*)[]>::value>::type * = nullptr>
+  span(const span<U, N> &other) noexcept : data_{other.data()}
+  {}
+
+  span(const span &) noexcept = default;
+
+  span &operator=(const span &) noexcept = default;
+
+  bool empty() const noexcept { return Extent == 0; }
+
+  T *data() const noexcept { return data_; }
+
+  size_t size() const noexcept { return Extent; }
+
+  T &operator[](size_t index) const noexcept
+  {
+    assert(index < Extent);
+    return data_[index];
+  }
+
+  T *begin() const noexcept { return data_; }
+
+  T *end() const noexcept { return data_ + Extent; }
+
+private:
+  T *data_;
+};
+
+template <class T>
+class span<T, dynamic_extent>
+{
+public:
+  static constexpr size_t extent = dynamic_extent;
+
+  span() noexcept : extent_{0}, data_{nullptr} {}
+
+  span(T *data, size_t count) noexcept : extent_{count}, data_{data} {}
+
+  span(T *first, T *last) noexcept
+      : extent_{static_cast<size_t>(std::distance(first, last))}, data_{first}
+  {
+    assert(first <= last);
+  }
+
+  template <size_t N>
+  span(T (&array)[N]) noexcept : extent_{N}, data_{array}
+  {}
+
+  template <size_t N>
+  span(std::array<T, N> &array) noexcept : extent_{N}, data_{array.data()}
+  {}
+
+  template <size_t N>
+  span(const std::array<T, N> &array) noexcept : extent_{N}, data_{array.data()}
+  {}
+
+  template <
+      class C,
+      typename std::enable_if<!detail::is_specialized_span_convertible<C>::value &&
+                              std::is_convertible<typename std::remove_pointer<decltype(nostd::data(
+                                                      std::declval<C &>()))>::type (*)[],
+                                                  T (*)[]>::value &&
+                              std::is_convertible<decltype(nostd::size(std::declval<const C &>())),
+                                                  size_t>::value>::type * = nullptr>
+  span(C &c) noexcept(noexcept(nostd::data(c), nostd::size(c)))
+      : extent_{nostd::size(c)}, data_{nostd::data(c)}
+  {}
+
+  template <
+      class C,
+      typename std::enable_if<!detail::is_specialized_span_convertible<C>::value &&
+                              std::is_convertible<typename std::remove_pointer<decltype(nostd::data(
+                                                      std::declval<const C &>()))>::type (*)[],
+                                                  T (*)[]>::value &&
+                              std::is_convertible<decltype(nostd::size(std::declval<const C &>())),
+                                                  size_t>::value>::type * = nullptr>
+  span(const C &c) noexcept(noexcept(nostd::data(c), nostd::size(c)))
+      : extent_{nostd::size(c)}, data_{nostd::data(c)}
+  {}
+
+  template <class U,
+            size_t N,
+            typename std::enable_if<std::is_convertible<U (*)[], T (*)[]>::value>::type * = nullptr>
+  span(const span<U, N> &other) noexcept : extent_{other.size()}, data_{other.data()}
+  {}
+
+  span(const span &) noexcept = default;
+
+  span &operator=(const span &) noexcept = default;
+
+  bool empty() const noexcept { return extent_ == 0; }
+
+  T *data() const noexcept { return data_; }
+
+  size_t size() const noexcept { return extent_; }
+
+  T &operator[](size_t index) const noexcept
+  {
+    assert(index < extent_);
+    return data_[index];
+  }
+
+  T *begin() const noexcept { return data_; }
+
+  T *end() const noexcept { return data_ + extent_; }
+
+private:
+  size_t extent_;
+  T *data_;
+};
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+#endif

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/string_view.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/string_view.h
@@ -1,0 +1,224 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(OPENTELEMETRY_STL_VERSION)
+#  if OPENTELEMETRY_STL_VERSION >= 2017
+#    include "opentelemetry/std/string_view.h"
+#    define OPENTELEMETRY_HAVE_STD_STRING_VIEW
+#  endif
+#endif
+
+#if !defined(OPENTELEMETRY_HAVE_STD_STRING_VIEW)
+#  include <algorithm>
+#  include <cstddef>
+#  include <cstring>
+#  include <ostream>
+#  include <stdexcept>
+#  include <string>
+
+#  include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+
+using Traits = std::char_traits<char>;
+
+/**
+ * Back port of std::string_view to work with pre-cpp-17 compilers.
+ *
+ * Note: This provides a subset of the methods available on std::string_view but
+ * tries to be as compatible as possible with the std::string_view interface.
+ */
+class string_view
+{
+public:
+  typedef std::size_t size_type;
+
+  static constexpr size_type npos = static_cast<size_type>(-1);
+
+  string_view() noexcept : length_(0), data_(nullptr) {}
+
+  string_view(const char *str) noexcept : length_(std::strlen(str)), data_(str) {}
+
+  string_view(const std::basic_string<char> &str) noexcept
+      : length_(str.length()), data_(str.c_str())
+  {}
+
+  string_view(const char *str, size_type len) noexcept : length_(len), data_(str) {}
+
+  explicit operator std::string() const { return {data_, length_}; }
+
+  const char *data() const noexcept { return data_; }
+
+  bool empty() const noexcept { return length_ == 0; }
+
+  size_type length() const noexcept { return length_; }
+
+  size_type size() const noexcept { return length_; }
+
+  const char *begin() const noexcept { return data(); }
+
+  const char *end() const noexcept { return data() + length(); }
+
+  const char &operator[](size_type i) { return *(data() + i); }
+
+  string_view substr(size_type pos, size_type n = npos) const
+  {
+    if (pos > length_)
+    {
+#  if __EXCEPTIONS
+      throw std::out_of_range{"opentelemetry::nostd::string_view"};
+#  else
+      std::terminate();
+#  endif
+    }
+    n = (std::min)(n, length_ - pos);
+    return string_view(data_ + pos, n);
+  }
+
+  int compare(string_view v) const noexcept
+  {
+    size_type len = (std::min)(size(), v.size());
+    int result    = Traits::compare(data(), v.data(), len);
+    if (result == 0)
+      result = size() == v.size() ? 0 : (size() < v.size() ? -1 : 1);
+    return result;
+  }
+
+  int compare(size_type pos1, size_type count1, string_view v) const
+  {
+    return substr(pos1, count1).compare(v);
+  }
+
+  int compare(size_type pos1,
+              size_type count1,
+              string_view v,
+              size_type pos2,
+              size_type count2) const
+  {
+    return substr(pos1, count1).compare(v.substr(pos2, count2));
+  }
+
+  int compare(const char *s) const { return compare(string_view(s)); }
+
+  int compare(size_type pos1, size_type count1, const char *s) const
+  {
+    return substr(pos1, count1).compare(string_view(s));
+  }
+
+  int compare(size_type pos1, size_type count1, const char *s, size_type count2) const
+  {
+    return substr(pos1, count1).compare(string_view(s, count2));
+  }
+
+  size_type find(char ch, size_type pos = 0) const noexcept
+  {
+    size_type res = npos;
+    if (pos < length())
+    {
+      auto found = Traits::find(data() + pos, length() - pos, ch);
+      if (found)
+      {
+        res = found - data();
+      }
+    }
+    return res;
+  }
+
+  bool operator<(const string_view v) const noexcept { return compare(v) < 0; }
+
+  bool operator>(const string_view v) const noexcept { return compare(v) > 0; }
+
+private:
+  // Note: uses the same binary layout as libstdc++'s std::string_view
+  // See
+  // https://github.com/gcc-mirror/gcc/blob/e0c554e4da7310df83bb1dcc7b8e6c4c9c5a2a4f/libstdc%2B%2B-v3/include/std/string_view#L466-L467
+  size_type length_;
+  const char *data_;
+};
+
+inline bool operator==(string_view lhs, string_view rhs) noexcept
+{
+  return lhs.length() == rhs.length() &&
+#  if defined(_MSC_VER)
+#    if _MSC_VER >= 1900 && _MSC_VER <= 1911
+         // Avoid SCL error in Visual Studio 2015, VS2017 update 1 to update 4
+         (std::memcmp(lhs.data(), rhs.data(), lhs.length()) == 0);
+#    else
+         std::equal(lhs.data(), lhs.data() + lhs.length(), rhs.data());
+#    endif
+#  else
+         std::equal(lhs.data(), lhs.data() + lhs.length(), rhs.data());
+#  endif
+}
+
+inline bool operator==(string_view lhs, const std::string &rhs) noexcept
+{
+  return lhs == string_view(rhs);
+}
+
+inline bool operator==(const std::string &lhs, string_view rhs) noexcept
+{
+  return string_view(lhs) == rhs;
+}
+
+inline bool operator==(string_view lhs, const char *rhs) noexcept
+{
+  return lhs == string_view(rhs);
+}
+
+inline bool operator==(const char *lhs, string_view rhs) noexcept
+{
+  return string_view(lhs) == rhs;
+}
+
+inline bool operator!=(string_view lhs, string_view rhs) noexcept
+{
+  return !(lhs == rhs);
+}
+
+inline bool operator!=(string_view lhs, const std::string &rhs) noexcept
+{
+  return !(lhs == rhs);
+}
+
+inline bool operator!=(const std::string &lhs, string_view rhs) noexcept
+{
+  return !(lhs == rhs);
+}
+
+inline bool operator!=(string_view lhs, const char *rhs) noexcept
+{
+  return !(lhs == rhs);
+}
+
+inline bool operator!=(const char *lhs, string_view rhs) noexcept
+{
+  return !(lhs == rhs);
+}
+
+inline std::ostream &operator<<(std::ostream &os, string_view s)
+{
+  return os.write(s.data(), static_cast<std::streamsize>(s.length()));
+}
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+
+namespace std
+{
+template <>
+struct hash<OPENTELEMETRY_NAMESPACE::nostd::string_view>
+{
+  std::size_t operator()(const OPENTELEMETRY_NAMESPACE::nostd::string_view &k) const
+  {
+    // TODO: for C++17 that has native support for std::basic_string_view it would
+    // be more performance-efficient to provide a zero-copy hash.
+    auto s = std::string(k.data(), k.size());
+    return std::hash<std::string>{}(s);
+  }
+};
+}  // namespace std
+#endif /* OPENTELEMETRY_HAVE_STD_STRING_VIEW */

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/type_traits.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/type_traits.h
@@ -1,0 +1,162 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(OPENTELEMETRY_STL_VERSION)
+#  if OPENTELEMETRY_STL_VERSION >= 2011
+#    include "opentelemetry/std/type_traits.h"
+#    define OPENTELEMETRY_HAVE_STD_TYPE_TRAITS
+#  endif
+#endif
+
+#if !defined(OPENTELEMETRY_HAVE_STD_TYPE_TRAITS)
+#  include <array>
+#  include <type_traits>
+
+#  include "opentelemetry/config.h"
+#  include "opentelemetry/nostd/detail/void.h"
+#  include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+/**
+ * Back port of std::add_pointer_t
+ */
+template <class T>
+using add_pointer_t = typename std::add_pointer<T>::type;
+
+/**
+ * Back port of std::enable_if_t
+ */
+template <bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+/**
+ * Back port of std::remove_const_t
+ */
+template <typename T>
+using remove_const_t = typename std::remove_const<T>::type;
+
+/**
+ * Back port of std::remove_reference_t
+ */
+template <typename T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+
+/**
+ * Back port of std::remove_cvref_t
+ */
+template <typename T>
+using remove_cvref_t = typename std::remove_cv<remove_reference_t<T>>::type;
+
+/**
+ * Back port of std::remove_all_extents
+ */
+template <typename T>
+struct remove_all_extents
+{
+  using type = T;
+};
+
+template <typename T, std::size_t N>
+struct remove_all_extents<std::array<T, N>> : remove_all_extents<T>
+{};
+
+/**
+ * Back port of std::remove_all_extents_t
+ */
+template <typename T>
+using remove_all_extents_t = typename remove_all_extents<T>::type;
+
+/**
+ * Back port of std::is_swappable
+ */
+namespace detail
+{
+namespace swappable
+{
+
+using std::swap;
+
+template <typename T>
+struct is_swappable
+{
+private:
+  template <typename U, typename = decltype(swap(std::declval<U &>(), std::declval<U &>()))>
+  inline static std::true_type test(int);
+
+  template <typename U>
+  inline static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+}  // namespace swappable
+}  // namespace detail
+
+using detail::swappable::is_swappable;
+
+/**
+ * Back port of std::is_swappable
+ */
+namespace detail
+{
+namespace swappable
+{
+template <bool IsSwappable, typename T>
+struct is_nothrow_swappable
+{
+  static constexpr bool value = noexcept(swap(std::declval<T &>(), std::declval<T &>()));
+};
+
+template <typename T>
+struct is_nothrow_swappable<false, T> : std::false_type
+{};
+}  // namespace swappable
+}  // namespace detail
+template <typename T>
+using is_nothrow_swappable = detail::swappable::is_nothrow_swappable<is_swappable<T>::value, T>;
+
+/**
+ * Back port of
+ *  std::is_trivialy_copy_constructible
+ *  std::is_trivialy_move_constructible
+ *  std::is_trivialy_copy_assignable
+ *  std::is_trivialy_move_assignable
+ */
+#  ifdef OPENTELEMETRY_TRIVIALITY_TYPE_TRAITS
+using std::is_trivially_copy_assignable;
+using std::is_trivially_copy_constructible;
+using std::is_trivially_move_assignable;
+using std::is_trivially_move_constructible;
+#  else
+template <typename T>
+struct is_trivially_copy_constructible
+{
+  static constexpr bool value = std::is_copy_constructible<T>::value && __has_trivial_copy(T);
+};
+
+template <typename T>
+struct is_trivially_move_constructible
+{
+  static constexpr bool value = __is_trivial(T);
+};
+
+template <typename T>
+struct is_trivially_copy_assignable
+{
+  static constexpr bool value = std::is_copy_assignable<T>::value && __has_trivial_assign(T);
+};
+
+template <typename T>
+struct is_trivially_move_assignable
+{
+  static constexpr bool value = __is_trivial(T);
+};
+#  endif
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+#endif /* OPENTELEMETRY_HAVE_STD_TYPE_TRAITS */

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/unique_ptr.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/unique_ptr.h
@@ -1,0 +1,180 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(OPENTELEMETRY_STL_VERSION)
+#  if OPENTELEMETRY_STL_VERSION >= 2011
+#    include "opentelemetry/std/unique_ptr.h"
+#    define OPENTELEMETRY_HAVE_STD_UNIQUE_PTR
+#  endif
+#endif
+
+#if !defined(OPENTELEMETRY_HAVE_STD_UNIQUE_PTR)
+#  include <cstddef>
+#  include <memory>
+#  include <type_traits>
+#  include <utility>
+
+#  include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+namespace detail
+{
+template <class T>
+struct unique_ptr_element_type
+{
+  using type = T;
+};
+
+template <class T>
+struct unique_ptr_element_type<T[]>
+{
+  using type = T;
+};
+}  // namespace detail
+
+/**
+ * Provide a simplified port of std::unique_ptr that has ABI stability.
+ *
+ * Note: This implementation doesn't allow for a custom deleter.
+ */
+template <class T>
+class unique_ptr
+{
+public:
+  using element_type = typename detail::unique_ptr_element_type<T>::type;
+  using pointer      = element_type *;
+
+  unique_ptr() noexcept : ptr_{nullptr} {}
+
+  unique_ptr(std::nullptr_t) noexcept : ptr_{nullptr} {}
+
+  explicit unique_ptr(pointer ptr) noexcept : ptr_{ptr} {}
+
+  unique_ptr(unique_ptr &&other) noexcept : ptr_{other.release()} {}
+
+  template <class U,
+            typename std::enable_if<std::is_convertible<U *, pointer>::value>::type * = nullptr>
+  unique_ptr(unique_ptr<U> &&other) noexcept : ptr_{other.release()}
+  {}
+
+  template <class U,
+            typename std::enable_if<std::is_convertible<U *, pointer>::value>::type * = nullptr>
+  unique_ptr(std::unique_ptr<U> &&other) noexcept : ptr_{other.release()}
+  {}
+
+  ~unique_ptr() { reset(); }
+
+  unique_ptr &operator=(unique_ptr &&other) noexcept
+  {
+    reset(other.release());
+    return *this;
+  }
+
+  unique_ptr &operator=(std::nullptr_t) noexcept
+  {
+    reset();
+    return *this;
+  }
+
+  template <class U,
+            typename std::enable_if<std::is_convertible<U *, pointer>::value>::type * = nullptr>
+  unique_ptr &operator=(unique_ptr<U> &&other) noexcept
+  {
+    reset(other.release());
+    return *this;
+  }
+
+  template <class U,
+            typename std::enable_if<std::is_convertible<U *, pointer>::value>::type * = nullptr>
+  unique_ptr &operator=(std::unique_ptr<U> &&other) noexcept
+  {
+    reset(other.release());
+    return *this;
+  }
+
+  operator std::unique_ptr<T>() &&noexcept { return std::unique_ptr<T>{release()}; }
+
+  operator bool() const noexcept { return ptr_ != nullptr; }
+
+  element_type &operator*() const noexcept { return *ptr_; }
+
+  pointer operator->() const noexcept { return get(); }
+
+  pointer get() const noexcept { return ptr_; }
+
+  void reset(pointer ptr = nullptr) noexcept
+  {
+    if (ptr_ != nullptr)
+    {
+      this->delete_ptr();
+    }
+    ptr_ = ptr;
+  }
+
+  pointer release() noexcept
+  {
+    auto result = ptr_;
+    ptr_        = nullptr;
+    return result;
+  }
+
+  void swap(unique_ptr &other) noexcept { std::swap(ptr_, other.ptr_); }
+
+private:
+  pointer ptr_;
+
+  void delete_ptr() noexcept
+  {
+    if (std::is_array<T>::value)
+    {
+      delete[] ptr_;
+    }
+    else
+    {
+      delete ptr_;
+    }
+  }
+};
+
+template <class T1, class T2>
+bool operator==(const unique_ptr<T1> &lhs, const unique_ptr<T2> &rhs) noexcept
+{
+  return lhs.get() == rhs.get();
+}
+
+template <class T>
+bool operator==(const unique_ptr<T> &lhs, std::nullptr_t) noexcept
+{
+  return lhs.get() == nullptr;
+}
+
+template <class T>
+bool operator==(std::nullptr_t, const unique_ptr<T> &rhs) noexcept
+{
+  return nullptr == rhs.get();
+}
+
+template <class T1, class T2>
+bool operator!=(const unique_ptr<T1> &lhs, const unique_ptr<T2> &rhs) noexcept
+{
+  return lhs.get() != rhs.get();
+}
+
+template <class T>
+bool operator!=(const unique_ptr<T> &lhs, std::nullptr_t) noexcept
+{
+  return lhs.get() != nullptr;
+}
+
+template <class T>
+bool operator!=(std::nullptr_t, const unique_ptr<T> &rhs) noexcept
+{
+  return nullptr != rhs.get();
+}
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+#endif /* OPENTELEMETRY_HAVE_STD_UNIQUE_PTR */

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/utility.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/utility.h
@@ -1,0 +1,160 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(OPENTELEMETRY_STL_VERSION)
+#  if OPENTELEMETRY_STL_VERSION >= 2014
+#    include "opentelemetry/std/utility.h"
+#    define OPENTELEMETRY_HAVE_STD_UTILITY
+#  endif
+#endif
+
+#if !defined(OPENTELEMETRY_HAVE_STD_UTILITY)
+#  include <cstddef>
+#  include <initializer_list>
+#  include <type_traits>
+
+#  include "opentelemetry/nostd/detail/decay.h"
+#  include "opentelemetry/nostd/detail/invoke.h"
+#  include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+/**
+ * Back port of std::data
+ *
+ * See https://en.cppreference.com/w/cpp/iterator/data
+ */
+template <class C>
+auto data(C &c) noexcept(noexcept(c.data())) -> decltype(c.data())
+{
+  return c.data();
+}
+
+template <class C>
+auto data(const C &c) noexcept(noexcept(c.data())) -> decltype(c.data())
+{
+  return c.data();
+}
+
+template <class T, size_t N>
+T *data(T (&array)[N]) noexcept
+{
+  return array;
+}
+
+template <class E>
+const E *data(std::initializer_list<E> list) noexcept
+{
+  return list.begin();
+}
+
+/**
+ * Back port of std::size
+ *
+ * See https://en.cppreference.com/w/cpp/iterator/size
+ */
+template <class C>
+auto size(const C &c) noexcept(noexcept(c.size())) -> decltype(c.size())
+{
+  return c.size();
+}
+
+template <class T, size_t N>
+size_t size(T (&/* array */)[N]) noexcept
+{
+  return N;
+}
+
+/**
+ * Back port of std::bool_constant
+ */
+template <bool B>
+using bool_constant = std::integral_constant<bool, B>;
+
+/**
+ * Back port of std::integer_sequence
+ */
+template <typename T, T... Is>
+struct integer_sequence
+{
+  using value_type = T;
+  static constexpr std::size_t size() noexcept { return sizeof...(Is); }
+};
+
+/**
+ * Back port of std::index_sequence
+ */
+template <std::size_t... Is>
+using index_sequence = integer_sequence<std::size_t, Is...>;
+
+/**
+ * Back port of std::make_index_sequence
+ */
+namespace detail
+{
+template <class, size_t>
+struct index_sequence_push_back
+{};
+
+template <size_t... Indexes, size_t I>
+struct index_sequence_push_back<index_sequence<Indexes...>, I>
+{
+  using type = index_sequence<Indexes..., I>;
+};
+
+template <class T, size_t I>
+using index_sequence_push_back_t = typename index_sequence_push_back<T, I>::type;
+
+template <size_t N>
+struct make_index_sequence_impl
+{
+  using type = index_sequence_push_back_t<typename make_index_sequence_impl<N - 1>::type, N - 1>;
+};
+
+template <>
+struct make_index_sequence_impl<0>
+{
+  using type = index_sequence<>;
+};
+}  // namespace detail
+
+template <size_t N>
+using make_index_sequence = typename detail::make_index_sequence_impl<N>::type;
+
+/**
+ * Back port of std::index_sequence_for
+ */
+template <class... Ts>
+using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+
+/**
+ * Back port of std::in_place_t
+ */
+struct in_place_t
+{
+  explicit in_place_t() = default;
+};
+
+/**
+ * Back port of std::in_place_index_t
+ */
+template <std::size_t I>
+struct in_place_index_t
+{
+  explicit in_place_index_t() = default;
+};
+
+/**
+ * Back port of std::in_place_type_t
+ */
+template <typename T>
+struct in_place_type_t
+{
+  explicit in_place_type_t() = default;
+};
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+#endif /* OPENTELEMETRY_HAVE_STD_UTILITY */

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/variant.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/nostd/variant.h
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/version.h"
+
+#if defined(OPENTELEMETRY_STL_VERSION)
+#  if OPENTELEMETRY_STL_VERSION >= 2017
+#    include "opentelemetry/std/variant.h"
+#    define OPENTELEMETRY_HAVE_STD_VARIANT
+#  endif
+#endif
+
+#if !defined(OPENTELEMETRY_HAVE_STD_VARIANT)
+
+#  ifndef HAVE_ABSEIL
+// We use a LOCAL snapshot of Abseil that is known to compile with Visual Studio 2015.
+// Header-only. Without compiling the actual Abseil binary. As Abseil moves on to new
+// toolchains, it may drop support for Visual Studio 2015 in future versions.
+
+#    if defined(__EXCEPTIONS)
+#      include <exception>
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+
+class bad_variant_access : public std::exception
+{
+public:
+  virtual const char *what() const noexcept override { return "bad_variant_access"; }
+};
+
+[[noreturn]] inline void throw_bad_variant_access()
+{
+  throw bad_variant_access{};
+}
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+#      define THROW_BAD_VARIANT_ACCESS opentelemetry::nostd::throw_bad_variant_access()
+#    else
+#      define THROW_BAD_VARIANT_ACCESS std::terminate()
+#    endif
+#  endif
+
+#  ifdef _MSC_VER
+// Abseil variant implementation contains some benign non-impacting warnings
+// that should be suppressed if compiling with Visual Studio 2017 and above.
+#    pragma warning(push)
+#    pragma warning(disable : 4245)  // conversion from int to const unsigned _int64
+#    pragma warning(disable : 4127)  // conditional expression is constant
+#  endif
+
+#  ifdef HAVE_ABSEIL
+#    include "absl/types/variant.h"
+#  else
+#    include "./internal/absl/types/variant.h"
+#  endif
+
+#  ifdef _MSC_VER
+#    pragma warning(pop)
+#  endif
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+#  ifdef HAVE_ABSEIL
+using absl::bad_variant_access;
+#  endif
+using absl::get;
+using absl::get_if;
+using absl::holds_alternative;
+using absl::monostate;
+using absl::variant;
+using absl::variant_alternative_t;
+using absl::variant_size;
+using absl::visit;
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+
+#endif /* OPENTELEMETRY_HAVE_STD_VARIANT */

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/dynamic_library_handle.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/dynamic_library_handle.h
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace plugin
+{
+/**
+ * Manage the ownership of a dynamically loaded library.
+ */
+class DynamicLibraryHandle
+{
+public:
+  virtual ~DynamicLibraryHandle() = default;
+};
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/dynamic_load_unix.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/dynamic_load_unix.h
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+
+#include <dlfcn.h>
+
+#include "opentelemetry/plugin/detail/dynamic_library_handle.h"
+#include "opentelemetry/plugin/detail/loader_info.h"
+#include "opentelemetry/plugin/detail/utility.h"
+#include "opentelemetry/plugin/factory.h"
+#include "opentelemetry/plugin/hook.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace plugin
+{
+class DynamicLibraryHandleUnix final : public DynamicLibraryHandle
+{
+public:
+  explicit DynamicLibraryHandleUnix(void *handle) noexcept : handle_{handle} {}
+
+  ~DynamicLibraryHandleUnix() override { ::dlclose(handle_); }
+
+private:
+  void *handle_;
+};
+
+inline std::unique_ptr<Factory> LoadFactory(const char *plugin, std::string &error_message) noexcept
+{
+  dlerror();  // Clear any existing error.
+
+  auto handle = ::dlopen(plugin, RTLD_NOW | RTLD_LOCAL);
+  if (handle == nullptr)
+  {
+    detail::CopyErrorMessage(dlerror(), error_message);
+    return nullptr;
+  }
+
+  std::shared_ptr<DynamicLibraryHandle> library_handle{new (std::nothrow)
+                                                           DynamicLibraryHandleUnix{handle}};
+  if (library_handle == nullptr)
+  {
+    return nullptr;
+  }
+
+  auto make_factory_impl =
+      reinterpret_cast<OpenTelemetryHook *>(::dlsym(handle, "OpenTelemetryMakeFactoryImpl"));
+  if (make_factory_impl == nullptr)
+  {
+    detail::CopyErrorMessage(dlerror(), error_message);
+    return nullptr;
+  }
+  if (*make_factory_impl == nullptr)
+  {
+    detail::CopyErrorMessage("Invalid plugin hook", error_message);
+    return nullptr;
+  }
+  LoaderInfo loader_info;
+  nostd::unique_ptr<char[]> plugin_error_message;
+  auto factory_impl = (**make_factory_impl)(loader_info, plugin_error_message);
+  if (factory_impl == nullptr)
+  {
+    detail::CopyErrorMessage(plugin_error_message.get(), error_message);
+    return nullptr;
+  }
+  return std::unique_ptr<Factory>{new (std::nothrow)
+                                      Factory{std::move(library_handle), std::move(factory_impl)}};
+}
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/dynamic_load_windows.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/dynamic_load_windows.h
@@ -1,0 +1,96 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/plugin/detail/dynamic_library_handle.h"
+#include "opentelemetry/plugin/detail/loader_info.h"
+#include "opentelemetry/plugin/detail/utility.h"
+#include "opentelemetry/plugin/factory.h"
+#include "opentelemetry/plugin/hook.h"
+#include "opentelemetry/version.h"
+
+#include <Windows.h>
+
+#include <WinBase.h>
+#include <errhandlingapi.h>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace plugin
+{
+namespace detail
+{
+inline void GetLastErrorMessage(std::string &error_message) noexcept
+{
+  auto error_code = ::GetLastError();
+  // See https://stackoverflow.com/a/455533/4447365
+  LPTSTR error_text = nullptr;
+  auto size         = ::FormatMessage(
+      FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
+      nullptr, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      reinterpret_cast<LPTSTR>(&error_text), 0, nullptr);
+  if (size == 0)
+  {
+    return;
+  }
+  CopyErrorMessage(error_text, error_message);
+  ::LocalFree(error_text);
+}
+}  // namespace detail
+
+class DynamicLibraryHandleWindows final : public DynamicLibraryHandle
+{
+public:
+  explicit DynamicLibraryHandleWindows(HINSTANCE handle) : handle_{handle} {}
+
+  ~DynamicLibraryHandleWindows() override { ::FreeLibrary(handle_); }
+
+private:
+  HINSTANCE handle_;
+};
+
+inline std::unique_ptr<Factory> LoadFactory(const char *plugin, std::string &error_message) noexcept
+{
+  auto handle = ::LoadLibrary(plugin);
+  if (handle == nullptr)
+  {
+    detail::GetLastErrorMessage(error_message);
+    return nullptr;
+  }
+
+  std::shared_ptr<DynamicLibraryHandle> library_handle{new (std::nothrow)
+                                                           DynamicLibraryHandleWindows{handle}};
+  if (library_handle == nullptr)
+  {
+    detail::CopyErrorMessage("Allocation failure", error_message);
+    return nullptr;
+  }
+
+  auto make_factory_impl = reinterpret_cast<OpenTelemetryHook *>(
+      ::GetProcAddress(handle, "OpenTelemetryMakeFactoryImpl"));
+  if (make_factory_impl == nullptr)
+  {
+    detail::GetLastErrorMessage(error_message);
+    return nullptr;
+  }
+  if (*make_factory_impl == nullptr)
+  {
+    detail::CopyErrorMessage("Invalid plugin hook", error_message);
+    return nullptr;
+  }
+
+  LoaderInfo loader_info;
+  nostd::unique_ptr<char[]> plugin_error_message;
+  auto factory_impl = (**make_factory_impl)(loader_info, plugin_error_message);
+  if (factory_impl == nullptr)
+  {
+    detail::CopyErrorMessage(plugin_error_message.get(), error_message);
+    return nullptr;
+  }
+  return std::unique_ptr<Factory>{new (std::nothrow)
+                                      Factory{std::move(library_handle), std::move(factory_impl)}};
+}
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/loader_info.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/loader_info.h
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace plugin
+{
+/**
+ * LoaderInfo describes the versioning of the loader.
+ *
+ * Plugins can check against this information and properly error out if they were built against an
+ * incompatible OpenTelemetry API.
+ */
+struct LoaderInfo
+{
+  nostd::string_view opentelemetry_version     = OPENTELEMETRY_VERSION;
+  nostd::string_view opentelemetry_abi_version = OPENTELEMETRY_ABI_VERSION;
+};
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/tracer_handle.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/tracer_handle.h
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+class Tracer;
+}  // namespace trace
+
+namespace plugin
+{
+/**
+ * Manage the ownership of a dynamically loaded tracer.
+ */
+class TracerHandle
+{
+public:
+  virtual ~TracerHandle() = default;
+
+  virtual trace::Tracer &tracer() const noexcept = 0;
+};
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/utility.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/detail/utility.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if __EXCEPTIONS
+#  include <new>
+#endif  // __EXCEPTIONS
+
+#include <string>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace plugin
+{
+namespace detail
+{
+inline void CopyErrorMessage(const char *source, std::string &destination) noexcept
+#if __EXCEPTIONS
+try
+#endif
+{
+  if (source == nullptr)
+  {
+    return;
+  }
+  destination.assign(source);
+}
+#if __EXCEPTIONS
+catch (const std::bad_alloc &)
+{}
+#endif
+}  // namespace detail
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/dynamic_load.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/dynamic_load.h
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#ifdef _WIN32
+#  include "opentelemetry/plugin/detail/dynamic_load_windows.h"
+#else
+#  include "opentelemetry/plugin/detail/dynamic_load_unix.h"
+#endif
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace plugin
+{
+
+class Factory;
+
+/**
+ * Load an OpenTelemetry implementation as a plugin.
+ * @param plugin the path to the plugin to load
+ * @param error_message on failure this is set to an error message
+ * @return a Factory that can be used to create OpenTelemetry objects or nullptr on failure.
+ */
+std::unique_ptr<Factory> LoadFactory(const char *plugin, std::string &error_message) noexcept;
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/factory.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/factory.h
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "opentelemetry/plugin/detail/utility.h"
+#include "opentelemetry/plugin/tracer.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace plugin
+{
+/**
+ * Factory creates OpenTelemetry objects from configuration strings.
+ */
+class Factory final
+{
+public:
+  class FactoryImpl
+  {
+  public:
+    virtual ~FactoryImpl() {}
+
+    virtual nostd::unique_ptr<TracerHandle> MakeTracerHandle(
+        nostd::string_view tracer_config,
+        nostd::unique_ptr<char[]> &error_message) const noexcept = 0;
+  };
+
+  Factory(std::shared_ptr<DynamicLibraryHandle> library_handle,
+          std::unique_ptr<FactoryImpl> &&factory_impl) noexcept
+      : library_handle_{std::move(library_handle)}, factory_impl_{std::move(factory_impl)}
+  {}
+
+  /**
+   * Construct a tracer from a configuration string.
+   * @param tracer_config a representation of the tracer's config as a string.
+   * @param error_message on failure this will contain an error message.
+   * @return a Tracer on success or nullptr on failure.
+   */
+  std::shared_ptr<trace::Tracer> MakeTracer(nostd::string_view tracer_config,
+                                            std::string &error_message) const noexcept
+  {
+    nostd::unique_ptr<char[]> plugin_error_message;
+    auto tracer_handle = factory_impl_->MakeTracerHandle(tracer_config, plugin_error_message);
+    if (tracer_handle == nullptr)
+    {
+      detail::CopyErrorMessage(plugin_error_message.get(), error_message);
+      return nullptr;
+    }
+    return std::shared_ptr<trace::Tracer>{new (std::nothrow)
+                                              Tracer{library_handle_, std::move(tracer_handle)}};
+  }
+
+private:
+  // Note: The order is important here.
+  //
+  // It's undefined behavior to close the library while a loaded FactoryImpl is still active.
+  std::shared_ptr<DynamicLibraryHandle> library_handle_;
+  std::unique_ptr<FactoryImpl> factory_impl_;
+};
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/hook.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/hook.h
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/version.h"
+
+#ifdef _WIN32
+
+/**
+ * Cross-platform helper macro to declare the symbol used to load an OpenTelemetry implementation
+ * as a plugin.
+ *
+ * Note: The symbols use weak linkage so as to support using an OpenTelemetry both as a regular
+ * library and a dynamically loaded plugin. The weak linkage allows for multiple implementations to
+ * be linked in without getting multiple definition errors.
+ */
+#  define OPENTELEMETRY_DEFINE_PLUGIN_HOOK(X)                                            \
+    extern "C" {                                                                         \
+    extern __declspec(dllexport)                                                         \
+        opentelemetry::plugin::OpenTelemetryHook const OpenTelemetryMakeFactoryImpl;     \
+                                                                                         \
+    __declspec(selectany)                                                                \
+        opentelemetry::plugin::OpenTelemetryHook const OpenTelemetryMakeFactoryImpl = X; \
+    }  // extern "C"
+
+#else
+
+#  define OPENTELEMETRY_DEFINE_PLUGIN_HOOK(X)                                                      \
+    extern "C" {                                                                                   \
+    __attribute((                                                                                  \
+        weak)) extern opentelemetry::plugin::OpenTelemetryHook const OpenTelemetryMakeFactoryImpl; \
+                                                                                                   \
+    opentelemetry::plugin::OpenTelemetryHook const OpenTelemetryMakeFactoryImpl = X;               \
+    }  // extern "C"
+
+#endif
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace plugin
+{
+
+struct LoaderInfo;
+class FactoryImpl;
+
+using OpenTelemetryHook =
+    nostd::unique_ptr<Factory::FactoryImpl> (*)(const LoaderInfo &loader_info,
+                                                nostd::unique_ptr<char[]> &error_message);
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/tracer.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/plugin/tracer.h
@@ -1,0 +1,125 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/common/key_value_iterable.h"
+#include "opentelemetry/plugin/detail/tracer_handle.h"
+#include "opentelemetry/trace/span_context_kv_iterable.h"
+#include "opentelemetry/trace/tracer.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace plugin
+{
+
+class DynamicLibraryHandle;
+
+class Span final : public trace::Span
+{
+public:
+  Span(std::shared_ptr<trace::Tracer> &&tracer, nostd::shared_ptr<trace::Span> span) noexcept
+      : tracer_{std::move(tracer)}, span_{span}
+  {}
+
+  // trace::Span
+  void SetAttribute(nostd::string_view name, const common::AttributeValue &value) noexcept override
+  {
+    span_->SetAttribute(name, value);
+  }
+
+  void AddEvent(nostd::string_view name) noexcept override { span_->AddEvent(name); }
+
+  void AddEvent(nostd::string_view name, common::SystemTimestamp timestamp) noexcept override
+  {
+    span_->AddEvent(name, timestamp);
+  }
+
+  void AddEvent(nostd::string_view name,
+                const common::KeyValueIterable &attributes) noexcept override
+  {
+    span_->AddEvent(name, attributes);
+  }
+
+  void AddEvent(nostd::string_view name,
+                common::SystemTimestamp timestamp,
+                const common::KeyValueIterable &attributes) noexcept override
+  {
+    span_->AddEvent(name, timestamp, attributes);
+  }
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  void AddLink(const trace::SpanContext &target,
+               const common::KeyValueIterable &attrs) noexcept override
+  {
+    span_->AddLink(target, attrs);
+  }
+
+  void AddLinks(const trace::SpanContextKeyValueIterable &links) noexcept override
+  {
+    span_->AddLinks(links);
+  }
+#endif
+
+  void SetStatus(trace::StatusCode code, nostd::string_view description) noexcept override
+  {
+    span_->SetStatus(code, description);
+  }
+
+  void UpdateName(nostd::string_view name) noexcept override { span_->UpdateName(name); }
+
+  void End(const trace::EndSpanOptions &options = {}) noexcept override { span_->End(options); }
+
+  bool IsRecording() const noexcept override { return span_->IsRecording(); }
+
+  trace::SpanContext GetContext() const noexcept override { return span_->GetContext(); }
+
+private:
+  std::shared_ptr<trace::Tracer> tracer_;
+  nostd::shared_ptr<trace::Span> span_;
+};
+
+class Tracer final : public trace::Tracer, public std::enable_shared_from_this<Tracer>
+{
+public:
+  Tracer(std::shared_ptr<DynamicLibraryHandle> library_handle,
+         std::unique_ptr<TracerHandle> &&tracer_handle) noexcept
+      : library_handle_{std::move(library_handle)}, tracer_handle_{std::move(tracer_handle)}
+  {}
+
+  // trace::Tracer
+  nostd::shared_ptr<trace::Span> StartSpan(
+      nostd::string_view name,
+      const common::KeyValueIterable &attributes,
+      const trace::SpanContextKeyValueIterable &links,
+      const trace::StartSpanOptions &options = {}) noexcept override
+  {
+    auto span = tracer_handle_->tracer().StartSpan(name, attributes, links, options);
+    if (span == nullptr)
+    {
+      return nostd::shared_ptr<trace::Span>(nullptr);
+    }
+    return nostd::shared_ptr<trace::Span>{new (std::nothrow) Span{this->shared_from_this(), span}};
+  }
+
+  void ForceFlushWithMicroseconds(uint64_t timeout) noexcept override
+  {
+    tracer_handle_->tracer().ForceFlushWithMicroseconds(timeout);
+  }
+
+  void CloseWithMicroseconds(uint64_t timeout) noexcept override
+  {
+    tracer_handle_->tracer().CloseWithMicroseconds(timeout);
+  }
+
+private:
+  // Note: The order is important here.
+  //
+  // It's undefined behavior to close the library while a loaded tracer is still active.
+  std::shared_ptr<DynamicLibraryHandle> library_handle_;
+  std::unique_ptr<TracerHandle> tracer_handle_;
+};
+}  // namespace plugin
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/std/shared_ptr.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/std/shared_ptr.h
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+// Standard Type aliases in nostd namespace
+namespace nostd
+{
+
+// nostd::shared_ptr<T...>
+template <class... _Types>
+using shared_ptr = std::shared_ptr<_Types...>;
+
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/std/span.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/std/span.h
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/version.h"
+
+// Standard library implementation requires at least C++17 compiler.
+// Older C++14 compilers may provide support for __has_include as a
+// conforming extension.
+#if defined __has_include
+#  if __has_include(<version>)  // Check for __cpp_{feature}
+#    include <version>
+#    if defined(__cpp_lib_span) && __cplusplus > 201703L
+#      define OPENTELEMETRY_HAVE_SPAN
+#    endif
+#  endif
+#  if !defined(OPENTELEMETRY_HAVE_SPAN)
+#    // Check for Visual Studio span
+#    if defined(_MSVC_LANG) && _HAS_CXX20
+#      define OPENTELEMETRY_HAVE_SPAN
+#    endif
+#    // Check for other compiler span implementation
+#    if !defined(_MSVC_LANG) && __has_include(<span>) && __cplusplus > 201703L
+// This works as long as compiler standard is set to C++20
+#      define OPENTELEMETRY_HAVE_SPAN
+#    endif
+#  endif
+#  if !__has_include(<gsl/gsl>)
+#    undef HAVE_GSL
+#  endif
+#endif
+
+#if !defined(OPENTELEMETRY_HAVE_SPAN)
+#  if defined(HAVE_GSL)
+#    include <type_traits>
+// Guidelines Support Library provides an implementation of std::span
+#    include <gsl/gsl>
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+using gsl::dynamic_extent;
+template <class ElementType, std::size_t Extent = gsl::dynamic_extent>
+using span = gsl::span<ElementType, Extent>;
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+#    define OPENTELEMETRY_HAVE_SPAN
+#  else
+// No `gsl::span`, no `std::span`, fallback to `nostd::span`
+#  endif
+
+#else  // OPENTELEMETRY_HAVE_SPAN
+// Using std::span (https://wg21.link/P0122R7) from Standard Library available in C++20 :
+// - GCC libstdc++ 10+
+// - Clang libc++ 7
+// - MSVC Standard Library 19.26*
+// - Apple Clang 10.0.0*
+#  include <limits>
+#  include <span>
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace nostd
+{
+constexpr std::size_t dynamic_extent = (std::numeric_limits<std::size_t>::max)();
+
+template <class ElementType, std::size_t Extent = nostd::dynamic_extent>
+using span = std::span<ElementType, Extent>;
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+#endif  // if OPENTELEMETRY_HAVE_SPAN

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/std/string_view.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/std/string_view.h
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string_view>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+// Standard Type aliases in nostd namespace
+namespace nostd
+{
+
+// nostd::string_view
+using string_view = std::string_view;
+
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/std/type_traits.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/std/type_traits.h
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <type_traits>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+// Standard Type aliases in nostd namespace
+namespace nostd
+{
+
+// nostd::enable_if_t<...>
+template <bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/std/unique_ptr.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/std/unique_ptr.h
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+// Standard Type aliases in nostd namespace
+namespace nostd
+{
+
+// nostd::unique_ptr<T...>
+template <class... _Types>
+using unique_ptr = std::unique_ptr<_Types...>;
+
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/std/utility.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/std/utility.h
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+// Standard Type aliases in nostd namespace
+namespace nostd
+{
+
+//
+// Backport of std::data
+//
+// See https://en.cppreference.com/w/cpp/iterator/data
+//
+template <class C>
+auto data(C &c) noexcept(noexcept(c.data())) -> decltype(c.data())
+{
+  return c.data();
+}
+
+template <class C>
+auto data(const C &c) noexcept(noexcept(c.data())) -> decltype(c.data())
+{
+  return c.data();
+}
+
+template <class T, std::size_t N>
+T *data(T (&array)[N]) noexcept
+{
+  return array;
+}
+
+template <class E>
+const E *data(std::initializer_list<E> list) noexcept
+{
+  return list.begin();
+}
+
+//
+// Backport of std::size
+//
+// See https://en.cppreference.com/w/cpp/iterator/size
+//
+template <class C>
+auto size(const C &c) noexcept(noexcept(c.size())) -> decltype(c.size())
+{
+  return c.size();
+}
+
+template <class T, std::size_t N>
+std::size_t size(T (&/* array */)[N]) noexcept
+{
+  return N;
+}
+
+template <std::size_t N>
+using make_index_sequence = std::make_index_sequence<N>;
+
+template <std::size_t... Ints>
+using index_sequence = std::index_sequence<Ints...>;
+
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/std/variant.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/std/variant.h
@@ -1,0 +1,230 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/version.h"
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <variant>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+// Standard Type aliases in nostd namespace
+namespace nostd
+{
+using std::get_if;
+using std::monostate;
+using std::variant_alternative_t;
+
+// nostd::variant<...>
+template <class... _Types>
+using variant = std::variant<_Types...>;
+
+template <class... _Types>
+using variant_size = std::variant_size<_Types...>;
+
+using monostate = std::monostate;
+
+#if defined(__APPLE__) && defined(_LIBCPP_USE_AVAILABILITY_APPLE)
+// Apple Platforms provide std::bad_variant_access only in newer versions of OS.
+// To keep API compatible with any version of OS - we are providing our own
+// implementation of nostd::bad_variant_access exception.
+#  if __EXCEPTIONS
+
+// nostd::bad_variant_access
+class bad_variant_access : public std::exception
+{
+public:
+  virtual const char *what() const noexcept override { return "bad_variant_access"; }
+};
+
+[[noreturn]] inline void throw_bad_variant_access()
+{
+  throw bad_variant_access{};
+}
+#  endif
+
+#  if __EXCEPTIONS
+#    define THROW_BAD_VARIANT_ACCESS throw_bad_variant_access()
+#  else
+#    define THROW_BAD_VARIANT_ACCESS std::terminate()
+#  endif
+
+//
+// nostd::get<...> for Apple Clang
+//
+template <typename T, class... Types>
+constexpr auto get_type = [](auto &&t) constexpr -> decltype(auto)
+{
+  auto v      = t;
+  auto result = std::get_if<T>(&v);  // TODO: optimize with std::forward(t) if t is not rvalue
+  if (result)
+  {
+    return *result;
+  }
+  THROW_BAD_VARIANT_ACCESS;
+  return *result;
+};
+
+template <std::size_t I, class... Types>
+constexpr auto get_index = [](auto &&t) constexpr -> decltype(auto)
+{
+  auto v      = t;
+  auto result = std::get_if<I>(&v);  // TODO: optimize with std::forward(t) if t is not rvalue
+  if (result)
+  {
+    return *result;
+  }
+  THROW_BAD_VARIANT_ACCESS;
+  return *result;
+};
+
+template <std::size_t I, class... Types>
+constexpr std::variant_alternative_t<I, std::variant<Types...>> &get(std::variant<Types...> &v)
+{
+  return get_index<I, Types...>(v);
+};
+
+template <std::size_t I, class... Types>
+constexpr std::variant_alternative_t<I, std::variant<Types...>> &&get(std::variant<Types...> &&v)
+{
+  return get_index<I, Types...>(std::forward<decltype(v)>(v));
+};
+
+template <std::size_t I, class... Types>
+constexpr const std::variant_alternative_t<I, std::variant<Types...>> &get(
+    const std::variant<Types...> &v)
+{
+  return get_index<I, Types...>(v);
+};
+
+template <std::size_t I, class... Types>
+constexpr const std::variant_alternative_t<I, std::variant<Types...>> &&get(
+    const std::variant<Types...> &&v)
+{
+  return get_index<I, Types...>(std::forward<decltype(v)>(v));
+};
+
+template <class T, class... Types>
+constexpr T &get(std::variant<Types...> &v)
+{
+  return get_type<T, Types...>(v);
+};
+
+template <class T, class... Types>
+constexpr T /*&&*/ get(std::variant<Types...> &&v)
+{
+  return get_type<T, Types...>(v);
+};
+
+template <class T, class... Types>
+constexpr const T &get(const std::variant<Types...> &v)
+{
+  return get_type<T, Types...>(v);
+};
+
+template <class T, class... Types>
+constexpr const T &&get(const std::variant<Types...> &&v)
+{
+  return get_type<T, Types...>(std::forward<decltype(v)>(v));
+};
+
+template <class _Callable, class... _Variants>
+constexpr auto visit(_Callable &&_Obj, _Variants &&... _Args)
+{
+  // Ref:
+  // https://stackoverflow.com/questions/52310835/xcode-10-call-to-unavailable-function-stdvisit
+  return std::__variant_detail::__visitation::__variant::__visit_value(_Obj, _Args...);
+};
+
+#else
+using std::bad_variant_access;
+
+template <std::size_t I, class... Types>
+constexpr std::variant_alternative_t<I, std::variant<Types...>> &get(std::variant<Types...> &v)
+{
+  return std::get<I, Types...>(v);
+}
+
+template <std::size_t I, class... Types>
+constexpr std::variant_alternative_t<I, std::variant<Types...>> &&get(std::variant<Types...> &&v)
+{
+  return std::get<I, Types...>(std::forward<decltype(v)>(v));
+}
+
+template <std::size_t I, class... Types>
+constexpr const std::variant_alternative_t<I, std::variant<Types...>> &get(
+    const std::variant<Types...> &v)
+{
+  return std::get<I, Types...>(v);
+}
+
+template <std::size_t I, class... Types>
+constexpr const std::variant_alternative_t<I, std::variant<Types...>> &&get(
+    const std::variant<Types...> &&v)
+{
+  return std::get<I, Types...>(std::forward<decltype(v)>(v));
+}
+
+template <class T, class... Types>
+constexpr T &get(std::variant<Types...> &v)
+{
+  return std::get<T, Types...>(v);
+}
+
+template <class T, class... Types>
+constexpr T &&get(std::variant<Types...> &&v)
+{
+  return std::get<T, Types...>(std::forward<decltype(v)>(v));
+}
+
+template <class T, class... Types>
+constexpr const T &get(const std::variant<Types...> &v)
+{
+  return std::get<T, Types...>(v);
+}
+
+template <class T, class... Types>
+constexpr const T &&get(const std::variant<Types...> &&v)
+{
+  return std::get<T, Types...>(std::forward<decltype(v)>(v));
+}
+
+template <class _Callable, class... _Variants>
+constexpr auto visit(_Callable &&_Obj, _Variants &&... _Args)
+{
+  return std::visit<_Callable, _Variants...>(static_cast<_Callable &&>(_Obj),
+                                             static_cast<_Variants &&>(_Args)...);
+}
+
+#endif
+
+/*
+# if _HAS_CXX20
+template <class _Ret, class _Callable, class... _Variants>
+constexpr _Ret visit(_Callable &&_Obj, _Variants &&... _Args)
+{
+  return std::visit<_Ret, _Callable, _Variants...>(
+      static_cast<_Callable &&>(_Obj),
+      static_cast<_Variants &&>(_Args)...);
+};
+# endif
+*/
+
+// nostd::holds_alternative
+template <std::size_t I, typename... Ts>
+inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept
+{
+  return v.index() == I;
+}
+
+template <typename T, typename... Ts>
+inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept
+{
+  return std::holds_alternative<T, Ts...>(v);
+}
+
+}  // namespace nostd
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/context.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/context.h
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+// Get Span from explicit context
+inline nostd::shared_ptr<Span> GetSpan(const context::Context &context) noexcept
+{
+  context::ContextValue span = context.GetValue(kSpanKey);
+  if (nostd::holds_alternative<nostd::shared_ptr<Span>>(span))
+  {
+    return nostd::get<nostd::shared_ptr<Span>>(span);
+  }
+  return nostd::shared_ptr<Span>(new DefaultSpan(SpanContext::GetInvalid()));
+}
+
+inline bool IsRootSpan(const context::Context &context) noexcept
+{
+  context::ContextValue is_root_span = context.GetValue(kIsRootSpanKey);
+  if (nostd::holds_alternative<bool>(is_root_span))
+  {
+    return nostd::get<bool>(is_root_span);
+  }
+  return false;
+}
+
+// Set Span into explicit context
+inline context::Context SetSpan(context::Context &context, nostd::shared_ptr<Span> span) noexcept
+{
+  return context.SetValue(kSpanKey, span);
+}
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/default_span.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/default_span.h
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/trace/span_context.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+/**
+ * DefaultSpan provides a non-operational Span that propagates
+ * the tracer context by wrapping it inside the Span object.
+ */
+
+class DefaultSpan : public Span
+{
+public:
+  // Returns an invalid span.
+  static DefaultSpan GetInvalid() { return DefaultSpan(SpanContext::GetInvalid()); }
+
+  trace::SpanContext GetContext() const noexcept override { return span_context_; }
+
+  bool IsRecording() const noexcept override { return false; }
+
+  void SetAttribute(nostd::string_view /* key */,
+                    const common::AttributeValue & /* value */) noexcept override
+  {}
+
+  void AddEvent(nostd::string_view /* name */) noexcept override {}
+
+  void AddEvent(nostd::string_view /* name */,
+                common::SystemTimestamp /* timestamp */) noexcept override
+  {}
+
+  void AddEvent(nostd::string_view /* name */,
+                const common::KeyValueIterable & /* attributes */) noexcept override
+  {}
+
+  void AddEvent(nostd::string_view /* name */,
+                common::SystemTimestamp /* timestamp */,
+                const common::KeyValueIterable & /* attributes */) noexcept override
+  {}
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  void AddLink(const SpanContext & /* target */,
+               const common::KeyValueIterable & /* attrs */) noexcept override
+  {}
+
+  void AddLinks(const SpanContextKeyValueIterable & /* links */) noexcept override {}
+#endif
+
+  void SetStatus(StatusCode /* status */, nostd::string_view /* description */) noexcept override {}
+
+  void UpdateName(nostd::string_view /* name */) noexcept override {}
+
+  void End(const EndSpanOptions & /* options */) noexcept override {}
+
+  nostd::string_view ToString() const noexcept { return "DefaultSpan"; }
+
+  DefaultSpan(SpanContext span_context) noexcept : span_context_(span_context) {}
+
+  // movable and copiable
+  DefaultSpan(DefaultSpan &&spn) noexcept : span_context_(spn.GetContext()) {}
+  DefaultSpan(const DefaultSpan &spn) noexcept : span_context_(spn.GetContext()) {}
+
+private:
+  SpanContext span_context_;
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/noop.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/noop.h
@@ -1,0 +1,142 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+// Please refer to provider.h for documentation on how to obtain a Tracer object.
+//
+// This file is part of the internal implementation of OpenTelemetry. Nothing in this file should be
+// used directly. Please refer to span.h and tracer.h for documentation on these interfaces.
+
+#include <memory>
+
+#include "opentelemetry/context/runtime_context.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/trace/span_context.h"
+#include "opentelemetry/trace/span_context_kv_iterable.h"
+#include "opentelemetry/trace/tracer.h"
+#include "opentelemetry/trace/tracer_provider.h"
+#include "opentelemetry/version.h"
+
+namespace trace_api = opentelemetry::trace;
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+/**
+ * No-op implementation of Span. This class should not be used directly.
+ */
+class OPENTELEMETRY_EXPORT NoopSpan final : public Span
+{
+public:
+  explicit NoopSpan(const std::shared_ptr<Tracer> &tracer) noexcept
+      : tracer_{tracer}, span_context_{new SpanContext(false, false)}
+  {}
+
+  explicit NoopSpan(const std::shared_ptr<Tracer> &tracer,
+                    nostd::unique_ptr<SpanContext> span_context) noexcept
+      : tracer_{tracer}, span_context_{std::move(span_context)}
+  {}
+
+  void SetAttribute(nostd::string_view /*key*/,
+                    const common::AttributeValue & /*value*/) noexcept override
+  {}
+
+  void AddEvent(nostd::string_view /*name*/) noexcept override {}
+
+  void AddEvent(nostd::string_view /*name*/,
+                common::SystemTimestamp /*timestamp*/) noexcept override
+  {}
+
+  void AddEvent(nostd::string_view /* name */,
+                const common::KeyValueIterable & /* attributes */) noexcept override
+  {}
+
+  void AddEvent(nostd::string_view /*name*/,
+                common::SystemTimestamp /*timestamp*/,
+                const common::KeyValueIterable & /*attributes*/) noexcept override
+  {}
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  void AddLink(const SpanContext & /* target */,
+               const common::KeyValueIterable & /* attrs */) noexcept override
+  {}
+
+  void AddLinks(const SpanContextKeyValueIterable & /* links */) noexcept override {}
+#endif
+
+  void SetStatus(StatusCode /*code*/, nostd::string_view /*description*/) noexcept override {}
+
+  void UpdateName(nostd::string_view /*name*/) noexcept override {}
+
+  void End(const EndSpanOptions & /*options*/) noexcept override {}
+
+  bool IsRecording() const noexcept override { return false; }
+
+  SpanContext GetContext() const noexcept override { return *span_context_.get(); }
+
+private:
+  std::shared_ptr<Tracer> tracer_;
+  nostd::unique_ptr<SpanContext> span_context_;
+};
+
+/**
+ * No-op implementation of Tracer.
+ */
+class OPENTELEMETRY_EXPORT NoopTracer final : public Tracer,
+                                              public std::enable_shared_from_this<NoopTracer>
+{
+public:
+  // Tracer
+  nostd::shared_ptr<Span> StartSpan(nostd::string_view /*name*/,
+                                    const common::KeyValueIterable & /*attributes*/,
+                                    const SpanContextKeyValueIterable & /*links*/,
+                                    const StartSpanOptions & /*options*/) noexcept override
+  {
+    // Don't allocate a no-op span for every StartSpan call, but use a static
+    // singleton for this case.
+    static nostd::shared_ptr<trace::Span> noop_span(new trace::NoopSpan{this->shared_from_this()});
+
+    return noop_span;
+  }
+
+  void ForceFlushWithMicroseconds(uint64_t /*timeout*/) noexcept override {}
+
+  void CloseWithMicroseconds(uint64_t /*timeout*/) noexcept override {}
+};
+
+/**
+ * No-op implementation of a TracerProvider.
+ */
+class OPENTELEMETRY_EXPORT NoopTracerProvider final : public trace::TracerProvider
+{
+public:
+  NoopTracerProvider() noexcept
+      : tracer_{nostd::shared_ptr<trace::NoopTracer>(new trace::NoopTracer)}
+  {}
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  nostd::shared_ptr<trace::Tracer> GetTracer(
+      nostd::string_view /* name */,
+      nostd::string_view /* version */,
+      nostd::string_view /* schema_url */,
+      const common::KeyValueIterable * /* attributes */) noexcept override
+  {
+    return tracer_;
+  }
+#else
+  nostd::shared_ptr<trace::Tracer> GetTracer(nostd::string_view /* name */,
+                                             nostd::string_view /* version */,
+                                             nostd::string_view /* schema_url */) noexcept override
+  {
+    return tracer_;
+  }
+#endif
+
+private:
+  nostd::shared_ptr<trace::Tracer> tracer_;
+};
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/b3_propagator.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/b3_propagator.h
@@ -1,0 +1,198 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+
+#include "detail/hex.h"
+#include "detail/string.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/trace/context.h"
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+namespace propagation
+{
+
+static const nostd::string_view kB3CombinedHeader = "b3";
+
+static const nostd::string_view kB3TraceIdHeader = "X-B3-TraceId";
+static const nostd::string_view kB3SpanIdHeader  = "X-B3-SpanId";
+static const nostd::string_view kB3SampledHeader = "X-B3-Sampled";
+
+/*
+     B3, single header:
+                   b3: 80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^ ^ ^^^^^^^^^^^^^^^^
+                       0          TraceId            31 33  SpanId    48 | 52 ParentSpanId 68
+                                                                        50 Debug flag
+     Multiheader version:                                           X-B3-Sampled
+                             X-B3-TraceId                X-B3-SpanId    X-B3-ParentSpanId (ignored)
+*/
+
+static const int kTraceIdHexStrLength = 32;
+static const int kSpanIdHexStrLength  = 16;
+
+// The B3PropagatorExtractor class provides an interface that enables extracting context from
+// headers of HTTP requests. HTTP frameworks and clients can integrate with B3Propagator by
+// providing the object containing the headers, and a getter function for the extraction. Based on:
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#b3-extract
+
+class B3PropagatorExtractor : public context::propagation::TextMapPropagator
+{
+public:
+  // Returns the context that is stored in the HTTP header carrier.
+  context::Context Extract(const context::propagation::TextMapCarrier &carrier,
+                           context::Context &context) noexcept override
+  {
+    SpanContext span_context = ExtractImpl(carrier);
+    nostd::shared_ptr<Span> sp{new DefaultSpan(span_context)};
+    if (span_context.IsValid())
+    {
+      return trace::SetSpan(context, sp);
+    }
+    else
+    {
+      return context;
+    }
+  }
+
+  static TraceId TraceIdFromHex(nostd::string_view trace_id)
+  {
+    uint8_t buf[kTraceIdHexStrLength / 2];
+    detail::HexToBinary(trace_id, buf, sizeof(buf));
+    return TraceId(buf);
+  }
+
+  static SpanId SpanIdFromHex(nostd::string_view span_id)
+  {
+    uint8_t buf[kSpanIdHexStrLength / 2];
+    detail::HexToBinary(span_id, buf, sizeof(buf));
+    return SpanId(buf);
+  }
+
+  static TraceFlags TraceFlagsFromHex(nostd::string_view trace_flags)
+  {
+    if (trace_flags.length() != 1 || (trace_flags[0] != '1' && trace_flags[0] != 'd'))
+    {  // check for invalid length of flags and treat 'd' as sampled
+      return TraceFlags(0);
+    }
+    return TraceFlags(TraceFlags::kIsSampled);
+  }
+
+private:
+  static SpanContext ExtractImpl(const context::propagation::TextMapCarrier &carrier)
+  {
+    nostd::string_view trace_id_hex;
+    nostd::string_view span_id_hex;
+    nostd::string_view trace_flags_hex;
+
+    // first let's try a single-header variant
+    auto singleB3Header = carrier.Get(kB3CombinedHeader);
+    if (!singleB3Header.empty())
+    {
+      std::array<nostd::string_view, 3> fields{};
+      // https://github.com/openzipkin/b3-propagation/blob/master/RATIONALE.md
+      if (detail::SplitString(singleB3Header, '-', fields.data(), 3) < 2)
+      {
+        return SpanContext::GetInvalid();
+      }
+
+      trace_id_hex    = fields[0];
+      span_id_hex     = fields[1];
+      trace_flags_hex = fields[2];
+    }
+    else
+    {
+      trace_id_hex    = carrier.Get(kB3TraceIdHeader);
+      span_id_hex     = carrier.Get(kB3SpanIdHeader);
+      trace_flags_hex = carrier.Get(kB3SampledHeader);
+    }
+
+    if (!detail::IsValidHex(trace_id_hex) || !detail::IsValidHex(span_id_hex))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    TraceId trace_id = TraceIdFromHex(trace_id_hex);
+    SpanId span_id   = SpanIdFromHex(span_id_hex);
+
+    if (!trace_id.IsValid() || !span_id.IsValid())
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    return SpanContext(trace_id, span_id, TraceFlagsFromHex(trace_flags_hex), true);
+  }
+};
+
+// The B3Propagator class provides interface that enables extracting and injecting context into
+// single header of HTTP Request.
+class B3Propagator : public B3PropagatorExtractor
+{
+public:
+  // Sets the context for a HTTP header carrier with self defined rules.
+  void Inject(context::propagation::TextMapCarrier &carrier,
+              const context::Context &context) noexcept override
+  {
+    SpanContext span_context = trace::GetSpan(context)->GetContext();
+    if (!span_context.IsValid())
+    {
+      return;
+    }
+
+    char trace_identity[kTraceIdHexStrLength + kSpanIdHexStrLength + 3];
+    static_assert(sizeof(trace_identity) == 51, "b3 trace identity buffer size mismatch");
+    span_context.trace_id().ToLowerBase16(nostd::span<char, 2 * TraceId::kSize>{
+        &trace_identity[0], static_cast<std::size_t>(kTraceIdHexStrLength)});
+    trace_identity[kTraceIdHexStrLength] = '-';
+    span_context.span_id().ToLowerBase16(nostd::span<char, 2 * SpanId::kSize>{
+        &trace_identity[kTraceIdHexStrLength + 1], static_cast<std::size_t>(kSpanIdHexStrLength)});
+    trace_identity[kTraceIdHexStrLength + kSpanIdHexStrLength + 1] = '-';
+    trace_identity[kTraceIdHexStrLength + kSpanIdHexStrLength + 2] =
+        span_context.trace_flags().IsSampled() ? '1' : '0';
+
+    carrier.Set(kB3CombinedHeader, nostd::string_view(trace_identity, sizeof(trace_identity)));
+  }
+
+  bool Fields(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept override
+  {
+    return callback(kB3CombinedHeader);
+  }
+};
+
+class B3PropagatorMultiHeader : public B3PropagatorExtractor
+{
+public:
+  void Inject(context::propagation::TextMapCarrier &carrier,
+              const context::Context &context) noexcept override
+  {
+    SpanContext span_context = GetSpan(context)->GetContext();
+    if (!span_context.IsValid())
+    {
+      return;
+    }
+    char trace_id[32];
+    TraceId(span_context.trace_id()).ToLowerBase16(trace_id);
+    char span_id[16];
+    SpanId(span_context.span_id()).ToLowerBase16(span_id);
+    char trace_flags[2];
+    TraceFlags(span_context.trace_flags()).ToLowerBase16(trace_flags);
+    carrier.Set(kB3TraceIdHeader, nostd::string_view(trace_id, sizeof(trace_id)));
+    carrier.Set(kB3SpanIdHeader, nostd::string_view(span_id, sizeof(span_id)));
+    carrier.Set(kB3SampledHeader, nostd::string_view(trace_flags + 1, 1));
+  }
+
+  bool Fields(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept override
+  {
+    return callback(kB3TraceIdHeader) && callback(kB3SpanIdHeader) && callback(kB3SampledHeader);
+  }
+};
+
+}  // namespace propagation
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/detail/hex.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/detail/hex.h
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+namespace propagation
+{
+// NOTE - code within `detail` namespace implements internal details, and not part
+// of the public interface.
+namespace detail
+{
+
+constexpr int8_t kHexDigits[256] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+};
+
+inline int8_t HexToInt(char c)
+{
+  return kHexDigits[uint8_t(c)];
+}
+
+inline bool IsValidHex(nostd::string_view s)
+{
+  return std::all_of(s.begin(), s.end(), [](char c) { return HexToInt(c) != -1; });
+}
+
+/**
+ * Converts a hexadecimal to binary format if the hex string will fit the buffer.
+ * Smaller hex strings are left padded with zeroes.
+ */
+inline bool HexToBinary(nostd::string_view hex, uint8_t *buffer, size_t buffer_size)
+{
+  std::memset(buffer, 0, buffer_size);
+
+  if (hex.size() > buffer_size * 2)
+  {
+    return false;
+  }
+
+  int64_t hex_size     = int64_t(hex.size());
+  int64_t buffer_pos   = int64_t(buffer_size) - (hex_size + 1) / 2;
+  int64_t last_hex_pos = hex_size - 1;
+
+  bool is_hex_size_odd = (hex_size % 2) == 1;
+  int64_t i            = 0;
+
+  if (is_hex_size_odd)
+  {
+    buffer[buffer_pos++] = HexToInt(hex[i++]);
+  }
+
+  for (; i < last_hex_pos; i += 2)
+  {
+    buffer[buffer_pos++] = (HexToInt(hex[i]) << 4) | HexToInt(hex[i + 1]);
+  }
+
+  return true;
+}
+
+}  // namespace detail
+}  // namespace propagation
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/detail/string.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/detail/string.h
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+namespace propagation
+{
+// NOTE - code within `detail` namespace implements internal details, and not part
+// of the public interface.
+namespace detail
+{
+
+/**
+ * Splits a string by separator, up to given buffer count words.
+ * Returns the amount of words the input was split into.
+ */
+inline size_t SplitString(nostd::string_view s,
+                          char separator,
+                          nostd::string_view *results,
+                          size_t count)
+{
+  if (count == 0)
+  {
+    return count;
+  }
+
+  size_t filled      = 0;
+  size_t token_start = 0;
+  for (size_t i = 0; i < s.size(); i++)
+  {
+    if (s[i] != separator)
+    {
+      continue;
+    }
+
+    results[filled++] = s.substr(token_start, i - token_start);
+
+    if (filled == count)
+    {
+      return count;
+    }
+
+    token_start = i + 1;
+  }
+
+  if (filled < count)
+  {
+    results[filled++] = s.substr(token_start);
+  }
+
+  return filled;
+}
+
+}  // namespace detail
+}  // namespace propagation
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -1,0 +1,189 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+
+#include "detail/hex.h"
+#include "detail/string.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/trace/context.h"
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+namespace propagation
+{
+static const nostd::string_view kTraceParent = "traceparent";
+static const nostd::string_view kTraceState  = "tracestate";
+static const size_t kVersionSize             = 2;
+static const size_t kTraceIdSize             = 32;
+static const size_t kSpanIdSize              = 16;
+static const size_t kTraceFlagsSize          = 2;
+static const size_t kTraceParentSize         = 55;
+
+// The HttpTraceContext provides methods to extract and inject
+// context into headers of HTTP requests with traces.
+// Example:
+//    HttpTraceContext().Inject(carrier, context);
+//    HttpTraceContext().Extract(carrier, context);
+
+class HttpTraceContext : public context::propagation::TextMapPropagator
+{
+public:
+  void Inject(context::propagation::TextMapCarrier &carrier,
+              const context::Context &context) noexcept override
+  {
+    SpanContext span_context = trace::GetSpan(context)->GetContext();
+    if (!span_context.IsValid())
+    {
+      return;
+    }
+    InjectImpl(carrier, span_context);
+  }
+
+  context::Context Extract(const context::propagation::TextMapCarrier &carrier,
+                           context::Context &context) noexcept override
+  {
+    SpanContext span_context = ExtractImpl(carrier);
+    nostd::shared_ptr<Span> sp{new DefaultSpan(span_context)};
+    if (span_context.IsValid())
+    {
+      return trace::SetSpan(context, sp);
+    }
+    else
+    {
+      return context;
+    }
+  }
+
+  static TraceId TraceIdFromHex(nostd::string_view trace_id)
+  {
+    uint8_t buf[kTraceIdSize / 2];
+    detail::HexToBinary(trace_id, buf, sizeof(buf));
+    return TraceId(buf);
+  }
+
+  static SpanId SpanIdFromHex(nostd::string_view span_id)
+  {
+    uint8_t buf[kSpanIdSize / 2];
+    detail::HexToBinary(span_id, buf, sizeof(buf));
+    return SpanId(buf);
+  }
+
+  static TraceFlags TraceFlagsFromHex(nostd::string_view trace_flags)
+  {
+    uint8_t flags;
+    detail::HexToBinary(trace_flags, &flags, sizeof(flags));
+    return TraceFlags(flags);
+  }
+
+private:
+  static constexpr uint8_t kInvalidVersion = 0xFF;
+
+  static bool IsValidVersion(nostd::string_view version_hex)
+  {
+    uint8_t version;
+    detail::HexToBinary(version_hex, &version, sizeof(version));
+    return version != kInvalidVersion;
+  }
+
+  static void InjectImpl(context::propagation::TextMapCarrier &carrier,
+                         const SpanContext &span_context)
+  {
+    char trace_parent[kTraceParentSize];
+    trace_parent[0] = '0';
+    trace_parent[1] = '0';
+    trace_parent[2] = '-';
+    span_context.trace_id().ToLowerBase16(
+        nostd::span<char, 2 * TraceId::kSize>{&trace_parent[3], kTraceIdSize});
+    trace_parent[kTraceIdSize + 3] = '-';
+    span_context.span_id().ToLowerBase16(
+        nostd::span<char, 2 * SpanId::kSize>{&trace_parent[kTraceIdSize + 4], kSpanIdSize});
+    trace_parent[kTraceIdSize + kSpanIdSize + 4] = '-';
+    span_context.trace_flags().ToLowerBase16(
+        nostd::span<char, 2>{&trace_parent[kTraceIdSize + kSpanIdSize + 5], 2});
+
+    carrier.Set(kTraceParent, nostd::string_view(trace_parent, sizeof(trace_parent)));
+    const auto trace_state = span_context.trace_state()->ToHeader();
+    if (!trace_state.empty())
+    {
+      carrier.Set(kTraceState, trace_state);
+    }
+  }
+
+  static SpanContext ExtractContextFromTraceHeaders(nostd::string_view trace_parent,
+                                                    nostd::string_view trace_state)
+  {
+    if (trace_parent.size() != kTraceParentSize)
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    std::array<nostd::string_view, 4> fields{};
+    if (detail::SplitString(trace_parent, '-', fields.data(), 4) != 4)
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    nostd::string_view version_hex     = fields[0];
+    nostd::string_view trace_id_hex    = fields[1];
+    nostd::string_view span_id_hex     = fields[2];
+    nostd::string_view trace_flags_hex = fields[3];
+
+    if (version_hex.size() != kVersionSize || trace_id_hex.size() != kTraceIdSize ||
+        span_id_hex.size() != kSpanIdSize || trace_flags_hex.size() != kTraceFlagsSize)
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    if (!detail::IsValidHex(version_hex) || !detail::IsValidHex(trace_id_hex) ||
+        !detail::IsValidHex(span_id_hex) || !detail::IsValidHex(trace_flags_hex))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    if (!IsValidVersion(version_hex))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    TraceId trace_id = TraceIdFromHex(trace_id_hex);
+    SpanId span_id   = SpanIdFromHex(span_id_hex);
+
+    if (!trace_id.IsValid() || !span_id.IsValid())
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    return SpanContext(trace_id, span_id, TraceFlagsFromHex(trace_flags_hex), true,
+                       trace::TraceState::FromHeader(trace_state));
+  }
+
+  static SpanContext ExtractImpl(const context::propagation::TextMapCarrier &carrier)
+  {
+    nostd::string_view trace_parent = carrier.Get(kTraceParent);
+    nostd::string_view trace_state  = carrier.Get(kTraceState);
+    if (trace_parent == "")
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    return ExtractContextFromTraceHeaders(trace_parent, trace_state);
+  }
+
+  bool Fields(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept override
+  {
+    return (callback(kTraceParent) && callback(kTraceState));
+  }
+};
+}  // namespace propagation
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/jaeger.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/propagation/jaeger.h
@@ -1,0 +1,131 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef OPENTELEMETRY_NO_DEPRECATED_CODE
+#  error "header <opentelemetry/trace/propagation/jaeger.h> is deprecated."
+#endif
+
+#include "detail/hex.h"
+#include "detail/string.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/trace/context.h"
+#include "opentelemetry/trace/default_span.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+namespace propagation
+{
+
+static const nostd::string_view kJaegerTraceHeader = "uber-trace-id";
+
+class OPENTELEMETRY_DEPRECATED JaegerPropagator : public context::propagation::TextMapPropagator
+{
+public:
+  void Inject(context::propagation::TextMapCarrier &carrier,
+              const context::Context &context) noexcept override
+  {
+    SpanContext span_context = trace::GetSpan(context)->GetContext();
+    if (!span_context.IsValid())
+    {
+      return;
+    }
+
+    const size_t trace_id_length = 32;
+    const size_t span_id_length  = 16;
+
+    // trace-id(32):span-id(16):0:debug(2)
+    char trace_identity[trace_id_length + span_id_length + 6];
+    span_context.trace_id().ToLowerBase16(
+        nostd::span<char, 2 * TraceId::kSize>{&trace_identity[0], trace_id_length});
+    trace_identity[trace_id_length] = ':';
+    span_context.span_id().ToLowerBase16(
+        nostd::span<char, 2 * SpanId::kSize>{&trace_identity[trace_id_length + 1], span_id_length});
+    trace_identity[trace_id_length + span_id_length + 1] = ':';
+    trace_identity[trace_id_length + span_id_length + 2] = '0';
+    trace_identity[trace_id_length + span_id_length + 3] = ':';
+    trace_identity[trace_id_length + span_id_length + 4] = '0';
+    trace_identity[trace_id_length + span_id_length + 5] = span_context.IsSampled() ? '1' : '0';
+
+    carrier.Set(kJaegerTraceHeader, nostd::string_view(trace_identity, sizeof(trace_identity)));
+  }
+
+  context::Context Extract(const context::propagation::TextMapCarrier &carrier,
+                           context::Context &context) noexcept override
+  {
+    SpanContext span_context = ExtractImpl(carrier);
+    nostd::shared_ptr<Span> sp{new DefaultSpan(span_context)};
+    if (span_context.IsValid())
+    {
+      return trace::SetSpan(context, sp);
+    }
+    else
+    {
+      return context;
+    }
+  }
+
+  bool Fields(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept override
+  {
+    return callback(kJaegerTraceHeader);
+  }
+
+private:
+  static constexpr uint8_t kIsSampled = 0x01;
+
+  static TraceFlags GetTraceFlags(uint8_t jaeger_flags)
+  {
+    uint8_t sampled = jaeger_flags & kIsSampled;
+    return TraceFlags(sampled);
+  }
+
+  static SpanContext ExtractImpl(const context::propagation::TextMapCarrier &carrier)
+  {
+    nostd::string_view trace_identity = carrier.Get(kJaegerTraceHeader);
+
+    const size_t trace_field_count = 4;
+    nostd::string_view trace_fields[trace_field_count];
+
+    if (detail::SplitString(trace_identity, ':', trace_fields, trace_field_count) !=
+        trace_field_count)
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    nostd::string_view trace_id_hex = trace_fields[0];
+    nostd::string_view span_id_hex  = trace_fields[1];
+    nostd::string_view flags_hex    = trace_fields[3];
+
+    if (!detail::IsValidHex(trace_id_hex) || !detail::IsValidHex(span_id_hex) ||
+        !detail::IsValidHex(flags_hex))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    uint8_t trace_id[16];
+    if (!detail::HexToBinary(trace_id_hex, trace_id, sizeof(trace_id)))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    uint8_t span_id[8];
+    if (!detail::HexToBinary(span_id_hex, span_id, sizeof(span_id)))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    uint8_t flags;
+    if (!detail::HexToBinary(flags_hex, &flags, sizeof(flags)))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    return SpanContext(TraceId(trace_id), SpanId(span_id), GetTraceFlags(flags), true);
+  }
+};
+
+}  // namespace propagation
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/provider.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/provider.h
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <mutex>
+
+#include "opentelemetry/common/macros.h"
+#include "opentelemetry/common/spin_lock_mutex.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/noop.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+class TracerProvider;
+
+/**
+ * Stores the singleton global TracerProvider.
+ */
+class OPENTELEMETRY_EXPORT Provider
+{
+public:
+  /**
+   * Returns the singleton TracerProvider.
+   *
+   * By default, a no-op TracerProvider is returned. This will never return a
+   * nullptr TracerProvider.
+   */
+  static nostd::shared_ptr<TracerProvider> GetTracerProvider() noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    return nostd::shared_ptr<TracerProvider>(GetProvider());
+  }
+
+  /**
+   * Changes the singleton TracerProvider.
+   */
+  static void SetTracerProvider(nostd::shared_ptr<TracerProvider> tp) noexcept
+  {
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    GetProvider() = tp;
+  }
+
+private:
+  OPENTELEMETRY_API_SINGLETON static nostd::shared_ptr<TracerProvider> &GetProvider() noexcept
+  {
+    static nostd::shared_ptr<TracerProvider> provider(new NoopTracerProvider);
+    return provider;
+  }
+
+  OPENTELEMETRY_API_SINGLETON static common::SpinLockMutex &GetLock() noexcept
+  {
+    static common::SpinLockMutex lock;
+    return lock;
+  }
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/scope.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/scope.h
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/context/runtime_context.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/trace/span_metadata.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+class Span;
+
+/**
+ * Controls how long a span is active.
+ *
+ * On creation of the Scope object, the given span is set to the currently
+ * active span. On destruction, the given span is ended and the previously
+ * active span will be the currently active span again.
+ */
+class Scope final
+{
+public:
+  /**
+   * Initialize a new scope.
+   * @param span the given span will be set as the currently active span.
+   */
+  Scope(const nostd::shared_ptr<Span> &span) noexcept
+      : token_(context::RuntimeContext::Attach(
+            context::RuntimeContext::GetCurrent().SetValue(kSpanKey, span)))
+  {}
+
+private:
+  nostd::unique_ptr<context::Token> token_;
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/semantic_conventions.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/semantic_conventions.h
@@ -1,0 +1,2728 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+  DO NOT EDIT, this is an Auto-generated file
+  from buildscripts/semantic-convention/templates/SemanticAttributes.h.j2
+*/
+
+#pragma once
+
+#include "opentelemetry/common/macros.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+namespace SemanticConventions
+{
+/**
+ * The URL of the OpenTelemetry schema for these keys and values.
+ */
+static constexpr const char *kSchemaUrl = "https://opentelemetry.io/schemas/1.24.0";
+
+/**
+ * The name of the invoked function.
+ *
+ * <p>Notes:
+  <ul> <li>SHOULD be equal to the {@code faas.name} resource attribute of the invoked function.</li>
+ </ul>
+ */
+static constexpr const char *kFaasInvokedName = "faas.invoked_name";
+
+/**
+ * The cloud provider of the invoked function.
+ *
+ * <p>Notes:
+  <ul> <li>SHOULD be equal to the {@code cloud.provider} resource attribute of the invoked
+ function.</li> </ul>
+ */
+static constexpr const char *kFaasInvokedProvider = "faas.invoked_provider";
+
+/**
+ * The cloud region of the invoked function.
+ *
+ * <p>Notes:
+  <ul> <li>SHOULD be equal to the {@code cloud.region} resource attribute of the invoked
+ function.</li> </ul>
+ */
+static constexpr const char *kFaasInvokedRegion = "faas.invoked_region";
+
+/**
+ * Type of the trigger which caused this function invocation.
+ */
+static constexpr const char *kFaasTrigger = "faas.trigger";
+
+/**
+ * The <a href="/docs/resource/README.md#service">{@code service.name}</a> of the remote service.
+ * SHOULD be equal to the actual {@code service.name} resource attribute of the remote service if
+ * any.
+ */
+static constexpr const char *kPeerService = "peer.service";
+
+/**
+ * Username or client_id extracted from the access token or <a
+ * href="https://tools.ietf.org/html/rfc7235#section-4.2">Authorization</a> header in the inbound
+ * request from outside the system.
+ */
+static constexpr const char *kEnduserId = "enduser.id";
+
+/**
+ * Actual/assumed role the client is making the request under extracted from token or application
+ * security context.
+ */
+static constexpr const char *kEnduserRole = "enduser.role";
+
+/**
+ * Scopes or granted authorities the client currently possesses extracted from token or application
+ * security context. The value would come from the scope associated with an <a
+ * href="https://tools.ietf.org/html/rfc6749#section-3.3">OAuth 2.0 Access Token</a> or an attribute
+ * value in a <a
+ * href="http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html">SAML 2.0
+ * Assertion</a>.
+ */
+static constexpr const char *kEnduserScope = "enduser.scope";
+
+/**
+ * Identifies the class / type of event.
+ *
+ * <p>Notes:
+  <ul> <li>Event names are subject to the same rules as <a
+ href="https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/common/attribute-naming.md">attribute
+ names</a>. Notably, event names are namespaced to avoid collisions and provide a clean separation
+ of semantics for events in separate domains like browser, mobile, and kubernetes.</li> </ul>
+ */
+static constexpr const char *kEventName = "event.name";
+
+/**
+ * A unique identifier for the Log Record.
+ *
+ * <p>Notes:
+  <ul> <li>If an id is provided, other log records with the same id will be considered duplicates
+and can be removed safely. This means, that two distinguishable log records MUST have different
+values. The id MAY be an <a href="https://github.com/ulid/spec">Universally Unique Lexicographically
+Sortable Identifier (ULID)</a>, but other identifiers (e.g. UUID) may be used as needed.</li> </ul>
+ */
+static constexpr const char *kLogRecordUid = "log.record.uid";
+
+/**
+ * The stream associated with the log. See below for a list of well-known values.
+ */
+static constexpr const char *kLogIostream = "log.iostream";
+
+/**
+ * The basename of the file.
+ */
+static constexpr const char *kLogFileName = "log.file.name";
+
+/**
+ * The basename of the file, with symlinks resolved.
+ */
+static constexpr const char *kLogFileNameResolved = "log.file.name_resolved";
+
+/**
+ * The full path to the file.
+ */
+static constexpr const char *kLogFilePath = "log.file.path";
+
+/**
+ * The full path to the file, with symlinks resolved.
+ */
+static constexpr const char *kLogFilePathResolved = "log.file.path_resolved";
+
+/**
+ * This attribute represents the state the application has transitioned into at the occurrence of
+ the event.
+ *
+ * <p>Notes:
+  <ul> <li>The iOS lifecycle states are defined in the <a
+ href="https://developer.apple.com/documentation/uikit/uiapplicationdelegate#1656902">UIApplicationDelegate
+ documentation</a>, and from which the {@code OS terminology} column values are derived.</li> </ul>
+ */
+static constexpr const char *kIosState = "ios.state";
+
+/**
+ * This attribute represents the state the application has transitioned into at the occurrence of
+ the event.
+ *
+ * <p>Notes:
+  <ul> <li>The Android lifecycle states are defined in <a
+ href="https://developer.android.com/guide/components/activities/activity-lifecycle#lc">Activity
+ lifecycle callbacks</a>, and from which the {@code OS identifiers} are derived.</li> </ul>
+ */
+static constexpr const char *kAndroidState = "android.state";
+
+/**
+ * The name of the connection pool; unique within the instrumented application. In case the
+ * connection pool implementation doesn't provide a name, then the <a
+ * href="/docs/database/database-spans.md#connection-level-attributes">db.connection_string</a>
+ * should be used
+ */
+static constexpr const char *kPoolName = "pool.name";
+
+/**
+ * The state of a connection in the pool
+ */
+static constexpr const char *kState = "state";
+
+/**
+ * Full type name of the <a
+ * href="https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler">{@code
+ * IExceptionHandler}</a> implementation that handled the exception.
+ */
+static constexpr const char *kAspnetcoreDiagnosticsHandlerType =
+    "aspnetcore.diagnostics.handler.type";
+
+/**
+ * Rate limiting policy name.
+ */
+static constexpr const char *kAspnetcoreRateLimitingPolicy = "aspnetcore.rate_limiting.policy";
+
+/**
+ * Rate-limiting result, shows whether the lease was acquired or contains a rejection reason
+ */
+static constexpr const char *kAspnetcoreRateLimitingResult = "aspnetcore.rate_limiting.result";
+
+/**
+ * Flag indicating if request was handled by the application pipeline.
+ */
+static constexpr const char *kAspnetcoreRequestIsUnhandled = "aspnetcore.request.is_unhandled";
+
+/**
+ * A value that indicates whether the matched route is a fallback route.
+ */
+static constexpr const char *kAspnetcoreRoutingIsFallback = "aspnetcore.routing.is_fallback";
+
+/**
+ * SignalR HTTP connection closure status.
+ */
+static constexpr const char *kSignalrConnectionStatus = "signalr.connection.status";
+
+/**
+ * <a
+ * href="https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md">SignalR
+ * transport type</a>
+ */
+static constexpr const char *kSignalrTransport = "signalr.transport";
+
+/**
+ * Name of the buffer pool.
+ *
+ * <p>Notes:
+  <ul> <li>Pool names are generally obtained via <a
+ href="https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()">BufferPoolMXBean#getName()</a>.</li>
+ </ul>
+ */
+static constexpr const char *kJvmBufferPoolName = "jvm.buffer.pool.name";
+
+/**
+ * Name of the memory pool.
+ *
+ * <p>Notes:
+  <ul> <li>Pool names are generally obtained via <a
+ href="https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()">MemoryPoolMXBean#getName()</a>.</li>
+ </ul>
+ */
+static constexpr const char *kJvmMemoryPoolName = "jvm.memory.pool.name";
+
+/**
+ * The type of memory.
+ */
+static constexpr const char *kJvmMemoryType = "jvm.memory.type";
+
+/**
+ * The device identifier
+ */
+static constexpr const char *kSystemDevice = "system.device";
+
+/**
+ * The logical CPU number [0..n-1]
+ */
+static constexpr const char *kSystemCpuLogicalNumber = "system.cpu.logical_number";
+
+/**
+ * The state of the CPU
+ */
+static constexpr const char *kSystemCpuState = "system.cpu.state";
+
+/**
+ * The memory state
+ */
+static constexpr const char *kSystemMemoryState = "system.memory.state";
+
+/**
+ * The paging access direction
+ */
+static constexpr const char *kSystemPagingDirection = "system.paging.direction";
+
+/**
+ * The memory paging state
+ */
+static constexpr const char *kSystemPagingState = "system.paging.state";
+
+/**
+ * The memory paging type
+ */
+static constexpr const char *kSystemPagingType = "system.paging.type";
+
+/**
+ * The filesystem mode
+ */
+static constexpr const char *kSystemFilesystemMode = "system.filesystem.mode";
+
+/**
+ * The filesystem mount path
+ */
+static constexpr const char *kSystemFilesystemMountpoint = "system.filesystem.mountpoint";
+
+/**
+ * The filesystem state
+ */
+static constexpr const char *kSystemFilesystemState = "system.filesystem.state";
+
+/**
+ * The filesystem type
+ */
+static constexpr const char *kSystemFilesystemType = "system.filesystem.type";
+
+/**
+ * A stateless protocol MUST NOT set this attribute
+ */
+static constexpr const char *kSystemNetworkState = "system.network.state";
+
+/**
+ * The process state, e.g., <a
+ * href="https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES">Linux Process State
+ * Codes</a>
+ */
+static constexpr const char *kSystemProcessesStatus = "system.processes.status";
+
+/**
+ * Client address - domain name if available without reverse DNS lookup; otherwise, IP address or
+ Unix domain socket name.
+ *
+ * <p>Notes:
+  <ul> <li>When observed from the server side, and when communicating through an intermediary,
+ {@code client.address} SHOULD represent the client address behind any intermediaries,  for example
+ proxies, if it's available.</li> </ul>
+ */
+static constexpr const char *kClientAddress = "client.address";
+
+/**
+ * Client port number.
+ *
+ * <p>Notes:
+  <ul> <li>When observed from the server side, and when communicating through an intermediary,
+ {@code client.port} SHOULD represent the client port behind any intermediaries,  for example
+ proxies, if it's available.</li> </ul>
+ */
+static constexpr const char *kClientPort = "client.port";
+
+/**
+ * The column number in {@code code.filepath} best representing the operation. It SHOULD point
+ * within the code unit named in {@code code.function}.
+ */
+static constexpr const char *kCodeColumn = "code.column";
+
+/**
+ * The source code file name that identifies the code unit as uniquely as possible (preferably an
+ * absolute file path).
+ */
+static constexpr const char *kCodeFilepath = "code.filepath";
+
+/**
+ * The method or function name, or equivalent (usually rightmost part of the code unit's name).
+ */
+static constexpr const char *kCodeFunction = "code.function";
+
+/**
+ * The line number in {@code code.filepath} best representing the operation. It SHOULD point within
+ * the code unit named in {@code code.function}.
+ */
+static constexpr const char *kCodeLineno = "code.lineno";
+
+/**
+ * The &quot;namespace&quot; within which {@code code.function} is defined. Usually the qualified
+ * class or module name, such that {@code code.namespace} + some separator + {@code code.function}
+ * form a unique identifier for the code unit.
+ */
+static constexpr const char *kCodeNamespace = "code.namespace";
+
+/**
+ * A stacktrace as a string in the natural representation for the language runtime. The
+ * representation is to be determined and documented by each language SIG.
+ */
+static constexpr const char *kCodeStacktrace = "code.stacktrace";
+
+/**
+ * The consistency level of the query. Based on consistency values from <a
+ * href="https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html">CQL</a>.
+ */
+static constexpr const char *kDbCassandraConsistencyLevel = "db.cassandra.consistency_level";
+
+/**
+ * The data center of the coordinating node for a query.
+ */
+static constexpr const char *kDbCassandraCoordinatorDc = "db.cassandra.coordinator.dc";
+
+/**
+ * The ID of the coordinating node for a query.
+ */
+static constexpr const char *kDbCassandraCoordinatorId = "db.cassandra.coordinator.id";
+
+/**
+ * Whether or not the query is idempotent.
+ */
+static constexpr const char *kDbCassandraIdempotence = "db.cassandra.idempotence";
+
+/**
+ * The fetch size used for paging, i.e. how many rows will be returned at once.
+ */
+static constexpr const char *kDbCassandraPageSize = "db.cassandra.page_size";
+
+/**
+ * The number of times a query was speculatively executed. Not set or {@code 0} if the query was not
+ * executed speculatively.
+ */
+static constexpr const char *kDbCassandraSpeculativeExecutionCount =
+    "db.cassandra.speculative_execution_count";
+
+/**
+ * The name of the primary Cassandra table that the operation is acting upon, including the keyspace
+ name (if applicable).
+ *
+ * <p>Notes:
+  <ul> <li>This mirrors the db.sql.table attribute but references cassandra rather than sql. It is
+ not recommended to attempt any client-side parsing of {@code db.statement} just to get this
+ property, but it should be set if it is provided by the library being instrumented. If the
+ operation is acting upon an anonymous table, or more than one table, this value MUST NOT be
+ set.</li> </ul>
+ */
+static constexpr const char *kDbCassandraTable = "db.cassandra.table";
+
+/**
+ * The connection string used to connect to the database. It is recommended to remove embedded
+ * credentials.
+ */
+static constexpr const char *kDbConnectionString = "db.connection_string";
+
+/**
+ * Unique Cosmos client instance id.
+ */
+static constexpr const char *kDbCosmosdbClientId = "db.cosmosdb.client_id";
+
+/**
+ * Cosmos client connection mode.
+ */
+static constexpr const char *kDbCosmosdbConnectionMode = "db.cosmosdb.connection_mode";
+
+/**
+ * Cosmos DB container name.
+ */
+static constexpr const char *kDbCosmosdbContainer = "db.cosmosdb.container";
+
+/**
+ * CosmosDB Operation Type.
+ */
+static constexpr const char *kDbCosmosdbOperationType = "db.cosmosdb.operation_type";
+
+/**
+ * RU consumed for that operation
+ */
+static constexpr const char *kDbCosmosdbRequestCharge = "db.cosmosdb.request_charge";
+
+/**
+ * Request payload size in bytes
+ */
+static constexpr const char *kDbCosmosdbRequestContentLength = "db.cosmosdb.request_content_length";
+
+/**
+ * Cosmos DB status code.
+ */
+static constexpr const char *kDbCosmosdbStatusCode = "db.cosmosdb.status_code";
+
+/**
+ * Cosmos DB sub status code.
+ */
+static constexpr const char *kDbCosmosdbSubStatusCode = "db.cosmosdb.sub_status_code";
+
+/**
+ * Represents the identifier of an Elasticsearch cluster.
+ */
+static constexpr const char *kDbElasticsearchClusterName = "db.elasticsearch.cluster.name";
+
+/**
+ * Represents the human-readable identifier of the node/instance to which a request was routed.
+ */
+static constexpr const char *kDbElasticsearchNodeName = "db.elasticsearch.node.name";
+
+/**
+ * An identifier (address, unique name, or any other identifier) of the database instance that is
+ * executing queries or mutations on the current connection. This is useful in cases where the
+ * database is running in a clustered environment and the instrumentation is able to record the node
+ * executing the query. The client may obtain this value in databases like MySQL using queries like
+ * {@code select @@hostname}.
+ */
+static constexpr const char *kDbInstanceId = "db.instance.id";
+
+/**
+ * The fully-qualified class name of the <a
+ * href="https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/">Java Database Connectivity
+ * (JDBC)</a> driver used to connect.
+ */
+static constexpr const char *kDbJdbcDriverClassname = "db.jdbc.driver_classname";
+
+/**
+ * The MongoDB collection being accessed within the database stated in {@code db.name}.
+ */
+static constexpr const char *kDbMongodbCollection = "db.mongodb.collection";
+
+/**
+ * The Microsoft SQL Server <a
+ href="https://docs.microsoft.com/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15">instance
+ name</a> connecting to. This name is used to determine the port of a named instance.
+ *
+ * <p>Notes:
+  <ul> <li>If setting a {@code db.mssql.instance_name}, {@code server.port} is no longer required
+ (but still recommended if non-standard).</li> </ul>
+ */
+static constexpr const char *kDbMssqlInstanceName = "db.mssql.instance_name";
+
+/**
+ * This attribute is used to report the name of the database being accessed. For commands that
+ switch the database, this should be set to the target database (even if the command fails).
+ *
+ * <p>Notes:
+  <ul> <li>In some SQL databases, the database name to be used is called &quot;schema name&quot;. In
+ case there are multiple layers that could be considered for database name (e.g. Oracle instance
+ name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema
+ name).</li> </ul>
+ */
+static constexpr const char *kDbName = "db.name";
+
+/**
+ * The name of the operation being executed, e.g. the <a
+ href="https://docs.mongodb.com/manual/reference/command/#database-operations">MongoDB command
+ name</a> such as {@code findAndModify}, or the SQL keyword.
+ *
+ * <p>Notes:
+  <ul> <li>When setting this to an SQL keyword, it is not recommended to attempt any client-side
+ parsing of {@code db.statement} just to get this property, but it should be set if the operation
+ name is provided by the library being instrumented. If the SQL statement has an ambiguous
+ operation, or performs more than one operation, this value may be omitted.</li> </ul>
+ */
+static constexpr const char *kDbOperation = "db.operation";
+
+/**
+ * The index of the database being accessed as used in the <a
+ * href="https://redis.io/commands/select">{@code SELECT} command</a>, provided as an integer. To be
+ * used instead of the generic {@code db.name} attribute.
+ */
+static constexpr const char *kDbRedisDatabaseIndex = "db.redis.database_index";
+
+/**
+ * The name of the primary table that the operation is acting upon, including the database name (if
+ applicable).
+ *
+ * <p>Notes:
+  <ul> <li>It is not recommended to attempt any client-side parsing of {@code db.statement} just to
+ get this property, but it should be set if it is provided by the library being instrumented. If the
+ operation is acting upon an anonymous table, or more than one table, this value MUST NOT be
+ set.</li> </ul>
+ */
+static constexpr const char *kDbSqlTable = "db.sql.table";
+
+/**
+ * The database statement being executed.
+ */
+static constexpr const char *kDbStatement = "db.statement";
+
+/**
+ * An identifier for the database management system (DBMS) product being used. See below for a list
+ * of well-known identifiers.
+ */
+static constexpr const char *kDbSystem = "db.system";
+
+/**
+ * Username for accessing the database.
+ */
+static constexpr const char *kDbUser = "db.user";
+
+/**
+ * Deprecated, use {@code network.protocol.name} instead.
+ *
+ * @deprecated Deprecated, use `network.protocol.name` instead.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kHttpFlavor = "http.flavor";
+
+/**
+ * Deprecated, use {@code http.request.method} instead.
+ *
+ * @deprecated Deprecated, use `http.request.method` instead.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kHttpMethod = "http.method";
+
+/**
+ * Deprecated, use {@code http.request.header.content-length} instead.
+ *
+ * @deprecated Deprecated, use `http.request.header.content-length` instead.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kHttpRequestContentLength = "http.request_content_length";
+
+/**
+ * Deprecated, use {@code http.response.header.content-length} instead.
+ *
+ * @deprecated Deprecated, use `http.response.header.content-length` instead.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kHttpResponseContentLength = "http.response_content_length";
+
+/**
+ * Deprecated, use {@code url.scheme} instead.
+ *
+ * @deprecated Deprecated, use `url.scheme` instead.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kHttpScheme = "http.scheme";
+
+/**
+ * Deprecated, use {@code http.response.status_code} instead.
+ *
+ * @deprecated Deprecated, use `http.response.status_code` instead.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kHttpStatusCode = "http.status_code";
+
+/**
+ * Deprecated, use {@code url.path} and {@code url.query} instead.
+ *
+ * @deprecated Deprecated, use `url.path` and `url.query` instead.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kHttpTarget = "http.target";
+
+/**
+ * Deprecated, use {@code url.full} instead.
+ *
+ * @deprecated Deprecated, use `url.full` instead.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kHttpUrl = "http.url";
+
+/**
+ * Deprecated, use {@code user_agent.original} instead.
+ *
+ * @deprecated Deprecated, use `user_agent.original` instead.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kHttpUserAgent = "http.user_agent";
+
+/**
+ * Deprecated, use {@code server.address}.
+ *
+ * @deprecated Deprecated, use `server.address`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetHostName = "net.host.name";
+
+/**
+ * Deprecated, use {@code server.port}.
+ *
+ * @deprecated Deprecated, use `server.port`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetHostPort = "net.host.port";
+
+/**
+ * Deprecated, use {@code server.address} on client spans and {@code client.address} on server
+ * spans.
+ *
+ * @deprecated Deprecated, use `server.address` on client spans and `client.address` on server
+ * spans.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetPeerName = "net.peer.name";
+
+/**
+ * Deprecated, use {@code server.port} on client spans and {@code client.port} on server spans.
+ *
+ * @deprecated Deprecated, use `server.port` on client spans and `client.port` on server spans.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetPeerPort = "net.peer.port";
+
+/**
+ * Deprecated, use {@code network.protocol.name}.
+ *
+ * @deprecated Deprecated, use `network.protocol.name`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetProtocolName = "net.protocol.name";
+
+/**
+ * Deprecated, use {@code network.protocol.version}.
+ *
+ * @deprecated Deprecated, use `network.protocol.version`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetProtocolVersion = "net.protocol.version";
+
+/**
+ * Deprecated, use {@code network.transport} and {@code network.type}.
+ *
+ * @deprecated Deprecated, use `network.transport` and `network.type`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetSockFamily = "net.sock.family";
+
+/**
+ * Deprecated, use {@code network.local.address}.
+ *
+ * @deprecated Deprecated, use `network.local.address`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetSockHostAddr = "net.sock.host.addr";
+
+/**
+ * Deprecated, use {@code network.local.port}.
+ *
+ * @deprecated Deprecated, use `network.local.port`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetSockHostPort = "net.sock.host.port";
+
+/**
+ * Deprecated, use {@code network.peer.address}.
+ *
+ * @deprecated Deprecated, use `network.peer.address`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetSockPeerAddr = "net.sock.peer.addr";
+
+/**
+ * Deprecated, no replacement at this time.
+ *
+ * @deprecated Deprecated, no replacement at this time.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetSockPeerName = "net.sock.peer.name";
+
+/**
+ * Deprecated, use {@code network.peer.port}.
+ *
+ * @deprecated Deprecated, use `network.peer.port`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetSockPeerPort = "net.sock.peer.port";
+
+/**
+ * Deprecated, use {@code network.transport}.
+ *
+ * @deprecated Deprecated, use `network.transport`.
+ */
+OPENTELEMETRY_DEPRECATED
+static constexpr const char *kNetTransport = "net.transport";
+
+/**
+ * Destination address - domain name if available without reverse DNS lookup; otherwise, IP address
+ or Unix domain socket name.
+ *
+ * <p>Notes:
+  <ul> <li>When observed from the source side, and when communicating through an intermediary,
+ {@code destination.address} SHOULD represent the destination address behind any intermediaries, for
+ example proxies, if it's available.</li> </ul>
+ */
+static constexpr const char *kDestinationAddress = "destination.address";
+
+/**
+ * Destination port number
+ */
+static constexpr const char *kDestinationPort = "destination.port";
+
+/**
+ * The disk IO operation direction.
+ */
+static constexpr const char *kDiskIoDirection = "disk.io.direction";
+
+/**
+ * Describes a class of error the operation ended with.
+ *
+ * <p>Notes:
+  <ul> <li>The {@code error.type} SHOULD be predictable and SHOULD have low cardinality.
+Instrumentations SHOULD document the list of errors they report.</li><li>The cardinality of {@code
+error.type} within one instrumentation library SHOULD be low. Telemetry consumers that aggregate
+data from multiple instrumentation libraries and applications should be prepared for {@code
+error.type} to have high cardinality at query time when no additional filters are
+applied.</li><li>If the operation has completed successfully, instrumentations SHOULD NOT set {@code
+error.type}.</li><li>If a specific domain defines its own set of error identifiers (such as HTTP or
+gRPC status codes), it's RECOMMENDED to:</li><li>Use a domain-specific attribute</li> <li>Set {@code
+error.type} to capture all errors, regardless of whether they are defined within the domain-specific
+set or not.</li>
+ </ul>
+ */
+static constexpr const char *kErrorType = "error.type";
+
+/**
+ * SHOULD be set to true if the exception event is recorded at a point where it is known that the
+exception is escaping the scope of the span.
+ *
+ * <p>Notes:
+  <ul> <li>An exception is considered to have escaped (or left) the scope of a span,
+if that span is ended while the exception is still logically &quot;in flight&quot;.
+This may be actually &quot;in flight&quot; in some languages (e.g. if the exception
+is passed to a Context manager's {@code __exit__} method in Python) but will
+usually be caught at the point of recording the exception in most languages.</li><li>It is usually
+not possible to determine at the point where an exception is thrown whether it will escape the scope
+of a span. However, it is trivial to know that an exception will escape, if one checks for an active
+exception just before ending the span, as done in the <a href="#recording-an-exception">example for
+recording span exceptions</a>.</li><li>It follows that an exception may still escape the scope of
+the span even if the {@code exception.escaped} attribute was not set or set to false, since the
+event might have been recorded at a time where it was not clear whether the exception will
+escape.</li> </ul>
+ */
+static constexpr const char *kExceptionEscaped = "exception.escaped";
+
+/**
+ * The exception message.
+ */
+static constexpr const char *kExceptionMessage = "exception.message";
+
+/**
+ * A stacktrace as a string in the natural representation for the language runtime. The
+ * representation is to be determined and documented by each language SIG.
+ */
+static constexpr const char *kExceptionStacktrace = "exception.stacktrace";
+
+/**
+ * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of
+ * the exception should be preferred over the static type in languages that support it.
+ */
+static constexpr const char *kExceptionType = "exception.type";
+
+/**
+ * The size of the request payload body in bytes. This is the number of bytes transferred excluding
+ * headers and is often, but not always, present as the <a
+ * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
+ * header. For requests using transport encoding, this should be the compressed size.
+ */
+static constexpr const char *kHttpRequestBodySize = "http.request.body.size";
+
+/**
+ * HTTP request method.
+ *
+ * <p>Notes:
+  <ul> <li>HTTP request method value SHOULD be &quot;known&quot; to the instrumentation.
+By default, this convention defines &quot;known&quot; methods as the ones listed in <a
+href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC9110</a> and the PATCH method
+defined in <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC5789</a>.</li><li>If the HTTP
+request method is not known to instrumentation, it MUST set the {@code http.request.method}
+attribute to {@code _OTHER}.</li><li>If the HTTP instrumentation could end up converting valid HTTP
+request methods to {@code _OTHER}, then it MUST provide a way to override the list of known HTTP
+methods. If this override is done via environment variable, then the environment variable MUST be
+named OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive
+known HTTP methods (this list MUST be a full override of the default known method, it is not a list
+of known methods in addition to the defaults).</li><li>HTTP method names are case-sensitive and
+{@code http.request.method} attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive,
+SHOULD populate a canonical equivalent. Tracing instrumentations that do so, MUST also set {@code
+http.request.method_original} to the original value.</li> </ul>
+ */
+static constexpr const char *kHttpRequestMethod = "http.request.method";
+
+/**
+ * Original HTTP method sent by the client in the request line.
+ */
+static constexpr const char *kHttpRequestMethodOriginal = "http.request.method_original";
+
+/**
+ * The ordinal number of request resending attempt (for any reason, including redirects).
+ *
+ * <p>Notes:
+  <ul> <li>The resend count SHOULD be updated each time an HTTP request gets resent by the client,
+ regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503
+ Server Unavailable, network issues, or any other).</li> </ul>
+ */
+static constexpr const char *kHttpRequestResendCount = "http.request.resend_count";
+
+/**
+ * The size of the response payload body in bytes. This is the number of bytes transferred excluding
+ * headers and is often, but not always, present as the <a
+ * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
+ * header. For requests using transport encoding, this should be the compressed size.
+ */
+static constexpr const char *kHttpResponseBodySize = "http.response.body.size";
+
+/**
+ * <a href="https://tools.ietf.org/html/rfc7231#section-6">HTTP response status code</a>.
+ */
+static constexpr const char *kHttpResponseStatusCode = "http.response.status_code";
+
+/**
+ * The matched route, that is, the path template in the format used by the respective server
+framework.
+ *
+ * <p>Notes:
+  <ul> <li>MUST NOT be populated when this is not supported by the HTTP server framework as the
+route attribute should have low-cardinality and the URI path can NOT substitute it. SHOULD include
+the <a href="/docs/http/http-spans.md#http-server-definitions">application root</a> if there is
+one.</li> </ul>
+ */
+static constexpr const char *kHttpRoute = "http.route";
+
+/**
+ * The number of messages sent, received, or processed in the scope of the batching operation.
+ *
+ * <p>Notes:
+  <ul> <li>Instrumentations SHOULD NOT set {@code messaging.batch.message_count} on spans that
+ operate with a single message. When a messaging client library supports both batch and
+ single-message API for the same operation, instrumentations SHOULD use {@code
+ messaging.batch.message_count} for batching APIs and SHOULD NOT use it for single-message
+ APIs.</li> </ul>
+ */
+static constexpr const char *kMessagingBatchMessageCount = "messaging.batch.message_count";
+
+/**
+ * A unique identifier for the client that consumes or produces a message.
+ */
+static constexpr const char *kMessagingClientId = "messaging.client_id";
+
+/**
+ * A boolean that is true if the message destination is anonymous (could be unnamed or have
+ * auto-generated name).
+ */
+static constexpr const char *kMessagingDestinationAnonymous = "messaging.destination.anonymous";
+
+/**
+ * The message destination name
+ *
+ * <p>Notes:
+  <ul> <li>Destination name SHOULD uniquely identify a specific queue, topic or other entity within
+the broker. If the broker doesn't have such notion, the destination name SHOULD uniquely identify
+the broker.</li> </ul>
+ */
+static constexpr const char *kMessagingDestinationName = "messaging.destination.name";
+
+/**
+ * Low cardinality representation of the messaging destination name
+ *
+ * <p>Notes:
+  <ul> <li>Destination names could be constructed from templates. An example would be a destination
+ name involving a user name or product id. Although the destination name in this case is of high
+ cardinality, the underlying template is of low cardinality and can be effectively used for grouping
+ and aggregation.</li> </ul>
+ */
+static constexpr const char *kMessagingDestinationTemplate = "messaging.destination.template";
+
+/**
+ * A boolean that is true if the message destination is temporary and might not exist anymore after
+ * messages are processed.
+ */
+static constexpr const char *kMessagingDestinationTemporary = "messaging.destination.temporary";
+
+/**
+ * A boolean that is true if the publish message destination is anonymous (could be unnamed or have
+ * auto-generated name).
+ */
+static constexpr const char *kMessagingDestinationPublishAnonymous =
+    "messaging.destination_publish.anonymous";
+
+/**
+ * The name of the original destination the message was published to
+ *
+ * <p>Notes:
+  <ul> <li>The name SHOULD uniquely identify a specific queue, topic, or other entity within the
+broker. If the broker doesn't have such notion, the original destination name SHOULD uniquely
+identify the broker.</li> </ul>
+ */
+static constexpr const char *kMessagingDestinationPublishName =
+    "messaging.destination_publish.name";
+
+/**
+ * The ordering key for a given message. If the attribute is not present, the message does not have
+ * an ordering key.
+ */
+static constexpr const char *kMessagingGcpPubsubMessageOrderingKey =
+    "messaging.gcp_pubsub.message.ordering_key";
+
+/**
+ * Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not
+ * producers.
+ */
+static constexpr const char *kMessagingKafkaConsumerGroup = "messaging.kafka.consumer.group";
+
+/**
+ * Partition the message is sent to.
+ */
+static constexpr const char *kMessagingKafkaDestinationPartition =
+    "messaging.kafka.destination.partition";
+
+/**
+ * Message keys in Kafka are used for grouping alike messages to ensure they're processed on the
+ same partition. They differ from {@code messaging.message.id} in that they're not unique. If the
+ key is {@code null}, the attribute MUST NOT be set.
+ *
+ * <p>Notes:
+  <ul> <li>If the key type is not string, it's string representation has to be supplied for the
+ attribute. If the key has no unambiguous, canonical string form, don't include its value.</li>
+ </ul>
+ */
+static constexpr const char *kMessagingKafkaMessageKey = "messaging.kafka.message.key";
+
+/**
+ * The offset of a record in the corresponding Kafka partition.
+ */
+static constexpr const char *kMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
+
+/**
+ * A boolean that is true if the message is a tombstone.
+ */
+static constexpr const char *kMessagingKafkaMessageTombstone = "messaging.kafka.message.tombstone";
+
+/**
+ * The size of the message body in bytes.
+ *
+ * <p>Notes:
+  <ul> <li>This can refer to both the compressed or uncompressed body size. If both sizes are known,
+the uncompressed body size should be used.</li> </ul>
+ */
+static constexpr const char *kMessagingMessageBodySize = "messaging.message.body.size";
+
+/**
+ * The conversation ID identifying the conversation to which the message belongs, represented as a
+ * string. Sometimes called &quot;Correlation ID&quot;.
+ */
+static constexpr const char *kMessagingMessageConversationId = "messaging.message.conversation_id";
+
+/**
+ * The size of the message body and metadata in bytes.
+ *
+ * <p>Notes:
+  <ul> <li>This can refer to both the compressed or uncompressed size. If both sizes are known, the
+uncompressed size should be used.</li> </ul>
+ */
+static constexpr const char *kMessagingMessageEnvelopeSize = "messaging.message.envelope.size";
+
+/**
+ * A value used by the messaging system as an identifier for the message, represented as a string.
+ */
+static constexpr const char *kMessagingMessageId = "messaging.message.id";
+
+/**
+ * A string identifying the kind of messaging operation.
+ *
+ * <p>Notes:
+  <ul> <li>If a custom value is used, it MUST be of low cardinality.</li> </ul>
+ */
+static constexpr const char *kMessagingOperation = "messaging.operation";
+
+/**
+ * RabbitMQ message routing key.
+ */
+static constexpr const char *kMessagingRabbitmqDestinationRoutingKey =
+    "messaging.rabbitmq.destination.routing_key";
+
+/**
+ * Name of the RocketMQ producer/consumer group that is handling the message. The client type is
+ * identified by the SpanKind.
+ */
+static constexpr const char *kMessagingRocketmqClientGroup = "messaging.rocketmq.client_group";
+
+/**
+ * Model of message consumption. This only applies to consumer spans.
+ */
+static constexpr const char *kMessagingRocketmqConsumptionModel =
+    "messaging.rocketmq.consumption_model";
+
+/**
+ * The delay time level for delay message, which determines the message delay time.
+ */
+static constexpr const char *kMessagingRocketmqMessageDelayTimeLevel =
+    "messaging.rocketmq.message.delay_time_level";
+
+/**
+ * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
+ */
+static constexpr const char *kMessagingRocketmqMessageDeliveryTimestamp =
+    "messaging.rocketmq.message.delivery_timestamp";
+
+/**
+ * It is essential for FIFO message. Messages that belong to the same message group are always
+ * processed one by one within the same consumer group.
+ */
+static constexpr const char *kMessagingRocketmqMessageGroup = "messaging.rocketmq.message.group";
+
+/**
+ * Key(s) of message, another way to mark message besides message id.
+ */
+static constexpr const char *kMessagingRocketmqMessageKeys = "messaging.rocketmq.message.keys";
+
+/**
+ * The secondary classifier of message besides topic.
+ */
+static constexpr const char *kMessagingRocketmqMessageTag = "messaging.rocketmq.message.tag";
+
+/**
+ * Type of message.
+ */
+static constexpr const char *kMessagingRocketmqMessageType = "messaging.rocketmq.message.type";
+
+/**
+ * Namespace of RocketMQ resources, resources in different namespaces are individual.
+ */
+static constexpr const char *kMessagingRocketmqNamespace = "messaging.rocketmq.namespace";
+
+/**
+ * An identifier for the messaging system being used. See below for a list of well-known
+ * identifiers.
+ */
+static constexpr const char *kMessagingSystem = "messaging.system";
+
+/**
+ * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
+ */
+static constexpr const char *kNetworkCarrierIcc = "network.carrier.icc";
+
+/**
+ * The mobile carrier country code.
+ */
+static constexpr const char *kNetworkCarrierMcc = "network.carrier.mcc";
+
+/**
+ * The mobile carrier network code.
+ */
+static constexpr const char *kNetworkCarrierMnc = "network.carrier.mnc";
+
+/**
+ * The name of the mobile carrier.
+ */
+static constexpr const char *kNetworkCarrierName = "network.carrier.name";
+
+/**
+ * This describes more details regarding the connection.type. It may be the type of cell technology
+ * connection, but it could be used for describing details about a wifi connection.
+ */
+static constexpr const char *kNetworkConnectionSubtype = "network.connection.subtype";
+
+/**
+ * The internet connection type.
+ */
+static constexpr const char *kNetworkConnectionType = "network.connection.type";
+
+/**
+ * The network IO operation direction.
+ */
+static constexpr const char *kNetworkIoDirection = "network.io.direction";
+
+/**
+ * Local address of the network connection - IP address or Unix domain socket name.
+ */
+static constexpr const char *kNetworkLocalAddress = "network.local.address";
+
+/**
+ * Local port number of the network connection.
+ */
+static constexpr const char *kNetworkLocalPort = "network.local.port";
+
+/**
+ * Peer address of the network connection - IP address or Unix domain socket name.
+ */
+static constexpr const char *kNetworkPeerAddress = "network.peer.address";
+
+/**
+ * Peer port number of the network connection.
+ */
+static constexpr const char *kNetworkPeerPort = "network.peer.port";
+
+/**
+ * <a href="https://osi-model.com/application-layer/">OSI application layer</a> or non-OSI
+ equivalent.
+ *
+ * <p>Notes:
+  <ul> <li>The value SHOULD be normalized to lowercase.</li> </ul>
+ */
+static constexpr const char *kNetworkProtocolName = "network.protocol.name";
+
+/**
+ * Version of the protocol specified in {@code network.protocol.name}.
+ *
+ * <p>Notes:
+  <ul> <li>{@code network.protocol.version} refers to the version of the protocol used and might be
+ different from the protocol client's version. If the HTTP client has a version of {@code 0.27.2},
+ but sends HTTP version {@code 1.1}, this attribute should be set to {@code 1.1}.</li> </ul>
+ */
+static constexpr const char *kNetworkProtocolVersion = "network.protocol.version";
+
+/**
+ * <a href="https://osi-model.com/transport-layer/">OSI transport layer</a> or <a
+href="https://wikipedia.org/wiki/Inter-process_communication">inter-process communication
+method</a>.
+ *
+ * <p>Notes:
+  <ul> <li>The value SHOULD be normalized to lowercase.</li><li>Consider always setting the
+transport when setting a port number, since a port number is ambiguous without knowing the
+transport. For example different processes could be listening on TCP port 12345 and UDP port
+12345.</li> </ul>
+ */
+static constexpr const char *kNetworkTransport = "network.transport";
+
+/**
+ * <a href="https://osi-model.com/network-layer/">OSI network layer</a> or non-OSI equivalent.
+ *
+ * <p>Notes:
+  <ul> <li>The value SHOULD be normalized to lowercase.</li> </ul>
+ */
+static constexpr const char *kNetworkType = "network.type";
+
+/**
+ * The <a href="https://connect.build/docs/protocol/#error-codes">error codes</a> of the Connect
+ * request. Error codes are always string values.
+ */
+static constexpr const char *kRpcConnectRpcErrorCode = "rpc.connect_rpc.error_code";
+
+/**
+ * The <a href="https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md">numeric status
+ * code</a> of the gRPC request.
+ */
+static constexpr const char *kRpcGrpcStatusCode = "rpc.grpc.status_code";
+
+/**
+ * {@code error.code} property of response if it is an error response.
+ */
+static constexpr const char *kRpcJsonrpcErrorCode = "rpc.jsonrpc.error_code";
+
+/**
+ * {@code error.message} property of response if it is an error response.
+ */
+static constexpr const char *kRpcJsonrpcErrorMessage = "rpc.jsonrpc.error_message";
+
+/**
+ * {@code id} property of request or response. Since protocol allows id to be int, string, {@code
+ * null} or missing (for notifications), value is expected to be cast to string for simplicity. Use
+ * empty string in case of {@code null} value. Omit entirely if this is a notification.
+ */
+static constexpr const char *kRpcJsonrpcRequestId = "rpc.jsonrpc.request_id";
+
+/**
+ * Protocol version as in {@code jsonrpc} property of request/response. Since JSON-RPC 1.0 doesn't
+ * specify this, the value can be omitted.
+ */
+static constexpr const char *kRpcJsonrpcVersion = "rpc.jsonrpc.version";
+
+/**
+ * The name of the (logical) method being called, must be equal to the $method part in the span
+ name.
+ *
+ * <p>Notes:
+  <ul> <li>This is the logical name of the method from the RPC interface perspective, which can be
+ different from the name of any implementing method/function. The {@code code.function} attribute
+ may be used to store the latter (e.g., method actually executing the call on the server side, RPC
+ client stub method on the client side).</li> </ul>
+ */
+static constexpr const char *kRpcMethod = "rpc.method";
+
+/**
+ * The full (logical) name of the service being called, including its package name, if applicable.
+ *
+ * <p>Notes:
+  <ul> <li>This is the logical name of the service from the RPC interface perspective, which can be
+ different from the name of any implementing class. The {@code code.namespace} attribute may be used
+ to store the latter (despite the attribute name, it may include a class name; e.g., class with
+ method actually executing the call on the server side, RPC client stub class on the client
+ side).</li> </ul>
+ */
+static constexpr const char *kRpcService = "rpc.service";
+
+/**
+ * A string identifying the remoting system. See below for a list of well-known identifiers.
+ */
+static constexpr const char *kRpcSystem = "rpc.system";
+
+/**
+ * Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain
+ socket name.
+ *
+ * <p>Notes:
+  <ul> <li>When observed from the client side, and when communicating through an intermediary,
+ {@code server.address} SHOULD represent the server address behind any intermediaries, for example
+ proxies, if it's available.</li> </ul>
+ */
+static constexpr const char *kServerAddress = "server.address";
+
+/**
+ * Server port number.
+ *
+ * <p>Notes:
+  <ul> <li>When observed from the client side, and when communicating through an intermediary,
+ {@code server.port} SHOULD represent the server port behind any intermediaries, for example
+ proxies, if it's available.</li> </ul>
+ */
+static constexpr const char *kServerPort = "server.port";
+
+/**
+ * Source address - domain name if available without reverse DNS lookup; otherwise, IP address or
+ Unix domain socket name.
+ *
+ * <p>Notes:
+  <ul> <li>When observed from the destination side, and when communicating through an intermediary,
+ {@code source.address} SHOULD represent the source address behind any intermediaries, for example
+ proxies, if it's available.</li> </ul>
+ */
+static constexpr const char *kSourceAddress = "source.address";
+
+/**
+ * Source port number
+ */
+static constexpr const char *kSourcePort = "source.port";
+
+/**
+ * Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
+ */
+static constexpr const char *kThreadId = "thread.id";
+
+/**
+ * Current thread name.
+ */
+static constexpr const char *kThreadName = "thread.name";
+
+/**
+ * String indicating the <a
+ href="https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5">cipher</a> used during the
+ current connection.
+ *
+ * <p>Notes:
+  <ul> <li>The values allowed for {@code tls.cipher} MUST be one of the {@code Descriptions} of the
+ <a
+ href="https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#table-tls-parameters-4">registered
+ TLS Cipher Suits</a>.</li> </ul>
+ */
+static constexpr const char *kTlsCipher = "tls.cipher";
+
+/**
+ * PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of
+ * {@code client.certificate_chain} since this value also exists in that list.
+ */
+static constexpr const char *kTlsClientCertificate = "tls.client.certificate";
+
+/**
+ * Array of PEM-encoded certificates that make up the certificate chain offered by the client. This
+ * is usually mutually-exclusive of {@code client.certificate} since that value should be the first
+ * certificate in the chain.
+ */
+static constexpr const char *kTlsClientCertificateChain = "tls.client.certificate_chain";
+
+/**
+ * Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the
+ * client. For consistency with other hash values, this value should be formatted as an uppercase
+ * hash.
+ */
+static constexpr const char *kTlsClientHashMd5 = "tls.client.hash.md5";
+
+/**
+ * Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by
+ * the client. For consistency with other hash values, this value should be formatted as an
+ * uppercase hash.
+ */
+static constexpr const char *kTlsClientHashSha1 = "tls.client.hash.sha1";
+
+/**
+ * Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by
+ * the client. For consistency with other hash values, this value should be formatted as an
+ * uppercase hash.
+ */
+static constexpr const char *kTlsClientHashSha256 = "tls.client.hash.sha256";
+
+/**
+ * Distinguished name of <a
+ * href="https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6">subject</a> of the issuer of
+ * the x.509 certificate presented by the client.
+ */
+static constexpr const char *kTlsClientIssuer = "tls.client.issuer";
+
+/**
+ * A hash that identifies clients based on how they perform an SSL/TLS handshake.
+ */
+static constexpr const char *kTlsClientJa3 = "tls.client.ja3";
+
+/**
+ * Date/Time indicating when client certificate is no longer considered valid.
+ */
+static constexpr const char *kTlsClientNotAfter = "tls.client.not_after";
+
+/**
+ * Date/Time indicating when client certificate is first considered valid.
+ */
+static constexpr const char *kTlsClientNotBefore = "tls.client.not_before";
+
+/**
+ * Also called an SNI, this tells the server which hostname to which the client is attempting to
+ * connect to.
+ */
+static constexpr const char *kTlsClientServerName = "tls.client.server_name";
+
+/**
+ * Distinguished name of subject of the x.509 certificate presented by the client.
+ */
+static constexpr const char *kTlsClientSubject = "tls.client.subject";
+
+/**
+ * Array of ciphers offered by the client during the client hello.
+ */
+static constexpr const char *kTlsClientSupportedCiphers = "tls.client.supported_ciphers";
+
+/**
+ * String indicating the curve used for the given cipher, when applicable
+ */
+static constexpr const char *kTlsCurve = "tls.curve";
+
+/**
+ * Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted
+ * tunnel.
+ */
+static constexpr const char *kTlsEstablished = "tls.established";
+
+/**
+ * String indicating the protocol being tunneled. Per the values in the <a
+ * href="https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids">IANA
+ * registry</a>, this string should be lower case.
+ */
+static constexpr const char *kTlsNextProtocol = "tls.next_protocol";
+
+/**
+ * Normalized lowercase protocol name parsed from original string of the negotiated <a
+ * href="https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES">SSL/TLS
+ * protocol version</a>
+ */
+static constexpr const char *kTlsProtocolName = "tls.protocol.name";
+
+/**
+ * Numeric part of the version parsed from the original string of the negotiated <a
+ * href="https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES">SSL/TLS
+ * protocol version</a>
+ */
+static constexpr const char *kTlsProtocolVersion = "tls.protocol.version";
+
+/**
+ * Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.
+ */
+static constexpr const char *kTlsResumed = "tls.resumed";
+
+/**
+ * PEM-encoded stand-alone certificate offered by the server. This is usually mutually-exclusive of
+ * {@code server.certificate_chain} since this value also exists in that list.
+ */
+static constexpr const char *kTlsServerCertificate = "tls.server.certificate";
+
+/**
+ * Array of PEM-encoded certificates that make up the certificate chain offered by the server. This
+ * is usually mutually-exclusive of {@code server.certificate} since that value should be the first
+ * certificate in the chain.
+ */
+static constexpr const char *kTlsServerCertificateChain = "tls.server.certificate_chain";
+
+/**
+ * Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the
+ * server. For consistency with other hash values, this value should be formatted as an uppercase
+ * hash.
+ */
+static constexpr const char *kTlsServerHashMd5 = "tls.server.hash.md5";
+
+/**
+ * Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by
+ * the server. For consistency with other hash values, this value should be formatted as an
+ * uppercase hash.
+ */
+static constexpr const char *kTlsServerHashSha1 = "tls.server.hash.sha1";
+
+/**
+ * Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by
+ * the server. For consistency with other hash values, this value should be formatted as an
+ * uppercase hash.
+ */
+static constexpr const char *kTlsServerHashSha256 = "tls.server.hash.sha256";
+
+/**
+ * Distinguished name of <a
+ * href="https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6">subject</a> of the issuer of
+ * the x.509 certificate presented by the client.
+ */
+static constexpr const char *kTlsServerIssuer = "tls.server.issuer";
+
+/**
+ * A hash that identifies servers based on how they perform an SSL/TLS handshake.
+ */
+static constexpr const char *kTlsServerJa3s = "tls.server.ja3s";
+
+/**
+ * Date/Time indicating when server certificate is no longer considered valid.
+ */
+static constexpr const char *kTlsServerNotAfter = "tls.server.not_after";
+
+/**
+ * Date/Time indicating when server certificate is first considered valid.
+ */
+static constexpr const char *kTlsServerNotBefore = "tls.server.not_before";
+
+/**
+ * Distinguished name of subject of the x.509 certificate presented by the server.
+ */
+static constexpr const char *kTlsServerSubject = "tls.server.subject";
+
+/**
+ * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.5">URI fragment</a> component
+ */
+static constexpr const char *kUrlFragment = "url.fragment";
+
+/**
+ * Absolute URL describing a network resource according to <a
+href="https://www.rfc-editor.org/rfc/rfc3986">RFC3986</a>
+ *
+ * <p>Notes:
+  <ul> <li>For network calls, URL usually has {@code scheme://host[:port][path][?query][#fragment]}
+format, where the fragment is not transmitted over HTTP, but if it is known, it SHOULD be included
+nevertheless.
+{@code url.full} MUST NOT contain credentials passed via URL in form of {@code
+https://username:password@www.example.com/}. In such case username and password SHOULD be redacted
+and attribute's value SHOULD be {@code https://REDACTED:REDACTED@www.example.com/}.
+{@code url.full} SHOULD capture the absolute URL when it is available (or can be reconstructed) and
+SHOULD NOT be validated or modified except for sanitizing purposes.</li> </ul>
+ */
+static constexpr const char *kUrlFull = "url.full";
+
+/**
+ * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.3">URI path</a> component
+ */
+static constexpr const char *kUrlPath = "url.path";
+
+/**
+ * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.4">URI query</a> component
+ *
+ * <p>Notes:
+  <ul> <li>Sensitive content provided in query string SHOULD be scrubbed when instrumentations can
+ identify it.</li> </ul>
+ */
+static constexpr const char *kUrlQuery = "url.query";
+
+/**
+ * The <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.1">URI scheme</a> component
+ * identifying the used protocol.
+ */
+static constexpr const char *kUrlScheme = "url.scheme";
+
+/**
+ * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
+ * User-Agent</a> header sent by the client.
+ */
+static constexpr const char *kUserAgentOriginal = "user_agent.original";
+
+/**
+ * A unique id to identify a session.
+ */
+static constexpr const char *kSessionId = "session.id";
+
+/**
+ * The previous {@code session.id} for this user, when known.
+ */
+static constexpr const char *kSessionPreviousId = "session.previous_id";
+
+/**
+ * The full invoked ARN as provided on the {@code Context} passed to the function ({@code
+ Lambda-Runtime-Invoked-Function-Arn} header on the {@code /runtime/invocation/next} applicable).
+ *
+ * <p>Notes:
+  <ul> <li>This may be different from {@code cloud.resource_id} if an alias is involved.</li> </ul>
+ */
+static constexpr const char *kAwsLambdaInvokedArn = "aws.lambda.invoked_arn";
+
+/**
+ * The <a href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id">event_id</a>
+ * uniquely identifies the event.
+ */
+static constexpr const char *kCloudeventsEventId = "cloudevents.event_id";
+
+/**
+ * The <a
+ * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1">source</a>
+ * identifies the context in which an event happened.
+ */
+static constexpr const char *kCloudeventsEventSource = "cloudevents.event_source";
+
+/**
+ * The <a
+ * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#specversion">version of
+ * the CloudEvents specification</a> which the event uses.
+ */
+static constexpr const char *kCloudeventsEventSpecVersion = "cloudevents.event_spec_version";
+
+/**
+ * The <a
+ * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject">subject</a> of
+ * the event in the context of the event producer (identified by source).
+ */
+static constexpr const char *kCloudeventsEventSubject = "cloudevents.event_subject";
+
+/**
+ * The <a
+ * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type">event_type</a>
+ * contains a value describing the type of event related to the originating occurrence.
+ */
+static constexpr const char *kCloudeventsEventType = "cloudevents.event_type";
+
+/**
+ * Parent-child Reference type
+ *
+ * <p>Notes:
+  <ul> <li>The causal relationship between a child Span and a parent Span.</li> </ul>
+ */
+static constexpr const char *kOpentracingRefType = "opentracing.ref_type";
+
+/**
+ * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status code
+ * is UNSET.
+ */
+static constexpr const char *kOtelStatusCode = "otel.status_code";
+
+/**
+ * Description of the Status if it has a value, otherwise not set.
+ */
+static constexpr const char *kOtelStatusDescription = "otel.status_description";
+
+/**
+ * The invocation ID of the current function invocation.
+ */
+static constexpr const char *kFaasInvocationId = "faas.invocation_id";
+
+/**
+ * The name of the source on which the triggering operation was performed. For example, in Cloud
+ * Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
+ */
+static constexpr const char *kFaasDocumentCollection = "faas.document.collection";
+
+/**
+ * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the
+ * name of the file, and in Cosmos DB the table name.
+ */
+static constexpr const char *kFaasDocumentName = "faas.document.name";
+
+/**
+ * Describes the type of the operation that was performed on the data.
+ */
+static constexpr const char *kFaasDocumentOperation = "faas.document.operation";
+
+/**
+ * A string containing the time when the data was accessed in the <a
+ * href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a> format expressed in <a
+ * href="https://www.w3.org/TR/NOTE-datetime">UTC</a>.
+ */
+static constexpr const char *kFaasDocumentTime = "faas.document.time";
+
+/**
+ * A string containing the schedule period as <a
+ * href="https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm">Cron
+ * Expression</a>.
+ */
+static constexpr const char *kFaasCron = "faas.cron";
+
+/**
+ * A string containing the function invocation time in the <a
+ * href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a> format expressed in <a
+ * href="https://www.w3.org/TR/NOTE-datetime">UTC</a>.
+ */
+static constexpr const char *kFaasTime = "faas.time";
+
+/**
+ * A boolean that is true if the serverless function is executed for the first time (aka
+ * cold-start).
+ */
+static constexpr const char *kFaasColdstart = "faas.coldstart";
+
+/**
+ * The unique identifier of the feature flag.
+ */
+static constexpr const char *kFeatureFlagKey = "feature_flag.key";
+
+/**
+ * The name of the service provider that performs the flag evaluation.
+ */
+static constexpr const char *kFeatureFlagProviderName = "feature_flag.provider_name";
+
+/**
+ * SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of the
+value can be used.
+ *
+ * <p>Notes:
+  <ul> <li>A semantic identifier, commonly referred to as a variant, provides a means
+for referring to a value without including the value itself. This can
+provide additional context for understanding the meaning behind a value.
+For example, the variant {@code red} maybe be used for the value {@code #c05543}.</li><li>A
+stringified version of the value can be used in situations where a semantic identifier is
+unavailable. String representation of the value should be determined by the implementer.</li> </ul>
+ */
+static constexpr const char *kFeatureFlagVariant = "feature_flag.variant";
+
+/**
+ * The AWS request ID as returned in the response headers {@code x-amz-request-id} or {@code
+ * x-amz-requestid}.
+ */
+static constexpr const char *kAwsRequestId = "aws.request_id";
+
+/**
+ * The value of the {@code AttributesToGet} request parameter.
+ */
+static constexpr const char *kAwsDynamodbAttributesToGet = "aws.dynamodb.attributes_to_get";
+
+/**
+ * The value of the {@code ConsistentRead} request parameter.
+ */
+static constexpr const char *kAwsDynamodbConsistentRead = "aws.dynamodb.consistent_read";
+
+/**
+ * The JSON-serialized value of each item in the {@code ConsumedCapacity} response field.
+ */
+static constexpr const char *kAwsDynamodbConsumedCapacity = "aws.dynamodb.consumed_capacity";
+
+/**
+ * The value of the {@code IndexName} request parameter.
+ */
+static constexpr const char *kAwsDynamodbIndexName = "aws.dynamodb.index_name";
+
+/**
+ * The JSON-serialized value of the {@code ItemCollectionMetrics} response field.
+ */
+static constexpr const char *kAwsDynamodbItemCollectionMetrics =
+    "aws.dynamodb.item_collection_metrics";
+
+/**
+ * The value of the {@code Limit} request parameter.
+ */
+static constexpr const char *kAwsDynamodbLimit = "aws.dynamodb.limit";
+
+/**
+ * The value of the {@code ProjectionExpression} request parameter.
+ */
+static constexpr const char *kAwsDynamodbProjection = "aws.dynamodb.projection";
+
+/**
+ * The value of the {@code ProvisionedThroughput.ReadCapacityUnits} request parameter.
+ */
+static constexpr const char *kAwsDynamodbProvisionedReadCapacity =
+    "aws.dynamodb.provisioned_read_capacity";
+
+/**
+ * The value of the {@code ProvisionedThroughput.WriteCapacityUnits} request parameter.
+ */
+static constexpr const char *kAwsDynamodbProvisionedWriteCapacity =
+    "aws.dynamodb.provisioned_write_capacity";
+
+/**
+ * The value of the {@code Select} request parameter.
+ */
+static constexpr const char *kAwsDynamodbSelect = "aws.dynamodb.select";
+
+/**
+ * The keys in the {@code RequestItems} object field.
+ */
+static constexpr const char *kAwsDynamodbTableNames = "aws.dynamodb.table_names";
+
+/**
+ * The JSON-serialized value of each item of the {@code GlobalSecondaryIndexes} request field
+ */
+static constexpr const char *kAwsDynamodbGlobalSecondaryIndexes =
+    "aws.dynamodb.global_secondary_indexes";
+
+/**
+ * The JSON-serialized value of each item of the {@code LocalSecondaryIndexes} request field.
+ */
+static constexpr const char *kAwsDynamodbLocalSecondaryIndexes =
+    "aws.dynamodb.local_secondary_indexes";
+
+/**
+ * The value of the {@code ExclusiveStartTableName} request parameter.
+ */
+static constexpr const char *kAwsDynamodbExclusiveStartTable = "aws.dynamodb.exclusive_start_table";
+
+/**
+ * The the number of items in the {@code TableNames} response parameter.
+ */
+static constexpr const char *kAwsDynamodbTableCount = "aws.dynamodb.table_count";
+
+/**
+ * The value of the {@code ScanIndexForward} request parameter.
+ */
+static constexpr const char *kAwsDynamodbScanForward = "aws.dynamodb.scan_forward";
+
+/**
+ * The value of the {@code Count} response parameter.
+ */
+static constexpr const char *kAwsDynamodbCount = "aws.dynamodb.count";
+
+/**
+ * The value of the {@code ScannedCount} response parameter.
+ */
+static constexpr const char *kAwsDynamodbScannedCount = "aws.dynamodb.scanned_count";
+
+/**
+ * The value of the {@code Segment} request parameter.
+ */
+static constexpr const char *kAwsDynamodbSegment = "aws.dynamodb.segment";
+
+/**
+ * The value of the {@code TotalSegments} request parameter.
+ */
+static constexpr const char *kAwsDynamodbTotalSegments = "aws.dynamodb.total_segments";
+
+/**
+ * The JSON-serialized value of each item in the {@code AttributeDefinitions} request field.
+ */
+static constexpr const char *kAwsDynamodbAttributeDefinitions =
+    "aws.dynamodb.attribute_definitions";
+
+/**
+ * The JSON-serialized value of each item in the the {@code GlobalSecondaryIndexUpdates} request
+ * field.
+ */
+static constexpr const char *kAwsDynamodbGlobalSecondaryIndexUpdates =
+    "aws.dynamodb.global_secondary_index_updates";
+
+/**
+ * The S3 bucket name the request refers to. Corresponds to the {@code --bucket} parameter of the <a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html">S3 API</a> operations.
+ *
+ * <p>Notes:
+  <ul> <li>The {@code bucket} attribute is applicable to all S3 operations that reference a bucket,
+i.e. that require the bucket name as a mandatory parameter. This applies to almost all S3 operations
+except {@code list-buckets}.</li> </ul>
+ */
+static constexpr const char *kAwsS3Bucket = "aws.s3.bucket";
+
+/**
+ * The source object (in the form {@code bucket}/{@code key}) for the copy operation.
+ *
+ * <p>Notes:
+  <ul> <li>The {@code copy_source} attribute applies to S3 copy operations and corresponds to the
+{@code --copy-source} parameter of the <a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html">copy-object operation
+within the S3 API</a>. This applies in particular to the following operations:</li><li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html">copy-object</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a></li>
+ </ul>
+ */
+static constexpr const char *kAwsS3CopySource = "aws.s3.copy_source";
+
+/**
+ * The delete request container that specifies the objects to be deleted.
+ *
+ * <p>Notes:
+  <ul> <li>The {@code delete} attribute is only applicable to the <a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html">delete-object</a>
+operation. The {@code delete} attribute corresponds to the {@code --delete} parameter of the <a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-objects.html">delete-objects
+operation within the S3 API</a>.</li> </ul>
+ */
+static constexpr const char *kAwsS3Delete = "aws.s3.delete";
+
+/**
+ * The S3 object key the request refers to. Corresponds to the {@code --key} parameter of the <a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html">S3 API</a> operations.
+ *
+ * <p>Notes:
+  <ul> <li>The {@code key} attribute is applicable to all object-related S3 operations, i.e. that
+require the object key as a mandatory parameter. This applies in particular to the following
+operations:</li><li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html">copy-object</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html">delete-object</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/get-object.html">get-object</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/head-object.html">head-object</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html">put-object</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html">restore-object</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/select-object-content.html">select-object-content</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html">abort-multipart-upload</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html">complete-multipart-upload</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/create-multipart-upload.html">create-multipart-upload</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html">list-parts</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a></li>
+ </ul>
+ */
+static constexpr const char *kAwsS3Key = "aws.s3.key";
+
+/**
+ * The part number of the part being uploaded in a multipart-upload operation. This is a positive
+integer between 1 and 10,000.
+ *
+ * <p>Notes:
+  <ul> <li>The {@code part_number} attribute is only applicable to the <a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part</a> and
+<a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a>
+operations. The {@code part_number} attribute corresponds to the {@code --part-number} parameter of
+the <a href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part
+operation within the S3 API</a>.</li> </ul>
+ */
+static constexpr const char *kAwsS3PartNumber = "aws.s3.part_number";
+
+/**
+ * Upload ID that identifies the multipart upload.
+ *
+ * <p>Notes:
+  <ul> <li>The {@code upload_id} attribute applies to S3 multipart-upload operations and corresponds
+to the {@code --upload-id} parameter of the <a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html">S3 API</a> multipart
+operations. This applies in particular to the following operations:</li><li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html">abort-multipart-upload</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html">complete-multipart-upload</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html">list-parts</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html">upload-part</a></li>
+<li><a
+href="https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html">upload-part-copy</a></li>
+ </ul>
+ */
+static constexpr const char *kAwsS3UploadId = "aws.s3.upload_id";
+
+/**
+ * The GraphQL document being executed.
+ *
+ * <p>Notes:
+  <ul> <li>The value may be sanitized to exclude sensitive information.</li> </ul>
+ */
+static constexpr const char *kGraphqlDocument = "graphql.document";
+
+/**
+ * The name of the operation being executed.
+ */
+static constexpr const char *kGraphqlOperationName = "graphql.operation.name";
+
+/**
+ * The type of the operation being executed.
+ */
+static constexpr const char *kGraphqlOperationType = "graphql.operation.type";
+
+/**
+ * Compressed size of the message in bytes.
+ */
+static constexpr const char *kMessageCompressedSize = "message.compressed_size";
+
+/**
+ * MUST be calculated as two different counters starting from {@code 1} one for sent messages and
+ one for received message.
+ *
+ * <p>Notes:
+  <ul> <li>This way we guarantee that the values will be consistent between different
+ implementations.</li> </ul>
+ */
+static constexpr const char *kMessageId = "message.id";
+
+/**
+ * Whether this is a received or sent message.
+ */
+static constexpr const char *kMessageType = "message.type";
+
+/**
+ * Uncompressed size of the message in bytes.
+ */
+static constexpr const char *kMessageUncompressedSize = "message.uncompressed_size";
+
+// Enum definitions
+namespace FaasInvokedProviderValues
+{
+/** Alibaba Cloud. */
+static constexpr const char *kAlibabaCloud = "alibaba_cloud";
+/** Amazon Web Services. */
+static constexpr const char *kAws = "aws";
+/** Microsoft Azure. */
+static constexpr const char *kAzure = "azure";
+/** Google Cloud Platform. */
+static constexpr const char *kGcp = "gcp";
+/** Tencent Cloud. */
+static constexpr const char *kTencentCloud = "tencent_cloud";
+}  // namespace FaasInvokedProviderValues
+
+namespace FaasTriggerValues
+{
+/** A response to some data source operation such as a database or filesystem read/write. */
+static constexpr const char *kDatasource = "datasource";
+/** To provide an answer to an inbound HTTP request. */
+static constexpr const char *kHttp = "http";
+/** A function is set to be executed when messages are sent to a messaging system. */
+static constexpr const char *kPubsub = "pubsub";
+/** A function is scheduled to be executed regularly. */
+static constexpr const char *kTimer = "timer";
+/** If none of the others apply. */
+static constexpr const char *kOther = "other";
+}  // namespace FaasTriggerValues
+
+namespace LogIostreamValues
+{
+/** Logs from stdout stream. */
+static constexpr const char *kStdout = "stdout";
+/** Events from stderr stream. */
+static constexpr const char *kStderr = "stderr";
+}  // namespace LogIostreamValues
+
+namespace IosStateValues
+{
+/** The app has become `active`. Associated with UIKit notification `applicationDidBecomeActive`. */
+static constexpr const char *kActive = "active";
+/** The app is now `inactive`. Associated with UIKit notification `applicationWillResignActive`. */
+static constexpr const char *kInactive = "inactive";
+/** The app is now in the background. This value is associated with UIKit notification
+ * `applicationDidEnterBackground`. */
+static constexpr const char *kBackground = "background";
+/** The app is now in the foreground. This value is associated with UIKit notification
+ * `applicationWillEnterForeground`. */
+static constexpr const char *kForeground = "foreground";
+/** The app is about to terminate. Associated with UIKit notification `applicationWillTerminate`. */
+static constexpr const char *kTerminate = "terminate";
+}  // namespace IosStateValues
+
+namespace AndroidStateValues
+{
+/** Any time before Activity.onResume() or, if the app has no Activity, Context.startService() has
+ * been called in the app for the first time. */
+static constexpr const char *kCreated = "created";
+/** Any time after Activity.onPause() or, if the app has no Activity, Context.stopService() has been
+ * called when the app was in the foreground state. */
+static constexpr const char *kBackground = "background";
+/** Any time after Activity.onResume() or, if the app has no Activity, Context.startService() has
+ * been called when the app was in either the created or background states. */
+static constexpr const char *kForeground = "foreground";
+}  // namespace AndroidStateValues
+
+namespace StateValues
+{
+/** idle. */
+static constexpr const char *kIdle = "idle";
+/** used. */
+static constexpr const char *kUsed = "used";
+}  // namespace StateValues
+
+namespace AspnetcoreRateLimitingResultValues
+{
+/** Lease was acquired. */
+static constexpr const char *kAcquired = "acquired";
+/** Lease request was rejected by the endpoint limiter. */
+static constexpr const char *kEndpointLimiter = "endpoint_limiter";
+/** Lease request was rejected by the global limiter. */
+static constexpr const char *kGlobalLimiter = "global_limiter";
+/** Lease request was canceled. */
+static constexpr const char *kRequestCanceled = "request_canceled";
+}  // namespace AspnetcoreRateLimitingResultValues
+
+namespace SignalrConnectionStatusValues
+{
+/** The connection was closed normally. */
+static constexpr const char *kNormalClosure = "normal_closure";
+/** The connection was closed due to a timeout. */
+static constexpr const char *kTimeout = "timeout";
+/** The connection was closed because the app is shutting down. */
+static constexpr const char *kAppShutdown = "app_shutdown";
+}  // namespace SignalrConnectionStatusValues
+
+namespace SignalrTransportValues
+{
+/** ServerSentEvents protocol. */
+static constexpr const char *kServerSentEvents = "server_sent_events";
+/** LongPolling protocol. */
+static constexpr const char *kLongPolling = "long_polling";
+/** WebSockets protocol. */
+static constexpr const char *kWebSockets = "web_sockets";
+}  // namespace SignalrTransportValues
+
+namespace JvmMemoryTypeValues
+{
+/** Heap memory. */
+static constexpr const char *kHeap = "heap";
+/** Non-heap memory. */
+static constexpr const char *kNonHeap = "non_heap";
+}  // namespace JvmMemoryTypeValues
+
+namespace SystemCpuStateValues
+{
+/** user. */
+static constexpr const char *kUser = "user";
+/** system. */
+static constexpr const char *kSystem = "system";
+/** nice. */
+static constexpr const char *kNice = "nice";
+/** idle. */
+static constexpr const char *kIdle = "idle";
+/** iowait. */
+static constexpr const char *kIowait = "iowait";
+/** interrupt. */
+static constexpr const char *kInterrupt = "interrupt";
+/** steal. */
+static constexpr const char *kSteal = "steal";
+}  // namespace SystemCpuStateValues
+
+namespace SystemMemoryStateValues
+{
+/** used. */
+static constexpr const char *kUsed = "used";
+/** free. */
+static constexpr const char *kFree = "free";
+/** shared. */
+static constexpr const char *kShared = "shared";
+/** buffers. */
+static constexpr const char *kBuffers = "buffers";
+/** cached. */
+static constexpr const char *kCached = "cached";
+}  // namespace SystemMemoryStateValues
+
+namespace SystemPagingDirectionValues
+{
+/** in. */
+static constexpr const char *kIn = "in";
+/** out. */
+static constexpr const char *kOut = "out";
+}  // namespace SystemPagingDirectionValues
+
+namespace SystemPagingStateValues
+{
+/** used. */
+static constexpr const char *kUsed = "used";
+/** free. */
+static constexpr const char *kFree = "free";
+}  // namespace SystemPagingStateValues
+
+namespace SystemPagingTypeValues
+{
+/** major. */
+static constexpr const char *kMajor = "major";
+/** minor. */
+static constexpr const char *kMinor = "minor";
+}  // namespace SystemPagingTypeValues
+
+namespace SystemFilesystemStateValues
+{
+/** used. */
+static constexpr const char *kUsed = "used";
+/** free. */
+static constexpr const char *kFree = "free";
+/** reserved. */
+static constexpr const char *kReserved = "reserved";
+}  // namespace SystemFilesystemStateValues
+
+namespace SystemFilesystemTypeValues
+{
+/** fat32. */
+static constexpr const char *kFat32 = "fat32";
+/** exfat. */
+static constexpr const char *kExfat = "exfat";
+/** ntfs. */
+static constexpr const char *kNtfs = "ntfs";
+/** refs. */
+static constexpr const char *kRefs = "refs";
+/** hfsplus. */
+static constexpr const char *kHfsplus = "hfsplus";
+/** ext4. */
+static constexpr const char *kExt4 = "ext4";
+}  // namespace SystemFilesystemTypeValues
+
+namespace SystemNetworkStateValues
+{
+/** close. */
+static constexpr const char *kClose = "close";
+/** close_wait. */
+static constexpr const char *kCloseWait = "close_wait";
+/** closing. */
+static constexpr const char *kClosing = "closing";
+/** delete. */
+static constexpr const char *kDelete = "delete";
+/** established. */
+static constexpr const char *kEstablished = "established";
+/** fin_wait_1. */
+static constexpr const char *kFinWait1 = "fin_wait_1";
+/** fin_wait_2. */
+static constexpr const char *kFinWait2 = "fin_wait_2";
+/** last_ack. */
+static constexpr const char *kLastAck = "last_ack";
+/** listen. */
+static constexpr const char *kListen = "listen";
+/** syn_recv. */
+static constexpr const char *kSynRecv = "syn_recv";
+/** syn_sent. */
+static constexpr const char *kSynSent = "syn_sent";
+/** time_wait. */
+static constexpr const char *kTimeWait = "time_wait";
+}  // namespace SystemNetworkStateValues
+
+namespace SystemProcessesStatusValues
+{
+/** running. */
+static constexpr const char *kRunning = "running";
+/** sleeping. */
+static constexpr const char *kSleeping = "sleeping";
+/** stopped. */
+static constexpr const char *kStopped = "stopped";
+/** defunct. */
+static constexpr const char *kDefunct = "defunct";
+}  // namespace SystemProcessesStatusValues
+
+namespace DbCassandraConsistencyLevelValues
+{
+/** all. */
+static constexpr const char *kAll = "all";
+/** each_quorum. */
+static constexpr const char *kEachQuorum = "each_quorum";
+/** quorum. */
+static constexpr const char *kQuorum = "quorum";
+/** local_quorum. */
+static constexpr const char *kLocalQuorum = "local_quorum";
+/** one. */
+static constexpr const char *kOne = "one";
+/** two. */
+static constexpr const char *kTwo = "two";
+/** three. */
+static constexpr const char *kThree = "three";
+/** local_one. */
+static constexpr const char *kLocalOne = "local_one";
+/** any. */
+static constexpr const char *kAny = "any";
+/** serial. */
+static constexpr const char *kSerial = "serial";
+/** local_serial. */
+static constexpr const char *kLocalSerial = "local_serial";
+}  // namespace DbCassandraConsistencyLevelValues
+
+namespace DbCosmosdbConnectionModeValues
+{
+/** Gateway (HTTP) connections mode. */
+static constexpr const char *kGateway = "gateway";
+/** Direct connection. */
+static constexpr const char *kDirect = "direct";
+}  // namespace DbCosmosdbConnectionModeValues
+
+namespace DbCosmosdbOperationTypeValues
+{
+/** invalid. */
+static constexpr const char *kInvalid = "Invalid";
+/** create. */
+static constexpr const char *kCreate = "Create";
+/** patch. */
+static constexpr const char *kPatch = "Patch";
+/** read. */
+static constexpr const char *kRead = "Read";
+/** read_feed. */
+static constexpr const char *kReadFeed = "ReadFeed";
+/** delete. */
+static constexpr const char *kDelete = "Delete";
+/** replace. */
+static constexpr const char *kReplace = "Replace";
+/** execute. */
+static constexpr const char *kExecute = "Execute";
+/** query. */
+static constexpr const char *kQuery = "Query";
+/** head. */
+static constexpr const char *kHead = "Head";
+/** head_feed. */
+static constexpr const char *kHeadFeed = "HeadFeed";
+/** upsert. */
+static constexpr const char *kUpsert = "Upsert";
+/** batch. */
+static constexpr const char *kBatch = "Batch";
+/** query_plan. */
+static constexpr const char *kQueryPlan = "QueryPlan";
+/** execute_javascript. */
+static constexpr const char *kExecuteJavascript = "ExecuteJavaScript";
+}  // namespace DbCosmosdbOperationTypeValues
+
+namespace DbSystemValues
+{
+/** Some other SQL database. Fallback only. See notes. */
+static constexpr const char *kOtherSql = "other_sql";
+/** Microsoft SQL Server. */
+static constexpr const char *kMssql = "mssql";
+/** Microsoft SQL Server Compact. */
+static constexpr const char *kMssqlcompact = "mssqlcompact";
+/** MySQL. */
+static constexpr const char *kMysql = "mysql";
+/** Oracle Database. */
+static constexpr const char *kOracle = "oracle";
+/** IBM Db2. */
+static constexpr const char *kDb2 = "db2";
+/** PostgreSQL. */
+static constexpr const char *kPostgresql = "postgresql";
+/** Amazon Redshift. */
+static constexpr const char *kRedshift = "redshift";
+/** Apache Hive. */
+static constexpr const char *kHive = "hive";
+/** Cloudscape. */
+static constexpr const char *kCloudscape = "cloudscape";
+/** HyperSQL DataBase. */
+static constexpr const char *kHsqldb = "hsqldb";
+/** Progress Database. */
+static constexpr const char *kProgress = "progress";
+/** SAP MaxDB. */
+static constexpr const char *kMaxdb = "maxdb";
+/** SAP HANA. */
+static constexpr const char *kHanadb = "hanadb";
+/** Ingres. */
+static constexpr const char *kIngres = "ingres";
+/** FirstSQL. */
+static constexpr const char *kFirstsql = "firstsql";
+/** EnterpriseDB. */
+static constexpr const char *kEdb = "edb";
+/** InterSystems Caché. */
+static constexpr const char *kCache = "cache";
+/** Adabas (Adaptable Database System). */
+static constexpr const char *kAdabas = "adabas";
+/** Firebird. */
+static constexpr const char *kFirebird = "firebird";
+/** Apache Derby. */
+static constexpr const char *kDerby = "derby";
+/** FileMaker. */
+static constexpr const char *kFilemaker = "filemaker";
+/** Informix. */
+static constexpr const char *kInformix = "informix";
+/** InstantDB. */
+static constexpr const char *kInstantdb = "instantdb";
+/** InterBase. */
+static constexpr const char *kInterbase = "interbase";
+/** MariaDB. */
+static constexpr const char *kMariadb = "mariadb";
+/** Netezza. */
+static constexpr const char *kNetezza = "netezza";
+/** Pervasive PSQL. */
+static constexpr const char *kPervasive = "pervasive";
+/** PointBase. */
+static constexpr const char *kPointbase = "pointbase";
+/** SQLite. */
+static constexpr const char *kSqlite = "sqlite";
+/** Sybase. */
+static constexpr const char *kSybase = "sybase";
+/** Teradata. */
+static constexpr const char *kTeradata = "teradata";
+/** Vertica. */
+static constexpr const char *kVertica = "vertica";
+/** H2. */
+static constexpr const char *kH2 = "h2";
+/** ColdFusion IMQ. */
+static constexpr const char *kColdfusion = "coldfusion";
+/** Apache Cassandra. */
+static constexpr const char *kCassandra = "cassandra";
+/** Apache HBase. */
+static constexpr const char *kHbase = "hbase";
+/** MongoDB. */
+static constexpr const char *kMongodb = "mongodb";
+/** Redis. */
+static constexpr const char *kRedis = "redis";
+/** Couchbase. */
+static constexpr const char *kCouchbase = "couchbase";
+/** CouchDB. */
+static constexpr const char *kCouchdb = "couchdb";
+/** Microsoft Azure Cosmos DB. */
+static constexpr const char *kCosmosdb = "cosmosdb";
+/** Amazon DynamoDB. */
+static constexpr const char *kDynamodb = "dynamodb";
+/** Neo4j. */
+static constexpr const char *kNeo4j = "neo4j";
+/** Apache Geode. */
+static constexpr const char *kGeode = "geode";
+/** Elasticsearch. */
+static constexpr const char *kElasticsearch = "elasticsearch";
+/** Memcached. */
+static constexpr const char *kMemcached = "memcached";
+/** CockroachDB. */
+static constexpr const char *kCockroachdb = "cockroachdb";
+/** OpenSearch. */
+static constexpr const char *kOpensearch = "opensearch";
+/** ClickHouse. */
+static constexpr const char *kClickhouse = "clickhouse";
+/** Cloud Spanner. */
+static constexpr const char *kSpanner = "spanner";
+/** Trino. */
+static constexpr const char *kTrino = "trino";
+}  // namespace DbSystemValues
+
+namespace HttpFlavorValues
+{
+/** HTTP/1.0. */
+static constexpr const char *kHttp10 = "1.0";
+/** HTTP/1.1. */
+static constexpr const char *kHttp11 = "1.1";
+/** HTTP/2. */
+static constexpr const char *kHttp20 = "2.0";
+/** HTTP/3. */
+static constexpr const char *kHttp30 = "3.0";
+/** SPDY protocol. */
+static constexpr const char *kSpdy = "SPDY";
+/** QUIC protocol. */
+static constexpr const char *kQuic = "QUIC";
+}  // namespace HttpFlavorValues
+
+namespace NetSockFamilyValues
+{
+/** IPv4 address. */
+static constexpr const char *kInet = "inet";
+/** IPv6 address. */
+static constexpr const char *kInet6 = "inet6";
+/** Unix domain socket path. */
+static constexpr const char *kUnix = "unix";
+}  // namespace NetSockFamilyValues
+
+namespace NetTransportValues
+{
+/** ip_tcp. */
+static constexpr const char *kIpTcp = "ip_tcp";
+/** ip_udp. */
+static constexpr const char *kIpUdp = "ip_udp";
+/** Named or anonymous pipe. */
+static constexpr const char *kPipe = "pipe";
+/** In-process communication. */
+static constexpr const char *kInproc = "inproc";
+/** Something else (non IP-based). */
+static constexpr const char *kOther = "other";
+}  // namespace NetTransportValues
+
+namespace DiskIoDirectionValues
+{
+/** read. */
+static constexpr const char *kRead = "read";
+/** write. */
+static constexpr const char *kWrite = "write";
+}  // namespace DiskIoDirectionValues
+
+namespace ErrorTypeValues
+{
+/** A fallback error value to be used when the instrumentation doesn&#39;t define a custom value. */
+static constexpr const char *kOther = "_OTHER";
+}  // namespace ErrorTypeValues
+
+namespace HttpRequestMethodValues
+{
+/** CONNECT method. */
+static constexpr const char *kConnect = "CONNECT";
+/** DELETE method. */
+static constexpr const char *kDelete = "DELETE";
+/** GET method. */
+static constexpr const char *kGet = "GET";
+/** HEAD method. */
+static constexpr const char *kHead = "HEAD";
+/** OPTIONS method. */
+static constexpr const char *kOptions = "OPTIONS";
+/** PATCH method. */
+static constexpr const char *kPatch = "PATCH";
+/** POST method. */
+static constexpr const char *kPost = "POST";
+/** PUT method. */
+static constexpr const char *kPut = "PUT";
+/** TRACE method. */
+static constexpr const char *kTrace = "TRACE";
+/** Any HTTP method that the instrumentation has no prior knowledge of. */
+static constexpr const char *kOther = "_OTHER";
+}  // namespace HttpRequestMethodValues
+
+namespace MessagingOperationValues
+{
+/** One or more messages are provided for publishing to an intermediary. If a single message is
+ * published, the context of the &#34;Publish&#34; span can be used as the creation context and no
+ * &#34;Create&#34; span needs to be created. */
+static constexpr const char *kPublish = "publish";
+/** A message is created. &#34;Create&#34; spans always refer to a single message and are used to
+ * provide a unique creation context for messages in batch publishing scenarios. */
+static constexpr const char *kCreate = "create";
+/** One or more messages are requested by a consumer. This operation refers to pull-based scenarios,
+ * where consumers explicitly call methods of messaging SDKs to receive messages. */
+static constexpr const char *kReceive = "receive";
+/** One or more messages are passed to a consumer. This operation refers to push-based scenarios,
+ * where consumer register callbacks which get called by messaging SDKs. */
+static constexpr const char *kDeliver = "deliver";
+}  // namespace MessagingOperationValues
+
+namespace MessagingRocketmqConsumptionModelValues
+{
+/** Clustering consumption model. */
+static constexpr const char *kClustering = "clustering";
+/** Broadcasting consumption model. */
+static constexpr const char *kBroadcasting = "broadcasting";
+}  // namespace MessagingRocketmqConsumptionModelValues
+
+namespace MessagingRocketmqMessageTypeValues
+{
+/** Normal message. */
+static constexpr const char *kNormal = "normal";
+/** FIFO message. */
+static constexpr const char *kFifo = "fifo";
+/** Delay message. */
+static constexpr const char *kDelay = "delay";
+/** Transaction message. */
+static constexpr const char *kTransaction = "transaction";
+}  // namespace MessagingRocketmqMessageTypeValues
+
+namespace MessagingSystemValues
+{
+/** Apache ActiveMQ. */
+static constexpr const char *kActivemq = "activemq";
+/** Amazon Simple Queue Service (SQS). */
+static constexpr const char *kAwsSqs = "aws_sqs";
+/** Azure Event Grid. */
+static constexpr const char *kAzureEventgrid = "azure_eventgrid";
+/** Azure Event Hubs. */
+static constexpr const char *kAzureEventhubs = "azure_eventhubs";
+/** Azure Service Bus. */
+static constexpr const char *kAzureServicebus = "azure_servicebus";
+/** Google Cloud Pub/Sub. */
+static constexpr const char *kGcpPubsub = "gcp_pubsub";
+/** Java Message Service. */
+static constexpr const char *kJms = "jms";
+/** Apache Kafka. */
+static constexpr const char *kKafka = "kafka";
+/** RabbitMQ. */
+static constexpr const char *kRabbitmq = "rabbitmq";
+/** Apache RocketMQ. */
+static constexpr const char *kRocketmq = "rocketmq";
+}  // namespace MessagingSystemValues
+
+namespace NetworkConnectionSubtypeValues
+{
+/** GPRS. */
+static constexpr const char *kGprs = "gprs";
+/** EDGE. */
+static constexpr const char *kEdge = "edge";
+/** UMTS. */
+static constexpr const char *kUmts = "umts";
+/** CDMA. */
+static constexpr const char *kCdma = "cdma";
+/** EVDO Rel. 0. */
+static constexpr const char *kEvdo0 = "evdo_0";
+/** EVDO Rev. A. */
+static constexpr const char *kEvdoA = "evdo_a";
+/** CDMA2000 1XRTT. */
+static constexpr const char *kCdma20001xrtt = "cdma2000_1xrtt";
+/** HSDPA. */
+static constexpr const char *kHsdpa = "hsdpa";
+/** HSUPA. */
+static constexpr const char *kHsupa = "hsupa";
+/** HSPA. */
+static constexpr const char *kHspa = "hspa";
+/** IDEN. */
+static constexpr const char *kIden = "iden";
+/** EVDO Rev. B. */
+static constexpr const char *kEvdoB = "evdo_b";
+/** LTE. */
+static constexpr const char *kLte = "lte";
+/** EHRPD. */
+static constexpr const char *kEhrpd = "ehrpd";
+/** HSPAP. */
+static constexpr const char *kHspap = "hspap";
+/** GSM. */
+static constexpr const char *kGsm = "gsm";
+/** TD-SCDMA. */
+static constexpr const char *kTdScdma = "td_scdma";
+/** IWLAN. */
+static constexpr const char *kIwlan = "iwlan";
+/** 5G NR (New Radio). */
+static constexpr const char *kNr = "nr";
+/** 5G NRNSA (New Radio Non-Standalone). */
+static constexpr const char *kNrnsa = "nrnsa";
+/** LTE CA. */
+static constexpr const char *kLteCa = "lte_ca";
+}  // namespace NetworkConnectionSubtypeValues
+
+namespace NetworkConnectionTypeValues
+{
+/** wifi. */
+static constexpr const char *kWifi = "wifi";
+/** wired. */
+static constexpr const char *kWired = "wired";
+/** cell. */
+static constexpr const char *kCell = "cell";
+/** unavailable. */
+static constexpr const char *kUnavailable = "unavailable";
+/** unknown. */
+static constexpr const char *kUnknown = "unknown";
+}  // namespace NetworkConnectionTypeValues
+
+namespace NetworkIoDirectionValues
+{
+/** transmit. */
+static constexpr const char *kTransmit = "transmit";
+/** receive. */
+static constexpr const char *kReceive = "receive";
+}  // namespace NetworkIoDirectionValues
+
+namespace NetworkTransportValues
+{
+/** TCP. */
+static constexpr const char *kTcp = "tcp";
+/** UDP. */
+static constexpr const char *kUdp = "udp";
+/** Named or anonymous pipe. */
+static constexpr const char *kPipe = "pipe";
+/** Unix domain socket. */
+static constexpr const char *kUnix = "unix";
+}  // namespace NetworkTransportValues
+
+namespace NetworkTypeValues
+{
+/** IPv4. */
+static constexpr const char *kIpv4 = "ipv4";
+/** IPv6. */
+static constexpr const char *kIpv6 = "ipv6";
+}  // namespace NetworkTypeValues
+
+namespace RpcConnectRpcErrorCodeValues
+{
+/** cancelled. */
+static constexpr const char *kCancelled = "cancelled";
+/** unknown. */
+static constexpr const char *kUnknown = "unknown";
+/** invalid_argument. */
+static constexpr const char *kInvalidArgument = "invalid_argument";
+/** deadline_exceeded. */
+static constexpr const char *kDeadlineExceeded = "deadline_exceeded";
+/** not_found. */
+static constexpr const char *kNotFound = "not_found";
+/** already_exists. */
+static constexpr const char *kAlreadyExists = "already_exists";
+/** permission_denied. */
+static constexpr const char *kPermissionDenied = "permission_denied";
+/** resource_exhausted. */
+static constexpr const char *kResourceExhausted = "resource_exhausted";
+/** failed_precondition. */
+static constexpr const char *kFailedPrecondition = "failed_precondition";
+/** aborted. */
+static constexpr const char *kAborted = "aborted";
+/** out_of_range. */
+static constexpr const char *kOutOfRange = "out_of_range";
+/** unimplemented. */
+static constexpr const char *kUnimplemented = "unimplemented";
+/** internal. */
+static constexpr const char *kInternal = "internal";
+/** unavailable. */
+static constexpr const char *kUnavailable = "unavailable";
+/** data_loss. */
+static constexpr const char *kDataLoss = "data_loss";
+/** unauthenticated. */
+static constexpr const char *kUnauthenticated = "unauthenticated";
+}  // namespace RpcConnectRpcErrorCodeValues
+
+namespace RpcGrpcStatusCodeValues
+{
+/** OK. */
+static constexpr const int kOk = 0;
+/** CANCELLED. */
+static constexpr const int kCancelled = 1;
+/** UNKNOWN. */
+static constexpr const int kUnknown = 2;
+/** INVALID_ARGUMENT. */
+static constexpr const int kInvalidArgument = 3;
+/** DEADLINE_EXCEEDED. */
+static constexpr const int kDeadlineExceeded = 4;
+/** NOT_FOUND. */
+static constexpr const int kNotFound = 5;
+/** ALREADY_EXISTS. */
+static constexpr const int kAlreadyExists = 6;
+/** PERMISSION_DENIED. */
+static constexpr const int kPermissionDenied = 7;
+/** RESOURCE_EXHAUSTED. */
+static constexpr const int kResourceExhausted = 8;
+/** FAILED_PRECONDITION. */
+static constexpr const int kFailedPrecondition = 9;
+/** ABORTED. */
+static constexpr const int kAborted = 10;
+/** OUT_OF_RANGE. */
+static constexpr const int kOutOfRange = 11;
+/** UNIMPLEMENTED. */
+static constexpr const int kUnimplemented = 12;
+/** INTERNAL. */
+static constexpr const int kInternal = 13;
+/** UNAVAILABLE. */
+static constexpr const int kUnavailable = 14;
+/** DATA_LOSS. */
+static constexpr const int kDataLoss = 15;
+/** UNAUTHENTICATED. */
+static constexpr const int kUnauthenticated = 16;
+}  // namespace RpcGrpcStatusCodeValues
+
+namespace RpcSystemValues
+{
+/** gRPC. */
+static constexpr const char *kGrpc = "grpc";
+/** Java RMI. */
+static constexpr const char *kJavaRmi = "java_rmi";
+/** .NET WCF. */
+static constexpr const char *kDotnetWcf = "dotnet_wcf";
+/** Apache Dubbo. */
+static constexpr const char *kApacheDubbo = "apache_dubbo";
+/** Connect RPC. */
+static constexpr const char *kConnectRpc = "connect_rpc";
+}  // namespace RpcSystemValues
+
+namespace TlsProtocolNameValues
+{
+/** ssl. */
+static constexpr const char *kSsl = "ssl";
+/** tls. */
+static constexpr const char *kTls = "tls";
+}  // namespace TlsProtocolNameValues
+
+namespace OpentracingRefTypeValues
+{
+/** The parent Span depends on the child Span in some capacity. */
+static constexpr const char *kChildOf = "child_of";
+/** The parent Span doesn&#39;t depend in any way on the result of the child Span. */
+static constexpr const char *kFollowsFrom = "follows_from";
+}  // namespace OpentracingRefTypeValues
+
+namespace OtelStatusCodeValues
+{
+/** The operation has been validated by an Application developer or Operator to have completed
+ * successfully. */
+static constexpr const char *kOk = "OK";
+/** The operation contains an error. */
+static constexpr const char *kError = "ERROR";
+}  // namespace OtelStatusCodeValues
+
+namespace FaasDocumentOperationValues
+{
+/** When a new object is created. */
+static constexpr const char *kInsert = "insert";
+/** When an object is modified. */
+static constexpr const char *kEdit = "edit";
+/** When an object is deleted. */
+static constexpr const char *kDelete = "delete";
+}  // namespace FaasDocumentOperationValues
+
+namespace GraphqlOperationTypeValues
+{
+/** GraphQL query. */
+static constexpr const char *kQuery = "query";
+/** GraphQL mutation. */
+static constexpr const char *kMutation = "mutation";
+/** GraphQL subscription. */
+static constexpr const char *kSubscription = "subscription";
+}  // namespace GraphqlOperationTypeValues
+
+namespace MessageTypeValues
+{
+/** sent. */
+static constexpr const char *kSent = "SENT";
+/** received. */
+static constexpr const char *kReceived = "RECEIVED";
+}  // namespace MessageTypeValues
+
+}  // namespace SemanticConventions
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span.h
@@ -1,0 +1,259 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/type_traits.h"
+#include "opentelemetry/trace/span_context.h"
+#include "opentelemetry/trace/span_context_kv_iterable.h"
+#include "opentelemetry/trace/span_context_kv_iterable_view.h"
+#include "opentelemetry/trace/span_metadata.h"
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+class Tracer;
+
+/**
+ * A Span represents a single operation within a Trace.
+ *
+ * Span attributes can be provided:
+ * - at span creation time, using Tracer::StartSpan(),
+ * - during the span lifetime, using Span::SetAttribute()
+ *
+ * Please note that head samplers,
+ * in the SDK (@ref opentelemetry::sdk::trace::Sampler),
+ * can only make sampling decisions based on data known
+ * at span creation time.
+ *
+ * When attributes are known early, adding attributes
+ * with @ref opentelemetry::trace::Tracer::StartSpan() is preferable.
+ *
+ * Attributes added or changed with Span::SetAttribute()
+ * can not change a sampler decision.
+ *
+ * Likewise, links can be provided:
+ * - at span creation time, using Tracer::StartSpan(),
+ * - during the span lifetime, using Span::AddLink() or Span::AddLinks().
+ *
+ * When links are known early, adding links
+ * with @ref opentelemetry::trace::Tracer::StartSpan() is preferable.
+ *
+ * Links added with Span::AddLink() or Span::AddLinks()
+ * can not change a sampler decision.
+ */
+class Span
+{
+public:
+  // Note that Spans should be created using the Tracer class. Please refer to
+  // tracer.h for documentation.
+  Span() = default;
+
+  // The Span destructor End()s the Span, if it hasn't been ended already.
+  virtual ~Span() = default;
+
+  // Not copiable or movable.
+  Span(const Span &) = delete;
+  Span(Span &&)      = delete;
+  Span &operator=(const Span &) = delete;
+  Span &operator=(Span &&) = delete;
+
+  /**
+   * Sets an attribute on the Span (ABI).
+   *
+   * If the Span previously contained a mapping for the key,
+   * the old value is replaced.
+   *
+   * See comments about sampling in @ref opentelemetry::trace::Span
+   */
+  virtual void SetAttribute(nostd::string_view key,
+                            const common::AttributeValue &value) noexcept = 0;
+
+  // Adds an event to the Span.
+  virtual void AddEvent(nostd::string_view name) noexcept = 0;
+
+  // Adds an event to the Span, with a custom timestamp.
+  virtual void AddEvent(nostd::string_view name, common::SystemTimestamp timestamp) noexcept = 0;
+
+  // Adds an event to the Span, with a custom timestamp, and attributes.
+  virtual void AddEvent(nostd::string_view name,
+                        common::SystemTimestamp timestamp,
+                        const common::KeyValueIterable &attributes) noexcept = 0;
+
+  virtual void AddEvent(nostd::string_view name,
+                        const common::KeyValueIterable &attributes) noexcept
+  {
+    this->AddEvent(name, std::chrono::system_clock::now(), attributes);
+  }
+
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+  void AddEvent(nostd::string_view name,
+                common::SystemTimestamp timestamp,
+                const T &attributes) noexcept
+  {
+    this->AddEvent(name, timestamp, common::KeyValueIterableView<T>{attributes});
+  }
+
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+  void AddEvent(nostd::string_view name, const T &attributes) noexcept
+  {
+    this->AddEvent(name, common::KeyValueIterableView<T>{attributes});
+  }
+
+  void AddEvent(nostd::string_view name,
+                common::SystemTimestamp timestamp,
+                std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>
+                    attributes) noexcept
+  {
+    this->AddEvent(name, timestamp,
+                   nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                       attributes.begin(), attributes.end()});
+  }
+
+  void AddEvent(nostd::string_view name,
+                std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>
+                    attributes) noexcept
+  {
+    this->AddEvent(name, std::chrono::system_clock::now(),
+                   nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                       attributes.begin(), attributes.end()});
+  }
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+
+  /**
+   * Add link (ABI).
+   *
+   * See comments about sampling in @ref opentelemetry::trace::Span
+   *
+   * @since ABI_VERSION 2
+   */
+  virtual void AddLink(const SpanContext &target,
+                       const common::KeyValueIterable &attrs) noexcept = 0;
+
+  /**
+   * Add links (ABI).
+   *
+   * See comments about sampling in @ref opentelemetry::trace::Span
+   *
+   * @since ABI_VERSION 2
+   */
+  virtual void AddLinks(const SpanContextKeyValueIterable &links) noexcept = 0;
+
+  /**
+   * Add link (API helper).
+   *
+   * See comments about sampling in @ref opentelemetry::trace::Span
+   *
+   * @since ABI_VERSION 2
+   */
+  template <class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
+  void AddLink(const SpanContext &target, const U &attrs)
+  {
+    common::KeyValueIterableView<U> view(attrs);
+    this->AddLink(target, view);
+  }
+
+  /**
+   * Add link (API helper).
+   *
+   * See comments about sampling in @ref opentelemetry::trace::Span
+   *
+   * @since ABI_VERSION 2
+   */
+  void AddLink(const SpanContext &target,
+               std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attrs)
+  {
+    /* Build a container from std::initializer_list. */
+    nostd::span<const std::pair<nostd::string_view, common::AttributeValue>> container{
+        attrs.begin(), attrs.end()};
+
+    /* Build a view on the container. */
+    common::KeyValueIterableView<
+        nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>>
+        view(container);
+
+    return this->AddLink(target, view);
+  }
+
+  /**
+   * Add links (API helper).
+   *
+   * See comments about sampling in @ref opentelemetry::trace::Span
+   *
+   * @since ABI_VERSION 2
+   */
+  template <class U, nostd::enable_if_t<detail::is_span_context_kv_iterable<U>::value> * = nullptr>
+  void AddLinks(const U &links)
+  {
+    SpanContextKeyValueIterableView<U> view(links);
+    this->AddLinks(view);
+  }
+
+  /**
+   * Add links (API helper).
+   *
+   * See comments about sampling in @ref opentelemetry::trace::Span
+   *
+   * @since ABI_VERSION 2
+   */
+  void AddLinks(
+      std::initializer_list<
+          std::pair<SpanContext,
+                    std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>>>
+          links)
+  {
+    /* Build a container from std::initializer_list. */
+    nostd::span<const std::pair<
+        SpanContext, std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>>>
+        container{links.begin(), links.end()};
+
+    /* Build a view on the container. */
+    SpanContextKeyValueIterableView<nostd::span<const std::pair<
+        SpanContext, std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>>>>
+        view(container);
+
+    return this->AddLinks(view);
+  }
+
+#endif /* OPENTELEMETRY_ABI_VERSION_NO */
+
+  // Sets the status of the span. The default status is Unset. Only the value of
+  // the last call will be
+  // recorded, and implementations are free to ignore previous calls.
+  virtual void SetStatus(StatusCode code, nostd::string_view description = "") noexcept = 0;
+
+  // Updates the name of the Span. If used, this will override the name provided
+  // during creation.
+  virtual void UpdateName(nostd::string_view name) noexcept = 0;
+
+  /**
+   * Mark the end of the Span.
+   * Only the timing of the first End call for a given Span will be recorded,
+   * and implementations are free to ignore all further calls.
+   * @param options can be used to manually define span properties like the end
+   * timestamp
+   */
+  virtual void End(const trace::EndSpanOptions &options = {}) noexcept = 0;
+
+  virtual trace::SpanContext GetContext() const noexcept = 0;
+
+  // Returns true if this Span is recording tracing events (e.g. SetAttribute,
+  // AddEvent).
+  virtual bool IsRecording() const noexcept = 0;
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_context.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_context.h
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/span_id.h"
+#include "opentelemetry/trace/trace_flags.h"
+#include "opentelemetry/trace/trace_id.h"
+#include "opentelemetry/trace/trace_state.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+/* SpanContext contains the state that must propagate to child Spans and across
+ * process boundaries. It contains TraceId and SpanId, TraceFlags, TraceState
+ * and whether it was propagated from a remote parent.
+ */
+class SpanContext final
+{
+public:
+  /* A temporary constructor for an invalid SpanContext.
+   * Trace id and span id are set to invalid (all zeros).
+   *
+   * @param sampled_flag a required parameter specifying if child spans should be
+   * sampled
+   * @param is_remote true if this context was propagated from a remote parent.
+   */
+  SpanContext(bool sampled_flag, bool is_remote) noexcept
+      : trace_id_(),
+        span_id_(),
+        trace_flags_(trace::TraceFlags((uint8_t)sampled_flag)),
+        is_remote_(is_remote),
+        trace_state_(TraceState::GetDefault())
+  {}
+
+  SpanContext(TraceId trace_id,
+              SpanId span_id,
+              TraceFlags trace_flags,
+              bool is_remote,
+              nostd::shared_ptr<TraceState> trace_state = TraceState::GetDefault()) noexcept
+      : trace_id_(trace_id),
+        span_id_(span_id),
+        trace_flags_(trace_flags),
+        is_remote_(is_remote),
+        trace_state_(trace_state)
+  {}
+
+  SpanContext(const SpanContext &ctx) = default;
+
+  // @returns whether this context is valid
+  bool IsValid() const noexcept { return trace_id_.IsValid() && span_id_.IsValid(); }
+
+  // @returns the trace_flags associated with this span_context
+  const trace::TraceFlags &trace_flags() const noexcept { return trace_flags_; }
+
+  // @returns the trace_id associated with this span_context
+  const trace::TraceId &trace_id() const noexcept { return trace_id_; }
+
+  // @returns the span_id associated with this span_context
+  const trace::SpanId &span_id() const noexcept { return span_id_; }
+
+  // @returns the trace_state associated with this span_context
+  const nostd::shared_ptr<trace::TraceState> trace_state() const noexcept { return trace_state_; }
+
+  /*
+   * @param that SpanContext for comparing.
+   * @return true if `that` equals the current SpanContext.
+   * N.B. trace_state is ignored for the comparison.
+   */
+  bool operator==(const SpanContext &that) const noexcept
+  {
+    return trace_id() == that.trace_id() && span_id() == that.span_id() &&
+           trace_flags() == that.trace_flags();
+  }
+
+  SpanContext &operator=(const SpanContext &ctx) = default;
+
+  bool IsRemote() const noexcept { return is_remote_; }
+
+  static SpanContext GetInvalid() noexcept { return SpanContext(false, false); }
+
+  bool IsSampled() const noexcept { return trace_flags_.IsSampled(); }
+
+private:
+  trace::TraceId trace_id_;
+  trace::SpanId span_id_;
+  trace::TraceFlags trace_flags_;
+  bool is_remote_;
+  nostd::shared_ptr<trace::TraceState> trace_state_;
+};
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_context_kv_iterable.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_context_kv_iterable.h
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/trace/span_context.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+/**
+ * Supports internal iteration over a collection of SpanContext/key-value pairs.
+ */
+class SpanContextKeyValueIterable
+{
+public:
+  virtual ~SpanContextKeyValueIterable() = default;
+
+  /**
+   * Iterate over SpanContext/key-value pairs
+   * @param callback a callback to invoke for each key-value for each SpanContext.
+   * If the callback returns false, the iteration is aborted.
+   * @return true if every SpanContext/key-value pair was iterated over
+   */
+  virtual bool ForEachKeyValue(
+      nostd::function_ref<bool(SpanContext, const common::KeyValueIterable &)> callback)
+      const noexcept = 0;
+  /**
+   * @return the number of key-value pairs
+   */
+  virtual size_t size() const noexcept = 0;
+};
+
+/**
+ * @brief Null Span context that does not carry any information.
+ */
+class NullSpanContext : public SpanContextKeyValueIterable
+{
+public:
+  bool ForEachKeyValue(nostd::function_ref<bool(SpanContext, const common::KeyValueIterable &)>
+                       /* callback */) const noexcept override
+  {
+    return true;
+  }
+
+  size_t size() const noexcept override { return 0; }
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_context_kv_iterable_view.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_context_kv_iterable_view.h
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/utility.h"
+#include "opentelemetry/trace/span_context.h"
+#include "opentelemetry/trace/span_context_kv_iterable.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+// NOTE - code within `detail` namespace implements internal details, and not part
+// of the public interface.
+namespace detail
+{
+template <class T>
+inline void take_span_context_kv(SpanContext, opentelemetry::common::KeyValueIterableView<T>)
+{}
+
+template <class T, nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+inline void take_span_context_kv(SpanContext, T &)
+{}
+
+inline void take_span_context_kv(
+    SpanContext,
+    std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>)
+{}
+
+template <class T>
+auto is_span_context_kv_iterable_impl(T iterable)
+    -> decltype(take_span_context_kv(std::begin(iterable)->first, std::begin(iterable)->second),
+                nostd::size(iterable),
+                std::true_type{});
+
+std::false_type is_span_context_kv_iterable_impl(...);
+
+template <class T>
+struct is_span_context_kv_iterable
+{
+  static const bool value =
+      decltype(detail::is_span_context_kv_iterable_impl(std::declval<T>()))::value;
+};
+}  // namespace detail
+
+template <class T>
+class SpanContextKeyValueIterableView final : public SpanContextKeyValueIterable
+{
+  static_assert(detail::is_span_context_kv_iterable<T>::value,
+                "Must be a context/key-value iterable");
+
+public:
+  explicit SpanContextKeyValueIterableView(const T &links) noexcept : container_{&links} {}
+
+  bool ForEachKeyValue(nostd::function_ref<bool(SpanContext, const common::KeyValueIterable &)>
+                           callback) const noexcept override
+  {
+    auto iter = std::begin(*container_);
+    auto last = std::end(*container_);
+    for (; iter != last; ++iter)
+    {
+      if (!this->do_callback(iter->first, iter->second, callback))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  size_t size() const noexcept override { return nostd::size(*container_); }
+
+private:
+  const T *container_;
+
+  bool do_callback(SpanContext span_context,
+                   const common::KeyValueIterable &attributes,
+                   nostd::function_ref<bool(SpanContext, const common::KeyValueIterable &)>
+                       callback) const noexcept
+  {
+    if (!callback(span_context, attributes))
+    {
+      return false;
+    }
+    return true;
+  }
+
+  template <class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
+  bool do_callback(SpanContext span_context,
+                   const U &attributes,
+                   nostd::function_ref<bool(SpanContext, const common::KeyValueIterable &)>
+                       callback) const noexcept
+  {
+    return do_callback(span_context, common::KeyValueIterableView<U>(attributes), callback);
+  }
+
+  bool do_callback(
+      SpanContext span_context,
+      std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes,
+      nostd::function_ref<bool(SpanContext, const common::KeyValueIterable &)> callback)
+      const noexcept
+  {
+    return do_callback(span_context,
+                       nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                           attributes.begin(), attributes.end()},
+                       callback);
+  }
+};
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_id.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_id.h
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+class SpanId final
+{
+public:
+  // The size in bytes of the SpanId.
+  static constexpr int kSize = 8;
+
+  // An invalid SpanId (all zeros).
+  SpanId() noexcept : rep_{0} {}
+
+  // Creates a SpanId with the given ID.
+  explicit SpanId(nostd::span<const uint8_t, kSize> id) noexcept { memcpy(rep_, id.data(), kSize); }
+
+  // Populates the buffer with the lowercase base16 representation of the ID.
+  void ToLowerBase16(nostd::span<char, 2 * kSize> buffer) const noexcept
+  {
+    constexpr char kHex[] = "0123456789abcdef";
+    for (int i = 0; i < kSize; ++i)
+    {
+      buffer[i * 2 + 0] = kHex[(rep_[i] >> 4) & 0xF];
+      buffer[i * 2 + 1] = kHex[(rep_[i] >> 0) & 0xF];
+    }
+  }
+
+  // Returns a nostd::span of the ID.
+  nostd::span<const uint8_t, kSize> Id() const noexcept
+  {
+    return nostd::span<const uint8_t, kSize>(rep_);
+  }
+
+  bool operator==(const SpanId &that) const noexcept { return memcmp(rep_, that.rep_, kSize) == 0; }
+
+  bool operator!=(const SpanId &that) const noexcept { return !(*this == that); }
+
+  // Returns false if the SpanId is all zeros.
+  bool IsValid() const noexcept
+  {
+    static constexpr uint8_t kEmptyRep[kSize] = {0};
+    return memcmp(rep_, kEmptyRep, kSize) != 0;
+  }
+
+  // Copies the opaque SpanId data to dest.
+  void CopyBytesTo(nostd::span<uint8_t, kSize> dest) const noexcept
+  {
+    memcpy(dest.data(), rep_, kSize);
+  }
+
+private:
+  uint8_t rep_[kSize];
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_metadata.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_metadata.h
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/timestamp.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+enum class SpanKind
+{
+  kInternal,
+  kServer,
+  kClient,
+  kProducer,
+  kConsumer,
+};
+
+// The key identifies the active span in the current context.
+constexpr char kSpanKey[]       = "active_span";
+constexpr char kIsRootSpanKey[] = "is_root_span";
+
+// StatusCode - Represents the canonical set of status codes of a finished Span.
+enum class StatusCode
+{
+  kUnset,  // default status
+  kOk,     // Operation has completed successfully.
+  kError   // The operation contains an error
+};
+
+/**
+ * EndSpanOptions provides options to set properties of a Span when it is
+ * ended.
+ */
+struct EndSpanOptions
+{
+  // Optionally sets the end time of a Span.
+  common::SteadyTimestamp end_steady_time;
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_startoptions.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/span_startoptions.h
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/timestamp.h"
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/nostd/variant.h"
+#include "opentelemetry/trace/span_context.h"
+#include "opentelemetry/trace/span_metadata.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+/**
+ * StartSpanOptions provides options to set properties of a Span at the time of
+ * its creation
+ */
+struct StartSpanOptions
+{
+  // Optionally sets the start time of a Span.
+  //
+  // If the start time of a Span is set, timestamps from both the system clock
+  // and steady clock must be provided.
+  //
+  // Timestamps from the steady clock can be used to most accurately measure a
+  // Span's duration, while timestamps from the system clock can be used to most
+  // accurately place a Span's
+  // time point relative to other Spans collected across a distributed system.
+  common::SystemTimestamp start_system_time;
+  common::SteadyTimestamp start_steady_time;
+
+  // Explicitly set the parent of a Span.
+  //
+  // The `parent` field is designed to establish  parent-child relationships
+  // in tracing spans. It can be set to either a `SpanContext` or a
+  // `context::Context` object.
+  //
+  // - When set to valid `SpanContext`, it directly assigns a specific Span as the parent
+  // of the newly created Span.
+  //
+  // - Alternatively, setting the `parent` field to a `context::Context` allows for
+  // more nuanced parent identification:
+  //   1. If the `Context` contains a Span object, this Span is treated as the parent.
+  //   2. If the `Context` contains the boolean flag `is_root_span` set to `true`,
+  //      it indicates that the new Span should be treated as a root Span, i.e., it
+  //      does not have a parent Span.
+  //   Example Usage:
+  //   ```cpp
+  //   trace_api::StartSpanOptions options;
+  //   opentelemetry::context::Context root;
+  //   root                    = root.SetValue(kIsRootSpanKey, true);
+  //   options.parent = root;
+  //   auto root_span = tracer->StartSpan("span root", options);
+  //  ```
+  //
+  // - If the `parent` field is not set, the newly created Span will inherit the
+  // parent of the currently active Span (if any) in the current context.
+  //
+  nostd::variant<SpanContext, context::Context> parent = SpanContext::GetInvalid();
+
+  // TODO:
+  // SpanContext remote_parent;
+  // Links
+  SpanKind kind = SpanKind::kInternal;
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/trace_flags.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/trace_flags.h
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+// TraceFlags represents options for a Trace. These options are propagated to all child Spans
+// and determine features such as whether a Span should be traced. TraceFlags
+// are implemented as a bitmask.
+class TraceFlags final
+{
+public:
+  static constexpr uint8_t kIsSampled = 1;
+  static constexpr uint8_t kIsRandom  = 2;
+
+  /**
+   * Valid flags in W3C Trace Context version 1.
+   * See https://www.w3.org/TR/trace-context-1/#trace-flags
+   */
+  static constexpr uint8_t kAllW3CTraceContext1Flags = kIsSampled;
+
+  /**
+   * Valid flags in W3C Trace Context version 2.
+   * See https://www.w3.org/TR/trace-context-1/#trace-flags
+   */
+  static constexpr uint8_t kAllW3CTraceContext2Flags = kIsSampled | kIsRandom;
+
+  TraceFlags() noexcept : rep_{0} {}
+
+  explicit TraceFlags(uint8_t flags) noexcept : rep_(flags) {}
+
+  bool IsSampled() const noexcept { return rep_ & kIsSampled; }
+
+  bool IsRandom() const noexcept { return rep_ & kIsRandom; }
+
+  // Populates the buffer with the lowercase base16 representation of the flags.
+  void ToLowerBase16(nostd::span<char, 2> buffer) const noexcept
+  {
+    constexpr char kHex[] = "0123456789ABCDEF";
+    buffer[0]             = kHex[(rep_ >> 4) & 0xF];
+    buffer[1]             = kHex[(rep_ >> 0) & 0xF];
+  }
+
+  uint8_t flags() const noexcept { return rep_; }
+
+  bool operator==(const TraceFlags &that) const noexcept { return rep_ == that.rep_; }
+
+  bool operator!=(const TraceFlags &that) const noexcept { return !(*this == that); }
+
+  // Copies the TraceFlags to dest.
+  void CopyBytesTo(nostd::span<uint8_t, 1> dest) const noexcept { dest[0] = rep_; }
+
+private:
+  uint8_t rep_;
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/trace_id.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/trace_id.h
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+// TraceId represents an opaque 128-bit trace identifier. The trace identifier
+// remains constant across the trace. A valid trace identifier is a 16-byte array with at
+// least one non-zero byte.
+class TraceId final
+{
+public:
+  // The size in bytes of the TraceId.
+  static constexpr int kSize = 16;
+
+  // An invalid TraceId (all zeros).
+  TraceId() noexcept : rep_{0} {}
+
+  // Creates a TraceId with the given ID.
+  explicit TraceId(nostd::span<const uint8_t, kSize> id) noexcept
+  {
+    memcpy(rep_, id.data(), kSize);
+  }
+
+  // Populates the buffer with the lowercase base16 representation of the ID.
+  void ToLowerBase16(nostd::span<char, 2 * kSize> buffer) const noexcept
+  {
+    constexpr char kHex[] = "0123456789abcdef";
+    for (int i = 0; i < kSize; ++i)
+    {
+      buffer[i * 2 + 0] = kHex[(rep_[i] >> 4) & 0xF];
+      buffer[i * 2 + 1] = kHex[(rep_[i] >> 0) & 0xF];
+    }
+  }
+
+  // Returns a nostd::span of the ID.
+  nostd::span<const uint8_t, kSize> Id() const noexcept
+  {
+    return nostd::span<const uint8_t, kSize>(rep_);
+  }
+
+  bool operator==(const TraceId &that) const noexcept
+  {
+    return memcmp(rep_, that.rep_, kSize) == 0;
+  }
+
+  bool operator!=(const TraceId &that) const noexcept { return !(*this == that); }
+
+  // Returns false if the TraceId is all zeros.
+  bool IsValid() const noexcept { return *this != TraceId(); }
+
+  // Copies the opaque TraceId data to dest.
+  void CopyBytesTo(nostd::span<uint8_t, kSize> dest) const noexcept
+  {
+    memcpy(dest.data(), rep_, kSize);
+  }
+
+private:
+  uint8_t rep_[kSize];
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/trace_state.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/trace_state.h
@@ -1,0 +1,321 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "opentelemetry/common/kv_properties.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/version.h"
+
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
+#  include <regex>
+#endif
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+/**
+ * TraceState carries tracing-system specific context in a list of key-value pairs. TraceState
+ * allows different vendors to propagate additional information and inter-operate with their legacy
+ * id formats.
+ *
+ * For more information, see the W3C Trace Context specification:
+ * https://www.w3.org/TR/trace-context
+ */
+class OPENTELEMETRY_EXPORT TraceState
+{
+public:
+  static constexpr int kKeyMaxSize         = 256;
+  static constexpr int kValueMaxSize       = 256;
+  static constexpr int kMaxKeyValuePairs   = 32;
+  static constexpr auto kKeyValueSeparator = '=';
+  static constexpr auto kMembersSeparator  = ',';
+
+  OPENTELEMETRY_API_SINGLETON static nostd::shared_ptr<TraceState> GetDefault()
+  {
+    static nostd::shared_ptr<TraceState> ts{new TraceState()};
+    return ts;
+  }
+
+  /**
+   * Returns shared_ptr to a newly created TraceState parsed from the header provided.
+   * @param header Encoding of the tracestate header defined by
+   * the W3C Trace Context specification https://www.w3.org/TR/trace-context/
+   * @return TraceState A new TraceState instance or DEFAULT
+   */
+  static nostd::shared_ptr<TraceState> FromHeader(nostd::string_view header) noexcept
+  {
+
+    common::KeyValueStringTokenizer kv_str_tokenizer(header);
+    size_t cnt = kv_str_tokenizer.NumTokens();  // upper bound on number of kv pairs
+    if (cnt > kMaxKeyValuePairs)
+    {
+      cnt = kMaxKeyValuePairs;
+    }
+
+    nostd::shared_ptr<TraceState> ts(new TraceState(cnt));
+    bool kv_valid;
+    nostd::string_view key, value;
+    while (kv_str_tokenizer.next(kv_valid, key, value) && ts->kv_properties_->Size() < cnt)
+    {
+      if (kv_valid == false)
+      {
+        return GetDefault();
+      }
+
+      if (!IsValidKey(key) || !IsValidValue(value))
+      {
+        // invalid header. return empty TraceState
+        ts->kv_properties_.reset(new common::KeyValueProperties());
+        break;
+      }
+
+      ts->kv_properties_->AddEntry(key, value);
+    }
+
+    return ts;
+  }
+
+  /**
+   * Creates a w3c tracestate header from TraceState object
+   */
+  std::string ToHeader() const noexcept
+  {
+    std::string header_s;
+    bool first = true;
+    kv_properties_->GetAllEntries(
+        [&header_s, &first](nostd::string_view key, nostd::string_view value) noexcept {
+          if (!first)
+          {
+            header_s.append(",");
+          }
+          else
+          {
+            first = false;
+          }
+          header_s.append(std::string(key.data(), key.size()));
+          header_s.append(1, kKeyValueSeparator);
+          header_s.append(std::string(value.data(), value.size()));
+          return true;
+        });
+    return header_s;
+  }
+
+  /**
+   *  Returns `value` associated with `key` passed as argument
+   *  Returns empty string if key is invalid  or not found
+   */
+  bool Get(nostd::string_view key, std::string &value) const noexcept
+  {
+    if (!IsValidKey(key))
+    {
+      return false;
+    }
+
+    return kv_properties_->GetValue(key, value);
+  }
+
+  /**
+   * Returns shared_ptr of `new` TraceState object with following mutations applied to the existing
+   * instance: Update Key value: The updated value must be moved to beginning of List Add : The new
+   * key-value pair SHOULD be added to beginning of List
+   *
+   * If the provided key-value pair is invalid, or results in transtate that violates the
+   * tracecontext specification, empty TraceState instance will be returned.
+   *
+   * If the existing object has maximum list members, it's copy is returned.
+   */
+  nostd::shared_ptr<TraceState> Set(const nostd::string_view &key,
+                                    const nostd::string_view &value) noexcept
+  {
+    auto curr_size = kv_properties_->Size();
+    if (!IsValidKey(key) || !IsValidValue(value))
+    {
+      // max size reached or invalid key/value. Returning empty TraceState
+      return TraceState::GetDefault();
+    }
+    auto allocate_size = curr_size;
+    if (curr_size < kMaxKeyValuePairs)
+    {
+      allocate_size += 1;
+    }
+    nostd::shared_ptr<TraceState> ts(new TraceState(allocate_size));
+    if (curr_size < kMaxKeyValuePairs)
+    {
+      // add new field first
+      ts->kv_properties_->AddEntry(key, value);
+    }
+    // add rest of the fields.
+    kv_properties_->GetAllEntries([&ts](nostd::string_view key, nostd::string_view value) {
+      ts->kv_properties_->AddEntry(key, value);
+      return true;
+    });
+    return ts;
+  }
+
+  /**
+   * Returns shared_ptr to a `new` TraceState object after removing the attribute with given key (
+   * if present )
+   * @returns empty TraceState object if key is invalid
+   * @returns copy of original TraceState object if key is not present (??)
+   */
+  nostd::shared_ptr<TraceState> Delete(const nostd::string_view &key) noexcept
+  {
+    if (!IsValidKey(key))
+    {
+      return TraceState::GetDefault();
+    }
+    auto curr_size     = kv_properties_->Size();
+    auto allocate_size = curr_size;
+    std::string unused;
+    if (kv_properties_->GetValue(key, unused))
+    {
+      allocate_size -= 1;
+    }
+    nostd::shared_ptr<TraceState> ts(new TraceState(allocate_size));
+    kv_properties_->GetAllEntries(
+        [&ts, &key](nostd::string_view e_key, nostd::string_view e_value) {
+          if (key != e_key)
+            ts->kv_properties_->AddEntry(e_key, e_value);
+          return true;
+        });
+    return ts;
+  }
+
+  // Returns true if there are no keys, false otherwise.
+  bool Empty() const noexcept { return kv_properties_->Size() == 0; }
+
+  // @return all key-values entris by repeatedly invoking the function reference passed as argument
+  // for each entry
+  bool GetAllEntries(
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)> callback) const noexcept
+  {
+    return kv_properties_->GetAllEntries(callback);
+  }
+  /** Returns whether key is a valid key. See https://www.w3.org/TR/trace-context/#key
+   * Identifiers MUST begin with a lowercase letter or a digit, and can only contain
+   * lowercase letters (a-z), digits (0-9), underscores (_), dashes (-), asterisks (*),
+   * and forward slashes (/).
+   * For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the vendor name.
+   *
+   */
+  static bool IsValidKey(nostd::string_view key)
+  {
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
+    return IsValidKeyRegEx(key);
+#else
+    return IsValidKeyNonRegEx(key);
+#endif
+  }
+
+  /** Returns whether value is a valid value. See https://www.w3.org/TR/trace-context/#value
+   * The value is an opaque string containing up to 256 printable ASCII (RFC0020)
+   *  characters ((i.e., the range 0x20 to 0x7E) except comma , and equal =)
+   */
+  static bool IsValidValue(nostd::string_view value)
+  {
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
+    return IsValidValueRegEx(value);
+#else
+    return IsValidValueNonRegEx(value);
+#endif
+  }
+
+private:
+  TraceState() : kv_properties_(new common::KeyValueProperties()) {}
+  TraceState(size_t size) : kv_properties_(new common::KeyValueProperties(size)) {}
+
+  static nostd::string_view TrimString(nostd::string_view str, size_t left, size_t right)
+  {
+    while (str[static_cast<std::size_t>(right)] == ' ' && left < right)
+    {
+      right--;
+    }
+    while (str[static_cast<std::size_t>(left)] == ' ' && left < right)
+    {
+      left++;
+    }
+    return str.substr(left, right - left + 1);
+  }
+
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
+  static bool IsValidKeyRegEx(nostd::string_view key)
+  {
+    static std::regex reg_key("^[a-z0-9][a-z0-9*_\\-/]{0,255}$");
+    static std::regex reg_key_multitenant(
+        "^[a-z0-9][a-z0-9*_\\-/]{0,240}(@)[a-z0-9][a-z0-9*_\\-/]{0,13}$");
+    std::string key_s(key.data(), key.size());
+    if (std::regex_match(key_s, reg_key) || std::regex_match(key_s, reg_key_multitenant))
+    {
+      return true;
+    }
+    return false;
+  }
+
+  static bool IsValidValueRegEx(nostd::string_view value)
+  {
+    // Hex 0x20 to 0x2B, 0x2D to 0x3C, 0x3E to 0x7E
+    static std::regex reg_value(
+        "^[\\x20-\\x2B\\x2D-\\x3C\\x3E-\\x7E]{0,255}[\\x21-\\x2B\\x2D-\\x3C\\x3E-\\x7E]$");
+    // Need to benchmark without regex, as a string object is created here.
+    return std::regex_match(std::string(value.data(), value.size()), reg_value);
+  }
+#else
+  static bool IsValidKeyNonRegEx(nostd::string_view key)
+  {
+    if (key.empty() || key.size() > kKeyMaxSize || !IsLowerCaseAlphaOrDigit(key[0]))
+    {
+      return false;
+    }
+
+    int ats = 0;
+
+    for (const char c : key)
+    {
+      if (!IsLowerCaseAlphaOrDigit(c) && c != '_' && c != '-' && c != '@' && c != '*' && c != '/')
+      {
+        return false;
+      }
+      if ((c == '@') && (++ats > 1))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static bool IsValidValueNonRegEx(nostd::string_view value)
+  {
+    if (value.empty() || value.size() > kValueMaxSize)
+    {
+      return false;
+    }
+
+    for (const char c : value)
+    {
+      if (c < ' ' || c > '~' || c == ',' || c == '=')
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+#endif
+
+  static bool IsLowerCaseAlphaOrDigit(char c) { return isdigit(c) || islower(c); }
+
+private:
+  // Store entries in a C-style array to avoid using std::array or std::vector.
+  nostd::unique_ptr<common::KeyValueProperties> kv_properties_;
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/tracer.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/tracer.h
@@ -1,0 +1,193 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <chrono>
+
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/trace/scope.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/trace/span_context_kv_iterable_view.h"
+#include "opentelemetry/trace/span_startoptions.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+/**
+ * Handles span creation and in-process context propagation.
+ *
+ * This class provides methods for manipulating the context, creating spans, and controlling spans'
+ * lifecycles.
+ */
+class Tracer
+{
+public:
+  virtual ~Tracer() = default;
+  /**
+   * Starts a span.
+   *
+   * Optionally sets attributes at Span creation from the given key/value pairs.
+   *
+   * Attributes will be processed in order, previous attributes with the same
+   * key will be overwritten.
+   */
+  virtual nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
+                                            const common::KeyValueIterable &attributes,
+                                            const SpanContextKeyValueIterable &links,
+                                            const StartSpanOptions &options = {}) noexcept = 0;
+
+  nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
+                                    const StartSpanOptions &options = {}) noexcept
+  {
+    return this->StartSpan(name, {}, {}, options);
+  }
+
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+  nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
+                                    const T &attributes,
+                                    const StartSpanOptions &options = {}) noexcept
+  {
+    return this->StartSpan(name, attributes, {}, options);
+  }
+
+  nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
+                                    const common::KeyValueIterable &attributes,
+                                    const StartSpanOptions &options = {}) noexcept
+  {
+    return this->StartSpan(name, attributes, NullSpanContext(), options);
+  }
+
+  template <class T,
+            class U,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr,
+            nostd::enable_if_t<detail::is_span_context_kv_iterable<U>::value> *   = nullptr>
+  nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
+                                    const T &attributes,
+                                    const U &links,
+                                    const StartSpanOptions &options = {}) noexcept
+  {
+    return this->StartSpan(name, common::KeyValueIterableView<T>(attributes),
+                           SpanContextKeyValueIterableView<U>(links), options);
+  }
+
+  nostd::shared_ptr<Span> StartSpan(
+      nostd::string_view name,
+      std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes,
+      const StartSpanOptions &options = {}) noexcept
+  {
+
+    return this->StartSpan(name, attributes, {}, options);
+  }
+
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+  nostd::shared_ptr<Span> StartSpan(
+      nostd::string_view name,
+      const T &attributes,
+      std::initializer_list<
+          std::pair<SpanContext,
+                    std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>>>
+          links,
+      const StartSpanOptions &options = {}) noexcept
+  {
+    return this->StartSpan(
+        name, attributes,
+        nostd::span<const std::pair<SpanContext, std::initializer_list<std::pair<
+                                                     nostd::string_view, common::AttributeValue>>>>{
+            links.begin(), links.end()},
+        options);
+  }
+
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+  nostd::shared_ptr<Span> StartSpan(
+      nostd::string_view name,
+      std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes,
+      const T &links,
+      const StartSpanOptions &options = {}) noexcept
+  {
+    return this->StartSpan(name,
+                           nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
+                               attributes.begin(), attributes.end()},
+                           links, options);
+  }
+
+  nostd::shared_ptr<Span> StartSpan(
+      nostd::string_view name,
+      std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes,
+      std::initializer_list<
+          std::pair<SpanContext,
+                    std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>>>
+          links,
+      const StartSpanOptions &options = {}) noexcept
+  {
+    return this->StartSpan(
+        name,
+        nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{attributes.begin(),
+                                                                                 attributes.end()},
+        nostd::span<const std::pair<SpanContext, std::initializer_list<std::pair<
+                                                     nostd::string_view, common::AttributeValue>>>>{
+            links.begin(), links.end()},
+        options);
+  }
+
+  /**
+   * Set the active span. The span will remain active until the returned Scope
+   * object is destroyed.
+   * @param span the span that should be set as the new active span.
+   * @return a Scope that controls how long the span will be active.
+   */
+  static Scope WithActiveSpan(nostd::shared_ptr<Span> &span) noexcept { return Scope{span}; }
+
+  /**
+   * Get the currently active span.
+   * @return the currently active span, or an invalid default span if no span
+   * is active.
+   */
+  static nostd::shared_ptr<Span> GetCurrentSpan() noexcept
+  {
+    context::ContextValue active_span = context::RuntimeContext::GetValue(kSpanKey);
+    if (nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span))
+    {
+      return nostd::get<nostd::shared_ptr<Span>>(active_span);
+    }
+    else
+    {
+      return nostd::shared_ptr<Span>(new DefaultSpan(SpanContext::GetInvalid()));
+    }
+  }
+
+  /**
+   * Force any buffered spans to flush.
+   * @param timeout to complete the flush
+   */
+  template <class Rep, class Period>
+  void ForceFlush(std::chrono::duration<Rep, Period> timeout) noexcept
+  {
+    this->ForceFlushWithMicroseconds(static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(timeout).count()));
+  }
+
+  virtual void ForceFlushWithMicroseconds(uint64_t timeout) noexcept = 0;
+
+  /**
+   * ForceFlush any buffered spans and stop reporting spans.
+   * @param timeout to complete the flush
+   */
+  template <class Rep, class Period>
+  void Close(std::chrono::duration<Rep, Period> timeout) noexcept
+  {
+    this->CloseWithMicroseconds(static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(timeout).count()));
+  }
+
+  virtual void CloseWithMicroseconds(uint64_t timeout) noexcept = 0;
+};
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/tracer_provider.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/trace/tracer_provider.h
@@ -1,0 +1,127 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/key_value_iterable.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+
+class Tracer;
+
+/**
+ * Creates new Tracer instances.
+ */
+class OPENTELEMETRY_EXPORT TracerProvider
+{
+public:
+  virtual ~TracerProvider() = default;
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+
+  /**
+   * Gets or creates a named Tracer instance (ABI).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Tracer instrumentation scope
+   * @param[in] version Instrumentation scope version
+   * @param[in] schema_url Instrumentation scope schema URL
+   * @param[in] attributes Instrumentation scope attributes (optional, may be nullptr)
+   */
+  virtual nostd::shared_ptr<Tracer> GetTracer(
+      nostd::string_view name,
+      nostd::string_view version,
+      nostd::string_view schema_url,
+      const common::KeyValueIterable *attributes) noexcept = 0;
+
+  /**
+   * Gets or creates a named Tracer instance (API helper).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Tracer instrumentation scope
+   * @param[in] version Instrumentation scope version, optional
+   * @param[in] schema_url Instrumentation scope schema URL, optional
+   */
+  nostd::shared_ptr<Tracer> GetTracer(nostd::string_view name,
+                                      nostd::string_view version    = "",
+                                      nostd::string_view schema_url = "")
+  {
+    return GetTracer(name, version, schema_url, nullptr);
+  }
+
+  /**
+   * Gets or creates a named Tracer instance (API helper).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Tracer instrumentation scope
+   * @param[in] version Instrumentation scope version
+   * @param[in] schema_url Instrumentation scope schema URL
+   * @param[in] attributes Instrumentation scope attributes
+   */
+  nostd::shared_ptr<Tracer> GetTracer(
+      nostd::string_view name,
+      nostd::string_view version,
+      nostd::string_view schema_url,
+      std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes)
+  {
+    /* Build a container from std::initializer_list. */
+    nostd::span<const std::pair<nostd::string_view, common::AttributeValue>> attributes_span{
+        attributes.begin(), attributes.end()};
+
+    /* Build a view on the container. */
+    common::KeyValueIterableView<
+        nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>>
+        iterable_attributes{attributes_span};
+
+    /* Add attributes using the view. */
+    return GetTracer(name, version, schema_url, &iterable_attributes);
+  }
+
+  /**
+   * Gets or creates a named Tracer instance (API helper).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Tracer instrumentation scope
+   * @param[in] version Instrumentation scope version
+   * @param[in] schema_url Instrumentation scope schema URL
+   * @param[in] attributes Instrumentation scope attributes container
+   */
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+  nostd::shared_ptr<Tracer> GetTracer(nostd::string_view name,
+                                      nostd::string_view version,
+                                      nostd::string_view schema_url,
+                                      const T &attributes)
+  {
+    /* Build a view on the container. */
+    common::KeyValueIterableView<T> iterable_attributes(attributes);
+
+    /* Add attributes using the view. */
+    return GetTracer(name, version, schema_url, &iterable_attributes);
+  }
+
+#else
+
+  /**
+   * Gets or creates a named tracer instance.
+   *
+   * Optionally a version can be passed to create a named and versioned tracer
+   * instance.
+   */
+  virtual nostd::shared_ptr<Tracer> GetTracer(nostd::string_view name,
+                                              nostd::string_view version    = "",
+                                              nostd::string_view schema_url = "") noexcept = 0;
+#endif
+};
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/third_party/opentelemetry-cpp/api/include/opentelemetry/version.h
+++ b/third_party/opentelemetry-cpp/api/include/opentelemetry/version.h
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/common/macros.h"
+#include "opentelemetry/detail/preprocessor.h"
+
+#ifndef OPENTELEMETRY_ABI_VERSION_NO
+#  define OPENTELEMETRY_ABI_VERSION_NO 1
+#endif
+
+#define OPENTELEMETRY_VERSION "1.14.2"
+#define OPENTELEMETRY_VERSION_MAJOR 1
+#define OPENTELEMETRY_VERSION_MINOR 14
+#define OPENTELEMETRY_VERSION_PATCH 2
+
+#define OPENTELEMETRY_ABI_VERSION OPENTELEMETRY_STRINGIFY(OPENTELEMETRY_ABI_VERSION_NO)
+
+// clang-format off
+#define OPENTELEMETRY_BEGIN_NAMESPACE \
+  namespace opentelemetry { inline namespace OPENTELEMETRY_CONCAT(v, OPENTELEMETRY_ABI_VERSION_NO) {
+
+#define OPENTELEMETRY_END_NAMESPACE \
+  }}
+
+#define OPENTELEMETRY_NAMESPACE opentelemetry :: OPENTELEMETRY_CONCAT(v, OPENTELEMETRY_ABI_VERSION_NO)
+
+// clang-format on

--- a/third_party/opentelemetry-cpp/api/test/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(core)
+add_subdirectory(context)
+add_subdirectory(plugin)
+add_subdirectory(nostd)
+add_subdirectory(trace)
+add_subdirectory(metrics)
+add_subdirectory(logs)
+add_subdirectory(common)
+add_subdirectory(baggage)
+add_subdirectory(singleton)

--- a/third_party/opentelemetry-cpp/api/test/baggage/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/baggage/BUILD
@@ -1,0 +1,30 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+cc_test(
+    name = "baggage_test",
+    srcs = [
+        "baggage_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+otel_cc_benchmark(
+    name = "baggage_benchmark",
+    srcs = ["baggage_benchmark.cc"],
+    tags = [
+        "api",
+        "benchmark",
+        "test",
+    ],
+    deps = ["//api"],
+)

--- a/third_party/opentelemetry-cpp/api/test/baggage/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/baggage/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+include(GoogleTest)
+
+foreach(testname baggage_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX baggage.
+    TEST_LIST ${testname})
+endforeach()
+
+if(WITH_BENCHMARK)
+  add_executable(baggage_benchmark baggage_benchmark.cc)
+  target_link_libraries(baggage_benchmark benchmark::benchmark
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+endif()
+add_subdirectory(propagation)

--- a/third_party/opentelemetry-cpp/api/test/baggage/baggage_benchmark.cc
+++ b/third_party/opentelemetry-cpp/api/test/baggage/baggage_benchmark.cc
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/baggage/baggage.h"
+#include "opentelemetry/nostd/string_view.h"
+
+#include <benchmark/benchmark.h>
+#include <cstdint>
+
+using namespace opentelemetry::baggage;
+namespace nostd = opentelemetry::nostd;
+
+namespace
+{
+
+const size_t kNumEntries = 10;
+
+std::string header_with_custom_entries(size_t num_entries)
+{
+  std::string header;
+  for (size_t i = 0; i < num_entries; i++)
+  {
+    std::string key   = "ADecentlyLargekey" + std::to_string(i);
+    std::string value = "ADecentlyLargeValue" + std::to_string(i);
+    header += key + "=" + value;
+    if (i != num_entries - 1)
+    {
+      header += ",";
+    }
+  }
+  return header;
+}
+
+void BM_CreateBaggageFromTenEntries(benchmark::State &state)
+{
+  std::string header = header_with_custom_entries(kNumEntries);
+  while (state.KeepRunning())
+  {
+    auto baggage = Baggage::FromHeader(header);
+  }
+}
+BENCHMARK(BM_CreateBaggageFromTenEntries);
+
+void BM_ExtractBaggageHavingTenEntries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(kNumEntries));
+  while (state.KeepRunning())
+  {
+    baggage->GetAllEntries(
+        [](nostd::string_view /* key */, nostd::string_view /* value */) { return true; });
+  }
+}
+BENCHMARK(BM_ExtractBaggageHavingTenEntries);
+
+void BM_CreateBaggageFrom180Entries(benchmark::State &state)
+{
+  std::string header = header_with_custom_entries(Baggage::kMaxKeyValuePairs);
+  while (state.KeepRunning())
+  {
+    auto baggage = Baggage::FromHeader(header);
+  }
+}
+BENCHMARK(BM_CreateBaggageFrom180Entries);
+
+void BM_ExtractBaggageWith180Entries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(Baggage::kMaxKeyValuePairs));
+  while (state.KeepRunning())
+  {
+    baggage->GetAllEntries(
+        [](nostd::string_view /* key */, nostd::string_view /* value */) { return true; });
+  }
+}
+BENCHMARK(BM_ExtractBaggageWith180Entries);
+
+void BM_SetValueBaggageWithTenEntries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(
+      header_with_custom_entries(kNumEntries - 1));  // 9 entries, and add one new
+  while (state.KeepRunning())
+  {
+    auto new_baggage = baggage->Set("new_key", "new_value");
+  }
+}
+BENCHMARK(BM_SetValueBaggageWithTenEntries);
+
+void BM_SetValueBaggageWith180Entries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(
+      Baggage::kMaxKeyValuePairs - 1));  // keep 179 entries, and add one new
+  while (state.KeepRunning())
+  {
+    auto new_baggage = baggage->Set("new_key", "new_value");
+  }
+}
+BENCHMARK(BM_SetValueBaggageWith180Entries);
+
+void BM_BaggageToHeaderTenEntries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(kNumEntries));
+  while (state.KeepRunning())
+  {
+    auto new_baggage = baggage->ToHeader();
+  }
+}
+BENCHMARK(BM_BaggageToHeaderTenEntries);
+
+void BM_BaggageToHeader180Entries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(Baggage::kMaxKeyValuePairs));
+  while (state.KeepRunning())
+  {
+    auto new_baggage = baggage->ToHeader();
+  }
+}
+BENCHMARK(BM_BaggageToHeader180Entries);
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/third_party/opentelemetry-cpp/api/test/baggage/baggage_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/baggage/baggage_test.cc
@@ -1,0 +1,218 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/string_view.h"
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+#include "opentelemetry/baggage/baggage.h"
+
+using namespace opentelemetry;
+using namespace opentelemetry::baggage;
+
+std::string header_with_custom_entries(size_t num_entries)
+{
+  std::string header;
+  for (size_t i = 0; i < num_entries; i++)
+  {
+    std::string key   = "key" + std::to_string(i);
+    std::string value = "value" + std::to_string(i);
+    header += key + "=" + value;
+    if (i != num_entries - 1)
+    {
+      header += ",";
+    }
+  }
+  return header;
+}
+
+std::string header_with_custom_size(size_t key_value_size, size_t num_entries)
+{
+  std::string header = "";
+  for (size_t i = 0; i < num_entries; i++)
+  {
+    std::string str = std::to_string(i + 1);
+    str += "=";
+    assert(key_value_size > str.size());
+    for (size_t j = str.size(); j < key_value_size; j++)
+    {
+      str += "a";
+    }
+
+    header += str + ',';
+  }
+
+  header.pop_back();
+  return header;
+}
+
+TEST(BaggageTest, ValidateExtractHeader)
+{
+  auto invalid_key_value_size_header = header_with_custom_size(Baggage::kMaxKeyValueSize + 5, 1);
+
+  struct
+  {
+    const char *input;
+    std::vector<const char *> keys;
+    std::vector<const char *> values;
+  } testcases[] = {
+      {"k1=v1", {"k1"}, {"v1"}},
+      {"k1=V1,K2=v2;metadata,k3=v3",
+       {"k1", "K2", "k3"},
+       {"V1", "v2;metadata", "v3"}},  // metadata is part of value
+      {",k1 =v1,k2=v2 ; metadata,",
+       {"k1", "k2"},
+       {"v1", "v2; metadata"}},  // key and value are trimmed
+      {"1a-2f%40foo=bar%251,a%2A%2Ffoo-_%2Fbar=bar+4",
+       {"1a-2f@foo", "a*/foo-_/bar"},
+       {"bar%1", "bar 4"}},                                       // decoding is done properly
+      {"k1=v1,invalidmember,k2=v2", {"k1", "k2"}, {"v1", "v2"}},  // invalid member is skipped
+      {",", {}, {}},
+      {",=,", {}, {}},
+      {"", {}, {}},
+      {"k1=%5zv", {}, {}},  // invalid hex : invalid second digit
+      {"k1=%5", {}, {}},    // invalid hex : missing two digits
+      {"k%z2=v1", {}, {}},  // invalid hex : invalid first digit
+      {"k%00=v1", {}, {}},  // key not valid
+      {"k=v%7f", {}, {}},   // value not valid
+      {invalid_key_value_size_header.data(), {}, {}}};
+  for (auto &testcase : testcases)
+  {
+    auto baggage = Baggage::FromHeader(testcase.input);
+    size_t index = 0;
+    baggage->GetAllEntries([&testcase, &index](nostd::string_view key, nostd::string_view value) {
+      EXPECT_EQ(key, testcase.keys[index]);
+      EXPECT_EQ(value, testcase.values[index]);
+      index++;
+      return true;
+    });
+  }
+
+  // For header with maximum threshold pairs, no pair is dropped
+  auto max_pairs_header = header_with_custom_entries(Baggage::kMaxKeyValuePairs);
+  EXPECT_EQ(Baggage::FromHeader(max_pairs_header.data())->ToHeader(), max_pairs_header.data());
+
+  // Entries beyond threshold are dropped
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(Baggage::kMaxKeyValuePairs + 1));
+  auto header  = baggage->ToHeader();
+  common::KeyValueStringTokenizer kv_str_tokenizer(header);
+  int expected_tokens = Baggage::kMaxKeyValuePairs;
+  EXPECT_EQ(kv_str_tokenizer.NumTokens(), expected_tokens);
+
+  // For header with total size more than threshold, baggage is empty
+  int num_pairs_with_max_size = Baggage::kMaxSize / Baggage::kMaxKeyValueSize;
+  auto invalid_total_size_header =
+      header_with_custom_size(Baggage::kMaxKeyValueSize, num_pairs_with_max_size + 1);
+  EXPECT_EQ(Baggage::FromHeader(invalid_total_size_header.data())->ToHeader(), "");
+}
+
+TEST(BaggageTest, ValidateInjectHeader)
+{
+  struct
+  {
+    std::vector<const char *> keys;
+    std::vector<const char *> values;
+    const char *header;
+  } testcases[] = {{{"k1"}, {"v1"}, "k1=v1"},
+                   {{"k3", "k2", "k1"}, {"", "v2", "v1"}, "k1=v1,k2=v2,k3="},  // empty value
+                   {{"1a-2f@foo", "a*/foo-_/bar"},
+                    {"bar%1", "bar 4"},
+                    "a%2A%2Ffoo-_%2Fbar=bar+4,1a-2f%40foo=bar%251"},  // encoding is done properly
+                   {{"foo 1"},
+                    {"bar 1;  metadata ; ;;"},
+                    "foo+1=bar+1;  metadata ; ;;"}};  // metadata is added without encoding
+
+  for (auto &testcase : testcases)
+  {
+    nostd::shared_ptr<Baggage> baggage(new Baggage{});
+    for (size_t i = 0; i < testcase.keys.size(); i++)
+    {
+      baggage = baggage->Set(testcase.keys[i], testcase.values[i]);
+    }
+    EXPECT_EQ(baggage->ToHeader(), testcase.header);
+  }
+}
+
+TEST(BaggageTest, BaggageGet)
+{
+  auto header  = header_with_custom_entries(Baggage::kMaxKeyValuePairs);
+  auto baggage = Baggage::FromHeader(header);
+
+  std::string value;
+  EXPECT_TRUE(baggage->GetValue("key0", value));
+  EXPECT_EQ(value, "value0");
+  EXPECT_TRUE(baggage->GetValue("key16", value));
+  EXPECT_EQ(value, "value16");
+
+  EXPECT_TRUE(baggage->GetValue("key31", value));
+  EXPECT_EQ(value, "value31");
+
+  EXPECT_FALSE(baggage->GetValue("key181", value));
+}
+
+TEST(BaggageTest, BaggageSet)
+{
+  std::string header = "k1=v1,k2=v2";
+  auto baggage       = Baggage::FromHeader(header);
+
+  std::string value;
+  baggage = baggage->Set("k3", "v3");
+  EXPECT_TRUE(baggage->GetValue("k3", value));
+  EXPECT_EQ(value, "v3");
+
+  baggage = baggage->Set("k3", "v3_1");  // key should be updated with the latest value
+  EXPECT_TRUE(baggage->GetValue("k3", value));
+  EXPECT_EQ(value, "v3_1");
+
+  header  = header_with_custom_entries(Baggage::kMaxKeyValuePairs);
+  baggage = Baggage::FromHeader(header);
+  baggage = baggage->Set("key0", "0");  // updating on max list should work
+  EXPECT_TRUE(baggage->GetValue("key0", value));
+  EXPECT_EQ(value, "0");
+
+  header  = "k1=v1,k2=v2";
+  baggage = Baggage::FromHeader(header);
+  baggage = baggage->Set("", "n_v1");  // adding invalid key, should return copy of same baggage
+  EXPECT_EQ(baggage->ToHeader(), header);
+
+  header  = "k1=v1,k2=v2";
+  baggage = Baggage::FromHeader(header);
+  baggage = baggage->Set("k1", "\x1A");  // adding invalid value, should return copy of same baggage
+  EXPECT_EQ(baggage->ToHeader(), header);
+}
+
+TEST(BaggageTest, BaggageRemove)
+{
+  auto header  = header_with_custom_entries(Baggage::kMaxKeyValuePairs);
+  auto baggage = Baggage::FromHeader(header);
+  std::string value;
+
+  // existing key is removed
+  EXPECT_TRUE(baggage->GetValue("key0", value));
+  auto new_baggage = baggage->Delete("key0");
+  EXPECT_FALSE(new_baggage->GetValue("key0", value));
+
+  // trying Delete on non existent key
+  EXPECT_FALSE(baggage->GetValue("key181", value));
+  auto new_baggage_2 = baggage->Delete("key181");
+  EXPECT_FALSE(new_baggage_2->GetValue("key181", value));
+}
+
+TEST(BaggageTest, BaggageGetAll)
+{
+  std::string baggage_header           = "k1=v1,k2=v2,k3=v3";
+  auto baggage                         = Baggage::FromHeader(baggage_header);
+  const int kNumPairs                  = 3;
+  nostd::string_view keys[kNumPairs]   = {"k1", "k2", "k3"};
+  nostd::string_view values[kNumPairs] = {"v1", "v2", "v3"};
+  size_t index                         = 0;
+  baggage->GetAllEntries(
+      [&keys, &values, &index](nostd::string_view key, nostd::string_view value) {
+        EXPECT_EQ(key, keys[index]);
+        EXPECT_EQ(value, values[index]);
+        index++;
+        return true;
+      });
+}

--- a/third_party/opentelemetry-cpp/api/test/baggage/propagation/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/baggage/propagation/BUILD
@@ -1,0 +1,19 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+cc_test(
+    name = "baggage_propagator_test",
+    srcs = [
+        "baggage_propagator_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/baggage/propagation/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/baggage/propagation/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+foreach(testname baggage_propagator_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX baggage.
+    TEST_LIST ${testname})
+endforeach()

--- a/third_party/opentelemetry-cpp/api/test/baggage/propagation/baggage_propagator_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/baggage/propagation/baggage_propagator_test.cc
@@ -1,0 +1,113 @@
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/baggage/propagation/baggage_propagator.h"
+#include <gtest/gtest.h>
+#include <map>
+#include <string>
+#include "opentelemetry/baggage/baggage_context.h"
+
+using namespace opentelemetry;
+using namespace opentelemetry::baggage::propagation;
+
+class BaggageCarrierTest : public context::propagation::TextMapCarrier
+{
+public:
+  BaggageCarrierTest() = default;
+  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  {
+    auto it = headers_.find(std::string(key));
+    if (it != headers_.end())
+    {
+      return nostd::string_view(it->second);
+    }
+    return "";
+  }
+  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  {
+    headers_[std::string(key)] = std::string(value);
+  }
+
+  std::map<std::string, std::string> headers_;
+};
+
+static BaggagePropagator format;
+
+TEST(BaggagePropagatorTest, ExtractNoBaggageHeader)
+{
+  BaggageCarrierTest carrier;
+  carrier.headers_      = {};
+  context::Context ctx1 = context::Context{};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+  auto ctx2_baggage     = baggage::GetBaggage(ctx2);
+  EXPECT_EQ(ctx2_baggage->ToHeader(), "");
+}
+
+TEST(BaggagePropagatorTest, ExtractAndInjectBaggage)
+{
+  // create header string for baggage larger than allowed size (kMaxKeyValueSize)
+  std::string very_large_baggage_header =
+      std::string(baggage::Baggage::kMaxKeyValueSize / 2 + 1, 'k') + "=" +
+      std::string(baggage::Baggage::kMaxKeyValueSize / 2 + 1, 'v');
+
+  std::map<std::string, std::string> baggages = {
+      {"key1=val1,key2=val2", "key1=val1,key2=val2"},                // valid header
+      {"key1 =   val1,  key2 =val2   ", "key1=val1,key2=val2"},      // valid header with spaces
+      {"key1=val1,key2=val2;prop=1", "key1=val1,key2=val2;prop=1"},  // valid header with properties
+      {"key%2C1=val1,key2=val2%2Cval3",
+       "key%2C1=val1,key2=val2%2Cval3"},                      // valid header with url escape
+      {"key1=val1,key2=val2,a,val3", "key1=val1,key2=val2"},  // valid header with invalid value
+      {"key1=,key2=val2", "key1=,key2=val2"},                 // valid header with empty value
+      {"invalid_header", ""},                                 // invalid header
+      {very_large_baggage_header, ""}};  // baggage header larger than allowed size.
+
+  for (auto baggage : baggages)
+  {
+    BaggageCarrierTest carrier1;
+    carrier1.headers_[baggage::kBaggageHeader.data()] = baggage.first;
+    context::Context ctx1                             = context::Context{};
+    context::Context ctx2                             = format.Extract(carrier1, ctx1);
+
+    BaggageCarrierTest carrier2;
+    format.Inject(carrier2, ctx2);
+    EXPECT_EQ(carrier2.headers_[baggage::kBaggageHeader.data()], baggage.second);
+
+    std::vector<std::string> fields;
+    format.Fields([&fields](nostd::string_view field) {
+      fields.push_back(field.data());
+      return true;
+    });
+    EXPECT_EQ(fields.size(), 1);
+    EXPECT_EQ(fields[0], baggage::kBaggageHeader.data());
+  }
+}
+
+TEST(BaggagePropagatorTest, InjectEmptyHeader)
+{
+  // Test Missing baggage from context
+  BaggageCarrierTest carrier;
+  context::Context ctx = context::Context{};
+  format.Inject(carrier, ctx);
+  EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
+
+  {
+    // Test empty baggage in context
+    BaggageCarrierTest carrier1;
+    carrier1.headers_[baggage::kBaggageHeader.data()] = "";
+    context::Context ctx1                             = context::Context{};
+    context::Context ctx2                             = format.Extract(carrier1, ctx1);
+    format.Inject(carrier, ctx2);
+    EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
+  }
+  {
+    // Invalid baggage in context
+    BaggageCarrierTest carrier1;
+    carrier1.headers_[baggage::kBaggageHeader.data()] = "InvalidBaggageData";
+    context::Context ctx1                             = context::Context{};
+    context::Context ctx2                             = format.Extract(carrier1, ctx1);
+
+    format.Inject(carrier, ctx2);
+    EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
+  }
+}

--- a/third_party/opentelemetry-cpp/api/test/common/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/common/BUILD
@@ -1,0 +1,45 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+otel_cc_benchmark(
+    name = "spinlock_benchmark",
+    srcs = ["spinlock_benchmark.cc"],
+    tags = [
+        "api",
+        "benchmark",
+        "test",
+    ],
+    deps = ["//api"],
+)
+
+cc_test(
+    name = "kv_properties_test",
+    srcs = [
+        "kv_properties_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "string_util_test",
+    srcs = [
+        "string_util_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/common/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/common/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+include(GoogleTest)
+
+foreach(testname kv_properties_test string_util_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX common.
+    TEST_LIST ${testname})
+endforeach()
+
+if(WITH_BENCHMARK)
+  add_executable(spinlock_benchmark spinlock_benchmark.cc)
+  target_link_libraries(spinlock_benchmark benchmark::benchmark
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+endif()

--- a/third_party/opentelemetry-cpp/api/test/common/kv_properties_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/common/kv_properties_test.cc
@@ -1,0 +1,235 @@
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <opentelemetry/common/kv_properties.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+// ------------------------- Entry class tests ---------------------------------
+
+using namespace opentelemetry;
+using opentelemetry::common::KeyValueProperties;
+// Test constructor that takes a key-value pair
+TEST(EntryTest, KeyValueConstruction)
+{
+  opentelemetry::nostd::string_view key = "test_key";
+  opentelemetry::nostd::string_view val = "test_value";
+  KeyValueProperties::Entry e(key, val);
+
+  EXPECT_EQ(key.size(), e.GetKey().size());
+  EXPECT_EQ(key, e.GetKey());
+
+  EXPECT_EQ(val.size(), e.GetValue().size());
+  EXPECT_EQ(val, e.GetValue());
+}
+
+// Test copy constructor
+TEST(EntryTest, Copy)
+{
+  KeyValueProperties::Entry e("test_key", "test_value");
+  KeyValueProperties::Entry copy(e);
+  EXPECT_EQ(copy.GetKey(), e.GetKey());
+  EXPECT_EQ(copy.GetValue(), e.GetValue());
+}
+
+// Test assignment operator
+TEST(EntryTest, Assignment)
+{
+  KeyValueProperties::Entry e("test_key", "test_value");
+  KeyValueProperties::Entry empty;
+  empty = e;
+  EXPECT_EQ(empty.GetKey(), e.GetKey());
+  EXPECT_EQ(empty.GetValue(), e.GetValue());
+}
+
+TEST(EntryTest, SetValue)
+{
+  KeyValueProperties::Entry e("test_key", "test_value");
+  opentelemetry::nostd::string_view new_val = "new_value";
+  e.SetValue(new_val);
+
+  EXPECT_EQ(new_val.size(), e.GetValue().size());
+  EXPECT_EQ(new_val, e.GetValue());
+}
+
+// ------------------------- KeyValueStringTokenizer tests ---------------------------------
+
+using opentelemetry::common::KeyValueStringTokenizer;
+using opentelemetry::common::KeyValueStringTokenizerOptions;
+
+TEST(KVStringTokenizer, SinglePair)
+{
+  bool valid_kv;
+  nostd::string_view key, value;
+  opentelemetry::nostd::string_view str = "k1=v1";
+  KeyValueStringTokenizerOptions opts;
+  KeyValueStringTokenizer tk(str, opts);
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k1");
+  EXPECT_EQ(value, "v1");
+  EXPECT_FALSE(tk.next(valid_kv, key, value));
+}
+
+TEST(KVStringTokenizer, AcceptEmptyEntries)
+{
+  bool valid_kv;
+  nostd::string_view key, value;
+  opentelemetry::nostd::string_view str = ":k1=v1::k2=v2: ";
+  KeyValueStringTokenizerOptions opts;
+  opts.member_separator     = ':';
+  opts.ignore_empty_members = false;
+
+  KeyValueStringTokenizer tk(str, opts);
+  EXPECT_TRUE(tk.next(valid_kv, key, value));  // empty pair
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k1");
+  EXPECT_EQ(value, "v1");
+  EXPECT_TRUE(tk.next(valid_kv, key, value));  // empty pair
+  EXPECT_EQ(key, "");
+  EXPECT_EQ(value, "");
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(tk.next(valid_kv, key, value));  // empty pair
+  EXPECT_FALSE(tk.next(valid_kv, key, value));
+}
+
+TEST(KVStringTokenizer, ValidPairsWithEmptyEntries)
+{
+  opentelemetry::nostd::string_view str = "k1:v1===k2:v2==";
+  bool valid_kv;
+  nostd::string_view key, value;
+  KeyValueStringTokenizerOptions opts;
+  opts.member_separator    = '=';
+  opts.key_value_separator = ':';
+
+  KeyValueStringTokenizer tk(str, opts);
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k1");
+  EXPECT_EQ(value, "v1");
+
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k2");
+  EXPECT_EQ(value, "v2");
+
+  EXPECT_FALSE(tk.next(valid_kv, key, value));
+}
+
+TEST(KVStringTokenizer, InvalidPairs)
+{
+  opentelemetry::nostd::string_view str = "k1=v1,invalid  ,,  k2=v2   ,invalid";
+  KeyValueStringTokenizer tk(str);
+  bool valid_kv;
+  nostd::string_view key, value;
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k1");
+  EXPECT_EQ(value, "v1");
+
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_FALSE(valid_kv);
+
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k2");
+  EXPECT_EQ(value, "v2");
+
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_FALSE(valid_kv);
+
+  EXPECT_FALSE(tk.next(valid_kv, key, value));
+}
+
+TEST(KVStringTokenizer, NumTokens)
+{
+  struct
+  {
+    const char *input;
+    size_t expected;
+  } testcases[] = {{"k1=v1", 1},
+                   {" ", 1},
+                   {"k1=v1,k2=v2,k3=v3", 3},
+                   {"k1=v1,", 1},
+                   {"k1=v1,k2=v2,invalidmember", 3},
+                   {"", 0}};
+  for (auto &testcase : testcases)
+  {
+    KeyValueStringTokenizer tk(testcase.input);
+    EXPECT_EQ(tk.NumTokens(), testcase.expected);
+  }
+}
+
+//------------------------- KeyValueProperties tests ---------------------------------
+
+TEST(KeyValueProperties, PopulateKVIterableContainer)
+{
+  std::vector<std::pair<std::string, std::string>> kv_pairs = {{"k1", "v1"}, {"k2", "v2"}};
+
+  auto kv_properties = KeyValueProperties(kv_pairs);
+  EXPECT_EQ(kv_properties.Size(), 2);
+
+  std::string value;
+  bool present = kv_properties.GetValue("k1", value);
+  EXPECT_TRUE(present);
+  EXPECT_EQ(value, "v1");
+
+  present = kv_properties.GetValue("k2", value);
+  EXPECT_TRUE(present);
+  EXPECT_EQ(value, "v2");
+}
+
+TEST(KeyValueProperties, AddEntry)
+{
+  auto kv_properties = KeyValueProperties(1);
+  kv_properties.AddEntry("k1", "v1");
+  std::string value;
+  bool present = kv_properties.GetValue("k1", value);
+  EXPECT_TRUE(present);
+  EXPECT_EQ(value, "v1");
+
+  kv_properties.AddEntry("k2", "v2");  // entry will not be added as max size reached.
+  EXPECT_EQ(kv_properties.Size(), 1);
+  present = kv_properties.GetValue("k2", value);
+  EXPECT_FALSE(present);
+}
+
+TEST(KeyValueProperties, GetValue)
+{
+  auto kv_properties = KeyValueProperties(1);
+  kv_properties.AddEntry("k1", "v1");
+  std::string value;
+  bool present = kv_properties.GetValue("k1", value);
+  EXPECT_TRUE(present);
+  EXPECT_EQ(value, "v1");
+
+  present = kv_properties.GetValue("k3", value);
+  EXPECT_FALSE(present);
+}
+
+TEST(KeyValueProperties, GetAllEntries)
+{
+  std::vector<std::pair<std::string, std::string>> kv_pairs = {
+      {"k1", "v1"}, {"k2", "v2"}, {"k3", "v3"}};
+  const size_t kNumPairs                              = 3;
+  opentelemetry::nostd::string_view keys[kNumPairs]   = {"k1", "k2", "k3"};
+  opentelemetry::nostd::string_view values[kNumPairs] = {"v1", "v2", "v3"};
+  auto kv_properties                                  = KeyValueProperties(kv_pairs);
+
+  size_t index = 0;
+  kv_properties.GetAllEntries(
+      [&keys, &values, &index](nostd::string_view key, nostd::string_view value) {
+        EXPECT_EQ(key, keys[index]);
+        EXPECT_EQ(value, values[index]);
+        index++;
+        return true;
+      });
+
+  EXPECT_EQ(index, kNumPairs);
+}

--- a/third_party/opentelemetry-cpp/api/test/common/spinlock_benchmark.cc
+++ b/third_party/opentelemetry-cpp/api/test/common/spinlock_benchmark.cc
@@ -1,0 +1,157 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/common/spin_lock_mutex.h"
+
+#include <benchmark/benchmark.h>
+#include <mutex>
+
+namespace
+{
+using opentelemetry::common::SpinLockMutex;
+
+constexpr int TightLoopLocks = 10000;
+
+// Runs a thrash-test where we spin up N threads, each of which will
+// attempt to lock-mutate-unlock a total of `TightLoopLocks` times.
+//
+// lock: A lambda denoting how to lock.   Accepts a reference to `SpinLockType`.
+// unlock: A lambda denoting how to unlock.   Accepts a reference to `SpinLockType`.
+template <typename SpinLockType, typename LockF, typename UnlockF>
+inline void SpinThrash(benchmark::State &s, SpinLockType &spinlock, LockF lock, UnlockF unlock)
+{
+  auto num_threads = s.range(0);
+  // Value we will increment, fighting over a spinlock.
+  // The contention is meant to be brief, as close to our expected
+  // use cases of "updating pointers" or "pushing an event onto a buffer".
+  std::int64_t value OPENTELEMETRY_MAYBE_UNUSED = 0;
+
+  std::vector<std::thread> threads;
+  threads.reserve(num_threads);
+
+  // Timing loop
+  for (auto _ : s)
+  {
+    for (auto i = 0; i < num_threads; i++)
+    {
+      threads.emplace_back([&] {
+        // Increment value once each time the lock is acquired.  Spin a few times
+        // to ensure maximum thread contention.
+        for (int i = 0; i < TightLoopLocks; i++)
+        {
+          lock(spinlock);
+          value++;
+          unlock(spinlock);
+        }
+      });
+    }
+    // Join threads
+    for (auto &thread : threads)
+      thread.join();
+    threads.clear();
+  }
+}
+
+// Benchmark of full spin-lock implementation.
+static void BM_SpinLockThrashing(benchmark::State &s)
+{
+  SpinLockMutex spinlock;
+  SpinThrash(
+      s, spinlock, [](SpinLockMutex &m) { m.lock(); }, [](SpinLockMutex &m) { m.unlock(); });
+}
+
+// Naive `while(try_lock()) {}` implementation of lock.
+static void BM_NaiveSpinLockThrashing(benchmark::State &s)
+{
+  SpinLockMutex spinlock;
+  SpinThrash(
+      s, spinlock,
+      [](SpinLockMutex &m) {
+        while (!m.try_lock())
+        {
+          // Left this comment to keep the same format on old and new versions of clang-format
+        }
+      },
+      [](SpinLockMutex &m) { m.unlock(); });
+}
+
+// Simple `while(try_lock()) { yield-processor }`
+static void BM_ProcYieldSpinLockThrashing(benchmark::State &s)
+{
+  SpinLockMutex spinlock;
+  SpinThrash<SpinLockMutex>(
+      s, spinlock,
+      [](SpinLockMutex &m) {
+        while (!m.try_lock())
+        {
+#if defined(_MSC_VER)
+          YieldProcessor();
+#elif defined(__i386__) || defined(__x86_64__)
+#  if defined(__clang__) || defined(__INTEL_COMPILER)
+          _mm_pause();
+#  else
+          __builtin_ia32_pause();
+#  endif
+#elif defined(__arm__)
+          __asm__ volatile("yield" ::: "memory");
+#endif
+        }
+      },
+      [](SpinLockMutex &m) { m.unlock(); });
+}
+
+// SpinLock thrashing with thread::yield().
+static void BM_ThreadYieldSpinLockThrashing(benchmark::State &s)
+{
+#if defined(__cpp_lib_atomic_value_initialization) && \
+    __cpp_lib_atomic_value_initialization >= 201911L
+  std::atomic_flag mutex{};
+#else
+  std::atomic_flag mutex = ATOMIC_FLAG_INIT;
+#endif
+  SpinThrash<std::atomic_flag>(
+      s, mutex,
+      [](std::atomic_flag &l) {
+        uint32_t try_count = 0;
+        while (l.test_and_set(std::memory_order_acq_rel))
+        {
+          ++try_count;
+          if (try_count % 32)
+          {
+            std::this_thread::yield();
+          }
+        }
+        std::this_thread::yield();
+      },
+      [](std::atomic_flag &l) { l.clear(std::memory_order_release); });
+}
+
+// Run the benchmarks at 2x thread/core and measure the amount of time to thrash around.
+BENCHMARK(BM_SpinLockThrashing)
+    ->RangeMultiplier(2)
+    ->Range(1, std::thread::hardware_concurrency())
+    ->MeasureProcessCPUTime()
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ProcYieldSpinLockThrashing)
+    ->RangeMultiplier(2)
+    ->Range(1, std::thread::hardware_concurrency())
+    ->MeasureProcessCPUTime()
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_NaiveSpinLockThrashing)
+    ->RangeMultiplier(2)
+    ->Range(1, std::thread::hardware_concurrency())
+    ->MeasureProcessCPUTime()
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ThreadYieldSpinLockThrashing)
+    ->RangeMultiplier(2)
+    ->Range(1, std::thread::hardware_concurrency())
+    ->MeasureProcessCPUTime()
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/third_party/opentelemetry-cpp/api/test/common/string_util_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/common/string_util_test.cc
@@ -1,0 +1,47 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <opentelemetry/common/string_util.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+// ------------------------- StringUtil class tests ---------------------------------
+
+using opentelemetry::common::StringUtil;
+
+TEST(StringUtilTest, TrimStringWithIndex)
+{
+  struct
+  {
+    const char *input;
+    const char *expected;
+  } testcases[] = {{"k1=v1", "k1=v1"},     {"k1=v1,k2=v2, k3=v3", "k1=v1,k2=v2, k3=v3"},
+                   {"   k1=v1", "k1=v1"},  {"k1=v1   ", "k1=v1"},
+                   {"   k1=v1 ", "k1=v1"}, {"  ", ""}};
+  for (auto &testcase : testcases)
+  {
+    EXPECT_EQ(StringUtil::Trim(testcase.input, 0, strlen(testcase.input) - 1), testcase.expected);
+  }
+}
+
+TEST(StringUtilTest, TrimString)
+{
+  struct
+  {
+    const char *input;
+    const char *expected;
+  } testcases[] = {{"k1=v1", "k1=v1"},
+                   {"k1=v1,k2=v2, k3=v3", "k1=v1,k2=v2, k3=v3"},
+                   {"   k1=v1", "k1=v1"},
+                   {"k1=v1   ", "k1=v1"},
+                   {"   k1=v1 ", "k1=v1"},
+                   {" ", ""},
+                   {"", ""}};
+  for (auto &testcase : testcases)
+  {
+    EXPECT_EQ(StringUtil::Trim(testcase.input), testcase.expected);
+  }
+}

--- a/third_party/opentelemetry-cpp/api/test/context/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/context/BUILD
@@ -1,0 +1,34 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+cc_test(
+    name = "context_test",
+    srcs = [
+        "context_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "runtime_context_test",
+    srcs = [
+        "runtime_context_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/context/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/context/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(propagation)
+
+include(GoogleTest)
+
+foreach(testname context_test runtime_context_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX context.
+    TEST_LIST ${testname})
+endforeach()

--- a/third_party/opentelemetry-cpp/api/test/context/context_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/context/context_test.cc
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/context/context.h"
+
+#include <map>
+
+#include <gtest/gtest.h>
+
+using namespace opentelemetry;
+
+// Tests that the context constructor accepts an std::map.
+TEST(ContextTest, ContextIterableAcceptsMap)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+  context::Context test_context                         = context::Context(map_test);
+}
+
+// Tests that the GetValue method returns the expected value.
+TEST(ContextTest, ContextGetValueReturnsExpectedValue)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123},
+                                                           {"foo_key", (int64_t)456}};
+  const context::Context test_context                   = context::Context(map_test);
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("test_key")), 123);
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("foo_key")), 456);
+}
+
+// Tests that the SetValues method accepts an std::map.
+TEST(ContextTest, ContextSetValuesAcceptsMap)
+{
+  std::map<std::string, context::ContextValue> map_test       = {{"test_key", (int64_t)123}};
+  std::map<std::string, context::ContextValue> map_test_write = {{"foo_key", (int64_t)456}};
+
+  context::Context test_context = context::Context(map_test);
+  context::Context foo_context  = test_context.SetValues(map_test_write);
+
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("test_key")), 123);
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("foo_key")), 456);
+}
+
+// Tests that the SetValues method accepts a nostd::string_view and
+// context::ContextValue.
+TEST(ContextTest, ContextSetValuesAcceptsStringViewContextValue)
+{
+  nostd::string_view string_view_test      = "string_view";
+  context::ContextValue context_value_test = (int64_t)123;
+
+  context::Context test_context = context::Context(string_view_test, context_value_test);
+  context::Context foo_context  = test_context.SetValue(string_view_test, context_value_test);
+
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue(string_view_test)), 123);
+}
+
+// Tests that the original context does not change when a value is
+// written to it.
+TEST(ContextTest, ContextImmutability)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+
+  context::Context context_test = context::Context(map_test);
+  context::Context context_foo  = context_test.SetValue("foo_key", (int64_t)456);
+
+  EXPECT_FALSE(nostd::holds_alternative<int64_t>(context_test.GetValue("foo_key")));
+}
+
+// Tests that writing the same to a context overwrites the original value.
+TEST(ContextTest, ContextKeyOverwrite)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+
+  context::Context context_test = context::Context(map_test);
+  context::Context context_foo  = context_test.SetValue("test_key", (int64_t)456);
+
+  EXPECT_EQ(nostd::get<int64_t>(context_foo.GetValue("test_key")), 456);
+}
+
+// Tests that the new Context Objects inherits the keys and values
+// of the original context object.
+TEST(ContextTest, ContextInheritance)
+{
+  using M = std::map<std::string, context::ContextValue>;
+
+  M m1 = {{"test_key", (int64_t)123}, {"foo_key", (int64_t)321}};
+  M m2 = {{"other_key", (int64_t)789}, {"another_key", (int64_t)987}};
+
+  context::Context test_context = context::Context(m1);
+  context::Context foo_context  = test_context.SetValues(m2);
+
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("test_key")), 123);
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("foo_key")), 321);
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("other_key")), 789);
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("another_key")), 987);
+
+  EXPECT_TRUE(nostd::holds_alternative<nostd::monostate>(test_context.GetValue("other_key")));
+  EXPECT_TRUE(nostd::holds_alternative<nostd::monostate>(test_context.GetValue("another_key")));
+}
+
+// Tests that copying a context copies the key value pairs as expected.
+TEST(ContextTest, ContextCopyOperator)
+{
+  std::map<std::string, context::ContextValue> test_map = {
+      {"test_key", (int64_t)123}, {"foo_key", (int64_t)456}, {"other_key", (int64_t)789}};
+
+  context::Context test_context   = context::Context(test_map);
+  context::Context copied_context = test_context;
+
+  EXPECT_EQ(nostd::get<int64_t>(copied_context.GetValue("test_key")), 123);
+  EXPECT_EQ(nostd::get<int64_t>(copied_context.GetValue("foo_key")), 456);
+  EXPECT_EQ(nostd::get<int64_t>(copied_context.GetValue("other_key")), 789);
+}
+
+// Tests that the Context accepts an empty map.
+TEST(ContextTest, ContextEmptyMap)
+{
+  std::map<std::string, context::ContextValue> map_test = {};
+  context::Context test_context                         = context::Context(map_test);
+}
+
+// Tests that if a key exists within a context has key will return true
+// false if not.
+TEST(ContextTest, ContextHasKey)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+  const context::Context context_test                   = context::Context(map_test);
+  EXPECT_TRUE(context_test.HasKey("test_key"));
+  EXPECT_FALSE(context_test.HasKey("foo_key"));
+}
+
+// Tests that a copied context returns true when compared
+TEST(ContextTest, ContextCopyCompare)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+  context::Context context_test                         = context::Context(map_test);
+  context::Context copied_test                          = context_test;
+  EXPECT_TRUE(context_test == copied_test);
+}
+
+// Tests that two differently constructed contexts return false when compared
+TEST(ContextTest, ContextDiffCompare)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+  std::map<std::string, context::ContextValue> map_foo  = {{"foo_key", (int64_t)123}};
+  context::Context context_test                         = context::Context(map_test);
+  context::Context foo_test                             = context::Context(map_foo);
+  EXPECT_FALSE(context_test == foo_test);
+}

--- a/third_party/opentelemetry-cpp/api/test/context/propagation/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/context/propagation/BUILD
@@ -1,0 +1,19 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+cc_test(
+    name = "composite_propagator_test",
+    srcs = [
+        "composite_propagator_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/context/propagation/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/context/propagation/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+foreach(testname composite_propagator_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX trace.
+    TEST_LIST ${testname})
+endforeach()

--- a/third_party/opentelemetry-cpp/api/test/context/propagation/composite_propagator_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/context/propagation/composite_propagator_test.cc
@@ -1,0 +1,141 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/trace/scope.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/trace/span_context.h"
+
+#include "opentelemetry/context/propagation/composite_propagator.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/trace/propagation/b3_propagator.h"
+#include "opentelemetry/trace/propagation/http_trace_context.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace opentelemetry;
+
+template <typename T>
+static std::string Hex(const T &id_item)
+{
+  char buf[T::kSize * 2];
+  id_item.ToLowerBase16(buf);
+  return std::string(buf, sizeof(buf));
+}
+
+class TextMapCarrierTest : public context::propagation::TextMapCarrier
+{
+public:
+  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  {
+    auto it = headers_.find(std::string(key));
+    if (it != headers_.end())
+    {
+      return nostd::string_view(it->second);
+    }
+    return "";
+  }
+  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  {
+    headers_[std::string(key)] = std::string(value);
+  }
+
+  std::map<std::string, std::string> headers_;
+};
+
+class CompositePropagatorTest : public ::testing::Test
+{
+
+public:
+  CompositePropagatorTest()
+  {
+    std::vector<std::unique_ptr<context::propagation::TextMapPropagator>> propogator_list = {};
+    std::unique_ptr<context::propagation::TextMapPropagator> w3c_propogator(
+        new trace::propagation::HttpTraceContext());
+    std::unique_ptr<context::propagation::TextMapPropagator> b3_propogator(
+        new trace::propagation::B3Propagator());
+    propogator_list.push_back(std::move(w3c_propogator));
+    propogator_list.push_back(std::move(b3_propogator));
+
+    composite_propagator_ =
+        new context::propagation::CompositePropagator(std::move(propogator_list));
+  }
+
+  ~CompositePropagatorTest() { delete composite_propagator_; }
+
+protected:
+  context::propagation::CompositePropagator *composite_propagator_;
+};
+
+TEST_F(CompositePropagatorTest, Extract)
+{
+  TextMapCarrierTest carrier;
+  carrier.headers_ = {
+      {"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"},
+      {"b3", "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90"}};
+  context::Context ctx1 = context::Context{};
+
+  context::Context ctx2 = composite_propagator_->Extract(carrier, ctx1);
+
+  auto ctx2_span = ctx2.GetValue(trace::kSpanKey);
+  EXPECT_TRUE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
+
+  auto span = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  // confirm last propagator in composite propagator list (B3 here) wins for same key
+  // ("active_span" here).
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "80f198ee56343ba864fe8b2a57d3eff7");
+  EXPECT_EQ(Hex(span->GetContext().span_id()), "e457b5a2e4d86bd1");
+  EXPECT_EQ(span->GetContext().IsSampled(), true);
+  EXPECT_EQ(span->GetContext().IsRemote(), true);
+
+  // Now check that last propagator does not win if there is no header for it
+  carrier.headers_ = {{"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-00"}};
+  ctx1             = context::Context{};
+
+  ctx2 = composite_propagator_->Extract(carrier, ctx1);
+
+  ctx2_span = ctx2.GetValue(trace::kSpanKey);
+  EXPECT_TRUE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
+
+  span = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  // Here the first propagator (W3C) wins
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "4bf92f3577b34da6a3ce929d0e0e4736");
+  EXPECT_EQ(Hex(span->GetContext().span_id()), "0102030405060708");
+  EXPECT_EQ(span->GetContext().IsSampled(), false);
+  EXPECT_EQ(span->GetContext().IsRemote(), true);
+}
+
+TEST_F(CompositePropagatorTest, Inject)
+{
+  TextMapCarrierTest carrier;
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false};
+  nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
+
+  // Set `sp` as the currently active span, which must be used by `Inject`.
+  trace::Scope scoped_span{sp};
+
+  composite_propagator_->Inject(carrier, context::RuntimeContext::GetCurrent());
+  EXPECT_EQ(carrier.headers_["traceparent"],
+            "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01");
+  EXPECT_EQ(carrier.headers_["b3"], "0102030405060708090a0b0c0d0e0f10-0102030405060708-1");
+
+  std::vector<std::string> fields;
+  composite_propagator_->Fields([&fields](nostd::string_view field) {
+    fields.push_back(field.data());
+    return true;
+  });
+  EXPECT_EQ(fields.size(), 3);
+  EXPECT_EQ(fields[0], trace::propagation::kTraceParent);
+  EXPECT_EQ(fields[1], trace::propagation::kTraceState);
+  EXPECT_EQ(fields[2], trace::propagation::kB3CombinedHeader);
+}

--- a/third_party/opentelemetry-cpp/api/test/context/runtime_context_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/context/runtime_context_test.cc
@@ -1,0 +1,138 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/context/runtime_context.h"
+#include "opentelemetry/context/context.h"
+
+#include <algorithm>
+#include <map>
+
+#include <gtest/gtest.h>
+
+using namespace opentelemetry;
+
+// Tests that GetCurrent returns the current context
+TEST(RuntimeContextTest, GetCurrent)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+  context::Context test_context                         = context::Context(map_test);
+  auto old_context = context::RuntimeContext::Attach(test_context);
+  EXPECT_EQ(context::RuntimeContext::GetCurrent(), test_context);
+}
+
+// Tests that detach resets the context to the previous context
+TEST(RuntimeContextTest, Detach)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+  context::Context test_context                         = context::Context(map_test);
+  context::Context foo_context                          = context::Context(map_test);
+
+  auto test_context_token = context::RuntimeContext::Attach(test_context);
+  auto foo_context_token  = context::RuntimeContext::Attach(foo_context);
+
+  foo_context_token.reset();
+  EXPECT_EQ(context::RuntimeContext::GetCurrent(), test_context);
+  test_context_token.reset();
+}
+
+// Tests that detach returns false when the wrong context is provided
+TEST(RuntimeContextTest, DetachWrongContext)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+  context::Context test_context                         = context::Context(map_test);
+  auto test_context_token = context::RuntimeContext::Attach(test_context);
+  EXPECT_TRUE(context::RuntimeContext::Detach(*test_context_token));
+  EXPECT_FALSE(context::RuntimeContext::Detach(*test_context_token));
+}
+
+// Tests that the ThreadLocalContext can handle three attached contexts
+TEST(RuntimeContextTest, ThreeAttachDetach)
+{
+  std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
+  context::Context test_context                         = context::Context(map_test);
+  context::Context foo_context                          = context::Context(map_test);
+  context::Context other_context                        = context::Context(map_test);
+  auto test_context_token  = context::RuntimeContext::Attach(test_context);
+  auto foo_context_token   = context::RuntimeContext::Attach(foo_context);
+  auto other_context_token = context::RuntimeContext::Attach(other_context);
+
+  EXPECT_TRUE(context::RuntimeContext::Detach(*other_context_token));
+  EXPECT_TRUE(context::RuntimeContext::Detach(*foo_context_token));
+  EXPECT_TRUE(context::RuntimeContext::Detach(*test_context_token));
+}
+
+// Tests that SetValue returns a context with the passed in data and the
+// RuntimeContext data when a context is not passed into the
+// RuntimeContext::SetValue method.
+TEST(RuntimeContextTest, SetValueRuntimeContext)
+{
+  context::Context foo_context  = context::Context("foo_key", (int64_t)596);
+  auto old_context_token        = context::RuntimeContext::Attach(foo_context);
+  context::Context test_context = context::RuntimeContext::SetValue("test_key", (int64_t)123);
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("test_key")), 123);
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("foo_key")), 596);
+}
+
+// Tests that SetValue returns a context with the passed in data and the
+// passed in context data when a context* is passed into the
+// RuntimeContext::SetValue method.
+TEST(RuntimeContextTest, SetValueOtherContext)
+{
+  context::Context foo_context = context::Context("foo_key", (int64_t)596);
+  context::Context test_context =
+      context::RuntimeContext::SetValue("test_key", (int64_t)123, &foo_context);
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("test_key")), 123);
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("foo_key")), 596);
+}
+
+// Tests that SetValue returns the ContextValue associated with the
+// passed in string and the current Runtime Context
+TEST(RuntimeContextTest, GetValueRuntimeContext)
+{
+  context::Context foo_context = context::Context("foo_key", (int64_t)596);
+  auto old_context_token       = context::RuntimeContext::Attach(foo_context);
+  EXPECT_EQ(nostd::get<int64_t>(context::RuntimeContext::GetValue("foo_key")), 596);
+}
+
+// Tests that SetValue returns the ContextValue associated with the
+// passed in string and the passed in context
+TEST(RuntimeContextTest, GetValueOtherContext)
+{
+  context::Context foo_context = context::Context("foo_key", (int64_t)596);
+  EXPECT_EQ(nostd::get<int64_t>(context::RuntimeContext::GetValue("foo_key", &foo_context)), 596);
+}
+
+// Test that any possible order of context detaching doesn't mess up the stack.
+TEST(RuntimeContextTest, DetachOutOfOrder)
+{
+  std::vector<size_t> indices;
+  indices.push_back(0);
+  indices.push_back(1);
+  indices.push_back(2);
+  indices.push_back(3);
+
+  std::vector<context::Context> contexts;
+  for (auto i : indices)
+  {
+    contexts.push_back(context::Context("index", (int64_t)i));
+  }
+
+  do
+  {
+    std::vector<nostd::unique_ptr<context::Token>> tokens;
+
+    for (auto &c : contexts)
+    {
+      tokens.push_back(context::RuntimeContext::Attach(c));
+    }
+
+    for (size_t i : indices)
+    {
+      auto token = std::move(tokens.at(i));
+      context::RuntimeContext::Detach(*token);
+    }
+
+    EXPECT_EQ(context::RuntimeContext::GetCurrent(), context::Context());
+
+  } while (std::next_permutation(indices.begin(), indices.end()));
+}

--- a/third_party/opentelemetry-cpp/api/test/core/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/core/BUILD
@@ -1,0 +1,32 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+cc_test(
+    name = "timestamp_test",
+    srcs = [
+        "timestamp_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "version_test",
+    srcs = [
+        "version_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/core/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/core/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+include(GoogleTest)
+
+add_executable(timestamp_test timestamp_test.cc)
+target_link_libraries(timestamp_test ${GTEST_BOTH_LIBRARIES}
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+gtest_add_tests(
+  TARGET timestamp_test
+  TEST_PREFIX trace.
+  TEST_LIST timestamp_test)
+
+add_executable(version_test version_test.cc)
+target_link_libraries(version_test ${GTEST_BOTH_LIBRARIES}
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+gtest_add_tests(
+  TARGET version_test
+  TEST_PREFIX version.
+  TEST_LIST version_test)

--- a/third_party/opentelemetry-cpp/api/test/core/timestamp_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/core/timestamp_test.cc
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/common/timestamp.h"
+
+#include <gtest/gtest.h>
+
+using opentelemetry::common::SteadyTimestamp;
+using opentelemetry::common::SystemTimestamp;
+
+template <class Timestamp>
+static bool AreNearlyEqual(const Timestamp &t1, const Timestamp &t2) noexcept
+{
+  return std::abs(std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count()) < 2;
+}
+
+TEST(SystemTimestampTest, Construction)
+{
+  auto now_system = std::chrono::system_clock::now();
+
+  SystemTimestamp t1;
+  EXPECT_EQ(t1.time_since_epoch(), std::chrono::nanoseconds{0});
+
+  SystemTimestamp t2{now_system};
+  EXPECT_TRUE(AreNearlyEqual(now_system, static_cast<std::chrono::system_clock::time_point>(t2)));
+  EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(now_system.time_since_epoch()),
+            t2.time_since_epoch());
+}
+
+TEST(SystemTimestampTest, Comparison)
+{
+  SystemTimestamp t1;
+  SystemTimestamp t2;
+  SystemTimestamp t3{std::chrono::nanoseconds{2}};
+
+  EXPECT_EQ(t1, t1);
+  EXPECT_EQ(t1, t2);
+  EXPECT_EQ(t2, t1);
+  EXPECT_NE(t1, t3);
+  EXPECT_NE(t3, t1);
+}
+
+TEST(SteadyTimestampTest, Construction)
+{
+  auto now_steady = std::chrono::steady_clock::now();
+
+  SteadyTimestamp t1;
+  EXPECT_EQ(t1.time_since_epoch(), std::chrono::nanoseconds{0});
+
+  SteadyTimestamp t2{now_steady};
+  EXPECT_TRUE(AreNearlyEqual(now_steady, static_cast<std::chrono::steady_clock::time_point>(t2)));
+  EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(now_steady.time_since_epoch()),
+            t2.time_since_epoch());
+}
+
+TEST(SteadyTimestampTest, Comparison)
+{
+  SteadyTimestamp t1;
+  SteadyTimestamp t2;
+  SteadyTimestamp t3{std::chrono::nanoseconds{2}};
+
+  EXPECT_EQ(t1, t1);
+  EXPECT_EQ(t1, t2);
+  EXPECT_EQ(t2, t1);
+  EXPECT_NE(t1, t3);
+  EXPECT_NE(t3, t1);
+}

--- a/third_party/opentelemetry-cpp/api/test/core/version_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/core/version_test.cc
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/version.h"
+
+#include <gtest/gtest.h>
+
+TEST(VersionTest, Consistency)
+{
+  char expected[10];
+  snprintf(expected, sizeof(expected), "%d.%d.%d", OPENTELEMETRY_VERSION_MAJOR,
+           OPENTELEMETRY_VERSION_MINOR, OPENTELEMETRY_VERSION_PATCH);
+
+  std::string actual = OPENTELEMETRY_VERSION;
+  EXPECT_EQ(actual, expected);
+}

--- a/third_party/opentelemetry-cpp/api/test/logs/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/logs/BUILD
@@ -1,0 +1,36 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+cc_test(
+    name = "provider_test",
+    srcs = [
+        "provider_test.cc",
+    ],
+    tags = [
+        "api",
+        "logs",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "logger_test",
+    srcs = [
+        "logger_test.cc",
+    ],
+    tags = [
+        "api",
+        "logs",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/logs/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/logs/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+foreach(testname provider_test logger_test)
+  add_executable(logs_api_${testname} "${testname}.cc")
+  target_link_libraries(logs_api_${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET logs_api_${testname}
+    TEST_PREFIX logs.
+    TEST_LIST logs_api_${testname})
+endforeach()
+
+if(WITH_BENCHMARK)
+  add_executable(logger_benchmark logger_benchmark.cc)
+  target_link_libraries(logger_benchmark benchmark::benchmark
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+endif()

--- a/third_party/opentelemetry-cpp/api/test/logs/logger_benchmark.cc
+++ b/third_party/opentelemetry-cpp/api/test/logs/logger_benchmark.cc
@@ -1,0 +1,256 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/common/timestamp.h"
+#include "opentelemetry/logs/logger.h"
+#include "opentelemetry/logs/provider.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+using opentelemetry::logs::EventId;
+using opentelemetry::logs::Logger;
+using opentelemetry::logs::LoggerProvider;
+using opentelemetry::logs::Provider;
+using opentelemetry::logs::Severity;
+using opentelemetry::nostd::shared_ptr;
+using opentelemetry::nostd::span;
+using opentelemetry::nostd::string_view;
+
+namespace common  = opentelemetry::common;
+namespace nostd   = opentelemetry::nostd;
+namespace trace   = opentelemetry::trace;
+namespace log_api = opentelemetry::logs;
+
+namespace
+{
+
+constexpr int64_t kMaxIterations = 1000000000;
+
+class Barrier
+{
+public:
+  explicit Barrier(std::size_t iCount) : mThreshold(iCount), mCount(iCount), mGeneration(0) {}
+
+  void Wait()
+  {
+    std::unique_lock<std::mutex> lLock{mMutex};
+    auto lGen = mGeneration;
+    if (!--mCount)
+    {
+      mGeneration++;
+      mCount = mThreshold;
+      mCond.notify_all();
+    }
+    else
+    {
+      mCond.wait(lLock, [this, lGen] { return lGen != mGeneration; });
+    }
+  }
+
+private:
+  std::mutex mMutex;
+  std::condition_variable mCond;
+  std::size_t mThreshold;
+  std::size_t mCount;
+  std::size_t mGeneration;
+};
+
+static void ThreadRoutine(Barrier &barrier,
+                          benchmark::State &state,
+                          int thread_id,
+                          std::function<void()> func)
+{
+  barrier.Wait();
+
+  if (thread_id == 0)
+  {
+    state.ResumeTiming();
+  }
+
+  barrier.Wait();
+
+  func();
+
+  if (thread_id == 0)
+  {
+    state.PauseTiming();
+  }
+
+  barrier.Wait();
+}
+
+void MultiThreadRunner(benchmark::State &state, std::function<void()> func)
+{
+  int num_threads = std::thread::hardware_concurrency();
+
+  Barrier barrier(num_threads);
+
+  std::vector<std::thread> threads;
+
+  for (int i = 0; i < num_threads; i++)
+  {
+    threads.emplace_back(ThreadRoutine, std::ref(barrier), std::ref(state), i, func);
+  }
+
+  for (auto &thread : threads)
+  {
+    thread.join();
+  }
+}
+
+static void BM_UnstructuredLog(benchmark::State &state)
+{
+  auto lp     = Provider::GetLoggerProvider();
+  auto logger = lp->GetLogger("UnstructuredLog");
+
+  for (auto _ : state)
+  {
+    state.PauseTiming();
+
+    MultiThreadRunner(state, [&logger]() {
+      for (int64_t i = 0; i < kMaxIterations; i++)
+      {
+        logger->Trace("This is a simple unstructured log message");
+      }
+    });
+
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_UnstructuredLog);
+
+static void BM_StructuredLogWithTwoAttributes(benchmark::State &state)
+{
+  auto lp     = Provider::GetLoggerProvider();
+  auto logger = lp->GetLogger("StructuredLog");
+
+  for (auto _ : state)
+  {
+    state.PauseTiming();
+
+    MultiThreadRunner(state, [&logger]() {
+      for (int64_t i = 0; i < kMaxIterations; i++)
+      {
+        logger->Trace(
+            "This is a simple structured log message from {process_id}:{thread_id}",
+            opentelemetry::common::MakeAttributes({{"process_id", 12347}, {"thread_id", 12348}}));
+      }
+    });
+
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_StructuredLogWithTwoAttributes);
+
+static void BM_StructuredLogWithEventIdAndTwoAttributes(benchmark::State &state)
+{
+  auto lp     = Provider::GetLoggerProvider();
+  auto logger = lp->GetLogger("StructuredLogWithEventId");
+
+  for (auto _ : state)
+  {
+    state.PauseTiming();
+
+    MultiThreadRunner(state, [&logger]() {
+      for (int64_t i = 0; i < kMaxIterations; i++)
+      {
+        logger->Trace(
+            0x12345678, "This is a simple structured log message from {process_id}:{thread_id}",
+            opentelemetry::common::MakeAttributes({{"process_id", 12347}, {"thread_id", 12348}}));
+      }
+    });
+
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_StructuredLogWithEventIdAndTwoAttributes);
+
+static void BM_StructuredLogWithEventIdStructAndTwoAttributes(benchmark::State &state)
+{
+  auto lp     = Provider::GetLoggerProvider();
+  auto logger = lp->GetLogger("StructuredLogWithEventId");
+
+  const EventId function_name_event_id{0x12345678, "Company.Component.SubComponent.FunctionName"};
+
+  for (auto _ : state)
+  {
+    state.PauseTiming();
+
+    MultiThreadRunner(state, [&logger, &function_name_event_id]() {
+      for (int64_t i = 0; i < kMaxIterations; i++)
+      {
+        logger->Trace(
+            function_name_event_id,
+            "Simulate function enter trace message from {process_id}:{thread_id}",
+            opentelemetry::common::MakeAttributes({{"process_id", 12347}, {"thread_id", 12348}}));
+      }
+    });
+
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_StructuredLogWithEventIdStructAndTwoAttributes);
+
+static void BM_EnabledOnSeverityReturnFalse(benchmark::State &state)
+{
+  auto lp     = Provider::GetLoggerProvider();
+  auto logger = lp->GetLogger("UnstructuredLogWithEnabledReturnFalse");
+
+  for (auto _ : state)
+  {
+    state.PauseTiming();
+
+    MultiThreadRunner(state, [&logger]() {
+      for (int64_t i = 0; i < kMaxIterations; i++)
+      {
+        if (logger->Enabled(Severity::kTrace))
+        {
+          logger->Trace("This log line would not be called");
+        }
+      }
+    });
+
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_EnabledOnSeverityReturnFalse);
+
+static void BM_EnabledOnSeverityAndEventIdReturnFalse(benchmark::State &state)
+{
+  auto lp     = Provider::GetLoggerProvider();
+  auto logger = lp->GetLogger("UnstructuredLogWithEnabledReturnFalse");
+
+  for (auto _ : state)
+  {
+    state.PauseTiming();
+
+    MultiThreadRunner(state, [&logger]() {
+      for (int64_t i = 0; i < kMaxIterations; i++)
+      {
+        if (logger->Enabled(Severity::kTrace, 0x12345678))
+        {
+          logger->Trace("This log line would not be called");
+        }
+      }
+    });
+
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_EnabledOnSeverityAndEventIdReturnFalse);
+
+}  // namespace
+
+int main(int argc, char **argv)
+{
+  benchmark::Initialize(&argc, argv);
+  benchmark::RunSpecifiedBenchmarks();
+}

--- a/third_party/opentelemetry-cpp/api/test/logs/logger_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/logs/logger_test.cc
@@ -1,0 +1,221 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <array>
+#include <vector>
+
+#include "opentelemetry/common/timestamp.h"
+#include "opentelemetry/logs/logger.h"
+#include "opentelemetry/logs/provider.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+
+using opentelemetry::logs::EventId;
+using opentelemetry::logs::Logger;
+using opentelemetry::logs::LoggerProvider;
+using opentelemetry::logs::Provider;
+using opentelemetry::logs::Severity;
+using opentelemetry::nostd::shared_ptr;
+using opentelemetry::nostd::span;
+using opentelemetry::nostd::string_view;
+namespace common = opentelemetry::common;
+namespace nostd  = opentelemetry::nostd;
+namespace trace  = opentelemetry::trace;
+
+// Check that the default logger is a noop logger instance
+TEST(Logger, GetLoggerDefault)
+{
+  auto lp = Provider::GetLoggerProvider();
+  const std::string schema_url{"https://opentelemetry.io/schemas/1.11.0"};
+  auto logger = lp->GetLogger("TestLogger", "opentelelemtry_library", "", schema_url);
+  auto name   = logger->GetName();
+  EXPECT_NE(nullptr, logger);
+  EXPECT_EQ(name, "noop logger");
+}
+
+// Test the two additional overloads for GetLogger()
+TEST(Logger, GetNoopLoggerNameWithArgs)
+{
+  auto lp = Provider::GetLoggerProvider();
+
+  const std::string schema_url{"https://opentelemetry.io/schemas/1.11.0"};
+  lp->GetLogger("NoopLoggerWithArgs", "opentelelemtry_library", "", schema_url);
+
+  lp->GetLogger("NoopLoggerWithOptions", "opentelelemtry_library", "", schema_url);
+}
+
+// Test the EmitLogRecord() overloads
+TEST(Logger, LogMethodOverloads)
+{
+  auto lp = Provider::GetLoggerProvider();
+  const std::string schema_url{"https://opentelemetry.io/schemas/1.11.0"};
+  auto logger = lp->GetLogger("TestLogger", "opentelelemtry_library", "", schema_url);
+
+  EventId trace_event_id{0x1, "TraceEventId"};
+  EventId debug_event_id{0x2, "DebugEventId"};
+  EventId info_event_id{0x3, "InfoEventId"};
+  EventId warn_event_id{0x4, "WarnEventId"};
+  EventId error_event_id{0x5, "ErrorEventId"};
+  EventId fatal_event_id{0x6, "FatalEventId"};
+
+  // Create a map to test the logs with
+  std::map<std::string, std::string> m = {{"key1", "value1"}};
+
+  // EmitLogRecord overloads
+  logger->EmitLogRecord(Severity::kTrace, "Test log message");
+  logger->EmitLogRecord(Severity::kInfo, "Test log message");
+  logger->EmitLogRecord(Severity::kDebug, m);
+  logger->EmitLogRecord(Severity::kWarn, "Logging a map", m);
+  logger->EmitLogRecord(Severity::kError,
+                        opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->EmitLogRecord(Severity::kFatal, "Logging an initializer list",
+                        opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->EmitLogRecord(Severity::kDebug, opentelemetry::common::MakeAttributes(m));
+  logger->EmitLogRecord(Severity::kDebug,
+                        common::KeyValueIterableView<std::map<std::string, std::string>>(m));
+  std::pair<nostd::string_view, common::AttributeValue> array[] = {{"key1", "value1"}};
+  logger->EmitLogRecord(Severity::kDebug, opentelemetry::common::MakeAttributes(array));
+  std::vector<std::pair<std::string, std::string>> vec = {{"key1", "value1"}};
+  logger->EmitLogRecord(Severity::kDebug, opentelemetry::common::MakeAttributes(vec));
+
+  // Severity methods
+  logger->Trace("Test log message");
+  logger->Trace("Test log message", m);
+  logger->Trace("Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Trace(m);
+  logger->Trace(opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Trace(trace_event_id, "Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Trace(trace_event_id.id_, "Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+
+  logger->Debug("Test log message");
+  logger->Debug("Test log message", m);
+  logger->Debug("Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Debug(m);
+  logger->Debug(opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Debug(debug_event_id, "Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Debug(debug_event_id.id_, "Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+
+  logger->Info("Test log message");
+  logger->Info("Test log message", m);
+  logger->Info("Test log message",
+               opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Info(m);
+  logger->Info(opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Info(info_event_id, "Test log message",
+               opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Info(info_event_id.id_, "Test log message",
+               opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+
+  logger->Warn("Test log message");
+  logger->Warn("Test log message", m);
+  logger->Warn("Test log message",
+               opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Warn(m);
+  logger->Warn(opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Warn(warn_event_id, "Test log message",
+               opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Warn(warn_event_id.id_, "Test log message",
+               opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+
+  logger->Error("Test log message");
+  logger->Error("Test log message", m);
+  logger->Error("Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Error(m);
+  logger->Error(opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Error(error_event_id, "Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Error(error_event_id.id_, "Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+
+  logger->Fatal("Test log message");
+  logger->Fatal("Test log message", m);
+  logger->Fatal("Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Fatal(m);
+  logger->Fatal(opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Fatal(fatal_event_id, "Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  logger->Fatal(fatal_event_id.id_, "Test log message",
+                opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+}
+
+TEST(Logger, EventLogMethodOverloads)
+{
+  auto lp = Provider::GetLoggerProvider();
+  const std::string schema_url{"https://opentelemetry.io/schemas/1.11.0"};
+  auto logger = lp->GetLogger("TestLogger", "opentelelemtry_library", "", schema_url);
+
+  auto elp          = Provider::GetEventLoggerProvider();
+  auto event_logger = elp->CreateEventLogger(logger, "otel-cpp.test");
+
+  std::map<std::string, std::string> m = {{"key1", "value1"}};
+
+  event_logger->EmitEvent("event name", Severity::kTrace, "Test log message");
+  event_logger->EmitEvent("event name", Severity::kInfo, "Test log message");
+  event_logger->EmitEvent("event name", Severity::kDebug, m);
+  event_logger->EmitEvent("event name", Severity::kWarn, "Logging a map", m);
+  event_logger->EmitEvent(
+      "event name", Severity::kError,
+      opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  event_logger->EmitEvent(
+      "event name", Severity::kFatal, "Logging an initializer list",
+      opentelemetry::common::MakeAttributes({{"key1", "value 1"}, {"key2", 2}}));
+  event_logger->EmitEvent("event name", Severity::kDebug, opentelemetry::common::MakeAttributes(m));
+  event_logger->EmitEvent("event name", Severity::kDebug,
+                          common::KeyValueIterableView<std::map<std::string, std::string>>(m));
+  std::pair<nostd::string_view, common::AttributeValue> array[] = {{"key1", "value1"}};
+  event_logger->EmitEvent("event name", Severity::kDebug,
+                          opentelemetry::common::MakeAttributes(array));
+  std::vector<std::pair<std::string, std::string>> vec = {{"key1", "value1"}};
+  event_logger->EmitEvent("event name", Severity::kDebug,
+                          opentelemetry::common::MakeAttributes(vec));
+}
+
+// Define a basic Logger class
+class TestLogger : public Logger
+{
+  const nostd::string_view GetName() noexcept override { return "test logger"; }
+
+  nostd::unique_ptr<opentelemetry::logs::LogRecord> CreateLogRecord() noexcept override
+  {
+    return nullptr;
+  }
+
+  using Logger::EmitLogRecord;
+
+  void EmitLogRecord(nostd::unique_ptr<opentelemetry::logs::LogRecord> &&) noexcept override {}
+};
+
+// Define a basic LoggerProvider class that returns an instance of the logger class defined above
+class TestProvider : public LoggerProvider
+{
+  nostd::shared_ptr<Logger> GetLogger(nostd::string_view /* logger_name */,
+                                      nostd::string_view /* library_name */,
+                                      nostd::string_view /* library_version */,
+                                      nostd::string_view /* schema_url */,
+                                      const common::KeyValueIterable & /* attributes */) override
+  {
+    return nostd::shared_ptr<Logger>(new TestLogger());
+  }
+};
+
+TEST(Logger, PushLoggerImplementation)
+{
+  // Push the new loggerprovider class into the global singleton
+  auto test_provider = shared_ptr<LoggerProvider>(new TestProvider());
+  Provider::SetLoggerProvider(test_provider);
+
+  auto lp = Provider::GetLoggerProvider();
+
+  // Check that the implementation was pushed by calling TestLogger's GetName()
+  nostd::string_view schema_url{"https://opentelemetry.io/schemas/1.11.0"};
+  auto logger = lp->GetLogger("TestLogger", "opentelelemtry_library", "", schema_url);
+  ASSERT_EQ("test logger", logger->GetName());
+}

--- a/third_party/opentelemetry-cpp/api/test/logs/provider_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/logs/provider_test.cc
@@ -1,0 +1,108 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <array>
+
+#include "opentelemetry/logs/provider.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+
+using opentelemetry::logs::EventLogger;
+using opentelemetry::logs::EventLoggerProvider;
+using opentelemetry::logs::Logger;
+using opentelemetry::logs::LoggerProvider;
+using opentelemetry::logs::Provider;
+using opentelemetry::nostd::shared_ptr;
+namespace nostd = opentelemetry::nostd;
+
+class TestProvider : public LoggerProvider
+{
+  nostd::shared_ptr<Logger> GetLogger(
+      nostd::string_view /* logger_name */,
+      nostd::string_view /* library_name */,
+      nostd::string_view /* library_version */,
+      nostd::string_view /* schema_url */,
+      const opentelemetry::common::KeyValueIterable & /* attributes */) override
+  {
+    return shared_ptr<Logger>(nullptr);
+  }
+};
+
+TEST(Provider, GetLoggerProviderDefault)
+{
+  auto tf = Provider::GetLoggerProvider();
+  EXPECT_NE(nullptr, tf);
+}
+
+TEST(Provider, SetLoggerProvider)
+{
+  auto tf = shared_ptr<LoggerProvider>(new TestProvider());
+  Provider::SetLoggerProvider(tf);
+  ASSERT_EQ(tf, Provider::GetLoggerProvider());
+}
+
+TEST(Provider, MultipleLoggerProviders)
+{
+  auto tf = shared_ptr<LoggerProvider>(new TestProvider());
+  Provider::SetLoggerProvider(tf);
+  auto tf2 = shared_ptr<LoggerProvider>(new TestProvider());
+  Provider::SetLoggerProvider(tf2);
+
+  ASSERT_NE(Provider::GetLoggerProvider(), tf);
+}
+
+TEST(Provider, GetLogger)
+{
+  auto tf = shared_ptr<LoggerProvider>(new TestProvider());
+  // tests GetLogger(name, version, schema)
+  const std::string schema_url{"https://opentelemetry.io/schemas/1.2.0"};
+  auto logger = tf->GetLogger("logger1", "opentelelemtry_library", "", schema_url);
+  EXPECT_EQ(nullptr, logger);
+
+  // tests GetLogger(name, arguments)
+
+  auto logger2 = tf->GetLogger("logger2", "opentelelemtry_library", "", schema_url);
+  EXPECT_EQ(nullptr, logger2);
+}
+
+class TestEventLoggerProvider : public EventLoggerProvider
+{
+public:
+  nostd::shared_ptr<EventLogger> CreateEventLogger(
+      nostd::shared_ptr<Logger> /*delegate_logger*/,
+      nostd::string_view /*event_domain*/) noexcept override
+  {
+    return nostd::shared_ptr<EventLogger>(nullptr);
+  }
+};
+
+TEST(Provider, GetEventLoggerProviderDefault)
+{
+  auto tf = Provider::GetEventLoggerProvider();
+  EXPECT_NE(nullptr, tf);
+}
+
+TEST(Provider, SetEventLoggerProvider)
+{
+  auto tf = nostd::shared_ptr<EventLoggerProvider>(new TestEventLoggerProvider());
+  Provider::SetEventLoggerProvider(tf);
+  ASSERT_EQ(tf, Provider::GetEventLoggerProvider());
+}
+
+TEST(Provider, MultipleEventLoggerProviders)
+{
+  auto tf = nostd::shared_ptr<EventLoggerProvider>(new TestEventLoggerProvider());
+  Provider::SetEventLoggerProvider(tf);
+  auto tf2 = nostd::shared_ptr<EventLoggerProvider>(new TestEventLoggerProvider());
+  Provider::SetEventLoggerProvider(tf2);
+
+  ASSERT_NE(Provider::GetEventLoggerProvider(), tf);
+}
+
+TEST(Provider, CreateEventLogger)
+{
+  auto tf     = nostd::shared_ptr<TestEventLoggerProvider>(new TestEventLoggerProvider());
+  auto logger = tf->CreateEventLogger(nostd::shared_ptr<Logger>(nullptr), "domain");
+
+  EXPECT_EQ(nullptr, logger);
+}

--- a/third_party/opentelemetry-cpp/api/test/metrics/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/metrics/BUILD
@@ -1,0 +1,34 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+cc_test(
+    name = "noop_sync_instrument_test",
+    srcs = [
+        "noop_sync_instrument_test.cc",
+    ],
+    tags = [
+        "metrics",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "meter_provider_test",
+    srcs = [
+        "meter_provider_test.cc",
+    ],
+    tags = [
+        "metrics",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/metrics/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/metrics/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+foreach(testname meter_provider_test noop_sync_instrument_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX metrics_new.
+    TEST_LIST ${testname})
+endforeach()

--- a/third_party/opentelemetry-cpp/api/test/metrics/meter_provider_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/metrics/meter_provider_test.cc
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "opentelemetry/metrics/noop.h"
+#include "opentelemetry/metrics/provider.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+
+using opentelemetry::metrics::Meter;
+using opentelemetry::metrics::MeterProvider;
+using opentelemetry::metrics::NoopMeterProvider;
+using opentelemetry::metrics::Provider;
+
+TEST(Provider, GetMeterProviderDefault)
+{
+  auto tf = Provider::GetMeterProvider();
+  EXPECT_NE(nullptr, tf);
+}
+
+TEST(Provider, SetMeterProvider)
+{
+  auto tf = opentelemetry::nostd::shared_ptr<MeterProvider>(new NoopMeterProvider());
+  Provider::SetMeterProvider(tf);
+  ASSERT_EQ(tf, Provider::GetMeterProvider());
+}
+
+TEST(Provider, MultipleMeterProviders)
+{
+  auto tf = opentelemetry::nostd::shared_ptr<MeterProvider>(new NoopMeterProvider());
+  Provider::SetMeterProvider(tf);
+  auto tf2 = opentelemetry::nostd::shared_ptr<MeterProvider>(new NoopMeterProvider());
+  Provider::SetMeterProvider(tf2);
+
+  ASSERT_NE(Provider::GetMeterProvider(), tf);
+}

--- a/third_party/opentelemetry-cpp/api/test/metrics/noop_sync_instrument_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/metrics/noop_sync_instrument_test.cc
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <map>
+#include "opentelemetry/metrics/noop.h"
+
+TEST(Counter, Add)
+{
+  std::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> counter{
+      new opentelemetry::metrics::NoopCounter<uint64_t>("test", "none", "unitless")};
+
+  std::map<std::string, std::string> labels = {{"k1", "v1"}};
+  counter->Add(10, labels);
+  counter->Add(10, labels, opentelemetry::context::Context{});
+  counter->Add(2);
+  counter->Add(2, opentelemetry::context::Context{});
+  counter->Add(10, {{"k1", "1"}, {"k2", 2}});
+  counter->Add(10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+}
+
+TEST(histogram, Record)
+{
+  std::shared_ptr<opentelemetry::metrics::Histogram<uint64_t>> histogram{
+      new opentelemetry::metrics::NoopHistogram<uint64_t>("test", "none", "unitless")};
+
+  std::map<std::string, std::string> labels = {{"k1", "v1"}};
+  histogram->Record(10, labels, opentelemetry::context::Context{});
+  histogram->Record(2, opentelemetry::context::Context{});
+
+  histogram->Record(10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+}
+
+TEST(UpDownCountr, Record)
+{
+  std::shared_ptr<opentelemetry::metrics::UpDownCounter<int64_t>> counter{
+      new opentelemetry::metrics::NoopUpDownCounter<int64_t>("test", "none", "unitless")};
+
+  std::map<std::string, std::string> labels = {{"k1", "v1"}};
+  counter->Add(10, labels);
+  counter->Add(10, labels, opentelemetry::context::Context{});
+  counter->Add(2);
+  counter->Add(2, opentelemetry::context::Context{});
+  counter->Add(10, {{"k1", "1"}, {"k2", 2}});
+  counter->Add(10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+}

--- a/third_party/opentelemetry-cpp/api/test/nostd/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/nostd/BUILD
@@ -1,0 +1,107 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+cc_test(
+    name = "function_ref_test",
+    srcs = [
+        "function_ref_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "string_view_test",
+    srcs = [
+        "string_view_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "variant_test",
+    srcs = [
+        "variant_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "unique_ptr_test",
+    srcs = [
+        "unique_ptr_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "utility_test",
+    srcs = [
+        "utility_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "span_test",
+    srcs = [
+        "span_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "shared_ptr_test",
+    srcs = [
+        "shared_ptr_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/nostd/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/nostd/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+include(GoogleTest)
+
+foreach(
+  testname
+  function_ref_test
+  string_view_test
+  unique_ptr_test
+  utility_test
+  span_test
+  shared_ptr_test
+  variant_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX nostd.
+    TEST_LIST ${testname})
+endforeach()

--- a/third_party/opentelemetry-cpp/api/test/nostd/function_ref_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/nostd/function_ref_test.cc
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/function_ref.h"
+
+#include <gtest/gtest.h>
+using namespace opentelemetry::nostd;
+
+int Call(function_ref<int()> f)
+{
+  return f();
+}
+
+int Return3()
+{
+  return 3;
+}
+
+TEST(FunctionRefTest, Call)
+{
+  int x = 9;
+
+  auto f = [&] { return x; };
+  EXPECT_EQ(Call(f), 9);
+
+  EXPECT_EQ(Call(Return3), 3);
+}
+
+TEST(FunctionRefTest, BoolConversion)
+{
+  auto f = [] { return 0; };
+  function_ref<int()> fref1{nullptr};
+  function_ref<int()> fref2{f};
+  EXPECT_TRUE(!static_cast<bool>(fref1));
+  EXPECT_TRUE(static_cast<bool>(fref2));
+}

--- a/third_party/opentelemetry-cpp/api/test/nostd/shared_ptr_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/nostd/shared_ptr_test.cc
@@ -1,0 +1,189 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+using opentelemetry::nostd::shared_ptr;
+
+class A
+{
+public:
+  explicit A(bool &destructed) noexcept : destructed_{destructed} { destructed_ = false; }
+
+  ~A() { destructed_ = true; }
+
+private:
+  bool &destructed_;
+};
+
+class B
+{
+public:
+  int f() const { return 123; }
+};
+
+class C
+{
+public:
+  virtual ~C() {}
+};
+
+class D : public C
+{
+public:
+  virtual ~D() {}
+};
+
+TEST(SharedPtrTest, DefaultConstruction)
+{
+  shared_ptr<int> ptr1;
+  EXPECT_EQ(ptr1.get(), nullptr);
+
+  shared_ptr<int> ptr2{nullptr};
+  EXPECT_EQ(ptr2.get(), nullptr);
+}
+
+TEST(SharedPtrTest, ExplicitConstruction)
+{
+  auto c = new C();
+  shared_ptr<C> ptr1{c};
+  EXPECT_EQ(ptr1.get(), c);
+
+  auto d = new D();
+  shared_ptr<C> ptr2{d};
+  EXPECT_EQ(ptr2.get(), d);
+}
+
+TEST(SharedPtrTest, MoveConstruction)
+{
+  auto value = new int{123};
+  shared_ptr<int> ptr1{value};
+  shared_ptr<int> ptr2{std::move(ptr1)};
+  EXPECT_EQ(ptr1.get(), nullptr);
+  EXPECT_EQ(ptr2.get(), value);
+}
+
+TEST(SharedPtrTest, MoveConstructionFromDifferentType)
+{
+  auto value = new int{123};
+  shared_ptr<int> ptr1{value};
+  shared_ptr<const int> ptr2{std::move(ptr1)};
+  EXPECT_EQ(ptr1.get(), nullptr);
+  EXPECT_EQ(ptr2.get(), value);
+}
+
+TEST(SharedPtrTest, MoveConstructionFromStdSharedPtr)
+{
+  auto value = new int{123};
+  std::shared_ptr<int> ptr1{value};
+  shared_ptr<int> ptr2{std::move(ptr1)};
+  EXPECT_EQ(ptr1.get(), nullptr);
+  EXPECT_EQ(ptr2.get(), value);
+}
+
+TEST(SharedPtrTest, Destruction)
+{
+  bool was_destructed;
+  shared_ptr<A>{new A{was_destructed}};
+  EXPECT_TRUE(was_destructed);
+}
+
+TEST(SharedPtrTest, Assignment)
+{
+  auto value = new int{123};
+  shared_ptr<int> ptr1;
+
+  ptr1 = shared_ptr<int>(value);
+  EXPECT_EQ(ptr1.get(), value);
+
+  ptr1 = nullptr;
+  EXPECT_EQ(ptr1.get(), nullptr);
+
+  auto value2                = new int{234};
+  const shared_ptr<int> ptr2 = shared_ptr<int>(value2);
+  ptr1                       = ptr2;
+  EXPECT_EQ(ptr1.get(), value2);
+
+  auto value3 = new int{345};
+  std::shared_ptr<int> ptr3(value3);
+  ptr1 = ptr3;
+  EXPECT_EQ(ptr1.get(), value3);
+}
+
+TEST(SharedPtrTest, BoolConversionOpertor)
+{
+  auto value = new int{123};
+  shared_ptr<int> ptr1{value};
+
+  EXPECT_TRUE(ptr1);
+  EXPECT_FALSE(shared_ptr<int>{});
+}
+
+TEST(SharedPtrTest, PointerOperators)
+{
+  auto value = new int{123};
+  shared_ptr<int> ptr1{value};
+
+  EXPECT_EQ(&*ptr1, value);
+  EXPECT_EQ(
+      shared_ptr<B> { new B }->f(), 123);
+}
+
+TEST(SharedPtrTest, Swap)
+{
+  auto value1 = new int{123};
+  shared_ptr<int> ptr1{value1};
+
+  auto value2 = new int{456};
+  shared_ptr<int> ptr2{value2};
+  ptr1.swap(ptr2);
+
+  EXPECT_EQ(ptr1.get(), value2);
+  EXPECT_EQ(ptr2.get(), value1);
+}
+
+TEST(SharedPtrTest, Comparison)
+{
+  shared_ptr<int> ptr1{new int{123}};
+  shared_ptr<int> ptr2{new int{456}};
+  shared_ptr<int> ptr3{};
+
+  EXPECT_EQ(ptr1, ptr1);
+  EXPECT_NE(ptr1, ptr2);
+
+  EXPECT_NE(ptr1, nullptr);
+  EXPECT_NE(nullptr, ptr1);
+
+  EXPECT_EQ(ptr3, nullptr);
+  EXPECT_EQ(nullptr, ptr3);
+}
+
+static void SharedPtrTest_Sort(size_t size = 10)
+{
+  std::vector<shared_ptr<const int>> nums;
+
+  for (int i = static_cast<int>(size); i > 0; i--)
+  {
+    nums.push_back(shared_ptr<int>(new int(i)));
+  }
+
+  auto nums2 = nums;
+
+  std::sort(nums.begin(), nums.end(),
+            [](shared_ptr<const int> a, shared_ptr<const int> b) { return *a < *b; });
+
+  EXPECT_NE(nums, nums2);
+
+  std::reverse(nums2.begin(), nums2.end());
+
+  EXPECT_EQ(nums, nums2);
+}
+
+TEST(SharedPtrTest, Sort)
+{
+  SharedPtrTest_Sort();
+}

--- a/third_party/opentelemetry-cpp/api/test/nostd/span_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/nostd/span_test.cc
@@ -1,0 +1,176 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/span.h"
+
+#include <cstdint>
+
+#include <algorithm>
+#include <array>
+#include <iterator>
+#include <list>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using opentelemetry::nostd::span;
+
+TEST(SpanTest, DefaultConstruction)
+{
+  span<int> s1;
+  EXPECT_EQ(s1.data(), nullptr);
+  EXPECT_EQ(s1.size(), 0);
+  EXPECT_TRUE(s1.empty());
+
+  span<int, 0> s2;
+  EXPECT_EQ(s2.data(), nullptr);
+  EXPECT_EQ(s2.size(), 0);
+  EXPECT_TRUE(s2.empty());
+
+  EXPECT_FALSE((std::is_default_constructible<span<int, 1>>::value));
+}
+
+TEST(SpanTest, Assignment)
+{
+  std::array<int, 3> array1 = {1, 2, 3};
+  std::array<int, 3> array2 = {1, 2, 3};
+  span<int> s1{array1.data(), array1.size()};
+  span<int, 3> s2{array1.data(), array1.size()};
+
+  span<int> s3;
+  s3 = s1;
+  EXPECT_EQ(s3.data(), array1.data());
+  EXPECT_EQ(s3.size(), array1.size());
+
+  span<int, 3> s4{array2};
+  s4 = s2;
+  EXPECT_EQ(s4.data(), array1.data());
+  EXPECT_EQ(s4.size(), array1.size());
+}
+
+TEST(SpanTest, PointerCountConstruction)
+{
+  std::array<int, 3> array = {1, 2, 3};
+
+  span<int> s1{array.data(), array.size()};
+  EXPECT_EQ(s1.data(), array.data());
+  EXPECT_EQ(s1.size(), array.size());
+
+  span<int, 3> s2{array.data(), array.size()};
+  EXPECT_EQ(s2.data(), array.data());
+  EXPECT_EQ(s2.size(), array.size());
+}
+
+TEST(SpanTest, RangeConstruction)
+{
+  int array[] = {1, 2, 3};
+
+  span<int> s1{std::begin(array), std::end(array)};
+  EXPECT_EQ(s1.data(), array);
+  EXPECT_EQ(s1.size(), 3);
+
+  span<int, 3> s2{std::begin(array), std::end(array)};
+  EXPECT_EQ(s2.data(), array);
+  EXPECT_EQ(s2.size(), 3);
+}
+
+TEST(SpanTest, ArrayConstruction)
+{
+  int array1[]              = {1, 2, 3};
+  std::array<int, 3> array2 = {1, 2, 3};
+
+  span<int> s1{array1};
+  EXPECT_EQ(s1.data(), array1);
+  EXPECT_EQ(s1.size(), 3);
+
+  span<int> s2{array2};
+  EXPECT_EQ(s2.data(), array2.data());
+  EXPECT_EQ(s2.size(), array2.size());
+
+  span<int, 3> s3{array1};
+  EXPECT_EQ(s3.data(), array1);
+  EXPECT_EQ(s3.size(), 3);
+
+  span<int, 3> s4{array2};
+  EXPECT_EQ(s4.data(), array2.data());
+  EXPECT_EQ(s4.size(), array2.size());
+
+  EXPECT_FALSE((std::is_constructible<span<int, 2>, int(&)[3]>::value));
+}
+
+TEST(SpanTest, ContainerConstruction)
+{
+  std::vector<int> v = {1, 2, 3};
+
+  span<int> s1{v};
+  EXPECT_EQ(s1.data(), v.data());
+  EXPECT_EQ(s1.size(), v.size());
+
+  span<int, 3> s2{v.data(), 3};
+
+  EXPECT_EQ(s2.data(), v.data());
+  EXPECT_EQ(s2.size(), v.size());
+
+  EXPECT_FALSE((std::is_constructible<span<int>, std::vector<double>>::value));
+  EXPECT_FALSE((std::is_constructible<span<int>, std::list<int>>::value));
+}
+
+TEST(SpanTest, OtherSpanConstruction)
+{
+  std::array<int, 3> array = {1, 2, 3};
+  span<int> s1{array.data(), array.size()};
+  span<int, 3> s2{array.data(), array.size()};
+
+  span<int> s3{s1};
+  EXPECT_EQ(s3.data(), array.data());
+  EXPECT_EQ(s3.size(), array.size());
+
+  span<int> s4{s2};
+  EXPECT_EQ(s4.data(), array.data());
+  EXPECT_EQ(s4.size(), array.size());
+
+  span<const int> s5{s1};
+  EXPECT_EQ(s5.data(), array.data());
+  EXPECT_EQ(s5.size(), array.size());
+
+  EXPECT_FALSE((std::is_constructible<span<int>, span<const int>>::value));
+  EXPECT_FALSE((std::is_constructible<span<int>, span<double>>::value));
+
+  span<int, 3> s6{s2};
+  EXPECT_EQ(s6.data(), array.data());
+  EXPECT_EQ(s6.size(), array.size());
+
+  span<const int, 3> s7{s2};
+  EXPECT_EQ(s7.data(), array.data());
+  EXPECT_EQ(s7.size(), array.size());
+
+  EXPECT_FALSE((std::is_constructible<span<int, 3>, span<int, 4>>::value));
+  EXPECT_FALSE((std::is_constructible<span<int, 3>, span<double, 3>>::value));
+}
+
+TEST(SpanTest, BracketOperator)
+{
+  std::array<int, 2> array = {1, 2};
+
+  span<int> s1{array.data(), array.size()};
+  EXPECT_EQ(s1[0], 1);
+  EXPECT_EQ(s1[1], 2);
+
+  span<int, 2> s2{array.data(), array.size()};
+  EXPECT_EQ(s2[0], 1);
+  EXPECT_EQ(s2[1], 2);
+}
+
+TEST(SpanTest, Iteration)
+{
+  std::array<int, 3> array = {1, 2, 3};
+
+  span<int> s1{array.data(), array.size()};
+  EXPECT_EQ(std::distance(s1.begin(), s1.end()), (ptrdiff_t)array.size());
+  EXPECT_TRUE(std::equal(s1.begin(), s1.end(), array.begin()));
+
+  span<int, 3> s2{array.data(), array.size()};
+  EXPECT_EQ(std::distance(s2.begin(), s2.end()), (ptrdiff_t)array.size());
+  EXPECT_TRUE(std::equal(s2.begin(), s2.end(), array.begin()));
+}

--- a/third_party/opentelemetry-cpp/api/test/nostd/string_view_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/nostd/string_view_test.cc
@@ -1,0 +1,125 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/string_view.h"
+
+#include <gtest/gtest.h>
+#include <cstring>
+#include <map>
+
+using opentelemetry::nostd::string_view;
+
+TEST(StringViewTest, DefaultConstruction)
+{
+  string_view ref;
+  EXPECT_EQ(ref.data(), nullptr);
+  EXPECT_EQ(ref.length(), 0);
+}
+
+TEST(StringViewTest, CStringInitialization)
+{
+  const char *val = "hello world";
+
+  string_view ref(val);
+
+  EXPECT_EQ(ref.data(), val);
+  EXPECT_EQ(ref.length(), std::strlen(val));
+}
+
+TEST(StringViewTest, StdStringInitialization)
+{
+  const std::string val = "hello world";
+
+  string_view ref(val);
+
+  EXPECT_EQ(ref.data(), val.data());
+  EXPECT_EQ(ref.length(), val.size());
+}
+
+TEST(StringViewTest, Copy)
+{
+  const std::string val = "hello world";
+
+  string_view ref(val);
+  string_view cpy(ref);
+
+  EXPECT_EQ(cpy.data(), val);
+  EXPECT_EQ(cpy.length(), val.length());
+  EXPECT_EQ(cpy, val);
+}
+
+TEST(StringViewTest, Accessor)
+{
+  string_view s = "abc123";
+  EXPECT_EQ(s.data(), &s[0]);
+  EXPECT_EQ(s.data() + 1, &s[1]);
+}
+
+TEST(StringViewTest, ExplicitStdStringConversion)
+{
+  std::string s = static_cast<std::string>(string_view{"abc"});
+  EXPECT_EQ(s, "abc");
+}
+
+TEST(StringViewTest, SubstrPortion)
+{
+  string_view s = "abc123";
+  EXPECT_EQ("123", s.substr(3));
+  EXPECT_EQ("12", s.substr(3, 2));
+}
+
+TEST(StringViewTest, SubstrOutOfRange)
+{
+  string_view s = "abc123";
+#if __EXCEPTIONS || (defined(OPENTELEMETRY_STL_VERSION) && (OPENTELEMETRY_STL_VERSION >= 2017))
+  EXPECT_THROW((void)s.substr(10), std::out_of_range);
+#else
+  EXPECT_DEATH({ s.substr(10); }, "");
+#endif
+}
+
+TEST(StringViewTest, FindSingleCharacter)
+{
+  string_view s = "abc";
+
+  // starting from 0-th position (default)
+  EXPECT_EQ(s.find('a'), 0);
+  EXPECT_EQ(s.find('b'), 1);
+  EXPECT_EQ(s.find('c'), 2);
+  EXPECT_EQ(s.find('d'), -1);  // FIXME: string_view:npos - problem with linker
+
+  // starting from given index
+  EXPECT_EQ(s.find('a', 1), -1);
+  EXPECT_EQ(s.find('b', 1), 1);
+
+  // out of index
+  EXPECT_EQ(s.find('a', 10), -1);
+}
+
+TEST(StringViewTest, Compare)
+{
+  string_view s1 = "aaa";
+  string_view s2 = "bbb";
+  string_view s3 = "aaa";
+
+  // Equals
+  EXPECT_EQ(s1, s3);
+  EXPECT_EQ(s1, s1);
+
+  // Less then
+  EXPECT_LT(s1, s2);
+
+  // Greater then
+  EXPECT_GT(s2, s1);
+}
+
+TEST(StringViewTest, MapKeyOrdering)
+{
+  std::map<string_view, size_t> m = {{"bbb", 2}, {"aaa", 1}, {"ccc", 3}};
+  size_t i                        = 1;
+  for (const auto &kv : m)
+  {
+    EXPECT_EQ(kv.second, i);
+    i++;
+  }
+}

--- a/third_party/opentelemetry-cpp/api/test/nostd/unique_ptr_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/nostd/unique_ptr_test.cc
@@ -1,0 +1,169 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/unique_ptr.h"
+
+#include <gtest/gtest.h>
+
+using opentelemetry::nostd::unique_ptr;
+
+class A
+{
+public:
+  explicit A(bool &destructed) noexcept : destructed_{destructed} { destructed_ = false; }
+
+  ~A() { destructed_ = true; }
+
+private:
+  bool &destructed_;
+};
+
+class B
+{
+public:
+  int f() const { return 123; }
+};
+
+TEST(UniquePtrTest, DefaultConstruction)
+{
+  unique_ptr<int> ptr1;
+  EXPECT_EQ(ptr1.get(), nullptr);
+
+  unique_ptr<int> ptr2{nullptr};
+  EXPECT_EQ(ptr2.get(), nullptr);
+}
+
+TEST(UniquePtrTest, ExplicitConstruction)
+{
+  auto value = new int{123};
+  unique_ptr<int> ptr1{value};
+  EXPECT_EQ(ptr1.get(), value);
+
+  auto array = new int[5];
+  unique_ptr<int[]> ptr2{array};
+  EXPECT_EQ(ptr2.get(), array);
+}
+
+TEST(UniquePtrTest, MoveConstruction)
+{
+  auto value = new int{123};
+  unique_ptr<int> ptr1{value};
+  unique_ptr<int> ptr2{std::move(ptr1)};
+  EXPECT_EQ(ptr1.get(), nullptr);
+  EXPECT_EQ(ptr2.get(), value);
+}
+
+TEST(UniquePtrTest, MoveConstructionFromDifferentType)
+{
+  auto value = new int{123};
+  unique_ptr<int> ptr1{value};
+  unique_ptr<const int> ptr2{std::move(ptr1)};
+  EXPECT_EQ(ptr1.get(), nullptr);
+  EXPECT_EQ(ptr2.get(), value);
+}
+
+TEST(UniquePtrTest, MoveConstructionFromStdUniquePtr)
+{
+  auto value = new int{123};
+  std::unique_ptr<int> ptr1{value};
+  unique_ptr<int> ptr2{std::move(ptr1)};
+  EXPECT_EQ(ptr1.get(), nullptr);
+  EXPECT_EQ(ptr2.get(), value);
+}
+
+TEST(UniquePtrTest, Destruction)
+{
+  bool was_destructed;
+  unique_ptr<A>{new A{was_destructed}};
+  EXPECT_TRUE(was_destructed);
+}
+
+TEST(UniquePtrTest, StdUniquePtrConversionOperator)
+{
+  auto value = new int{123};
+  unique_ptr<int> ptr1{value};
+  std::unique_ptr<int> ptr2{std::move(ptr1)};
+  EXPECT_EQ(ptr1.get(), nullptr);
+  EXPECT_EQ(ptr2.get(), value);
+
+  value = new int{456};
+  ptr1  = unique_ptr<int>{value};
+  ptr2  = std::move(ptr1);
+  EXPECT_EQ(ptr1.get(), nullptr);
+  EXPECT_EQ(ptr2.get(), value);
+
+  ptr2 = nullptr;
+  EXPECT_EQ(ptr2.get(), nullptr);
+
+  EXPECT_TRUE((std::is_assignable<std::unique_ptr<int>, unique_ptr<int> &&>::value));
+  EXPECT_FALSE((std::is_assignable<std::unique_ptr<int>, unique_ptr<int> &>::value));
+}
+
+TEST(UniquePtrTest, BoolConversionOpertor)
+{
+  auto value = new int{123};
+  unique_ptr<int> ptr1{value};
+
+  EXPECT_TRUE(ptr1);
+  EXPECT_FALSE(unique_ptr<int>{});
+}
+
+TEST(UniquePtrTest, PointerOperators)
+{
+  auto value = new int{123};
+  unique_ptr<int> ptr1{value};
+
+  EXPECT_EQ(&*ptr1, value);
+  EXPECT_EQ(
+      unique_ptr<B> { new B }->f(), 123);
+}
+
+TEST(UniquePtrTest, Reset)
+{
+  bool was_destructed1;
+  unique_ptr<A> ptr{new A{was_destructed1}};
+  bool was_destructed2 = true;
+  ptr.reset(new A{was_destructed2});
+  EXPECT_TRUE(was_destructed1);
+  EXPECT_FALSE(was_destructed2);
+  ptr.reset();
+  EXPECT_TRUE(was_destructed2);
+}
+
+TEST(UniquePtrTest, Release)
+{
+  auto value = new int{123};
+  unique_ptr<int> ptr{value};
+  EXPECT_EQ(ptr.release(), value);
+  EXPECT_EQ(ptr.get(), nullptr);
+  delete value;
+}
+
+TEST(UniquePtrTest, Swap)
+{
+  auto value1 = new int{123};
+  unique_ptr<int> ptr1{value1};
+
+  auto value2 = new int{456};
+  unique_ptr<int> ptr2{value2};
+  ptr1.swap(ptr2);
+
+  EXPECT_EQ(ptr1.get(), value2);
+  EXPECT_EQ(ptr2.get(), value1);
+}
+
+TEST(UniquePtrTest, Comparison)
+{
+  unique_ptr<int> ptr1{new int{123}};
+  unique_ptr<int> ptr2{new int{456}};
+  unique_ptr<int> ptr3{};
+
+  EXPECT_EQ(ptr1, ptr1);
+  EXPECT_NE(ptr1, ptr2);
+
+  EXPECT_NE(ptr1, nullptr);
+  EXPECT_NE(nullptr, ptr1);
+
+  EXPECT_EQ(ptr3, nullptr);
+  EXPECT_EQ(nullptr, ptr3);
+}

--- a/third_party/opentelemetry-cpp/api/test/nostd/utility_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/nostd/utility_test.cc
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/utility.h"
+
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace nostd = opentelemetry::nostd;
+
+template <class T>
+auto IsDataCallable(const T &t) -> decltype(nostd::data(t), std::true_type{});
+
+std::false_type IsDataCallable(...);
+
+template <class T>
+auto IsSizeCallable(const T &t) -> decltype(nostd::size(t), std::true_type{});
+
+std::false_type IsSizeCallable(...);
+
+TEST(UtilityTest, Data)
+{
+  std::vector<int> v = {1, 2, 3};
+  int array[3]       = {1, 2, 3};
+  std::initializer_list<int> list{1, 2, 3};
+  int x       = 0;
+  std::ignore = x;
+
+  EXPECT_EQ(nostd::data(v), v.data());
+  EXPECT_EQ(nostd::data(array), array);
+  EXPECT_EQ(nostd::data(list), list.begin());
+  EXPECT_FALSE(decltype(IsDataCallable(x)){});
+}
+
+TEST(UtilityTest, Size)
+{
+  std::vector<int> v = {1, 2, 3};
+  int array[3]       = {1, 2, 3};
+  int x              = 0;
+  std::ignore        = x;
+
+  EXPECT_EQ(nostd::size(v), v.size());
+  EXPECT_EQ(nostd::size(array), 3);
+
+  EXPECT_FALSE(decltype(IsSizeCallable(x)){});
+}
+
+TEST(UtilityTest, MakeIndexSequence)
+{
+  EXPECT_TRUE((std::is_same<nostd::make_index_sequence<0>, nostd::index_sequence<>>::value));
+  EXPECT_TRUE((std::is_same<nostd::make_index_sequence<1>, nostd::index_sequence<0>>::value));
+  EXPECT_TRUE((std::is_same<nostd::make_index_sequence<2>, nostd::index_sequence<0, 1>>::value));
+}

--- a/third_party/opentelemetry-cpp/api/test/nostd/variant_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/nostd/variant_test.cc
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/variant.h"
+
+#include <string>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+namespace nostd = opentelemetry::nostd;
+
+class DestroyCounter
+{
+public:
+  explicit DestroyCounter(int *count) : count_{count} {}
+  ~DestroyCounter() { ++*count_; }
+
+private:
+  int *count_;
+};
+
+TEST(VariantSizeTest, GetVariantSize)
+{
+  EXPECT_EQ(nostd::variant_size<nostd::variant<>>::value, 0);
+  EXPECT_EQ(nostd::variant_size<nostd::variant<int>>::value, 1);
+  EXPECT_EQ((nostd::variant_size<nostd::variant<int, double>>::value), 2);
+}
+
+#if 0  // Disable this test for now. It does not compile with Visual Studio 2015.
+TEST(VariantAlternativeTest, GetVariantSize)
+{
+  EXPECT_TRUE((std::is_same<nostd::variant_alternative_t<0, nostd::variant<int>>, int>::value));
+  EXPECT_TRUE(
+      (std::is_same<nostd::variant_alternative_t<1, nostd::variant<int, double>>, double>::value));
+  EXPECT_TRUE((std::is_same<nostd::variant_alternative_t<1, const nostd::variant<int, double>>,
+                            const double>::value));
+}
+#endif
+
+TEST(VariantTest, Get)
+{
+  nostd::variant<int, float> v, w;
+  v = 12;
+  EXPECT_EQ(nostd::get<int>(v), 12);
+  EXPECT_EQ(nostd::get<0>(v), 12);
+  w = v;
+  EXPECT_EQ(nostd::get<int>(w), 12);
+  EXPECT_EQ(*nostd::get_if<int>(&v), 12);
+  EXPECT_EQ(nostd::get_if<float>(&v), nullptr);
+#if __EXCEPTIONS || (defined(OPENTELEMETRY_STL_VERSION) && (OPENTELEMETRY_STL_VERSION >= 2017))
+  EXPECT_THROW(nostd::get<float>(w), nostd::bad_variant_access);
+#else
+  EXPECT_DEATH({ nostd::get<float>(w); }, "");
+#endif
+}
+
+TEST(VariantTest, Comparison)
+{
+  nostd::variant<int, float> v, w;
+  EXPECT_TRUE(v == w);
+  EXPECT_FALSE(v != w);
+  v = 3.0f;
+  EXPECT_TRUE(v != w);
+  EXPECT_FALSE(v == w);
+  v = 2;
+  w = 3;
+  EXPECT_TRUE(v != w);
+  EXPECT_FALSE(v == w);
+  EXPECT_TRUE(v < w);
+  EXPECT_FALSE(v > w);
+}
+
+TEST(VariantTest, Visit)
+{
+  nostd::variant<int, float> v;
+  struct
+  {
+    int operator()(int) { return 0; }
+    int operator()(float) { return 1; }
+  } a;
+  EXPECT_EQ(nostd::visit(a, v), 0);
+  v = 2.0f;
+  EXPECT_EQ(nostd::visit(a, v), 1);
+}
+
+TEST(VariantTest, Destructor)
+{
+  nostd::variant<int, DestroyCounter> v;
+  int destroy_count = 0;
+  v                 = DestroyCounter{&destroy_count};
+  destroy_count     = 0;
+  v                 = 1;
+  EXPECT_EQ(destroy_count, 1);
+  {
+    nostd::variant<int, DestroyCounter> w;
+    w             = DestroyCounter{&destroy_count};
+    destroy_count = 0;
+  }
+  EXPECT_EQ(destroy_count, 1);
+}
+
+TEST(VariantTest, Conversion)
+{
+  nostd::variant<std::string> x("abc");
+  x = "def";
+  EXPECT_EQ(nostd::get<std::string>(x), "def");
+
+  nostd::variant<std::string, void const *> y("abc");
+  EXPECT_TRUE(nostd::holds_alternative<void const *>(y));
+  y = std::string{"xyz"};
+  EXPECT_TRUE(nostd::holds_alternative<std::string>(y));
+}
+
+TEST(VariantTest, Construction)
+{
+  nostd::variant<bool, const char *, std::string> v{"abc"};
+  EXPECT_EQ(v.index(), 1);
+}

--- a/third_party/opentelemetry-cpp/api/test/plugin/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/plugin/BUILD
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+cc_test(
+    name = "dynamic_load_test",
+    srcs = [
+        "dynamic_load_test.cc",
+    ],
+    linkopts = [
+        "-ldl",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/plugin/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/plugin/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+include(GoogleTest)
+
+add_executable(dynamic_load_test dynamic_load_test.cc)
+target_link_libraries(dynamic_load_test ${GTEST_BOTH_LIBRARIES}
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+target_link_libraries(dynamic_load_test ${CMAKE_DL_LIBS})
+gtest_add_tests(
+  TARGET dynamic_load_test
+  TEST_PREFIX plugin.
+  TEST_LIST dynamic_load_test)

--- a/third_party/opentelemetry-cpp/api/test/plugin/dynamic_load_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/plugin/dynamic_load_test.cc
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/plugin/dynamic_load.h"
+#include "opentelemetry/plugin/factory.h"
+
+#include <gtest/gtest.h>
+
+TEST(LoadFactoryTest, FailureTest)
+{
+  std::string error_message;
+  auto factory = opentelemetry::plugin::LoadFactory("no-such-plugin", error_message);
+  EXPECT_EQ(factory, nullptr);
+  EXPECT_FALSE(error_message.empty());
+}

--- a/third_party/opentelemetry-cpp/api/test/singleton/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/singleton/BUILD
@@ -1,0 +1,189 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+DEFAULT_WIN_COPTS = [
+]
+
+# gcc and clang, assumed to be used on this platform
+DEFAULT_NOWIN_COPTS = [
+    "-fvisibility=default",
+]
+
+HIDDEN_WIN_COPTS = [
+]
+
+# gcc and clang, assumed to be used on this platform
+HIDDEN_NOWIN_COPTS = [
+    "-fvisibility=hidden",
+]
+
+cc_library(
+    name = "component_a",
+    srcs = [
+        "component_a.cc",
+    ],
+    hdrs = [
+        "component_a.h",
+    ],
+    linkstatic = True,
+    deps = [
+        "//api",
+    ],
+)
+
+cc_library(
+    name = "component_b",
+    srcs = [
+        "component_b.cc",
+    ],
+    hdrs = [
+        "component_b.h",
+    ],
+    linkstatic = True,
+    deps = [
+        "//api",
+    ],
+)
+
+cc_library(
+    name = "component_c",
+    srcs = [
+        "component_c.cc",
+    ],
+    hdrs = [
+        "component_c.h",
+    ],
+    copts = select({
+        "//bazel:windows": DEFAULT_WIN_COPTS,
+        "//conditions:default": DEFAULT_NOWIN_COPTS,
+    }),
+    linkstatic = False,
+    deps = [
+        "//api",
+    ],
+)
+
+cc_library(
+    name = "component_d",
+    srcs = [
+        "component_d.cc",
+    ],
+    hdrs = [
+        "component_d.h",
+    ],
+    copts = select({
+        "//bazel:windows": HIDDEN_WIN_COPTS,
+        "//conditions:default": HIDDEN_NOWIN_COPTS,
+    }),
+    linkstatic = False,
+    deps = [
+        "//api",
+    ],
+)
+
+cc_library(
+    name = "component_e",
+    srcs = [
+        "component_e.cc",
+    ],
+    hdrs = [
+        "component_e.h",
+    ],
+    copts = select({
+        "//bazel:windows": DEFAULT_WIN_COPTS,
+        "//conditions:default": DEFAULT_NOWIN_COPTS,
+    }),
+    linkstatic = False,
+    deps = [
+        "//api",
+    ],
+)
+
+cc_library(
+    name = "component_f",
+    srcs = [
+        "component_f.cc",
+    ],
+    hdrs = [
+        "component_f.h",
+    ],
+    copts = select({
+        "//bazel:windows": HIDDEN_WIN_COPTS,
+        "//conditions:default": HIDDEN_NOWIN_COPTS,
+    }),
+    linkstatic = False,
+    deps = [
+        "//api",
+    ],
+)
+
+# no cc_shared_library in bazel 4.2
+cc_binary(
+    name = "component_g",
+    srcs = [
+        "component_g.cc",
+    ],
+    copts = select({
+        "//bazel:windows": DEFAULT_WIN_COPTS,
+        "//conditions:default": DEFAULT_NOWIN_COPTS,
+    }),
+    linkshared = True,
+    deps = [
+        "//api",
+    ],
+)
+
+# no cc_shared_library in bazel 4.2
+cc_binary(
+    name = "component_h",
+    srcs = [
+        "component_h.cc",
+    ],
+    copts = select({
+        "//bazel:windows": HIDDEN_WIN_COPTS,
+        "//conditions:default": HIDDEN_NOWIN_COPTS,
+    }),
+    linkshared = True,
+    deps = [
+        "//api",
+    ],
+)
+
+#
+# To build this test alone:
+# - bazel build //api/test/singleton:singleton_test
+# - bazel build //api/test/singleton:component_g
+# - bazel build //api/test/singleton:component_h
+#
+# Note that singleton_test does not depend on
+# component_g and component_h, on purpose.
+#
+# To run this test:
+# bazel test //api/test/singleton:singleton_test
+#
+
+cc_test(
+    name = "singleton_test",
+    srcs = [
+        "singleton_test.cc",
+    ],
+    defines = ["BAZEL_BUILD"],
+    linkopts = [
+        "-ldl",
+    ],
+    linkstatic = False,
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "component_a",
+        "component_b",
+        "component_c",
+        "component_d",
+        "component_e",
+        "component_f",
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/singleton/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/singleton/CMakeLists.txt
@@ -1,0 +1,61 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+include(GoogleTest)
+
+# Header only singletons are not available in windows yet.
+
+if(NOT WIN32)
+
+  add_library(component_a STATIC component_a.cc)
+  target_link_libraries(component_a opentelemetry_api)
+
+  add_library(component_b STATIC component_b.cc)
+  target_link_libraries(component_b opentelemetry_api)
+
+  add_library(component_c SHARED component_c.cc)
+  set_target_properties(component_c PROPERTIES CXX_VISIBILITY_PRESET default)
+  target_link_libraries(component_c opentelemetry_api)
+
+  add_library(component_d SHARED component_d.cc)
+  set_target_properties(component_d PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  target_link_libraries(component_d opentelemetry_api)
+
+  add_library(component_e SHARED component_e.cc)
+  set_target_properties(component_e PROPERTIES CXX_VISIBILITY_PRESET default)
+  target_link_libraries(component_e opentelemetry_api)
+
+  add_library(component_f SHARED component_f.cc)
+  set_target_properties(component_f PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  target_link_libraries(component_f opentelemetry_api)
+
+  add_library(component_g SHARED component_g.cc)
+  set_target_properties(component_g PROPERTIES CXX_VISIBILITY_PRESET default)
+  target_link_libraries(component_g opentelemetry_api)
+
+  add_library(component_h SHARED component_h.cc)
+  set_target_properties(component_h PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  target_link_libraries(component_h opentelemetry_api)
+
+  add_executable(singleton_test singleton_test.cc)
+
+  # Not linking with component_g and component_h on purpose
+  target_link_libraries(
+    singleton_test
+    component_a
+    component_b
+    component_c
+    component_d
+    component_e
+    component_f
+    ${GTEST_BOTH_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CMAKE_DL_LIBS}
+    opentelemetry_api)
+
+  gtest_add_tests(
+    TARGET singleton_test
+    TEST_PREFIX singleton.
+    TEST_LIST singleton_test)
+
+endif()

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_a.cc
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_a.cc
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/version.h"
+
+#include "component_a.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+static nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("A", "10.1");
+}
+
+static void f1()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("A::f1"));
+}
+
+static void f2()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("A::f2"));
+
+  f1();
+  f1();
+}
+
+void do_something_in_a()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("A::library"));
+
+  f2();
+}

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_a.h
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_a.h
@@ -1,0 +1,4 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+void do_something_in_a();

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_b.cc
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_b.cc
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/version.h"
+
+#include "component_b.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+static nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("B", "20.2");
+}
+
+static void f1()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("B::f1"));
+}
+
+static void f2()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("B::f2"));
+
+  f1();
+  f1();
+}
+
+void do_something_in_b()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("B::library"));
+
+  f2();
+}

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_b.h
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_b.h
@@ -1,0 +1,4 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+void do_something_in_b();

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_c.cc
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_c.cc
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/version.h"
+
+#define BUILD_COMPONENT_C
+
+#include "component_c.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+static nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("C", "30.3");
+}
+
+static void f1()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("C::f1"));
+}
+
+static void f2()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("C::f2"));
+
+  f1();
+  f1();
+}
+
+void do_something_in_c()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("C::library"));
+
+  f2();
+}

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_c.h
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_c.h
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if defined(_MSC_VER)
+// component_c is a DLL
+
+#  ifdef BUILD_COMPONENT_C
+__declspec(dllexport)
+#  else
+__declspec(dllimport)
+#  endif
+
+#endif
+
+    void do_something_in_c();

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_d.cc
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_d.cc
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/version.h"
+
+#define BUILD_COMPONENT_D
+
+#include "component_d.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+static nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("D", "40.4");
+}
+
+static void f1()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("D::f1"));
+}
+
+static void f2()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("D::f2"));
+
+  f1();
+  f1();
+}
+
+void do_something_in_d()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("D::library"));
+
+  f2();
+}

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_d.h
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_d.h
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Make the entry point visible, loaded dynamically
+
+#if defined(_MSC_VER)
+// component_d is a DLL
+
+#  ifdef BUILD_COMPONENT_D
+__declspec(dllexport)
+#  else
+__declspec(dllimport)
+#  endif
+
+#else
+// component_d is a shared library (*.so)
+// component_d is compiled with visibility("hidden"),
+__attribute__((visibility("default")))
+#endif
+
+    void do_something_in_d();

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_e.cc
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_e.cc
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/version.h"
+
+#define BUILD_COMPONENT_E
+
+#include "component_e.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+static nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("E", "50.5");
+}
+
+static void f1()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("E::f1"));
+}
+
+static void f2()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("E::f2"));
+
+  f1();
+  f1();
+}
+
+void do_something_in_e()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("E::library"));
+
+  f2();
+}

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_e.h
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_e.h
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if defined(_MSC_VER)
+// component_e is a DLL
+
+#  ifdef BUILD_COMPONENT_E
+__declspec(dllexport)
+#  else
+__declspec(dllimport)
+#  endif
+
+#endif
+
+    void do_something_in_e();

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_f.cc
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_f.cc
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/version.h"
+
+#define BUILD_COMPONENT_F
+
+#include "component_f.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+static nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("F", "60.6");
+}
+
+static void f1()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("F::f1"));
+}
+
+static void f2()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("F::f2"));
+
+  f1();
+  f1();
+}
+
+void do_something_in_f()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("F::library"));
+
+  f2();
+}

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_f.h
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_f.h
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Make the entry point visible, loaded dynamically
+
+#if defined(_MSC_VER)
+// component_f is a DLL
+
+#  ifdef BUILD_COMPONENT_F
+__declspec(dllexport)
+#  else
+__declspec(dllimport)
+#  endif
+
+#else
+// component_f is a shared library (*.so)
+// component_f is compiled with visibility("hidden"),
+__attribute__((visibility("default")))
+#endif
+
+    void do_something_in_f();

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_g.cc
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_g.cc
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/version.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+static nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("G", "70.7");
+}
+
+static void f1()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("G::f1"));
+}
+
+static void f2()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("G::f2"));
+
+  f1();
+  f1();
+}
+
+extern "C"
+
+#if defined(_MSC_VER)
+    // component_g is a DLL
+    __declspec(dllexport)
+#endif
+
+        void do_something_in_g()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("G::library"));
+
+  f2();
+}

--- a/third_party/opentelemetry-cpp/api/test/singleton/component_h.cc
+++ b/third_party/opentelemetry-cpp/api/test/singleton/component_h.cc
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/version.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+static nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("H", "80.8");
+}
+
+static void f1()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("H::f1"));
+}
+
+static void f2()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("H::f2"));
+
+  f1();
+  f1();
+}
+
+extern "C"
+
+#if defined(_MSC_VER)
+    // component_h is a DLL
+
+    __declspec(dllexport)
+
+#else
+// component_h is a shared library (*.so)
+// component_h is compiled with visibility("hidden"),
+__attribute__((visibility("default")))
+#endif
+
+        void do_something_in_h()
+{
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("H::library"));
+
+  f2();
+}

--- a/third_party/opentelemetry-cpp/api/test/singleton/singleton_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/singleton/singleton_test.cc
@@ -1,0 +1,404 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+/*
+  TODO:
+  Once singleton are supported for windows,
+  expand this test to use ::LoadLibrary, ::GetProcAddress, ::FreeLibrary
+*/
+#ifndef _WIN32
+#  include <dlfcn.h>
+#endif
+
+#include <iostream>
+
+#include "component_a.h"
+#include "component_b.h"
+#include "component_c.h"
+#include "component_d.h"
+#include "component_e.h"
+#include "component_f.h"
+
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/trace/span_context_kv_iterable.h"
+#include "opentelemetry/trace/span_startoptions.h"
+#include "opentelemetry/trace/tracer_provider.h"
+
+using namespace opentelemetry;
+
+void do_something()
+{
+  do_something_in_a();
+  do_something_in_b();
+  do_something_in_c();
+  do_something_in_d();
+  do_something_in_e();
+  do_something_in_f();
+
+  /*
+    See https://github.com/bazelbuild/bazel/issues/4218
+
+    There is no way to set LD_LIBRARY_PATH in bazel,
+    for dlopen() to find the library.
+
+    Verified manually that dlopen("/full/path/to/libcomponent_g.so") works,
+    and that the test passes in this case.
+  */
+
+#ifndef BAZEL_BUILD
+  /* Call do_something_in_g() */
+
+  void *component_g = dlopen("libcomponent_g.so", RTLD_NOW);
+  EXPECT_NE(component_g, nullptr);
+
+  auto *func_g = (void (*)())dlsym(component_g, "do_something_in_g");
+  EXPECT_NE(func_g, nullptr);
+
+  (*func_g)();
+
+  dlclose(component_g);
+
+  /* Call do_something_in_h() */
+
+  void *component_h = dlopen("libcomponent_h.so", RTLD_NOW);
+  EXPECT_NE(component_h, nullptr);
+
+  auto *func_h = (void (*)())dlsym(component_h, "do_something_in_h");
+  EXPECT_NE(func_h, nullptr);
+
+  (*func_h)();
+
+  dlclose(component_h);
+#endif
+}
+
+int span_a_lib_count   = 0;
+int span_a_f1_count    = 0;
+int span_a_f2_count    = 0;
+int span_b_lib_count   = 0;
+int span_b_f1_count    = 0;
+int span_b_f2_count    = 0;
+int span_c_lib_count   = 0;
+int span_c_f1_count    = 0;
+int span_c_f2_count    = 0;
+int span_d_lib_count   = 0;
+int span_d_f1_count    = 0;
+int span_d_f2_count    = 0;
+int span_e_lib_count   = 0;
+int span_e_f1_count    = 0;
+int span_e_f2_count    = 0;
+int span_f_lib_count   = 0;
+int span_f_f1_count    = 0;
+int span_f_f2_count    = 0;
+int span_g_lib_count   = 0;
+int span_g_f1_count    = 0;
+int span_g_f2_count    = 0;
+int span_h_lib_count   = 0;
+int span_h_f1_count    = 0;
+int span_h_f2_count    = 0;
+int unknown_span_count = 0;
+
+void reset_counts()
+{
+  span_a_lib_count   = 0;
+  span_a_f1_count    = 0;
+  span_a_f2_count    = 0;
+  span_b_lib_count   = 0;
+  span_b_f1_count    = 0;
+  span_b_f2_count    = 0;
+  span_c_lib_count   = 0;
+  span_c_f1_count    = 0;
+  span_c_f2_count    = 0;
+  span_d_lib_count   = 0;
+  span_d_f1_count    = 0;
+  span_d_f2_count    = 0;
+  span_e_lib_count   = 0;
+  span_e_f1_count    = 0;
+  span_e_f2_count    = 0;
+  span_f_lib_count   = 0;
+  span_f_f1_count    = 0;
+  span_f_f2_count    = 0;
+  span_g_lib_count   = 0;
+  span_g_f1_count    = 0;
+  span_g_f2_count    = 0;
+  span_h_lib_count   = 0;
+  span_h_f1_count    = 0;
+  span_h_f2_count    = 0;
+  unknown_span_count = 0;
+}
+
+class MyTracer : public trace::Tracer
+{
+public:
+  nostd::shared_ptr<trace::Span> StartSpan(
+      nostd::string_view name,
+      const common::KeyValueIterable & /* attributes */,
+      const trace::SpanContextKeyValueIterable & /* links */,
+      const trace::StartSpanOptions & /* options */) noexcept override
+  {
+    nostd::shared_ptr<trace::Span> result(new trace::DefaultSpan(trace::SpanContext::GetInvalid()));
+
+    /*
+      Unit test code, no need to be fancy.
+    */
+
+    if (name == "A::library")
+    {
+      span_a_lib_count++;
+    }
+    else if (name == "A::f1")
+    {
+      span_a_f1_count++;
+    }
+    else if (name == "A::f2")
+    {
+      span_a_f2_count++;
+    }
+    else if (name == "B::library")
+    {
+      span_b_lib_count++;
+    }
+    else if (name == "B::f1")
+    {
+      span_b_f1_count++;
+    }
+    else if (name == "B::f2")
+    {
+      span_b_f2_count++;
+    }
+    else if (name == "C::library")
+    {
+      span_c_lib_count++;
+    }
+    else if (name == "C::f1")
+    {
+      span_c_f1_count++;
+    }
+    else if (name == "C::f2")
+    {
+      span_c_f2_count++;
+    }
+    else if (name == "D::library")
+    {
+      span_d_lib_count++;
+    }
+    else if (name == "D::f1")
+    {
+      span_d_f1_count++;
+    }
+    else if (name == "D::f2")
+    {
+      span_d_f2_count++;
+    }
+    else if (name == "E::library")
+    {
+      span_e_lib_count++;
+    }
+    else if (name == "E::f1")
+    {
+      span_e_f1_count++;
+    }
+    else if (name == "E::f2")
+    {
+      span_e_f2_count++;
+    }
+    else if (name == "F::library")
+    {
+      span_f_lib_count++;
+    }
+    else if (name == "F::f1")
+    {
+      span_f_f1_count++;
+    }
+    else if (name == "F::f2")
+    {
+      span_f_f2_count++;
+    }
+    else if (name == "G::library")
+    {
+      span_g_lib_count++;
+    }
+    else if (name == "G::f1")
+    {
+      span_g_f1_count++;
+    }
+    else if (name == "G::f2")
+    {
+      span_g_f2_count++;
+    }
+    else if (name == "H::library")
+    {
+      span_h_lib_count++;
+    }
+    else if (name == "H::f1")
+    {
+      span_h_f1_count++;
+    }
+    else if (name == "H::f2")
+    {
+      span_h_f2_count++;
+    }
+    else
+    {
+      unknown_span_count++;
+    }
+
+    return result;
+  }
+
+  void ForceFlushWithMicroseconds(uint64_t /* timeout */) noexcept override {}
+
+  void CloseWithMicroseconds(uint64_t /* timeout */) noexcept override {}
+};
+
+class MyTracerProvider : public trace::TracerProvider
+{
+public:
+  static std::shared_ptr<trace::TracerProvider> Create()
+  {
+    std::shared_ptr<trace::TracerProvider> result(new MyTracerProvider());
+    return result;
+  }
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  nostd::shared_ptr<trace::Tracer> GetTracer(
+      nostd::string_view /* name */,
+      nostd::string_view /* version */,
+      nostd::string_view /* schema_url */,
+      const common::KeyValueIterable * /* attributes */) noexcept override
+  {
+    nostd::shared_ptr<trace::Tracer> result(new MyTracer());
+    return result;
+  }
+#else
+  nostd::shared_ptr<trace::Tracer> GetTracer(nostd::string_view /* name */,
+                                             nostd::string_view /* version */,
+                                             nostd::string_view /* schema_url */) noexcept override
+  {
+    nostd::shared_ptr<trace::Tracer> result(new MyTracer());
+    return result;
+  }
+#endif
+};
+
+void setup_otel()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> provider = MyTracerProvider::Create();
+
+  // The whole point of this test is to make sure
+  // that the API singleton behind SetTracerProvider()
+  // works for all components, static and dynamic.
+
+  // Set the global tracer provider
+  trace_api::Provider::SetTracerProvider(provider);
+}
+
+void cleanup_otel()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> provider(
+      new opentelemetry::trace::NoopTracerProvider());
+
+  // Set the global tracer provider
+  trace_api::Provider::SetTracerProvider(provider);
+}
+
+TEST(SingletonTest, Uniqueness)
+{
+  do_something();
+
+  EXPECT_EQ(span_a_lib_count, 0);
+  EXPECT_EQ(span_a_f1_count, 0);
+  EXPECT_EQ(span_a_f2_count, 0);
+  EXPECT_EQ(span_b_lib_count, 0);
+  EXPECT_EQ(span_b_f1_count, 0);
+  EXPECT_EQ(span_b_f2_count, 0);
+  EXPECT_EQ(span_c_lib_count, 0);
+  EXPECT_EQ(span_c_f1_count, 0);
+  EXPECT_EQ(span_c_f2_count, 0);
+  EXPECT_EQ(span_d_lib_count, 0);
+  EXPECT_EQ(span_d_f1_count, 0);
+  EXPECT_EQ(span_d_f2_count, 0);
+  EXPECT_EQ(span_e_lib_count, 0);
+  EXPECT_EQ(span_e_f1_count, 0);
+  EXPECT_EQ(span_e_f2_count, 0);
+  EXPECT_EQ(span_f_lib_count, 0);
+  EXPECT_EQ(span_f_f1_count, 0);
+  EXPECT_EQ(span_f_f2_count, 0);
+  EXPECT_EQ(span_g_lib_count, 0);
+  EXPECT_EQ(span_g_f1_count, 0);
+  EXPECT_EQ(span_g_f2_count, 0);
+  EXPECT_EQ(span_h_lib_count, 0);
+  EXPECT_EQ(span_h_f1_count, 0);
+  EXPECT_EQ(span_h_f2_count, 0);
+  EXPECT_EQ(unknown_span_count, 0);
+
+  reset_counts();
+  setup_otel();
+
+  do_something();
+
+  EXPECT_EQ(span_a_lib_count, 1);
+  EXPECT_EQ(span_a_f1_count, 2);
+  EXPECT_EQ(span_a_f2_count, 1);
+  EXPECT_EQ(span_b_lib_count, 1);
+  EXPECT_EQ(span_b_f1_count, 2);
+  EXPECT_EQ(span_b_f2_count, 1);
+  EXPECT_EQ(span_c_lib_count, 1);
+  EXPECT_EQ(span_c_f1_count, 2);
+  EXPECT_EQ(span_c_f2_count, 1);
+  EXPECT_EQ(span_d_lib_count, 1);
+  EXPECT_EQ(span_d_f1_count, 2);
+  EXPECT_EQ(span_d_f2_count, 1);
+  EXPECT_EQ(span_e_lib_count, 1);
+  EXPECT_EQ(span_e_f1_count, 2);
+  EXPECT_EQ(span_e_f2_count, 1);
+  EXPECT_EQ(span_f_lib_count, 1);
+  EXPECT_EQ(span_f_f1_count, 2);
+  EXPECT_EQ(span_f_f2_count, 1);
+
+#ifndef BAZEL_BUILD
+  EXPECT_EQ(span_g_lib_count, 1);
+  EXPECT_EQ(span_g_f1_count, 2);
+  EXPECT_EQ(span_g_f2_count, 1);
+  EXPECT_EQ(span_h_lib_count, 1);
+  EXPECT_EQ(span_h_f1_count, 2);
+  EXPECT_EQ(span_h_f2_count, 1);
+#endif
+
+  EXPECT_EQ(unknown_span_count, 0);
+
+  reset_counts();
+  cleanup_otel();
+
+  do_something();
+
+  EXPECT_EQ(span_a_lib_count, 0);
+  EXPECT_EQ(span_a_f1_count, 0);
+  EXPECT_EQ(span_a_f2_count, 0);
+  EXPECT_EQ(span_b_lib_count, 0);
+  EXPECT_EQ(span_b_f1_count, 0);
+  EXPECT_EQ(span_b_f2_count, 0);
+  EXPECT_EQ(span_c_lib_count, 0);
+  EXPECT_EQ(span_c_f1_count, 0);
+  EXPECT_EQ(span_c_f2_count, 0);
+  EXPECT_EQ(span_d_lib_count, 0);
+  EXPECT_EQ(span_d_f1_count, 0);
+  EXPECT_EQ(span_d_f2_count, 0);
+  EXPECT_EQ(span_e_lib_count, 0);
+  EXPECT_EQ(span_e_f1_count, 0);
+  EXPECT_EQ(span_e_f2_count, 0);
+  EXPECT_EQ(span_f_lib_count, 0);
+  EXPECT_EQ(span_f_f1_count, 0);
+  EXPECT_EQ(span_f_f2_count, 0);
+  EXPECT_EQ(span_g_lib_count, 0);
+  EXPECT_EQ(span_g_f1_count, 0);
+  EXPECT_EQ(span_g_f2_count, 0);
+  EXPECT_EQ(span_h_lib_count, 0);
+  EXPECT_EQ(span_h_f1_count, 0);
+  EXPECT_EQ(span_h_f2_count, 0);
+  EXPECT_EQ(unknown_span_count, 0);
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/trace/BUILD
@@ -1,0 +1,204 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+cc_test(
+    name = "default_span_test",
+    srcs = [
+        "default_span_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "noop_test",
+    srcs = [
+        "noop_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "key_value_iterable_view_test",
+    srcs = [
+        "key_value_iterable_view_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+otel_cc_benchmark(
+    name = "span_id_benchmark",
+    srcs = ["span_id_benchmark.cc"],
+    tags = [
+        "api",
+        "benchmark",
+        "test",
+        "trace",
+    ],
+    deps = ["//api"],
+)
+
+otel_cc_benchmark(
+    name = "span_benchmark",
+    srcs = ["span_benchmark.cc"],
+    tags = [
+        "api",
+        "benchmark",
+        "test",
+        "trace",
+    ],
+    deps = ["//api"],
+)
+
+cc_test(
+    name = "provider_test",
+    srcs = [
+        "provider_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "span_id_test",
+    srcs = [
+        "span_id_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "trace_flags_test",
+    srcs = [
+        "trace_flags_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "trace_id_test",
+    srcs = [
+        "trace_id_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "span_context_test",
+    srcs = [
+        "span_context_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "trace_state_test",
+    srcs = [
+        "trace_state_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "scope_test",
+    srcs = [
+        "scope_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "tracer_test",
+    srcs = [
+        "tracer_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/trace/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/trace/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(propagation)
+
+foreach(
+  testname
+  key_value_iterable_view_test
+  provider_test
+  span_id_test
+  trace_id_test
+  trace_flags_test
+  span_context_test
+  scope_test
+  noop_test
+  trace_state_test
+  tracer_test)
+  add_executable(api_${testname} "${testname}.cc")
+  target_link_libraries(api_${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET api_${testname}
+    TEST_PREFIX trace.
+    TEST_LIST api_${testname})
+endforeach()
+
+if(WITH_BENCHMARK)
+  add_executable(span_id_benchmark span_id_benchmark.cc)
+  target_link_libraries(span_id_benchmark benchmark::benchmark
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  add_executable(span_benchmark span_benchmark.cc)
+  target_link_libraries(span_benchmark benchmark::benchmark
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+endif()

--- a/third_party/opentelemetry-cpp/api/test/trace/default_span_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/default_span_test.cc
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/trace/span_context.h"
+
+#include <cstring>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using opentelemetry::trace::DefaultSpan;
+using opentelemetry::trace::SpanContext;
+
+TEST(DefaultSpanTest, GetContext)
+{
+  SpanContext span_context = SpanContext(false, false);
+  DefaultSpan sp           = DefaultSpan(span_context);
+  EXPECT_EQ(span_context, sp.GetContext());
+}
+}  // namespace

--- a/third_party/opentelemetry-cpp/api/test/trace/key_value_iterable_view_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/key_value_iterable_view_test.cc
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/common/key_value_iterable_view.h"
+
+#include <gtest/gtest.h>
+#include <map>
+#include "opentelemetry/nostd/type_traits.h"
+
+using namespace opentelemetry;
+
+static int TakeKeyValues(const common::KeyValueIterable &iterable)
+{
+  std::map<std::string, common::AttributeValue> result;
+  int count = 0;
+  iterable.ForEachKeyValue(
+      [&](nostd::string_view /* key */, common::AttributeValue /* value */) noexcept {
+        ++count;
+        return true;
+      });
+  return count;
+}
+
+template <class T, nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+static int TakeKeyValues(const T &iterable)
+{
+  return TakeKeyValues(common::KeyValueIterableView<T>{iterable});
+}
+
+TEST(KeyValueIterableViewTest, is_key_value_iterable)
+{
+  using M1 = std::map<std::string, std::string>;
+  EXPECT_TRUE(bool{common::detail::is_key_value_iterable<M1>::value});
+
+  using M2 = std::map<std::string, int>;
+  EXPECT_TRUE(bool{common::detail::is_key_value_iterable<M2>::value});
+
+  using M3 = std::map<std::string, common::AttributeValue>;
+  EXPECT_TRUE(bool{common::detail::is_key_value_iterable<M3>::value});
+
+  struct A
+  {};
+  using M4 = std::map<std::string, A>;
+  EXPECT_FALSE(bool{common::detail::is_key_value_iterable<M4>::value});
+}
+
+TEST(KeyValueIterableViewTest, ForEachKeyValue)
+{
+  std::map<std::string, std::string> m1 = {{"abc", "123"}, {"xyz", "456"}};
+  EXPECT_EQ(TakeKeyValues(m1), 2);
+
+  std::vector<std::pair<std::string, int>> v1 = {{"abc", 123}, {"xyz", 456}};
+  EXPECT_EQ(TakeKeyValues(v1), 2);
+}
+
+TEST(KeyValueIterableViewTest, ForEachKeyValueWithExit)
+{
+  using M = std::map<std::string, std::string>;
+  M m1    = {{"abc", "123"}, {"xyz", "456"}};
+  common::KeyValueIterableView<M> iterable{m1};
+  int count = 0;
+  auto exit = iterable.ForEachKeyValue(
+      [&count](nostd::string_view /*key*/, common::AttributeValue /*value*/) noexcept {
+        ++count;
+        return false;
+      });
+  EXPECT_EQ(count, 1);
+  EXPECT_FALSE(exit);
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/noop_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/noop_test.cc
@@ -1,0 +1,96 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/noop.h"
+#include "opentelemetry/common/timestamp.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace trace_api = opentelemetry::trace;
+namespace nonstd    = opentelemetry::nostd;
+namespace common    = opentelemetry::common;
+
+TEST(NoopTest, UseNoopTracers)
+{
+  std::shared_ptr<trace_api::Tracer> tracer{new trace_api::NoopTracer{}};
+  auto s1 = tracer->StartSpan("abc");
+
+  std::map<std::string, std::string> attributes1;
+  s1->AddEvent("abc", attributes1);
+
+  std::vector<std::pair<std::string, int>> attributes2;
+  s1->AddEvent("abc", attributes2);
+
+  s1->AddEvent("abc", {{"a", 1}, {"b", "2"}, {"c", 3.0}});
+
+  std::vector<std::pair<std::string, std::vector<int>>> attributes3;
+  s1->AddEvent("abc", attributes3);
+
+  s1->SetAttribute("abc", 4);
+
+  s1->AddEvent("abc");  // add Empty
+
+  EXPECT_EQ(s1->IsRecording(), false);
+
+  s1->SetStatus(trace_api::StatusCode::kUnset, "span unset");
+
+  s1->UpdateName("test_name");
+
+  common::SystemTimestamp t1;
+  s1->AddEvent("test_time_stamp", t1);
+
+  s1->GetContext();
+}
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+TEST(NoopTest, UseNoopTracersAbiv2)
+{
+  std::shared_ptr<trace_api::Tracer> tracer{new trace_api::NoopTracer{}};
+  auto s1 = tracer->StartSpan("abc");
+
+  EXPECT_EQ(s1->IsRecording(), false);
+
+  trace_api::SpanContext target(false, false);
+  s1->AddLink(target, {{"noop1", 1}});
+
+  s1->AddLinks({{trace_api::SpanContext(false, false), {{"noop2", 2}}}});
+}
+#endif /* OPENTELEMETRY_ABI_VERSION_NO >= 2 */
+
+TEST(NoopTest, StartSpan)
+{
+  std::shared_ptr<trace_api::Tracer> tracer{new trace_api::NoopTracer{}};
+
+  std::map<std::string, std::string> attrs = {{"a", "3"}};
+  std::vector<std::pair<trace_api::SpanContext, std::map<std::string, std::string>>> links = {
+      {trace_api::SpanContext(false, false), attrs}};
+  auto s1 = tracer->StartSpan("abc", attrs, links);
+
+  auto s2 =
+      tracer->StartSpan("efg", {{"a", 3}}, {{trace_api::SpanContext(false, false), {{"b", 4}}}});
+}
+
+TEST(NoopTest, CreateSpanValidSpanContext)
+{
+  // Create valid spancontext for NoopSpan
+
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  auto trace_id                 = trace_api::TraceId{buf_trace};
+  auto span_id                  = trace_api::SpanId{buf_span};
+  auto span_context             = nonstd::unique_ptr<trace_api::SpanContext>(
+      new trace_api::SpanContext{trace_id, span_id, trace_api::TraceFlags{true}, false});
+  std::shared_ptr<trace_api::Tracer> tracer{new trace_api::NoopTracer{}};
+  auto s1 =
+      nonstd::shared_ptr<trace_api::Span>(new trace_api::NoopSpan(tracer, std::move(span_context)));
+  auto stored_span_context = s1->GetContext();
+  EXPECT_EQ(stored_span_context.span_id(), span_id);
+  EXPECT_EQ(stored_span_context.trace_id(), trace_id);
+
+  s1->AddEvent("even1");  // noop
+  s1->End();              // noop
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/propagation/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/trace/propagation/BUILD
@@ -1,0 +1,55 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+cc_test(
+    name = "http_text_format_test",
+    srcs = [
+        "http_text_format_test.cc",
+        "util.h",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "b3_propagation_test",
+    srcs = [
+        "b3_propagation_test.cc",
+        "util.h",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "jaeger_propagation_test",
+    srcs = [
+        "jaeger_propagation_test.cc",
+        "util.h",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/trace/propagation/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/trace/propagation/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(detail)
+
+foreach(testname http_text_format_test b3_propagation_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX trace.
+    TEST_LIST ${testname})
+endforeach()
+
+if(NOT WITH_NO_DEPRECATED_CODE)
+  foreach(testname jaeger_propagation_test)
+
+    add_executable(${testname} "${testname}.cc")
+    target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                          ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+    gtest_add_tests(
+      TARGET ${testname}
+      TEST_PREFIX trace.
+      TEST_LIST ${testname})
+  endforeach()
+endif()

--- a/third_party/opentelemetry-cpp/api/test/trace/propagation/b3_propagation_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/propagation/b3_propagation_test.cc
@@ -1,0 +1,206 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/context/runtime_context.h"
+#include "opentelemetry/trace/propagation/b3_propagator.h"
+#include "opentelemetry/trace/scope.h"
+#include "util.h"
+
+#include <map>
+
+#include <gtest/gtest.h>
+
+using namespace opentelemetry;
+
+class TextMapCarrierTest : public context::propagation::TextMapCarrier
+{
+public:
+  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  {
+    auto it = headers_.find(std::string(key));
+    if (it != headers_.end())
+    {
+      return nostd::string_view(it->second);
+    }
+    return "";
+  }
+  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  {
+    headers_[std::string(key)] = std::string(value);
+  }
+
+  std::map<std::string, std::string> headers_;
+};
+
+using MapB3Context = trace::propagation::B3Propagator;
+
+static MapB3Context format = MapB3Context();
+
+using MapB3ContextMultiHeader = trace::propagation::B3PropagatorMultiHeader;
+
+static MapB3ContextMultiHeader formatMultiHeader = MapB3ContextMultiHeader();
+
+TEST(B3PropagationTest, TraceFlagsBufferGeneration)
+{
+  EXPECT_EQ(MapB3Context::TraceFlagsFromHex("0"), trace::TraceFlags());
+  EXPECT_EQ(MapB3Context::TraceFlagsFromHex("1"), trace::TraceFlags(trace::TraceFlags::kIsSampled));
+}
+
+TEST(B3PropagationTest, PropagateInvalidContext)
+{
+  // Do not propagate invalid trace context.
+  TextMapCarrierTest carrier;
+  context::Context ctx{
+      trace::kSpanKey,
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
+  format.Inject(carrier, ctx);
+  EXPECT_TRUE(carrier.headers_.count("b3") == 0);
+}
+
+TEST(B3PropagationTest, ExtractInvalidContext)
+{
+  TextMapCarrierTest carrier;
+  carrier.headers_      = {{"b3", "00000000000000000000000000000000-0000000000000000-0"}};
+  context::Context ctx1 = context::Context{};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+  auto ctx2_span        = ctx2.GetValue(trace::kSpanKey);
+  EXPECT_FALSE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
+}
+
+TEST(B3PropagationTest, DoNotOverwriteContextWithInvalidSpan)
+{
+  TextMapCarrierTest carrier;
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false};
+  nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
+
+  // Make sure this invalid span does not overwrite the active span context
+  carrier.headers_ = {{"b3", "00000000000000000000000000000000-0000000000000000-0"}};
+  context::Context ctx1{trace::kSpanKey, sp};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+  auto ctx2_span        = ctx2.GetValue(trace::kSpanKey);
+  auto span             = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "0102030405060708090a0b0c0d0e0f10");
+}
+
+TEST(B3PropagationTest, DoNotExtractWithInvalidHex)
+{
+  TextMapCarrierTest carrier;
+  carrier.headers_      = {{"b3", "0000000zzz0000000000000000000000-0000000zzz000000-1"}};
+  context::Context ctx1 = context::Context{};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+  auto ctx2_span        = ctx2.GetValue(trace::kSpanKey);
+  EXPECT_FALSE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
+}
+
+TEST(B3PropagationTest, SetRemoteSpan)
+{
+  TextMapCarrierTest carrier;
+  carrier.headers_ = {
+      {"b3", "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90"}};
+  context::Context ctx1 = context::Context{};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+
+  auto ctx2_span = ctx2.GetValue(trace::kSpanKey);
+  EXPECT_TRUE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
+
+  auto span = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "80f198ee56343ba864fe8b2a57d3eff7");
+  EXPECT_EQ(Hex(span->GetContext().span_id()), "e457b5a2e4d86bd1");
+  EXPECT_EQ(span->GetContext().IsSampled(), true);
+  EXPECT_EQ(span->GetContext().IsRemote(), true);
+}
+
+TEST(B3PropagationTest, SetRemoteSpan_TraceIdShort)
+{
+  TextMapCarrierTest carrier;
+  carrier.headers_      = {{"b3", "80f198ee56343ba8-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90"}};
+  context::Context ctx1 = context::Context{};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+
+  auto ctx2_span = ctx2.GetValue(trace::kSpanKey);
+  EXPECT_TRUE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
+
+  auto span = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "000000000000000080f198ee56343ba8");
+  EXPECT_EQ(Hex(span->GetContext().span_id()), "e457b5a2e4d86bd1");
+  EXPECT_EQ(span->GetContext().IsSampled(), true);
+  EXPECT_EQ(span->GetContext().IsRemote(), true);
+}
+
+TEST(B3PropagationTest, SetRemoteSpan_SingleHeaderNoFlags)
+{
+  TextMapCarrierTest carrier;
+  carrier.headers_      = {{"b3", "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1"}};
+  context::Context ctx1 = context::Context{};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+
+  auto ctx2_span = ctx2.GetValue(trace::kSpanKey);
+  EXPECT_TRUE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
+
+  auto span = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "80f198ee56343ba864fe8b2a57d3eff7");
+  EXPECT_EQ(Hex(span->GetContext().span_id()), "e457b5a2e4d86bd1");
+  EXPECT_EQ(span->GetContext().IsSampled(), false);
+  EXPECT_EQ(span->GetContext().IsRemote(), true);
+}
+
+TEST(B3PropagationTest, SetRemoteSpanMultiHeader)
+{
+  TextMapCarrierTest carrier;
+  carrier.headers_      = {{"X-B3-TraceId", "80f198ee56343ba864fe8b2a57d3eff7"},
+                      {"X-B3-SpanId", "e457b5a2e4d86bd1"},
+                      {"X-B3-Sampled", "1"}};
+  context::Context ctx1 = context::Context{};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+
+  auto ctx2_span = ctx2.GetValue(trace::kSpanKey);
+  EXPECT_TRUE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
+
+  auto span = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "80f198ee56343ba864fe8b2a57d3eff7");
+  EXPECT_EQ(Hex(span->GetContext().span_id()), "e457b5a2e4d86bd1");
+  EXPECT_EQ(span->GetContext().IsSampled(), true);
+  EXPECT_EQ(span->GetContext().IsRemote(), true);
+}
+
+TEST(B3PropagationTest, GetCurrentSpan)
+{
+  TextMapCarrierTest carrier;
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false};
+  nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
+
+  // Set `sp` as the currently active span, which must be used by `Inject`.
+  trace::Scope scoped_span{sp};
+
+  format.Inject(carrier, context::RuntimeContext::GetCurrent());
+  EXPECT_EQ(carrier.headers_["b3"], "0102030405060708090a0b0c0d0e0f10-0102030405060708-1");
+}
+
+TEST(B3PropagationTest, GetCurrentSpanMultiHeader)
+{
+  TextMapCarrierTest carrier;
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false};
+  nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
+
+  // Set `sp` as the currently active span, which must be used by `Inject`.
+  trace::Scope scoped_span{sp};
+
+  formatMultiHeader.Inject(carrier, context::RuntimeContext::GetCurrent());
+  EXPECT_EQ(carrier.headers_["X-B3-TraceId"], "0102030405060708090a0b0c0d0e0f10");
+  EXPECT_EQ(carrier.headers_["X-B3-SpanId"], "0102030405060708");
+  EXPECT_EQ(carrier.headers_["X-B3-Sampled"], "1");
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/propagation/detail/BUILD
+++ b/third_party/opentelemetry-cpp/api/test/trace/propagation/detail/BUILD
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
+cc_test(
+    name = "hex_test",
+    srcs = [
+        "hex_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/third_party/opentelemetry-cpp/api/test/trace/propagation/detail/CMakeLists.txt
+++ b/third_party/opentelemetry-cpp/api/test/trace/propagation/detail/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+foreach(testname hex_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  gtest_add_tests(
+    TARGET ${testname}
+    TEST_PREFIX trace.
+    TEST_LIST ${testname})
+endforeach()

--- a/third_party/opentelemetry-cpp/api/test/trace/propagation/detail/hex_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/propagation/detail/hex_test.cc
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/propagation/detail/hex.h"
+
+#include <map>
+
+#include <gtest/gtest.h>
+
+using namespace opentelemetry;
+
+TEST(HexTest, ConvertOddLength)
+{
+  const int kLength        = 16;
+  std::string trace_id_hex = "78cfcfec62ae9e9";
+  uint8_t trace_id[kLength];
+  trace::propagation::detail::HexToBinary(trace_id_hex, trace_id, sizeof(trace_id));
+
+  const uint8_t expected_trace_id[kLength] = {0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,
+                                              0x7, 0x8c, 0xfc, 0xfe, 0xc6, 0x2a, 0xe9, 0xe9};
+
+  for (int i = 0; i < kLength; ++i)
+  {
+    EXPECT_EQ(trace_id[i], expected_trace_id[i]);
+  }
+}
+
+TEST(HexTest, ConvertEvenLength)
+{
+  const int kLength        = 16;
+  std::string trace_id_hex = "078cfcfec62ae9e9";
+  uint8_t trace_id[kLength];
+  trace::propagation::detail::HexToBinary(trace_id_hex, trace_id, sizeof(trace_id));
+
+  const uint8_t expected_trace_id[kLength] = {0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,
+                                              0x7, 0x8c, 0xfc, 0xfe, 0xc6, 0x2a, 0xe9, 0xe9};
+
+  for (int i = 0; i < kLength; ++i)
+  {
+    EXPECT_EQ(trace_id[i], expected_trace_id[i]);
+  }
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/propagation/http_text_format_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/propagation/http_text_format_test.cc
@@ -1,0 +1,230 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/context/propagation/global_propagator.h"
+#include "opentelemetry/context/runtime_context.h"
+#include "opentelemetry/trace/context.h"
+#include "opentelemetry/trace/propagation/http_trace_context.h"
+#include "opentelemetry/trace/scope.h"
+#include "util.h"
+
+#include <map>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+using namespace opentelemetry;
+
+class TextMapCarrierTest : public context::propagation::TextMapCarrier
+{
+public:
+  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  {
+    auto it = headers_.find(std::string(key));
+    if (it != headers_.end())
+    {
+      return nostd::string_view(it->second);
+    }
+    return "";
+  }
+  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  {
+    headers_[std::string(key)] = std::string(value);
+  }
+
+  std::map<std::string, std::string> headers_;
+};
+
+using MapHttpTraceContext = trace::propagation::HttpTraceContext;
+
+static MapHttpTraceContext format = MapHttpTraceContext();
+
+TEST(TextMapPropagatorTest, TraceFlagsBufferGeneration)
+{
+  EXPECT_EQ(MapHttpTraceContext::TraceFlagsFromHex("00"), trace::TraceFlags());
+}
+
+TEST(TextMapPropagatorTest, NoSendEmptyTraceState)
+{
+  // If the trace state is empty, do not set the header.
+  TextMapCarrierTest carrier;
+  carrier.headers_ = {{"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"}};
+  context::Context ctx1 = context::Context{
+      trace::kSpanKey,
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+  TextMapCarrierTest carrier2;
+  format.Inject(carrier2, ctx2);
+  EXPECT_TRUE(carrier2.headers_.count("traceparent") > 0);
+  EXPECT_FALSE(carrier2.headers_.count("tracestate") > 0);
+}
+
+TEST(TextMapPropagatorTest, PropogateTraceState)
+{
+  TextMapCarrierTest carrier;
+  carrier.headers_ = {{"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"},
+                      {"tracestate", "congo=t61rcWkgMzE"}};
+  context::Context ctx1 = context::Context{
+      trace::kSpanKey,
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+
+  TextMapCarrierTest carrier2;
+  format.Inject(carrier2, ctx2);
+
+  EXPECT_TRUE(carrier2.headers_.count("traceparent") > 0);
+  EXPECT_TRUE(carrier2.headers_.count("tracestate") > 0);
+  EXPECT_EQ(carrier2.headers_["tracestate"], "congo=t61rcWkgMzE");
+}
+
+TEST(TextMapPropagatorTest, PropagateInvalidContext)
+{
+  // Do not propagate invalid trace context.
+  TextMapCarrierTest carrier;
+  context::Context ctx{
+      trace::kSpanKey,
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
+  format.Inject(carrier, ctx);
+  EXPECT_TRUE(carrier.headers_.count("traceparent") == 0);
+  EXPECT_TRUE(carrier.headers_.count("tracestate") == 0);
+}
+
+TEST(TextMapPropagatorTest, SetRemoteSpan)
+{
+  TextMapCarrierTest carrier;
+  carrier.headers_ = {{"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"}};
+  context::Context ctx1 = context::Context{};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+
+  auto ctx2_span = ctx2.GetValue(trace::kSpanKey);
+  EXPECT_TRUE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
+
+  auto span = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "4bf92f3577b34da6a3ce929d0e0e4736");
+  EXPECT_EQ(Hex(span->GetContext().span_id()), "0102030405060708");
+  EXPECT_EQ(span->GetContext().IsSampled(), true);
+  EXPECT_EQ(span->GetContext().IsRemote(), true);
+}
+
+TEST(TextMapPropagatorTest, DoNotOverwriteContextWithInvalidSpan)
+{
+  TextMapCarrierTest carrier;
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false};
+  nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
+
+  // Make sure this invalid span does not overwrite the active span context
+  carrier.headers_ = {{"traceparent", "00-FOO92f3577b34da6a3ce929d0e0e4736-010BAR0405060708-01"}};
+  context::Context ctx1{trace::kSpanKey, sp};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+  auto ctx2_span        = ctx2.GetValue(trace::kSpanKey);
+  auto span             = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "0102030405060708090a0b0c0d0e0f10");
+}
+
+TEST(TextMapPropagatorTest, GetCurrentSpan)
+{
+  TextMapCarrierTest carrier;
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
+  auto trace_state = trace::TraceState::FromHeader("congo=t61rcWkgMzE");
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false, trace_state};
+  nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
+
+  // Set `sp` as the currently active span, which must be used by `Inject`.
+  trace::Scope scoped_span{sp};
+
+  format.Inject(carrier, context::RuntimeContext::GetCurrent());
+  EXPECT_EQ(carrier.headers_["traceparent"],
+            "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01");
+  EXPECT_EQ(carrier.headers_["tracestate"], "congo=t61rcWkgMzE");
+}
+
+TEST(TextMapPropagatorTest, InvalidIdentitiesAreNotExtracted)
+{
+  TextMapCarrierTest carrier;
+  std::vector<std::string> traces = {
+      "ff-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01",
+      "00-0af7651916cd43dd8448eb211c80319c1-b9c7c989f97918e1-01",
+      "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e11-01",
+      "0-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01",
+      "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-0",
+      "00-0af7651916cd43dd8448eb211c8031-b9c7c989f97918e1-01",
+      "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97-01",
+      "00-1-1-00",
+      "00--b9c7c989f97918e1-01",
+      "00-0af7651916cd43dd8448eb211c80319c1--01",
+      "",
+      "---",
+  };
+
+  for (auto &trace : traces)
+  {
+    carrier.headers_      = {{"traceparent", trace}};
+    context::Context ctx1 = context::Context{};
+    context::Context ctx2 = format.Extract(carrier, ctx1);
+
+    auto span = trace::GetSpan(ctx2)->GetContext();
+    EXPECT_FALSE(span.IsValid());
+  }
+}
+
+TEST(GlobalTextMapPropagator, NoOpPropagator)
+{
+
+  auto propagator = context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+  TextMapCarrierTest carrier;
+
+  carrier.headers_ = {{"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"},
+                      {"tracestate", "congo=t61rcWkgMzE"}};
+  context::Context ctx1 = context::Context{
+      trace::kSpanKey,
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
+  context::Context ctx2 = propagator->Extract(carrier, ctx1);
+
+  TextMapCarrierTest carrier2;
+  propagator->Inject(carrier2, ctx2);
+
+  EXPECT_TRUE(carrier2.headers_.count("tracestate") == 0);
+  EXPECT_TRUE(carrier2.headers_.count("traceparent") == 0);
+}
+
+TEST(GlobalPropagator, SetAndGet)
+{
+
+  auto trace_state_value = "congo=t61rcWkgMzE";
+  context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+      nostd::shared_ptr<context::propagation::TextMapPropagator>(new MapHttpTraceContext()));
+
+  auto propagator = context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+
+  TextMapCarrierTest carrier;
+  carrier.headers_ = {{"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"},
+                      {"tracestate", trace_state_value}};
+  context::Context ctx1 = context::Context{
+      trace::kSpanKey,
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
+  context::Context ctx2 = propagator->Extract(carrier, ctx1);
+
+  TextMapCarrierTest carrier2;
+  propagator->Inject(carrier2, ctx2);
+
+  EXPECT_TRUE(carrier.headers_.count("traceparent") > 0);
+  EXPECT_TRUE(carrier.headers_.count("tracestate") > 0);
+  EXPECT_EQ(carrier.headers_["tracestate"], trace_state_value);
+
+  std::vector<std::string> fields;
+  propagator->Fields([&fields](nostd::string_view field) {
+    fields.push_back(field.data());
+    return true;
+  });
+  EXPECT_EQ(fields.size(), 2);
+  EXPECT_EQ(fields[0], trace::propagation::kTraceParent);
+  EXPECT_EQ(fields[1], trace::propagation::kTraceState);
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/propagation/jaeger_propagation_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/propagation/jaeger_propagation_test.cc
@@ -1,0 +1,187 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/propagation/jaeger.h"
+#include "opentelemetry/trace/scope.h"
+#include "util.h"
+
+#include <map>
+
+#include <gtest/gtest.h>
+
+using namespace opentelemetry;
+
+class TextMapCarrierTest : public context::propagation::TextMapCarrier
+{
+public:
+  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  {
+    auto it = headers_.find(std::string(key));
+    if (it != headers_.end())
+    {
+      return nostd::string_view(it->second);
+    }
+    return "";
+  }
+  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  {
+    headers_[std::string(key)] = std::string(value);
+  }
+
+  std::map<std::string, std::string> headers_;
+};
+
+using Propagator = trace::propagation::JaegerPropagator;
+
+static Propagator format = Propagator();
+
+TEST(JaegerPropagatorTest, ExtractValidSpans)
+{
+  struct TestTrace
+  {
+    std::string trace_state;
+    std::string expected_trace_id;
+    std::string expected_span_id;
+    bool sampled;
+  };
+
+  std::vector<TestTrace> traces = {
+      {
+          "4bf92f3577b34da6a3ce929d0e0e4736:0102030405060708:0:00",
+          "4bf92f3577b34da6a3ce929d0e0e4736",
+          "0102030405060708",
+          false,
+      },
+      {
+          "4bf92f3577b34da6a3ce929d0e0e4736:0102030405060708:0:ff",
+          "4bf92f3577b34da6a3ce929d0e0e4736",
+          "0102030405060708",
+          true,
+      },
+      {
+          "4bf92f3577b34da6a3ce929d0e0e4736:0102030405060708:0:f",
+          "4bf92f3577b34da6a3ce929d0e0e4736",
+          "0102030405060708",
+          true,
+      },
+      {
+          "a3ce929d0e0e4736:0102030405060708:0:00",
+          "0000000000000000a3ce929d0e0e4736",
+          "0102030405060708",
+          false,
+      },
+      {
+          "A3CE929D0E0E4736:ABCDEFABCDEF1234:0:01",
+          "0000000000000000a3ce929d0e0e4736",
+          "abcdefabcdef1234",
+          true,
+      },
+      {
+          "ff:ABCDEFABCDEF1234:0:0",
+          "000000000000000000000000000000ff",
+          "abcdefabcdef1234",
+          false,
+      },
+      {
+          "4bf92f3577b34da6a3ce929d0e0e4736:0102030405060708:0102030405060708:00",
+          "4bf92f3577b34da6a3ce929d0e0e4736",
+          "0102030405060708",
+          false,
+      },
+
+  };
+
+  for (TestTrace &test_trace : traces)
+  {
+    TextMapCarrierTest carrier;
+    carrier.headers_      = {{"uber-trace-id", test_trace.trace_state}};
+    context::Context ctx1 = context::Context{};
+    context::Context ctx2 = format.Extract(carrier, ctx1);
+
+    auto span = trace::GetSpan(ctx2)->GetContext();
+    EXPECT_TRUE(span.IsValid());
+
+    EXPECT_EQ(Hex(span.trace_id()), test_trace.expected_trace_id);
+    EXPECT_EQ(Hex(span.span_id()), test_trace.expected_span_id);
+    EXPECT_EQ(span.IsSampled(), test_trace.sampled);
+    EXPECT_EQ(span.IsRemote(), true);
+  }
+}
+
+TEST(JaegerPropagatorTest, ExctractInvalidSpans)
+{
+  TextMapCarrierTest carrier;
+  std::vector<std::string> traces = {
+      "4bf92f3577b34da6a3ce929d0e0e47344:0102030405060708:0:00",  // too long trace id
+      "4bf92f3577b34da6a3ce929d0e0e4734:01020304050607089:0:00",  // too long span id
+      "4bf92f3577b34da6x3ce929d0y0e4734:01020304050607089:0:00",  // invalid trace id character
+      "4bf92f3577b34da6a3ce929d0e0e4734:01020304g50607089:0:00",  // invalid span id character
+      "4bf92f3577b34da6a3ce929d0e0e4734::0:00",
+      "",
+      "::::",
+      "0:0:0:0",
+      ":abcdef12:0:0",
+  };
+
+  for (auto &trace : traces)
+  {
+    carrier.headers_      = {{"uber-trace-id", trace}};
+    context::Context ctx1 = context::Context{};
+    context::Context ctx2 = format.Extract(carrier, ctx1);
+
+    auto span = trace::GetSpan(ctx2)->GetContext();
+    EXPECT_FALSE(span.IsValid());
+  }
+}
+
+TEST(JaegerPropagatorTest, DoNotOverwriteContextWithInvalidSpan)
+{
+  TextMapCarrierTest carrier;
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false};
+  nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
+
+  // Make sure this invalid span does not overwrite the active span context
+  carrier.headers_ = {{"uber-trace-id", "foo:bar:0:00"}};
+  context::Context ctx1{trace::kSpanKey, sp};
+  context::Context ctx2 = format.Extract(carrier, ctx1);
+  auto ctx2_span        = ctx2.GetValue(trace::kSpanKey);
+  auto span             = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
+
+  EXPECT_EQ(Hex(span->GetContext().trace_id()), "0102030405060708090a0b0c0d0e0f10");
+}
+
+TEST(JaegerPropagatorTest, InjectsContext)
+{
+  TextMapCarrierTest carrier;
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false};
+  nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
+  trace::Scope scoped_span{sp};
+
+  format.Inject(carrier, context::RuntimeContext::GetCurrent());
+  EXPECT_EQ(carrier.headers_["uber-trace-id"],
+            "0102030405060708090a0b0c0d0e0f10:0102030405060708:0:01");
+
+  std::vector<std::string> fields;
+  format.Fields([&fields](nostd::string_view field) {
+    fields.push_back(field.data());
+    return true;
+  });
+  EXPECT_EQ(fields.size(), 1);
+  EXPECT_EQ(fields[0], opentelemetry::trace::propagation::kJaegerTraceHeader);
+}
+
+TEST(JaegerPropagatorTest, DoNotInjectInvalidContext)
+{
+  TextMapCarrierTest carrier;
+  context::Context ctx{
+      trace::kSpanKey,
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
+  format.Inject(carrier, ctx);
+  EXPECT_TRUE(carrier.headers_.count("uber-trace-id") == 0);
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/propagation/util.h
+++ b/third_party/opentelemetry-cpp/api/test/trace/propagation/util.h
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+template <typename T>
+static std::string Hex(const T &id_item)
+{
+  char buf[T::kSize * 2];
+  id_item.ToLowerBase16(buf);
+  return std::string(buf, sizeof(buf));
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/provider_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/provider_test.cc
@@ -1,0 +1,49 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/tracer_provider.h"
+
+#include <gtest/gtest.h>
+
+using opentelemetry::trace::Provider;
+using opentelemetry::trace::Tracer;
+using opentelemetry::trace::TracerProvider;
+
+namespace nostd = opentelemetry::nostd;
+
+class TestProvider : public TracerProvider
+{
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  nostd::shared_ptr<Tracer> GetTracer(
+      nostd::string_view /* name */,
+      nostd::string_view /* version */,
+      nostd::string_view /* schema_url */,
+      const opentelemetry::common::KeyValueIterable * /* attributes */) noexcept override
+  {
+    return nostd::shared_ptr<Tracer>(nullptr);
+  }
+#else
+  nostd::shared_ptr<Tracer> GetTracer(nostd::string_view /* name */,
+                                      nostd::string_view /* version */,
+                                      nostd::string_view /* schema_url */) noexcept override
+  {
+    return nostd::shared_ptr<Tracer>(nullptr);
+  }
+#endif
+};
+
+TEST(Provider, GetTracerProviderDefault)
+{
+  auto tf = Provider::GetTracerProvider();
+  EXPECT_NE(nullptr, tf);
+}
+
+TEST(Provider, SetTracerProvider)
+{
+  auto tf = nostd::shared_ptr<TracerProvider>(new TestProvider());
+  Provider::SetTracerProvider(tf);
+  ASSERT_EQ(tf, Provider::GetTracerProvider());
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/scope_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/scope_test.cc
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/scope.h"
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/noop.h"
+
+#include <gtest/gtest.h>
+
+using opentelemetry::trace::kSpanKey;
+using opentelemetry::trace::NoopSpan;
+using opentelemetry::trace::Scope;
+using opentelemetry::trace::Span;
+namespace nostd   = opentelemetry::nostd;
+namespace context = opentelemetry::context;
+
+TEST(ScopeTest, Construct)
+{
+  nostd::shared_ptr<Span> span(new NoopSpan(nullptr));
+  Scope scope(span);
+
+  context::ContextValue active_span_value = context::RuntimeContext::GetValue(kSpanKey);
+  ASSERT_TRUE(nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span_value));
+
+  auto active_span = nostd::get<nostd::shared_ptr<Span>>(active_span_value);
+  ASSERT_EQ(active_span, span);
+}
+
+TEST(ScopeTest, Destruct)
+{
+  nostd::shared_ptr<Span> span(new NoopSpan(nullptr));
+  Scope scope(span);
+
+  {
+    nostd::shared_ptr<Span> span_nested(new NoopSpan(nullptr));
+    Scope scope_nested(span_nested);
+
+    context::ContextValue active_span_value = context::RuntimeContext::GetValue(kSpanKey);
+    ASSERT_TRUE(nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span_value));
+
+    auto active_span = nostd::get<nostd::shared_ptr<Span>>(active_span_value);
+    ASSERT_EQ(active_span, span_nested);
+  }
+
+  context::ContextValue active_span_value = context::RuntimeContext::GetValue(kSpanKey);
+  ASSERT_TRUE(nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span_value));
+
+  auto active_span = nostd::get<nostd::shared_ptr<Span>>(active_span_value);
+  ASSERT_EQ(active_span, span);
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/span_benchmark.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/span_benchmark.cc
@@ -1,0 +1,129 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/context.h"
+#include "opentelemetry/trace/noop.h"
+#include "opentelemetry/trace/span_id.h"
+#include "opentelemetry/trace/trace_id.h"
+
+#include <cstdint>
+
+#include <benchmark/benchmark.h>
+
+using opentelemetry::trace::SpanContext;
+namespace trace_api = opentelemetry::trace;
+namespace nostd     = opentelemetry::nostd;
+namespace context   = opentelemetry::context;
+
+namespace
+{
+
+std::shared_ptr<trace_api::Tracer> initTracer()
+{
+  return std::shared_ptr<trace_api::Tracer>(new trace_api::NoopTracer());
+}
+
+// Test to measure performance for span creation
+void BM_SpanCreation(benchmark::State &state)
+{
+  auto tracer = initTracer();
+  while (state.KeepRunning())
+  {
+    auto span = tracer->StartSpan("span");
+    span->End();
+  }
+}
+BENCHMARK(BM_SpanCreation);
+
+// Test to measure performance for single span creation with scope
+void BM_SpanCreationWithScope(benchmark::State &state)
+{
+  auto tracer = initTracer();
+  while (state.KeepRunning())
+  {
+    auto span  = tracer->StartSpan("span");
+    auto scope = tracer->WithActiveSpan(span);
+    span->End();
+  }
+}
+BENCHMARK(BM_SpanCreationWithScope);
+
+// Test to measure performance for nested span creation with scope
+void BM_NestedSpanCreationWithScope(benchmark::State &state)
+{
+  auto tracer = initTracer();
+  while (state.KeepRunning())
+  {
+    auto o_span  = tracer->StartSpan("outer");
+    auto o_scope = tracer->WithActiveSpan(o_span);
+    {
+      auto i_span  = tracer->StartSpan("inner");
+      auto i_scope = tracer->WithActiveSpan(i_span);
+      {
+        auto im_span  = tracer->StartSpan("innermost");
+        auto im_scope = tracer->WithActiveSpan(im_span);
+        im_span->End();
+      }
+      i_span->End();
+    }
+    o_span->End();
+  }
+}
+
+BENCHMARK(BM_NestedSpanCreationWithScope);
+
+// Test to measure performance for nested span creation with manual span context management
+void BM_SpanCreationWithManualSpanContextPropagation(benchmark::State &state)
+{
+  auto tracer              = initTracer();
+  constexpr uint8_t buf1[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  trace_api::SpanId span_id(buf1);
+  constexpr uint8_t buf2[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1};
+  trace_api::TraceId trace_id(buf2);
+
+  while (state.KeepRunning())
+  {
+    auto outer_span = nostd::shared_ptr<trace_api::Span>(
+        new trace_api::DefaultSpan(SpanContext(trace_id, span_id, trace_api::TraceFlags(), false)));
+    trace_api::StartSpanOptions options;
+    options.parent          = outer_span->GetContext();
+    auto inner_span         = tracer->StartSpan("inner", options);
+    auto inner_span_context = inner_span->GetContext();
+    options.parent          = inner_span_context;
+    auto innermost_span     = tracer->StartSpan("innermost", options);
+    innermost_span->End();
+    inner_span->End();
+  }
+}
+BENCHMARK(BM_SpanCreationWithManualSpanContextPropagation);
+
+// Test to measure performance for nested span creation with context propagation
+void BM_SpanCreationWitContextPropagation(benchmark::State &state)
+{
+  auto tracer              = initTracer();
+  constexpr uint8_t buf1[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  trace_api::SpanId span_id(buf1);
+  constexpr uint8_t buf2[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1};
+  trace_api::TraceId trace_id(buf2);
+
+  while (state.KeepRunning())
+  {
+    auto current_ctx        = context::RuntimeContext::GetCurrent();
+    auto outer_span_context = SpanContext(trace_id, span_id, trace_api::TraceFlags(), false);
+    auto outer_span =
+        nostd::shared_ptr<trace_api::Span>(new trace_api::DefaultSpan(outer_span_context));
+    trace_api::SetSpan(current_ctx, outer_span);
+    auto inner_child = tracer->StartSpan("inner");
+    auto inner_scope = tracer->WithActiveSpan(inner_child);
+    {
+      auto innermost_child = tracer->StartSpan("innermost");
+      auto innermost_scope = tracer->WithActiveSpan(innermost_child);
+      innermost_child->End();
+    }
+    inner_child->End();
+  }
+}
+BENCHMARK(BM_SpanCreationWitContextPropagation);
+}  // namespace
+BENCHMARK_MAIN();

--- a/third_party/opentelemetry-cpp/api/test/trace/span_context_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/span_context_test.cc
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/span_context.h"
+#include "opentelemetry/trace/span_id.h"
+#include "opentelemetry/trace/trace_id.h"
+
+#include <gtest/gtest.h>
+
+using opentelemetry::trace::SpanContext;
+namespace trace_api = opentelemetry::trace;
+
+TEST(SpanContextTest, IsSampled)
+{
+  SpanContext s1(true, true);
+
+  ASSERT_EQ(s1.IsSampled(), true);
+
+  SpanContext s2(false, true);
+
+  ASSERT_EQ(s2.IsSampled(), false);
+}
+
+TEST(SpanContextTest, IsRemote)
+{
+  SpanContext s1(true, true);
+
+  ASSERT_EQ(s1.IsRemote(), true);
+
+  SpanContext s2(true, false);
+
+  ASSERT_EQ(s2.IsRemote(), false);
+}
+
+TEST(SpanContextTest, TraceFlags)
+{
+  SpanContext s1(true, true);
+
+  ASSERT_EQ(s1.trace_flags().flags(), 1);
+
+  SpanContext s2(false, true);
+
+  ASSERT_EQ(s2.trace_flags().flags(), 0);
+}
+
+// Test that SpanContext is invalid
+TEST(SpanContextTest, Invalid)
+{
+  SpanContext s1 = SpanContext::GetInvalid();
+  EXPECT_FALSE(s1.IsValid());
+
+  // Test that trace id and span id are invalid
+  EXPECT_EQ(s1.trace_id(), trace_api::TraceId());
+  EXPECT_EQ(s1.span_id(), trace_api::SpanId());
+}

--- a/third_party/opentelemetry-cpp/api/test/trace/span_id_benchmark.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/span_id_benchmark.cc
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/span_id.h"
+
+#include <benchmark/benchmark.h>
+#include <cstdint>
+
+namespace
+{
+using opentelemetry::trace::SpanId;
+constexpr uint8_t bytes[] = {1, 2, 3, 4, 5, 6, 7, 8};
+
+void BM_SpanIdDefaultConstructor(benchmark::State &state)
+{
+  while (state.KeepRunning())
+  {
+    benchmark::DoNotOptimize(SpanId());
+  }
+}
+BENCHMARK(BM_SpanIdDefaultConstructor);
+
+void BM_SpanIdConstructor(benchmark::State &state)
+{
+  while (state.KeepRunning())
+  {
+    benchmark::DoNotOptimize(SpanId(bytes));
+  }
+}
+BENCHMARK(BM_SpanIdConstructor);
+
+void BM_SpanIdToLowerBase16(benchmark::State &state)
+{
+  SpanId id(bytes);
+  char buf[SpanId::kSize * 2];
+  while (state.KeepRunning())
+  {
+    id.ToLowerBase16(buf);
+    benchmark::DoNotOptimize(buf);
+  }
+}
+BENCHMARK(BM_SpanIdToLowerBase16);
+
+void BM_SpanIdIsValid(benchmark::State &state)
+{
+  SpanId id(bytes);
+  while (state.KeepRunning())
+  {
+    benchmark::DoNotOptimize(id.IsValid());
+  }
+}
+BENCHMARK(BM_SpanIdIsValid);
+
+}  // namespace
+BENCHMARK_MAIN();

--- a/third_party/opentelemetry-cpp/api/test/trace/span_id_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/span_id_test.cc
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/span_id.h"
+
+#include <cstring>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using opentelemetry::trace::SpanId;
+
+std::string Hex(const opentelemetry::trace::SpanId &span)
+{
+  char buf[16];
+  span.ToLowerBase16(buf);
+  return std::string(buf, sizeof(buf));
+}
+
+TEST(SpanIdTest, DefaultConstruction)
+{
+  SpanId id;
+  EXPECT_FALSE(id.IsValid());
+  EXPECT_EQ("0000000000000000", Hex(id));
+}
+
+TEST(SpanIdTest, ValidId)
+{
+  constexpr uint8_t buf[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  SpanId id(buf);
+  EXPECT_TRUE(id.IsValid());
+  EXPECT_EQ("0102030405060708", Hex(id));
+  EXPECT_NE(SpanId(), id);
+  EXPECT_EQ(SpanId(buf), id);
+}
+
+TEST(SpanIdTest, LowercaseBase16)
+{
+  constexpr uint8_t buf[] = {1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+  SpanId id(buf);
+  EXPECT_TRUE(id.IsValid());
+  EXPECT_EQ("0102aabbccddeeff", Hex(id));
+  EXPECT_NE(SpanId(), id);
+  EXPECT_EQ(SpanId(buf), id);
+}
+
+TEST(SpanIdTest, CopyBytesTo)
+{
+  constexpr uint8_t src[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  SpanId id(src);
+  uint8_t buf[8];
+  id.CopyBytesTo(buf);
+  EXPECT_TRUE(memcmp(src, buf, 8) == 0);
+}
+}  // namespace

--- a/third_party/opentelemetry-cpp/api/test/trace/trace_flags_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/trace_flags_test.cc
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/trace_flags.h"
+
+#include <cstring>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using opentelemetry::trace::TraceFlags;
+
+std::string Hex(const TraceFlags &flags)
+{
+  char buf[2];
+  flags.ToLowerBase16(buf);
+  return std::string(buf, sizeof(buf));
+}
+
+TEST(TraceFlagsTest, DefaultConstruction)
+{
+  TraceFlags flags;
+  EXPECT_FALSE(flags.IsSampled());
+  EXPECT_EQ(0, flags.flags());
+  EXPECT_EQ("00", Hex(flags));
+}
+
+TEST(TraceFlagsTest, Sampled)
+{
+  TraceFlags flags{TraceFlags::kIsSampled};
+  EXPECT_TRUE(flags.IsSampled());
+  EXPECT_EQ(1, flags.flags());
+  EXPECT_EQ("01", Hex(flags));
+
+  uint8_t buf[1];
+  flags.CopyBytesTo(buf);
+  EXPECT_EQ(1, buf[0]);
+}
+
+}  // namespace

--- a/third_party/opentelemetry-cpp/api/test/trace/trace_id_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/trace_id_test.cc
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/trace_id.h"
+
+#include <cstring>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using opentelemetry::trace::TraceId;
+
+std::string Hex(const opentelemetry::trace::TraceId &trace)
+{
+  char buf[32];
+  trace.ToLowerBase16(buf);
+  return std::string(buf, sizeof(buf));
+}
+
+TEST(TraceIdTest, DefaultConstruction)
+{
+  TraceId id;
+  EXPECT_FALSE(id.IsValid());
+  EXPECT_EQ("00000000000000000000000000000000", Hex(id));
+}
+
+TEST(TraceIdTest, ValidId)
+{
+  constexpr uint8_t buf[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1};
+  TraceId id(buf);
+  EXPECT_TRUE(id.IsValid());
+  EXPECT_EQ("01020304050607080807060504030201", Hex(id));
+  EXPECT_NE(TraceId(), id);
+  EXPECT_EQ(TraceId(buf), id);
+}
+
+TEST(TraceIdTest, LowercaseBase16)
+{
+  constexpr uint8_t buf[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+  TraceId id(buf);
+  EXPECT_TRUE(id.IsValid());
+  EXPECT_EQ("01020304050607080807aabbccddeeff", Hex(id));
+  EXPECT_NE(TraceId(), id);
+  EXPECT_EQ(TraceId(buf), id);
+}
+
+TEST(TraceIdTest, CopyBytesTo)
+{
+  constexpr uint8_t src[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1};
+  TraceId id(src);
+  uint8_t buf[TraceId::kSize];
+  id.CopyBytesTo(buf);
+  EXPECT_TRUE(memcmp(src, buf, sizeof(buf)) == 0);
+}
+}  // namespace

--- a/third_party/opentelemetry-cpp/api/test/trace/trace_state_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/trace_state_test.cc
@@ -1,0 +1,196 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/trace/trace_state.h"
+
+#include <gtest/gtest.h>
+#include "opentelemetry/nostd/string_view.h"
+
+namespace
+{
+
+using opentelemetry::trace::TraceState;
+namespace nostd = opentelemetry::nostd;
+
+// Random string of length 257. Used for testing strings with max length 256.
+const char *kLongString =
+    "4aekid3he76zgytjavudqqeltyvu5zqio2lx7d92dlxlf0z4883irvxuwelsq27sx1mlrjg3r7ad3jeq09rjppyd9veorg"
+    "2nmihy4vilabfts8bsxruih0urusmjnglzl3iwpjinmo835dbojcrd73p56nw80v4xxrkye59ytmu5v84ysfa24d58ovv9"
+    "w1n54n0mhhf4z0mpv6oudywrp9vfoks6lrvxv3uihvbi2ihazf237kvt1nbsjn3kdvfdb";
+
+// -------------------------- TraceState class tests ---------------------------
+
+std::string create_ts_return_header(std::string header)
+{
+  auto ts = TraceState::FromHeader(header);
+  return ts->ToHeader();
+}
+
+std::string header_with_max_members()
+{
+  std::string header = "";
+  auto max_members   = TraceState::kMaxKeyValuePairs;
+  for (int i = 0; i < max_members; i++)
+  {
+    std::string key   = "key" + std::to_string(i);
+    std::string value = "value" + std::to_string(i);
+    header += key + "=" + value;
+    if (i != max_members - 1)
+    {
+      header += ",";
+    }
+  }
+  return header;
+}
+
+TEST(TraceStateTest, ValidateHeaderParsing)
+{
+  auto max_trace_state_header = header_with_max_members();
+
+  struct
+  {
+    const char *input;
+    const char *expected;
+  } testcases[] = {{"k1=v1", "k1=v1"},
+                   {"K1=V1", ""},
+                   {"k1=v1,k2=v2,k3=v3", "k1=v1,k2=v2,k3=v3"},
+                   {"k1=v1,k2=v2,,", "k1=v1,k2=v2"},
+                   {"k1=v1,k2=v2,invalidmember", ""},
+                   {"1a-2f@foo=bar1,a*/foo-_/bar=bar4", "1a-2f@foo=bar1,a*/foo-_/bar=bar4"},
+                   {"1a-2f@foo=bar1,*/foo-_/bar=bar4", ""},
+                   {",k1=v1", "k1=v1"},
+                   {",", ""},
+                   {",=,", ""},
+                   {"", ""},
+                   {max_trace_state_header.data(), max_trace_state_header.data()}};
+  for (auto &testcase : testcases)
+  {
+    EXPECT_EQ(create_ts_return_header(testcase.input), testcase.expected);
+  }
+}
+
+TEST(TraceStateTest, TraceStateGet)
+{
+
+  std::string trace_state_header = header_with_max_members();
+  auto ts                        = TraceState::FromHeader(trace_state_header);
+
+  std::string value;
+  EXPECT_TRUE(ts->Get("key0", value));
+  EXPECT_EQ(value, "value0");
+  EXPECT_TRUE(ts->Get("key16", value));
+  EXPECT_EQ(value, "value16");
+  EXPECT_TRUE(ts->Get("key31", value));
+  EXPECT_EQ(value, "value31");
+  EXPECT_FALSE(ts->Get("key32", value));
+}
+
+TEST(TraceStateTest, TraceStateSet)
+{
+  std::string trace_state_header = "k1=v1,k2=v2";
+  auto ts1                       = TraceState::FromHeader(trace_state_header);
+  auto ts1_new                   = ts1->Set("k3", "v3");
+  EXPECT_EQ(ts1_new->ToHeader(), "k3=v3,k1=v1,k2=v2");
+
+  trace_state_header = header_with_max_members();
+  auto ts2           = TraceState::FromHeader(trace_state_header);
+  auto ts2_new =
+      ts2->Set("n_k1", "n_v1");  // adding to max list, should return copy of existing list
+  EXPECT_EQ(ts2_new->ToHeader(), trace_state_header);
+
+  trace_state_header = "k1=v1,k2=v2";
+  auto ts3           = TraceState::FromHeader(trace_state_header);
+  auto ts3_new       = ts3->Set("*n_k1", "n_v1");  // adding invalid key, should return empty
+  EXPECT_EQ(ts3_new->ToHeader(), "");
+}
+
+TEST(TraceStateTest, TraceStateDelete)
+{
+  std::string trace_state_header = "k1=v1,k2=v2,k3=v3";
+  auto ts1                       = TraceState::FromHeader(trace_state_header);
+  auto ts1_new                   = ts1->Delete(std::string("k1"));
+  EXPECT_EQ(ts1_new->ToHeader(), "k2=v2,k3=v3");
+
+  trace_state_header = "k1=v1";  // single list member
+  auto ts2           = TraceState::FromHeader(trace_state_header);
+  auto ts2_new       = ts2->Delete(std::string("k1"));
+  EXPECT_EQ(ts2_new->ToHeader(), "");
+
+  trace_state_header = "k1=v1";  // single list member, delete invalid entry
+  auto ts3           = TraceState::FromHeader(trace_state_header);
+  auto ts3_new       = ts3->Delete(std::string("InvalidKey"));
+  EXPECT_EQ(ts3_new->ToHeader(), "");
+}
+
+TEST(TraceStateTest, Empty)
+{
+  std::string trace_state_header = "";
+  auto ts                        = TraceState::FromHeader(trace_state_header);
+  EXPECT_TRUE(ts->Empty());
+
+  trace_state_header = "k1=v1,k2=v2";
+  auto ts1           = TraceState::FromHeader(trace_state_header);
+  EXPECT_FALSE(ts1->Empty());
+}
+
+TEST(TraceStateTest, GetAllEntries)
+{
+  std::string trace_state_header       = "k1=v1,k2=v2,k3=v3";
+  auto ts1                             = TraceState::FromHeader(trace_state_header);
+  const int kNumPairs                  = 3;
+  nostd::string_view keys[kNumPairs]   = {"k1", "k2", "k3"};
+  nostd::string_view values[kNumPairs] = {"v1", "v2", "v3"};
+  size_t index                         = 0;
+  ts1->GetAllEntries([&keys, &values, &index](nostd::string_view key, nostd::string_view value) {
+    EXPECT_EQ(key, keys[index]);
+    EXPECT_EQ(value, values[index]);
+    index++;
+    return true;
+  });
+}
+
+TEST(TraceStateTest, IsValidKey)
+{
+  EXPECT_TRUE(TraceState::IsValidKey("valid-key23/*"));
+  EXPECT_FALSE(TraceState::IsValidKey("Invalid_key"));
+  EXPECT_FALSE(TraceState::IsValidKey("invalid$Key&"));
+  EXPECT_FALSE(TraceState::IsValidKey(""));
+  EXPECT_FALSE(TraceState::IsValidKey(kLongString));
+}
+
+TEST(TraceStateTest, IsValidValue)
+{
+  EXPECT_TRUE(TraceState::IsValidValue("valid-val$%&~"));
+  EXPECT_FALSE(TraceState::IsValidValue("\tinvalid"));
+  EXPECT_FALSE(TraceState::IsValidValue("invalid="));
+  EXPECT_FALSE(TraceState::IsValidValue("invalid,val"));
+  EXPECT_FALSE(TraceState::IsValidValue(""));
+  EXPECT_FALSE(TraceState::IsValidValue(kLongString));
+}
+
+// Tests that keys and values don't depend on null terminators
+TEST(TraceStateTest, MemorySafe)
+{
+  std::string trace_state_header       = "";
+  auto ts                              = TraceState::FromHeader(trace_state_header);
+  const int kNumPairs                  = 3;
+  nostd::string_view key_string        = "test_key_1test_key_2test_key_3";
+  nostd::string_view val_string        = "test_val_1test_val_2test_val_3";
+  nostd::string_view keys[kNumPairs]   = {key_string.substr(0, 10), key_string.substr(10, 10),
+                                        key_string.substr(20, 10)};
+  nostd::string_view values[kNumPairs] = {val_string.substr(0, 10), val_string.substr(10, 10),
+                                          val_string.substr(20, 10)};
+
+  auto ts1     = ts->Set(keys[2], values[2]);
+  auto ts2     = ts1->Set(keys[1], values[1]);
+  auto ts3     = ts2->Set(keys[0], values[0]);
+  size_t index = 0;
+
+  ts3->GetAllEntries([&keys, &values, &index](nostd::string_view key, nostd::string_view value) {
+    EXPECT_EQ(key, keys[index]);
+    EXPECT_EQ(value, values[index]);
+    index++;
+    return true;
+  });
+}
+}  // namespace

--- a/third_party/opentelemetry-cpp/api/test/trace/tracer_test.cc
+++ b/third_party/opentelemetry-cpp/api/test/trace/tracer_test.cc
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/noop.h"
+#include "opentelemetry/trace/scope.h"
+
+#include <gtest/gtest.h>
+
+namespace trace_api = opentelemetry::trace;
+namespace nostd     = opentelemetry::nostd;
+namespace context   = opentelemetry::context;
+
+TEST(TracerTest, GetCurrentSpan)
+{
+  std::unique_ptr<trace_api::Tracer> tracer(new trace_api::NoopTracer());
+  nostd::shared_ptr<trace_api::Span> span_first(new trace_api::NoopSpan(nullptr));
+  nostd::shared_ptr<trace_api::Span> span_second(new trace_api::NoopSpan(nullptr));
+
+  auto current = tracer->GetCurrentSpan();
+  ASSERT_FALSE(current->GetContext().IsValid());
+
+  {
+    auto scope_first = tracer->WithActiveSpan(span_first);
+    current          = tracer->GetCurrentSpan();
+    ASSERT_EQ(current, span_first);
+
+    {
+      auto scope_second = tracer->WithActiveSpan(span_second);
+      current           = tracer->GetCurrentSpan();
+      ASSERT_EQ(current, span_second);
+    }
+    current = tracer->GetCurrentSpan();
+    ASSERT_EQ(current, span_first);
+  }
+
+  current = tracer->GetCurrentSpan();
+  ASSERT_FALSE(current->GetContext().IsValid());
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124800

Summary:
https://github.com/pytorch/pytorch/issues/124612
OpenTelemetry git repo has a lot of its own third party deps, most of
which are irrelevant when we are compiling against API only.
1. Remove opentelemetry as a submodule.
2. Add only `opentelemetry-cpp/api directory`.
3. Add a README.md that explains how API was copied.