### PR TITLE
[custom_op] register_autograd supports non-tensor kwargonly-args

### DIFF
--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -22,18 +22,18 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
     name: str = f"GeneratedBackwardFor_{op._namespace}_{op._opname}_{op._overloadname}"
 
     saved_keyset = None
-    saved_kwargs = None
+    saved_keyword_only_args = None
     has_kwarg_only_args = utils.has_kwarg_only_args(op._schema)
 
     def forward(ctx, *args):
         with _C._AutoDispatchBelowAutograd():
-            nonlocal saved_keyset, saved_kwargs
+            nonlocal saved_keyset, saved_keyword_only_args
             keyset = saved_keyset
             assert keyset is not None, "Should have been set by autograd_impl"
             saved_keyset = None
-            kwargs = saved_kwargs
+            kwargs = saved_keyword_only_args
             assert kwargs is not None, "Should have been set by autograd_impl"
-            saved_kwargs = None
+            saved_keyword_only_args = None
             result = op.redispatch(keyset & _C._after_autograd_keyset, *args, **kwargs)
             if info._setup_context_fn:
                 if has_kwarg_only_args:
@@ -70,15 +70,17 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
     ):
         Generated = supports_tensorlist(Generated)
 
-    def autograd_impl(keyset, *args, **kwargs):
+    # The dispatcher passes any keyword-only-args as kwargs and the
+    # rest of the args (even if specified as kwargs) as args.
+    def autograd_impl(keyset, *args, **keyword_only_args):
         # We set a nonlocal to ferry keyset from here to the forward.
         # This supports recursive calls (we implement the forward carefully so
         # that it'll read saved_keyset before making a recursive call to the op).
-        nonlocal saved_keyset, saved_kwargs
+        nonlocal saved_keyset, saved_keyword_only_args
         assert saved_keyset is None
         saved_keyset = keyset
-        assert saved_kwargs is None
-        saved_kwargs = kwargs
+        assert saved_keyword_only_args is None
+        saved_keyword_only_args = keyword_only_args
         result = Generated.apply(*args)  # type: ignore[attr-defined]
         return result
 

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -221,3 +221,17 @@ def handle_dispatch_mode(curr_mode, op_overload, *args, **kwargs):
     # TODO: check that I got these args correct (in C++, we pass in "0000"??)
 
     return curr_mode.__torch_dispatch__(op_overload, overload_types, args, kwargs)
+
+
+def has_kwarg_only_args(schema: _C.FunctionSchema):
+    return any(a.kwarg_only for a in schema.arguments)
+
+
+def has_kwarg_only_tensors(schema: _C.FunctionSchema):
+    for a in schema.arguments:
+        if not (is_tensor_like_type(a.type) or is_tensorlist_like_type(a.type)):
+            continue
+        if not a.kwarg_only:
+            continue
+        return True
+    return False

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -105,7 +105,7 @@ def is_functional_schema(schema: Any) -> bool:
     return is_functional(schema)
 
 
-def is_tensorlist_like_type(typ: torch.Type):
+def is_tensorlist_like_type(typ: torch.JitType):
     return (
         typ == _C.ListType(_C.TensorType.get())
         or typ == _C.ListType(_C.OptionalType(_C.TensorType.get()))
@@ -114,7 +114,7 @@ def is_tensorlist_like_type(typ: torch.Type):
     )
 
 
-def is_tensor_like_type(typ: torch.Type):
+def is_tensor_like_type(typ: torch.JitType):
     return typ == _C.TensorType.get() or typ == _C.OptionalType(_C.TensorType.get())
 
 

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -105,7 +105,8 @@ def is_functional_schema(schema: Any) -> bool:
     return is_functional(schema)
 
 
-def is_tensorlist_like_type(typ: torch.JitType):
+# should be torch._C.JitType but that annotation is busted
+def is_tensorlist_like_type(typ: Any) -> bool:
     return (
         typ == _C.ListType(_C.TensorType.get())
         or typ == _C.ListType(_C.OptionalType(_C.TensorType.get()))
@@ -114,7 +115,8 @@ def is_tensorlist_like_type(typ: torch.JitType):
     )
 
 
-def is_tensor_like_type(typ: torch.JitType):
+# should be torch._C.JitType but that annotation is busted
+def is_tensor_like_type(typ: Any) -> bool:
     return typ == _C.TensorType.get() or typ == _C.OptionalType(_C.TensorType.get())
 
 

--- a/torch/testing/_internal/autograd_function_db.py
+++ b/torch/testing/_internal/autograd_function_db.py
@@ -142,6 +142,9 @@ def sample_inputs_numpy_mul(opinfo, device, dtype, requires_grad, **kwargs):
     # Broadcasting
     yield SampleInput(make_arg(4, low=0.9, high=2), args=(make_arg(3, 4, low=0.9, high=2),))
 
+def sample_inputs_numpy_mul_scalar(opinfo, device, dtype, requires_grad, **kwargs):
+    make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    yield SampleInput(make_arg(4, low=0.9, high=2), args=(), kwargs={"scalar": 3.14})
 
 class MulGenVmap(torch.autograd.Function):
     generate_vmap_rule = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124852
* __->__ #124806
* #124805
* #124637

The user does not need to return gradients for these args.

We also change how setup_context works to adapt to kwargonly-args. If
the user's op has no kwonly-args, then their setup_context function must
look like `setup_context(ctx, inputs, output)`: we require that the
arguments have the same names.

If the user's op has kwonly-args, then their setup_context function must
look like `setup_context(ctx, inputs, keyword_only_inputs, output)`.
We require that the arguments have the same names.

Test Plan:
- new tests