### PR TITLE
[foreach] Use same `dtypes` when  `dtypesIfCUDA` is `None`

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -388,9 +388,10 @@ void foreach_tensor_zero_cuda_(TensorList tensors) {
   std::vector<std::vector<at::Tensor>> tensor_lists;
   tensor_lists.emplace_back(tensors.vec());
 
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
       ScalarType::Half,
       ScalarType::BFloat16,
+      ScalarType::Bool,
       tensors[0].scalar_type(),
       "foreach_zero_cuda_",
       [&]() {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9217,6 +9217,8 @@ class foreach_inputs_sample_func:
             # unary
             if opinfo.ref in (torch.abs, torch.neg):
                 return False
+            if opinfo.ref_inplace in (torch.Tensor.zero_,):
+                return False
             return dtype in integral_types_and(torch.bool)
         if self.arity < 2 or rightmost_arg_type == ForeachRightmostArgType.Tensor:
             return None

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9477,43 +9477,53 @@ foreach_unary_op_db: List[OpInfo] = [
         'exp',
         foreach_inputs_sample_func(1, False, False),
         backward_requires_result=True,
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'acos',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'asin',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'atan',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'cos',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'cosh',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'log',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'log10',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'log2',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'tan',
         foreach_inputs_sample_func(1, False, False),
         backward_requires_result=True,
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
         decorators=(
             # due to https://github.com/pytorch/pytorch/pull/102427 enabling jiterator for complex
             DecorateInfo(
@@ -9532,6 +9542,7 @@ foreach_unary_op_db: List[OpInfo] = [
         'tanh',
         foreach_inputs_sample_func(1, False, False),
         backward_requires_result=True,
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
         decorators=(
             DecorateInfo(
                 toleranceOverride(
@@ -9546,10 +9557,12 @@ foreach_unary_op_db: List[OpInfo] = [
     ForeachFuncInfo(
         'sin',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'sinh',
         foreach_inputs_sample_func(1, False, False),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half,),
     ),
     ForeachFuncInfo(
         'neg',

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -2714,7 +2714,7 @@ class ForeachFuncInfo(OpInfo):
         sample_inputs_func,
         *,
         dtypes=floating_and_complex_types(),
-        dtypesIfCUDA=floating_and_complex_types_and(torch.half),
+        dtypesIfCUDA=None,
         dtypesIfROCM=None,
         supports_alpha_param=False,
         supports_autograd=True,


### PR DESCRIPTION
in order to avoid accidentally testing cuda path with fewer dtypes 