### PR TITLE
Explicitly enable CPU fallback environment for XPU test

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -283,11 +283,6 @@ test_python() {
   assert_git_not_dirty
 }
 
-test_python_xpu() {
-  # shellcheck disable=SC2086
-  PYTORCH_ENABLE_XPU_FALLBACK=1 time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests $INCLUDE_CLAUSE --verbose $PYTHON_TEST_EXTRA_OPTION
-  assert_git_not_dirty
-}
 
 test_dynamo_shard() {
   if [[ -z "$NUM_TEST_SHARDS" ]]; then
@@ -1274,7 +1269,8 @@ elif [[ "${BUILD_ENVIRONMENT}" == *rocm* && -n "$TESTS_TO_INCLUDE" ]]; then
   test_aten
 elif [[ "${BUILD_ENVIRONMENT}" == *xpu* ]]; then
   install_torchvision
-  test_python_xpu
+  export PYTORCH_ENABLE_XPU_FALLBACK=1
+  test_python
   test_aten
   test_xpu_bin
 else

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -283,6 +283,11 @@ test_python() {
   assert_git_not_dirty
 }
 
+test_python_xpu() {
+  # shellcheck disable=SC2086
+  PYTORCH_ENABLE_XPU_FALLBACK=1 time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests $INCLUDE_CLAUSE --verbose $PYTHON_TEST_EXTRA_OPTION
+  assert_git_not_dirty
+}
 
 test_dynamo_shard() {
   if [[ -z "$NUM_TEST_SHARDS" ]]; then
@@ -1269,7 +1274,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *rocm* && -n "$TESTS_TO_INCLUDE" ]]; then
   test_aten
 elif [[ "${BUILD_ENVIRONMENT}" == *xpu* ]]; then
   install_torchvision
-  test_python
+  test_python_xpu
   test_aten
   test_xpu_bin
 else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124823
* __->__ #124822

torch-xpu-ops turned off CPU fallback by default

Signed-off-by: Feng Yuan <feng1.yuan@intel.com>

cc @frank-wei @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10