### PR TITLE
[inductor] add uint8 SDPA pattern

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -65,8 +65,9 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                     x.requires_grad = training
 
             if not self.use_static_shapes:
-                for arg in args2:
-                    torch._dynamo.mark_dynamic(arg, 0)
+                torch._dynamo.mark_dynamic(args2[0], 0)
+                torch._dynamo.mark_dynamic(args2[1], 0)
+                torch._dynamo.mark_dynamic(args2[2], 0)
 
             dropout_arg = [training] if has_dropout else []
             torch.manual_seed(1234)

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -4,9 +4,9 @@ import itertools
 import math
 
 import torch
-import torch._inductor.config
 import torch.utils.checkpoint
 from torch._dynamo.utils import counters
+from torch._inductor import config
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_cuda import (
@@ -65,9 +65,8 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                     x.requires_grad = training
 
             if not self.use_static_shapes:
-                torch._dynamo.mark_dynamic(args2[0], 0)
-                torch._dynamo.mark_dynamic(args2[1], 0)
-                torch._dynamo.mark_dynamic(args2[2], 0)
+                for arg in args2:
+                    torch._dynamo.mark_dynamic(arg, 0)
 
             dropout_arg = [training] if has_dropout else []
             torch.manual_seed(1234)
@@ -828,6 +827,95 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             check_train=False,
         )
 
+    @skipIfRocm
+    @config.patch({"freezing": True})
+    def _test_sdpa_rewriter_19(self):
+        if not self.use_static_shapes:
+            self.skipTest("Causes ConstraintViolationError. TODO: investigate")
+
+        # uint8 sdpa
+        import torch.ao.quantization.quantizer.x86_inductor_quantizer as xiq
+        from torch._export import capture_pre_autograd_graph
+        from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
+        from torch.ao.quantization.quantizer.x86_inductor_quantizer import (
+            X86InductorQuantizer,
+        )
+
+        class SelfAttnLikeModule(torch.nn.Module):
+            def __init__(
+                self,
+                input_dim,
+                num_attention_heads=None,
+                attention_head_size=None,
+            ) -> None:
+                super().__init__()
+                self.input_dim = input_dim
+                self.q_proj = torch.nn.Linear(input_dim, input_dim, bias=False)
+                self.k_proj = torch.nn.Linear(input_dim, input_dim, bias=False)
+                self.v_proj = torch.nn.Linear(input_dim, input_dim, bias=False)
+                self.softmax = torch.nn.Softmax(dim=-1)
+                assert num_attention_heads is not None
+                assert attention_head_size is not None
+                self.num_attention_heads = num_attention_heads
+                self.attention_head_size = attention_head_size
+                self.all_head_size = self.num_attention_heads * self.attention_head_size
+                self.dense = torch.nn.Linear(self.all_head_size, self.all_head_size)
+                self.dropout = torch.nn.Dropout(0)
+
+            def transpose_for_scores(self, x: torch.Tensor) -> torch.Tensor:
+                new_x_shape = x.size()[:-1] + (
+                    self.num_attention_heads,
+                    self.attention_head_size,
+                )
+                x = x.view(new_x_shape)
+                return x.permute([0, 2, 1, 3])
+
+            def forward(self, x, mask):
+                q = self.q_proj(x)
+                k = self.k_proj(x)
+                v = self.v_proj(x)
+                q = self.transpose_for_scores(q)
+                k = self.transpose_for_scores(k)
+                v = self.transpose_for_scores(v)
+                scores = torch.matmul(q, k.transpose(-1, -2)) / (self.input_dim**0.5)
+                scores = scores + mask
+                attention = self.softmax(scores)
+                attention = self.dropout(attention)
+                context_layer = torch.matmul(attention, v)
+                context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+                context_layer = context_layer.view(
+                    context_layer.size()[:-2] + (self.all_head_size,)
+                )
+                return self.dense(context_layer)
+
+        def _generate_qdq_quantized_model(mod, inputs, quantizer):
+            with torch.no_grad():
+                export_model = capture_pre_autograd_graph(mod, inputs)
+                prepare_model = prepare_pt2e(export_model, quantizer)
+                prepare_model(*inputs)
+                convert_model = convert_pt2e(prepare_model)
+                torch.ao.quantization.move_exported_model_to_eval(convert_model)
+                return convert_model
+
+        mod = SelfAttnLikeModule(
+            input_dim=64 * 16,
+            num_attention_heads=16,
+            attention_head_size=64,
+        ).eval()
+        inputs = [
+            torch.randn((2, 384, 64 * 16), device=self.device),
+            torch.randn((2, 1, 1, 384), device=self.device),
+        ]
+
+        quantizer = X86InductorQuantizer()
+        quantizer.set_global(xiq.get_default_x86_inductor_quantization_config())
+        quantizer.set_function_type_qconfig(
+            torch.matmul, quantizer.get_global_quantization_config()
+        )
+        convert_model = _generate_qdq_quantized_model(mod, inputs, quantizer)
+
+        self._check_common(convert_model, args1=inputs, check_train=False, atol=3e-3)
+
 
 if HAS_CUDA and PLATFORM_SUPPORTS_FUSED_ATTENTION:
 
@@ -946,6 +1034,9 @@ if HAS_CPU:
         )
         test_sdpa_rewriter_18_cpu = functools.partialmethod(
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_18
+        )
+        test_sdpa_rewriter_19_cpu = functools.partialmethod(
+            TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_19
         )
 
     class SDPAPatternRewriterCpuDynamicTests(SDPAPatternRewriterCpuTests):

--- a/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_19.py
+++ b/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_19.py
@@ -1,0 +1,85 @@
+# mypy: ignore-errors
+
+# noqa: F401, E501
+# This is an auto-generated file. Please do not modify it by hand.
+# To re-generate, run:
+# cd ~/pytorch && python torchgen/fuse/gen_patterns.py
+
+import torch
+import torch._inductor
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+from torch._inductor.pattern_matcher import (
+   Arg,
+   CallFunction,
+   CallFunctionVarArgs,
+   CallMethod,
+   CallMethodVarArgs,
+   CallModule,
+   CallModuleVarArgs,
+   ExclusiveKeywordArg,
+   Ignored,
+   KeywordArg,
+   ListOf,
+   MultiOutputPattern,
+   PatternExpr,
+   RepeatedExpr,
+   _TargetArgsExpr,
+   _TargetExpr,
+   _TargetExprVarArgs,
+)
+permute_default = CallFunction(aten.permute.default, KeywordArg('query'), Ignored())
+convert_element_type_default = CallFunction(prims.convert_element_type.default, permute_default, Ignored())
+sub_Tensor = CallFunction(aten.sub.Tensor, convert_element_type_default, KeywordArg('q_zp'))
+mul_Tensor = CallFunction(aten.mul.Tensor, sub_Tensor, KeywordArg('q_scale'))
+expand_default = CallFunction(aten.expand.default, mul_Tensor, Ignored())
+clone_default = CallFunction(aten.clone.default, expand_default, memory_format=torch.contiguous_format)
+view_default = CallFunction(aten.view.default, clone_default, Ignored())
+permute_default_1 = CallFunction(aten.permute.default, KeywordArg('key'), Ignored())
+permute_default_2 = CallFunction(aten.permute.default, permute_default_1, Ignored())
+convert_element_type_default_1 = CallFunction(prims.convert_element_type.default, permute_default_2, Ignored())
+sub_Tensor_1 = CallFunction(aten.sub.Tensor, convert_element_type_default_1, KeywordArg('k_zp'))
+mul_Tensor_1 = CallFunction(aten.mul.Tensor, sub_Tensor_1, KeywordArg('k_scale'))
+expand_default_1 = CallFunction(aten.expand.default, mul_Tensor_1, Ignored())
+clone_default_1 = CallFunction(aten.clone.default, expand_default_1, memory_format=torch.contiguous_format)
+view_default_1 = CallFunction(aten.view.default, clone_default_1, Ignored())
+bmm_default = CallFunction(aten.bmm.default, view_default, view_default_1)
+view_default_2 = CallFunction(aten.view.default, bmm_default, Ignored())
+div_Tensor = CallFunction(aten.div.Tensor, view_default_2, KeywordArg('inv_scale'))
+add_Tensor = CallFunction(aten.add.Tensor, div_Tensor, KeywordArg('attn_mask'), _users=2)
+amax_default = CallFunction(aten.amax.default, add_Tensor, Ignored(), True)
+sub_Tensor_2 = CallFunction(aten.sub.Tensor, add_Tensor, amax_default)
+exp_default = CallFunction(aten.exp.default, sub_Tensor_2, _users=2)
+sum_dim_IntList = CallFunction(aten.sum.dim_IntList, exp_default, Ignored(), True)
+div_Tensor_1 = CallFunction(aten.div.Tensor, exp_default, sum_dim_IntList)
+clone_default_2 = CallFunction(aten.clone.default, div_Tensor_1)
+mul_Tensor_2 = CallFunction(aten.mul.Tensor, clone_default_2, KeywordArg('a_inv_scale'))
+round_default = CallFunction(aten.round.default, mul_Tensor_2)
+add_Tensor_1 = CallFunction(aten.add.Tensor, round_default, KeywordArg('a_zp'))
+clamp_min_default = CallFunction(aten.clamp_min.default, add_Tensor_1, Ignored())
+clamp_max_default = CallFunction(aten.clamp_max.default, clamp_min_default, Ignored())
+convert_element_type_default_2 = CallFunction(prims.convert_element_type.default, clamp_max_default, Ignored())
+convert_element_type_default_3 = CallFunction(prims.convert_element_type.default, convert_element_type_default_2, Ignored())
+sub_Tensor_3 = CallFunction(aten.sub.Tensor, convert_element_type_default_3, KeywordArg('a_zp'))
+mul_Tensor_3 = CallFunction(aten.mul.Tensor, sub_Tensor_3, KeywordArg('a_scale'))
+expand_default_2 = CallFunction(aten.expand.default, mul_Tensor_3, Ignored())
+view_default_3 = CallFunction(aten.view.default, expand_default_2, Ignored())
+permute_default_3 = CallFunction(aten.permute.default, KeywordArg('value'), Ignored())
+convert_element_type_default_4 = CallFunction(prims.convert_element_type.default, permute_default_3, Ignored())
+sub_Tensor_4 = CallFunction(aten.sub.Tensor, convert_element_type_default_4, KeywordArg('v_zp'))
+mul_Tensor_4 = CallFunction(aten.mul.Tensor, sub_Tensor_4, KeywordArg('v_scale'))
+expand_default_3 = CallFunction(aten.expand.default, mul_Tensor_4, Ignored())
+clone_default_3 = CallFunction(aten.clone.default, expand_default_3, memory_format=torch.contiguous_format)
+view_default_4 = CallFunction(aten.view.default, clone_default_3, Ignored())
+bmm_default_1 = CallFunction(aten.bmm.default, view_default_3, view_default_4)
+view_default_5 = CallFunction(aten.view.default, bmm_default_1, Ignored())
+permute_default_4 = CallFunction(aten.permute.default, view_default_5, Ignored())
+clone_default_4 = CallFunction(aten.clone.default, permute_default_4, memory_format=torch.contiguous_format)
+mul_Tensor_5 = CallFunction(aten.mul.Tensor, clone_default_4, KeywordArg('o_inv_scale'))
+round_default_1 = CallFunction(aten.round.default, mul_Tensor_5)
+add_Tensor_2 = CallFunction(aten.add.Tensor, round_default_1, KeywordArg('o_zp'))
+clamp_min_default_1 = CallFunction(aten.clamp_min.default, add_Tensor_2, Ignored())
+clamp_max_default_1 = CallFunction(aten.clamp_max.default, clamp_min_default_1, Ignored())
+_sfdp_pattern_19_u8_inference = CallFunction(prims.convert_element_type.default, clamp_max_default_1, Ignored(), _users=0)


### PR DESCRIPTION
Under the setting of static shape and type int8-fp32, the PR can match a uint8 SDPA, tested with Bert-Large. The current uint8 SDPA internally calls fp32 SDPA kernel by converting input into fp32 and output into uint8.

**TODO:**

Pattern:
- [ ] Support dynamic shape.
- [ ] Support type int8-bf16.

Kernel:
- [ ] Add uint8 SDPA API with additional inputs of scale and zero point pairs.
- [ ] Support uint8 SDPA kernel with e.g. brgemm.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang