### PR TITLE
[privateuse1] _refs.masked_fill support privateuse1 when value.device.type is cpu

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -684,8 +684,7 @@ def forward(self, x_1, start_1):
 
     def test_masked_fill(self, device):
         from torch.fx.experimental.proxy_tensor import make_fx
-        device = device.rstrip(":0123456789")
-        if device not in ["xpu", "cuda", torch._C._get_privateuse1_backend_name()]:
+        if torch.device(device).type not in ["xpu", "cuda", torch._C._get_privateuse1_backend_name()]:
             self.skipTest("only runs on XPU and CUDA and PrivateUse1.")
 
         def func(scores, mask, value):

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -682,6 +682,24 @@ def forward(self, x_1, start_1):
     convert_element_type = torch.ops.prims.convert_element_type.default(add, torch.float32);  add = None
     return convert_element_type""")
 
+    def test_masked_fill(self, device):
+        from torch.fx.experimental.proxy_tensor import make_fx
+        device = device.rstrip(":0123456789")
+        if device not in ["xpu", "cuda", torch._C._get_privateuse1_backend_name()]:
+            self.skipTest("only runs on XPU and CUDA and PrivateUse1.")
+
+        def func(scores, mask, value):
+            return scores.masked_fill(mask, value)
+
+        scores_t = torch.tensor([1, 2, 3, 4], device=device)
+        mask_t = torch.tensor([True, True, True, True], device=device)
+        value_t = torch.tensor(0, dtype=scores_t.dtype)
+        cfunc = make_fx(func, decomposition_table=decomposition_table)
+        fx_g = cfunc(scores_t, mask_t, value_t)
+        self.assertExpectedInline(fx_g.code.strip(), """\
+def forward(self, scores_1, mask_1, value_1):
+    where = torch.ops.prims.where.default(mask_1, value_1, scores_1);  mask_1 = value_1 = scores_1 = None
+    return where""")
 
     class DecompCrossRefMode(TorchDispatchMode):
         def __init__(self, test_case, saved_precision, saved_rel_tol, dtype, run_all):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5552,7 +5552,10 @@ def masked_fill(a: TensorLikeType, mask: TensorLikeType, value: TensorOrNumberLi
             lambda: f"only supports a 0-dimensional value tensor, but got tensor with {value_ndim} dimension",
         )
         # `masked_fill` allows cpu scalar to be moved to cuda and xpu but not otherwise.
-        is_cpu_scalar = a.device.type in ["cuda", "xpu"] and value.device.type == "cpu"
+        is_cpu_scalar = (
+            a.device.type in ["cuda", "xpu", torch._C._get_privateuse1_backend_name()]
+            and value.device.type == "cpu"
+        )
         torch._check(
             is_cpu_scalar or value.device == a.device,
             lambda: "Expected `value` to be on same device as `a`",


### PR DESCRIPTION
_refs.masked_fill support privateuse1 when value.device.type is cpu.

1. maybe I should consider whether this modification meets the expectations of other privateuse1 devices,
2. add TestCase

Fixes #124693
