### PR TITLE
[Aten] Fix XPU convolution_overrideable input memory format.

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1619,6 +1619,10 @@ at::Tensor _convolution(
 #endif
       break;
     case ConvBackend::Overrideable:
+      input = input.contiguous(backend_memory_format);
+      weight = weight.contiguous(backend_memory_format);
+      bias = bias.defined() ? bias.contiguous() : bias;
+
       output = at::convolution_overrideable(
           input, weight, bias, params.stride, params.padding, params.dilation, params.transposed,
           params.output_padding, params.groups);
@@ -2194,6 +2198,8 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
       break;
     case ConvBackend::Overrideable:
       // Only reach here when input is backend with out-of-source implementation.
+      input = input.contiguous(backend_memory_format);
+      weight = weight.contiguous(backend_memory_format);
       std::tie(backend_grad_input, backend_grad_weight, backend_grad_bias) =
         at::convolution_backward_overrideable(grad_output, input, weight, params.stride, params.padding,
           params.dilation, params.transposed, params.output_padding, params.groups, output_mask);

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1619,10 +1619,6 @@ at::Tensor _convolution(
 #endif
       break;
     case ConvBackend::Overrideable:
-      input = input.contiguous(backend_memory_format);
-      weight = weight.contiguous(backend_memory_format);
-      bias = bias.defined() ? bias.contiguous() : bias;
-
       output = at::convolution_overrideable(
           input, weight, bias, params.stride, params.padding, params.dilation, params.transposed,
           params.output_padding, params.groups);

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -2198,8 +2198,6 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
       break;
     case ConvBackend::Overrideable:
       // Only reach here when input is backend with out-of-source implementation.
-      input = input.contiguous(backend_memory_format);
-      weight = weight.contiguous(backend_memory_format);
       std::tie(backend_grad_input, backend_grad_weight, backend_grad_bias) =
         at::convolution_backward_overrideable(grad_output, input, weight, params.stride, params.padding,
           params.dilation, params.transposed, params.output_padding, params.groups, output_mask);

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -10,6 +10,7 @@
 #include <ATen/native/utils/ParamUtils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNN.h>
 #include <torch/library.h>
+#include <ATen/native/ConvUtils.h>
 
 using namespace dnnl;
 using namespace at::native;
@@ -572,9 +573,18 @@ Tensor convolution_overrideable(
   c10::MaybeOwned<Tensor> bias_r_maybe_owned =
       at::borrow_from_optional_tensor(bias_r_opt);
   const Tensor& bias_r = *bias_r_maybe_owned;
+
+  auto k = weight_r.ndimension();
+  at::MemoryFormat backend_memory_format = at::MemoryFormat::Contiguous;
+  if (xpu_conv_use_channels_last(input_r, weight_r)) {
+      backend_memory_format = (k == 5) ? at::MemoryFormat::ChannelsLast3d : at::MemoryFormat::ChannelsLast;
+  }
+  Tensor input_c = input_r.contiguous(backend_memory_format);
+  Tensor weight_c = weight_r.contiguous(backend_memory_format);
+
   return _convolution(
-      input_r,
-      weight_r,
+      input_c,
+      weight_c,
       bias_r,
       stride_,
       padding_,

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -1260,7 +1260,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         out = get_conv_out(device, torch.float32)
         assert_size_stride(out, (2, 512, 7, 7), (25088, 1, 3584, 512))
 
-        # xpu does not support float64 for chanel last conv.
+        # Like most conv backend, xpu does not support float64 for chanel last conv.
         # input NHWC, output NCHW
         out = get_conv_out(device, torch.float64)
         assert_size_stride(out, (2, 512, 7, 7), (25088, 49, 7, 1))

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -13,8 +13,8 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import tf32_is_not_fp32
 from torch.testing._internal.common_device_type import (
     dtypes,
-    onlyXPU,
     instantiate_device_type_tests,
+    onlyXPU,
 )
 from torch.testing._internal.common_dtype import floating_types_and
 from torch.testing._internal.common_nn import _test_module_empty_input, NNTestCase
@@ -1260,9 +1260,8 @@ class TestConvolutionNNDeviceType(NNTestCase):
             # input NHWC, output NCHW
             assert_size_stride(out, (2, 512, 7, 7), (25088, 49, 7, 1))
         else:
-        # input NHWC, output NHWC
+            # input NHWC, output NHWC
             assert_size_stride(out, (2, 512, 7, 7), (25088, 1, 3584, 512))
-
 
 
 instantiate_device_type_tests(TestConvolutionNNDeviceType, globals(), only_for="xpu")

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -13,6 +13,7 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import tf32_is_not_fp32
 from torch.testing._internal.common_device_type import (
     dtypes,
+    onlyXPU,
     instantiate_device_type_tests,
 )
 from torch.testing._internal.common_dtype import floating_types_and
@@ -1241,29 +1242,27 @@ class TestConvolutionNNDeviceType(NNTestCase):
         self.assertEqual(grad_input.shape, input.shape)
         self.assertEqual(grad_weight.shape, weight.shape)
 
-    def test_channels_last_ouput_stride(self, device):
-        dtype = torch.float32
+    @onlyXPU
+    @dtypes(torch.float16, torch.bfloat16, torch.float32, torch.float64)
+    def test_channels_last_ouput_stride(self, device, dtype):
+        input = torch.randn(
+            (2, 3, 16, 16), device=device, dtype=dtype, requires_grad=True
+        )
+        weight = torch.randn(
+            (512, 3, 3, 3), device=device, dtype=dtype, requires_grad=True
+        )
+        input = input.to(memory_format=torch.channels_last)
+        weight = weight.to(memory_format=torch.channels_last)
+        out = torch.conv2d(input, weight, None, (2, 2), (0, 0), (1, 1), 1)
 
-        def get_conv_out(device, dtype):
-            input = torch.randn(
-                (2, 3, 16, 16), device=device, dtype=dtype, requires_grad=True
-            )
-            weight = torch.randn(
-                (512, 3, 3, 3), device=device, dtype=dtype, requires_grad=True
-            )
-            input = input.to(memory_format=torch.channels_last)
-            weight = weight.to(memory_format=torch.channels_last)
-            out = torch.conv2d(input, weight, None, (2, 2), (0, 0), (1, 1), 1)
-            return out
-
+        if dtype is torch.float64:
+            # Like most conv backend, xpu does not support float64 for chanel last conv.
+            # input NHWC, output NCHW
+            assert_size_stride(out, (2, 512, 7, 7), (25088, 49, 7, 1))
+        else:
         # input NHWC, output NHWC
-        out = get_conv_out(device, torch.float32)
-        assert_size_stride(out, (2, 512, 7, 7), (25088, 1, 3584, 512))
+            assert_size_stride(out, (2, 512, 7, 7), (25088, 1, 3584, 512))
 
-        # Like most conv backend, xpu does not support float64 for chanel last conv.
-        # input NHWC, output NCHW
-        out = get_conv_out(device, torch.float64)
-        assert_size_stride(out, (2, 512, 7, 7), (25088, 49, 7, 1))
 
 
 instantiate_device_type_tests(TestConvolutionNNDeviceType, globals(), only_for="xpu")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124841

[Aten] Fix convolution_overrideable input memory format.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10