### PR TITLE
[export] Fix state dict reparametrization in non-strict.

### DIFF
--- a/torch/nn/utils/stateless.py
+++ b/torch/nn/utils/stateless.py
@@ -93,6 +93,7 @@ def _reparametrize_module(
     *,
     tie_weights: bool = False,
     strict: bool = False,
+    stack_weights: bool = False,
 ) -> Iterator[None]:
     if tie_weights:
         untied_parameters_and_buffers = _untie_named_tensors_map(
@@ -127,6 +128,11 @@ def _reparametrize_module(
         )
         yield
     finally:
+        if stack_weights:
+            # When stacking is enabled, we will restore the weights in LIFO order.
+            orig_parameters_and_buffers = dict(
+                reversed(orig_parameters_and_buffers.items())
+            )
         new_parameters_and_buffers, _ = accessor.swap_tensors_dict(
             orig_parameters_and_buffers, allow_missing=True
         )


### PR DESCRIPTION
Summary: 

There are multiple things implemented incorrectly in non strict for reparametrizing state dict:
1. The same fake tensor should be generated for duplicated weights.
2. We should snapshot state dict in the beginning to always hold the invariant that ep.state_dict == mod.state_dict()
3. We will overwrite real weights with fake weights if we don't restore the weights in LIFO ordering.
4. We don't turn on strict checking which could sliently fail on corner cases.

This diff aims to solve all these issues at once.

Test Plan: CI

Differential Revision: D56505020


