### PR TITLE
Assert that all runtime assertions are added to graph, we didn't miss any

### DIFF
--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -259,3 +259,5 @@ def insert_deferred_runtime_asserts(
                     )
 
                 add_runtime_asserts(ras)
+
+    assert not ras_by_symbol, f"Unhandled runtime assertions: {ras_by_symbol}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124848
* #123735
* #124785
* #124782
* #124739
* #124394
* #124316
* #124314
* #124310

