### PR TITLE
[custom_op] setup_context fills in default values

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2229,6 +2229,38 @@ class TestCustomOpAPI(TestCase):
             self.assertEqual(x.grad, torch.tensor([3.14, 3.14, 3.14]))
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_register_autograd_defaults(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define("foo(Tensor w, int x = 2, *, int y = 3, int z) -> Tensor")
+
+            def foo_impl(w, x=2, *, y=3, z):
+                return w * x * y * z
+
+            lib.impl("foo", foo_impl, "CPU")
+
+            called = False
+
+            def backward(ctx, grad):
+                nonlocal called
+                called = True
+                return grad * ctx.c
+
+            def setup_context(ctx, inputs, keyword_only_inputs, output):
+                assert len(inputs) == 2
+                assert inputs[1] == 2
+                assert keyword_only_inputs == {"y": 3, "z": 42}
+                ctx.c = keyword_only_inputs["y"] * keyword_only_inputs["z"] * inputs[1]
+
+            torch.library.register_autograd(
+                "_torch_testing::foo", backward, setup_context=setup_context, lib=lib
+            )
+
+            w = torch.randn(3, requires_grad=True)
+            torch.ops._torch_testing.foo(w, z=42).sum().backward()
+            self.assertTrue(called)
+            self.assertEqual(w.grad, torch.full_like(w, 2 * 3 * 42))
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_manual_schema_error(self):
         with self.assertRaisesRegex(ValueError, "the op mutates {'x'}"):
 

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -156,6 +156,24 @@ def mutates_and_returns_first_arg(op: torch._ops.OpOverload):
     return True
 
 
+def fill_defaults(schema, args, kwargs):
+    new_args = []
+    new_kwargs = {}
+    for i in range(len(schema.arguments)):
+        info = schema.arguments[i]
+        if info.kwarg_only:
+            if info.name in kwargs:
+                new_kwargs[info.name] = kwargs[info.name]
+            else:
+                new_kwargs[info.name] = info.default_value
+        else:
+            if i < len(args):
+                new_args.append(args[i])
+            else:
+                new_args.append(info.default_value)
+    return tuple(new_args), new_kwargs
+
+
 def zip_schema(
     schema: _C.FunctionSchema, args: Tuple[Any, ...], kwargs: Dict[str, Any]
 ) -> Iterable[Tuple[_C.Argument, Any]]:

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -18,6 +18,7 @@ __all__ = [
     "FunctionMeta",
     "Function",
     "once_differentiable",
+    "traceable",
     "InplaceFunction",
     "NestedIOFunction",
 ]
@@ -32,8 +33,8 @@ class FunctionCtx:
     def save_for_backward(self, *tensors: torch.Tensor):
         r"""Save given tensors for a future call to :func:`~Function.backward`.
 
-        ``save_for_backward`` should be called at most once, in either the
-        :func:`setup_context` or :func:`forward` methods, and only with tensors.
+        ``save_for_backward`` should be called at most once, only from inside the
+        :func:`forward` method, and only with tensors.
 
         All tensors intended to be used in the backward pass should be saved
         with ``save_for_backward`` (as opposed to directly on ``ctx``) to prevent
@@ -91,9 +92,8 @@ class FunctionCtx:
     def save_for_forward(self, *tensors: torch.Tensor):
         r"""Save given tensors for a future call to :func:`~Function.jvp`.
 
-        ``save_for_forward`` should be called at most once, in either the
-        :func:`setup_context` or :func:`forward` methods, and all arguments
-        should be tensors.
+        ``save_for_forward`` should be only called once, from inside the :func:`forward`
+        method, and only be called with tensors.
 
         In :func:`jvp`, saved objects can be accessed through the :attr:`saved_tensors`
         attribute.
@@ -145,8 +145,8 @@ class FunctionCtx:
     def mark_dirty(self, *args: torch.Tensor):
         r"""Mark given tensors as modified in an in-place operation.
 
-        This should be called at most once, in either the :func:`setup_context`
-        or :func:`forward` methods, and all arguments should be inputs.
+        **This should be called at most once, only from inside the**
+        :func:`forward` **method, and all arguments should be inputs.**
 
         Every tensor that's been modified in-place in a call to :func:`forward`
         should be given to this function, to ensure correctness of our checks.
@@ -189,8 +189,8 @@ class FunctionCtx:
     def mark_non_differentiable(self, *args: torch.Tensor):
         r"""Mark outputs as non-differentiable.
 
-        This should be called at most once, in either the :func:`setup_context`
-        or :func:`forward` methods, and all arguments should be tensor outputs.
+        **This should be called at most once, only from inside the**
+        :func:`forward` **method, and all arguments should be tensor outputs.**
 
         This will mark outputs as not requiring gradients, increasing the
         efficiency of backward computation. You still need to accept a gradient
@@ -221,8 +221,7 @@ class FunctionCtx:
     def set_materialize_grads(self, value: bool):
         r"""Set whether to materialize grad tensors. Default is ``True``.
 
-        This should be called only from either the :func:`setup_context` or
-        :func:`forward` methods.
+        **This should be called only from inside the** :func:`forward` **method**
 
         If ``True``, undefined grad tensors will be expanded to tensors full of zeros
         prior to calling the :func:`backward` and :func:`jvp` methods.
@@ -312,6 +311,14 @@ class BackwardCFunction(_C._FunctionBase, FunctionCtx, _HookMixin):
         return self._forward_cls._compiled_autograd_key(self)  # type: ignore[attr-defined]
 
 
+def _warn_traceable_deprecated():
+    warnings.warn(
+        "The is_traceable field on torch.autograd.Function is deprecated "
+        "and will be removed in PyTorch 2.4.",
+        stacklevel=3,
+    )
+
+
 class FunctionMeta(type):
     """Function metaclass.
 
@@ -331,7 +338,24 @@ class FunctionMeta(type):
         )
         cls._backward_cls = backward_fn
 
+        if "is_traceable" in attrs and attrs["is_traceable"] is True:
+            _warn_traceable_deprecated()
+
         super().__init__(name, bases, attrs)
+
+    def __getattribute__(cls, name):
+        if name == "is_traceable":
+            _warn_traceable_deprecated()
+        return super().__getattribute__(name)
+
+    def __setattr__(cls, name, value):
+        if name == "is_traceable" and value is True:
+            warnings.warn(
+                "The is_traceable field on torch.autograd.Function is deprecated "
+                "and will be removed in PyTorch 2.4.",
+                stacklevel=2,
+            )
+        return super().__setattr__(name, value)
 
 
 class _SingleLevelFunction(
@@ -508,6 +532,9 @@ class Function(_SingleLevelFunction):
             "(Example: https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)"
         )
 
+    # for the tracer
+    is_traceable = False
+
     """
     Bool that specifies if PyTorch should attempt to autogenerate
     :func:`torch.vmap` support for this autograd.Function. You may set this to
@@ -630,6 +657,26 @@ def once_differentiable(fn):
         return err_fn(*[fake_requires_grad(v) for v in outputs])
 
     return wrapper
+
+
+def traceable(fn_cls):
+    r"""Mark Function as traceable for the JIT.
+
+    Traceable functions have additional restrictions - they can't pass any
+    data-dependent values to backward (e.g. Prod passes the output, which makes
+    it non-traceable), and their backward should be implemented entirely in terms
+    of operations on autograd Tensors in all cases.
+
+    DON'T USE THIS DECORATOR. IT IS FOR INTERNAL USE ONLY AND SHOULD BE HANDLED WITH
+    CARE (or can give incorrect results otherwise).
+    """
+    warnings.warn(
+        "torch.autograd.function.traceable is deprecated "
+        "and will be removed in PyTorch 2.4.",
+        stacklevel=2,
+    )
+    fn_cls.is_traceable = True
+    return fn_cls
 
 
 class InplaceFunction(Function):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124852
* #124806
* #124805
* #124637

This is to mirror autograd.Function's setup_context behavior.
The PyTorch Dispatcher removes default values for "FC/BC reasons", but I
convinced myself there's no FC/BC problem for the setup_context API.

Test Plan:
- new tests