### PR TITLE
Match insignificant strides for sdpa inputs

### DIFF
--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -164,6 +164,9 @@ class TestSDPAPatternRewriterTemplate(TestCase):
     def _test_insignificant_strides(self):
         f32 = torch.float32
 
+        # repro taken from https://github.com/pytorch/pytorch/issues/124289
+        # constant_pad_nd is a single element tensor that gets expanded
+
         def forward(
             permute_3: "f32[1, 32, 1, 128]",
             permute_4: "f32[1, 32, 1, 128]",

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -6,6 +6,7 @@ import math
 import torch
 import torch._inductor.config
 import torch.utils.checkpoint
+from torch._dynamo.debug_utils import aot_graph_input_parser
 from torch._dynamo.utils import counters
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
@@ -159,6 +160,81 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                     rtol=rtol,
                     check_train=False,
                 )
+
+    def _test_insignificant_strides(self):
+        f32 = torch.float32
+        i64 = torch.int64
+
+        def forward(
+            permute_3: "f32[1, 32, 1, 128]",
+            permute_4: "f32[1, 32, 1, 128]",
+            permute_5: "f32[1, 32, 1, 128]",
+            permute_6: "f32[1, 1, 64]",
+            mul_2: "f32[1, 1, 1, 1]",
+        ):
+            cat = torch.ops.aten.cat.default([permute_6, permute_6], 2)
+            permute_6 = None
+            cos = torch.ops.aten.cos.default(cat)
+            sin = torch.ops.aten.sin.default(cat)
+            unsqueeze_10 = torch.ops.aten.unsqueeze.default(cos, 1)
+            cos = None
+            unsqueeze_11 = torch.ops.aten.unsqueeze.default(sin, 1)
+            sin = None
+            mul_5 = torch.ops.aten.mul.Tensor(permute_3, unsqueeze_10)
+            slice_10 = torch.ops.aten.slice.Tensor(permute_3, 3, 0, 64)
+            slice_11 = torch.ops.aten.slice.Tensor(
+                permute_3, 3, 64, 9223372036854775807
+            )
+            permute_3 = None
+            neg = torch.ops.aten.neg.default(slice_11)
+            slice_11 = None
+            cat_1 = torch.ops.aten.cat.default([neg, slice_10], 3)
+            neg = slice_10 = None
+            mul_6 = torch.ops.aten.mul.Tensor(cat_1, unsqueeze_11)
+            cat_1 = None
+            add_1 = torch.ops.aten.add.Tensor(mul_5, mul_6)
+            mul_5 = mul_6 = None
+            mul_7 = torch.ops.aten.mul.Tensor(permute_4, unsqueeze_10)
+            unsqueeze_10 = None
+            slice_12 = torch.ops.aten.slice.Tensor(permute_4, 3, 0, 64)
+            slice_13 = torch.ops.aten.slice.Tensor(
+                permute_4, 3, 64, 9223372036854775807
+            )
+            permute_4 = None
+            neg_1 = torch.ops.aten.neg.default(slice_13)
+            slice_13 = None
+            cat_2 = torch.ops.aten.cat.default([neg_1, slice_12], 3)
+            neg_1 = slice_12 = None
+            mul_8 = torch.ops.aten.mul.Tensor(cat_2, unsqueeze_11)
+            cat_2 = unsqueeze_11 = None
+            add_2 = torch.ops.aten.add.Tensor(mul_7, mul_8)
+            mul_7 = mul_8 = None
+            slice_14 = torch.ops.aten.slice.Tensor(mul_2, 0, 0, 9223372036854775807)
+            mul_2 = None
+            slice_15 = torch.ops.aten.slice.Tensor(slice_14, 1, 0, 9223372036854775807)
+            slice_14 = None
+            slice_16 = torch.ops.aten.slice.Tensor(slice_15, 2, 0, 9223372036854775807)
+            slice_15 = None
+            constant_pad_nd = torch.ops.aten.constant_pad_nd.default(
+                slice_16, [0, 7], 0.0
+            )
+            slice_16 = None
+            slice_17 = torch.ops.aten.slice.Tensor(constant_pad_nd, -1, 0, 1)
+            constant_pad_nd = None
+            expand_5 = torch.ops.aten.expand.default(slice_17, [1, 32, 1, 1])
+            _scaled_dot_product_efficient_attention = (
+                torch.ops.aten._scaled_dot_product_efficient_attention.default(
+                    add_1, add_2, permute_5, expand_5, True
+                )
+            )
+            return _scaled_dot_product_efficient_attention
+
+        kwargs = aot_graph_input_parser(forward, device="cuda")
+        # runs successfully
+        out_eager = forward(**kwargs)
+        out_c = torch.compile(forward)(**kwargs)
+        # dont compare philox_seed/offset
+        torch.testing.assert_close(out_eager[0:2], out_c[0:2])
 
     def _test_pattern_fails_with_reuse(self):
         """
@@ -838,6 +914,9 @@ if HAS_CUDA and PLATFORM_SUPPORTS_FUSED_ATTENTION:
         )
         test_sdpa_rewriter_1_freezing = (
             TestSDPAPatternRewriterTemplate._test_sdpa_rewriter_1_freezing
+        )
+        test_insignificant_strides = (
+            TestSDPAPatternRewriterTemplate._test_insignificant_strides
         )
         test_pattern_fails_with_reuse_cuda = (
             TestSDPAPatternRewriterTemplate._test_pattern_fails_with_reuse

--- a/test/inductor/test_fused_attention.py
+++ b/test/inductor/test_fused_attention.py
@@ -163,7 +163,6 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
     def _test_insignificant_strides(self):
         f32 = torch.float32
-        i64 = torch.int64
 
         def forward(
             permute_3: "f32[1, 32, 1, 128]",

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -997,7 +997,9 @@ class GraphLowering(torch.fx.Interpreter):
                 # AOT Autograd tries to detect stride divergence of inductor from output metadata.
                 # Here, we try to avoid spurious divergence by matching insignificant strides such as
                 result_correct_strides.append(
-                    self.match_insignificant_strides(r, fx_node.meta["val"].stride())
+                    self.try_match_insignificant_strides(
+                        r, fx_node.meta["val"].stride()
+                    )
                 )
 
         self.graph_outputs = result_correct_strides
@@ -1046,11 +1048,18 @@ class GraphLowering(torch.fx.Interpreter):
         finally:
             self.current_node = old
 
-    def match_insignificant_strides(
+    def try_match_insignificant_strides(
         self,
         tensor,
         meta_strides_inp: Tuple[Union[int, torch.SymInt], ...],
     ) -> ir.TensorBox:
+        """
+        Tries to match the strides of the tensor to those in the meta_strides. Strides of insignificant
+        dimensions - size 0 or 1 - will be updated.
+
+        If there are real stride differences (NHWC vs NCHW) then the input will be returned.
+        """
+
         # should have already been realized
         assert torch._inductor.ir.is_storage_and_layout(tensor)
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1885,7 +1885,7 @@ def sdpa_constraint(fx_node, *args, **kwargs):
         try:
             arg.get_stride()
             if is_aligned_realized_tensor(arg):
-                return V.graph.match_insignificant_strides(
+                return V.graph.try_match_insignificant_strides(
                     ir.ExternKernel.realize_input(arg), meta_stride
                 )
         except AttributeError:
@@ -1897,7 +1897,7 @@ def sdpa_constraint(fx_node, *args, **kwargs):
         if isinstance(arg.data, ir.BaseView):
             if not is_aligned(arg):
                 if is_aligned(arg.unwrap_view()):
-                    return V.graph.match_insignificant_strides(
+                    return V.graph.try_match_insignificant_strides(
                         ir.ExternKernel.realize_input(arg), meta_stride
                     )
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1894,7 +1894,8 @@ def sdpa_constraint(fx_node, *args, **kwargs):
         if isinstance(arg.data, ir.BaseView):
             if not is_aligned(arg):
                 if is_aligned(arg.unwrap_view()):
-                    return arg
+                    arg = ir.TensorBox(ir.ExternKernel.realize_input(arg))
+                    return V.graph.match_insignificant_strides(arg, meta_val.stride())
 
         return ir.ExternKernel.require_stride_order(arg, stride_order)
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1855,8 +1855,9 @@ def sdpa_constraint(fx_node, *args, **kwargs):
             return arg
 
         meta_val = fx_arg.meta["val"]
+        meta_stride = meta_val.stride()
 
-        stride_order = ir.get_stride_order(meta_val.stride())
+        stride_order = ir.get_stride_order(meta_stride)
         if stride_order and stride_order[-1] != 0:
             # contiguous stride order
             stride_order = list(reversed(range(len(arg.get_size()))))
@@ -1884,7 +1885,9 @@ def sdpa_constraint(fx_node, *args, **kwargs):
         try:
             arg.get_stride()
             if is_aligned_realized_tensor(arg):
-                return arg
+                return V.graph.match_insignificant_strides(
+                    ir.ExternKernel.realize_input(arg), meta_stride
+                )
         except AttributeError:
             pass
 
@@ -1894,8 +1897,9 @@ def sdpa_constraint(fx_node, *args, **kwargs):
         if isinstance(arg.data, ir.BaseView):
             if not is_aligned(arg):
                 if is_aligned(arg.unwrap_view()):
-                    arg = ir.TensorBox(ir.ExternKernel.realize_input(arg))
-                    return V.graph.match_insignificant_strides(arg, meta_val.stride())
+                    return V.graph.match_insignificant_strides(
+                        ir.ExternKernel.realize_input(arg), meta_stride
+                    )
 
         return ir.ExternKernel.require_stride_order(arg, stride_order)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124859
* #124751

Fix for https://github.com/pytorch/pytorch/issues/124289.

There was a tensor which had a single, expanded element. inductor generated the strides as all 0, while sdpa expects a dense last dimension `t.stride(-1) == 1`. While these are equivalent, we still hit an error in the kernel. We could make fixes in sdpa, but matching the insignificant strides in inductor also works and I am less aware of the downstream sdpa kernel details. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang