### PR TITLE
Added FixedQParam per-tensor observer for weight tensors

### DIFF
--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -7,6 +7,7 @@ from torch.ao.quantization.observer import (
     HistogramObserver,
     MovingAveragePerChannelMinMaxObserver,
     FixedQParamsObserver,
+    FixedWeightQParamsObserver,
     default_fixed_qparams_range_0to1_observer,
     default_fixed_qparams_range_neg1to1_observer,
     _with_args,
@@ -270,10 +271,12 @@ class FixedQParamsFakeQuantize(FakeQuantize):
     """
 
     # TODO: rename observer to observer_ctr
-    def __init__(self, observer):
-        super().__init__(observer=observer)
-        assert type(self.activation_post_process) == FixedQParamsObserver, \
-            f"{self.__class__.__name__}'s observer must be a {FixedQParamsObserver.__name__}"
+    def __init__(self, observer, **observer_kwargs):
+        super().__init__(observer=observer, **observer_kwargs)
+        assert type(self.activation_post_process) in [
+            FixedQParamsObserver, FixedWeightQParamsObserver
+        ], f"{self.__class__.__name__}'s observer must be an instance of " +\
+        f"{FixedQParamsObserver.__name__} or {FixedWeightQParamsObserver.__name__}"
         self._observer_ctr = observer
         self.scale = self.activation_post_process.scale
         self.zero_point = self.activation_post_process.zero_point

--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -276,7 +276,8 @@ class FixedQParamsFakeQuantize(FakeQuantize):
         assert type(self.activation_post_process) in [
             FixedQParamsObserver, FixedWeightQParamsObserver
         ], f"{self.__class__.__name__}'s observer must be an instance of " +\
-        f"{FixedQParamsObserver.__name__} or {FixedWeightQParamsObserver.__name__}"
+        f"{FixedQParamsObserver.__name__} or " +\
+        f"{FixedWeightQParamsObserver.__name__}"
         self._observer_ctr = observer
         self.scale = self.activation_post_process.scale
         self.zero_point = self.activation_post_process.zero_point


### PR DESCRIPTION
As part of the quantization suite, this PR adds a `FixedWeightQParamsObserver` observer for tensor-wise quantization of weight tensors. 

This allows one to use the `FixedQParamsFakeQuantize` quantization module class for weights (per tensor granularity) as well as activations.

**Why we care:** This allows one to have fixed per-tensor qparams for weight tensors , whereas previously this was not supported. 

## Example use case:
```
import torch
from torch.ao.quantization.observer import FixedWeightQParamsObserver
from torch.ao.quantization.fake_quantize import FixedQParamsFakeQuantize, FakeQuantize

# Basic model
model = torch.nn.Sequential(
    torch.nn.Conv2d(10, 10, (3,3)),
)

# Weight quantization module
fixed_weight_qconfig = FixedQParamsFakeQuantize.with_args(
    observer=FixedWeightQParamsObserver.with_args(
        scale=1,
        zero_point=0.0,
        quant_min=-128,
        quant_max=127,
        dtype=torch.qint8,
        qscheme=torch.per_tensor_symmetric,
    )
)

# Activation quantization module
activation_qconfig = FakeQuantize.with_args(
    observer=torch.ao.quantization.observer.HistogramObserver.with_args(
        quant_min=0,
        quant_max=255,
        dtype=torch.quint8,
        qscheme=torch.per_tensor_affine,
    )
)

# Create qconfig
qconfig = torch.quantization.QConfig(activation=activation_qconfig,
                                      weight=fixed_weight_qconfig)
model.qconfig = qconfig
model.train()

# Get fake quant and converted models
fake_quant_model = torch.ao.quantization.prepare_qat(model)
converted_model = torch.ao.quantization.convert(fake_quant_model)

```

## Printing out the model
Printing out the fake-quant model gives:
```
fake_quant_model[0]
Conv2d(
  10, 10, kernel_size=(3, 3), stride=(1, 1)
  (weight_fake_quant): FixedQParamsFakeQuantize(
    fake_quant_enabled=tensor([1], dtype=torch.uint8), observer_enabled=tensor([1], dtype=torch.uint8), scale=tensor([1.]), zero_point=tensor([0], dtype=torch.int32), dtype=torch.qint8, quant_min=-128, quant_max=127, qscheme=torch.per_tensor_symmetric
    (activation_post_process): FixedWeightQParamsObserver()
  )
  (activation_post_process): FakeQuantize(
    fake_quant_enabled=tensor([1], dtype=torch.uint8), observer_enabled=tensor([1], dtype=torch.uint8), quant_min=0, quant_max=255, dtype=torch.quint8, qscheme=torch.per_tensor_affine, ch_axis=-1, scale=tensor([1.]), zero_point=tensor([0], dtype=torch.int32)
    (activation_post_process): HistogramObserver(min_val=inf, max_val=-inf)
  )
)
```
and the converted model gives:
```
>> converted_model[0].weight()
...
      [0., 0., 0.]]]], size=(10, 10, 3, 3), dtype=torch.qint8,
       quantization_scheme=torch.per_tensor_affine, scale=1.0, zero_point=0)
```
