### PR TITLE
[parametrization] fix `requires_grad` propagation

### DIFF
--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1416,7 +1416,7 @@ class TestNNParametrization(NNTestCase):
 
     def test_register_parametrization_no_grad(self):
         r"""Test that it is possible to register a parametrization without gradient"""
-        class NoResize(nn.Module):
+        class SplitAndCat(nn.Module):
             def right_inverse(self, x):
                 return x[0], x[1]
 
@@ -1427,7 +1427,7 @@ class TestNNParametrization(NNTestCase):
 
         model.weight.requires_grad = False
         # One parametrization with unsafe=True
-        parametrize.register_parametrization(model, "weight", NoResize())
+        parametrize.register_parametrization(model, "weight", SplitAndCat())
         # making sure the decomposed Tensors both have requires_grad == False
         self.assertFalse(model.parametrizations.weight.original0.requires_grad)
         self.assertFalse(model.parametrizations.weight.original1.requires_grad)

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1415,14 +1415,13 @@ class TestNNParametrization(NNTestCase):
                         gradcheck(fn, (m.parametrizations.weight.original,))
 
     def test_register_parametrization_no_grad(self):
-        r"""Test that it is possible to register a parametrization without gradient
-        """
+        r"""Test that it is possible to register a parametrization without gradient"""
         class NoResize(nn.Module):
             def right_inverse(self, x):
                 return x[0], x[1]
 
             def forward(self, x0, x1):
-                return torch.cat(x0, x1)
+                return torch.cat([x0, x1])
 
         model = nn.Linear(8, 8)
 

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1416,9 +1416,11 @@ class TestNNParametrization(NNTestCase):
 
     def test_register_parametrization_no_grad(self):
         r"""Test that it is possible to register a parametrization without gradient"""
+
         class SplitAndCat(nn.Module):
             def right_inverse(self, x):
-                return torch.split(x, 4)
+                # split the tensor in two halfs
+                return torch.split(x, x.shape[1] // 2)
 
             def forward(self, x0, x1):
                 return torch.cat([x0, x1])
@@ -1431,7 +1433,6 @@ class TestNNParametrization(NNTestCase):
         # making sure the decomposed Tensors both have requires_grad == False
         self.assertFalse(model.parametrizations.weight.original0.requires_grad)
         self.assertFalse(model.parametrizations.weight.original1.requires_grad)
-
 
     @swap([True, False])
     def test_new_spectral_norm_load_state_dict(self):

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1430,7 +1430,7 @@ class TestNNParametrization(NNTestCase):
         model.weight.requires_grad = False
         parametrize.register_parametrization(model, "weight", SplitAndCat())
         # making sure the parameterized and decomposed Tensors both have requires_grad == False
-        self.assertFalse(model.parametrizations.weight.requires_grad)
+        self.assertFalse(model.weight.requires_grad)
         self.assertFalse(model.parametrizations.weight.original0.requires_grad)
         self.assertFalse(model.parametrizations.weight.original1.requires_grad)
 

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1418,7 +1418,7 @@ class TestNNParametrization(NNTestCase):
         r"""Test that it is possible to register a parametrization without gradient"""
         class SplitAndCat(nn.Module):
             def right_inverse(self, x):
-                return x[0], x[1]
+                return torch.split(x, 4)
 
             def forward(self, x0, x1):
                 return torch.cat([x0, x1])

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1428,9 +1428,9 @@ class TestNNParametrization(NNTestCase):
         model = nn.Linear(8, 8)
 
         model.weight.requires_grad = False
-        # One parametrization with unsafe=True
         parametrize.register_parametrization(model, "weight", SplitAndCat())
-        # making sure the decomposed Tensors both have requires_grad == False
+        # making sure the parameterized and decomposed Tensors both have requires_grad == False
+        self.assertFalse(model.parametrizations.weight.requires_grad)
         self.assertFalse(model.parametrizations.weight.original0.requires_grad)
         self.assertFalse(model.parametrizations.weight.original1.requires_grad)
 

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -440,7 +440,7 @@ def register_parametrization(
         ``parametrizations`` are implemented with ``ModuleDict`` mapping from tensor_name to a
         ``ParametrizationList`` (a subclass of ``ModuleList``), so each ``parametrization`` will be a ``ModuleList``
         when the model calls ``self.weight`` in forward, instead of returnning the original weight, it
-        will return the ``parametrization``\ s (`ModuleList`) that's registered for the weight (for the first
+        will return the list of ``parametrization`` (`ModuleList`) that's registered for the weight (for the first
         parametrization, the weight might be "decomposed" into multiple tensors stored as ``original0``,
         ``original1``, ``original2`` etc. depending on the specific parametrization),
         and it will run the forward method for each of the module (parametrization) one by one, taking

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -436,13 +436,13 @@ def register_parametrization(
     with names ``original0``, ``original1``,...
 
 
-    What happens during `forward` run:
-        `parametrizations` are implemented with `ModuleDict` mapping from tensor_name to a
-        `ParametrizationList` (a subclass of `ModuleList`), so each `parametrization` will be a `ModuleList`
-        when the model calls `self.weight` in forward, instead of returnning the original weight, it
-        will return the `parametrization`s (`ModuleList`) that's registered for the weight (for the first
-        parametrization, the weight might be "decomposed" into multiple tensors stored as `original0`,
-        `original1`, `original2` etc. depending on the specific parametrization),
+    What happens during ``forward`` run:
+        ``parametrizations`` are implemented with ``ModuleDict`` mapping from tensor_name to a
+        ``ParametrizationList`` (a subclass of ``ModuleList``), so each ``parametrization`` will be a ``ModuleList``
+        when the model calls ``self.weight`` in forward, instead of returnning the original weight, it
+        will return the ``parametrization``\ s (`ModuleList`) that's registered for the weight (for the first
+        parametrization, the weight might be "decomposed" into multiple tensors stored as ``original0``,
+        ``original1``, ``original2`` etc. depending on the specific parametrization),
         and it will run the forward method for each of the module (parametrization) one by one, taking
         the output of previous parametrization as input.
 

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -420,8 +420,9 @@ def register_parametrization(
 
         def right_inverse(self, X: Tensor) -> Union[Tensor, Sequence[Tensor]]
 
-    This method is called on the unparametrized tensor (original ``module.weight``) when the first paramet`rization
-    is registered to compute the initial value of the original tensor (or tensors) that original unparameterized tensor can be "decomposed" into.
+    This method is called on the unparametrized tensor (original ``module.weight``) when the first parametrization
+    is registered to compute the initial value of the original tensor (or tensors) that original
+    unparameterized tensor can be "decomposed" into.
     If this method is not implemented, the original tensor will be just the unparametrized tensor.
 
     If all the parametrizations registered on a tensor implement `right_inverse` it is possible
@@ -435,10 +436,11 @@ def register_parametrization(
     with names ``original0``, ``original1``,...
 
 
-    What happens during eager mode `forward` run:
-        `parametrizations` are implemented with `ModuleList`, so each `parametrization` will be a `Module`
+    What happens during `forward` run:
+        `parametrizations` are implemented with `ModuleDict` mapping from tensor_name to a
+        `ParametrizationList` (a subclass of `ModuleList`), so each `parametrization` will be a `ModuleList`
         when the model calls `self.weight` in forward, instead of returnning the original weight, it
-        will return the `parametrizations` (`ModuleList`) that's registered for the weight (for the first
+        will return the `parametrization`s (`ModuleList`) that's registered for the weight (for the first
         parametrization, the weight might be "decomposed" into multiple tensors stored as `original0`,
         `original1`, `original2` etc. depending on the specific parametrization),
         and it will run the forward method for each of the module (parametrization) one by one, taking

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -180,7 +180,7 @@ class ParametrizationList(ModuleList):
                 # add the new parameters to the optimizer after registering the parametrization
                 # (this is documented)
                 if isinstance(original, Parameter):
-                    originali = Parameter(originali)
+                    originali = Parameter(originali, original.requires_grad)
                 originali.requires_grad_(original.requires_grad)
                 _register_parameter_or_buffer(self, f"original{i}", originali)
 
@@ -394,6 +394,8 @@ def register_parametrization(
     If the original tensor requires a gradient, the backward pass will differentiate
     through :attr:`parametrization`, and the optimizer will update the tensor accordingly.
 
+    What happens during `register_parametrization`:
+
     The first time that a module registers a parametrization, this function will add an attribute
     ``parametrizations`` to the module of type :class:`~ParametrizationList`.
 
@@ -418,8 +420,8 @@ def register_parametrization(
 
         def right_inverse(self, X: Tensor) -> Union[Tensor, Sequence[Tensor]]
 
-    This method is called on the unparametrized tensor when the first parametrization
-    is registered to compute the initial value of the original tensor.
+    This method is called on the unparametrized tensor (original ``module.weight``) when the first paramet`rization
+    is registered to compute the initial value of the original tensor (or tensors) that original unparameterized tensor can be "decomposed" into.
     If this method is not implemented, the original tensor will be just the unparametrized tensor.
 
     If all the parametrizations registered on a tensor implement `right_inverse` it is possible
@@ -431,6 +433,17 @@ def register_parametrization(
 
     In this case, the unconstrained tensors are also located under ``module.parametrizations.weight``
     with names ``original0``, ``original1``,...
+
+
+    What happens during eager mode `forward` run:
+        `parametrizations` are implemented with `ModuleList`, so each `parametrization` will be a `Module`
+        when the model calls `self.weight` in forward, instead of returnning the original weight, it
+        will return the `parametrizations` (`ModuleList`) that's registered for the weight (for the first
+        parametrization, the weight might be "decomposed" into multiple tensors stored as `original0`,
+        `original1`, `original2` etc. depending on the specific parametrization),
+        and it will run the forward method for each of the module (parametrization) one by one, taking
+        the output of previous parametrization as input.
+
 
     .. note::
 

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -394,8 +394,6 @@ def register_parametrization(
     If the original tensor requires a gradient, the backward pass will differentiate
     through :attr:`parametrization`, and the optimizer will update the tensor accordingly.
 
-    What happens during `register_parametrization`:
-
     The first time that a module registers a parametrization, this function will add an attribute
     ``parametrizations`` to the module of type :class:`~ParametrizationList`.
 
@@ -420,9 +418,8 @@ def register_parametrization(
 
         def right_inverse(self, X: Tensor) -> Union[Tensor, Sequence[Tensor]]
 
-    This method is called on the unparametrized tensor (original ``module.weight``) when the first parametrization
-    is registered to compute the initial value of the original tensor (or tensors) that original
-    unparameterized tensor can be "decomposed" into.
+    This method is called on the unparametrized tensor when the first parametrization
+    is registered to compute the initial value of the original tensor.
     If this method is not implemented, the original tensor will be just the unparametrized tensor.
 
     If all the parametrizations registered on a tensor implement `right_inverse` it is possible
@@ -434,18 +431,6 @@ def register_parametrization(
 
     In this case, the unconstrained tensors are also located under ``module.parametrizations.weight``
     with names ``original0``, ``original1``,...
-
-
-    What happens during ``forward`` run:
-        ``parametrizations`` are implemented with ``ModuleDict`` mapping from tensor_name to a
-        ``ParametrizationList`` (a subclass of ``ModuleList``), so each ``parametrization`` will be a ``ModuleList``
-        when the model calls ``self.weight`` in forward, instead of returnning the original weight, it
-        will return the list of ``parametrization`` (`ModuleList`) that's registered for the weight (for the first
-        parametrization, the weight might be "decomposed" into multiple tensors stored as ``original0``,
-        ``original1``, ``original2`` etc. depending on the specific parametrization),
-        and it will run the forward method for each of the module (parametrization) one by one, taking
-        the output of previous parametrization as input.
-
 
     .. note::
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124888

Summary:
Previously the `requires_grad` is not propagated from original Tensor to decomposed tensors

Test Plan:
python test/test_parametrization.py -k test_register_parametrization_no_grad

Reviewers:

Subscribers:

Tasks:

Tags: