### PR TITLE
[onnx.export] Avoid linear look up in env for exist_in_env

### DIFF
--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -32,6 +32,7 @@ def as_graphcontext(graph: torch.Graph) -> jit_utils.GraphContext:
         original_node=None,  # type: ignore[arg-type]
         params_dict={},
         env={},
+        values_in_env=set(),
     )
 
 

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -652,12 +652,14 @@ def _jit_onnx_convert_pattern_from_subblock(
     block: Block,
     n: Node,
     env: Dict[Value, Value],
+    values_in_env: Set[Value],
 ) -> List[Value]: ...
 def _jit_pass_onnx_block(
     old_block: Block,
     new_block: Block,
     operator_export_type: _onnx.OperatorExportTypes,
     env: Dict[Value, Value],
+    values_in_env: Set[Value],
     is_sub_block: _bool,
 ) -> Dict[Value, Value]: ...
 def _jit_pass_onnx_assign_scoped_names_for_node_and_value(graph: Graph) -> None: ...

--- a/torch/csrc/jit/passes/onnx.h
+++ b/torch/csrc/jit/passes/onnx.h
@@ -15,12 +15,14 @@ TORCH_API py::dict BlockToONNX(
     Block* new_block,
     ::torch::onnx::OperatorExportTypes operator_export_type,
     py::dict& env,
+    py::set& values_in_env,
     bool is_sub_block = false);
 TORCH_API void NodeToONNX(
     Node* old_node,
     Block* new_block,
     ::torch::onnx::OperatorExportTypes operator_export_type,
-    py::dict& env);
+    py::dict& env,
+    py::set& values_in_env);
 TORCH_API void RemovePrintOps(std::shared_ptr<Graph>& graph);
 TORCH_API void PreprocessCaffe2Ops(std::shared_ptr<Graph>& graph);
 

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
@@ -286,7 +286,8 @@ std::vector<Value*> ReshapeToAdvancedIndexingFormat(
 std::vector<Value*> ConvertIndexPutToONNX(
     Block* new_block,
     Node* old_node,
-    py::dict& env) {
+    py::dict& env,
+    py::set& values_in_env) {
   if (old_node->kind() != Symbol::fromQualString("onnx::Placeholder") ||
       (old_node->s(attr::name) != "index_put" &&
        old_node->s(attr::name) != "index_put_")) {
@@ -350,7 +351,12 @@ std::vector<Value*> ConvertIndexPutToONNX(
       continue;
     }
 
-    NodeToONNX(at_n, new_block, torch::onnx::OperatorExportTypes::ONNX, env);
+    NodeToONNX(
+        at_n,
+        new_block,
+        torch::onnx::OperatorExportTypes::ONNX,
+        env,
+        values_in_env);
   }
 
   // Find onnx outputs corresponding to the aten outputs of index_put.
@@ -368,7 +374,8 @@ std::vector<Value*> ConvertIndexPutToONNX(
 std::vector<Value*> ConvertPatternFromSubblock(
     Block* new_block,
     Node* old_node,
-    py::dict& env) {
+    py::dict& env,
+    py::set& values_in_env) {
   std::vector<Value*> res;
 
   if (old_node->kind() != Symbol::fromQualString("onnx::Placeholder")) {
@@ -379,7 +386,7 @@ std::vector<Value*> ConvertPatternFromSubblock(
   // subblock.
   auto op_name = old_node->s(attr::name);
   if (op_name == "index_put" || op_name == "index_put_") {
-    res = ConvertIndexPutToONNX(new_block, old_node, env);
+    res = ConvertIndexPutToONNX(new_block, old_node, env, values_in_env);
   }
 
   return res;

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.h
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.h
@@ -39,7 +39,8 @@ namespace jit {
 TORCH_API std::vector<Value*> ConvertPatternFromSubblock(
     Block* new_block,
     Node* old_node,
-    py::dict& env);
+    py::dict& env,
+    py::set& values_in_env);
 
 } // namespace jit
 } // namespace torch

--- a/torch/onnx/_internal/jit_utils.py
+++ b/torch/onnx/_internal/jit_utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import dataclasses
 import re
 import typing
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 import torch
 from torch import _C
@@ -34,6 +34,7 @@ class GraphContext:
         original_node: Current node that is being converted from.
         params_dict: Mapping from graph initializer name to IValue.
         env: Mapping from Torch domain graph Value to ONNX domain graph Value.
+        values_in_env: Set of all values in env, for constant-time lookups.
         new_nodes: List that tracks all new nodes that are added (used to make
             sure metadata is propagated to all new nodes).
     """
@@ -44,6 +45,7 @@ class GraphContext:
     original_node: _C.Node
     params_dict: Dict[str, "_C.IValue"]
     env: Dict[_C.Value, _C.Value]
+    values_in_env: Set[_C.Value]
     new_nodes: List[_C.Node] = dataclasses.field(default_factory=list)
 
     # Relay methods from _C.Graph for compatibility with symbolic functions that expect

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -6737,6 +6737,7 @@ def prim_device(g: jit_utils.GraphContext, *inputs, **kwargs) -> None:
 def prim_loop(g: jit_utils.GraphContext, *inputs, **attrs) -> List[_C.Value]:
     node = g.original_node
     env = g.env
+    values_in_env = g.values_in_env
     params_dict = g.params_dict
 
     operator_export_type = GLOBALS.operator_export_type
@@ -6771,6 +6772,7 @@ def prim_loop(g: jit_utils.GraphContext, *inputs, **attrs) -> List[_C.Value]:
             new_block_context.block,
             operator_export_type,
             env,
+            values_in_env,
             False,
         )
     fixed_outputs = torch._C._jit_pass_fixup_onnx_controlflow_node(
@@ -6790,6 +6792,7 @@ def prim_if(g: jit_utils.GraphContext, *inputs, **attrs) -> List[_C.Value]:
     n = g.original_node
     block = g.block
     env = g.env
+    values_in_env = g.values_in_env
     params_dict = g.params_dict
 
     operator_export_type = GLOBALS.operator_export_type
@@ -6833,6 +6836,7 @@ def prim_if(g: jit_utils.GraphContext, *inputs, **attrs) -> List[_C.Value]:
             block,
             operator_export_type,
             env,
+            values_in_env,
             True,
         )
         if_output_list = list(n.outputs())
@@ -6860,6 +6864,7 @@ def prim_if(g: jit_utils.GraphContext, *inputs, **attrs) -> List[_C.Value]:
                 new_block_context.block,
                 operator_export_type,
                 env,
+                values_in_env,
                 False,
             )
         fixed_outputs = torch._C._jit_pass_fixup_onnx_controlflow_node(
@@ -6930,8 +6935,11 @@ def onnx_placeholder(g: jit_utils.GraphContext, *inputs, **attrs):
     node = g.original_node
     block = g.block
     env = g.env
+    values_in_env = g.values_in_env
 
-    return torch._C._jit_onnx_convert_pattern_from_subblock(block, node, env)
+    return torch._C._jit_onnx_convert_pattern_from_subblock(
+        block, node, env, values_in_env
+    )
 
 
 @_onnx_symbolic("aten::resolve_conj")

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1771,6 +1771,7 @@ def _run_symbolic_method(g, op_name, symbolic_fn, args):
             original_node=None,  # type: ignore[arg-type]
             params_dict=_params_dict,
             env={},
+            values_in_env=set(),
             new_nodes=[],
         )
         return symbolic_fn(graph_context, *args)
@@ -1886,6 +1887,7 @@ def _run_symbolic_function(
     node: _C.Node,
     inputs: Any,
     env: Dict[_C.Value, _C.Value],
+    values_in_env: Set[_C.Value],
     new_nodes: List[_C.Node],
     operator_export_type=_C_onnx.OperatorExportTypes.ONNX,
 ) -> Optional[Union[_C.Value, Sequence[Optional[_C.Value]]]]:
@@ -1917,6 +1919,7 @@ def _run_symbolic_function(
         original_node=node,
         params_dict=_params_dict,
         env=env,
+        values_in_env=values_in_env,
         new_nodes=new_nodes,
     )
 


### PR DESCRIPTION
This PR is part of a series of PRs to significantly speed up torch.onnx.export for models with many nodes (e.g. LLM). See #121422 for more analysis.

- As part of torch.onnx.export, a reverse look-up is made in env. This is done for each node, and this look-up costs in proportional to the graph size, which incurs and overall O(N^2) time complexity.
- A pragmatic solution is simply to keep a separate data structure to make this de facto constant time. So, this introduces a set containing all the values of env. Open to other ideas. Ideally `exist_in_env` wouldn't be needed at all, but to preserve current behavior exactly I'm not sure how that can be done.
- Resolves (4) in #121422.
- This code change and the choice of py::set looks a bit more natural on top of #123063, where the env is changed from a std::unordered_map to a py::dict.

Partially fixes #121422