### PR TITLE
Make triton autotuning configs not error upon failure

### DIFF
--- a/torch/_inductor/kernel/templated_attention.py
+++ b/torch/_inductor/kernel/templated_attention.py
@@ -284,6 +284,7 @@ def templated_attention(*args, **kwargs):
                     (128, 128, 4, 3),
                     (128, 128, 8, 2),
                     (64, 128, 4, 3),
+                    (64, 64, 4, 3),
                 ]
             # Note, we don't need to pass in the captured buffers explicitly
             # because they're implicitly added by the score_mod function

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -192,13 +192,15 @@ class CachingAutotuner(KernelInterface):
             compiled_binaries = []
             if not self.configs:
                 raise RuntimeError("No triton configs are available")
-
             for c in self.configs:
                 try:
                     compiled_binary, launcher = self._precompile_config(
                         c, warm_cache_only
                     )
                 except OutOfResources as e:
+                    if len(self.configs) == 1:
+                        # There are no valid Triton configs
+                        raise e
                     # Skip the config if we run out of resource
                     continue
                 self.launchers.append(launcher)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -199,12 +199,6 @@ class CachingAutotuner(KernelInterface):
                         c, warm_cache_only
                     )
                 except OutOfResources as e:
-                    if len(self.configs) == 1:
-                        raise RuntimeError(
-                            f"Failed to compile triton config: {c}. "
-                            f"Report a fatal compilation error. "
-                            f"{e}"
-                        )
                     # Skip the config if we run out of resource
                     continue
                 self.launchers.append(launcher)

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1013,6 +1013,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 [c for c in choices if hasattr(c, "precompile")],
                 timeout=precompilation_timeout_seconds,
             )
+            from triton.runtime.autotuner import OutOfResources
 
             @functools.lru_cache(None)
             def wait_on_futures():
@@ -1031,6 +1032,9 @@ class AlgorithmSelectorCache(PersistentCache):
                         f"Precompilation timed out after {precompilation_timeout_seconds} seconds."  # noqa: G004
                     )
                 except StopIteration:
+                    pass
+                except OutOfResources:
+                    # This config is invalid due to requiring too many resources
                     pass
 
                 executor.shutdown(wait=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124914



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang