### PR TITLE
remove empty partition

### DIFF
--- a/test/test_fx_passes.py
+++ b/test/test_fx_passes.py
@@ -234,6 +234,11 @@ class TestPartitionFunctions:
         a2 = e + f
         return a0, a1, a2
 
+    @staticmethod
+    def forward18(a, b, c):
+        a0, a1 = torch.ops.aten.var_mean(a)
+        return a0
+
 # A mock OperatorSupport class, where only operator.add is supported
 class MockOperatorSupport(OperatorSupport):
     def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
@@ -277,6 +282,8 @@ class TestFXGraphPasses(JitTestCase):
         (TestPartitionFunctions.forward15, [['add_1', 'add', 'permute_1', 'view', 'permute_2', 'permute_3', 'permute']], False),
         (TestPartitionFunctions.forward16, [["permute_1", "add_1", "add"]], True),
         (TestPartitionFunctions.forward16, [['add_1', 'add', 'permute_1', 'view', 'permute_2', 'permute_3', 'permute']], False),
+        # should be empty partition, not a partiton with empty nodes
+        (TestPartitionFunctions.forward18, [], False),
     ])
     def test_partitioner(self, fn, expected_partition, bookend_non_compute_pass):
         traced = symbolic_trace(fn)

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -260,7 +260,7 @@ class CapabilityBasedPartitioner:
         for id, partition in partitions_by_id.items():
             logger.debug("partition #%s: %s", id, [node.name for node in partition.nodes])
 
-        return list(partitions_by_id.values())
+        return [partition for partition in partitions_by_id.values() if partition.size() > 0]
 
     def fuse_partitions(self, partitions: List[Partition]) -> GraphModule:
         logger.debug("Fusing partitions...")


### PR DESCRIPTION
In some rare scenarios, the partitioner will produce an empty partition. it's a waste of time to compile an empty graph.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen