### PR TITLE
Forward fix: disable two unrelated tests for ROCm

### DIFF
--- a/test/test_cpp_extensions_mtia_backend.py
+++ b/test/test_cpp_extensions_mtia_backend.py
@@ -18,10 +18,9 @@ from torch.testing._internal.common_utils import (
 )
 from torch.utils.cpp_extension import CUDA_HOME, ROCM_HOME
 
-
-TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
+# define TEST_ROCM before changing TEST_CUDA
 TEST_ROCM = TEST_CUDA and torch.version.hip is not None and ROCM_HOME is not None
-
+TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
 
 def remove_build_path():
     if sys.platform == "win32":

--- a/test/test_cpp_extensions_mtia_backend.py
+++ b/test/test_cpp_extensions_mtia_backend.py
@@ -33,7 +33,7 @@ def remove_build_path():
 
 
 @unittest.skipIf(
-    IS_ARM64 or not IS_LINUX or TEST_CUDA or TEST_PRIVATEUSE1,
+    IS_ARM64 or not IS_LINUX or TEST_CUDA or TEST_PRIVATEUSE1 or TEST_ROCM,
     "Only on linux platform and mutual exclusive to other backends",
 )
 @torch.testing._internal.common_utils.markDynamoStrictTest

--- a/test/test_cpp_extensions_mtia_backend.py
+++ b/test/test_cpp_extensions_mtia_backend.py
@@ -22,6 +22,7 @@ from torch.utils.cpp_extension import CUDA_HOME, ROCM_HOME
 TEST_ROCM = TEST_CUDA and torch.version.hip is not None and ROCM_HOME is not None
 TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
 
+
 def remove_build_path():
     if sys.platform == "win32":
         # Not wiping extensions build folder because Windows

--- a/test/test_cpp_extensions_stream_and_event.py
+++ b/test/test_cpp_extensions_stream_and_event.py
@@ -18,9 +18,9 @@ from torch.testing._internal.common_utils import (
 )
 from torch.utils.cpp_extension import CUDA_HOME, ROCM_HOME
 
-
-TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
+# define TEST_ROCM before changing TEST_CUDA
 TEST_ROCM = TEST_CUDA and torch.version.hip is not None and ROCM_HOME is not None
+TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
 
 
 def remove_build_path():

--- a/test/test_cpp_extensions_stream_and_event.py
+++ b/test/test_cpp_extensions_stream_and_event.py
@@ -35,7 +35,7 @@ def remove_build_path():
 # Since we use a fake MTIA device backend to test generic Stream/Event, device backends are mutual exclusive to each other.
 # The test will be skipped if any of the following conditions are met:
 @unittest.skipIf(
-    IS_ARM64 or not IS_LINUX or TEST_CUDA or TEST_PRIVATEUSE1,
+    IS_ARM64 or not IS_LINUX or TEST_CUDA or TEST_PRIVATEUSE1 or TEST_ROCM,
     "Only on linux platform and mutual exclusive to other backends",
 )
 @torch.testing._internal.common_utils.markDynamoStrictTest


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124924

ROCm CIs pick up two unrelated tests from #123614. Skip those two tests if TEST_ROCm is true and they shouldn't be run on ROCm since it loaded a fake device backend in the test. 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang