### PR TITLE
[RFC][FSDP2] Renamed `FSDP` to `FSDPModule`

### DIFF
--- a/torch/distributed/_composable/fsdp/__init__.py
+++ b/torch/distributed/_composable/fsdp/__init__.py
@@ -1,2 +1,2 @@
 from ._fsdp_api import CPUOffloadPolicy, MixedPrecisionPolicy, OffloadPolicy
-from .fully_shard import FSDP, fully_shard
+from .fully_shard import FSDPModule, fully_shard


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124936
* #124787
* #124780
* #124768
* #124767
* #124741
* #124651

This PR renames the `FSDP` class to `FSDPModule`. This is a BC breaking change. The rationale is that `FSDPModule` is more descriptive since `fully_shard` is a module-level API (applied to a `module` arg), so the `FSDP` class will always correspond to a module.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k