### PR TITLE
[RFC][FSDP2] Renamed `FSDP` to `FSDPModule`

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 
 from torch.distributed._composable import checkpoint, replicate
 from torch.distributed._composable.fsdp import (
-    FSDP,
+    FSDPModule,
     fully_shard,
     MixedPrecisionPolicy,
     OffloadPolicy,
@@ -630,13 +630,13 @@ class TestFullyShardUnshardMultiProcess(FSDPTest):
 
             def forward(self, x: torch.Tensor):
                 y1, work1 = self.reduce_module1(x)
-                if isinstance(self.mlps.mlp1, FSDP):
+                if isinstance(self.mlps.mlp1, FSDPModule):
                     self.mlps.mlp1.unshard(async_op=True)
                 y2, work2 = self.reduce_module2(x)
-                if isinstance(self.mlps.mlp2, FSDP):
+                if isinstance(self.mlps.mlp2, FSDPModule):
                     self.mlps.mlp2.unshard(async_op=True)
                 y3, work3 = self.reduce_module3(x)
-                if isinstance(self.mlps.mlp3, FSDP):
+                if isinstance(self.mlps.mlp3, FSDPModule):
                     self.mlps.mlp3.unshard(async_op=True)
                 return self.mlps([y1, y2, y3], [work1, work2, work3])
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_state.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state.py
@@ -4,7 +4,7 @@ import copy
 import unittest
 
 import torch.nn as nn
-from torch.distributed._composable.fsdp import FSDP, fully_shard
+from torch.distributed._composable.fsdp import FSDPModule, fully_shard
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_fsdp import FSDPTestMultiThread, MLP
 from torch.testing._internal.common_utils import run_tests
@@ -47,22 +47,22 @@ class TestFullyShardState(FSDPTestMultiThread):
         model = MLP(8)
         fully_shard(model)
         self.assertTrue(isinstance(model, MLP))
-        self.assertTrue(isinstance(model, FSDP))
+        self.assertTrue(isinstance(model, FSDPModule))
         self.assertEqual(model.__class__.__name__, "FSDPMLP")
         for module in model.modules():
             if module is model:
                 continue
-            self.assertFalse(isinstance(module, FSDP))
+            self.assertFalse(isinstance(module, FSDPModule))
 
         # Check that slicing into a `Sequential` does not preserve FSDP
         model = nn.Sequential(*[MLP(8) for _ in range(3)])
         fully_shard(model)
         self.assertTrue(isinstance(model, nn.Sequential))
-        self.assertTrue(isinstance(model, FSDP))
+        self.assertTrue(isinstance(model, FSDPModule))
         self.assertEqual(model.__class__.__name__, "FSDPSequential")
         sliced_model = model[:2]
         self.assertTrue(isinstance(sliced_model, nn.Sequential))
-        self.assertFalse(isinstance(sliced_model, FSDP))
+        self.assertFalse(isinstance(sliced_model, FSDPModule))
 
     @unittest.skipIf(not TEST_CUDA, "no cuda")
     def test_fully_shard_unsupported_module_cls(self):

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -13,7 +13,7 @@ import torch.nn as nn
 from torch.distributed._composable import checkpoint, replicate
 from torch.distributed._composable.fsdp import (
     CPUOffloadPolicy,
-    FSDP,
+    FSDPModule,
     fully_shard,
     OffloadPolicy,
 )
@@ -144,7 +144,7 @@ class TestFullyShardRegisteredParams(FSDPTestMultiThread):
             self._assert_tensor_params(root_params)
             self._assert_same_params(model.parameters(), ref_model.parameters())
             for module in model.modules():
-                if isinstance(module, FSDP):
+                if isinstance(module, FSDPModule):
                     module.reshard()  # however, we can manually reshard
             self._assert_dtensor_params(model.parameters())
             self._assert_same_params(model.parameters(), ref_model.parameters())
@@ -854,7 +854,7 @@ class TestFullyShardGradientAccumulation(FSDPTest):
         # memory usage since we do not reshard after forward
         if use_explicit_unshard:
             for module in model.modules():
-                if isinstance(module, FSDP):
+                if isinstance(module, FSDPModule):
                     module.unshard(async_op=True)
 
         # Emulate the 1f1b pipeline schedule and only reduce gradients on the

--- a/torch/distributed/_composable/fsdp/__init__.py
+++ b/torch/distributed/_composable/fsdp/__init__.py
@@ -1,2 +1,2 @@
 from ._fsdp_api import CPUOffloadPolicy, MixedPrecisionPolicy, OffloadPolicy
-from .fully_shard import FSDP, fully_shard
+from .fully_shard import FSDPModule, fully_shard


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #124955
* #124787
* #124780
* #124768
* #124767
* #124741
* #124651

This PR renames the `FSDP` class to `FSDPModule`. This is a BC breaking change. The rationale is that `FSDPModule` is more descriptive since `fully_shard` is a module-level API (applied to a `module` arg), so the `FSDP` class will always correspond to a module.

Also, users commonly import `FullyShardedDataParallel` as `FSDP`, so this can help avoid some name conflict in some cases.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k