### PR TITLE
Make c10d_functional ops call into _c10d_functional ops

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -559,7 +559,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
             .check("buf3 = torch.ops._c10d_functional.wait_tensor.default(buf0")
             .check("buf5 = empty_strided")
             .check(".run(buf5, 16")
-            .check("return (buf3, buf5")
+            .check("return (buf0, buf5")
             .run(code)
         )
         out = compiled(inputs, **self.get_world_trs())

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1026,6 +1026,18 @@ def reduce_scatter_tensor_inplace(
     return output.copy_(reduce_scatter_tensor(input, op, scatter_dim, group, tag))
 
 
+REDUCE_OP_TO_STR = {
+    dist.ReduceOp.SUM: "sum",
+    dist.ReduceOp.AVG: "avg",
+    dist.ReduceOp.PRODUCT: "product",
+    dist.ReduceOp.MIN: "min",
+    dist.ReduceOp.MAX: "max",
+    dist.ReduceOp.BAND: "band",
+    dist.ReduceOp.BOR: "bor",
+    dist.ReduceOp.BXOR: "bxor",
+}
+
+
 def all_reduce_inplace(
     tensor: torch.Tensor,
     op: str = "sum",

--- a/torch/distributed/_functional_collectives_impl.py
+++ b/torch/distributed/_functional_collectives_impl.py
@@ -1,32 +1,11 @@
-import logging
 from typing import List, Optional
 
 import torch
 import torch.distributed.distributed_c10d as c10d
 
 """
-Moved eager kernel implementations to a separate file partly for readability and partly as it is currently
-easier in dynamo to set tracing policy on a file-by-file level.
-
-Do not put code in this file that Dynamo is expected to trace into, as dynamo may disallow this whole file.
-
-DEBUG/TESTING HELPERS:
-
-This module includes some helpers that are quite useful when debugging or testing functional collectives:
-
-_tensor_needs_wait
-_outstanding_wait_count
-_wait_all
-
-"""
-
-logger = logging.getLogger(__name__)
-
-"""
-Kernel implementations (for eager runtime only) - should never be traced by torch.compile
-
-These functions should all be bound to dispatcher ops.  During tracing, the op itself should be
-captured in the graph and the backend should implement the op however it prefers.
+This file contains the op impls for the legacy (c10d_functional) functional collectives.
+These impls simply call into the native (_c10d_functional) functional collectives.
 """
 
 

--- a/torch/distributed/_functional_collectives_impl.py
+++ b/torch/distributed/_functional_collectives_impl.py
@@ -13,6 +13,7 @@ def _broadcast(input, src, tag, ranks, group_size):
     group_name = c10d._resolve_group_name_by_ranks_and_tag(ranks, tag)
     return torch.ops._c10d_functional.broadcast(
         input,
+        src,
         group_name,
     )
 

--- a/torch/distributed/_functional_collectives_impl.py
+++ b/torch/distributed/_functional_collectives_impl.py
@@ -1,10 +1,7 @@
 import logging
-import warnings
-import weakref
-from typing import cast, Dict, List, Optional
+from typing import List, Optional
 
 import torch
-import torch.distributed as dist
 import torch.distributed.distributed_c10d as c10d
 
 """
@@ -25,144 +22,6 @@ _wait_all
 
 logger = logging.getLogger(__name__)
 
-_use_native_funcol: Optional[bool] = None
-
-
-data_ptr_to_work: Dict[int, "_WaitRegistration"] = dict()
-work_version = 0
-
-
-class _WaitRegistration:
-    def __init__(self, work):
-        global work_version
-        self.work = work
-        self.version = work_version
-        self.ptrs = set()
-        self.ptr_alias_count = {}
-        self.cleanup_count = 0
-        work_version += 1
-
-    def _register_tensor_ptr(self, data_ptr):
-        global data_ptr_to_work
-        data_ptr_to_work[data_ptr] = self
-        self.ptrs.add(data_ptr)
-
-    def _record_wrapper(self, ptr):
-        self._register_tensor_ptr(ptr)
-        self.ptr_alias_count.setdefault(ptr, 0)
-        self.ptr_alias_count[ptr] += 1
-        self.cleanup_count += 1
-
-    def wait(self):
-        if self.work is not None:
-            self.work.wait()
-            self.work = None
-        self.cleanup()
-
-    def decrement_live_tensor(self, ptr):
-        self.cleanup_count -= 1
-        if self.cleanup_count == 0:
-            self.wait()
-        else:
-            self.ptr_alias_count[ptr] -= 1
-            if (
-                self.ptr_alias_count[ptr] < 1
-                and data_ptr_to_work.get(ptr, None) == self
-            ):
-                del data_ptr_to_work[ptr]
-
-    def cleanup(self):
-        for ptr in self.ptrs:
-            if data_ptr_to_work.get(ptr, None) == self:
-                del data_ptr_to_work[ptr]
-
-
-def _register_tensor_work(tensor_or_list, work_or_list):
-    if not isinstance(tensor_or_list, list):
-        tensor_or_list = [tensor_or_list]
-    if not isinstance(work_or_list, list):
-        reg = _WaitRegistration(work_or_list)
-        for tensor in tensor_or_list:
-            reg._register_tensor_ptr(tensor.data_ptr())
-    else:
-        for tensor, work in zip(tensor_or_list, work_or_list):
-            reg = _WaitRegistration(work)
-            reg._register_tensor_ptr(tensor.data_ptr())
-
-
-def _wait_reg_dec(ptr, wait_reg):
-    wait_reg.decrement_live_tensor(ptr)
-
-
-def _register_tensor_wrapper(tensor) -> None:
-    global data_ptr_to_work
-
-    # FIXME: This is almost definitely a bug.
-    if isinstance(
-        tensor.elem,
-        (
-            torch._subclasses.fake_tensor.FakeTensor,
-            torch._subclasses.functional_tensor.FunctionalTensor,
-        ),
-    ):
-        data_ptr = 0
-    else:
-        data_ptr = tensor.elem.data_ptr()
-
-    # Note: we should NEVER try to trace this, bc it registers runtime stuff during trace.
-    # Instead, backends must call this themselves when implementing traced collectives.
-    wait_reg = data_ptr_to_work.get(data_ptr, None)
-    if wait_reg is None:
-        warnings.warn(
-            "Trying to register finalizer to AsyncCollectiveTensor but the inner tensor is already gone"
-        )
-    else:
-        # We force the collective to be waited in the case this tensor goes away to reduce the change of deadlocks.
-        # NOTE: we register the callback to the ACT wrapper class, for the following reasons:
-        # 1. The inner tensor is referenced by the associated Work object, so it's uncollective until we release the
-        #  associated work object
-        # 2. There's a n-to-1 relationship between wrappers and inner tensor due to non-waitable ops like view()
-        wait_reg._record_wrapper(data_ptr)
-        weakref.finalize(tensor, _wait_reg_dec, data_ptr, wait_reg)
-
-
-def _wait_tensor(tensor: torch.Tensor) -> torch.Tensor:
-    global data_ptr_to_work
-    data_ptr = tensor.data_ptr()
-    wait_reg = data_ptr_to_work.get(data_ptr)
-    if wait_reg is not None:
-        wait_reg.wait()
-    return tensor
-
-
-def _tensor_needs_wait(tensor: torch.Tensor) -> bool:
-    """Returns true if ```tensor``` needs to be waited. Works with ACS and inner tensors."""
-    if hasattr(tensor, "_get_acs_underlying_tensor"):
-        tensor = tensor._get_acs_underlying_tensor()
-    data_ptr = tensor.data_ptr()
-    wait_reg = data_ptr_to_work.get(data_ptr)
-    return wait_reg is not None and wait_reg.work is not None
-
-
-def _outstanding_wait_count() -> int:
-    """Returns the number of outstanding work objects waiting to be waited (sic)."""
-    return len(data_ptr_to_work)
-
-
-def _wait_all() -> None:
-    """Wait for all outstanding collectives."""
-    for work_reg in list(data_ptr_to_work.values()):
-        work_reg.wait()
-
-
-def _str_to_reduce_op(reduceOp: str) -> dist.ReduceOp:
-    reduceOp = reduceOp.upper()
-    op = dist.ReduceOp.RedOpType.__members__.get(reduceOp)
-    if op is None:
-        raise ValueError(f"Invalid reduce operation {reduceOp}")
-    return cast(dist.ReduceOp, op)
-
-
 """
 Kernel implementations (for eager runtime only) - should never be traced by torch.compile
 
@@ -171,119 +30,64 @@ captured in the graph and the backend should implement the op however it prefers
 """
 
 
-def _broadcast(self, src, tag, ranks, group_size):
-    group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
-    assert group is not None
-
-    inplace_tensor = self.clone(memory_format=torch.contiguous_format)
-    work = dist.broadcast(inplace_tensor, src, group=group, async_op=True)
-    _register_tensor_work(inplace_tensor, work)
-
-    return inplace_tensor
-
-
-# TODO assert if ranks has duplicated entries
-def _all_reduce(self, reduceOp, tag, ranks, group_size):
-    op = _str_to_reduce_op(reduceOp)
-    group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
-    assert group is not None
-
-    inplace_tensor = self.clone(memory_format=torch.contiguous_format)
-    work = dist.all_reduce(inplace_tensor, op=op, group=group, async_op=True)
-    _register_tensor_work(inplace_tensor, work)
-
-    return inplace_tensor
-
-
-def _all_reduce_coalesced(self, reduceOp, tag, ranks, group_size):
-    op = _str_to_reduce_op(reduceOp)
-    group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
-    assert group is not None
-
-    inplace_tensor_list = [t.clone(memory_format=torch.contiguous_format) for t in self]
-    work = dist.all_reduce_coalesced(
-        inplace_tensor_list, op=op, group=group, async_op=True
-    )
-    _register_tensor_work(inplace_tensor_list, work)
-
-    return inplace_tensor_list
-
-
-def _all_gather_into_tensor(shard, tag, ranks, group_size):
-    # TODO add dim support?
-    group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
-    assert group is not None
-    out_size = list(shard.size())
-    out_size[0] *= group_size
-    out_tensor = shard.new_empty(out_size)
-    assert out_tensor.is_contiguous()
-    # FIXME gloo doesn't support _allgather_base
-    if dist.get_backend(group) == dist.Backend.GLOO or shard.is_cpu:
-        tensor_list = list(torch.chunk(out_tensor, group_size))
-        work = dist.all_gather(tensor_list, shard, group=group, async_op=True)
-    else:
-        work = dist.all_gather_into_tensor(
-            out_tensor, shard, group=group, async_op=True
-        )
-    _register_tensor_work(out_tensor, work)
-
-    return out_tensor
-
-
-def _all_gather_into_tensor_coalesced(self, tag, rankset, group_size):
-    group = c10d._find_or_create_pg_by_ranks_and_tag(tag, rankset, group_size)
-    assert group is not None
-
-    def mk_out_tensor(shard):
-        out_size = list(shard.size())
-        out_size[0] *= group_size
-        out_tensor = shard.new_empty(out_size)
-        assert out_tensor.is_contiguous()
-        return out_tensor
-
-    out_tensors = [mk_out_tensor(t) for t in self]
-
-    work_list = _all_gather_into_tensor_coalesced_fallback(
-        output_tensors=out_tensors, input_tensors=self, group=group, async_op=True
+def _broadcast(input, src, tag, ranks, group_size):
+    group_name = c10d._resolve_group_name_by_ranks_and_tag(ranks, tag)
+    return torch.ops._c10d_functional.broadcast(
+        input,
+        group_name,
     )
 
-    _register_tensor_work(out_tensors, work_list)
-    return out_tensors
+
+def _all_reduce(input, reduce_op, tag, ranks, group_size):
+    group_name = c10d._resolve_group_name_by_ranks_and_tag(ranks, tag)
+    return torch.ops._c10d_functional.all_reduce(
+        input,
+        reduce_op,
+        group_name,
+    )
+
+
+def _all_reduce_coalesced(inputs, reduce_op, tag, ranks, group_size):
+    group_name = c10d._resolve_group_name_by_ranks_and_tag(ranks, tag)
+    return torch.ops._c10d_functional.all_reduce_coalesced(
+        inputs,
+        reduce_op,
+        group_name,
+    )
+
+
+def _all_gather_into_tensor(input, tag, ranks, group_size):
+    group_name = c10d._resolve_group_name_by_ranks_and_tag(ranks, tag)
+    return torch.ops._c10d_functional.all_gather_into_tensor(
+        input,
+        group_size,
+        group_name,
+    )
+
+
+def _all_gather_into_tensor_coalesced(input, tag, ranks, group_size):
+    group_name = c10d._resolve_group_name_by_ranks_and_tag(ranks, tag)
+    return torch.ops._c10d_functional.all_gather_into_tensor_coalesced(
+        input,
+        group_size,
+        group_name,
+    )
 
 
 def _reduce_scatter_tensor(
     input: torch.Tensor,
-    reduceOp: str,
+    reduce_op: str,
     tag: str,
     ranks: List[int],
     group_size: int,
 ):
-    # TODO add dim support?
-    group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
-    assert group is not None
-    op = _str_to_reduce_op(reduceOp)
-
-    if dist.get_backend(group) == dist.Backend.GLOO or input.is_cpu:
-        # cpu::gloo backend does not have reduce_scatter we fallback to do all_reduce
-        # + local chunk
-        logger.warning(
-            "ProcessGroupGloo does not support reduce_scatter, falling back with all reduce!"
-        )
-        reduction_input = input.clone()
-        group_rank = dist.get_rank(group)
-        work = dist.all_reduce(reduction_input, op=op, group=group, async_op=True)
-        out_tensor = reduction_input.chunk(group_size, dim=0)[group_rank]
-        _register_tensor_work(out_tensor, work)
-    else:
-        out_size = list(input.size())
-        out_size[0] //= group_size
-        out_tensor = input.new_empty(out_size)
-        work = dist.reduce_scatter_tensor(
-            out_tensor, input, op=op, group=group, async_op=True
-        )
-        _register_tensor_work(out_tensor, work)
-
-    return out_tensor
+    group_name = c10d._resolve_group_name_by_ranks_and_tag(ranks, tag)
+    return torch.ops._c10d_functional.reduce_scatter_tensor(
+        input,
+        reduce_op,
+        group_size,
+        group_name,
+    )
 
 
 def _reduce_scatter_tensor_coalesced(
@@ -293,67 +97,13 @@ def _reduce_scatter_tensor_coalesced(
     ranks: List[int],
     group_size: int,
 ):
-    group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
-    assert group is not None
-    op = _str_to_reduce_op(reduce_op)
-
-    def mk_out_tensor(shard):
-        out_size = list(shard.size())
-        out_size[0] //= group_size
-        out_tensor = shard.new_empty(out_size)
-        assert out_tensor.is_contiguous()
-        return out_tensor
-
-    out_tensors = [mk_out_tensor(t) for t in inputs]
-
-    work_list = _reduce_scatter_tensor_coalesced_fallback(
-        output_tensors=out_tensors,
-        input_tensors=inputs,
-        op=op,
-        group=group,
-        async_op=False,
+    group_name = c10d._resolve_group_name_by_ranks_and_tag(ranks, tag)
+    return torch.ops._c10d_functional.reduce_scatter_tensor_coalesced(
+        inputs,
+        reduce_op,
+        group_size,
+        group_name,
     )
-
-    _register_tensor_work(out_tensors, work_list)
-    return out_tensors
-
-
-def _all_gather_into_tensor_coalesced_fallback(
-    output_tensors, input_tensors, group, async_op=False
-):
-    # all_gather_coalesced is useless, it doesn't work under NCCL and does lots of copies under Gloo
-    # all_gather is useless too because it's single tensor
-    # NCCL's PG::all_gather with multiple tensors is broken, it only works for the multi-device setting
-    #  and fails if you mix same-size with different-size tensor lists.
-    # _coalescing_manager crashed NCCL when used with all_gather_into_tensor.
-    if input_tensors[0].is_cpu or not async_op:
-        work_list = []
-        out_tensors_sliced = [
-            list(torch.chunk(out_tensor, dist.get_world_size(group)))
-            for out_tensor in output_tensors
-        ]
-        for shard, out_tensor in zip(input_tensors, out_tensors_sliced):
-            work = c10d.all_gather(out_tensor, shard, group=group, async_op=async_op)
-            work_list.append(work)
-        return work_list
-    else:
-        with c10d._coalescing_manager(group=group, async_ops=True) as cm:
-            for in_t, out_t in zip(input_tensors, output_tensors):
-                dist.all_gather_into_tensor(out_t, in_t, group=group, async_op=True)
-        return cm
-
-
-def _reduce_scatter_tensor_coalesced_fallback(
-    output_tensors, input_tensors, op, group, async_op=False
-):
-    # All the same reasons as the all_gather fallback
-    work_list = []
-    for shard, out_tensor in zip(input_tensors, output_tensors):
-        work = c10d.reduce_scatter_tensor(
-            out_tensor, shard, op=op, group=group, async_op=async_op
-        )
-        work_list.append(work)
-    return work_list
 
 
 def _all_to_all_single(
@@ -364,27 +114,22 @@ def _all_to_all_single(
     ranks: List[int],
     group_size: int,
 ):
-    group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
-
-    if output_split_sizes is not None:
-        torch._check(
-            input.dim() >= 1,
-            lambda: f"Expected input to have at least 1 dim but got {input.dim()} dim",
+    if output_split_sizes is None or input_split_sizes is None:
+        assert output_split_sizes is None and input_split_sizes is None, (
+            "output_split_sizes and input_split_sizes must either be "
+            "specified together or both set to None"
         )
-        out_size = list(input.size())
-        out_size[0] = sum(output_split_sizes)
-        out_tensor = input.new_empty(out_size)
-    else:
-        out_tensor = input.new_empty(input.size())
+        output_split_sizes = [input.shape[0] // group_size] * group_size
+        input_split_sizes = output_split_sizes
 
-    work = c10d.all_to_all_single(
-        out_tensor,
+    group_name = c10d._resolve_group_name_by_ranks_and_tag(ranks, tag)
+    return torch.ops._c10d_functional.all_to_all_single(
         input,
-        output_split_sizes=output_split_sizes,
-        input_split_sizes=input_split_sizes,
-        group=group,
-        async_op=True,
+        output_split_sizes,
+        input_split_sizes,
+        group_name,
     )
-    _register_tensor_work(out_tensor, work)
 
-    return out_tensor
+
+def _wait_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    return torch.ops._c10d_functional.wait_tensor(tensor)

--- a/torch/distributed/_spmd/api.py
+++ b/torch/distributed/_spmd/api.py
@@ -294,8 +294,8 @@ SPMD_DECOMP_TABLE = {
 
 
 DEDUP_TARGETS: Set[torch._ops.OpOverload] = {
-    torch.ops.c10d_functional.all_reduce.default,
-    torch.ops.c10d_functional.wait_tensor.default,
+    torch.ops._c10d_functional.all_reduce.default,
+    torch.ops._c10d_functional.wait_tensor.default,
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124992
* __->__ #124979

This PR removes the legacy impls of c10d_functional ops which are now irrelevant. For backward compatibility purpose, c10d_functional ops now call into _c10d_functional ops.

We also changed c10d_functional ops to be CompositeExplicitAutograd, so that when traced, only _c10d_functional ops appear in the graph. After this, we'll be able to remove the Inductor IR for the legacy functional collectives.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k