### PR TITLE
Print flexibility for tensor output

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -66,7 +66,7 @@ std::ostream& operator<<(std::ostream & out, const DeprecatedTypeProperties& t) 
   return out << t.toString();
 }
 
-static std::tuple<double, int> __printFormat(std::ostream& stream, const Tensor& self, int64_t precision) {
+static std::tuple<double, int> __printFormat(std::ostream& stream, const Tensor& self, int64_t precision, bool fixed) {
   auto size = self.numel();
   if(size == 0) {
     return std::make_tuple(1., 0);
@@ -122,6 +122,9 @@ static std::tuple<double, int> __printFormat(std::ostream& stream, const Tensor&
     if(expMax > 9) {
       sz = 11;
       stream << std::scientific << std::setprecision(precision);
+      if (fixed) {
+        stream << std::fixed;
+      }
     } else {
       sz = static_cast<int>(expMax) + 1;
       stream << defaultfloat;
@@ -133,11 +136,17 @@ static std::tuple<double, int> __printFormat(std::ostream& stream, const Tensor&
         sz = sz + 1;
       }
       stream << std::scientific << std::setprecision(precision);
+      if (fixed) {
+        stream << std::fixed;
+      }
     } else {
       if(expMax > 5 || expMax < 0) {
         sz = 7;
         scale = std::pow(10, expMax-1);
         stream << std::fixed << std::setprecision(precision);
+        if (!fixed) {
+          stream << std::scientific;
+        }
       } else {
         if(expMax == 0) {
           sz = 7;
@@ -145,6 +154,9 @@ static std::tuple<double, int> __printFormat(std::ostream& stream, const Tensor&
           sz = static_cast<int>(expMax) + 6;
         }
         stream << std::fixed << std::setprecision(precision);
+        if (!fixed) {
+          stream << std::scientific;
+        }
       }
     }
   }
@@ -162,9 +174,9 @@ static void printScale(std::ostream & stream, double scale) {
   FormatGuard guard(stream);
   stream << defaultfloat << scale << " *" << '\n';
 }
-static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t linesize, int64_t precision, int64_t indent)
+static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t linesize, int64_t precision, bool fixed, int64_t indent)
 {
-  auto [scale, sz] = __printFormat(stream, self, precision);
+  auto [scale, sz] = __printFormat(stream, self, precision, fixed);
 
   __printIndent(stream, indent);
   int64_t nColumnPerLine = (linesize-indent)/(sz+1);
@@ -211,7 +223,7 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
   }
 }
 
-static void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize, int64_t precision)
+static void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize, int64_t precision, bool fixed)
 {
   std::vector<int64_t> counter(self.ndimension()-2);
   bool start = true;
@@ -248,14 +260,14 @@ static void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize, 
       stream << counter[i]+1 << ",";
     }
     stream << ".,.) = " << '\n';
-    __printMatrix(stream, tensor, linesize, precision, 1);
+    __printMatrix(stream, tensor, linesize, precision, fixed, 1);
   }
 }
 
-void print(const Tensor & t, int64_t linesize, int64_t precision) {
-  print(std::cout,t,linesize, precision);
+void print(const Tensor & t, int64_t linesize, int64_t precision, bool fixed) {
+  print(std::cout,t,linesize, precision, fixed);
 }
-std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesize, int64_t precision) {
+std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesize, int64_t precision, bool fixed) {
   FormatGuard guard(stream);
   if(!tensor_.defined()) {
     stream << "[ Tensor (undefined) ]";
@@ -283,7 +295,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
       stream << "[ " << tensor_.toString() << "{}";
     } else if(tensor.ndimension() == 1) {
       if (tensor.numel() > 0) {
-        auto [scale, sz] = __printFormat(stream, tensor, precision);
+        auto [scale, sz] = __printFormat(stream, tensor, precision, fixed);
         if(scale != 1) {
           printScale(stream, scale);
         }
@@ -295,12 +307,12 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
       stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "}";
     } else if(tensor.ndimension() == 2) {
       if (tensor.numel() > 0) {
-        __printMatrix(stream, tensor, linesize, precision, 0);
+        __printMatrix(stream, tensor, linesize, precision, fixed, 0);
       }
       stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "," <<  tensor.size(1) << "}";
     } else {
       if (tensor.numel() > 0) {
-        __printTensor(stream, tensor, linesize, precision);
+        __printTensor(stream, tensor, linesize, precision, fixed);
       }
       stream << "[ " << tensor_.toString() << "{" << tensor.size(0);
       for (const auto i : c10::irange(1, tensor.ndimension())) {
@@ -317,10 +329,10 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
           tensor_.qscheme() == c10::kPerChannelAffineFloatQParams) {
         stream << ", scales: ";
         Tensor scales = tensor_.q_per_channel_scales();
-        print(stream, scales, linesize, precision);
+        print(stream, scales, linesize, precision, fixed);
         stream << ", zero_points: ";
         Tensor zero_points = tensor_.q_per_channel_zero_points();
-        print(stream, zero_points, linesize, precision);
+        print(stream, zero_points, linesize, precision, fixed);
         stream << ", axis: " << tensor_.q_per_channel_axis();
       }
     }

--- a/aten/src/ATen/core/Formatting.h
+++ b/aten/src/ATen/core/Formatting.h
@@ -19,7 +19,7 @@ TORCH_API std::ostream& print(
     const Tensor& tensor,
     int64_t linesize);
 static inline std::ostream& operator<<(std::ostream & out, const Tensor & t) {
-  return print(out,t,80);
+  return print(out,t,80,4);
 }
-TORCH_API void print(const Tensor & t, int64_t linesize=80);
+TORCH_API void print(const Tensor & t, int64_t linesize=80, int64_t precision=4);
 }

--- a/aten/src/ATen/core/Formatting.h
+++ b/aten/src/ATen/core/Formatting.h
@@ -17,7 +17,7 @@ TORCH_API std::ostream& operator<<(std::ostream& out, const DeprecatedTypeProper
 TORCH_API std::ostream& print(
     std::ostream& stream,
     const Tensor& tensor,
-    int64_t linesize);
+    int64_t linesize, int64_t precision);
 static inline std::ostream& operator<<(std::ostream & out, const Tensor & t) {
   return print(out,t,80,4);
 }

--- a/aten/src/ATen/core/Formatting.h
+++ b/aten/src/ATen/core/Formatting.h
@@ -17,9 +17,11 @@ TORCH_API std::ostream& operator<<(std::ostream& out, const DeprecatedTypeProper
 TORCH_API std::ostream& print(
     std::ostream& stream,
     const Tensor& tensor,
-    int64_t linesize, int64_t precision);
+    int64_t linesize,
+    int64_t precision,
+    bool fixed);
 static inline std::ostream& operator<<(std::ostream & out, const Tensor & t) {
-  return print(out,t,80,4);
+  return print(out,t,80,4,true);
 }
-TORCH_API void print(const Tensor & t, int64_t linesize=80, int64_t precision=4);
+TORCH_API void print(const Tensor & t, int64_t linesize=80, int64_t precision=4, bool fixed=true);
 }

--- a/test/cpp/api/print.cpp
+++ b/test/cpp/api/print.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include <c10/util/irange.h>
+#include <test/cpp/api/support.h>
+#include <torch/torch.h>
+
+TEST(PrintTest, Precision) {
+    auto t = torch::tensor({{0.21861312}});
+    torch::print(t, 80, 4, true);
+    torch::print(t, 80, 8, true);
+}
+
+TEST(PrintTest, Fixed) {
+    auto t = torch::tensor({{0.85897932}});
+    torch::print(t, 80, 8, true);
+    torch::print(t, 80, 8, false);
+}
+
+TEST(PrintTest, PrintFlexibility) {
+    auto t = torch::tensor({{83902821284}});
+    torch::print(t, 80, 11, false);
+    torch::print(t, 80, 2, true);
+}

--- a/test/cpp/api/print.cpp
+++ b/test/cpp/api/print.cpp
@@ -4,19 +4,22 @@
 #include <torch/torch.h>
 
 TEST(PrintTest, Precision) {
-    auto t = torch::tensor({{0.21861312}});
+    auto t = torch::tensor({{0.21862027}});
     torch::print(t, 80, 4, true);
     torch::print(t, 80, 8, true);
+    ASSERT_EQ(1, 1);
 }
 
 TEST(PrintTest, Fixed) {
     auto t = torch::tensor({{0.85897932}});
     torch::print(t, 80, 8, true);
     torch::print(t, 80, 8, false);
+    ASSERT_EQ(1, 1);
 }
 
 TEST(PrintTest, PrintFlexibility) {
-    auto t = torch::tensor({{83902821284}});
-    torch::print(t, 80, 11, false);
+    auto t = torch::tensor({{83902821}});
+    torch::print(t, 80, 8, false);
     torch::print(t, 80, 2, true);
+    ASSERT_EQ(1, 1);
 }

--- a/test/cpp/api/print.cpp
+++ b/test/cpp/api/print.cpp
@@ -2,10 +2,13 @@
 #include <c10/util/irange.h>
 #include <test/cpp/api/support.h>
 #include <torch/torch.h>
+#include <iostream>
+
 
 TEST(PrintTest, Precision) {
     auto t = torch::tensor({0.21862027});
     torch::print(t, 80, 4, true);
+    std::cout << "\n";
     torch::print(t, 80, 8, true);
     ASSERT_EQ(1, 1);
 }
@@ -13,13 +16,15 @@ TEST(PrintTest, Precision) {
 TEST(PrintTest, Fixed) {
     auto t = torch::tensor({0.85897932});
     torch::print(t, 80, 8, true);
+    std::cout << "\n";
     torch::print(t, 80, 8, false);
     ASSERT_EQ(1, 1);
 }
 
 TEST(PrintTest, PrintFlexibility) {
-    auto t = torch::tensor({83902821});
+    auto t = torch::tensor({0.53728212});
     torch::print(t, 80, 8, false);
+    std::cout << "\n";
     torch::print(t, 80, 2, true);
     ASSERT_EQ(1, 1);
 }

--- a/test/cpp/api/print.cpp
+++ b/test/cpp/api/print.cpp
@@ -4,21 +4,21 @@
 #include <torch/torch.h>
 
 TEST(PrintTest, Precision) {
-    auto t = torch::tensor({{0.21862027}});
+    auto t = torch::tensor({0.21862027});
     torch::print(t, 80, 4, true);
     torch::print(t, 80, 8, true);
     ASSERT_EQ(1, 1);
 }
 
 TEST(PrintTest, Fixed) {
-    auto t = torch::tensor({{0.85897932}});
+    auto t = torch::tensor({0.85897932});
     torch::print(t, 80, 8, true);
     torch::print(t, 80, 8, false);
     ASSERT_EQ(1, 1);
 }
 
 TEST(PrintTest, PrintFlexibility) {
-    auto t = torch::tensor({{83902821}});
+    auto t = torch::tensor({83902821});
     torch::print(t, 80, 8, false);
     torch::print(t, 80, 2, true);
     ASSERT_EQ(1, 1);


### PR DESCRIPTION
Fixes #111704 by adding print flexibility.
