### PR TITLE
Fix process group initialize twice error in distributed launcher test

### DIFF
--- a/test/distributed/launcher/bin/test_script_init_method.py
+++ b/test/distributed/launcher/bin/test_script_init_method.py
@@ -72,6 +72,7 @@ def main():
             f"Wrong world size derived. Expected: {world_size}, Got: {derived_world_size}"
         )
 
+    dist.destroy_process_group()
     print("Done")
 
 

--- a/test/distributed/launcher/bin/test_script_init_method.py
+++ b/test/distributed/launcher/bin/test_script_init_method.py
@@ -9,6 +9,7 @@
 
 import argparse
 import os
+import time
 
 import torch
 import torch.distributed as dist
@@ -73,6 +74,7 @@ def main():
         )
 
     dist.destroy_process_group()
+    time.sleep(10)
     print("Done")
 
 


### PR DESCRIPTION
These two test cases `test_init_method_env` and `test_init_method_tcp` in test/distributed/launcher/run_test.py influence each other when run together by initializing the default process group twice.
Error message:
```bash
===================================================================================================================================================== FAILURES =====================================================================================================================================================
______________________________________________________________________________________________________________________________________ ElasticLaunchTest.test_init_method_tcp ______________________________________________________________________________________________________________________________________
Traceback (most recent call last):                                                                                                                        
  File "/opt/conda/lib/python3.10/unittest/case.py", line 59, in testPartExecutor                                                    
    yield                                                                                                                                                 
  File "/opt/conda/lib/python3.10/unittest/case.py", line 591, in run                                                                                     
    self._callTestMethod(testMethod)                                                                                                                      
  File "/opt/conda/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()                                                                                                                                              
  File "/workspace/run_test.py", line 591, in test_init_method_tcp                                                                                        
    runpy.run_path(sys.argv[0], run_name="__main__")                                                                                                      
  File "/opt/conda/lib/python3.10/runpy.py", line 289, in run_path                                                                                                                                                                                                                                                  
    return _run_module_code(code, init_globals, run_name,                                                                                                 
  File "/opt/conda/lib/python3.10/runpy.py", line 96, in _run_module_code                                                                                 
    _run_code(code, mod_globals, init_globals,                                                                                                            
  File "/opt/conda/lib/python3.10/runpy.py", line 86, in _run_code                                                                                                                                                                                                                                                  
    exec(code, run_globals)                                                                                                                                                                                                                                                                                         
  File "/workspace/bin/test_script_init_method.py", line 79, in <module>                                                                                                                                                                                                                                            
    main()                                                                                                                                                
  File "/workspace/bin/test_script_init_method.py", line 48, in main                                                                                      
    dist.init_process_group(                                                 
  File "/opt/conda/lib/python3.10/site-packages/torch/distributed/c10d_logger.py", line 75, in wrapper                                                    
    return func(*args, **kwargs)                                                                                                                                                                                                                                                                                    
  File "/opt/conda/lib/python3.10/site-packages/torch/distributed/c10d_logger.py", line 89, in wrapper
    func_return = func(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py", line 1257, in init_process_group
    raise ValueError("trying to initialize the default process group twice!") 
ValueError: trying to initialize the default process group twice!
============================================================================================================================================= short test summary info ==============================================================================================================================================
FAILED run_test.py::ElasticLaunchTest::test_init_method_tcp - ValueError: trying to initialize the default process group twice!
==================================================================================================================================== 1 failed, 3 passed, 21 deselected in 7.69s ====================================================================================================================================

```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k