### PR TITLE
Delete unused param 'OP' in KERNEL_PRIVATEUSEONE

### DIFF
--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -728,7 +728,7 @@ copy pasted in from VariableTypeEverything.cpp with appropriate substitutions.
 
 // KERNEL_PRIVATEUSEONE/KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_PRIVATEUSEONE
 // registration (OP, POLICY) or (OP, OVERLOAD, POLICY) for AutocastPrivateUse1
-#define KERNEL_PRIVATEUSEONE(OP, ...) \
+#define KERNEL_PRIVATEUSEONE(...) \
   KERNEL(c10::DeviceType::PrivateUse1, __VA_ARGS__)
 
 #define KERNEL_DIFFERENT_REDISPATCH_SIGNATURE_PRIVATEUSEONE( \


### PR DESCRIPTION
Parameter 'OP' is unused but occupies  a position that will cause the length of \_\_VA_ARGS\__  less than expected.
Missed this diff in https://github.com/pytorch/pytorch/pull/124050.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5