### PR TITLE
Export torch.newaxis=None for Python Array API/Numpy consistency

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1266,7 +1266,8 @@ def _check_tensor_all(cond, message=None):  # noqa: F811
 # For Python Array API (https://data-apis.org/array-api/latest/API_specification/constants.html) and
 # NumPy consistency (https://numpy.org/devdocs/reference/constants.html)
 from math import e , nan , inf , pi
-__all__.extend(['e', 'pi', 'nan', 'inf'])
+newaxis: None = None
+__all__.extend(['e', 'pi', 'nan', 'inf', 'newaxis'])
 
 ################################################################################
 # Define Storage and Tensor classes


### PR DESCRIPTION
Fixes #65307

For consistency with Python Array API (https://data-apis.org/array-api/latest/API_specification/constants.html) and NumPy  (https://numpy.org/devdocs/reference/constants.html), I added `torch.newaxis = None`.

Note that the consistency is directly mentioned also in the `__init__.py`, right above the added export.

The `torch.newaxis` is also mentioned in #110636.

cc @mruberry @rgommers