### PR TITLE
[BE]: Update ruff to v0.4.4

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2144,7 +2144,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.4.1',
+    'ruff==0.4.2',
 ]
 is_formatter = true
 

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2144,7 +2144,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.4.2',
+    'ruff==0.4.4',
 ]
 is_formatter = true
 

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/generate-wrapper.py
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/generate-wrapper.py
@@ -124,9 +124,9 @@ if __name__ == "__main__":
                 # because they are ignored by arc focus & buck project.
 
                 if condition is None:
-                    print("#include <%s>" % filename, file=wrapper)
+                    print(f"#include <{filename}>", file=wrapper)
                 else:
                     # Include source file only if condition is satisfied
-                    print("#if %s" % condition, file=wrapper)
-                    print("#include <%s>" % filename, file=wrapper)
-                    print("#endif /* %s */" % condition, file=wrapper)
+                    print(f"#if {condition}", file=wrapper)
+                    print(f"#include <{filename}>", file=wrapper)
+                    print(f"#endif /* {condition} */", file=wrapper)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,3 +181,6 @@ select = [
 "torch/utils/collect_env.py" = [
     "UP", # collect_env.py needs to work with older versions of Python
 ]
+"torch/_vendor/**" = [
+    "UP", # No need to mess with _vendor
+]

--- a/scripts/release_notes/common.py
+++ b/scripts/release_notes/common.py
@@ -252,7 +252,7 @@ def github_data(pr_number):
         }
       }
     }
-    """
+    """  # noqa: UP031
         % pr_number
     )
     query = run_query(query)

--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -102,10 +102,10 @@ class AbstractTimeoutTest:
     def _init_methods(self):
         f = tempfile.NamedTemporaryFile(delete=False)
         if sys.platform == "win32":
-            yield "file:///%s" % f.name.replace("\\", "/")
+            yield "file:///{}".format(f.name.replace("\\", "/"))
             f.close()
         else:
-            yield "file://%s" % f.name
+            yield f"file://{f.name}"
             f.close()
             yield "tcp://127.0.0.1:%d" % common.find_free_port()
 

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1076,7 +1076,7 @@ class DistributedDataParallelTest(
                 False, gradient_as_bucket_view=gradient_as_bucket_view
             )
         except Exception as ex:
-            self.fail("Unexpected exception: %s" % ex)
+            self.fail(f"Unexpected exception: {ex}")
 
         # Test find_unused_parameters defaults to False
         try:
@@ -1084,7 +1084,7 @@ class DistributedDataParallelTest(
                 True, test_default=True, gradient_as_bucket_view=gradient_as_bucket_view
             )
         except Exception as ex:
-            self.fail("Unexpected exception: %s" % ex)
+            self.fail(f"Unexpected exception: {ex}")
 
     # TODO: Combine the following tests once https://github.com/pytorch/pytorch/issues/55967
     # is resolved.

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4654,10 +4654,10 @@ class TestRsample(DistributionsTestCase):
                 rtol=0,
                 msg="\n".join(
                     [
-                        "alpha = alpha_c + %.2g" % shift,
-                        "expected_grad: %.5g" % expected_grad,
-                        "actual_grad: %.5g" % actual_grad,
-                        "error = %.2g" % torch.abs(expected_grad - actual_grad).max(),
+                        f"alpha = alpha_c + {shift:.2g}",
+                        f"expected_grad: {expected_grad:.5g}",
+                        f"actual_grad: {actual_grad:.5g}",
+                        f"error = {torch.abs(expected_grad - actual_grad).max():.2g}",
                     ]
                 ),
             )

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4657,7 +4657,7 @@ class TestRsample(DistributionsTestCase):
                         "alpha = alpha_c + %.2g" % shift,  # noqa: UP031
                         "expected_grad: %.5g" % expected_grad,  # noqa: UP031
                         "actual_grad: %.5g" % actual_grad,  # noqa: UP031
-                        "error = %.2g"
+                        "error = %.2g"  # noqa: UP031
                         % torch.abs(expected_grad - actual_grad).max(),  # noqa: UP031
                     ]
                 ),

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4654,10 +4654,11 @@ class TestRsample(DistributionsTestCase):
                 rtol=0,
                 msg="\n".join(
                     [
-                        f"alpha = alpha_c + {shift:.2g}",
-                        f"expected_grad: {expected_grad:.5g}",
-                        f"actual_grad: {actual_grad:.5g}",
-                        f"error = {torch.abs(expected_grad - actual_grad).max():.2g}",
+                        "alpha = alpha_c + %.2g" % shift,  # noqa: UP031
+                        "expected_grad: %.5g" % expected_grad,  # noqa: UP031
+                        "actual_grad: %.5g" % actual_grad,  # noqa: UP031
+                        "error = %.2g"
+                        % torch.abs(expected_grad - actual_grad).max(),  # noqa: UP031
                     ]
                 ),
             )

--- a/test/nn/test_module_hooks.py
+++ b/test/nn/test_module_hooks.py
@@ -1292,7 +1292,7 @@ class TestModuleHookNN(NNTestCase):
         try:
             mod(inp.detach(), inp)
         except Exception as ex:
-            self.fail("Unexpected exception: %s" % ex)
+            self.fail(f"Unexpected exception: {ex}")
 
     def test_hook_extra_input(self):
         class MyModule(nn.Module):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5798,7 +5798,7 @@ class TestQuantizeFx(QuantizationTestCase):
             self.checkGraphModuleNodes(model, expected_node_occurrence=expected_node_occurrence)
         except AssertionError as e:
             if qconfig_name is not None:
-                print("ERROR: Validation for QConfig '%s' failed" % qconfig_name)
+                print(f"ERROR: Validation for QConfig '{qconfig_name}' failed")
             raise e
 
     def test_backend_config_quantization_range(self):

--- a/test/test_jit_llga_fuser.py
+++ b/test/test_jit_llga_fuser.py
@@ -127,7 +127,7 @@ def get_eltwise_fn(name):
     elif name == 'hardswish_':
         return torch.nn.Hardswish(inplace=True)
     else:
-        raise NameError('Eltwise function %s not found' % name)
+        raise NameError(f'Eltwise function {name} not found')
 
 
 @unittest.skipIf(IS_AVX512_UNSUPPORTED, "This test fails for BF16 on machines without AVX512.")

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1699,7 +1699,7 @@ $0: f32[] = torch._ops.aten.empty.memory_format([], device=device(type='cpu'), p
                     wrap, func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
                 )
                 logging.getLogger("NonWrapperSubclass").info(
-                    f"{func.__module__}.{func.__name__}", args, kwargs, rs
+                    f"{func.__module__}.{func.__name__}", args, kwargs, rs  # noqa: G004
                 )
                 return rs
 

--- a/test/torch_np/numpy_tests/core/test_multiarray.py
+++ b/test/torch_np/numpy_tests/core/test_multiarray.py
@@ -965,7 +965,7 @@ class TestCreation(TestCase):
         nstr = ["123", "123"]
         result = np.array([123, 123], dtype=int)
         for type in types:
-            msg = "String conversion for %s" % type
+            msg = f"String conversion for {type}"
             assert_equal(np.array(nstr, dtype=type), result, err_msg=msg)
 
     def test_void(self):
@@ -1621,7 +1621,7 @@ class TestMethods(TestCase):
         a = np.arange(101, dtype=dtype)
         b = np.flip(a)
         for kind in self.sort_kinds:
-            msg = "scalar sort, kind=%s" % kind
+            msg = f"scalar sort, kind={kind}"
             c = a.copy()
             c.sort(kind=kind)
             assert_equal(c, a, msg)
@@ -1637,7 +1637,7 @@ class TestMethods(TestCase):
         a = np.arange(-50, 51, dtype=dtype)
         b = np.flip(a)
         for kind in self.sort_kinds:
-            msg = "scalar sort, kind=%s" % (kind)
+            msg = f"scalar sort, kind={kind}"
             c = a.copy()
             c.sort(kind=kind)
             assert_equal(c, a, msg)
@@ -1777,13 +1777,13 @@ class TestMethods(TestCase):
         ai = a * 1j + 1
         bi = b * 1j + 1
         for kind in self.sort_kinds:
-            msg = "complex argsort, kind=%s" % kind
+            msg = f"complex argsort, kind={kind}"
             assert_equal(ai.copy().argsort(kind=kind), a, msg)
             assert_equal(bi.copy().argsort(kind=kind), b, msg)
         ai = a + 1j
         bi = b + 1j
         for kind in self.sort_kinds:
-            msg = "complex argsort, kind=%s" % kind
+            msg = f"complex argsort, kind={kind}"
             assert_equal(ai.copy().argsort(kind=kind), a, msg)
             assert_equal(bi.copy().argsort(kind=kind), b, msg)
 
@@ -1844,10 +1844,10 @@ class TestMethods(TestCase):
         # test for floats arrays containing nans. Explicitly test
         # half, single, and double precision floats to verify that
         # the NaN-handling is correct.
-        msg = "Test real (%s) searchsorted with nans, side='l'" % a.dtype
+        msg = f"Test real ({a.dtype}) searchsorted with nans, side='l'"
         b = a.searchsorted(a, side="left")
         assert_equal(b, np.arange(3), msg)
-        msg = "Test real (%s) searchsorted with nans, side='r'" % a.dtype
+        msg = f"Test real ({a.dtype}) searchsorted with nans, side='r'"
         b = a.searchsorted(a, side="right")
         assert_equal(b, np.arange(1, 4), msg)
         # check keyword arguments
@@ -3318,20 +3318,20 @@ class TestArgmax(TestCase):
             sup.filter(RuntimeWarning, "invalid value encountered in reduce")
             val = np.max(arr)
 
-        assert_equal(np.argmax(arr), pos, err_msg="%r" % arr)
-        assert_equal(arr[np.argmax(arr)], val, err_msg="%r" % arr)
+        assert_equal(np.argmax(arr), pos, err_msg=f"{arr!r}")
+        assert_equal(arr[np.argmax(arr)], val, err_msg=f"{arr!r}")
 
         # add padding to test SIMD loops
         rarr = np.repeat(arr, 129)
         rpos = pos * 129
-        assert_equal(np.argmax(rarr), rpos, err_msg="%r" % rarr)
-        assert_equal(rarr[np.argmax(rarr)], val, err_msg="%r" % rarr)
+        assert_equal(np.argmax(rarr), rpos, err_msg=f"{rarr!r}")
+        assert_equal(rarr[np.argmax(rarr)], val, err_msg=f"{rarr!r}")
 
         padd = np.repeat(np.min(arr), 513)
         rarr = np.concatenate((arr, padd))
         rpos = pos
-        assert_equal(np.argmax(rarr), rpos, err_msg="%r" % rarr)
-        assert_equal(rarr[np.argmax(rarr)], val, err_msg="%r" % rarr)
+        assert_equal(np.argmax(rarr), rpos, err_msg=f"{rarr!r}")
+        assert_equal(rarr[np.argmax(rarr)], val, err_msg=f"{rarr!r}")
 
     def test_maximum_signed_integers(self):
         a = np.array([1, 2**7 - 1, -(2**7)], dtype=np.int8)
@@ -3427,20 +3427,20 @@ class TestArgmin(TestCase):
             sup.filter(RuntimeWarning, "invalid value encountered in reduce")
             min_val = np.min(arr)
 
-        assert_equal(np.argmin(arr), pos, err_msg="%r" % arr)
-        assert_equal(arr[np.argmin(arr)], min_val, err_msg="%r" % arr)
+        assert_equal(np.argmin(arr), pos, err_msg=f"{arr!r}")
+        assert_equal(arr[np.argmin(arr)], min_val, err_msg=f"{arr!r}")
 
         # add padding to test SIMD loops
         rarr = np.repeat(arr, 129)
         rpos = pos * 129
-        assert_equal(np.argmin(rarr), rpos, err_msg="%r" % rarr)
-        assert_equal(rarr[np.argmin(rarr)], min_val, err_msg="%r" % rarr)
+        assert_equal(np.argmin(rarr), rpos, err_msg=f"{rarr!r}")
+        assert_equal(rarr[np.argmin(rarr)], min_val, err_msg=f"{rarr!r}")
 
         padd = np.repeat(np.max(arr), 513)
         rarr = np.concatenate((arr, padd))
         rpos = pos
-        assert_equal(np.argmin(rarr), rpos, err_msg="%r" % rarr)
-        assert_equal(rarr[np.argmin(rarr)], min_val, err_msg="%r" % rarr)
+        assert_equal(np.argmin(rarr), rpos, err_msg=f"{rarr!r}")
+        assert_equal(rarr[np.argmin(rarr)], min_val, err_msg=f"{rarr!r}")
 
     def test_minimum_signed_integers(self):
         a = np.array([1, -(2**7), -(2**7) + 1, 2**7 - 1], dtype=np.int8)

--- a/test/torch_np/numpy_tests/core/test_numeric.py
+++ b/test/torch_np/numpy_tests/core/test_numeric.py
@@ -456,10 +456,10 @@ class TestBoolArray(TestCase):
         for i in list(range(9, 6000, 507)) + [7764, 90021, -10]:
             d = np.array([False] * 100043, dtype=bool)
             d[i] = True
-            assert_(np.any(d), msg="%r" % i)
+            assert_(np.any(d), msg=f"{i!r}")
             e = np.array([True] * 100043, dtype=bool)
             e[i] = False
-            assert_(not np.all(e), msg="%r" % i)
+            assert_(not np.all(e), msg=f"{i!r}")
 
     def test_logical_not_abs(self):
         assert_array_equal(~self.t, self.f)
@@ -831,20 +831,20 @@ class TestTypes(TestCase):
         #           shouldn't narrow the float/complex type
         for a in [np.array([True, False]), np.array([-3, 12], dtype=np.int8)]:
             b = 1.234 * a
-            assert_equal(b.dtype, np.dtype("f8"), "array type %s" % a.dtype)
+            assert_equal(b.dtype, np.dtype("f8"), f"array type {a.dtype}")
             b = np.float64(1.234) * a
-            assert_equal(b.dtype, np.dtype("f8"), "array type %s" % a.dtype)
+            assert_equal(b.dtype, np.dtype("f8"), f"array type {a.dtype}")
             b = np.float32(1.234) * a
-            assert_equal(b.dtype, np.dtype("f4"), "array type %s" % a.dtype)
+            assert_equal(b.dtype, np.dtype("f4"), f"array type {a.dtype}")
             b = np.float16(1.234) * a
-            assert_equal(b.dtype, np.dtype("f2"), "array type %s" % a.dtype)
+            assert_equal(b.dtype, np.dtype("f2"), f"array type {a.dtype}")
 
             b = 1.234j * a
-            assert_equal(b.dtype, np.dtype("c16"), "array type %s" % a.dtype)
+            assert_equal(b.dtype, np.dtype("c16"), f"array type {a.dtype}")
             b = np.complex128(1.234j) * a
-            assert_equal(b.dtype, np.dtype("c16"), "array type %s" % a.dtype)
+            assert_equal(b.dtype, np.dtype("c16"), f"array type {a.dtype}")
             b = np.complex64(1.234j) * a
-            assert_equal(b.dtype, np.dtype("c8"), "array type %s" % a.dtype)
+            assert_equal(b.dtype, np.dtype("c8"), f"array type {a.dtype}")
 
         # The following use-case is problematic, and to resolve its
         # tricky side-effects requires more changes.
@@ -976,7 +976,7 @@ class TestFromiter(TestCase):
         # Raise an exception at the desired index in the iterator.
         for e in range(n):
             if e == eindex:
-                raise NIterError("error at index %s" % eindex)
+                raise NIterError(f"error at index {eindex}")
             yield e
 
     @parametrize("dtype", [int])

--- a/test/torch_np/numpy_tests/core/test_scalarmath.py
+++ b/test/torch_np/numpy_tests/core/test_scalarmath.py
@@ -363,9 +363,9 @@ class TestModulus(TestCase):
         b = np.array(1.0, dtype=dt)
         a = np.nextafter(np.array(0.0, dtype=dt), -b)
         rem = operator.mod(a, b)
-        assert_(rem <= b, "dt: %s" % dt)
+        assert_(rem <= b, f"dt: {dt}")
         rem = operator.mod(-a, -b)
-        assert_(rem >= -b, "dt: %s" % dt)
+        assert_(rem >= -b, f"dt: {dt}")
 
         # Check nans, inf
         #     with suppress_warnings() as sup:
@@ -380,14 +380,14 @@ class TestModulus(TestCase):
             finf = np.array(np.inf, dtype=dt)
             fnan = np.array(np.nan, dtype=dt)
             rem = operator.mod(fone, fzer)
-            assert_(np.isnan(rem), "dt: %s" % dt)
+            assert_(np.isnan(rem), f"dt: {dt}")
             # MSVC 2008 returns NaN here, so disable the check.
             # rem = operator.mod(fone, finf)
             # assert_(rem == fone, 'dt: %s' % dt)
             rem = operator.mod(fone, fnan)
-            assert_(np.isnan(rem), "dt: %s" % dt)
+            assert_(np.isnan(rem), f"dt: {dt}")
             rem = operator.mod(finf, fone)
-            assert_(np.isnan(rem), "dt: %s" % dt)
+            assert_(np.isnan(rem), f"dt: {dt}")
             for op in [floordiv_and_mod, divmod]:
                 div, mod = op(fone, fzer)
                 assert_(np.isinf(div)) and assert_(np.isnan(mod))

--- a/test/torch_np/numpy_tests/lib/test_function_base.py
+++ b/test/torch_np/numpy_tests/lib/test_function_base.py
@@ -855,7 +855,7 @@ class TestDelete(TestCase):
     def _check_inverse_of_slicing(self, indices):
         a_del = delete(self.a, indices)
         nd_a_del = delete(self.nd_a, indices, axis=1)
-        msg = "Delete failed for obj: %r" % indices
+        msg = f"Delete failed for obj: {indices!r}"
         assert_array_equal(setxor1d(a_del, self.a[indices,]), self.a, err_msg=msg)
         xor = setxor1d(nd_a_del[0, :, 0], self.nd_a[0, indices, 0])
         assert_array_equal(xor, self.nd_a[0, :, 0], err_msg=msg)

--- a/test/torch_np/test_ndarray_methods.py
+++ b/test/torch_np/test_ndarray_methods.py
@@ -466,14 +466,14 @@ class TestArgmax(TestCase):
         # add padding to test SIMD loops
         rarr = np.repeat(arr, 129)
         rpos = pos * 129
-        assert_equal(np.argmax(rarr), rpos, err_msg="%r" % rarr)
-        assert_equal(rarr[np.argmax(rarr)], val, err_msg="%r" % rarr)
+        assert_equal(np.argmax(rarr), rpos, err_msg=f"{rarr!r}")
+        assert_equal(rarr[np.argmax(rarr)], val, err_msg=f"{rarr!r}")
 
         padd = np.repeat(np.min(arr), 513)
         rarr = np.concatenate((arr, padd))
         rpos = pos
-        assert_equal(np.argmax(rarr), rpos, err_msg="%r" % rarr)
-        assert_equal(rarr[np.argmax(rarr)], val, err_msg="%r" % rarr)
+        assert_equal(np.argmax(rarr), rpos, err_msg=f"{rarr!r}")
+        assert_equal(rarr[np.argmax(rarr)], val, err_msg=f"{rarr!r}")
 
     def test_maximum_signed_integers(self):
         a = np.array([1, 2**7 - 1, -(2**7)], dtype=np.int8)
@@ -573,20 +573,20 @@ class TestArgmin(TestCase):
         #            sup.filter(RuntimeWarning, "invalid value encountered in reduce")
         min_val = np.min(arr)
 
-        assert_equal(np.argmin(arr), pos, err_msg="%r" % arr)
-        assert_equal(arr[np.argmin(arr)], min_val, err_msg="%r" % arr)
+        assert_equal(np.argmin(arr), pos, err_msg=f"{arr!r}")
+        assert_equal(arr[np.argmin(arr)], min_val, err_msg=f"{arr!r}")
 
         # add padding to test SIMD loops
         rarr = np.repeat(arr, 129)
         rpos = pos * 129
-        assert_equal(np.argmin(rarr), rpos, err_msg="%r" % rarr)
-        assert_equal(rarr[np.argmin(rarr)], min_val, err_msg="%r" % rarr)
+        assert_equal(np.argmin(rarr), rpos, err_msg=f"{rarr!r}")
+        assert_equal(rarr[np.argmin(rarr)], min_val, err_msg=f"{rarr!r}")
 
         padd = np.repeat(np.max(arr), 513)
         rarr = np.concatenate((arr, padd))
         rpos = pos
-        assert_equal(np.argmin(rarr), rpos, err_msg="%r" % rarr)
-        assert_equal(rarr[np.argmin(rarr)], min_val, err_msg="%r" % rarr)
+        assert_equal(np.argmin(rarr), rpos, err_msg=f"{rarr!r}")
+        assert_equal(rarr[np.argmin(rarr)], min_val, err_msg=f"{rarr!r}")
 
     def test_minimum_signed_integers(self):
         a = np.array([1, -(2**7), -(2**7) + 1, 2**7 - 1], dtype=np.int8)

--- a/tools/gen_vulkan_spv.py
+++ b/tools/gen_vulkan_spv.py
@@ -222,8 +222,7 @@ def preprocess(
                 blank_lines -= 1
             python_lines.append(
                 python_indent
-                + "print(%s, file=OUT_STREAM)"
-                % escape(input_line[len(python_indent) :])
+                + f"print({escape(input_line[len(python_indent) :])}, file=OUT_STREAM)"
             )
         last_indent = input_indent
 

--- a/torch/_numpy/testing/utils.py
+++ b/torch/_numpy/testing/utils.py
@@ -599,7 +599,7 @@ def assert_array_compare(
         if (x_id == y_id).all().item() is not True:
             msg = build_err_msg(
                 [x, y],
-                err_msg + "\nx and y %s location mismatch:" % (hasval),
+                err_msg + f"\nx and y {hasval} location mismatch:",
                 verbose=verbose,
                 header=header,
                 names=("x", "y"),
@@ -1168,7 +1168,7 @@ def decorate_methods(cls, decorator, testmatch=None):
 
     """
     if testmatch is None:
-        testmatch = re.compile(r"(?:^|[\\b_\\.%s-])[Tt]est" % os.sep)
+        testmatch = re.compile(rf"(?:^|[\\b_\\.{os.sep}-])[Tt]est")
     else:
         testmatch = re.compile(testmatch)
     cls_attr = cls.__dict__

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1132,16 +1132,14 @@ class Tensor(torch._C.TensorBase):
         # hasattr(cpu_tensor, "__cuda_array_interface__") is False.
         if not self.is_cuda:
             raise AttributeError(
-                "Can't get __cuda_array_interface__ on non-CUDA tensor type: %s "
+                f"Can't get __cuda_array_interface__ on non-CUDA tensor type: {self.type()} "
                 "If CUDA data is required use tensor.cuda() to copy tensor to device memory."
-                % self.type()
             )
 
         if self.is_sparse:
             raise AttributeError(
-                "Can't get __cuda_array_interface__ on sparse type: %s "
+                f"Can't get __cuda_array_interface__ on sparse type: {self.type()} "
                 "Use Tensor.to_dense() to convert to a dense tensor first."
-                % self.type()
             )
 
         # RuntimeError, matching tensor.__array__() behavior.

--- a/torch/_vendor/packaging/__init__.py
+++ b/torch/_vendor/packaging/__init__.py
@@ -12,4 +12,4 @@ __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"
 
 __license__ = "BSD-2-Clause or Apache-2.0"
-__copyright__ = "2014 %s" % __author__
+__copyright__ = f"2014 {__author__}"

--- a/torch/_vendor/packaging/__init__.py
+++ b/torch/_vendor/packaging/__init__.py
@@ -12,4 +12,4 @@ __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"
 
 __license__ = "BSD-2-Clause or Apache-2.0"
-__copyright__ = f"2014 {__author__}"
+__copyright__ = "2014 %s" % __author__

--- a/torch/ao/quantization/pt2e/qat_utils.py
+++ b/torch/ao/quantization/pt2e/qat_utils.py
@@ -710,7 +710,7 @@ def _copy_over_q_dq_args(original_node: Node, replacement_node: Node):
         # Args: input, scale, zp, [axis, qmin, qmax, dtype]
         start_copy_arg_index = 3
     else:
-        raise ValueError("Expected quantize/dequantize nodes, got '%s'" % original_node.target)
+        raise ValueError(f"Expected quantize/dequantize nodes, got '{original_node.target}'")
     replacement_node.args = (
         replacement_node.args[:start_copy_arg_index] + original_node.args[start_copy_arg_index:]
     )

--- a/torch/backends/__init__.py
+++ b/torch/backends/__init__.py
@@ -41,9 +41,8 @@ class ContextProp:
             self.setter(val)
         else:
             raise RuntimeError(
-                "not allowed to set %s flags "
+                f"not allowed to set {obj.__name__} flags "
                 "after disable_global_flags; please use flags() context manager instead"
-                % obj.__name__
             )
 
 

--- a/torch/distributed/pipeline/sync/skip/namespace.py
+++ b/torch/distributed/pipeline/sync/skip/namespace.py
@@ -14,7 +14,7 @@ __all__ = ["Namespace"]
 
 
 @total_ordering
-class Namespace(metaclass=abc.ABCMeta):
+class Namespace(metaclass=abc.ABCMeta):  # noqa: B024
     """Namespace for isolating skip tensors used by :meth:`isolate()
     <torchpipe.skip.skippable.Skippable.isolate>`.
     """

--- a/torch/distributed/pipeline/sync/skip/skippable.py
+++ b/torch/distributed/pipeline/sync/skip/skippable.py
@@ -427,5 +427,5 @@ def verify_skippables(module: nn.Sequential) -> None:
 
     if msgs:
         raise TypeError(
-            "one or more pairs of stash and pop do not match:\n\n%s" "" % "\n".join("* %s" % x for x in msgs)
+            "one or more pairs of stash and pop do not match:\n\n{}" "".format("\n".join(f"* {x}" for x in msgs))
         )

--- a/torch/fx/experimental/optimization.py
+++ b/torch/fx/experimental/optimization.py
@@ -402,7 +402,7 @@ def optimize_for_inference(
         if node.target == 'to_mkldnn' or node.target == 'to_dense':
             mkldnn_conversions += 1
 
-    logging.getLogger(__name__).info(f"mkldnn conversions: {mkldnn_conversions}")
+    logging.getLogger(__name__).info("mkldnn conversions: %s", mkldnn_conversions)
     fx_graph.lint()
     result = fx.GraphModule(model, fx_graph)
     return result

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1432,7 +1432,7 @@ class ShapeGuardPrinter(StrPrinter):
         self.var_to_sources = var_to_sources
 
     def _print_Not(self, expr):
-        return 'not %s' % (self.parenthesize(expr.args[0], PRECEDENCE["Not"]))
+        return 'not {}'.format(self.parenthesize(expr.args[0], PRECEDENCE["Not"]))
 
     def _print_And(self, expr):
         return self.stringify(expr.args, " and ", PRECEDENCE["And"])

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -273,9 +273,9 @@ def spawn(fn, args=(), nprocs=1, join=True, daemon=False, start_method="spawn"):
     """
     if start_method != "spawn":
         msg = (
-            "This method only supports start_method=spawn (got: %s).\n"
+            f"This method only supports start_method=spawn (got: {start_method}).\n"
             "To use a different start_method use:\n\t\t"
-            " torch.multiprocessing.start_processes(...)" % start_method
+            " torch.multiprocessing.start_processes(...)"
         )
         warnings.warn(msg)
     return start_processes(fn, args, nprocs, join, daemon, start_method="spawn")

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1446,7 +1446,7 @@ def _setup_trace_module_map(
                 raise RuntimeError(
                     "Only type of the `nn.Module` should be "
                     "passed in the set for argument `export_modules_as_functions`. "
-                    "Got `%s`." % (type(v).__name__)
+                    f"Got `{type(v).__name__}`."
                 )
 
         module_typenames = {_find_typename(v) for v in export_modules_as_functions}

--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -136,7 +136,8 @@ class LoggingTensorHandler(logging.Handler):
             self.tracebacks_list.append(record.traceback)
 
 def log_input(name: str, var: object):
-    logging.getLogger("LoggingTensor").info("input %s %s %s", (name,), {}, var)
+    # likely an error, unsure of how to fix. See #125031
+    logging.getLogger("LoggingTensor").info("input", (name,), {}, var)  # noqa: PLE1205
 
 class GatherTraceback(logging.Filter):
     def __init__(self, python=True, script=True, cpp=False):

--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -79,7 +79,7 @@ class LoggingTensor(torch.Tensor):
 
         with cls.context():
             rs = tree_map(wrap, func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs)))
-        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)
+        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)  # noqa: G004
         return rs
 
 class LoggingTensorMode(TorchDispatchMode):
@@ -87,7 +87,7 @@ class LoggingTensorMode(TorchDispatchMode):
         if kwargs is None:
             kwargs = {}
         rs = func(*args, **kwargs)
-        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)
+        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)  # noqa: G004
         return rs
 
 class LoggingTensorReentrant(LoggingTensor):
@@ -134,9 +134,6 @@ class LoggingTensorHandler(logging.Handler):
         self.log_list.append(f'{fmt_rets} = {record.msg}({fmt_args})')
         if self.tracebacks_list is not None:
             self.tracebacks_list.append(record.traceback)
-
-def log_input(name: str, var: object):
-    logging.getLogger("LoggingTensor").info("input", (name,), {}, var)
 
 class GatherTraceback(logging.Filter):
     def __init__(self, python=True, script=True, cpp=False):

--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -79,7 +79,7 @@ class LoggingTensor(torch.Tensor):
 
         with cls.context():
             rs = tree_map(wrap, func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs)))
-        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)  # noqa: G004
+        logging.getLogger("LoggingTensor").info("%s.%s %s %s %s", func.__module__, func.__name__, args, kwargs, rs)
         return rs
 
 class LoggingTensorMode(TorchDispatchMode):
@@ -87,7 +87,7 @@ class LoggingTensorMode(TorchDispatchMode):
         if kwargs is None:
             kwargs = {}
         rs = func(*args, **kwargs)
-        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)  # noqa: G004
+        logging.getLogger("LoggingTensor").info("%s.%s %s %s %s", func.__module__, func.__name__, args, kwargs, rs)
         return rs
 
 class LoggingTensorReentrant(LoggingTensor):
@@ -136,7 +136,7 @@ class LoggingTensorHandler(logging.Handler):
             self.tracebacks_list.append(record.traceback)
 
 def log_input(name: str, var: object):
-    logging.getLogger("LoggingTensor").info("input", (name,), {}, var)  # noqa: PLE1205
+    logging.getLogger("LoggingTensor").info("input %s %s %s", (name,), {}, var)
 
 class GatherTraceback(logging.Filter):
     def __init__(self, python=True, script=True, cpp=False):

--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -135,6 +135,9 @@ class LoggingTensorHandler(logging.Handler):
         if self.tracebacks_list is not None:
             self.tracebacks_list.append(record.traceback)
 
+def log_input(name: str, var: object):
+    logging.getLogger("LoggingTensor").info("input", (name,), {}, var)  # noqa: PLE1205
+
 class GatherTraceback(logging.Filter):
     def __init__(self, python=True, script=True, cpp=False):
         self.python = python

--- a/torch/testing/_internal/logging_tensor.py
+++ b/torch/testing/_internal/logging_tensor.py
@@ -79,7 +79,7 @@ class LoggingTensor(torch.Tensor):
 
         with cls.context():
             rs = tree_map(wrap, func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs)))
-        logging.getLogger("LoggingTensor").info("%s.%s %s %s %s", func.__module__, func.__name__, args, kwargs, rs)
+        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)  # noqa: G004
         return rs
 
 class LoggingTensorMode(TorchDispatchMode):
@@ -87,7 +87,7 @@ class LoggingTensorMode(TorchDispatchMode):
         if kwargs is None:
             kwargs = {}
         rs = func(*args, **kwargs)
-        logging.getLogger("LoggingTensor").info("%s.%s %s %s %s", func.__module__, func.__name__, args, kwargs, rs)
+        logging.getLogger("LoggingTensor").info(f"{func.__module__}.{func.__name__}", args, kwargs, rs)  # noqa: G004
         return rs
 
 class LoggingTensorReentrant(LoggingTensor):
@@ -136,7 +136,6 @@ class LoggingTensorHandler(logging.Handler):
             self.tracebacks_list.append(record.traceback)
 
 def log_input(name: str, var: object):
-    # likely an error, unsure of how to fix. See #125031
     logging.getLogger("LoggingTensor").info("input", (name,), {}, var)  # noqa: PLE1205
 
 class GatherTraceback(logging.Filter):

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -846,7 +846,7 @@ class SummaryWriter:
         retval = rawstr
         retval = retval.replace("%", f"%{ord('%'):02x}")
         retval = retval.replace("/", f"%{ord('/'):02x}")
-        retval = retval.replace("\\", "%{:02x}".format(ord("\\")))
+        retval = retval.replace("\\", "%%%02x" % (ord("\\")))  # noqa: UP031
         return retval
 
     def add_embedding(
@@ -916,7 +916,7 @@ class SummaryWriter:
                     "warning: Embedding dir exists, did you set global_step for add_embedding()?"
                 )
             else:
-                raise FileExistsError(
+                raise Exception(  # noqa: TRY002
                     f"Path: `{save_path}` exists, but is a file. Cannot proceed."
                 )
         else:

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -846,7 +846,7 @@ class SummaryWriter:
         retval = rawstr
         retval = retval.replace("%", f"%{ord('%'):02x}")
         retval = retval.replace("/", f"%{ord('/'):02x}")
-        retval = retval.replace("\\", "%%%02x" % (ord("\\")))
+        retval = retval.replace("\\", "%{:02x}".format(ord("\\")))
         return retval
 
     def add_embedding(

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -916,7 +916,7 @@ class SummaryWriter:
                     "warning: Embedding dir exists, did you set global_step for add_embedding()?"
                 )
             else:
-                raise Exception(  # noqa: TRY002
+                raise FileExistsError(
                     f"Path: `{save_path}` exists, but is a file. Cannot proceed."
                 )
         else:

--- a/torchgen/static_runtime/generator.py
+++ b/torchgen/static_runtime/generator.py
@@ -402,7 +402,7 @@ def test_value_expression(
         num_dim = test_tensor_dim(op_name)
         size_per_dim = math.ceil(num_tensors / float(num_dim))
         size_per_dim += size_per_dim % 2
-        tensor_size_ex = "{%s}" % (",".join([f"{size_per_dim}"] * num_dim))
+        tensor_size_ex = "{{{}}}".format(",".join([f"{size_per_dim}"] * num_dim))
     if should_use_int_tensor(op_name):
         tensor_expression = f"at::randint(1, 100, {tensor_size_ex}, at::kInt)"
     elif should_use_complex_tensor(op_name):


### PR DESCRIPTION
Update ruff version to 0.4.2. This version mostly has bugfixes for the new parser and also updates the f-string rule to be able to apply more fixes.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @rohan-varma