### PR TITLE
[codemod] Remove unused variables in caffe2/aten/src/ATen/test/scalar_test.cpp

### DIFF
--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -28,8 +28,6 @@
 using std::cout;
 using namespace at;
 
-constexpr auto Float = ScalarType::Float;
-
 template<typename scalar_type>
 struct Foo {
   static void apply(Tensor a, Tensor b) {

--- a/caffe2/utils/math_test.cc
+++ b/caffe2/utils/math_test.cc
@@ -166,8 +166,6 @@ TEST(MathTest, GemmNoTransTrans) {
 
 namespace {
 
-constexpr float kEps = 1e-5;
-
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class GemmBatchedTest
     : public testing::TestWithParam<testing::tuple<bool, bool>> {


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Reviewed By: palmje

Differential Revision: D56587751
