### PR TITLE
[unwind] replace LONG_LONG_MAX by the portable LLONG_MAX

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -120,8 +120,8 @@ static const char* process_name() {
 }
 
 struct Version {
-  uint64_t adds_ = LONG_LONG_MAX;
-  uint64_t subs_ = LONG_LONG_MAX;
+  uint64_t adds_ = LLONG_MAX;
+  uint64_t subs_ = LLONG_MAX;
 };
 
 struct UnwindCache {


### PR DESCRIPTION
This fixes a compilation error on systems with the musl c library.

Fixes #ISSUE_NUMBER
