### PR TITLE
[codemod] Fix missing field initializer in caffe2/torch/lib/libshm/core.cpp +2

### DIFF
--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -11,7 +11,7 @@ std::unordered_map<std::string, ClientSocket> managers;
 std::string manager_executable_path;
 
 AllocInfo get_alloc_info(const char* filename) {
-  AllocInfo info = {0};
+  AllocInfo info = {};
   info.pid = getpid();
   info.free = false;
   size_t len = strlen(filename);

--- a/torch/lib/libshm/socket.h
+++ b/torch/lib/libshm/socket.h
@@ -49,7 +49,7 @@ class Socket {
     char* buffer = (char*)_buffer;
     size_t bytes_received = 0;
     ssize_t step_received;
-    struct pollfd pfd = {0};
+    struct pollfd pfd = {};
     pfd.fd = socket_fd;
     pfd.events = POLLIN;
     while (bytes_received < num_bytes) {


### PR DESCRIPTION
Summary:
The LLVM warning `-Wmissing-field-initializers` has found one or more structs in this diff's files which were missing field initializers.

This can be unintended such as:
```
my_struct s1 = {0}; // Initializes *only* the first field to zero; others to default values
my_struct s2 = {}; // Initializes *all* fields to default values (often zero)
```
or it may be because only some of the members of a struct are initialized, perhaps because the items were added to the struct but not every instance of it was updated.

To fix the problem, I've either used `{}` to initialize all fields to default or added appropriate default initializations to the missing fields.

Test Plan: Sandcastle

Reviewed By: palmje

Differential Revision: D56614179
