### PR TITLE
[Pytorch 2] Forward fix for broken test

### DIFF
--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -305,12 +305,12 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
                 beta=beta,
             )
 
-    use_aten = use_aten_gemm_kernels()
-    if len(choices) == 0 and not use_aten:
+    add_aten_fallback = False
+    if len(choices) == 0:
         log.warning("No choices for GEMM, using ATen backend as fallback")
-        use_aten = True
+        add_aten_fallback = True
 
-    if use_aten:
+    if add_aten_fallback:
         choices.append(
             aten_addmm.bind(
                 (inp_expanded, mat1, mat2),


### PR DESCRIPTION
Summary:
This is a forward Hotfix for T186742340.

Some recent changes in Pytorch / Inductor ( D56458606) led to aten.addmm operators being inserted twice into the list of choices to select from during autotuning. This appears to have triggered a test failure in fbcode.

This fix prevents the aten operators being added twice to the list of choices for autotuning.

Test Plan:
* Pytorch CI
 * CUDA_LAUNCH_BLOCKING=1 buck2 test 'fbcode//mode/opt' fbcode//accelerators/pytorch/lib/pt2_utils/tests:compile_pt2_test -- --exact 'accelerators/pytorch/lib/pt2_utils/tests:compile_pt2_test - test_compile_pt2 (accelerators.pytorch.lib.pt2_utils.tests.compile_pt2_test.TestCompilePT2)'

Differential Revision: D56642879


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @muchulee8 @ColinPeppler @amjames @desertfire @chauhang