### PR TITLE
[ez][CI] Move test_linalg and test_sparse_csr off CI_SERIAL_LIST

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -217,7 +217,6 @@ CI_SERIAL_LIST = [
     "test_cpp_api_parity",
     "test_reductions",
     "test_fx_backends",
-    "test_linalg",
     "test_cpp_extensions_jit",
     "test_torch",
     "test_tensor_creation_ops",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -220,7 +220,6 @@ CI_SERIAL_LIST = [
     "test_cpp_extensions_jit",
     "test_torch",
     "test_tensor_creation_ops",
-    "test_sparse_csr",
     "test_dispatch",
     "test_python_dispatch",  # torch.library creation and deletion must be serialized
     "test_spectral_ops",  # Cause CUDA illegal memory access https://github.com/pytorch/pytorch/issues/88916


### PR DESCRIPTION
* https://github.com/pytorch/pytorch/pull/124649 for context
