### PR TITLE
[ROCm] Implement forward AD for miopen_batch_norm

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -519,6 +519,7 @@ BatchNormBackend _select_batch_norm_backend(
       && weight.defined() && bias.defined()
       && ((running_mean.defined() && running_var.defined())
         || (!running_mean.defined() && !running_var.defined() && training))
+      && (input.dim() >= 3)
       && detail::getCUDAHooks().compiledWithMIOpen()
       && cudnn_enabled
       && input.suggest_memory_format() != MemoryFormat::ChannelsLast

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -83,7 +83,8 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
     checkAllSameType(c, {input, weight});
   }
   checkAllSameType(c, {weight, bias, running_mean, running_var});
-  checkAllContiguous(c, {input, weight, bias, running_mean, running_var});
+  checkAllContiguous(c, {weight, bias, running_mean, running_var});
+  TORCH_CHECK(input->is_contiguous(input->suggest_memory_format()));
   checkDimRange(c, input, 2, 6 /* exclusive */);
   auto num_features = input->size(1);
   for (auto t : {weight, bias, running_mean, running_var}) {

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -935,8 +935,6 @@ aten::min.dim_min
 aten::min.unary_out
 aten::miopen_batch_norm
 aten::miopen_batch_norm.out
-aten::miopen_batch_norm_backward
-aten::miopen_batch_norm_backward.out
 aten::miopen_convolution
 aten::miopen_convolution.out
 aten::miopen_convolution_add_relu

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -348,7 +348,7 @@ def is_inplace(op, variant):
 
 
 vjp_fail = {
-    xfail('tensor_split'),  # data_ptr composite compliance
+    xfail("tensor_split"),  # data_ptr composite compliance
     # https://github.com/pytorch/pytorch/issues/96560
     decorate("nn.functional.scaled_dot_product_attention", decorator=skipIfRocm),
 }

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -349,7 +349,6 @@ def is_inplace(op, variant):
 
 vjp_fail = {
     xfail('tensor_split'),  # data_ptr composite compliance
-    decorate('nn.functional.instance_norm', decorator=skipIfRocm),
     # https://github.com/pytorch/pytorch/issues/96560
     decorate("nn.functional.scaled_dot_product_attention", decorator=skipIfRocm),
 }
@@ -568,8 +567,6 @@ class TestOperators(TestCase):
                 xfail(
                     "NumpyExpMarkDirtyAutogradFunction"
                 ),  # TODO: https://github.com/pytorch/pytorch/issues/91280
-                # ROCm: NotImplementedError
-                decorate("nn.functional.instance_norm", decorator=skipIfRocm),
                 # --- Non-Contiguous Failures! ---
                 # This is expected to fail as the operator
                 # expects last dim to have stride=1
@@ -1278,9 +1275,6 @@ class TestOperators(TestCase):
         xfail("_native_batch_norm_legit"),
         # TODO: implement batching rule
         xfail("_batch_norm_with_update"),
-        # https://github.com/pytorch/pytorch/issues/96560
-        # ROCm: NotImplementedError
-        decorate("nn.functional.instance_norm", decorator=skipIfRocm),
         # ----------------------------------------------------------------------
     }
 

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -348,9 +348,8 @@ def is_inplace(op, variant):
 
 
 vjp_fail = {
-    xfail("tensor_split"),  # data_ptr composite compliance
-    decorate("nn.functional.batch_norm", decorator=skipIfRocm),
-    decorate("nn.functional.instance_norm", decorator=skipIfRocm),
+    xfail('tensor_split'),  # data_ptr composite compliance
+    decorate('nn.functional.instance_norm', decorator=skipIfRocm),
     # https://github.com/pytorch/pytorch/issues/96560
     decorate("nn.functional.scaled_dot_product_attention", decorator=skipIfRocm),
 }

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -568,9 +568,6 @@ class TestOperators(TestCase):
                 xfail(
                     "NumpyExpMarkDirtyAutogradFunction"
                 ),  # TODO: https://github.com/pytorch/pytorch/issues/91280
-                # https://github.com/pytorch/pytorch/issues/96560
-                # ROCm: NotImplementedError
-                decorate("nn.functional.batch_norm", decorator=skipIfRocm),
                 # ROCm: NotImplementedError
                 decorate("nn.functional.instance_norm", decorator=skipIfRocm),
                 # --- Non-Contiguous Failures! ---

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4200,8 +4200,6 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("tril"),  # Exception not raised on error input
                 xfail("triu"),  # Exception not raised on error input
                 xfail("as_strided", "partial_views"),
-                # https://github.com/pytorch/pytorch/issues/96560
-                decorate("nn.functional.batch_norm", decorator=skipIfRocm),
                 # RuntimeError: output with shape [4, 4] doesn't match the broadcast shape [1, 4, 4]
                 xfail("addcdiv"),
                 xfail("addcmul"),
@@ -4375,8 +4373,6 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("linalg.lu", ""),
                 skip("linalg.ldl_solve", ""),
                 skip("_softmax_backward_data"),
-                # https://github.com/pytorch/pytorch/issues/96560
-                decorate("nn.functional.batch_norm", decorator=skipIfRocm),
                 # One or more of the overload doesn't have a Batch rule.
                 xfail("bincount"),
                 # RuntimeError: Expected all tensors to be on the same device,

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -59,7 +59,6 @@ from torch.testing._internal.common_utils import (
     markDynamoStrictTest,
     parametrize,
     run_tests,
-    skipIfRocm,
     skipIfTorchDynamo,
     subtest,
     TEST_WITH_TORCHDYNAMO,

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2733,6 +2733,7 @@
 
 - name: miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)
   input, weight, bias: "grad.defined() ? (training ? miopen_batch_norm_backward(input, grad.contiguous(), weight, running_mean, running_var, result1, result2, epsilon) : native_batch_norm_backward(grad, input, weight, running_mean, running_var, result1, result2, training, epsilon, grad_input_mask)) : std::tuple<Tensor, Tensor, Tensor>()"
+  result0: batch_norm_jvp(input_p, input_t, weight_p, weight_t, bias_p, bias_t, running_mean, running_var, result1, result2, training, epsilon)
 
 - name: miopen_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon) -> (Tensor, Tensor, Tensor)
   save_mean: not_implemented("miopen_batch_norm_backward save_mean")

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -279,6 +279,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.linalg_cross,
             aten.cudnn_batch_norm,
             aten.cudnn_batch_norm_backward,
+            aten.miopen_batch_norm_backward,
             aten.deg2rad,
             aten.deg2rad_,
             aten.detach,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2318,6 +2318,30 @@ def native_batch_norm_backward_out(
 
     return grad_input
 
+@register_decomposition(aten.miopen_batch_norm_backward)
+@out_wrapper("out0", "out1", "out2")
+def miopen_batch_norm_backward(
+    input: Tensor,
+    grad_output: Tensor,
+    weight: Tensor,
+    running_mean: Optional[Tensor],
+    running_var: Optional[Tensor],
+    save_mean: Optional[Tensor],
+    save_var: Optional[Tensor],
+    epsilon: float,
+):
+    return aten.native_batch_norm_backward(
+        grad_output,
+        input,
+        weight,
+        running_mean,
+        running_var,
+        save_mean,
+        save_var,
+        True,
+        epsilon,
+        [True, True, True],
+    )
 
 @register_decomposition(aten.cudnn_batch_norm_backward)
 @out_wrapper("out0", "out1", "out2")

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2318,6 +2318,7 @@ def native_batch_norm_backward_out(
 
     return grad_input
 
+
 @register_decomposition(aten.miopen_batch_norm_backward)
 @out_wrapper("out0", "out1", "out2")
 def miopen_batch_norm_backward(
@@ -2342,6 +2343,7 @@ def miopen_batch_norm_backward(
         epsilon,
         [True, True, True],
     )
+
 
 @register_decomposition(aten.cudnn_batch_norm_backward)
 @out_wrapper("out0", "out1", "out2")

--- a/torch/_decomp/decompositions_for_jvp.py
+++ b/torch/_decomp/decompositions_for_jvp.py
@@ -329,3 +329,4 @@ _register_jit_decomposition_for_jvp(torch.ops.aten.native_layer_norm_backward.de
 _register_jit_decomposition_for_jvp(torch.ops.aten.native_batch_norm_backward.default)
 _register_jit_decomposition_for_jvp(torch.ops.aten.cudnn_batch_norm_backward.default)
 _register_jit_decomposition_for_jvp(torch.ops.aten.batch_norm_backward.default)
+_register_jit_decomposition_for_jvp(torch.ops.aten.miopen_batch_norm_backward.default)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14951,8 +14951,6 @@ op_db: List[OpInfo] = [
                # RuntimeError: Cannot insert a Tensor that requires grad as a constant.
                # Consider making it a parameter or input, or detaching the gradient
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float32,)),
-               DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_forward_ad',
-                            active_if=TEST_WITH_ROCM)
            ],
            sample_inputs_func=sample_inputs_instance_norm,
            supports_expanded_weight=True,),
@@ -16273,10 +16271,6 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestNNCOpInfo', 'test_nnc_correctness'),
                DecorateInfo(unittest.skip('Skipped!'), 'TestNNCOpInfo', 'test_nnc_correctness',
                             device_type='cpu', dtypes=(torch.bfloat16, torch.float16)),
-               # Trying to use forward AD with miopen_batch_norm that does not support it
-               # because it has not been implemented yet.
-               DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_forward_ad',
-                            device_type="cuda", active_if=TEST_WITH_ROCM),
                DecorateInfo(toleranceOverride({torch.float32: tol(atol=5e-05, rtol=1e-05)}),
                             'TestCompositeCompliance', 'test_forward_ad', device_type="cpu"),
            )),


### PR DESCRIPTION
Implements forward automatic differentiation support for miopen_batch_norm as well as unskips the associated unit tests. Also fixes a class of functorch related unit tests that fail due to failing a contiguous tensor assertion in BatchNorm_miopen.cpp. Solution was to just limit tensors to miopen_batch_norm that have at least 3 dimensions. The exact restriction already existed in the cudnn path and is why the tests in question only failed on ROCm.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang