### PR TITLE
[pruning]add dropout to list of supported activation functions

### DIFF
--- a/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
+++ b/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
@@ -57,6 +57,7 @@ def _get_supported_activation_functions():
         F.softsign,
         F.tanhshrink,
         F.gelu,
+        F.dropout,
     }
     return SUPPORTED_ACTIVATION_FUNCTIONS
 
@@ -84,6 +85,7 @@ def _get_supported_activation_modules():
         nn.Softsign,
         nn.Tanhshrink,
         nn.GELU,
+        nn.Dropout,
     }
     return SUPPORTED_ACTIVATION_MODULES
 


### PR DESCRIPTION
Summary:
Add nn.Dropout and F.dropout to list of suppported activation functions

Test Plan:
```
python test/test_ao_sparsity.py -- TestBaseSparsifier
```
cc @kit1980  @andrewor14 @jcaip Could you please help to review this tiny change?