### PR TITLE
Add templated attention BLOCK_M & BLOCK_N default size for different head_dim

### DIFF
--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -211,7 +211,7 @@ def generate_experiment_configs() -> List[ExperimentConfig]:
     batch_sizes = [1, 8, 16]
     num_heads = [16]
     q_kv_seq_lens = [(512, 512), (1024, 1024), (4096, 4096)]
-    head_dims = [64]
+    head_dims = [64, 128]
     dtypes = [
         torch.bfloat16,
     ]

--- a/torch/_inductor/kernel/templated_attention.py
+++ b/torch/_inductor/kernel/templated_attention.py
@@ -174,14 +174,18 @@ sdpa_template = TritonTemplate(
 
 
 def _get_default_config(query):
+    head_dim = query.get_size()[-1]
     default_config = None
     is_big_shared_mem = utils.get_gpu_shared_memory() > 128 * 1024
 
     if is_big_shared_mem:
         if query.get_dtype() == torch.float32:
-            default_config = (64, 64, 4, 3)
+            default_config = (128, 32, 4, 3)
         else:
-            default_config = (128, 64, 4, 3)
+            if head_dim == 64:
+                default_config = (128, 64, 4, 3)
+            else:
+                default_config = (128, 32, 4, 3)
     else:
         if query.get_dtype() == torch.float32:
             default_config = (32, 32, 4, 3)


### PR DESCRIPTION
Run different head_dims [64, 128], which are the most popular ones across major GPT models.
Enumerate different ```BLOCK_M``` and ```BLOCK_N``` candidates [16, 32, 64, 128], and get the best config as default one.

## Before
```
| Type    |   Speedup |   batch_size |   num_heads |   q_seq_len |   k_seq_len |   head_dim | score_mod   | dtype          |
|---------|-----------|--------------|-------------|-------------|-------------|------------|-------------|----------------|
| Average |     0.704 |              |             |             |             |            |             |                |
| Max     |     0.953 |            1 |          16 |         512 |         512 |         64 | noop        | torch.bfloat16 |
| Min     |     0.482 |            1 |          16 |        4096 |        4096 |        128 | causal_mask | torch.bfloat16 |
```
## After
```
| Type    |   Speedup |   batch_size |   num_heads |   q_seq_len |   k_seq_len |   head_dim | score_mod   | dtype          |
|---------|-----------|--------------|-------------|-------------|-------------|------------|-------------|----------------|
| Average |     0.823 |              |             |             |             |            |             |                |
| Max     |     0.926 |            1 |          16 |         512 |         512 |         64 | noop        | torch.bfloat16 |
| Min     |     0.723 |            1 |          16 |         512 |         512 |        128 | causal_mask | torch.bfloat16 |
```


cc @ezyang @msaroufim @bdhirsh @anijain2305 @chauhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire