### PR TITLE
LONG_LONG_MAX not portable

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -114,8 +114,8 @@ static const char* process_name() {
 }
 
 struct Version {
-  uint64_t adds_ = LONG_LONG_MAX;
-  uint64_t subs_ = LONG_LONG_MAX;
+  uint64_t adds_ = LLONG_MAX;
+  uint64_t subs_ = LLONG_MAX;
 };
 
 struct UnwindCache {


### PR DESCRIPTION
Use LLONG_MAX instead

Should fix build on musl: https://bugs.gentoo.org/930641
