### PR TITLE
[dtensor] use str for reduce_op

### DIFF
--- a/test/distributed/_tensor/test_pointwise_ops.py
+++ b/test/distributed/_tensor/test_pointwise_ops.py
@@ -16,7 +16,6 @@ from torch.distributed._tensor.placement_types import (
     Replicate,
     Shard,
 )
-from torch.distributed.distributed_c10d import ReduceOp
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorOpTestBase,
@@ -257,7 +256,7 @@ class DistElementwiseOpsTest(DTensorOpTestBase):
         with self.assertRaisesRegex(RuntimeError, "supported"):
             self._run_sharded_elementwise_ops(
                 device_mesh=device_mesh,
-                placements=[_Partial(ReduceOp.SUM)],
+                placements=[_Partial("sum")],
                 input_size=(8, 5),
                 op=torch.nn.functional.dropout,
             )

--- a/torch/distributed/_spmd/data_parallel.py
+++ b/torch/distributed/_spmd/data_parallel.py
@@ -6,7 +6,6 @@ from typing import Any, cast, Dict, List, Optional, Tuple
 
 import torch
 
-import torch.distributed.distributed_c10d as c10d
 import torch.fx as fx
 import torch.library
 import torch.nn as nn
@@ -158,9 +157,8 @@ def _gen_partial_strategy(mesh: DeviceMesh) -> PlacementStrategy:
     # TODO: Only NCCL supports AVG so using backend like Gloo would
     # crash, we should figure out a way to support avg reduction
     # for non-NCCL backend
-    reduce_op = c10d.ReduceOp.AVG  # type: ignore[attr-defined]
     return PlacementStrategy(
-        output_specs=DTensorSpec(mesh=mesh, placements=(_Partial(reduce_op),)),
+        output_specs=DTensorSpec(mesh=mesh, placements=(_Partial("avg"),)),
     )
 
 

--- a/torch/distributed/_tensor/ops/embedding_ops.py
+++ b/torch/distributed/_tensor/ops/embedding_ops.py
@@ -114,7 +114,7 @@ class _MaskPartial(_Partial):
 
         # perform sum reduction
         return funcol.all_reduce(
-            tensor, reduceOp=self.reduce_op.name, group=(mesh, mesh_dim)
+            tensor, reduceOp=self.reduce_op, group=(mesh, mesh_dim)
         )
 
     def _reduce_shard_value(

--- a/torch/distributed/_tensor/ops/math_ops.py
+++ b/torch/distributed/_tensor/ops/math_ops.py
@@ -6,7 +6,6 @@ from typing import cast, List, Optional, Sequence, Tuple, Union
 
 import torch
 
-import torch.distributed.distributed_c10d as c10d
 from torch.distributed._tensor.op_schema import (
     OpSchema,
     OpStrategy,
@@ -47,7 +46,7 @@ class NormReduction:
     norm_type: Union[int, float, str]
 
 
-ReductionOpType = Union[NormReduction, c10d.ReduceOp.RedOpType]
+ReductionOpType = Union[NormReduction, str]
 
 
 @dataclass(frozen=True)
@@ -74,11 +73,11 @@ class _NormPartial(_Partial):
         """Set the appropriate reduce op based on the norm type."""
         # Use `object.__setattr__` to bypass frozen checks
         if self.norm_type in (float("inf"), "inf"):
-            object.__setattr__(self, "reduce_op", c10d.ReduceOp.MAX)
+            object.__setattr__(self, "reduce_op", "sum")
         elif self.norm_type in (float("-inf"), "-inf"):
-            object.__setattr__(self, "reduce_op", c10d.ReduceOp.MIN)
+            object.__setattr__(self, "reduce_op", "min")
         elif isinstance(self.norm_type, (int, float)):
-            object.__setattr__(self, "reduce_op", c10d.ReduceOp.SUM)
+            object.__setattr__(self, "reduce_op", "sum")
         else:
             raise NotImplementedError(f"Unsupported norm type: {self.norm_type}")
 
@@ -94,9 +93,9 @@ class _NormPartial(_Partial):
         One such f(x) is f(x) = x / sqrt(4). This generalizes to d ranks and
         p-norm as f(x) = x / d^(1/p).
         """
-        if self.reduce_op in (c10d.ReduceOp.MAX, c10d.ReduceOp.MIN):
+        if self.reduce_op in ("max", "min"):
             return tensor
-        elif self.reduce_op == c10d.ReduceOp.SUM:
+        elif self.reduce_op == "sum":
             if self.norm_type == 0:
                 raise NotImplementedError(f"Unsupported norm type:: {self.norm_type}")
             elif self.norm_type == 1:
@@ -125,14 +124,14 @@ class _NormPartial(_Partial):
         return self._post_reduce_transform(reduced_tensor)
 
     def _pre_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
-        if self.reduce_op == c10d.ReduceOp.SUM:
+        if self.reduce_op == "sum":
             assert isinstance(self.norm_type, (int, float)), f"{self.norm_type}"
             if self.norm_type != 0 and self.norm_type != 1:
                 return tensor**self.norm_type
         return tensor
 
     def _post_reduce_transform(self, tensor: torch.Tensor) -> torch.Tensor:
-        if self.reduce_op == c10d.ReduceOp.SUM:
+        if self.reduce_op == "sum":
             assert isinstance(self.norm_type, (int, float)), f"{self.norm_type}"
             if self.norm_type != 0 and self.norm_type != 1:
                 return tensor ** (1.0 / self.norm_type)
@@ -230,7 +229,7 @@ def common_reduction_strategy(
     reduce_dims: List[int],
     keep_dim: bool = False,
     reduction_linear: bool = True,
-    reduction_op: ReductionOpType = c10d.ReduceOp.SUM,
+    reduction_op: ReductionOpType = "sum",
 ) -> OpStrategy:
     """
     reduction_linear means that the reduction `f` follows this rule:
@@ -277,22 +276,22 @@ def common_reduction_strategy(
 
 
 LINEAR_REDUCTION_OP_MAP = {
-    aten.all.default: c10d.ReduceOp.SUM,
-    aten.all.dim: c10d.ReduceOp.SUM,
-    aten.sum.default: c10d.ReduceOp.SUM,
-    aten.sum.dim_IntList: c10d.ReduceOp.SUM,
-    aten.prod.default: c10d.ReduceOp.PRODUCT,
-    aten.prod.dim_int: c10d.ReduceOp.PRODUCT,
-    aten.prod.int_out: c10d.ReduceOp.PRODUCT,
-    aten.mean.default: c10d.ReduceOp.AVG,
-    aten.mean.dim: c10d.ReduceOp.AVG,
-    aten.mean.out: c10d.ReduceOp.AVG,
-    aten.max.default: c10d.ReduceOp.MAX,
-    aten.max.dim: c10d.ReduceOp.MAX,
-    aten.max.out: c10d.ReduceOp.MAX,
-    aten.min.default: c10d.ReduceOp.MIN,
-    aten.min.dim: c10d.ReduceOp.MIN,
-    aten.min.out: c10d.ReduceOp.MIN,
+    aten.all.default: "sum",
+    aten.all.dim: "sum",
+    aten.sum.default: "sum",
+    aten.sum.dim_IntList: "sum",
+    aten.prod.default: "product",
+    aten.prod.dim_int: "product",
+    aten.prod.int_out: "product",
+    aten.mean.default: "avg",
+    aten.mean.dim: "avg",
+    aten.mean.out: "avg",
+    aten.max.default: "max",
+    aten.max.dim: "max",
+    aten.max.out: "max",
+    aten.min.default: "min",
+    aten.min.dim: "min",
+    aten.min.out: "min",
 }
 
 
@@ -542,7 +541,7 @@ def nll_loss_forward_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrate
             )
         else:
             if reduction == Reduction.MEAN.value:
-                reduction_op = c10d.ReduceOp.AVG
+                reduction_op = "avg"
                 if not is_tensor_evenly_shardable(
                     target_expected_spec.shape, target_expected_spec
                 ):
@@ -551,7 +550,7 @@ def nll_loss_forward_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrate
                         resulting in biased mean result."
                     )
             else:  # reduction == Reduction.SUM.value:
-                reduction_op = c10d.ReduceOp.SUM
+                reduction_op = "sum"
             reduce_dims = list(range(target_expected_spec.ndim))
             reduce_dims_map = _infer_reduce_dims_map(
                 reduce_dims, target_expected_spec.ndim, keep_dim=False
@@ -572,7 +571,7 @@ def nll_loss_forward_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrate
                 target_expected_spec.placements,
                 reduce_dims,
                 reduce_dims_map,
-                c10d.ReduceOp.SUM,
+                "sum",
             )
             total_weight_expected_spec = DTensorSpec(
                 mesh=mesh,
@@ -899,7 +898,7 @@ def layer_norm_bwd_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy
                 outer_dims, input_src_spec.ndim, False
             )
             out_placements = map_placements_after_reduction(
-                inp_placements, outer_dims, reduce_dims_map, c10d.ReduceOp.SUM
+                inp_placements, outer_dims, reduce_dims_map, "sum"
             )
             output_specs_list.append(
                 DTensorSpec(
@@ -932,7 +931,7 @@ def layer_norm_bwd_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy
                 outer_dims, grad_out_spec.ndim, False
             )
             out_placements = map_placements_after_reduction(
-                inp_placements, outer_dims, reduce_dims_map, c10d.ReduceOp.SUM
+                inp_placements, outer_dims, reduce_dims_map, "sum"
             )
             output_specs_list.append(
                 DTensorSpec(

--- a/torch/distributed/_tensor/ops/math_ops.py
+++ b/torch/distributed/_tensor/ops/math_ops.py
@@ -73,7 +73,7 @@ class _NormPartial(_Partial):
         """Set the appropriate reduce op based on the norm type."""
         # Use `object.__setattr__` to bypass frozen checks
         if self.norm_type in (float("inf"), "inf"):
-            object.__setattr__(self, "reduce_op", "sum")
+            object.__setattr__(self, "reduce_op", "max")
         elif self.norm_type in (float("-inf"), "-inf"):
             object.__setattr__(self, "reduce_op", "min")
         elif isinstance(self.norm_type, (int, float)):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125172

This PR use str for reduce_op directly instead of the c10d enum. Since
our functional collective already uses str, there's no reason that we
need the c10d enum anymore as that requires a conversion

Also the str hash + eq performance is actually significantly faster than
the c10d type, so this would somewhat improves the CPU overhead too

Some local cpu benchmarks on `1000000` hash operations:

```
Hash performance for string type: 0.039897 seconds
Hash performance for integer type: 0.304665 seconds
```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k