### PR TITLE
Export `torch.jit.interface` from `torch.jit` package

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -81,6 +81,7 @@ __all__ = [
     "export_opnames",
     "fork",
     "freeze",
+    "interface",
     "ignore",
     "isinstance",
     "load",


### PR DESCRIPTION
Seems like this symbol was overlooked when other symbols were exported from `torch.jit`.