### PR TITLE
[Don't Merge] dump indoctor build command.

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1674,6 +1674,8 @@ def cpp_compile_command(
 
 def run_command_and_check(cmd: str):
     cmd = shlex.split(cmd)
+    print("!!! current working dir: ", os.getcwd())
+    print("!!! run_command_and_check --> cmd: ", cmd)
     try:
         subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:
@@ -2013,6 +2015,8 @@ def cpp_prefix() -> str:
 def compile_file(
     input_path: Union[str, List[str]], output_path: str, cmd: List[str]
 ) -> None:
+    print("!!! current working dir: ", os.getcwd())
+    print("!!! compile_file --> cmd: ", cmd)
     input_paths = [input_path] if isinstance(input_path, str) else input_path
     input_files = [
         os.path.basename(ip) if config.is_fbcode() else ip for ip in input_paths


### PR DESCRIPTION
Background:
Intel pytorch team can't access Meta internal environment, but we still to make our patches compatiable to Meta internal fb_code.

This is a dummy PR can dump inductor build command line. We need Meta engineer help us run some case in fb_code environment and dump command line to us.

example:
<img width="917" alt="image" src="https://github.com/pytorch/pytorch/assets/8433590/9f89752d-9a41-4861-9a8d-ef190c1d5028">

CC: @chunyuan-w 

cc @ezyang @msaroufim @bdhirsh @anijain2305 @chauhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire