### PR TITLE
fix loading optimizer options from archive

### DIFF
--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -102,6 +102,12 @@ void test_serialize_optimizer(
   auto optim2_2 = OptimizerClass(model2->parameters(), options);
   auto optim3 = OptimizerClass(model3->parameters(), options);
   auto optim3_2 = OptimizerClass(model3->parameters(), options);
+  for (auto& param_group : optim3_2.param_groups()) {
+    const double lr = param_group.options().get_lr();
+    // change the learning rate, which will be overwritten by the loading
+    // otherwise, test cannot check if options are saved and loaded correctly
+    param_group.options().set_lr(lr + 1);
+  }
 
   auto x = torch::ones({10, 5});
 

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -106,7 +106,7 @@ void test_serialize_optimizer(
     const double lr = param_group.options().get_lr();
     // change the learning rate, which will be overwritten by the loading
     // otherwise, test cannot check if options are saved and loaded correctly
-    param_group.options().set_lr(lr + 1);
+    param_group.options().set_lr(lr + 0.01);
   }
 
   auto x = torch::ones({10, 5});

--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -200,8 +200,10 @@ void serialize(serialize::InputArchive& archive, Optimizer& optimizer) {
       }
     }
 
-    auto &saved_options = reinterpret_cast<DerivedOptimizerParamOptions&>(*saved_param_groups[i].second);
-    auto &current_options = reinterpret_cast<DerivedOptimizerParamOptions&>(optimizer.param_groups()[i].options());
+    auto& saved_options = reinterpret_cast<DerivedOptimizerParamOptions&>(
+        *saved_param_groups[i].second);
+    auto& current_options = reinterpret_cast<DerivedOptimizerParamOptions&>(
+        optimizer.param_groups()[i].options());
     current_options = saved_options;
   }
 }

--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -180,7 +180,7 @@ void serialize(serialize::InputArchive& archive, Optimizer& optimizer) {
   detail::serialize<DerivedOptimizerParamOptions>(
       param_groups_archive, saved_param_groups);
 
-  // update state
+  // update state and optimizer options
   TORCH_CHECK(
       saved_param_groups.size() == optimizer.param_groups().size(),
       "loaded state dict has a different number of parameter groups");
@@ -199,6 +199,10 @@ void serialize(serialize::InputArchive& archive, Optimizer& optimizer) {
             std::move(saved_state[param_group_old_key]);
       }
     }
+
+    auto &saved_options = reinterpret_cast<DerivedOptimizerParamOptions&>(*saved_param_groups[i].second);
+    auto &current_options = reinterpret_cast<DerivedOptimizerParamOptions&>(optimizer.param_groups()[i].options());
+    current_options = saved_options;
   }
 }
 


### PR DESCRIPTION
This PR makes libtorch behave the same as PyTorch when loading optimizer state from archive. With PyTorch, options of parameter groups are loaded from the archive, which is missing currently in libtorch.
