### PR TITLE
fix: typo

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3210,7 +3210,7 @@ def binary_cross_entropy_with_logits(
             operations. For a target of size [B, C, H, W] (where B is batch size) pos_weight of
             size [B, C, H, W] will apply different pos_weights to each element of the batch or
             [C, H, W] the same pos_weights across the batch. To apply the same positive weight
-            along all spacial dimensions for a 2D multi-class target [C, H, W] use: [C, 1, 1].
+            along all spatial dimensions for a 2D multi-class target [C, H, W] use: [C, 1, 1].
             Default: ``None``
 
     Examples::


### PR DESCRIPTION
Fixes spelling error: spacial is an incorrect spelling of spatial
