### PR TITLE
Fix logic to find sbgemm in BLAS library

### DIFF
--- a/cmake/Modules/FindBLAS.cmake
+++ b/cmake/Modules/FindBLAS.cmake
@@ -385,16 +385,6 @@ IF (BLAS_LIBRARIES)
   cmake_pop_check_state()
 ENDIF(BLAS_LIBRARIES)
 
-# Blas has bfloat16 support?
-IF(BLAS_LIBRARIES)
-  SET(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES})
-  check_function_exists("sbgemm_" BLAS_HAS_SBGEMM)
-  set(CMAKE_REQUIRED_LIBRARIES)
-  IF(BLAS_HAS_SBGEMM)
-    add_compile_options(-DBLAS_HAS_SBGEMM)
-  ENDIF(BLAS_HAS_SBGEMM)
-ENDIF(BLAS_LIBRARIES)
-
 # epilogue
 
 if(BLAS_LIBRARIES)
@@ -416,3 +406,13 @@ ENDIF(NOT BLAS_FIND_QUIETLY)
 
 # Do nothing is BLAS was found before
 ENDIF(NOT BLAS_FOUND)
+
+# Blas has bfloat16 support?
+IF(BLAS_LIBRARIES)
+  SET(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES})
+  check_function_exists("sbgemm_" BLAS_HAS_SBGEMM)
+  set(CMAKE_REQUIRED_LIBRARIES)
+  IF(BLAS_HAS_SBGEMM)
+    add_compile_options(-DBLAS_HAS_SBGEMM)
+  ENDIF(BLAS_HAS_SBGEMM)
+ENDIF(BLAS_LIBRARIES)


### PR DESCRIPTION
Current logic to set the HAS_SBGEMM flag is ignored in case the BLAS libraries are found already, ie, if set from environment variable BLAS=OpenBLAS . If BLAS_LIBRARIES are already set the code to find if BLAS_LIBRARY has sbgemm is never executed. The following commit brings out this logic outside unconditionally.

Fixes #ISSUE_NUMBER


cc @frank-wei @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10