### PR TITLE
Fix random_mps_impl to accept non-contiguous tensors

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3157,6 +3157,15 @@ class TestMPS(TestCaseMPS):
         helper((2, 3, 4))
         helper((2, 8, 4, 5))
 
+    def test_rand_like(self):
+        t = torch.ones(3,2,2).to('mps').permute(2,0,1)
+        t_rand = torch.rand_like(t)
+
+        self.assertFalse(torch.allclose(t_rand, t))
+
+        self.assertTrue(torch.all(t_rand >= 0))
+        self.assertTrue(torch.all(t_rand < 1))
+
     def test_threshold(self):
         def helper(threshold, value, num_elems, inplace=False, requires_grad=True):
             m = nn.Threshold(threshold=threshold, value=value, inplace=inplace)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3158,7 +3158,7 @@ class TestMPS(TestCaseMPS):
         helper((2, 8, 4, 5))
 
     def test_rand_like(self):
-        t = torch.ones(3,2,2).to('mps').permute(2,0,1)
+        t = torch.ones(3, 2, 2).to('mps').permute(2, 0, 1)
         t_rand = torch.rand_like(t)
 
         self.assertFalse(torch.allclose(t_rand, t))

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2004,20 +2004,22 @@ def sample_inputs_bernoulli(self, device, dtype, requires_grad, **kwargs):
                         requires_grad=requires_grad)
         yield SampleInput(t)
 
-    if device == 'mps':
+    if device == 'mps:0':
         # bernoulli uses random_mps_impl under the hood and random_mps_impl support more than one element of the written-to
         # tensor referring to a single memory location by copying the results as a workaround.
         x = torch.rand((1,), device=device).expand((6,))
         yield SampleInput(torch.rand_like(x), kwargs={'out': x})
 
 def error_inputs_bernoulli(op_info, device, **kwargs):
-    if device == 'mps':
-        return
-    # more than one element of the written-to tensor refers to a single memory location
-    x = torch.rand((1,), device=device).expand((6,))
-    err_msg = 'unsupported operation'
-    yield ErrorInput(SampleInput(torch.rand_like(x), kwargs={'out': x}),
-                     error_regex=err_msg)
+    if device == 'mps:0':
+        # TODO: Find a better way to skip error inputs for mps
+        yield ErrorInput()
+    else:
+        # more than one element of the written-to tensor refers to a single memory location
+        x = torch.rand((1,), device=device).expand((6,))
+        err_msg = 'unsupported operation'
+        yield ErrorInput(SampleInput(torch.rand_like(x), kwargs={'out': x}),
+                        error_regex=err_msg)
 
 def sample_inputs_logcumsumexp(self, device, dtype, requires_grad, **kwargs):
     inputs = (

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2004,10 +2004,20 @@ def sample_inputs_bernoulli(self, device, dtype, requires_grad, **kwargs):
                         requires_grad=requires_grad)
         yield SampleInput(t)
 
-    # bernoulli uses random_mps_impl under the hood and random_mps_impl support more than one element of the written-to
-    # tensor referring to a single memory location by copying the results as a workaround.
+    if device == 'mps':
+        # bernoulli uses random_mps_impl under the hood and random_mps_impl support more than one element of the written-to
+        # tensor referring to a single memory location by copying the results as a workaround.
+        x = torch.rand((1,), device=device).expand((6,))
+        yield SampleInput(torch.rand_like(x), kwargs={'out': x})
+
+def error_inputs_bernoulli(op_info, device, **kwargs):
+    if device == 'mps':
+        return
+    # more than one element of the written-to tensor refers to a single memory location
     x = torch.rand((1,), device=device).expand((6,))
-    yield SampleInput(torch.rand_like(x), kwargs={'out': x})
+    err_msg = 'unsupported operation'
+    yield ErrorInput(SampleInput(torch.rand_like(x), kwargs={'out': x}),
+                    error_regex=err_msg)
 
 def sample_inputs_logcumsumexp(self, device, dtype, requires_grad, **kwargs):
     inputs = (
@@ -18941,6 +18951,7 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs_bernoulli,
+           error_inputs_func=error_inputs_bernoulli,
            skips=(
                # vmap: We do not yet support calling random operations inside of vmap
                DecorateInfo(unittest.expectedFailure, 'TestFwdGradients', 'test_forward_mode_AD'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2004,6 +2004,11 @@ def sample_inputs_bernoulli(self, device, dtype, requires_grad, **kwargs):
                         requires_grad=requires_grad)
         yield SampleInput(t)
 
+    # bernoulli uses random_mps_impl under the hood and random_mps_impl support more than one element of the written-to
+    # tensor referring to a single memory location by copying the results as a workaround.
+    x = torch.rand((1,), device=device).expand((6,))
+    yield SampleInput(torch.rand_like(x), kwargs={'out': x})
+
 def sample_inputs_logcumsumexp(self, device, dtype, requires_grad, **kwargs):
     inputs = (
         ((S, S, S), 0),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2017,7 +2017,7 @@ def error_inputs_bernoulli(op_info, device, **kwargs):
     x = torch.rand((1,), device=device).expand((6,))
     err_msg = 'unsupported operation'
     yield ErrorInput(SampleInput(torch.rand_like(x), kwargs={'out': x}),
-                    error_regex=err_msg)
+                     error_regex=err_msg)
 
 def sample_inputs_logcumsumexp(self, device, dtype, requires_grad, **kwargs):
     inputs = (

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2004,13 +2004,6 @@ def sample_inputs_bernoulli(self, device, dtype, requires_grad, **kwargs):
                         requires_grad=requires_grad)
         yield SampleInput(t)
 
-def error_inputs_bernoulli(op_info, device, **kwargs):
-    # more than one element of the written-to tensor refers to a single memory location
-    x = torch.rand((1,), device=device).expand((6,))
-    err_msg = 'unsupported operation'
-    yield ErrorInput(SampleInput(torch.rand_like(x), kwargs={'out': x}),
-                     error_regex=err_msg)
-
 def sample_inputs_logcumsumexp(self, device, dtype, requires_grad, **kwargs):
     inputs = (
         ((S, S, S), 0),
@@ -18943,7 +18936,6 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs_bernoulli,
-           error_inputs_func=error_inputs_bernoulli,
            skips=(
                # vmap: We do not yet support calling random operations inside of vmap
                DecorateInfo(unittest.expectedFailure, 'TestFwdGradients', 'test_forward_mode_AD'),


### PR DESCRIPTION
Fixes #124029

Follows the pattern of allocating contiguous memory and copying the results in https://github.com/pytorch/pytorch/pull/123049/files 