### PR TITLE
[AOTI] Update C-shim codegen to handle rocm

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -409,9 +409,15 @@ set(GENERATED_TESTING_PYTHON
   "${TORCH_SRC_DIR}/testing/_internal/generated/annotated_fn_args.py"
   )
 
-set(GENERATED_CXX_TORCH_CUDA
-  "${TORCH_SRC_DIR}/csrc/inductor/aoti_torch/generated/c_shim_cuda.cpp"
-  )
+if(USE_ROCM)
+  set(GENERATED_CXX_TORCH_CUDA
+    "${TORCH_SRC_DIR}/csrc/inductor/aoti_torch/generated/c_shim_hip.cpp"
+    )
+else()
+  set(GENERATED_CXX_TORCH_CUDA
+    "${TORCH_SRC_DIR}/csrc/inductor/aoti_torch/generated/c_shim_cuda.cpp"
+    )
+endif()
 
 set(TORCH_GENERATED_CODE
   ${GENERATED_CXX_TORCH}

--- a/torchgen/utils.py
+++ b/torchgen/utils.py
@@ -121,6 +121,15 @@ def string_stable_hash(s: str) -> int:
     return int.from_bytes(sha1, byteorder="little")
 
 
+def get_backend_str(dispatch_key, rocm: bool) -> str:
+    if dispatch_key is None:
+        return ""
+    backend_str = dispatch_key.lower()
+    if backend_str == "cuda" and rocm:
+        backend_str = "hip"
+    return backend_str
+
+
 # A small abstraction for writing out generated files and keeping track
 # of what files have been written (so you can write out a list of output
 # files)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125233

Summary: Instead of hipifying generated C shim files, we change the torchgen script to generate hipified code.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang