### PR TITLE
Revert "[benchmark][cudagraph] Explicitly call aten.div with CUDA denominator for cudagraphs (#119729)"

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: inductor"]
 import functools
-import io
 import re
 import sys
 import unittest
@@ -1343,24 +1342,6 @@ TORCH_LIBRARY(test_autograd_cpp_node_data_dependent, m) {
 
             out = compiled_fn(activations)
             self.assertTrue(len(activations) == 0)
-
-    @unittest.skipIf(not HAS_CUDA, "requires cuda")
-    def test_cudagraphs_cpu_division(self):
-        from torch._dynamo.testing import reduce_to_scalar_loss
-
-        model = torch.nn.Linear(10, 10, dtype=torch.float16).cuda()
-        inputs = torch.randn(10, 10, dtype=torch.float16).cuda()
-        out = model(inputs)
-        loss = reduce_to_scalar_loss(out)
-        torch._inductor.config.triton.cudagraphs = True
-
-        stderr_msgs = io.StringIO()
-        with mock.patch("sys.stderr", stderr_msgs), compiled_autograd.enable(
-            compiler_fn
-        ):
-            loss.backward()
-
-        self.assertFalse("skipping cudagraphs" in stderr_msgs.getvalue())
 
     def test_verbose_logs_graph(self):
         torch._logging.set_logs(compiled_autograd_verbose=True)

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -103,7 +103,7 @@ def reduce_to_scalar_loss(out):
     """Reduce the output of a model to get scalar loss"""
     if isinstance(out, torch.Tensor):
         # Mean does not work on integer tensors
-        return out.sum() / torch.tensor(out.numel(), device=out.device)
+        return out.sum() / out.numel()
     elif isinstance(out, (list, tuple)):
         return sum(reduce_to_scalar_loss(x) for x in out) / len(out)
     elif type(out).__name__ in (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125246

This reverts commit 62b5738a8bf325d79468b839b8412b87cb9951c1.

https://github.com/pytorch/pytorch/pull/119729/ regresses cudagraph dashboard. Moving the one-time per iteration loss from CPU to CUDA is somehow causing a lot of copies:


current (top) vs with revert (bottom)
![image](https://github.com/pytorch/pytorch/assets/9547562/62dfbf66-7edc-4a3c-ba7f-1ec057fba950)





cc @ezyang @msaroufim @bdhirsh @anijain2305 @chauhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire