### PR TITLE
[TorchScript] attach target function to OSError when source can't be found

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -380,7 +380,10 @@ def get_type_hint_captures(fn):
     # This may happen in cases where the function is synthesized dynamically at runtime.
     src = loader.get_source(fn)
     if src is None:
-        src = inspect.getsource(fn)
+        try:
+            src = inspect.getsource(fn)
+        except OSError as e:
+            raise OSError(f"Failed to get source for {fn} using inspect.getsource") from e
 
     # Gather a dictionary of parameter name -> type, skipping any parameters whose annotated
     # types are strings. These are only understood by TorchScript in the context of a type annotation

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -383,7 +383,9 @@ def get_type_hint_captures(fn):
         try:
             src = inspect.getsource(fn)
         except OSError as e:
-            raise OSError(f"Failed to get source for {fn} using inspect.getsource") from e
+            raise OSError(
+                f"Failed to get source for {fn} using inspect.getsource"
+            ) from e
 
     # Gather a dictionary of parameter name -> type, skipping any parameters whose annotated
     # types are strings. These are only understood by TorchScript in the context of a type annotation


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125248

Before, it would be hard to figure out which function/module in particular was causing the OSError. Now we'll try to print the function/module string.

Differential Revision: [D56768365](https://our.internmc.facebook.com/intern/diff/D56768365)