### PR TITLE
switch tests from constrain_as* to torch._check*

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -703,7 +703,7 @@ class CompileTest(TestCase):
         def _tolist_with_constrain_as_size(tensor):
             lst = tensor.tolist()
             for elem in lst:
-                torch._constrain_as_size(elem)
+                torch._check_is_size(elem)
             return lst
 
         def func(

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -35,7 +35,7 @@ from torch.utils._triton import has_triton
 def _tolist_with_constrain_as_size(tensor):
     lst = tensor.tolist()
     for elem in lst:
-        torch._constrain_as_size(elem)
+        torch._check_is_size(elem)
     return lst
 
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2604,7 +2604,7 @@ def forward(self, x):
     def test_export_preserve_constraints_as_metadata_scalar(self):
         def f(x, y):
             b = x.item()
-            torch._constrain_as_size(b)
+            torch._check_is_size(b)
             return torch.empty((b, y.shape[0]))
 
         x = torch.tensor([3])
@@ -2634,7 +2634,8 @@ def forward(self, x):
     def test_export_preserve_constraints_as_metadata_tensor(self):
         def f(x):
             b = x.nonzero()
-            torch._constrain_as_value(b.shape[0], min=2, max=5)
+            torch._check(b.shape[0] >= 2)
+            torch._check(b.shape[0] <= 5)
             return b
 
         y = torch.tensor([8, 8, 6])
@@ -2652,7 +2653,7 @@ def forward(self, x):
     def test_exported_graph_serialization(self):
         def f(x, y):
             b = x.item()
-            torch._constrain_as_size(b)
+            torch._check_is_size(b)
             return torch.empty((b, y.shape[0]))
 
         x = torch.tensor([3])

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8491,7 +8491,9 @@ def ___make_guard_fn():
         def f(lengths, values):
             sizes = lengths.tolist()
             for s in sizes:
-                torch._constrain_as_size(s, min=2, max=100)
+                torch._check_is_size(s)
+                torch._check(s >= 2)
+                torch._check(s <= 100)
             return torch.split(values, sizes)
 
         f(torch.tensor([2, 3, 4]), torch.randn(9))

--- a/test/export/test_pass_infra.py
+++ b/test/export/test_pass_infra.py
@@ -50,12 +50,14 @@ class TestPassInfra(TestCase):
             def forward(self, pred, x, y):
                 def true_fn(x, y):
                     b = x.item()
-                    torch._constrain_as_value(b, min=2, max=5)
+                    torch._check(b >= 2)
+                    torch._check(b <= 5)
                     return x - y
 
                 def false_fn(x, y):
                     c = y.item()
-                    torch._constrain_as_value(c, min=2, max=5)
+                    torch._check(c >= 2)
+                    torch._check(c <= 5)
                     return x + y
 
                 ret = control_flow.cond(pred, true_fn, false_fn, [x, y])

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -773,7 +773,7 @@ class TestDeserialize(TestCase):
         class Module(torch.nn.Module):
             def forward(self, x, y):
                 n = x.item()
-                torch._constrain_as_size(n, min=2)
+                torch._check_is_size(n)
                 return y.sum() + torch.ones(n, 5).sum()
 
         f = Module()

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10002,7 +10002,9 @@ if HAS_GPU and RUN_GPU and not TEST_WITH_ASAN:
                 return a[y.to(torch.int64)]
 
             def fn2(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-                torch._constrain_as_size(b.shape[0], 2, 100)
+                torch._check_is_size(b.shape[0])
+                torch._check(b.shape[0] >= 2)
+                torch._check(b.shape[0] <= 100)
                 return fn1(a, b)
 
             fn1_opt = torch._dynamo.optimize("inductor")(fn1)

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -780,7 +780,9 @@ class TestInductorDynamic(TestCase):
         @torch.compile(fullgraph=True, dynamic=True)
         def f(x):
             a = x.item()
-            torch._constrain_as_size(a, min=1, max=10)
+            torch._check_is_size(a)
+            torch._check(a >= 1)
+            torch._check(a <= 10)
             return torch.ones(a, a)
 
         f(torch.tensor([5], device=device))

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1347,7 +1347,7 @@ def forward(self, crop_camera_1, mask_1):
                 for s in p.shape:
                     guard_int(s)
             x = x[mask]
-            torch._constrain_as_value(x.shape[0], min=1)
+            torch._check(x.shape[0] >= 1)
             for p in params.values():
                 p.grad = None
             return torch.func.functional_call(mod, {**params, **buffers}, (x,)).sum()
@@ -1498,6 +1498,7 @@ def forward(self, x_1, y_1):
             # tolist not directly supported atm
             sizes = [lengths[i].item() for i in range(lengths.size(0))]
             for s in sizes:
+                # TODO(avik): no assertion generated with torch._check_is_size?
                 torch._constrain_as_size(s)
             return torch.split(values, sizes)
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2057,7 +2057,7 @@ def _constrain_as_size(symbol, min: Optional[builtins.int] = None, max: Optional
       GuardOnDataDependentSymNode errors upon export, since we cannot guard on unbacked SymInts.
 
     This function has unusual semantics which distinguish it from
-    constrain_as_value.  Specifically, in some circumstances in framework
+    _constrain_as_value.  Specifically, in some circumstances in framework
     code, we will treat this int as >= 2 (when we do a size-oblivious guard).
     This makes it easier to This makes it easier to use the unbacked int in
     size contexts, as we will often attempt to guard on a size being zero/one

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1819,7 +1819,7 @@ def get_fake_value(node, tx, allow_non_graph_fake=False):
                 "Tried to use data-dependent value in the subsequent computation. "
                 "This can happen when we encounter unbounded dynamic value that is unknown during tracing time.  "
                 "You will need to explicitly give hint to the compiler. Please take a look at "
-                f"constrain_as_value OR constrain_as_size APIs.  {cause}",
+                f"torch._check OR torch._check_is_size APIs.  {cause}",
                 case_name="constrain_as_size_example",
             )
         elif isinstance(cause, ValueRangeError):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -997,7 +997,7 @@ class SymNodeVariable(VariableTracker):
         except GuardOnDataDependentSymNode as e:
             raise UserError(  # noqa: TRY200
                 UserErrorType.ANTI_PATTERN,
-                f"Consider annotating your code using torch._constrain_as_*(). {str(e)}",
+                f"Consider annotating your code using torch._check*(). {str(e)}",
                 case_name="constrain_as_size_example",
             )
 

--- a/torch/_export/db/examples/constrain_as_size_example.py
+++ b/torch/_export/db/examples/constrain_as_size_example.py
@@ -13,8 +13,8 @@ from torch._export.db.case import export_case
 class ConstrainAsSizeExample(torch.nn.Module):
     """
     If the value is not known at tracing time, you can provide hint so that we
-    can trace further. Please look at constrain_as_value and constrain_as_size APIs
-    constrain_as_size is used for values that NEED to be used for constructing
+    can trace further. Please look at torch._check and torch._check_is_size APIs.
+    torch._check_is_size is used for values that NEED to be used for constructing
     tensor.
     """
 
@@ -23,5 +23,6 @@ class ConstrainAsSizeExample(torch.nn.Module):
 
     def forward(self, x):
         a = x.item()
-        torch._constrain_as_size(a, min=0, max=5)
+        torch._check_is_size(a)
+        torch._check(a <= 5)
         return torch.zeros((a, 5))

--- a/torch/_export/db/examples/constrain_as_value_example.py
+++ b/torch/_export/db/examples/constrain_as_value_example.py
@@ -13,8 +13,8 @@ from torch._export.db.case import export_case
 class ConstrainAsValueExample(torch.nn.Module):
     """
     If the value is not known at tracing time, you can provide hint so that we
-    can trace further. Please look at constrain_as_value and constrain_as_size APIs.
-    constrain_as_value is used for values that don't need to be used for constructing
+    can trace further. Please look at torch._check and torch._check_is_size APIs.
+    torch._check is used for values that don't need to be used for constructing
     tensor.
     """
 
@@ -23,7 +23,8 @@ class ConstrainAsValueExample(torch.nn.Module):
 
     def forward(self, x, y):
         a = x.item()
-        torch._constrain_as_value(a, min=0, max=5)
+        torch._check(a >= 0)
+        torch._check(a <= 5)
 
         if a < 6:
             return y.sin()

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -703,7 +703,8 @@ class FakeTensor(torch.Tensor):
         for _ in range(self.shape[0]):
             s = shape_env.create_unbacked_symint()
             # max value?
-            torch._constrain_as_size(s, min=2)
+            torch._check_is_size(s)
+            torch._check(s >= 2)
             out.append(s)
         return out
 

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -444,7 +444,7 @@ def _export_to_torch_ir(
         except GuardOnDataDependentSymNode as e:
             raise UserError(  # noqa: TRY200
                 UserErrorType.ANTI_PATTERN,
-                f"Consider annotating your code using torch._constrain_as_*(). {str(e)}",
+                f"Consider annotating your code using torch._check*(). {str(e)}",
                 case_name="constrain_as_size_example",
             )
 


### PR DESCRIPTION
To fix data-dependent errors we want to recommend that people use `torch._check*` APIs. The `constrain_as*` APIs should be fully subsumed by them, and in the future we should kill them entirely.

Differential Revision: D56774333


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @ezyang @msaroufim @bdhirsh @anijain2305 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire