### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from a few files

### DIFF
--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -197,7 +197,7 @@ void PyTorchStreamReader::init() {
   std::string version(static_cast<const char*>(version_ptr.get()), version_size);
   try {
     version_ = std::stoull(version);
-  } catch (const std::invalid_argument& e) {
+  } catch (const std::invalid_argument&) {
     CAFFE_THROW("Couldn't parse the version ",
                  version,
                  " as Long Long.");

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -107,16 +107,16 @@ static inline void PyErr_SetString(PyObject* type, const std::string& message) {
     throw;                                                          \
   }                                                                 \
   }                                                                 \
-  catch (py::error_already_set & e) {                               \
+  catch (py::error_already_set&) {                                  \
     throw;                                                          \
   }                                                                 \
-  catch (py::builtin_exception & e) {                               \
+  catch (py::builtin_exception&) {                                  \
     throw;                                                          \
   }                                                                 \
-  catch (torch::jit::JITException & e) {                            \
+  catch (torch::jit::JITException&) {                               \
     throw;                                                          \
   }                                                                 \
-  catch (const std::exception& e) {                                 \
+  catch (const std::exception&) {                                   \
     torch::translate_exception_to_python(std::current_exception()); \
     throw py::error_already_set();                                  \
   }
@@ -128,7 +128,7 @@ static inline void PyErr_SetString(PyObject* type, const std::string& message) {
     throw;                                                          \
   }                                                                 \
   }                                                                 \
-  catch (const std::exception& e) {                                 \
+  catch (const std::exception&) {                                   \
     torch::translate_exception_to_python(std::current_exception()); \
     return retval;                                                  \
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1258,7 +1258,7 @@ void ProcessGroupNCCL::heartbeatMonitor() {
                 vec.size() == sizeof(int),
                 "Invalid size for the timeout rank ID");
             std::memcpy(&timeOutRank, vec.data(), vec.size());
-          } catch (const std::exception& e) {
+          } catch (const std::exception&) {
             LOG(ERROR)
                 << "Failed to get timeout rank ID from the global store.";
           }

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -178,7 +178,7 @@ c10::optional<c10::Device> SchemaTypeParser::tryToParseDeviceType() {
       std::string::size_type num_len;
       try {
         device_idx = std::stoi(num, &num_len);
-      } catch (const std::invalid_argument& e) {
+      } catch (const std::invalid_argument&) {
         throw ErrorReport(L.cur())
             << "Device index cannot be converted to integer";
       } catch (const std::out_of_range& e) {


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: palmje


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k