### PR TITLE
[FSDP2] Removed logic to save and remove pre-backward hook handles

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -512,8 +512,8 @@ class TestFullyShardBackwardPrefetch(FSDPTest):
             loss2.sum().backward(retain_graph=True)
             expected_events = [
                 ("unshard", "1.lin2", TrainingState.PRE_BACKWARD),
-                # Check that `1.lin1` is not prefetched since it is not used
-                # for this backward
+                # NOTE: This `1.lin1` unshard is a mistargeted prefetch.
+                ("unshard", "1.lin1", TrainingState.PRE_BACKWARD),
                 ("post_backward", "1.lin2", TrainingState.POST_BACKWARD),
                 ("unshard", "0", TrainingState.PRE_BACKWARD),
                 ("post_backward", "0", TrainingState.POST_BACKWARD),
@@ -524,8 +524,8 @@ class TestFullyShardBackwardPrefetch(FSDPTest):
             model.set_is_last_backward(True)
             loss1.sum().backward()
             expected_events = [
-                # Check that `1.lin2` is not unsharded
-                ("unshard", "1.lin1", TrainingState.PRE_BACKWARD),
+                # NOTE: `1.lin1` is already unsharded from the mistargeted
+                # prefetch in the first backward.
                 # Prefetch `0`
                 ("unshard", "0", TrainingState.PRE_BACKWARD),
                 ("post_backward", "1.lin1", TrainingState.POST_BACKWARD),

--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -478,7 +478,7 @@ class TestFullyShardBackwardPrefetch(FSDPTest):
         """
         Test a model with a linear module then a split into two linear modules,
         where we run backward through one path first before the other, meaning
-        that (1) onlyh one linear of the two split is used per backward and (2)
+        that (1) only one linear of the two split is used per backward and (2)
         the initial shared linear is used in both backwards.
         """
         dim = 8
@@ -526,8 +526,9 @@ class TestFullyShardBackwardPrefetch(FSDPTest):
             expected_events = [
                 # Check that `1.lin2` is not unsharded
                 ("unshard", "1.lin1", TrainingState.PRE_BACKWARD),
-                ("post_backward", "1.lin1", TrainingState.POST_BACKWARD),
+                # Prefetch `0`
                 ("unshard", "0", TrainingState.PRE_BACKWARD),
+                ("post_backward", "1.lin1", TrainingState.POST_BACKWARD),
                 ("post_backward", "0", TrainingState.POST_BACKWARD),
             ]
             self.assertEqual(events, expected_events)

--- a/torch/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -5,7 +5,6 @@ from typing import Any, cast, Dict, List, NamedTuple, Optional, Set, Tuple, Unio
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.autograd.graph import Node
 from torch.distributed.fsdp._common_utils import _named_parameters_with_duplicates
 from torch.utils._pytree import tree_flatten, tree_unflatten
 from torch.utils.hooks import RemovableHandle
@@ -123,11 +122,6 @@ class FSDPParamGroup:
         self.comm_ctx = FSDPCommContext()
         # Group's indices in the shared post-forward order
         self._post_forward_indices: List[int] = []
-        # Used to avoid mistargeted backward prefetches when the module is used
-        # in forward but not in backward: for each forward, we record a tuple
-        # of the output's grad fns and later query the autograd engine whether
-        # any grad fn will execute in the current backward to know to prefetch.
-        self.all_forward_output_grad_fns: Set[Tuple[Node, ...]] = set()
         # Whether to reduce gradients at all (whether for FSDP or HSDP)
         self.reduce_grads: bool = True
         # Whether to all-reduce gradients for HSDP; only used if
@@ -368,7 +362,6 @@ class FSDPParamGroup:
                 fsdp_param.grad_offload_event.synchronize()
                 fsdp_param.grad_offload_event = None
         self._post_forward_indices.clear()
-        self.all_forward_output_grad_fns.clear()
 
     def _prefetch_unshard(self):
         if self._training_state == TrainingState.PRE_BACKWARD:
@@ -378,18 +371,14 @@ class FSDPParamGroup:
             curr_index = self._post_forward_indices.pop()
             if (target_index := curr_index - 1) < 0:
                 return
+            # Prefetch naively using the reverse post-forward order, which may
+            # have mistargeted prefetches if not all modules used in forward
+            # are used in this backward
             target_fsdp_param_group = self.comm_ctx.post_forward_order[target_index]
-            if any(
-                torch._C._will_engine_execute_node(grad_fn)  # type: ignore[attr-defined]
-                for grad_fns in target_fsdp_param_group.all_forward_output_grad_fns
-                for grad_fn in grad_fns
-            ):
-                with torch.profiler.record_function(
-                    "FSDP::backward_prefetch"
-                ), target_fsdp_param_group.use_training_state(
-                    TrainingState.PRE_BACKWARD
-                ):
-                    target_fsdp_param_group.unshard()
+            with torch.profiler.record_function(
+                "FSDP::backward_prefetch"
+            ), target_fsdp_param_group.use_training_state(TrainingState.PRE_BACKWARD):
+                target_fsdp_param_group.unshard()
 
     # Utilities #
     def _to_sharded(self):

--- a/torch/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -305,13 +305,11 @@ class FSDPParamGroup:
         self.comm_ctx.post_forward_order.append(self)
         self._post_forward_indices.append(post_forward_index)
 
-    def pre_backward(self, forward_grad_fns: Tuple[Any, ...], *unused: Any):
+    def pre_backward(self, *unused: Any):
         with torch.profiler.record_function("FSDP::pre_backward"):
             self._training_state = TrainingState.PRE_BACKWARD
             self.unshard()  # no-op if prefetched
             self.wait_for_unshard()
-            # Can be already removed if running multiple `backward`s
-            self.all_forward_output_grad_fns.discard(forward_grad_fns)
             self._prefetch_unshard()
 
     def post_backward(self, *unused: Any):

--- a/torch/distributed/_composable/fsdp/_fsdp_state.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_state.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 import torch.nn as nn
 from torch.autograd import Variable
-from torch.autograd.graph import Node, register_multi_grad_hook
+from torch.autograd.graph import register_multi_grad_hook
 from torch.distributed._composable_state import (
     _get_module_state,
     _insert_module_state,
@@ -199,7 +199,7 @@ class FSDPState(_State):
                 )
         return output
 
-    def _pre_backward(self: Tuple[Node, ...], *unused: Any) -> None:
+    def _pre_backward(self, *unused: Any) -> None:
         self._training_state = TrainingState.PRE_BACKWARD
         self._register_root_post_backward_final_callback()
         if self._fsdp_param_group:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125269
* #125191
* #125190

1. This PR removes the logic for saving and removing the pre-backward hook handles (which is registered via `register_multi_grad_hook(mode="any")`).
2. This PR removes the logic for _trying_ to guard against mistargeted prefetches that relies on querying if the engine will execute the module output tensors' `grad_fn`s. (See https://github.com/pytorch/pytorch/pull/118118 for original motivation.)

For 1, the logic was error prone since it relied on `set_is_last_backward(False)` being set correctly or else pre-backward hooks could be de-registered too early. We would prefer to match the hook lifetimes with that of the autograd graph. This solves a bug with a 1f1b interleaved schedule.

If we directly remove the manual saving/removing hook handle logic, then we have a ref cycle where the tensors' `grad_fn`s are passed to the hook function. We decide to simply remove this `grad_fn` logic since (1) it cannot perfectly prevent mistargeted prefetches and (2) it introduces undesired complexity. In the future, we may prefer a different mechanism to override the prefetching for more complex/dynamic use cases.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k