### PR TITLE
[Inductor] Further tune block size for templated attention on H100

### DIFF
--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, List
 
 import torch
-from .. import config, utils
+from .. import config
 from ..lowering import empty_strided, lowerings, register_lowering
 from ..select_algorithm import autotune_select_algorithm, TritonTemplate
 

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -176,9 +176,19 @@ sdpa_template = TritonTemplate(
 def _get_default_config(query):
     head_dim = query.get_size()[-1]
     default_config = None
-    is_big_shared_mem = utils.get_gpu_shared_memory() > 128 * 1024
 
-    if is_big_shared_mem:
+    if torch.cuda.get_device_capability() >= (9, 0):  # H100
+        if query.get_dtype() == torch.float32:
+            if head_dim == 64:
+                default_config = (128, 32, 4, 3)
+            else:
+                default_config = (32, 64, 4, 3)
+        else:
+            if head_dim == 64:
+                default_config = (128, 64, 4, 3)
+            else:
+                default_config = (64, 32, 4, 3)
+    elif torch.cuda.get_device_capability() >= (8, 0):  # A100
         if query.get_dtype() == torch.float32:
             default_config = (128, 32, 4, 3)
         else:
@@ -188,7 +198,7 @@ def _get_default_config(query):
                 default_config = (128, 32, 4, 3)
     else:
         if query.get_dtype() == torch.float32:
-            default_config = (32, 32, 4, 3)
+            default_config = (32, 16, 4, 3)
         else:
             default_config = (64, 32, 4, 3)
 


### PR DESCRIPTION
Run a script to enumerate and get the best default block size for templated attention.

A100 -> no change, check numbers at #125139
H100
## torch.bfloat16

Before:
```
| Type    |   Speedup |   batch_size |   num_heads |   q_seq_len |   k_seq_len |   head_dim | score_mod     | dtype          |
|---------|-----------|--------------|-------------|-------------|-------------|------------|---------------|----------------|
| Average |     1.103 |              |             |             |             |            |               |                |
| Max     |     1.322 |            8 |          16 |         512 |         512 |         64 | noop          | torch.bfloat16 |
| Min     |     0.829 |            1 |          16 |        1024 |        1024 |        128 | relative_bias | torch.bfloat16 |

```
After:
```
| Type    |   Speedup |   batch_size |   num_heads |   q_seq_len |   k_seq_len |   head_dim | score_mod     | dtype          |
|---------|-----------|--------------|-------------|-------------|-------------|------------|---------------|----------------|
| Average |     1.137 |              |             |             |             |            |               |                |
| Max     |     1.442 |            1 |          16 |         512 |         512 |        128 | relative_bias | torch.bfloat16 |
| Min     |     0.913 |            1 |          16 |        1024 |        1024 |         64 | head_bias     | torch.bfloat16 |
```

## torch.float32
Before:
```
| Type    |   Speedup |   batch_size |   num_heads |   q_seq_len |   k_seq_len |   head_dim | score_mod     | dtype         |
|---------|-----------|--------------|-------------|-------------|-------------|------------|---------------|---------------|
| Average |     2.269 |              |             |             |             |            |               |               |
| Max     |     3.740 |           16 |          16 |        1024 |        1024 |         64 | noop          | torch.float32 |
| Min     |     0.761 |            1 |          16 |         512 |         512 |        128 | relative_bias | torch.float32 |
```
After:
```
| Type    |   Speedup |   batch_size |   num_heads |   q_seq_len |   k_seq_len |   head_dim | score_mod   | dtype         |
|---------|-----------|--------------|-------------|-------------|-------------|------------|-------------|---------------|
| Average |     2.489 |              |             |             |             |            |             |               |
| Max     |     3.755 |           16 |          16 |        4096 |        4096 |         64 | noop        | torch.float32 |
| Min     |     1.609 |            1 |          16 |         512 |         512 |         64 | head_bias   | torch.float32 |
```


cc @ezyang @msaroufim @bdhirsh @anijain2305 @chauhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire