### PR TITLE
Add lintrunner as dev dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ filelock
 networkx
 jinja2
 fsspec
+lintrunner
 # setuptools was removed from default python install
 setuptools ; python_version >= "3.12"
 packaging


### PR DESCRIPTION
As per title. We expect people to use it before pushing any PR.