### PR TITLE
add simple test for nccl metadata

### DIFF
--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -10,9 +10,7 @@
 #include <libkineto.h>
 #endif
 #ifdef USE_DISTRIBUTED
-// #ifdef USE_C10D
 #include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
-// #endif // USE_C10D
 #endif // USE_DISTRIBUTED
 
 namespace torch {
@@ -337,7 +335,6 @@ std::vector<std::string> inputTypes(const at::RecordFunction& fn) {
 // -- NCCL Metadata -----------------------------------------------------------
 // ----------------------------------------------------------------------------
 #ifdef USE_DISTRIBUTED
-// #ifdef USE_C10D
 static constexpr auto kCommsName = "Collective name";
 static constexpr auto kDtype = "dtype";
 static constexpr auto kInMsgNelems = "In msg nelems";
@@ -352,14 +349,12 @@ static constexpr auto kProcessGroupDesc = "Process Group Description";
 static constexpr auto kGroupRanks = "Process Group Ranks";
 
 static constexpr int32_t kTruncatLength = 30;
-// #endif // USE_C10D
 #endif // USE_DISTRIBUTED
 
 std::unordered_map<std::string, std::string> saveNcclMeta(
     const at::RecordFunction& fn) {
   std::unordered_map<std::string, std::string> map;
 #ifdef USE_DISTRIBUTED
-  // #ifdef USE_C10D
   auto debugInfo = dynamic_cast<ParamCommsDebugInfo*>(
       c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PARAM_COMMS_INFO));
   if (debugInfo == nullptr) {
@@ -434,7 +429,6 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
                 ", "),
             groupRanks.back()));
   }
-// #endif // USE_C10D
 #endif // USE_DISTRIBUTED
   return map;
 }

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -10,9 +10,9 @@
 #include <libkineto.h>
 #endif
 #ifdef USE_DISTRIBUTED
-#ifdef USE_C10D
+// #ifdef USE_C10D
 #include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
-#endif // USE_C10D
+// #endif // USE_C10D
 #endif // USE_DISTRIBUTED
 
 namespace torch {
@@ -337,7 +337,7 @@ std::vector<std::string> inputTypes(const at::RecordFunction& fn) {
 // -- NCCL Metadata -----------------------------------------------------------
 // ----------------------------------------------------------------------------
 #ifdef USE_DISTRIBUTED
-#ifdef USE_C10D
+// #ifdef USE_C10D
 static constexpr auto kCommsName = "Collective name";
 static constexpr auto kDtype = "dtype";
 static constexpr auto kInMsgNelems = "In msg nelems";
@@ -352,14 +352,14 @@ static constexpr auto kProcessGroupDesc = "Process Group Description";
 static constexpr auto kGroupRanks = "Process Group Ranks";
 
 static constexpr int32_t kTruncatLength = 30;
-#endif // USE_C10D
+// #endif // USE_C10D
 #endif // USE_DISTRIBUTED
 
 std::unordered_map<std::string, std::string> saveNcclMeta(
     const at::RecordFunction& fn) {
   std::unordered_map<std::string, std::string> map;
 #ifdef USE_DISTRIBUTED
-#ifdef USE_C10D
+  // #ifdef USE_C10D
   auto debugInfo = dynamic_cast<ParamCommsDebugInfo*>(
       c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PARAM_COMMS_INFO));
   if (debugInfo == nullptr) {
@@ -434,7 +434,7 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
                 ", "),
             groupRanks.back()));
   }
-#endif // USE_C10D
+// #endif // USE_C10D
 #endif // USE_DISTRIBUTED
   return map;
 }

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1,6 +1,7 @@
 # mypy: ignore-errors
 
 import copy
+import json
 import itertools
 import math
 import os
@@ -8,7 +9,7 @@ import random
 import sys
 import tempfile
 import time
-from collections import namedtuple, OrderedDict
+from collections import namedtuple, OrderedDict, defaultdict
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from datetime import timedelta
@@ -81,6 +82,7 @@ from torch.testing._internal.common_utils import (
     IS_SANDCASTLE,
     skip_but_pass_in_sandcastle,
     skip_but_pass_in_sandcastle_if,
+    TemporaryFileName,
 )
 
 import torch.distributed.optim.post_localSGD_optimizer as post_localSGD_optimizer
@@ -204,6 +206,16 @@ def get_profiling_event(event_name, profiler, dedup_gpu_user_annotation=False):
         )
     ]
 
+def get_profiler_nccl_meta(prof):
+    """Torch profiler includes nccl metadata in an inserted operator called "record_param_comms"
+    We will need to test metadata obtained from profiler here"""
+    with TemporaryFileName(mode="w+") as fname:
+        prof.export_chrome_trace(fname)
+        with open(fname) as f:
+            events = json.load(f)["traceEvents"]
+    print(f"Trace saved to {fname}")
+
+    return [e for e in events if e.get("name") == "record_param_comms"]
 
 # Base error message substring on unfinished reductions.
 ddp_prev_reduction_unfinished_str = (
@@ -658,6 +670,37 @@ class DistributedTest:
                 dist.all_gather(gathered_bufs_m2, buf2)
                 for b in gathered_bufs_m2:
                     self.assertEqual(b, buf2)
+
+        def _validate_profiler_nccl_meta(self, prof):
+            """Torch profiler includes nccl metadata in an inserted operator called "record_param_comms"
+            We test for basic fields in this profiler event that correspond to the nccl communication
+            collectives"""
+            # prof.export_chrome_trace(f"/tmp/test_dpp_trace_{self.rank}.json")
+            nccl_meta_events = get_profiler_nccl_meta(prof)
+            self.assertGreater(len(nccl_meta_events), 0)
+
+            per_coll_meta = defaultdict(list)
+            for e in nccl_meta_events:
+                args = e.get("args", {})
+                collname = args.get("Collective name", "")
+                self.assertNotEqual(collname, "")
+                self.assertNotEqual(args.get("dtype", ""), "")
+
+                per_coll_meta[collname].append(args)
+                if collname in {"wait"}:
+                    continue
+
+                self.assertEqual(args["Process Group Description"], "default_pg")
+                self.assertNotEqual(args["Process Group Ranks"], "")
+
+                self.assertGreaterEqual(args.get("In msg nelems", -1), 0)
+                self.assertGreaterEqual(args.get("Out msg nelems", -1), 0)
+                self.assertGreaterEqual(args.get("Group size", -1), 0)
+                self.assertGreaterEqual(args.get("Global rank start", -1), 0)
+                self.assertGreaterEqual(args.get("Global rank stride", -1), 0)
+
+            # print(per_coll_meta)
+            return per_coll_meta
 
         def test_dump_DDP_relevant_env_vars(self):
             with captured_output() as (out, _):
@@ -1587,6 +1630,7 @@ class DistributedTest:
                         ]
                         for event in events:
                             self.assertTrue(event.input_shapes in expected_shapes)
+
 
         @skip_if_no_gpu
         @skip_but_pass_in_sandcastle_if(BACKEND != "nccl", "NCCL Send Recv Only")
@@ -6880,6 +6924,8 @@ class DistributedTest:
             events = get_profiling_event("search_unused_parameters", prof)
             self.assertEqual(len(events), 1)
 
+            return prof
+
         @require_backend_is_available(DistTestCases.backend_feature["gpu"])
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle("Currently failing in NVIDIA internal CI")
@@ -6898,7 +6944,20 @@ class DistributedTest:
             cpu_act = torch.profiler.ProfilerActivity.CPU
             cuda_act = torch.profiler.ProfilerActivity.CUDA
             torch_profiler_ctx = torch.profiler.profile(activities=[cpu_act, cuda_act])
-            self._test_ddp_profiling(profiler_ctx=torch_profiler_ctx)
+            prof = self._test_ddp_profiling(profiler_ctx=torch_profiler_ctx)
+
+            if dist.get_backend() == "nccl":
+                nccl_meta = self._validate_profiler_nccl_meta(prof)
+                self.assertEqual(len(nccl_meta["allreduce"]), 2)
+                self.assertEqual(len(nccl_meta["wait"]), 1)
+
+                # check allreduce message sizes
+                a0 = nccl_meta["allreduce"][0]
+                self.assertEqual(a0["Out msg nelems"], 100, msg=f"{a0}")
+                self.assertEqual(a0["dtype"], "Float", msg=f"{a0}")
+                a1 = nccl_meta["allreduce"][1]
+                self.assertEqual(a1["Out msg nelems"], 1, msg=f"{a1}")
+                self.assertEqual(a1["dtype"], "Int", msg=f"{a1}")
 
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -219,6 +219,9 @@ def get_profiler_nccl_meta(prof):
         events = json.load(f)["traceEvents"]
     print(f"Trace saved to {trace_file}")
 
+    # Comment to debug
+    os.remove(trace_file)
+
     return [e for e in events if e.get("name") == "record_param_comms"]
 
 # Base error message substring on unfinished reductions.
@@ -6949,6 +6952,8 @@ class DistributedTest:
             if dist.get_backend() != "nccl":
                 return
 
+            # Note comment out the "os.remove(trace_file)" in `get_profiler_nccl_meta()`
+            # to debug any mismatches.
             nccl_meta_events = get_profiler_nccl_meta(prof)
             self.assertGreater(len(nccl_meta_events), 0)
 


### PR DESCRIPTION
Add a few test cases to verify newly added NCCL metadata in profiler events
The test looks at the following blocks record_param_comms
```
{
  "ph": "X",
  "cat": "cpu_op",
  "name": "record_param_comms",
  "pid": 2840966,
  "tid": 2844581,
  "ts": 2424859.045,
  "dur": 203.866,
  "args": {
    "Collective name": "allreduce",
    "Process Group Description": "default_pg",
    "dtype": "Float",
    "In msg nelems": 100,
    "Global rank start": 0,
    "Group size": 2,
    "Process Group Ranks": "[0, 1]",
    "Record function id": 0,
    "Out msg nelems": 100,
    "Global rank stride": 1,
    "Process Group Name": "0",
  }
}
```

## Unit test

```
>$ touch /tmp/barrier && TEMP_DIR="/tmp" BACKEND="nccl" WORLD_SIZE="2" python test/distributed/test_distributed_spawn.py -v TestDistBackendWithSpawn.test_ddp_profiling_torch_profiler

test_ddp_profiling_torch_profiler (__main__.TestDistBackendWithSpawn.test_ddp_profiling_torch_profiler) ... NCCL version 2.20.5+cuda12.0
STAGE:2024-05-01 16:41:15 2840966:2840966 ActivityProfilerController.cpp:316] Completed Stage: Warm Up
STAGE:2024-05-01 16:41:15 2840965:2840965 ActivityProfilerController.cpp:316] Completed Stage: Warm Up
STAGE:2024-05-01 16:41:17 2840965:2840965 ActivityProfilerController.cpp:322] Completed Stage: Collection
STAGE:2024-05-01 16:41:17 2840966:2840966 ActivityProfilerController.cpp:322] Completed Stage: Collection
STAGE:2024-05-01 16:41:17 2840966:2840966 ActivityProfilerController.cpp:326] Completed Stage: Post Processing
STAGE:2024-05-01 16:41:17 2840965:2840965 ActivityProfilerController.cpp:326] Completed Stage: Post Processing
STAGE:2024-05-01 16:41:18 2840966:2840966 ActivityProfilerController.cpp:316] Completed Stage: Warm STAGE:2024-05-01 16:41:18 2840965:2840965 ActivityProfilerController.cpp:316] Completed Stage: Warm Up
STAGE:2024-05-01 16:41:18 2840965:2840965 ActivityProfilerController.cpp:322] Completed Stage: Collection
STAGE:2024-05-01 16:41:18 2840966:2840966 ActivityProfilerController.cpp:322] Completed Stage: Collection
STAGE:2024-05-01 16:41:18 2840965:2840965 ActivityProfilerController.cpp:326] Completed Stage: Post Processing
STAGE:2024-05-01 16:41:18 2840966:2840966 ActivityProfilerController.cpp:326] Completed Stage: Post Processing
Trace saved to /tmp/tmpvwivp7mo.json
Trace saved to /tmp/tmpvwvsc1fy.json
ok
```


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k