### PR TITLE
[DCP] Always create requests for non-tensor objects

### DIFF
--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -92,7 +92,7 @@ class TestSavePlan(TestCase):
         st = create_sharded_tensor(rank=1, world_size=4, shards_per_rank=1)
         state_dict = {"tensor": tensor, "value": val, "st": st}
         plan = create_default_local_save_plan(state_dict, False)
-        self.assertEqual(2, len(plan.items))
+        self.assertEqual(3, len(plan.items))
         wi = plan.items[0]
         self.assertEqual(wi.index, MetadataIndex("tensor", [0]))
         self.assertEqual(wi.type, WriteItemType.TENSOR)
@@ -104,7 +104,7 @@ class TestSavePlan(TestCase):
         self.assertEqual(wi.tensor_data.chunk.offsets, torch.Size([0]))
         self.assertEqual(wi.tensor_data.chunk.sizes, torch.Size([10]))
 
-        st_wi = plan.items[1]
+        st_wi = plan.items[2]
         self.assertEqual(st_wi.index, MetadataIndex("st", [8]))
         self.assertEqual(st_wi.type, WriteItemType.SHARD)
         self.assertEqual(st_wi.tensor_data.size, st.size())

--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -338,7 +338,10 @@ def create_default_local_save_plan(
         if isinstance(obj, DTensor):
             if obj.device_mesh.get_coordinate() is not None:
                 requests += _create_write_items(fqn, obj)
-        elif isinstance(obj, (torch.Tensor)) or is_coordinator:
+        else:
+            # For the plain tensor and non-tensor values, add the request for all
+            # the ranks. Coordinator will decides whether to deduplicate the
+            # values based on the keys.
             requests += _create_write_items(fqn, obj)
 
     return SavePlan(requests)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #125339
* #125338
* #125337
* #125336
* #125335
* __->__ #125334
* #125501

Summary:
If an object only exists on certain non-coordinator ranks, we still need to save them. Otherwise, we lose these objects. If they are duplicated, DCP will deduplicate them.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC