### PR TITLE
[DCP] Always flatten mapping even if no tensors present

### DIFF
--- a/test/distributed/checkpoint/test_traverse.py
+++ b/test/distributed/checkpoint/test_traverse.py
@@ -30,11 +30,15 @@ class TestTraverse(TestCase):
         self.assertIn(("key0",), data)
         self.assertEqual(data[("key0",)], 1)
 
-        self.assertIn(("key1",), data)
-        self.assertEqual(data[("key1",)], [1, 2])
+        self.assertIn(("key1", 0), data)
+        self.assertEqual(data[("key1", 0)], 1)
+        self.assertIn(("key1", 1), data)
+        self.assertEqual(data[("key1", 1)], 2)
 
-        self.assertIn(("key2",), data)
-        self.assertEqual(data[("key2",)], {1: 2, 2: 3})
+        self.assertIn(("key2", "1"), data)
+        self.assertEqual(data[("key2", "1")], 2)
+        self.assertIn(("key2", "2"), data)
+        self.assertEqual(data[("key2", "2")], 3)
 
         self.assertIn(("key3",), data)
         self.assertEqual(data[("key3",)], torch.tensor([1]))
@@ -67,12 +71,16 @@ class TestTraverse(TestCase):
         self.assertIn(("key1", 1, 1), data)
         self.assertEqual(data[("key1", 1, 1)], torch.tensor([2]))
 
-        self.assertIn(("key1", 1, 2), data)
-        self.assertEqual(data[("key1", 1, 2)], [44, 55])
-        self.assertNotIn(("key1", 1, 2, 0), data)
+        self.assertIn(("key1", 1, 2, 0), data)
+        self.assertEqual(data[("key1", 1, 2, 0)], 44)
+        self.assertIn(("key1", 1, 2, 1), data)
+        self.assertEqual(data[("key1", 1, 2, 1)], 55)
+        self.assertNotIn(("key1", 1, 2), data)
 
-        self.assertIn(("key1", 2), data)
-        self.assertEqual(data[("key1", 2)], [66, 77])
+        self.assertIn(("key1", 2, 0), data)
+        self.assertEqual(data[("key1", 2, 0)], 66)
+        self.assertIn(("key1", 2, 1), data)
+        self.assertEqual(data[("key1", 2, 1)], 77)
 
     def test_traverse_nested_dict(self) -> None:
         state_dict = {

--- a/torch/distributed/checkpoint/_traverse.py
+++ b/torch/distributed/checkpoint/_traverse.py
@@ -2,7 +2,6 @@
 from typing import (
     Callable,
     cast,
-    Collection,
     List,
     Mapping,
     MutableMapping,
@@ -27,51 +26,26 @@ CONTAINER_TYPE = MutableMapping[PATH_ITEM, STATE_DICT_ITEM]
 __all__ = ["traverse_state_dict", "set_element", "get_element", "print_tensor"]
 
 
-def _keep_visiting_tensors(value: STATE_DICT_ITEM) -> bool:
-    return isinstance(value, torch.Tensor)
-
-
 # TODO: update docstring for traverse.py
 def traverse_state_dict(
     state_dict: STATE_DICT_TYPE,
     visitor: Callable[[OBJ_PATH, STATE_DICT_ITEM], None],
-    keep_traversing: Callable[[STATE_DICT_ITEM], bool] = _keep_visiting_tensors,
 ) -> None:
     """
     Invoke ``visitor`` for each value recursively in ``state_dict``.
-
-    Traversal is short-circuited when if finds a collection for which ``keep_visiting_tensors`` evaluates
-    to false for all elements.
-    By default, all collections with at least one ``torch.Tensor`` element are traversed.
-    Visitor takes a path argument that is a tuple of the keys used to reach it.
+    Mapping, list, and tuple will be flattened and other value types are treated
+    as the terminal values and will invoke ``visitor``.
     """
 
-    # a value is terminal if it has no other containers values inside it
-    def _is_terminal(value: STATE_DICT_ITEM) -> bool:
-        values: Collection[STATE_DICT_ITEM]
-        if isinstance(value, Mapping):
-            values = value.values()
-        elif isinstance(value, list):
-            values = value
-        else:
-            return True
-
-        for entry in values:
-            if isinstance(entry, (Mapping, list)) and not _is_terminal(entry):
-                return False
-            if keep_traversing is not None and keep_traversing(entry):
-                return False
-        return True
-
     def _traverse_obj(path: OBJ_PATH, value: STATE_DICT_ITEM) -> None:
-        if _is_terminal(value):
-            visitor(path, value)
-        elif isinstance(value, Mapping):
+        if isinstance(value, Mapping):
             for k, v in value.items():
                 _traverse_obj(path + (str(k),), v)
-        elif isinstance(value, list):
+        elif isinstance(value, (list, tuple)):
             for i, v in enumerate(value):
                 _traverse_obj(path + (i,), v)
+        else:
+            visitor(path, value)
 
     for key, value in state_dict.items():
         _traverse_obj((str(key),), value)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #125339
* #125338
* #125337
* #125336
* __->__ #125335
* #125334
* #125501

Summary:
 Right now DCP only flatten a mapping (e.g., dict) if that mapping has tensor objects. This behavior is odd as users may save different non-tensor objects on different ranks. Without flattening the mappings, we may lose these non-tensor objects. One use case is dataloader state_dict.

 We may also want to do so for a list/tuple. But this will cause extra pickles. So we don't do this for now.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC