### PR TITLE
Do not call has_pending_mutation with None as input. 

### DIFF
--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -112,9 +112,8 @@ class OptimizerVariable(UserDefinedObjectVariable):
         for g in self.value.param_groups:
             for p in g["params"]:
                 side_effects = tx.output.side_effects
-                if side_effects.has_pending_mutation(
-                    side_effects.id_to_variable.get(id(p), None)
-                ):
+                variable = side_effects.id_to_variable.get(id(p), None)
+                if variable and side_effects.has_pending_mutation(variable):
                     from ..exc import Unsupported
 
                     raise Unsupported("Pending mutation on parameter")

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -318,6 +318,7 @@ class OptimizerVariable(UserDefinedObjectVariable):
                         else:
                             arg.items.append(SourcelessBuilder.create(tx, val))
 
+
     def create_finalizer(self, tx):
         names_to_delete = self.static_tensor_names
         value = self.value

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -318,7 +318,6 @@ class OptimizerVariable(UserDefinedObjectVariable):
                         else:
                             arg.items.append(SourcelessBuilder.create(tx, val))
 
-
     def create_finalizer(self, tx):
         names_to_delete = self.static_tensor_names
         value = self.value


### PR DESCRIPTION
#fix https://github.com/pytorch/pytorch/issues/125315

Several failures when inlining nn module is enabled are due to passing None to has_pending_mutation 
from previous code, it sounds like its expected for variable to be none when not found, In that case we should skip it and not call has_pending_mutation
this is tested in https://github.com/pytorch/pytorch/pull/125354
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #125354
* __->__ #125351



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang