### PR TITLE
Add module tracker

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -125,6 +125,7 @@ Features described in this documentation are classified by release status:
    torch.utils.mobile_optimizer <mobile_optimizer>
    torch.utils.model_zoo <model_zoo>
    torch.utils.tensorboard <tensorboard>
+   torch.utils.module_tracker <module_tracker>
    type_info
    named_tensor
    name_inference

--- a/docs/source/module_tracker.rst
+++ b/docs/source/module_tracker.rst
@@ -6,4 +6,3 @@ This utility can be used to track the current position inside an :class:`torch.n
 It can be used within other tracking tools to be able to easily associate measured quantities to user-friendly names. This is used in particular in the FlopCounterMode today.
 
 .. autoclass:: torch.utils.module_tracker.ModuleTracker
-

--- a/docs/source/module_tracker.rst
+++ b/docs/source/module_tracker.rst
@@ -1,0 +1,9 @@
+torch.utils.module_tracker
+===================================
+.. automodule:: torch.utils.module_tracker
+
+This utility can be used to track the current position inside an :class:`torch.nn.Module` hierarchy.
+It can be used within other tracking tools to be able to easily associate measured quantities to user-friendly names. This is used in particular in the FlopCounterMode today.
+
+.. autoclass:: torch.utils.module_tracker.ModuleTracker
+

--- a/test/test_module_tracker.py
+++ b/test/test_module_tracker.py
@@ -1,0 +1,47 @@
+import torch
+from torch.utils.module_tracker import ModuleTracker
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+from copy import copy
+
+class TestModuleTracker(TestCase):
+    def test_module_hierarchy(self):
+        seen_fw = []
+        seen_bw = []
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                x = x['a'].relu_()
+                seen_fw.append((copy(tracker.parents), tracker.is_bw))
+                x.register_hook(lambda grad: seen_bw.append((copy(tracker.parents), tracker.is_bw)))
+                return {'a': torch.mm(x, x)}
+
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = Foo()
+                self.b = Foo()
+
+            def forward(self, x):
+                return self.b(self.a(x))
+
+        mod = Mod()
+
+        with ModuleTracker() as tracker:
+            mod({'a': torch.randn(10, 10, requires_grad=True).clone()})['a'].sum().backward()
+            mod({'a': torch.randn(10, 10, requires_grad=True).clone()})['a'].sum().backward()
+
+        self.assertEqual(seen_fw, [
+            ({"Global", "Mod", "Mod.a"}, False),
+            ({"Global", "Mod", "Mod.b"}, False),
+            ({"Global", "Mod", "Mod.a"}, False),
+            ({"Global", "Mod", "Mod.b"}, False)])
+
+        self.assertEqual(seen_bw, [
+            ({"Global", "Mod", "Mod.b"}, True),
+            ({"Global", "Mod", "Mod.a"}, True),
+            ({"Global", "Mod", "Mod.b"}, True),
+            ({"Global", "Mod", "Mod.a"}, True)])
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/test_module_tracker.py
+++ b/test/test_module_tracker.py
@@ -1,19 +1,25 @@
-import torch
-from torch.utils.module_tracker import ModuleTracker
-from torch.testing._internal.common_utils import TestCase, run_tests
+# Owner(s): ["module: unknown"]
 
 from copy import copy
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.utils.module_tracker import ModuleTracker
+
 
 class TestModuleTracker(TestCase):
     def test_module_hierarchy(self):
         seen_fw = []
         seen_bw = []
+
         class Foo(torch.nn.Module):
             def forward(self, x):
-                x = x['a'].relu_()
+                x = x["a"].relu_()
                 seen_fw.append((copy(tracker.parents), tracker.is_bw))
-                x.register_hook(lambda grad: seen_bw.append((copy(tracker.parents), tracker.is_bw)))
-                return {'a': torch.mm(x, x)}
+                x.register_hook(
+                    lambda grad: seen_bw.append((copy(tracker.parents), tracker.is_bw))
+                )
+                return {"a": torch.mm(x, x)}
 
         class Mod(torch.nn.Module):
             def __init__(self):
@@ -27,21 +33,33 @@ class TestModuleTracker(TestCase):
         mod = Mod()
 
         with ModuleTracker() as tracker:
-            mod({'a': torch.randn(10, 10, requires_grad=True).clone()})['a'].sum().backward()
-            mod({'a': torch.randn(10, 10, requires_grad=True).clone()})['a'].sum().backward()
+            mod({"a": torch.randn(10, 10, requires_grad=True).clone()})[
+                "a"
+            ].sum().backward()
+            mod({"a": torch.randn(10, 10, requires_grad=True).clone()})[
+                "a"
+            ].sum().backward()
 
-        self.assertEqual(seen_fw, [
-            ({"Global", "Mod", "Mod.a"}, False),
-            ({"Global", "Mod", "Mod.b"}, False),
-            ({"Global", "Mod", "Mod.a"}, False),
-            ({"Global", "Mod", "Mod.b"}, False)])
+        self.assertEqual(
+            seen_fw,
+            [
+                ({"Global", "Mod", "Mod.a"}, False),
+                ({"Global", "Mod", "Mod.b"}, False),
+                ({"Global", "Mod", "Mod.a"}, False),
+                ({"Global", "Mod", "Mod.b"}, False),
+            ],
+        )
 
-        self.assertEqual(seen_bw, [
-            ({"Global", "Mod", "Mod.b"}, True),
-            ({"Global", "Mod", "Mod.a"}, True),
-            ({"Global", "Mod", "Mod.b"}, True),
-            ({"Global", "Mod", "Mod.a"}, True)])
+        self.assertEqual(
+            seen_bw,
+            [
+                ({"Global", "Mod", "Mod.b"}, True),
+                ({"Global", "Mod", "Mod.a"}, True),
+                ({"Global", "Mod", "Mod.b"}, True),
+                ({"Global", "Mod", "Mod.a"}, True),
+            ],
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_tests()

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -348,8 +348,7 @@ class FlopCounterMode(TorchDispatchMode):
     .. code-block:: python
 
         mod = ...
-        flop_counter = FlopCounterMode(mod)
-        with flop_counter:
+        with FlopCounterMode(mod) as flop_counter:
             mod.sum().backward()
 
     """

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -1,13 +1,13 @@
 import torch
-import torch.nn as nn
 from torch.utils._pytree import tree_map, tree_flatten, tree_unflatten
-from typing import List, Any, Dict, Optional, Union, NamedTuple
+from .module_tracker import ModuleTracker
+from typing import List, Any, Dict, Optional, Union
 from collections import defaultdict
 from torch.utils._python_dispatch import TorchDispatchMode
-from torch.utils.hooks import RemovableHandle
 from torch._decomp import register_decomposition
 from math import prod
 from functools import wraps
+import warnings
 
 
 
@@ -361,100 +361,16 @@ class FlopCounterMode(TorchDispatchMode):
             custom_mapping: Optional[Dict[Any, Any]] = None):
         self.flop_counts: Dict[str, Dict[Any, int]] = defaultdict(lambda: defaultdict(int))
         self.depth = depth
-        self.parents = ["Global"]
-        self.in_backward = False
         self.display = display
         if custom_mapping is None:
             custom_mapping = {}
-        if isinstance(mods, torch.nn.Module):
-            mods = [mods]
-        self.mods = mods
-        # Keys will include the modules in `mods` and their submodules
-        self._module_to_forward_hook_handles: Dict[nn.Module, _ForwardHookHandles] = {}
+        if mods is not None:
+            warnings.warn("mods argument is not needed anymore, you can stop passing it", stacklevel=2)
         self.flop_registry = {
             **flop_registry,
             **{k: v if getattr(v, "_get_raw", False) else shape_wrapper(v) for k, v in custom_mapping.items()}
         }
-
-    def _register_forward_hooks(self):
-        if self.mods is None:
-            return
-        for mod in self.mods:
-            prefix = type(mod).__name__
-            for name, module in dict(mod.named_modules()).items():
-                if name == "":
-                    name = prefix
-                else:
-                    name = ".".join([prefix, name])
-
-                forward_pre_hook_handle, forward_hook_handle = (None, None)
-
-                try:
-                    forward_pre_hook_handle = module.register_forward_pre_hook(self._enter_module(name))
-                    forward_hook_handle = module.register_forward_hook(self._exit_module(name))
-                except RuntimeError:
-                    # ignore any module that doesn't support forward hook, e.g. script.
-                    if forward_pre_hook_handle is not None:
-                        forward_pre_hook_handle.remove()
-                else:
-                    self._module_to_forward_hook_handles[module] = _ForwardHookHandles(
-                        forward_pre_hook_handle, forward_hook_handle
-                    )
-
-    def _deregister_forward_hooks(self):
-        for forward_hook_handles in self._module_to_forward_hook_handles.values():
-            forward_hook_handles[0].remove()
-            forward_hook_handles[1].remove()
-        self._module_to_forward_hook_handles.clear()
-
-    def _enter_module(self, name):
-        def f(module, inputs):
-            out = _pytreeify_preserve_structure(self._create_pre_module(name))(inputs)
-            return out
-
-        return f
-
-    def _exit_module(self, name):
-        def f(module, inputs, outputs):
-            outputs = _pytreeify_preserve_structure(self._create_post_module(name))(outputs)
-            return outputs
-        return f
-
-    def _create_post_module(self, name):
-        class PushState(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, *args):
-                assert self.parents[-1] == name, f"{self.parents[-1]} is not {name}"
-                self.parents.pop()
-                args = tree_map(lambda x: x.clone() if isinstance(x, torch.Tensor) else x, args)
-                return args
-
-            @staticmethod
-            def backward(ctx, *grad_outs):
-                self.in_backward = True
-                self.parents.append(name)
-                return grad_outs
-
-        return PushState.apply
-
-    def _create_pre_module(self, name):
-        class PopState(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, *args):
-                if self.in_backward:
-                    self.parents = ["Global"]
-                    self.in_backward = True
-                self.parents.append(name)
-                args = tree_map(lambda x: x.clone() if isinstance(x, torch.Tensor) else x, args)
-                return args
-
-            @staticmethod
-            def backward(ctx, *grad_outs):
-                assert self.parents[-1] == name
-                self.parents.pop()
-                return grad_outs
-
-        return PopState.apply
+        self.mod_tracker = ModuleTracker()
 
     def get_total_flops(self) -> int:
         return sum(self.flop_counts['Global'].values())
@@ -507,7 +423,7 @@ class FlopCounterMode(TorchDispatchMode):
                 ])
             return values
 
-        for mod in self.flop_counts.keys():
+        for mod in sorted(self.flop_counts.keys()):
             if mod == 'Global':
                 continue
             mod_depth = mod.count(".") + 1
@@ -533,15 +449,15 @@ class FlopCounterMode(TorchDispatchMode):
 
     def __enter__(self):
         self.flop_counts.clear()
-        self._register_forward_hooks()
+        self.mod_tracker.__enter__()
         super().__enter__()
         return self
 
     def __exit__(self, *args):
+        super().__exit__(*args)
+        self.mod_tracker.__exit__()
         if self.display:
             print(self.get_table(self.depth))
-        self._deregister_forward_hooks()
-        super().__exit__(*args)
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         kwargs = kwargs if kwargs else {}
@@ -552,17 +468,7 @@ class FlopCounterMode(TorchDispatchMode):
         if func_packet in self.flop_registry:
             flop_count_func = self.flop_registry[func_packet]
             flop_count = flop_count_func(*args, **kwargs, out_val=out)  # type: ignore[operator]
-            if len(set(self.parents)) != len(self.parents):
-                print(
-                    "The module hierarchy tracking seems to be messed up."
-                    "Please file a bug or just run the flop counter without"
-                    "tracking the module hierarchy (i.e. `with FlopCounterMode():`)"
-                )
-            for par in set(self.parents):
+            for par in set(self.mod_tracker.parents):
                 self.flop_counts[par][func_packet] += flop_count
 
         return out
-
-class _ForwardHookHandles(NamedTuple):
-    forward_pre_hook_handle: RemovableHandle
-    forward_hook_handle: RemovableHandle

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -1,5 +1,7 @@
 import weakref
 
+from typing import Set
+
 import torch
 from torch.autograd.graph import register_multi_grad_hook
 from torch.nn.modules.module import (
@@ -8,7 +10,6 @@ from torch.nn.modules.module import (
 )
 from torch.utils._pytree import tree_flatten
 
-from typing import Set
 
 class ModuleTracker:
     """

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -8,6 +8,7 @@ from torch.nn.modules.module import (
 )
 from torch.utils._pytree import tree_flatten
 
+from typing import Set
 
 class ModuleTracker:
     """
@@ -16,7 +17,8 @@ class ModuleTracker:
     executed).
 
     You can access the ``parents`` attribute on this context manager to get the set of all the
-    Modules currently being executed via their fqn.
+    Modules currently being executed via their fqn (fully qualified named, also used as the key within
+    the state_dict).
     You can access the ``is_bw`` attribute to know if you are currently running in backward or not.
 
     Note that the ``parents`` is never empty and always contains the "Global" key. The ``is_bw`` flag
@@ -38,6 +40,16 @@ class ModuleTracker:
 
             mod(torch.rand(2, 2))
 
+    """
+
+    parents: Set[str]
+    """
+    A Set containing the fqn for each module currently running their forward
+    """
+
+    is_bw: bool
+    """
+    A boolean marking if this is currently running during the backward pass or not
     """
 
     def __init__(self):

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -15,13 +15,14 @@ class ModuleTracker:
     so that other system which Module is currently being executed (or its backward is being
     executed).
 
-    You can access the ``parents`` attribute on this context manager to get the set of all the current
+    You can access the ``parents`` attribute on this context manager to get the set of all the
     Modules currently being executed via their fqn.
     You can access the ``is_bw`` attribute to know if you are currently running in backward or not.
 
     Note that the ``parents`` is never empty and always contains the "Global" key. The ``is_bw`` flag
     will remain ``True`` after the forward until another Module is executed. If you need it to be
-    more accurate, please submit an issue.
+    more accurate, please submit an issue requesting this. Adding a map from fqn to the module instance
+    is possible but not done yet, please submit and issue requesting this if you need it.
 
     Example usage
 

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -14,18 +14,18 @@ from torch.utils._pytree import tree_flatten
 class ModuleTracker:
     """
     ``ModuleTracker`` is a context manager that tracks the nn.Module hierarchy during execution
-    so that other system which Module is currently being executed (or its backward is being
+    so that other system can query which Module is currently being executed (or its backward is being
     executed).
 
     You can access the ``parents`` attribute on this context manager to get the set of all the
-    Modules currently being executed via their fqn (fully qualified named, also used as the key within
+    Modules currently being executed via their fqn (fully qualified name, also used as the key within
     the state_dict).
     You can access the ``is_bw`` attribute to know if you are currently running in backward or not.
 
-    Note that the ``parents`` is never empty and always contains the "Global" key. The ``is_bw`` flag
+    Note that ``parents`` is never empty and always contains the "Global" key. The ``is_bw`` flag
     will remain ``True`` after the forward until another Module is executed. If you need it to be
     more accurate, please submit an issue requesting this. Adding a map from fqn to the module instance
-    is possible but not done yet, please submit and issue requesting this if you need it.
+    is possible but not done yet, please submit an issue requesting this if you need it.
 
     Example usage
 
@@ -68,7 +68,7 @@ class ModuleTracker:
         if mod not in self._seen_modules:
             for name, submod in mod.named_children():
                 self._known_modules[submod] = f"{mod_name}.{name}"
-        return self._known_modules[mod]
+        return mod_name
 
     def _get_append_fn(self, name, is_bw):
         def fn(*args):
@@ -78,7 +78,7 @@ class ModuleTracker:
             if name in self.parents:
                 print(
                     "The module hierarchy tracking seems to be messed up."
-                    "Please file a bug to PyTorch`)"
+                    "Please file a bug to PyTorch."
                 )
             self.parents.add(name)
 

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -30,6 +30,7 @@ class ModuleTracker:
     Example usage
 
     .. code-block:: python
+
         mod = torch.nn.Linear(2, 2)
 
         with ModuleTracker() as tracker:

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -1,0 +1,106 @@
+import torch
+from torch import nn
+from torch.nn.modules.module import register_module_forward_hook, register_module_forward_pre_hook
+from torch.autograd.graph import register_multi_grad_hook
+from torch.utils._pytree import tree_flatten
+
+import weakref
+import gc
+from collections import OrderedDict
+
+class ModuleTracker():
+    """
+    ``ModuleTracker`` is a context manager that tracks the nn.Module hierarchy during execution
+    so that other system which Module is currently being executed (or its backward is being
+    executed).
+
+    You can access the ``parents`` attribute on this context manager to get the set of all the current
+    Modules currently being executed via their fqn.
+    You can access the ``is_bw`` attribute to know if you are currently running in backward or not.
+
+    Note that the ``parents`` is never empty and always contains the "Global" key. The ``is_bw`` flag
+    will remain ``True`` after the forward until another Module is executed. If you need it to be
+    more accurate, please submit an issue.
+
+    Example usage
+
+    .. code-block:: python
+        mod = torch.nn.Linear(2, 2)
+
+        with ModuleTracker() as tracker:
+            # Access anything during the forward pass
+            def my_linear(m1, m2, bias):
+                print(f"Current modules: {tracker.parents}")
+                return torch.mm(m1, m2.t()) + bias
+            torch.nn.functional.linear = my_linear
+
+            mod(torch.rand(2, 2))
+
+    """
+
+    def __init__(self):
+        self.parents = {"Global"}
+        # This is used to reset parents at the end of the backward
+        self.is_bw = False
+        self._known_modules = weakref.WeakKeyDictionary()
+        self._seen_modules = set()
+
+    def _get_mod_name(self, mod):
+        if mod not in self._known_modules:
+            self._known_modules[mod] = type(mod).__name__
+        mod_name = self._known_modules[mod]
+        if mod not in self._seen_modules:
+            for name, submod in mod.named_children():
+                self._known_modules[submod] = f"{mod_name}.{name}"
+        return self._known_modules[mod]
+
+    def _get_append_fn(self, name, is_bw):
+        def fn(*args):
+            if self.is_bw != is_bw:
+                self.parents = {"Global"}
+                self.is_bw = is_bw
+            if name in self.parents:
+                print(
+                    "The module hierarchy tracking seems to be messed up."
+                    "Please file a bug to PyTorch`)"
+                )
+            self.parents.add(name)
+        return fn
+
+    def _get_pop_fn(self, name, is_bw):
+        def fn(*args):
+            if name in self.parents:
+                self.parents.remove(name)
+            elif not is_bw:
+                # Due to some input/output not requiring gradients, we cannot enforce
+                # proper nesting in backward
+                raise RuntimeError("The Module hierarchy tracking is wrong. Report a bug to PyTorch")
+        return fn
+
+    def _fw_pre_hook(self, mod, input):
+        name = self._get_mod_name(mod)
+        self._get_append_fn(name, False)()
+
+        args, _ = tree_flatten(input)
+        tensors = list(a for a in args if isinstance(a, torch.Tensor) and a.requires_grad)
+        if tensors:
+            register_multi_grad_hook(tensors, self._get_pop_fn(name, True))
+
+    def _fw_post_hook(self, mod, input, output):
+        name = self._get_mod_name(mod)
+        self._get_pop_fn(name, False)()
+
+        args, _ = tree_flatten(output)
+        tensors = list(a for a in args if isinstance(a, torch.Tensor) and a.requires_grad)
+        if tensors:
+            register_multi_grad_hook(tensors, self._get_append_fn(name, True))
+
+    def __enter__(self):
+        self._fw_pre_handle = register_module_forward_pre_hook(self._fw_pre_hook)
+        self._fw_post_handle = register_module_forward_hook(self._fw_post_hook)
+        return self
+
+    def __exit__(self, *args):
+        self._fw_pre_handle.remove()
+        self._fw_post_handle.remove()
+


### PR DESCRIPTION
This does a few things that were originally a few PRs but I am on a new machine and don't have ghstack.
If it is too problematic to review, I can re-split, just let me know.
This does:
- Cleanup context manager use in test_flop_counter
- Remove need for mod argument in FlopCounterMode, warning about it
- Re-implement a Module tracker from scratch using global forward Module use and multi_grad_hook (we cannot use global backward Module hook because they don't look for nested Tensor and they're custom Function based instead of multi_grad_hook).
- Update FlopCouterMode to use the new ModuleTracker. All the existing test suite passes as-is (only changes there are new tests and refactoring mentioned above)