### PR TITLE
[c10d] only PG0 should dump when monitoring thread timed out

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -389,6 +389,7 @@ TEST_F(ProcessGroupNCCLErrorsTest, testNCCLErrorsNoHeartbeat) {
       setenv("TORCH_NCCL_DEBUG_INFO_TEMP_FILE", tempFilename.c_str(), 1) == 0);
   // Enable nccl flight recorder.
   ASSERT_TRUE(setenv("TORCH_NCCL_TRACE_BUFFER_SIZE", "10", 1) == 0);
+  ASSERT_TRUE(setenv(c10d::TORCH_NCCL_DUMP_ON_TIMEOUT[0].c_str(), "1", 1) == 0);
   auto options = c10d::ProcessGroupNCCL::Options::create();
   // Set a long watchdog timeout, so that we have enough time to lock the
   // watchdog and let the heartbeat monitor thread to kick in.

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1251,7 +1251,9 @@ void ProcessGroupNCCL::heartbeatMonitor() {
         if (globalStore_->check({std::string(EXCEPTION_DUMP)})) {
           int timeOutRank = -1;
           if (!shouldDump_.load()) {
-            LOG(ERROR) << logPrefix() << "First PG on this rank detecting the dump signal through tcpstore.";
+            LOG(ERROR)
+                << logPrefix()
+                << "First PG on this rank detecting the dump signal through tcpstore.";
           }
           shouldDump_.store(true);
           try {
@@ -1299,7 +1301,9 @@ void ProcessGroupNCCL::heartbeatMonitor() {
         heartBeatCounter = heartbeat;
       } else {
         if (!shouldDump_.load()) {
-          LOG(ERROR) << logPrefix() << "First PG on this rank that detected no heartbeat of its watchdog.";
+          LOG(ERROR)
+              << logPrefix()
+              << "First PG on this rank that detected no heartbeat of its watchdog.";
         }
         shouldDump_.store(true);
         // No heartbeat increase detected and timeout.
@@ -1577,14 +1581,14 @@ void ProcessGroupNCCL::watchdogHandler() {
       if (work.exception()) {
         // log as soon as exception is detected
         LOG(ERROR) << c10::str(
-              logPrefix(),
-              "Exception (either an error or timeout) detected by watchdog at work: ",
-              work.seq_,
-              ", last enqueued NCCL work: ",
-              lastEnqueuedSeq_,
-              ", last completed NCCL work: ",
-              lastCompletedSeq_,
-              ".");
+            logPrefix(),
+            "Exception (either an error or timeout) detected by watchdog at work: ",
+            work.seq_,
+            ", last enqueued NCCL work: ",
+            lastEnqueuedSeq_,
+            ", last completed NCCL work: ",
+            lastCompletedSeq_,
+            ".");
         // try to dump flight records if exception happens.
         // Flight recorder behavior should be independent of desync Debug
         if (dumpOnException_) {
@@ -1595,7 +1599,8 @@ void ProcessGroupNCCL::watchdogHandler() {
                 reinterpret_cast<uint8_t*>(&rank) + sizeof(rank));
             globalStore_->set(std::string(EXCEPTION_DUMP), vec);
             if (!shouldDump_.load()) {
-              LOG(ERROR) << logPrefix() << "First watchdog to set the dump signal.";
+              LOG(ERROR) << logPrefix()
+                         << "First watchdog to set the dump signal.";
             }
             // signal the monitor thread to start dumping
             shouldDump_.store(true);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125356

Summary:
We found that some dumps are missing when monitoring thread timeout.
This is likely due to multiple PGs could still dump the same records
at the same time. So we should allow only PG0 to actualy dump
Test Plan:
 unit test
python test/run_test.py --cpp --verbose -i cpp/ProcessGroupNCCLErrorsTest
Tags:

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k