### PR TITLE
[ATen-VK] Resolve compiler_flags to allow Mac build

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Adapter.cpp
+++ b/aten/src/ATen/native/vulkan/api/Adapter.cpp
@@ -44,10 +44,10 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
       handle, &queue_family_count, queue_families.data());
 
   // Find the total number of compute queues
-  for (const VkQueueFamilyProperties& properties : queue_families) {
+  for (const VkQueueFamilyProperties& p : queue_families) {
     // Check if this family has compute capability
-    if (properties.queueFlags & VK_QUEUE_COMPUTE_BIT) {
-      num_compute_queues += properties.queueCount;
+    if (p.queueFlags & VK_QUEUE_COMPUTE_BIT) {
+      num_compute_queues += p.queueCount;
     }
   }
 }

--- a/c2_defs.bzl
+++ b/c2_defs.bzl
@@ -274,6 +274,9 @@ C2_FBOBJC_EXTRA_TARGET_CONFIG = {
     "MTL_LANGUAGE_REVISION": "Metal12",
 }
 
+def get_c2_torch_vulkan_compiler_flags():
+    return ["-Wno-missing-prototypes"]
+
 def get_c2_default_cxx_args():
     return dict(
         header_namespace = "",


### PR DESCRIPTION
Summary:
## `-Wmissing-prototypes`

In ATen-Vulkan, we often define functions in `.cpp` files without declaring them in `.h` files without hiding them in an anonymous namespace.

Example: [`Packing.cpp`'s channel_image_repacking()](https://github.com/pytorch/pytorch/blob/f1f142c44f81384afbdba5e451fc15744868bf26/aten/src/ATen/native/vulkan/impl/Packing.cpp#L299-L348)

On Mac, this results in a `-Wmissing-prototypes` warning, which is disabled in this change.

## `-Wshadow`

In `Adapter.cpp`, we overwrite a variable called `properties`, which we fix in this change as opposed to disabling the warning.

Test Plan: CI

Differential Revision: D56850324
