### PR TITLE
Avoid changing RNG state for `DataLoader(..., shuffle=False)`

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1372,6 +1372,32 @@ except RuntimeError as e:
             del loader1_it
             del loader2_it
 
+    def test_no_shuffle_preserves_RNG_state(self):
+        seed_reset = torch.seed()
+
+        try:
+            torch.manual_seed(seed_reset)
+            before = torch.randint(0, 200, (1, )).item()
+
+            torch.manual_seed(seed_reset)
+            data = torch.arange(100)
+            dl = DataLoader(data, batch_size=4, shuffle=False)
+            iter(dl)
+            after = torch.randint(0, 200, (1, )).item()
+
+            self.assertEqual(before, after)
+
+        finally:
+            torch.manual_seed(seed_reset)
+
+        generator = torch.Generator()
+        generator.manual_seed(seed_reset)
+        data = torch.arange(100)
+        dl = DataLoader(data, batch_size=4, shuffle=False, generator=generator)
+        iter(dl)
+
+        self.assertEqual(seed_reset, generator.initial_seed())
+
     def test_segfault(self):
         p = ErrorTrackingProcess(target=_test_segfault)
         p.start()

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1375,21 +1375,19 @@ except RuntimeError as e:
     def test_no_shuffle_preserves_RNG_state(self):
         seed_reset = torch.seed()
 
-        try:
-            torch.manual_seed(seed_reset)
-            before = torch.randint(0, 200, (1, )).item()
+        # Test the global seed
+        torch.manual_seed(seed_reset)
+        before = torch.randint(0, 200, (1,)).item()
 
-            torch.manual_seed(seed_reset)
-            data = torch.arange(100)
-            dl = DataLoader(data, batch_size=4, shuffle=False)
-            iter(dl)
-            after = torch.randint(0, 200, (1, )).item()
+        torch.manual_seed(seed_reset)
+        data = torch.arange(100)
+        dl = DataLoader(data, batch_size=4, shuffle=False)
+        iter(dl)
+        after = torch.randint(0, 200, (1,)).item()
 
-            self.assertEqual(before, after)
+        self.assertEqual(before, after)
 
-        finally:
-            torch.manual_seed(seed_reset)
-
+        # Test with a generator
         generator = torch.Generator()
         generator.manual_seed(seed_reset)
         data = torch.arange(100)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -597,7 +597,17 @@ class _BaseDataLoaderIter:
         self._timeout = loader.timeout
         self._collate_fn = loader.collate_fn
         self._sampler_iter = iter(self._index_sampler)
-        self._base_seed = torch.empty((), dtype=torch.int64).random_(generator=loader.generator).item()
+
+        def init_base_seed():
+            tmp_generator = torch.Generator()
+            if loader.generator is None:
+                initial_seed = torch.initial_seed()
+            else:
+                initial_seed = loader.generator.initial_seed()
+            tmp_generator.manual_seed(initial_seed)
+            return torch.empty((), dtype=torch.int64).random_(generator=tmp_generator).item()
+
+        self._base_seed = init_base_seed()
         self._persistent_workers = loader.persistent_workers
         self._num_yielded = 0
         self._profile_name = f"enumerate(DataLoader)#{self.__class__.__name__}.__next__"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125370

Fixes #122697