### PR TITLE
Always pass down kernel_file and grid as string

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -794,14 +794,18 @@ class CachingAutotuner(KernelInterface):
         # manager is a nullcontext.
         if autograd_profiler._is_profiler_enabled:
             # grid can be a tuple of ints or a string.
-            grid_info = (
-                grid if isinstance(grid, tuple) else getattr(grid, "grid_fn_str", None)
-            )
+            if isinstance(grid, tuple):
+                grid_info = "("
+                for e in grid:
+                    grid_info = grid_info + f"{e},"
+                grid_info = grid_info + ")"
+            else:
+                grid_info = getattr(grid, "grid_fn_str", "")
             with torch._C._profiler._RecordFunctionFast(
                 self.inductor_meta.get("kernel_name", "triton kernel"),
                 args,
                 {
-                    "kernel_file": self.filename,
+                    "kernel_file": "" if self.filename is None else self.filename,
                     "kernel_backend": "triton",
                     "grid": grid_info,
                     "stream": stream,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -795,10 +795,7 @@ class CachingAutotuner(KernelInterface):
         if autograd_profiler._is_profiler_enabled:
             # grid can be a tuple of ints or a string.
             if isinstance(grid, tuple):
-                grid_info = "("
-                for e in grid:
-                    grid_info = grid_info + f"{e},"
-                grid_info = grid_info + ")"
+                grid_info = str(grid)
             else:
                 grid_info = getattr(grid, "grid_fn_str", "")
             with torch._C._profiler._RecordFunctionFast(


### PR DESCRIPTION
From my test with Ads production workload, I found sometime kernel_file is None and grid is a tuple. It will crash since ExecutionTraceObserver expects string for both kernel_file and grid. This PR is to make sure  kernel_file and grid are always passed down as string. Need to find the root cause why kernel_file is none.

Unit test:
     buck test  @mode/dev-nosan caffe2/test:profiler -- test_execution_trace_with_pt2



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang