### PR TITLE
[AOTI] Generate mul_Scalar instead of mul_Tensor

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -71,6 +71,7 @@ test_failures_cpp_wrapper = {
 
 if config.abi_compatible:
     xfail_list = [
+        "test_add_complex_cpu",
         "test_bernoulli1_cpu",  # cpp fallback op naming issue
         "test_conv2d_binary_inplace_fusion_failed_cpu",
         "test_conv2d_binary_inplace_fusion_pass_cpu",
@@ -173,6 +174,7 @@ if RUN_CPU:
         code_string_count: dict = {}
 
     for item in [
+        BaseTest("test_add_complex"),
         BaseTest("test_add_complex4"),
         BaseTest("test_as_strided"),  # buffer reuse
         BaseTest("test_bernoulli1"),

--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -97,6 +97,7 @@ if TEST_WITH_ROCM:
 
 if config.abi_compatible:
     xfail_list = [
+        "test_add_complex_cuda",
         "test_bernoulli1_cuda",  # cpp fallback op naming issue
         "test_conv_backward_cuda",
         "test_profiler_mark_wrapper_call_cuda",
@@ -183,6 +184,7 @@ if RUN_CUDA:
 
     # Maintain two separate test lists for cuda and cpp for now
     for item in [
+        BaseTest("test_add_complex"),
         BaseTest("test_add_complex4"),
         BaseTest("test_as_strided"),  # buffer reuse
         BaseTest("test_batch_norm_2d_2"),

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5522,6 +5522,15 @@ class FallbackKernel(ExternKernelAlloc):
         if kernel.namespace == "aten":  # type: ignore[union-attr]
             # Aten Fallback Ops
             assert isinstance(kernel, torch._ops.OpOverload)
+
+            if (
+                kernel == aten.mul.Tensor
+                and len(self.inputs) == 1
+                and len(self.constant_args) == 1
+            ):
+                # When aten.mul.Tensor's second arg is constant, cpp wrapper expects to call mul_Scalar
+                kernel = aten.mul.Scalar
+
             if V.graph.cpp_wrapper:
                 if (
                     config.is_fbcode()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125397
* #125329

Summary: Fix https://github.com/pytorch/pytorch/issues/117365. When the second argument to aten.mul.Tensor is a scalar (e.g. scale factor), the cpp wrapper expects to generate a call to mul_Scalar when fallback happens (e.g. Complex dtype).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang