### PR TITLE
Fix hardcoded rocm warp size

### DIFF
--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -125,7 +125,11 @@ inline __host__ __device__ uint32_t getAlignmentRoundUp(const void* p) {
   return diff == 0 ? 0 : uint32_t(Align) - diff;
 }
 
+#if defined(USE_ROCM)
+constexpr int32_t kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
+#else
 constexpr int32_t kWarpSize = 32;
+#endif
 
 #if (defined(CUDA_VERSION) && CUDA_VERSION >= 12000) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800))
 // f16 vector types

--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -126,7 +126,7 @@ inline __host__ __device__ uint32_t getAlignmentRoundUp(const void* p) {
 }
 
 #if defined(USE_ROCM)
-constexpr int32_t kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
+constexpr int32_t kWarpSize = warpSize;
 #else
 constexpr int32_t kWarpSize = 32;
 #endif

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
@@ -242,8 +242,11 @@ struct AttentionBackwardKernel {
   static constexpr bool kKeysQueriesAlignedToBlockSize =
       kKeysQueriesAlignedToBlockSize_;
 
+#if defined(USE_ROCM) 
+  static constexpr int64_t kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
+#else
   static constexpr int64_t kWarpSize = 32;
-
+#endif
   // If this is true, we store and accumulate dK/dV in RF
   // rather than going back to gmem everytime
   static constexpr bool kIsHalf = cutlass::sizeof_bits<scalar_t>::value <= 16;

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
@@ -242,7 +242,7 @@ struct AttentionBackwardKernel {
   static constexpr bool kKeysQueriesAlignedToBlockSize =
       kKeysQueriesAlignedToBlockSize_;
 
-#if defined(USE_ROCM) 
+#if defined(USE_ROCM)
   static constexpr int64_t kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
 #else
   static constexpr int64_t kWarpSize = 32;

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h
@@ -243,7 +243,7 @@ struct AttentionBackwardKernel {
       kKeysQueriesAlignedToBlockSize_;
 
 #if defined(USE_ROCM)
-  static constexpr int64_t kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
+  static constexpr int64_t kWarpSize = warpSize;
 #else
   static constexpr int64_t kWarpSize = 32;
 #endif

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -122,8 +122,12 @@ struct AttentionKernel {
   static_assert(kKeysPerBlock % 32 == 0, "");
   static constexpr int kNumWarpsPerBlock =
       kQueriesPerBlock * kKeysPerBlock / (32 * 32);
+  
+#if defined(USE_ROCM)
+  static constexpr int kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
+#else
   static constexpr int kWarpSize = 32;
-
+#endif
   // Launch bounds
   static constexpr int kNumThreads = kWarpSize * kNumWarpsPerBlock;
   static constexpr int kMinBlocksPerSm =

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -122,7 +122,7 @@ struct AttentionKernel {
   static_assert(kKeysPerBlock % 32 == 0, "");
   static constexpr int kNumWarpsPerBlock =
       kQueriesPerBlock * kKeysPerBlock / (32 * 32);
-  
+
 #if defined(USE_ROCM)
   static constexpr int kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
 #else

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h
@@ -124,7 +124,7 @@ struct AttentionKernel {
       kQueriesPerBlock * kKeysPerBlock / (32 * 32);
 
 #if defined(USE_ROCM)
-  static constexpr int kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
+  static constexpr int kWarpSize = warpSize;
 #else
   static constexpr int kWarpSize = 32;
 #endif

--- a/torch/csrc/distributed/c10d/intra_node_comm.cu
+++ b/torch/csrc/distributed/c10d/intra_node_comm.cu
@@ -10,7 +10,11 @@ namespace intra_node_comm {
 static constexpr size_t kBytesPerThread = 16;
 static constexpr size_t kMaxAllReduceBlocks = 24;
 static constexpr size_t kThreadsPerBlock = 1024;
+#if defined(USE_ROCM)
+static constexpr size_t kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
+#else
 static constexpr size_t kWarpSize = 32;
+#endif
 
 static constexpr size_t kHcmThreshBytes = 256 * 1024;
 static constexpr size_t kOneShotThreshBytes = 256 * 1024;

--- a/torch/csrc/distributed/c10d/intra_node_comm.cu
+++ b/torch/csrc/distributed/c10d/intra_node_comm.cu
@@ -11,7 +11,7 @@ static constexpr size_t kBytesPerThread = 16;
 static constexpr size_t kMaxAllReduceBlocks = 24;
 static constexpr size_t kThreadsPerBlock = 1024;
 #if defined(USE_ROCM)
-static constexpr size_t kWarpSize = __AMDGCN_WAVEFRONT_SIZE;
+static constexpr size_t kWarpSize = warpSize;
 #else
 static constexpr size_t kWarpSize = 32;
 #endif


### PR DESCRIPTION
Update warp size constants(32) with __AMDGCN_WAVEFRONT_SIZE for ROCm

fix the reduction in `caffe2/sgd/adagrad_fused_op_gpu.cuh` ( not sure if ppl still use this kernel)
expect perf uplift for other cases

```
constexpr int kWarpSize = 32;

template <typename T>
inline __device__ T shfl_xor(const T val, int laneMask, int width = kWarpSize) {
#if !defined(USE_ROCM)
  return __shfl_xor_sync(0xffffffff, val, laneMask, width);
#else
  return __shfl_xor(val, laneMask, width);
#endif
}

/// Sums a register value across all warp threads
template <typename T, int ReduceWidth = kWarpSize>
inline __device__ T warpReduceAllSum(T val) {
#pragma unroll
  for (int mask = ReduceWidth / 2; mask > 0; mask >>= 1) {
    val += shfl_xor(val, mask);
  }
  return val;
}
```


Note that hardcoded warp size in `default_warp_iterator_from_smem.h` is not changed(not applicable to rocm)


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @XilunWu @tianyu-l @yf225 @chauhang