### PR TITLE
skip triton template precompilation in 311.0-3.11.7 to workaround 311 cpython bug

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -64,14 +64,6 @@ class KernelNamespace:
 extern_kernels = KernelNamespace()
 
 
-@functools.lru_cache(None)
-def warn_ast_parse_3_11():
-    log.warning(
-        "Skipping parallel precompilation of triton max-autotune templates due to https://github.com/python/cpython/issues/106905. "
-        "Update python 3.11 version past 3.11.8 to reenable."
-    )
-
-
 class PartialRender:
     """
     Some parts of a template need to be generated at the end, but
@@ -984,12 +976,12 @@ class AlgorithmSelectorCache(PersistentCache):
             if num_workers <= 0:
                 return no_op
 
+            # https://github.com/python/cpython/issues/106905
             if (
                 sys.version_info.major == 3
                 and sys.version_info.minor == 11
                 and sys.version_info.micro <= 8
             ):
-                warn_ast_parse_3_11()
                 return no_op
 
             # TODO - debug issue

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -64,6 +64,13 @@ class KernelNamespace:
 extern_kernels = KernelNamespace()
 
 
+@functools.lru_cache(None)
+def warn_ast_parse_3_11():
+    log.warning(
+        "Skipping parallel precompilation of triton max-autotune templates due to https://github.com/python/cpython/issues/106905. Update python 3.11 version past 3.11.8 to reenable."
+    )
+
+
 class PartialRender:
     """
     Some parts of a template need to be generated at the end, but
@@ -974,6 +981,14 @@ class AlgorithmSelectorCache(PersistentCache):
                 len(choices),
             )
             if num_workers <= 0:
+                return no_op
+
+            if (
+                sys.version_info.major == 3
+                and sys.version_info.minor == 11
+                and sys.version_info.micro <= 8
+            ):
+                warn_ast_parse_3_11()
                 return no_op
 
             # TODO - debug issue

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -67,7 +67,8 @@ extern_kernels = KernelNamespace()
 @functools.lru_cache(None)
 def warn_ast_parse_3_11():
     log.warning(
-        "Skipping parallel precompilation of triton max-autotune templates due to https://github.com/python/cpython/issues/106905. Update python 3.11 version past 3.11.8 to reenable."
+        "Skipping parallel precompilation of triton max-autotune templates due to https://github.com/python/cpython/issues/106905. "
+        "Update python 3.11 version past 3.11.8 to reenable."
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125446
* #125289

Fix for https://github.com/pytorch/pytorch/issues/125374. We dont have CI for this specific versions, but I verified locally. THere is a cpython bug from 3.11.0->3.11.7 where the ast parsing state is global, and errors with multiple threads. when dust settles a little around the new process based compilation we can look into migrating.  


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang