### PR TITLE
[dynamo] fix potentially missing _torchdynamo_inline from ScriptFunction

### DIFF
--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -1391,6 +1391,7 @@ def script(
         _check_directly_compile_overloaded(obj)
         maybe_already_compiled_fn = _try_get_jit_cached_function(obj)
         if maybe_already_compiled_fn:
+            maybe_already_compiled_fn._torchdynamo_inline = obj  # type: ignore[attr-defined]
             return maybe_already_compiled_fn
         ast = get_jit_def(obj, obj.__name__)
         if _rcb is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125447

Fix https://github.com/pytorch/pytorch/issues/119747

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang