### PR TITLE
[export] Fix deserializer node meta handling.

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1638,14 +1638,6 @@ class GraphModuleDeserializer(metaclass=Final):
             self.deserialize_outputs(serialized_node, fx_node)
             fx_node.meta.update(self.deserialize_metadata(serialized_node.metadata))
 
-            # assign nn_module_stack metadata to submodule/subgraph nodes for higher order ops
-            if serialized_node.target.startswith(('torch.ops.higher_order', 'torch._higher_order_ops')):
-                for node in fx_node._args:
-                    if not isinstance(node, torch.fx.Node):
-                        continue
-                    if node.op not in ["placeholder", "output"] and node.meta.get("nn_module_stack") is None:
-                        node.meta["nn_module_stack"] = copy.copy(fx_node.meta["nn_module_stack"])
-
         elif isinstance(target, torch._ops.OpOverload):
             # For convenience: if this node returns a single tensor, name the
             # newly-created node after it. This ensures that these tensor values


### PR DESCRIPTION
Summary: The code seems not needed because serializer shouldn't make any meaningful decision about what goes to node metadata.

Test Plan: CI

Differential Revision: D56918543


