### PR TITLE
[AMD] Fix cutlass path in inductor

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -757,7 +757,7 @@ class cuda:
     cutlass_dir = os.environ.get(
         "TORCHINDUCTOR_CUTLASS_DIR",
         build_paths.cutlass()
-        if is_fbcode()
+        if is_fbcode() and not torch.version.hip
         else os.path.abspath(
             os.path.join(os.path.dirname(torch.__file__), "../third_party/cutlass/")
         ),


### PR DESCRIPTION
Summary: Trunk is broken because fbcode triton-amd doesn't have cutlass path

Test Plan: It now runs.

Differential Revision: D56923833




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang