### PR TITLE
[TD] Enable TD on AVX related configs

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -74,7 +74,7 @@ HAVE_TEST_SELECTION_TOOLS = True
 # Make sure to remove REPO_ROOT after import is done
 sys.path.remove(str(REPO_ROOT))
 
-
+TEST_CONFIG = os.getenv("TEST_CONFIG", "")
 RERUN_DISABLED_TESTS = os.getenv("PYTORCH_TEST_RERUN_DISABLED_TESTS", "0") == "1"
 DISTRIBUTED_TEST_PREFIX = "distributed"
 INDUCTOR_TEST_PREFIX = "inductor"
@@ -491,9 +491,7 @@ def run_test(
         and not is_cpp_test
         and "-n" not in command
     )
-    is_slow = "slow" in os.environ.get("TEST_CONFIG", "") or "slow" in os.environ.get(
-        "BUILD_ENVRIONMENT", ""
-    )
+    is_slow = "slow" in TEST_CONFIG or "slow" in os.environ.get("BUILD_ENVRIONMENT", "")
     timeout = (
         None
         if not options.enable_timeout
@@ -1183,14 +1181,16 @@ def parse_args():
             or TEST_WITH_ASAN
             or (
                 strtobool(os.environ.get("TD_DISTRIBUTED", "False"))
-                and os.getenv("TEST_CONFIG") == "distributed"
+                and TEST_CONFIG == "distributed"
                 and TEST_CUDA
             )
             or (IS_WINDOWS and not TEST_CUDA)
+            or TEST_CONFIG == "nogpu_AVX512"
+            or TEST_CONFIG == "nogpu_NO_AVX2"
         )
         and get_pr_number() is not None
         and not strtobool(os.environ.get("NO_TD", "False"))
-        and "slow" not in os.getenv("TEST_CONFIG", "")
+        and "slow" not in TEST_CONFIG
         and "slow" not in os.getenv("BUILD_ENVIRONMENT", ""),
     )
     parser.add_argument(

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -37,6 +37,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_CROSSREF,
     TEST_WITH_ROCM,
+    TEST_WITH_SLOW,
     TEST_WITH_SLOW_GRADCHECK,
 )
 
@@ -491,12 +492,11 @@ def run_test(
         and not is_cpp_test
         and "-n" not in command
     )
-    is_slow = "slow" in TEST_CONFIG or "slow" in os.environ.get("BUILD_ENVRIONMENT", "")
     timeout = (
         None
         if not options.enable_timeout
         else THRESHOLD * 6
-        if is_slow
+        if TEST_WITH_SLOW
         else THRESHOLD * 3
         if should_retry
         and isinstance(test_module, ShardedTest)
@@ -1190,8 +1190,7 @@ def parse_args():
         )
         and get_pr_number() is not None
         and not strtobool(os.environ.get("NO_TD", "False"))
-        and "slow" not in TEST_CONFIG
-        and "slow" not in os.getenv("BUILD_ENVIRONMENT", ""),
+        and not TEST_WITH_SLOW,
     )
     parser.add_argument(
         "additional_unittest_args",


### PR DESCRIPTION
On test configs `nogpu_AVX512` and `nogpu_NO_AVX2`, which are the next longest jobs on trunk after windows