### PR TITLE
[TD][ez] Better check for is pr or not

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -59,6 +59,7 @@ from tools.testing.discover_tests import (
 )
 from tools.testing.do_target_determination_for_s3 import import_results
 from tools.testing.target_determination.gen_artifact import gen_ci_artifact
+from tools.testing.target_determination.heuristics.utils import get_pr_number
 
 from tools.testing.test_run import TestRun
 from tools.testing.test_selections import (
@@ -1187,7 +1188,7 @@ def parse_args():
             )
             or (IS_WINDOWS and not TEST_CUDA)
         )
-        and os.getenv("BRANCH", "") != "main"
+        and get_pr_number() is not None
         and not strtobool(os.environ.get("NO_TD", "False"))
         and "slow" not in os.getenv("TEST_CONFIG", "")
         and "slow" not in os.getenv("BUILD_ENVIRONMENT", ""),


### PR DESCRIPTION
You can trigger ciflow tags on main branch commits, so we should be more conservative when checking to see if a workflow is a PR/on the main branch.

get_pr_number checks for the pr number based on the PR_NUMBER env var or a tag of the for `ciflow/workflow/pr number`

If we fail to find something like this, then assume it is on the main branch
