### PR TITLE
[Reland] Fakify script object inputs and attributes for non-strict ex…

### DIFF
--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -13,6 +13,10 @@ from typing import List, Set
 import torch
 from functorch.experimental.control_flow import cond
 from torch._dynamo.eval_frame import is_dynamo_supported
+from torch._export.non_strict_utils import (
+    _fakify_script_objects,
+    _gather_constant_attrs,
+)
 from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
 from torch._export.passes.functionalize_side_effectful_ops_pass import (
     _FunctionalizeSideEffectfulOpsPass,
@@ -34,26 +38,24 @@ from torch._export.utils import (
     sequential_split,
 )
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
-from torch._higher_order_ops.torchbind import enable_torchbind_tracing
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.export import export
 from torch.export._remove_auto_functionalized_pass import (
     unsafe_remove_auto_functionalized_pass,
 )
 from torch.export._remove_effect_tokens_pass import _remove_effect_tokens
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.passes.infra.partitioner import Partition
 from torch.fx.passes.operator_support import OperatorSupport
 from torch.library import _scoped_library, impl
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
-    find_library_location,
-    IS_FBCODE,
-    IS_MACOS,
-    IS_SANDCASTLE,
     IS_WINDOWS,
     run_tests,
     skipIfTorchDynamo,
     TestCase,
 )
+from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 from torch.utils import _pytree as pytree
 
 
@@ -85,6 +87,53 @@ def _get_output_names(gm: torch.fx.GraphModule) -> List[str]:
     # if isinstance(args, tuple) and len(args) == 1:
     #     args = args[0]
     return [str(arg) for arg in args]
+
+
+class ModelsWithScriptObjectAttr:
+    class Simple(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.attr = torch.classes._TorchScriptTesting._Foo(10, 20)
+
+    class SimpleWithAttrInContainer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.attr = torch.classes._TorchScriptTesting._Foo(10, 20)
+            self.pytree_attr2 = [
+                torch.classes._TorchScriptTesting._Foo(1, 2),
+                {
+                    torch.classes._TorchScriptTesting._Foo(3, 4),
+                },
+                {"foo": torch.classes._TorchScriptTesting._Foo(5, 6)},
+            ]
+
+    class NestedWithAttrInContainer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.attr = torch.classes._TorchScriptTesting._Foo(10, 20)
+            self.pytree_attr2 = [
+                torch.classes._TorchScriptTesting._Foo(1, 2),
+                {
+                    torch.classes._TorchScriptTesting._Foo(3, 4),
+                },
+                {"foo": torch.classes._TorchScriptTesting._Foo(5, 6)},
+            ]
+            self.sub_mod = ModelsWithScriptObjectAttr.Simple()
+            self.sub_mod2 = ModelsWithScriptObjectAttr.SimpleWithAttrInContainer()
+
+    class MoreNestedWithAttrInContainer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.attr = torch.classes._TorchScriptTesting._Foo(10, 20)
+            self.pytree_attr2 = [
+                torch.classes._TorchScriptTesting._Foo(1, 2),
+                {
+                    torch.classes._TorchScriptTesting._Foo(3, 4),
+                },
+                {"foo": torch.classes._TorchScriptTesting._Foo(5, 6)},
+            ]
+            self.sub_mod = ModelsWithScriptObjectAttr.Simple()
+            self.sub_mod2 = ModelsWithScriptObjectAttr.NestedWithAttrInContainer()
 
 
 def _set_grad_enabled_tests():
@@ -213,17 +262,7 @@ class TestPasses(TestCase):
         self.SEQUENTIAL_SPLIT_INLINE_TESTS = _sequential_split_inline_tests()
         self.SET_GRAD_ENABLED_TESTS = _set_grad_enabled_tests()
 
-        if IS_SANDCASTLE or IS_FBCODE:
-            torch.ops.load_library(
-                "//caffe2/test/cpp/jit:test_custom_class_registrations"
-            )
-        elif IS_MACOS:
-            raise unittest.SkipTest("non-portable load_library call used in test")
-        else:
-            lib_file_path = find_library_location("libtorchbind_test.so")
-            if IS_WINDOWS:
-                lib_file_path = find_library_location("torchbind_test.dll")
-            torch.ops.load_library(str(lib_file_path))
+        init_torchbind_implementations()
 
     def tearDown(self):
         self.SEQUENTIAL_SPLIT_INLINE_TESTS.clear()
@@ -421,8 +460,7 @@ class TestPasses(TestCase):
 
         m = MyModule()
         inputs = (torch.ones(2, 3),)
-        with enable_torchbind_tracing():
-            ep = torch.export.export(m, inputs, strict=False)
+        ep = torch.export.export(m, inputs, strict=False)
 
         inp = torch.randn(2, 3)
         orig_res = m(inp)
@@ -434,6 +472,48 @@ class TestPasses(TestCase):
 
         self.assertTrue(torch.allclose(orig_res, ep_res))
         self.assertTrue(torch.allclose(orig_res, without_token_res))
+
+    def test_fakify_script_objects(self):
+        for m in [
+            ModelsWithScriptObjectAttr.Simple(),
+            ModelsWithScriptObjectAttr.SimpleWithAttrInContainer(),
+            ModelsWithScriptObjectAttr.NestedWithAttrInContainer(),
+            ModelsWithScriptObjectAttr.MoreNestedWithAttrInContainer(),
+        ]:
+            constant_attrs = _gather_constant_attrs(m)
+            fake_mode = FakeTensorMode(
+                shape_env=ShapeEnv(tracked_fakes=[]),
+                allow_non_fake_inputs=True,
+            )
+            with _fakify_script_objects(m, tuple(), {}, fake_mode) as (
+                patched_mod,
+                _,
+                _,
+                fake_constant_attrs,
+                fake_to_real,
+            ):
+                self.assertEqual(len(fake_constant_attrs), len(constant_attrs))
+                for fake_obj, fqn in fake_constant_attrs.items():
+                    self.assertEqual(constant_attrs[fake_to_real[fake_obj]], fqn)
+
+    # TODO: _gather_constants doesn't recursively look into the pytree containers.
+    @unittest.expectedFailure
+    def test_fakify_script_objects_properly_handle_containers(self):
+        m = ModelsWithScriptObjectAttr.SimpleWithAttrInContainer()
+        constant_attrs = _gather_constant_attrs(m)
+        fake_mode = FakeTensorMode(
+            shape_env=ShapeEnv(tracked_fakes=[]),
+            allow_non_fake_inputs=True,
+        )
+        with _fakify_script_objects(m, tuple(), {}, fake_mode) as (
+            patched_mod,
+            _,
+            _,
+            fake_constant_attrs,
+            fake_to_real,
+        ):
+            self.assertTrue("attr" in fake_constant_attrs.values())
+            self.assertTrue("pytree_attr2" in fake_constant_attrs.values())
 
     def test_runtime_assert_inline_constraints_for_item(self) -> None:
         class M(torch.nn.Module):

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -3,6 +3,7 @@ PYTEST_DONT_REWRITE (prevents pytest from rewriting assertions, which interferes
 with test_sym_bool)
 """
 
+
 # Owner(s): ["oncall: export"]
 import copy
 import io
@@ -30,17 +31,15 @@ from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.export import Dim, export, load, save
 from torch.fx.experimental.symbolic_shapes import is_concrete_int, ValueRanges
 from torch.testing._internal.common_utils import (
-    find_library_location,
     instantiate_parametrized_tests,
-    IS_FBCODE,
-    IS_MACOS,
-    IS_SANDCASTLE,
     IS_WINDOWS,
     parametrize,
     run_tests,
     TemporaryFileName,
     TestCase,
 )
+
+from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
 
 def get_filtered_export_db_tests():
@@ -347,17 +346,8 @@ class TestSerialize(TestCase):
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestDeserialize(TestCase):
     def setUp(self):
-        if IS_SANDCASTLE or IS_FBCODE:
-            torch.ops.load_library(
-                "//caffe2/test/cpp/jit:test_custom_class_registrations"
-            )
-        elif IS_MACOS:
-            raise unittest.SkipTest("non-portable load_library call used in test")
-        else:
-            lib_file_path = find_library_location("libtorchbind_test.so")
-            if IS_WINDOWS:
-                lib_file_path = find_library_location("torchbind_test.dll")
-            torch.ops.load_library(str(lib_file_path))
+        super().setUp()
+        init_torchbind_implementations()
 
     def _check_graph_nodes(self, gm1, gm2, _check_meta=True):
         # TODO: The _check_meta flag bypasses checking for
@@ -837,8 +827,7 @@ class TestDeserialize(TestCase):
 
         m = MyModule()
         inputs = (torch.ones(2, 3),)
-        with enable_torchbind_tracing():
-            self.check_graph(m, inputs, strict=False)
+        self.check_graph(m, inputs, strict=False)
 
     def test_custom_obj(self):
         class MyModule(torch.nn.Module):
@@ -853,8 +842,7 @@ class TestDeserialize(TestCase):
 
         m = MyModule()
         inputs = (torch.ones(2, 3),)
-        with enable_torchbind_tracing():
-            self.check_graph(m, inputs, strict=False)
+        self.check_graph(m, inputs, strict=False)
 
     def test_custom_obj_list_out(self):
         class MyModule(torch.nn.Module):
@@ -870,8 +858,7 @@ class TestDeserialize(TestCase):
 
         m = MyModule()
         inputs = (torch.ones(2, 3),)
-        with enable_torchbind_tracing():
-            self.check_graph(m, inputs, strict=False)
+        self.check_graph(m, inputs, strict=False)
 
 
 instantiate_parametrized_tests(TestDeserialize)
@@ -1061,17 +1048,8 @@ class TestSaveLoad(TestCase):
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestSerializeCustomClass(TestCase):
     def setUp(self):
-        if IS_SANDCASTLE or IS_FBCODE:
-            torch.ops.load_library(
-                "//caffe2/test/cpp/jit:test_custom_class_registrations"
-            )
-        elif IS_MACOS:
-            raise unittest.SkipTest("non-portable load_library call used in test")
-        else:
-            lib_file_path = find_library_location("libtorchbind_test.so")
-            if IS_WINDOWS:
-                lib_file_path = find_library_location("torchbind_test.dll")
-            torch.ops.load_library(str(lib_file_path))
+        super().setUp()
+        init_torchbind_implementations()
 
     def test_custom_class(self):
         custom_obj = torch.classes._TorchScriptTesting._PickleTester([3, 4])

--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -41,6 +41,8 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TestCase,
 )
+
+from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 from torch.utils._pytree import (
     LeafSpec,
     tree_flatten,
@@ -562,18 +564,21 @@ class TestUnflatten(TestCase):
 
     @skipIfTorchDynamo("custom objects not supported in dynamo yet")
     def test_unflatten_constant_obj(self):
-        if IS_MACOS:
-            raise unittest.SkipTest("non-portable load_library call used in test")
-        elif IS_SANDCASTLE or IS_FBCODE:
-            torch.ops.load_library(
-                "//caffe2/test/cpp/jit:test_custom_class_registrations"
-            )
-        elif IS_WINDOWS:
-            lib_file_path = find_library_location("torchbind_test.dll")
-            torch.ops.load_library(str(lib_file_path))
-        else:
-            lib_file_path = find_library_location("libtorchbind_test.so")
-            torch.ops.load_library(str(lib_file_path))
+        init_torchbind_implementations()
+
+        @torch._library.register_fake_class("_TorchScriptTesting::_Foo")
+        class FakeFoo:
+            def __init__(self, x: int, y: int):
+                self.x = x
+                self.y = y
+
+            @classmethod
+            def from_real(cls, foo):
+                (x, y), _ = foo.__getstate__()
+                return cls(x, y)
+
+            def add_tensor(self, z):
+                return (self.x + self.y) * z
 
         class SubMod(torch.nn.Module):
             def __init__(self):

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -1,8 +1,10 @@
+import contextlib
 import inspect
 from collections import defaultdict
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 import torch
+import torch.utils._pytree as pytree
 from torch._dynamo.source import (
     AttrSource,
     GetItemSource,
@@ -12,7 +14,9 @@ from torch._dynamo.source import (
 )
 from torch._dynamo.variables.builder import TrackedFake
 from torch._export.passes.add_runtime_assertions_for_constraints_pass import InputDim
+from torch._export.passes.lift_constants_pass import ConstantAttrMap
 from torch._guards import Source
+from torch._library.fake_class_registry import FakeScriptObject
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.export import Constraint
 from torch.export.dynamic_shapes import _tree_map
@@ -66,6 +70,7 @@ def fakify(
     source = key_path_to_source(kp)
     if _is_constant_argument(t) or isinstance(t, torch.ScriptObject):
         return t
+
     if not isinstance(t, torch.Tensor):
         raise ValueError(f"Unsupported input type {type(t)}")
     n_dims = len(t.shape)
@@ -320,3 +325,111 @@ def make_constraints(
             range_constraints[symbol] = shape_env.var_to_range[symbol]
 
     return range_constraints
+
+
+def _gather_constant_attrs(m: torch.nn.Module) -> ConstantAttrMap:
+    """Search the module hierarchy, gathering up all tensor and ScriptObject constants.
+
+    Returns a dictionary mapping hash(value) to the name of the constant. We
+    have to abuse `hash` here unfortunately, see: [ScriptObject hash].
+    """
+    constants = ConstantAttrMap()
+    buffers_parameters = set(m.buffers())
+    buffers_parameters.update(m.parameters())
+
+    def inner(m: torch.nn.Module, prefix_atoms: List[str], constants):
+        for k, v in m.__dict__.items():
+            if isinstance(
+                v,
+                (
+                    torch.Tensor,
+                    torch.ScriptObject,
+                    FakeScriptObject,
+                ),
+            ):
+                if v in buffers_parameters:
+                    # filter out buffers and parameters, leaving only constants
+                    continue
+
+                fqn = ".".join(prefix_atoms + [k])
+                if v in constants:
+                    raise ValueError(
+                        f"Duplicate reference to constant attribute found: '{constants[v]}' and '{fqn}'."
+                    )
+
+                constants[v] = fqn
+        for k, v in m.named_children():
+            inner(v, prefix_atoms + [k], constants)
+
+    inner(m, [], constants)
+    return constants
+
+
+@contextlib.contextmanager
+def _fakify_script_objects(
+    mod: torch.nn.Module,
+    args: Tuple[Any],
+    kwargs: Dict[Any, Any],
+    fake_mode: torch._subclasses.fake_tensor.FakeTensorMode,
+):
+    # This context manager is used to fakify script objects into FakeScriptObject.
+    # Inputs:
+    #   mod: the module to be exported, it (and its recursive submodules)'s script object attrs haven't been fakified.
+    #   args, kwargs: the args and kwargs inputs for mod, script object inputs haven't been fakified.
+    #   fake_mode: the fake mode to be used for fakifying script objects. It's the same mode that fakify input tensors.
+    #
+    # Returns:
+    #   mod: the patched module, its (and its recursive submodules) script object attrs have been fakified.
+    #   fake_args, fake_kwargs: new fakified args and kwargs.
+    #        Script object inputs have been fakified. Don't touch the tensors.
+    #   fake_constant_attrs: a new map from FakeScriptObject to the fqn of the original script object.
+    #   fake_to_real: a mapping between FakeScriptObject and the original script object in order to un-do the patching.
+
+    constant_attrs: ConstantAttrMap = _gather_constant_attrs(mod)
+    assert not any(
+        isinstance(obj, FakeScriptObject) for obj in constant_attrs.values()
+    ), "Mod shouldn't contain any FakeScriptObject."
+    assert not pytree.tree_any(
+        lambda obj: isinstance(obj, FakeScriptObject), (args, kwargs)
+    ), "args and kwargs shouldn't contain any FakeScriptObject."
+
+    patched_attr = {}
+    fake_constant_attrs = ConstantAttrMap()
+    fake_to_real = {}
+
+    def _maybe_fakify_obj(obj):
+        if not torch._library.fake_class_registry.has_fake_class(obj._type().qualified_name()):  # type: ignore[attr-defined]
+            return obj
+        fake_obj = torch._library.fake_class_registry.to_fake_obj(fake_mode, obj)
+        fake_to_real[fake_obj] = obj
+        return fake_obj
+
+    def _leaf_mod_and_attr(
+        mod: torch.nn.Module, attr_fqn: str
+    ) -> Tuple[torch.nn.Module, str]:
+        *prefix_attr, last_attr = attr_fqn.split(".")
+        cur_mod = mod
+        for attr in prefix_attr:
+            cur_mod = getattr(cur_mod, attr)
+        return cur_mod, last_attr
+
+    try:
+        for obj, fqn in constant_attrs.items():
+            if isinstance(obj, torch.ScriptObject):
+                cur_mod, attr = _leaf_mod_and_attr(mod, fqn)
+                assert obj is getattr(cur_mod, attr)
+                fake_script_obj = _maybe_fakify_obj(obj)
+                setattr(cur_mod, attr, fake_script_obj)
+                fake_constant_attrs[fake_script_obj] = fqn
+                patched_attr[fqn] = obj
+            else:
+                fake_constant_attrs[obj] = fqn
+
+        fake_args, fake_kwargs = pytree.tree_map_only(
+            torch.ScriptObject, _maybe_fakify_obj, (args, kwargs)
+        )
+        yield (mod, fake_args, fake_kwargs, fake_constant_attrs, fake_to_real)
+    finally:
+        for fqn, orig_obj in patched_attr.items():
+            cur_mod, attr = _leaf_mod_and_attr(mod, fqn)
+            setattr(cur_mod, attr, orig_obj)

--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Union
 import torch
 from torch._export.verifier import SpecViolationError
 from torch._guards import detect_fake_mode
+
+from torch._library.fake_class_registry import FakeScriptObject
 from torch.export.exported_program import (
     ArgumentSpec,
     CustomObjArgument,
@@ -15,33 +17,35 @@ from torch.export.exported_program import (
 
 
 class ConstantAttrMap(collections.abc.MutableMapping):
-    """A mapping class that understands how to use module constants (tensors and
-    ScriptObjects) as keys. We store tensors normally, but ScriptObjects are
-    stored by hash, because different torch.ScriptObjects can point to the same
-    underlying value (but we guarantee that they will `hash()` to the same value
+    """A mapping class that understands how to use module constants (tensors,
+    ScriptObjects, FakeScriptObjects) as keys. We store tensors and FakeScriptObjects normally,
+    but ScriptObjects are stored by hash, because different torch.ScriptObjects can point to
+    the same underlying value (but we guarantee that they will `hash()` to the same value
     if that's the case).
     """
 
     def __init__(self):
         # Underlying dict that we use to implement this mapping.
-        self._constant_attrs: Dict[Union[int, torch.Tensor], Any] = {}
+        self._constant_attrs: Dict[Union[int, torch.Tensor, FakeScriptObject], Any] = {}
         # Map from the hash(ScriptObject) to the ScriptObject itself. Used for
         # APIs like `__iter__` that should look like they're returning the
         # original ScriptObjects.
         self._script_object_map: Dict[int, torch.ScriptObject] = {}
 
-    def __getitem__(self, key: Union[torch.Tensor, torch.ScriptObject]) -> Any:
+    def __getitem__(
+        self, key: Union[torch.Tensor, torch.ScriptObject, FakeScriptObject]
+    ) -> Any:
         real_key = hash(key) if isinstance(key, torch.ScriptObject) else key
-        assert isinstance(real_key, (int, torch.Tensor))
+        assert isinstance(real_key, (int, torch.Tensor, FakeScriptObject))
         return self._constant_attrs[real_key]
 
     def __setitem__(
-        self, key: Union[torch.Tensor, torch.ScriptObject], value: Any
+        self, key: Union[torch.Tensor, torch.ScriptObject, FakeScriptObject], value: Any
     ) -> None:
         if isinstance(key, torch.ScriptObject):
             self._constant_attrs[hash(key)] = value
             self._script_object_map[hash(key)] = key
-        elif isinstance(key, torch.Tensor):
+        elif isinstance(key, (torch.Tensor, FakeScriptObject)):
             self._constant_attrs[key] = value
         else:
             raise TypeError(
@@ -83,7 +87,7 @@ def lift_constants_pass(
     gm: torch.fx.GraphModule,
     graph_signature: ExportGraphSignature,
     constant_attrs: ConstantAttrMap,
-) -> Dict[str, Union[torch.Tensor, torch._C.ScriptObject]]:
+) -> Dict[str, Union[torch.Tensor, torch.ScriptObject, FakeScriptObject]]:
     """
     Takes a graph module, graph signature, and modifies them implace to lift any
     constants (tensors or custom classes) as inputs to the graph. Returns a
@@ -101,7 +105,9 @@ def lift_constants_pass(
     Returns:
         A dictionary of fqn => constant value.
     """
-    all_constants: Dict[str, Union[torch.Tensor, torch._C.ScriptObject]] = {}
+    all_constants: Dict[
+        str, Union[torch.Tensor, torch.ScriptObject, FakeScriptObject]
+    ] = {}
 
     inputs = graph_signature.input_specs
     num_custom_obj = sum(
@@ -135,7 +141,7 @@ def lift_constants_pass(
                 gm.graph.erase_node(node)
                 continue
 
-            # For ScriptObject and Tensor constants:
+            # For ScriptObject, Tensor and FakeScriptObject constants:
             # First check if the constant was an attribute on some module by
             # consulting `constant_attrs` map. If it is, use the fqn that keeps
             # its location consistent with the eager module.
@@ -144,7 +150,7 @@ def lift_constants_pass(
             # constant (e.g. x + torch.tensor(0)), and thus did not have a
             # specific location in the eager module. In that case, just generate
             # some name and attach it to the module in which it was used.
-            if isinstance(constant_val, torch.ScriptObject):
+            if isinstance(constant_val, (torch.ScriptObject, FakeScriptObject)):
                 constant_kind = InputKind.CUSTOM_OBJ
                 constant_fqn = constant_attrs.get(constant_val)
                 if constant_fqn is not None:
@@ -203,6 +209,14 @@ def lift_constants_pass(
                     input_spec_arg = CustomObjArgument(
                         name=const_placeholder_node.name, class_fqn=class_fqn
                     )
+                elif isinstance(constant_val, FakeScriptObject):
+                    class_fqn = constant_val.script_class_name
+                    const_placeholder_node.meta["val"] = CustomObjArgument(
+                        constant_fqn, class_fqn
+                    )
+                    input_spec_arg = CustomObjArgument(
+                        name=const_placeholder_node.name, class_fqn=class_fqn
+                    )
                 else:
                     raise SpecViolationError(
                         f"tried to lift unsupported type {type(constant_val)} from node {node.format_node()}"
@@ -229,24 +243,36 @@ def lift_constants_pass(
 
 def rewrite_script_object_meta(
     gm: torch.fx.GraphModule,
-) -> Dict[str, Union[torch.Tensor, torch.ScriptObject]]:
-    """When tracing, we produce a graph with an actual ScriptObject in the
-    meta["val"]. Eventually we want to change this behavior, when FakeMode infra
-    for ScriptObjects lands.
+) -> Dict[str, Union[torch.Tensor, torch.ScriptObject, FakeScriptObject],]:
+    """When tracing, we produce a graph with FakeScriptObject in the
+    meta["val"].
 
     For now, we rewrie meta["val"] to be a placeholder CustomObjArgument
     """
-    constants: Dict[str, Union[torch.Tensor, torch._C.ScriptObject]] = {}
+    constants: Dict[
+        str,
+        Union[
+            torch.Tensor,
+            torch.ScriptObject,
+            FakeScriptObject,
+        ],
+    ] = {}
     for node in gm.graph.nodes:
-        if "val" not in node.meta or not isinstance(
-            node.meta["val"], torch.ScriptObject
-        ):
+        if "val" not in node.meta:
             continue
 
-        old_meta = node.meta["val"]
-        class_fqn = old_meta._type().qualified_name()  # type: ignore[attr-defined]
-        new_meta = CustomObjArgument(node.name, class_fqn)
-        constants[node.name] = old_meta
-        node.meta["val"] = new_meta
+        if isinstance(node.meta["val"], torch.ScriptObject):
+            old_meta = node.meta["val"]
+            class_fqn = old_meta._type().qualified_name()  # type: ignore[attr-defined]
+            new_meta = CustomObjArgument(node.name, class_fqn)
+            constants[node.name] = old_meta
+            node.meta["val"] = new_meta
+
+        elif isinstance(node.meta["val"], FakeScriptObject):
+            old_meta = node.meta["val"]  # type: ignore[assignment]
+            class_fqn = old_meta.script_class_name  # type: ignore[attr-defined]
+            new_meta = CustomObjArgument(node.name, class_fqn)
+            constants[node.name] = old_meta
+            node.meta["val"] = new_meta
 
     return constants

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -807,6 +807,7 @@ class TorchBindOpOverload(OpOverload):
             DispatchKey.AutogradCPU,
             DispatchKey.AutogradCUDA,
             DispatchKey.ADInplaceOrView,
+            DispatchKey.BackendSelect,
             DispatchKey.PythonTLSSnapshot,
             DispatchKey.PythonDispatcher,
         ]
@@ -889,8 +890,13 @@ class TorchBindOpOverload(OpOverload):
                 )
 
             raise RuntimeError(
-                f"Cannot handle FakeScriptObject with python dispatcher with dispatch key {handler}."
-                f"Please implement it by annotating a python callable with py_impl({handler})."
+                f"Torchbind op {self} received a FakeScriptObject input when dispatching {handler}."
+                f" but no python implementation is found."
+                f" Please file an issue on this when you encounter this error."
+                f" This error can happen when you export or compile the model."
+                f" It can still happpen even if a C++ implementation for {dispatch_key}. "
+                f" has been registered. That's because FakeScriptObject purely lives in python and cannot work "
+                f" with a C++ implementation."
             )
 
         assert isinstance(handler, Callable)  # type: ignore[arg-type]

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -15,6 +15,8 @@ import torch.fx
 import torch.utils._pytree as pytree
 from torch._dynamo.exc import UserError, UserErrorType
 from torch._export.non_strict_utils import (
+    _fakify_script_objects,
+    _gather_constant_attrs,
     make_constraints,
     make_fake_inputs,
     make_fake_params_buffers,
@@ -34,6 +36,8 @@ from torch._export.verifier import SpecViolationError
 from torch._export.wrappers import _wrap_submodules
 from torch._functorch.aot_autograd import aot_export_module
 from torch._guards import detect_fake_mode
+
+from torch._library.fake_class_registry import FakeScriptObject
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._utils_internal import log_export_usage
 from torch.export.dynamic_shapes import _combine_args
@@ -69,7 +73,6 @@ from .graph_signature import (
     TensorArgument,
     TokenArgument,
 )
-
 
 log = logging.getLogger(__name__)
 
@@ -454,37 +457,6 @@ def _export_to_torch_ir(
     return gm_torch_level
 
 
-def _gather_constant_attrs(m: torch.nn.Module) -> ConstantAttrMap:
-    """Search the module hierarchy, gathering up all tensor and ScriptObject constants.
-
-    Returns a dictionary mapping hash(value) to the name of the constant. We
-    have to abuse `hash` here unfortunately, see: [ScriptObject hash].
-    """
-    constants = ConstantAttrMap()
-    buffers_parameters = set(m.buffers())
-    buffers_parameters.update(m.parameters())
-
-    def inner(m: torch.nn.Module, prefix_atoms: List[str], constants):
-        for k, v in m.__dict__.items():
-            if isinstance(v, (torch.Tensor, torch.ScriptObject)):
-                if v in buffers_parameters:
-                    # filter out buffers and parameters, leaving only constants
-                    continue
-
-                fqn = ".".join(prefix_atoms + [k])
-                if v in constants:
-                    raise ValueError(
-                        f"Duplicate reference to constant attribute found: '{constants[v]}' and '{fqn}'."
-                    )
-
-                constants[v] = fqn
-        for k, v in m.named_children():
-            inner(v, prefix_atoms + [k], constants)
-
-    inner(m, [], constants)
-    return constants
-
-
 def _export_non_strict(
     mod: torch.nn.Module,
     fake_args,
@@ -587,9 +559,9 @@ def _export_non_strict(
         elif isinstance(val, torch.SymInt):
             return SymIntArgument(name=node.name)
         elif isinstance(val, torch.ScriptObject):
-            return CustomObjArgument(
-                name=node.name, class_fqn=val._type().qualified_name()  # type: ignore[attr-defined]
-            )
+            return CustomObjArgument(name=node.name, class_fqn=val._type().qualified_name())  # type: ignore[attr-defined]
+        elif isinstance(val, FakeScriptObject):
+            return CustomObjArgument(name=node.name, class_fqn=val.script_class_name)
         elif isinstance(val, (int, bool, str, float, type(None))):
             return ConstantArgument(name=node.name, value=val)
         else:
@@ -644,7 +616,14 @@ def _export_non_strict(
     class _ExportedProgramNonStrict:
         gm: torch.fx.GraphModule
         sig: ExportGraphSignature
-        constants: Dict[str, Union[torch.Tensor, torch._C.ScriptObject]]
+        constants: Dict[
+            str,
+            Union[
+                torch.Tensor,
+                FakeScriptObject,
+                torch.ScriptObject,
+            ],
+        ]
 
     return _ExportedProgramNonStrict(
         gm,
@@ -942,8 +921,6 @@ def _export(
     if isinstance(dynamic_shapes, torch.export.ShapesCollection):
         dynamic_shapes = dynamic_shapes.dynamic_shapes(mod, args, kwargs)
 
-    constant_attrs = _gather_constant_attrs(mod)
-
     flat_args, orig_in_spec = pytree.tree_flatten((args, kwargs))
     original_state_dict = mod.state_dict(keep_vars=True)
     forward_arg_names = _get_forward_arg_names(mod, args, kwargs)
@@ -1030,16 +1007,32 @@ def _export(
         fake_params_buffers = make_fake_params_buffers(
             fake_mode, _get_params_buffers(mod)
         )
+
         with fake_mode:
-            ep_non_strict = _export_non_strict(
-                mod,
-                fake_args,
-                fake_kwargs,
-                fake_params_buffers,
-                constant_attrs,
-                pre_dispatch=pre_dispatch,
-                transform=_tuplify_outputs,
-            )
+            with _fakify_script_objects(mod, fake_args, fake_kwargs, fake_mode) as (
+                patched_mod,
+                new_fake_args,
+                new_fake_kwargs,
+                new_fake_constant_attrs,
+                map_fake_to_real,
+            ):
+                ep_non_strict = _export_non_strict(
+                    patched_mod,
+                    new_fake_args,
+                    new_fake_kwargs,
+                    fake_params_buffers,
+                    new_fake_constant_attrs,
+                    pre_dispatch=pre_dispatch,
+                    transform=_tuplify_outputs,
+                )
+                # ep_non_strict.constants contains only fake script objects, we need to map them back
+                ep_non_strict.constants = {
+                    fqn: map_fake_to_real[obj]
+                    if isinstance(obj, FakeScriptObject)
+                    else obj
+                    for fqn, obj in ep_non_strict.constants.items()
+                }
+
         ep_non_strict.gm.meta["inline_constraints"] = {
             k: v
             for k, v in fake_mode.shape_env.var_to_range.items()
@@ -1220,6 +1213,7 @@ def _export(
     _normalize_nn_module_stack(gm_torch_level, type(mod))
 
     # NOTE: graph module expects only positional args
+    constant_attrs = _gather_constant_attrs(mod)
     ep_non_strict = _export_non_strict(
         gm_torch_level,
         _convert_to_positional_args(orig_arg_names, fake_args, fake_kwargs),

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -10,6 +10,7 @@ from typing import Any, cast, Dict, List, Optional, Tuple, Union
 import torch
 import torch.fx._pytree as fx_pytree
 import torch.utils._pytree as pytree
+from torch._library.fake_class_registry import FakeScriptObject
 from torch.export._tree_utils import reorder_kwargs
 from torch.export.exported_program import (
     ConstantArgument,
@@ -56,7 +57,16 @@ def _assign_attr(
         assert isinstance(from_obj, torch.Tensor)
         to_module.register_buffer(field, from_obj, persistent=persistent)
     elif attr_kind == _AttrKind.CONSTANT:
-        assert isinstance(from_obj, (torch.Tensor, torch.ScriptObject))
+        assert not isinstance(
+            from_obj, FakeScriptObject
+        ), "FakeScriptObject should only exist during tracing."
+        assert isinstance(
+            from_obj,
+            (
+                torch.Tensor,
+                torch.ScriptObject,
+            ),
+        )
         setattr(to_module, field, from_obj)
 
 

--- a/torch/testing/_internal/torchbind_impls.py
+++ b/torch/testing/_internal/torchbind_impls.py
@@ -1,32 +1,120 @@
+import contextlib
+
 import torch
 
 
-def register_if_not(qualname):
-    entry = torch._library.simple_registry.singleton.find(qualname)
-    if entry.abstract_impl.kernel is None:
-        return torch.library.impl_abstract(qualname)
-    else:
+_TORCHBIND_IMPLS_INITIALIZED = False
 
-        def dummy_wrapper(fn):
-            return fn
 
-        return dummy_wrapper
+def init_torchbind_implementations():
+    global _TORCHBIND_IMPLS_INITIALIZED
+    if _TORCHBIND_IMPLS_INITIALIZED:
+        return
+
+    load_torchbind_test_lib()
+    register_fake_operators()
+    register_fake_classes()
+    _TORCHBIND_IMPLS_INITIALIZED = True
 
 
 # put these under a function because the corresponding library might not be loaded yet.
 def register_fake_operators():
-    @register_if_not("_TorchScriptTesting::takes_foo_python_meta")
+    @torch.library.register_fake("_TorchScriptTesting::takes_foo_python_meta")
     def fake_takes_foo(foo, z):
         return foo.add_tensor(z)
 
-    @register_if_not("_TorchScriptTesting::queue_pop")
+    @torch.library.register_fake("_TorchScriptTesting::queue_pop")
     def fake_queue_pop(tq):
         return tq.pop()
 
-    @register_if_not("_TorchScriptTesting::queue_push")
+    @torch.library.register_fake("_TorchScriptTesting::queue_push")
     def fake_queue_push(tq, x):
         return tq.push(x)
 
-    @register_if_not("_TorchScriptTesting::queue_size")
+    @torch.library.register_fake("_TorchScriptTesting::queue_size")
     def fake_queue_size(tq):
         return tq.size()
+
+    def meta_takes_foo_list_return(foo, x):
+        a = foo.add_tensor(x)
+        b = foo.add_tensor(a)
+        c = foo.add_tensor(b)
+        return [a, b, c]
+
+    def meta_takes_foo_tuple_return(foo, x):
+        a = foo.add_tensor(x)
+        b = foo.add_tensor(a)
+        return (a, b)
+
+    torch.ops._TorchScriptTesting.takes_foo_list_return.default.py_impl(
+        torch._C.DispatchKey.Meta
+    )(meta_takes_foo_list_return)
+
+    torch.ops._TorchScriptTesting.takes_foo_tuple_return.default.py_impl(
+        torch._C.DispatchKey.Meta
+    )(meta_takes_foo_tuple_return)
+
+    torch.ops._TorchScriptTesting.takes_foo.default.py_impl(torch._C.DispatchKey.Meta)(
+        lambda cc, x: cc.add_tensor(x)
+    )
+
+
+def register_fake_classes():
+    @torch._library.register_fake_class("_TorchScriptTesting::_Foo")
+    class FakeFoo:
+        def __init__(self, x: int, y: int):
+            self.x = x
+            self.y = y
+
+        @classmethod
+        def from_real(cls, foo):
+            (x, y), _ = foo.__getstate__()
+            return cls(x, y)
+
+        def add_tensor(self, z):
+            return (self.x + self.y) * z
+
+    @torch._library.register_fake_class("_TorchScriptTesting::_ContainsTensor")
+    class FakeContainsTensor:
+        def __init__(self, x: torch.Tensor):
+            self.x = x
+
+        @classmethod
+        def from_real(cls, foo):
+            ctx = torch.library.get_ctx()
+            return cls(ctx.to_fake_tensor(foo.get()))
+
+        def get(self):
+            return self.x
+
+
+def load_torchbind_test_lib():
+    import unittest
+
+    from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
+        find_library_location,
+        IS_FBCODE,
+        IS_MACOS,
+        IS_SANDCASTLE,
+        IS_WINDOWS,
+    )
+
+    if IS_SANDCASTLE or IS_FBCODE:
+        torch.ops.load_library("//caffe2/test/cpp/jit:test_custom_class_registrations")
+    elif IS_MACOS:
+        raise unittest.SkipTest("non-portable load_library call used in test")
+    else:
+        lib_file_path = find_library_location("libtorchbind_test.so")
+        if IS_WINDOWS:
+            lib_file_path = find_library_location("torchbind_test.dll")
+        torch.ops.load_library(str(lib_file_path))
+
+
+@contextlib.contextmanager
+def _register_py_impl_temporarily(op_overload, key, fn):
+    try:
+        op_overload.py_impl(key)(fn)
+        yield
+    finally:
+        del op_overload.py_kernels[key]
+        op_overload._dispatch_cache.clear()


### PR DESCRIPTION
A re-land of #124239.

This PR fakify ScriptObject inputs and attributes in export non-strict mode by default.

The basic idea is to only fakify the script object during tracing (i.e. aot_export). After we get the traced graph module, eagerly executing, serializing, or running more passes will use the real script objects. This is essentially treating the script object as constant tensor.

Concretely, we

fakify all the script object inputs, and module attributes (gathered by constant_attrs).
patch the module's attributes with fakified script object
right after aot_export, remove the patching (to avoid changing the original module) then modify the exported graph module's attribute to real script object.