### PR TITLE
[codemod][quick][careful] Remove unused-but-set variables in caffe2/binaries/benchmark_helper.h +2

### DIFF
--- a/binaries/benchmark_helper.h
+++ b/binaries/benchmark_helper.h
@@ -54,11 +54,6 @@ void writeTextOutput(
   CAFFE_ENFORCE(blob_proto.has_tensor());
   caffe2::TensorProto tensor_proto = blob_proto.tensor();
   int dims_size = tensor_proto.dims_size();
-  long long elem_dim_size =
-      dims_size > 1 ? tensor_proto.dims(1) : tensor_proto.dims(0);
-  for (const auto i : c10::irange(2, dims_size)) {
-    elem_dim_size *= tensor_proto.dims(i);
-  }
   std::vector<std::string> lines;
   std::string dims;
   for (const auto i : c10::irange(dims_size)) {


### PR DESCRIPTION
Summary:
This diff removes a variable that was set, but which was not used.

LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused but set variables often indicate a programming mistake, but can also just be unnecessary cruft that harms readability and performance.

Removing this variable will not change how your code works, but the unused variable may indicate your code isn't working the way you thought it was. I've gone through each of these by hand, but mistakes may have slipped through. If you feel the diff needs changes before landing, **please commandeer** and make appropriate changes: there are hundreds of these and responding to them individually is challenging.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Test Plan: Sandcastle

Differential Revision: D56887039


