### PR TITLE
Don't use wrap_fx_proxy_cls for wrap_symint

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1389,13 +1389,8 @@ class VariableBuilder:
             source=self.get_source(),
         )
 
-        unspec_var = wrap_fx_proxy_cls(
-            SymNodeVariable,  # NB: this doesn't actually do anything
-            tx=self.tx,
-            proxy=proxy,
-            example_value=wrapped_value,
-            **options,
-        )
+        set_example_value(proxy.node, wrapped_value)
+        unspec_var = SymNodeVariable(proxy, wrapped_value, **options)
         self.tx.output.unspec_variable_map[self.name] = unspec_var
 
         if not is_constant_source(self.get_source()):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #125496
* __->__ #125494
* #125483
* #125419

We use very little of the code in wrap_fx_proxy_cls, so dupe it out.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang