### PR TITLE
[AOTI] Add a missing mypy ignore

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5547,7 +5547,7 @@ class FallbackKernel(ExternKernelAlloc):
                     self.set_cpp_kernel(kernel)
                 else:
                     self.cpp_kernel_name = get_aten_cpp_kernel_name(kernel)
-                    schema = kernel._schema
+                    schema = kernel._schema  # type: ignore[union-attr]
                     self.init_args_default_value(schema)
             else:
                 self.python_kernel_name = str(kernel)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125508

Summary: Caused by https://github.com/pytorch/pytorch/pull/125397, but somehow was not caught by CI.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang