### PR TITLE
[export] handle constant aliasing for export

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4828,6 +4828,40 @@ def forward(self, x, y):
                 _disable_forced_specializations=True,
             )
 
+    def test_constant_aliasing(self):
+        class M1(torch.nn.Module):
+            def __init__(self, m2, foo):
+                super().__init__()
+                self.m2 = m2
+                self.foo = foo
+
+            def forward(self, x):
+                return x + self.foo + self.m2(x)
+
+        class M2(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.foo = torch.ones(3, 3)
+
+            def forward(self, x):
+                return x + self.foo
+
+        m2 = M2()
+        m1 = M1(m2, m2.foo)
+        inps = (torch.ones(3, 3),)
+        ep = torch.export.export(m1, inps, strict=False)
+        # check both constants appear in list
+        self.assertEqual(sorted(list(ep.constants)), ["foo", "m2.foo"])
+        # check only one input spec exists
+        num_constant_inputs = [
+            spec.kind == InputKind.CONSTANT_TENSOR
+            for spec in ep.graph_signature.input_specs
+        ].count(True)
+        self.assertEqual(num_constant_inputs, 1)
+        # unflatten
+        unflattened = unflatten(ep)
+        self.assertTrue(torch.allclose(m1(*inps), unflattened(*inps)))
+
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestOneOffModelExportResult(TestCase):

--- a/test/export/test_lift_unlift.py
+++ b/test/export/test_lift_unlift.py
@@ -396,17 +396,19 @@ class ConstantAttrMapTest(TestCase):
         constant_attr_map = ConstantAttrMap()
         const_obj = torch.classes._TorchScriptTesting._Foo(10, 20)
         const_tensor = torch.ones(2, 3)
-        constant_attr_map[const_obj] = "foo.bar"
-        constant_attr_map[const_tensor] = "foo.bar.baz"
+        constant_attr_map.add(const_obj, "foo.bar")
+        constant_attr_map.add(const_tensor, "foo.bar.baz")
         self.assertEqual(len(constant_attr_map), 2)
         self.assertEqual(list(constant_attr_map), [const_obj, const_tensor])
         self.assertEqual(list(constant_attr_map.keys()), [const_obj, const_tensor])
-        self.assertEqual(list(constant_attr_map.values()), ["foo.bar", "foo.bar.baz"])
-        self.assertEqual(constant_attr_map[const_obj], "foo.bar")
-        self.assertEqual(constant_attr_map[const_tensor], "foo.bar.baz")
+        self.assertEqual(
+            list(constant_attr_map.values()), [["foo.bar"], ["foo.bar.baz"]]
+        )
+        self.assertEqual(constant_attr_map[const_obj], ["foo.bar"])
+        self.assertEqual(constant_attr_map[const_tensor], ["foo.bar.baz"])
         self.assertTrue(const_obj in constant_attr_map)
         with self.assertRaises(TypeError):
-            constant_attr_map[1] = "foo.bar"
+            constant_attr_map.add(1, "foo.bar")
 
         del constant_attr_map[const_obj]
         self.assertEqual(len(constant_attr_map), 1)

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -358,12 +358,7 @@ def _gather_constant_attrs(m: torch.nn.Module) -> ConstantAttrMap:
                     continue
 
                 fqn = ".".join(prefix_atoms + [k])
-                if v in constants:
-                    raise ValueError(
-                        f"Duplicate reference to constant attribute found: '{constants[v]}' and '{fqn}'."
-                    )
-
-                constants[v] = fqn
+                constants.add(v, fqn)
         for k, v in m.named_children():
             inner(v, prefix_atoms + [k], constants)
 
@@ -420,16 +415,18 @@ def _fakify_script_objects(
         return cur_mod, last_attr
 
     try:
-        for obj, fqn in constant_attrs.items():
+        for obj, fqns in constant_attrs.items():
             if isinstance(obj, torch.ScriptObject):
-                cur_mod, attr = _leaf_mod_and_attr(mod, fqn)
-                assert obj is getattr(cur_mod, attr)
                 fake_script_obj = _maybe_fakify_obj(obj)
-                setattr(cur_mod, attr, fake_script_obj)
-                fake_constant_attrs[fake_script_obj] = fqn
-                patched_attr[fqn] = obj
+                for fqn in fqns:
+                    cur_mod, attr = _leaf_mod_and_attr(mod, fqn)
+                    assert obj is getattr(cur_mod, attr)
+                    setattr(cur_mod, attr, fake_script_obj)
+                    fake_constant_attrs.add(fake_script_obj, fqn)
+                    patched_attr[fqn] = obj
             else:
-                fake_constant_attrs[obj] = fqn
+                for fqn in fqns:
+                    fake_constant_attrs.add(obj, fqn)
 
         fake_args, fake_kwargs = pytree.tree_map_only(
             torch.ScriptObject, _maybe_fakify_obj, (args, kwargs)

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -270,7 +270,7 @@ def _remap_constants(
     constants: Dict[str, Union[torch.Tensor, torch.ScriptObject]],
 ) -> None:
     """Rewrite the graph signature and constants table to use the FQN from the original module."""
-    remap_table: Dict[str, str] = {}
+    remap_table: Dict[str, List[str]] = {}
     for name, value in constants.items():
         if value in orig_constant_attrs:
             remap_table[name] = orig_constant_attrs[value]
@@ -282,11 +282,13 @@ def _remap_constants(
         ):
             orig_target = spec.target
             assert orig_target is not None
-            spec.target = remap_table.get(orig_target, orig_target)
+            targets = remap_table.get(orig_target, [orig_target])
+            spec.target = targets[0]
 
             constant = constants[orig_target]
             del constants[orig_target]
-            constants[spec.target] = constant
+            for target in targets:
+                constants[target] = constant
 
 
 def _rename_constants_nodes(

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -4,8 +4,7 @@ import operator
 from collections import defaultdict
 from copy import deepcopy
 from enum import Enum
-from itertools import chain
-from typing import Any, cast, Dict, List, Optional, Tuple, Union
+from typing import Any, cast, Dict, List, Optional, Set, Tuple, Union
 
 import torch
 import torch.fx._pytree as fx_pytree
@@ -200,15 +199,16 @@ class UnflattenedModule(torch.nn.Module):
                 persistent=persistent,
             )
 
-        for fqn in chain(
-            self.graph_signature.lifted_tensor_constants,
-            self.graph_signature.lifted_custom_objs,
-        ):
-            constant = export_module.constants[fqn]
-            if isinstance(constant, torch.Tensor):
-                constant = constant.clone()
+        # use id map so we don't double-clone aliased constants
+        id_to_const: Dict[int, Union[torch.Tensor, torch._C.ScriptObject]] = {}
+        for fqn, constant in export_module.constants.items():
+            if id(constant) not in id_to_const:
+                if isinstance(constant, torch.Tensor):
+                    constant = constant.clone()
+                id_to_const[id(constant)] = constant
+            _constant = id_to_const[id(constant)]
             _assign_attr(
-                constant,
+                _constant,
                 self,
                 fqn,
                 attr_kind=_AttrKind.CONSTANT,
@@ -217,6 +217,7 @@ class UnflattenedModule(torch.nn.Module):
         # This is to handle parameters/buffers that point to the same tensor
         # object id -> list of (node_name, target_name)
         consts_map: Dict[int, List[Tuple[str, str]]] = defaultdict(list)
+        consts_targets: Set[str] = set()
 
         def add_to_consts_map(obj_id, node_name, target_name):
             name_list = consts_map[obj_id]
@@ -231,6 +232,7 @@ class UnflattenedModule(torch.nn.Module):
                 add_to_consts_map(
                     id(export_module.state_dict[s.target]), s.arg.name, s.target
                 )
+                consts_targets.add(s.target)
             elif (
                 (s.kind == InputKind.BUFFER and not s.persistent)
                 or s.kind == InputKind.CONSTANT_TENSOR
@@ -241,6 +243,16 @@ class UnflattenedModule(torch.nn.Module):
                 add_to_consts_map(
                     id(export_module.constants[s.target]), s.arg.name, s.target
                 )
+                consts_targets.add(s.target)
+
+        # add constants that are aliased and don't appear in graph signature
+        for const_name, const in export_module.constants.items():
+            if const_name not in consts_targets:
+                assert (
+                    id(const) in consts_map
+                ), "Constants should be either aliased or appear in graph signature"
+                ph_name, _ = consts_map[id(const)][0]
+                add_to_consts_map(id(const), ph_name, const_name)
 
         # node name -> list of possible targets
         inputs_to_state: Dict[str, List[str]] = {}
@@ -583,9 +595,11 @@ class _ModuleFrame:
             _add_submodule(
                 parent.module,
                 accessor,
-                self.module
-                if self.cached_graph_module is None
-                else self.cached_graph_module,
+                (
+                    self.module
+                    if self.cached_graph_module is None
+                    else self.cached_graph_module
+                ),
             )
             self.parent_call_module = parent.graph.call_module(accessor)
 
@@ -614,9 +628,11 @@ class _ModuleFrame:
                         op="call_function",
                         target=operator.getitem,
                         args=(flat_args, idx),
-                        name=arg.name
-                        if not isinstance(arg, ConstantArgument)
-                        else f"_constant_{idx}",
+                        name=(
+                            arg.name
+                            if not isinstance(arg, ConstantArgument)
+                            else f"_constant_{idx}"
+                        ),
                     )
                     if isinstance(arg, ConstantArgument):
                         continue


### PR DESCRIPTION
Summary: Currently export will [error out](https://github.com/pytorch/pytorch/blob/2b5ae2611e22d992565f202df9267fe66469efaa/torch/export/_trace.py#L477) if a constant is aliased. This PR supports this by modifying ConstantAttrMap to map constants to a list of FQNs instead of a single FQN, populating the ExportedProgram constants dict to contain multiple entries to the same constant.

Test Plan: added test case in test_export.py

Differential Revision: D56955654
