### PR TITLE
Nested Tensor + AOTI test

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -2676,6 +2676,62 @@ class AOTInductorTestsTemplate:
         example_inputs = (torch.randn(16, 16, 16, device=self.device),)
         self.check_model(Model(), example_inputs)
 
+    def test_nested_tensor_from_jagged(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mlp = nn.Sequential(
+                    nn.Linear(128, 64), nn.ReLU(), nn.Linear(64, 32), nn.Sigmoid()
+                )
+
+            def forward(self, values, offsets):
+                nt = torch.nested.nested_tensor_from_jagged(values, offsets)
+                res = self.mlp(nt)
+                return res.values()
+
+        model = Model().to(device=self.device)
+
+        example_inputs_1 = (
+            torch.randn((15, 128), device=self.device),
+            torch.tensor([0, 3, 4, 10, 15], device=self.device),
+        )
+
+        # same "NT batch size", different actual amount of data
+        example_inputs_2 = (
+            torch.randn((31, 128), device=self.device),
+            torch.tensor([0, 1, 20, 25, 31], device=self.device),
+        )
+
+        # different "NT batch size"
+        example_inputs_3 = (
+            torch.randn((37, 128), device=self.device),
+            torch.tensor([0, 5, 16, 25, 29, 37], device=self.device),
+        )
+
+        with torch.no_grad(), config.patch(
+            {
+                "abi_compatible": self.abi_compatible,
+                "aot_inductor.debug_compile": True,
+            }
+        ):
+            dim0_values = Dim("dim0_values", min=1, max=128)
+            dim0_offsets = Dim("dim0_offsets", min=1, max=9)
+            dynamic_shapes = {"values": {0: dim0_values}, "offsets": {0: dim0_offsets}}
+            so_path: str = AOTIRunnerUtil.compile(
+                model, example_inputs_1, dynamic_shapes=dynamic_shapes
+            )
+        aot_inductor_module = AOTIRunnerUtil.load(self.device, so_path)
+
+        self.assertEqual(
+            aot_inductor_module(*example_inputs_1), model(*example_inputs_1)
+        )
+        self.assertEqual(
+            aot_inductor_module(*example_inputs_2), model(*example_inputs_2)
+        )
+        self.assertEqual(
+            aot_inductor_module(*example_inputs_3), model(*example_inputs_3)
+        )
+
     def test_misc_1(self):
         class Model(nn.Module):
             def __init__(self):


### PR DESCRIPTION
Since we expect AOTI to be important for serving NJT in the future, I'm adding a test demonstrating that AOTI currently works with NJT when NJT is entirely in the graph (no NJTs going in or out), and to prevent regressions.

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang