### PR TITLE
chore: `Dockerfile` should set the `syntax` directive to v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-# syntax = docker/dockerfile:experimental
+# syntax=docker/dockerfile:1
+
+# NOTE: Building this image requires a minimum docker version of either:
+#  - > 18.06 with `experimental` enabled and ENV `DOCKER_BUILDKIT=1`
+#  - >= 23.0 releases (Feb 2023) use BuildKit by default
 #
-# NOTE: To build this you will need a docker version > 18.06 with
-#       experimental enabled and DOCKER_BUILDKIT=1
-#
-#       If you do not use buildkit you are not going to have a good time
-#
-#       For reference:
-#           https://docs.docker.com/develop/develop-images/build_enhancements/
+# For reference:
+# - https://docs.docker.com/build/buildkit/#getting-started
+# - https://docs.docker.com/build/dockerfile/frontend/#stable-channel
+# - https://docs.docker.com/engine/release-notes/23.0/
+# - https://hub.docker.com/layers/docker/dockerfile/1.0/images/sha256-92f5351b2fca8f7e2f452aa9aec1c34213cdd2702ca92414eee6466fab21814a?context=explore
+
 ARG BASE_IMAGE=ubuntu:22.04
 ARG PYTHON_VERSION=3.11
 


### PR DESCRIPTION
Adopt `syntax=docker/dockerfile:1` whcih has been stable since 2018, while still best practice to declare in 2024.

- Syntax features dependent upon the [`syntax` directive version are documented here](https://hub.docker.com/r/docker/dockerfile).
- While you can set a fixed minor version, [Docker officially advises to only pin the major version](https://docs.docker.com/build/dockerfile/frontend/#stable-channel):
  > _We recommend using `docker/dockerfile:1`, which always points to the latest stable release of the version 1 syntax, and receives both "minor" and "patch" updates for the version 1 release cycle._
  > _BuildKit automatically checks for updates of the syntax when performing a build, making sure you are using the most current version._

---

## Support for building with Docker prior to v23 (released on Feb 2023)

**NOTE:** `18.06` may not be the accurate minimum version for using `docker/dockerfile:1`, according to the [DockerHub tag history](https://hub.docker.com/layers/docker/dockerfile/1.0/images/sha256-92f5351b2fca8f7e2f452aa9aec1c34213cdd2702ca92414eee6466fab21814a?context=explore) `1.0` of the syntax seems to be from Dec 2018, which is probably why `docker/dockerfile:experimental` was paired with it in this file.

Personally, I'd favor only supporting builds with Docker v23. This is only relevant for someone building this `Dockerfile` locally, the user could still extend the already built and published image from a registry on older versions of Docker without any concern for this directive which only applies to building this `Dockerfile`, not images that extend it.

However if you're reluctant, you may want to refer others to [this Docker docs page](https://docs.docker.com/build/buildkit/#getting-started) where they should only need the ENV `DOCKER_BUILDKIT=1`, presumably the requirement for `experimental` was dropped with `syntax=docker/dockerfile:1` with releases of Docker since Dec 2018. Affected users can often quite easily install a newer version of Docker on their OS, as per Dockers official guidance (_usually via including an additional repo to the package manager_).

---

## Reference links

Since one of these was already included in the inline note (now a broken link), I've included relevant links mentioned above. You could alternatively rely on `git blame` with a commit message referencing the links or this PR for more information.

Feel free to remove any of the reference links, they're mostly only relevant to maintainers to be aware of (_which this PR itself has detailed adequately above_).

cc @seemethere @malfet @pytorch/pytorch-dev-infra