### PR TITLE
[export] Fix serialization of empty torch artifact

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -873,6 +873,20 @@ class TestDeserialize(TestCase):
         with enable_torchbind_tracing():
             self.check_graph(m, inputs, strict=False)
 
+    def test_export_no_inputs(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.p = torch.ones(3, 3)
+
+            def forward(self):
+                return self.p * self.p
+
+        ep = torch.export.export(M(), ())
+        ep._example_inputs = None
+        roundtrip_ep = deserialize(serialize(ep))
+        self.assertTrue(torch.allclose(ep.module()(), roundtrip_ep.module()()))
+
 
 instantiate_parametrized_tests(TestDeserialize)
 

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -284,7 +284,10 @@ def _reconstruct_fake_tensor(
     return fake_tensor
 
 
-def serialize_torch_artifact(artifact: Dict[str, Any]) -> bytes:
+def serialize_torch_artifact(artifact: Optional[Any]) -> bytes:
+    if artifact is None:
+        return b""
+
     assert (
         FakeTensor not in copyreg.dispatch_table
     ), "Refusing to stomp on existing FakeTensor reducer"


### PR DESCRIPTION
A previous PR added support for serializing/deserializing example inputs, but this fails when `example_inputs` is none.