### PR TITLE
[export] handle new roots & root swapping in derived dims suggested fixes

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -968,6 +968,35 @@ class TestExport(TestCase):
             6,
         )
 
+    def test_specialize_derived_dim_roots(self):
+        # dim & derived dim both specialize
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                return x.reshape([-1]) + y
+
+        dy = Dim("dy", min=6)
+        x, y = torch.randn(6, 2), torch.randn(12)
+        dynamic_shapes = {
+            "x": (dy - 6, 2),
+            "y": (dy,),
+        }
+        try:
+            export(Foo(), (x, y), dynamic_shapes=dynamic_shapes)
+            raise Exception(
+                "export() call should have failed with dynamic shapes error."
+            )
+        except torch._dynamo.exc.UserError as exc:
+            expected_error_msg = (
+                "Specializations unexpectedly required \(dy\)!(.*\n)*.*"
+                ".*dy - 6.*must be specialized to 6 because the guards generated for it are too complex(.*\n)*.*"
+                "Suggested fixes(.*\n)*.*"
+                ".*dy = 12(.*\n)*.*"
+            )
+            self.assertTrue(re.search(expected_error_msg, exc.args[0]) is not None)
+            self.assertTrue(
+                "dy - 6 = 6" not in exc.args[0]
+            )  # don't suggest fix for non-root dim
+
     def test_derived_dim_out_of_order_simplified(self):
         _dimz = torch.export.Dim("_dimz", min=6, max=8)
         dimy = _dimz - 1
@@ -979,22 +1008,25 @@ class TestExport(TestCase):
                 return x + y[1:] + z[2:]
 
         foo = Foo()
-
         u, v, w = torch.randn(5), torch.randn(6), torch.randn(7)
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.UserError,
-            (
-                "Constraints violated \\(dimz\\)!(.*\n)*.*"
-                "The values of dimz.*must always be related to the values of _dimz - 2.*by.*(.*\n)*.*"
-                "Suggested fixes:(.*\n)*.*"
-                "dimz = _dimz"
-            ),
-        ):
+        try:
             export(
                 foo,
                 (u, v, w),
                 dynamic_shapes=({0: dimx}, {0: dimy}, {0: dimz}),
             )
+        except torch._dynamo.exc.UserError as exc:
+            expected_error_msg = (
+                "Constraints violated \(dimz\)!(.*\n)*.*"
+                "The values of dimz.*must always be related to the values of _dimz - 2.*by.*(.*\n)*.*"
+                "Suggested fixes:(.*\n)*.*"
+                "dimz = _dimz"
+            )
+            self.assertTrue(re.search(expected_error_msg, exc.args[0]) is not None)
+            # don't suggest fix for non-root dims, and no need to update root here
+            self.assertTrue("_dimz - 2 = Dim(" not in exc.args[0])
+            self.assertTrue("_dimz - 1 = _dimz - 1" not in exc.args[0])
+            self.assertTrue("_dimz = Dim(" not in exc.args[0])
 
         dimz = dimx + 2  # works, effectively = _dimz
         ep = export(
@@ -1887,6 +1919,55 @@ class TestExport(TestCase):
                 inputs,
                 dynamic_shapes={"x": (batch, M, K), "y": (batch, K, N)},
             )
+
+    def test_suggested_fixes_new_roots(self):
+        from torch.export import dims
+
+        # suggested fixes should introduce new root dim for modulo guard
+        class Foo(torch.nn.Module):
+            def forward(self, x, y, z):
+                # dy = 3 * _dx
+                # dx = 3 * _dx - 1
+                # dz = 3 * _dx + 2
+                # suggested fixes results will look something like
+                # {"dx": {"eq": 3*_dx-1, "min": 5, "max": 36}, "dy": {"eq": dx+1}, ...}
+                if x.shape[0] >= 5 and x.shape[0] <= 36 and y.shape[0] % 3 == 0:
+                    return x + y[1:] + z[3:]
+
+        foo = Foo()
+        inputs = (
+            torch.randn(
+                11,
+            ),
+            torch.randn(
+                12,
+            ),
+            torch.randn(
+                14,
+            ),
+        )
+        dx, dy, dz = dims("dx", "dy", "dz")
+        dynamic_shapes = {
+            "x": (dx,),
+            "y": (dy,),
+            "z": (dz,),
+        }
+        with self.assertRaisesRegex(  # figure out regex later
+            torch._dynamo.exc.UserError,
+            (
+                "Constraints violated.*!(.*\n)*.*"
+                "Suggested fixes(.*\n)*.*"
+                "_dx = Dim\(\\'_dx\\', max=12\)(.*\n)*.*"
+                "dx = 3\*_dx - 1(.*\n)*.*"
+                "dy = 3\*_dx(.*\n)*.*"
+                "dz = 3\*_dx \+ 2"
+            ),
+        ):
+            export(Foo(), inputs, dynamic_shapes=dynamic_shapes)
+        # retry export
+        _dx = Dim("_dx", min=2, max=12)
+        dynamic_shapes = {"x": (3 * _dx - 1,), "y": (3 * _dx,), "z": (3 * _dx + 2,)}
+        export(Foo(), inputs, dynamic_shapes=dynamic_shapes)
 
     def test_dynamic_shapes_spec_with_pytree(self):
         from torch.export import Dim, export
@@ -5065,7 +5146,6 @@ def forward(self, x, y):
             torch._dynamo.exc.UserError,
             r".*Specializations unexpectedly required(.*\n)*"
             r"Suggested fixes:(.*\n)*"
-            r".*dy = Dim.*(.*\n)*"
             r".*dw0 = 3(.*\n)*"
             r".*dw1 = 4(.*\n)*"
             r".*dx0 = 12(.*\n)*"
@@ -5082,9 +5162,6 @@ def forward(self, x, y):
             torch._dynamo.exc.UserError,
             r".*Constraints violated(.*\n)*"
             r"Suggested fixes:(.*\n)*"
-            r".*dw0 = Dim.*(.*\n)*"
-            r".*dw1 = Dim.*(.*\n)*"
-            r".*dy = Dim.*(.*\n)*"
             r".*dz = dy(.*\n)*",
         ) as msg:
             torch.export._trace._export(

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -2435,7 +2435,7 @@ class TestDimConstraints(TestCase):
         def dummy_fn(a, b, c, d, e, f):
             pass
 
-        action_code = dim_constraints.prettify_results(inspect.signature(dummy_fn))
+        action_code = dim_constraints.prettify_results(inspect.signature(dummy_fn), {})
         static_code, dynamic_code = re.findall(r"```(.*?)```", action_code, re.DOTALL)
         expected_static = """
 def specializations(a, b, c, d, e, f):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1333,7 +1333,10 @@ def export(
             dim_constraints.remove_redundant_dynamic_results()
             forced_specializations = dim_constraints.forced_specializations()
             msg = dim_constraints.prettify_results(
-                original_signature, constraint_violation_error, forced_specializations
+                original_signature,
+                dynamic_shapes,
+                constraint_violation_error,
+                forced_specializations,
             )
             if constraint_violation_error:
                 constraint_violation_error.args = (

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -223,6 +223,7 @@ def _flatten_dynamic_shapes(
 def produce_guards_and_solve_constraints(
     fake_mode: FakeTensorMode,
     gm: torch.fx.GraphModule,
+    dynamic_shapes: Union[Dict[str, Any], Tuple[Any], List[Any], None],
     equalities_inputs: EqualityConstraint,
     original_signature: inspect.Signature,
     _disable_forced_specializations: Optional[bool] = False,
@@ -273,7 +274,10 @@ def produce_guards_and_solve_constraints(
     forced_specializations = dim_constraints.forced_specializations()
     if not _is_torch_jit_trace:
         msg = dim_constraints.prettify_results(
-            original_signature, constraint_violation_error, forced_specializations
+            original_signature,
+            dynamic_shapes,
+            constraint_violation_error,
+            forced_specializations,
         )
     else:
         # FIXME(ycao): This is a hack to get around missing signature from ScriptMethod

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1269,6 +1269,7 @@ def _non_strict_export(
         produce_guards_and_solve_constraints(
             fake_mode,
             aten_export_artifact.gm,
+            dynamic_shapes,
             equalities_inputs,
             original_signature,
             _disable_forced_specializations=_disable_forced_specializations,


### PR DESCRIPTION
Pull Request resolved: https://github.com/pytorch/pytorch/pull/125543

This PR address 2 issues with derived dim suggested fixes, 1) newly introduced roots, and 2) root swapping.

1 | Newly introduced roots appear with modulo guards, e.g. Mod(dx, 2) = 0 suggests dx is a derived dim equal to 2 * _dx, introducing a new root _dx. Currently the final suggested fixes handle this correctly, but we can get intermediate results where related derived dims don't rely on a unified root, and are a mixture of min/max range and derived suggestions. 

For example:
```
"dx": {"eq": 3*_dx-1, "max": 36}
"dy": {"eq": dx+1}
This should lead to suggested fixes
  _dx = Dim('_dx', max=12)
  dx = 3 * _dx - 1
  dy = 3 * _dx
```

This PR prettifies the suggested fixes routine by unifying to a single root, and making each intermediate suggestion either a derived dim or min/max range, not both.

2 | The current suggested fixes for derived dims can lead to root dims/derived dims being swapped, e.g. `dy - 1, dy` -> `dx, dx + 1`. This leads to problematic suggested fixes that look like `dy - 1 = Dim("dy - 1")` since we don't have access to the original variable name.

This PR only adds a suggested fix for the root dim, and removes all other derived suggestions.

For example, with the export test case test_derived_dim_out_of_order_simplified:
```
_dimz = torch.export.Dim("_dimz", min=6, max=8)
dimy = _dimz - 1
dimx = dimy - 1
dimz = torch.export.Dim("dimz", min=6, max=8)  # doesn't work, should be = _dimz

class Foo(torch.nn.Module):
    def forward(self, x, y, z):
        return x + y[1:] + z[2:]

foo = Foo()
u, v, w = torch.randn(5), torch.randn(6), torch.randn(7)
export(
    foo,
    (u, v, w),
    dynamic_shapes=({0: dimx}, {0: dimy}, {0: dimz}),
)
```

Before:
```
Suggested fixes:
  _dimz = Dim('_dimz', min=3, max=9223372036854775807)  # 2 <= _dimz - 1 <= 9223372036854775806
  _dimz - 2 = Dim('_dimz - 2', min=4, max=6)
  _dimz = Dim('_dimz', min=2, max=9223372036854775806)  # 2 <= _dimz <= 9223372036854775806
  _dimz - 1 = _dimz - 1
  dimz = _dimz
```

New suggested fixes:
```
Suggested fixes:
  dimz = _dimz
```

Note: This assumes the specified derived relations between dims are correct. This should be valid because: 1) if the relation is plain wrong (e.g. (dx, dx - 1) provided with inputs (6, 4)), this gets caught in beforehand in produce_guards. 2) if the relation is correct but does not match the emitted guard, for example:
```
def forward(self, x, y):
    return x.reshape([-1]) + y  # guard: s0 * 2 = s1
dx = Dim("dx")
export(
    model,
    (torch.randn(6, 2), torch.randn(12)),
    dynamic_shapes={"x": (dx, 2), "y": (dx + 6, )}
)
```
This produces two linear equations, leading to specialization since a) produce_guards is able to solve for a concrete value, and b) the export constraint solver will anyways force specializations due to range constraints.
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang