### PR TITLE
CI: aarch64 linux: upgrade ACL version to 24.04

### DIFF
--- a/.ci/docker/common/install_acl.sh
+++ b/.ci/docker/common/install_acl.sh
@@ -1,6 +1,6 @@
 set -euo pipefail
 
-readonly version=v23.08
+readonly version=v24.04
 readonly src_host=https://review.mlplatform.org/ml
 readonly src_repo=ComputeLibrary
 


### PR DESCRIPTION
Arm Compute Library (ACL) version is updated to 24.04 to make oneDNN 3.4 work on aarch64 linux. 

