### PR TITLE
[MPS][BE] Introduce MetalShaderLibary class

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -329,6 +329,19 @@ inline bool is_dense_in_storage(const at::Tensor& t) {
   return compute_storage_numel_distance(t) == static_cast<size_t>(t.numel());
 }
 
+
+class MetalShaderLibrary {
+public:
+  MetalShaderLibrary(const std::string& src): shaderSource(src) {}
+  MetalShaderLibrary(const MetalShaderLibrary&) = delete;
+  id<MTLComputePipelineState> getPipelineStateForFunc(const std::string& fname);
+private:
+  id<MTLLibrary> getLibrary();
+  std::string shaderSource;
+  id<MTLLibrary> library = nil;
+  std::unordered_map<std::string, id<MTLComputePipelineState>> cplMap;
+};
+
 static inline void mtl_setBuffer(id<MTLComputeCommandEncoder> encoder, const Tensor& t, unsigned idx) {
   [encoder setBuffer:getMTLBufferStorage(t)
               offset:t.storage_offset() * t.element_size()

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -72,6 +72,9 @@ static inline std::string getMPSTypeString(const Tensor& t, bool short_name = fa
   return getMPSTypeString(t.scalar_type(), short_name);
 }
 std::string scalarToMetalTypeString(const c10::ScalarType& scalar_type);
+static inline std::string scalarToMetalTypeString(const Tensor& t) {
+  return scalarToMetalTypeString(t.scalar_type());
+}
 NSArray<NSNumber*>* getTensorAxes(const Tensor& t);
 NSArray<NSNumber*>* getTensorAxes(const IntArrayRef& sizes, at::OptionalIntArrayRef dim);
 std::string getMPSShapeString(MPSShape* shape);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -616,8 +616,7 @@ id<MTLBuffer> generateKernelDataOffsets(id<MTLComputeCommandEncoder> commandEnco
   return kernelDataOffsets;
 }
 
-
-id<MTLLibrary>  MetalShaderLibrary::getLibrary() {
+id<MTLLibrary> MetalShaderLibrary::getLibrary() {
   if (library) {
     return library;
   }
@@ -627,9 +626,7 @@ id<MTLLibrary>  MetalShaderLibrary::getLibrary() {
                                                                                       : MTLLanguageVersion2_3];
   auto str = [NSString stringWithCString:shaderSource.c_str() encoding:NSASCIIStringEncoding];
   auto device = MPSDevice::getInstance()->device();
-  library = [device newLibraryWithSource:str
-                                 options:options
-                                   error:&error];
+  library = [device newLibraryWithSource:str options:options error:&error];
   TORCH_CHECK(library, "Failed to create metal library, error: ", [[error description] UTF8String]);
   return library;
 }

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -6,6 +6,7 @@
 #include <ATen/native/mps/MPSGraphSonomaOps.h>
 #include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <fmt/format.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -617,34 +618,73 @@ id<MTLBuffer> generateKernelDataOffsets(id<MTLComputeCommandEncoder> commandEnco
 }
 
 id<MTLLibrary> MetalShaderLibrary::getLibrary() {
-  if (library) {
-    return library;
+  if (C10_UNLIKELY(!library)) {
+    TORCH_INTERNAL_ASSERT(nparams == 0);
+    library = compileLibrary(shaderSource);
   }
+  return library;
+}
+
+id<MTLLibrary> MetalShaderLibrary::getLibrary(const std::initializer_list<std::string>& params) {
+  TORCH_INTERNAL_ASSERT(nparams == params.size());
+  std::string key = "";
+  for (auto p : params) {
+    key += ":" + p;
+  }
+  auto lib = libMap[key];
+  if (lib) {
+    return lib;
+  }
+  auto it = params.begin();
+  switch (nparams) {
+    case 1:
+      lib = compileLibrary(fmt::format(shaderSource, *it));
+      break;
+    case 2: {
+      auto& first = *it++;
+      auto& second = *it;
+      lib = compileLibrary(fmt::format(shaderSource, first, second));
+      break;
+    }
+    case 3: {
+      auto& first = *it++;
+      auto& second = *it++;
+      auto& third = *it;
+      lib = compileLibrary(fmt::format(shaderSource, first, second, third));
+      break;
+    }
+    default:
+      TORCH_INTERNAL_ASSERT(false, "Unsupported number of paramaters ", nparams);
+  }
+  return libMap[key] = lib;
+}
+
+id<MTLLibrary> MetalShaderLibrary::compileLibrary(const std::string& src) {
   NSError* error = nil;
   MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
   [options setLanguageVersion:is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) ? MTLLanguageVersion3_1
                                                                                       : MTLLanguageVersion2_3];
-  auto str = [NSString stringWithCString:shaderSource.c_str() encoding:NSASCIIStringEncoding];
+  auto str = [NSString stringWithCString:src.c_str() encoding:NSASCIIStringEncoding];
   auto device = MPSDevice::getInstance()->device();
   library = [device newLibraryWithSource:str options:options error:&error];
   TORCH_CHECK(library, "Failed to create metal library, error: ", [[error description] UTF8String]);
   return library;
 }
 
-id<MTLComputePipelineState> MetalShaderLibrary::getPipelineStateForFunc(const std::string& fname) {
-  auto cpl = cplMap[fname];
+id<MTLComputePipelineState> MetalShaderLibrary::getLibraryPipelineState(id<MTLLibrary> lib, const std::string& fname) {
+  auto key = fmt::format("{}:{}", reinterpret_cast<void*>(lib), fname);
+  auto cpl = cplMap[key];
   if (cpl) {
     return cpl;
   }
 
   NSError* error = nil;
-  id<MTLLibrary> lib = getLibrary();
   id<MTLFunction> func = [lib newFunctionWithName:[NSString stringWithUTF8String:fname.c_str()]];
   TORCH_CHECK(func, "Failed to create function state object for: ", fname);
   cpl = [[lib device] newComputePipelineStateWithFunction:func error:&error];
   TORCH_CHECK(cpl, "Failed to created pipeline state object, error: ", [[error description] UTF8String]);
 
-  return cplMap[fname] = cpl;
+  return cplMap[key] = cpl;
 }
 
 } // namespace at::native::mps

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -24,7 +24,7 @@
 namespace at::native {
 namespace mps {
 
-static const char* METAL_BINARY = R"BINARY_METAL(
+static MetalShaderLibrary lib(R"BINARY_METAL(
 
 #include <metal_stdlib>
 using namespace metal;
@@ -252,44 +252,7 @@ kernel void complex_kernel<DTYPE>(       \
 REGISTER_COMPLEX_OUT_OP(float);
 REGISTER_COMPLEX_OUT_OP(half);
 
-)BINARY_METAL";
-
-using namespace mps;
-
-static id<MTLLibrary> compileBinaryOpsLibrary(id<MTLDevice> device) {
-  static id<MTLLibrary> binaryLibrary = nil;
-  if (binaryLibrary) {
-    return binaryLibrary;
-  }
-
-  NSError* error = nil;
-  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-  [options setLanguageVersion:is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) ? MTLLanguageVersion3_1
-                                                                                      : MTLLanguageVersion2_3];
-  binaryLibrary = [device newLibraryWithSource:[NSString stringWithCString:METAL_BINARY encoding:NSASCIIStringEncoding]
-                                       options:options
-                                         error:&error];
-  TORCH_CHECK(binaryLibrary, "Failed to create metal binary library, error: ", [[error description] UTF8String]);
-  return binaryLibrary;
-}
-
-static id<MTLComputePipelineState> binaryPipelineState(id<MTLDevice> device, const std::string& kernel) {
-  static std::unordered_map<std::string, id<MTLComputePipelineState>> psoCache;
-  id<MTLComputePipelineState> pso = psoCache[kernel];
-  if (pso) {
-    return pso;
-  }
-
-  NSError* error = nil;
-  id<MTLLibrary> binaryLib = compileBinaryOpsLibrary(device);
-  id<MTLFunction> binaryFunc = [binaryLib newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]];
-  TORCH_CHECK(binaryFunc, "Failed to create function state object for: ", kernel);
-  pso = [device newComputePipelineStateWithFunction:binaryFunc error:&error];
-  TORCH_CHECK(pso, "Failed to created pipeline state object, error: ", [[error description] UTF8String]);
-
-  psoCache[kernel] = pso;
-  return pso;
-}
+)BINARY_METAL");
 
 static void binary_mps_impl(TensorIteratorBase& iter, const std::string func_name) {
   TORCH_CHECK(iter.common_dtype() != at::kDouble, "float64 is not supported on MPS");
@@ -309,7 +272,7 @@ static void binary_mps_impl(TensorIteratorBase& iter, const std::string func_nam
       const std::string kernel = func_name + "_" + scalarToMetalTypeString(input.scalar_type());
       auto kernelDataOffsets = generateKernelDataOffsets(computeEncoder, iter);
 
-      id<MTLComputePipelineState> binaryPSO = binaryPipelineState(device, kernel);
+      id<MTLComputePipelineState> binaryPSO = lib.getPipelineStateForFunc(kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled
       getMPSProfiler().beginProfileKernel(binaryPSO, kernel, {input, other});

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -269,7 +269,7 @@ static void binary_mps_impl(TensorIteratorBase& iter, const std::string func_nam
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      const std::string kernel = func_name + "_" + scalarToMetalTypeString(input.scalar_type());
+      const std::string kernel = func_name + "_" + scalarToMetalTypeString(input);
       auto kernelDataOffsets = generateKernelDataOffsets(computeEncoder, iter);
 
       id<MTLComputePipelineState> binaryPSO = lib.getPipelineStateForFunc(kernel);

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -138,8 +138,8 @@ static void handle_tensor_tensor_binary_op(const Tensor& self,
                                            const std::string& kernel_name) {
   using namespace at::mps;
   MPSStream* stream = getCurrentMPSStream();
-  id<MTLComputePipelineState> cplState = getCPLState(
-      getMetalType(output), getMetalType(self), getMetalType(other), kernel_name);
+  id<MTLComputePipelineState> cplState =
+      getCPLState(getMetalType(output), getMetalType(self), getMetalType(other), kernel_name);
   uint32_t length = output.numel();
   if (length == 0) {
     return;
@@ -169,8 +169,8 @@ static void handle_tensor_scalar_binary_op(const Tensor& self,
                                            const std::string& kernel_name) {
   using namespace at::mps;
   MPSStream* stream = getCurrentMPSStream();
-  id<MTLComputePipelineState> cplState = getCPLState(
-      getMetalType(output), getMetalType(self), getMetalType(other), kernel_name);
+  id<MTLComputePipelineState> cplState =
+      getCPLState(getMetalType(output), getMetalType(self), getMetalType(other), kernel_name);
   uint64_t sval = other.to<int64_t>();
   uint32_t length = output.numel();
   if (length == 0) {
@@ -267,8 +267,8 @@ static void _bitwise_not_out_mps(const Tensor& self, const Tensor& output_) {
   }
   using namespace at::mps;
   MPSStream* stream = getCurrentMPSStream();
-  id<MTLComputePipelineState> cplState = getCPLState(
-      getMetalType(output), getMetalType(self), getMetalType(self), "bitwise_not");
+  id<MTLComputePipelineState> cplState =
+      getCPLState(getMetalType(output), getMetalType(self), getMetalType(self), "bitwise_not");
   dispatch_sync(stream->queue(), ^() {
     getMPSProfiler().beginProfileKernel(cplState, "bitwise_not", {self});
 

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -117,48 +117,19 @@ static const std::string& getMetalType(const c10::Scalar& s) {
   return getMetalType(s.type());
 }
 
-static id<MTLLibrary> compileBitwiseOpsLibrary(id<MTLDevice> device,
-                                               const std::string& t1,
-                                               const std::string& t2,
-                                               const std::string& t3) {
-  auto key = t1 + t2 + t3;
-  static std::unordered_map<std::string, id<MTLLibrary>> libMap;
-  auto it = libMap.find(key);
-  if (it != libMap.end()) {
-    return it->second;
-  }
-  NSError* error = nil;
-  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-  [options setLanguageVersion:MTLLanguageVersion2_3];
-  auto rc =
-      [device newLibraryWithSource:[NSString stringWithUTF8String:fmt::format(BITWISE_OPS_TEMPLATE, t1, t2, t3).c_str()]
-                           options:options
-                             error:&error];
-  TORCH_CHECK(rc != nil && error == nil, "Failed to compile library: ", [[error localizedDescription] UTF8String]);
-  libMap[key] = rc;
-  return rc;
-}
-
-static id<MTLComputePipelineState> getCPLState(id<MTLDevice> device,
-                                               const std::string& t1,
+static id<MTLComputePipelineState> getCPLState(const std::string& t1,
                                                const std::string& t2,
                                                const std::string& t3,
                                                const std::string& fname) {
-  auto key = t1 + t2 + t3 + fname;
-  static std::unordered_map<std::string, id<MTLComputePipelineState>> cplMap;
-  auto it = cplMap.find(key);
-  if (it != cplMap.end()) {
-    return it->second;
+  auto key = t1 + t2 + t3;
+  static std::unordered_map<std::string, MetalShaderLibrary> libMap;
+  auto it = libMap.find(key);
+  if (it == libMap.end()) {
+    std::string src = fmt::format(BITWISE_OPS_TEMPLATE, t1, t2, t3);
+    bool rc = false;
+    std::tie(it, rc) = libMap.emplace(key, src);
   }
-  NSError* error = nil;
-  auto library = compileBitwiseOpsLibrary(device, t1, t2, t3);
-  id<MTLFunction> func = [library newFunctionWithName:[NSString stringWithUTF8String:fname.c_str()]];
-  TORCH_CHECK(func != nil, "Can't get function ", fname);
-  auto rc = [device newComputePipelineStateWithFunction:func error:&error];
-  TORCH_CHECK(
-      rc != nil && error == nil, "Failed to construct pipeline state: ", [[error localizedDescription] UTF8String]);
-  cplMap[key] = rc;
-  return rc;
+  return it->second.getPipelineStateForFunc(fname);
 }
 
 static void handle_tensor_tensor_binary_op(const Tensor& self,
@@ -168,7 +139,7 @@ static void handle_tensor_tensor_binary_op(const Tensor& self,
   using namespace at::mps;
   MPSStream* stream = getCurrentMPSStream();
   id<MTLComputePipelineState> cplState = getCPLState(
-      MPSDevice::getInstance()->device(), getMetalType(output), getMetalType(self), getMetalType(other), kernel_name);
+      getMetalType(output), getMetalType(self), getMetalType(other), kernel_name);
   uint32_t length = output.numel();
   if (length == 0) {
     return;
@@ -199,7 +170,7 @@ static void handle_tensor_scalar_binary_op(const Tensor& self,
   using namespace at::mps;
   MPSStream* stream = getCurrentMPSStream();
   id<MTLComputePipelineState> cplState = getCPLState(
-      MPSDevice::getInstance()->device(), getMetalType(output), getMetalType(self), getMetalType(other), kernel_name);
+      getMetalType(output), getMetalType(self), getMetalType(other), kernel_name);
   uint64_t sval = other.to<int64_t>();
   uint32_t length = output.numel();
   if (length == 0) {
@@ -297,7 +268,7 @@ static void _bitwise_not_out_mps(const Tensor& self, const Tensor& output_) {
   using namespace at::mps;
   MPSStream* stream = getCurrentMPSStream();
   id<MTLComputePipelineState> cplState = getCPLState(
-      MPSDevice::getInstance()->device(), getMetalType(output), getMetalType(self), getMetalType(self), "bitwise_not");
+      getMetalType(output), getMetalType(self), getMetalType(self), "bitwise_not");
   dispatch_sync(stream->queue(), ^() {
     getMPSProfiler().beginProfileKernel(cplState, "bitwise_not", {self});
 

--- a/aten/src/ATen/native/mps/operations/Bucketization.mm
+++ b/aten/src/ATen/native/mps/operations/Bucketization.mm
@@ -17,7 +17,7 @@
 namespace at::native {
 namespace mps {
 
-static const char* METAL_BUCKETIZATION = R"BUCKETIZE_METAL(
+static MetalShaderLibrary lib(R"BUCKETIZE_METAL(
 
 #include <metal_stdlib>
 using namespace metal;
@@ -194,44 +194,7 @@ REGISTER_SEARCHSORTED_OP(int, long);
 REGISTER_SEARCHSORTED_OP(long, int);
 REGISTER_SEARCHSORTED_OP(long, long);
 
-)BUCKETIZE_METAL";
-
-static id<MTLLibrary> compileBucketizationOpsLibrary(id<MTLDevice> device) {
-  static id<MTLLibrary> bucketizationLibrary = nil;
-  if (bucketizationLibrary) {
-    return bucketizationLibrary;
-  }
-
-  NSError* error = nil;
-  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-  [options setLanguageVersion:MTLLanguageVersion2_3];
-  bucketizationLibrary = [device newLibraryWithSource:[NSString stringWithCString:METAL_BUCKETIZATION
-                                                                         encoding:NSASCIIStringEncoding]
-                                              options:options
-                                                error:&error];
-  TORCH_CHECK(
-      bucketizationLibrary, "Failed to create metal bucketization library, error: ", [[error description] UTF8String]);
-  return bucketizationLibrary;
-}
-
-static id<MTLComputePipelineState> bucketizationPipelineState(id<MTLDevice> device, const std::string& kernel) {
-  static std::unordered_map<std::string, id<MTLComputePipelineState>> psoCache;
-  id<MTLComputePipelineState> pso = psoCache[kernel];
-  if (pso) {
-    return pso;
-  }
-
-  NSError* error = nil;
-  id<MTLLibrary> bucketizationLib = compileBucketizationOpsLibrary(device);
-  id<MTLFunction> bucketizationFunc =
-      [bucketizationLib newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]];
-  TORCH_CHECK(bucketizationFunc, "Failed to create function state object for: ", kernel);
-  pso = [device newComputePipelineStateWithFunction:bucketizationFunc error:&error];
-  TORCH_CHECK(pso, "Failed to created pipeline state object, error: ", [[error description] UTF8String]);
-
-  psoCache[kernel] = pso;
-  return pso;
-}
+)BUCKETIZE_METAL");
 
 static void searchsorted_mps_contiguous(Tensor& result,
                                         const Tensor& input,
@@ -250,7 +213,6 @@ static void searchsorted_mps_contiguous(Tensor& result,
   int64_t right_i64 = right;
   int64_t is_1d_boundaries = boundaries.dim() == 1;
 
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
@@ -258,7 +220,7 @@ static void searchsorted_mps_contiguous(Tensor& result,
 
       const std::string kernel = "searchsorted_" + scalarToMetalTypeString(input.scalar_type()) + "_" +
           scalarToMetalTypeString(result.scalar_type()) + (sorter.defined() ? "_sorter" : "");
-      id<MTLComputePipelineState> bucketizationPSO = mps::bucketizationPipelineState(device, kernel);
+      id<MTLComputePipelineState> bucketizationPSO = lib.getPipelineStateForFunc(kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled
       getMPSProfiler().beginProfileKernel(bucketizationPSO, kernel, {input, boundaries, sorter});

--- a/aten/src/ATen/native/mps/operations/Bucketization.mm
+++ b/aten/src/ATen/native/mps/operations/Bucketization.mm
@@ -218,8 +218,8 @@ static void searchsorted_mps_contiguous(Tensor& result,
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
 
-      const std::string kernel = "searchsorted_" + scalarToMetalTypeString(input.scalar_type()) + "_" +
-          scalarToMetalTypeString(result.scalar_type()) + (sorter.defined() ? "_sorter" : "");
+      const std::string kernel = "searchsorted_" + scalarToMetalTypeString(input) + "_" +
+          scalarToMetalTypeString(result) + (sorter.defined() ? "_sorter" : "");
       id<MTLComputePipelineState> bucketizationPSO = lib.getPipelineStateForFunc(kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled

--- a/aten/src/ATen/native/mps/operations/CrossKernel.mm
+++ b/aten/src/ATen/native/mps/operations/CrossKernel.mm
@@ -8,7 +8,9 @@
 namespace at::native {
 namespace {
 
-static const char* METAL_CROSS = R"CROSS_METAL(
+using namespace mps;
+
+static MetalShaderLibrary lib(R"CROSS_METAL(
 #include <metal_array>
 
 #include <metal_stdlib>
@@ -76,44 +78,7 @@ REGISTER_CROSS_OP(char);
 REGISTER_CROSS_OP(uchar);
 REGISTER_CROSS_OP(bool);
 
-)CROSS_METAL";
-
-using namespace mps;
-
-static id<MTLLibrary> compileCrossOpLibrary(id<MTLDevice> device) {
-  static id<MTLLibrary> crossLibrary = nil;
-  if (crossLibrary) {
-    return crossLibrary;
-  }
-
-  NSError* error = nil;
-  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-  [options setLanguageVersion:MTLLanguageVersion2_3];
-  crossLibrary = [device newLibraryWithSource:[NSString stringWithCString:METAL_CROSS encoding:NSASCIIStringEncoding]
-                                      options:options
-                                        error:&error];
-  TORCH_CHECK(crossLibrary, "Failed to create metal cross library, error: ", [[error description] UTF8String]);
-  return crossLibrary;
-}
-
-static id<MTLComputePipelineState> crossPipelineState(id<MTLDevice> device, ScalarType scalar_type) {
-  std::string kernel = "cross_" + scalarToMetalTypeString(scalar_type);
-  static std::unordered_map<std::string, id<MTLComputePipelineState>> psoCache;
-  id<MTLComputePipelineState> pso = psoCache[kernel];
-  if (pso) {
-    return pso;
-  }
-
-  NSError* error = nil;
-  id<MTLLibrary> crossLib = compileCrossOpLibrary(device);
-  id<MTLFunction> crossFunc = [crossLib newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]];
-  TORCH_CHECK(crossFunc, "Failed to create function state object for: ", kernel);
-  pso = [device newComputePipelineStateWithFunction:crossFunc error:&error];
-  TORCH_CHECK(pso, "Failed to created pipeline state object, error: ", [[error description] UTF8String]);
-
-  psoCache[kernel] = pso;
-  return pso;
-}
+)CROSS_METAL");
 
 void cross_mps_impl(const Tensor& out, const Tensor& input, const Tensor& other, int64_t dim) {
   TORCH_CHECK(input.dtype() != at::kDouble, "float64 is not supported on MPS");
@@ -139,7 +104,7 @@ void cross_mps_impl(const Tensor& out, const Tensor& input, const Tensor& other,
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       auto kernelDataOffsets = generateKernelDataOffsets(computeEncoder, iter);
 
-      id<MTLComputePipelineState> crossPSO = crossPipelineState(device, out.scalar_type());
+      auto crossPSO = lib.getPipelineStateForFunc("cross_" + scalarToMetalTypeString(out));
 
       // this function call is a no-op if MPS Profiler is not enabled
       getMPSProfiler().beginProfileKernel(crossPSO, "cross", {input, other});

--- a/aten/src/ATen/native/mps/operations/Gamma.mm
+++ b/aten/src/ATen/native/mps/operations/Gamma.mm
@@ -408,9 +408,7 @@ static id<MTLLibrary> compileGammaOpsLibrary(id<MTLDevice> device, const std::st
   return rc;
 }
 
-static id<MTLComputePipelineState> getCPLState(const std::string& t1,
-                                               const std::string& t2,
-                                               const std::string& fname) {
+static id<MTLComputePipelineState> getCPLState(const std::string& t1, const std::string& t2, const std::string& fname) {
   auto key = t1 + t2;
   static std::unordered_map<std::string, MetalShaderLibrary> libMap;
   auto it = libMap.find(key);

--- a/aten/src/ATen/native/mps/operations/Gamma.mm
+++ b/aten/src/ATen/native/mps/operations/Gamma.mm
@@ -391,8 +391,8 @@ kernel void polygamma(device {0} *input [[buffer(0)]],
 )METAL",
                               2);
 
-static id<MTLComputePipelineState> getCPLState(const std::string& t1, const std::string& t2, const std::string& fname) {
-  return lib.getPipelineStateForFunc(fname, {t1, t2});
+static id<MTLComputePipelineState> getCPLState(const Tensor& t1, const Tensor& t2, const std::string& fname) {
+  return lib.getPipelineStateForFunc(fname, {scalarToMetalTypeString(t1), scalarToMetalTypeString(t2)});
 }
 
 } // namespace mps
@@ -414,12 +414,8 @@ TORCH_IMPL_FUNC(lgamma_out_mps)(const Tensor& self, const Tensor& output_) {
 
   using namespace mps;
 
-  std::string input_type = scalarToMetalTypeString(self.scalar_type());
-  std::string output_type = scalarToMetalTypeString(output.scalar_type());
-
   @autoreleasepool {
-    id<MTLDevice> device = MPSDevice::getInstance()->device();
-    id<MTLComputePipelineState> cplState = getCPLState(input_type, output_type, "lgamma");
+    id<MTLComputePipelineState> cplState = getCPLState(self, output, "lgamma");
 
     MPSStream* mpsStream = getCurrentMPSStream();
     dispatch_sync(mpsStream->queue(), ^() {
@@ -458,12 +454,8 @@ TORCH_IMPL_FUNC(digamma_out_mps)(const Tensor& self, const Tensor& output_) {
 
   using namespace mps;
 
-  std::string input_type = scalarToMetalTypeString(self.scalar_type());
-  std::string output_type = scalarToMetalTypeString(output.scalar_type());
-
   @autoreleasepool {
-    id<MTLDevice> device = MPSDevice::getInstance()->device();
-    id<MTLComputePipelineState> cplState = getCPLState(input_type, output_type, "digamma");
+    id<MTLComputePipelineState> cplState = getCPLState(self, output, "digamma");
 
     MPSStream* mpsStream = getCurrentMPSStream();
     dispatch_sync(mpsStream->queue(), ^() {
@@ -503,8 +495,6 @@ TORCH_IMPL_FUNC(polygamma_out_mps)(const int64_t order, const Tensor& self, cons
 
   using namespace mps;
 
-  std::string input_type = scalarToMetalTypeString(self.scalar_type());
-  std::string output_type = scalarToMetalTypeString(output.scalar_type());
   std::string func_name;
 
   if (order == 0) {
@@ -516,9 +506,7 @@ TORCH_IMPL_FUNC(polygamma_out_mps)(const int64_t order, const Tensor& self, cons
   }
 
   @autoreleasepool {
-    id<MTLDevice> device = MPSDevice::getInstance()->device();
-
-    id<MTLComputePipelineState> cplState = getCPLState(input_type, output_type, func_name);
+    id<MTLComputePipelineState> cplState = getCPLState(self, output, func_name);
 
     MPSStream* mpsStream = getCurrentMPSStream();
     dispatch_sync(mpsStream->queue(), ^() {

--- a/aten/src/ATen/native/mps/operations/Gamma.mm
+++ b/aten/src/ATen/native/mps/operations/Gamma.mm
@@ -412,7 +412,7 @@ static id<MTLComputePipelineState> getCPLState(const std::string& t1, const std:
   auto key = t1 + t2;
   static std::unordered_map<std::string, MetalShaderLibrary> libMap;
   auto it = libMap.find(key);
-  if (it != libMap.end()) {
+  if (it == libMap.end()) {
     bool rc = false;
     std::tie(it, rc) = libMap.emplace(key, fmt::format(GAMMA_OPS_TEMPLATE, t1, t2));
   }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -79,7 +79,7 @@ INSTANTIATE_NAIVE_MM(bfloat);
 Tensor& do_metal_mm(const Tensor& self, const Tensor& other, Tensor& output) {
   auto stream = getCurrentMPSStream();
   auto device = MPSDevice::getInstance()->device();
-  auto matmulPSO = lib.getPipelineStateForFunc("naive_matmul_" + mps::scalarToMetalTypeString(output.scalar_type()));
+  auto matmulPSO = lib.getPipelineStateForFunc("naive_matmul_" + mps::scalarToMetalTypeString(output));
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       getMPSProfiler().beginProfileKernel(matmulPSO, "naive_matmul", {self, other});

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -25,7 +25,7 @@
 namespace at::native {
 namespace mps {
 namespace {
-static const char* METAL_LINALG = R"MATMUL_METAL(
+static MetalShaderLibrary lib(R"MATMUL_METAL(
 #include <metal_array>
 
 using namespace metal;
@@ -74,48 +74,12 @@ INSTANTIATE_NAIVE_MM(half);
 #if __METAL_VERSION__ >= 310
 INSTANTIATE_NAIVE_MM(bfloat);
 #endif
-)MATMUL_METAL";
-
-id<MTLLibrary> compileLinalgOpLibrary(id<MTLDevice> device) {
-  static id<MTLLibrary> linalgLibrary = nil;
-  if (linalgLibrary) {
-    return linalgLibrary;
-  }
-
-  NSError* error = nil;
-  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-  [options setLanguageVersion:is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) ? MTLLanguageVersion3_1
-                                                                                      : MTLLanguageVersion2_3];
-  linalgLibrary = [device newLibraryWithSource:[NSString stringWithCString:METAL_LINALG encoding:NSASCIIStringEncoding]
-                                       options:options
-                                         error:&error];
-  TORCH_CHECK(linalgLibrary, "Failed to create metal linalg library, error: ", [[error description] UTF8String]);
-  return linalgLibrary;
-}
-
-id<MTLComputePipelineState> matmulPipelineState(id<MTLDevice> device, ScalarType scalar_type) {
-  std::string kernel = "naive_matmul_" + mps::scalarToMetalTypeString(scalar_type);
-  static std::unordered_map<std::string, id<MTLComputePipelineState>> psoCache;
-  id<MTLComputePipelineState> pso = psoCache[kernel];
-  if (pso) {
-    return pso;
-  }
-
-  NSError* error = nil;
-  id<MTLLibrary> linalgLib = compileLinalgOpLibrary(device);
-  id<MTLFunction> matmulFunc = [linalgLib newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]];
-  TORCH_CHECK(matmulFunc, "Failed to create function state object for: ", kernel);
-  pso = [device newComputePipelineStateWithFunction:matmulFunc error:&error];
-  TORCH_CHECK(pso, "Failed to created pipeline state object, error: ", [[error description] UTF8String]);
-
-  psoCache[kernel] = pso;
-  return pso;
-}
+)MATMUL_METAL");
 
 Tensor& do_metal_mm(const Tensor& self, const Tensor& other, Tensor& output) {
   auto stream = getCurrentMPSStream();
   auto device = MPSDevice::getInstance()->device();
-  auto matmulPSO = matmulPipelineState(device, output.scalar_type());
+  auto matmulPSO = lib.getPipelineStateForFunc("naive_matmul_" + mps::scalarToMetalTypeString(output.scalar_type()));
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
       getMPSProfiler().beginProfileKernel(matmulPSO, "naive_matmul", {self, other});

--- a/aten/src/ATen/native/mps/operations/Quantized.mm
+++ b/aten/src/ATen/native/mps/operations/Quantized.mm
@@ -18,7 +18,7 @@ namespace at::native {
 
 using namespace mps;
 
-static const char* METAL_QUANTIZED = R"BINARY_QUANTIZED(
+static at::native::mps::MetalShaderLibrary lib(R"METAL_QUANTIZED(
 #include <metal_stdlib>
 using namespace metal;
 
@@ -84,43 +84,7 @@ INSTANTIATE_INT4MM(bfloat, 64);
 INSTANTIATE_INT4MM(bfloat, 128);
 INSTANTIATE_INT4MM(bfloat, 256);
 #endif
-)BINARY_QUANTIZED";
-
-static id<MTLLibrary> compileQuantizedOpsLibrary(id<MTLDevice> device) {
-  static id<MTLLibrary> binaryLibrary = nil;
-  if (binaryLibrary) {
-    return binaryLibrary;
-  }
-
-  NSError* error = nil;
-  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-  [options setLanguageVersion:is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) ? MTLLanguageVersion3_1
-                                                                                      : MTLLanguageVersion2_3];
-  binaryLibrary = [device newLibraryWithSource:[NSString stringWithCString:METAL_QUANTIZED
-                                                                  encoding:NSASCIIStringEncoding]
-                                       options:options
-                                         error:&error];
-  TORCH_CHECK(binaryLibrary, "Failed to create metal quantized library, error: ", [[error description] UTF8String]);
-  return binaryLibrary;
-}
-
-static id<MTLComputePipelineState> quantizedPipelineState(id<MTLDevice> device, const std::string& kernel) {
-  static std::unordered_map<std::string, id<MTLComputePipelineState>> psoCache;
-  id<MTLComputePipelineState> pso = psoCache[kernel];
-  if (pso) {
-    return pso;
-  }
-
-  NSError* error = nil;
-  id<MTLLibrary> binaryLib = compileQuantizedOpsLibrary(device);
-  id<MTLFunction> binaryFunc = [binaryLib newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]];
-  TORCH_CHECK(binaryFunc, "Failed to create function state object for: ", kernel);
-  pso = [device newComputePipelineStateWithFunction:binaryFunc error:&error];
-  TORCH_CHECK(pso, "Failed to created pipeline state object, error: ", [[error description] UTF8String]);
-
-  psoCache[kernel] = pso;
-  return pso;
-}
+)METAL_QUANTIZED");
 
 Tensor _weight_int4pack_mm_mps(const Tensor& A, const Tensor& B, int64_t qGroupSize, const Tensor& qScaleAndZeros) {
   constexpr int64_t kNTileSize = 8;
@@ -165,7 +129,7 @@ Tensor _weight_int4pack_mm_mps(const Tensor& A, const Tensor& B, int64_t qGroupS
 #endif
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       const std::string kernel = fmt::format("int4pack_mm_{}_{}", qGroupSize, scalarToMetalTypeString(A.scalar_type()));
-      id<MTLComputePipelineState> quantizedPSO = quantizedPipelineState(device, kernel);
+      id<MTLComputePipelineState> quantizedPSO = lib.getPipelineStateForFunc(kernel);
       [computeEncoder setComputePipelineState:quantizedPSO];
       mtl_setBuffer(computeEncoder, A, 0);
       mtl_setBuffer(computeEncoder, B, 1);

--- a/aten/src/ATen/native/mps/operations/Quantized.mm
+++ b/aten/src/ATen/native/mps/operations/Quantized.mm
@@ -128,7 +128,7 @@ Tensor _weight_int4pack_mm_mps(const Tensor& A, const Tensor& B, int64_t qGroupS
       }
 #endif
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      const std::string kernel = fmt::format("int4pack_mm_{}_{}", qGroupSize, scalarToMetalTypeString(A.scalar_type()));
+      const std::string kernel = fmt::format("int4pack_mm_{}_{}", qGroupSize, scalarToMetalTypeString(A));
       id<MTLComputePipelineState> quantizedPSO = lib.getPipelineStateForFunc(kernel);
       [computeEncoder setComputePipelineState:quantizedPSO];
       mtl_setBuffer(computeEncoder, A, 0);

--- a/aten/src/ATen/native/mps/operations/RenormKernel.mm
+++ b/aten/src/ATen/native/mps/operations/RenormKernel.mm
@@ -45,7 +45,6 @@ REGISTER_RENORM_OP(half);
 
 )RENORM_METAL");
 
-
 void renorm_out_mps(const Tensor& self, const Scalar& p, int64_t dim, const Scalar& maxnorm, const Tensor& out) {
   auto self_sizes = self.sizes();
   dim = c10::maybe_wrap_dim(dim, self_sizes.size());
@@ -62,7 +61,7 @@ void renorm_out_mps(const Tensor& self, const Scalar& p, int64_t dim, const Scal
   id<MTLBuffer> normBuffer = getMTLBufferStorage(norm);
   id<MTLBuffer> factorBuffer = getMTLBufferStorage(factor);
 
-  string key = "renorm_" + scalarToMetalTypeString(self.scalar_type());
+  string key = "renorm_" + scalarToMetalTypeString(self);
   MPSStream* mpsStream = getCurrentMPSStream();
   id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
   id<MTLComputePipelineState> renormPSO = lib.getPipelineStateForFunc(key);

--- a/aten/src/ATen/native/mps/operations/RenormKernel.mm
+++ b/aten/src/ATen/native/mps/operations/RenormKernel.mm
@@ -15,7 +15,9 @@
 namespace at::native {
 namespace {
 
-static const char* METAL_RENORM = R"RENORM_METAL(
+using namespace mps;
+
+static MetalShaderLibrary lib(R"RENORM_METAL(
 
 #include <metal_stdlib>
 using namespace metal;
@@ -41,48 +43,8 @@ kernel void renorm<DTYPE>(constant DTYPE* norm [[buffer(0)]],      \
 REGISTER_RENORM_OP(float);
 REGISTER_RENORM_OP(half);
 
-)RENORM_METAL";
+)RENORM_METAL");
 
-using namespace mps;
-
-static id<MTLLibrary> compileRenormLibrary(id<MTLDevice> device, const std::string& key) {
-  static std::unordered_map<std::string, id<MTLLibrary>> libMap;
-  auto it = libMap.find(key);
-  if (it != libMap.end()) {
-    return it->second;
-  }
-
-  NSError* error = nil;
-  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-  [options setLanguageVersion:MTLLanguageVersion2_3];
-stringWithCString:
-  id<MTLLibrary> renormLibrary = [device newLibraryWithSource:[NSString stringWithUTF8String:METAL_RENORM]
-                                                      options:options
-                                                        error:&error];
-  TORCH_CHECK(
-      renormLibrary, "Failed to to create renorm mps kernel library, error: ", error.localizedDescription.UTF8String);
-
-  libMap[key] = renormLibrary;
-  return renormLibrary;
-}
-
-static id<MTLComputePipelineState> renormPipelineState(id<MTLDevice> device, const std::string& key) {
-  static std::unordered_map<std::string, id<MTLComputePipelineState>> psoCache;
-  id<MTLComputePipelineState> pso = psoCache[key];
-  if (pso) {
-    return pso;
-  }
-
-  NSError* error = nil;
-  id<MTLLibrary> renormLib = compileRenormLibrary(device, key);
-  id<MTLFunction> renormFunc = [renormLib newFunctionWithName:[NSString stringWithUTF8String:key.c_str()]];
-  TORCH_CHECK(renormFunc, "Failed to create function state object for: ", key);
-  pso = [device newComputePipelineStateWithFunction:renormFunc error:&error];
-  TORCH_CHECK(pso, "Failed to created pipeline state object, error: ", [[error description] UTF8String]);
-
-  psoCache[key] = pso;
-  return pso;
-}
 
 void renorm_out_mps(const Tensor& self, const Scalar& p, int64_t dim, const Scalar& maxnorm, const Tensor& out) {
   auto self_sizes = self.sizes();
@@ -103,7 +65,7 @@ void renorm_out_mps(const Tensor& self, const Scalar& p, int64_t dim, const Scal
   string key = "renorm_" + scalarToMetalTypeString(self.scalar_type());
   MPSStream* mpsStream = getCurrentMPSStream();
   id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-  id<MTLComputePipelineState> renormPSO = renormPipelineState(device, key);
+  id<MTLComputePipelineState> renormPSO = lib.getPipelineStateForFunc(key);
 
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -10,10 +10,6 @@
 #include <ATen/ops/repeat_native.h>
 #include <fmt/format.h>
 
-#ifdef __OBJC__
-#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
-#endif
-
 namespace at::native {
 
 Tensor permute_mps(const Tensor& self, IntArrayRef dims) {
@@ -110,7 +106,8 @@ kernel void repeat_interleave(constant {0}     * repeat_ptr                [[buf
     result_ptr[j] = tid;
   }}
 }}
-)METAL_REPEAT", 1);
+)METAL_REPEAT",
+                                   1);
 
 template <typename index_t>
 void computeRepeatIndices(const index_t* repeat_ptr,

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -97,7 +97,7 @@ Tensor repeat_mps(const Tensor& self, IntArrayRef repeats) {
   return result;
 }
 
-static const char* METAL_REPEAT_INTERLEAVE = R"METAL_REPEAT(
+static mps::MetalShaderLibrary lib(R"METAL_REPEAT(
 kernel void repeat_interleave(constant {0}     * repeat_ptr                [[buffer(0)]],
                               constant int64_t * cumsum_ptr                [[buffer(1)]],
                               device {0}       * result_ptr                [[buffer(2)]],
@@ -110,45 +110,7 @@ kernel void repeat_interleave(constant {0}     * repeat_ptr                [[buf
     result_ptr[j] = tid;
   }}
 }}
-)METAL_REPEAT";
-
-static id<MTLLibrary> compileRepeatInterleaveLib(id<MTLDevice> device, const std::string& t1) {
-  auto key = t1;
-  static std::unordered_map<std::string, id<MTLLibrary>> libMap;
-  auto it = libMap.find(key);
-  if (it != libMap.end()) {
-    return it->second;
-  }
-  NSError* error = nil;
-  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-  [options setLanguageVersion:MTLLanguageVersion2_3];
-  auto rc =
-      [device newLibraryWithSource:[NSString stringWithUTF8String:fmt::format(METAL_REPEAT_INTERLEAVE, t1).c_str()]
-                           options:options
-                             error:&error];
-  TORCH_CHECK(rc != nil && error == nil, "Failed to compile library: ", [[error localizedDescription] UTF8String]);
-  libMap[key] = rc;
-  return rc;
-}
-
-static id<MTLComputePipelineState> getPipelineState(id<MTLDevice> device, const std::string& t1) {
-  static std::string kernel = "repeat_interleave";
-  auto key = kernel + t1;
-  static std::unordered_map<std::string, id<MTLComputePipelineState>> cplMap;
-  auto it = cplMap.find(key);
-  if (it != cplMap.end()) {
-    return it->second;
-  }
-  NSError* error = nil;
-  auto library = compileRepeatInterleaveLib(device, t1);
-  id<MTLFunction> func = [library newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()]];
-  TORCH_CHECK(func != nil, "Can't get kernel ", kernel);
-  auto rc = [device newComputePipelineStateWithFunction:func error:&error];
-  TORCH_CHECK(
-      rc != nil && error == nil, "Failed to construct pipeline state: ", [[error localizedDescription] UTF8String]);
-  cplMap[key] = rc;
-  return rc;
-}
+)METAL_REPEAT", 1);
 
 template <typename index_t>
 void computeRepeatIndices(const index_t* repeat_ptr,
@@ -174,7 +136,7 @@ void computeRepeatIndices(const index_t* repeat_ptr,
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      id<MTLComputePipelineState> pipelineState = getPipelineState(MPSDevice::getInstance()->device(), scalar_type);
+      id<MTLComputePipelineState> pipelineState = lib.getPipelineStateForFunc("repeat_interleave", {scalar_type});
 
       // this function call is a no-op if MPS Profiler is not enabled
       getMPSProfiler().beginProfileKernel(pipelineState, "repeat_interleave:" + scalar_type, false);

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -39,45 +39,7 @@ static const std::string& getMetalType(const Tensor& t) {
   return getMetalType(t.scalar_type());
 }
 
-static id<MTLLibrary> compileUnaryOpsLibrary(id<MTLDevice> device, const std::string& t1, const std::string& t2) {
-  auto key = t1 + t2;
-  static std::unordered_map<std::string, id<MTLLibrary>> libMap;
-  auto it = libMap.find(key);
-  if (it != libMap.end()) {
-    return it->second;
-  }
-  NSError* error = nil;
-  MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-  [options setLanguageVersion:MTLLanguageVersion2_3];
-  auto rc =
-      [device newLibraryWithSource:[NSString stringWithUTF8String:fmt::format(UNARY_KERNEL_TEMPLATE, t1, t2).c_str()]
-                           options:options
-                             error:&error];
-  TORCH_CHECK(rc != nil && error == nil, "Failed to compile library: ", [[error localizedDescription] UTF8String]);
-  libMap[key] = rc;
-  return rc;
-}
-
-static id<MTLComputePipelineState> getCPLState(id<MTLDevice> device,
-                                               const std::string& t1,
-                                               const std::string& t2,
-                                               const std::string& fname) {
-  auto key = t1 + t2 + fname;
-  static std::unordered_map<std::string, id<MTLComputePipelineState>> cplMap;
-  auto it = cplMap.find(key);
-  if (it != cplMap.end()) {
-    return it->second;
-  }
-  NSError* error = nil;
-  auto library = compileUnaryOpsLibrary(device, t1, t2);
-  id<MTLFunction> func = [library newFunctionWithName:[NSString stringWithUTF8String:fname.c_str()]];
-  TORCH_CHECK(func != nil, "Can't get function ", fname);
-  auto rc = [device newComputePipelineStateWithFunction:func error:&error];
-  TORCH_CHECK(
-      rc != nil && error == nil, "Failed to construct pipeline state: ", [[error localizedDescription] UTF8String]);
-  cplMap[key] = rc;
-  return rc;
-}
+static mps::MetalShaderLibrary lib(UNARY_KERNEL_TEMPLATE, 2);
 
 TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output_) {
   // handle erfinv ops using metal kernel
@@ -96,8 +58,7 @@ TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output_) {
   using namespace mps;
   @autoreleasepool {
     id<MTLDevice> device = MPSDevice::getInstance()->device();
-    id<MTLComputePipelineState> cplState =
-        getCPLState(device, getMetalType(outputTensor), getMetalType(self), "erfinv_mps_kernel");
+    id<MTLComputePipelineState> cplState = lib.getPipelineStateForFunc("erfinv_mps_kernel", {getMetalType(outputTensor), getMetalType(self)});
 
     if (!self.is_contiguous()) {
       inputTensor = inputTensor.contiguous();

--- a/aten/src/ATen/native/mps/operations/UnaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryKernel.mm
@@ -57,8 +57,7 @@ TORCH_IMPL_FUNC(erfinv_out_mps)(const Tensor& self, const Tensor& output_) {
   }
   using namespace mps;
   @autoreleasepool {
-    id<MTLDevice> device = MPSDevice::getInstance()->device();
-    id<MTLComputePipelineState> cplState = lib.getPipelineStateForFunc("erfinv_mps_kernel", {getMetalType(outputTensor), getMetalType(self)});
+    auto cplState = lib.getPipelineStateForFunc("erfinv_mps_kernel", {getMetalType(outputTensor), getMetalType(self)});
 
     if (!self.is_contiguous()) {
       inputTensor = inputTensor.contiguous();


### PR DESCRIPTION
That factors out a repeated pattern of creating a library/fetching a func from source

Typical usecase
```cpp
static MetalShaderLibrary lib(SHADER_SOURCE);
...

id<MTLComputePipelineState> cplState = lib.getPipelieStateForFunc("kernel_name")
```
- Make it possible to use with templated sources
- Add `scalarToMetalTypeString(const Tensor&)` variant to avoid repeated `scalarToMetalTypeString(t.scalar_type())` calls in the code

I.e. it makes no functional changes, but reduces MPS codebase size by 365 lines