### PR TITLE
Forbid subclassing _TensorBase directly

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -769,7 +769,7 @@ $1: f32[] = torch._ops.my_lib.weird.default(['None', '$0'])""",
         # test all sequence types are permissible returns
         for list_type in (list, tuple):
 
-            class A(torch._C.TensorBase):
+            class A(torch.Tensor):
                 @staticmethod
                 def __new__(cls, elem):
                     return torch.Tensor._make_subclass(cls, elem, elem.requires_grad)
@@ -789,7 +789,7 @@ $1: f32[] = torch._ops.my_lib.weird.default(['None', '$0'])""",
 
     def test_invalid_ret(self) -> None:
         # test invalid return gets reasonable error message
-        class A(torch._C.TensorBase):
+        class A(torch.Tensor):
             @staticmethod
             def __new__(cls, elem):
                 return torch.Tensor._make_subclass(cls, elem, elem.requires_grad)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9779,8 +9779,13 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         # Direct construction not OK
         self.assertRaises(RuntimeError, lambda: torch._C.TensorBase())
 
-        # But construction of subclass is OK
-        class T(torch._C.TensorBase):
+        # Subclassing it directly no OK
+        with self.assertRaisesRegex(RuntimeError, "Cannot subclass"):
+            class T(torch._C.TensorBase):
+                pass
+
+        # Doing so with Tensor is ok though
+        class T(torch.Tensor):
             pass
 
         T()
@@ -9799,7 +9804,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
 
         # OK to call super().__new__, see
         # https://github.com/pytorch/pytorch/issues/57421
-        class TestTensor(torch._C.TensorBase):
+        class TestTensor(torch.Tensor):
             @staticmethod
             def __new__(cls, x, *args, **kwargs):
                 return super().__new__(cls, x, *args, **kwargs)
@@ -9999,7 +10004,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
 
     def test_tensor_slot_dealloc(self):
 
-        class SlotTensor1(torch._C.TensorBase):
+        class SlotTensor1(torch.Tensor):
             __slots__ = ['slot1']
 
         class SlotTensor2(SlotTensor1):
@@ -10062,7 +10067,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
     def test_tensor_finalizer_dealloc(self):
         m = [False]
 
-        class FinalizerTensor(torch._C.TensorBase):
+        class FinalizerTensor(torch.Tensor):
             def __del__(self):
                 m[0] = True
 
@@ -10200,7 +10205,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         m1 = [False]
         m2 = [False]
 
-        class SlotTensor1(torch._C.TensorBase):
+        class SlotTensor1(torch.Tensor):
             __slots__ = ['slot1']
 
             def __del__(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9781,7 +9781,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
 
         # Subclassing it directly no OK
         with self.assertRaisesRegex(RuntimeError, "Cannot subclass"):
-            class T(torch._C.TensorBase):
+            class Tfail(torch._C.TensorBase):
                 pass
 
         # Doing so with Tensor is ok though

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2267,7 +2267,8 @@ int THPVariableMetaType_init(PyObject* cls, PyObject* args, PyObject* kwargs) {
   }
 
   // Forbid subclassing _TensorBase directly
-  py::tuple mro = py::reinterpret_borrow<py::tuple>(((PyTypeObject*)cls)->tp_mro);
+  py::tuple mro =
+      py::reinterpret_borrow<py::tuple>(((PyTypeObject*)cls)->tp_mro);
   bool is_subclass_of_thpvariable = false;
   for (py::handle h : mro) {
     if (h.ptr() == THPVariableClass) {

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2266,6 +2266,20 @@ int THPVariableMetaType_init(PyObject* cls, PyObject* args, PyObject* kwargs) {
     return 0;
   }
 
+  // Forbid subclassing _TensorBase directly
+  py::tuple mro = py::reinterpret_borrow<py::tuple>(((PyTypeObject*)cls)->tp_mro);
+  bool is_subclass_of_thpvariable = false;
+  for (py::handle h : mro) {
+    if (h.ptr() == THPVariableClass) {
+      is_subclass_of_thpvariable = true;
+      break;
+    }
+  }
+  if (!is_subclass_of_thpvariable) {
+    PyErr_SetString(PyExc_RuntimeError, "Cannot subclass _TensorBase directly");
+    return -1;
+  }
+
   // If the user provided a torch_dispatch implementation, disable
   // torch_function.
   py::object torch_dispatch_impl = py::reinterpret_steal<py::object>(
@@ -2275,13 +2289,6 @@ int THPVariableMetaType_init(PyObject* cls, PyObject* args, PyObject* kwargs) {
   if (torch_dispatch_impl.ptr() != torch_dispatch_default.ptr()) {
     py::object torch_function_impl = py::reinterpret_steal<py::object>(
         PyObject_GetAttrString(cls, "__torch_function__"));
-    // This will only fail if the user subclasses _TensorBase directly.
-    // Ignore the error here to let the class __init__ code fail with a nice
-    // error message.
-    if (!torch_function_impl) {
-      PyErr_Clear();
-      return 0;
-    }
     py::object torch_function_default_bound = py::reinterpret_steal<py::object>(
         PyObject_GetAttrString(THPVariableClass, "__torch_function__"));
 


### PR DESCRIPTION
As per title.
This ensures that all the places where we assume the method defined in _tensor.py do exist.

BC-Breaking: This is bc-breaking as the user cannot subclass this private class anymore.
You should replace any use of _TensorBase to Tensor.