### PR TITLE
[XPU] Enable autocast for xpu

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2077,6 +2077,10 @@ class BenchmarkRunner:
                 self.autocast = torch.cuda.amp.autocast
             if devices == ["cpu"]:
                 self.autocast = torch.cpu.amp.autocast
+            if devices == ["xpu"]:
+                import functools
+                self.autocast = functools.partial(torch.amp.autocast, device_type="xpu")
+
             if self.args.amp_dtype:
                 amp_dtype = (
                     torch.float16


### PR DESCRIPTION
This PR adds the `torch.amp.autocast` API for XPU device. 

For the CUDA/CPU, the API is not changed, because the `torch.cuda.amp.autocast` supports TorchScripts, while the `torch.amp.autocast` doesn't.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang