### PR TITLE
Remove duplicated nodes in dfs_iter_find_cycle

### DIFF
--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -98,7 +98,7 @@ class CapabilityBasedPartitioner:
             merged_nodes = copy(partitions_by_id[self_id].nodes)
             merged_nodes.update(partitions_by_id[other_id].nodes)
 
-            def dfs_iter_find_cycle(all_user_nodes: List[Node]):
+            def dfs_iter_find_cycle(all_user_nodes: Set[Node]):
                 for user_node in all_user_nodes:
                     visited_partition_ids = set()
 
@@ -128,11 +128,11 @@ class CapabilityBasedPartitioner:
                 return False
 
             # check if merge would create cyclic dependency.
-            all_user_nodes = []
+            all_user_nodes = set()
             for node in merged_nodes:
                 for user_node in node.users:
                     if user_node not in merged_nodes:
-                        all_user_nodes.append(user_node)
+                        all_user_nodes.add(user_node)
 
             if dfs_iter_find_cycle(all_user_nodes):
                 # return false indicating cyclic dependency found and


### PR DESCRIPTION
In case the `dfs_iter_find_cycle` function receives duplicated node entries in the `all_user_nodes` argument, it will still process each one of them. This commit changes the `all_user_nodes` list into a set, so each element is unique, resulting in a shorter execution time of the `propose_partitions` function.

Fixes #125584 


cc @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv @msaroufim @bdhirsh @anijain2305 @chauhang