### PR TITLE
Remove fbobjc_configs from xplat

### DIFF
--- a/c2_defs.bzl
+++ b/c2_defs.bzl
@@ -8,7 +8,6 @@ load("@fbsource//tools/build_defs:fb_xplat_cxx_library.bzl", "fb_xplat_cxx_libra
 load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode", "is_fbcode_mode_mac")
 load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "APPLE", "CXX", "IOS", "MACOSX", "WINDOWS")
 load("@fbsource//tools/build_defs/apple:build_mode_defs.bzl", "is_production_build")
-load("@fbsource//tools/build_defs/apple:config_utils_defs.bzl", "STATIC_LIBRARY_IOS_CONFIG", "STATIC_LIBRARY_MAC_CONFIG", "fbobjc_configs")
 load("@fbsource//xplat/caffe2:buckbuild.bzl", "read_bool")
 load("@fbsource//xplat/pfh/Msgr/Mobile/ProductInfra:DEFS.bzl", "Msgr_Mobile_ProductInfra")
 
@@ -295,10 +294,6 @@ def get_c2_default_cxx_args():
             (".*x86.*", C2_FBANDROID_X86_COMPILER_FLAGS),
         ],
         fbobjc_compiler_flags = get_c2_fbobjc_compiler_flags() + get_c2_fbobjc_xplat_compiler_flags(),
-        fbobjc_configs = fbobjc_configs(
-            STATIC_LIBRARY_IOS_CONFIG,
-            extra_target_config = C2_FBOBJC_EXTRA_TARGET_CONFIG,
-        ),
         fbobjc_exported_platform_preprocessor_flags = [
             (
                 "iphoneos",
@@ -310,9 +305,6 @@ def get_c2_default_cxx_args():
             ("iphoneos", C2_FBOBJC_IPHONE_COMPILER_FLAGS),
         ],
         macosx_compiler_flags = C2_FBOBJC_MACOSX_COMPILER_FLAGS,
-        fbobjc_macosx_configs_override = fbobjc_configs(
-            STATIC_LIBRARY_MAC_CONFIG,
-        ),
         macosx_frameworks_override = get_c2_fbobjc_frameworks(),
         preprocessor_flags = [
             # Use the internal pthreadpool impl for all Caffe2 targets on all


### PR DESCRIPTION
Summary: Pull out the configs attributes in xplat targets, these no longer do anything.

Test Plan:
```
$ buck2 uquery //xplat/... > /dev/null
```

Reviewed By: d16r

Differential Revision: D56855974


