### PR TITLE
Start refactoring runtime wrappers

### DIFF
--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -212,13 +212,14 @@ def aot_dispatch_base(
     if not hasattr(compiled_fw_func, "_boxed_call"):
         compiled_fw_func = make_boxed_func(compiled_fw_func)
 
-    compiled_fn = RuntimeWrapper.post_compile(
-        compiled_fw_func,
-        aot_config,
-        fw_metadata=fw_metadata,
+    compiled_fn = RuntimeWrapper(
         indices_of_inps_to_detach=[],
         trace_joint=False,
         disable_amp=disable_amp,
+    ).post_compile(
+        compiled_fw_func,
+        aot_config,
+        fw_metadata=fw_metadata,
     )
 
     return compiled_fn
@@ -1041,13 +1042,14 @@ Got grad_output types: {str(grad_output_types)}"""
                 return (*[None] * num_tokens, *outs_wrapped)
             return (*[None] * num_tokens, *out)
 
-    compiled_function = RuntimeWrapper.post_compile(
-        CompiledFunction.apply,
-        aot_config,
-        fw_metadata=fw_metadata,
+    compiled_function = RuntimeWrapper(
         indices_of_inps_to_detach=_indices_of_inps_to_detach,
         trace_joint=True,
         disable_amp=disable_amp,
+    ).post_compile(
+        CompiledFunction.apply,
+        aot_config,
+        fw_metadata=fw_metadata,
     )
 
     if not config.debug_assert:

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -40,8 +40,8 @@ from .logging_utils import describe_input, format_guard_bug_msg, track_graph_com
 
 from .runtime_wrappers import (
     aot_dispatch_subclass_wrapper,
-    RuntimeWrapper,
     functionalized_rng_runtime_epilogue,
+    RuntimeWrapper,
 )
 from .schemas import (
     AOTConfig,

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -119,7 +119,9 @@ class CompilerWrapper:
             new_flat_args,
             new_aot_config,
             new_fw_metadata,
-        ) = cls.pre_compile(flat_fn, flat_args, aot_config, fw_metadata, **kwargs)
+        ) = cls.pre_compile(
+            flat_fn, flat_args, aot_config, fw_metadata=fw_metadata, **kwargs
+        )
         compiled_fn = compiler_fn(
             wrapped_flat_fn, new_flat_args, new_aot_config, fw_metadata=new_fw_metadata
         )

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -138,7 +138,7 @@ class CompilerWrapper:
 # - the autograd cases inserts TensorAlias wrapper objects for outputs that alias inputs
 class RuntimeWrapper(CompilerWrapper):
     @classmethod
-    def post_compile(
+    def post_compile(  # type: ignore[override]
         cls,
         compiled_fn,
         aot_config: AOTConfig,
@@ -147,6 +147,7 @@ class RuntimeWrapper(CompilerWrapper):
         indices_of_inps_to_detach: List[int],
         trace_joint: bool,
         disable_amp: bool,
+        **kwargs,
     ):
         return _create_runtime_wrapper(
             compiled_fn,

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -51,6 +51,7 @@ from .utils import (
 
 zip = strict_zip
 
+
 class CompilerWrapper:
     """
     A wrapper around the inputs and outputs to the compiler_fn. We separate these into two parts:
@@ -63,13 +64,15 @@ class CompilerWrapper:
     """
 
     @classmethod
-    def pre_compile(cls,
+    def pre_compile(
+        cls,
         flat_fn,
-        flat_args : List[Tensor],
-        aot_config : AOTConfig,
+        flat_args: List[Tensor],
+        aot_config: AOTConfig,
         *,
-        fw_metadata : ViewAndMutationMeta,
-        **kwargs):
+        fw_metadata: ViewAndMutationMeta,
+        **kwargs,
+    ):
         """
         Process the inputs to the compiler_fn. You can pass in extra metadata via kwargs.
         Args:
@@ -100,7 +103,6 @@ class CompilerWrapper:
         """
         return compiled_fn
 
-
     @classmethod
     def create(
         cls,
@@ -110,11 +112,20 @@ class CompilerWrapper:
         *,
         fw_metadata: ViewAndMutationMeta,
         compiler_fn,
-        **kwargs
+        **kwargs,
     ):
-        wrapped_flat_fn, new_flat_args, new_aot_config, new_fw_metadata = cls.pre_compile(flat_fn, flat_args, aot_config, fw_metadata, **kwargs)
-        compiled_fn = compiler_fn(wrapped_flat_fn, new_flat_args, new_aot_config, fw_metadata=new_fw_metadata)
-        return cls.post_compile(compiled_fn, new_aot_config, fw_metadata=new_fw_metadata, **kwargs)
+        (
+            wrapped_flat_fn,
+            new_flat_args,
+            new_aot_config,
+            new_fw_metadata,
+        ) = cls.pre_compile(flat_fn, flat_args, aot_config, fw_metadata, **kwargs)
+        compiled_fn = compiler_fn(
+            wrapped_flat_fn, new_flat_args, new_aot_config, fw_metadata=new_fw_metadata
+        )
+        return cls.post_compile(
+            compiled_fn, new_aot_config, fw_metadata=new_fw_metadata, **kwargs
+        )
 
 
 # The wrapper created by this function handles all of the runtime aliasing and mutation "epilogue" logic
@@ -127,7 +138,8 @@ class CompilerWrapper:
 # - the autograd cases inserts TensorAlias wrapper objects for outputs that alias inputs
 class RuntimeWrapper(CompilerWrapper):
     @classmethod
-    def post_compile(cls,
+    def post_compile(
+        cls,
         compiled_fn,
         aot_config: AOTConfig,
         *,
@@ -159,8 +171,8 @@ class RuntimeWrapper(CompilerWrapper):
             compiled_fn = make_boxed_func(compiled_fn)
 
         # Note [Inputs needed in runtime epilogue after list clearing]
-        # In Python functions, you can't free the input arguments of a function within the scope of that function. A workaround is to
-        # wrap the input arguments in a list, and clear the list from within the function.
+        # In Python functions, you can't free the input arguments of a function within the scope of that function.
+        # A workaround is to wrap the input arguments in a list, and clear the list from within the function.
         # Here, this is implemented as `call_func_at_runtime_with_args(..., steal_args=True)`.
         #
         # This is needed for Compiled Autograd since some of the inputs (activations) should be freed early.
@@ -246,7 +258,9 @@ class RuntimeWrapper(CompilerWrapper):
                 updated_inputs = all_outs[:num_mutations_to_apply]
                 fw_outs = all_outs[num_mutations_to_apply:]
 
-                for i, inpt_idx in enumerate(runtime_metadata.mutated_inp_runtime_indices):
+                for i, inpt_idx in enumerate(
+                    runtime_metadata.mutated_inp_runtime_indices
+                ):
                     meta = runtime_metadata.input_info[inpt_idx]
                     if not meta.mutates_data and not meta.mutates_metadata:
                         continue
@@ -317,7 +331,9 @@ class RuntimeWrapper(CompilerWrapper):
                     fw_outs_no_intermediate_bases = fw_outs[
                         : -runtime_metadata.num_intermediate_bases
                     ]
-                    intermediate_bases = fw_outs[-runtime_metadata.num_intermediate_bases :]
+                    intermediate_bases = fw_outs[
+                        -runtime_metadata.num_intermediate_bases :
+                    ]
                 else:
                     fw_outs_no_intermediate_bases = fw_outs
                     intermediate_bases = []
@@ -358,7 +374,8 @@ class RuntimeWrapper(CompilerWrapper):
                     elif info.output_type == OutputType.alias_of_intermediate:
                         base_tensor_list = intermediate_bases
                     elif (
-                        info.output_type == OutputType.alias_of_intermediate_save_as_output
+                        info.output_type
+                        == OutputType.alias_of_intermediate_save_as_output
                     ):
                         base_tensor_list = intermediate_bases
                     else:
@@ -392,6 +409,7 @@ class RuntimeWrapper(CompilerWrapper):
             return ret_outs
 
         return runtime_wrapper
+
 
 # Calling convention: If we are running functionalized RNG, then outs consists
 # of (user_outs, rng_offset)

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -51,6 +51,71 @@ from .utils import (
 
 zip = strict_zip
 
+class CompilerWrapper:
+    """
+    A wrapper around the inputs and outputs to the compiler_fn. We separate these into two parts:
+
+    1. The prologue, which edits the input to the compiler_fn(flat_fn, flat_args, etc)
+    2. The epilogue, which edits the outputs of the compiler_fn (compiled_fn, real arguments)
+
+    Each wrapper below should be implemented as a CompilerWrapper, so that we can facilitate
+    caching on the compiled output, and re-wrapping the output via epilogues.
+    """
+
+    @classmethod
+    def pre_compile(cls,
+        flat_fn,
+        flat_args : List[Tensor],
+        aot_config : AOTConfig,
+        *,
+        fw_metadata : ViewAndMutationMeta,
+        **kwargs):
+        """
+        Process the inputs to the compiler_fn. You can pass in extra metadata via kwargs.
+        Args:
+        flat_fn: The function to compile
+        flat_args: Metadata from example inputs of the function to compile
+        aot_config: AOTConfig passed in at compile time
+        fw_metadata: ViewAndMutationMeta generated from flat_fn and flat_args
+        kwargs: Extra metadata available at compile time
+        """
+        return flat_fn, flat_args, aot_config, fw_metadata
+
+    @classmethod
+    def post_compile(cls, compiled_fn, aot_config, *, fw_metadata, **kwargs):
+        """
+        Given an output of the compiler, wrap it with information received from prologue.
+        Args:
+        compiled_fn: Callable after calling compiler_fn
+        aot_config: AOTConfig after calling prologue
+        fw_metadata: ViewAndMutationMeta after calling prologue
+        kwargs: Any extra metadata that's available post compile needed to pass to the wrapper
+        Example:
+
+        def wrapped_compiled_fn(args):
+            # do something with args, aot_config, fw_metadata
+            return compiled_fn(args)
+
+        return wrapped_compiled_fn
+        """
+        return compiled_fn
+
+
+    @classmethod
+    def create(
+        cls,
+        flat_fn,
+        flat_args: List[Tensor],
+        aot_config: AOTConfig,
+        *,
+        fw_metadata: ViewAndMutationMeta,
+        compiler_fn,
+        **kwargs
+    ):
+        wrapped_flat_fn, new_flat_args, new_aot_config, new_fw_metadata = cls.pre_compile(flat_fn, flat_args, aot_config, fw_metadata, **kwargs)
+        compiled_fn = compiler_fn(wrapped_flat_fn, new_flat_args, new_aot_config, fw_metadata=new_fw_metadata)
+        return cls.post_compile(compiled_fn, new_aot_config, fw_metadata=new_fw_metadata, **kwargs)
+
 
 # The wrapper created by this function handles all of the runtime aliasing and mutation "epilogue" logic
 # that needs to run after the compiled function.
@@ -60,253 +125,273 @@ zip = strict_zip
 # This is because there are some minor differences in how we treat these cases at runtime:
 # - resize_() is currently handled in the inference case, but not fully handled in the autograd case.
 # - the autograd cases inserts TensorAlias wrapper objects for outputs that alias inputs
-def create_runtime_wrapper(
-    compiled_fn,
-    *,
-    runtime_metadata: ViewAndMutationMeta,
-    indices_of_inps_to_detach: List[int],
-    trace_joint: bool,
-    keep_input_mutations: bool,
-    disable_amp: bool,
-):
-    if not hasattr(compiled_fn, "_boxed_call"):
-        compiled_fn = make_boxed_func(compiled_fn)
+class RuntimeWrapper(CompilerWrapper):
+    @classmethod
+    def post_compile(cls,
+        compiled_fn,
+        aot_config: AOTConfig,
+        *,
+        fw_metadata: ViewAndMutationMeta,
+        indices_of_inps_to_detach: List[int],
+        trace_joint: bool,
+        disable_amp: bool,
+    ):
+        return RuntimeWrapper._create_runtime_wrapper(
+            compiled_fn,
+            runtime_metadata=fw_metadata,
+            indices_of_inps_to_detach=indices_of_inps_to_detach,
+            trace_joint=trace_joint,
+            keep_input_mutations=aot_config.keep_inference_input_mutations,
+            disable_amp=disable_amp,
+        )
 
-    # Note [Inputs needed in runtime epilogue after list clearing]
-    # In Python functions, you can't free the input arguments of a function within the scope of that function. A workaround is to
-    # wrap the input arguments in a list, and clear the list from within the function.
-    # Here, this is implemented as `call_func_at_runtime_with_args(..., steal_args=True)`.
-    #
-    # This is needed for Compiled Autograd since some of the inputs (activations) should be freed early.
-    # However, we cannot blindly clear the entire list, because AOTAutograd may need access to some of the graph inputs
-    # **after** the compiled function has finished running. There are two main cases:
-    #   (1) Input mutations: If there are an input mutations that we must run outside of the graph, we need access to the input.
-    #   (2) Output aliasing: Outputs that aliases graph inputs generally must be regenerated outside of the `autograd.Function`,
-    #       and doing so requires us accessing the corresponding input after the compiled artifact has run.
-    epilogue_args_idx = []
-    epilogue_args_idx.extend(runtime_metadata.mutated_inp_runtime_indices)
-    num_tokens = len(runtime_metadata.tokens)
-    for info in runtime_metadata.output_info:
-        if (
-            info.output_type == OutputType.alias_of_input
-            or info.output_type == OutputType.is_input
-        ):
-            assert isinstance(info.base_idx, int)
-            epilogue_args_idx.append(info.base_idx + num_tokens)
+    @staticmethod
+    def _create_runtime_wrapper(
+        compiled_fn,
+        *,
+        runtime_metadata: ViewAndMutationMeta,
+        indices_of_inps_to_detach: List[int],
+        trace_joint: bool,
+        keep_input_mutations: bool,
+        disable_amp: bool,
+    ):
+        if not hasattr(compiled_fn, "_boxed_call"):
+            compiled_fn = make_boxed_func(compiled_fn)
 
-    def runtime_wrapper(args: List[Any]):
-        if config.unlift_effect_tokens:
-            assert num_tokens == 0
-        elif num_tokens > 0:
-            # Pass in effect tokens (See Note [Side-Effectful Tokens in AOTAutograd])
-            old_args = args
-            args = [[None] * num_tokens, *args]
-            old_args.clear()
+        # Note [Inputs needed in runtime epilogue after list clearing]
+        # In Python functions, you can't free the input arguments of a function within the scope of that function. A workaround is to
+        # wrap the input arguments in a list, and clear the list from within the function.
+        # Here, this is implemented as `call_func_at_runtime_with_args(..., steal_args=True)`.
+        #
+        # This is needed for Compiled Autograd since some of the inputs (activations) should be freed early.
+        # However, we cannot blindly clear the entire list, because AOTAutograd may need access to some of the graph inputs
+        # **after** the compiled function has finished running. There are two main cases:
+        #   (1) Input mutations: If there are an input mutations that we must run outside of the graph, we need access to the input.
+        #   (2) Output aliasing: Outputs that aliases graph inputs generally must be regenerated outside of the `autograd.Function`,
+        #       and doing so requires us accessing the corresponding input after the compiled artifact has run.
+        epilogue_args_idx = []
+        epilogue_args_idx.extend(runtime_metadata.mutated_inp_runtime_indices)
+        num_tokens = len(runtime_metadata.tokens)
+        for info in runtime_metadata.output_info:
+            if (
+                info.output_type == OutputType.alias_of_input
+                or info.output_type == OutputType.is_input
+            ):
+                assert isinstance(info.base_idx, int)
+                epilogue_args_idx.append(info.base_idx + num_tokens)
 
-        # stash a ref to each input tensor we plan to use after the compiled function
-        orig_inputs = {i: args[i] for i in epilogue_args_idx}
+        def runtime_wrapper(args: List[Any]):
+            if config.unlift_effect_tokens:
+                assert num_tokens == 0
+            elif num_tokens > 0:
+                # Pass in effect tokens (See Note [Side-Effectful Tokens in AOTAutograd])
+                old_args = args
+                args = [[None] * num_tokens, *args]
+                old_args.clear()
 
-        if trace_joint:
-            args_ = list(args)
-            # See Note [Detaching inputs that never need gradients]
-            for idx in indices_of_inps_to_detach:
-                if isinstance(args_[idx], torch.Tensor):
-                    args_[idx] = args_[idx].detach()
-            with torch.autograd._force_original_view_tracking(True):
-                all_outs = call_func_at_runtime_with_args(
-                    compiled_fn, args_, disable_amp=disable_amp, steal_args=True
-                )
-        else:
-            # When we have an inference graph, we run with torch.no_grad.
-            # It's possible to get an inference graph with inputs that require grad,
-            # in which case we want to make sure autograd is disabled
-            # (since e.g., inductor will generate aten.addmm.out calls which autograd will complain on)
-            if torch.is_grad_enabled():
-                with torch.no_grad():
+            # stash a ref to each input tensor we plan to use after the compiled function
+            orig_inputs = {i: args[i] for i in epilogue_args_idx}
+
+            if trace_joint:
+                args_ = list(args)
+                # See Note [Detaching inputs that never need gradients]
+                for idx in indices_of_inps_to_detach:
+                    if isinstance(args_[idx], torch.Tensor):
+                        args_[idx] = args_[idx].detach()
+                with torch.autograd._force_original_view_tracking(True):
+                    all_outs = call_func_at_runtime_with_args(
+                        compiled_fn, args_, disable_amp=disable_amp, steal_args=True
+                    )
+            else:
+                # When we have an inference graph, we run with torch.no_grad.
+                # It's possible to get an inference graph with inputs that require grad,
+                # in which case we want to make sure autograd is disabled
+                # (since e.g., inductor will generate aten.addmm.out calls which autograd will complain on)
+                if torch.is_grad_enabled():
+                    with torch.no_grad():
+                        all_outs = call_func_at_runtime_with_args(
+                            compiled_fn, args, disable_amp=disable_amp, steal_args=True
+                        )
+                else:
                     all_outs = call_func_at_runtime_with_args(
                         compiled_fn, args, disable_amp=disable_amp, steal_args=True
                     )
-            else:
-                all_outs = call_func_at_runtime_with_args(
-                    compiled_fn, args, disable_amp=disable_amp, steal_args=True
+            del args
+
+            num_mutated_runtime_inps = runtime_metadata.num_mutated_inp_runtime_indices
+            num_intermediate_bases = runtime_metadata.num_intermediate_bases
+
+            if keep_input_mutations and trace_joint:
+                num_input_mutations_handled_by_autograd = (
+                    runtime_metadata.num_mutated_graph_handled_indices_seen_by_autograd
                 )
-        del args
+                # autograd.Function requires us to return the mutated inputs as extra outputs to the autograd.Function.forward
+                if num_input_mutations_handled_by_autograd > 0:
+                    all_outs = all_outs[:-num_input_mutations_handled_by_autograd]
 
-        num_mutated_runtime_inps = runtime_metadata.num_mutated_inp_runtime_indices
-        num_intermediate_bases = runtime_metadata.num_intermediate_bases
-
-        if keep_input_mutations and trace_joint:
-            num_input_mutations_handled_by_autograd = (
-                runtime_metadata.num_mutated_graph_handled_indices_seen_by_autograd
+            assert (
+                len(all_outs)
+                == num_mutated_runtime_inps
+                + runtime_metadata.num_outputs
+                + num_intermediate_bases
+                + num_tokens
             )
-            # autograd.Function requires us to return the mutated inputs as extra outputs to the autograd.Function.forward
-            if num_input_mutations_handled_by_autograd > 0:
-                all_outs = all_outs[:-num_input_mutations_handled_by_autograd]
 
-        assert (
-            len(all_outs)
-            == num_mutated_runtime_inps
-            + runtime_metadata.num_outputs
-            + num_intermediate_bases
-            + num_tokens
-        )
+            # Toss out the effect tokens (See Note [Side-Effectful Tokens in AOTAutograd])
+            all_outs = all_outs[num_tokens:]
 
-        # Toss out the effect tokens (See Note [Side-Effectful Tokens in AOTAutograd])
-        all_outs = all_outs[num_tokens:]
+            # Step 3: After running the compiled fw, apply updates to mutated inputs
+            num_mutations_to_apply = runtime_metadata.num_mutated_inp_runtime_indices
+            if num_mutations_to_apply > 0:
+                updated_inputs = all_outs[:num_mutations_to_apply]
+                fw_outs = all_outs[num_mutations_to_apply:]
 
-        # Step 3: After running the compiled fw, apply updates to mutated inputs
-        num_mutations_to_apply = runtime_metadata.num_mutated_inp_runtime_indices
-        if num_mutations_to_apply > 0:
-            updated_inputs = all_outs[:num_mutations_to_apply]
-            fw_outs = all_outs[num_mutations_to_apply:]
-
-            for i, inpt_idx in enumerate(runtime_metadata.mutated_inp_runtime_indices):
-                meta = runtime_metadata.input_info[inpt_idx]
-                if not meta.mutates_data and not meta.mutates_metadata:
-                    continue
-                original_inpt = orig_inputs[inpt_idx]
-                updated_inpt = updated_inputs[i]
-                if meta.mutates_storage_metadata:
-                    # See Note [set_() Input Mutations in AOTAutograd]
-                    # mutates_storage_metadata means our input saw a x.set_(y) call.
-                    # What if x **also** saw a data and/or a metadata mutation?
-                    # (1) If the [meta]data mutation occurred after the set_(),
-                    #     then there is no need to copy_() the data.
-                    #     When we perform x.set_(x_updated), we are guaranteed that
-                    #     x_updated already has the final version of the data/metadata
-                    # (2) If a data mutation occurred before the set_().
-                    #     This case seems very difficult to support.
-                    #     TODO: discuss on the PR and decide if we want to tr to
-                    #     either support it, or detect and ban it.
-                    if trace_joint:
-                        assert isinstance(updated_inpt, TensorAlias)
-                        updated_inpt = updated_inpt.alias
-                    with torch.no_grad():
-                        original_inpt.set_(updated_inpt)
-                    continue
-                if meta.mutates_metadata and not meta.mutates_data:
-                    if trace_joint:
-                        assert isinstance(updated_inpt, TensorAlias)
-                        updated_inpt = updated_inpt.alias
-                    # We need to grab the size/stride/storage_offset from the compiled forward,
-                    # and use that to mutate the metadata of the input
-                    original_inpt.as_strided_(
-                        updated_inpt.size(),
-                        updated_inpt.stride(),
-                        updated_inpt.storage_offset(),
-                    )
-                else:
-                    if meta.mutates_data and meta.mutates_metadata:
+                for i, inpt_idx in enumerate(runtime_metadata.mutated_inp_runtime_indices):
+                    meta = runtime_metadata.input_info[inpt_idx]
+                    if not meta.mutates_data and not meta.mutates_metadata:
+                        continue
+                    original_inpt = orig_inputs[inpt_idx]
+                    updated_inpt = updated_inputs[i]
+                    if meta.mutates_storage_metadata:
+                        # See Note [set_() Input Mutations in AOTAutograd]
+                        # mutates_storage_metadata means our input saw a x.set_(y) call.
+                        # What if x **also** saw a data and/or a metadata mutation?
+                        # (1) If the [meta]data mutation occurred after the set_(),
+                        #     then there is no need to copy_() the data.
+                        #     When we perform x.set_(x_updated), we are guaranteed that
+                        #     x_updated already has the final version of the data/metadata
+                        # (2) If a data mutation occurred before the set_().
+                        #     This case seems very difficult to support.
+                        #     TODO: discuss on the PR and decide if we want to tr to
+                        #     either support it, or detect and ban it.
+                        if trace_joint:
+                            assert isinstance(updated_inpt, TensorAlias)
+                            updated_inpt = updated_inpt.alias
+                        with torch.no_grad():
+                            original_inpt.set_(updated_inpt)
+                        continue
+                    if meta.mutates_metadata and not meta.mutates_data:
+                        if trace_joint:
+                            assert isinstance(updated_inpt, TensorAlias)
+                            updated_inpt = updated_inpt.alias
+                        # We need to grab the size/stride/storage_offset from the compiled forward,
+                        # and use that to mutate the metadata of the input
                         original_inpt.as_strided_(
                             updated_inpt.size(),
                             updated_inpt.stride(),
                             updated_inpt.storage_offset(),
                         )
                     else:
-                        assert meta.mutates_data
-                    if meta.is_leaf and original_inpt.requires_grad:
-                        # We can hit this situation in this case:
-                        #   def f(x):
-                        #       x.detach().mul_(2)
-                        #       return x + 1
-                        # AOTAutograd will see a mutation in the above case, and try to
-                        # apply a copy_() here, in the epilogue.
-                        # But if x required gradients, and is a leaf, then autograd
-                        # will yell at us for trying to mutate it.
-                        # However, it's only possible to end up in this scenario (like the above)
-                        # if all of the mutations to the leaf input were non-autograd-tracking mutations
-                        # (aka mutations under no_grad(), or on detached views).
-                        # In that case, we fully want to hide the mutation from autograd, so detaching is ok.
-                        original_inpt.detach().copy_(updated_inpt)
-                    else:
-                        original_inpt.copy_(updated_inpt)
-        else:
-            fw_outs = all_outs
-
-        # Step 4: Manually regenerate any outputs that are aliased to inputs, instead of
-        # compiling them.
-        if runtime_metadata.num_outputs_aliased > 0:
-            # The compiled forward also returned intermediate bases. We don't want to return them to the user.
-            if runtime_metadata.num_intermediate_bases > 0:
-                fw_outs_no_intermediate_bases = fw_outs[
-                    : -runtime_metadata.num_intermediate_bases
-                ]
-                intermediate_bases = fw_outs[-runtime_metadata.num_intermediate_bases :]
+                        if meta.mutates_data and meta.mutates_metadata:
+                            original_inpt.as_strided_(
+                                updated_inpt.size(),
+                                updated_inpt.stride(),
+                                updated_inpt.storage_offset(),
+                            )
+                        else:
+                            assert meta.mutates_data
+                        if meta.is_leaf and original_inpt.requires_grad:
+                            # We can hit this situation in this case:
+                            #   def f(x):
+                            #       x.detach().mul_(2)
+                            #       return x + 1
+                            # AOTAutograd will see a mutation in the above case, and try to
+                            # apply a copy_() here, in the epilogue.
+                            # But if x required gradients, and is a leaf, then autograd
+                            # will yell at us for trying to mutate it.
+                            # However, it's only possible to end up in this scenario (like the above)
+                            # if all of the mutations to the leaf input were non-autograd-tracking mutations
+                            # (aka mutations under no_grad(), or on detached views).
+                            # In that case, we fully want to hide the mutation from autograd, so detaching is ok.
+                            original_inpt.detach().copy_(updated_inpt)
+                        else:
+                            original_inpt.copy_(updated_inpt)
             else:
-                fw_outs_no_intermediate_bases = fw_outs
-                intermediate_bases = []
+                fw_outs = all_outs
 
-            assert len(fw_outs_no_intermediate_bases) == len(
-                runtime_metadata.output_info
-            )
-            fw_outs_including_aliases = []
-            for i, (o, info) in enumerate(
-                zip(fw_outs_no_intermediate_bases, runtime_metadata.output_info)
-            ):
-                if info.output_type in [
-                    OutputType.non_alias,
-                    OutputType.unsafe_view_alias,
-                    OutputType.custom_function_view,
-                ]:
-                    fw_outs_including_aliases.append(o)
-                    continue
-                if trace_joint:
-                    assert isinstance(o, TensorAlias)
-                    o_ = o.alias
+            # Step 4: Manually regenerate any outputs that are aliased to inputs, instead of
+            # compiling them.
+            if runtime_metadata.num_outputs_aliased > 0:
+                # The compiled forward also returned intermediate bases. We don't want to return them to the user.
+                if runtime_metadata.num_intermediate_bases > 0:
+                    fw_outs_no_intermediate_bases = fw_outs[
+                        : -runtime_metadata.num_intermediate_bases
+                    ]
+                    intermediate_bases = fw_outs[-runtime_metadata.num_intermediate_bases :]
                 else:
-                    o_ = o
+                    fw_outs_no_intermediate_bases = fw_outs
+                    intermediate_bases = []
 
-                o_grad = runtime_metadata.output_info[i].requires_grad
-                if info.output_type == OutputType.alias_of_input:
-                    aliased_base_tensor = orig_inputs[info.base_idx + num_tokens]  # type: ignore[index]
+                assert len(fw_outs_no_intermediate_bases) == len(
+                    runtime_metadata.output_info
+                )
+                fw_outs_including_aliases = []
+                for i, (o, info) in enumerate(
+                    zip(fw_outs_no_intermediate_bases, runtime_metadata.output_info)
+                ):
+                    if info.output_type in [
+                        OutputType.non_alias,
+                        OutputType.unsafe_view_alias,
+                        OutputType.custom_function_view,
+                    ]:
+                        fw_outs_including_aliases.append(o)
+                        continue
+                    if trace_joint:
+                        assert isinstance(o, TensorAlias)
+                        o_ = o.alias
+                    else:
+                        o_ = o
+
+                    o_grad = runtime_metadata.output_info[i].requires_grad
+                    if info.output_type == OutputType.alias_of_input:
+                        aliased_base_tensor = orig_inputs[info.base_idx + num_tokens]  # type: ignore[index]
+                        regenerated_out = gen_alias_from_base(
+                            aliased_base_tensor, o_, o_grad, info.functional_tensor
+                        )
+                        fw_outs_including_aliases.append(regenerated_out)
+                        continue
+                    elif info.output_type == OutputType.is_input:
+                        aliased_base_tensor = orig_inputs[info.base_idx + num_tokens]  # type: ignore[index]
+                        regenerated_out = aliased_base_tensor
+                        fw_outs_including_aliases.append(regenerated_out)
+                        continue
+                    elif info.output_type == OutputType.alias_of_intermediate:
+                        base_tensor_list = intermediate_bases
+                    elif (
+                        info.output_type == OutputType.alias_of_intermediate_save_as_output
+                    ):
+                        base_tensor_list = intermediate_bases
+                    else:
+                        assert (
+                            info.output_type
+                            == OutputType.alias_of_intermediate_base_is_user_output
+                        )
+                        base_tensor_list = fw_outs_no_intermediate_bases
+                    aliased_base_tensor = base_tensor_list[info.base_idx]
+                    # TODO: handle the custom autograd function case here.
+                    # We need a way to check whether a tensor came from a custom autograd fn from python,
+                    # AND a way to replay that custom view fn.
                     regenerated_out = gen_alias_from_base(
                         aliased_base_tensor, o_, o_grad, info.functional_tensor
                     )
                     fw_outs_including_aliases.append(regenerated_out)
-                    continue
-                elif info.output_type == OutputType.is_input:
-                    aliased_base_tensor = orig_inputs[info.base_idx + num_tokens]  # type: ignore[index]
-                    regenerated_out = aliased_base_tensor
-                    fw_outs_including_aliases.append(regenerated_out)
-                    continue
-                elif info.output_type == OutputType.alias_of_intermediate:
-                    base_tensor_list = intermediate_bases
-                elif (
-                    info.output_type == OutputType.alias_of_intermediate_save_as_output
-                ):
-                    base_tensor_list = intermediate_bases
-                else:
-                    assert (
-                        info.output_type
-                        == OutputType.alias_of_intermediate_base_is_user_output
-                    )
-                    base_tensor_list = fw_outs_no_intermediate_bases
-                aliased_base_tensor = base_tensor_list[info.base_idx]
-                # TODO: handle the custom autograd function case here.
-                # We need a way to check whether a tensor came from a custom autograd fn from python,
-                # AND a way to replay that custom view fn.
-                regenerated_out = gen_alias_from_base(
-                    aliased_base_tensor, o_, o_grad, info.functional_tensor
-                )
-                fw_outs_including_aliases.append(regenerated_out)
-            ret_outs = fw_outs_including_aliases
-        else:
-            ret_outs = fw_outs
+                ret_outs = fw_outs_including_aliases
+            else:
+                ret_outs = fw_outs
 
-        if runtime_metadata.dynamic_outputs:
-            for t, o in zip(ret_outs, runtime_metadata.output_info):
-                if o.dynamic_dims is None:
-                    continue
-                if hasattr(t, "_dynamo_weak_dynamic_indices"):
-                    t._dynamo_weak_dynamic_indices |= o.dynamic_dims
-                else:
-                    t._dynamo_weak_dynamic_indices = o.dynamic_dims.copy()
-        if runtime_metadata.grad_enabled_mutation is not None:
-            torch.set_grad_enabled(runtime_metadata.grad_enabled_mutation)
-        return ret_outs
+            if runtime_metadata.dynamic_outputs:
+                for t, o in zip(ret_outs, runtime_metadata.output_info):
+                    if o.dynamic_dims is None:
+                        continue
+                    if hasattr(t, "_dynamo_weak_dynamic_indices"):
+                        t._dynamo_weak_dynamic_indices |= o.dynamic_dims
+                    else:
+                        t._dynamo_weak_dynamic_indices = o.dynamic_dims.copy()
+            if runtime_metadata.grad_enabled_mutation is not None:
+                torch.set_grad_enabled(runtime_metadata.grad_enabled_mutation)
+            return ret_outs
 
-    return runtime_wrapper
-
+        return runtime_wrapper
 
 # Calling convention: If we are running functionalized RNG, then outs consists
 # of (user_outs, rng_offset)

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -148,7 +148,7 @@ class RuntimeWrapper(CompilerWrapper):
         trace_joint: bool,
         disable_amp: bool,
     ):
-        return RuntimeWrapper._create_runtime_wrapper(
+        return _create_runtime_wrapper(
             compiled_fn,
             runtime_metadata=fw_metadata,
             indices_of_inps_to_detach=indices_of_inps_to_detach,
@@ -157,258 +157,253 @@ class RuntimeWrapper(CompilerWrapper):
             disable_amp=disable_amp,
         )
 
-    @staticmethod
-    def _create_runtime_wrapper(
-        compiled_fn,
-        *,
-        runtime_metadata: ViewAndMutationMeta,
-        indices_of_inps_to_detach: List[int],
-        trace_joint: bool,
-        keep_input_mutations: bool,
-        disable_amp: bool,
-    ):
-        if not hasattr(compiled_fn, "_boxed_call"):
-            compiled_fn = make_boxed_func(compiled_fn)
 
-        # Note [Inputs needed in runtime epilogue after list clearing]
-        # In Python functions, you can't free the input arguments of a function within the scope of that function.
-        # A workaround is to wrap the input arguments in a list, and clear the list from within the function.
-        # Here, this is implemented as `call_func_at_runtime_with_args(..., steal_args=True)`.
-        #
-        # This is needed for Compiled Autograd since some of the inputs (activations) should be freed early.
-        # However, we cannot blindly clear the entire list, because AOTAutograd may need access to some of the graph inputs
-        # **after** the compiled function has finished running. There are two main cases:
-        #   (1) Input mutations: If there are an input mutations that we must run outside of the graph, we need access to the input.
-        #   (2) Output aliasing: Outputs that aliases graph inputs generally must be regenerated outside of the `autograd.Function`,
-        #       and doing so requires us accessing the corresponding input after the compiled artifact has run.
-        epilogue_args_idx = []
-        epilogue_args_idx.extend(runtime_metadata.mutated_inp_runtime_indices)
-        num_tokens = len(runtime_metadata.tokens)
-        for info in runtime_metadata.output_info:
-            if (
-                info.output_type == OutputType.alias_of_input
-                or info.output_type == OutputType.is_input
-            ):
-                assert isinstance(info.base_idx, int)
-                epilogue_args_idx.append(info.base_idx + num_tokens)
+def _create_runtime_wrapper(
+    compiled_fn,
+    *,
+    runtime_metadata: ViewAndMutationMeta,
+    indices_of_inps_to_detach: List[int],
+    trace_joint: bool,
+    keep_input_mutations: bool,
+    disable_amp: bool,
+):
+    if not hasattr(compiled_fn, "_boxed_call"):
+        compiled_fn = make_boxed_func(compiled_fn)
 
-        def runtime_wrapper(args: List[Any]):
-            if config.unlift_effect_tokens:
-                assert num_tokens == 0
-            elif num_tokens > 0:
-                # Pass in effect tokens (See Note [Side-Effectful Tokens in AOTAutograd])
-                old_args = args
-                args = [[None] * num_tokens, *args]
-                old_args.clear()
+    # Note [Inputs needed in runtime epilogue after list clearing]
+    # In Python functions, you can't free the input arguments of a function within the scope of that function. A workaround is to
+    # wrap the input arguments in a list, and clear the list from within the function.
+    # Here, this is implemented as `call_func_at_runtime_with_args(..., steal_args=True)`.
+    #
+    # This is needed for Compiled Autograd since some of the inputs (activations) should be freed early.
+    # However, we cannot blindly clear the entire list, because AOTAutograd may need access to some of the graph inputs
+    # **after** the compiled function has finished running. There are two main cases:
+    #   (1) Input mutations: If there are an input mutations that we must run outside of the graph, we need access to the input.
+    #   (2) Output aliasing: Outputs that aliases graph inputs generally must be regenerated outside of the `autograd.Function`,
+    #       and doing so requires us accessing the corresponding input after the compiled artifact has run.
+    epilogue_args_idx = []
+    epilogue_args_idx.extend(runtime_metadata.mutated_inp_runtime_indices)
+    num_tokens = len(runtime_metadata.tokens)
+    for info in runtime_metadata.output_info:
+        if (
+            info.output_type == OutputType.alias_of_input
+            or info.output_type == OutputType.is_input
+        ):
+            assert isinstance(info.base_idx, int)
+            epilogue_args_idx.append(info.base_idx + num_tokens)
 
-            # stash a ref to each input tensor we plan to use after the compiled function
-            orig_inputs = {i: args[i] for i in epilogue_args_idx}
+    def runtime_wrapper(args: List[Any]):
+        if config.unlift_effect_tokens:
+            assert num_tokens == 0
+        elif num_tokens > 0:
+            # Pass in effect tokens (See Note [Side-Effectful Tokens in AOTAutograd])
+            old_args = args
+            args = [[None] * num_tokens, *args]
+            old_args.clear()
 
-            if trace_joint:
-                args_ = list(args)
-                # See Note [Detaching inputs that never need gradients]
-                for idx in indices_of_inps_to_detach:
-                    if isinstance(args_[idx], torch.Tensor):
-                        args_[idx] = args_[idx].detach()
-                with torch.autograd._force_original_view_tracking(True):
-                    all_outs = call_func_at_runtime_with_args(
-                        compiled_fn, args_, disable_amp=disable_amp, steal_args=True
-                    )
-            else:
-                # When we have an inference graph, we run with torch.no_grad.
-                # It's possible to get an inference graph with inputs that require grad,
-                # in which case we want to make sure autograd is disabled
-                # (since e.g., inductor will generate aten.addmm.out calls which autograd will complain on)
-                if torch.is_grad_enabled():
-                    with torch.no_grad():
-                        all_outs = call_func_at_runtime_with_args(
-                            compiled_fn, args, disable_amp=disable_amp, steal_args=True
-                        )
-                else:
+        # stash a ref to each input tensor we plan to use after the compiled function
+        orig_inputs = {i: args[i] for i in epilogue_args_idx}
+
+        if trace_joint:
+            args_ = list(args)
+            # See Note [Detaching inputs that never need gradients]
+            for idx in indices_of_inps_to_detach:
+                if isinstance(args_[idx], torch.Tensor):
+                    args_[idx] = args_[idx].detach()
+            with torch.autograd._force_original_view_tracking(True):
+                all_outs = call_func_at_runtime_with_args(
+                    compiled_fn, args_, disable_amp=disable_amp, steal_args=True
+                )
+        else:
+            # When we have an inference graph, we run with torch.no_grad.
+            # It's possible to get an inference graph with inputs that require grad,
+            # in which case we want to make sure autograd is disabled
+            # (since e.g., inductor will generate aten.addmm.out calls which autograd will complain on)
+            if torch.is_grad_enabled():
+                with torch.no_grad():
                     all_outs = call_func_at_runtime_with_args(
                         compiled_fn, args, disable_amp=disable_amp, steal_args=True
                     )
-            del args
-
-            num_mutated_runtime_inps = runtime_metadata.num_mutated_inp_runtime_indices
-            num_intermediate_bases = runtime_metadata.num_intermediate_bases
-
-            if keep_input_mutations and trace_joint:
-                num_input_mutations_handled_by_autograd = (
-                    runtime_metadata.num_mutated_graph_handled_indices_seen_by_autograd
+            else:
+                all_outs = call_func_at_runtime_with_args(
+                    compiled_fn, args, disable_amp=disable_amp, steal_args=True
                 )
-                # autograd.Function requires us to return the mutated inputs as extra outputs to the autograd.Function.forward
-                if num_input_mutations_handled_by_autograd > 0:
-                    all_outs = all_outs[:-num_input_mutations_handled_by_autograd]
+        del args
 
-            assert (
-                len(all_outs)
-                == num_mutated_runtime_inps
-                + runtime_metadata.num_outputs
-                + num_intermediate_bases
-                + num_tokens
+        num_mutated_runtime_inps = runtime_metadata.num_mutated_inp_runtime_indices
+        num_intermediate_bases = runtime_metadata.num_intermediate_bases
+
+        if keep_input_mutations and trace_joint:
+            num_input_mutations_handled_by_autograd = (
+                runtime_metadata.num_mutated_graph_handled_indices_seen_by_autograd
             )
+            # autograd.Function requires us to return the mutated inputs as extra outputs to the autograd.Function.forward
+            if num_input_mutations_handled_by_autograd > 0:
+                all_outs = all_outs[:-num_input_mutations_handled_by_autograd]
 
-            # Toss out the effect tokens (See Note [Side-Effectful Tokens in AOTAutograd])
-            all_outs = all_outs[num_tokens:]
+        assert (
+            len(all_outs)
+            == num_mutated_runtime_inps
+            + runtime_metadata.num_outputs
+            + num_intermediate_bases
+            + num_tokens
+        )
 
-            # Step 3: After running the compiled fw, apply updates to mutated inputs
-            num_mutations_to_apply = runtime_metadata.num_mutated_inp_runtime_indices
-            if num_mutations_to_apply > 0:
-                updated_inputs = all_outs[:num_mutations_to_apply]
-                fw_outs = all_outs[num_mutations_to_apply:]
+        # Toss out the effect tokens (See Note [Side-Effectful Tokens in AOTAutograd])
+        all_outs = all_outs[num_tokens:]
 
-                for i, inpt_idx in enumerate(
-                    runtime_metadata.mutated_inp_runtime_indices
-                ):
-                    meta = runtime_metadata.input_info[inpt_idx]
-                    if not meta.mutates_data and not meta.mutates_metadata:
-                        continue
-                    original_inpt = orig_inputs[inpt_idx]
-                    updated_inpt = updated_inputs[i]
-                    if meta.mutates_storage_metadata:
-                        # See Note [set_() Input Mutations in AOTAutograd]
-                        # mutates_storage_metadata means our input saw a x.set_(y) call.
-                        # What if x **also** saw a data and/or a metadata mutation?
-                        # (1) If the [meta]data mutation occurred after the set_(),
-                        #     then there is no need to copy_() the data.
-                        #     When we perform x.set_(x_updated), we are guaranteed that
-                        #     x_updated already has the final version of the data/metadata
-                        # (2) If a data mutation occurred before the set_().
-                        #     This case seems very difficult to support.
-                        #     TODO: discuss on the PR and decide if we want to tr to
-                        #     either support it, or detect and ban it.
-                        if trace_joint:
-                            assert isinstance(updated_inpt, TensorAlias)
-                            updated_inpt = updated_inpt.alias
-                        with torch.no_grad():
-                            original_inpt.set_(updated_inpt)
-                        continue
-                    if meta.mutates_metadata and not meta.mutates_data:
-                        if trace_joint:
-                            assert isinstance(updated_inpt, TensorAlias)
-                            updated_inpt = updated_inpt.alias
-                        # We need to grab the size/stride/storage_offset from the compiled forward,
-                        # and use that to mutate the metadata of the input
+        # Step 3: After running the compiled fw, apply updates to mutated inputs
+        num_mutations_to_apply = runtime_metadata.num_mutated_inp_runtime_indices
+        if num_mutations_to_apply > 0:
+            updated_inputs = all_outs[:num_mutations_to_apply]
+            fw_outs = all_outs[num_mutations_to_apply:]
+
+            for i, inpt_idx in enumerate(runtime_metadata.mutated_inp_runtime_indices):
+                meta = runtime_metadata.input_info[inpt_idx]
+                if not meta.mutates_data and not meta.mutates_metadata:
+                    continue
+                original_inpt = orig_inputs[inpt_idx]
+                updated_inpt = updated_inputs[i]
+                if meta.mutates_storage_metadata:
+                    # See Note [set_() Input Mutations in AOTAutograd]
+                    # mutates_storage_metadata means our input saw a x.set_(y) call.
+                    # What if x **also** saw a data and/or a metadata mutation?
+                    # (1) If the [meta]data mutation occurred after the set_(),
+                    #     then there is no need to copy_() the data.
+                    #     When we perform x.set_(x_updated), we are guaranteed that
+                    #     x_updated already has the final version of the data/metadata
+                    # (2) If a data mutation occurred before the set_().
+                    #     This case seems very difficult to support.
+                    #     TODO: discuss on the PR and decide if we want to tr to
+                    #     either support it, or detect and ban it.
+                    if trace_joint:
+                        assert isinstance(updated_inpt, TensorAlias)
+                        updated_inpt = updated_inpt.alias
+                    with torch.no_grad():
+                        original_inpt.set_(updated_inpt)
+                    continue
+                if meta.mutates_metadata and not meta.mutates_data:
+                    if trace_joint:
+                        assert isinstance(updated_inpt, TensorAlias)
+                        updated_inpt = updated_inpt.alias
+                    # We need to grab the size/stride/storage_offset from the compiled forward,
+                    # and use that to mutate the metadata of the input
+                    original_inpt.as_strided_(
+                        updated_inpt.size(),
+                        updated_inpt.stride(),
+                        updated_inpt.storage_offset(),
+                    )
+                else:
+                    if meta.mutates_data and meta.mutates_metadata:
                         original_inpt.as_strided_(
                             updated_inpt.size(),
                             updated_inpt.stride(),
                             updated_inpt.storage_offset(),
                         )
                     else:
-                        if meta.mutates_data and meta.mutates_metadata:
-                            original_inpt.as_strided_(
-                                updated_inpt.size(),
-                                updated_inpt.stride(),
-                                updated_inpt.storage_offset(),
-                            )
-                        else:
-                            assert meta.mutates_data
-                        if meta.is_leaf and original_inpt.requires_grad:
-                            # We can hit this situation in this case:
-                            #   def f(x):
-                            #       x.detach().mul_(2)
-                            #       return x + 1
-                            # AOTAutograd will see a mutation in the above case, and try to
-                            # apply a copy_() here, in the epilogue.
-                            # But if x required gradients, and is a leaf, then autograd
-                            # will yell at us for trying to mutate it.
-                            # However, it's only possible to end up in this scenario (like the above)
-                            # if all of the mutations to the leaf input were non-autograd-tracking mutations
-                            # (aka mutations under no_grad(), or on detached views).
-                            # In that case, we fully want to hide the mutation from autograd, so detaching is ok.
-                            original_inpt.detach().copy_(updated_inpt)
-                        else:
-                            original_inpt.copy_(updated_inpt)
+                        assert meta.mutates_data
+                    if meta.is_leaf and original_inpt.requires_grad:
+                        # We can hit this situation in this case:
+                        #   def f(x):
+                        #       x.detach().mul_(2)
+                        #       return x + 1
+                        # AOTAutograd will see a mutation in the above case, and try to
+                        # apply a copy_() here, in the epilogue.
+                        # But if x required gradients, and is a leaf, then autograd
+                        # will yell at us for trying to mutate it.
+                        # However, it's only possible to end up in this scenario (like the above)
+                        # if all of the mutations to the leaf input were non-autograd-tracking mutations
+                        # (aka mutations under no_grad(), or on detached views).
+                        # In that case, we fully want to hide the mutation from autograd, so detaching is ok.
+                        original_inpt.detach().copy_(updated_inpt)
+                    else:
+                        original_inpt.copy_(updated_inpt)
+        else:
+            fw_outs = all_outs
+
+        # Step 4: Manually regenerate any outputs that are aliased to inputs, instead of
+        # compiling them.
+        if runtime_metadata.num_outputs_aliased > 0:
+            # The compiled forward also returned intermediate bases. We don't want to return them to the user.
+            if runtime_metadata.num_intermediate_bases > 0:
+                fw_outs_no_intermediate_bases = fw_outs[
+                    : -runtime_metadata.num_intermediate_bases
+                ]
+                intermediate_bases = fw_outs[-runtime_metadata.num_intermediate_bases :]
             else:
-                fw_outs = all_outs
+                fw_outs_no_intermediate_bases = fw_outs
+                intermediate_bases = []
 
-            # Step 4: Manually regenerate any outputs that are aliased to inputs, instead of
-            # compiling them.
-            if runtime_metadata.num_outputs_aliased > 0:
-                # The compiled forward also returned intermediate bases. We don't want to return them to the user.
-                if runtime_metadata.num_intermediate_bases > 0:
-                    fw_outs_no_intermediate_bases = fw_outs[
-                        : -runtime_metadata.num_intermediate_bases
-                    ]
-                    intermediate_bases = fw_outs[
-                        -runtime_metadata.num_intermediate_bases :
-                    ]
+            assert len(fw_outs_no_intermediate_bases) == len(
+                runtime_metadata.output_info
+            )
+            fw_outs_including_aliases = []
+            for i, (o, info) in enumerate(
+                zip(fw_outs_no_intermediate_bases, runtime_metadata.output_info)
+            ):
+                if info.output_type in [
+                    OutputType.non_alias,
+                    OutputType.unsafe_view_alias,
+                    OutputType.custom_function_view,
+                ]:
+                    fw_outs_including_aliases.append(o)
+                    continue
+                if trace_joint:
+                    assert isinstance(o, TensorAlias)
+                    o_ = o.alias
                 else:
-                    fw_outs_no_intermediate_bases = fw_outs
-                    intermediate_bases = []
+                    o_ = o
 
-                assert len(fw_outs_no_intermediate_bases) == len(
-                    runtime_metadata.output_info
-                )
-                fw_outs_including_aliases = []
-                for i, (o, info) in enumerate(
-                    zip(fw_outs_no_intermediate_bases, runtime_metadata.output_info)
-                ):
-                    if info.output_type in [
-                        OutputType.non_alias,
-                        OutputType.unsafe_view_alias,
-                        OutputType.custom_function_view,
-                    ]:
-                        fw_outs_including_aliases.append(o)
-                        continue
-                    if trace_joint:
-                        assert isinstance(o, TensorAlias)
-                        o_ = o.alias
-                    else:
-                        o_ = o
-
-                    o_grad = runtime_metadata.output_info[i].requires_grad
-                    if info.output_type == OutputType.alias_of_input:
-                        aliased_base_tensor = orig_inputs[info.base_idx + num_tokens]  # type: ignore[index]
-                        regenerated_out = gen_alias_from_base(
-                            aliased_base_tensor, o_, o_grad, info.functional_tensor
-                        )
-                        fw_outs_including_aliases.append(regenerated_out)
-                        continue
-                    elif info.output_type == OutputType.is_input:
-                        aliased_base_tensor = orig_inputs[info.base_idx + num_tokens]  # type: ignore[index]
-                        regenerated_out = aliased_base_tensor
-                        fw_outs_including_aliases.append(regenerated_out)
-                        continue
-                    elif info.output_type == OutputType.alias_of_intermediate:
-                        base_tensor_list = intermediate_bases
-                    elif (
-                        info.output_type
-                        == OutputType.alias_of_intermediate_save_as_output
-                    ):
-                        base_tensor_list = intermediate_bases
-                    else:
-                        assert (
-                            info.output_type
-                            == OutputType.alias_of_intermediate_base_is_user_output
-                        )
-                        base_tensor_list = fw_outs_no_intermediate_bases
-                    aliased_base_tensor = base_tensor_list[info.base_idx]
-                    # TODO: handle the custom autograd function case here.
-                    # We need a way to check whether a tensor came from a custom autograd fn from python,
-                    # AND a way to replay that custom view fn.
+                o_grad = runtime_metadata.output_info[i].requires_grad
+                if info.output_type == OutputType.alias_of_input:
+                    aliased_base_tensor = orig_inputs[info.base_idx + num_tokens]  # type: ignore[index]
                     regenerated_out = gen_alias_from_base(
                         aliased_base_tensor, o_, o_grad, info.functional_tensor
                     )
                     fw_outs_including_aliases.append(regenerated_out)
-                ret_outs = fw_outs_including_aliases
-            else:
-                ret_outs = fw_outs
+                    continue
+                elif info.output_type == OutputType.is_input:
+                    aliased_base_tensor = orig_inputs[info.base_idx + num_tokens]  # type: ignore[index]
+                    regenerated_out = aliased_base_tensor
+                    fw_outs_including_aliases.append(regenerated_out)
+                    continue
+                elif info.output_type == OutputType.alias_of_intermediate:
+                    base_tensor_list = intermediate_bases
+                elif (
+                    info.output_type == OutputType.alias_of_intermediate_save_as_output
+                ):
+                    base_tensor_list = intermediate_bases
+                else:
+                    assert (
+                        info.output_type
+                        == OutputType.alias_of_intermediate_base_is_user_output
+                    )
+                    base_tensor_list = fw_outs_no_intermediate_bases
+                aliased_base_tensor = base_tensor_list[info.base_idx]
+                # TODO: handle the custom autograd function case here.
+                # We need a way to check whether a tensor came from a custom autograd fn from python,
+                # AND a way to replay that custom view fn.
+                regenerated_out = gen_alias_from_base(
+                    aliased_base_tensor, o_, o_grad, info.functional_tensor
+                )
+                fw_outs_including_aliases.append(regenerated_out)
+            ret_outs = fw_outs_including_aliases
+        else:
+            ret_outs = fw_outs
 
-            if runtime_metadata.dynamic_outputs:
-                for t, o in zip(ret_outs, runtime_metadata.output_info):
-                    if o.dynamic_dims is None:
-                        continue
-                    if hasattr(t, "_dynamo_weak_dynamic_indices"):
-                        t._dynamo_weak_dynamic_indices |= o.dynamic_dims
-                    else:
-                        t._dynamo_weak_dynamic_indices = o.dynamic_dims.copy()
-            if runtime_metadata.grad_enabled_mutation is not None:
-                torch.set_grad_enabled(runtime_metadata.grad_enabled_mutation)
-            return ret_outs
+        if runtime_metadata.dynamic_outputs:
+            for t, o in zip(ret_outs, runtime_metadata.output_info):
+                if o.dynamic_dims is None:
+                    continue
+                if hasattr(t, "_dynamo_weak_dynamic_indices"):
+                    t._dynamo_weak_dynamic_indices |= o.dynamic_dims
+                else:
+                    t._dynamo_weak_dynamic_indices = o.dynamic_dims.copy()
+        if runtime_metadata.grad_enabled_mutation is not None:
+            torch.set_grad_enabled(runtime_metadata.grad_enabled_mutation)
+        return ret_outs
 
-        return runtime_wrapper
+    return runtime_wrapper
 
 
 # Calling convention: If we are running functionalized RNG, then outs consists

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -70,9 +70,7 @@ from ._aot_autograd.runtime_wrappers import (  # noqa: F401
     aot_dispatch_subclass_wrapper,
     aot_wrapper_dedupe,
     aot_wrapper_synthetic_base,
-    create_runtime_wrapper,
     functionalized_rng_runtime_epilogue,
-    merge_view_inputs,
 )
 from ._aot_autograd.schemas import (  # noqa: F401
     AOTConfig,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #125610
* __->__ #125595


This is the first PR in a series where I try to organize our runtime wrappers a bit: specifically, I'd like to separate wrappers into objects that have (up to) 2 methods:
A **pre-compile** function, which takes in flat_fn and flat_args (inputs to the compiler) and wraps/modifies them
A **post-compile** function, which takes in a compiled_fn and runtime args and wraps the compiled_function. 

Extra metadata necessary to run the compile functions can be stored on the attributes of the class. This way, when we think about caching, the set of attributes on the class should be the exact set of metadata that we need to serialize and save in the cache (along with common data, like fw_metadata)