### PR TITLE
[CI] Move gha artifact download before xml parsing for test stat uploads

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -49,22 +49,6 @@ jobs:
       - run: |
           pip3 install requests==2.26 rockset==1.0.3 boto3==1.19.12
 
-      - name: Upload test stats
-        env:
-          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
-          WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
-          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
-          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          echo "${WORKFLOW_URL}"
-          python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --head-branch "${HEAD_BRANCH}" --head-repository "${HEAD_REPOSITORY}"
-          python3 -m tools.stats.upload_sccache_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
-
       - name: Upload test artifacts
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -80,6 +64,22 @@ jobs:
           # Note that in the case of Linux and Windows, their artifacts have already been uploaded to S3, so there simply won't be
           # anything on GitHub to upload. The command should return right away
           python3 -m tools.stats.upload_artifacts --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --repo "${REPO_FULLNAME}"
+
+      - name: Upload test stats
+        env:
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          echo "${WORKFLOW_URL}"
+          python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --head-branch "${HEAD_BRANCH}" --head-repository "${HEAD_REPOSITORY}"
+          python3 -m tools.stats.upload_sccache_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
 
       - name: Analyze disabled tests rerun
         env:

--- a/tools/stats/check_disabled_tests.py
+++ b/tools/stats/check_disabled_tests.py
@@ -7,7 +7,6 @@ from tempfile import TemporaryDirectory
 from typing import Any, Dict, Generator, Tuple
 
 from tools.stats.upload_stats_lib import (
-    download_gha_artifacts,
     download_s3_artifacts,
     is_rerun_disabled_tests,
     unzip,
@@ -110,12 +109,6 @@ def get_test_reports(
 
         artifact_paths = download_s3_artifacts(
             "test-reports", workflow_run_id, workflow_run_attempt
-        )
-        for path in artifact_paths:
-            unzip(path)
-
-        artifact_paths = download_gha_artifacts(
-            "test-report", workflow_run_id, workflow_run_attempt
         )
         for path in artifact_paths:
             unzip(path)

--- a/tools/stats/test_dashboard.py
+++ b/tools/stats/test_dashboard.py
@@ -12,7 +12,6 @@ import requests
 
 from tools.stats.upload_stats_lib import (
     _get_request_headers,
-    download_gha_artifacts,
     download_s3_artifacts,
     get_job_id,
     unzip,
@@ -67,12 +66,6 @@ def get_td_exclusions(
             "test-jsons", workflow_run_id, workflow_run_attempt
         )
         for path in s3_paths:
-            unzip(path)
-
-        artifact_paths = download_gha_artifacts(
-            "test-jsons", workflow_run_id, workflow_run_attempt
-        )
-        for path in artifact_paths:
             unzip(path)
 
         grouped_tests: Dict[str, Any] = defaultdict(lambda: defaultdict(set))

--- a/tools/stats/upload_sccache_stats.py
+++ b/tools/stats/upload_sccache_stats.py
@@ -6,9 +6,7 @@ from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
 
 from tools.stats.upload_stats_lib import (
-    download_gha_artifacts,
     download_s3_artifacts,
-    unzip,
     upload_to_rockset,
 )
 
@@ -22,12 +20,6 @@ def get_sccache_stats(
 
         # Download and extract all the reports (both GHA and S3)
         download_s3_artifacts("sccache-stats", workflow_run_id, workflow_run_attempt)
-
-        artifact_paths = download_gha_artifacts(
-            "sccache-stats", workflow_run_id, workflow_run_attempt
-        )
-        for path in artifact_paths:
-            unzip(path)
 
         stats_jsons = []
         for json_file in Path(".").glob("**/*.json"):

--- a/tools/stats/upload_sccache_stats.py
+++ b/tools/stats/upload_sccache_stats.py
@@ -5,10 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
 
-from tools.stats.upload_stats_lib import (
-    download_s3_artifacts,
-    upload_to_rockset,
-)
+from tools.stats.upload_stats_lib import download_s3_artifacts, upload_to_rockset
 
 
 def get_sccache_stats(

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List
 
 from tools.stats.test_dashboard import upload_additional_info
 from tools.stats.upload_stats_lib import (
-    download_gha_artifacts,
     download_s3_artifacts,
     get_job_id,
     unzip,
@@ -121,12 +120,6 @@ def get_tests(workflow_run_id: int, workflow_run_attempt: int) -> List[Dict[str,
             "test-report", workflow_run_id, workflow_run_attempt
         )
         for path in s3_paths:
-            unzip(path)
-
-        artifact_paths = download_gha_artifacts(
-            "test-report", workflow_run_id, workflow_run_attempt
-        )
-        for path in artifact_paths:
             unzip(path)
 
         # Parse the reports and transform them to JSON


### PR DESCRIPTION
Move gha artifact download to before any xml parsing is done for uplaod-test-stats

Do not download gha artifacts during xml parsing since got uploaded to s3 in the above and will be downloaded when all the artifacts are downloaded from s3

The previous method resulted in dups if you run the script again  

TODO: write a deduper so we don't have to worry at all