### PR TITLE
Capture uninitialized tensor as "None"

### DIFF
--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -56,6 +56,9 @@ inline std::string getValueType(
   if (val.isTensor()) {
     // Add tensor element data type.
     type += fmt::format("({})", std::string(val.toTensor().dtype().name()));
+    if (type == "Tensor(nullptr (uninitialized))")
+      // This is the case that the input tensor is optional and it is "None"
+      type = "None";
   } else if (val.isTuple()) {
     const auto& val_container = val.toTupleRef().elements();
     std::vector<std::string> str_array;
@@ -403,15 +406,18 @@ inline std::string convertIValue(
       numel = t->numel();
       itemsize = t->itemsize();
       device_str = t->device().str();
+
+      return fmt::format(
+          "[{},{},{},{},{},\"{}\"]",
+          tensor_id,
+          storage_id,
+          offset,
+          numel,
+          itemsize,
+          device_str);
+    } else {
+      return "\"<None>\"";
     }
-    return fmt::format(
-        "[{},{},{},{},{},\"{}\"]",
-        tensor_id,
-        storage_id,
-        offset,
-        numel,
-        itemsize,
-        device_str);
   } else if (val.isTuple()) {
     std::vector<std::string> str_array;
     const auto& val_tuple = val.toTupleRef().elements();


### PR DESCRIPTION
Summary: When an operator has an optional input tensor, and it is None, the returned type is Tensor(nullptr (uninitialized)). Need to change it to "None" to make ET passser happy.

Test Plan: buck2 test mode/dev-nosan //caffe2/test:profiler -- test_execution_trace

Differential Revision: D57019222


