### PR TITLE
[BE] Explicitly handle all types `c10::isSigned`

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -430,9 +430,10 @@ static inline ScalarType toUnderlying(ScalarType t) {
 static inline bool isSignedType(ScalarType t) {
   TORCH_CHECK(!isQIntType(t), "isSignedType not supported for quantized types");
 
-#define CASE_ISSIGNED(name)                      \
-  case ScalarType::name:                         \
-    return std::numeric_limits<::c10::impl::ScalarTypeToCPPTypeT<ScalarType::name>>::is_signed;
+#define CASE_ISSIGNED(name)     \
+  case ScalarType::name:        \
+    return std::numeric_limits< \
+        ::c10::impl::ScalarTypeToCPPTypeT<ScalarType::name>>::is_signed;
 
   switch (t) {
     case ScalarType::QInt8:
@@ -447,26 +448,26 @@ static inline bool isSignedType(ScalarType t) {
     case ScalarType::Bits8:
     case ScalarType::Bits16:
       TORCH_CHECK(false, "Bits types are undefined");
-    CASE_ISSIGNED(UInt16);
-    CASE_ISSIGNED(UInt32);
-    CASE_ISSIGNED(UInt64);
-    CASE_ISSIGNED(BFloat16);
-    CASE_ISSIGNED(Float8_e5m2);
-    CASE_ISSIGNED(Float8_e5m2fnuz);
-    CASE_ISSIGNED(Float8_e4m3fn);
-    CASE_ISSIGNED(Float8_e4m3fnuz);
-    CASE_ISSIGNED(Byte);
-    CASE_ISSIGNED(Char);
-    CASE_ISSIGNED(Short);
-    CASE_ISSIGNED(Int);
-    CASE_ISSIGNED(Long);
-    CASE_ISSIGNED(Half);
-    CASE_ISSIGNED(Float);
-    CASE_ISSIGNED(Double);
-    CASE_ISSIGNED(ComplexHalf);
-    CASE_ISSIGNED(ComplexFloat);
-    CASE_ISSIGNED(ComplexDouble);
-    CASE_ISSIGNED(Bool);
+      CASE_ISSIGNED(UInt16);
+      CASE_ISSIGNED(UInt32);
+      CASE_ISSIGNED(UInt64);
+      CASE_ISSIGNED(BFloat16);
+      CASE_ISSIGNED(Float8_e5m2);
+      CASE_ISSIGNED(Float8_e5m2fnuz);
+      CASE_ISSIGNED(Float8_e4m3fn);
+      CASE_ISSIGNED(Float8_e4m3fnuz);
+      CASE_ISSIGNED(Byte);
+      CASE_ISSIGNED(Char);
+      CASE_ISSIGNED(Short);
+      CASE_ISSIGNED(Int);
+      CASE_ISSIGNED(Long);
+      CASE_ISSIGNED(Half);
+      CASE_ISSIGNED(Float);
+      CASE_ISSIGNED(Double);
+      CASE_ISSIGNED(ComplexHalf);
+      CASE_ISSIGNED(ComplexFloat);
+      CASE_ISSIGNED(ComplexDouble);
+      CASE_ISSIGNED(Bool);
     case ScalarType::UInt1:
     case ScalarType::UInt2:
     case ScalarType::UInt3:
@@ -478,6 +479,8 @@ static inline bool isSignedType(ScalarType t) {
     case ScalarType::Undefined:
     case ScalarType::NumOptions:
       break;
+      // Do not add default here, but rather define behavior of every new entry
+      // here
   }
   TORCH_CHECK(false, "Unknown ScalarType ", t);
 #undef CASE_ISSIGNED

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -428,8 +428,6 @@ static inline ScalarType toUnderlying(ScalarType t) {
 }
 
 static inline bool isSignedType(ScalarType t) {
-  TORCH_CHECK(!isQIntType(t), "isSignedType not supported for quantized types");
-
 #define CASE_ISSIGNED(name)     \
   case ScalarType::name:        \
     return std::numeric_limits< \
@@ -480,7 +478,7 @@ static inline bool isSignedType(ScalarType t) {
     case ScalarType::NumOptions:
       break;
       // Do not add default here, but rather define behavior of every new entry
-      // here
+      // here.  `-Wswitch-enum` would raise a warning in those cases.
   }
   TORCH_CHECK(false, "Unknown ScalarType ", t);
 #undef CASE_ISSIGNED

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -429,34 +429,58 @@ static inline ScalarType toUnderlying(ScalarType t) {
 
 static inline bool isSignedType(ScalarType t) {
   TORCH_CHECK(!isQIntType(t), "isSignedType not supported for quantized types");
-#define CASE_SIGNED(ctype, name) \
-  case ScalarType::name:         \
-    return std::numeric_limits<ctype>::is_signed;
+
+#define CASE_ISSIGNED(name)                      \
+  case ScalarType::name:                         \
+    return std::numeric_limits<::c10::impl::ScalarTypeToCPPTypeT<ScalarType::name>>::is_signed;
 
   switch (t) {
+    case ScalarType::QInt8:
+    case ScalarType::QUInt8:
+    case ScalarType::QInt32:
+    case ScalarType::QUInt4x2:
+    case ScalarType::QUInt2x4:
+      TORCH_CHECK(false, "isSignedType not supported for quantized types");
     case ScalarType::Bits1x8:
     case ScalarType::Bits2x4:
     case ScalarType::Bits4x2:
     case ScalarType::Bits8:
     case ScalarType::Bits16:
       TORCH_CHECK(false, "Bits types are undefined");
-    case ScalarType::ComplexHalf:
-    case ScalarType::ComplexFloat:
-    case ScalarType::ComplexDouble:
+    CASE_ISSIGNED(UInt16);
+    CASE_ISSIGNED(UInt32);
+    CASE_ISSIGNED(UInt64);
+    CASE_ISSIGNED(BFloat16);
+    CASE_ISSIGNED(Float8_e5m2);
+    CASE_ISSIGNED(Float8_e5m2fnuz);
+    CASE_ISSIGNED(Float8_e4m3fn);
+    CASE_ISSIGNED(Float8_e4m3fnuz);
+    CASE_ISSIGNED(Byte);
+    CASE_ISSIGNED(Char);
+    CASE_ISSIGNED(Short);
+    CASE_ISSIGNED(Int);
+    CASE_ISSIGNED(Long);
+    CASE_ISSIGNED(Half);
+    CASE_ISSIGNED(Float);
+    CASE_ISSIGNED(Double);
+    CASE_ISSIGNED(ComplexHalf);
+    CASE_ISSIGNED(ComplexFloat);
+    CASE_ISSIGNED(ComplexDouble);
+    CASE_ISSIGNED(Bool);
+    case ScalarType::UInt1:
+    case ScalarType::UInt2:
+    case ScalarType::UInt3:
+    case ScalarType::UInt4:
+    case ScalarType::UInt5:
+    case ScalarType::UInt6:
+    case ScalarType::UInt7:
       return true;
-      AT_FORALL_SCALAR_TYPES_AND7(
-          Half,
-          Bool,
-          BFloat16,
-          Float8_e5m2,
-          Float8_e4m3fn,
-          Float8_e5m2fnuz,
-          Float8_e4m3fnuz,
-          CASE_SIGNED)
-    default:
-      TORCH_CHECK(false, "Unknown ScalarType");
+    case ScalarType::Undefined:
+    case ScalarType::NumOptions:
+      break;
   }
-#undef CASE_SIGNED
+  TORCH_CHECK(false, "Unknown ScalarType ", t);
+#undef CASE_ISSIGNED
 }
 
 static inline bool isUnderlying(ScalarType type, ScalarType qtype) {


### PR DESCRIPTION
By defining `CASE_ISSIGNED` macros that just returns `std::numeric_limits<dtype>::is_signed`  for the types where it makes sense and explicitly code some types when it does not

Remove `default:` case from the switch to avoid regressions like the one reported in https://github.com/pytorch/pytorch/issues/125124 , as [`-Wswitch-enum`](https://clang.llvm.org/docs/DiagnosticsReference.html#wswitch-enum) in combination with `-Werror` will raise an error in case of a missing entry, for example:
```
/Users/nshulga/git/pytorch/pytorch/c10/core/ScalarType.h:518:11: warning: enumeration value 'QInt32' not handled in switch [-Wswitch]
  switch (t) {
          ^
/Users/nshulga/git/pytorch/pytorch/c10/core/ScalarType.h:518:11: note: add missing switch cases
  switch (t) {
          ^
1 warning generated.
```

Fixes https://github.com/pytorch/pytorch/issues/125124
