### PR TITLE
[Profiler] Do not emit a warning when using CPU profiler

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -241,21 +241,22 @@ class profile:
                 use_kineto
             ), "Device-only events supported only with Kineto (use_kineto=True)"
 
-        VALID_DEVICE_OPTIONS = ["cuda", "xpu"]
-        if _get_privateuse1_backend_name() != "privateuseone":
-            VALID_DEVICE_OPTIONS.append(_get_privateuse1_backend_name())
-        if self.use_device not in VALID_DEVICE_OPTIONS:
-            warn(f"The {self.use_device} is not a valid device option.")
-            self.use_device = None
+        if self.use_device is not None:
+            VALID_DEVICE_OPTIONS = ["cuda", "xpu"]
+            if _get_privateuse1_backend_name() != "privateuseone":
+                VALID_DEVICE_OPTIONS.append(_get_privateuse1_backend_name())
+            if self.use_device not in VALID_DEVICE_OPTIONS:
+                warn(f"The {self.use_device} is not a valid device option.")
+                self.use_device = None
 
-        if self.use_device == "cuda" and not torch.cuda.is_available():
-            warn("CUDA is not available, disabling CUDA profiling")
-            self.use_cuda = False
-            self.use_device = None
+            if self.use_device == "cuda" and not torch.cuda.is_available():
+                warn("CUDA is not available, disabling CUDA profiling")
+                self.use_cuda = False
+                self.use_device = None
 
-        if self.use_device == "xpu" and not torch.xpu.is_available():
-            warn("XPU is not available, disabling XPU profiling")
-            self.use_device = None
+            if self.use_device == "xpu" and not torch.xpu.is_available():
+                warn("XPU is not available, disabling XPU profiling")
+                self.use_device = None
 
         self.kineto_activities = set()
         if self.use_cpu:


### PR DESCRIPTION
This fixes a logic regression introduced by https://github.com/pytorch/pytorch/pull/123247 where 
```python
if self.use_device and self.use_device != _get_privateuse1_backend_name():
``` 
was replaced with
```python
        VALID_DEVICE_OPTIONS = ["cuda", "xpu", "privateuseone"]
        if self.use_device not in VALID_DEVICE_OPTIONS:
```

That triggers a warning every time code is invoke with `self.use_device` set to None

This change also skips all the checks which are useless if `use_device` is None to begin with