### PR TITLE
cprofile every compile id [x/y] to keep consistent with tlparse

### DIFF
--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -7,9 +7,9 @@ import unittest
 
 import torch
 from torch import nn, Tensor
+from torch._dynamo.convert_frame import maybe_cprofile
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import rand_strided, reduce_to_scalar_loss
-from torch._dynamo.utils import maybe_cprofile
 from torch._inductor import config, ir, metrics
 from torch._inductor.fx_passes import pad_mm as pad_mm_pass
 from torch._inductor.runtime.runtime_utils import do_bench

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -300,10 +300,10 @@ def maybe_cprofile(func):
 def cprofile_wrapper(func):
     @functools.wraps(func)
     def profile_wrapper(*args, **kwargs):
-        global FRAME_COUNTER
-        global FRAME_COMPILE_COUNTER
+        trace_id = CompileContext.current_trace_id()
+        assert trace_id, "Trace id is None"
         profile_path = Path(
-            f"/tmp/{func.__name__}_{FRAME_COUNTER}_{FRAME_COMPILE_COUNTER}.profile"
+            f"/tmp/{func.__name__}_{str(trace_id).replace('/','_')}.profile"
         )
         prof = cProfile.Profile()
         prof.enable()
@@ -312,10 +312,9 @@ def cprofile_wrapper(func):
         profile_latency = time.time() - start_ts
         prof.disable()
         log.info(
-            "### Cprofile for %s compile id [%d/%d] took %.3f seconds ###",
+            "### Cprofile for %s trace id [%s] took %.3f seconds ###",
             func.__name__,
-            FRAME_COUNTER,
-            FRAME_COMPILE_COUNTER,
+            trace_id,
             profile_latency,
         )
         ps = pstats.Stats(prof)

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -87,7 +87,6 @@ from .utils import (
     is_namedtuple,
     istype,
     LazyString,
-    maybe_cprofile,
     orig_code_map,
     record_compilation_metrics,
     reset_graph_break_dup_checker,

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -87,7 +87,6 @@ from .utils import (
     is_namedtuple,
     istype,
     LazyString,
-    maybe_cprofile,
     orig_code_map,
     record_compilation_metrics,
     reset_graph_break_dup_checker,
@@ -428,7 +427,6 @@ def register_bytecode_hook(hook: BytecodeHook) -> RemovableHandle:
 
 @compile_time_strobelight_meta(phase_name="_compile")
 @_use_lazy_graph_module(config.use_lazy_graph_module)
-@maybe_cprofile
 def _compile(
     code: types.CodeType,
     globals: Dict[str, object],

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -351,6 +351,12 @@ def cprofile_wrapper(func):
 
         maybe_upload_prof_stats_to_manifold(str(profile_path))  # fb-only
 
+        torch._logging.trace_structured(
+            "artifact",
+            lambda: { "name": "dynamo_cprofile_prof", "type": "prof", "encoding": "ascii" },
+            payload_fn=lambda: base64.encodebytes(open(profile_path, 'rb').read()),
+        )
+
         return retval
 
     return profile_wrapper

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1,3 +1,4 @@
+import base64
 import collections
 import cProfile
 import dis
@@ -353,8 +354,12 @@ def cprofile_wrapper(func):
 
         torch._logging.trace_structured(
             "artifact",
-            lambda: { "name": "dynamo_cprofile_prof", "type": "prof", "encoding": "ascii" },
-            payload_fn=lambda: base64.encodebytes(open(profile_path, 'rb').read()),
+            lambda: {
+                "name": "dynamo_cprofile_prof",
+                "type": "prof",
+                "encoding": "ascii",
+            },
+            payload_fn=lambda: base64.encodebytes(open(profile_path, "rb").read()),
         )
 
         return retval

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -357,9 +357,11 @@ def cprofile_wrapper(func):
             lambda: {
                 "name": "dynamo_cprofile_prof",
                 "type": "prof",
-                "encoding": "ascii",
+                "encoding": "base64",
             },
-            payload_fn=lambda: base64.encodebytes(open(profile_path, "rb").read()),
+            payload_fn=lambda: base64.encodebytes(
+                open(profile_path, "rb").read()
+            ).decode("ascii"),
         )
 
         return retval

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -153,11 +153,14 @@ def cprofile_wrapper(func):
         retval = prof.runcall(func, *args, **kwargs)
         profile_latency = time.time() - start_ts
         prof.disable()
-        print(
+        log.info(
             f"### Cprofile for {func.__name__} iter {profile_cnt} took {profile_latency:.3f} seconds ###"
         )
         ps = pstats.Stats(prof)
-        prof.dump_stats(profile_path)
+        try:
+            prof.dump_stats(profile_path)
+        except PermissionError:
+            log.info(f"Cannot write to {str(profile_path)}")
         svg_path = profile_path.with_suffix(".svg")
         try:
             gprof2dot_process = subprocess.Popen(
@@ -176,9 +179,9 @@ def cprofile_wrapper(func):
                 ["dot", "-Tsvg", "-o", str(svg_path)],
                 stdin=gprof2dot_process.stdout,
             )
-            print(f"Generated SVG from profile at {str(svg_path)}")
+            log.info(f"Generated SVG from profile at {str(svg_path)}")
         except FileNotFoundError:
-            print(
+            log.info(
                 "Failed to generate SVG from profile -- dumping stats instead."
                 "Try installing gprof2dot and dot for a better visualization"
             )

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -154,13 +154,16 @@ def cprofile_wrapper(func):
         profile_latency = time.time() - start_ts
         prof.disable()
         log.info(
-            f"### Cprofile for {func.__name__} iter {profile_cnt} took {profile_latency:.3f} seconds ###"
+            "### Cprofile for %s iter %d took %.3f seconds ###",
+            func.__name__,
+            profile_cnt,
+            profile_latency,
         )
         ps = pstats.Stats(prof)
         try:
             prof.dump_stats(profile_path)
         except PermissionError:
-            log.info(f"Cannot write to {str(profile_path)}")
+            log.info("Cannot write to %s", str(profile_path))
         svg_path = profile_path.with_suffix(".svg")
         try:
             gprof2dot_process = subprocess.Popen(

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -182,7 +182,7 @@ def cprofile_wrapper(func):
                 ["dot", "-Tsvg", "-o", str(svg_path)],
                 stdin=gprof2dot_process.stdout,
             )
-            log.info(f"Generated SVG from profile at {str(svg_path)}")
+            log.info("Generated SVG from profile at %s", str(svg_path))
         except FileNotFoundError:
             log.info(
                 "Failed to generate SVG from profile -- dumping stats instead."

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2,7 +2,6 @@ import atexit
 import collections
 import contextlib
 import copy
-import cProfile
 import dataclasses
 import datetime
 import dis
@@ -16,9 +15,7 @@ import logging
 import math
 import operator
 import os
-import pstats
 import re
-import subprocess
 import sys
 import textwrap
 import threading
@@ -28,7 +25,6 @@ import typing
 import weakref
 from contextlib import contextmanager
 from functools import lru_cache, wraps
-from pathlib import Path
 from types import MethodWrapperType
 from typing import (
     Any,
@@ -49,8 +45,6 @@ from typing import (
     Union,
     ValuesView,
 )
-
-from torch._utils_internal import maybe_upload_prof_stats_to_manifold
 
 from ..utils.hooks import RemovableHandle
 
@@ -133,69 +127,6 @@ def tabulate(rows, headers):
         return "\n".join(
             ", ".join(map(str, row)) for row in itertools.chain([headers], rows)
         )
-
-
-def maybe_cprofile(func):
-    if config.cprofile:
-        return cprofile_wrapper(func)
-    return func
-
-
-def cprofile_wrapper(func):
-    @wraps(func)
-    def profile_wrapper(*args, **kwargs):
-        global timer_counter
-        profile_cnt = next(timer_counter)
-        profile_path = Path("/tmp/" + func.__name__ + f"{profile_cnt}.profile")
-        prof = cProfile.Profile()
-        prof.enable()
-        start_ts = time.time()
-        retval = prof.runcall(func, *args, **kwargs)
-        profile_latency = time.time() - start_ts
-        prof.disable()
-        log.info(
-            "### Cprofile for %s iter %d took %.3f seconds ###",
-            func.__name__,
-            profile_cnt,
-            profile_latency,
-        )
-        ps = pstats.Stats(prof)
-        try:
-            prof.dump_stats(profile_path)
-        except PermissionError:
-            log.info("Cannot write to %s", str(profile_path))
-        svg_path = profile_path.with_suffix(".svg")
-        try:
-            gprof2dot_process = subprocess.Popen(
-                [
-                    "gprof2dot",
-                    "-f",
-                    "pstats",
-                    "--node-label=total-time-percentage",
-                    "--node-label=self-time-percentage",
-                    "--node-label=total-time",
-                    str(profile_path),
-                ],
-                stdout=subprocess.PIPE,
-            )
-            subprocess.check_call(
-                ["dot", "-Tsvg", "-o", str(svg_path)],
-                stdin=gprof2dot_process.stdout,
-            )
-            log.info("Generated SVG from profile at %s", str(svg_path))
-        except FileNotFoundError:
-            log.info(
-                "Failed to generate SVG from profile -- dumping stats instead."
-                "Try installing gprof2dot and dot for a better visualization"
-            )
-            ps.sort_stats(pstats.SortKey.TIME).print_stats(20)
-            ps.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(20)
-
-        maybe_upload_prof_stats_to_manifold(str(profile_path))  # fb-only
-
-        return retval
-
-    return profile_wrapper
 
 
 curr_frame = 0

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -423,6 +423,7 @@ def get_patched_config_dict(config_patches=None) -> Dict[str, Any]:
 # the backward graph as well.
 @_use_lazy_graph_module(dynamo_config.use_lazy_graph_module)
 @dynamo_utils.dynamo_timed(phase_name="inductor_compile")
+@dynamo_utils.maybe_cprofile
 def compile_fx_inner(
     gm: torch.fx.GraphModule,
     example_inputs: List[torch.Tensor],
@@ -1413,7 +1414,6 @@ def compile_fx(
 
     @compile_time_strobelight_meta(phase_name="bw_compiler")
     @dynamo_utils.dynamo_timed
-    @dynamo_utils.maybe_cprofile
     def bw_compiler(model: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
         user_visible_outputs = {}
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -423,7 +423,6 @@ def get_patched_config_dict(config_patches=None) -> Dict[str, Any]:
 # the backward graph as well.
 @_use_lazy_graph_module(dynamo_config.use_lazy_graph_module)
 @dynamo_utils.dynamo_timed(phase_name="inductor_compile")
-@dynamo_utils.maybe_cprofile
 def compile_fx_inner(
     gm: torch.fx.GraphModule,
     example_inputs: List[torch.Tensor],


### PR DESCRIPTION
This PR moves cprofile decorator to keep consistent with `torch_inductor_stats` logging and is needed by fbcode diffs of profiling enablement in internal e2e jobs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang