### PR TITLE
[compiled autograd][dynamo] improve lifted autograd.Function.backward handling and fallback to pseudo-eager

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -766,7 +766,7 @@ main()
                 return inductor.compile(gm_, example_inputs_)
 
             return torch.compile(
-                gm, backend=inner_compiler, fullgraph=False, dynamic=True
+                gm, backend=inner_compiler, fullgraph=True, dynamic=True
             )
 
         def fn():

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1536,17 +1536,7 @@ def wrap_test_class(orig_cls):
     )
 
 
-known_graph_breaks_tests = {
-    # autograd.Function eager fallback
-    "test_autograd_python_custom_function_inplace",
-    "test_custom_function_saved_tensors",
-    "test_custom_function_setup_context_simple",
-    "test_dep_nograd",
-    "test_function_returns_input",
-    "test_return_leaf_inplace",
-    "test_saved_tensor_hooks_custom_function_intermediates",
-    "test_too_many_grads",
-}
+known_graph_breaks_tests = {}
 
 # These groups of tests aren't supported yet
 known_failures_re = re.compile(

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -613,9 +613,7 @@ main()
                 loss.backward()
                 yield x.grad
 
-        self.check_output_and_recompiles(
-            fn, count=[2, 4], compiler_fn=make_compiler_fn(fullgraph=False)
-        )
+        self.check_output_and_recompiles(fn, count=2)
 
     def test_custom_fn_saved_multiple_tensors(self):
         def fn():
@@ -638,9 +636,7 @@ main()
                 loss.backward()
                 yield x.grad
 
-        self.check_output_and_recompiles(
-            fn, count=[2, 4], compiler_fn=make_compiler_fn(fullgraph=False)
-        )
+        self.check_output_and_recompiles(fn, count=2)
 
     def test_custom_fn_saved_multiple_tensors_dedup(self):
         def fn():
@@ -662,9 +658,7 @@ main()
                 loss.backward()
                 yield x.grad
 
-        self.check_output_and_recompiles(
-            fn, count=[2, 4], compiler_fn=make_compiler_fn(fullgraph=False)
-        )
+        self.check_output_and_recompiles(fn, count=2)
 
     def test_custom_fn_saved_shape_tensor(self):
         def fn():
@@ -686,9 +680,7 @@ main()
                 loss.backward()
                 yield x.grad
 
-        self.check_output_and_recompiles(
-            fn, count=[2, 4], compiler_fn=make_compiler_fn(fullgraph=False)
-        )
+        self.check_output_and_recompiles(fn, count=2)
 
     def test_custom_fn_saved_attr(self):
         def fn():
@@ -710,13 +702,9 @@ main()
                 loss.backward()
                 yield x.grad
 
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.InternalTorchDynamoError,
-            "is not subscriptable",
-        ):
-            self.check_output_and_recompiles(
-                fn, count=[2, 4], compiler_fn=make_compiler_fn(fullgraph=False)
-            )
+        self.check_output_and_recompiles(
+            fn, count=[2, 6], compiler_fn=make_compiler_fn(fullgraph=False)
+        )
 
     def test_custom_fn_multiple_grads(self):
         def fn():
@@ -738,9 +726,7 @@ main()
                 yield x.grad
                 yield y.grad
 
-        self.check_output_and_recompiles(
-            fn, count=[2, 4], compiler_fn=make_compiler_fn(fullgraph=False)
-        )
+        self.check_output_and_recompiles(fn, count=2)
 
     def test_custom_fn_non_variable_input(self):
         def fn():
@@ -764,9 +750,7 @@ main()
                 yield y
                 yield z
 
-        self.check_output_and_recompiles(
-            fn, count=[2, 4], compiler_fn=make_compiler_fn(fullgraph=False)
-        )
+        self.check_output_and_recompiles(fn, count=2)
 
     @unittest.skipIf(not HAS_CUDA, "requires cuda")
     def test_custom_fn_output_metadata(self):
@@ -806,9 +790,9 @@ main()
             yield x.device
             yield x.grad
 
-        self.check_output_and_recompiles(fn, count=[1, 2], compiler_fn=my_compiler_fn)
+        self.check_output_and_recompiles(fn, count=1)
 
-    def test_custom_fns_with_same_graph(self):
+    def test_custom_fn_with_same_graph(self):
         def fn():
             class MyFn1(torch.autograd.Function):
                 @staticmethod
@@ -838,10 +822,10 @@ main()
                 yield x.grad
 
         self.check_output_and_recompiles(
-            fn, count=[2, 4], compiler_fn=make_compiler_fn(fullgraph=False)
+            fn, count=2
         )  # should compile once for MyFn1 and once for MyFn2
 
-    def test_dynamically_defined_class(self):
+    def test_custom_fn_dynamically_defined_class(self):
         def fn():
             def create_class(multiplier: int):
                 class DynamicFn(torch.autograd.Function):
@@ -862,9 +846,7 @@ main()
                 loss.backward()
                 yield x.grad
 
-        self.check_output_and_recompiles(
-            fn, count=[3, 6], compiler_fn=make_compiler_fn(fullgraph=False)
-        )
+        self.check_output_and_recompiles(fn, count=3)
 
     def test_mismatch_fake_tensor_mode(self, dynamic_shape=False):
         """

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -109,12 +109,12 @@ class AutogradCompilerInstance:
         backward_idx: int,
     ):
         assert self.hooks_proxy is not None
-        backward_fn = self.hooks_proxy[backward_idx]  # type: ignore[index]
+        backward_c_function = self.hooks_proxy[backward_idx]  # type: ignore[index]
         proxies = self.fx_tracer.create_proxy(
             kind="call_function",
             target=call_backward,
             args=(
-                backward_fn,
+                backward_c_function,
                 self.to_proxy(saved_tensors),
                 *self.to_proxy(inputs),
             ),

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -81,6 +81,7 @@ class FakeBackwardCFunction:
         return getattr(self.real, name)
 
 
+# This function corresponds to the "eager" implementation of a lifted autograd.Function.backward
 def call_backward(backward_c_function, saved_tensors, *args):
     fake = FakeBackwardCFunction(backward_c_function, saved_tensors)
     grads = fake._forward_cls.backward(fake, *args)  # type: ignore[attr-defined]

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -866,13 +866,16 @@ class OutputGraph:
 
     def handle_aliases_for_stolen_lists(self, tx):
         # If list inputs are stolen, but still needed after the function call, create aliases to keep them alive
-        alias_insts = []
+        maybe_gm = self.local_scope.get("self")
+        stolen_list_names = get_locals_to_steal(maybe_gm)
+        if not stolen_list_names:
+            return []
 
+        alias_insts = []
         needs_alias: Dict[
             str, List[Union[VariableTracker, AttributeMutationExisting]]
         ] = {}
-        maybe_gm = self.local_scope.get("self")
-        stolen_list_names = get_locals_to_steal(maybe_gm)
+
         queue = [
             *tx.stack,
             *tx.symbolic_locals.values(),

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -618,6 +618,8 @@ class VariableBuilder:
                 source=self.source,
             )
         elif isinstance(value, torch.autograd.function.BackwardCFunction):
+            # WARNING: accessing saved_tensors directly from BackwardCFunction is side-effectful
+            # and will throw unless retain_graph=True
             install_guard(
                 self.source.make_guard(GuardBuilder.TYPE_MATCH),
             )

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -134,6 +134,7 @@ from .lists import (
     TupleVariable,
 )
 from .misc import (
+    AutogradBackwardCFunctionVariable,
     AutogradFunctionContextVariable,
     AutogradFunctionVariable,
     ComptimeVariable,
@@ -616,6 +617,11 @@ class VariableBuilder:
                 value,
                 source=self.source,
             )
+        elif isinstance(value, torch.autograd.function.BackwardCFunction):
+            install_guard(
+                self.source.make_guard(GuardBuilder.TYPE_MATCH),
+            )
+            return AutogradBackwardCFunctionVariable(value, source=self.source)
         elif isinstance(value, torch.autograd.function.FunctionCtx):
             saved_tensors_source = AttrSource(self.source, "saved_tensors")
             install_guard(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -619,7 +619,7 @@ class VariableBuilder:
             )
         elif isinstance(value, torch.autograd.function.BackwardCFunction):
             # WARNING: accessing saved_tensors directly from BackwardCFunction is side-effectful
-            # and will throw unless retain_graph=True
+            # and will throw unless backward ran with retain_graph=True
             install_guard(
                 self.source.make_guard(GuardBuilder.TYPE_MATCH),
             )

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -501,31 +501,6 @@ class AutogradFunctionVariable(VariableTracker):
                 unimplemented(f"Unsupported method: {name}")
 
 
-class AutogradBackwardCFunctionVariable(VariableTracker):
-    """represents a torch.autograd.BackwardCFunction subclass"""
-
-    _nonvar_fields = {
-        "fn_cls",
-        *VariableTracker._nonvar_fields,
-    }
-
-    def __init__(self, fn_cls, **kwargs):
-        super().__init__(**kwargs)
-        assert self.source
-        self.fn_cls = fn_cls
-
-    def python_type(self):
-        return self.fn_cls
-
-    def var_getattr(self, tx, name):
-        if name == "_forward_cls":
-            return AutogradFunctionVariable(
-                self.fn_cls._forward_cls, source=AttrSource(self.source, "_forward_cls")
-            )
-
-        return super().var_getattr(tx, name)
-
-
 @dataclasses.dataclass
 class SavedTensorBox:
     tensors: List[VariableTracker] = dataclasses.field(default_factory=list)

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1649,7 +1649,7 @@ class GraphLowering(torch.fx.Interpreter):
 
         log_module_code(mod.__file__)
         log.debug("Output code written to: %s", mod.__file__)
-        # output_code_log.debug("Output code: \n%s", code)
+        output_code_log.debug("Output code: \n%s", code)
         trace_structured(
             "inductor_output_code",
             lambda: {"filename": mod.__file__},

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1649,7 +1649,7 @@ class GraphLowering(torch.fx.Interpreter):
 
         log_module_code(mod.__file__)
         log.debug("Output code written to: %s", mod.__file__)
-        output_code_log.debug("Output code: \n%s", code)
+        # output_code_log.debug("Output code: \n%s", code)
         trace_structured(
             "inductor_output_code",
             lambda: {"filename": mod.__file__},

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -35,7 +35,7 @@ struct PyNode : public Node {
       const std::vector<bool>& is_variable_input);
 
   variable_list apply(variable_list&& inputs) override;
-  variable_list compiled_apply(
+  variable_list defer_to_dynamo(
       variable_list&& inputs,
       std::optional<PyObject*> compiler);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125661

- `FakeContext` hides all fields other than ctx.saved_tensors, this dynamo errors when the autograd.Function.backward uses other attrs on ctx and it also doesn't allow fallback to eager.
- If we remove it, we still can't fallback to eager: node variables are already freed (ctx.saved_tensors throws)
- However, we can fallback to "pseudo-eager" by using a duck-typed ctx and routing the ctx.saved_tensors to lifted tensors
- Dynamo tries to inline external_utils.call_backward, treats BackwardCFunction as a AutogradFunctionContextVariable (only used up until we create the fake context: FakeBackwardCFunction)
- we call_function backward from the forward class AutogradFunctionVariable, and we still pass in the fake context as a UserDefinedObjectVariable (can later use AutogradFunctionContextVariable + HOO graph speculate)

Fixes #125489  #124827

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang