### PR TITLE
GitHub workflows / Dynamic rollout

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -310,3 +310,5 @@ lxml==5.0.0.
 #Description: This is a requirement of unittest-xml-reporting
 
 # Python-3.9 binaries
+
+PyGithub==2.3.0

--- a/.github/scripts/get_workflow_type.py
+++ b/.github/scripts/get_workflow_type.py
@@ -1,0 +1,98 @@
+from argparse import ArgumentParser
+from typing import Any
+import json
+
+from github import Auth, Github
+from github.Issue import Issue
+
+
+WORKFLOW_TYPE_LABEL = "label"
+WORKFLOW_TYPE_RG = "rg"
+WORKFLOW_TYPE_BOTH = "both"
+
+
+def parse_args() -> Any:
+    parser = ArgumentParser("Get dynamic rollout settings")
+    parser.add_argument("--github-token", type=str, required=True, help="GitHub token")
+    parser.add_argument(
+        "--github-repo",
+        type=str,
+        required=False,
+        default="pytorch/test-infra",
+        help="GitHub repo to get the issue",
+    )
+    parser.add_argument(
+        "--github-issue", type=int, required=True, help="GitHub issue umber"
+    )
+    parser.add_argument(
+        "--github-user", type=str, required=True, help="GitHub username"
+    )
+    parser.add_argument(
+        "--github-branch", type=str, required=True, help="Current GitHub branch"
+    )
+
+    return parser.parse_args()
+
+
+def get_gh_client(github_token: str) -> Github:
+    auth = Auth.Token(github_token)
+    return Github(auth=auth)
+
+
+def get_issue(gh: Github, repo: str, issue_num: int) -> Issue:
+    repo = gh.get_repo(repo)
+    return repo.get_issue(number=issue_num)
+
+
+def is_exception_branch(branch: str) -> bool:
+    return branch.split("/")[0] in {"main", "nightly", "release", "landchecks"}
+
+
+def get_workflow_type(issue: Issue, username: str) -> str:
+    user_list = issue.get_comments()[0].body.split("\r\n")
+    try:
+        run_option = issue.get_comments()[1].body.split("\r\n")[0]
+    except Exception as e:
+        run_option = "single"
+
+    if user_list[0] == "!":
+        return WORKFLOW_TYPE_LABEL
+    elif user_list[1] == "*":
+        if run_option == WORKFLOW_TYPE_BOTH:
+            # Use ARC runners and old runners for everyone
+            return WORKFLOW_TYPE_BOTH
+        else:
+            # Use only ARC runners for everyone
+            return WORKFLOW_TYPE_RG
+    elif username in user_list:
+        if run_option == WORKFLOW_TYPE_BOTH:
+            # Use ARC runners and old runners for a specific user
+            return WORKFLOW_TYPE_BOTH
+        else:
+            # Use only ARC runners for a specific user
+            return WORKFLOW_TYPE_RG
+    else:
+        # Use old runners by default
+        return WORKFLOW_TYPE_LABEL
+
+
+def main() -> None:
+    args = parse_args()
+
+    if is_exception_branch(args.github_branch):
+        output = {"workflow_type": WORKFLOW_TYPE_LABEL}
+    else:
+        try:
+            gh = get_gh_client(args.github_token)
+            issue = get_issue(gh, args.github_repo, args.github_issue)
+
+            output = {"workflow_type": get_workflow_type(issue, args.github_user)}
+        except Exception as e:
+            output = {"workflow_type": WORKFLOW_TYPE_LABEL}
+
+    json_output = json.dumps(output)
+    print(json_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/get_workflow_type.py
+++ b/.github/scripts/get_workflow_type.py
@@ -1,6 +1,6 @@
+import json
 from argparse import ArgumentParser
 from typing import Any
-import json
 
 from github import Auth, Github
 from github.Issue import Issue

--- a/.github/scripts/get_workflow_type.py
+++ b/.github/scripts/get_workflow_type.py
@@ -56,6 +56,7 @@ def get_workflow_type(issue: Issue, username: str) -> str:
         run_option = "single"
 
     if user_list[0] == "!":
+        # Use old runners for everyone
         return WORKFLOW_TYPE_LABEL
     elif user_list[1] == "*":
         if run_option == WORKFLOW_TYPE_BOTH:

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -1,0 +1,58 @@
+name: Check whether the workflow owner can use ARC runners
+
+on:
+  workflow_call:
+    inputs:
+      user_name:
+        required: true
+        type: string
+        description: The name of the workflow owner.
+      curr_branch:
+        required: true
+        type: string
+        description: Current branch.
+      issue_number:
+        required: false
+        type: string
+        default: "5132"
+
+    outputs:
+      workflow-type:
+        description: Type of runners to use
+        value: ${{ jobs.runner-determinator.outputs.workflow-type }}
+
+jobs:
+  runner-determinator:
+    runs-on: linux.4xlarge
+    outputs:
+      workflow-type: ${{ steps.set-condition.outputs.workflow-type }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ inputs.issue_number }}
+      USERNAME: ${{ inputs.user_name }}
+    steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Install dependencies
+        run: python3 -m pip install urllib3==1.26.18 PyGithub==2.3.0
+
+      - name: Get the workflow type for the current user
+        id: set-condition
+        run: |
+          curr_branch="${{ inputs.curr_branch }}"
+          echo "Current branch is '$curr_branch'"
+
+          output="$(python3 .github/scripts/get_workflow_type.py \
+            --github-token "$GITHUB_TOKEN" \
+            --github-issue "$ISSUE_NUMBER" \
+            --github-branch "$curr_branch" \
+            --github-user "$USERNAME")"
+
+          echo "Output: '${output}'"
+
+          WORKFLOW_TYPE=$(echo "${output}" | jq -r '.workflow_type')
+          echo "workflow-type=$WORKFLOW_TYPE" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR introduces a tool to dynamically switch between ARC runners and old runners without having to update the PR to the latest version. 

There is also a third option - use both runners at the same time (aka shadow deployment). In this case, failed workflows using ARC launchers will not block merge process.

The GitHub issue is used to control access to ARC launchers - [Access Rules Issue](https://github.com/pytorch/test-infra/issues/5132):

* In the FIRST comment you can specify who will use the ARC runners:
   * Add a GitHub username to use ARC runners.
   * Add "*" at the beginning to switch ALL users to ARC runners.
   * Add "!" at the beginning to switch ALL users to old runners.
* In the SECOND comment you can specify do we need to run ARC runners and old runners at the same time.
   * To use both runners, add a second comment with the word "both".
   * If we want to use only one type of runners, just remove the second comment.