### PR TITLE
Experiment - remove the CUDA_NO* flags and see what breaks

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -421,10 +421,6 @@ cc_library(
 
 torch_cuda_half_options = [
     "-DCUDA_HAS_FP16=1",
-    "-D__CUDA_NO_HALF_OPERATORS__",
-    "-D__CUDA_NO_HALF_CONVERSIONS__",
-    "-D__CUDA_NO_BFLOAT16_CONVERSIONS__",
-    "-D__CUDA_NO_HALF2_OPERATORS__",
 ]
 
 cu_library(

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1605,11 +1605,7 @@ if(NOT INTERN_BUILD_MOBILE)
   endif()
 
   message(STATUS "Found CUDA with FP16 support, compiling with torch.cuda.HalfTensor")
-  string(APPEND CMAKE_CUDA_FLAGS " -DCUDA_HAS_FP16=1"
-                                 " -D__CUDA_NO_HALF_OPERATORS__"
-                                 " -D__CUDA_NO_HALF_CONVERSIONS__"
-                                 " -D__CUDA_NO_HALF2_OPERATORS__"
-                                 " -D__CUDA_NO_BFLOAT16_CONVERSIONS__")
+  string(APPEND CMAKE_CUDA_FLAGS " -DCUDA_HAS_FP16=1")
 
   string(APPEND CMAKE_C_FLAGS_RELEASE " -DNDEBUG")
   string(APPEND CMAKE_CXX_FLAGS_RELEASE " -DNDEBUG")

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -224,10 +224,6 @@ MSVC_IGNORE_CUDAFE_WARNINGS = [
 ]
 
 COMMON_NVCC_FLAGS = [
-    '-D__CUDA_NO_HALF_OPERATORS__',
-    '-D__CUDA_NO_HALF_CONVERSIONS__',
-    '-D__CUDA_NO_BFLOAT16_CONVERSIONS__',
-    '-D__CUDA_NO_HALF2_OPERATORS__',
     '--expt-relaxed-constexpr'
 ]
 


### PR DESCRIPTION
These flags ostensibly resolve operator definition ambiguity between torch and cuda. The hypothesis here is that we may not need these anymore. We don't know though, and would like to run some quick CI checks to see what fails, and where. 