### PR TITLE
[DSD]  Fix set_optimizer_state_dict() changes the parameters with some optimizers

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -24,6 +24,7 @@ from torch.distributed.checkpoint.state_dict import (
     get_model_state_dict,
     get_state_dict,
     set_model_state_dict,
+    set_optimizer_state_dict,
     set_state_dict,
     StateDictOptions,
 )
@@ -95,11 +96,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             dist_model, optimizers=dist_optim, options=options
         )
         self._verify_msd(msd, dist_msd, options)
-        # TODO: temporarily disable this check, as it seems for AdamW,
-        # setting the state dict affect the state_dict value.
-        # We need to investigate the root cause.
-        # Open Issue: https://github.com/pytorch/pytorch/issues/121186
-        # self._verify_osd_by_load(model, optim, copy_optim, dist_osd)
+        self._verify_osd_by_load(model, optim, copy_optim, dist_osd)
         self._verify_osd(model, optim, osd, dist_osd)
 
         # Initialize a completely new model to simulate checkpoint load.
@@ -117,10 +114,14 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         # We can directly load them back. This asser is to ensure that optimizer
         # state storage are initialized.
         # self.assertEqual(len(curr_dist_osd[STATE]), len(dist_osd[STATE]))
-        set_state_dict(
+        set_model_state_dict(
+            dist_model,
+            model_state_dict=dist_msd,
+            options=options,
+        )
+        set_optimizer_state_dict(
             dist_model,
             optimizers=dist_optim,
-            model_state_dict=dist_msd,
             optim_state_dict=dist_osd,
             options=options,
         )

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -25,7 +25,6 @@ from torch.distributed.checkpoint.state_dict import (
     get_state_dict,
     set_model_state_dict,
     set_optimizer_state_dict,
-    set_state_dict,
     StateDictOptions,
 )
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #125339
* #125338
* __->__ #125708

Summary:
Some optimizers, like AdamW, change the parameters even if gradients are zero. So `set_optimizer_state_dict()` may affect the parameters values with these optimizers. This PR fixes the issue.

This PR also fixes https://github.com/pytorch/pytorch/issues/121186.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC