### PR TITLE
Add FlopCounter implementations for NestedTensor SDPA kernels

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -327,6 +327,132 @@ class TestFlopCounter(TestCase):
         self.assertExpectedInline(str(flops_fw_bw_math), """805306368""")
         self.assertExpectedInline(str(flops_fw_bw_efficient), """939524096""")
 
+    @unittest.skipIf(not HAS_CUDA, "CUDA not available")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION or not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+                     "Does not support all SDPA backends (pre-SM80 hardware on CUDA)")
+    def test_sdpa_nested_tensor(self):
+
+        def get_flops(q, k, v, backend, with_backward=False):
+            mode = FlopCounterMode()
+
+            if backend == "math":
+                backend = torch.backends.cuda.sdp_kernel(enable_flash=False, enable_math=True, enable_mem_efficient=False)
+            elif backend == "flash":
+                backend = torch.backends.cuda.sdp_kernel(enable_flash=True, enable_math=False, enable_mem_efficient=False)
+            elif backend == "mem_efficient":
+                backend = torch.backends.cuda.sdp_kernel(enable_flash=False, enable_math=False, enable_mem_efficient=True)
+
+            with backend, mode:
+                out = F.scaled_dot_product_attention(q, k, v, dropout_p=0, is_causal=True)
+                if with_backward:
+                    if out.is_nested:
+                        out.values().sum().backward()
+                    else:
+                        out.sum().backward()
+
+            return int(get_total_flops(mode))
+
+        def get_nested_inputs(
+            batch_size,
+            n_heads,
+            max_seq_len_q,
+            max_seq_len_k,
+            head_dim,
+            head_dim_v,
+            dtype,
+        ):
+            q_lengths = torch.tensor([
+                max_seq_len_q // 4,
+                max_seq_len_q // 4 * 2,
+                max_seq_len_q // 4 * 3,
+                max_seq_len_q // 4 * 4
+            ])
+            k_lengths = torch.tensor([
+                max_seq_len_k // 4,
+                max_seq_len_k // 4 * 2,
+                max_seq_len_k // 4 * 3,
+                max_seq_len_k // 4 * 4
+            ])
+            q_offsets, k_offsets = (
+                torch.cat((torch.tensor([0]), torch.cumsum(lengths, dim=0))).cuda()
+                for lengths in (q_lengths, k_lengths)
+            )
+            q_values = torch.randn(q_offsets[-1], head_dim * n_heads, dtype=dtype, requires_grad=True, device="cuda")
+            k_values = torch.randn(k_offsets[-1], head_dim * n_heads, dtype=dtype, requires_grad=True, device="cuda")
+            v_values = torch.randn(k_offsets[-1], head_dim_v * n_heads, dtype=dtype, requires_grad=True, device="cuda")
+
+            q = torch.nested.nested_tensor_from_jagged(q_values, q_offsets)
+            k = torch.nested.nested_tensor_from_jagged(k_values, k_offsets)
+            v = torch.nested.nested_tensor_from_jagged(v_values, k_offsets)
+
+            q = q.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
+            k = k.view(batch_size, -1, n_heads, head_dim).transpose(1, 2)
+            v = v.view(batch_size, -1, n_heads, head_dim_v).transpose(1, 2)
+
+            return q, k, v
+
+        def get_dense_inputs(
+            batch_size,
+            n_heads,
+            max_seq_len_q,
+            max_seq_len_k,
+            head_dim,
+            head_dim_v,
+            dtype,
+        ):
+            dense_q = torch.randn(batch_size, n_heads, max_seq_len_q, head_dim, device="cuda", dtype=dtype, requires_grad=True)
+            dense_k = torch.randn(batch_size, n_heads, max_seq_len_k, head_dim, device="cuda", dtype=dtype, requires_grad=True)
+            dense_v = torch.randn(batch_size, n_heads, max_seq_len_k, head_dim_v, device="cuda", dtype=dtype, requires_grad=True)
+
+            return dense_q, dense_k, dense_v
+
+        uniform_config = {
+            "batch_size": 4,
+            "n_heads": 8,
+            "max_seq_len_q": 128,
+            "max_seq_len_k": 128,
+            "head_dim": 64,
+            "head_dim_v": 64,
+            "dtype": torch.float16,
+        }
+
+        # max_seq_len_q != max_seq_len_k doesn't work for flash attention with dense tensors.
+        differing_config = {
+            "batch_size": 4,
+            "n_heads": 8,
+            "max_seq_len_q": 128,
+            "max_seq_len_k": 256,
+            "head_dim": 64,
+            "head_dim_v": 64,
+            "dtype": torch.float16,
+        }
+
+        self.assertEqual(
+            get_flops(*get_dense_inputs(**uniform_config), backend="flash", with_backward=False),
+            get_flops(*get_nested_inputs(**uniform_config), backend="flash", with_backward=False),
+        )
+        self.assertEqual(
+            get_flops(*get_dense_inputs(**uniform_config), backend="mem_efficient", with_backward=False),
+            get_flops(*get_nested_inputs(**uniform_config), backend="mem_efficient", with_backward=False),
+        )
+        self.assertEqual(
+            get_flops(*get_dense_inputs(**differing_config), backend="mem_efficient", with_backward=False),
+            get_flops(*get_nested_inputs(**differing_config), backend="mem_efficient", with_backward=False),
+        )
+
+        self.assertEqual(
+            get_flops(*get_dense_inputs(**uniform_config), backend="flash", with_backward=True),
+            get_flops(*get_nested_inputs(**uniform_config), backend="flash", with_backward=True),
+        )
+        self.assertEqual(
+            get_flops(*get_dense_inputs(**uniform_config), backend="mem_efficient", with_backward=True),
+            get_flops(*get_nested_inputs(**uniform_config), backend="mem_efficient", with_backward=True),
+        )
+        self.assertEqual(
+            get_flops(*get_dense_inputs(**differing_config), backend="mem_efficient", with_backward=True),
+            get_flops(*get_nested_inputs(**differing_config), backend="mem_efficient", with_backward=True),
+        )
+
     def test_addmm_out(self):
         def f(x):
             y = torch.zeros(10, 10)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125712

This adds implementations for:
* _flash_attention_forward
* _efficient_attention_forward
* _flash_attention_backward
* _efficient_attention_backward

The implementations: (a) effectively "pad" the nested tensors to max seq len, and (b) call the normal flop calculation for SDPA assuming that every element in the batch had the max seq len. So, this is actually an upper bound for the FLOPs, assuming that the nested tensor had all sequences at max seq len.

Differential Revision: [D57072116](https://our.internmc.facebook.com/intern/diff/D57072116)