### PR TITLE
[dtensor] migrate torch.bernoulli from rule-based sharding prop to strategy-based

### DIFF
--- a/torch/distributed/_tensor/ops/experimental_ops.py
+++ b/torch/distributed/_tensor/ops/experimental_ops.py
@@ -8,9 +8,20 @@ except ModuleNotFoundError:
     np = None  # type: ignore[assignment]
 
 import torch
-from torch.distributed._tensor.op_schema import OpSchema, OutputSharding
-from torch.distributed._tensor.ops.utils import register_prop_rule
+from torch.distributed._tensor.op_schema import (
+    OpSchema,
+    OpStrategy,
+    OutputSharding,
+    PlacementStrategy,
+    RuntimeSchemaInfo,
+)
+from torch.distributed._tensor.ops.utils import (
+    generate_redistribute_costs,
+    register_op_strategy,
+    register_prop_rule,
+)
 from torch.distributed._tensor.placement_types import DTensorSpec, TensorMeta
+from torch.distributed.device_mesh import DeviceMesh
 
 aten = torch.ops.aten
 
@@ -41,9 +52,48 @@ def slice_backward_rules(op_schema: OpSchema) -> OutputSharding:
     return OutputSharding(grad_input_spec)
 
 
-@register_prop_rule(aten.bernoulli.default)
-@register_prop_rule(aten.bernoulli_.float)
-def bernoulli_rules(op_schema: OpSchema) -> OutputSharding:
-    input_spec = op_schema.args_schema[0]
-    assert isinstance(input_spec, DTensorSpec)
-    return OutputSharding(input_spec)
+@register_op_strategy(
+    [aten.bernoulli.default, aten.bernoulli.out, aten.bernoulli_.float],
+    schema_info=RuntimeSchemaInfo(static_kwargkey=["out"]),
+)
+def bernoulli_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy:
+    # args: input
+    # kwargs: generator, out
+    assert len(op_schema.args_schema) == 1
+    input_strategy = op_schema.args_schema[0]
+    assert isinstance(input_strategy, OpStrategy)
+
+    # construct output strategy
+    output_strategy = OpStrategy([])
+    for idx, input_placement_strategy in enumerate(input_strategy.strategies):
+        input_src_spec = input_placement_strategy.output_spec
+
+        needs_redistribute = False
+        if "out" in op_schema.kwargs_schema:
+            out_kwarg_strategy = op_schema.kwargs_schema["out"]
+            assert isinstance(out_kwarg_strategy, OpStrategy)
+            out_src_spec = out_kwarg_strategy.strategies[idx].output_spec
+            if input_src_spec.placements != out_src_spec.placements:
+                needs_redistribute = True
+
+        if needs_redistribute:
+            assert isinstance(out_src_spec, DTensorSpec)
+            output_strategy.strategies.append(
+                PlacementStrategy(
+                    output_specs=out_src_spec,
+                    input_specs=[out_src_spec],
+                    redistribute_cost=[
+                        generate_redistribute_costs(input_strategy, out_src_spec)
+                    ],
+                )
+            )
+        else:
+            output_strategy.strategies.append(
+                PlacementStrategy(
+                    output_specs=input_src_spec,
+                    input_specs=[input_src_spec],
+                    redistribute_cost=[[0.0 for _ in input_strategy.strategies]],
+                )
+            )
+
+    return output_strategy


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125716



cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang