### PR TITLE
[TorchElastic] Option for sharing TCPStore created by rdzv handlers

### DIFF
--- a/docs/source/elastic/rendezvous.rst
+++ b/docs/source/elastic/rendezvous.rst
@@ -16,7 +16,6 @@ Registry
    :members:
 
 .. autoclass:: RendezvousHandlerRegistry
-   :members:
 
 .. automodule:: torch.distributed.elastic.rendezvous.registry
 
@@ -27,6 +26,16 @@ Handler
 
 .. autoclass:: RendezvousHandler
    :members:
+
+Dataclasses
+-----------
+.. autoclass:: RendezvousInfo
+
+.. currentmodule:: torch.distributed.elastic.rendezvous.api
+
+.. autoclass:: RendezvousStoreInfo
+
+   .. automethod:: build(rank, store)
 
 Exceptions
 ----------

--- a/test/distributed/elastic/rendezvous/api_test.py
+++ b/test/distributed/elastic/rendezvous/api_test.py
@@ -6,13 +6,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, cast, Dict, SupportsInt, Tuple
+from typing import Any, cast, Dict, SupportsInt
 from unittest import TestCase
 
-from torch.distributed import Store
 from torch.distributed.elastic.rendezvous import (
     RendezvousHandler,
     RendezvousHandlerRegistry,
+    RendezvousInfo,
     RendezvousParameters,
 )
 
@@ -196,7 +196,7 @@ class _DummyRendezvousHandler(RendezvousHandler):
     def get_backend(self) -> str:
         return "dummy_backend"
 
-    def next_rendezvous(self) -> Tuple[Store, int, int]:
+    def next_rendezvous(self) -> RendezvousInfo:
         raise NotImplementedError
 
     def is_closed(self) -> bool:

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -54,9 +54,9 @@ class EtcdServerTest(unittest.TestCase):
                 last_call_timeout=30,
             )
             rdzv_handler = EtcdRendezvousHandler(rdzv)
-            store, rank, world_size = rdzv_handler.next_rendezvous()
-            self.assertIsNotNone(store)
-            self.assertEqual(0, rank)
-            self.assertEqual(1, world_size)
+            rdzv_info = rdzv_handler.next_rendezvous()
+            self.assertIsNotNone(rdzv_info.store)
+            self.assertEqual(0, rdzv_info.rank)
+            self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()

--- a/test/distributed/elastic/rendezvous/static_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/static_rendezvous_test.py
@@ -91,12 +91,12 @@ class StaticTCPRendezvousTest(unittest.TestCase):
         rdzv_handler = create_rdzv_handler(rdzv_params)
 
         # Call rendezvous two times
-        store, rank, world_size = rdzv_handler.next_rendezvous()
-        self.assertIsNotNone(store)
-        self.assertEqual(0, rank)
-        self.assertEqual(1, world_size)
+        rdzv_info = rdzv_handler.next_rendezvous()
+        self.assertIsNotNone(rdzv_info.store)
+        self.assertEqual(0, rdzv_info.rank)
+        self.assertEqual(1, rdzv_info.world_size)
 
-        store, rank, world_size = rdzv_handler.next_rendezvous()
-        self.assertIsNotNone(store)
-        self.assertEqual(0, rank)
-        self.assertEqual(1, world_size)
+        rdzv_info = rdzv_handler.next_rendezvous()
+        self.assertIsNotNone(rdzv_info.store)
+        self.assertEqual(0, rdzv_info.rank)
+        self.assertEqual(1, rdzv_info.world_size)

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -273,10 +273,9 @@ class LocalElasticAgent(SimpleElasticAgent):
         spec = worker_group.spec
         store = worker_group.store
         assert store is not None
-        master_addr, master_port = super()._get_master_addr_port(store)
         restart_count = spec.max_restarts - self._remaining_restarts
 
-        use_agent_store = spec.rdzv_handler.get_backend() == "static"
+        use_agent_store: bool = spec.rdzv_handler.use_agent_store
 
         args: Dict[int, Tuple] = {}
         envs: Dict[int, Dict[str, str]] = {}
@@ -293,8 +292,8 @@ class LocalElasticAgent(SimpleElasticAgent):
                 "WORLD_SIZE": str(worker.world_size),
                 "GROUP_WORLD_SIZE": str(worker_group.group_world_size),
                 "ROLE_WORLD_SIZE": str(worker.role_world_size),
-                "MASTER_ADDR": master_addr,
-                "MASTER_PORT": str(master_port),
+                "MASTER_ADDR": worker_group.master_addr,
+                "MASTER_PORT": str(worker_group.master_port),
                 "TORCHELASTIC_RESTART_COUNT": str(restart_count),
                 "TORCHELASTIC_MAX_RESTARTS": str(spec.max_restarts),
                 "TORCHELASTIC_RUN_ID": spec.rdzv_handler.get_run_id(),

--- a/torch/distributed/elastic/rendezvous/__init__.py
+++ b/torch/distributed/elastic/rendezvous/__init__.py
@@ -128,7 +128,23 @@ of the following implementations that come with PyTorch:
      )
 """
 
-from .api import *  # noqa: F403
+
+from .api import (
+    RendezvousClosedError,
+    RendezvousConnectionError,
+    RendezvousError,
+    RendezvousGracefulExitError,
+    RendezvousHandler,
+    RendezvousHandlerCreator,
+    RendezvousHandlerRegistry,
+    RendezvousInfo,
+    RendezvousParameters,
+    RendezvousStateError,
+    RendezvousStoreInfo,
+    RendezvousTimeoutError,
+    rendezvous_handler_registry,
+)
+
 from .registry import _register_default_handlers
 
 
@@ -143,8 +159,10 @@ __all__ = [
     "RendezvousHandler",
     "RendezvousHandlerCreator",
     "RendezvousHandlerRegistry",
+    "RendezvousInfo",
     "RendezvousParameters",
     "RendezvousStateError",
+    "RendezvousStoreInfo",
     "RendezvousTimeoutError",
     "rendezvous_handler_registry",
 ]

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -26,13 +26,21 @@ from .api import (
     RendezvousError,
     RendezvousGracefulExitError,
     RendezvousHandler,
+    RendezvousInfo,
     RendezvousParameters,
     RendezvousStateError,
+    RendezvousStoreInfo,
     RendezvousTimeoutError,
 )
 from .utils import _delay, _PeriodicTimer
 
-__all__ = ['RendezvousBackend', 'RendezvousTimeout', 'RendezvousSettings', 'DynamicRendezvousHandler', 'create_handler']
+__all__ = [
+    "RendezvousBackend",
+    "RendezvousTimeout",
+    "RendezvousSettings",
+    "DynamicRendezvousHandler",
+    "create_handler",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -1090,7 +1098,7 @@ class DynamicRendezvousHandler(RendezvousHandler):
         """See base class."""
         return self._backend_name
 
-    def next_rendezvous(self) -> Tuple[Store, int, int]:
+    def next_rendezvous(self) -> RendezvousInfo:
         """See base class."""
         msg = (
             f"The node '{self._this_node}' attempts to join the next round of the rendezvous "
@@ -1138,7 +1146,13 @@ class DynamicRendezvousHandler(RendezvousHandler):
         self._record(message=msg, rank=rank)
         logger.info(msg)
 
-        return store, rank, world_size
+        bootstrap_store_info = RendezvousStoreInfo.build(rank, store)
+        return RendezvousInfo(
+            store,
+            rank,
+            world_size,
+            bootstrap_store_info,
+        )
 
     def is_closed(self) -> bool:
         """See base class."""

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -18,13 +18,22 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousClosedError,
     RendezvousError,
     RendezvousHandler,
+    RendezvousInfo,
     RendezvousParameters,
+    RendezvousStoreInfo,
     RendezvousTimeoutError,
 )
 
 from .utils import parse_rendezvous_endpoint
 from .etcd_store import EtcdStore, cas_delay
 
+__all__ = [
+    "EtcdRendezvousRetryableFailure",
+    "EtcdRendezvousRetryImmediately",
+    "EtcdRendezvousHandler",
+    "EtcdRendezvous",
+    "create_rdzv_handler"
+]
 
 _log_fmt = logging.Formatter("%(levelname)s %(asctime)s %(message)s")
 _log_handler = logging.StreamHandler(sys.stderr)
@@ -153,7 +162,8 @@ class EtcdRendezvousHandler(RendezvousHandler):
         logger.info("Creating EtcdStore as the c10d::Store implementation")
         store = self._rdzv_impl.setup_kv_store(rdzv_version)
 
-        return store, rank, world_size
+        bootstrap_store_info = RendezvousStoreInfo.build(rank, store)
+        return RendezvousInfo(store, rank, world_size, bootstrap_store_info)
 
     def is_closed(self):
         try:

--- a/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
@@ -8,12 +8,18 @@
 
 import datetime
 import logging
-from typing import Tuple, cast, Optional
+from typing import cast, Optional
 
-# pyre-ignore[21]: Could not find name `Store` in `torch.distributed`.
 from torch.distributed import Store, TCPStore, PrefixStore
-from torch.distributed.elastic.rendezvous import RendezvousHandler, RendezvousParameters
+from torch.distributed.elastic.rendezvous import (
+    RendezvousInfo,
+    RendezvousHandler,
+    RendezvousStoreInfo,
+    RendezvousParameters
+)
 from torch.distributed.elastic.rendezvous.utils import parse_rendezvous_endpoint
+
+__all__ = ["StaticTCPRendezvous", "create_rdzv_handler"]
 
 logger = logging.getLogger(__name__)
 
@@ -48,10 +54,14 @@ class StaticTCPRendezvous(RendezvousHandler):
     def get_backend(self) -> str:
         return "static"
 
-    def next_rendezvous(self) -> Tuple[Store, int, int]:
+    @property
+    def use_agent_store(self) -> bool:
+        return True
+
+    def next_rendezvous(self) -> RendezvousInfo:
         logger.info("Creating TCPStore as the c10d::Store implementation")
+        is_master = self.rank == 0
         if not self._store:
-            is_master = self.rank == 0
             self._store = TCPStore(  # type: ignore[call-arg]
                 self.master_addr,
                 self.master_port,
@@ -61,7 +71,14 @@ class StaticTCPRendezvous(RendezvousHandler):
                 multi_tenant=True,
             )
         store = PrefixStore(self.run_id, self._store)
-        return store, self.rank, self.world_size
+        # TCPStore server instance is used by trainer code
+        bootstrap_store_info = RendezvousStoreInfo(self.master_addr, self.master_port)
+        return RendezvousInfo(
+            store,
+            self.rank,
+            self.world_size,
+            bootstrap_store_info,
+        )
 
     def is_closed(self):
         return False


### PR DESCRIPTION
Summary:

1. Define explicit `use_agent_store` on rdzv handlers. Handlers that set is true can share the store. 
2. Instead of agent coordinating master_add/master_port values, the logic is now encapsulated by a *rdzv_handler* where `RendezvousInfo` will have `RendezvousStoreInfo` object that handlers must return. 
    - Depending on the implementation they can either:
         - point to existing store (and expected to `use_agent_store` as true - point 1). Client code will rely on `TORCHELASTIC_USE_AGENT_STORE` env variable to know if the store is shared.
         - build args that `torch.distributed.init_process_group` can bootstrap by creating new store. 

Additional points:

- When TCPStore is shared, it should be wrapped in PrefixStore to qualify/scope namespace for other usecases.
- `next_rendezvous` signature changed to return instance of `RendezvousInfo` instead of a (store, rank, world_size) tuple for extensibility purposes.


Why:
- Reduce moving parts
   - easier to swap implementation
   - improve tractability
   - addressing perf/debug-ability will benefit all usecases
   - 
Test Plan: CI

Differential Revision: D57055235


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k