### PR TITLE
Various improvements to error handling during autotuning

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -9,6 +9,7 @@ import torch
 from torch import multiprocessing as mp
 from torch._dynamo import reset
 from torch._dynamo.testing import reset_rng_state
+from torch._dynamo.exc import BackendCompilerFailed
 from torch._inductor import config
 from torch._inductor.autotune_process import (
     BenchmarkRequest,
@@ -621,6 +622,42 @@ class TestMaxAutotune(TestCase):
     @config.patch(max_autotune=True)
     def test_empty_conv_input_with_1x1_kernel(self):
         self.test_empty_conv_input(kernel_size=1)
+
+    @config.patch(
+        max_autotune=True,
+        max_autotune_gemm_backends="",
+        autotune_fallback_to_aten=False,
+    )
+    def test_no_valid_choices(self):
+        a = torch.zeros([2, 2], device="cuda")
+        b = torch.zeros([2, 2], device="cuda")
+        with self.assertRaises(BackendCompilerFailed) as context:
+            torch.compile(lambda a, b: a.matmul(b))(a, b)
+        self.assertIn("NoValidChoicesError", str(context.exception))
+
+    @parametrize("multi_template", (True, False))
+    @config.patch(
+        max_autotune=True,
+        max_autotune_gemm_backends="TRITON",
+        autotune_fallback_to_aten=False,
+    )
+    def test_inf_timing(self, multi_template):
+        from unittest.mock import patch
+
+        lookup = AlgorithmSelectorCache.lookup
+
+        def mock_lookup(self, *args, **kwargs):
+            timings = lookup(self, *args, **kwargs)
+            return {choice: float("inf") for choice in timings.keys()}
+
+        a = torch.zeros([16, 16], device="cuda")
+        b = torch.zeros([16, 16], device="cuda")
+        with patch.object(AlgorithmSelectorCache, "lookup", mock_lookup), config.patch(
+            benchmark_multi_templates=multi_template
+        ):
+            with self.assertRaises(BackendCompilerFailed) as context:
+                torch.compile(lambda a, b: a.matmul(b))(a, b)
+            self.assertIn("NoValidChoicesError", str(context.exception))
 
 
 class TestBenchmarkRequest(BenchmarkRequest):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -238,6 +238,11 @@ max_autotune_gemm_backends = os.environ.get(
     "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS", "ATEN,TRITON"
 ).upper()
 
+# Whether we fall back to ATen or hard error when no matches are found during autotuning
+autotune_fallback_to_aten = (
+    os.environ.get("TORCHINDUCTOR_AUTOTUNE_FALLBACK_TO_ATEN", "1") == "1"
+)
+
 # the value used as a fallback for the unbacked SymInts
 # that can appear in the input shapes (e.g., in autotuning)
 unbacked_symint_fallback = 8192

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -150,12 +150,19 @@ def tuned_mm(mat1, mat2, *, layout=None):
     if static_shape and is_nonzero and use_cutlass_template(layout, m, n, k):
         CUTLASSGemmTemplate.add_cutlass_gemm_choices(choices, layout, [mat1, mat2])
 
-    if len(choices) == 0 and not use_aten_gemm_kernels():
+    if (
+        len(choices) == 0
+        and not use_aten_gemm_kernels()
+        and inductor_config.autotune_fallback_to_aten
+    ):
         log.warning("No choices for GEMM, using ATen backend as fallback")
-        choices.append(aten_mm.bind((mat1, mat2), aten_layout))
+        return aten_mm.bind((mat1, mat2), aten_layout).output_node()
+
     try:
         return autotune_select_algorithm("mm", choices, [mat1, mat2], layout)
     except NoValidChoicesError:
+        if not inductor_config.autotune_fallback_to_aten:
+            raise
         log.warning("All choices for GEMM were invalid, using ATen backend as fallback")
         return aten_mm.bind((mat1, mat2), aten_layout).output_node()
 
@@ -218,6 +225,8 @@ def tuned_int_mm(mat1, mat2, *, layout=None):
     try:
         return autotune_select_algorithm("int_mm", choices, [mat1, mat2], layout)
     except NoValidChoicesError:
+        if not inductor_config.autotune_fallback_to_aten:
+            raise
         log.warning("All choices for GEMM were invalid, using ATen backend as fallback")
         choices = [aten__int_mm.bind((mat1, mat2), layout)]
         return autotune_select_algorithm("int_mm", choices, [mat1, mat2], layout)
@@ -338,6 +347,8 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
             "addmm", choices, [inp_expanded, mat1, mat2], layout
         )
     except NoValidChoicesError:
+        if not inductor_config.autotune_fallback_to_aten:
+            raise
         log.warning("All choices for GEMM were invalid, using ATen backend as fallback")
         fallback_choice = aten_addmm.bind(
             (inp, mat1, mat2),

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1097,6 +1097,11 @@ class AlgorithmSelectorCache(PersistentCache):
             )
             autotune_elapse = time.time() - autotune_start_ts
 
+            if timings and all(
+                not math.isfinite(timing) for timing in timings.values()
+            ):
+                raise NoValidChoicesError
+
             if make_benchmark_fn.cache_info().currsize:
                 counters["inductor"]["select_algorithm_autotune"] += 1
 
@@ -1148,8 +1153,6 @@ class AlgorithmSelectorCache(PersistentCache):
 
         selected_key = builtins.min(timings, key=timings.__getitem__)
         selected_time = timings[selected_key]
-        if (not isinstance(selected_time, float)) or (not math.isfinite(selected_time)):
-            raise NoValidChoicesError
         selected_choice = selected_key.output_node()
         log.debug("selected choice: %s", str(selected_choice))
         return selected_choice
@@ -1248,6 +1251,9 @@ class AlgorithmSelectorCache(PersistentCache):
                         "CUDA compilation error during autotuning: \n%s. \nIgnoring this choice.",
                         str(e),
                     )
+                    timing = float("inf")
+                except NotImplementedError as e:
+                    log.warning("Not yet implemented: %s", e)
                     timing = float("inf")
                 except RuntimeError as e:
                     msg = str(e)


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/121497 made "no choices found" into a soft error, falling back to the ATen kernel in those cases. However, when running benchmarks, we want to be certain that we are actually invoking a particular backend; if we can't, we should hard error. As such, I have added an `autotune_fallback_to_aten` flag to control this behavior.

That PR also introduces a `NoValidChoicesError` type, and has catch blocks for it, but it seems that the code doesn't actually throw this exception. I have added the appropriate throws, as well as tests.

Test Plan: python test/inductor/test_max_autotune.py

Differential Revision: D56764094




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang


@diff-train-skip-merge
Reverted internally due to the conflict with GH.