### PR TITLE
[DeviceMesh] Make _validate_tp_mesh_dim support 3D

### DIFF
--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -43,18 +43,3 @@ def _validate_tp_mesh_dim(
     if device_mesh.ndim > 1:
         raise ValueError(f"Tensor Parallel only accepts a 1D DeviceMesh, but found {device_mesh.ndim}D!"
                          "If you have a 2-D or N-D device_mesh, consider passing in device_mesh[\"tp\"]")
-
-    parent_mesh = _mesh_resources.get_parent_mesh(device_mesh)
-    if parent_mesh:
-        if parent_mesh.ndim != 2:
-            raise RuntimeError(
-                f"Found TP device_mesh has a parent mesh with dims {parent_mesh.ndim}",
-                "Currently we only support 2D TP composition with DP.",
-            )
-
-        tp_mesh_dim = _mesh_resources.get_parent_mesh_dim(device_mesh)
-        if tp_mesh_dim != 1:
-            raise RuntimeError(
-                f"Found TP device_mesh on the {tp_mesh_dim} dimension of its parent mesh.",
-                "Currently we only support intranode TP and TP needs to be the innermost dimension on its parent mesh.",
-            )

--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -43,3 +43,12 @@ def _validate_tp_mesh_dim(
     if device_mesh.ndim > 1:
         raise ValueError(f"Tensor Parallel only accepts a 1D DeviceMesh, but found {device_mesh.ndim}D!"
                          "If you have a 2-D or N-D device_mesh, consider passing in device_mesh[\"tp\"]")
+
+    parent_mesh = _mesh_resources.get_parent_mesh(device_mesh)
+    if parent_mesh:
+        tp_mesh_dim_in_parent = _mesh_resources.get_parent_mesh_dim(device_mesh)
+        if tp_mesh_dim_in_parent != parent_mesh.ndim - 1:
+            raise RuntimeError(
+                f"Found TP device_mesh on the {tp_mesh_dim_in_parent} dimension of its parent mesh.",
+                "Currently we only support intranode TP and TP needs to be the innermost dimension on its parent mesh.",
+            )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #125250
* __->__ #125763

Currently a 3D mesh with a submesh sliced out for TP is going to fail
this check.

According to @wanchaol in [this
comment](https://github.com/pytorch/pytorch/pull/125250#discussion_r1586653669)
it should be OK to remove these checks.  Though I would appreciate a
more careful review here, since I'm not too sure if there are other edge
cases where these checks are important.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225 @chauhang @d4l3k