### PR TITLE
inductor: dont emit triton float8 code unless GPU supports it

### DIFF
--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -3,6 +3,19 @@ import hashlib
 
 
 @functools.lru_cache(None)
+def device_supports_triton_float8() -> bool:
+    import torch
+
+    n = torch.cuda.device_count()
+    if n < 1:
+        return False
+    capabilities = {torch.cuda.get_device_capability(i) for i in range(n)}
+    min_capability = sorted(capabilities)[0]
+    # triton requires CUDA arch for native float8 support >= 89
+    return min_capability[0] >= 8 or (min_capability[0] == 8 and min_capability[1] >= 9)
+
+
+@functools.lru_cache(None)
 def has_triton_package() -> bool:
     try:
         import triton


### PR DESCRIPTION
I was running float8 + compile on my A100, and even with the `emulate=True` flag in the float8_experimental codebase, I still couldn't run my float8 repro code because inductor was unconditionally generated float8 triton code (which triton will fail to compile on A100's).

This was my attempt to avoid lowering float8 conversions to triton when we detect we are on a GPU without the proper SM architecture (less than 89). At least locally on my A100, I confirmed that triton float8 code is no longer being generated.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125765
* #125677
* #125676



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang