### PR TITLE
Use nvidia/cuda:CUDA_VERSION-devel-ubuntu22.04 as base for official Docker release

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -12,7 +12,7 @@ CUDA_VERSION_SHORT       ?= 12.1
 CUDA_VERSION             ?= 12.1.1
 CUDNN_VERSION            ?= 8
 BASE_RUNTIME              = ubuntu:22.04
-BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu22.04
+BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-devel-ubuntu22.04
 CMAKE_VARS               ?=
 
 # The conda channel to use to install cudatoolkit


### PR DESCRIPTION
We don't need to install cudnn system wide. We already install it with pytorch install during this step:
```
[conda-installs 2/3] RUN case linux/amd64 in          "linux/arm64")  pip install --extra-index-url https://download.pytorch.org/whl/cpu/ torch torchvision torchaudio ;;          *)              /opt/conda/bin/conda install -c "pytorch-nightly" -c "nvidia" -y "python=3.10" pytorch torchvision torchaudio "pytorch-cuda=$(echo 12.1.1 | cut -d'.' -f 1-2)"  ;;     esac &&     /opt/conda/bin/conda clean -ya
```
Ref: https://github.com/pytorch/pytorch/actions/runs/8998055687/job/24717424912


Validate via: https://github.com/pytorch/builder/actions/workflows/validate_docker_images.yml