### PR TITLE
Fix Tensor-likes leak of test_module_order  (__main__.OptimizedModuleTest)

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1790,6 +1790,9 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 1)
 
+        # Ensure that modification in user module causes recompile
+        mod.eval()
+
         mod._modules["linear1"] = mod._modules.pop("linear1")
         ref = fn(torch.ones(1))
         res = opt_fn(torch.ones(1))


### PR DESCRIPTION
Fixes #125567

# Tests
This PR is tested with the following command and no error shows. So the flaky test error should be resolved.
`pytest test/dynamo/test_modules.py::OptimizedModuleTest::test_dunder_call_explicitly test/dynamo/test_modules.py::OptimizedModuleTest::test_module_order`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang