### PR TITLE
[caffe2] Lazily symbolize backtrace in c10::Error

### DIFF
--- a/c10/test/util/lazy_test.cpp
+++ b/c10/test/util/lazy_test.cpp
@@ -1,0 +1,97 @@
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <c10/util/Lazy.h>
+#include <gtest/gtest.h>
+
+namespace c10_test {
+
+// Long enough not to fit in typical SSO.
+const std::string kLongString = "I am a long enough string";
+
+TEST(LazyTest, OptimisticLazy) {
+  std::atomic<size_t> invocations = 0;
+  auto factory = [&] {
+    ++invocations;
+    return kLongString;
+  };
+
+  c10::OptimisticLazy<std::string> s;
+
+  constexpr size_t kNumThreads = 16;
+  std::vector<std::thread> threads;
+  std::atomic<std::string*> address = nullptr;
+
+  for (size_t i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&] {
+      auto* p = &s.ensure(factory);
+      auto old = address.exchange(p);
+      if (old != nullptr) {
+        // Even racing ensure()s should return a stable reference.
+        EXPECT_EQ(old, p);
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  EXPECT_GE(invocations.load(), 1);
+  EXPECT_EQ(*address.load(), kLongString);
+
+  invocations = 0;
+  s.reset();
+  s.ensure(factory);
+  EXPECT_EQ(invocations.load(), 1);
+
+  invocations = 0;
+
+  auto sCopy = s;
+  EXPECT_EQ(sCopy.ensure(factory), kLongString);
+  EXPECT_EQ(invocations.load(), 0);
+
+  auto sMove = std::move(s);
+  EXPECT_EQ(sMove.ensure(factory), kLongString);
+  EXPECT_EQ(invocations.load(), 0);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  EXPECT_EQ(s.ensure(factory), kLongString);
+  EXPECT_EQ(invocations.load(), 1);
+
+  invocations = 0;
+
+  s = sCopy;
+  EXPECT_EQ(s.ensure(factory), kLongString);
+  EXPECT_EQ(invocations.load(), 0);
+
+  s = std::move(sCopy);
+  EXPECT_EQ(s.ensure(factory), kLongString);
+  EXPECT_EQ(invocations.load(), 0);
+}
+
+TEST(LazyTest, PrecomputedLazyValue) {
+  static const std::string kLongString = "I am a string";
+  EXPECT_EQ(
+      std::make_shared<c10::PrecomputedLazyValue<std::string>>(kLongString)
+          ->get(),
+      kLongString);
+}
+
+TEST(LazyTest, OptimisticLazyValue) {
+  static const std::string kLongString = "I am a string";
+
+  class LazyString : public c10::OptimisticLazyValue<std::string> {
+    std::string compute() const override {
+      return kLongString;
+    }
+  };
+
+  auto ls = std::make_shared<LazyString>();
+  EXPECT_EQ(ls->get(), kLongString);
+
+  // Returned reference should be stable.
+  EXPECT_EQ(&ls->get(), &ls->get());
+}
+
+} // namespace c10_test

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -8,7 +8,7 @@
 
 namespace c10 {
 
-Error::Error(std::string msg, std::string backtrace, const void* caller)
+Error::Error(std::string msg, Backtrace backtrace, const void* caller)
     : msg_(std::move(msg)), backtrace_(std::move(backtrace)), caller_(caller) {
   refresh_what();
 }
@@ -23,7 +23,7 @@ Error::Error(
     const uint32_t line,
     const char* condition,
     const std::string& msg,
-    const std::string& backtrace,
+    Backtrace backtrace,
     const void* caller)
     : Error(
           str("[enforce fail at ",
@@ -34,7 +34,7 @@ Error::Error(
               condition,
               ". ",
               msg),
-          backtrace,
+          std::move(backtrace),
           caller) {}
 
 std::string Error::compute_what(bool include_backtrace) const {
@@ -51,15 +51,37 @@ std::string Error::compute_what(bool include_backtrace) const {
     }
   }
 
-  if (include_backtrace) {
-    oss << "\n" << backtrace_;
+  if (include_backtrace && backtrace_) {
+    oss << "\n" << backtrace_->get();
   }
 
   return oss.str();
 }
 
+const Error::Backtrace& Error::backtrace() const {
+  return backtrace_;
+}
+
+const char* Error::what() const noexcept {
+  return what_
+      .ensure([this] {
+        try {
+          return compute_what(/*include_backtrace*/ true);
+        } catch (...) {
+          // what() is noexcept, we need to return something here.
+          return std::string{"<Error computing Error::what()>"};
+        }
+      })
+      .c_str();
+}
+
 void Error::refresh_what() {
-  what_ = compute_what(/*include_backtrace*/ true);
+  // Do not compute what_ eagerly, as it would trigger the computation of the
+  // backtrace. Instead, invalidate it, it will be computed on first access.
+  // refresh_what() is only called by non-const public methods which are not
+  // supposed to be called concurrently with any other method, so it is safe to
+  // invalidate here.
+  what_.reset();
   what_without_backtrace_ = compute_what(/*include_backtrace*/ false);
 }
 

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -3,10 +3,12 @@
 
 #include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/Lazy.h>
 #include <c10/util/StringUtil.h>
 
 #include <cstdint>
 #include <exception>
+#include <memory>
 #include <string>
 #include <variant>
 #include <vector>
@@ -25,6 +27,12 @@ namespace c10 {
 /// NB: c10::Error is handled specially by the default torch to suppress the
 /// backtrace, see torch/csrc/Exceptions.h
 class C10_API Error : public std::exception {
+ public:
+  // Symbolizing the backtrace can be expensive; pass it around as a lazy string
+  // so it is symbolized only if actually needed.
+  using Backtrace = std::shared_ptr<const LazyValue<std::string>>;
+
+ private:
   // The actual error message.
   std::string msg_;
 
@@ -36,14 +44,14 @@ class C10_API Error : public std::exception {
   // The C++ backtrace at the point when this exception was raised.  This
   // may be empty if there is no valid backtrace.  (We don't use optional
   // here to reduce the dependencies this file has.)
-  std::string backtrace_;
+  Backtrace backtrace_;
 
   // These two are derived fields from msg_stack_ and backtrace_, but we need
   // fields for the strings so that we can return a const char* (as the
   // signature of std::exception requires).  Currently, the invariant
   // is that these fields are ALWAYS populated consistently with respect
   // to msg_stack_ and backtrace_.
-  std::string what_;
+  mutable OptimisticLazy<std::string> what_;
   std::string what_without_backtrace_;
 
   // This is a little debugging trick: you can stash a relevant pointer
@@ -64,13 +72,13 @@ class C10_API Error : public std::exception {
       const uint32_t line,
       const char* condition,
       const std::string& msg,
-      const std::string& backtrace,
+      Backtrace backtrace,
       const void* caller = nullptr);
 
   // Base constructor
   Error(
       std::string msg,
-      std::string backtrace = "",
+      Backtrace backtrace = nullptr,
       const void* caller = nullptr);
 
   // Add some new context to the message stack.  The last added context
@@ -87,16 +95,12 @@ class C10_API Error : public std::exception {
     return context_;
   }
 
-  const std::string& backtrace() const {
-    return backtrace_;
-  }
+  const Backtrace& backtrace() const;
 
   /// Returns the complete error message, including the source location.
   /// The returned pointer is invalidated if you call add_context() on
   /// this object.
-  const char* what() const noexcept override {
-    return what_.c_str();
-  }
+  const char* what() const noexcept override;
 
   const void* caller() const noexcept {
     return caller_;

--- a/c10/util/Lazy.h
+++ b/c10/util/Lazy.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <atomic>
+#include <utility>
+
+namespace c10 {
+
+/**
+ * Thread-safe lazy value with opportunistic concurrency: on concurrent first
+ * access, the factory may be called by multiple threads, but only one result is
+ * stored and its reference returned to all the callers.
+ *
+ * Value is heap-allocated; this optimizes for the case in which the value is
+ * never actually computed.
+ */
+template <class T>
+class OptimisticLazy {
+ public:
+  OptimisticLazy() = default;
+  OptimisticLazy(const OptimisticLazy& other) {
+    if (T* value = other.value_.load(std::memory_order_acquire)) {
+      value_ = new T(*value);
+    }
+  }
+  OptimisticLazy(OptimisticLazy&& other) noexcept
+      : value_(other.value_.exchange(nullptr, std::memory_order_acq_rel)) {}
+  ~OptimisticLazy() {
+    reset();
+  }
+
+  template <class Factory>
+  T& ensure(Factory&& factory) {
+    if (T* value = value_.load(std::memory_order_acquire)) {
+      return *value;
+    }
+    T* value = new T(factory());
+    T* old = nullptr;
+    if (!value_.compare_exchange_strong(
+            old, value, std::memory_order_release, std::memory_order_acquire)) {
+      delete value;
+      value = old;
+    }
+    return *value;
+  }
+
+  // The following methods are not thread-safe: they should not be called
+  // concurrently with any other method.
+
+  OptimisticLazy& operator=(const OptimisticLazy& other) {
+    *this = OptimisticLazy{other};
+    return *this;
+  }
+
+  OptimisticLazy& operator=(OptimisticLazy&& other) noexcept {
+    if (this != &other) {
+      reset();
+      value_.store(
+          other.value_.exchange(nullptr, std::memory_order_acquire),
+          std::memory_order_release);
+    }
+    return *this;
+  }
+
+  void reset() {
+    if (T* old = value_.load(std::memory_order_relaxed)) {
+      value_.store(nullptr, std::memory_order_relaxed);
+      delete old;
+    }
+  }
+
+ private:
+  std::atomic<T*> value_{nullptr};
+};
+
+/**
+ * Interface for a value that is computed on first access.
+ */
+template <class T>
+class LazyValue {
+ public:
+  virtual ~LazyValue() = default;
+
+  virtual const T& get() const = 0;
+};
+
+/**
+ * Convenience thread-safe LazyValue implementation with opportunistic
+ * concurrency.
+ */
+template <class T>
+class OptimisticLazyValue : public LazyValue<T> {
+ public:
+  const T& get() const override {
+    return value_.ensure([this] { return compute(); });
+  }
+
+ private:
+  virtual T compute() const = 0;
+
+  mutable OptimisticLazy<T> value_;
+};
+
+/**
+ * Convenience immutable (thus thread-safe) LazyValue implementation for cases
+ * in which the value is not actually lazy.
+ */
+template <class T>
+class PrecomputedLazyValue : public LazyValue<T> {
+ public:
+  PrecomputedLazyValue(T value) : value_(std::move(value)) {}
+
+  const T& get() const override {
+    return value_;
+  }
+
+ private:
+  T value_;
+};
+
+} // namespace c10

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -1,7 +1,9 @@
 #include <c10/util/Backtrace.h>
 #include <c10/util/Flags.h>
+#include <c10/util/Lazy.h>
 #include <c10/util/Logging.h>
 #ifdef FBCODE_CAFFE2
+#include <common/process/StackTrace.h>
 #include <folly/synchronization/SanitizeThread.h>
 #endif
 
@@ -24,16 +26,37 @@ C10_DEFINE_bool(
 namespace c10 {
 
 namespace {
-std::function<string()>* GetFetchStackTrace() {
-  static std::function<string()> func = []() {
-    return get_backtrace(/*frames_to_skip=*/1);
+std::function<::c10::Error::Backtrace()>& GetFetchStackTrace() {
+  static std::function<::c10::Error::Backtrace()> func = []() {
+#ifdef FBCODE_CAFFE2
+    // Same implementation as get_backtrace() in fbcode, but with lazy
+    // symbolization.
+    class LazyBacktrace : public OptimisticLazyValue<std::string> {
+      facebook::process::StackTrace st_;
+
+      std::string compute() const override {
+        return st_.toString();
+      }
+    };
+
+    return std::make_shared<LazyBacktrace>();
+#else
+    return std::make_shared<PrecomputedLazyValue<std::string>>(
+        get_backtrace(/*frames_to_skip=*/1));
+#endif
   };
-  return &func;
+  return func;
 };
 } // namespace
 
-void SetStackTraceFetcher(std::function<string(void)> fetcher) {
-  *GetFetchStackTrace() = std::move(fetcher);
+void SetStackTraceFetcher(std::function<::c10::Error::Backtrace()> fetcher) {
+  GetFetchStackTrace() = std::move(fetcher);
+}
+
+void SetStackTraceFetcher(std::function<string()> fetcher) {
+  SetStackTraceFetcher([fetcher = std::move(fetcher)] {
+    return std::make_shared<PrecomputedLazyValue<std::string>>(fetcher());
+  });
 }
 
 void ThrowEnforceNotMet(
@@ -42,7 +65,7 @@ void ThrowEnforceNotMet(
     const char* condition,
     const std::string& msg,
     const void* caller) {
-  c10::Error e(file, line, condition, msg, (*GetFetchStackTrace())(), caller);
+  c10::Error e(file, line, condition, msg, GetFetchStackTrace()(), caller);
   if (FLAGS_caffe2_use_fatal_for_enforce) {
     LOG(FATAL) << e.msg();
   }
@@ -65,7 +88,7 @@ void ThrowEnforceFiniteNotMet(
     const std::string& msg,
     const void* caller) {
   throw c10::EnforceFiniteError(
-      file, line, condition, msg, (*GetFetchStackTrace())(), caller);
+      file, line, condition, msg, GetFetchStackTrace()(), caller);
 }
 
 void ThrowEnforceFiniteNotMet(
@@ -76,15 +99,35 @@ void ThrowEnforceFiniteNotMet(
     const void* caller) {
   ThrowEnforceFiniteNotMet(file, line, condition, std::string(msg), caller);
 }
+
+namespace {
+
+class PyTorchStyleBacktrace : public OptimisticLazyValue<std::string> {
+ public:
+  PyTorchStyleBacktrace(SourceLocation source_location)
+      : backtrace_(GetFetchStackTrace()()), source_location_(source_location) {}
+
+ private:
+  std::string compute() const override {
+    return str(
+        "Exception raised from ",
+        source_location_,
+        " (most recent call first):\n",
+        backtrace_->get());
+  }
+
+  ::c10::Error::Backtrace backtrace_;
+  SourceLocation source_location_;
+};
+
+} // namespace
+
 // PyTorch-style error message
 // (This must be defined here for access to GetFetchStackTrace)
 Error::Error(SourceLocation source_location, std::string msg)
     : Error(
           std::move(msg),
-          str("Exception raised from ",
-              source_location,
-              " (most recent call first):\n",
-              (*GetFetchStackTrace())())) {}
+          std::make_shared<PyTorchStyleBacktrace>(source_location)) {}
 
 using APIUsageLoggerType = std::function<void(const std::string&)>;
 using APIUsageMetadataLoggerType = std::function<void(

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -126,7 +126,14 @@ constexpr bool IsUsingGoogleLogging() {
  */
 C10_API void ShowLogInfoToStderr();
 
-C10_API void SetStackTraceFetcher(std::function<string(void)> fetcher);
+C10_API void SetStackTraceFetcher(
+    std::function<::c10::Error::Backtrace()> fetcher);
+
+/**
+ * Convenience function for non-lazy stack trace fetchers. The Backtrace
+ * overload should be preferred when stringifying the backtrace is expensive.
+ */
+C10_API void SetStackTraceFetcher(std::function<std::string()> fetcher);
 
 using EnforceNotMet = ::c10::Error;
 


### PR DESCRIPTION
Summary:
The macros that build `c10::Error` compute the stack trace at the point of throwing, which is then returned as part of the `what()`. If `what()` is never called, which is the case for most exceptions (since logging is throttled), the cost of computing the stack trace was wasted.

By far, the most expensive part of computing the stack trace is its symbolization; just unwinding the stack and collecting the instruction addresses is comparatively cheap. We can thus defer the symbolization to first invocation of `what()`.

Test Plan:
Added unit tests exercising the lazy nature of `what()`.

Ran an adfinder canary: https://www.internalfb.com/intern/ads/canary/460118801509424346

We can see that the cost of symbolization is obliterated (meaning that `what()` is virtually never called, as expected):
 {F1496627896}

Differential Revision: D57128632


