### PR TITLE
add core tag to linalg_vector_norm

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14041,6 +14041,7 @@
   python_module: linalg
   variants: function
   structured_delegate: linalg_vector_norm.out
+  tags: core
 
 - func: linalg_vector_norm.out(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   python_module: linalg


### PR DESCRIPTION
Summary: Add core tag to `linear_vector_norm`, from larryliu0820 https://github.com/pytorch/pytorch/blob/main/test/expect/HasDecompTest.test_aten_core_operators.expect#L311-L312

Test Plan: CI and this error is gone with the encoder model

Differential Revision: D57118368


