### PR TITLE
Add support for BF16 to FakeQuant operations

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2556,7 +2556,7 @@ void _fake_quantize_tensor_helper(
     .add_input(input)
     .build();
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_type_handling", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_type_handling", [&] {
     iter_combined.for_each([&](char** data, const int64_t* strides, int64_t n) {
       for (const auto i : c10::irange(n)) {
         scalar_t* output_val = (scalar_t*)(data[0] + i * strides[0]);
@@ -2665,7 +2665,7 @@ void _fake_quant_per_channel_cachemask_cpu_helper(
     // When zero_point is float, quantize mirroring affine quantizer equation
     // Xq = Round(Xf * inv_scale + zero_point)
     // where zero_point is in float.
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(zero_point_dtype, "fake_quantize_channel_cachemask_cpu_zero_point_handling", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, zero_point_dtype, "fake_quantize_channel_cachemask_cpu_zero_point_handling", [&] {
       // write mask
       cpu_kernel(iter_mask, [=](SelfType self, float scale, scalar_t zero_point) -> bool {
         float inv_scale = 1.0f / scale;
@@ -2721,7 +2721,7 @@ void fake_quant_per_channel_cachemask_cpu(
   // TODO(future, optional): read once, write twice.  Not done at the moment
   //   for simplicity, as we do not expect this to be a bottleneck.
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "fake_quantize_channel_cachemask_cpu_type_handling", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "fake_quantize_channel_cachemask_cpu_type_handling", [&] {
     _fake_quant_per_channel_cachemask_cpu_helper<scalar_t>(iter, iter_mask, quant_min, quant_max);
   });
 }

--- a/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
+++ b/aten/src/ATen/native/quantized/cuda/FakeQuantizeCore.cu
@@ -35,7 +35,7 @@ void fake_quantize_tensor_cachemask_kernel_cuda(
     .add_output(mask)
     .add_input(input)
     .build();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
     gpu_kernel_multiple_outputs(
       iter,
       [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
@@ -69,7 +69,7 @@ void fake_quantize_tensor_cachemask_tensor_qparams_kernel_cuda(
     .add_output(mask)
     .add_input(input)
     .build();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
     gpu_kernel_multiple_outputs(
       iter,
       [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
@@ -140,7 +140,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
     // When zero_point is float, quantize mirroring affine quantizer equation
     // Xq = Round(Xf * inv_scale + zero_point)
     // where zero_point is in float.
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(zero_point_dtype, "fake_quantize_channel_cachemask_cuda_mask_type_handling", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, zero_point_dtype, "fake_quantize_channel_cachemask_cuda_mask_type_handling", [&] {
       // write mask
       gpu_kernel(iter_mask,
         [=] GPU_LAMBDA (const SelfType input_val, const float scale, const scalar_t zero_point) -> bool {
@@ -182,7 +182,7 @@ void _fake_quant_per_channel_cachemask_cuda_helper(
 
 void fake_quant_per_channel_cachemask_cuda(
     TensorIterator &iter, TensorIterator &iter_mask, int64_t quant_min, int64_t quant_max) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "fake_quantize_channel_cachemask_cpu_type_handling", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "fake_quantize_channel_cachemask_cpu_type_handling", [&] {
     _fake_quant_per_channel_cachemask_cuda_helper<scalar_t>(iter, iter_mask, quant_min, quant_max);
   });
 }


### PR DESCRIPTION
Repro script:
```
import torch

x = torch.randn(2, 2, 2, dtype=torch.bfloat16)
scales = (torch.randn(2) + 1) * 0.05
zero_points = torch.zeros(2).to(torch.int32)
output = torch.fake_quantize_per_channel_affine(x, scales, zero_points, 1, 0, 255)
```

Error:
```
Traceback (most recent call last):
  File "/home/user/repro.py", line 6, in <module>
    torch.fake_quantize_per_channel_affine(x, scales, zero_points, 1, 0, 255)
RuntimeError: "fake_quantize_channel_cachemask_cpu_type_handling" not implemented for 'BFloat16'
```

After -- repro script runs without the above error

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10