### PR TITLE
Make attention bias optional in _scaled_dot_product_efficient_attention_bwd

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14697,7 +14697,7 @@
     NestedTensorCUDA: _scaled_dot_product_efficient_attention_nestedtensor_cuda
   tags: nondeterministic_seeded
 
-- func: _scaled_dot_product_efficient_attention_backward(Tensor grad_out_, Tensor query, Tensor key, Tensor value, Tensor attn_bias, Tensor out, Tensor logsumexp, Tensor philox_seed, Tensor philox_offset, float dropout_p, bool[4] grad_input_mask, bool is_causal=False, *, float? scale=None) -> (Tensor, Tensor, Tensor, Tensor)
+- func: _scaled_dot_product_efficient_attention_backward(Tensor grad_out_, Tensor query, Tensor key, Tensor value, Tensor? attn_bias, Tensor out, Tensor logsumexp, Tensor philox_seed, Tensor philox_offset, float dropout_p, bool[4] grad_input_mask, bool is_causal=False, *, float? scale=None) -> (Tensor, Tensor, Tensor, Tensor)
   device_check: NoCheck
   dispatch:
     CUDA: _scaled_dot_product_efficient_attention_backward_cuda


### PR DESCRIPTION
atten_bias is optional in _scaled_dot_product_efficient_attention, NOT optional in _scaled_dot_product_efficient_attention_bwd. This does not make since if atten_bias does not exist, how to get the gradient of it? 

This PR is to change atten_bias to optional in _scaled_dot_product_efficient_attention_bwd. Since _scaled_dot_product_efficient_attention_bwd must return a tensor for grad_atten, a fake tensor with 1 element is returned. 

The use case for calling _scaled_dot_product_efficient_attention_bwd is: in execution trace, we captured every function call for FWD and BWD, and ET replay is going to call these functions.