### PR TITLE
Stack tensors for adamax

### DIFF
--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -12,6 +12,7 @@ from .optimizer import (
     _get_scalar_dtype,
     _get_value,
     _maximize_doc,
+    _stack_if_compiling,
     _use_grad_for_differentiable,
     _view_as_real,
     Optimizer,
@@ -386,7 +387,9 @@ def _multi_tensor_adamax(
             bias_corrections = [
                 1 - beta1 ** _get_value(step) for step in grouped_state_steps
             ]
-            step_size = [(_get_value(lr) / bc) * -1 for bc in bias_corrections]
+            step_size = _stack_if_compiling(
+                [(_get_value(lr) / bc) * -1 for bc in bias_corrections]
+            )
             torch._foreach_addcdiv_(
                 grouped_params, grouped_exp_avgs, grouped_exp_infs, step_size
             )


### PR DESCRIPTION
This is a workaround to avoid `item()` calls in Adamax. Earlier in the function we use calls to `_get_value` to extract either the value from item (in eager) or the tensor (in compile). As a result we also need to stack these tensors if we're compiling because the `foreach_addcdiv` does not support having a list of tensors as the `value` argument. So if compiling we stack them into a single tensor, if we aren't compiling we leave them as is: a list of scalars

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #124544
* #125826
* #125825
* __->__ #125833
* #125824
* #125823

