### PR TITLE
[BE] Rename `macos-12` to `macos-13`/`macos-` jobs

### DIFF
--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -24,11 +24,6 @@ on:
         default: "3.8"
         description: |
           The python version to be used. Will be 3.8 by default
-      arch:
-        required: true
-        type: string
-        description: |
-          Contains the architecture to run the tests with
       timeout-minutes:
         required: false
         type: number
@@ -44,7 +39,7 @@ jobs:
     # Also ensure that we always run with the right architecture
     defaults:
       run:
-        shell: arch -arch ${{ inputs.arch }} bash -e -l {0}
+        shell: bash -e -l {0}
     strategy:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
@@ -132,12 +127,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-matrix: ${{ inputs.test-matrix }}
           job-name: ${{ steps.get-job-id.outputs.job-name }}
-
-      - name: Pre-process arm64 wheels
-        if: inputs.build-environment == 'macos-12-py3-arm64'
-        run: |
-          # As wheels are cross-compiled they are reported as x86_64 ones
-          ORIG_WHLNAME=$(ls -1 dist/*.whl); ARM_WHLNAME=${ORIG_WHLNAME/x86_64/arm64}; mv "${ORIG_WHLNAME}" "${ARM_WHLNAME}"
 
       - name: Set Test step time
         id: test-timeout

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -32,7 +32,7 @@ jobs:
   macos-py3-arm64-mps-test:
     name: macos-py3-arm64-mps
     uses: ./.github/workflows/_mac-test-mps.yml
-    needs: macos-py3-arm64-build
+    needs: macos-13-py3-arm64-build
     with:
       sync-tag: macos-py3-arm64-mps-test
       build-environment: macos-13-py3-arm64

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -13,33 +13,29 @@ concurrency:
 permissions: read-all
 
 jobs:
-  macos-12-py3-arm64-build:
-    name: macos-12-py3-arm64
+  macos-13-py3-arm64-build:
+    name: macos-13-py3-arm64
     uses: ./.github/workflows/_mac-build.yml
     with:
-      sync-tag: macos-12-py3-arm64-build
-      build-environment: macos-12-py3-arm64
+      sync-tag: macos-py3-arm64-build
+      build-environment: macos-13-py3-arm64
       runner-type: macos-m1-stable
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python-version: 3.9.12
-      # We need to set the environment file here instead of trying to detect it automatically because
-      # MacOS arm64 is cross-compiled from x86-64. Specifically, it means that arm64 conda environment
-      # is needed when building PyTorch MacOS arm64 from x86-64
-      environment-file: .github/requirements/conda-env-macOS-ARM64
       test-matrix: |
         { include: [
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-stable" },
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m2-14" },
         ]}
 
-  macos-12-py3-arm64-mps-test:
-    name: macos-12-py3-arm64-mps
+  macos-py3-arm64-mps-test:
+    name: macos-py3-arm64-mps
     uses: ./.github/workflows/_mac-test-mps.yml
-    needs: macos-12-py3-arm64-build
+    needs: macos-py3-arm64-build
     with:
-      sync-tag: macos-12-py3-arm64-mps-test
-      build-environment: macos-12-py3-arm64
+      sync-tag: macos-py3-arm64-mps-test
+      build-environment: macos-13-py3-arm64
       # Same as the build job
       python-version: 3.9.12
-      test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
+      test-matrix: ${{ needs.macos-13-py3-arm64-build.outputs.test-matrix }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -106,20 +106,16 @@ jobs:
           { config: "default", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
-  macos-12-py3-arm64-build:
+  macos-13-py3-arm64-build:
     name: macos-12-py3-arm64
     uses: ./.github/workflows/_mac-build.yml
     with:
-      sync-tag: macos-12-py3-arm64-build
-      build-environment: macos-12-py3-arm64
+      sync-tag: macos-py3-arm64-build
+      build-environment: macos-13-py3-arm64
       runner-type: macos-m1-stable
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python-version: 3.9.12
-      # We need to set the environment file here instead of trying to detect it automatically because
-      # MacOS arm64 is cross-compiled from x86-64. Specifically, it means that arm64 conda environment
-      # is needed when building PyTorch MacOS arm64 from x86-64
-      environment-file: .github/requirements/conda-env-macOS-ARM64
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 3, runner: "macos-m1-stable" },
@@ -127,14 +123,14 @@ jobs:
           { config: "default", shard: 3, num_shards: 3, runner: "macos-m1-stable" },
         ]}
 
-  macos-12-py3-arm64-mps-test:
-    name: macos-12-py3-arm64-mps
+  macos-py3-arm64-mps-test:
+    name: macos-py3-arm64-mps
     uses: ./.github/workflows/_mac-test-mps.yml
-    needs: macos-12-py3-arm64-build
+    needs: macos-13-py3-arm64-build
     if: needs.macos-12-py3-arm64-build.outputs.build-outcome == 'success'
     with:
-      sync-tag: macos-12-py3-arm64-mps-test
-      build-environment: macos-12-py3-arm64
+      sync-tag: macos-py3-arm64-mps-test
+      build-environment: macos-13-py3-arm64
       # Same as the build job
       python-version: 3.9.12
       test-matrix: |
@@ -144,14 +140,14 @@ jobs:
 
         ]}
 
-  macos-12-py3-arm64-test:
-    name: macos-12-py3-arm64
+  macos-13-py3-arm64-test:
+    name: macos-13-py3-arm64
     uses: ./.github/workflows/_mac-test.yml
     needs:
-      - macos-12-py3-arm64-build
+      - macos-13-py3-arm64-build
       - target-determination
     with:
-      build-environment: macos-12-py3-arm64
+      build-environment: macos-13-py3-arm64
       # Same as the build job
       python-version: 3.9.12
       test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -107,7 +107,7 @@ jobs:
         ]}
 
   macos-13-py3-arm64-build:
-    name: macos-12-py3-arm64
+    name: macos-13-py3-arm64
     uses: ./.github/workflows/_mac-build.yml
     with:
       sync-tag: macos-py3-arm64-build
@@ -127,7 +127,7 @@ jobs:
     name: macos-py3-arm64-mps
     uses: ./.github/workflows/_mac-test-mps.yml
     needs: macos-13-py3-arm64-build
-    if: needs.macos-12-py3-arm64-build.outputs.build-outcome == 'success'
+    if: needs.macos-13-py3-arm64-build.outputs.build-outcome == 'success'
     with:
       sync-tag: macos-py3-arm64-mps-test
       build-environment: macos-13-py3-arm64
@@ -150,8 +150,7 @@ jobs:
       build-environment: macos-13-py3-arm64
       # Same as the build job
       python-version: 3.9.12
-      test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
-      arch: arm64
+      test-matrix: ${{ needs.macos-13-py3-arm64-build.outputs.test-matrix }}
 
   win-vs2019-cpu-py3-build:
     name: win-vs2019-cpu-py3


### PR DESCRIPTION
As CI does not have any MacOS 12 runners anymore
Cleanup any misleading references about cross-compilation as M1 builds are done natively for quite some time
