### PR TITLE
Fix the link to torch.compiler_custom_backends.

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1834,7 +1834,8 @@ def compile(model: Optional[Callable] = None, *,
 
         - Experimental or debug in-tree backends can be seen with `torch._dynamo.list_backends(None)`
 
-        - To register an out-of-tree custom backend: https://pytorch.org/docs/main/torch.compiler_custom_backends.html
+        - To register an out-of-tree custom backend:
+       https://pytorch.org/docs/main/torch.compiler_custom_backends.html#registering-custom-backends
        mode (str): Can be either "default", "reduce-overhead", "max-autotune" or "max-autotune-no-cudagraphs"
 
         - "default" is the default mode, which is a good balance between performance and overhead


### PR DESCRIPTION
Tiny fix. Fixes #119272

cc: @svekars @brycebortree
