### PR TITLE
Fix unused variable 'kEps'

### DIFF
--- a/caffe2/utils/math_gpu_test.cc
+++ b/caffe2/utils/math_gpu_test.cc
@@ -224,8 +224,6 @@ TEST(MathUtilGPUTest, testCopyVector) {
 
 namespace {
 
-constexpr float kEps = 1e-5;
-
 class GemmBatchedGPUTest
     : public testing::TestWithParam<testing::tuple<bool, bool>> {
  protected:


### PR DESCRIPTION
Summary:
> fbcode/caffe2/caffe2/utils/math_gpu_test.cc:227:17: error: unused variable 'kEps' [-Werror,-Wunused-const-variable]

See https://www.internalfb.com/intern/test/844425000398735?ref_report_id=0

Created from CodeHub with https://fburl.com/edit-in-codehub

Test Plan: Sandcastle run

Reviewed By: r-barnes

Differential Revision: D56731004


