### PR TITLE
[PT2] Register fake impl for quantized embedding bag ops

### DIFF
--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -10,6 +10,7 @@ extern template int register_conv_params<3>();
 int register_embedding_params();
 
 TORCH_LIBRARY(quantized, m) {
+  m.set_python_module("caffe2.torch.fb.model_transform.splitting.split_dispatcher");
   register_linear_params();
   register_conv_params<2>();
   register_conv_params<3>();


### PR DESCRIPTION
Summary: Register fake impl for quantized embedding bag ops (e.g. quantized::embedding_bag_4bit_rowwise_offsets) and bypass registration if it has been registered.

Test Plan:
Before:
```
NotImplementedError: quantized::embedding_bag_4bit_rowwise_offsets: attempted to run this operator with Meta tensors, but there was no fake impl or Meta kernel registered
```
See context here -
https://fb.workplace.com/groups/1075192433118967/permalink/1423106614994212/

After:
Snapsoht was published successfully with PT2Archive.
```
AIMP_DISABLE_PRUNING=false  fdb buck2 run mode/opt-split-dwarf -c python.package_style=inplace -c fbcode.enable_gpu_sections=true  lego/scripts:lego_cli -- debug-locally --model_entity_id 545861329  --config_version 14 --publish_context OFFLINE_PUBLISH    --lego_pipeline aiplatform.modelstore.model_generation.lego.lego_pipeline_builder.gmpp_lego_pipeline --gmpp_config '{"gmpp_pipeline_descriptor": "aiplatform.modelstore.model_generation.v1.ads_pipelines.aimp_pyper_pipeline.model_generation_pipeline", "worker_process_number":24, "worker_thread_per_process_number": 12, "use_work_assignment": true}' --publish_config_overrides '{"gpu_inference_options": "{\"submodules_to_lower\": []}"}'  2>&1 | tee ./gmpp_lc_aimp.txt
```

Reviewed By: ydwu4

Differential Revision: D57172944


