### PR TITLE
Speedup `convert<float>(Vectorized<half>::loadu(ptr, 8))` on ARM

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_half_neon.h
@@ -298,19 +298,18 @@ class Vectorized<c10::Half> {
     } else if (count == (size() >> 1)) {
       Vectorized<c10::Half> res;
       res.values.val[0] = vld1q_f16(reinterpret_cast<const float16_t*>(ptr));
-      res.values.val[1] = vdupq_n_f16(0);
+      std::memset(&res.values.val[1], 0, sizeof(res.values.val[1]));
       return res;
-    } else {
-      __at_align__ float16_t tmp_values[size()];
-      for (const auto i : c10::irange(size())) {
-        tmp_values[i] = 0;
-      }
-      std::memcpy(
-          tmp_values,
-          reinterpret_cast<const float16_t*>(ptr),
-          count * sizeof(float16_t));
-      return vld1q_f16_x2(reinterpret_cast<const float16_t*>(tmp_values));
     }
+    __at_align__ float16_t tmp_values[size()];
+    for (const auto i : c10::irange(size())) {
+      tmp_values[i] = 0;
+    }
+    std::memcpy(
+        tmp_values,
+        reinterpret_cast<const float16_t*>(ptr),
+        count * sizeof(float16_t));
+    return vld1q_f16_x2(reinterpret_cast<const float16_t*>(tmp_values));
   }
   void store(void* ptr, int64_t count = size()) const {
     if (count == size()) {


### PR DESCRIPTION
By replacing `vdupq_n_f16(0)` with simple `std::memset`

Otherwise Apple's clang fails to dead-code eliminate that instruction, which results in a slower codepath.

I.e. following [snippet](https://godbolt.org/z/c757TaM1Y) (that mimics vec library parts)
```cpp
#include <arm_neon.h>
#include <tuple>
#include <cstring>

struct Foo {
  Foo() = default;
  Foo(float16x8x2_t v) : values(v) {} 
  operator float16x8x2_t() const { return values; }
  float16x8x2_t values;
};

struct Bar {
  Bar() = default;
  Bar(float32x4x2_t v) : values(v) {} 
  Bar(float32x4_t val0, float32x4_t val1) : values{val0, val1} {}
  inline void store(float *ptr) {
    vst1q_f32(ptr, values.val[0]);
    vst1q_f32(ptr + 4, values.val[1]);
  }
  float32x4x2_t values;
};

inline Foo loadu(const void* ptr, int64_t count) {
  if (count == 16) {
    return vld1q_f16_x2(reinterpret_cast<const float16_t*>(ptr));
  } else if (count == 8) {
    Foo res;
    res.values.val[0] = vld1q_f16(reinterpret_cast<const float16_t*>(ptr));
    //res.values.val[1] = vdupq_n_f16(0);
    std::memset(&res.values.val[1], 0, sizeof(res.values.val[1]));
    return res;
  }
  float16_t tmp_values[16];
  for (auto i = 0; i < 16; ++i) {
    tmp_values[i] = 0;
  }
  std::memcpy(
    tmp_values,
    reinterpret_cast<const float16_t*>(ptr),
    count * sizeof(float16_t));
  return vld1q_f16_x2(reinterpret_cast<const float16_t*>(tmp_values));
}

inline std::tuple<Bar, Bar> convert_half_float(const Foo& a) {
  float16x8x2_t arr = a;
  float16x8_t x = arr.val[0];
  float16x8_t y = arr.val[1];
  float32x4_t x1 = vcvt_f32_f16(vget_low_f16(x));
  float32x4_t x2 = vcvt_f32_f16(vget_high_f16(x));
  float32x4_t y1 = vcvt_f32_f16(vget_low_f16(y));
  float32x4_t y2 = vcvt_f32_f16(vget_high_f16(y));
  return { Bar(x1, x2), Bar(y1, y2) };

}

inline Bar cvt(const Foo& x) {
  auto rc = convert_half_float(x);
  return std::get<0>(rc);
}

void convert(const float16_t* inp, float* outp) {
    for(auto idx = 0; idx < 1024; idx += 8) {
        auto tmp0 = loadu(inp + idx, 8);
        auto tmp1 = cvt(tmp0);
        tmp1.store(outp + idx);
    }
}

Foo load8(const float16_t* inp) {
    return loadu(inp, 8);
}
```
if compiled with `-O3 -fno-unsafe-math-optimizations` produces
```asm
convert(half const*, float*):
0000000000000000	add	x8, x1, #0x10
0000000000000004	mov	x9, #-0x8
0000000000000008	ldr	q0, [x0], #0x10                 ; Latency: 4
000000000000000c	fcvtl	v1.4s, v0.4h                    ; Latency: 2
0000000000000010	fcvtl2	v0.4s, v0.8h                    ; Latency: 2
0000000000000014	stp	q1, q0, [x8, #-0x10]            ; Latency: 4
0000000000000018	add	x9, x9, #0x8
000000000000001c	add	x8, x8, #0x20
0000000000000020	cmp	x9, #0x3f8
0000000000000024	b.lo	0x8
0000000000000028	ret
load8(half const*):
000000000000002c	ldr	q0, [x0]                        ; Latency: 4
0000000000000030	movi.2d	v1, #0000000000000000           ; Latency: 2
0000000000000034	ret
```
but with `vdupq_n_f16` same yielded
```asm
convert(half const*, float*):
0000000000000000	add	x8, x1, #0x10
0000000000000004	mov	x9, #-0x8
0000000000000008	ldr	q0, [x0], #0x10                 ; Latency: 4
000000000000000c	scvtf	s1, wzr                         ; Latency: 10
0000000000000010	fcvt	h1, s1                          ; Latency: 4
0000000000000014	fcvtl	v1.4s, v0.4h                    ; Latency: 2
0000000000000018	fcvtl2	v0.4s, v0.8h                    ; Latency: 2
000000000000001c	stp	q1, q0, [x8, #-0x10]            ; Latency: 4
0000000000000020	add	x9, x9, #0x8
0000000000000024	add	x8, x8, #0x20
0000000000000028	cmp	x9, #0x3f8
000000000000002c	b.lo	0x8
0000000000000030	ret
load8(half const*):
0000000000000034	scvtf	s1, wzr                         ; Latency: 10
0000000000000038	ldr	q0, [x0]                        ; Latency: 4
000000000000003c	fcvt	h1, s1                          ; Latency: 4
0000000000000040	dup.8h	v1, v1[0]                       ; Latency: 7
0000000000000044	ret
```
(see `scvtf` completely eliminated from `convert` code and replaced with faster `movi.2d` in `load8`)
Fixes https://github.com/pytorch/pytorch/issues/125735


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10