### PR TITLE
Add unsupport explanation in torch.dot ducment

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4029,6 +4029,7 @@ Computes the dot product of two 1D tensors.
 
     Unlike NumPy's dot, torch.dot intentionally only supports computing the dot product
     of two 1D tensors with the same number of elements.
+    Keyword argument of torch.dot is unsupported.
 
 Args:
     input (Tensor): first tensor in the dot product, must be 1D.
@@ -4041,6 +4042,10 @@ Example::
 
     >>> torch.dot(torch.tensor([2, 3]), torch.tensor([2, 1]))
     tensor(7)
+    >>> t1, t2 = torch.tensor([0,1]), torch.tensor([2,3])
+    >>> torch.dot(t1, t2)
+    tensor(3)
+    
 """.format(
         **common_args
     ),


### PR DESCRIPTION
Fixes #125842

Add unsupported declaration on <code>torch.dot</code>, avoid misused like:

```python
>>> t1, t2 = torch.tensor([0,1]), torch.tensor([2,3])
>>> torch.dot(input=t1, other=t2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: dot() missing 1 required positional arguments: "tensor"
```