### PR TITLE
[BE][Easy] Remove usage of deprecated `ast.Str`, `ast.Ellipsis` and `ast.NameConstant`

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -355,7 +355,7 @@ def get_annotation_str(annotation):
         return f"{get_annotation_str(annotation.value)}[{get_annotation_str(subscript_slice)}]"
     elif isinstance(annotation, ast.Tuple):
         return ",".join([get_annotation_str(elt) for elt in annotation.elts])
-    elif isinstance(annotation, (ast.Constant, ast.NameConstant)):
+    elif isinstance(annotation, ast.Constant):
         return f"{annotation.value}"
 
     # If an AST node is not handled here, it's probably handled in ScriptTypeParser.

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -879,7 +879,11 @@ def _check_overload_body(func):
         return isinstance(x, ast.Pass)
 
     def is_ellipsis(x):
-        return isinstance(x, ast.Expr) and isinstance(x.value, ast.Ellipsis)
+        return (
+            isinstance(x, ast.Expr)
+            and isinstance(x.value, ast.Constant)
+            and x.value.value is Ellipsis
+        )
 
     if len(body) != 1 or not (is_pass(body[0]) or is_ellipsis(body[0])):
         msg = (

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -1206,8 +1206,8 @@ class ExprBuilder(Builder):
                     raise NotSupportedError(r, "Don't support formatting in JoinedStr")
                 s += "{}"
                 args.append(build_expr(ctx, value.value))
-            elif isinstance(value, ast.Str):
-                s += value.s
+            elif isinstance(value, ast.Constant):
+                s += value.value
             else:
                 raise NotSupportedError(r, "Unsupported value in JoinedStr")
 

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -1072,7 +1072,7 @@ class ExprBuilder(Builder):
                     sub_exprs.append(build_Index(ctx, base, expr))
                 elif sub_type is ast.Slice:
                     sub_exprs.append(build_SliceExpr(ctx, base, expr))
-                elif sub_type is ast.Ellipsis:
+                elif sub_type is ast.Constant and expr.value is Ellipsis:
                     sub_exprs.append(Dots(base.range()))
                 else:
                     raise NotSupportedError(


### PR DESCRIPTION
`ast.Str`, `ast.Ellipsis`, and `ast.NameConstant` are deprecated in Python 3.8 and will be removed in Python 3.14. Replace them with `ast.Constant`.

Ref: https://docs.python.org/3/library/ast.html#node-classes

> **Changed in version 3.8:** Class [ast.Constant](https://docs.python.org/3/library/ast.html#ast.Constant) is now used for all constants.
>
> **Deprecated since version 3.8:** Old classes ast.Num, ast.Str, ast.Bytes, ast.NameConstant and ast.Ellipsis are still available, but they will be removed in future Python releases. In the meantime, instantiating them will return an instance of a different class.

CI log: https://github.com/metaopt/torchopt/actions/runs/9031146681/job/24816802280?pr=216#step:11:6706