### PR TITLE
cond_batch_rule with boolean pred

### DIFF
--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -327,7 +327,8 @@ def cond_batch_rule(interpreter, pred, true_fn, false_fn, inputs):
         isinstance(i, torch.Tensor) for i in inputs
     ), "Cond inputs must be a list of tensors"
 
-    pred_ = get_unwrapped(pred) if is_batchedtensor(pred) else pred
+    pred_is_batched = isinstance(pred, torch.Tensor) and is_batchedtensor(pred)
+    pred_ = get_unwrapped(pred) if pred_is_batched else pred
 
     # unbatched tensors are not vmapped
     tensors, in_dims = zip(
@@ -337,7 +338,7 @@ def cond_batch_rule(interpreter, pred, true_fn, false_fn, inputs):
         ]
     )
 
-    if is_batchedtensor(pred):
+    if pred_is_batched:
         # prepend "pred" and vmap everything
         tensors = (pred_,) + tensors
         in_dims = (0,) + in_dims

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -127,7 +127,7 @@ def cond(pred, true_fn, false_fn, operands):
             lambda t: not isinstance(t, torch.Tensor), operands
         ):
             raise RuntimeError(
-                "Expect operands to be a tuple of possibly nested dict/list/tuple that only"
+                "Expect operands to be a tuple of possibly nested dict/list/tuple that only "
                 f"consists of tensor leaves, but got {operands}."
             )
 


### PR DESCRIPTION
`cond_batch_rule` does not work with boolean pred, although pred can be a boolean in `torch.cond` signature.