### PR TITLE
[TD] Enable test removal on most default configs + distributed CUDA for everyone

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,6 +1,5 @@
 tracking_issue: 24422
 ciflow_tracking_issue: 64124
-TD_rollout_issue: 123120
 ciflow_push_tags:
 - ciflow/binaries
 - ciflow/binaries_conda

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1198,7 +1198,8 @@ def parse_args():
         and not TEST_WITH_ROCM
         and not IS_MACOS
         and not "onnx" in BUILD_ENVIRONMENT
-        and not "debug" in BUILD_ENVIRONMENT,
+        and not "debug" in BUILD_ENVIRONMENT
+        and not "parallelnative" in BUILD_ENVIRONMENT,
     )
     parser.add_argument(
         "additional_unittest_args",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -495,7 +495,7 @@ def run_test(
         None
         if not options.enable_timeout
         else THRESHOLD * 6
-        if TEST_WITH_SLOW
+        if IS_SLOW
         else THRESHOLD * 3
         if should_retry
         and isinstance(test_module, ShardedTest)
@@ -1194,7 +1194,8 @@ def parse_args():
         )
         and get_pr_number() is not None
         and not strtobool(os.environ.get("NO_TD", "False"))
-        and not IS_SLOW,
+        and not IS_SLOW
+        and not TEST_WITH_ROCM,
     )
     parser.add_argument(
         "additional_unittest_args",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -37,7 +37,6 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
     TEST_WITH_CROSSREF,
     TEST_WITH_ROCM,
-    TEST_WITH_SLOW,
     TEST_WITH_SLOW_GRADCHECK,
 )
 
@@ -76,9 +75,11 @@ HAVE_TEST_SELECTION_TOOLS = True
 sys.path.remove(str(REPO_ROOT))
 
 TEST_CONFIG = os.getenv("TEST_CONFIG", "")
+BUILD_ENVIRONMENT = os.getenv("BUILD_ENVIRONMENT", "")
 RERUN_DISABLED_TESTS = os.getenv("PYTORCH_TEST_RERUN_DISABLED_TESTS", "0") == "1"
 DISTRIBUTED_TEST_PREFIX = "distributed"
 INDUCTOR_TEST_PREFIX = "inductor"
+IS_SLOW = "slow" in TEST_CONFIG or "slow" in BUILD_ENVIRONMENT
 
 
 # Note [ROCm parallel CI testing]
@@ -1180,18 +1181,20 @@ def parse_args():
         and (
             TEST_WITH_CROSSREF
             or TEST_WITH_ASAN
-            or (
-                strtobool(os.environ.get("TD_DISTRIBUTED", "False"))
-                and TEST_CONFIG == "distributed"
-                and TEST_CUDA
-            )
+            or (TEST_CONFIG == "distributed" and TEST_CUDA)
             or (IS_WINDOWS and not TEST_CUDA)
             or TEST_CONFIG == "nogpu_AVX512"
             or TEST_CONFIG == "nogpu_NO_AVX2"
+            or (
+                "sm86" not in BUILD_ENVIRONMENT
+                and TEST_CONFIG == "default"
+                and TEST_CUDA
+            )
+            or (not TEST_CUDA and TEST_CONFIG == "default")
         )
         and get_pr_number() is not None
         and not strtobool(os.environ.get("NO_TD", "False"))
-        and not TEST_WITH_SLOW,
+        and not IS_SLOW,
     )
     parser.add_argument(
         "additional_unittest_args",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1197,7 +1197,8 @@ def parse_args():
         and not IS_SLOW
         and not TEST_WITH_ROCM
         and not IS_MACOS
-        and not "onnx" in BUILD_ENVIRONMENT,
+        and not "onnx" in BUILD_ENVIRONMENT
+        and not "debug" in BUILD_ENVIRONMENT,
     )
     parser.add_argument(
         "additional_unittest_args",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1197,9 +1197,9 @@ def parse_args():
         and not IS_SLOW
         and not TEST_WITH_ROCM
         and not IS_MACOS
-        and not "onnx" in BUILD_ENVIRONMENT
-        and not "debug" in BUILD_ENVIRONMENT
-        and not "parallelnative" in BUILD_ENVIRONMENT,
+        and "onnx" not in BUILD_ENVIRONMENT
+        and "debug" not in BUILD_ENVIRONMENT
+        and "parallelnative" not in BUILD_ENVIRONMENT,
     )
     parser.add_argument(
         "additional_unittest_args",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1195,7 +1195,9 @@ def parse_args():
         and get_pr_number() is not None
         and not strtobool(os.environ.get("NO_TD", "False"))
         and not IS_SLOW
-        and not TEST_WITH_ROCM,
+        and not TEST_WITH_ROCM
+        and not IS_MACOS
+        and not "onnx" in BUILD_ENVIRONMENT,
     )
     parser.add_argument(
         "additional_unittest_args",


### PR DESCRIPTION
yolo

Add the longest jobs in pull:
* default cpu configs
* non sm86 cuda
* distributed cuda for everyone 

Still excluding
* slow, inductor, rocm, onnx, mac, dynamo
* distributed cpu
* windows cuda