### PR TITLE
Speed up _extract_graph_with_inputs_outputs

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -97,6 +97,9 @@ def _extract_graph_with_inputs_outputs(joint_graph, inputs, outputs):
 
     for node in joint_graph.nodes:
         if node in env:
+            # Node must be one of our inputs. (Any member of env which wasn't an
+            # input to start must have been created by this loop and won't be in
+            # joint_graph.nodes).
             continue
         elif node.op == "placeholder":
             env[node] = InvalidNode

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -88,9 +88,6 @@ def _extract_graph_with_inputs_outputs(joint_graph, inputs, outputs):
     new_graph = fx.Graph()
     env = {}
 
-    # Ensure we can ask about our input nodes quickly.
-    inputs = inputs if isinstance(inputs, set) else set(inputs)
-
     # Add new placeholder nodes in the order specified by the inputs
     for node in inputs:
         new_node = new_graph.placeholder(node.name)
@@ -99,7 +96,7 @@ def _extract_graph_with_inputs_outputs(joint_graph, inputs, outputs):
         env[node] = new_node
 
     for node in joint_graph.nodes:
-        if node in inputs:
+        if node in env:
             continue
         elif node.op == "placeholder":
             env[node] = InvalidNode

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -88,6 +88,9 @@ def _extract_graph_with_inputs_outputs(joint_graph, inputs, outputs):
     new_graph = fx.Graph()
     env = {}
 
+    # Ensure we can ask about our input nodes quickly.
+    inputs = inputs if isinstance(inputs, set) else set(inputs)
+
     # Add new placeholder nodes in the order specified by the inputs
     for node in inputs:
         new_node = new_graph.placeholder(node.name)


### PR DESCRIPTION
_extract_graph_with_inputs_outputs() does membership testing on the input nodes but often that collection is a list so the test is O(n).  Ensure it's a set before looping over all the nodes.

This change speeds up the internal repro (D57090987) by about 18%:
before:
```
708.88user 15.86system 12:16.19elapsed 98%CPU (0avgtext+0avgdata 12898628maxresident)k
0inputs+91968outputs (3major+3532970minor)pagefaults 0swaps
```
after:
```
583.39user 15.98system 10:10.11elapsed 98%CPU (0avgtext+0avgdata 12895108maxresident)k
0inputs+87488outputs (4major+3374582minor)pagefaults 0swaps
```


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125937

