### PR TITLE
[ROCm] turn off MI50 CI runners

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -225,8 +225,8 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
-          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
+          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.2" },
+          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.2" },
         ]}
 
   linux-focal-rocm6_1-py3_8-test:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -425,9 +425,9 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.2" },
+          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.2" },
+          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.2" },
         ]}
 
   linux-focal-cuda12_1-py3_10-gcc9-sm86-build:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -119,7 +119,7 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "slow", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
+          { config: "slow", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.2" },
         ]}
 
   linux-focal-rocm6_1-py3_8-test:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -192,7 +192,7 @@ jobs:
       sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.2" },
         ]}
 
   linux-focal-rocm6_1-py3_8-test:


### PR DESCRIPTION
change labels linux.rocm.gpu to linux.rocm.gpu.2


cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang