### PR TITLE
[TorchScript] Better support for non-nn.Module classes defined in different file

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -697,6 +697,7 @@ def _jit_script_class_compile(
     definition: ClassDef,
     defaults: Dict[str, Dict[str, Any]],
     rcb: ResolutionCallback,
+    per_method_rcb: Optional[Dict[str, ResolutionCallback]],
 ): ...
 def _parse_source_def(src: str) -> Def: ...
 def import_ir_module(

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -248,16 +248,20 @@ def get_class_assigns(ctx, cls_ast):
     return assigns
 
 
-def get_jit_class_def(cls, self_name):
-    # Get defs for each method within the current class independently
-    # TODO: proper overriding analysis when implementing class inheritance
-    methods = inspect.getmembers(
+def get_jit_class_methods(cls):
+    return inspect.getmembers(
         cls,
         predicate=lambda m: (inspect.ismethod(m) or inspect.isfunction(m))
         and not is_static_fn(cls, m.__name__)
         and m.__name__ in cls.__dict__
         and not _is_drop_fn(m),
     )
+
+
+def get_jit_class_def(cls, self_name):
+    # Get defs for each method within the current class independently
+    # TODO: proper overriding analysis when implementing class inheritance
+    methods = get_jit_class_methods(cls)
 
     def is_classmethod(fn):
         return inspect.ismethod(fn) and getattr(fn, "__self__", None) == cls


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125950

**Motivating Issue**:

We had this example:
```python
# a.py
import torch
from math import sqrt

# This file is used by test_class_type_closure

class MySqrtClass:
    value: float

    def __init__(self):
        self.value = 4.0

    def get_sqrt_inverse(self) -> float:
        return sqrt(1.0 / self.value)
```


```python
# b.py
import torch
from a import MySqrtClass

torch.jit.script(MySqrtClass)
```

This would fail to script:
```
Traceback (most recent call last):
  File "/data/users/dberard/scripts/ts_use_sqrt.py", line 10, in <module>
    torch.jit.script(ts_sqrt.MyConfig)
  File "/data/users/dberard/pytorch/torch/jit/_script.py", line 1378, in script
    _compile_and_register_class(obj, _rcb, qualified_name)
  File "/data/users/dberard/pytorch/torch/jit/_recursive.py", line 73, in _compile_and_register_class
    script_class = torch._C._jit_script_class_compile(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError:
undefined value sqrt:
  File "/data/users/dberard/scripts/ts_sqrt.py", line 17
    def get_sqrt_inverse(self) -> float:
        return sqrt(1 / self.value)
```

**Fix details**:
In TorchScript, we use "resolution callbacks" - python callables that will map a string to an object. In this case, the resolution callback was unable to identify that `sqrt` was actually `math.sqrt`.

We have multiple types of resolution callbacks: two are `createResolutionCallbackFromFrame` and `createResolutionCallbackFromClosure`.

In this case, we were using `createResolutionCallbackFromFrame`. But this doesn't work if `jit.script` is called from a different file than the class definition.

Fix: `createResolutionCallbackFromClosure` for each of the methods on a class (which is similar to what we do for an nn.Module). Pass this into the C++ function so that we can use the individual RCBs for each of the methods. If a method doesn't have an RCB for some reason, then fallback to the old RCB method where we look at the current frame.

Differential Revision: [D57224315](https://our.internmc.facebook.com/intern/diff/D57224315)