### PR TITLE
[fbcode] remove xcode_public_headers_symlinks

### DIFF
--- a/c2_defs.bzl
+++ b/c2_defs.bzl
@@ -313,7 +313,6 @@ def get_c2_default_cxx_args():
         ],
         visibility = ["PUBLIC"],
         windows_preferred_linkage = "static" if is_arvr_mode() else None,
-        xcode_public_headers_symlinks = True,
     )
 
 def get_c2_aten_cpu_fbobjc_macosx_deps():

--- a/third_party/BUCK.oss
+++ b/third_party/BUCK.oss
@@ -384,7 +384,6 @@ cxx_library(
     visibility = [
         "PUBLIC",
     ],
-    xcode_public_headers_symlinks = True,
     exported_deps = [
         ":gtest_headers",
     ],


### PR DESCRIPTION
Summary: These attributes do nothing in Buck 2, we can remove them.

Test Plan:
```
$ buck2 uquery //... > /dev/null
```

Differential Revision: D57169445


