### PR TITLE
Make adding Buffers more like adding Parameters

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -22,6 +22,7 @@ These are the basic building blocks for graphs:
     :nosignatures:
     :template: classtemplate.rst
 
+    ~parameter.Buffer
     ~parameter.Parameter
     ~parameter.UninitializedParameter
     ~parameter.UninitializedBuffer

--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -889,7 +889,7 @@ class TestFullyShardHSDPBroadcast(FSDPTestMultiThread):
         model_args = ModelArgs()
         model = Transformer(model_args)
         # Add a buffer to show that this flow works for buffers too
-        model.register_buffer("buf", torch.randn((model_args.dim,)))
+        model.buf = torch.nn.Buffer(torch.randn((model_args.dim,)))
         for module in model.modules():
             if isinstance(module, TransformerBlock):
                 fully_shard(module, mesh=mesh)

--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -60,7 +60,7 @@ class TestFlattenParams(FSDPTest):
             dim_feedforward=128,
             dropout=0.1,
         )
-        module.register_buffer("dummy_buffer", torch.tensor(1.0))
+        module.dummy_buffer = nn.Buffer(torch.tensor(1.0))
 
         def get_input(device, dtype):
             torch.manual_seed(1)  # keep everything deterministic

--- a/test/distributed/fsdp/test_fsdp_meta.py
+++ b/test/distributed/fsdp/test_fsdp_meta.py
@@ -73,7 +73,7 @@ class MyLinear(nn.Linear):
 class MyBuffer(nn.Module):
     def __init__(self, device: torch.device):
         super().__init__()
-        self.register_buffer("buf", torch.empty((3, 3), device=device))
+        self.buf = torch.nn.Buffer(torch.empty((3, 3), device=device))
 
     def reset_parameters(self, *args, **kwargs):
         torch.manual_seed(42)

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -818,7 +818,7 @@ class TestFSDPMiscMultiThread(FSDPTestMultiThread):
                 super().__init__()
                 self.a = nn.Linear(1, 1)
                 self.b = nn.Linear(1, 1)
-                self.a.register_buffer("buf", torch.ones(1))
+                self.a.buf = torch.nn.Buffer(torch.ones(1))
 
         m = CPUGPUModule()
         m = FSDP(m, device_id=self.rank, ignored_modules=[m.a], use_orig_params=True)

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -596,11 +596,11 @@ class TestFSDPMiscMultiProcess(FSDPTest):
 
         # Check that `device_id` with `sync_module_states=True` works
         nested_wrapped_module = init_nested_wrapped_module()
-        nested_wrapped_module.register_buffer(
-            "buf", torch.ones((2, 2), device="cpu") * self.rank
+        nested_wrapped_module.buf = nn.Buffer(
+            torch.ones((2, 2), device="cpu") * self.rank
         )
-        nested_wrapped_module.module[0].register_buffer(
-            "buf", torch.ones((3, 2), device="cpu") * self.rank
+        nested_wrapped_module.module[0].buf = nn.Buffer(
+            torch.ones((3, 2), device="cpu") * self.rank
         )
         nested_wrapped_module = FSDP(
             nested_wrapped_module,
@@ -894,7 +894,7 @@ class TestFSDPMiscMultiThread(FSDPTestMultiThread):
                 torch.manual_seed(rank)
                 torch.cuda.manual_seed(rank)
                 self.lin = nn.Linear(10, 10, bias=False)
-                self.register_buffer("buffer", torch.ones(1) * rank)
+                self.buffer = nn.Buffer(torch.ones(1) * rank)
 
         m = MyModel(self.rank).cuda()
         _assert_module_states(

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -103,7 +103,7 @@ class Model(Module):
         super().__init__()
         self.inner = Linear(*INNER_SHAPE)
         if register_buffers:
-            self.inner.register_buffer("buffer", torch.randn(BUFFER_SHAPE))
+            self.inner.buffer = nn.Buffer(torch.randn(BUFFER_SHAPE))
             self.inner.register_buffer(
                 "non_persistent_buffer", torch.randn(BUFFER_SHAPE), persistent=False
             )
@@ -122,7 +122,7 @@ class Model(Module):
             )
         self.outer = Linear(*OUTER_SHAPE)
         if register_buffers:
-            self.outer.register_buffer("buffer", torch.randn(BUFFER_SHAPE))
+            self.outer.buffer = nn.Buffer(torch.randn(BUFFER_SHAPE))
             self.outer.register_buffer(
                 "non_persistent_buffer", torch.randn(BUFFER_SHAPE), persistent=False
             )

--- a/test/distributed/fsdp/test_fsdp_tp_integration.py
+++ b/test/distributed/fsdp/test_fsdp_tp_integration.py
@@ -425,7 +425,7 @@ class TestTPFSDPIntegration(FSDPTest):
                     torch.randn(8, 8), tp_mesh, [Replicate()], run_check=False
                 )
                 self.param = torch.nn.Parameter(replicated_dt)
-                self.register_buffer("buf", replicated_buffer_dt)
+                self.buf = torch.nn.Buffer(replicated_buffer_dt)
 
             def forward(self, x):
                 return self.param + self.buffer + 1

--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -437,7 +437,7 @@ class TestUnshardParams(TestUnshardParamsBase):
             CUDAInitMode.CUDA_BEFORE,
             deterministic=True,
         )
-        model.register_buffer("buffer", torch.ones(1))
+        model.buffer = nn.Buffer(torch.ones(1))
         # Wrap the top-level with FSDP since `named_parameters()` and
         # `named_buffers` will contain FSDP prefixes if called on a non-FSDP
         # root module
@@ -450,7 +450,7 @@ class TestUnshardParams(TestUnshardParamsBase):
             ),
             self.process_group,
         )
-        fsdp_model.register_buffer("buffer", torch.ones(1))
+        fsdp_model.buffer = nn.Buffer(torch.ones(1))
         with FSDP.summon_full_params(fsdp_model):
             for call in ["named_parameters", "named_buffers"]:
                 for (n1, p1), (n2, p2) in itertools.zip_longest(

--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -859,8 +859,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
                 torch.nn.Linear(HIDDEN_DIM, HIDDEN_DIM),
                 torch.nn.Linear(HIDDEN_DIM, OUTPUT_DIM),
             ).to(self.device)
-            model.register_buffer(
-                "test_buffer",
+            model.test_buffer = torch.nn.Buffer(
                 torch.ones((1), device=self.device) * self.rank,
             )
             # Define models/optimizers for DDP with ZeRO and DDP with local

--- a/test/distributed/pipelining/model_registry.py
+++ b/test/distributed/pipelining/model_registry.py
@@ -11,7 +11,7 @@ class ExampleCode(torch.nn.Module):
         super().__init__()
         self.mm_param0 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
         self.mm_param1 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
-        self.register_buffer("cval", torch.randn((d_hid,), requires_grad=False))
+        self.cval = torch.nn.Buffer(torch.randn((d_hid,), requires_grad=False))
         self.lin0 = torch.nn.Linear(d_hid, d_hid)
         self.lin1 = torch.nn.Linear(d_hid, d_hid)
 

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -44,7 +44,7 @@ class TestDataParallel(TestCase):
         class TestModule(nn.Module):
             def __init__(self, t):
                 super().__init__()
-                self.t_rg = nn.Buffer(t, t.requires_grad)
+                self.t_rg = nn.Buffer(t, requires_grad=t.requires_grad)
                 self.t_not_rg = nn.Buffer(t.clone().detach())
 
             def forward(self, x):

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -44,7 +44,7 @@ class TestDataParallel(TestCase):
         class TestModule(nn.Module):
             def __init__(self, t):
                 super().__init__()
-                self.t_rg = nn.Buffer(t, requires_grad=t.requires_grad)
+                self.t_rg = nn.Buffer(t)
                 self.t_not_rg = nn.Buffer(t.clone().detach())
 
             def forward(self, x):

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -44,8 +44,8 @@ class TestDataParallel(TestCase):
         class TestModule(nn.Module):
             def __init__(self, t):
                 super().__init__()
-                self.register_buffer("t_rg", t)
-                self.register_buffer("t_not_rg", t.clone().detach())
+                self.t_rg = nn.Buffer(t, t.requires_grad)
+                self.t_not_rg = nn.Buffer(t.clone().detach())
 
             def forward(self, x):
                 return x * self.t_rg + self.t_not_rg

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -1412,8 +1412,8 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
             def __init__(self) -> None:
                 super().__init__()
                 self._param = torch.randn((3,), device="cuda")
-                self.register_buffer(
-                    "_buf", torch.randn((3,), requires_grad=False, device="cuda")
+                self._buf = torch.nn.Buffer(
+                    torch.randn((3,), requires_grad=False, device="cuda")
                 )
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -1443,8 +1443,8 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
         class BufModule(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.register_buffer(
-                    "_buf", torch.randn((3,), requires_grad=False, device="cuda")
+                self._buf = nn.Buffer(
+                    torch.randn((3,), requires_grad=False, device="cuda")
                 )
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -1456,7 +1456,7 @@ class TestSingleProc(DynamoDistributedSingleProcTestCase):
                 self._param = nn.Parameter(torch.randn((1,), device="cuda"))
                 self._buf_module = BufModule()
                 # Share the buffer, meaning same tensor but different source
-                self.register_buffer("_buf", self._buf_module._buf)
+                self._buf = self._buf_module._buf
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 # Use the same buffer tensor twice in the compiled forward,

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1116,7 +1116,7 @@ def forward(self, x, y):
             def __init__(self):
                 super().__init__()
                 self.weight = torch.nn.Parameter(torch.ones(1, 1))
-                self.register_buffer("buffer", torch.ones(1, 1))
+                self.buffer = torch.nn.Buffer(torch.ones(1, 1))
 
             def forward(self, x):
                 x = torch.nn.functional.linear(x, torch.randn(4, 4))
@@ -3160,7 +3160,7 @@ def forward(self, x):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.ones(6, 2))
+                self.buffer1 = torch.nn.Buffer(torch.ones(6, 2))
 
             def forward(self, x):
                 x.add_(2)

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3772,7 +3772,7 @@ G['macademia'], accessed at:
         class A(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.zeros(6, 4))
+                self.buffer1 = torch.nn.Buffer(torch.zeros(6, 4))
 
             def forward(self):
                 return self.buffer1.sum()
@@ -3780,7 +3780,7 @@ G['macademia'], accessed at:
         class B(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer2", torch.ones(6, 4))
+                self.buffer2 = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self):
                 return self.buffer2.sum()
@@ -3808,7 +3808,7 @@ G['macademia'], accessed at:
         class A(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.zeros(6, 4))
+                self.buffer1 = torch.nn.Buffer(torch.zeros(6, 4))
 
             def forward(self):
                 return self.buffer1.sum()
@@ -3816,7 +3816,7 @@ G['macademia'], accessed at:
         class B(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer2", torch.ones(6, 4))
+                self.buffer2 = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self):
                 return self.buffer2.sum()
@@ -3853,7 +3853,7 @@ G['macademia'], accessed at:
         class A(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.zeros(6, 4))
+                self.buffer1 = torch.nn.Buffer(torch.zeros(6, 4))
 
             def forward(self):
                 return self.buffer1.sum()
@@ -3861,7 +3861,7 @@ G['macademia'], accessed at:
         class B(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer2", torch.ones(6, 4))
+                self.buffer2 = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self):
                 return self.buffer2.sum()
@@ -4156,7 +4156,7 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
         class Module(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.zeros(5, 5))
+                self.buffer1 = torch.nn.Buffer(torch.zeros(5, 5))
 
             def forward(self, x):
                 self.buffer1.add_(1)
@@ -4175,7 +4175,7 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
         class Child(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer2", torch.zeros(5))
+                self.buffer2 = torch.nn.Buffer(torch.zeros(5))
 
             def forward(self, x):
                 return x.sum() + self.buffer2.sum()
@@ -4183,7 +4183,7 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
         class Module(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.zeros(5))
+                self.buffer1 = torch.nn.Buffer(torch.zeros(5))
                 self.child = Child()
 
             def forward(self, x):

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -1451,7 +1451,7 @@ def forward(self, child, const_unused):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.ones(6, 4))
+                self.buffer = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self, x):
                 def true_fn(x):
@@ -1487,7 +1487,7 @@ def forward(self, child, const_unused):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.ones(6, 4))
+                self.buffer = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self, x, y):
                 def true_fn(x):
@@ -1712,7 +1712,7 @@ def forward(self):
         class Module(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("w", torch.ones(6, 4))
+                self.w = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self, xs):
                 def body(x):
@@ -1742,7 +1742,7 @@ def forward(self):
         class Module(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("w", torch.ones(6, 4))
+                self.w = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self, xs):
                 def body(x):

--- a/test/dynamo/test_minifier.py
+++ b/test/dynamo/test_minifier.py
@@ -125,8 +125,8 @@ class CpuCudaModule(torch.nn.Module):
         self.m_y = torch.nn.Linear(20, 20)
         self.p_x = torch.nn.Parameter(torch.randn(20, 20).cuda())
         self.p_y = torch.nn.Parameter(torch.randn(20, 20))
-        self.register_buffer("b_x", torch.ones(20, 20).cuda())
-        self.register_buffer("b_y", torch.ones(20, 20))
+        self.b_x = torch.nn.Buffer(torch.ones(20, 20).cuda())
+        self.b_y = torch.nn.Buffer(torch.ones(20, 20))
 
     def forward(self, x, y):
         return self.m_x(x) + self.p_x + self.b_x, self.m_y(y) + self.p_y + self.b_y

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9615,7 +9615,7 @@ def ___make_guard_fn():
             def __init__(self):
                 super().__init__()
                 self.register_parameter("0", torch.nn.Parameter(torch.randn(3, 4)))
-                self.register_buffer("test_buf", torch.randn(3, 4))
+                self.test_buf = torch.nn.Buffer(torch.randn(3, 4))
                 self.register_parameter(
                     "test_param", torch.nn.Parameter(torch.randn(3, 4))
                 )
@@ -9630,7 +9630,7 @@ def ___make_guard_fn():
                 self.register_parameter(
                     "test_param", torch.nn.Parameter(torch.randn(3, 4))
                 )
-                self.register_buffer("test_buf", torch.randn(3, 4))
+                self.test_buf = torch.nn.Buffer(torch.randn(3, 4))
 
             def forward(self, x):
                 return (self.foo_bar(x) + self.test_param) * self.test_buf

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2700,7 +2700,9 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         class TestModule(torch.nn.Module):
             def __init__(self, buf) -> None:
                 super().__init__()
-                self.buf = torch.nn.Buffer(buf)
+                # FIXME: Changing this one to nn.Buffer fails because value in self.tx.output.side_effects
+                # will no longer evaluate to True 
+                self.register_buffer("buf", buf)
 
             def forward(self, x):
                 return self.buf * x

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2700,9 +2700,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         class TestModule(torch.nn.Module):
             def __init__(self, buf) -> None:
                 super().__init__()
-                # FIXME: Changing this one to nn.Buffer fails because value in self.tx.output.side_effects
-                # will no longer evaluate to True
-                self.register_buffer("buf", buf)
+                self.buf = torch.nn.Buffer(buf)
 
             def forward(self, x):
                 return self.buf * x

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1618,7 +1618,7 @@ class MockModule(torch.nn.Module):
         super().__init__()
         self.relu = torch.nn.ReLU()
         self.linear = torch.nn.Linear(10, 10)
-        self.register_buffer("buf0", torch.randn(10, 10))
+        self.buf0 = torch.nn.Buffer(torch.randn(10, 10))
 
     def forward(self, x):
         return self.relu(self.linear(x) + self.buf0)
@@ -1831,7 +1831,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             def __init__(self):
                 super().__init__()
                 self.linear = torch.nn.Linear(10, 10)
-                self.register_buffer("buf0", torch.randn(10, 10))
+                self.buf0 = torch.nn.Buffer(torch.randn(10, 10))
 
             def forward(self, x):
                 return self.r(torch.sin(x)) + self.buf0
@@ -1858,7 +1858,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             def __init__(self):
                 super().__init__()
                 self.linear = torch.nn.Linear(10, 10)
-                self.register_buffer("buf0", torch.randn(10, 10))
+                self.register_buffer("buf0", torch.nn.Buffer(torch.randn(10, 10)))
                 self.register_parameter(
                     name="param0", param=torch.nn.Parameter(torch.randn(10, 10))
                 )

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2701,7 +2701,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             def __init__(self, buf) -> None:
                 super().__init__()
                 # FIXME: Changing this one to nn.Buffer fails because value in self.tx.output.side_effects
-                # will no longer evaluate to True 
+                # will no longer evaluate to True
                 self.register_buffer("buf", buf)
 
             def forward(self, x):

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -1749,8 +1749,8 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         class MyModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("b1", torch.ones([1]))
-                self.register_buffer("b2", torch.ones([2]))
+                self.b1 = torch.nn.Buffer(torch.ones([1]))
+                self.b2 = torch.nn.Buffer(torch.ones([2]))
 
             def forward(self, x):
                 return x
@@ -1858,7 +1858,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
             def __init__(self):
                 super().__init__()
                 self.linear = torch.nn.Linear(10, 10)
-                self.register_buffer("buf0", torch.nn.Buffer(torch.randn(10, 10)))
+                self.buf0 = torch.nn.Buffer(torch.nn.Buffer(torch.randn(10, 10)))
                 self.register_parameter(
                     name="param0", param=torch.nn.Parameter(torch.randn(10, 10))
                 )
@@ -2700,7 +2700,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         class TestModule(torch.nn.Module):
             def __init__(self, buf) -> None:
                 super().__init__()
-                self.register_buffer("buf", buf)
+                self.buf = torch.nn.Buffer(buf)
 
             def forward(self, x):
                 return self.buf * x
@@ -2739,7 +2739,7 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         class TestModule(torch.nn.Module):
             def __init__(self, buf) -> None:
                 super().__init__()
-                self.register_buffer("buf", buf)
+                self.buf = torch.nn.Buffer(buf)
 
             def forward(self, x):
                 return self.buf * x

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2700,7 +2700,9 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         class TestModule(torch.nn.Module):
             def __init__(self, buf) -> None:
                 super().__init__()
-                self.buf = torch.nn.Buffer(buf)
+                # Changing this one to nn.Buffer fails because `nn.Buffer` does a .detach()
+                # so the value in self.tx.output.side_effects will no longer evaluate to True
+                self.register_buffer("buf", buf)
 
             def forward(self, x):
                 return self.buf * x

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2168,8 +2168,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         class MyModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("sorted", torch.ones(4, 4))
-                self.register_buffer("indices", torch.ones(4, 4, dtype=torch.long))
+                self.sorted = torch.nn.Buffer(torch.ones(4, 4))
+                self.indices = torch.nn.Buffer(torch.ones(4, 4, dtype=torch.long))
 
             def forward(self, x):
                 torch.sort(x, out=(self.sorted, self.indices))
@@ -2200,7 +2200,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         class MyModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("base", torch.ones(4, 4))
+                self.base = torch.nn.Buffer(torch.ones(4, 4))
 
             def forward(self, x):
                 torch.sigmoid(x, out=self.base)
@@ -2508,8 +2508,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("x", torch.ones(3))
-                self.register_buffer("y", torch.ones(3))
+                self.x = torch.nn.Buffer(torch.ones(3))
+                self.y = torch.nn.Buffer(torch.ones(3))
 
             def forward(self, inp):
                 res = 0

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -577,7 +577,7 @@ class TestConverter(TestCase):
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.register_buffer("w", torch.randn(1))
+                self.w = torch.nn.Buffer(torch.randn(1))
 
             def forward(self, x: torch.Tensor):
                 return self.w + x
@@ -586,7 +586,7 @@ class TestConverter(TestCase):
             def __init__(self) -> None:
                 super().__init__()
                 self.m = M()
-                self.register_buffer("w", torch.randn(1))
+                self.w = torch.nn.Buffer(torch.randn(1))
 
             def forward(self, x: torch.Tensor):
                 return self.w + self.m(x)
@@ -595,7 +595,7 @@ class TestConverter(TestCase):
             def __init__(self) -> None:
                 super().__init__()
                 self.m = NestedM()
-                self.register_buffer("w", torch.randn(1))
+                self.w = torch.nn.Buffer(torch.randn(1))
 
             def forward(self, x: torch.Tensor):
                 return self.w + self.m(x)
@@ -610,7 +610,7 @@ class TestConverter(TestCase):
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.register_buffer("w", torch.randn(1))
+                self.w = torch.nn.Buffer(torch.randn(1))
                 self.count = 1
 
             def forward(self, x: torch.Tensor):
@@ -621,7 +621,7 @@ class TestConverter(TestCase):
                 super().__init__()
                 self.m1 = M()
                 self.m2 = M()
-                self.register_buffer("w", torch.randn(1))
+                self.w = torch.nn.Buffer(torch.randn(1))
 
             def forward(self, x: torch.Tensor):
                 if torch.sum(x) > 1:
@@ -636,7 +636,7 @@ class TestConverter(TestCase):
                 super().__init__()
                 self.m1 = NestedM()
                 self.m2 = NestedM()
-                self.register_buffer("w", torch.randn(1))
+                self.w = torch.nn.Buffer(torch.randn(1))
 
             def forward(self, x: torch.Tensor):
                 if torch.max(x) > 1:
@@ -1034,7 +1034,7 @@ class TestConverter(TestCase):
         class Module(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("data", torch.ones(3, 2))
+                self.data = torch.nn.Buffer(torch.ones(3, 2))
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 self.data = self.data + x
@@ -1048,7 +1048,7 @@ class TestConverter(TestCase):
         class Module(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("data", torch.ones(3, 2))
+                self.data = torch.nn.Buffer(torch.ones(3, 2))
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 self.data = self.data + x
@@ -1115,7 +1115,7 @@ class TestConverter(TestCase):
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.register_buffer("w2", torch.ones(1))
+                self.w2 = torch.nn.Buffer(torch.ones(1))
 
             def forward(self, x: torch.Tensor):
                 self.w2 += 1

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -20,7 +20,7 @@ class TestExperiment(TestCase):
         class B(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.ones(3))
+                self.buffer1 = torch.nn.Buffer(torch.ones(3))
 
             def forward(self, x):
                 y = x + 2

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -481,8 +481,8 @@ graph():
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("u", torch.ones(1))
-                self.register_buffer("v", torch.ones(1))
+                self.u = torch.nn.Buffer(torch.ones(1))
+                self.v = torch.nn.Buffer(torch.ones(1))
 
             def forward(self, x, ys, zs, c):
                 y = ys[0] + ys[1] + zs["a"] + zs["b"]
@@ -596,7 +596,7 @@ graph():
         class M(torch.nn.Module):  # simple with register buffer
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.ones(2, 3), persistent=False)
+                self.buf = torch.nn.Buffer(torch.ones(2, 3), persistent=False)
 
             def forward(self, x):
                 # x = 2
@@ -1318,8 +1318,8 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, c_
         class MyLinear(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("weight", torch.randn(20, 98))
-                self.register_buffer("bias", torch.randn(20))
+                self.weight = torch.nn.Buffer(torch.randn(20, 98))
+                self.bias = torch.nn.Buffer(torch.randn(20))
 
             def forward(self, x):
                 return torch.nn.functional.linear(x, self.weight, self.bias)
@@ -1503,7 +1503,7 @@ def forward(self, x):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.ones(4, 4))
+                self.buffer = torch.nn.Buffer(torch.ones(4, 4))
 
             def forward(self, x):
                 x.add_(5)
@@ -1547,7 +1547,7 @@ def forward(self, x):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.ones(4, 4))
+                self.buffer = torch.nn.Buffer(torch.ones(4, 4))
 
             def forward(self, x):
                 x.add_(5)
@@ -1584,7 +1584,7 @@ def forward(self, x):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.ones(4, 4))
+                self.buffer = torch.nn.Buffer(torch.ones(4, 4))
 
             def forward(self, container):
                 x = container[0][0]
@@ -1612,7 +1612,7 @@ def forward(self, x):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.ones(2, 2))
+                self.buffer = torch.nn.Buffer(torch.ones(2, 2))
                 self.linear = torch.nn.Linear(2, 2)
 
             def forward(self, x):
@@ -3669,7 +3669,7 @@ def forward(self, x):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.zeros(1))
+                self.buf = torch.nn.Buffer(torch.zeros(1))
 
             def forward(self, x):
                 self.buf.add_(1)
@@ -3698,7 +3698,7 @@ def forward(self, x):
         class Bar(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.ones(1))
+                self.buf = torch.nn.Buffer(torch.ones(1))
 
             def forward(self, x):
                 self.buf.add_(1)
@@ -3707,7 +3707,7 @@ def forward(self, x):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.zeros(1))
+                self.buf = torch.nn.Buffer(torch.zeros(1))
                 self.bar = Bar()
 
             def forward(self, x):
@@ -3797,7 +3797,7 @@ def forward(self, x):
         class Bar(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.ones(1))
+                self.buf = torch.nn.Buffer(torch.ones(1))
 
             def forward(self, x):
                 self.buf.add_(1)
@@ -3806,7 +3806,7 @@ def forward(self, x):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.zeros(1))
+                self.buf = torch.nn.Buffer(torch.zeros(1))
                 self.bar = Bar()
 
             def forward(self, x):
@@ -3850,7 +3850,7 @@ def forward(self, x):
         class Bar(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.ones(1))
+                self.buf = torch.nn.Buffer(torch.ones(1))
 
             def forward(self, x):
                 self.buf.add_(1)
@@ -3859,7 +3859,7 @@ def forward(self, x):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.zeros(1))
+                self.buf = torch.nn.Buffer(torch.zeros(1))
                 self.bar = Bar()
 
             def forward(self, x):
@@ -3906,7 +3906,7 @@ def forward(self, x):
         class A(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.ones(6, 4))
+                self.buffer = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self):
                 return self.buffer.cos()
@@ -3962,7 +3962,7 @@ def forward(self, b_a_buffer, x):
                 self.register_parameter(
                     "param", torch.nn.Parameter(torch.ones(2, 3), requires_grad=False)
                 )
-                self.register_buffer("buffer", torch.ones(2, 3) + 1)
+                self.buffer = torch.nn.Buffer(torch.ones(2, 3) + 1)
 
             def true_fn(self, x):
                 return x + self.param
@@ -3995,7 +3995,7 @@ def forward(self, b_a_buffer, x):
                 self.register_parameter(
                     "param", torch.nn.Parameter(torch.tensor(5), requires_grad=False)
                 )
-                self.register_buffer("buffer", torch.tensor(6) + 1)
+                self.buffer = torch.nn.Buffer(torch.tensor(6) + 1)
 
         m1 = M1()
 
@@ -4587,7 +4587,7 @@ graph():
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.ones(4, 4))
+                self.buffer = torch.nn.Buffer(torch.ones(4, 4))
 
             def forward(self, x):
                 self.buffer.add_(4)
@@ -5054,7 +5054,7 @@ graph():
         class Child2(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("child2buffer", torch.ones(2, 3))
+                self.child2buffer = torch.nn.Buffer(torch.ones(2, 3))
 
             def forward(self, x):
                 return x - self.child2buffer
@@ -5114,7 +5114,7 @@ graph():
             def __init__(self):
                 super().__init__()
                 self.leaf = Leaf()
-                self.register_buffer("buffer", torch.randn(4, 4))
+                self.buffer = torch.nn.Buffer(torch.randn(4, 4))
 
             def forward(self, x):
                 return self.buffer.sum() + self.leaf(x).sum()
@@ -5171,7 +5171,7 @@ graph():
             def __init__(self):
                 super().__init__()
                 self.leaf = Leaf()
-                self.register_buffer("buffer", torch.randn(4, 4))
+                self.buffer = torch.nn.Buffer(torch.randn(4, 4))
 
             def forward(self, x):
                 return self.buffer.sum() + self.leaf(x).sum()
@@ -5369,8 +5369,8 @@ def forward(self, p_bar_linear_weight, p_bar_linear_bias, x):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("pred", torch.tensor(False))
-                self.register_buffer("t", torch.tensor(10))
+                self.pred = torch.nn.Buffer(torch.tensor(False))
+                self.t = torch.nn.Buffer(torch.tensor(10))
 
             def forward(self, x, y):
                 def true_fn(x, y):
@@ -5505,7 +5505,7 @@ def forward(self, x, b_t, y):
         class MyModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("foo", torch.rand(2, 3), persistent=False)
+                self.foo = torch.nn.Buffer(torch.rand(2, 3), persistent=False)
 
             def forward(self, x):
                 return self.foo + x
@@ -5583,8 +5583,8 @@ def forward(self, x, b_t, y):
             def __init__(self):
                 super().__init__()
                 self.foo = torch.nn.Parameter(torch.randn(4, 4))
-                self.register_buffer("bar", torch.randn(4, 4), persistent=False)
-                self.register_buffer("baz", torch.randn(4, 4), persistent=True)
+                self.bar = torch.nn.Buffer(torch.randn(4, 4), persistent=False)
+                self.baz = torch.nn.Buffer(torch.randn(4, 4), persistent=True)
 
             def forward(self, x):
                 return self.foo + x + self.bar + self.baz
@@ -5671,7 +5671,7 @@ def forward(self, x, b_t, y):
         class MyModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("foo", torch.randn(4, 4))
+                self.foo = torch.nn.Buffer(torch.randn(4, 4))
 
             def forward(self, x):
                 self.foo.add_(1)
@@ -5809,8 +5809,8 @@ def forward(self, x):
             def __init__(self):
                 super().__init__()
                 self.param = torch.nn.Parameter(torch.randn(4))
-                self.register_buffer("alpha", torch.randn(4), persistent=True)
-                self.register_buffer("beta", torch.randn(4), persistent=False)
+                self.alpha = torch.nn.Buffer(torch.randn(4), persistent=True)
+                self.beta = torch.nn.Buffer(torch.randn(4), persistent=False)
                 self.gamma = torch.randn(4)
 
             def forward(self, p, b_alpha, b, c_gamma):

--- a/test/export/test_pass_infra.py
+++ b/test/export/test_pass_infra.py
@@ -81,8 +81,8 @@ class TestPassInfra(TestCase):
                 self.my_parameter = torch.nn.Parameter(torch.tensor(2.0))
 
                 # Define two buffers
-                self.register_buffer("my_buffer1", torch.tensor(3.0))
-                self.register_buffer("my_buffer2", torch.tensor(4.0))
+                self.my_buffer1 = torch.nn.Buffer(torch.tensor(3.0))
+                self.my_buffer2 = torch.nn.Buffer(torch.tensor(4.0))
 
             def forward(self, x1, x2):
                 # Use the parameter, buffers, and both inputs in the forward method
@@ -115,8 +115,8 @@ class TestPassInfra(TestCase):
 
                 self.my_parameter = torch.nn.Parameter(torch.tensor(2.0))
 
-                self.register_buffer("my_buffer1", torch.tensor(3.0))
-                self.register_buffer("my_buffer2", torch.tensor(4.0))
+                self.my_buffer1 = torch.nn.Buffer(torch.tensor(3.0))
+                self.my_buffer2 = torch.nn.Buffer(torch.tensor(4.0))
 
             def forward(self, x1, x2):
                 # Use the parameter, buffers, and both inputs in the forward method
@@ -157,8 +157,8 @@ class TestPassInfra(TestCase):
 
                 self.my_parameter = torch.nn.Parameter(torch.tensor(2.0))
 
-                self.register_buffer("my_buffer1", torch.tensor(3.0))
-                self.register_buffer("my_buffer2", torch.tensor(4.0))
+                self.my_buffer1 = torch.nn.Buffer(torch.tensor(3.0))
+                self.my_buffer2 = torch.nn.Buffer(torch.tensor(4.0))
 
             def forward(self, x1, x2):
                 # Use the parameter, buffers, and both inputs in the forward method

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -872,7 +872,7 @@ def forward(self, sin, cos):
             class M(torch.nn.Module):
                 def __init__(self):
                     super().__init__()
-                    self.register_buffer("state", torch.zeros(1))
+                    self.state = torch.nn.Buffer(torch.zeros(1))
 
                 def forward(self, x):
                     return torch.ops.DO_NOT_USE_TEST_ONLY.custom_mutator(x, self.state)
@@ -913,7 +913,7 @@ def forward(self, sin, cos):
             class M(torch.nn.Module):
                 def __init__(self):
                     super().__init__()
-                    self.register_buffer("state", torch.zeros(1))
+                    self.state = torch.nn.Buffer(torch.zeros(1))
 
                 def forward(self, x):
                     return torch.ops.DO_NOT_USE_TEST_ONLY.custom_mutator_tuple(

--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -79,7 +79,7 @@ class TestUnflatten(TestCase):
         class Child2(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("child2buffer", torch.ones(2, 3))
+                self.child2buffer = torch.nn.Buffer(torch.ones(2, 3))
 
             def forward(self, x):
                 return x - self.child2buffer
@@ -121,7 +121,7 @@ class TestUnflatten(TestCase):
         class Child(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("child2buffer", torch.ones(2, 3))
+                self.child2buffer = torch.nn.Buffer(torch.ones(2, 3))
 
             def forward(self, x):
                 self.child2buffer.add_(x)
@@ -157,7 +157,7 @@ class TestUnflatten(TestCase):
         class Child(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("child2buffer", torch.ones(2, 3))
+                self.child2buffer = torch.nn.Buffer(torch.ones(2, 3))
 
             def forward(self, x):
                 return x - self.child2buffer
@@ -388,7 +388,7 @@ class TestUnflatten(TestCase):
         class Child2(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("child2buffer", torch.ones(2, 3))
+                self.child2buffer = torch.nn.Buffer(torch.ones(2, 3))
 
             def forward(self, x):
                 return x - self.child2buffer
@@ -481,7 +481,7 @@ class TestUnflatten(TestCase):
             def __init__(self):
                 super().__init__()
                 self.leaf = Leaf()
-                self.register_buffer("buffer", torch.randn(4, 4))
+                self.buffer = torch.nn.Buffer(torch.randn(4, 4))
 
             def forward(self, x, z):
                 return self.buffer.sum() + self.leaf(x).sum() + z[0].sum() + z[1].sum()
@@ -663,7 +663,7 @@ class TestUnflatten(TestCase):
         class Module2(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.rand(3, 4))
+                self.buffer = torch.nn.Buffer(torch.rand(3, 4))
                 self.register_parameter("param", torch.nn.Parameter(torch.rand(3, 4)))
 
             def forward(self, x):
@@ -672,7 +672,7 @@ class TestUnflatten(TestCase):
         class Module1(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.rand(3, 4))
+                self.buffer = torch.nn.Buffer(torch.rand(3, 4))
                 self.register_parameter("param", torch.nn.Parameter(torch.rand(3, 4)))
 
             def forward(self, x):
@@ -778,7 +778,7 @@ class TestUnflatten(TestCase):
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.register_buffer("const", torch.ones(4, 8))
+                self.const = torch.nn.Buffer(torch.ones(4, 8))
                 self.layers = torch.nn.ModuleList([layer() for _ in range(2)])
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/test/export/test_verifier.py
+++ b/test/export/test_verifier.py
@@ -165,8 +165,8 @@ class TestVerifier(TestCase):
 
                 self.my_parameter = torch.nn.Parameter(torch.tensor(2.0))
 
-                self.register_buffer("my_buffer1", torch.tensor(3.0))
-                self.register_buffer("my_buffer2", torch.tensor(4.0))
+                self.my_buffer1 = torch.nn.Buffer(torch.tensor(3.0))
+                self.my_buffer2 = torch.nn.Buffer(torch.tensor(4.0))
 
             def forward(self, x1, x2):
                 # Use the parameter, buffers, and both inputs in the forward method
@@ -188,8 +188,8 @@ class TestVerifier(TestCase):
 
                 self.my_parameter = torch.nn.Parameter(torch.tensor(2.0))
 
-                self.register_buffer("my_buffer1", torch.tensor(3.0))
-                self.register_buffer("my_buffer2", torch.tensor(4.0))
+                self.my_buffer1 = torch.nn.Buffer(torch.tensor(3.0))
+                self.my_buffer2 = torch.nn.Buffer(torch.tensor(4.0))
 
             def forward(self, x1, x2):
                 # Use the parameter, buffers, and both inputs in the forward method

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3587,7 +3587,7 @@ def forward(self, tangents_1):
         class MyModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.zeros(1))
+                self.buf = torch.nn.Buffer(torch.zeros(1))
                 self.w1 = torch.nn.Parameter(torch.zeros(1))
                 self.w2 = torch.nn.Parameter(torch.zeros(1))
 
@@ -3642,7 +3642,7 @@ def forward(self, primals_1, primals_2, primals_3, primals_4):
         class MyModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.ones(4, 4))
+                self.buf = torch.nn.Buffer(torch.ones(4, 4))
                 self.w = torch.nn.Parameter(
                     torch.Tensor([[4, 5], [1, 2], [6, 7], [8, 9]])
                 )
@@ -4222,7 +4222,7 @@ def forward(self, arg0_1, arg1_1):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("foo", torch.zeros(2, 2))
+                self.foo = torch.nn.Buffer(torch.zeros(2, 2))
 
             def forward(self, x):
                 self.foo.add_(4)

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3868,7 +3868,7 @@ def forward(self, tangents_1):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer", torch.ones(4, 5))
+                self.buffer = torch.nn.Buffer(torch.ones(4, 5))
 
             def forward(self, x):
                 y = self.buffer.add_(3)
@@ -4796,7 +4796,7 @@ class <lambda>(torch.nn.Module):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.ones(6, 4))
+                self.buffer1 = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self, x):
                 x.add_(4)
@@ -4822,7 +4822,7 @@ def forward(self, arg0_1, arg1_1):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.ones(6, 4))
+                self.buffer1 = torch.nn.Buffer(torch.ones(6, 4))
 
             def forward(self, x, y):
                 y.add_(4)

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -138,7 +138,7 @@ def _while_loop_tests():
         def __init__(self):
             super().__init__()
             self.linear = torch.nn.Linear(2, 2)
-            self.register_buffer("dec", torch.tensor(1))
+            self.dec = torch.nn.Buffer(torch.tensor(1))
 
         def forward(self, iter, x):
             def cond_fn(it, x):
@@ -154,7 +154,7 @@ def _while_loop_tests():
             super().__init__()
             self.mod = SimpleWithLinear()
             self.outer_linear = torch.nn.Linear(2, 2)
-            self.register_buffer("dec", torch.tensor(1))
+            self.dec = torch.nn.Buffer(torch.tensor(1))
 
         def forward(self, iter, x):
             def cond_fn(it, x):
@@ -2969,7 +2969,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
                 self.register_parameter(
                     "param", torch.nn.Parameter(torch.ones(2, 3), requires_grad=False)
                 )
-                self.register_buffer("buffer", torch.ones(2, 3) + 1)
+                self.buffer = torch.nn.Buffer(torch.ones(2, 3) + 1)
 
         my_mode = Mod()
 

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3712,8 +3712,8 @@ class TestMakeFunctional(TestCase):
                 super().__init__()
                 self.bias = nn.Parameter(torch.randn(3))
                 self.linear = nn.Linear(3, 3)
-                self.register_buffer("buffer", torch.randn(3))
-                self.register_buffer("buffer_tied", self.buffer)
+                self.buffer = nn.Buffer(torch.randn(3))
+                self.buffer_tied = self.buffer
 
             def forward(self, x):
                 x = self.linear(x)
@@ -3743,7 +3743,7 @@ class TestMakeFunctional(TestCase):
             def __init__(self):
                 super().__init__()
                 self.linear = nn.Linear(3, 3)
-                self.register_buffer("buffer", torch.randn(3))
+                self.buffer = nn.Buffer(torch.randn(3))
 
             def forward(self, x):
                 x = self.linear(x)
@@ -3765,7 +3765,7 @@ class TestMakeFunctional(TestCase):
             def __init__(self):
                 super().__init__()
                 self.linear = nn.Linear(3, 3)
-                self.register_buffer("buffer", torch.randn(3))
+                self.buffer = nn.Buffer(torch.randn(3))
 
             def forward(self, x):
                 x = self.linear(x)
@@ -3825,8 +3825,8 @@ class TestMakeFunctional(TestCase):
                 self.linear = nn.Linear(3, 3)
                 self.weight = self.linear.weight
                 self.bias = self.linear.bias
-                self.register_buffer("buffer", torch.randn(3))
-                self.register_buffer("buffer_tied", self.buffer)
+                self.buffer = nn.Buffer(torch.randn(3))
+                self.buffer_tied = self.buffer
 
             def forward(self, x):
                 x = self.linear(x)

--- a/test/higher_order_ops/test_with_effects.py
+++ b/test/higher_order_ops/test_with_effects.py
@@ -110,7 +110,7 @@ def forward(self, arg0_1, arg1_1):
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.ones(3))
+                self.buf = torch.nn.Buffer(torch.ones(3))
 
             def forward(self, x):
                 torch.ops.aten._print("moo")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1354,7 +1354,7 @@ class AOTInductorTestsTemplate:
         class Model(torch.nn.Module):
             def __init__(self, device):
                 super().__init__()
-                self.register_buffer("foo", torch.randn(4, 4, device=device))
+                self.foo = torch.nn.Buffer(torch.randn(4, 4, device=device))
 
             def forward(self, x):
                 self.foo.add_(1)
@@ -1388,8 +1388,8 @@ class AOTInductorTestsTemplate:
         class Model(torch.nn.Module):
             def __init__(self, device):
                 super().__init__()
-                self.register_buffer("foo", torch.arange(10, device=device))
-                self.register_buffer("bar", torch.arange(10, device=device))
+                self.foo = torch.nn.Buffer(torch.arange(10, device=device))
+                self.bar = torch.nn.Buffer(torch.arange(10, device=device))
 
             def forward(self, x):
                 self.bar.mul_(2)
@@ -1411,8 +1411,8 @@ class AOTInductorTestsTemplate:
             ):
                 super().__init__()
                 cache_shape = (max_batch_size, n_heads, max_seq_length, head_dim)
-                self.register_buffer("k_cache", torch.zeros(cache_shape, dtype=dtype))
-                self.register_buffer("v_cache", torch.zeros(cache_shape, dtype=dtype))
+                self.k_cache = torch.nn.Buffer(torch.zeros(cache_shape, dtype=dtype))
+                self.v_cache = torch.nn.Buffer(torch.zeros(cache_shape, dtype=dtype))
 
             def update(self, input_pos, k_val, v_val):
                 # input_pos: [S], k_val: [B, H, S, D]
@@ -2390,7 +2390,7 @@ class AOTInductorTestsTemplate:
             def __init__(self):
                 super().__init__()
                 self.register_parameter("0", torch.nn.Parameter(torch.randn(3, 4)))
-                self.register_buffer("test_buf", torch.randn(3, 4))
+                self.test_buf = torch.nn.Buffer(torch.randn(3, 4))
                 self.register_parameter(
                     "test_param", torch.nn.Parameter(torch.randn(3, 4))
                 )
@@ -2405,7 +2405,7 @@ class AOTInductorTestsTemplate:
                 self.register_parameter(
                     "test_param", torch.nn.Parameter(torch.randn(3, 4))
                 )
-                self.register_buffer("test_buf", torch.randn(3, 4))
+                self.test_buf = torch.nn.Buffer(torch.randn(3, 4))
 
             def forward(self, x):
                 return (self.foo_bar(x) + self.test_param) * self.test_buf
@@ -2442,7 +2442,7 @@ class AOTInductorTestsTemplate:
         class NestedChild(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("nestedchild3buffer", torch.ones(2, 3) * 3)
+                self.nestedchild3buffer = torch.nn.Buffer(torch.ones(2, 3) * 3)
 
             def forward(self, x):
                 return x / self.nestedchild3buffer
@@ -2462,7 +2462,7 @@ class AOTInductorTestsTemplate:
         class Child2(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("child2buffer", torch.ones(2, 3) * 2)
+                self.child2buffer = torch.nn.Buffer(torch.ones(2, 3) * 2)
 
             def forward(self, x):
                 return x - self.child2buffer

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -353,7 +353,7 @@ class CPUReproTests(TestCase):
         class Model(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("foo", torch.rand((3, 10)))
+                self.foo = torch.nn.Buffer(torch.rand((3, 10)))
 
             def forward(self, x):
                 lx = [x, x.clone(), x.clone()]

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -605,8 +605,7 @@ class CudaReproTests(TestCase):
                 start = math.log2(0.5)
                 end = math.log2(1 / (2**8))
 
-                self.register_buffer(
-                    "scales",
+                self.scales = nn.Buffer(
                     2
                     ** torch.arange(
                         start,

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -1969,7 +1969,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
                 def __init__(self, param, buf) -> None:
                     super().__init__()
                     self.weight = param
-                    self.register_buffer("buf", buf)
+                    self.buf = torch.nn.Buffer(buf)
 
                 def forward(self, x):
                     return x * self.weight + self.buf

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4287,7 +4287,7 @@ class CommonTemplate:
         class MyModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.zeros(1))
+                self.buf = torch.nn.Buffer(torch.zeros(1))
                 self.w1 = torch.nn.Parameter(torch.zeros(1))
                 self.w2 = torch.nn.Parameter(torch.zeros(1))
 
@@ -4334,7 +4334,7 @@ class CommonTemplate:
         class MyModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.ones(4, 4))
+                self.buf = torch.nn.Buffer(torch.ones(4, 4))
                 self.w = torch.nn.Parameter(
                     torch.Tensor([[4, 5], [1, 2], [6, 7], [8, 9]])
                 )

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -9470,9 +9470,7 @@ class CommonTemplate:
         class Repro(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer(
-                    "_tensor_constant0", torch.randn([], dtype=torch.float32)
-                )
+                self._tensor_constant0 = nn.Buffer(torch.randn([], dtype=torch.float32))
 
             def forward(self, arg0_1, arg1_1):
                 convert_element_type = torch.ops.prims.convert_element_type.default(

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -483,7 +483,7 @@ class TestSaveLoad(JitTestCase):
                 self.register_parameter(
                     "parameter_a", torch.nn.Parameter(torch.randn(4))
                 )
-                self.register_buffer("buffer", torch.randn(4))
+                self.buffer = torch.nn.Buffer(torch.randn(4))
                 self.t = torch.rand(4)  # not buffer
 
                 self.parameter_b = torch.nn.Parameter(torch.randn(4))
@@ -1142,7 +1142,7 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 self.register_parameter(
                     "parameter_a", torch.nn.Parameter(torch.randn(4))
                 )
-                self.register_buffer("buffer", torch.randn(4))
+                self.buffer = torch.nn.Buffer(torch.randn(4))
                 self.t = torch.rand(4)  # not buffer
 
                 self.parameter_b = torch.nn.Parameter(torch.randn(4))

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -488,6 +488,7 @@ class TestSaveLoad(JitTestCase):
 
                 self.parameter_b = torch.nn.Parameter(torch.randn(4))
                 self.submodule_b = Submodule()
+                self.buffer_b = torch.nn.Buffer(torch.randn(4))
 
         m = TestModule()
         m_loaded = self.getExportImportCopy(torch.jit.script(m))
@@ -527,7 +528,7 @@ class TestSaveLoad(JitTestCase):
                 super().__init__()
                 self.foo = torch.nn.Linear(2, 3, device="meta")
                 self.bar = torch.nn.Linear(3, 4)
-                self.register_buffer("buffer", torch.randn(4, device="meta"))
+                self.buffer = torch.nn.Buffer(torch.randn(4, device="meta"))
 
             def forward(self, x):
                 x = self.foo(x)
@@ -1146,6 +1147,7 @@ class TestSaveLoadFlatbuffer(JitTestCase):
 
                 self.parameter_b = torch.nn.Parameter(torch.randn(4))
                 self.submodule_b = Submodule()
+                self.buffer_b = torch.nn.Buffer(torch.randn(4))
 
         m = TestModule()
         m_loaded = self.getExportImportCopy(torch.jit.script(m))

--- a/test/nn/test_load_state_dict.py
+++ b/test/nn/test_load_state_dict.py
@@ -573,7 +573,7 @@ class TestLoadStateDictSwap(TestCase):
     def test_swap_subclass(self, assign):
         def _create_model(subclass=None):
             m = torch.nn.Linear(2, 3, bias=False)
-            m.register_buffer("buf", torch.randn(2, 3))
+            m.buf = torch.nn.Buffer(torch.randn(2, 3))
             if subclass is not None:
                 m.weight = torch.nn.Parameter(subclass(m.weight))
                 m.buf = subclass(m.buf)

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -11,7 +11,7 @@ import torch.nn.init as init
 import torch.nn.utils.parametrize as parametrize
 from torch import Tensor
 from torch.__future__ import get_swap_module_params_on_conversion
-from torch.nn import Parameter
+from torch.nn import Buffer, Parameter
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_nn import NNTestCase
@@ -361,7 +361,7 @@ class TestNNParametrization(NNTestCase):
 
         # Instantiate parametrizations on buffers. It should work as expected
         delattr(model, "bias")
-        model.register_buffer("bias", torch.ones(8))
+        model.bias = Buffer(torch.ones(8))
         parametrize.register_parametrization(model, "bias", FirstZero())
         parametrize.register_parametrization(model, "bias", LastZero())
         self.assertTrue(parametrize.is_parametrized(model))
@@ -391,8 +391,8 @@ class TestNNParametrization(NNTestCase):
         class Orthogonal(nn.Module):
             def __init__(self, n):
                 super().__init__()
-                self.register_buffer("id", torch.eye(n))
-                self.register_buffer("B", torch.empty(n, n))
+                self.id = Buffer(torch.eye(n))
+                self.B = Buffer(torch.empty(n, n))
                 init.orthogonal_(self.B)
 
             def forward(self, X):
@@ -456,7 +456,7 @@ class TestNNParametrization(NNTestCase):
         class Orthogonal(nn.Module):
             def __init__(self, n):
                 super().__init__()
-                self.register_buffer("B", torch.eye(n))
+                self.B = Buffer(torch.eye(n))
 
             def forward(self, X):
                 Id = torch.eye(X.size(0))

--- a/test/nn/test_parametrization.py
+++ b/test/nn/test_parametrization.py
@@ -1766,7 +1766,7 @@ class TestNNParametrization(NNTestCase):
         ):
             model = nn.Linear(2, 2)
             buf = torch.randn(2, 2)
-            model.register_buffer("buf", buf)
+            model.buf = torch.nn.Buffer(buf)
             if (
                 type_before_registration == TwoTensor
                 and type_after_registration == Tensor

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -407,7 +407,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 super().__init__()
                 self.conv2 = nn.Conv2d(32, 64, 3, 1, bias=False)
                 self.fc1 = nn.Linear(9216, 128, bias=False)
-                self.register_buffer("buffer", torch.randn(1, 128))
+                self.buffer = torch.nn.Buffer(torch.randn(1, 128))
 
             def forward(self, tensor_x: torch.Tensor):
                 tensor_x = self.conv2(tensor_x)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -293,7 +293,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 self,
             ):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
 
             def forward(self, x):
                 scale_1 = self.weight.reshape(1, -1, 1, 1)
@@ -4355,7 +4355,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         class GatherModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
                 # torch.nn.Embedding is converted to ONNX::Gather.
                 # Constant folding will be triggerred for constant inputs.
                 # This pattern is common for constant mask inputs in transformer models.
@@ -4374,7 +4374,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         class GatherModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(2))
+                self.weight = torch.nn.Buffer(torch.ones(2))
 
             def forward(self, x):
                 # shape is of rank 0
@@ -4389,7 +4389,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         class GatherModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("rb", torch.randn(1, 1, 3, 1, 1))
+                self.rb = torch.nn.Buffer(torch.randn(1, 1, 3, 1, 1))
 
             def forward(self, x):
                 x += self.rb[0]
@@ -9663,7 +9663,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         class ShapeModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
 
             def forward(self, x):
                 shape = self.weight.shape[0]
@@ -11164,7 +11164,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             def __init__(self, embedding_dim):
                 super().__init__()
                 self.weights = InnerModule2.get_embedding(embedding_dim)
-                self.register_buffer("_float_tensor", torch.FloatTensor(1))
+                self._float_tensor = torch.nn.Buffer(torch.FloatTensor(1))
                 self.const = 2
 
             @staticmethod
@@ -11226,7 +11226,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 self.embedding_dim = embedding_dim
                 self.const = 2.5
                 self.weights = InnerModule.get_embedding(self.embedding_dim)
-                self.register_buffer("_float_tensor", torch.FloatTensor(1))
+                self._float_tensor = torch.nn.Buffer(torch.FloatTensor(1))
 
             @staticmethod
             def get_embedding(embedding_dim: int):

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -544,7 +544,7 @@ class TestUtilityFuns(_BaseTestCase):
                 self,
             ):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
 
             def forward(self, x):
                 b = self.weight.reshape(1, -1, 1, 1)
@@ -567,7 +567,7 @@ class TestUtilityFuns(_BaseTestCase):
                 self,
             ):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
 
             def forward(self, x):
                 div = self.weight.div(torch.tensor([1, 2, 3, 4, 5]))
@@ -590,7 +590,7 @@ class TestUtilityFuns(_BaseTestCase):
                 self,
             ):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
 
             def forward(self, x):
                 mul = self.weight.mul(torch.tensor([1, 2, 3, 4, 5]))
@@ -613,7 +613,7 @@ class TestUtilityFuns(_BaseTestCase):
                 self,
             ):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
 
             def forward(self, x):
                 add = self.weight + torch.tensor([1, 2, 3, 4, 5])
@@ -644,7 +644,7 @@ class TestUtilityFuns(_BaseTestCase):
                 self,
             ):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
 
             def forward(self, x):
                 sub = self.weight - torch.tensor([1, 2, 3, 4, 5])
@@ -675,7 +675,7 @@ class TestUtilityFuns(_BaseTestCase):
                 self,
             ):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
 
             def forward(self, x):
                 sqrt = torch.sqrt(self.weight)
@@ -695,7 +695,7 @@ class TestUtilityFuns(_BaseTestCase):
         class ShapeModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("weight", torch.ones(5))
+                self.weight = torch.nn.Buffer(torch.ones(5))
 
             def forward(self, x):
                 shape = self.weight.shape[0]

--- a/test/onnx/torch_export/test_torch_export_with_onnxruntime.py
+++ b/test/onnx/torch_export/test_torch_export_with_onnxruntime.py
@@ -112,7 +112,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         class Bar(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.ones(1))
+                self.buf = torch.nn.Buffer(torch.ones(1))
 
             def forward(self, x):
                 self.buf.add_(1)
@@ -121,7 +121,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buf", torch.zeros(1))
+                self.buf = torch.nn.Buffer(torch.zeros(1))
                 self.bar = Bar()
 
             def forward(self, x):

--- a/test/quantization/core/test_quantized_tensor.py
+++ b/test/quantization/core/test_quantized_tensor.py
@@ -1452,7 +1452,7 @@ class TestQuantizedTensor(TestCase):
                     s = torch.rand(5, dtype=torch.float64) + 0.1
                     zp = torch.randint(5, 15, (5,))
                     x_q = torch.quantize_per_channel(x, s, zp, 1, torch.quint8)
-                self.register_buffer('x', x_q)
+                self.x = torch.nn.Buffer(x_q)
 
             @torch.jit.script_method
             def forward(self):

--- a/test/quantization/eager/test_quantize_eager_qat.py
+++ b/test/quantization/eager/test_quantize_eager_qat.py
@@ -95,9 +95,9 @@ class _ReferenceConvBnNd(torch.nn.Conv2d, torch.nn.modules.conv._ConvNd):
         self.beta = nn.Parameter(torch.empty(out_channels))
         self.affine = True
         self.track_running_stats = True
-        self.register_buffer('running_mean', torch.zeros(out_channels))
-        self.register_buffer('running_var', torch.ones(out_channels))
-        self.register_buffer('num_batches_tracked', torch.tensor(0, dtype=torch.long))
+        self.running_mean = nn.Buffer(torch.zeros(out_channels))
+        self.running_var = nn.Buffer(torch.ones(out_channels))
+        self.num_batches_tracked = nn.Buffer(torch.tensor(0, dtype=torch.long))
         self.activation_post_process = self.qconfig.activation()
         self.weight_fake_quant = self.qconfig.weight()
         if bias:

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -854,7 +854,7 @@ class TestFX(JitTestCase):
                 self.mm_param = torch.nn.Parameter(torch.randn(d_hid, d_hid))
                 self.mm_param2 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
                 self.lin = torch.nn.Linear(d_hid, d_hid)
-                self.register_buffer('buffer', torch.randn(bs + 100, d_hid))
+                self.buffer = torch.nn.Buffer(torch.randn(bs + 100, d_hid))
 
             def forward(self, x):
                 x = torch.mm(x, self.mm_param)
@@ -2703,7 +2703,7 @@ class TestFX(JitTestCase):
         class GetItemBase(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer('pe', torch.randn(8, 8))
+                self.pe = torch.nn.Buffer(torch.randn(8, 8))
 
         class GetItem1(GetItemBase):
             def forward(self, x):
@@ -3068,7 +3068,7 @@ class TestFX(JitTestCase):
             def __init__(self):
                 super().__init__()
                 self.linear = torch.nn.Linear(100, 200)
-                self.register_buffer("buf", torch.randn(2, 3))
+                self.buf = torch.nn.Buffer(torch.randn(2, 3))
                 self.net_c = C()
 
             def forward(self, x):
@@ -3238,7 +3238,7 @@ class TestFX(JitTestCase):
             def __init__(self):
                 super().__init__()
                 self.l1 = torch.nn.Linear(1, 1)
-                self.register_buffer('buffer', torch.ones(1))
+                self.buffer = torch.nn.Buffer(torch.ones(1))
 
             def forward(self, x):
                 return self.l1(x) + self.buffer

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -3385,7 +3385,7 @@ class TestFX(JitTestCase):
         class MyModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("my_buff", torch.rand(3, 4))
+                self.my_buff = torch.nn.Buffer(torch.rand(3, 4))
                 self.register_parameter(
                     "my_param", torch.nn.Parameter(torch.rand(3, 4))
                 )
@@ -3834,7 +3834,7 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
 
     def test_insert_arg(self):
         m = symbolic_trace(SimpleTest())
-        m.register_buffer("buf", torch.tensor(0))
+        m.buf = torch.nn.Buffer(torch.tensor(0))
         output_node = next(iter(reversed(m.graph.nodes)))
         with m.graph.inserting_before(output_node):
             a = m.graph.get_attr("buf")
@@ -4168,7 +4168,7 @@ class TestFXAPIBackwardCompatibility(JitTestCase):
     def test_preserve_unused_attr_after_unpickle(self):
         gm = torch.fx.symbolic_trace(Add())
         gm.add_submodule("foo", Add())
-        gm.register_buffer("dummy_buffer", torch.empty(1))
+        gm.dummy_buffer = torch.nn.Buffer(torch.empty(1))
         gm.register_parameter("dummy_parameter", torch.nn.Parameter(torch.empty(1)))
         b = io.BytesIO()
         torch.save(gm, b)

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -1250,8 +1250,8 @@ class {test_classname}(torch.nn.Module):
                 self.seq = torch.nn.Sequential(torch.nn.BatchNorm1d(2, 2))
                 self.linear = torch.nn.Linear(2, 2)
                 self.attr = torch.randn(2)
-                self.register_buffer("attr2", torch.randn(2))
-                self.register_buffer("attr3", torch.ones(2, dtype=torch.int32))
+                self.attr2 = torch.nn.Buffer(torch.randn(2))
+                self.attr3 = torch.nn.Buffer(torch.ones(2, dtype=torch.int32))
 
             def forward(self, x):
                 return self.linear(self.seq(self.W + self.attr + self.attr2 + self.attr3 + x))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -479,7 +479,7 @@ class TestJit(JitTestCase):
         class MyModule(torch.jit.ScriptModule):
             def __init__(self):
                 super().__init__()
-                self.register_buffer('b0', torch.randn(1, 3))
+                self.b0 = nn.Buffer(torch.randn(1, 3))
                 self.p0 = nn.Parameter(torch.randn(2, 3))
 
             @torch.jit.script_method
@@ -535,7 +535,7 @@ class TestJit(JitTestCase):
                 super().__init__()
                 whole_tensor = torch.randn(4, 5, dtype=torch.float, device='cpu')
                 self.p0 = nn.Parameter(whole_tensor.narrow(0, 0, 1))
-                self.register_buffer('b0', whole_tensor.narrow(0, 3, 1))
+                self.b0 = nn.Buffer(whole_tensor.narrow(0, 3, 1))
 
         m = Foo()
         m2 = self.getExportImportCopy(m, map_location=torch.device('cuda:0'))
@@ -3924,7 +3924,7 @@ def foo(x):
         a.p = nn.Parameter(torch.rand(3, 4))
         a.foo = nn.Module()
         a.foo.name = 'foo'
-        a.foo.register_buffer('b', torch.rand(1, 1))
+        a.foo.b = nn.Buffer(torch.rand(1, 1))
         a.foo.bar = nn.Module()
         a.foo.bar.name = 'bar'
         a.foo.bar.an_int = 4
@@ -8894,7 +8894,7 @@ dedent """
         class ModuleBufferMutate(torch.jit.ScriptModule):
             def __init__(self):
                 super().__init__()
-                self.register_buffer('running_var', torch.tensor(0, dtype=torch.long))
+                self.running_var = nn.Buffer(torch.tensor(0, dtype=torch.long))
 
             @torch.jit.script_method
             def forward(self):
@@ -9021,12 +9021,12 @@ dedent """
         def __init__(self):
             super(TestScript.DerivedStateModule, self).__init__()
             self.param = torch.nn.Parameter(torch.ones(3, 4, dtype=torch.float))
-            self.register_buffer('derived', torch.neg(self.param).detach().clone())
+            self.derived = nn.Buffer(torch.neg(self.param).detach().clone())
 
             # This is a flag so we can test that the pack method was called
-            self.register_buffer('pack_called', torch.zeros(1, dtype=torch.long))
+            self.pack_called = nn.Buffer(torch.zeros(1, dtype=torch.long))
             # This is a flag so we can test that the unpack method was called
-            self.register_buffer('unpack_called', torch.zeros(1, dtype=torch.long))
+            self.unpack_called = nn.Buffer(torch.zeros(1, dtype=torch.long))
 
         @torch.jit.script_method
         def _pack(self):
@@ -9206,7 +9206,7 @@ dedent """
         class SubSubMod(torch.jit.ScriptModule):
             def __init__(self):
                 super().__init__()
-                self.register_buffer('buf', torch.ones(3, 4) * 3)
+                self.buf = nn.Buffer(torch.ones(3, 4) * 3)
 
             @torch.jit.script_method
             def _pack(self):
@@ -9223,7 +9223,7 @@ dedent """
         class SubMod(torch.jit.ScriptModule):
             def __init__(self):
                 super().__init__()
-                self.register_buffer('buf', torch.ones(3, 4) * 2)
+                self.buf = nn.Buffer(torch.ones(3, 4) * 2)
                 self.ssm = SubSubMod()
 
             @torch.jit.script_method
@@ -9242,7 +9242,7 @@ dedent """
             def __init__(self):
                 super().__init__()
                 self.submod = SubMod()
-                self.register_buffer('buf', torch.ones(3, 4) * 1)
+                self.buf = nn.Buffer(torch.ones(3, 4) * 1)
 
             @torch.jit.script_method
             def _pack(self):
@@ -13075,7 +13075,7 @@ dedent """
                 self.out_features = out_features
                 self.weight = torch.nn.Parameter(torch.empty(out_features, in_features))
                 self.bias = torch.nn.Parameter(torch.empty(out_features))
-                self.register_buffer('counter', torch.ones(out_features))
+                self.counter = nn.Buffer(torch.ones(out_features))
                 self.reset_parameters()
 
             def reset_parameters(self):
@@ -13128,7 +13128,7 @@ dedent """
                 super().__init__()
                 self.weight = torch.nn.Parameter(torch.ones(out_features, in_features))
                 self.bias = torch.nn.Parameter(torch.ones(out_features))
-                self.register_buffer("buffer", torch.ones(out_features))
+                self.buffer = nn.Buffer(torch.ones(out_features))
                 self.submodule = Submodule()
 
             def forward(self, x):
@@ -13583,8 +13583,8 @@ dedent """
 
             def __init__(self, number):
                 super().__init__()
-                self.register_buffer('buffer1', torch.ones(2, 2))
-                self.register_buffer('buffer2', torch.ones(2, 2))
+                self.buffer1 = nn.Buffer(torch.ones(2, 2))
+                self.buffer2 = nn.Buffer(torch.ones(2, 2))
                 self.number = number
 
             @torch.jit.script_method
@@ -13602,8 +13602,8 @@ dedent """
 
             def __init__(self, number, submodule):
                 super().__init__()
-                self.register_buffer('buffer1', torch.ones(2, 2))
-                self.register_buffer('buffer2', torch.ones(2, 2))
+                self.buffer1 = nn.Buffer(torch.ones(2, 2))
+                self.buffer2 = nn.Buffer(torch.ones(2, 2))
                 self.number = number
                 self.submodule = submodule
 
@@ -13639,8 +13639,8 @@ dedent """
         class NoArgState(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer('buffer1', torch.ones(2, 2))
-                self.register_buffer('buffer2', torch.ones(2, 2))
+                self.buffer1 = nn.Buffer(torch.ones(2, 2))
+                self.buffer2 = nn.Buffer(torch.ones(2, 2))
 
             def forward(self):
                 pass
@@ -15091,7 +15091,7 @@ dedent """
                 def __init__(self):
                     super().__init__()
                     tensor = torch.zeros(1, requires_grad=False)
-                    self.register_buffer('some_state', torch.nn.Parameter(tensor))
+                    self.some_state = nn.Buffer(torch.nn.Parameter(tensor))
 
                 @torch.jit.script_method
                 def forward(self, x):
@@ -15434,8 +15434,8 @@ dedent """
                 self.mod = (torch.nn.ReLU())
                 self.mod2 = (torch.nn.ReLU())
                 self.mod3 = torch.nn.Sequential(torch.nn.Sequential(torch.nn.ReLU()))
-                self.register_buffer('x', torch.zeros(3))
-                self.register_buffer('y', torch.zeros(3))
+                self.x = nn.Buffer(torch.zeros(3))
+                self.y = nn.Buffer(torch.zeros(3))
                 self.z = torch.zeros(3)
 
             def bleh(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15833,7 +15833,7 @@ dedent """
 
             def __init__(self):
                 super().__init__()
-                self.register_buffer("foo", torch.ones(1))
+                self.foo = torch.nn.Buffer(torch.ones(1))
                 self.register_parameter("bar", torch.nn.Parameter(torch.ones(1)))
                 self.baz = torch.ones(1)
                 self.my_constant = 1

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -19,7 +19,7 @@ import torch.nn.functional as F
 import itertools
 from collections import defaultdict
 from torch import inf
-from torch.nn import Parameter
+from torch.nn import Buffer, Parameter
 from torch.testing._internal import opinfo
 from torch.testing._internal.common_utils import \
     (gradcheck, gradgradcheck, parametrize, run_tests, TestCase, download_file, IS_CI,
@@ -8601,14 +8601,14 @@ class TestNNMPS(NNTestCase):
             def __init__(self):
                 super().__init__()
                 self.layer_dummy_param = Parameter(torch.empty(3, 5))
-                self.register_buffer('layer_dummy_buf', torch.zeros(1, 3, 3, 7))
+                self.layer_dummy_buf = Buffer(torch.zeros(1, 3, 3, 7))
 
         class Net(nn.Module):
             def __init__(self):
                 super().__init__()
                 self.l1 = Layer()
                 self.dummy_param = Parameter(torch.empty(3, 5))
-                self.register_buffer('dummy_buf', torch.zeros(7, 3, 3, 1))
+                self.dummy_buf = Buffer(torch.zeros(7, 3, 3, 1))
 
         l = Layer()
         n = Net()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -26,7 +26,7 @@ from torch.nn.utils import clip_grad_norm_, clip_grad_value_
 from torch.nn.utils import parameters_to_vector, vector_to_parameters
 from torch.nn.utils.fusion import fuse_conv_bn_weights
 from torch.nn.utils.fusion import fuse_linear_bn_weights
-from torch.nn import Parameter
+from torch.nn import Buffer, Parameter
 from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_math_dtypes, floating_types
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
@@ -360,8 +360,8 @@ class TestNN(NNTestCase):
         class M(nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer("buffer1", torch.empty(3, 5))
-                self.register_buffer("buffer2", self.buffer1)
+                self.buffer1 = Buffer(torch.empty(3, 5))
+                self.buffer2 = self.buffer1
 
         m = M()
         self.assertEqual(names(m.named_buffers()),
@@ -420,7 +420,7 @@ class TestNN(NNTestCase):
         linear = nn.Linear(2, 2)
         linear._test_submodule = nn.Linear(2, 2)
         linear._test_parameter = Parameter(torch.empty(2, 2))
-        linear.register_buffer('_test_buffer', torch.empty(2, 2))
+        linear._test_buffer = Buffer(torch.empty(2, 2))
         keys = dir(linear)
         self.assertIn('_test_submodule', keys)
         self.assertIn('_test_parameter', keys)
@@ -525,6 +525,9 @@ class TestNN(NNTestCase):
         with self.assertRaises(KeyError):
             m.register_buffer('attribute_name', torch.rand(5))
 
+        with self.assertRaises(KeyError):
+            m.attribute_name = Buffer(torch.rand(5))
+
         del m.attribute_name
         m.register_parameter('attribute_name', nn.Parameter())
         with self.assertRaises(KeyError):
@@ -551,12 +554,18 @@ class TestNN(NNTestCase):
         self.assertEqual(m.buffer_name, buffer2)
         m.register_buffer('buffer_name', buffer3)
         self.assertEqual(m.buffer_name, buffer3)
+        m.buffer_name = Buffer(buffer1)
+        self.assertEqual(m.buffer_name, Buffer(buffer1))
+        m.buffer_name = Buffer(buffer2)
+        self.assertEqual(m.buffer_name, Buffer(buffer2))
+        m.buffer_name = Buffer(buffer3)
+        self.assertEqual(m.buffer_name, Buffer(buffer3))
 
     def test_get_buffer(self):
         m = nn.Module()
         buffer1 = torch.randn(2, 3)
         buffer2 = torch.randn(4, 5)
-        m.register_buffer('foo', buffer1)
+        m.foo = Buffer(buffer1)
         m.register_buffer('bar', buffer2)
         self.assertEqual(buffer1, m.get_buffer('foo'))
         self.assertEqual(buffer2, m.get_buffer('bar'))
@@ -570,13 +579,13 @@ class TestNN(NNTestCase):
         class Sub(nn.Module):
             def __init__(self, foo, bar):
                 super().__init__()
-                self.register_buffer('foo', foo)
+                self.foo = Buffer(foo)
                 self.subsub = SubSub(bar)
 
         class SubSub(nn.Module):
             def __init__(self, bar):
                 super().__init__()
-                self.register_buffer('bar', bar)
+                self.bar = Buffer(bar)
 
         foo = torch.randn(2, 3)
         bar = torch.randn(4, 5)
@@ -586,33 +595,35 @@ class TestNN(NNTestCase):
 
     def test_buffer_not_persistent(self):
         m = nn.Module()
-        m.register_buffer('buf', torch.rand(5), persistent=False)
+        m.buf = nn.Buffer(torch.rand(5), persistent=False)
         self.assertTrue(len(list(m.buffers())) == 1)
         self.assertTrue(len(m.state_dict()) == 0)
 
     def test_buffer_not_persistent_del(self):
         m = nn.Module()
-        m.register_buffer('buf', torch.rand(5), persistent=False)
+        m.buf = nn.Buffer(torch.rand(5), persistent=False)
         del m.buf
         self.assertTrue(len(list(m.buffers())) == 0)
 
     def test_buffer_not_persistent_overwrite(self):
         m = nn.Module()
-        m.register_buffer('buf', torch.rand(5), persistent=False)
-        m.register_buffer('buf', torch.rand(5))
+        m.buf = nn.Buffer(torch.rand(5), persistent=False)
+        m.buf = nn.Buffer(torch.rand(5))
 
         # can we overwrite a non-persistent buffer with a persistent one?
         self.assertTrue(len(list(m.buffers())) == 1)
         self.assertTrue(len(m.state_dict()) == 1)
 
         # can we overwrite a persistent buffer with a non-persistent one?
-        m.register_buffer('buf', torch.rand(5), persistent=False)
+        m.buf = nn.Buffer(torch.rand(5), persistent=False)
         self.assertTrue(len(list(m.buffers())) == 1)
         self.assertTrue(len(m.state_dict()) == 0)
 
     def test_buffer_not_persistent_assign(self):
         m = nn.Module()
-        m.register_buffer('buf', torch.rand(5), persistent=False)
+        m.buf = nn.Buffer(torch.rand(5), persistent=False)
+        self.assertTrue(len(list(m.buffers())) == 1)
+        self.assertTrue(len(m.state_dict()) == 0)
 
         # Assigning None removes the buffer but if we then assign a new Tensor
         # to the same property, it should still be marked as a buffer.
@@ -630,7 +641,7 @@ class TestNN(NNTestCase):
 
     def test_buffer_not_persistent_load(self):
         m = nn.Module()
-        m.register_buffer('buf', torch.rand(5), persistent=False)
+        m.buf = nn.Buffer(torch.rand(5), persistent=False)
         m.load_state_dict({})
 
     def test_register_parameter_raises_error_if_name_is_not_string(self):
@@ -649,6 +660,11 @@ class TestNN(NNTestCase):
 
         del m.attribute_name
         m.register_buffer('attribute_name', torch.rand(5))
+        with self.assertRaises(KeyError):
+            m.register_parameter('attribute_name', nn.Parameter())
+
+        del m.attribute_name
+        m.attribute_name = Buffer(torch.rand(5))
         with self.assertRaises(KeyError):
             m.register_parameter('attribute_name', nn.Parameter())
 
@@ -1640,7 +1656,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         net.l = l
         net.l2 = l
         net.add_module('empty', None)
-        net.register_buffer('indices', torch.LongTensor(1))
+        net.indices = Buffer(torch.LongTensor(1))
         net.float()
         self.assertIsInstance(l.weight.data, torch.FloatTensor)
         self.assertIsInstance(l.bias.data, torch.FloatTensor)
@@ -2465,8 +2481,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         del l.a, l.b
         self.assertEqual(list(l.children()), [])
 
-        buf = torch.randn(10)
-        l.register_buffer('buf', buf)
+        buf = Buffer(torch.randn(10))
+        l.buf = buf
         self.assertIs(l.buf, buf)
         l.buf = None
         self.assertIs(l.buf, None)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -369,6 +369,19 @@ class TestNN(NNTestCase):
         self.assertEqual(names(m.named_buffers(remove_duplicate=False)),
                          ["buffer1", "buffer2"])
 
+    def test_buffer_bad_module_subclass(self):
+        class MyBadModule(nn.Linear):
+            def __init__(self):
+                super().__init__(2, 2)
+                self.bar = Buffer(torch.rand(2, 2))
+
+            def register_buffer(self, name, value):
+                # persistent is explicitly missing!
+                super().register_buffer(name, value, True)
+
+        foo = MyBadModule()
+        self.assertIsNotNone(foo.bar)
+
     def test_call_supports_python_dict_output(self):
         class Net(nn.Module):
             def __init__(self):

--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -18,7 +18,7 @@ class MockModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.l1 = torch.nn.Linear(1, 1)
-        self.register_buffer('buffer', torch.ones(1))
+        self.buffer = torch.nn.Buffer(torch.ones(1))
         self.foo = 0.0
 
     def forward(self, x):
@@ -30,8 +30,8 @@ class MockTiedModule(torch.nn.Module):
         super().__init__()
         self.l1 = torch.nn.Linear(1, 1)
         self.tied_bias = self.l1.bias
-        self.register_buffer('buffer', torch.ones(1))
-        self.register_buffer('tied_buffer', self.buffer)
+        self.buffer = torch.nn.Buffer(torch.ones(1))
+        self.tied_buffer = self.buffer
 
     def forward(self, x):
         return self.l1(x) + self.tied_bias + self.buffer + self.tied_buffer
@@ -427,7 +427,7 @@ class TestStatelessFunctionalAPI(TestCase):
     def test_tied_weights_warns(self, functional_call):
         module = MockModule()
         module.tied_bias = module.l1.bias
-        module.register_buffer("tied_buffer", module.buffer)
+        module.tied_buffer = torch.nn.Buffer(module.buffer)
 
     @parametrize("functional_call", [
         subtest(torch.func.functional_call, "torch_func"),
@@ -632,7 +632,7 @@ class TestStatelessFunctionalAPI(TestCase):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer('foo', torch.tensor([0.0]))
+                self.foo = torch.nn.Buffer(torch.tensor([0.0]))
 
             def forward(self, x):
                 self.foo = self.foo + 1
@@ -656,7 +656,7 @@ class TestStatelessFunctionalAPI(TestCase):
         class Foo(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.register_buffer('foo', torch.tensor([0.0]))
+                self.foo = torch.nn.Buffer(torch.tensor([0.0]))
 
             def forward(self, x):
                 self.foo.add_(1)
@@ -778,7 +778,7 @@ class TestStatelessFunctionalAPI(TestCase):
             def __init__(self):
                 super().__init__()
                 self.l1 = torch.nn.Linear(1, 1)
-                self.register_buffer('buffer', torch.ones(1))
+                self.buffer = torch.nn.Buffer(torch.ones(1))
 
             def forward(self, x):
                 parameters = tuple(self.parameters())

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -174,6 +174,7 @@ manual_torch_name_rule_map = {
     # https://github.com/pytorch/pytorch/issues/93501
     "torch.nn.utils.rnn.pack_padded_sequence": SkipFunctionVariable,
     "torch.nn.Parameter": TorchInGraphFunctionVariable,
+    "torch.nn.Buffer": TorchInGraphFunctionVariable,
     "torch._nested_tensor_from_mask": SkipFunctionVariable,
     "torch._nested_from_padded": SkipFunctionVariable,
     "torch.nested.nested_tensor_from_jagged": UserFunctionVariable,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -695,6 +695,7 @@ def istensor(obj):
     """Check of obj is a tensor"""
     tensor_list: Tuple[type, ...] = (
         torch.Tensor,
+        torch.nn.Buffer,
         torch.nn.Parameter,
         *config.traceable_tensor_subclasses,
     )

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -695,7 +695,6 @@ def istensor(obj):
     """Check of obj is a tensor"""
     tensor_list: Tuple[type, ...] = (
         torch.Tensor,
-        torch.nn.Buffer,
         torch.nn.Parameter,
         *config.traceable_tensor_subclasses,
     )

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -977,7 +977,11 @@ class VariableBuilder:
             # unlikely to change, so its ok to skip the guard here.
             return MethodWrapperVariable(value)
         elif issubclass(type(value), type):
-            if value in (torch.utils.hooks.BackwardHook, torch.nn.Parameter):
+            if value in (
+                torch.utils.hooks.BackwardHook,
+                torch.nn.Parameter,
+                torch.nn.Buffer,
+            ):
                 # TODO(jansel): combine this case with the one above
                 return trace_rules.lookup(value).create_with_source(
                     value, source=self.source

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -389,7 +389,6 @@ class VariableBuilder:
             (
                 (
                     torch.Tensor,
-                    torch.nn.Buffer,
                     torch.nn.Parameter,
                     torch._subclasses.FakeTensor,
                     torch._subclasses.functional_tensor.FunctionalTensor,
@@ -1391,7 +1390,6 @@ class VariableBuilder:
         else:
             assert type(value) in (
                 torch.Tensor,
-                torch.nn.Buffer,
                 torch.nn.Parameter,
                 torch._subclasses.fake_tensor.FakeTensor,
                 torch._subclasses.functional_tensor.FunctionalTensor,
@@ -2534,7 +2532,7 @@ def wrap_to_fake_tensor_and_record(
     e, tx, *, source: Optional[Source], is_tensor: bool, parent_context=None
 ):
     if (
-        type(e) in (torch.Tensor, torch.nn.Buffer, torch.nn.Parameter, FakeTensor)
+        type(e) in (torch.Tensor, torch.nn.Parameter, FakeTensor)
         or isinstance(e, torch.Tensor)
         or is_traceable_wrapper_subclass(e)
     ):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2016,6 +2016,7 @@ def wrap_fx_proxy_cls(
 
     if isinstance(example_value, torch.Tensor):
         is_parameter = isinstance(example_value, torch.nn.Parameter)
+        is_buffer = isinstance(example_value, torch.nn.Buffer)
 
         # NB: In most (all?) cases, this does not actually do a clone.
         # (WARNING: this means that if we mutate metadata on the fake
@@ -2030,7 +2031,11 @@ def wrap_fx_proxy_cls(
         ):
             tensor_type = subclass_type if subclass_type else torch.Tensor
             specialized_props["class_type"] = (
-                torch.nn.Parameter if is_parameter else tensor_type
+                torch.nn.Parameter
+                if is_parameter
+                else torch.nn.Buffer
+                if is_buffer
+                else tensor_type
             )
 
         options.update(specialized_props)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -389,6 +389,7 @@ class VariableBuilder:
             (
                 (
                     torch.Tensor,
+                    torch.nn.Buffer,
                     torch.nn.Parameter,
                     torch._subclasses.FakeTensor,
                     torch._subclasses.functional_tensor.FunctionalTensor,
@@ -1386,6 +1387,7 @@ class VariableBuilder:
         else:
             assert type(value) in (
                 torch.Tensor,
+                torch.nn.Buffer,
                 torch.nn.Parameter,
                 torch._subclasses.fake_tensor.FakeTensor,
                 torch._subclasses.functional_tensor.FunctionalTensor,
@@ -2523,7 +2525,7 @@ def wrap_to_fake_tensor_and_record(
     e, tx, *, source: Optional[Source], is_tensor: bool, parent_context=None
 ):
     if (
-        type(e) in (torch.Tensor, torch.nn.Parameter, FakeTensor)
+        type(e) in (torch.Tensor, torch.nn.Buffer, torch.nn.Parameter, FakeTensor)
         or isinstance(e, torch.Tensor)
         or is_traceable_wrapper_subclass(e)
     ):

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2315,6 +2315,7 @@ def _check_for_subclass_arg(x: object) -> bool:
         and isinstance(x, Tensor)
         and type(x) is not Tensor
         and type(x) is not torch.nn.Parameter
+        and type(x) is not torch.nn.Buffer
     )
 
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2315,7 +2315,6 @@ def _check_for_subclass_arg(x: object) -> bool:
         and isinstance(x, Tensor)
         and type(x) is not Tensor
         and type(x) is not torch.nn.Parameter
-        and type(x) is not torch.nn.Buffer
     )
 
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -427,6 +427,17 @@ def _rebuild_qtensor(
     return tensor
 
 
+def _rebuild_buffer(data, requires_grad, persistent):
+    buffer = torch.nn.Buffer(data, requires_grad, persistent)
+    return buffer
+
+
+def _rebuild_buffer_with_state(data, requires_grad, persistent, state):
+    buffer = torch.nn.Buffer(data, requires_grad, persistent)
+    buffer = _set_obj_state(buffer, state)
+    return buffer
+
+
 def _rebuild_parameter(data, requires_grad, backward_hooks):
     param = torch.nn.Parameter(data, requires_grad)
     # NB: This line exists only for backwards compatibility; the

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -427,17 +427,6 @@ def _rebuild_qtensor(
     return tensor
 
 
-def _rebuild_buffer(data, requires_grad, persistent):
-    buffer = torch.nn.Buffer(data, requires_grad, persistent)
-    return buffer
-
-
-def _rebuild_buffer_with_state(data, requires_grad, persistent, state):
-    buffer = torch.nn.Buffer(data, requires_grad, persistent)
-    buffer = _set_obj_state(buffer, state)
-    return buffer
-
-
 def _rebuild_parameter(data, requires_grad, backward_hooks):
     param = torch.nn.Parameter(data, requires_grad)
     # NB: This line exists only for backwards compatibility; the

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -504,7 +504,7 @@ def fetch_object_proxy(tracer: _ProxyTracer, t: PySymType) -> Union[_PySymProxyT
 def fetch_object_proxy(tracer: _ProxyTracer, t: Union[Tensor, _AnyScriptObjectType, PySymType]) -> object:
     return get_proxy_slot(t, tracer, t)
 
-HANDLED_TYPES = (Tensor, torch.nn.Parameter, FakeTensor)
+HANDLED_TYPES = (torch.Tensor, torch.nn.Parameter, torch.nn.Buffer, FakeTensor)
 
 
 def _maybe_record_pointwise_barrier(func: object, proxy_mode: ProxyTorchDispatchMode) -> None:

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -504,7 +504,7 @@ def fetch_object_proxy(tracer: _ProxyTracer, t: PySymType) -> Union[_PySymProxyT
 def fetch_object_proxy(tracer: _ProxyTracer, t: Union[Tensor, _AnyScriptObjectType, PySymType]) -> object:
     return get_proxy_slot(t, tracer, t)
 
-HANDLED_TYPES = (torch.Tensor, torch.nn.Parameter, torch.nn.Buffer, FakeTensor)
+HANDLED_TYPES = (Tensor, torch.nn.Parameter, FakeTensor)
 
 
 def _maybe_record_pointwise_barrier(func: object, proxy_mode: ProxyTorchDispatchMode) -> None:

--- a/torch/nn/__init__.py
+++ b/torch/nn/__init__.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 from torch.nn.parameter import (
+    Buffer as Buffer,
     Parameter as Parameter,
     UninitializedBuffer as UninitializedBuffer,
     UninitializedParameter as UninitializedParameter,

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -229,14 +229,14 @@ class Buffer(torch.Tensor, metaclass=_BufferMeta):
     Buffers are :class:`~torch.Tensor` subclasses, that have a
     very special property when used with :class:`Module` s - when they're
     assigned as Module attributes they are automatically added to the list of
-    its buffers, and will appear e.g. in :meth:`~Module.buffers` iterator.
+    its buffers, and will appear e.g. in :meth:`~torch.nn.Module.buffers` iterator.
     Assigning a Tensor doesn't have such effect. One can still assign a Tensor as explicitly by using
-    a the modules `~register_buffer` function.
+    a the modules :meth:`~torch.nn.Module.register_buffer` function.
 
     Args:
         data (Tensor): buffer tensor.
         persistent (bool, optional): whether the buffer is part of the module's
-            :attr:`state_dict`. Default: `True`
+            :attr:`state_dict`. Default: ``True``
     """
 
     def __new__(cls, data=None, persistent=True):

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -244,7 +244,7 @@ class Buffer(torch.Tensor, metaclass=_BufferMeta):
 
         # Path for custom tensors: set a flag on the instance to indicate buffer-ness.
         t = data.detach().requires_grad_(requires_grad)
-        if type(t) is not type(data) and not isinstance(data, Parameter):
+        if type(t) is not type(data) and not isinstance(data, Buffer):
             raise RuntimeError(
                 f"Creating a Buffer from an instance of type {type(data).__name__} "
                 "requires that detach() returns an instance of the same type, but return "

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -210,6 +210,75 @@ class UninitializedParameter(UninitializedTensorMixin, Parameter):
             return result
 
 
+# Metaclass to combine _TensorMeta and the instance check override for Buffer.
+class _BufferMeta(torch._C._TensorMeta):
+    # Make `isinstance(t, Buffer)` return True for custom tensor instances that have the _is_buffer flag.
+    def __instancecheck__(self, instance):
+        return isinstance(instance, torch.Tensor) and getattr(instance, '_is_buffer', False)
+
+
+class Buffer(torch.Tensor, metaclass=_BufferMeta):
+    r"""A kind of Tensor that should not be considered a model
+    parameter. For example, BatchNorm's ``running_mean`` is not a parameter, but is part of the module's state.
+
+    Buffers are :class:`~torch.Tensor` subclasses, that have a
+    very special property when used with :class:`Module` s - when they're
+    assigned as Module attributes they are automatically added to the list of
+    its buffers, and will appear e.g. in :meth:`~Module.buffers` iterator.
+    Assigning a Tensor doesn't have such effect. One can still assign a Tensor as explicitly by using
+    a the modules `~register_buffer` function.
+
+    Args:
+        data (Tensor): buffer tensor.
+        requires_grad (bool, optional): if the buffer requires gradient.
+            Default: `False`
+        persistent (bool, optional): whether the buffer is part of the module's
+            :attr:`state_dict`. Default: `True`
+    """
+    def __new__(cls, data=None, requires_grad=False, persistent=True):
+        if data is None:
+            data = torch.empty(0)
+
+        # Path for custom tensors: set a flag on the instance to indicate buffer-ness.
+        t = data.detach().requires_grad_(requires_grad)
+        if type(t) is not type(data) and not isinstance(data, Parameter):
+            raise RuntimeError(f"Creating a Buffer from an instance of type {type(data).__name__} "
+                               "requires that detach() returns an instance of the same type, but return "
+                               f"type {type(t).__name__} was found instead. To use the type as a "
+                               "Buffer, please correct the detach() semantics defined by "
+                               "its __torch_dispatch__() implementation.")
+        t.persistent = persistent
+        t._is_buffer = True
+        return t
+
+    def __deepcopy__(self, memo):
+        if id(self) in memo:
+            return memo[id(self)]
+        else:
+            result = type(self)(self.data.clone(memory_format=torch.preserve_format), self.requires_grad, self.persistent)
+            memo[id(self)] = result
+            return result
+
+    def __repr__(self):
+        return 'Buffer containing:\n' + super().__repr__()
+
+    def __reduce_ex__(self, proto):
+        state = torch._utils._get_obj_state(self)
+
+        if not state:
+            return (
+                torch._utils._rebuild_buffer,
+                (self.data, self.requires_grad, self.persistent)
+            )
+
+        return (
+            torch._utils._rebuild_buffer_with_state,
+            (self.data, self.requires_grad, self.persistent, state)
+        )
+
+    __torch_function__ = _disabled_torch_function_impl
+
+
 class UninitializedBuffer(UninitializedTensorMixin, torch.Tensor):
     r"""A buffer that is not initialized.
 
@@ -228,7 +297,10 @@ class UninitializedBuffer(UninitializedTensorMixin, torch.Tensor):
 
     cls_to_become = torch.Tensor
 
-    def __new__(cls, requires_grad=False, device=None, dtype=None) -> None:
+    def __new__(cls, requires_grad=False, device=None, dtype=None, persistent=True) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
         data = torch.empty(0, **factory_kwargs)
-        return torch.Tensor._make_subclass(cls, data, requires_grad)
+        ret = torch.Tensor._make_subclass(cls, data, requires_grad)
+        ret.persistent = persistent
+        ret._is_buffer = True
+        return ret

--- a/torch/nn/parameter.pyi
+++ b/torch/nn/parameter.pyi
@@ -19,8 +19,23 @@ class UninitializedParameter(Tensor):
         dtype: dtype | None = None,
     ) -> None: ...
 
+class Buffer(Tensor):
+    persistent: builtins.bool
+    def __init__(
+        self,
+        data: Tensor = ...,
+        requires_grad: builtins.bool = ...,
+        persistent: builtins.bool = ...,
+    ): ...
+
 class UninitializedBuffer(Tensor):
-    def __init__(self, data: Tensor = ..., requires_grad: bool = ...) -> None: ...
+    persistent: builtins.bool
+    def __init__(
+        self,
+        data: Tensor = ...,
+        requires_grad: builtins.bool = ...,
+        persistent: builtins.bool = ...,
+    ): ...
     def materialize(
         self,
         shape: tuple[int, ...],

--- a/torch/nn/parameter.pyi
+++ b/torch/nn/parameter.pyi
@@ -20,21 +20,21 @@ class UninitializedParameter(Tensor):
     ) -> None: ...
 
 class Buffer(Tensor):
-    persistent: builtins.bool
+    persistent: bool
     def __init__(
         self,
         data: Tensor = ...,
-        requires_grad: builtins.bool = ...,
-        persistent: builtins.bool = ...,
+        requires_grad: bool = ...,
+        persistent: bool = ...,
     ): ...
 
 class UninitializedBuffer(Tensor):
-    persistent: builtins.bool
+    persistent: bool
     def __init__(
         self,
         data: Tensor = ...,
-        requires_grad: builtins.bool = ...,
-        persistent: builtins.bool = ...,
+        requires_grad: bool = ...,
+        persistent: bool = ...,
     ): ...
     def materialize(
         self,

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3970,14 +3970,14 @@ def _create_basic_net():
         def __init__(self):
             super().__init__()
             self.layer_dummy_param = nn.Parameter(torch.empty(3, 5))
-            self.register_buffer('layer_dummy_buf', torch.zeros(1, 3, 3, 7))
+            self.layer_dummy_buf = nn.Buffer(torch.zeros(1, 3, 3, 7))
 
     class Net(nn.Module):
         def __init__(self):
             super().__init__()
             self.l1 = Layer()
             self.dummy_param = nn.Parameter(torch.empty(3, 5))
-            self.register_buffer('dummy_buf', torch.zeros(7, 3, 3, 1))
+            self.dummy_buf = nn.Buffer(torch.zeros(7, 3, 3, 1))
 
     l = Layer()
     n = Net()


### PR DESCRIPTION
Add similar semantics for creating a buffer object similar to creating a parameter. This is done by introducing a new Buffer class that can be used for type disambiguation. The underlying functionality of registering a buffer remains the same as the register_buffer method has not been changed. The persistent parameter in the Buffer type is to indicate whether a buffer object should be persistent or not. Other non-test changes have to do with getting the new Buffer type recognized by inductor and dynamo. Remaining changes are test changes to make sure that the Buffer type can be used as a drop in replacement for register_buffer as it just leads to register_buffer being called. The addition of this new functionality still allows for normal tensors to be used as buffers so these changes are intended to be backwards compatible.

Fixes #35735


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @tianyu-l @peterbell10