### PR TITLE
Add missing type uint16, uint32, and uint64 to TensorHash in LTC.

### DIFF
--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -135,6 +135,12 @@ static inline hash_t TensorHash(const at::Tensor& tensor) {
       return DataHash(ctensor.const_data_ptr<c10::complex<float>>(), size);
     case at::ScalarType::ComplexDouble:
       return DataHash(ctensor.const_data_ptr<c10::complex<double>>(), size);
+    case at::ScalarType::UInt16:
+      return DataHash(ctensor.const_data_ptr<uint16_t>(), size);
+    case at::ScalarType::UInt32:
+      return DataHash(ctensor.const_data_ptr<uint32_t>(), size);
+    case at::ScalarType::UInt64:
+      return DataHash(ctensor.const_data_ptr<uint64_t>(), size);
     default:
       TORCH_INTERNAL_ASSERT(
           false, "Unsupported scalar type:", ctensor.scalar_type());

--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -108,6 +108,8 @@ static inline hash_t Hash(const c10::Scalar& value) {
 }
 
 static inline hash_t TensorHash(const at::Tensor& tensor) {
+  TORCH_INTERNAL_ASSERT(
+      false, "Unsupported scalar type:"); // This is to figure out where to add the tests.
   at::Tensor ctensor = tensor.contiguous();
   int64_t size = ctensor.numel() * ctensor.element_size();
   switch (ctensor.scalar_type()) {

--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -108,8 +108,6 @@ static inline hash_t Hash(const c10::Scalar& value) {
 }
 
 static inline hash_t TensorHash(const at::Tensor& tensor) {
-  TORCH_INTERNAL_ASSERT(
-      false, "Unsupported scalar type:"); // This is to figure out where to add the tests.
   at::Tensor ctensor = tensor.contiguous();
   int64_t size = ctensor.numel() * ctensor.element_size();
   switch (ctensor.scalar_type()) {


### PR DESCRIPTION
If I do:

```
xla_device = xm.xla_device()
xla_tensor_0 = torch.tensor(42, dtype=torch.uint32).to(xla_device)
```

I got the error:

```
RuntimeError: false INTERNAL ASSERT FAILED at "/ansible/pytorch/torch/csrc/lazy/core/hash.h":139, please report a bug to PyTorch. Unsupported scalar type:UInt16
```

This PR intends to fix this issue.
The data type can be found in pytorch/c10/core/ScalarType.h.