### PR TITLE
Fix sync on index_select decomposition when the index has one element

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4020,10 +4020,10 @@ def index_select(x: TensorLike, dim: int, index: TensorLike):
     )
     if index.ndim == 0:
         index = index.unsqueeze(0)
-    if x.ndim == 0:
+    if x.numel() == 1:
         # Treat scalars as elements of \R^1
         # We cannot use x[idx] here as it accesses item() (??), hence this awkward construction
-        return torch.empty_like(x).index_copy(0, index, x.expand_as(index))
+        return torch.empty_like(x).index_copy(0, index, x.squeeze().expand_as(index))
 
     idx = (slice(None),) * dim + (index,)
     return x[idx]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #125973

The previous fix was not general enough.

Fixes https://github.com/pytorch/pytorch/pull/125952