### PR TITLE
Remove AnalyzeTemporaryDtors from clang-tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -61,6 +61,5 @@ readability-simplify-subscript-expr,
 readability-string-compare,
 '
 HeaderFilterRegex: '^(aten/|c10/|torch/).*$'
-AnalyzeTemporaryDtors: false
 WarningsAsErrors: '*'
 ...


### PR DESCRIPTION
Remove AnalyzeTemporaryDtors from clang-tidy config which is not used in newer releases.

 