### PR TITLE
Add obc counter for TS migration.

### DIFF
--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -450,7 +450,7 @@ void ScriptModuleSerializer::serialize(
     const ExtraFilesMap& extra_files,
     bool bytecode_format,
     bool save_mobile_debug_info) {
-  C10_LOG_API_USAGE_ONCE("torch.script.save");
+  C10_LOG_API_USAGE_ONCE("torch.jit.save");
   writeExtraFiles(module, extra_files);
   // Serialize the model object
   writeArchive(

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -254,7 +254,7 @@ Module ScriptModuleDeserializer::deserialize(
   // we populate the upgraders map before any load starts
   populate_upgraders_graph_map();
 
-  C10_LOG_API_USAGE_ONCE("torch.script.load");
+  C10_LOG_API_USAGE_ONCE("torch.jit.load");
   device_ = device;
   // Load extra files.
   for (const auto& kv : extra_files) {


### PR DESCRIPTION
Summary: Since table caffe2_pytorch_usage_stats only has 1 day retention which renders it useless for TS migration purposes, we want to build a lightweight counter mechanism to collect usage data about torch jit APIs which can monitor the usage decline in the long term.

Test Plan: CI

Reviewed By: SherlockNoMad

Differential Revision: D57216847


