### PR TITLE
[Bazel] Build shared libraries to reduce total binary size

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -98,6 +98,7 @@ build --per_file_copt='^//.*\.(cpp|cc)$'@-Wno-missing-field-initializers
 
 build --per_file_copt='^//.*\.(cpp|cc)$'@-Wno-unused-function
 build --per_file_copt='^//.*\.(cpp|cc)$'@-Wno-unused-variable
+build --per_file_copt='^//.*\.(cpp|cc)$'@-Wno-sign-compare
 
 build --per_file_copt='//:aten/src/ATen/RegisterCompositeExplicitAutograd\.cpp$'@-Wno-error=unused-function
 build --per_file_copt='//:aten/src/ATen/RegisterCompositeImplicitAutograd\.cpp$'@-Wno-error=unused-function

--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -263,7 +263,7 @@ if [[ "$BUILD_ENVIRONMENT" == *-bazel-* ]]; then
     # Build torch, the Python module, and tests for CPU-only
     tools/bazel build --config=no-tty "${BAZEL_MEM_LIMIT}" "${BAZEL_CPU_LIMIT}" --config=cpu-only :torch :torch/_C.so :all_tests
   else
-    tools/bazel build --config=no-tty "${BAZEL_MEM_LIMIT}" "${BAZEL_CPU_LIMIT}" //...
+    tools/bazel build --config=no-tty "${BAZEL_MEM_LIMIT}" "${BAZEL_CPU_LIMIT}" //:all
   fi
 else
   # check that setup.py would fail with bad arguments

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@pytorch//third_party:substitution.bzl", "header_template_rule", "template_rule")
@@ -33,6 +32,24 @@ COMMON_COPTS = [
     # https://github.com/pytorch/pytorch/pull/55292
     "-DCUB_WRAPPED_NAMESPACE=at_cuda_detail",
 ])
+
+cc_binary(
+    name = "libc10.so",
+    deps = [
+        "//c10",
+    ],
+    linkshared = True,
+)
+
+cc_library(
+    name = "c10",
+    srcs = [
+        ":libc10.so",
+    ],
+    deps = [
+        "//c10:headers",
+    ],
+)
 
 aten_generation_srcs = ["aten/src/ATen/native/native_functions.yaml"] + ["aten/src/ATen/native/tags.yaml"] + glob(["aten/src/ATen/templates/**"])
 
@@ -305,13 +322,14 @@ cc_library(
         ],
     ) + [
         ":aten_src_ATen_config",
+        ":aten_src_ATen_cuda_config",
         ":generated_aten_cpp",
     ],
     includes = [
         "aten/src",
     ],
     deps = [
-        "//c10",
+        "//c10:headers",
     ],
 )
 
@@ -330,7 +348,7 @@ intern_build_aten_ops(
     deps = [
         ":aten_headers",
         "@fbgemm",
-        "@mkl",
+        "@mkl_headers",
         "@sleef",
     ],
 )
@@ -369,6 +387,7 @@ cc_library(
         ":torch_headers",
         "@fbgemm",
         "@ideep",
+        "@fmt",
     ],
     alwayslink = True,
 )
@@ -383,7 +402,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":aten_headers",
-        "//c10",
         "@cuda",
         "@cuda//:cuda_driver",
         "@cuda//:nvrtc",
@@ -403,7 +421,6 @@ cc_binary(
 cc_library(
     name = "aten_cuda_cpp",
     srcs = [":aten_cuda_cpp_srcs"] + generated_cuda_cpp,
-    hdrs = [":aten_src_ATen_cuda_config"],
     copts = ATEN_COPTS,
     visibility = ["//visibility:public"],
     deps = [
@@ -432,7 +449,7 @@ cu_library(
     visibility = ["//visibility:public"],
     deps = [
         ":aten_cuda_cpp",
-        "//c10/util:bit_cast",
+        "//c10:headers",
         "@cuda//:cublas",
         "@cuda//:cufft",
         "@cuda//:cusparse",
@@ -516,7 +533,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":caffe2_core_macros",
-        "//c10",
     ],
 )
 
@@ -637,7 +653,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":caffe2_headers",
-        "//c10",
+        "//c10:headers",
     ],
     alwayslink = True,
 )
@@ -656,7 +672,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":caffe2_headers",
-        "//c10",
+        "//c10:headers",
     ],
     alwayslink = True,
 )
@@ -678,7 +694,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":caffe2_headers",
-        "//c10",
+        "//c10:headers",
     ],
     alwayslink = True,
 )
@@ -713,10 +729,10 @@ cc_library(
     deps = [
         ":aten_headers",
         ":caffe2_headers",
-        "//c10",
-        "@com_github_google_flatbuffers//:flatbuffers",
+        "//c10:headers",
+        "@com_github_google_flatbuffers//:public_headers",
         "@local_config_python//:python_headers",
-        "@onnx",
+        "@onnx//:onnx_headers",
     ],
     alwayslink = True,
 )
@@ -745,8 +761,8 @@ torch_sources = {
     )
 }.keys()
 
-cc_library(
-    name = "torch",
+cc_binary(
+    name = "libtorch.so",
     srcs = if_cuda(glob(
         libtorch_cuda_sources,
         exclude = [
@@ -768,14 +784,38 @@ cc_library(
     deps = [
         ":caffe2",
         ":torch_headers",
-        "@kineto",
         "@cpp-httplib",
+        "@com_github_google_flatbuffers//:flatbuffers",
+        "@kineto",
     ] + if_cuda([
         "@cuda//:nvToolsExt",
         "@cutlass",
         ":torch_cuda",
     ]),
-    alwayslink = True,
+    linkshared = True,
+)
+
+cc_library(
+    name = "torch",
+    srcs = [
+        ":libtorch.so",
+    ],
+    deps = [
+        ":torch_headers",
+        ":c10",
+        "@mkl",
+    ] + if_cuda([
+        "@cuda",
+        "@cuda//:cublas",
+        "@cuda//:curand",
+        "@cuda//:cufft",
+        "@cuda//:cusolver",
+        "@cuda//:cusparse",
+        "@cuda//:nvrtc",
+        "@cuda//:nvToolsExt",
+        "@cudnn",
+    ]),
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -788,6 +828,7 @@ cc_library(
         ":torch",
     ],
 )
+
 
 cc_library(
     name = "libtorch_headers",
@@ -812,30 +853,42 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "torch_python",
+cc_binary(
+    name = "libtorch_python.so",
     srcs = libtorch_python_core_sources
-        + if_cuda(libtorch_python_cuda_sources)
+        + if_cuda(glob(libtorch_python_cuda_sources, exclude = ["torch/csrc/cuda/python_nccl.cpp"]))
         + if_cuda(libtorch_python_distributed_sources)
-        + GENERATED_AUTOGRAD_PYTHON,
-    hdrs = glob([
-        "torch/csrc/generic/*.cpp",
+        + GENERATED_AUTOGRAD_PYTHON
+        + glob([
+            "torch/csrc/generic/*.cpp",
     ]),
     copts = COMMON_COPTS + if_cuda(["-DUSE_CUDA=1"]),
     deps = [
         ":torch",
-        ":shm",
+        "@cpp-httplib",
         "@pybind11",
+        "@kineto",
+        "@fmt",
+    ],
+    linkshared = True,
+)
+
+cc_library(
+    name = "torch_python",
+    srcs = [
+        ":libtorch_python.so",
     ],
 )
 
-pybind_extension(
-    name = "torch/_C",
+cc_binary(
+    name = "torch/_C.so",
     srcs = ["torch/csrc/stub.c"],
     deps = [
         ":torch_python",
-        ":aten_nvrtc",
+        ":shm",
+        "@pybind11",
     ],
+    linkshared = True,
 )
 
 cc_library(
@@ -847,14 +900,13 @@ cc_library(
         "functorch/csrc/dim/*.cpp",
     ]),
     deps = [
-        ":aten_nvrtc",
-        ":torch_python",
+        ":libtorch_headers",
         "@pybind11",
     ],
 )
 
-pybind_extension(
-    name = "functorch/_C",
+cc_binary(
+    name = "functorch/_C.so",
     copts=[
         "-DTORCH_EXTENSION_NAME=_C"
     ],
@@ -863,9 +915,9 @@ pybind_extension(
     ],
     deps = [
         ":functorch",
-        ":torch_python",
-        ":aten_nvrtc",
+        ":torch",
     ],
+    linkshared = True,
 )
 
 cc_binary(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,6 +57,9 @@ load(':bazel/glog.bzl', 'glog_library')
 # TODO: figure out why enabling gflags leads to SIGSEV on the logging init
 glog_library(with_gflags=0)
     """,
+    patches = [
+        "@//third_party:glog.patch",
+    ],
     strip_prefix = "glog-0.4.0",
     urls = [
         "https://github.com/google/glog/archive/v0.4.0.tar.gz",
@@ -65,6 +68,9 @@ glog_library(with_gflags=0)
 
 http_archive(
     name = "com_github_gflags_gflags",
+    patches = [
+        "@//third_party:gflags.patch",
+    ],
     strip_prefix = "gflags-2.2.2",
     urls = [
         "https://github.com/gflags/gflags/archive/v2.2.2.tar.gz",
@@ -164,7 +170,7 @@ new_local_repository(
 
 new_local_repository(
     name = "opentelemetry-cpp",
-    build_file = "//third_party::opentelemetry-cpp.BUILD",
+    build_file = "//third_party:opentelemetry-cpp.BUILD",
     path = "third_party/opentelemetry-cpp",
 )
 
@@ -261,9 +267,14 @@ new_local_repository(
     path = "third_party/cudnn_frontend/",
 )
 
-local_repository(
+new_patched_local_repository(
     name = "com_github_google_flatbuffers",
+    build_file = "@//third_party/flatbuffers:BUILD.bazel",
     path = "third_party/flatbuffers",
+    patch_strip = 1,
+    patches = [
+        "@//third_party:flatbuffers.patch",
+    ],
 )
 
 local_repository(

--- a/c10/BUILD.bazel
+++ b/c10/BUILD.bazel
@@ -28,3 +28,26 @@ config_setting(
     name = "using_glog",
     flag_values = {":use_glog": "true"},
 )
+
+cc_library(
+    name = "headers",
+    hdrs = [
+        "//c10/core:headers",
+        "//c10/cuda:headers",
+        "//c10/mobile:headers",
+        "//c10/util:headers",
+    ],
+    deps = [
+        "//c10/core:alignment",
+        "//c10/cuda:Macros",
+        "//c10/macros",
+        "@cuda//:cuda_headers",
+    ] + select({
+        ":using_gflags": ["@com_github_gflags_gflags//:gflags_headers"],
+        "//conditions:default": [],
+    }) + select({
+        ":using_glog": ["@com_github_glog//:glog_headers"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/c10/test/build.bzl
+++ b/c10/test/build.bzl
@@ -61,7 +61,7 @@ def define_targets(rules):
         name = "util/bit_cast_test",
         srcs = ["util/bit_cast_test.cpp"],
         deps = [
-            "//c10/util:bit_cast",
+            "//c10:headers",
             "@com_google_googletest//:gtest_main",
         ],
     )
@@ -70,7 +70,7 @@ def define_targets(rules):
         name = "util/ssize_test",
         srcs = ["util/ssize_test.cpp"],
         deps = [
-            "//c10/util:ssize",
+            "//c10",
             "@com_google_googletest//:gtest_main",
         ],
     )

--- a/c10/util/build.bzl
+++ b/c10/util/build.bzl
@@ -4,6 +4,7 @@ def define_targets(rules):
         srcs = ["TypeCast.cpp"],
         hdrs = ["TypeCast.h"],
         linkstatic = True,
+        alwayslink = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
@@ -33,7 +34,6 @@ def define_targets(rules):
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
-            ":bit_cast",
             "//c10/macros",
             "@fmt",
         ] + rules.select({
@@ -49,24 +49,11 @@ def define_targets(rules):
     )
 
     rules.cc_library(
-        name = "bit_cast",
-        hdrs = ["bit_cast.h"],
-        visibility = ["//:__subpackages__"],
-    )
-
-    rules.cc_library(
-        name = "ssize",
-        hdrs = ["ssize.h"],
-        linkstatic = True,
-        visibility = ["//:__subpackages__"],
-        deps = [":base"],
-    )
-
-    rules.cc_library(
         name = "typeid",
         srcs = ["typeid.cpp"],
         hdrs = ["typeid.h"],
         linkstatic = True,
+        alwayslink = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
@@ -80,10 +67,6 @@ def define_targets(rules):
         name = "headers",
         srcs = rules.glob(
             ["*.h"],
-            exclude = [
-                "bit_cast.h",
-                "ssize.h",
-            ],
         ),
         visibility = [
             "//:__pkg__",

--- a/third_party/cpp-httplib.BUILD
+++ b/third_party/cpp-httplib.BUILD
@@ -4,7 +4,7 @@ cc_library(
     name = "cpp-httplib",
     hdrs = ["httplib.h"],
     includes = [
-        "/",
+        ".",
     ],
     visibility = ["//visibility:public"],
 )

--- a/third_party/flatbuffers.patch
+++ b/third_party/flatbuffers.patch
@@ -1,0 +1,45 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index de910bc..52f72b8 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -28,16 +28,15 @@ config_setting(
+ # Public flatc library to compile flatbuffer files at runtime.
+ cc_library(
+     name = "flatbuffers",
+-    hdrs = ["//:public_headers"],
+     linkstatic = 1,
+-    strip_include_prefix = "/include",
+     deps = ["//src:flatbuffers"],
+ )
+ 
+ # Public C++ headers for the Flatbuffers library.
+-filegroup(
++cc_library(
+     name = "public_headers",
+-    srcs = [
++    strip_include_prefix = "/include",
++    hdrs = [
+         "include/flatbuffers/allocator.h",
+         "include/flatbuffers/array.h",
+         "include/flatbuffers/base.h",
+diff --git a/src/BUILD.bazel b/src/BUILD.bazel
+index 66c355d..54222cd 100644
+--- a/src/BUILD.bazel
++++ b/src/BUILD.bazel
+@@ -18,7 +18,7 @@ cc_library(
+         "reflection.cpp",
+         "util.cpp",
+     ],
+-    hdrs = ["//:public_headers"],
++    deps = ["//:public_headers"],
+     linkopts = select({
+         # TODO: Bazel uses `clang` instead of `clang++` to link
+         # C++ code on BSD. Temporarily adding these linker flags while
+@@ -28,7 +28,6 @@ cc_library(
+         "//:platform_openbsd": ["-lm"],
+         "//conditions:default": [],
+     }),
+-    strip_include_prefix = "/include",
+     visibility = ["//:__pkg__"],
+ )
+ 

--- a/third_party/gflags.patch
+++ b/third_party/gflags.patch
@@ -1,0 +1,27 @@
+diff --git bazel/gflags.bzl bazel/gflags.bzl
+index 533fd61..616dd4e 100644
+--- bazel/gflags.bzl
++++ bazel/gflags.bzl
+@@ -92,12 +92,20 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
+     else:
+         name += "_nothreads"
+         copts += ["-DNO_THREADS"]
++
++    headers  = name + "_headers"
+     native.cc_library(
+-        name       = name,
++        name       = headers,
+         hdrs       = hdrs,
++        include_prefix = 'gflags',
++        visibility = ["//visibility:public"],
++    )
++
++    native.cc_library(
++        name       = name,
+         srcs       = srcs,
+         copts      = copts,
+         linkopts   = linkopts,
+         visibility = ["//visibility:public"],
+-        include_prefix = 'gflags'
++        deps = [headers],
+     )

--- a/third_party/glog.patch
+++ b/third_party/glog.patch
@@ -1,0 +1,53 @@
+diff --git bazel/glog.bzl bazel/glog.bzl
+index f9b33d4..b95d8da 100644
+--- bazel/glog.bzl
++++ bazel/glog.bzl
+@@ -13,6 +13,22 @@ def glog_library(namespace='google', with_gflags=1, **kwargs):
+     else:
+         gendir = '$(GENDIR)'
+ 
++    native.cc_library(
++        name = 'glog_headers',
++        visibility = [ '//visibility:public' ],
++        hdrs = [
++            ':logging_h',
++            ':raw_logging_h',
++            ':stl_logging_h',
++            ':vlog_is_on_h',
++            'src/glog/log_severity.h',
++        ],
++        strip_include_prefix = 'src',
++        deps = [
++            '@com_github_gflags_gflags//:gflags_headers',
++        ] if with_gflags else [],
++    )
++
+     native.cc_library(
+         name = 'glog',
+         visibility = [ '//visibility:public' ],
+@@ -39,14 +55,6 @@ def glog_library(namespace='google', with_gflags=1, **kwargs):
+             'src/utilities.h',
+             'src/vlog_is_on.cc',
+         ],
+-        hdrs = [
+-            ':logging_h',
+-            ':raw_logging_h',
+-            ':stl_logging_h',
+-            ':vlog_is_on_h',
+-            'src/glog/log_severity.h',
+-        ],
+-        strip_include_prefix = 'src',
+         copts = [
+             # Disable warnings that exists in glog.
+             '-Wno-sign-compare',
+@@ -77,9 +85,7 @@ def glog_library(namespace='google', with_gflags=1, **kwargs):
+             # Use gflags to parse CLI arguments.
+             '-DHAVE_LIB_GFLAGS',
+         ] if with_gflags else []),
+-        deps = [
+-            '@com_github_gflags_gflags//:gflags',
+-        ] if with_gflags else [],
++        deps = [':glog_headers'],
+         **kwargs
+     )
+ 

--- a/third_party/onnx.BUILD
+++ b/third_party/onnx.BUILD
@@ -43,6 +43,34 @@ genrule(
 )
 
 cc_library(
+    name = "onnx_headers",
+    hdrs = glob([
+        "onnx/*.h",
+        "onnx/version_converter/*.h",
+        "onnx/common/*.h",
+        "onnx/defs/**/*.h",
+        "onnx/shape_inference/*.h",
+        "onnx/version_converter/adapters/*.h",
+    ]) + [
+        "onnx/onnx-ml.pb.h",
+        "onnx/onnx-operators-ml.pb.h",
+        "onnx/onnx-data.pb.h",
+    ],
+    includes = [
+        ".",
+        "onnx/",
+    ],
+    defines = [
+        "ONNX_ML=1",
+        "ONNX_NAMESPACE=onnx_torch",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":onnx_proto_lib",
+    ],
+)
+
+cc_library(
     name = "onnx",
     srcs = glob(
         [
@@ -56,29 +84,9 @@ cc_library(
             "onnx/cpp2py_export.cc",
         ],
     ),
-    hdrs = glob([
-        "onnx/*.h",
-        "onnx/version_converter/*.h",
-        "onnx/common/*.h",
-        "onnx/defs/**/*.h",
-        "onnx/shape_inference/*.h",
-        "onnx/version_converter/adapters/*.h",
-    ]) + [
-        "onnx/onnx-ml.pb.h",
-        "onnx/onnx-operators-ml.pb.h",
-        "onnx/onnx-data.pb.h",
-    ],
-    defines = [
-        "ONNX_ML=1",
-        "ONNX_NAMESPACE=onnx_torch",
-    ],
-    includes = [
-        ".",
-        "onnx/",
-    ],
     visibility = ["//visibility:public"],
     deps = [
-        ":onnx_proto_lib",
+        ":onnx_headers",
     ],
 )
 


### PR DESCRIPTION
Using `@pytorch//:pytorch_py` right now is not very practical since libtorch is statically linked into several binaries for python, making the total binary size so big. This PR forces `libc10`, `libtorch`, and `libtorch_python` to be shared libraries, like the CMake build, reducing the total binary size by half. 

