### PR TITLE
allow to use bf16 as fp32 internal precision for mkldnn rnn

### DIFF
--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -1480,6 +1480,7 @@ class TestMkldnn(TestCase):
         return input
 
     @unittest.skipIf(IS_WINDOWS, "Limit support for bf16 path")
+    @bf32_on_and_off()
     def test_lstm(self):
         seed = 2023
         torch.manual_seed(seed)

--- a/torch/testing/_internal/common_mkldnn.py
+++ b/torch/testing/_internal/common_mkldnn.py
@@ -22,28 +22,34 @@ def bf32_is_not_fp32():
 def bf32_off():
     old_matmul_precision = torch.backends.mkldnn.matmul.fp32_precision
     old_conv_precision = torch.backends.mkldnn.conv.fp32_precision
+    old_rnn_precision = torch.backends.mkldnn.rnn.fp32_precision
     try:
         torch.backends.mkldnn.matmul.fp32_precision = "ieee"
         torch.backends.mkldnn.conv.fp32_precision = "ieee"
+        torch.backends.mkldnn.rnn.fp32_precision = "ieee"
         yield
     finally:
         torch.backends.mkldnn.matmul.fp32_precision = old_matmul_precision
         torch.backends.mkldnn.conv.fp32_precision = old_conv_precision
+        torch.backends.mkldnn.rnn.fp32_precision = old_rnn_precision
 
 
 @contextlib.contextmanager
 def bf32_on(self, bf32_precision=1e-5):
     old_matmul_precision = torch.backends.mkldnn.matmul.fp32_precision
     old_conv_precision = torch.backends.mkldnn.conv.fp32_precision
+    old_rnn_precision = torch.backends.mkldnn.rnn.fp32_precision
     old_precision = self.precision
     try:
         torch.backends.mkldnn.matmul.fp32_precision = "bf16"
         torch.backends.mkldnn.conv.fp32_precision = "bf16"
+        torch.backends.mkldnn.rnn.fp32_precision = "bf16"
         self.precision = bf32_precision
         yield
     finally:
         torch.backends.mkldnn.matmul.fp32_precision = old_matmul_precision
         torch.backends.mkldnn.conv.fp32_precision = old_conv_precision
+        torch.backends.mkldnn.rnn.fp32_precision = old_rnn_precision
         self.precision = old_precision
 
 


### PR DESCRIPTION
Allow to use BF16 as the internal computation data types by torch.backends.mkldnn.rnn.fp32_precision="bf16"

#### TestPlan
```
python test/test_mkldnn.py -k lstm
```

#### Benchmarking
On 56 core SPR
**Forward**
Input (input_size, hidden_size, n_layers, bidirectional, bias, batch_first, dropput, BS, seq_len) | fp32 ms | bf16 internal ms | Speed up
-- | -- | -- | --
1, 16, 3, True, True, True, 0.4, 5, 3 | 1.4053| 1.3634| 1.03
1, 128, 3, True, True, True, 0.7, 16, 113 | 11.6396| 13.5223| 0.86
1, 512, 3, True, True, True, 0.1, 32, 87 | 32.4179| 32.8236| 0.99
1, 1024, 3, True, True, True, 0.4, 32, 227 | 207.9305| 207.9305| 1.00

**Backward**

Input (input_size, hidden_size, n_layers, bidirectional, bias, batch_first, dropput, BS, seq_len) | fp32 ms | bf16 internal ms | Speed up
-- | -- | -- | --
1, 16, 3, True, True, True, 0.4, 5, 3 | 1.1918| 1.3828| 0.86
1, 128, 3, True, True, True, 0.7, 16, 113 | 17.9153| 13.5223| 0.99
1, 512, 3, True, True, True, 0.1, 32, 87 | 71.8731| 32.8236| 0.99
1, 1024, 3, True, True, True, 0.4, 32, 227 | 471.3289| 471.3418| 1.00





Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126054
* __->__ #126051
* #126050
* #125888



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal