### PR TITLE
[Inductor][CPP] Enable the LocalBuffer

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -488,8 +488,6 @@ class OuterLoopFusedSchedulerNode(FusedSchedulerNode):
         loop_nest_list: List[LoopNestWithSplit] = [
             kernel.loop_nest for kernel in cpp_kernel_proxy_list
         ]
-        metrics.cpp_outer_loop_fused_inner_counts.append(len(loop_nest_list))
-
         kernel_group = cpp_kernel_proxy_list[0].kernel_group
 
         def _merge_outer_fusion_loop_levels(
@@ -3805,6 +3803,12 @@ class CppScheduling(BaseScheduling):
                 cpp_kernel_proxy_list, node.outer_loop_fusion_depth
             ):
                 return False
+            metrics.cpp_outer_loop_fused_inner_counts.append(
+                metrics.CPPOuterLoopFusedCOUNT(
+                    len(cpp_kernel_proxy_list),
+                    with_local_buffer=True,
+                )
+            )
             outer_fusion_cpp_kernel_proxy = node.merge_outer_fusion_kernels(
                 cpp_kernel_proxy_list,
             )
@@ -3841,6 +3845,12 @@ class CppScheduling(BaseScheduling):
                     cpp_kernel_proxy_list, node.outer_loop_fusion_depth
                 ):
                     # Merge the cpp_kernel_proxy_list into cpp_kernel_proxy
+                    metrics.cpp_outer_loop_fused_inner_counts.append(
+                        metrics.CPPOuterLoopFusedCOUNT(
+                            len(cpp_kernel_proxy_list),
+                            with_local_buffer=False,
+                        )
+                    )
                     outer_fusion_cpp_kernel_proxy = node.merge_outer_fusion_kernels(
                         cpp_kernel_proxy_list,
                     )

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <limits>
 #include <omp.h>
+#include <memory>
 
 // WARNING: be extra careful when including more ATen/c10 header files here!
 // Because AOTInductor generated code will copy-paste this cpp_prefix.h for

--- a/torch/_inductor/metrics.py
+++ b/torch/_inductor/metrics.py
@@ -39,9 +39,16 @@ ir_nodes_pre_fusion = 0
 # counters for tracking to_dtype inserted
 cpp_to_dtype_count = 0
 
+
+class CPPOuterLoopFusedCOUNT:
+    def __init__(self, inner_kernel_number, with_local_buffer):
+        # counts the number of inner kernels in each outer loop fusion
+        self.inner_kernel_number = inner_kernel_number
+        self.with_local_buffer = with_local_buffer
+
+
 # The length counts the number of outer loop fusions.
-# Each element counts the number of inner kernels in each outer loop fusion.
-cpp_outer_loop_fused_inner_counts: List[int] = []
+cpp_outer_loop_fused_inner_counts: List[CPPOuterLoopFusedCOUNT] = []
 
 num_comprehensive_padding = 0
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126056
* __->__ #126055

**Summary**
Currently, the Inductor CPP backend [generated code](https://gist.github.com/leslie-fang-intel/98f91d43dabed581a1ffe23daf133a65#file-bf16-softmax-generated-code-wo-local-buffer-py) for `Softmax` with BF16 data type is significantly slower than the [ATen Implementation](https://github.com/pytorch/pytorch/blob/9a2beb862d9c30f037c9b2eac878ec3f9227a5e2/aten/src/ATen/native/cpu/SoftMaxKernel.cpp#L149). Upon comparing the generated code with ATen, the performance bottleneck appears to be related to the usage of [local buffer in ATen](https://github.com/pytorch/pytorch/blob/9a2beb862d9c30f037c9b2eac878ec3f9227a5e2/aten/src/ATen/native/cpu/SoftMaxKernel.cpp#L159-L160). 

In the current implementation, the Inductor uses the output buffer of Kernel Group Args to store and load temporary result (such as `exp`), since this buffer is corresponding to a `SchedulerNode`. Each thread accesses a portion of this output buffer via indexing. However, since this buffer (take this `exp` as example) is only utilized internally within decomposed `softmax`, this buffer can be replaced with a thread-local buffer similar to ATen's approach.

In this PR, we have introduced the optimizations of `LocalBuffer`. Following this enhancement, the [new generated Inductor code with local buffer](https://gist.github.com/leslie-fang-intel/98f91d43dabed581a1ffe23daf133a65#file-bf16-softmax-generated-code-w-local-buffer-py) for BF16 `Softmax` demonstrates significantly improved performance. Running the benchmark [here](https://gist.github.com/leslie-fang-intel/37d81441237b5139c8295f5e6c4cd31a) to test this BF16 `Softmax` case on an 8480 Xeon server shows similar performance between the Inductor CPP Backend and the ATen implementation.

**Implementation**
* In the codegen of `codegen_outer_loop_node`, we will analyze `codegen_outer_loop_node` to find which scheduler node can be replaced with local buffer. And we save this information into `CPPKernelProxy` and propagate to `CPPKernel`.
* In the codegen phase of `CPPKernel`, we will save/load this `LocalBuffer` instead of original buffer.
* In the codegen Loop phase, we will allocate the `LocalBuffer` with size and data type.


**Test Plan**
```
python -u -m pytest -s -v inductor/test_cpu_repro.py -k test_local_buffer_in_outer_loop_fusion
```

**Next Step**
In next PR, we will remove the output buffer which replaced to local buffer in the Args of Kernel Group and the allocation of this buffer in wrapper code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang