### PR TITLE
[Inductor][CPP] Avoid Allocation of Buffer which replaced with LocalBuffer

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -413,6 +413,19 @@ class BaseSchedulerNode:
             V.graph.wrapper_code.codegen_allocation(self.node)
             return
 
+        if (
+            hasattr(V.kernel, "local_buffer")
+            and V.kernel.local_buffer is not None
+            and hasattr(V.kernel.local_buffer, "original_node_name")
+            and V.kernel.local_buffer.original_node_name == self.node.get_name()
+        ):
+            # Avoid allocation of this buffer since its usage has been
+            # replaced with local buffer. And never resue this buffer,
+            # sinice it's not real allocated.
+            V.graph.never_reuse_buffers.add(self.node.get_name())
+            V.graph.wrapper_code.freed.add(self.node.get_name())
+            return
+
         # hacky check for if V.kernel is a real kernel or NullHandler
         if (
             hasattr(V.kernel, "args")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126056
* #126055

**Summary**
Following previous PR, since an `output buffer` has been replaced with `Local Buffer`, we remove this output buffer in Kernel Args and the allocation of this buffer.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang