### PR TITLE
[Doc] Add deprecated autocast comments for doc

### DIFF
--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -256,7 +256,7 @@ class TestAutocastCPU(TestCase):
     def test_cpu_autocast_deprecated_warning(self):
         with self.assertWarnsRegex(
             DeprecationWarning,
-            "torch.cpu.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead.",
+            "torch.cpu.amp.autocast\(args...\) is deprecated. Please use torch.amp.autocast\('cpu', args...\) instead.",
         ):
             with torch.cpu.amp.autocast():
                 _ = torch.ones(10)

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -253,6 +253,14 @@ class TestAutocastCPU(TestCase):
                 cpu_autocast_output = getattr(torch, op)(*args, **maybe_kwargs)
             self.assertEqual(generic_autocast_output, cpu_autocast_output)
 
+    def test_cpu_autocast_deprecated_warning(self):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            "torch.cpu.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead.",
+        ):
+            with torch.cpu.amp.autocast():
+                _ = torch.ones(10)
+
 
 class CustomLinear(torch.autograd.Function):
     @staticmethod

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -256,7 +256,7 @@ class TestAutocastCPU(TestCase):
     def test_cpu_autocast_deprecated_warning(self):
         with self.assertWarnsRegex(
             DeprecationWarning,
-            "torch.cpu.amp.autocast\(args...\) is deprecated. Please use torch.amp.autocast\('cpu', args...\) instead.",
+            r"torch.cpu.amp.autocast\(args...\) is deprecated. Please use torch.amp.autocast\('cpu', args...\) instead.",
         ):
             with torch.cpu.amp.autocast():
                 _ = torch.ones(10)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1981,7 +1981,7 @@ torch.cuda.synchronize()
     def test_cuda_autocast_deprecated_warning(self):
         with self.assertWarnsRegex(
             DeprecationWarning,
-            "torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cuda', args...) instead.",
+            "torch.cuda.amp.autocast\(args...\) is deprecated. Please use torch.amp.autocast\('cuda', args...\) instead.",
         ):
             with torch.cuda.amp.autocast():
                 _ = torch.ones(10)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1978,6 +1978,14 @@ torch.cuda.synchronize()
         self.assertTrue(output.dtype is torch.float16)
         output.sum().backward()
 
+    def test_cuda_autocast_deprecated_warning(self):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            "torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cuda', args...) instead.",
+        ):
+            with torch.cuda.amp.autocast():
+                _ = torch.ones(10)
+
     @slowTest
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     @serialTest()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1981,7 +1981,7 @@ torch.cuda.synchronize()
     def test_cuda_autocast_deprecated_warning(self):
         with self.assertWarnsRegex(
             DeprecationWarning,
-            "torch.cuda.amp.autocast\(args...\) is deprecated. Please use torch.amp.autocast\('cuda', args...\) instead.",
+            r"torch.cuda.amp.autocast\(args...\) is deprecated. Please use torch.amp.autocast\('cuda', args...\) instead.",
         ):
             with torch.cuda.amp.autocast():
                 _ = torch.ones(10)

--- a/torch/cpu/amp/autocast_mode.py
+++ b/torch/cpu/amp/autocast_mode.py
@@ -24,7 +24,8 @@ class autocast(torch.amp.autocast_mode.autocast):
             self.fast_dtype = dtype
             return
         warnings.warn(
-            "torch.cpu.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead."
+            "torch.cpu.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead.",
+            DeprecationWarning,
         )
         super().__init__(
             "cpu", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled

--- a/torch/cpu/amp/autocast_mode.py
+++ b/torch/cpu/amp/autocast_mode.py
@@ -1,4 +1,5 @@
 from typing import Any
+import warnings
 
 import torch
 
@@ -22,6 +23,7 @@ class autocast(torch.amp.autocast_mode.autocast):
             self.device = "cpu"
             self.fast_dtype = dtype
             return
+        warnings.warn("torch.cpu.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead.")
         super().__init__(
             "cpu", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled
         )

--- a/torch/cpu/amp/autocast_mode.py
+++ b/torch/cpu/amp/autocast_mode.py
@@ -8,7 +8,7 @@ __all__ = ["autocast"]
 class autocast(torch.amp.autocast_mode.autocast):
     r"""
     See :class:`torch.autocast`.
-    ``torch.cpu.amp.autocast(args...)`` is equivalent to ``torch.autocast("cpu", args...)``
+    ``torch.cpu.amp.autocast(args...)`` is deprecated. Please use ``torch.amp.autocast("cpu", args...)`` instead.
     """
 
     def __init__(

--- a/torch/cpu/amp/autocast_mode.py
+++ b/torch/cpu/amp/autocast_mode.py
@@ -1,5 +1,5 @@
-from typing import Any
 import warnings
+from typing import Any
 
 import torch
 
@@ -23,7 +23,9 @@ class autocast(torch.amp.autocast_mode.autocast):
             self.device = "cpu"
             self.fast_dtype = dtype
             return
-        warnings.warn("torch.cpu.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead.")
+        warnings.warn(
+            "torch.cpu.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead."
+        )
         super().__init__(
             "cpu", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled
         )

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -33,7 +33,8 @@ class autocast(torch.amp.autocast_mode.autocast):
             self.fast_dtype = dtype
             return
         warnings.warn(
-            "torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead."
+            "torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead.",
+            DeprecationWarning,
         )
         super().__init__(
             "cuda", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -17,7 +17,7 @@ __all__ = ["autocast", "custom_fwd", "custom_bwd"]
 class autocast(torch.amp.autocast_mode.autocast):
     r"""See :class:`torch.autocast`.
 
-    ``torch.cuda.amp.autocast(args...)`` is equivalent to ``torch.autocast("cuda", args...)``
+    ``torch.cuda.amp.autocast(args...)`` is deprecated. Please use ``torch.amp.autocast("cuda", args...)`` instead.
     """
 
     def __init__(

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -33,7 +33,7 @@ class autocast(torch.amp.autocast_mode.autocast):
             self.fast_dtype = dtype
             return
         warnings.warn(
-            "torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead.",
+            "torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cuda', args...) instead.",
             DeprecationWarning,
         )
         super().__init__(

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -32,7 +32,9 @@ class autocast(torch.amp.autocast_mode.autocast):
             self.device = "cuda"
             self.fast_dtype = dtype
             return
-        warnings.warn("torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead.")
+        warnings.warn(
+            "torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead."
+        )
         super().__init__(
             "cuda", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled
         )

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -1,5 +1,6 @@
 import collections
 import functools
+import warnings
 
 import torch
 
@@ -31,6 +32,7 @@ class autocast(torch.amp.autocast_mode.autocast):
             self.device = "cuda"
             self.fast_dtype = dtype
             return
+        warnings.warn("torch.cuda.amp.autocast(args...) is deprecated. Please use torch.amp.autocast('cpu', args...) instead.")
         super().__init__(
             "cuda", enabled=enabled, dtype=dtype, cache_enabled=cache_enabled
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126062

# Motivation
We generalize a device-agnostic API `torch.amp.autocast` in [#125103](https://github.com/pytorch/pytorch/pull/125103).  After that,
- `torch.cpu.amp.autocast(args...)` is completely equivalent to `torch.amp.autocast('cpu', args...)`, and
- `torch.cuda.amp.autocast(args...)` is completely equivalent to `torch.amp.autocast('cuda', args...)`

no matter in eager mode or JIT mode.
Base on this point, we would like to deprecate `torch.cpu.amp.autocast` and `torch.cuda.amp.autocast` to **strongly recommend** developer to use `torch.amp.autocast` that is a device-agnostic API.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @mcarilli @ptrblck @leslie-fang-intel