### PR TITLE
[caffe2] Make all get_backtrace() implementations lazy (#125750)

### DIFF
--- a/c10/util/Backtrace.h
+++ b/c10/util/Backtrace.h
@@ -2,16 +2,30 @@
 #define C10_UTIL_BACKTRACE_H_
 
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <typeinfo>
 
 #include <c10/macros/Macros.h>
+#include <c10/util/Lazy.h>
 
 namespace c10 {
+
+// Symbolizing the backtrace can be expensive; pass it around as a lazy string
+// so it is symbolized only if actually needed.
+using Backtrace = std::shared_ptr<const LazyValue<std::string>>;
+
+// DEPRECATED: Prefer get_lazy_backtrace().
 C10_API std::string get_backtrace(
     size_t frames_to_skip = 0,
     size_t maximum_number_of_frames = 64,
     bool skip_python_frames = true);
+
+C10_API Backtrace get_lazy_backtrace(
+    size_t frames_to_skip = 0,
+    size_t maximum_number_of_frames = 64,
+    bool skip_python_frames = true);
+
 } // namespace c10
 
 #endif // C10_UTIL_BACKTRACE_H_

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -58,7 +58,7 @@ std::string Error::compute_what(bool include_backtrace) const {
   return oss.str();
 }
 
-const Error::Backtrace& Error::backtrace() const {
+const Backtrace& Error::backtrace() const {
   return backtrace_;
 }
 

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -3,6 +3,7 @@
 
 #include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/Backtrace.h>
 #include <c10/util/Lazy.h>
 #include <c10/util/StringUtil.h>
 
@@ -27,11 +28,6 @@ namespace c10 {
 /// NB: c10::Error is handled specially by the default torch to suppress the
 /// backtrace, see torch/csrc/Exceptions.h
 class C10_API Error : public std::exception {
- public:
-  // Symbolizing the backtrace can be expensive; pass it around as a lazy string
-  // so it is symbolized only if actually needed.
-  using Backtrace = std::shared_ptr<const LazyValue<std::string>>;
-
  private:
   // The actual error message.
   std::string msg_;

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -8,6 +8,7 @@
 #include <sstream>
 
 #include <c10/macros/Macros.h>
+#include <c10/util/Backtrace.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Flags.h>
 #include <c10/util/StringUtil.h>
@@ -126,8 +127,7 @@ constexpr bool IsUsingGoogleLogging() {
  */
 C10_API void ShowLogInfoToStderr();
 
-C10_API void SetStackTraceFetcher(
-    std::function<::c10::Error::Backtrace()> fetcher);
+C10_API void SetStackTraceFetcher(std::function<::c10::Backtrace()> fetcher);
 
 /**
  * Convenience function for non-lazy stack trace fetchers. The Backtrace


### PR DESCRIPTION
Summary:

#125682 (D56586844) added support for lazy symbolization to `Error` and adopted it for internal use cases; this commit adopts it for `get_backtrace()` as well.

Test Plan:
Sandcastle and GH CI.

NOTE: This is a resubmit of D56881683, a spurious copypasted line in the Android implementation broke the build, but this was not surfaced by diff tests.

Reproed the breakage with
```
$ fbpython scripts/build_android_app/build_android_app.py --buck-config-files='@//fbandroid/mode/have_libgflags @//fbandroid/mode/static_linking @//xplat/langtech/mobile/android_opt_buck_config_with_et_boltnn' --build-target='fbsource//xplat/langtech/mobile:transcribe_binAndroid-android-arm64'
```
Verified that the fixed diff builds successfully.

Differential Revision: D57275456


