### PR TITLE
Fixed CUDA randint generation for large ranges.

### DIFF
--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -32,9 +32,9 @@ namespace {
 // launch bounds used for kernels utilizing TensorIterator
 const uint32_t block_size_bound = 256;
 const uint32_t grid_size_bound = 4;
-// number of randoms given by distributions like curand_uniform4, curand_uniform2_double
-// used in calculating philox offset.
-const uint32_t curand4_engine_calls = 4;
+// At the time of writing, there is no curand_* call that increments the offset by more than 4.
+// See: https://docs.nvidia.com/cuda/archive/11.8.0/curand/group__DEVICE.html
+const uint32_t max_generator_offsets_per_curand_call = 4;
 
 // utility function that calculates proper philox_offset
 // for distributions utilizing TensorIterator. For distributions using
@@ -42,14 +42,13 @@ const uint32_t curand4_engine_calls = 4;
 // thread yielding one element per thread. For the edge of the grid-stride
 // loop, if the tensor size is large, the unroll loop will kick in and the float4
 // from curand4 will start getting utilized (for common tensor sizes, we end up
-// using rand.x from each thread). Hence, the philox_offset is
-// (number of elements per thread * number of engine calls), which makes
+// using rand.x from each thread). The philox_offset calculation was changed to
+// (number of elements per thread * maximum generator increment per "curand_*" call), which makes
 // sure that philox offset increment is not less than the number of randoms used
 // in each thread.
-std::tuple<uint64_t, dim3, dim3> calc_execution_policy(int64_t total_elements) {
+std::tuple<uint64_t, dim3, dim3> calc_execution_policy(const int64_t total_elements, const uint32_t unroll_factor) {
   const uint64_t numel = static_cast<uint64_t>(total_elements);
   const uint32_t block_size = block_size_bound;
-  const uint32_t unroll = curand4_engine_calls;
   dim3 dim_block(block_size);
   dim3 grid((numel + block_size - 1) / block_size);
   uint32_t blocks_per_sm = at::cuda::getCurrentDeviceProperties()->maxThreadsPerMultiProcessor / block_size;
@@ -57,8 +56,7 @@ std::tuple<uint64_t, dim3, dim3> calc_execution_policy(int64_t total_elements) {
       static_cast<uint32_t>(at::cuda::getCurrentDeviceProperties()->multiProcessorCount) * blocks_per_sm,
       grid.x);
   //number of times random will be generated per thread, to offset philox counter in thc random state
-  uint64_t counter_offset = ((numel - 1) / (block_size * grid.x * unroll) + 1)
-                                * curand4_engine_calls;
+  uint64_t counter_offset = ((numel - 1) / (block_size * grid.x * unroll_factor) + 1) * max_generator_offsets_per_curand_call;
   return std::make_tuple(counter_offset, grid, dim_block);
 }
 
@@ -110,7 +108,7 @@ __global__ void distribution_elementwise_grid_stride_kernel(int numel,
  */
 template<typename scalar_t,
          typename accscalar_t,
-         int unroll_factor,
+         typename dist_func_return_t,
          typename RNG,
          typename dist_t,
          typename transform_t>
@@ -118,13 +116,14 @@ void distribution_nullary_kernel(at::TensorIteratorBase& iter,
                                  RNG gen,
                                  const dist_t& dist_func,
                                  const transform_t transform_func) {
-  static_assert(unroll_factor >= 1, "unroll_factor must be >= 1.");
+  const int unroll_factor = sizeof(dist_func_return_t) / sizeof(accscalar_t);
+  TORCH_CHECK(unroll_factor >= 1, "unroll_factor must be >= 1.");
   int64_t numel = iter.numel();
   if (numel == 0) {
     return;
   }
 
-  auto execution_policy = calc_execution_policy(numel);
+  auto execution_policy = calc_execution_policy(numel, unroll_factor);
   auto counter_offset = std::get<0>(execution_policy);
   auto grid = std::get<1>(execution_policy);
   auto block = std::get<2>(execution_policy);
@@ -137,7 +136,7 @@ void distribution_nullary_kernel(at::TensorIteratorBase& iter,
 
   if (!iter.can_use_32bit_indexing()) {
     for (auto& sub_iter : iter.with_32bit_indexing()) {
-      distribution_nullary_kernel<scalar_t, accscalar_t, unroll_factor>(sub_iter,
+      distribution_nullary_kernel<scalar_t, accscalar_t, dist_func_return_t>(sub_iter,
         gen, dist_func, transform_func);
     }
     return;
@@ -297,7 +296,7 @@ void random_from_to_kernel(TensorIteratorBase& iter, uint64_t range, int64_t bas
       auto random_func = [range, base] __device__ (uint64_t rand) {
         return transformation::uniform_int_from_to<scalar_t>(rand, range, base);
       };
-      distribution_nullary_kernel<scalar_t, uint64_t, curand4_engine_calls/2>(iter,
+      distribution_nullary_kernel<scalar_t, uint64_t, ulonglong2>(iter,
         gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) -> ulonglong2 {
           ulonglong2 ret;
@@ -311,9 +310,9 @@ void random_from_to_kernel(TensorIteratorBase& iter, uint64_t range, int64_t bas
       auto random_func = [range, base] __device__ (uint32_t rand) {
         return transformation::uniform_int_from_to<scalar_t>(rand, range, base);
       };
-      distribution_nullary_kernel<scalar_t, uint32_t, curand4_engine_calls>(iter,
+      distribution_nullary_kernel<scalar_t, uint32_t, uint4>(iter,
         gen,
-        [] __device__ (curandStatePhilox4_32_10_t* state) {
+        [] __device__ (curandStatePhilox4_32_10_t* state) -> uint4 {
           return curand4(state);
         },
         random_func);
@@ -334,7 +333,7 @@ void random_full_64_bits_range_kernel(TensorIteratorBase& iter, RNG gen) {
       auto random_func = [] __device__ (uint64_t rand) {
         return transformation::uniform_int_full_range<scalar_t>(rand);
       };
-      distribution_nullary_kernel<scalar_t, uint64_t, curand4_engine_calls/2>(iter,
+      distribution_nullary_kernel<scalar_t, uint64_t, ulonglong2>(iter,
         gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) -> ulonglong2 {
           ulonglong2 ret;
@@ -367,7 +366,7 @@ void random_kernel(TensorIteratorBase& iter, RNG gen) {
       auto random_func = [] __device__ (uint64_t rand) {
         return transformation::uniform_int<scalar_t>(rand);
       };
-      distribution_nullary_kernel<scalar_t, uint64_t, curand4_engine_calls/2>(iter, gen,
+      distribution_nullary_kernel<scalar_t, uint64_t, ulonglong2>(iter, gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) -> ulonglong2 {
           ulonglong2 ret;
           uint4 rand_val = curand4(state);
@@ -380,9 +379,9 @@ void random_kernel(TensorIteratorBase& iter, RNG gen) {
       auto random_func = [] __device__ (uint32_t rand) {
         return transformation::uniform_int<scalar_t>(rand);
       };
-      distribution_nullary_kernel<scalar_t, uint32_t, curand4_engine_calls>(iter,
+      distribution_nullary_kernel<scalar_t, uint32_t, uint4>(iter,
         gen,
-        [] __device__ (curandStatePhilox4_32_10_t* state) {
+        [] __device__ (curandStatePhilox4_32_10_t* state) -> uint4 {
           return curand4(state);
         },
         random_func);
@@ -399,32 +398,32 @@ struct RandomKernel {
 
 // ====================================================================================================================
 
-template<typename scalar_t, typename accscalar_t, size_t curand4_engine_calls, typename RNG, typename transform_t>
+template<typename scalar_t, typename accscalar_t, typename RNG, typename transform_t>
 void uniform_and_transform(TensorIteratorBase& iter, RNG gen, transform_t transform) {
   if (std::is_same<scalar_t, double>::value) {
-    distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls/2>(iter,
+    distribution_nullary_kernel<scalar_t, accscalar_t, double2>(iter,
       gen,
-      [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform2_double(state); },
+      [] __device__ (curandStatePhilox4_32_10_t* state) -> double2 { return curand_uniform2_double(state); },
       transform);
   } else {
-    distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls>(iter,
+    distribution_nullary_kernel<scalar_t, accscalar_t, float4>(iter,
       gen,
-      [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform4(state); },
+      [] __device__ (curandStatePhilox4_32_10_t* state) -> float4 { return curand_uniform4(state); },
       transform);
   }
 }
 
-template<typename scalar_t, typename accscalar_t, size_t curand4_engine_calls, typename RNG, typename transform_t>
+template<typename scalar_t, typename accscalar_t, typename RNG, typename transform_t>
 void normal_and_transform(TensorIteratorBase& iter, RNG gen, transform_t transform) {
   if (std::is_same<scalar_t, double>::value) {
-    distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls/2>(iter,
+    distribution_nullary_kernel<scalar_t, accscalar_t, double2>(iter,
       gen,
-      [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_normal2_double(state); },
+      [] __device__ (curandStatePhilox4_32_10_t* state) -> double2 { return curand_normal2_double(state); },
       transform);
   } else {
-    distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls>(iter,
+    distribution_nullary_kernel<scalar_t, accscalar_t, float4>(iter,
       gen,
-      [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_normal4(state); },
+      [] __device__ (curandStatePhilox4_32_10_t* state) -> float4 { return curand_normal4(state); },
       transform);
   }
 }
@@ -442,7 +441,7 @@ void normal_kernel(const TensorBase &self, double mean_, double std_, RNG gen) {
     auto normal_func = [mean, std] __device__ (accscalar_t rand) {
       return static_cast<scalar_t>(transformation::normal<accscalar_t>(rand, mean, std));
     };
-    normal_and_transform<scalar_t, accscalar_t, curand4_engine_calls>(iter, gen, normal_func);
+    normal_and_transform<scalar_t, accscalar_t>(iter, gen, normal_func);
    });
 }
 
@@ -475,7 +474,7 @@ void uniform_kernel(TensorIteratorBase& iter, double from_, double to_, RNG gen)
       auto reverse_bound_value = value == to ? from : value;
       return reverse_bound_value;
     };
-    uniform_and_transform<scalar_t, opmath_t, curand4_engine_calls>(iter, gen, uniform_func);
+    uniform_and_transform<scalar_t, opmath_t>(iter, gen, uniform_func);
    });
 }
 
@@ -498,7 +497,7 @@ void log_normal_kernel(TensorIteratorBase& iter, double mean_, double std_, RNG 
     auto log_normal_func = [mean, std] __device__ (accscalar_t rand) {
       return static_cast<scalar_t>(transformation::log_normal<accscalar_t>(transformation::normal<accscalar_t>(rand, mean, std)));
     };
-    normal_and_transform<scalar_t, accscalar_t, curand4_engine_calls>(iter, gen, log_normal_func);
+    normal_and_transform<scalar_t, accscalar_t>(iter, gen, log_normal_func);
    });
 }
 
@@ -519,7 +518,7 @@ void geometric_kernel(TensorIteratorBase& iter, double p, RNG gen) {
     auto geometric_func = [p] __device__ (accscalar_t rand) {
       return static_cast<scalar_t>(transformation::geometric<accscalar_t>(rand, p));
     };
-    uniform_and_transform<scalar_t, accscalar_t, curand4_engine_calls>(iter, gen, geometric_func);
+    uniform_and_transform<scalar_t, accscalar_t>(iter, gen, geometric_func);
   });
 }
 
@@ -542,7 +541,7 @@ void exponential_kernel(TensorIteratorBase& iter, double lambda_, RNG gen) {
     auto exponential_func = [lambda] __device__ (accscalar_t rand) {
       return static_cast<scalar_t>(transformation::exponential<accscalar_t>(rand, lambda));
     };
-    uniform_and_transform<scalar_t, accscalar_t, curand4_engine_calls>(iter, gen, exponential_func);
+    uniform_and_transform<scalar_t, accscalar_t>(iter, gen, exponential_func);
    });
 }
 
@@ -565,7 +564,7 @@ void cauchy_kernel(TensorIteratorBase& iter, double median_, double sigma_, RNG 
     auto cauchy_func = [median, sigma] __device__ (accscalar_t rand) {
       return static_cast<scalar_t>(transformation::cauchy<accscalar_t>(rand, median, sigma));
     };
-    uniform_and_transform<scalar_t, accscalar_t, curand4_engine_calls>(iter, gen, cauchy_func);
+    uniform_and_transform<scalar_t, accscalar_t>(iter, gen, cauchy_func);
    });
 }
 
@@ -655,7 +654,7 @@ void bernoulli_kernel(TensorIteratorBase& iter, double p, RNG gen) {
       auto bernoulli_func = [p] __device__ (accscalar_t rand) {
         return static_cast<scalar_t>(transformation::bernoulli<accscalar_t>(rand, p));
       };
-      uniform_and_transform<scalar_t, accscalar_t, curand4_engine_calls>(iter, gen, bernoulli_func);
+      uniform_and_transform<scalar_t, accscalar_t>(iter, gen, bernoulli_func);
    });
 }
 

--- a/aten/src/ATen/native/cuda/RreluWithNoise.cu
+++ b/aten/src/ATen/native/cuda/RreluWithNoise.cu
@@ -80,7 +80,8 @@ inline void _rrelu_with_noise_cuda_train(
   Tensor tmp_output = output.contiguous();
 
   int64_t numel = input.numel();
-  auto execution_policy = calc_execution_policy(numel);
+  const int unroll_factor = std::is_same<scalar_t, double>::value ? 2 : 4;
+  auto execution_policy = calc_execution_policy(numel, unroll_factor);
 
   auto counter_offset = std::get<0>(execution_policy);
   auto grid = std::get<1>(execution_policy);

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4451,7 +4451,7 @@ class TestCudaMallocAsync(TestCase):
 
             def alloc():
                 nonlocal total, c
-                b = random.randrange(2 * 1024 * 1024 // 4, 200 * 1024 * 1024 // 4)
+                b = random.randrange(2 * 1024 * 1024 // 4, 20 * 1024 * 1024 // 4)
                 mem.append((c, torch.full((b,), c, dtype=torch.int32, device="cuda")))
                 c += 1
                 total += b
@@ -4465,7 +4465,7 @@ class TestCudaMallocAsync(TestCase):
 
             choices = [alloc, free, torch.cuda.memory.empty_cache]
             for i in range(N):
-                while total >= 1024 * 1024 * 1024 / 4:
+                while total >= 1024 * 1024 * 1024 / (4 * 10):
                     free()
                 (action,) = random.choices(choices, weights=[1, 1 if mem else 0, 0.1])
                 action()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -975,6 +975,52 @@ except RuntimeError as e:
         res_cpu = src.cpu()[idx.cpu()]
         self.assertEqual(res.cpu(), res_cpu)
 
+    def test_randint_randomness_for_large_range(self) -> None:
+        # For large ranges, randint generation is slightly different. This lead to a subtle bug where some Philox
+        # offsets were not calculated correctly, resulting in reused random states.
+        # See https://github.com/pytorch/pytorch/issues/125224
+        size = 1_000_000
+        high = 6_000_000_000  # Keep this above 2**32
+
+        def run(dev: torch.device) -> int:
+            # Measure how many unique numbers are generated in 2 consecutive calls to randint. If random states are
+            # reused, this will yield fewer unique numbers.
+            gen = torch.Generator(device=dev)
+            gen.manual_seed(0)
+            t1 = torch.randint(
+                0, high, [size], device=dev, generator=gen, dtype=torch.int64
+            )
+            t2 = torch.randint(
+                0, high, [size], device=dev, generator=gen, dtype=torch.int64
+            )
+            return torch.stack([t1, t2]).unique().shape[0]
+
+        # Use CPU as reference. The results should not deviate too much.
+        assert abs(run(torch.device("cuda")) - run(torch.device("cpu"))) < 10_000
+
+    @parametrize("dtype", [torch.float32, torch.double])
+    def test_random_no_reused_random_states(self, dtype: torch.dtype) -> None:
+        # Test if random states do not overlap between consecutive rand/randn calls.
+        # See https://github.com/pytorch/pytorch/issues/125224
+
+        def run(func, dev: torch.device, dtype: torch.dtype) -> int:
+            # Measure how many unique numbers are generated in 2 consecutive calls. If random states are
+            # reused, this will yield fewer unique numbers.
+            size = 1000000
+            gen = torch.Generator(device=dev)
+            gen.manual_seed(0)
+            t1 = func((size,), device=dev, generator=gen, dtype=dtype)
+            t2 = func((size,), device=dev, generator=gen, dtype=dtype)
+            return torch.stack([t1, t2]).unique().shape[0]
+
+        # Use CPU as reference. The results should not deviate too much.
+        for func in [torch.rand, torch.randn]:
+            deviation = abs(
+                run(func, torch.device("cuda"), dtype)
+                - run(func, torch.device("cpu"), dtype)
+            )
+            assert deviation < 50_000, deviation
+
     def test_min_max_inits(self):
         # Testing if THC_reduceAll received the correct index initialization.
         # This affects the result of THC_reduceAll operations at extreme values


### PR DESCRIPTION
Fixes #125224

For large ranges, calls to CUDA `randint` use a different `unroll_factor` to generate random ints. This `unroll_factor` was not considered correctly in the calculation of the Philox offsets. Thus, some of the random states were reused, resulting in lower entropy (see #125224).

This also affects multiple other random functions, such as `torch.rand` and `torch.randn`.