### PR TITLE
[torchrec] Replacing ShardedTensor with DTensor for RW sharding

### DIFF
--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -273,7 +273,7 @@ def _save_state_dict(
         planner = DefaultSavePlanner()
     assert planner is not None
 
-    global_metatadata = None
+    global_metadata = None
 
     ckpt_kwargs = {}
     if (ckpt_id := getattr(storage_writer, "checkpoint_id", None)) is not None:
@@ -304,10 +304,10 @@ def _save_state_dict(
 
     @_dcp_method_logger(**ckpt_kwargs)
     def global_step(all_local_plans):
-        nonlocal global_metatadata
+        nonlocal global_metadata
 
         assert planner is not None
-        all_local_plans, global_metatadata = planner.create_global_plan(all_local_plans)
+        all_local_plans, global_metadata = planner.create_global_plan(all_local_plans)
         all_local_plans = storage_writer.prepare_global_plan(all_local_plans)
         return all_local_plans
 
@@ -324,8 +324,8 @@ def _save_state_dict(
 
     @_dcp_method_logger(**ckpt_kwargs)
     def finish_checkpoint(all_results):
-        assert global_metatadata is not None
-        storage_writer.finish(metadata=global_metatadata, results=all_results)
-        return global_metatadata
+        assert global_metadata is not None
+        storage_writer.finish(metadata=global_metadata, results=all_results)
+        return global_metadata
 
     return distW.all_reduce("write", write_data, finish_checkpoint)

--- a/torch/distributed/checkpoint/utils.py
+++ b/torch/distributed/checkpoint/utils.py
@@ -302,7 +302,10 @@ def _find_shard(tensor: ShardedTensor, index: MetadataIndex) -> Shard:
 
 def find_tensor_shard(tensor: torch.Tensor, index: MetadataIndex) -> torch.Tensor:
     if isinstance(tensor, DTensor):
-        return tensor.to_local()
+        local_tensor = tensor.to_local()
+        if hasattr(local_tensor, "_local_shards"):
+            return getattr(local_tensor, "_local_shards")[0]
+        return local_tensor
     if isinstance(tensor, ShardedTensor):
         return _find_shard(tensor, index).tensor
     if index.offset is not None:


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/1991

**This is the first part of migration TorchRec state dict checkpointing from ShardedTensor to DTensor. It sets up the necessary infra to support additional sharding schemes. The general approach is to keep ShardedTensor paths and remove them once all sharding types are supported on DTensor. This includes ShardingPlan and ShardedTensor dataclasses such as ShardedTensorMetadata.**

NOTE: This version of LocalShardsWrapper does not support empty shards, that is added in the next diff enabling CW. D57063512

**This diff includes:**
+ LocalShardsWrapper torch.tensor subclass to be used with DTensor
+ Changes in TorchRec state_dict load and creation to use DTensor for Row Wise path in both EmbeddingCollection and EmbeddingBagCollection
+ Changes to DCP to support LocalShardsWrapper for saving and reading (WriteItems and ReadItems)
+ Added DTensor paths to callsites where ShardedTensors are expected.

**LocalShardsWrapper supports the following torch ops:**
+ torch.ops._c10d_functional.all_gather_into_tensor.default
+ aten._to_copy.default
+ aten.view.default
+ aten.equal.default

With extensibility to add more as required by use cases.

See https://docs.google.com/document/d/16Ptl50mGFJW2cljdF2HQ6FwsiA0scwbAbjx_4dhabJw/edit?usp=drivesdk for more info regarding design and approach.

Test Plan:
TODO: add a MAST job using RW and preempt to test checkpointing

```
buck2 test 'fbcode//mode/opt' fbcode//torchrec/distributed/tests:test_model_parallel_nccl
```
```
buck2 test 'fbcode//mode/opt' fbcode//torchrec/distributed/tests:test_model_parallel_nccl_single_rank -- --exact 'torchrec/distributed/tests:test_model_parallel_nccl_single_rank - torchrec.distributed.tests.test_model_parallel_nccl_single_rank.ModelParallelStateDictTestNccl: test_load_state_dict'
```

Sandcastle

Differential Revision: D54375878


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC