### PR TITLE
[DCP] adds type safety to str filtering in EmptyStateDict

### DIFF
--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -258,7 +258,7 @@ class _EmptyStateDictLoadPlanner(DefaultLoadPlanner):
         for unflattened_key in planner_data:
             if unflattened_keys:
                 unflattened_keys.append(
-                    ".".join([unflattened_keys[-1], unflattened_key])
+                    ".".join([unflattened_keys[-1], str(unflattened_key)])
                 )
 
             else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126082

[DCP] adds type safety to str filtering in EmptyStateDict

Differential Revision: [D57281133](https://our.internmc.facebook.com/intern/diff/D57281133/)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k