### PR TITLE
Fix public binding to actually traverse modules

### DIFF
--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -902,7 +902,9 @@
     "cast",
     "closing",
     "contextmanager",
-    "get_source_lines_and_file"
+    "get_source_lines_and_file",
+    "get_default_mmap_options",
+    "set_default_mmap_options"
   ],
   "torch.sparse": [
     "BFloat16Tensor",
@@ -1714,7 +1716,12 @@
     "env",
     "get_logger",
     "macros",
-    "record"
+    "record",
+    "DefaultLogsSpecs",
+    "LogsSpecs",
+    "Optional",
+    "Set",
+    "Type"
   ],
   "torch.fx.annotate": [
     "Proxy",
@@ -1932,7 +1939,8 @@
     "track_tensor",
     "track_tensor_tree",
     "wrap_key",
-    "wrapper_and_args_for_make_fx"
+    "wrapper_and_args_for_make_fx",
+    "TorchFunctionMetadataMode"
   ],
   "torch.fx.experimental.rewriter": [
     "Any",
@@ -2013,7 +2021,13 @@
     "parallel_and",
     "parallel_or",
     "safe_expand",
-    "uninteresting_files"
+    "uninteresting_files",
+    "CallMethodKey",
+    "DivideByKey",
+    "PropagateUnbackedSymInts",
+    "ShapeEnvSettings",
+    "log_lru_cache_stats",
+    "lru_cache"
   ],
   "torch.fx.experimental.unification.match": [
     "first",
@@ -2603,5 +2617,135 @@
   ],
   "torch.version": [
     "get_file_path"
+  ],
+  "torch.ao.nn.intrinsic.modules": [
+    "_FusedModule"
+  ],
+  "torch.distributed.benchmarks.benchmark_ddp_rpc": [
+    "BackendType",
+    "DDP",
+    "DistributedOptimizer",
+    "RRef",
+    "TensorPipeRpcBackendOptions"
+  ],
+  "torch.distributed.pipelining": [
+    "ArgsChunkSpec",
+    "KwargsChunkSpec",
+    "Pipe",
+    "PipelineStage",
+    "SplitPoint",
+    "annotate_split_points",
+    "pipe_split",
+    "pipeline"
+  ],
+  "torch.distributed.pipelining.PipelineSchedule": [
+    "ABC",
+    "Any",
+    "Callable",
+    "Dict",
+    "List",
+    "Optional",
+    "Pipe",
+    "PipelineStageBase",
+    "Tuple",
+    "Union",
+    "abstractmethod",
+    "defaultdict",
+    "merge_chunks",
+    "record_function",
+    "split_args_kwargs_into_chunks"
+  ],
+  "torch.distributed.pipelining.microbatch": [
+    "Any",
+    "Dict",
+    "List",
+    "Optional",
+    "Tuple",
+    "tree_flatten",
+    "tree_unflatten"
+  ],
+  "torch.export": [
+    "Constraint",
+    "ShapesCollection"
+  ],
+  "torch.export.dynamic_shapes": [
+    "Constraint",
+    "ShapesCollection"
+  ],
+  "torch.export.graph_signature": [
+    "TokenArgument"
+  ],
+  "torch.fx.experimental.shape_inference.infer_shape": [
+    "DimDynamic",
+    "FakeTensorMode",
+    "LocalSource",
+    "ShapeEnv",
+    "defaultdict",
+    "infer_symbol_values",
+    "make_fx"
+  ],
+  "torch.fx.experimental.shape_inference.infer_symbol_values": [
+    "Any",
+    "DefaultDict",
+    "Dict",
+    "List",
+    "Tuple",
+    "Union"
+  ],
+  "torch.fx.passes.runtime_assert": [
+    "Any",
+    "Dict",
+    "GraphModule",
+    "Optional",
+    "Set",
+    "ShapeEnv",
+    "SymNode",
+    "compatibility",
+    "lazy_format_graph_code"
+  ],
+  "torch.library": [
+    "opcheck",
+    "register_autograd",
+    "register_kernel"
+  ],
+  "torch.mtia": [
+    "DeferredMtiaCallError",
+    "StreamContext"
+  ],
+  "torch.onnx.symbolic_helper": [
+    "Any",
+    "Callable",
+    "List",
+    "Literal",
+    "NoReturn",
+    "Number",
+    "Optional",
+    "Sequence",
+    "Set",
+    "Tuple",
+    "Union"
+  ],
+  "torch.onnx.symbolic_opset18": [
+    "amax",
+    "amin",
+    "aminmax",
+    "embedding_bag",
+    "linalg_vector_norm",
+    "max",
+    "maximum",
+    "min",
+    "minimum"
+  ],
+  "torch.onnx.symbolic_opset20": [
+    "_affine_grid_generator",
+    "_grid_sampler",
+    "convert_grid_sample_mode"
+  ],
+  "torch.utils.data.datapipes.dataframe.dataframe_wrapper": [
+    "Any",
+    "Optional"
+  ],
+  "torch.utils.hipify.hipify_python": [
+    "TrieNode"
   ]
 }

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -46,6 +46,9 @@
     "scatter",
     "gather"
   ],
+  "torch.csrc.jit.tensorexpr.scripts.bisect": [
+    "bisect"
+  ],
   "torch.cuda.nccl": [
     "init_rank",
     "is_available",

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -281,7 +281,7 @@ class TestPublicBindings(TestCase):
 
     def test_modules_can_be_imported(self):
         failures = []
-        for _, modname, _ in _discover_path_importables(str(torch.__path__), "torch"):
+        for _, modname, _ in _find_all_importables(torch):
             try:
                 # TODO: fix "torch/utils/model_dump/__main__.py"
                 # which calls sys.exit() when we try to import it
@@ -536,7 +536,7 @@ class TestPublicBindings(TestCase):
                     if not elem.startswith('_'):
                         check_one_element(elem, modname, mod, is_public=True, is_all=False)
 
-        for _, modname, _ in _discover_path_importables(str(torch.__path__), "torch"):
+        for _, modname, _ in _find_all_importables(torch):
             test_module(modname)
 
         test_module('torch')

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -281,7 +281,7 @@ class TestPublicBindings(TestCase):
 
     def test_modules_can_be_imported(self):
         failures = []
-        for _, modname, _ in _find_all_importables(torch):
+        for modname in _find_all_importables(torch):
             try:
                 # TODO: fix "torch/utils/model_dump/__main__.py"
                 # which calls sys.exit() when we try to import it
@@ -536,7 +536,7 @@ class TestPublicBindings(TestCase):
                     if not elem.startswith('_'):
                         check_one_element(elem, modname, mod, is_public=True, is_all=False)
 
-        for _, modname, _ in _find_all_importables(torch):
+        for modname in _find_all_importables(torch):
             test_module(modname)
 
         test_module('torch')
@@ -546,6 +546,7 @@ class TestPublicBindings(TestCase):
         msg += "Make sure that everything that is public is expected (in particular that the module " \
             "has a properly populated `__all__` attribute) and that everything that is supposed to be public " \
             "does look public (it does not start with `_` and has a `__module__` that is properly populated)."
+
         msg += "\n\nFull list:\n"
         msg += "\n".join(map(str, failure_list))
 

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -446,6 +446,7 @@ class TestPublicBindings(TestCase):
 
     # AttributeError: module 'torch.distributed' has no attribute '_shard'
     @unittest.skipIf(IS_WINDOWS or IS_JETSON, "Distributed Attribute Error")
+    @skipIfTorchDynamo("Broken and not relevant for now")
     def test_correct_module_names(self):
         '''
         An API is considered public, if  its  `__module__` starts with `torch.`

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -279,7 +279,7 @@ class TestPublicBindings(TestCase):
         return True
 
 
-    @unittest.skipIf(IS_WINDOWS, "Inductor modules hard fail on windows")
+    @unittest.skipIf(IS_WINDOWS or IS_MACOS, "Inductor/Distributed modules hard fail on windows and macos")
     @skipIfTorchDynamo("Broken and not relevant for now")
     def test_modules_can_be_imported(self):
         failures = []

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -1,6 +1,6 @@
 # Owner(s): ["module: autograd"]
 
-from torch.testing._internal.common_utils import TestCase, run_tests, IS_JETSON, IS_WINDOWS, skipIfTorchDynamo
+from torch.testing._internal.common_utils import TestCase, run_tests, IS_JETSON, IS_WINDOWS, IS_MACOS, skipIfTorchDynamo
 from torch._utils_internal import get_file_path_2
 
 import pkgutil
@@ -279,6 +279,7 @@ class TestPublicBindings(TestCase):
         return True
 
 
+    @unittest.skipIf(IS_WINDOWS, "Inductor modules hard fail on windows")
     @skipIfTorchDynamo("Broken and not relevant for now")
     def test_modules_can_be_imported(self):
         failures = []
@@ -445,7 +446,7 @@ class TestPublicBindings(TestCase):
         self.assertEqual("", "\n".join(errors))
 
     # AttributeError: module 'torch.distributed' has no attribute '_shard'
-    @unittest.skipIf(IS_WINDOWS or IS_JETSON, "Distributed Attribute Error")
+    @unittest.skipIf(IS_WINDOWS or IS_JETSON or IS_MACOS, "Distributed Attribute Error")
     @skipIfTorchDynamo("Broken and not relevant for now")
     def test_correct_module_names(self):
         '''

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -298,6 +298,7 @@ class TestPublicBindings(TestCase):
             "torch._inductor.codegen.cuda.cuda_kernel",
             "torch.onnx._internal.fx._pass",
             "torch.onnx._internal.fx.analysis",
+            "torch.onnx._internal.fx.analysis.unsupported_nodes",
             "torch.onnx._internal.fx.decomposition_skip",
             "torch.onnx._internal.fx.diagnostics",
             "torch.onnx._internal.fx.fx_onnx_interpreter",
@@ -305,6 +306,13 @@ class TestPublicBindings(TestCase):
             "torch.onnx._internal.fx.onnxfunction_dispatcher",
             "torch.onnx._internal.fx.op_validation",
             "torch.onnx._internal.fx.passes",
+            "torch.onnx._internal.fx.passes._utils",
+            "torch.onnx._internal.fx.passes.decomp",
+            "torch.onnx._internal.fx.passes.functionalization",
+            "torch.onnx._internal.fx.passes.modularization",
+            "torch.onnx._internal.fx.passes.readability",
+            "torch.onnx._internal.fx.passes.type_promotion",
+            "torch.onnx._internal.fx.passes.virtualization",
             "torch.onnx._internal.fx.type_utils",
             "torch.testing._internal.common_distributed",
             "torch.testing._internal.common_fsdp",
@@ -371,6 +379,12 @@ class TestPublicBindings(TestCase):
             "torch.distributed.examples.memory_tracker_example",
             "torch.testing._internal.distributed.rpc.fb.thrift_rpc_agent_test_fixture",
             "torch.utils._cxx_pytree",
+            "torch.utils.tensorboard._convert_np",
+            "torch.utils.tensorboard._embedding",
+            "torch.utils.tensorboard._onnx_graph",
+            "torch.utils.tensorboard._proto_graph",
+            "torch.utils.tensorboard._pytorch_graph",
+            "torch.utils.tensorboard._utils",
         }
 
         # No new entries should be added to this list.
@@ -408,6 +422,12 @@ class TestPublicBindings(TestCase):
             "torch.distributed.tensor.parallel",
             "torch.distributed.utils",
             "torch.utils.tensorboard",
+            "torch.utils.tensorboard.summary",
+            "torch.utils.tensorboard.writer",
+            "torch.ao.quantization.experimental.fake_quantize",
+            "torch.ao.quantization.experimental.linear",
+            "torch.ao.quantization.experimental.observer",
+            "torch.ao.quantization.experimental.qconfig",
         }
 
         errors = []

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -1,6 +1,6 @@
 # Owner(s): ["module: autograd"]
 
-from torch.testing._internal.common_utils import TestCase, run_tests, IS_JETSON, IS_WINDOWS
+from torch.testing._internal.common_utils import TestCase, run_tests, IS_JETSON, IS_WINDOWS, skipIfTorchDynamo
 from torch._utils_internal import get_file_path_2
 
 import pkgutil
@@ -279,6 +279,7 @@ class TestPublicBindings(TestCase):
         return True
 
 
+    @skipIfTorchDynamo("Broken and not relevant for now")
     def test_modules_can_be_imported(self):
         failures = []
         for modname in _find_all_importables(torch):

--- a/torch/ao/quantization/pt2e/export_utils.py
+++ b/torch/ao/quantization/pt2e/export_utils.py
@@ -8,7 +8,6 @@ from torch.ao.quantization.utils import _assert_and_get_unique_device
 
 __all__ = [
     "model_is_exported",
-    "_WrapperModule",
 ]
 
 

--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -21,7 +21,6 @@ from torch.ao.quantization.quantizer import QuantizationAnnotation
 
 __all__ = [
     "fold_bn_weights_into_conv_node",
-    "_get_aten_graph_module_for_pattern",
     "remove_tensor_overload_for_qdq_ops",
 ]
 

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -31,7 +31,24 @@ from .graph import _engine_run_backward
 
 from .variable import Variable
 
-__all__ = ["Variable", "Function", "backward", "grad_mode"]
+__all__ = [
+    "Variable",
+    "Function",
+    "backward",
+    "grad_mode",
+    "NestedIOFunction",
+    "detect_anomaly",
+    "enable_grad",
+    "grad",
+    "gradcheck",
+    "gradgradcheck",
+    "inference_mode",
+    "no_grad",
+    "set_detect_anomaly",
+    "set_grad_enabled",
+    "set_multithreading_enabled",
+    "variable",
+]
 
 _OptionalTensor = Optional[torch.Tensor]
 _ShapeorNestedShape = Union[_size, Sequence[_size], torch.Tensor]

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -398,7 +398,7 @@ def sdp_kernel(
         ),
         FutureWarning,
     )
-    from torch.nn.attention import sdpa_kernel, SDPBackend
+    from torch.nn.attention import sdpa_kernel
 
     backend_list = []
     if enable_flash:

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -15,7 +15,6 @@ __all__ = [
     "preferred_blas_library",
     "cufft_plan_cache",
     "matmul",
-    "SDPBackend",
     "SDPAParams",
     "enable_cudnn_sdp",
     "cudnn_sdp_enabled",

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -134,7 +134,7 @@ from os.path import expanduser
 from typing import Dict, List
 
 from torch.distributed.elastic.multiprocessing import (
-    DefaultLogsSpecs,
+    DefaultLogsSpecs as _DefaultLogsSpecs,
     start_processes,
     Std,
 )
@@ -682,7 +682,7 @@ won't take effect even if it is set explicitly."
             entrypoint=entrypoint,
             args=launch_args,
             envs=launch_envs,
-            logs_specs=DefaultLogsSpecs(log_dir=args.log_path, tee=launch_tee),
+            logs_specs=_DefaultLogsSpecs(log_dir=args.log_path, tee=launch_tee),
         )
         ctx.wait()
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1336,7 +1336,6 @@ __all__ = [
     "DeferredCudaCallError",
     "Event",
     "ExternalStream",
-    "OutOfMemoryError",
     "Stream",
     "StreamContext",
     "amp",

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -1,5 +1,4 @@
 import torch
-from torch.amp.grad_scaler import OptState
 
 __all__ = ["GradScaler"]
 

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -1,7 +1,7 @@
 import torch
 from torch.amp.grad_scaler import OptState
 
-__all__ = ["GradScaler", "OptState"]
+__all__ = ["GradScaler"]
 
 
 class GradScaler(torch.amp.GradScaler):

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -1,5 +1,5 @@
 import gc
-from typing import Optional
+import typing
 
 import torch
 from torch.utils import _pytree
@@ -142,7 +142,7 @@ class graph:
         https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85
     """  # noqa: B950
 
-    default_capture_stream: Optional["torch.cuda.Stream"] = None
+    default_capture_stream: typing.Optional["torch.cuda.Stream"] = None
 
     def __init__(
         self,

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -56,7 +56,7 @@ from torch.distributed.checkpoint.storage import (
 from torch.distributed.checkpoint.utils import _create_file_view
 from torch.futures import Future
 
-__all__ = ["FileSystemWriter", "FileSystemReader"]
+__all__ = ["FileSystemWriter", "FileSystemReader", "FileSystem", "FileSystemBase"]
 
 
 @dataclass

--- a/torch/distributed/checkpoint/metadata.py
+++ b/torch/distributed/checkpoint/metadata.py
@@ -13,6 +13,7 @@ __all__ = [
     "Metadata",
     "MetadataIndex",
     "TensorProperties",
+    "StorageMeta",
 ]
 
 

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -51,6 +51,28 @@ from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils._pytree import tree_map_only
 
+__all__ = [
+    "FLAT_PARAM",
+    "PG",
+    "PG_PREFIX",
+    "STATE",
+    "STATE_PREFIX",
+    "PARAMS",
+    "FQNS_T",
+    "PrimitiveType",
+    "ValueType",
+    "DictValueType",
+    "ListDictValueType",
+    "OptimizerStateType",
+    "gc_context",
+    "StateDictOptions",
+    "get_model_state_dict",
+    "get_optimizer_state_dict",
+    "get_state_dict",
+    "set_model_state_dict",
+    "set_optimizer_state_dict",
+    "set_state_dict",
+]
 
 FLAT_PARAM = "_flat_param"
 PG = "param_groups"

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -66,7 +66,7 @@ __all__ = [
     'ProcessGroup', 'ReduceOp', 'ReduceOptions', 'ReduceScatterOptions',
     'ScatterOptions', 'Store', 'DebugLevel', 'get_debug_level', 'Work',
     'default_pg_timeout', 'get_group_rank', 'get_global_rank', 'get_process_group_ranks',
-    'reduce_op', 'all_gather_into_tensor', 'reduce_scatter_tensor',
+    'reduce_op', 'all_gather_into_tensor', 'reduce_scatter_tensor', 'get_node_local_rank',
 ]
 
 _MPI_AVAILABLE = True

--- a/torch/distributed/elastic/agent/server/health_check_server.py
+++ b/torch/distributed/elastic/agent/server/health_check_server.py
@@ -14,6 +14,7 @@ log = get_logger(__name__)
 
 __all__ = ["HealthCheckServer", "create_healthcheck_server"]
 
+
 class HealthCheckServer:
     """
     Interface for health check monitoring server, which can be extended

--- a/torch/distributed/elastic/agent/server/health_check_server.py
+++ b/torch/distributed/elastic/agent/server/health_check_server.py
@@ -12,6 +12,7 @@ from torch.distributed.elastic.utils.logging import get_logger
 
 log = get_logger(__name__)
 
+__all__ = ["HealthCheckServer", "create_healthcheck_server"]
 
 class HealthCheckServer:
     """

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -50,6 +50,8 @@ __all__ = [
     "get_std_cm",
     "MultiprocessContext",
     "SubprocessContext",
+    "LogsDest",
+    "LogsSpecs",
 ]
 
 class SignalException(Exception):

--- a/torch/distributed/elastic/timer/debug_info_logging.py
+++ b/torch/distributed/elastic/timer/debug_info_logging.py
@@ -14,6 +14,7 @@ logger = get_logger(__name__)
 
 __all__ = ["log_debug_info_for_expired_timers"]
 
+
 def log_debug_info_for_expired_timers(
     run_id: str,
     expired_timers: Dict[int, List[str]],

--- a/torch/distributed/elastic/timer/debug_info_logging.py
+++ b/torch/distributed/elastic/timer/debug_info_logging.py
@@ -12,6 +12,7 @@ from torch.distributed.elastic.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+__all__ = ["log_debug_info_for_expired_timers"]
 
 def log_debug_info_for_expired_timers(
     run_id: str,

--- a/torch/distributed/elastic/utils/distributed.py
+++ b/torch/distributed/elastic/utils/distributed.py
@@ -15,6 +15,7 @@ import torch.distributed as dist
 from torch.distributed.elastic.utils.logging import get_logger
 from torch.distributed.elastic.utils.store import barrier
 
+__all__ = ["create_c10d_store", "get_free_port", "get_socket_with_port"]
 
 logger = get_logger(__name__)
 

--- a/torch/distributed/elastic/utils/store.py
+++ b/torch/distributed/elastic/utils/store.py
@@ -13,6 +13,8 @@ from contextlib import contextmanager
 _NUM_MEMBERS = "/num_members"
 _LAST_MEMBER_CHECKIN = "/last_member"
 
+__all__ = ["store_timeout", "get_all", "synchronize", "barrier"]
+
 @contextmanager
 def store_timeout(store, timeout: float):
     """

--- a/torch/distributed/optim/__init__.py
+++ b/torch/distributed/optim/__init__.py
@@ -35,3 +35,5 @@ if hasattr(torch._C, "_rpc_init"):
 
 from .post_localSGD_optimizer import PostLocalSGDOptimizer
 from .zero_redundancy_optimizer import ZeroRedundancyOptimizer
+
+__all__= ["as_functional_optim", "DistributedOptimizer", "PostLocalSGDOptimizer", "ZeroRedundancyOptimizer"]

--- a/torch/distributed/optim/__init__.py
+++ b/torch/distributed/optim/__init__.py
@@ -36,4 +36,4 @@ if hasattr(torch._C, "_rpc_init"):
 from .post_localSGD_optimizer import PostLocalSGDOptimizer
 from .zero_redundancy_optimizer import ZeroRedundancyOptimizer
 
-__all__= ["as_functional_optim", "DistributedOptimizer", "PostLocalSGDOptimizer", "ZeroRedundancyOptimizer"]
+__all__ = ["as_functional_optim", "DistributedOptimizer", "PostLocalSGDOptimizer", "ZeroRedundancyOptimizer"]

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -18,6 +18,7 @@ from .constants import default_pg_timeout
 
 _rendezvous_handlers: Dict[str, Callable[..., Iterator[Tuple[Store, int, int]]]] = {}
 
+__all__ = ["register_rendezvous_handler", "rendezvous"]
 
 def register_rendezvous_handler(scheme, handler):
     """

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -10,6 +10,7 @@ from torch.nn.modules.module import (
 )
 from torch.utils._pytree import tree_flatten
 
+__all__ = ["ModuleTracker"]
 
 class ModuleTracker:
     """

--- a/torch/utils/module_tracker.py
+++ b/torch/utils/module_tracker.py
@@ -12,6 +12,7 @@ from torch.utils._pytree import tree_flatten
 
 __all__ = ["ModuleTracker"]
 
+
 class ModuleTracker:
     """
     ``ModuleTracker`` is a context manager that tracks the nn.Module hierarchy during execution


### PR DESCRIPTION
The current call passes in `['/actual/path']` to os.walk which is a string pointing to no path and thus silently leads to and empty traversal.
There is an unused function just above that handles that, so I guess this is what was supposed to be called.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @ezyang @gchanan @LucasLLC