### PR TITLE
[inductor] make mm template work with non-contiguous input

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -622,6 +622,20 @@ class TestMaxAutotune(TestCase):
     def test_empty_conv_input_with_1x1_kernel(self):
         self.test_empty_conv_input(kernel_size=1)
 
+    def test_non_contiguous_input(self):
+        """
+        Make sure the triton template can work with non-contiguous inputs without crash.
+        Check https://github.com/pytorch/pytorch/issues/125437 for more details.
+        """
+        x = torch.empty_strided((50257, 32768), ((1, 50304)), dtype=torch.bfloat16, device='cuda')
+        y = torch.empty_strided((32768, 768), (768, 1), dtype=torch.bfloat16, device='cuda')
+
+        @torch.compile(mode="max-autotune")
+        def f(x, y):
+            return x @ y
+
+        f(x, y)
+
 
 class TestBenchmarkRequest(BenchmarkRequest):
     def __init__(

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -622,19 +622,81 @@ class TestMaxAutotune(TestCase):
     def test_empty_conv_input_with_1x1_kernel(self):
         self.test_empty_conv_input(kernel_size=1)
 
-    def test_non_contiguous_input(self):
+    def test_non_contiguous_input_mm(self):
         """
         Make sure the triton template can work with non-contiguous inputs without crash.
         Check https://github.com/pytorch/pytorch/issues/125437 for more details.
         """
-        x = torch.empty_strided((50257, 32768), ((1, 50304)), dtype=torch.bfloat16, device='cuda')
-        y = torch.empty_strided((32768, 768), (768, 1), dtype=torch.bfloat16, device='cuda')
+        x = torch.empty_strided(
+            (50257, 32768), (1, 50304), dtype=torch.bfloat16, device="cuda"
+        )
+        y = torch.empty_strided(
+            (32768, 768), (768, 1), dtype=torch.bfloat16, device="cuda"
+        )
 
         @torch.compile(mode="max-autotune")
         def f(x, y):
             return x @ y
 
-        f(x, y)
+        ref = x @ y
+        act = f(x, y)
+        self.assertTrue(torch.allclose(ref, act, atol=4 * 1e-3, rtol=4 * 1e-3))
+
+    def test_non_contiguous_input_addmm(self):
+        b = torch.empty((768), dtype=torch.bfloat16, device="cuda")
+        x = torch.empty_strided(
+            (50257, 32768), (1, 50304), dtype=torch.bfloat16, device="cuda"
+        )
+        y = torch.empty_strided(
+            (32768, 768), (768, 1), dtype=torch.bfloat16, device="cuda"
+        )
+
+        @torch.compile(mode="max-autotune")
+        def f(x, y):
+            return torch.addmm(b, x, y)
+
+        ref = torch.addmm(b, x, y)
+        act = f(x, y)
+        self.assertTrue(torch.allclose(ref, act, atol=4 * 1e-3, rtol=4 * 1e-3))
+
+    def test_non_contiguous_input_bmm(self):
+        x = torch.empty_strided(
+            (1, 50257, 32768), (0, 1, 50304), dtype=torch.bfloat16, device="cuda"
+        )
+        y = torch.empty_strided(
+            (1, 32768, 768), (0, 768, 1), dtype=torch.bfloat16, device="cuda"
+        )
+
+        @torch.compile(mode="max-autotune")
+        def f(x, y):
+            return torch.bmm(x, y)
+
+        ref = torch.bmm(x, y)
+        act = f(x, y)
+        self.assertTrue(torch.allclose(ref, act, atol=4 * 1e-3, rtol=4 * 1e-3))
+
+    def test_non_contiguous_input_mm_plus_mm(self):
+        x1 = torch.empty_strided(
+            (50257, 32768), (1, 50304), dtype=torch.bfloat16, device="cuda"
+        )
+        y1 = torch.empty_strided(
+            (32768, 768), (768, 1), dtype=torch.bfloat16, device="cuda"
+        )
+
+        x2 = torch.empty_strided(
+            (50257, 32768), (1, 50304), dtype=torch.bfloat16, device="cuda"
+        )
+        y2 = torch.empty_strided(
+            (32768, 768), (768, 1), dtype=torch.bfloat16, device="cuda"
+        )
+
+        @torch.compile(mode="max-autotune")
+        def f(x1, y1, x2, y2):
+            return x1 @ y1 + x2 @ y2
+
+        ref = x1 @ y1 + x2 @ y2
+        act = f(x1, y1, x2, y2)
+        self.assertTrue(torch.allclose(ref, act, atol=4 * 1e-3, rtol=4 * 1e-3))
 
 
 class TestBenchmarkRequest(BenchmarkRequest):

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -59,8 +59,15 @@ bmm_template = TritonTemplate(
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
-    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    if (stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1):
+        ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    else:
+        ram = rm % M
+    if (stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1):
+        rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    else:
+        rbn = rn % N
+
     rk = tl.arange(0, BLOCK_K)
 
     idx_q = tl.program_id(1)  # batch dimension for BMM

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -65,8 +65,14 @@ mm_template = TritonTemplate(
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
-    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    if (stride_am == 1 and stride_ak == M) or (stride_am == K and stride_ak == 1):
+        ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    else:
+        ram = rm % M
+    if (stride_bk == 1 and stride_bn == K) or (stride_bk == N and stride_bn == 1):
+        rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    else:
+        rbn = rn % N
     rk = tl.arange(0, BLOCK_K)
     A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
     B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)

--- a/torch/_inductor/kernel/mm_plus_mm.py
+++ b/torch/_inductor/kernel/mm_plus_mm.py
@@ -55,16 +55,14 @@ mm_plus_mm_template = TritonTemplate(
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
 
-    if (
-        (stride_am == 1 and stride_ak == M) or (stride_am == K1 and stride_ak == 1))
-        and ((stride_cm == 1 and stride_ck == M) or (stride_cm == K1 and stride_ck == 1)):
+    if (((stride_am == 1 and stride_ak == M) or (stride_am == K1 and stride_ak == 1))
+        and ((stride_cm == 1 and stride_ck == M) or (stride_cm == K1 and stride_ck == 1))):
         ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
     else:
         ram = rm % M
 
-    if (
-        (stride_bk == 1 and stride_bn == K1) or (stride_bk == N and stride_bn == 1))
-        and ((stride_dk == 1 and stride_dn == K1) or (stride_dk == N and stride_dn == 1)):
+    if (((stride_bk == 1 and stride_bn == K1) or (stride_bk == N and stride_bn == 1))
+        and ((stride_dk == 1 and stride_dn == K1) or (stride_dk == N and stride_dn == 1))):
         rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
     else:
         rbn = rn % N

--- a/torch/_inductor/kernel/mm_plus_mm.py
+++ b/torch/_inductor/kernel/mm_plus_mm.py
@@ -54,8 +54,21 @@ mm_plus_mm_template = TritonTemplate(
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
-    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+
+    if (
+        (stride_am == 1 and stride_ak == M) or (stride_am == K1 and stride_ak == 1))
+        and ((stride_cm == 1 and stride_ck == M) or (stride_cm == K1 and stride_ck == 1)):
+        ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    else:
+        ram = rm % M
+
+    if (
+        (stride_bk == 1 and stride_bn == K1) or (stride_bk == N and stride_bn == 1))
+        and ((stride_dk == 1 and stride_dn == K1) or (stride_dk == N and stride_dn == 1)):
+        rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    else:
+        rbn = rn % N
+
     rk = tl.arange(0, BLOCK_K)
     A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
     B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126106

Fix https://github.com/pytorch/pytorch/issues/125437 .

Triton matmul template does not work well with non-contiguous inputs and cause mis-aligned memory access. It happens both for inductor matmul template and triton.ops.matmul op. This PR avoid adding `tl.multiple_of` and `tl.max_contiguous` if the input tensors are not contiguous. This work around the issue. We'll follow up and try to figure out  the root cause in the GH issue.


The if/else added to the template should be resolved at compile time and they by themselves does not cause any perf hit.


Test:
```
TORCHINDUCTOR_MAX_AUTOTUNE=1 python benchmarks/dynamo/huggingface.py --backend inductor --amp --accuracy --only BertForMaskedLM --training
```
Previously fail with misaligned memory access and now pass

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang