### PR TITLE
[AOTI] Fix a problem in https://github.com/pytorch/pytorch/pull/125730

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1158,7 +1158,9 @@ class CppWrapperCpu(WrapperCodeGen):
                 # so just avoid wrapping integers.
                 # Name matching is to find tensor is hacky, but fixing all the
                 # ArrayRefTensor issues is not a priority for now.
-                if isinstance(piece, str) and piece.startswith(("buf", "arg")):
+                if isinstance(piece, str) and piece.startswith(
+                    ("buf", "arg", "wrap_with_raii_handle_if_needed")
+                ):
                     piece = f"convert_arrayref_tensor_to_tensor({piece})"
                 wrapped_args.append(piece)
 


### PR DESCRIPTION
Summary: `generate_c_shim_extern_kernel_call` needs to handle tensor args wrapped with wrap_with_raii_handle_if_needed, to fix some internal test failures

Differential Revision: D57293873


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang