### PR TITLE
Update context manager for cudnn

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -491,6 +491,18 @@ bool check_runtime_enabled_cudnn(sdp_params const& params, bool debug) {
   return true;
 }
 
+bool check_runtime_disabled_cudnn(sdp_params const& params, bool debug) {
+  // We check the global context to see if user has explicitly turned of cudnn
+  // sdp kernels
+  if (!at::globalContext().userEnabledCuDNNSDP()) {
+    if (debug) {
+      TORCH_WARN("CuDNN attention has been runtime disabled.");
+    }
+    return false;
+  }
+  return true;
+}
+
 bool check_cudnn_requires_grad(sdp_params const& params, bool debug) {
   // Check that the input is causal
   if (input_requires_grad(params)) {
@@ -511,6 +523,7 @@ bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
   constexpr auto general_constraints =
       array_of<bool (*)(sdp_params const&, bool)>(
           check_runtime_enabled_cudnn,
+          check_runtime_disabled_cudnn,
           check_cudnn_hardware_support,
           check_all_tensors_on_device,
           check_cudnn_tensor_shapes,


### PR DESCRIPTION
# Summay
Updates the context manager to support cudnn backend

This results were done using cuda toolkit 12-3 and cudnn 9.0.0. 
 
## H100 Numbers
 _power limited_ 
 ``` Markdown
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|   Batch Size |   Sequence Length |   Heads |   Head Dim |   Flash Time (µs) |   CUDNN Time (µs) |   Speedup (CUDNN/Flash) |
+==============+===================+=========+============+===================+===================+=========================+
|            1 |              4096 |      32 |         64 |           665.053 |           498.59  |                 1.33387 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |              4096 |      16 |        128 |           591.225 |           323.828 |                 1.82574 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |              8192 |      32 |         64 |          2579.77  |          1933.34  |                 1.33436 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |              8192 |      16 |        128 |          2297.4   |          1211.33  |                 1.89659 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |             16384 |      32 |         64 |         10178.2   |          7619.18  |                 1.33587 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |             16384 |      16 |        128 |          9093.51  |          4725.03  |                 1.92454 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |             32768 |      32 |         64 |         39893.1   |         29850.6   |                 1.33643 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |             32768 |      16 |        128 |         36160.9   |         18615.9   |                 1.94247 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |             65536 |      32 |         64 |        157965     |        116794     |                 1.35251 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |             65536 |      16 |        128 |        142039     |         73102.1   |                 1.94303 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |            131072 |      32 |         64 |        621100     |        465143     |                 1.33529 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
|            1 |            131072 |      16 |        128 |        556142     |        289776     |                 1.91922 |
+--------------+-------------------+---------+------------+-------------------+-------------------+-------------------------+
```

## A100 Numbers
```Markdown
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|   Batch Size |   Sequence Length |   Heads |   Head Dim |   Flash Time (µs) |   CUDNN Time (µs) |   Flex Time (µs) |   Speedup (CUDNN/Flash) |   Speedup (Flex/Flash) |
+==============+===================+=========+============+===================+===================+==================+=========================+========================+
|            1 |              4096 |      32 |         64 |           799.391 |           836.327 |          981.234 |                0.955836 |               0.814679 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |              4096 |      16 |        128 |           750.131 |           806.964 |          944.766 |                0.929572 |               0.793986 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |              8192 |      32 |         64 |          3211.84  |          3234.41  |         3803.09  |                0.993022 |               0.844534 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |              8192 |      16 |        128 |          2984.2   |          3164.66  |         3626.79  |                0.942979 |               0.822821 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |             16384 |      32 |         64 |         12630.6   |         12673.1   |        14900.6   |                0.996643 |               0.847653 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |             16384 |      16 |        128 |         11722.7   |         12499.4   |        13763.5   |                0.937862 |               0.851725 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |             32768 |      32 |         64 |         50068.3   |         51061.2   |        60094     |                0.980556 |               0.833167 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |             32768 |      16 |        128 |         46283.6   |         49708.7   |        55336.7   |                0.931096 |               0.836399 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |             65536 |      32 |         64 |        203124     |        203083     |       239618     |                1.0002   |               0.847701 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |             65536 |      16 |        128 |        187326     |        198364     |       221912     |                0.944355 |               0.844145 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |            131072 |      32 |         64 |        816813     |        827419     |       978836     |                0.987182 |               0.834473 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
|            1 |            131072 |      16 |        128 |        749693     |        845463     |       905696     |                0.886725 |               0.827754 |
+--------------+-------------------+---------+------------+-------------------+-------------------+------------------+-------------------------+------------------------+
```


## Script
``` Python
import os
import torch
from typing import Callable
from torch.nn.attention import SDPBackend, sdpa_kernel
from itertools import product
from tqdm import tqdm
from tabulate import tabulate

os.environ["TORCH_CUDNN_SDPA_ENABLED"] = "1"

causal = False

from triton.testing import do_bench
from torch.nn.functional import scaled_dot_product_attention as sdpa


def benchmark_torch_function_in_microseconds(func: Callable, *args, **kwargs) -> float:
    # warmup
    for _ in range(5):
        func(*args, **kwargs)
    return do_bench(lambda: func(*args, **kwargs)) * 1e3


def run_attention_test(backend_name, backend_enum):
    results = []
    batch_sizes = [1]
    seq_lengths = [4096, 8192, 16384, 32768, 65536, 131072]

    torch.cuda.empty_cache()
    for b, s in tqdm(product(batch_sizes, seq_lengths), total=len(batch_sizes) * len(seq_lengths), desc=backend_name):
        for h, d in zip((32, 16), (64, 128)):
            q, k, v = torch.randn(
                b, s, h * d * 3, dtype=torch.bfloat16, device="cuda", requires_grad=False
            ).chunk(3, dim=-1)
            q = q.view(b, -1, h, d).transpose(1, 2)
            k = k.view(b, -1, h, d).transpose(1, 2)
            v = v.view(b, -1, h, d).transpose(1, 2)
            with torch.no_grad(), sdpa_kernel(backend_enum):
                time = benchmark_torch_function_in_microseconds(sdpa, q, k, v, is_causal=False)
            results.append((backend_name, b, s, h, d, time))
    return results


flash_results = run_attention_test("Flash Attention", SDPBackend.FLASH_ATTENTION)
cudnn_results = run_attention_test("CUDNN Attention", SDPBackend.CUDNN_ATTENTION)

# Combine results for comparison
combined_results = []
for flash, cudnn in zip(flash_results, cudnn_results):
    speedup = flash[5] / cudnn[5]
    combined_results.append(
        (flash[1], flash[2], flash[3], flash[4], flash[5], cudnn[5], speedup)
    )

# Tabulate the results
headers = [
    "Batch Size",
    "Sequence Length",
    "Heads",
    "Head Dim",
    "Flash Time (s)",
    "CUDNN Time (s)",
    "Speedup (CUDNN/Flash)",
]
table = tabulate(combined_results, headers, tablefmt="grid")
print(table)

```