### PR TITLE
[PT2][COFFEE] pad mm + contigous layout change passes

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -56,6 +56,8 @@ pre_grad_pass_names = [
 
 post_grad_pass_names = [
     "decompose_mm_pass",
+    "make_mmt_contiguous_pass",
+    "pad_mm_pass",
 ]
 
 for pass_name in pre_grad_pass_names:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1698,3 +1698,20 @@ def run_and_get_cpp_code(fn, *args, **kwargs):
         output_code_log.setLevel(prev_level)
         output_code_log.removeHandler(ch)
     return result, s
+
+
+def print_mm_pattern(match, inputs: List[torch.fx.Node], pass_name: str = ""):
+    node = match.nodes[-1]
+    log.debug(
+        "mm pattern node %s of pass %s with input shape: %s",
+        node.target,
+        pass_name,
+        ", ".join(
+            str(input.meta["val"].shape) if "val" in input.meta else "None"
+            for input in inputs
+        ),
+    )
+
+
+def is_aten_node_meta_valid(node: torch.fx.Node):
+    return "val" in node.meta


### PR DESCRIPTION
Summary:
context: https://docs.google.com/document/d/16i-vpuu4VsrKVsOZDq_VpLTfwoB4Ld8A3QHooWLsTTc/edit

1. Add two more passes, i.e., pad_mm + contigous layout enablement. We use build-in pad function, which shows faster in my experiments compared to pad_dim

2. Revive the large-k decompose with a separete pass to enable future use for other models in case we observe gains

Test Plan:
# local reproduce
checkout commit id: e9901bd610dd
set config as follows:
```
	
        torch._inductor.config.post_grad_fusion_options = {
            "make_mmt_contiguous_pass": {},
            "pad_mm_pass": {},
            "decompose_mm_pass": {},
        }
```
```
buck2 run mode/opt //scripts/weichenmeta/coffee:lce_perf
```
https://pxl.cl/4S0gf
P1361918604
see config setting and detailed results in D57312038

Differential Revision: D57197480




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang