### PR TITLE
[Reopen] Upgrade submodule oneDNN to v3.4.2

### DIFF
--- a/.ci/docker/common/install_acl.sh
+++ b/.ci/docker/common/install_acl.sh
@@ -1,6 +1,6 @@
 set -euo pipefail
 
-readonly version=v23.08
+readonly version=v24.04
 readonly src_host=https://review.mlplatform.org/ml
 readonly src_repo=ComputeLibrary
 

--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -63,9 +63,9 @@ template_rule(
     out = "include/oneapi/dnnl/dnnl_version.h",
     substitutions = {
         "@DNNL_VERSION_MAJOR@": "3",
-        "@DNNL_VERSION_MINOR@": "3",
-        "@DNNL_VERSION_PATCH@": "6",
-        "@DNNL_VERSION_HASH@": "86e6af5974177e513fd3fee58425e1063e7f1361",
+        "@DNNL_VERSION_MINOR@": "4",
+        "@DNNL_VERSION_PATCH@": "2",
+        "@DNNL_VERSION_HASH@": "1137e04ec0b5251ca2b4400a4fd3c667ce843d67",
     },
 )
 


### PR DESCRIPTION
Reopen of https://github.com/pytorch/pytorch/pull/122472

## Improvements
This upgrade fixes the following issues:
- https://github.com/pytorch/pytorch/issues/120982

This upgrade brings the following new features:
- Introduced memory descriptor serialization API. This API is needed to support freezing on CPU in AOTInductor (https://github.com/pytorch/pytorch/issues/114450)

## Validation results on CPU
Original results with oneDNN v3.4.1 are here: https://github.com/pytorch/pytorch/pull/122472#issue-2201602846

Need to rerun validation and update results.
**Results of reruns**

1. Torchbench cpu userbenchmark inference & training

Perf_Geomean | Ratio   (oneDNN v3.4.2/baseline)
-- | --
eager_throughtput_bf16_infer | 1.00x
eager_throughtput_fp32_infer | 1.00x
jit_llga_throughtput_amp_bf16 | 0.99x
jit_llga_throughtput_fp32 | 1.00x
eager_throughtput_fx_int8 | 1.01x
eager_throughtput_bf16_train | 0.99x
eager_throughtput_fp32_train | 0.99x

2. Dynamo benchmarks

Precision | Shape | Wrapper | Thread | Eager Ratio old/new GEOMEAN | Inductor Ratio old/new GEOMEAN
-- | -- | -- | -- | -- | --
Float32 | Static | Default | Multiple | 1.010737 | 1.019399
Float32 | Static | Default | Single | 1.002681 | 1.001732
Float32 | Dynamic | Default | Multiple | 1.006492 | 1.007722
Float32 | Dynamic | Default | Single | 1.003639 | 1.002965
AMP | Static | Default | Multiple | 1.001126 | 1.005045
AMP | Static | Default | Single | 0.995729 | 0.994613
AMP | Dynamic | Default | Multiple | 0.995276 | 0.998698
AMP | Dynamic | Default | Single | 0.997459 | 0.993833

All tests geomean ratio is good, but detected 1 model AMP training performance drop with oneDNN v3.4.2 as below. The issue has been reported to oneDNN team.

model_name | oneDNN   v3.4.2 | baseline | throughput   ratio(new/old)
-- | -- | -- | --
pytorch_stargan-train_throughput | 69.759 | 85.378 | 0.8171

Dynamo benchmarks

Precision | Shape | Wrapper | Thread | Ratio   old/new GEOMEAN | Ratio   old/new GEOMEAN
-- | -- | -- | -- | -- | --
  |   |   |   | Eager | Inductor
Float32 | Static | Default | Multiple | 1.010736824 | 1.019399
  |   |   | Single | 1.002680965 | 1.001732
Float32 | Dynamic | Default | Multiple | 1.006492275 | 1.007722
  |   |   | Single | 1.003638601 | 1.002965
AMP | Static | Default | Multiple | 1.001125822 | 1.005045
  |   |   | Single | 0.99572873 | 0.994613
AMP | Dynamic | Default | Multiple | 0.995275854 | 0.998698
  |   |   | Single | 0.99745925 | 0.993833

Inductor benchmarks

Dtype | Throughput   ratio new/old Geomean
-- | --
all | 99.60%
fp32 | 99.84%
bf16 | 99.55%
int8 | 99.08%
fp16 | 99.86%

---

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @snadampal