### PR TITLE
Move compute unbacked bindings call to track_tensor_tree

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -26,13 +26,13 @@ from unittest.mock import patch
 
 import numpy as np
 import torch
-from torch import Tensor
 import torch._dynamo.testing
 
 import torch._inductor.test_case
 import torch.onnx.operators
 
 import torch.utils._pytree as pytree
+from torch import Tensor
 from torch._C import FileCheck
 from torch._dynamo import allow_in_graph, bytecode_analysis, bytecode_transformation
 from torch._dynamo.eval_frame import _debug_get_cache_entry_list
@@ -8519,9 +8519,11 @@ def ___make_guard_fn():
         capture_scalar_outputs=True, capture_dynamic_output_shape_ops=True
     )
     def test_unbacked_auto_functionalize_op(self):
-        @torch.library.custom_op("mylib::mk_image", mutates_args=("decoder",), device_types=["cpu"])
+        @torch.library.custom_op(
+            "mylib::mk_image", mutates_args=("decoder",), device_types=["cpu"]
+        )
         def mk_image(decoder: Tensor) -> Tensor:
-            return torch.randn(2,3,4,5)
+            return torch.randn(2, 3, 4, 5)
 
         @torch.library.register_fake("mylib::mk_image")
         def _(decoder: Tensor) -> Tensor:

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -214,6 +214,8 @@ def track_tensor(tensor, proxy, *, constant, tracer):
     set_proxy_slot(tensor, tracer, _ProxyTensor(proxy, constant))
 
 def track_tensor_tree(inner_res, proxy_res, *, constant, tracer):
+    _set_unbacked_bindings(inner_res, proxy_res)
+
     def wrap_with_proxy(e, proxy, constant):
         if isinstance(e, torch.Tensor):
             track_tensor(e, proxy, tracer=tracer, constant=constant)
@@ -520,21 +522,6 @@ def proxy_call(proxy_mode, func, pre_dispatch, args, kwargs):
             constant = func(*const_args, **const_kwargs)
     else:
         constant = None
-
-    from .symbolic_shapes import compute_unbacked_bindings
-    # Can't use detect_fake_mode here,
-    #
-    # python test/distributed/_tensor/test_dtensor_compile.py -k
-    # test_tp_compile_fullgraph_is_seq_parallel_False
-    #
-    # will fail.  Very strange, it probably isn't right for them to be using
-    # two fake modes there...
-    fake_mode = torch._C._get_dispatch_mode(
-        torch._C._TorchDispatchModeKey.FAKE
-    )
-    if fake_mode and fake_mode.shape_env:
-        if symbol_to_path := compute_unbacked_bindings(fake_mode.shape_env, out):
-            proxy_out.node.meta["unbacked_bindings"] = symbol_to_path
 
     track_tensor_tree(out, proxy_out, constant=constant, tracer=tracer)
     return out
@@ -1310,3 +1297,22 @@ def get_isolated_graphmodule(func, args, kwargs, tracing_mode="real"):
     with disable_proxy_modes_tracing():
         gm = make_fx(wrapped, tracing_mode=tracing_mode)(all_args)
     return gm
+
+
+def _set_unbacked_bindings(out, out_proxy):
+    """A helper function for setting up unbacked_bindings on the destination FX graph."""
+    from .symbolic_shapes import compute_unbacked_bindings
+
+    # Can't use detect_fake_mode here,
+    #
+    # python test/distributed/_tensor/test_dtensor_compile.py -k
+    # test_tp_compile_fullgraph_is_seq_parallel_False
+    #
+    # will fail.  Very strange, it probably isn't right for them to be using
+    # two fake modes there...
+    fake_mode = torch._C._get_dispatch_mode(
+        torch._C._TorchDispatchModeKey.FAKE
+    )
+    if fake_mode and fake_mode.shape_env:
+        if symbol_to_path := compute_unbacked_bindings(fake_mode.shape_env, out):
+            out_proxy.node.meta["unbacked_bindings"] = symbol_to_path


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126168

This ensures we hit it in all the HOP proxy tensor implementations

Fixes https://github.com/pytorch/pytorch/issues/125869

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang