### PR TITLE
Remove branch from ReferenceAnalysis mod implementation

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8332,6 +8332,18 @@ def ___make_guard_fn():
         self.assertEqual(counter.frame_count, 1)
         self.assertEqual(counter.op_count, 3)
 
+    @torch._dynamo.config.patch(
+        capture_scalar_outputs=True, capture_dynamic_output_shape_ops=True
+    )
+    def test_unbacked_modulus(self):
+        @torch.compile(fullgraph=True)
+        def f(x, w):
+            y = x.item()
+            torch._check(y % 4 == 0)
+            return x * w
+
+        f(torch.tensor(20), torch.randn(3))
+
     def test_tracing_nested_py_tree(self):
         import torch.utils._pytree as pytree
 

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -71,8 +71,7 @@ class ReferenceAnalysis:
     @staticmethod
     def mod(x, y):
         ret = abs(x) % abs(y)
-        if x < 0:
-            ret *= -1
+        ret *= x // abs(x)
         return ret
 
     @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126170

This is still slightly wrong for floats, but it covers the most common
case.  A proper fix involves refactoring all of the modulus machinery to
distinguish between Python modulus and C modulus, and a way of
preferentially converting things into C modulus as much as possible.

Bandaids over https://github.com/pytorch/pytorch/issues/125376

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang