### PR TITLE
Add some type annotations to python stream and event classes

### DIFF
--- a/torch/_streambase.py
+++ b/torch/_streambase.py
@@ -5,27 +5,27 @@ class _StreamBase(ABC):
     r"""Base stream class abstraction for multi backends Stream to herit from"""
 
     @abstractmethod
-    def wait_event(self, event):
+    def wait_event(self, event) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def wait_stream(self, stream):
+    def wait_stream(self, stream) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def record_event(self, event=None):
+    def record_event(self, event=None) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def query(self):
+    def query(self) -> bool:
         raise NotImplementedError
 
     @abstractmethod
-    def synchronize(self):
+    def synchronize(self) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def __eq__(self, stream):
+    def __eq__(self, stream) -> bool:
         raise NotImplementedError
 
 
@@ -33,13 +33,13 @@ class _EventBase(ABC):
     r"""Base Event class abstraction for multi backends Event to herit from"""
 
     @abstractmethod
-    def wait(self, stream=None):
+    def wait(self, stream=None) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def query(self):
+    def query(self) -> bool:
         raise NotImplementedError
 
     @abstractmethod
-    def synchronize(self):
+    def synchronize(self) -> None:
         raise NotImplementedError

--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -11,6 +11,7 @@ import torch
 from .. import device as _device
 from . import amp
 
+
 __all__ = [
     "is_available",
     "synchronize",
@@ -49,7 +50,6 @@ def synchronize(device: _device_t = None) -> None:
 
     N.B. This function only exists to facilitate device-agnostic code.
     """
-    pass
 
 
 class Stream:
@@ -57,7 +57,7 @@ class Stream:
     N.B. This class only exists to facilitate device-agnostic code
     """
 
-    def __init__(self, priority: int = -1):
+    def __init__(self, priority: int = -1) -> None:
         pass
 
     def wait_stream(self, stream) -> None:
@@ -68,13 +68,13 @@ class Event:
     def query(self) -> bool:
         return True
 
-    def record(self, stream=None):
+    def record(self, stream=None) -> None:
         pass
 
-    def synchronize(self):
+    def synchronize(self) -> None:
         pass
 
-    def wait(self, stream=None):
+    def wait(self, stream=None) -> None:
         pass
 
 
@@ -100,6 +100,7 @@ class StreamContext(AbstractContextManager):
     N.B. This class only exists to facilitate device-agnostic code
 
     """
+
     cur_stream: Optional[Stream]
 
     def __init__(self, stream):
@@ -115,7 +116,7 @@ class StreamContext(AbstractContextManager):
         self.prev_stream = _current_stream
         _current_stream = cur_stream
 
-    def __exit__(self, type: Any, value: Any, traceback: Any):
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
         cur_stream = self.stream
         if cur_stream is None:
             return
@@ -146,7 +147,6 @@ def set_device(device: _device_t) -> None:
 
     N.B. This function only exists to facilitate device-agnostic code
     """
-    pass
 
 
 def current_device() -> str:

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -36,7 +36,7 @@ class Stream(torch._C._CudaStreamBase, _StreamBase):
             with torch.cuda.device(device):
                 return super().__new__(cls, priority=priority, **kwargs)
 
-    def wait_event(self, event):
+    def wait_event(self, event) -> None:
         r"""Make all future work submitted to the stream wait for an event.
 
         Args:
@@ -53,7 +53,7 @@ class Stream(torch._C._CudaStreamBase, _StreamBase):
         """
         event.wait(self)
 
-    def wait_stream(self, stream):
+    def wait_stream(self, stream) -> None:
         r"""Synchronize with another stream.
 
         All future work submitted to this stream will wait until all kernels
@@ -82,7 +82,7 @@ class Stream(torch._C._CudaStreamBase, _StreamBase):
         event.record(self)
         return event
 
-    def query(self):
+    def query(self) -> bool:
         r"""Check if all the work submitted has been completed.
 
         Returns:
@@ -90,7 +90,7 @@ class Stream(torch._C._CudaStreamBase, _StreamBase):
         """
         return super().query()
 
-    def synchronize(self):
+    def synchronize(self) -> None:
         r"""Wait for all the kernels in this stream to complete.
 
         .. note:: This is a wrapper around ``cudaStreamSynchronize()``: see
@@ -102,7 +102,7 @@ class Stream(torch._C._CudaStreamBase, _StreamBase):
     def _as_parameter_(self):
         return ctypes.c_void_p(self.cuda_stream)
 
-    def __eq__(self, o):
+    def __eq__(self, o) -> bool:
         if isinstance(o, Stream):
             return super().__eq__(o)
         return False
@@ -128,7 +128,7 @@ class ExternalStream(Stream):
         stream_ptr(int): Integer representation of the `cudaStream_t` value.
             allocated externally.
         device(torch.device or int, optional): the device where the stream
-            was originally allocated. if device is specified incorrectly,
+            was originally allocated. If device is specified incorrectly,
             subsequent launches using this stream may fail.
     """
 
@@ -183,7 +183,7 @@ class Event(torch._C._CudaEventBase, _EventBase):
             stream = torch.cuda.current_stream()
         super().record(stream)
 
-    def wait(self, stream=None):
+    def wait(self, stream=None) -> None:
         r"""Make all future work submitted to the given stream wait for this event.
 
         Use ``torch.cuda.current_stream()`` if no stream is specified.
@@ -212,7 +212,7 @@ class Event(torch._C._CudaEventBase, _EventBase):
         """
         return super().elapsed_time(end_event)
 
-    def synchronize(self):
+    def synchronize(self) -> None:
         r"""Wait for the event to complete.
 
         Waits until the completion of all work currently captured in this event.
@@ -234,7 +234,7 @@ class Event(torch._C._CudaEventBase, _EventBase):
     def _as_parameter_(self):
         return ctypes.c_void_p(self.cuda_event)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.cuda_event:
             return f"<torch.cuda.Event {self._as_parameter_.value:#x}>"
         else:

--- a/torch/xpu/streams.py
+++ b/torch/xpu/streams.py
@@ -2,6 +2,7 @@ import ctypes
 
 import torch
 from torch._streambase import _EventBase, _StreamBase
+
 from .._utils import _dummy_type
 
 
@@ -34,7 +35,7 @@ class Stream(torch._C._XpuStreamBase, _StreamBase):
             with torch.xpu.device(device):
                 return super().__new__(cls, priority=priority, **kwargs)
 
-    def wait_event(self, event):
+    def wait_event(self, event) -> None:
         r"""Make all future work submitted to the stream wait for an event.
 
         Args:
@@ -42,7 +43,7 @@ class Stream(torch._C._XpuStreamBase, _StreamBase):
         """
         event.wait(self)
 
-    def wait_stream(self, stream):
+    def wait_stream(self, stream) -> None:
         r"""Synchronize with another stream.
 
         All future work submitted to this stream will wait until all kernels
@@ -68,7 +69,7 @@ class Stream(torch._C._XpuStreamBase, _StreamBase):
         event.record(self)
         return event
 
-    def query(self):
+    def query(self) -> bool:
         r"""Check if all the work submitted has been completed.
 
         Returns:
@@ -76,7 +77,7 @@ class Stream(torch._C._XpuStreamBase, _StreamBase):
         """
         return super().query()
 
-    def synchronize(self):
+    def synchronize(self) -> None:
         r"""Wait for all the kernels in this stream to complete."""
         super().synchronize()
 
@@ -114,7 +115,7 @@ class Event(torch._C._XpuEventBase, _EventBase):
     def __new__(cls, enable_timing=False):
         return super().__new__(cls, enable_timing=enable_timing)
 
-    def record(self, stream=None):
+    def record(self, stream=None) -> None:
         r"""Record the event in a given stream.
 
         Uses ``torch.xpu.current_stream()`` if no stream is specified. The
@@ -124,7 +125,7 @@ class Event(torch._C._XpuEventBase, _EventBase):
             stream = torch.xpu.current_stream()
         super().record(stream)
 
-    def wait(self, stream=None):
+    def wait(self, stream=None) -> None:
         r"""Make all future work submitted to the given stream wait for this event.
 
         Use ``torch.xpu.current_stream()`` if no stream is specified.
@@ -133,7 +134,7 @@ class Event(torch._C._XpuEventBase, _EventBase):
             stream = torch.xpu.current_stream()
         super().wait(stream)
 
-    def query(self):
+    def query(self) -> bool:
         r"""Check if all work currently captured by event has completed.
 
         Returns:
@@ -150,7 +151,7 @@ class Event(torch._C._XpuEventBase, _EventBase):
         """
         return super().elapsed_time(end_event)
 
-    def synchronize(self):
+    def synchronize(self) -> None:
         r"""Wait for the event to complete.
 
         Waits until the completion of all work currently captured in this event.


### PR DESCRIPTION
For recent device agnostic code changes, we need type hinting on the parent classes for better tooling support.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10