### PR TITLE
[Profiler] Clean up deprecated use_cuda by default

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -195,7 +195,7 @@ class profile:
         self,
         enabled=True,
         *,
-        use_cuda=False,
+        use_cuda=False,  # Deprecated
         use_device=None,
         record_shapes=False,
         with_flops=False,

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -148,7 +148,6 @@ class _KinetoProfile:
     def prepare_trace(self):
         if self.profiler is None:
             self.profiler = prof.profile(
-                use_cuda=(ProfilerActivity.CUDA in self.activities),
                 use_cpu=(ProfilerActivity.CPU in self.activities),
                 use_mtia=(ProfilerActivity.MTIA in self.activities),
                 use_device=self.use_device,


### PR DESCRIPTION
Summary: Should not be setting use_cuda by default anymore, since it is deprecated. Instead it will be set via use_device="cuda".

Test Plan:
CI and ran locally:

Before:
```
[INFO: pytorch_resnet_integration_test.py:  196]: step: 80, peak allocated GPU mem: 3.17GB, peak active GPU mem: 3.17GB, peak reserved GPU mem: 3.39GB.
/data/users/aaronshi/fbsource/buck-out/v2/gen/fbcode/277373c3e83d278c/kineto/libkineto/fb/integration_tests/__pytorch_resnet_integration_test__/pytorch_resnet_integration_test#link-tree/torch/autograd/profiler.py:215: UserWarning:

The attribute `use_cuda` will be deprecated soon, please use ``use_device = 'cuda'`` instead.

  Log file: /tmp/libkineto_activities_812639.json
  Trace start time: 2024-05-14 08:44:50  Trace duration: 500ms
  Warmup duration: 5s
  Max GPU buffer size: 128MB
  Enabled activities: cpu_op,user_annotation,gpu_user_annotation,gpu_memcpy,gpu_memset,kernel,external_correlation,cuda_runtime,cuda_driver,cpu_instant_event,python_function,xpu_runtime,privateuse1_runtime,privateuse1_driver
  Manifold bucket: gpu_traces
  Manifold object: tree/traces/clientAPI/0/1715701483/devvm2184.cco0/libkineto_activities_812639.json
  Trace compression enabled: 1
  TTL in seconds: 31536000 (365 days)
INFO:2024-05-14 08:44:43 812639:812639 CuptiActivityProfiler.cpp:971] Enabling GPU tracing
```

After:
```
[INFO: pytorch_resnet_integration_test.py:  196]: step: 80, peak allocated GPU mem: 3.17GB, peak active GPU mem: 3.17GB, peak reserved GPU mem: 3.39GB.
  Log file: /tmp/libkineto_activities_903554.json
  Trace start time: 2024-05-14 09:05:47  Trace duration: 500ms
  Warmup duration: 5s
  Max GPU buffer size: 128MB
  Enabled activities: cpu_op,user_annotation,gpu_user_annotation,gpu_memcpy,gpu_memset,kernel,external_correlation,cuda_runtime,cuda_driver,cpu_instant_event,python_function,xpu_runtime,privateuse1_runtime,privateuse1_driver
  Manifold bucket: gpu_traces
  Manifold object: tree/traces/clientAPI/0/1715702740/devvm2184.cco0/libkineto_activities_903554.json
  Trace compression enabled: 1
  TTL in seconds: 31536000 (365 days)
INFO:2024-05-14 09:05:40 903554:903554 CuptiActivityProfiler.cpp:971] Enabling GPU tracing
```

Differential Revision: D57337445

Pulled By: aaronenyeshi


