### PR TITLE
[MPS] Add workaround for nonzero with large/complex inputs 

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -42,7 +42,7 @@
 #include <ATen/ops/view_as_real.h>
 #endif
 
-#define NONZERO_MAX_SIZE 1024
+#define NONZERO_MAX_SIZE (2 ^ 24)
 
 namespace at::native {
 namespace mps {

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -42,7 +42,7 @@
 #include <ATen/ops/view_as_real.h>
 #endif
 
-constexpr auto nonZeroMaxSize == 1UL << 24;
+constexpr auto nonZeroMaxSize = 1UL << 24;
 
 namespace at::native {
 namespace mps {

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -42,7 +42,7 @@
 #include <ATen/ops/view_as_real.h>
 #endif
 
-#define NONZERO_MAX_SIZE (2 ^ 24)
+#define NONZERO_MAX_SIZE 16777216 // 2 ^ 24
 
 namespace at::native {
 namespace mps {

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -302,8 +302,9 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   TORCH_CHECK(self.dim() <= maxDimensions, "nonzero is not supported for tensor with more than ", 16, " dimensions");
   TORCH_CHECK(out_.is_mps());
 
-  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && (self.numel() >= nonZeroMaxSize || self.is_complex())) {
-    https://github.com/pytorch/pytorch/issues/122916
+  if (!is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) &&
+      (self.numel() >= nonZeroMaxSize || self.is_complex())) {
+  https: // github.com/pytorch/pytorch/issues/122916
     TORCH_WARN_ONCE("MPS: nonzero op is not natively supported for the provided input on MacOS14",
                     "Falling back on CPU. This may have performance implications.",
                     "See github.com/pytorch/pytorch/issues/122916 for further info");
@@ -312,7 +313,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
     out_.copy_(out_fallback);
     return out_;
   }
-  
+
   MPSStream* stream = getCurrentMPSStream();
   using CachedGraph = MPSUnaryCachedGraph;
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -302,8 +302,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   TORCH_CHECK(self.dim() <= maxDimensions, "nonzero is not supported for tensor with more than ", 16, " dimensions");
   TORCH_CHECK(out_.is_mps());
 
-  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) && self.numel() < nonZeroMaxSize &&
-      !self.is_complex()) {
+  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) && self.numel() < nonZeroMaxSize && !self.is_complex()) {
     // If conditions are met, use native nonzero op for better performance
     return nonzero_out_native_mps(self, out_);
   }

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -42,7 +42,7 @@
 #include <ATen/ops/view_as_real.h>
 #endif
 
-#define NONZERO_MAX_SIZE 16777216 // 2 ^ 24
+constexpr auto nonZeroMaxSize == 1UL << 24;
 
 namespace at::native {
 namespace mps {
@@ -218,7 +218,6 @@ static Tensor nonzero_fallback(const Tensor& self) {
 }
 
 static Tensor& nonzero_out_native_mps(const Tensor& self, Tensor& out_) {
-
   using namespace mps;
 
   int64_t nDim = self.dim();
@@ -303,9 +302,8 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   TORCH_CHECK(self.dim() <= maxDimensions, "nonzero is not supported for tensor with more than ", 16, " dimensions");
   TORCH_CHECK(out_.is_mps());
 
-  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS)
-    && self.numel() < NONZERO_MAX_SIZE
-    && !self.is_complex()) {
+  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) && self.numel() < NONZERO_MAX_SIZE &&
+      !self.is_complex()) {
     // If conditions are met, use native nonzero op for better performance
     return nonzero_out_native_mps(self, out_);
   }

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -302,7 +302,7 @@ Tensor& nonzero_out_mps(const Tensor& self, Tensor& out_) {
   TORCH_CHECK(self.dim() <= maxDimensions, "nonzero is not supported for tensor with more than ", 16, " dimensions");
   TORCH_CHECK(out_.is_mps());
 
-  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) && self.numel() < NONZERO_MAX_SIZE &&
+  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) && self.numel() < nonZeroMaxSize &&
       !self.is_complex()) {
     // If conditions are met, use native nonzero op for better performance
     return nonzero_out_native_mps(self, out_);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10689,6 +10689,7 @@ class TestAdvancedIndexing(TestCaseMPS):
                 torch.Size((6, 2)),
                 torch.Size((3, 2, 2)),
                 torch.Size((5, 5, 5)),
+                torch.Size((20000, 10000)),
             ]
 
             def gen_nontrivial_input(shape, dtype, device):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10689,7 +10689,6 @@ class TestAdvancedIndexing(TestCaseMPS):
                 torch.Size((6, 2)),
                 torch.Size((3, 2, 2)),
                 torch.Size((5, 5, 5)),
-                torch.Size((20000, 10000)),
             ]
 
             def gen_nontrivial_input(shape, dtype, device):


### PR DESCRIPTION
Fixes Issue #122916


Resolves correctness issue seen with large inputs to the mps nonzero op by using a different scatter mode. Native nonzero op is still used with smaller inputs for better performance.