### PR TITLE
Do not print escape characters in xdoctest logs

### DIFF
--- a/.ci/pytorch/docs-test.sh
+++ b/.ci/pytorch/docs-test.sh
@@ -6,4 +6,4 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 echo "Testing pytorch docs"
 
 cd docs
-make doctest
+TERM=vt100 make doctest


### PR DESCRIPTION
By invoking make with `vt100` terminal settings
Test Plan:
[Before](https://github.com/pytorch/pytorch/actions/runs/9086391859/job/24972547633)
```
2024-05-14T21:50:09.0459741Z [01mreading sources... [39;49;00m[ 57%] [35mgenerated/torch.func.stack_module_state .. generated/torch.gradient[39;49;00m
2024-05-14T21:50:09.2204992Z [01mreading sources... [39;49;00m[ 59%] [35mgenerated/torch.greater .. generated/torch.jit.ignore[39;49;00m
2024-05-14T21:50:09.9598581Z [01mreading sources... [39;49;00m[ 61%] [35mgenerated/torch.jit.interface .. generated/torch.linalg.multi_dot[39;49;00m
2024-05-14T21:50:10.5383853Z [01mreading sources... [39;49;00m[ 64%] [35mgenerated/torch.linalg.norm .. generated/torch.moveaxis[39;49;00m
```
[After](https://github.com/pytorch/pytorch/actions/runs/9086780396/job/24973727737?pr=126219)
```
2024-05-14T22:27:22.9388802Z reading sources... [ 57%] generated/torch.func.stack_module_state .. generated/torch.gradient
2024-05-14T22:27:23.5874407Z reading sources... [ 59%] generated/torch.greater .. generated/torch.jit.ignore
2024-05-14T22:27:23.7649947Z reading sources... [ 61%] generated/torch.jit.interface .. generated/torch.linalg.multi_dot
2024-05-14T22:27:24.3492981Z reading sources... [ 64%] generated/torch.linalg.norm .. generated/torch.moveaxis
2024-05-14T22:27:24.9723946Z reading sources... [ 66%] generated/torch.movedim .. generated/torch.nn.AdaptiveLogSoftmaxWithLoss
```
Fixes https://github.com/pytorch/pytorch/issues/123166
