### PR TITLE
verbose cache entries for gemm tunings

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -242,6 +242,11 @@ max_autotune_gemm_backends = os.environ.get(
     "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_BACKENDS", "ATEN,TRITON,CPP"
 ).upper()
 
+# Verbose cache entries for GEMM tunings that include configuration
+# details for Triton templates such as BLOCK_M, BLOCK_N, BLOCK_K,
+# num_stages, num_warps, etc.
+max_autotune_gemm_verbose_cache = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_VERBOSE_CACHE") == "1"
+
 # the value used as a fallback for the unbacked SymInts
 # that can appear in the input shapes (e.g., in autotuning)
 unbacked_symint_fallback = 8192

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -245,9 +245,9 @@ max_autotune_gemm_backends = os.environ.get(
 # Verbose cache entries for GEMM tunings that include configuration
 # details for Triton templates such as BLOCK_M, BLOCK_N, BLOCK_K,
 # num_stages, num_warps, etc.
-max_autotune_gemm_verbose_cache = os.environ.get(
-    "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_VERBOSE_CACHE"
-) == "1"
+max_autotune_gemm_verbose_cache = (
+    os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_VERBOSE_CACHE") == "1"
+)
 
 # the value used as a fallback for the unbacked SymInts
 # that can appear in the input shapes (e.g., in autotuning)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -245,7 +245,9 @@ max_autotune_gemm_backends = os.environ.get(
 # Verbose cache entries for GEMM tunings that include configuration
 # details for Triton templates such as BLOCK_M, BLOCK_N, BLOCK_K,
 # num_stages, num_warps, etc.
-max_autotune_gemm_verbose_cache = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_VERBOSE_CACHE") == "1"
+max_autotune_gemm_verbose_cache = os.environ.get(
+    "TORCHINDUCTOR_MAX_AUTOTUNE_GEMM_VERBOSE_CACHE"
+) == "1"
 
 # the value used as a fallback for the unbacked SymInts
 # that can appear in the input shapes (e.g., in autotuning)

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -794,7 +794,7 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
                 self.name.rsplit("_", 1)[0],
                 self.bmreq.module_cache_key,
             ]
-        )
+        ) if not config.max_autotune_gemm_verbose_cache else self.debug_extra
 
     def output_node(self):
         return ir.TensorBox.create(

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -789,12 +789,16 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
         return f"template_kernels.{self.name}"
 
     def hash_key(self):
-        return "-".join(
-            [
-                self.name.rsplit("_", 1)[0],
-                self.bmreq.module_cache_key,
-            ]
-        ) if not config.max_autotune_gemm_verbose_cache else self.debug_extra
+        return (
+            "-".join(
+                [
+                    self.name.rsplit("_", 1)[0],
+                    self.bmreq.module_cache_key,
+                ]
+            )
+            if not config.max_autotune_gemm_verbose_cache
+            else self.debug_extra
+        )
 
     def output_node(self):
         return ir.TensorBox.create(


### PR DESCRIPTION
add an option to switch triton hash key to a more verbose output that can help with performance debugging; the hash key now includes Triton template configs like BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps, etc.

new cache entries look like:
`"ACC_TYPE='tl.float32', ALLOW_TF32=True, BLOCK_K=16, BLOCK_M=16, BLOCK_N=32, B_PROLOGUE_CAST_TYPE=None, EVEN_K=True, GROUP_M=8, num_stages=3, num_warps=2"`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang