### PR TITLE
[RELEASE ONLY CHANGES] Increase timeout for linux binary jobs, fix workflow lint (#121851)

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -78,7 +78,7 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.runs_on }}
-    timeout-minutes: 180
+    timeout-minutes: 210
     env:
       PYTORCH_ROOT: ${{ inputs.PYTORCH_ROOT }}
       BUILDER_ROOT: ${{ inputs.BUILDER_ROOT }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -113,6 +113,7 @@ jobs:
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"
 
+        export RELEASE_VERSION_TAG="2.3"
         # Regenerate workflows
         .github/scripts/generate_ci_workflows.py
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

* [release only] Increase timeout job for linux binary builds by 30min

* fix lint