### PR TITLE
[ONNX] Adds Support for Some Bitwise Ops in Onnx Exporter

### DIFF
--- a/test/onnx/expect/TestOperators.test_bitwise_and.expect
+++ b/test/onnx/expect/TestOperators.test_bitwise_and.expect
@@ -1,0 +1,134 @@
+ir_version: 8
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    input: "onnx::Cast_0"
+    output: "onnx::BitwiseAnd_2"
+    name: "Cast_1"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 5
+      type: INT
+    }
+  }
+  node {
+    input: "onnx::Cast_1"
+    output: "onnx::BitwiseAnd_3"
+    name: "Cast_2"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 5
+      type: INT
+    }
+  }
+  node {
+    input: "onnx::BitwiseAnd_2"
+    input: "onnx::BitwiseAnd_3"
+    output: "4"
+    name: "BitwiseAnd_3"
+    op_type: "BitwiseAnd"
+  }
+  node {
+    output: "onnx::BitwiseAnd_8"
+    name: "Constant_4"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 2
+        raw_data: "\002"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "onnx::Cast_0"
+    input: "onnx::BitwiseAnd_8"
+    output: "7"
+    name: "BitwiseAnd_5"
+    op_type: "BitwiseAnd"
+  }
+  name: "main_graph"
+  input {
+    name: "onnx::Cast_0"
+    type {
+      tensor_type {
+        elem_type: 2
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "onnx::Cast_1"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "4"
+    type {
+      tensor_type {
+        elem_type: 5
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "7"
+    type {
+      tensor_type {
+        elem_type: 2
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 18
+}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -940,6 +940,15 @@ class TestOperators(common_utils.TestCase):
         input = torch.arange(24, dtype=torch.uint8).reshape(3, 4, 2)
         self.assertONNX(BitshiftModel(), input, opset_version=11)
 
+    def test_bitwise_and(self):
+        class BiwiseAndModel(torch.nn.Module):
+            def forward(self, input, other):
+                return torch.bitwise_and(input, other), input & 2
+
+        input = torch.randint(0, 100, (2, 3, 4), dtype=torch.uint8)
+        other = torch.randint(-50, 50, (2, 3, 4), dtype=torch.int8)
+        self.assertONNX(BiwiseAndModel(), (input, other), opset_version=18)
+
     @skipIfCaffe2
     def test_layer_norm_aten(self):
         model = torch.nn.LayerNorm([10, 10])

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3721,6 +3721,20 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         input = torch.arange(24, dtype=torch.int64).reshape(3, 4, 2)
         self.run_test(BitshiftModel(), input)
 
+    @skipIfUnsupportedMinOpsetVersion(18)
+    def test_bitwise_and(self):
+        class BitwiseAndModel(torch.nn.Module):
+            def forward(self, input, other):
+                return (
+                    input & 20,
+                    torch.bitwise_and(input, other),
+                    other & torch.tensor([1, 2], dtype=torch.int32),
+                )
+
+        input = torch.randint(0, 255, (3, 4, 2), dtype=torch.uint8)
+        other = torch.randint(-128, 127, (3, 4, 2), dtype=torch.int8)
+        self.run_test(BitwiseAndModel(), (input, other))
+
     # uint8 not implemented in ORT for Mul used in
     # exporting bitshift for opset_version < 10
     @skipIfUnsupportedMinOpsetVersion(11)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1037,6 +1037,7 @@ def index_copy(g: jit_utils.GraphContext, self, dim, index, source):
     return scatter(g, self, dim, expanded_index, source)
 
 
+@_onnx_symbolic("aten::bitwise_right_shift")
 @_onnx_symbolic("aten::__rshift_")
 @_beartype.beartype
 def __rshift_(g: jit_utils.GraphContext, self, other):
@@ -1071,6 +1072,7 @@ def __rshift_(g: jit_utils.GraphContext, self, other):
     return rshift
 
 
+@_onnx_symbolic("aten::bitwise_left_shift")
 @_onnx_symbolic("aten::__lshift_")
 @_beartype.beartype
 def __lshift_(g: jit_utils.GraphContext, self, other):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -23,6 +23,8 @@ from torch.onnx._internal import _beartype, jit_utils, registration
 # see Note [Edit Symbolic Files] in README.md
 
 __all__ = [
+    "__lshift_",
+    "__rshift_",
     "add",
     "append",
     "arange",

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -23,8 +23,6 @@ from torch.onnx._internal import _beartype, jit_utils, registration
 # see Note [Edit Symbolic Files] in README.md
 
 __all__ = [
-    "__lshift_",
-    "__rshift_",
     "add",
     "append",
     "arange",

--- a/torch/onnx/symbolic_opset18.py
+++ b/torch/onnx/symbolic_opset18.py
@@ -46,6 +46,8 @@ def bitwise_and(g: jit_utils.GraphContext, self, other):
     promotion_jit_type = symbolic_helper._type_promote_from_values(*ranked_args)
     self = symbolic_helper._maybe_cast_to_type(g, self, promotion_jit_type)
     other = symbolic_helper._maybe_cast_to_type(g, other, promotion_jit_type)
+    if (promotion_jit_type == _type_utils.JitScalarType.BOOL):
+        return g.op("And", self, other)
     return g.op("BitwiseAnd", self, other)
 
 

--- a/torch/onnx/symbolic_opset18.py
+++ b/torch/onnx/symbolic_opset18.py
@@ -22,13 +22,14 @@ from typing import List, Optional, Sequence, Tuple
 
 import torch
 from torch import _C
-from torch.onnx import _type_utils, symbolic_helper, symbolic_opset9 as opset9
+from torch.onnx import symbolic_helper, _type_utils, symbolic_opset9 as opset9
 from torch.onnx._internal import _beartype, jit_utils, registration
 
 # EDITING THIS FILE? READ THIS FIRST!
 # see Note [Edit Symbolic Files] in symbolic_helper.py
 
 __all__ = [
+    "bitwise_and",
     "col2im",
 ]
 

--- a/torch/onnx/symbolic_opset18.py
+++ b/torch/onnx/symbolic_opset18.py
@@ -30,7 +30,6 @@ from torch.onnx._internal import _beartype, jit_utils, registration
 # see Note [Edit Symbolic Files] in symbolic_helper.py
 
 __all__ = [
-    "bitwise_and",
     "col2im",
 ]
 
@@ -40,7 +39,7 @@ _onnx_symbolic = functools.partial(registration.onnx_symbolic, opset=18)
 @_onnx_symbolic("aten::__and_")
 @_onnx_symbolic("aten::bitwise_and")
 @_beartype.beartype
-def bitwise_and(g: jit_utils.GraphContext, self, other):
+def __and_(g: jit_utils.GraphContext, self, other):
     # do type promotion (scalars don't seem to apply)
     args = [self, other]
     # type promotion doesn't happen with torch.bitwise_and(tensor, scalar)

--- a/torch/onnx/symbolic_opset18.py
+++ b/torch/onnx/symbolic_opset18.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Sequence, Tuple
 
 import torch
 from torch import _C
-from torch.onnx import symbolic_helper, _type_utils, symbolic_opset9 as opset9
+from torch.onnx import _type_utils, symbolic_helper, symbolic_opset9 as opset9
 from torch.onnx._internal import _beartype, jit_utils, registration
 
 # EDITING THIS FILE? READ THIS FIRST!

--- a/torch/onnx/symbolic_opset18.py
+++ b/torch/onnx/symbolic_opset18.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Sequence, Tuple
 
 import torch
 from torch import _C
-from torch.onnx import symbolic_helper, symbolic_opset9 as opset9
+from torch.onnx import symbolic_helper, _type_utils, symbolic_opset9 as opset9
 from torch.onnx._internal import _beartype, jit_utils, registration
 
 # EDITING THIS FILE? READ THIS FIRST!
@@ -33,6 +33,30 @@ __all__ = [
 ]
 
 _onnx_symbolic = functools.partial(registration.onnx_symbolic, opset=18)
+
+
+@_onnx_symbolic("aten::bitwise_and")
+@_beartype.beartype
+def bitwise_and(g: jit_utils.GraphContext, self, other):
+    # cast to largest bitwidth between self and other:
+    self_jit_type = _type_utils.JitScalarType.from_value(self)
+    other_jit_type = _type_utils.JitScalarType.from_value(other)
+    self_dtype = self_jit_type.dtype()
+    other_dtype = other_jit_type.dtype()
+    promotion_dtype = torch.promote_types(self_dtype, other_dtype)
+    if self_dtype == promotion_dtype and other_dtype != promotion_dtype:
+        other = g.op(
+            "Cast",
+            other,
+            to_i=self_jit_type.onnx_type(),
+        )
+    if other_dtype == promotion_dtype and self_dtype != promotion_dtype:
+        self = g.op(
+            "Cast",
+            self,
+            to_i=other_jit_type.onnx_type(),
+        )
+    return g.op("BitwiseAnd", self, other)
 
 
 @_onnx_symbolic("aten::col2im")


### PR DESCRIPTION
Addresses #126194 

Adds support for 
- "aten::bitwise_right_shift"
- "aten::bitwise_left_shift"
- "aten::bitwise_and"

