### PR TITLE
Don't assert about pending when we are peeking

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -602,13 +602,14 @@ def compute_unbacked_bindings(shape_env, example_value, old_example_value=None, 
             return r
 
         symbol_to_path = free_unbacked_symbols_with_path(example_value, ())
-        assert not pending, (
-            f"pending {pending} not in {example_value} " +
-            (
-                repr((example_value.stride(), example_value.storage_offset()))
-                if isinstance(example_value, torch.Tensor)
-                else ""
-            )
+        if not peek:
+            assert not pending, (
+                f"pending {pending} not in {example_value} " +
+                (
+                    repr((example_value.stride(), example_value.storage_offset()))
+                    if isinstance(example_value, torch.Tensor)
+                    else ""
+                )
         )
         # Why do we have to do some rebinding here?  If the original FX node
         # wasn't a binding site because you had a memo hit, but post

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -610,7 +610,7 @@ def compute_unbacked_bindings(shape_env, example_value, old_example_value=None, 
                     if isinstance(example_value, torch.Tensor)
                     else ""
                 )
-        )
+            )
         # Why do we have to do some rebinding here?  If the original FX node
         # wasn't a binding site because you had a memo hit, but post
         # translation you aren't a memo hit anymore, there's now a new binding


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126239

Internal xref https://fb.workplace.com/groups/6829516587176185/posts/7211398545654652/

In particular, when we're collecting forward metadata, we aren't going
to discharge any of the pending, so we'll be continuously collecting
more and more pending symbols that we may not be able to resolve.  This
is fine.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>