### PR TITLE
Expose StreamBase and EventBase

### DIFF
--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -2,7 +2,8 @@ import inspect
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Type, Union
 
 import torch
-from torch._streambase import _EventBase, _StreamBase
+from torch.streambase import EventBase, StreamBase
+from torch.streambase import EventBase as _EventBase
 
 get_cuda_stream: Optional[Callable[[int], int]]
 if torch.cuda._is_compiled():
@@ -22,12 +23,12 @@ class DeviceInterfaceMeta(type):
         class_member = args[2]
         if "Event" in class_member:
             assert inspect.isclass(class_member["Event"]) and issubclass(
-                class_member["Event"], _EventBase
-            ), "DeviceInterface member Event should be inherit from _EventBase"
+                class_member["Event"], EventBase
+            ), "DeviceInterface member Event should be inherit from EventBase"
         if "Stream" in class_member:
             assert inspect.isclass(class_member["Stream"]) and issubclass(
-                class_member["Stream"], _StreamBase
-            ), "DeviceInterface member Stream should be inherit from _StreamBase"
+                class_member["Stream"], StreamBase
+            ), "DeviceInterface member Stream should be inherit from StreamBase"
         return super().__new__(metacls, *args, **kwargs)
 
 
@@ -147,7 +148,7 @@ class CudaInterface(DeviceInterface):
     device = torch.cuda.device
 
     # register Event and Stream class into the backend interface
-    # make sure Event and Stream are implemented and inherited from the _EventBase and _StreamBase
+    # make sure Event and Stream are implemented and inherited from the EventBase and StreamBase
     Event = torch.cuda.Event
     Stream = torch.cuda.Stream
 

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -2,8 +2,11 @@ import inspect
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Type, Union
 
 import torch
-from torch.streambase import EventBase, StreamBase
-from torch.streambase import EventBase as _EventBase
+from torch.streambase import (  # noqa: F401
+    EventBase,
+    EventBase as _EventBase,
+    StreamBase,
+)
 
 get_cuda_stream: Optional[Callable[[int], int]]
 if torch.cuda._is_compiled():

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -13,7 +13,7 @@ import torch.nn
 import torch.onnx.operators
 from torch._logging import warning_once
 
-from torch._streambase import _StreamBase
+from torch.streambase import StreamBase
 from ..._guards import TracingContext
 from .. import config, polyfill, variables
 from ..codegen import PyCodegen
@@ -230,7 +230,7 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             assert len(args) <= 1 and len(kwargs) == 0
             inf_mode = args[0].as_python_constant() if len(args) == 1 else True
             return InferenceModeVariable.create(tx, inf_mode)
-        elif inspect.isclass(self.value) and issubclass(self.value, _StreamBase):
+        elif inspect.isclass(self.value) and issubclass(self.value, StreamBase):
             from torch._dynamo.variables.builder import wrap_fx_proxy_cls
 
             return wrap_fx_proxy_cls(

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -1,7 +1,7 @@
 import ctypes
 
 import torch
-from torch._streambase import _EventBase, _StreamBase
+from torch.streambase import EventBase, StreamBase
 from .._utils import _dummy_type
 
 
@@ -11,7 +11,7 @@ if not hasattr(torch._C, "_CudaStreamBase"):
     torch._C.__dict__["_CudaEventBase"] = _dummy_type("_CudaEventBase")
 
 
-class Stream(torch._C._CudaStreamBase, _StreamBase):
+class Stream(torch._C._CudaStreamBase, StreamBase):
     r"""Wrapper around a CUDA stream.
 
     A CUDA stream is a linear sequence of execution that belongs to a specific
@@ -137,7 +137,7 @@ class ExternalStream(Stream):
             return super().__new__(cls, stream_ptr=stream_ptr, **kwargs)
 
 
-class Event(torch._C._CudaEventBase, _EventBase):
+class Event(torch._C._CudaEventBase, EventBase):
     r"""Wrapper around a CUDA event.
 
     CUDA events are synchronization markers that can be used to monitor the

--- a/torch/streambase.py
+++ b/torch/streambase.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 
-class _StreamBase(ABC):
+class StreamBase(ABC):
     r"""Base stream class abstraction for multi backends Stream to herit from"""
 
     @abstractmethod
@@ -29,7 +29,7 @@ class _StreamBase(ABC):
         raise NotImplementedError
 
 
-class _EventBase(ABC):
+class EventBase(ABC):
     r"""Base Event class abstraction for multi backends Event to herit from"""
 
     @abstractmethod

--- a/torch/xpu/streams.py
+++ b/torch/xpu/streams.py
@@ -1,8 +1,7 @@
 import ctypes
 
 import torch
-from torch._streambase import _EventBase, _StreamBase
-
+from torch.streambase import EventBase, StreamBase
 from .._utils import _dummy_type
 
 
@@ -12,7 +11,7 @@ if not hasattr(torch._C, "_XpuStreamBase"):
     torch._C.__dict__["_XpuEventBase"] = _dummy_type("_XpuEventBase")
 
 
-class Stream(torch._C._XpuStreamBase, _StreamBase):
+class Stream(torch._C._XpuStreamBase, StreamBase):
     r"""Wrapper around a XPU stream.
 
     A XPU stream is a linear sequence of execution that belongs to a specific
@@ -97,7 +96,7 @@ class Stream(torch._C._XpuStreamBase, _StreamBase):
         return f"torch.xpu.Stream(device={self.device} sycl_queue={self.sycl_queue:#x})"
 
 
-class Event(torch._C._XpuEventBase, _EventBase):
+class Event(torch._C._XpuEventBase, EventBase):
     r"""Wrapper around a XPU event.
 
     XPU events are synchronization markers that can be used to monitor the


### PR DESCRIPTION
So that we can use them in type hinting to avoid device-specific types like CUDAStream and XPUStream.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang