### PR TITLE
Fix torch.histc when min and max are equal

### DIFF
--- a/aten/src/ATen/native/Histogram.cpp
+++ b/aten/src/ATen/native/Histogram.cpp
@@ -215,9 +215,10 @@ std::pair<double, double> histc_select_outer_bin_edges(const Tensor& input,
         rightmost_edge = std::get<1>(extrema).item<double>();
     }
 
+    // expand empty range to avoid divide by zero
     if (leftmost_edge == rightmost_edge) {
-        leftmost_edge -= 1;
-        rightmost_edge += 1;
+        leftmost_edge -= 0.5;
+        rightmost_edge += 0.5;
     }
 
     TORCH_CHECK(!(std::isinf(leftmost_edge) || std::isinf(rightmost_edge) ||

--- a/aten/src/ATen/native/Histogram.cpp
+++ b/aten/src/ATen/native/Histogram.cpp
@@ -209,7 +209,7 @@ std::pair<double, double> histc_select_outer_bin_edges(const Tensor& input,
     double leftmost_edge = min.to<double>();
     double rightmost_edge = max.to<double>();
 
-    if (leftmost_edge == rightmost_edge && input.numel() > 0) {
+    if (leftmost_edge == 0.0 && rightmost_edge == 0.0 && input.numel() > 0) {
         auto extrema = aminmax(input);
         leftmost_edge = std::get<0>(extrema).item<double>();
         rightmost_edge = std::get<1>(extrema).item<double>();

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -322,13 +322,15 @@ Tensor _histc_cuda_template(
       c10::nullopt /* pin_memory */);
   input_t minvalue = min;
   input_t maxvalue = max;
-  if (min == max && self.numel() > 0) {
+  if (min == 0.0 && max == 0.0 && self.numel() > 0) {
     minvalue = *self.min().cpu().const_data_ptr<input_t>();
     maxvalue = *self.max().cpu().const_data_ptr<input_t>();
   }
+
+  // expand empty range to avoid divide by zero
   if (minvalue == maxvalue) {
-    minvalue = minvalue - 1;
-    maxvalue = maxvalue + 1;
+    minvalue = minvalue - static_cast<input_t>(0.5);
+    maxvalue = maxvalue + static_cast<input_t>(0.5);
   }
 
 #if !defined(USE_ROCM)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10632,6 +10632,17 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self._checked_swap(t6, t7)
 
 
+    def test_histc_when_min_is_equal_to_max(self):
+        # both min and max are non-zero
+        t = torch.tensor([1, 2, 3, 3, 4, 5, 6, 7, 8], dtype=torch.float)
+        res = torch.histc(t, 5, 7, 7)
+        self.assertEqual(res, torch.tensor([0., 0., 1., 0., 0.]))
+
+        # both min and max are zero, then the minimum and maximum values of the data are used
+        res = torch.histc(t, 5, 0, 0)
+        self.assertEqual(res, torch.tensor([2., 2., 2., 1., 2.]))
+
+
 # The following block extends TestTorch with negative dim wrapping tests
 # FIXME: replace these with OpInfo sample inputs or systemic OpInfo tests
 # Functions to test negative dimension wrapping


### PR DESCRIPTION
Fixes #126021

original implementation: #58780

As https://github.com/pytorch/pytorch/issues/126021#issuecomment-2108044935 said, when min and max values are equal and not zero, the output does not match the [documentation][2], which states: "If min and max are both zero, the minimum and maximum values of the data are used".

[2]: https://pytorch.org/docs/stable/generated/torch.histc.html
