### PR TITLE
[FSDP] Fixed docs for inter/intra node PG helpers

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -216,11 +216,11 @@ def _init_intra_node_process_group(num_devices_per_node: int) -> dist.ProcessGro
     Return a process group across the current node.
 
     For example, given each row is a distinct node:
-    0 1 2 3 4 5 6 7 8
-    9 10 11 12 13 14 15
+    0  1  2  3  4  5  6  7
+    8  9 10 11 12 13 14 15
     This API would return an intra-node subgroup across
-    [0, 7] or [8, 15] depending on the process's rank.
-    For example, rank 3 would get [0, 7].
+    [0, 1, ..., 7] or [8, 9, ..., 15] depending on the process's rank.
+    For example, rank 3 would get [0, 1, ..., 7].
     """
     intra_node_subgroup, _ = dist.new_subgroups(num_devices_per_node)
     return intra_node_subgroup
@@ -235,11 +235,11 @@ def _init_inter_node_process_group(
     Return an inter-node process group where each contained rank has the same local rank.
 
     For example, given each row is a distinct node:
-    0 1 2 3 4 5 6 7 8
-    9 10 11 12 13 14 15
-    This API would return inter-node process group {0, 8}, {1, 9}, {2, 10}, and so forth
-    depending on the process's rank. For example, rank 1 would get {1, 9}, rank 5
-    would get {5, 13}.
+    0  1  2  3  4  5  6  7
+    8  9 10 11 12 13 14 15
+    This API would return inter-node process group [0, 8], [1, 9], [2, 10], and so forth
+    depending on the process's rank. For example, rank 1 would get [1, 9], rank 5
+    would get [5, 13].
     """
     # the inter-node pg that is returned
     inter_node_pg = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126258
* __->__ #126288

1. This fixes an issue where we had 9 ranks in one node and 7 in the other.
2. This makes the notation more explicit that `[0, 7]` is `[0, 1, ..., 7]`.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k