### PR TITLE
Fix aarch64 debug build with GCC

### DIFF
--- a/aten/src/ATen/native/cpu/int8mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int8mm_kernel.cpp
@@ -255,7 +255,6 @@ inline void tinygemm_kernel_(
     c10::ForcedUnroll<BLOCK_N>{}([&](auto i) {
       C[m * ldc + i] = reduce(c_val[i]) * vgetq_lane_f32(scale_val, i);
     });
-  }
 #else
     // Workaround GCCs inability to infer lane index at compile time
     // See https://github.com/pytorch/pytorch/issues/126283
@@ -263,6 +262,7 @@ inline void tinygemm_kernel_(
       C[m * ldc + i] = reduce(c_val[i]) * float(scales[i]);
     });
 #endif
+  }
 }
 
 template <int BLOCK_M, int BLOCK_N>

--- a/aten/src/ATen/native/cpu/int8mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int8mm_kernel.cpp
@@ -250,11 +250,19 @@ inline void tinygemm_kernel_(
       });
     }
 
+#if __OPTIMIZE__      
     float32x4_t scale_val = load_as_float32x4(scales);
     c10::ForcedUnroll<BLOCK_N>{}([&](auto i) {
       C[m * ldc + i] = reduce(c_val[i]) * vgetq_lane_f32(scale_val, i);
     });
   }
+#else
+    // Workaround GCCs inability to infer lane index at compile time
+    // See https://github.com/pytorch/pytorch/issues/126283
+    c10::ForcedUnroll<BLOCK_N>{}([&](auto i) {
+      C[m * ldc + i] = reduce(c_val[i]) * float(scales[i]);
+    });    
+#endif
 }
 
 template <int BLOCK_M, int BLOCK_N>

--- a/aten/src/ATen/native/cpu/int8mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int8mm_kernel.cpp
@@ -250,7 +250,7 @@ inline void tinygemm_kernel_(
       });
     }
 
-#if __OPTIMIZE__      
+#if __OPTIMIZE__
     float32x4_t scale_val = load_as_float32x4(scales);
     c10::ForcedUnroll<BLOCK_N>{}([&](auto i) {
       C[m * ldc + i] = reduce(c_val[i]) * vgetq_lane_f32(scale_val, i);
@@ -261,7 +261,7 @@ inline void tinygemm_kernel_(
     // See https://github.com/pytorch/pytorch/issues/126283
     c10::ForcedUnroll<BLOCK_N>{}([&](auto i) {
       C[m * ldc + i] = reduce(c_val[i]) * float(scales[i]);
-    });    
+    });
 #endif
 }
 


### PR DESCRIPTION
By working around GCCs quirks in instantiating templates that require immediate values.
Provide alternative implementation for scaling the output if compiled without any optimizations (both GCC and clang define `__OPTIMIZE__` if invoked with anything but `-O0`)

Test plan (after change was reverted): ssh into aarch64 runner and rebuild given file with `-O0`

Fixes https://github.com/pytorch/pytorch/issues/126283


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @snadampal 