### PR TITLE
fixing torch.ops.aten.linear handling 1d weight with bias

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -95,7 +95,7 @@ Tensor linear(const Tensor& input, const Tensor& weight, const std::optional<Ten
     // Fused op is marginally faster.
     return at::addmm(*bias, input, weight.t());
   }
-  if (bias->defined() && !input.is_xla()) {
+  if (weight_dim == 2 && bias->defined() && !input.is_xla()) {
     // Also hit the fused path for contiguous 3D input, if not using xla
     // backend. Reshaping/flattening has some performance implications on xla.
     if (input.is_contiguous() && input_dim == 3) {

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -91,7 +91,7 @@ Tensor linear(const Tensor& input, const Tensor& weight, const std::optional<Ten
     return xnnpack::linear(input, weight, *bias);
   }
 #endif
-  if (input_dim == 2 && bias->defined()) {
+  if (input_dim == 2 && weight_dim == 2 && bias->defined()) {
     // Fused op is marginally faster.
     return at::addmm(*bias, input, weight.t());
   }

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4601,15 +4601,15 @@ def sample_inputs_linear(self, device, dtype, requires_grad, **kwargs):
             itertools.product([True, False], features_options, batch_options):
         input_tensor = create_tensor(batch_shape + [in_feat])
         weight = create_tensor([out_feat, in_feat])
-        1d_weight = create_tensor([in_feat])
+        weight_1d = create_tensor([in_feat])
         if not has_bias:
             yield SampleInput(input_tensor, weight)
-            yield SampleInput(input_tensor, 1d_weight)
+            yield SampleInput(input_tensor, weight_1d)
             continue
 
         bias = create_tensor([out_feat])
         yield SampleInput(input_tensor, weight, bias)
-        yield SampleInput(input_tensor, 1d_weight, bias)
+        yield SampleInput(input_tensor, weight_1d, bias)
 
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4601,12 +4601,17 @@ def sample_inputs_linear(self, device, dtype, requires_grad, **kwargs):
             itertools.product([True, False], features_options, batch_options):
         input_tensor = create_tensor(batch_shape + [in_feat])
         weight = create_tensor([out_feat, in_feat])
+        1d_weight = create_tensor([in_feat])
         if not has_bias:
             yield SampleInput(input_tensor, weight)
+            yield SampleInput(input_tensor, 1d_weight)
             continue
 
         bias = create_tensor([out_feat])
         yield SampleInput(input_tensor, weight, bias)
+        yield SampleInput(input_tensor, 1d_weight, bias)
+
+
 
     # 5D tensor, used to crash on MPS, see https://github.com/pytorch/pytorch/issues/114942
     yield SampleInput(create_tensor(2, 1, 2, 1, 2), create_tensor(4, 2))


### PR DESCRIPTION
torch.nn.functional.linear cannot handle 1d weight with bias, even though it's supported in the doc: https://pytorch.org/docs/stable/generated/torch.nn.functional.linear

```
>>> x = torch.randn(2, 4)
>>> w2 = torch.randn(4)
>>> b = torch.randn(3)
>>> torch.nn.functional.linear(x, w2, b)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: mat2 must be a matrix, got 1-D tensor
```

