### PR TITLE
[TD] Upload names of failures to s3 for pytest cache

### DIFF
--- a/.github/scripts/pytest_caching_utils.py
+++ b/.github/scripts/pytest_caching_utils.py
@@ -239,9 +239,13 @@ def _merged_lastfailed_content(
     return to_lastfailed
 
 
-def _merge_additional_failures_files(source_pytest_cache: Path, dest_pytest_cache: Path) -> None:
+def _merge_additional_failures_files(
+    source_pytest_cache: Path, dest_pytest_cache: Path
+) -> None:
     # Simple cases where one of the files doesn't exist
-    source_lastfailed_file = source_pytest_cache / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    source_lastfailed_file = (
+        source_pytest_cache / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    )
     dest_lastfailed_file = dest_pytest_cache / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
 
     if not source_lastfailed_file.exists():

--- a/.github/scripts/pytest_caching_utils.py
+++ b/.github/scripts/pytest_caching_utils.py
@@ -18,6 +18,7 @@ PYTEST_CACHE_KEY_PREFIX = "pytest_cache"
 PYTEST_CACHE_DIR_NAME = ".pytest_cache"
 BUCKET = "gha-artifacts"
 LASTFAILED_FILE_PATH = Path("v/cache/lastfailed")
+TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL = "previous_failures_additional.json"
 
 # Temp folders
 ZIP_UPLOAD = "zip-upload"
@@ -191,6 +192,10 @@ def _merge_pytest_caches(
         pytest_cache_dir_to_merge_from, pytest_cache_dir_to_merge_into
     )
 
+    _merge_additional_failures_files(
+        pytest_cache_dir_to_merge_from, pytest_cache_dir_to_merge_into
+    )
+
 
 def _merge_lastfailed_files(source_pytest_cache: Path, dest_pytest_cache: Path) -> None:
     # Simple cases where one of the files doesn't exist
@@ -232,3 +237,23 @@ def _merged_lastfailed_content(
             del to_lastfailed[""]
 
     return to_lastfailed
+
+
+def _merge_additional_failures_files(source_pytest_cache: Path, dest_pytest_cache: Path) -> None:
+    # Simple cases where one of the files doesn't exist
+    source_lastfailed_file = source_pytest_cache / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    dest_lastfailed_file = dest_pytest_cache / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+
+    if not source_lastfailed_file.exists():
+        return
+    if not dest_lastfailed_file.exists():
+        copy_file(source_lastfailed_file, dest_lastfailed_file)
+        return
+
+    # Both files exist, so we need to merge them
+    from_lastfailed = load_json_file(source_lastfailed_file)
+    to_lastfailed = load_json_file(dest_lastfailed_file)
+    merged_content = list(set(from_lastfailed + to_lastfailed))
+
+    # Save the results
+    write_json_file(dest_lastfailed_file, merged_content)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -59,6 +59,9 @@ from tools.testing.discover_tests import (
 )
 from tools.testing.do_target_determination_for_s3 import import_results
 from tools.testing.target_determination.gen_artifact import gen_ci_artifact
+from tools.testing.target_determination.heuristics.previously_failed_in_pr import (
+    gen_additional_test_failures_file,
+)
 from tools.testing.target_determination.heuristics.utils import get_pr_number
 
 from tools.testing.test_run import TestRun
@@ -1795,6 +1798,9 @@ def main():
                         **test_stats,
                     },
                 )
+            gen_additional_test_failures_file(
+                [test.test_file for test, _ in all_failures]
+            )
 
     if len(all_failures):
         for _, err in all_failures:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -145,6 +145,7 @@ class TestCheckpoint(TestCase):
                     self.assertEqual(m.counter, 1)
 
     def test_checkpoint_valid(self):
+        self.assertEqual(2, 1)
         model = nn.Sequential(
             nn.Linear(100, 50),
             nn.ReLU(),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -145,7 +145,6 @@ class TestCheckpoint(TestCase):
                     self.assertEqual(m.counter, 1)
 
     def test_checkpoint_valid(self):
-        self.assertEqual(2, 1)
         model = nn.Sequential(
             nn.Linear(100, 50),
             nn.ReLU(),

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -28,6 +28,7 @@ TEST_CLASS_RATINGS_FILE = "test-class-ratings.json"
 TD_HEURISTIC_PROFILING_FILE = "td_heuristic_profiling.json"
 TD_HEURISTIC_HISTORICAL_EDITED_FILES = "td_heuristic_historical_edited_files.json"
 TD_HEURISTIC_PREVIOUSLY_FAILED = "previous_failures.json"
+TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL = "previous_failures_additional.json"
 
 FILE_CACHE_LIFESPAN_SECONDS = datetime.timedelta(hours=3).seconds
 

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -167,12 +167,16 @@ def copy_pytest_cache() -> None:
 
 
 def copy_additional_previous_failures() -> None:
-    original_path = REPO_ROOT / ".pytest_cache" / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    original_path = (
+        REPO_ROOT / ".pytest_cache" / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    )
     if not original_path.exists():
         return
     shutil.copyfile(
         original_path,
-        REPO_ROOT / ADDITIONAL_CI_FILES_FOLDER / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL,
+        REPO_ROOT
+        / ADDITIONAL_CI_FILES_FOLDER
+        / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL,
     )
 
 

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -166,6 +166,16 @@ def copy_pytest_cache() -> None:
     )
 
 
+def copy_additional_previous_failures() -> None:
+    original_path = REPO_ROOT / ".pytest_cache" / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    if not original_path.exists():
+        return
+    shutil.copyfile(
+        original_path,
+        REPO_ROOT / ADDITIONAL_CI_FILES_FOLDER / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL,
+    )
+
+
 def get_from_test_infra_generated_stats(
     from_file: str, to_file: str, failure_explanation: str
 ) -> Dict[str, Any]:

--- a/tools/testing/do_target_determination_for_s3.py
+++ b/tools/testing/do_target_determination_for_s3.py
@@ -8,6 +8,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools.stats.import_test_stats import (
+    copy_additional_previous_failures,
     copy_pytest_cache,
     get_td_heuristic_historial_edited_files_json,
     get_td_heuristic_profiling_json,
@@ -51,6 +52,7 @@ def main() -> None:
     get_td_heuristic_historial_edited_files_json()
     get_td_heuristic_profiling_json()
     copy_pytest_cache()
+    copy_additional_previous_failures()
 
     aggregated_heuristics = get_test_prioritizations(selected_tests)
 

--- a/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
+++ b/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
@@ -69,7 +69,7 @@ def gen_additional_test_failures_file(tests: List[str]) -> None:
 
 
 def read_additional_test_failures_file() -> Set[str]:
-    path = REPO_ROOT / ".pytest_cache" / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    path = REPO_ROOT / ADDITIONAL_CI_FILES_FOLDER / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
     if not os.path.exists(path):
         print(f"could not find path {path}")
         return set()

--- a/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
+++ b/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
@@ -62,8 +62,11 @@ def gen_additional_test_failures_file(tests: List[str]) -> None:
     # (ex doctests).  In these cases, there will be no entry in the pytest
     # cache, so we should generate a separate file for them and upload it to s3
     # along with the pytest cache
+    pytest_cache_dir = REPO_ROOT / ".pytest_cache"
+    if not os.path.exists(pytest_cache_dir):
+        os.makedirs(pytest_cache_dir)
     with open(
-        REPO_ROOT / ".pytest_cache" / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL, "w"
+        pytest_cache_dir / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL, "w"
     ) as f:
         json.dump(tests, f, indent=2)
 

--- a/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
+++ b/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Set
 from tools.stats.import_test_stats import (
     ADDITIONAL_CI_FILES_FOLDER,
     TD_HEURISTIC_PREVIOUSLY_FAILED,
+    TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL,
 )
 
 from tools.testing.target_determination.heuristics.interface import (
@@ -25,7 +26,7 @@ class PreviouslyFailedInPR(HeuristicInterface):
         super().__init__(**kwargs)
 
     def get_prediction_confidence(self, tests: List[str]) -> TestPrioritizations:
-        critical_tests = get_previous_failures()
+        critical_tests = get_previous_failures() | read_additional_test_failures_file()
         return TestPrioritizations(
             tests, {TestRun(test): 1 for test in critical_tests if test in tests}
         )
@@ -54,3 +55,25 @@ def _parse_prev_failing_test_files(last_failed_tests: Dict[str, bool]) -> Set[st
             prioritized_tests.add(test_file)
 
     return prioritized_tests
+
+
+def gen_additional_test_failures_file(tests: List[str]) -> None:
+    # Segfaults usually result in no xml and some tests don't run through pytest
+    # (ex doctests).  In these cases, there will be no entry in the pytest
+    # cache, so we should generate a separate file for them and upload it to s3
+    # along with the pytest cache
+    with open(
+        REPO_ROOT / ".pytest_cache" / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL, "w"
+    ) as f:
+        json.dump(tests, f, indent=2)
+
+
+def read_additional_test_failures_file() -> Set[str]:
+    path = REPO_ROOT / ".pytest_cache" / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    if not os.path.exists(path):
+        print(f"could not find path {path}")
+        return set()
+    with open(path) as f:
+        s = set(json.load(f))
+        print(f"additional failures: {s}")
+        return s

--- a/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
+++ b/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
@@ -65,9 +65,7 @@ def gen_additional_test_failures_file(tests: List[str]) -> None:
     pytest_cache_dir = REPO_ROOT / ".pytest_cache"
     if not os.path.exists(pytest_cache_dir):
         os.makedirs(pytest_cache_dir)
-    with open(
-        pytest_cache_dir / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL, "w"
-    ) as f:
+    with open(pytest_cache_dir / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL, "w") as f:
         json.dump(tests, f, indent=2)
 
 

--- a/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
+++ b/tools/testing/target_determination/heuristics/previously_failed_in_pr.py
@@ -69,7 +69,11 @@ def gen_additional_test_failures_file(tests: List[str]) -> None:
 
 
 def read_additional_test_failures_file() -> Set[str]:
-    path = REPO_ROOT / ADDITIONAL_CI_FILES_FOLDER / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    path = (
+        REPO_ROOT
+        / ADDITIONAL_CI_FILES_FOLDER
+        / TD_HEURISTIC_PREVIOUSLY_FAILED_ADDITIONAL
+    )
     if not os.path.exists(path):
         print(f"could not find path {path}")
         return set()


### PR DESCRIPTION
Some tests don't get run through pytest and pytest crashes when a test segfaults, so in both caess, the pytest cache won't have an entry (similar to https://github.com/pytorch/test-infra/pull/5205).

Instead, manually upload/download an extra file that lists the failing test files

Technically this would be more general than the pytest cache