### PR TITLE
Fix public api allowlist logical merge conflict

### DIFF
--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -2030,6 +2030,7 @@
     "PropagateUnbackedSymInts",
     "ShapeEnvSettings",
     "log_lru_cache_stats",
+    "PendingUnbackedSymbolNotFound",
     "lru_cache"
   ],
   "torch.fx.experimental.unification.match": [


### PR DESCRIPTION
Skip the newly added bad API from https://github.com/pytorch/pytorch/pull/126212 to keep CI green.

cc @ezyang this should be fixed properly.