### PR TITLE
[dynamo] use proxies to nn.Module in dynamo generated GraphModules

### DIFF
--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -87,10 +87,10 @@ if TEST_Z3:
 
     # TODO model is somehow not being freed when z3 is available
     unittest.expectedFailure(
-        DynamicShapesMiscTests.test_custom_module_free_dynamic_shapes  # noqa: F821
+        DynamicShapesMiscTests.test_outside_linear_module_free_dynamic_shapes  # noqa: F821
     )
     unittest.expectedFailure(
-        DynamicShapesMiscTests.test_sequential_module_free_dynamic_shapes  # noqa: F821
+        DynamicShapesMiscTests.test_parameter_free_dynamic_shapes  # noqa: F821
     )
 
 unittest.expectedFailure(

--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -87,9 +87,6 @@ if TEST_Z3:
 
     # TODO model is somehow not being freed when z3 is available
     unittest.expectedFailure(
-        DynamicShapesMiscTests.test_outside_linear_module_free_dynamic_shapes  # noqa: F821
-    )
-    unittest.expectedFailure(
         DynamicShapesMiscTests.test_parameter_free_dynamic_shapes  # noqa: F821
     )
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9751,12 +9751,47 @@ fn
             lambda mod: mod[0],
         )
 
-    @unittest.expectedFailure
     def test_linear_module_free(self):
         self._test_compile_model_free(
             lambda: (torch.nn.Linear(100, 100), torch.randn(100, 100)),
             lambda mod: mod,
         )
+
+    def test_outside_linear_module_free(self):
+        # Compared to test_linear_module_free, the linear
+        # layer is not the code object that is directly compiled.
+        def model_inp_ctr():
+            fc = torch.nn.Linear(100, 100)
+
+            class Mod(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.fc_ref = fc
+
+                def forward(self, x):
+                    return self.fc_ref(x[0])
+
+            # return fc to keep it alive in _test_compile_model_free
+            return Mod(), (torch.randn(100, 100), fc)
+
+        self._test_compile_model_free(model_inp_ctr, lambda mod: mod.fc_ref)
+
+    def test_parameter_free(self):
+        def model_inp_ctr():
+            param = torch.nn.Parameter(torch.randn(100, 100))
+
+            class Mod(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.param = param
+
+                def forward(self, x):
+                    return self.param * x[0]
+
+            # return param to keep it alive in _test_compile_model_free
+            return Mod(), (torch.randn(100, 100), param)
+
+        self._test_compile_model_free(model_inp_ctr, lambda mod: mod.param)
 
     def test_dynamo_cache_move_to_front(self):
         class Mod(torch.nn.Module):

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -86,6 +86,7 @@ from .utils import (
     lazy_format_graph_code,
     lazy_format_graph_tabular,
     LazyString,
+    nn_module_proxy,
     same,
 )
 from .variables.base import VariableTracker
@@ -903,7 +904,16 @@ class OutputGraph(Checkpointable[OutputGraphState]):
         self.cleanup_graph()
         tx.prune_dead_locals()
         stack_values = list(tx.stack)
-        root = FakeRootModule(self.nn_modules)
+        # Use nn.Module "proxies" in the constructed GraphModule so that
+        # the resulting GM does not hold additional strong references to the original modules.
+        # This prevents a strong ref cycle where Dynamo created code holds on to references
+        # to modules that also have Dynamo code cache invalidation checks.
+        # When cache invalidation runs, the generated GM will be invalidated, which also deletes
+        # the proxies.
+        nn_modules_proxies = {
+            name: nn_module_proxy(mod) for name, mod in self.nn_modules.items()
+        }
+        root = FakeRootModule(nn_modules_proxies)
         # Add all the local vars to the "stack" so restore at the end
         restore_vars = []
         val_to_names: Dict[VariableTracker, List[str]] = {}

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2546,3 +2546,18 @@ def invalid_removeable_handle():
         pass
 
     return RemovableHandle(Invalid())
+
+
+# Returns a "proxy" (new object with the same class and dict) for (non-GraphModule) nn.Module's.
+# Attribute changes to the original object/proxy will be reflected in the other.
+# This is useful for cases where we want a keep-alive reference to a module without increasing
+# its reference count.
+def nn_module_proxy(mod):
+    if not isinstance(mod, torch.nn.Module):
+        return mod
+    if isinstance(mod, torch.fx.GraphModule):
+        # Dynamo-generated GM's shouldn't contain user-created GM's
+        return mod
+    proxy = mod.__class__.__new__(mod.__class__)
+    proxy.__dict__ = mod.__dict__
+    return proxy


### PR DESCRIPTION
Fixes remaining refleaks found when debugging https://github.com/pytorch/pytorch/issues/119607, tests added in https://github.com/pytorch/pytorch/pull/120657.

Also fixes some tests that xfail: https://github.com/pytorch/pytorch/issues/120631 (not entirely sure why), but introduced tests now fail.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/120756
Approved by: https://github.com/jansel

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang