### PR TITLE
[Traceable FSDP2] Add all_gather_into_tensor out variant

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -198,7 +198,10 @@ class TestWithNCCL(MultiProcessTestCase):
         # Test out-variant of all_gather_into_tensor
         output = torch.empty(expect.shape, device=self.device)
         output = torch.ops._c10d_functional.all_gather_into_tensor_out(
-            input, self.world_size, "default", out=output,
+            input,
+            self.world_size,
+            "default",
+            out=output,
         )
         output = torch.ops._c10d_functional.wait_tensor(output)
         assert torch.allclose(output, expect)

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -195,6 +195,15 @@ class TestWithNCCL(MultiProcessTestCase):
         assert torch.allclose(output, expect)
         assert output.eq(expect).all()
 
+        # Test inplace version of all_gather_into_tensor
+        output = torch.empty(expect.shape, device=self.device)
+        output = torch.ops._c10d_functional.all_gather_into_tensor_(
+            output, input, self.world_size, "default"
+        )
+        output = torch.ops._c10d_functional.wait_tensor(output)
+        assert torch.allclose(output, expect)
+        assert output.eq(expect).all()
+
         # Test Python API and AsyncCollectiveTensor
         output = all_gather_tensor(
             input,

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -195,7 +195,7 @@ class TestWithNCCL(MultiProcessTestCase):
         assert torch.allclose(output, expect)
         assert output.eq(expect).all()
 
-        # Test inplace version of all_gather_into_tensor
+        # Test out-variant of all_gather_into_tensor
         output = torch.empty(expect.shape, device=self.device)
         output = torch.ops._c10d_functional.all_gather_into_tensor_out(
             input, self.world_size, "default", out=output,

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -197,8 +197,8 @@ class TestWithNCCL(MultiProcessTestCase):
 
         # Test inplace version of all_gather_into_tensor
         output = torch.empty(expect.shape, device=self.device)
-        output = torch.ops._c10d_functional.all_gather_into_tensor_(
-            output, input, self.world_size, "default"
+        output = torch.ops._c10d_functional.all_gather_into_tensor_out(
+            input, self.world_size, "default", out=output,
         )
         output = torch.ops._c10d_functional.wait_tensor(output)
         assert torch.allclose(output, expect)

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -196,11 +196,11 @@ at::Tensor all_gather_into_tensor(
       inputs, group_size, std::move(group_name))[0];
 }
 
-at::Tensor& all_gather_into_tensor_(
-    at::Tensor& output,
+at::Tensor& all_gather_into_tensor_out(
     at::Tensor& input,
     int64_t group_size,
-    std::string group_name) {
+    std::string group_name,
+    at::Tensor& output) {
   c10d::AllgatherOptions opts;
 
   auto group = c10d::resolve_process_group(group_name);
@@ -335,10 +335,10 @@ TORCH_LIBRARY(_c10d_functional, m) {
       {at::Tag::pt2_compliant_tag});
 
   m.def(
-      "all_gather_into_tensor_(Tensor(a!) output, Tensor input, int group_size, str group_name) -> Tensor(a!)",
+      "all_gather_into_tensor_out(Tensor input, int group_size, str group_name, *, Tensor(a!) out) -> Tensor(a!)",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd,
-          ::all_gather_into_tensor_),
+          ::all_gather_into_tensor_out),
       {at::Tag::pt2_compliant_tag});
 
   m.def(

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -196,6 +196,19 @@ at::Tensor all_gather_into_tensor(
       inputs, group_size, std::move(group_name))[0];
 }
 
+at::Tensor& all_gather_into_tensor_(
+    at::Tensor& output,
+    at::Tensor& input,
+    int64_t group_size,
+    std::string group_name) {
+  c10d::AllgatherOptions opts;
+
+  auto group = c10d::resolve_process_group(group_name);
+  auto work = group->_allgather_base(output, input, opts);
+  c10d::RankLocal<WorkRegistry>::get().register_work(output, work);
+  return output;
+}
+
 at::Tensor allocate_reduce_scatter_output(
     const at::Tensor& input,
     const int64_t group_size) {
@@ -319,6 +332,13 @@ TORCH_LIBRARY(_c10d_functional, m) {
       "all_reduce_coalesced_(Tensor[](a!) inputs, str reduce_op, str group_name) -> Tensor[](a!)",
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd, ::all_reduce_coalesced_),
+      {at::Tag::pt2_compliant_tag});
+
+  m.def(
+      "all_gather_into_tensor_(Tensor(a!) output, Tensor input, int group_size, str group_name) -> Tensor(a!)",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd,
+          ::all_gather_into_tensor_),
       {at::Tag::pt2_compliant_tag});
 
   m.def(

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -894,7 +894,7 @@ def _all_to_all_single_meta(
         return input.new_empty(out_size)
 
 
-def _all_gather_into_tensor__native_meta(output, input, group_size, group_name):
+def _all_gather_into_tensor_out_native_meta(input, group_size, group_name, *, out):
     shape = list(input.size())
     shape[0] *= group_size
     return input.new_empty(shape)
@@ -939,7 +939,7 @@ if not torch._running_with_deploy():
     lib_impl.impl("all_reduce_coalesced_", _all_reduce_coalesced__meta, "Meta")
     lib_impl.impl("wait_tensor", _wait_tensor_meta, "Meta")
     lib_impl.impl(
-        "all_gather_into_tensor_", _all_gather_into_tensor__native_meta, "Meta"
+        "all_gather_into_tensor_out", _all_gather_into_tensor_out_native_meta, "Meta"
     )
     lib_impl.impl("all_gather_into_tensor", _all_gather_into_tensor_native_meta, "Meta")
     lib_impl.impl(

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -894,6 +894,12 @@ def _all_to_all_single_meta(
         return input.new_empty(out_size)
 
 
+def _all_gather_into_tensor__native_meta(output, input, group_size, group_name):
+    shape = list(input.size())
+    shape[0] *= group_size
+    return input.new_empty(shape)
+
+
 def _all_gather_into_tensor_native_meta(input, group_size, group_name):
     shape = list(input.size())
     shape[0] *= group_size
@@ -932,6 +938,9 @@ if not torch._running_with_deploy():
     lib_impl.impl("all_reduce_coalesced", _all_reduce_coalesced_meta, "Meta")
     lib_impl.impl("all_reduce_coalesced_", _all_reduce_coalesced__meta, "Meta")
     lib_impl.impl("wait_tensor", _wait_tensor_meta, "Meta")
+    lib_impl.impl(
+        "all_gather_into_tensor_", _all_gather_into_tensor__native_meta, "Meta"
+    )
     lib_impl.impl("all_gather_into_tensor", _all_gather_into_tensor_native_meta, "Meta")
     lib_impl.impl(
         "all_gather_into_tensor_coalesced",


### PR DESCRIPTION
This PR adds `torch.ops._c10d_functional.all_gather_into_tensor_out`.

It's important for tracing FSDP2, because FSDP2 pre-allocates the output buffer of AllGather, and makes input buffer an alias of the output buffer, and expects both of them to be used to achieve lower memory usage. If we don't preserve this behavior and instead functionalize the AllGather op, AllGather op will then create a brand-new output buffer (instead of reusing), thus significantly increasing the memory usage.

The expectation is that we will "re-inplace" the AllGather op by switching to the out variant in Inductor post-grad stage via an FX pass, so this API is not expected to be directly used by users.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang @d4l3k