### PR TITLE
Add distributed/_tensor/test_attention to ROCM_BLOCKLIST

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -181,6 +181,7 @@ ROCM_BLOCKLIST = [
     "test_jit_legacy",
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
+    "distributed/_tensor/test_attention",
 ]
 
 XPU_BLOCKLIST = [


### PR DESCRIPTION
Fixes #125504
Fixes #126252
Fixes #126296
Fixes #126330

This PR doesn't really fix the RingAttentionTest tests for ROCm, but explicitly adds the whole test file to ROCM_BLOCKLIST to get a clean signal on ROCm distributed CI. We will enable these tests in a follow-up PR.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang