### PR TITLE
[Traceable FSDP2] Use DTensor.from_local() in _from_local_no_grad when compile

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_common.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_common.py
@@ -116,21 +116,30 @@ def _from_local_no_grad(
     global_size: torch.Size,
     global_stride: Tuple[int, ...],
 ) -> DTensor:
+        """
+    This method is similar to ``DTensor.from_local()`` except that in eager mode
+    it avoids some CPU overhead by avoiding default args and not being differentiable.
     """
-    This method is similar to ``DTensor.from_local()`` except it avoids some
-    CPU overhead by avoiding default args and not being differentiable.
-    """
-    return DTensor(
-        # Use the local tensor directly instead of constructing a new tensor
-        # variable, e.g. with `view_as()`, since this is not differentiable
-        local_tensor,
-        device_mesh,
-        placements,
-        shape=global_size,
-        dtype=local_tensor.dtype,
-        requires_grad=local_tensor.requires_grad,
-        stride=global_stride,
-    )
+    if not torch._dynamo.compiled_autograd.compiled_autograd_enabled:
+        return DTensor(
+            # Use the local tensor directly instead of constructing a new tensor
+            # variable, e.g. with `view_as()`, since this is not differentiable
+            local_tensor,
+            device_mesh,
+            placements,
+            shape=global_size,
+            dtype=local_tensor.dtype,
+            requires_grad=local_tensor.requires_grad,
+            stride=global_stride,
+        )
+    else:
+        return DTensor.from_local(
+            local_tensor,
+            device_mesh,
+            placements,
+            shape=global_size,
+            stride=global_stride,
+        )
 
 
 def _to_dtype_if_needed(

--- a/torch/distributed/_composable/fsdp/_fsdp_common.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_common.py
@@ -116,7 +116,7 @@ def _from_local_no_grad(
     global_size: torch.Size,
     global_stride: Tuple[int, ...],
 ) -> DTensor:
-        """
+    """
     This method is similar to ``DTensor.from_local()`` except that in eager mode
     it avoids some CPU overhead by avoiding default args and not being differentiable.
     """


### PR DESCRIPTION
As discussed before, for now Dynamo is not able to support DTensor constructor, and instead we have to use `DTensor.from_local()`.

This won't affect eager and it's a compile-only change.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang @d4l3k