### PR TITLE
[Storage_ipc] Option II: Provides IPC extensions for 3rd devices. 

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -50,6 +50,24 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   void cuFFTClearPlanCache(DeviceIndex device_index) const override;
   int getNumGPUs() const override;
   void deviceSynchronize(DeviceIndex device_index) const override;
+  void getIpcHandleSize(size_t& ipc_memory_handle_size,
+                        size_t& ipc_event_handle_size) const override;
+  void StorageShareDevice(const c10::Storage& storage,
+                          ptrdiff_t& offset_bytes,
+                          char*& new_memory_handle,
+                          char*& new_event_handle,
+                          char*& new_ref_counter,
+                          uint64_t& new_ref_counter_offset,
+                          bool& new_event_sync_required) const override;
+  void StorageNewSharedDevice(const c10::DeviceIndex& device,
+                              bool& event_sync_required,
+                              std::string& s_ipc_event_handle,
+                              std::string& s_handle,
+                              std::string& ref_counter_handle,
+                              ptrdiff_t& ref_counter_offset,
+                              ptrdiff_t& storage_offset_bytes,
+                              c10::DataPtr& data_ptr) const override;
+  void getIpcRefCounterFileSize(int64_t& ipc_ref_counter_file_size) const override;
 };
 
 } // at::cuda::detail

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -54,9 +54,9 @@ struct CUDAHooks : public at::CUDAHooksInterface {
                         size_t& ipc_event_handle_size) const override;
   void StorageShareDevice(const c10::Storage& storage,
                           ptrdiff_t& offset_bytes,
-                          char*& new_memory_handle,
-                          char*& new_event_handle,
-                          char*& new_ref_counter,
+                          std::unique_ptr<char[]>& new_memory_handle,
+                          std::unique_ptr<char[]>& new_event_handle,
+                          std::unique_ptr<char[]>& new_ref_counter,
                           uint64_t& new_ref_counter_offset,
                           bool& new_event_sync_required) const override;
   void StorageNewSharedDevice(const c10::DeviceIndex& device,

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -49,9 +49,9 @@ struct TORCH_API AcceleratorHooksInterface {
 
   virtual void StorageShareDevice(const c10::Storage& storage,
                                   ptrdiff_t& offset_bytes,
-                                  char*& new_memory_handle,
-                                  char*& new_event_handle,
-                                  char*& new_ref_counter,
+                                  std::unique_ptr<char[]>& new_memory_handle,
+                                  std::unique_ptr<char[]>& new_event_handle,
+                                  std::unique_ptr<char[]>& new_ref_counter,
                                   uint64_t& new_ref_counter_offset,
                                   bool& new_event_sync_required) const {
   TORCH_CHECK(false, "Backend doesn't support StorageShareDevice");

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -2,6 +2,8 @@
 
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
+#include <c10/core/Storage.h>
+#include <c10/core/DeviceGuard.h>
 namespace at {
 
 // AcceleratorHooksInterface is a shared interface provided by all
@@ -39,6 +41,37 @@ struct TORCH_API AcceleratorHooksInterface {
     TORCH_CHECK(false, "Backend doesn't support maybeExchangeDevice()");
     return -1;
   }
+
+  virtual void getIpcHandleSize(size_t& ipc_memory_handle_size,
+                                size_t& ipc_event_handle_size) const{
+    TORCH_CHECK(false, "Backend doesn't support getIpcHandleSize");
+  }
+
+  virtual void StorageShareDevice(const c10::Storage& storage,
+                                  ptrdiff_t& offset_bytes,
+                                  char*& new_memory_handle,
+                                  char*& new_event_handle,
+                                  char*& new_ref_counter,
+                                  uint64_t& new_ref_counter_offset,
+                                  bool& new_event_sync_required) const {
+  TORCH_CHECK(false, "Backend doesn't support StorageShareDevice");
+  };
+
+  virtual void StorageNewSharedDevice(const c10::DeviceIndex& device,
+                                      bool& event_sync_required,
+                                      std::string& s_ipc_event_handle,
+                                      std::string& s_handle,
+                                      std::string& ref_counter_handle,
+                                      ptrdiff_t& ref_counter_offset,
+                                      ptrdiff_t& storage_offset_bytes,
+                                      c10::DataPtr& data_ptr) const {
+  TORCH_CHECK(false, "Backend doesn't support StorageNewSharedDevice");
+  };
+
+  virtual void getIpcRefCounterFileSize(int64_t& ipc_ref_counter_file_size) const {
+    TORCH_CHECK(false, "Backend doesn't support getIpcRefCounterFileSize");
+  };
+
 };
 
 } // namespace at

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -41,6 +41,25 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
         false,
         "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `resizePrivateUse1Bytes`.");
   }
+
+  virtual void* Storage_shareDevice(void* self, void* noargs) const {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false,
+        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `Storage_sharedevice`.");
+  }
+
+  virtual void* Storage_newSharedDevice(void* _unused, void* args) const {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false,
+        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `Storage_newSharedDevice`.");
+  }
+
+  virtual void* Storage_releaseIPCCounterDevice(void* _unused, void* args) const {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false,
+        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `releaseIPCCounterDevice`.");
+  }
+
 };
 
 struct TORCH_API PrivateUse1HooksArgs {};

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -42,24 +42,6 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
         "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `resizePrivateUse1Bytes`.");
   }
 
-  virtual void* Storage_shareDevice(void* self, void* noargs) const {
-    TORCH_CHECK_NOT_IMPLEMENTED(
-        false,
-        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `Storage_sharedevice`.");
-  }
-
-  virtual void* Storage_newSharedDevice(void* _unused, void* args) const {
-    TORCH_CHECK_NOT_IMPLEMENTED(
-        false,
-        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `Storage_newSharedDevice`.");
-  }
-
-  virtual void* Storage_releaseIPCCounterDevice(void* _unused, void* args) const {
-    TORCH_CHECK_NOT_IMPLEMENTED(
-        false,
-        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `releaseIPCCounterDevice`.");
-  }
-
 };
 
 struct TORCH_API PrivateUse1HooksArgs {};

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -56,7 +56,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
         size_bytes_(std::move(size_bytes)),
         size_bytes_is_heap_allocated_(size_bytes_.is_heap_allocated()),
         resizable_(resizable),
-        received_cuda_(false),
+        received_device_(false),
         allocator_(allocator) {
     if (resizable) {
       TORCH_INTERNAL_ASSERT(
@@ -232,12 +232,12 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
 
   // This method can be used only after storage construction and cannot be used
   // to modify storage status
-  void set_received_cuda(bool received_cuda) {
-    received_cuda_ = received_cuda;
+  void set_received_device(bool received_device) {
+    received_device_ = received_device;
   }
 
-  bool received_cuda() {
-    return received_cuda_;
+  bool received_device() {
+    return received_device_;
   }
 
   impl::PyObjectSlot* pyobj_slot() {
@@ -294,7 +294,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   bool resizable_;
   // Identifies that Storage was received from another process and doesn't have
   // local to process cuda memory allocation
-  bool received_cuda_;
+  bool received_device_;
   // All special checks in data/data_ptr calls are guarded behind this single
   // boolean. This is for performance: .data/.data_ptr calls are commonly in the
   // hot-path.

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -293,7 +293,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   bool size_bytes_is_heap_allocated_;
   bool resizable_;
   // Identifies that Storage was received from another process and doesn't have
-  // local to process cuda memory allocation
+  // local to process device memory allocation
   bool received_device_;
   // All special checks in data/data_ptr calls are guarded behind this single
   // boolean. This is for performance: .data/.data_ptr calls are commonly in the

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -357,7 +357,7 @@ class TestTorchDeviceType(TestCase):
                 s0.cuda()
 
             with self.assertRaisesRegex(RuntimeError, r'only available on CUDA'):
-                s0._share_cuda_()
+                s0._share_device_()
 
             with self.assertRaisesRegex(TypeError, r"cannot pin 'torch.storage.UntypedStorage' only CPU memory can be pinned"):
                 s0.pin_memory()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1945,6 +1945,33 @@ __all__.extend(
 )
 
 ################################################################################
+# Get Device Module
+################################################################################
+
+def get_device_module(device: Optional[Union[torch.device, str]] = None):
+    """
+    Returns the module associated with a given device(e.g., torch.device('cuda'), "mtia:0", "xpu", ...).
+    If no device is given, return the module for the current accelerator or CPU if none is present.
+    """
+    if isinstance(device, torch.device):
+        device_module_name = device.type
+    elif isinstance(device, str):
+        device_module_name = torch.device(device).type
+    elif device is None:
+        # Using default accelerator type. If no accelerator is available, it automatically returns CPU device.
+        device_module_name = torch._C._get_accelerator().type
+    else:
+        raise RuntimeError(
+            f"Invalid value of device '{device}', expect torch.device, str, or None"
+        )
+    device_module = getattr(torch, device_module_name, None)
+    if device_module is None:
+        raise RuntimeError(
+            f"Device '{device_module_name}' does not have a corresponding module registered as 'torch.{device_module_name}'."
+        )
+    return device_module
+
+################################################################################
 # Import TorchDynamo's lazy APIs to avoid circular dependenices
 ################################################################################
 
@@ -2460,31 +2487,6 @@ else:
             return importlib.import_module(f".{name}", __name__)
 
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
-
-
-def get_device_module(device: Optional[Union[torch.device, str]] = None):
-    """
-    Returns the module associated with a given device(e.g., torch.device('cuda'), "mtia:0", "xpu", ...).
-    If no device is given, return the module for the current accelerator or CPU if none is present.
-    """
-    if isinstance(device, torch.device):
-        device_module_name = device.type
-    elif isinstance(device, str):
-        device_module_name = torch.device(device).type
-    elif device is None:
-        # Using default accelerator type. If no accelerator is available, it automatically returns CPU device.
-        device_module_name = torch._C._get_accelerator().type
-    else:
-        raise RuntimeError(
-            f"Invalid value of device '{device}', expect torch.device, str, or None"
-        )
-    device_module = getattr(torch, device_module_name, None)
-    if device_module is None:
-        raise RuntimeError(
-            f"Device '{device_module_name}' does not have a corresponding module registered as 'torch.{device_module_name}'."
-        )
-    return device_module
-
 
 def _constrain_as_size(
     symbol,

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -369,6 +369,11 @@ static PyObject* THPStorage_shareDevice(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   THPStorage_assertNotNull(self);
   const auto& storage = THPStorage_Unpack(self);
+
+  TORCH_CHECK(
+      storage.device_type() == at::getAccelerator(true).value(),
+      "_share_device_: only available on device tensor");
+
   c10::StorageImpl* storage_impl = storage.unsafeGetStorageImpl();
   if (storage_impl->received_device()) {
     AT_ERROR(

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -146,7 +146,7 @@ def rebuild_cuda_tensor(
         )
         if storage is None:
             torch.cuda._lazy_init()
-            storage = storage_cls._new_shared_cuda(
+            storage = storage_cls._new_shared_device(
                 storage_device,
                 storage_handle,
                 storage_size_bytes,
@@ -162,7 +162,7 @@ def rebuild_cuda_tensor(
         else:
             # We already ref counting this Storage, but producer needs new ref-counters to be released.
             storage_cls._release_ipc_counter(
-                ref_counter_handle, ref_counter_offset, device=storage_device
+                ref_counter_handle, ref_counter_offset
             )
 
     _storage = (
@@ -319,7 +319,7 @@ def reduce_tensor(tensor):
             ref_counter_offset,
             event_handle,
             event_sync_required,
-        ) = storage._share_cuda_()
+        ) = storage._share_device_()
         tensor_offset = tensor.storage_offset()
         shared_cache[handle] = StorageWeakRef(storage)
         # _backward_hooks purposely omitted here, see

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -91,7 +91,7 @@ class _StorageBase:
     @classmethod
     def _new_shared_filename_cpu(cls: Type[T], manager, obj, size, *, device=None, dtype=None) -> T: ...  # type: ignore[empty-body] # noqa: E704
     @classmethod
-    def _release_ipc_counter_cuda(cls: Type[T], *args, **kwargs) -> T: ...  # type: ignore[empty-body] # noqa: E704
+    def _release_ipc_counter_device(cls: Type[T], *args, **kwargs) -> T: ...  # type: ignore[empty-body] # noqa: E704
     @classmethod
     def _new_with_weak_ptr(cls: Type[T], *args, **kwargs) -> T: ...  # type: ignore[empty-body] # noqa: E704
     def _shared_decref(self) -> T: ...  # type: ignore[empty-body, misc, type-var] # noqa: E704
@@ -100,10 +100,10 @@ class _StorageBase:
     def _weak_ref(self, *args, **kwargs) -> T: ...  # type: ignore[empty-body, misc, type-var] # noqa: E704
     def _set_from_file(self, *args, **kwargs): ...  # noqa: E704
     def _set_cdata(self, *args, **kwargs): ...  # noqa: E704
-    def _share_cuda_(self, *args, **kwargs): ...  # noqa: E704
+    def _share_device_(self, *args, **kwargs): ...  # noqa: E704
     def is_shared(self) -> bool: ...  # type: ignore[empty-body] # noqa: E704
     @classmethod
-    def _new_shared_cuda(cls: Type[T], *args, **kwargs) -> T: ...  # type: ignore[empty-body] # noqa: E704
+    def _new_shared_device(cls: Type[T], *args, **kwargs) -> T: ...  # type: ignore[empty-body] # noqa: E704
     def _shared_incref(self, *args, **kwargs): ...  # noqa: E704
     @classmethod
     def _free_weak_ref(cls, *args, **kwargs): ...  # noqa: E704
@@ -1196,8 +1196,8 @@ class TypedStorage:
     def _set_cdata(self, *args, **kwargs):
         return self._untyped_storage._set_cdata(*args, **kwargs)
 
-    def _share_cuda_(self, *args, **kwargs):
-        return self._untyped_storage._share_cuda_(*args, **kwargs)
+    def _share_device_(self, *args, **kwargs):
+        return self._untyped_storage._share_device_(*args, **kwargs)
 
     def is_shared(self):
         _warn_typed_storage_removal()
@@ -1208,8 +1208,8 @@ class TypedStorage:
         return self._untyped_storage.is_shared()
 
     @classmethod
-    def _new_shared_cuda(cls, *args, **kwargs):
-        return torch.UntypedStorage._new_shared_cuda(*args, **kwargs)
+    def _new_shared_device(cls, *args, **kwargs):
+        return torch.UntypedStorage._new_shared_device(*args, **kwargs)
 
     def _share_filename_cpu_(self, *args, **kwargs):
         manager_handle, storage_handle, size = self._untyped_storage._share_filename_cpu_(*args, **kwargs)
@@ -1220,8 +1220,8 @@ class TypedStorage:
         return self
 
     @classmethod
-    def _release_ipc_counter(cls, *args, device=None, **kwargs):
-        return torch.UntypedStorage._release_ipc_counter_cuda(*args, **kwargs)
+    def _release_ipc_counter(cls, *args, **kwargs):
+        return torch.UntypedStorage._release_ipc_counter_device(*args, **kwargs)
 
     def _shared_incref(self, *args, **kwargs):
         return self._untyped_storage._shared_incref(*args, **kwargs)
@@ -1269,7 +1269,7 @@ class _LegacyStorage(TypedStorage, metaclass=_LegacyStorageMeta):
 
     @classmethod
     def _release_ipc_counter(cls, *args, **kwargs):
-        return torch.UntypedStorage._release_ipc_counter_cuda(*args, **kwargs)
+        return torch.UntypedStorage._release_ipc_counter_device(*args, **kwargs)
 
     @classmethod
     def _new_shared_filename(cls, manager, obj, size):


### PR DESCRIPTION
I am working on IPC-related interfaces to support third-party devices. 
This is another option for IPC support for third party devices.

1. The share_cuda_ interface is changed to share_device_
2. The backend uses getAccelerator to determine the device and distribute different devices.
3. Add the share_device implementation of third-party devices to PrivateUse1HooksInterface

In this way, third-party devices and CUDA will use the same interface, and the device distinction is hidden in the backend. Users also need to manually set the device type (although these are internal interfaces).

another plan: https://github.com/pytorch/pytorch/pull/125122

Do you think which is feasible? Looking forward to your suggestions
Fixes #124902

cc @albanD 
