### PR TITLE
[XPU] call empty_cache for dynamo tests

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -358,12 +358,17 @@ def empty_gpu_cache(device):
     """
     Explicitly empty gpu cache to avoid OOM in subsequent run.
     """
-    assert (
-        device != ""
-    ), "The empty_gpu_cache needs to be called with a non empty device str"
+
+    if device not in ["cuda", "xpu"]:
+        log.warning(
+            "Trying to call the empty_gpu_cache for device: %s, which is not in list [cuda, xpu]",
+            device,
+        )
+        return
+
     if device == "cuda":
         torch.cuda.empty_cache()
-    if device == "xpu":
+    elif device == "xpu":
         torch.xpu.empty_cache()
 
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -358,6 +358,7 @@ def empty_gpu_cache(device):
     """
     Explicitly empty gpu cache to avoid OOM in subsequent run.
     """
+    assert device != "", "The empty_gpu_cache needs to be called with a non empty device str"
     if device == "cuda":
         torch.cuda.empty_cache()
     if device == "xpu":

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -358,7 +358,9 @@ def empty_gpu_cache(device):
     """
     Explicitly empty gpu cache to avoid OOM in subsequent run.
     """
-    assert device != "", "The empty_gpu_cache needs to be called with a non empty device str"
+    assert (
+        device != ""
+    ), "The empty_gpu_cache needs to be called with a non empty device str"
     if device == "cuda":
         torch.cuda.empty_cache()
     if device == "xpu":
@@ -2105,7 +2107,6 @@ class BenchmarkRunner:
                     else torch.bfloat16
                 )
                 self.autocast_arg["dtype"] = amp_dtype
-
 
     def init_optimizer(self, name, device, params):
         if device == "cuda" and self.args.training and name not in CI_SKIP_OPTIMIZER:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -357,10 +357,11 @@ def patch_torch_manual_seed():
 def empty_gpu_cache():
     """
     Explicitly empty gpu cache to avoid OOM in subsequent run.
-    Note that there should be no side effect to call empty_cache for non-existing devices.
     """
-    torch.cuda.empty_cache()
-    torch.xpu.empty_cache()
+    if HAS_CUDA:
+        torch.cuda.empty_cache()
+    if HAS_XPU:
+        torch.xpu.empty_cache()
 
 
 def synchronize():


### PR DESCRIPTION
When running a batch of models, lacking `empty_cache()` would result in OOM for subsequent models.

This PR unifies the `empty_cache` call for both CUDA and XPU.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang