### PR TITLE
make torch.save(PrivateUse1's Tensor) more generalizable

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -259,10 +259,7 @@ class Tensor(torch._C.TensorBase):
         # 2. Python list is not a good fit due to performance reason.
         #    `tolist()` converts every single element in the tensor into python objects
         #    and serialize them one by one.
-        if self.device.type in ["xla", "mtia", "maia"] or (
-            not torch._C._has_storage(self)
-            and self.device.type == torch._C._get_privateuse1_backend_name()
-        ):
+        if self.device.type in ["xla", "mtia", "maia"]:
             # Convert BFloat16 tesors to Float32 before conversion to numpy, as numpy doesn't
             # support BFloat16. The rebuild tensor from numpy takes in the original self.dtype,
             # this would reconstruct the BFloat16 tensor from numpy.


### PR DESCRIPTION
Fixes [#121797 ](https://github.com/pytorch/pytorch/issues/121797)
As described in the issue, currently, torch is unable to save `SpraseCOOTensor in PrivateUse1` (including csr/csc/bsr/bsc). The reason is that SparseTensor does not have storage, and numpy cannot handle sparse, so it cannot be saved.
I think `PrivateUse1` should be more `CUDA` oriented than a few special devices like `XLA, MTIA, MAIA`.
Please let me know if the deleted code is necessary in some special scenarios.

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens