### PR TITLE
Fix inplace lshift usage

### DIFF
--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2633,7 +2633,6 @@ struct to_ir {
       case '^':
         return use_inplace_op ? aten::bitwise_xor : aten::__xor__;
       case TK_LSHIFT:
-        // NOLINTNEXTLINE(bugprone-branch-clone)
         return use_inplace_op ? aten::__ilshift__ : aten::__lshift__;
       case TK_RSHIFT:
         return use_inplace_op ? aten::__irshift__ : aten::__rshift__;

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -2634,7 +2634,7 @@ struct to_ir {
         return use_inplace_op ? aten::bitwise_xor : aten::__xor__;
       case TK_LSHIFT:
         // NOLINTNEXTLINE(bugprone-branch-clone)
-        return use_inplace_op ? aten::__lshift__ : aten::__lshift__;
+        return use_inplace_op ? aten::__ilshift__ : aten::__lshift__;
       case TK_RSHIFT:
         return use_inplace_op ? aten::__irshift__ : aten::__rshift__;
       case TK_POW:


### PR DESCRIPTION
It seems that there is a typo: for the rhift op we distinguish between inplace and regular implementation but for the lshift we call __lshift__ in both situations.
