### PR TITLE
Revert "[Export] Allow ExportedProgram to take empty decomp table (#126142)"

### DIFF
--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -547,8 +547,7 @@ class ExportedProgram:
                 placeholders.append(node)
             return placeholders
 
-        if decomp_table is None:
-            decomp_table = core_aten_decompositions()
+        decomp_table = decomp_table or core_aten_decompositions()
 
         old_placeholders = _get_placeholders(self.graph_module)
         fake_args = [node.meta["val"] for node in old_placeholders]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126443
* #126442
* #126441
* #126440
* #126439
* #126438
* #126437
* #126436
* #126435
* #126434
* #126433
* #126432
* #126431
* #126430
* #126429
* #126428
* #126427
* #126426
* #126425
* __->__ #126424

This reverts commit 51e9bb87834439118403ef46bdb028cead29e7d2.