### PR TITLE
Revert "Make propagate_real_tensor more safe (#126281)"

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -868,6 +868,9 @@ class FakeTensorTest(TestCase):
                 == torch.channels_last
             )
 
+    # Propagate real tensors doesn't work when original input arguments are
+    # fake
+    @expectedFailurePropagateRealTensors
     def test_export_numpy(self):
         class MyNumpyModel(torch.nn.Module):
             def forward(self, input):
@@ -1474,6 +1477,7 @@ class FakeTensorPropTest(TestCase):
                     failed = True
                 self.assertTrue(failed)
 
+    @expectedFailurePropagateRealTensors  # Propagate real tensors doesn't work with fake-on-fake
     def test_fake_tensor_prop_on_nn_module_with_optional_args(self):
         class OptionalArgumentInBetween(torch.nn.Module):
             def __init__(self):
@@ -1506,6 +1510,7 @@ class FakeTensorPropTest(TestCase):
                 value, None, another_optional_value
             )
 
+    @expectedFailurePropagateRealTensors  # TODO: not sure about this one, kinda strange
     def test_unbacked_shape_realloc(self):
         def f(x):
             return x.nonzero()

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -465,30 +465,6 @@ class MetaTensorDesc:
         return self.size
 
 
-# A more faithful reproduction would do a copy on the entire
-# storage, but this needs to be done carefully because the
-# underlying storage could have larger extent than is implied
-# by size/stride.  The real fix is to properly call
-# meta_storage recursively here.
-#
-# These "safe" functions are intended to be used under no_dispatch() mode.
-# The no_dispatch() here is intended to prevent ambient fake tensor mode from
-# fakeifying the operation.  But if we are given an honest to goodness
-# FakeTensor as src, we MUST NOT run the copy/clone operation.  A better way
-# to do this would be to not use no_dispatch and instead just disable fake
-# tensor mode only (allowing for subclass dispatch to occur)
-def _safe_copy(dst, src):
-    if type(src) is not torch.Tensor:
-        return
-    dst.copy_(src)
-
-
-def _safe_clone(src):
-    if type(src) is not torch.Tensor:
-        return None
-    return src.clone()
-
-
 # This is a class for converting multiple tensors into meta tensors which
 # share the same view/storage structure.  The operation model is you allocate
 # one of these, and then call it repeatedly on all the tensors you want to
@@ -537,8 +513,6 @@ class MetaConverter:
                 lambda: torch.empty(s.size, dtype=torch.uint8, device="meta"),
             ).untyped_storage()
             if self.copy_data:
-                # NB: no_dispatch is needed because internally storage copy is
-                # implemented as Tensor operations
                 with torch.no_grad(), no_dispatch():
                     assert s.data is not None
                     r_s.real_storage = s.data.clone()
@@ -703,6 +677,13 @@ class MetaConverter:
                         ),
                     )
                 )
+                # Note [Inaccessible data is not copied]
+                # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                # A more faithful reproduction would do a copy on the entire
+                # storage, but this needs to be done carefully because the
+                # underlying storage could have larger extent than is implied
+                # by size/stride.  The real fix is to properly call
+                # meta_storage recursively here.
                 if self.copy_data:
                     with torch.no_grad(), no_dispatch():
                         r.real_tensor = torch.empty_strided(
@@ -712,7 +693,9 @@ class MetaConverter:
                             device=inner_t.device,
                         )
                         assert inner_t.data is not None
-                        _safe_copy(r.real_tensor, inner_t.data)
+                        r.real_tensor.copy_(
+                            inner_t.data
+                        )  # Note [Inaccessible data is not copied]
                 return r
 
             transformed_tensors_dict = {
@@ -960,7 +943,7 @@ class MetaConverter:
                         # Pray that sparse clone doesn't lose information
                         assert t.data is not None
                         with torch.no_grad(), no_dispatch():
-                            r.real_tensor = _safe_clone(t.data)
+                            r.real_tensor = t.data.clone()
                     assert safe_is_leaf(r), "the callback you passed in doesn't detach"
                     # Note [is_coalesced is dispatched]
                     # Strangely enough, is_coalesced() is a dispatched operator,
@@ -1012,7 +995,7 @@ class MetaConverter:
                         # Pray sparse clone doesn't lose information
                         assert t.data is not None
                         with torch.no_grad(), no_dispatch():
-                            r.real_tensor = _safe_clone(t.data)
+                            r.real_tensor = t.data.clone()
                     assert safe_is_leaf(r), "the callback you passed in doesn't detach"
                     if t.requires_grad:
                         r.requires_grad = True
@@ -1050,7 +1033,9 @@ class MetaConverter:
                                 t.size, t.stride, dtype=t.dtype, device=t.device
                             )
                             assert t.data is not None
-                            _safe_copy(r.real_tensor, t.data)
+                            r.real_tensor.copy_(
+                                t.data
+                            )  # Note [Inaccessible data is not copied]
                     assert safe_is_leaf(r), "the callback you passed in doesn't detach"
                     if t.requires_grad:
                         r.requires_grad = True
@@ -1150,7 +1135,10 @@ class MetaConverter:
                                         device=t.device,
                                     )
                                     assert t.data is not None
-                                    _safe_copy(r.real_tensor, t.data)  # type: ignore[attr-defined]
+                                    # Note [Inaccessible data is not copied]
+                                    r.real_tensor.copy_(  # type: ignore[attr-defined]
+                                        t.data
+                                    )
                         return r
 
                     r = _to_fake_tensor(t)
@@ -1285,13 +1273,6 @@ class MetaConverter:
                 else:
                     is_leaf = t.is_leaf
 
-                    # Graph-Break for wrapped tensors
-                    if (
-                        not (t.is_batchedtensor or t.is_gradtrackingtensor)
-                        and t.is_functorch_wrapped
-                    ) or t.is_legacy_batchedtensor:
-                        return NotImplemented
-
                     (
                         sizes,
                         strides,
@@ -1320,7 +1301,6 @@ class MetaConverter:
                                 r.real_tensor = torch.empty_strided(
                                     t.size, t.stride, dtype=t.dtype, device=t.device
                                 )
-                                _safe_copy(r.real_tensor, t.data)
 
                     assert safe_is_leaf(r), "the callback you passed in doesn't detach"
                     if t.requires_grad:
@@ -1340,6 +1320,13 @@ class MetaConverter:
                                 1,
                             )(r)
 
+                    # Graph-Break for wrapped tensors
+                    if (
+                        not (t.is_batchedtensor or t.is_gradtrackingtensor)
+                        and t.is_functorch_wrapped
+                    ) or t.is_legacy_batchedtensor:
+                        return NotImplemented
+
                     s = t.storage
                     assert s is not None
                     if s.id not in self.storage_memo and (
@@ -1352,9 +1339,11 @@ class MetaConverter:
                         # You're normal and happy, install the fresh storage into the memo
                         self.set_storage_memo(s, r.untyped_storage())
                         if self.copy_data:
-                            r.untyped_storage().real_storage = (
-                                r.real_tensor.untyped_storage()
-                            )
+                            with torch.no_grad(), no_dispatch():
+                                r.real_tensor.untyped_storage().copy_(s.data)
+                                r.untyped_storage().real_storage = (
+                                    r.real_tensor.untyped_storage()
+                                )
                     else:
                         # You're in crazy town; somehow you gave us a tensor
                         # that wasn't a view, but had nonzero storage offset,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126443
* #126442
* #126441
* #126440
* #126439
* #126438
* #126437
* #126436
* #126435
* #126434
* #126433
* #126432
* #126431
* #126430
* #126429
* #126428
* __->__ #126427
* #126426
* #126425
* #126424

This reverts commit 3ae118204e3f7536c9481de23c5d3d7e9c6fc804.