### PR TITLE
Revert "Also remove compile_time_strobelight_meta frame when generating stack (#126289)"

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -773,22 +773,6 @@ def _compile(
             "".join(CapturedTraceback.extract(skip=2 + skip).format()),
         )
         # -4: -2 as above, plus trace_structured frames
-        #
-        # NB: the frame looks like this:
-        #
-        # # handled by skip argument
-        # torch/_dynamo/convert_frame.py:1069 in catch_errors
-        # torch/_dynamo/convert_frame.py:910 in _convert_frame
-        # torch/_dynamo/convert_frame.py:464 in _convert_frame_assert
-        # torch/_utils_internal.py:70 in wrapper_function
-        #
-        # # 2 current frame and context lib
-        # env/lib/python3.10/contextlib.py:79 in inner
-        # torch/_dynamo/convert_frame.py:776 in _compile
-        #
-        # # 2 extra here
-        # torch/_logging/_internal.py:1064 in trace_structured
-        # torch/_dynamo/convert_frame.py:780 in <lambda>
         torch._logging.trace_structured(
             "dynamo_start",
             lambda: {

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -63,14 +63,10 @@ def throw_abstract_impl_not_imported_error(opname, module, context):
 
 
 # Meta only, act as nop otherwise.
-#
-# NB!  This treats "skip" kwarg specially!!
 def compile_time_strobelight_meta(phase_name):
     def compile_time_strobelight_meta_inner(function):
         @functools.wraps(function)
         def wrapper_function(*args, **kwargs):
-            if "skip" in kwargs:
-                kwargs["skip"] = kwargs["skip"] + 1
             return function(*args, **kwargs)
 
         return wrapper_function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126443
* #126442
* #126441
* #126440
* #126439
* #126438
* #126437
* #126436
* #126435
* #126434
* #126433
* #126432
* #126431
* #126430
* #126429
* __->__ #126428
* #126427
* #126426
* #126425
* #126424

This reverts commit b2d9b80fbaee97d6dcba822a1756f44630dd7a2a.