### PR TITLE
Revert "[FSDP2] support fully_shard(model_on_meta, cpu_offload) (#126305)"

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -78,9 +78,9 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
                 nn.Linear(mlp_dim, mlp_dim, bias=False),
                 nn.Linear(mlp_dim, mlp_dim, bias=False),
             )
-        for module in model:
-            fully_shard(module, offload_policy=offload_policy)
-        fully_shard(model, offload_policy=offload_policy)
+            for module in model:
+                fully_shard(module, offload_policy=offload_policy)
+            fully_shard(model, offload_policy=offload_policy)
 
         # split full sd into multiple pieces
         # to test loading with `strict=False`

--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -245,7 +245,7 @@ class FSDPParam:
         self.padded_sharded_param_size = padded_sharded_param.size()
         if sharded_param.numel() > 0:
             padded_sharded_param[: sharded_param.size(0)].copy_(sharded_param)
-        if self.offload_to_cpu and not padded_sharded_param.is_meta:
+        if self.offload_to_cpu and not torch.empty(0).is_meta:
             padded_sharded_param = padded_sharded_param.cpu()
             if self.pin_memory:
                 padded_sharded_param = padded_sharded_param.pin_memory()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126443
* #126442
* #126441
* #126440
* #126439
* #126438
* #126437
* #126436
* #126435
* #126434
* #126433
* #126432
* #126431
* __->__ #126430
* #126429
* #126428
* #126427
* #126426
* #126425
* #126424

This reverts commit a7af53cec1d421d2f6d99c9cb7fb341a691fc371.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k