### PR TITLE
Revert "[dynamo][inline-inbuilt-nn-modules] Bug fix - Only unspecialized nn modules (#126303)"

### DIFF
--- a/torch/_dynamo/mutation_guard.py
+++ b/torch/_dynamo/mutation_guard.py
@@ -103,11 +103,7 @@ def is_dynamic_nn_module(obj, is_export):
     # 1) Input signature problem because params are lifted as inputs
     # 2) nn module stack info changes
     # 3) adjust failing tests
-    if (
-        isinstance(obj, torch.nn.Module)
-        and config.inline_inbuilt_nn_modules
-        and not is_export
-    ):
+    if config.inline_inbuilt_nn_modules and not is_export:
         return True
     dyn = GenerationTracker.dynamic_classes.get(type(obj)) or GenerationTracker.check(
         obj


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126443
* #126442
* #126441
* #126440
* #126439
* #126438
* #126437
* #126436
* #126435
* #126434
* #126433
* #126432
* __->__ #126431
* #126430
* #126429
* #126428
* #126427
* #126426
* #126425
* #126424

This reverts commit bcdd0b11ca82b9a0a60608ca433bb464ddf30fc1.