### PR TITLE
Revert "[dynamo] graph break on issubclass call with non-const args (#125943)"

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4962,15 +4962,6 @@ def forward(self, primals_1, primals_2):
         inp = torch.randn(3, 3)
         self.assertEqual(fn(inp), opt_fn(inp))
 
-    def test_nonconst_issubclass(self):
-        def fn(x):
-            if issubclass(x.__class__, np.ndarray):
-                return 1
-            return 0
-
-        opt_fn = torch.compile(fn, backend="eager")
-        opt_fn(np.ones([3, 3]))
-
 
 instantiate_parametrized_tests(ReproTests)
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1402,15 +1402,10 @@ class BuiltinVariable(VariableTracker):
 
     def call_issubclass(self, tx, left_ty, right_ty):
         """Checks if first arg is subclass of right arg"""
-        try:
-            left_ty_py = left_ty.as_python_constant()
-            right_ty_py = right_ty.as_python_constant()
-        except NotImplementedError:
-            unimplemented(
-                f"call_issubclass args not constant left_ty: {left_ty}, right_ty: {right_ty}"
-            )
+        left_ty = left_ty.as_python_constant()
+        right_ty = right_ty.as_python_constant()
 
-        return variables.ConstantVariable(issubclass(left_ty_py, right_ty_py))
+        return variables.ConstantVariable(issubclass(left_ty, right_ty))
 
     def call_super(self, tx, a, b):
         return variables.SuperVariable(a, b)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126443
* #126442
* #126441
* #126440
* #126439
* #126438
* #126437
* #126436
* #126435
* #126434
* __->__ #126433
* #126432
* #126431
* #126430
* #126429
* #126428
* #126427
* #126426
* #126425
* #126424

This reverts commit 56a89fcc08cfe79ab802573638fefcadc4b441d6.