### PR TITLE
Revert "Fix triton codegen main do_bench_gpu import error (#126213)"

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2662,7 +2662,7 @@ class TritonKernel(Kernel):
 
             result.writeline("args = get_args()")
             result.writeline(
-                "ms = do_bench(lambda: call(args), rep=40, fast_flush=True)"
+                "ms = do_bench_gpu(lambda: call(args), rep=40, fast_flush=True)"
             )
             result.writeline(f"num_gb = {num_gb}")
             result.writeline("gb_per_s = num_gb / (ms / 1e3)")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126443
* #126442
* #126441
* #126440
* #126439
* #126438
* #126437
* #126436
* __->__ #126435
* #126434
* #126433
* #126432
* #126431
* #126430
* #126429
* #126428
* #126427
* #126426
* #126425
* #126424

This reverts commit b5432ad5ab2004432c1a984662a3835b93aa9569.