### PR TITLE
Revert "Remove expected failure in `test_eager_transforms.py` (#125883)"

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -67,7 +67,9 @@ from torch.testing._internal.common_dtype import get_all_fp_dtypes
 from torch.testing._internal.common_utils import (
     freeze_rng_state,
     instantiate_parametrized_tests,
+    IS_ARM64,
     IS_FBCODE,
+    IS_MACOS,
     IS_WINDOWS,
     markDynamoStrictTest,
     parametrize,
@@ -5080,7 +5082,9 @@ class TestCompileTransforms(TestCase):
     @skipIfRocm(msg="test leaks memory on ROCm")
     # torch.compile is not supported on Windows
     # Triton only supports GPU with SM70 or later.
-    @expectedFailureIf(IS_WINDOWS or (TEST_CUDA and not SM70OrLater))
+    @expectedFailureIf(
+        (IS_ARM64 and not IS_MACOS) or IS_WINDOWS or (TEST_CUDA and not SM70OrLater)
+    )
     def test_compile_vmap_hessian(self, device):
         # The model and inputs are a smaller version
         # of code at benchmark repo:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126443
* #126442
* #126441
* #126440
* #126439
* #126438
* __->__ #126437
* #126436
* #126435
* #126434
* #126433
* #126432
* #126431
* #126430
* #126429
* #126428
* #126427
* #126426
* #126425
* #126424

This reverts commit 5af4b492852a0c8db03d04c71cae3a3d164d407f.