### PR TITLE
Revert "Improve Storage copy_ size mismatch error message (#126280)"

### DIFF
--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -94,13 +94,7 @@ static PyObject* THPStorage_copy_(
   TORCH_CHECK(
       !invalid, "Attempted to call copy_() on an invalid python storage.")
 
-  TORCH_CHECK(
-      self_.nbytes() == src.nbytes(),
-      "size does not match, self was ",
-      self_.nbytes(),
-      " bytes but src was ",
-      src.nbytes(),
-      " bytes");
+  TORCH_CHECK(self_.nbytes() == src.nbytes(), "size does not match");
 
   at::storage_copy(self_, src, non_blocking);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #126443
* #126442
* __->__ #126441
* #126440
* #126439
* #126438
* #126437
* #126436
* #126435
* #126434
* #126433
* #126432
* #126431
* #126430
* #126429
* #126428
* #126427
* #126426
* #126425
* #126424

This reverts commit f0d34941ddef1b7fcff7be6f6e0153cd99b52183.