### PR TITLE
Revert "[onnx.export] Avoid unnecessary copy of debug_names (#123026)"

### DIFF
--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -310,25 +310,14 @@ void NodeToONNX(
         if (old->hasDebugName() && !exist_in_env) {
           auto old_name = outputs[i]->debugName();
           auto new_name = old->debugNameBase();
-          Value* found_value;
-          bool exists;
-          // In this scope, we fetch debug_names as a const reference and then
-          // construct an iterator exist_name based on it. This iterator will
-          // be corrupted if the underlying map of debug_names changes. This
-          // will happen as a side-effect of setDebugName. For these reasons,
-          // we make an explicit scope for exist_name and make sure that
-          // setDebugName is never called with this scope.
-          {
-            const auto& debug_names = new_block->owningGraph()->debugNames();
-            auto exist_name = debug_names.find(new_name);
-            exists = exist_name != debug_names.end();
-            if (exists) {
-              found_value = exist_name->second;
-            }
-          }
+          auto debug_names = new_block->owningGraph()->debugNames();
+          auto exist_name = debug_names.find(new_name);
           outputs[i]->setDebugName(new_name);
-          if (exists) {
-            found_value->setDebugName(new_name);
+          if (exist_name != debug_names.end()) {
+            // setDebugName changes name of existing value with same name.
+            // Set again to revert the changes, but update name for new value
+            // with suffix.
+            exist_name->second->setDebugName(new_name);
           }
           ConstantValueMap::UpdateValueName(old_name, outputs[i]->debugName());
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126443
* #126442
* #126441
* #126440
* #126439
* #126438
* #126437
* #126436
* #126435
* #126434
* #126433
* #126432
* #126431
* #126430
* #126429
* #126428
* #126427
* #126426
* #126425
* #126424

This reverts commit 31d22858e96ecfa0971e86e9f8d026a3d03c648f.