### PR TITLE
[release/2.3] Added cublasGemmAlgo_t -> hipblasGemmAlgo_t 

### DIFF
--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -454,6 +454,7 @@ CUDA_TYPE_NAME_MAP = collections.OrderedDict(
         ("cublasDiagType_t", ("hipblasDiagType_t", CONV_TYPE, API_BLAS)),
         ("cublasSideMode_t", ("hipblasSideMode_t", CONV_TYPE, API_BLAS)),
         ("cublasPointerMode_t", ("hipblasPointerMode_t", CONV_TYPE, API_BLAS)),
+        ("cublasGemmAlgo_t", ("hipblasGemmAlgo_t", CONV_TYPE, API_BLAS)),
         (
             "cublasAtomicsMode_t",
             ("hipblasAtomicsMode_t", CONV_TYPE, API_BLAS, HIP_UNSUPPORTED),


### PR DESCRIPTION
This PR is to add cublasGemmAlgo_t -> hipblasGemmAlgo_t to cuda_to_hip_mappings.py.
It is required for DeepSpeed transformer extension build on ROCm.