### PR TITLE
[cprofile] log manifold link instead of raw data to trace_structured

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -354,7 +354,7 @@ def cprofile_wrapper(func):
             torch._logging.trace_structured(
                 "link",
                 lambda: {
-                    "name": "manifold_url",
+                    "name": "cprofile_manifold_url",
                     "url": manifold_link
                 },
             )

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -350,20 +350,14 @@ def cprofile_wrapper(func):
             ps.sort_stats(pstats.SortKey.TIME).print_stats(20)
             ps.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(20)
 
-        maybe_upload_prof_stats_to_manifold(str(profile_path))  # fb-only
-
-        torch._logging.trace_structured(
-            "artifact",
-            lambda: {
-                "name": "dynamo_cprofile_prof",
-                "type": "prof",
-                "encoding": "base64",
-            },
-            payload_fn=lambda: base64.encodebytes(
-                open(profile_path, "rb").read()
-            ).decode("ascii"),
-        )
-
+        if manifold_link:=maybe_upload_prof_stats_to_manifold(str(profile_path)):  # fb-only
+            torch._logging.trace_structured(
+                "link",
+                lambda: {
+                    "name": "manifold_url",
+                    "url": manifold_link
+                },
+            )
         return retval
 
     return profile_wrapper

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1,4 +1,3 @@
-import base64
 import collections
 import cProfile
 import dis
@@ -350,13 +349,12 @@ def cprofile_wrapper(func):
             ps.sort_stats(pstats.SortKey.TIME).print_stats(20)
             ps.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(20)
 
-        if manifold_link:=maybe_upload_prof_stats_to_manifold(str(profile_path)):  # fb-only
+        if manifold_link := maybe_upload_prof_stats_to_manifold(
+            str(profile_path)
+        ):  # fb-only
             torch._logging.trace_structured(
                 "link",
-                lambda: {
-                    "name": "cprofile_manifold_url",
-                    "url": manifold_link
-                },
+                lambda: {"name": "cprofile_manifold_url", "url": manifold_link},
             )
         return retval
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import tempfile
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import torch
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -195,6 +195,6 @@ USE_RTLD_GLOBAL_WITH_LIBTORCH = False
 REQUIRES_SET_PYTHON_MODULE = False
 
 
-def maybe_upload_prof_stats_to_manifold(profile_path: str) -> None:
+def maybe_upload_prof_stats_to_manifold(profile_path: str) -> Optional[str]:
     print("Uploading profile stats (fb-only otherwise no-op)")
-    pass
+    return None


### PR DESCRIPTION
Internal D57459752 returns manifold URL and this PR adds to tlparse payload

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang