### PR TITLE
[WIP][XPU] Support elapsed_time in XPUEvent

### DIFF
--- a/c10/xpu/XPUStream.cpp
+++ b/c10/xpu/XPUStream.cpp
@@ -99,7 +99,9 @@ void initDeviceStreamState(DeviceIndex device) {
   using namespace sycl::ext::oneapi::property;
   // Need to align with StreamIdType.
   const std::vector<sycl::property_list> properties = {
-      {sycl::property::queue::in_order(), queue::priority_normal()},
+      {sycl::property::queue::in_order(),
+       queue::priority_normal(),
+       sycl::property::queue::enable_profiling()},
       {sycl::property::queue::in_order(), queue::priority_high()}};
   for (const auto p : c10::irange(max_compile_time_stream_priorities)) {
     for (const auto i : c10::irange(kStreamsPerPool)) {


### PR DESCRIPTION
Adds support for `elapsed_time` in `XPUEvent`. This is required for torch inductor support for the XPU backend for Triton, b/c `do_bench` in Triton uses `elapsed_time` and is called from `do_bench` in inductor.

I was not sure of the performance impact of enabling profiling in the sycl queues - I expect it is minimal, but for now I only enabled profiling in the normal priority queue. 

