### PR TITLE
[torchbench] Add torchao to PT2 Benchmark Runner

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3486,6 +3486,18 @@ def parse_args(args=None):
         help="Measure speedup with TorchInductor",
     )
     group.add_argument(
+        "--quantization",
+        choices=[
+            "int8dynamic",
+            "int8weightonly",
+            "int4weightonly",
+            "autoquant",
+            "noquant",
+        ],
+        default=None,
+        help="Measure speedup of torchao quantization with TorchInductor baseline",
+    )
+    group.add_argument(
         "--export",
         action="store_true",
         help="Measure pass rate with export",
@@ -3679,6 +3691,9 @@ def run(runner, args, original_dir=None):
     if args.inductor:
         assert args.backend is None
         args.backend = "inductor"
+    if args.quantization:
+        assert args.backend is None
+        args.backend = "torchao"
     if args.dynamic_batch_only:
         args.dynamic_shapes = True
         torch._dynamo.config.assume_static_by_default = True
@@ -3957,6 +3972,20 @@ def run(runner, args, original_dir=None):
 
             # AOTInductor doesn't support control flow yet
             runner.skip_models.update(runner.skip_models_due_to_control_flow)
+        elif args.backend == "torchao":
+            assert "cuda" in args.devices, "Quantization requires CUDA device."
+            assert args.bfloat16, "Quantization requires dtype bfloat16."
+            from .torchao import setup_baseline, torchao_optimize_ctx
+
+            setup_baseline()
+            baseline_ctx = functools.partial(
+                torch.compile,
+                backend="inductor",
+                fullgraph=args.nopython,
+                mode=args.inductor_compile_mode,
+            )
+            runner.model_iter_fn = baseline_ctx(runner.model_iter_fn)
+            optimize_ctx = torchao_optimize_ctx(args.quantization)
         else:
             optimize_ctx = torch._dynamo.optimize(args.backend, nopython=args.nopython)
         experiment = speedup_experiment

--- a/benchmarks/dynamo/torchao.py
+++ b/benchmarks/dynamo/torchao.py
@@ -1,0 +1,54 @@
+from typing import Any, Callable
+
+import torch
+
+
+def setup_baseline():
+    torch._dynamo.epilogue_fusion = False
+    torch._dynamo.config.automatic_dynamic_shapes = False
+    torch._dynamo.config.force_parameter_static_shapes = False
+    torch._dynamo.config.cache_size_limit = 10000
+    torch._inductor.config.force_fuse_int_mm_with_mul = True
+    torch._inductor.config.use_mixed_mm = True
+
+
+def torchao_optimize_ctx(quantization: str):
+    import torchao
+    from torchao.quantization import (
+        change_linear_weights_to_int4_woqtensors,
+        change_linear_weights_to_int8_dqtensors,
+        change_linear_weights_to_int8_woqtensors,
+    )
+
+    def inner(model_iter_fn: Callable):
+        def _torchao_apply(module: torch.nn.Module, example_inputs: Any):
+            if getattr(module, "_quantized", None) is None:
+                if quantization == "int8dynamic":
+                    change_linear_weights_to_int8_dqtensors(module)
+                elif quantization == "int8weightonly":
+                    change_linear_weights_to_int8_woqtensors(module)
+                elif quantization == "int4weightonly":
+                    change_linear_weights_to_int4_woqtensors(module)
+                elif quantization == "autoquant":
+                    torchao.autoquant(module, error_on_unseen=False)
+                    if isinstance(example_inputs, dict):
+                        module(**example_inputs)
+                    else:
+                        module(*example_inputs)
+                    from torchao.quantization.autoquant import AUTOQUANT_CACHE
+
+                    assert (
+                        len(AUTOQUANT_CACHE) > 0
+                    ), f"Err: found no autoquantizable layers in model {type(module)}, stopping autoquantization"
+                elif quantization == "noquant":
+                    pass
+                else:
+                    raise AssertionError(
+                        f"Unsupposed quantization mode {quantization}."
+                    )
+                setattr(module, "_quantized", True)  # noqa: B010
+            model_iter_fn(module, example_inputs)
+
+        return _torchao_apply
+
+    return inner


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/benchmark/pull/2268

Support torchao performance and accuracy tests in PT2 Benchmark Runner, using the inductor backend as the baseline.

Test Plan:
```
$ buck2 run mode/opt //caffe2/benchmarks/dynamo:torchbench -- --only BERT_pytorch --bfloat16 --quantization int8dynamic --performance --inference --print-memory

loading model: 0it [00:50, ?it/s]
cuda eval  BERT_pytorch
memory: eager: 0.75 GB, dynamo: 0.75 GB, ratio: 1.00
running benchmark: 100%
1.003x
```

Reviewed By: jerryzh168

Differential Revision: D57463273


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang