### PR TITLE
[distributed] Add cpp-httplib to pytorch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -152,3 +152,6 @@
 [submodule "third_party/opentelemetry-cpp"]
 	path = third_party/opentelemetry-cpp
 	url = https://github.com/open-telemetry/opentelemetry-cpp.git
+[submodule "third_party/cpp-httplib"]
+	path = third_party/cpp-httplib
+	url = git@github.com:yhirose/cpp-httplib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -155,3 +155,4 @@
 [submodule "third_party/cpp-httplib"]
 	path = third_party/cpp-httplib
 	url = git@github.com:yhirose/cpp-httplib.git
+	branch = v0.15.3


### PR DESCRIPTION
Adds https://github.com/yhirose/cpp-httplib such that we are able to use https for host to host communication in distributed (specifically torchrun)

Todo: We likely need to add cpp-httplib somewhere in the build (cmake/bazel) but first we should write the code for it.