### PR TITLE
Tool for scouting exportability in one shot

### DIFF
--- a/test/export/test_tools.py
+++ b/test/export/test_tools.py
@@ -1,0 +1,67 @@
+# Owner(s): ["oncall: export"]
+
+import torch
+from torch._dynamo.test_case import TestCase
+from torch._export.tools import report_exportability
+
+from torch.testing._internal.common_utils import run_tests
+
+torch.library.define(
+    "testlib::op_missing_meta",
+    "(Tensor(a!) x, Tensor(b!) z) -> Tensor",
+    tags=torch.Tag.pt2_compliant_tag,
+)
+
+
+@torch.library.impl("testlib::op_missing_meta", "cpu")
+@torch._dynamo.disable
+def op_missing_meta(x, z):
+    x.add_(5)
+    z.add_(5)
+    return x + z
+
+
+class TestExportTools(TestCase):
+    def test_report_exportability_basic(self):
+        class Module(torch.nn.Module):
+            def forward(self, x, y):
+                return x[0] + y
+
+        f = Module()
+        inp = ([torch.ones(1, 3)], torch.ones(1, 3))
+
+        report = report_exportability(f, inp)
+        self.assertTrue(len(report) == 1)
+        self.assertTrue(report[""] is None)
+
+    def test_report_exportability_with_issues(self):
+        class Unsupported(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.testlib.op_missing_meta(x, x.cos())
+
+        class Supported(torch.nn.Module):
+            def forward(self, x):
+                return x.sin()
+
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.unsupported = Unsupported()
+                self.supported = Supported()
+
+            def forward(self, x):
+                y = torch.nonzero(x)
+                return self.unsupported(y) + self.supported(y)
+
+        f = Module()
+        inp = (torch.ones(4, 4),)
+
+        report = report_exportability(f, inp, strict=False, pre_dispatch=True)
+
+        self.assertTrue(report[""] is not None)
+        self.assertTrue(report["unsupported"] is not None)
+        self.assertTrue(report["supported"] is None)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_export/tools.py
+++ b/torch/_export/tools.py
@@ -1,0 +1,139 @@
+import logging
+import warnings
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+import torch
+import torch.export
+import torch.export._trace
+from torch._utils_internal import log_export_usage
+
+log = logging.getLogger(__name__)
+
+__all__ = ["report_exportability"]
+
+
+def _generate_inputs_for_submodules(
+    model: torch.nn.Module,
+    target_submodules: Iterable[str],
+    args: Tuple[Any, ...],
+    kwargs: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Tuple[Any, Any]]:
+    """
+    Generate inputs for targeting submdoules in the given model. Note that if two submodules refer to the same obj, this
+    function doesn't work.
+
+    Args:
+        model: root model.
+        inputs: inputs to the root model.
+        target_submodules: submodules that we want to generate inputs for.
+
+    Returns:
+        A dict that maps from submodule name to its inputs.
+    """
+    kwargs = kwargs or {}
+
+    handles = []
+    results = {}
+    submodule_to_names = {mod: name for name, mod in model.named_modules()}
+
+    def pre_forward(module, module_args, module_kwargs):
+        results[submodule_to_names[module]] = (module_args, module_kwargs)
+
+    try:
+        for name, mod in model.named_modules():
+            if name in target_submodules:
+                handles.append(
+                    mod.register_forward_pre_hook(pre_forward, with_kwargs=True)
+                )
+        model(*args, **kwargs)
+    except Exception as e:
+        warnings.warn(
+            f"Failed to generate submodule inputs because of the following error:\n{e}"
+        )
+    finally:
+        for h in handles:
+            h.remove()
+    return results
+
+
+def report_exportability(
+    mod: torch.nn.Module,
+    args: Tuple[Any, ...],
+    kwargs: Optional[Dict[str, Any]] = None,
+    *,
+    strict: bool = True,
+    pre_dispatch: bool = False,
+) -> Dict[str, Optional[Exception]]:
+    """
+    Report exportability issues for a module in one-shot.
+
+    Args:
+        mod: root module.
+        args: args to the root module.
+        kwargs: kwargs to the root module.
+    Returns:
+        A dict that maps from submodule name to the exception that was raised when trying to export it.
+        `None` means the module is exportable without issue.
+    Sample output:
+        {
+            '': UnsupportedOperatorException(func=<OpOverload(op='testlib.op_missing_meta', overload='default')>),
+            'submod_1': UnsupportedOperatorException(func=<OpOverload(op='testlib.op_missing_meta', overload='default')>),
+            'submod_2': None
+        }
+    """
+
+    log_export_usage(event="export.report_exportability")
+
+    kwargs = kwargs or {}
+
+    all_submod_names = [name for name, _ in mod.named_modules() if name != ""]
+    submod_inputs = _generate_inputs_for_submodules(mod, all_submod_names, args, kwargs)
+
+    report: Dict[str, Optional[Exception]] = {}
+
+    def try_export(module, module_name, args, kwargs):
+        nonlocal submod_inputs, report, strict, pre_dispatch
+
+        if args is not None or kwargs is not None:
+            try:
+                torch.export._trace._export(
+                    module,
+                    args,
+                    kwargs,
+                    strict=strict,
+                    pre_dispatch=pre_dispatch,
+                )
+                report[module_name] = None
+                log.info("Successfully exported `%s`", module_name)
+                return
+            except Exception as e:
+                short_msg = repr(e).split("\n")[0]
+                log.warning(
+                    "Failed exporting `%s` with exception: %s", module_name, short_msg
+                )
+                report[module_name] = e
+
+        for name, submod in module.named_children():
+            sub_module_name = name if module_name == "" else f"{module_name}.{name}"
+
+            submod_args, submod_kwargs = submod_inputs.get(
+                sub_module_name, (None, None)
+            )
+
+            try_export(submod, sub_module_name, submod_args, submod_kwargs)
+
+        return
+
+    try_export(mod, "", args, kwargs)
+
+    unique_issues = set()
+    for exception in report.values():
+        if exception is not None:
+            key = repr(exception).split("\\n")[0]
+            unique_issues.add(key)
+
+    log.warning("Found %d export issues:", len(unique_issues))
+    for issue in unique_issues:
+        log.warning(issue)
+
+    return report


### PR DESCRIPTION
Summary:
Tool for scouting exportability issues in one shot. 

- Collect sample inputs for all submodules by running eager inference with forward_pre_hook. 
- Start from root module, recursively try exporting child modules, if current module export fails. 

Limitations: 
- only works for nn.module that contains tree-like submodules structure. this doesn't work for flatten GraphModule. 

TODO: support dynamic_dims


Sample output: https://docs.google.com/spreadsheets/d/1jnixrqBTYbWO_y6AaKA13XqOZmeB1MQAMuWL30dGoOg/edit?usp=sharing 

```
exportability_report = 
        {
            '': UnsupportedOperatorException(func=<OpOverload(op='testlib.op_missing_meta', overload='default')>),
            'submod_1': UnsupportedOperatorException(func=<OpOverload(op='testlib.op_missing_meta', overload='default')>),
            'submod_2': None
        }
```

Test Plan: buck2 run mode/dev-nosan fbcode//caffe2/test:test_export -- -r TestExportTools

Differential Revision: D57466486


