### PR TITLE
Remove dist_ prefix from TORCH_LOGS shortcuts

### DIFF
--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -26,13 +26,13 @@ register_log("dynamic", DYNAMIC)
 register_log("torch", "torch")
 register_log("distributed", DISTRIBUTED)
 register_log(
-    "dist_c10d", ["torch.distributed.distributed_c10d", "torch.distributed.rendezvous"]
+    "c10d", ["torch.distributed.distributed_c10d", "torch.distributed.rendezvous"]
 )
 register_log(
-    "dist_ddp", ["torch.nn.parallel.distributed", "torch._dynamo.backends.distributed"]
+    "ddp", ["torch.nn.parallel.distributed", "torch._dynamo.backends.distributed"]
 )
-register_log("dist_pp", ["torch.distributed.pipelining"])
-register_log("dist_fsdp", ["torch.distributed.fsdp"])
+register_log("pp", ["torch.distributed.pipelining"])
+register_log("fsdp", ["torch.distributed.fsdp"])
 register_log("onnx", "torch.onnx")
 register_log("export", ["torch._dynamo", "torch.export", *DYNAMIC])
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126499
* #126322

e.g. dist_ddp -> ddp

'distributed' shortcut remains unchained

Feedback has been that it is not appealing to have the dist_ prefix,
and the main reason for it was to keep the distributed shortcuts grouped
together in the help menu.  It's nice to have shorter shortcuts.