### PR TITLE
Add a registry for GraphModuleSerializer

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -64,7 +64,7 @@ class TestSerialize(TestCase):
             def namespace(self):
                 return "foo"
 
-            def op_name(self, op_name):
+            def op_name(self, op_type):
                 return "target"
 
             def serialize_target(self, target):
@@ -79,8 +79,7 @@ class TestSerialize(TestCase):
         # Register the custom op handler.
         foo_custom_op = FooCustomOp()
         torch._export.serde.serialize.register_custom_op_serialization(
-            foo_custom_op,
-            foo_custom_op.serialize_target,
+            foo_custom_op, type(foo_custom_op)
         )
 
         # Inject the custom operator.

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -520,7 +520,7 @@ class GraphModuleSerializer(metaclass=Final):
                 outputs=self.serialize_hoo_outputs(node),
                 metadata=self.serialize_metadata(node),
             )
-        elif isinstance(node.target, CustomOpHandler):
+        elif type(node.target) in _serialize_registry:
             custom_op_handler = node.target
 
             # Sanity check for unhandled serialization.

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -528,8 +528,8 @@ class GraphModuleSerializer(metaclass=Final):
 
             ex_node = Node(
                 target=_serialization_registry[type(node.target)](node.target),  # Jump to custom serialization function.
-                inputs=self.serialize_hoo_inputs(node.args, node.kwargs),
-                outputs=self.serialize_hoo_outputs(node),
+                inputs=self.serialize_inputs(node.args, node.kwargs),
+                outputs=self.serialize_outputs(node),
                 metadata=self.serialize_metadata(node),
             )
         else:

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -526,8 +526,9 @@ class GraphModuleSerializer(metaclass=Final):
             # Sanity check for unhandled serialization.
             assert type(node.target) in _serialization_registry, f"Miss {type(node.target)} custom op seralization"
 
+            handler = _serialization_registry[type(node.target)]
             ex_node = Node(
-                target=_serialization_registry[type(node.target)](node.target),  # Jump to custom serialization function.
+                target=f"${handler.namespace()}:{handler.op_name(node.target)}",  # Jump to custom serialization function.
                 inputs=self.serialize_inputs(node.args, node.kwargs),
                 outputs=self.serialize_outputs(node),
                 metadata=self.serialize_metadata(node),

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -604,7 +604,10 @@ class GraphModuleSerializer(metaclass=Final):
         return serialized_args
 
     def serialize_inputs(
-        self, target: torch._ops.OpOverload, args, kwargs=None
+        self,
+        target: Any,  # torch._ops.OpOverload and other custom operator types.
+        args,
+        kwargs=None
     ) -> List[NamedArgument]:
         assert isinstance(target, torch._ops.OpOverload) or isinstance(target, allowed_registered_op_types())
         kwargs = kwargs or {}

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2822,7 +2822,7 @@ class CustomOpHandler:
         raise NotImplementedError(f"{cls.__class__} op_type() must be implemented")
 
     def op_schema(self, op_type):
-        pass
+        raise NotImplementedError(f"{cls.__class__} op_schema() must be implemented")
 
 
 def register_custom_op_handler(

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2815,9 +2815,6 @@ def register_custom_op_serialization(
     assert isinstance(op_handler, CustomOpHandler), f"Expected CustomOpHandler, got {type(op_handler)}."
 
     namespace = op_handler.namespace()
-    # FIXME: hardcoded target because currently custom op serialization only handles
-    # node.target during serialization.
-    op_name = op_handler.op_name("target")
 
     if namespace not in _serialization_registry:
         _serialization_registry[namespace] = {}

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2823,4 +2823,5 @@ def register_custom_op_serialization(
 # Registry to store all custom serialization implementations.
 # The registry maps a operation to its serialization function (a callable), in their own
 # namespace to avoid conflicts.
-_serialization_registry: Dict[str, Dict[str, Callable]] = {}
+_deserialization_registry: Dict[str, CustomOpHandler] = {}
+_serialization_registry: Dict[Type[Any], CustomOpHandler] = {}

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2809,7 +2809,7 @@ class CustomOpHandler:
 
 def register_custom_op_serialization(
     op_handler: CustomOpHandler,
-    serialization_fn: Callable[[Tuple[GraphModuleSerializer, torch.fx.Node], Node], Node],
+    op_type,
 ):
     """Register custom serialization method for a node."""
     assert isinstance(op_handler, CustomOpHandler), f"Expected CustomOpHandler, got {type(op_handler)}."

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2815,16 +2815,20 @@ class CustomOpHandler:
     """
     Base class for handling custom operators.
     """
-    def namespace(self):
+    @classmethod
+    def namespace(cls):
         raise NotImplementedError(f"{cls.__class__} namespace() must be implemented")
 
-    def op_name(self, op_type):
+    @classmethod
+    def op_name(cls, op_type):
         raise NotImplementedError(f"{cls.__class__} op_name() must be implemented")
 
-    def op_type(self, op_name):
+    @classmethod
+    def op_type(cls, op_name):
         raise NotImplementedError(f"{cls.__class__} op_type() must be implemented")
 
-    def op_schema(self, op_type):
+    @classmethod
+    def op_schema(cls, op_type):
         raise NotImplementedError(f"{cls.__class__} op_schema() must be implemented")
 
 

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -362,13 +362,24 @@ def serialize_range_constraints(
     }
 
 
+def _get_schema_from_target(target):
+    if isinstance(target, torch._ops.OpOverload):
+        return target._schema
+    elif type(target) in _serialization_registry:
+        return _serialization_registry[type(target)].op_schema(type(target))
+    raise Exception(f"Cannot find schema for {type(target)}")
+
+
 def _is_single_tensor_return(target: torch._ops.OpOverload) -> bool:
-    returns = target._schema.returns
+    schema = _get_schema_from_target(target)
+    returns = schema.returns
     return len(returns) == 1 and isinstance(returns[0].real_type, torch.TensorType)
 
 
 def _is_single_tensor_list_return(target: torch._ops.OpOverload) -> bool:
-    returns = target._schema.returns
+    schema = _get_schema_from_target(target)
+    returns = schema.returns
+
     if len(returns) != 1:
         return False
     return_type = returns[0].real_type
@@ -520,16 +531,16 @@ class GraphModuleSerializer(metaclass=Final):
                 outputs=self.serialize_hoo_outputs(node),
                 metadata=self.serialize_metadata(node),
             )
-        elif type(node.target) in _serialize_registry:
+        elif type(node.target) in _serialization_registry:
             custom_op_handler = node.target
 
             # Sanity check for unhandled serialization.
-            assert type(node.target) in _serialization_registry, f"Miss {type(node.target)} custom op seralization"
+            assert type(node.target) in _serialization_registry, f"Miss {type(node.target)} CustomOpHandler"
 
             handler = _serialization_registry[type(node.target)]
             ex_node = Node(
-                target=f"${handler.namespace()}:{handler.op_name(node.target)}",  # Jump to custom serialization function.
-                inputs=self.serialize_inputs(node.args, node.kwargs),
+                target=f"${handler.namespace()}:{handler.op_name(node.target)}",
+                inputs=self.serialize_inputs(node.target, node.args, node.kwargs),
                 outputs=self.serialize_outputs(node),
                 metadata=self.serialize_metadata(node),
             )
@@ -595,10 +606,13 @@ class GraphModuleSerializer(metaclass=Final):
     def serialize_inputs(
         self, target: torch._ops.OpOverload, args, kwargs=None
     ) -> List[NamedArgument]:
-        assert isinstance(target, torch._ops.OpOverload)
+        assert isinstance(target, torch._ops.OpOverload) or isinstance(target, allowed_registered_op_types())
         kwargs = kwargs or {}
         serialized_args = []
-        for i, schema_arg in enumerate(target._schema.arguments):
+
+        schema = _get_schema_from_target(target)
+
+        for i, schema_arg in enumerate(schema.arguments):
             if schema_arg.name in kwargs:
                 serialized_args.append(
                     NamedArgument(
@@ -1089,12 +1103,11 @@ class GraphModuleSerializer(metaclass=Final):
         mostly reuse the names coming from FX. This function computes a mapping from
         the FX representation to our representation, preserving the names.
         """
-        assert node.op == "call_function" and isinstance(
-            node.target, torch._ops.OpOverload
-        )
+        assert node.op == "call_function"
+        assert isinstance(node.target, torch._ops.OpOverload) or isinstance(node.target, allowed_registered_op_types())
 
-        assert isinstance(node.target, torch._ops.OpOverload)
-        returns = node.target._schema.returns
+        schema = _get_schema_from_target(node.target)
+        returns = schema.returns
 
         if len(returns) == 0:
             return []
@@ -2799,26 +2812,40 @@ class CustomOpHandler:
     """
     Base class for handling custom operators.
     """
-    @classmethod
-    def namespace(cls):
+    def namespace(self):
         raise NotImplementedError(f"{cls.__class__} namespace() must be implemented")
 
-    @classmethod
-    def op_name(cls, op_type):
+    def op_name(self, op_type):
         raise NotImplementedError(f"{cls.__class__} op_name() must be implemented")
 
+    def op_type(self, op_name):
+        raise NotImplementedError(f"{cls.__class__} op_type() must be implemented")
 
-def register_custom_op_serialization(
+    def op_schema(self, op_type):
+        pass
+
+
+def register_custom_op_handler(
     op_handler: CustomOpHandler,
     op_type: Type[Any],
 ):
-    """Register custom serialization method for a node."""
+    """Register custom de/serialization method for a node."""
     assert isinstance(op_handler, CustomOpHandler), f"Expected CustomOpHandler, got {type(op_handler)}."
     _serialization_registry[op_type] = op_handler
+    # FIXME: handles deserialization later.
+    _deserialization_registry[op_handler.namespace()] = op_handler
+
+
+def allowed_registered_op_types():
+    return tuple(
+        _serialization_registry.keys()
+    )
+
 
 # Registry to store all custom serialization implementations.
 # The registry maps a operation to its serialization function (a callable), in their own
 # namespace to avoid conflicts.
+# Serialization: Op type --> custom handler.
+# De-serialization: Namespace --> custom handler.
 _serialization_registry: Dict[Type[Any], CustomOpHandler] = {}
-# FIXME: add custom op support for deserialization later.
 _deserialization_registry: Dict[str, CustomOpHandler] = {}

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2818,8 +2818,7 @@ def register_custom_op_serialization(
 
     if namespace not in _serialization_registry:
         _serialization_registry[namespace] = {}
-    _serialization_registry[namespace][op_name] = serialization_fn
-
+    _serialization_registry[op_type] = op_handler
 
 # Registry to store all custom serialization implementations.
 # The registry maps a operation to its serialization function (a callable), in their own

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -133,7 +133,7 @@ class Verifier(metaclass=_VerifierMeta):
         ]
 
     def allowed_op_types(self) -> Tuple[Type[Any], ...]:
-        return (OpOverload, HigherOrderOperator)
+        return (OpOverload, HigherOrderOperator, *torch._export.serde.serialize.allowed_registered_op_types())
 
     def allowed_getattr_types(self) -> Tuple[Type[Any], ...]:
         return (torch.fx.GraphModule,)
@@ -182,12 +182,11 @@ class Verifier(metaclass=_VerifierMeta):
                 # TODO (tmanlaibaatar)
                 # Predispatch export is able to contain autograd ops.
                 # These will be modeled as HOO later
-                torch._C._set_grad_enabled
-
+                torch._C._set_grad_enabled,
             )
 
             if not isinstance(op, _allowed_op_types()):
-                if op not in _allowed_builtin_ops() and op not in _allowed_torch_functions and not isinstance(op, torch._export.serde.serialize.CustomOpHandler):
+                if op not in _allowed_builtin_ops() and op not in _allowed_torch_functions:
                     raise SpecViolationError(
                         f"Operator '{op}' is not an allowed operator type: {_allowed_op_types()}\n"
                         f"Valid builtin ops: {_allowed_builtin_ops()}"

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -187,7 +187,7 @@ class Verifier(metaclass=_VerifierMeta):
             )
 
             if not isinstance(op, _allowed_op_types()):
-                if op not in _allowed_builtin_ops() and op not in _allowed_torch_functions:
+                if op not in _allowed_builtin_ops() and op not in _allowed_torch_functions and not isinstance(op, torch._export.serde.serialize.CustomOpHandler):
                     raise SpecViolationError(
                         f"Operator '{op}' is not an allowed operator type: {_allowed_op_types()}\n"
                         f"Valid builtin ops: {_allowed_builtin_ops()}"

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -133,7 +133,8 @@ class Verifier(metaclass=_VerifierMeta):
         ]
 
     def allowed_op_types(self) -> Tuple[Type[Any], ...]:
-        return (OpOverload, HigherOrderOperator, *torch._export.serde.serialize.allowed_registered_op_types())
+        from torch._export.serde.serialize import allowed_registered_op_types  # Avoid circular import.
+        return (OpOverload, HigherOrderOperator, *allowed_registered_op_types())
 
     def allowed_getattr_types(self) -> Tuple[Type[Any], ...]:
         return (torch.fx.GraphModule,)


### PR DESCRIPTION
This PR adds a registration function and a global registry for GraphModuleSerializer. After this PR, custom serialization methods can be done through registration instead of subclassing for ease of maintenance. 

## Changes
- Add a test case where it injects custom op to test serialization.
- Add custom op handler
- Change allowed op for verifier