### PR TITLE
Add fake impl for aten.unique_dim

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2522,8 +2522,8 @@ class TestFakeTensor(TestCase):
                         or name in sometimes_dynamic_output_op_test
                     )
                     self.assertTrue(
-                        mode.shape_env is None
-                        or not mode.shape_env.allow_dynamic_output_shape_ops
+                        fake_mode.shape_env is None
+                        or not fake_mode.shape_env.allow_dynamic_output_shape_ops
                         or name not in supported_dynamic_output_op_tests
                     )
                 except torch._subclasses.fake_tensor.DataDependentOutputException:

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1948,7 +1948,6 @@ symbolic_tensor_failures = {
     xfail('nn.functional.ctc_loss'),  # aten._ctc_loss.Tensor - couldn't find symbolic meta function/decomposition
     xfail('quantile', ''),  # Could not run 'aten::equal' with arguments from the 'Meta' backend.
     xfail('unique_consecutive', ''),  # aten.unique_consecutive.default - couldn't find symbolic meta function/decomposition
-    xfail('unique', ''),  # aten._unique2.default - couldn't find symbolic meta function/decomposition
 
     xfail('max_pool2d_with_indices_backward', ''),  # Expected a value of type 'List[int]' for argument 'kernel_size' but...
 
@@ -1979,8 +1978,6 @@ symbolic_tensor_failures.update(symbolic_tensor_segfaults)
 inplace_symbolic_tensor_failures = {
     # bugs
     xfail('float_power', ''),  # base given to float_power_ has dtype Float but the operation's result requires dtype Double
-    # decomp not implemented
-    xfail('unique', ''),
 }
 
 out_symbolic_tensor_failures = {

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -303,9 +303,9 @@ def _unique(
     if dim is None:
         ret = [arg.new_empty((nnz,))]
     else:
-        ret = [arg.new_empty(*arg.shape[:dim], nnz, *arg.shape[dim + 1:])]
+        ret = [arg.new_empty(*arg.shape[:dim], nnz, *arg.shape[dim + 1 :])]
 
-    return_if_dim_and_cpu = dim is not None and arg.fake_device == torch.device('cpu')
+    return_if_dim_and_cpu = dim is not None and arg.fake_device == torch.device("cpu")
     if return_inverse or return_if_dim_and_cpu:
         inverse = arg.new_empty(arg.shape if dim is None else (arg.shape[dim],))
     else:
@@ -325,15 +325,7 @@ def _unique(
 def unique2(
     fake_mode, func, arg, sorted=True, return_inverse=False, return_counts=False
 ):
-    return _unique(
-        fake_mode,
-        func,
-        arg,
-        None,
-        sorted,
-        return_inverse,
-        return_counts
-    )
+    return _unique(fake_mode, func, arg, None, sorted, return_inverse, return_counts)
 
 
 @register_op_impl(aten.unique_dim.default)
@@ -348,7 +340,7 @@ def unique_dim(
         dim if dim >= 0 else dim % max(arg.ndim, 1),
         sorted,
         return_inverse,
-        return_counts
+        return_counts,
     )
 
 

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -345,7 +345,7 @@ def unique_dim(
         func,
         arg,
         # normalize dim to be non-negative
-        dim if dim >= 0 else arg.ndim + dim,
+        dim if dim >= 0 else dim % max(arg.ndim, 1),
         sorted,
         return_inverse,
         return_counts


### PR DESCRIPTION
Follow-up to #113118 and #124306.

Developed in coordination with the solution to https://github.com/microsoft/onnxscript/pull/1547

This PR adds the missing fake tensor implementation for `aten.unique_dim`, thus enabling tracing and compilation of `torch.unique` when `dim` is not None. 

Local testing has proceeded with the following simple script (provided that one has checked out the changes in https://github.com/microsoft/onnxscript/pull/1547):

```python
    import onnx
    import onnxruntime as ort
    import logging
    import numpy as np
    onnx_program = torch.onnx.dynamo_export(
        lambda x: torch.unique(x,
                               dim=0,
                               return_inverse=True),
        torch.arange(10),
        export_options=torch.onnx.ExportOptions(
            dynamic_shapes=True,
            diagnostic_options=torch.onnx.DiagnosticOptions(
                verbosity_level=logging.DEBUG)))
    onnx_program.save("torch_unique.onnx")
    onnx_inputs = onnx_program.adapt_torch_inputs_to_onnx(torch.arange(10))
    onnx_outputs = onnx_program(*onnx_inputs)
    loaded_onnx_program = onnx.load("torch_unique.onnx")
    onnx.checker.check_model(loaded_onnx_program)
    ort_session = ort.InferenceSession("torch_unique.onnx")
    inputs = np.random.randint(0, 10, 10)
    print(f"Inputs: {inputs}")
    outputs = ort_session.run(None,
                              {
                                  "l_x_": inputs
                              })
    print(f"Outputs: {outputs}")
    print("Success")
``` 

cc @ezyang @msaroufim @bdhirsh @anijain2305 @chauhang