### PR TITLE
xpu: pass MAX_JOBS building xpu_mkldnn_proj

### DIFF
--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -28,6 +28,14 @@ IF(NOT MKLDNN_FOUND)
     endif()
 
     set(DNNL_MAKE_COMMAND "cmake" "--build" ".")
+    include(ProcessorCount)
+    ProcessorCount(proc_cnt)
+    if ((DEFINED ENV{MAX_JOBS}) AND ("$ENV{MAX_JOBS}" LESS_EQUAL ${proc_cnt}))
+      list(APPEND DNNL_MAKE_COMMAND "-j" "$ENV{MAX_JOBS}")
+      if(CMAKE_GENERATOR MATCHES "Make|Ninja")
+        list(APPEND DNNL_MAKE_COMMAND "--" "-l" "$ENV{MAX_JOBS}")
+      endif()
+    endif()
     ExternalProject_Add(xpu_mkldnn_proj
       SOURCE_DIR ${MKLDNN_ROOT}
       PREFIX ${XPU_MKLDNN_DIR_PREFIX}


### PR DESCRIPTION
mkldnn is quite big project and MAX_JOBS support is essential when building on a system with big number of cpus and limited memory.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @EikanWang @fengyuan14 @guangyey