### PR TITLE
[DSD] Correctly handle _extra_state (#125336)

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -517,6 +517,25 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
         self.assertEqual(original_keys, new_keys)
 
+    @with_comms
+    @skip_if_lt_x_gpu(1)
+    def test_extra_state(self) -> None:
+        model = CompositeParamModel(device=torch.device("cuda"))
+
+        def get_extra_state(self):
+            return "MyState"
+
+        def set_extra_state(self, state):
+            return
+
+        UnitModule.get_extra_state = get_extra_state
+        UnitModule.set_extra_state = set_extra_state
+
+        ddp_model = DDP(copy.deepcopy(model))
+        set_model_state_dict(ddp_model, get_model_state_dict(ddp_model))
+        self.assertEqual(model.state_dict()["u1._extra_state"], "MyState")
+        self.assertEqual(model.state_dict(), get_model_state_dict(ddp_model))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -535,7 +535,6 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         set_model_state_dict(ddp_model, get_model_state_dict(ddp_model))
         self.assertEqual(model.state_dict()["u1._extra_state"], "MyState")
         self.assertEqual(model.state_dict(), get_model_state_dict(ddp_model))
-        
     @with_comms
     @skip_if_lt_x_gpu(1)
     def test_activation_ckpt_fqns_fsdp1(self) -> None:

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -535,6 +535,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         set_model_state_dict(ddp_model, get_model_state_dict(ddp_model))
         self.assertEqual(model.state_dict()["u1._extra_state"], "MyState")
         self.assertEqual(model.state_dict(), get_model_state_dict(ddp_model))
+
     @with_comms
     @skip_if_lt_x_gpu(1)
     def test_activation_ckpt_fqns_fsdp1(self) -> None:

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -8,6 +8,7 @@ from typing import (
     Callable,
     cast,
     Dict,
+    Generator,
     Iterable,
     List,
     no_type_check,
@@ -184,9 +185,46 @@ def _get_fqns(
                 fqn_obj_names.append(curr_obj_name)
         else:
             fqn_obj_names.append(curr_obj_name)
-            curr_obj = getattr(curr_obj, curr_obj_name)
+            if curr_obj_name == nn.modules.module._EXTRA_STATE_KEY_SUFFIX:
+                if i != len(obj_names) - 1:
+                    raise RuntimeError("Expect `_extra_state` to be the last obj name")
+            else:
+                curr_obj = getattr(curr_obj, curr_obj_name)
 
     return {".".join(fqn_obj_names).replace(_CHECKPOINT_PREFIX, "")}
+
+
+class _EXTRA_STATE:
+    pass
+
+
+def _iterate_valid_model_state(model):
+    visited_modules: Set[nn.Module] = set()
+
+    def recurse(module: nn.Module, curr_fqn: str) -> Generator:
+        visited_modules.add(module)
+
+        curr_fqn = f"{curr_fqn}." if curr_fqn else ""
+        for name, submodule in module.named_children():
+            if submodule in visited_modules:
+                continue
+            new_fqn = f"{curr_fqn}{name}"
+            yield from recurse(submodule, new_fqn)
+
+        for name, obj in chain(
+            module.named_buffers(recurse=False), module.named_parameters(recurse=False)
+        ):
+            new_fqn = f"{curr_fqn}{name}"
+            yield new_fqn, obj
+
+        if (
+            getattr(module.__class__, "get_extra_state", nn.Module.get_extra_state)
+            != nn.Module.get_extra_state
+        ):
+            new_fqn = f"{curr_fqn}{nn.modules.module._EXTRA_STATE_KEY_SUFFIX}"
+            yield new_fqn, _EXTRA_STATE()
+
+    yield from recurse(model, "")
 
 
 def _verify_options(
@@ -211,11 +249,13 @@ def _verify_options(
         Union[str, torch.Tensor], Union[Set[str], torch.Tensor]
     ] = {}
     all_fqns = set()
-    for name, param in chain(model.named_parameters(), model.named_buffers()):
+    for name, param in _iterate_valid_model_state(model):
         fqns = _get_fqns(model, name)
-        fqn_param_mapping[param] = fqns
+        if not isinstance(param, _EXTRA_STATE):
+            fqn_param_mapping[param] = fqns
         for fqn in fqns:
-            fqn_param_mapping[fqn] = param
+            if not isinstance(param, _EXTRA_STATE):
+                fqn_param_mapping[fqn] = param
             all_fqns.add(fqn)
 
     submodule_prefixes = set()
@@ -391,7 +431,7 @@ def _get_model_state_dict(
                 state_dict.pop(fqn)
 
     for key, p in list(state_dict.items()):
-        if p.is_meta:
+        if torch.is_tensor(p) and p.is_meta:
             state_dict.pop(key)
 
     if info.full_state_dict:
@@ -413,7 +453,7 @@ def _load_model_state_dict(
     if not info.handle_model or not state_dict:
         return _IncompatibleKeys({}, {})
 
-    for key, _ in chain(model.named_parameters(), model.named_buffers()):
+    for key, _ in _iterate_valid_model_state(model):
         fqns = _get_fqns(model, key)
         fqns_with_prefix = _get_fqns(
             model, key, skip_ddp_prefix=False, skip_compiler_prefix=False


### PR DESCRIPTION
Pr for 2.3 cherry-pick

Summary:
distributed_state_dict should not try to use `getattr` to get `_extra_state` as this is not well-defined.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/125336
Approved by: https://github.com/LucasLLC
ghstack dependencies: #125333, #125501, #125334, #125335

Fixes #ISSUE_NUMBER


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC