### PR TITLE
[PTD] export stream id in process group nccl

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -638,6 +638,11 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   void performNocolorSplit(at::Device device);
 
+  c10::StreamId getStreamId(
+      OpType opType,
+      std::optional<int> peer = c10::nullopt,
+      std::optional<at::Device> device = c10::nullopt);
+
  protected:
   // Helper that broadcasts nccl unique ID to all ranks through the store
   void broadcastUniqueNCCLID(


### PR DESCRIPTION
Summary:
In our pipeline parallel use cases, we need to stash multiple activations in CPU memory.
We don't want to just use existing AC support as that would lead to recomputing the activation which is sometimes cost prohibitive.

To better time the overlap, we want to do roughly this:
* P2P comm in stream X during fwd pass
* As soon as send/recv finishes, we want to offload the activation to CPU mem (pre-pinned) as a callback in a separate copy stream Y (in other words, we schedule `Y.wait_stream(X)`)
* In bwd pass, before actual bwd starts we want to make sure the activation is copied back to GPU (either current waits for Y, or X waits for Y, whichever suits).

Today, NCCL pg does not expose the stream while it does hold onto A stream from pool once the NCCL communicator is established. This exposes that.

Test Plan: tested using an internal lib for now

Differential Revision: D57496237




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k