### PR TITLE
Remove MAX_STACK_ENTRY from _build_table

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -877,7 +877,6 @@ def _build_table(
     row_format_lst = [""]
     header_sep_lst = [""]
     line_length_lst = [-SPACING_SIZE]
-    MAX_STACK_ENTRY = 5
 
     def add_column(padding, text_dir=">"):
         row_format_lst[0] += (
@@ -1043,7 +1042,7 @@ def _build_table(
 
         if has_stack:
             empty_headers = [""] * (len(headers) - 1)
-            for entry in evt.stack[1:MAX_STACK_ENTRY]:
+            for entry in evt.stack[1:]:
                 append(
                     row_format.format(
                         *(empty_headers + [trim_path(entry, src_column_width)])


### PR DESCRIPTION
Summary:
As reported by this issue: https://github.com/pytorch/pytorch/issues/83584

We already store the entries in evt.stack so there is no need to cap the limit when we output the table to 5

Test Plan: Regression testing should cover this. We have unit tests to check the stack already.

Differential Revision: D57513565


