### PR TITLE
[compiled autograd] Better cache miss logging

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1559,29 +1559,19 @@ TORCH_LIBRARY(test_autograd_cpp_node_data_dependent, m) {
             self.check_output_and_recompiles(fn, count=2)
 
         patterns1 = [
-            r".*Creating cache entry for torch::autograd::GraphRoot, with key of size (\d+)\n",
-            r".*Creating cache entry for SumBackward0, with key of size (\d+)\n",
-            r".*Creating cache entry for ReluBackward0, with key of size (\d+)\n",
-            r".*Creating cache entry for AddmmBackward0, with key of size 1(\d+)\n",
-            r".*Creating cache entry for TBackward0, with key of size (\d+)\n",
-            r".*Creating cache entry for torch::autograd::AccumulateGrad, with key of size (\d+)\n",
-            r".*Creating cache entry for ReluBackward0, with key of size (\d+)\n",
-            r".*Creating cache entry for AddmmBackward0, with key of size (\d+)\n",
-            r".*Creating cache entry for TBackward0, with key of size (\d+)\n",
-            r".*Creating cache entry for torch::autograd::AccumulateGrad, with key of size (\d+)\n",
-            r".*Creating cache entry for torch::autograd::AccumulateGrad, with key of size (\d+)\n",
-            r".*Creating cache entry for torch::autograd::AccumulateGrad, with key of size (\d+)\n",
+            r".*Cache miss due to new autograd node: torch::autograd::GraphRoot \(NodeCall 0\) with key size (\d+), "
+            r"previous key sizes=\[\]\n",
         ]
 
         # recompile
         patterns2 = [
-            r".*cache miss: marking sizes\[(\d+)\] as dynamic\n",
-            r".*cache miss: marking sizes\[(\d+)\] as dynamic\n",
-            r".*cache miss: marking sizes\[(\d+)\] as dynamic\n",
-            r".*cache miss: marking sizes\[(\d+)\] as dynamic\n",
-            r".*cache miss: marking sizes\[(\d+)\] as dynamic\n",
-            r".*cache miss: marking sizes\[(\d+)\] as dynamic\n",
-            r".*cache miss: marking sizes\[(\d+)\] as dynamic\n",
+            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of torch::autograd::GraphRoot \(NodeCall 0\)\n",
+            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of SumBackward0 \(NodeCall 1\)\n",
+            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of SumBackward0 \(NodeCall 1\)\n",
+            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of ReluBackward0 \(NodeCall 2\)\n",
+            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of AddmmBackward0 \(NodeCall 3\)\n",
+            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of torch::autograd::AccumulateGrad \(NodeCall 5\)\n",
+            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of ReluBackward0 \(NodeCall 6\)\n",
         ]
 
         all_logs = logs.getvalue()
@@ -1589,7 +1579,10 @@ TORCH_LIBRARY(test_autograd_cpp_node_data_dependent, m) {
         pattern1 = r"".join(patterns1)
         matches1 = re.findall(pattern1, all_logs)
         self.assertEqual(len(matches1), 1)
-        self.assertEqual(len(matches1[0]), len(patterns1))
+        assert isinstance(
+            matches1[0], str
+        )  # for a single match: matches1=['match'], for multiple matches: matches1=[('match1', 'match2')]...
+        self.assertEqual(len(matches1), len(patterns1))
 
         pattern2 = r"".join(patterns2)
         matches2 = re.findall(pattern2, all_logs)

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1565,13 +1565,14 @@ TORCH_LIBRARY(test_autograd_cpp_node_data_dependent, m) {
 
         # recompile
         patterns2 = [
-            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of torch::autograd::GraphRoot \(NodeCall 0\)\n",
-            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of SumBackward0 \(NodeCall 1\)\n",
-            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of SumBackward0 \(NodeCall 1\)\n",
-            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of ReluBackward0 \(NodeCall 2\)\n",
-            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of AddmmBackward0 \(NodeCall 3\)\n",
-            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of torch::autograd::AccumulateGrad \(NodeCall 5\)\n",
-            r".*Cache miss due to dynamic shapes: collected size idx (\d+) of ReluBackward0 \(NodeCall 6\)\n",
+            r".*Cache miss due to changed shapes: marking size idx (\d+) of torch::autograd::GraphRoot \(NodeCall 0\) as dynamic\n",
+            r".*Cache miss due to changed shapes: marking size idx (\d+) of SumBackward0 \(NodeCall 1\) as dynamic\n",
+            r".*Cache miss due to changed shapes: marking size idx (\d+) of SumBackward0 \(NodeCall 1\) as dynamic\n",
+            r".*Cache miss due to changed shapes: marking size idx (\d+) of ReluBackward0 \(NodeCall 2\) as dynamic\n",
+            r".*Cache miss due to changed shapes: marking size idx (\d+) of AddmmBackward0 \(NodeCall 3\) as dynamic\n",
+            r".*Cache miss due to changed shapes: marking size idx (\d+) of torch::autograd::AccumulateGrad "
+            r"\(NodeCall 5\) as dynamic\n",
+            r".*Cache miss due to changed shapes: marking size idx (\d+) of ReluBackward0 \(NodeCall 6\) as dynamic\n",
         ]
 
         all_logs = logs.getvalue()

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -131,7 +131,7 @@ struct VerboseLogger {
         continue;
       }
       oss << it->key_size;
-      if (std::next(it) == cached_keys.end()) {
+      if (std::next(it) != cached_keys.end()) {
         oss << ",";
       }
     }

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/utils/pythoncapi_compat.h>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <vector>
 
 /*
@@ -85,10 +86,78 @@ static void check(bool result) {
 
 // snapshot of python verbose logging toggle
 static PyObject* python_verbose_logger = nullptr;
-void verbose_log_fn(std::string_view msg) {
-  TORCH_CHECK(python_verbose_logger != nullptr);
-  check(PyObject_CallFunction(python_verbose_logger, "s", msg.data()));
-}
+struct VerboseLogger {
+  static std::optional<VerboseLogger> create() {
+    if (python_verbose_logger == nullptr) {
+      return std::nullopt;
+    }
+    return VerboseLogger();
+  }
+
+  void verbose_log_fn(std::string_view msg) const {
+    TORCH_CHECK(python_verbose_logger != nullptr);
+    check(PyObject_CallFunction(python_verbose_logger, "s", msg.data()));
+  }
+
+  void log_node_check(
+      const Node& fn,
+      size_t size_inputs_num,
+      std::unordered_set<CacheKey> cached_keys,
+      const CacheKey& key,
+      size_t node_idx) {
+    std::string node_name =
+        fn.name() + " (NodeCall " + std::to_string(node_idx) + ")";
+
+    cumulative_sizes_per_node[size_inputs_num] = node_name;
+
+    if (!logged_node_miss && cached_keys.find(key) == cached_keys.end()) {
+      _log_node_miss(typeid(fn), cached_keys, key, node_name);
+      logged_node_miss = true;
+    }
+  }
+
+  void _log_node_miss(
+      const std::type_info& node_type,
+      std::unordered_set<CacheKey> cached_keys,
+      const CacheKey& key,
+      const std::string& node_name) const {
+    std::ostringstream oss;
+    oss << "Cache miss due to new autograd node: " << node_name
+        << " with key size " << std::to_string(key.key_size)
+        << ", previous key sizes=[";
+
+    for (auto it = cached_keys.begin(); it != cached_keys.end(); it++) {
+      if (it->node_type != node_type) {
+        continue;
+      }
+      oss << it->key_size;
+      if (std::next(it) == cached_keys.end()) {
+        oss << ",";
+      }
+    }
+    oss << "]";
+    verbose_log_fn(oss.str());
+  }
+
+  void log_dynamic_shapes_check(size_t size_idx) const {
+    if (cumulative_sizes_per_node.empty()) {
+      return;
+    }
+
+    auto it = cumulative_sizes_per_node.lower_bound(size_idx);
+    TORCH_CHECK(it != cumulative_sizes_per_node.end());
+    size_t start_idx =
+        it == cumulative_sizes_per_node.begin() ? 0 : std::prev(it)->first;
+    verbose_log_fn(
+        "Cache miss due to dynamic shapes: collected size idx " +
+        std::to_string(size_idx - start_idx) + " of " + it->second);
+  }
+
+  // track which size index belongs to which node
+  std::map<size_t, std::string> cumulative_sizes_per_node;
+  // only log cache miss due to node key once
+  bool logged_node_miss = false;
+};
 
 struct CacheNode {
   // A node in the shadow graph, we follow next edges until we reach the end of
@@ -134,7 +203,9 @@ struct CacheNode {
   CacheNode& operator=(const CacheNode&) = delete;
   CacheNode& operator=(CacheNode&&) = delete;
 
-  bool check_dynamic_sizes(AutogradCompilerCall& call) {
+  bool check_dynamic_sizes(
+      AutogradCompilerCall& call,
+      const std::optional<VerboseLogger>& vlogger) {
     /*
     We start off by assuming everything is static, then we mark things
     as dynamic when we see them change.  This function:
@@ -160,10 +231,8 @@ struct CacheNode {
       if (changed_value) {
         if (!was_dynamic) {
           cache_hit = false;
-          if (python_verbose_logger != nullptr) {
-            verbose_log_fn(
-                "cache miss: marking sizes[" + std::to_string(i) +
-                "] as dynamic");
+          if (vlogger.has_value()) {
+            vlogger->log_dynamic_shapes_check(i);
           }
         }
         expected = SizeInput(SizeInput::DYNAMIC, data[i].value);
@@ -360,6 +429,8 @@ CacheNode* _compiled_autograd_impl(
   calls.reserve(
       check_exec_info ? graph_task.exec_info_.size() : dependencies.size() + 1);
 
+  int i = 0;
+  std::optional<VerboseLogger> vlogger = VerboseLogger::create();
   while (!worklist.empty()) {
     std::shared_ptr<Node> fn = std::move(worklist.back());
     worklist.pop_back();
@@ -374,11 +445,17 @@ CacheNode* _compiled_autograd_impl(
         node_args.collect(call.node->next_edges());
       }
       CacheKey key = node_args.key();
-      if (python_verbose_logger != nullptr &&
-          cache->lookup(key, /*create=*/false) == nullptr) {
-        verbose_log_fn(
-            "Creating cache entry for " + fn->name() + ", with key of size " +
-            std::to_string(key.key_size));
+      if (vlogger.has_value()) {
+        std::unordered_set<CacheKey> cached_keys;
+        for (const auto& [k, _] : cache->next) {
+          cached_keys.emplace(k);
+        }
+        vlogger->log_node_check(
+            *fn,
+            compiler_call.all_size_inputs.size(),
+            std::move(cached_keys),
+            key,
+            i);
       }
       cache = cache->lookup(key);
     }
@@ -403,10 +480,11 @@ CacheNode* _compiled_autograd_impl(
         worklist.emplace_back(edge.function);
       }
     }
+    i++;
   }
 
   // TODO(jansel): some dynamic sizes seem to be ints not symints
-  if (!cache->check_dynamic_sizes(compiler_call)) {
+  if (!cache->check_dynamic_sizes(compiler_call, vlogger)) {
     // cache miss, need to capture FX graph
     ClosingTHPObjectPtr py_compiler(
         check(PyObject_CallNoArgs((the_autograd_compiler))));

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -87,7 +87,7 @@ static void check(bool result) {
 // snapshot of python verbose logging toggle
 static PyObject* python_verbose_logger = nullptr;
 struct VerboseLogger {
-  static std::optional<VerboseLogger> create() {
+  static std::optional<VerboseLogger> maybe_create() {
     if (python_verbose_logger == nullptr) {
       return std::nullopt;
     }
@@ -430,7 +430,7 @@ CacheNode* _compiled_autograd_impl(
       check_exec_info ? graph_task.exec_info_.size() : dependencies.size() + 1);
 
   int i = 0;
-  std::optional<VerboseLogger> vlogger = VerboseLogger::create();
+  std::optional<VerboseLogger> vlogger = VerboseLogger::maybe_create();
   while (!worklist.empty()) {
     std::shared_ptr<Node> fn = std::move(worklist.back());
     worklist.pop_back();

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -149,8 +149,9 @@ struct VerboseLogger {
     size_t start_idx =
         it == cumulative_sizes_per_node.begin() ? 0 : std::prev(it)->first;
     verbose_log_fn(
-        "Cache miss due to dynamic shapes: collected size idx " +
-        std::to_string(size_idx - start_idx) + " of " + it->second);
+        "Cache miss due to changed shapes: marking size idx " +
+        std::to_string(size_idx - start_idx) + " of " + it->second +
+        " as dynamic");
   }
 
   // track which size index belongs to which node


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126602
* #126483
* #126148
* #126146
* #126144

- log only first node key cache miss
- log existing node key sizes
- log which node's collected sizes became dynamic
e.g.
```
DEBUG:torch._dynamo.compiled_autograd.__compiled_autograd_verbose:Cache miss due to new autograd node: torch::autograd::GraphRoot (NodeCall 0) with key size 39, previous key sizes=[]
...
DEBUG:torch._dynamo.compiled_autograd.__compiled_autograd_verbose:Cache miss due to new autograd node: torch::autograd::AccumulateGrad (NodeCall 5) with key size 32, previous key sizes=[21]
...
DEBUG:torch._dynamo.compiled_autograd.__compiled_autograd_verbose:Cache miss due to dynamic shapes: collected size idx 0 of torch::autograd::GraphRoot (NodeCall 0)
DEBUG:torch._dynamo.compiled_autograd.__compiled_autograd_verbose:Cache miss due to dynamic shapes: collected size idx 2 of SumBackward0 (NodeCall 1)
DEBUG:torch._dynamo.compiled_autograd.__compiled_autograd_verbose:Cache miss due to dynamic shapes: collected size idx 4 of SumBackward0 (NodeCall 1)
DEBUG:torch._dynamo.compiled_autograd.__compiled_autograd_verbose:Cache miss due to dynamic shapes: collected size idx 2 of ReluBackward0 (NodeCall 2)
DEBUG:torch._dynamo.compiled_autograd.__compiled_autograd_verbose:Cache miss due to dynamic shapes: collected size idx 9 of AddmmBackward0 (NodeCall 3)
DEBUG:torch._dynamo.compiled_autograd.__compiled_autograd_verbose:Cache miss due to dynamic shapes: collected size idx 2 of torch::autograd::AccumulateGrad (NodeCall 5)
DEBUG:torch._dynamo.compiled_autograd.__compiled_autograd_verbose:Cache miss due to dynamic shapes: collected size idx 2 of ReluBackward0 (NodeCall 6)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang