### PR TITLE
Allow linalg.lstsq to use svd to compute the result for rank deficient matrices.

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -3433,6 +3433,7 @@ static void linalg_lstsq_out_info(
     if (input.numel() == 0) {
         auto output_shape = input.sizes().vec();
         output_shape.back() = other.size(-1);
+        rank.zero_();
         solution.zero_();
     } else {
         auto [U, S, Vh] = at::_linalg_svd(input, false, true, "gesvd");
@@ -3487,7 +3488,7 @@ static void linalg_lstsq_out_info(
     solution.set_(solution.storage(), solution_view.storage_offset(),
                   solution_view.sizes(), solution_view.strides());
   } else {
-    solution = at::zeros({solution.size(-1), n}, solution.options());
+    solution.zero_(); // this is incorrect. How do we proceed?
   }
   if (m == 0) {
     solution.zero_();

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -314,7 +314,6 @@ class TestLinalg(TestCase):
             m = a.size(-2)
             n = a.size(-1)
             res = torch.linalg.lstsq(a, b, rcond=rcond, driver=driver)
-            print('after lstsq')
             sol = res.solution
 
             # Only checks gelsd, gelss, gelsy drivers

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -314,6 +314,7 @@ class TestLinalg(TestCase):
             m = a.size(-2)
             n = a.size(-1)
             res = torch.linalg.lstsq(a, b, rcond=rcond, driver=driver)
+            print('after lstsq')
             sol = res.solution
 
             # Only checks gelsd, gelss, gelsy drivers


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/117122

This PR adds the logic so that in the case of rank deficient matrices, it can fallback to an SVD backend for batched mode. 

I apologize for the previous PR... I messed up a rebase and it ended up showing a million changes. 

cc @lezcano 