### PR TITLE
[c10d] Fix stuck after onCompletionhook exception was caught

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2273,6 +2273,22 @@ class WorkHookTest(MultiProcessTestCase):
         self.assertEqual(num_hook_fired, work_count)
         self.assertEqual(work, seq)
 
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_on_completion_hook_exception(self):
+        pg = self._get_process_group()
+
+        def hook(work_info: torch._C._distributed_c10d.WorkInfo):
+            raise RuntimeError("hook error")
+
+        pg._register_on_completion_hook(hook)
+        tensor = torch.ones([2, 3]).cuda(self.rank) * self.rank
+        pg.broadcast([tensor]).wait()
+
+        # N.B.: destroy_process_group is necessary to wait for
+        # all pending works to finish.
+        c10d.destroy_process_group(pg)
+
 
 class NcclErrorHandlingTest(MultiProcessTestCase):
     def setUp(self):


### PR DESCRIPTION
Currently, the thread runhookloop will not clean the completedWorkList_ if the onCompletionHook raise an exception. 
It leads to the main thread which called waitForPendingWorks will be stucked.

Test Case:
``` 
  def test_on_completion_hook_exception(self):
        pg = self._get_process_group()

        def hook(work_info: torch._C._distributed_c10d.WorkInfo):
            raise RuntimeError("hook error")

        pg._register_on_completion_hook(hook)
        tensor = torch.ones([2, 3]).cuda(self.rank) * self.rank
        pg.broadcast([tensor]).wait()

        # N.B.: destroy_process_group is necessary to wait for
        # all pending works to finish.
        c10d.destroy_process_group(pg)
```


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang