### PR TITLE
[ez] Add --save-xml option to run_test

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -989,7 +989,7 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
         # is much slower than running them directly
         pytest_args.extend(["-n", str(NUM_PROCS)])
 
-        if options.save_xml:
+        if options.generate_xml:
             # Add the option to generate XML test report here as C++ tests
             # won't go into common_utils
             test_report_path = get_report_path(pytest=True)
@@ -1256,7 +1256,7 @@ def parse_args():
         help="Run tests without translation validation.",
     )
     parser.add_argument(
-        "--save-xml",
+        "--generate-xml",
         action="store_true",
         default=IS_CI,
         help="Save XML test reports to test/test-reports",

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -990,7 +990,7 @@ def get_pytest_args(options, is_cpp_test=False, is_distributed_test=False):
         # is much slower than running them directly
         pytest_args.extend(["-n", str(NUM_PROCS)])
 
-        if IS_CI:
+        if options.save_xml:
             # Add the option to generate XML test report here as C++ tests
             # won't go into common_utils
             test_report_path = get_report_path(pytest=True)
@@ -1256,6 +1256,12 @@ def parse_args():
         "--no-translation-validation",
         action="store_false",
         help="Run tests without translation validation.",
+    )
+    parser.add_argument(
+        "--save-xml",
+        action="store_true",
+        default=IS_CI,
+        help="Save XML test reports to test/test-reports",
     )
 
     group = parser.add_mutually_exclusive_group()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -29,7 +29,6 @@ from torch.testing._internal.common_utils import (
     IS_CI,
     IS_MACOS,
     IS_WINDOWS,
-    parser as common_parser,
     retry_shell,
     set_cwd,
     shell,
@@ -1054,7 +1053,6 @@ def parse_args():
         description="Run the PyTorch unit test suite",
         epilog="where TESTS is any of: {}".format(", ".join(TESTS)),
         formatter_class=argparse.RawTextHelpFormatter,
-        parents=[common_parser],
     )
     parser.add_argument(
         "-v",


### PR DESCRIPTION
Move configuration of xml generation from checking for IS_CI to using an argument flag

Remove the parser from common_utils as a parent parser, I don't think any of those options are being used in run_test.py, so if people do want to use them, they can be added using the additional_unittest_args option