### PR TITLE
[WIP][pipelining] Add param aliasing test

### DIFF
--- a/test/distributed/pipelining/model_registry.py
+++ b/test/distributed/pipelining/model_registry.py
@@ -32,6 +32,27 @@ class ExampleCode(torch.nn.Module):
         return x
 
 
+class ModelWithParamAlias(torch.nn.Module):
+    default_dhid = 512
+    default_batch_size = 256
+
+    def __init__(self, d_hid: int = default_dhid):
+        super().__init__()
+        self.mm_param1 = self.mm_param0 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.lin1 = self.lin0 = torch.nn.Linear(d_hid, d_hid)
+
+    def forward(self, x, y):
+        x = torch.mm(x, self.mm_param0)
+        x = x + y
+        x = self.lin0(x)
+        x = torch.relu(x)
+        pipe_split()
+        x = torch.mm(x, self.mm_param1)
+        x = self.lin1(x)
+        x = torch.relu(x)
+        return x
+
+
 # MLP Layer
 class MLPModule(torch.nn.Module):
     def __init__(self, d_hid):

--- a/test/distributed/pipelining/test_pipe.py
+++ b/test/distributed/pipelining/test_pipe.py
@@ -2,7 +2,7 @@
 # Owner(s): ["oncall: distributed"]
 import torch
 
-from model_registry import MLPModule
+from model_registry import MLPModule, ModelWithParamAlias
 from torch.distributed.pipelining import pipe_split, pipeline
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -64,8 +64,20 @@ class MultiMLP(torch.nn.Module):
         return x - y
 
 
+EXPECTED_N_STAGES = {
+    ExampleCode: 4,
+    MultiMLP: 4,
+    ModelWithParamAlias: 2,
+}
+
+# Currently, we don't enforce full set equality on the FQNs between the original
+# and pipelined models, because in the multi-use param case, PP will deduplicate
+# the FQNs from the state_dict.
+# TODO
+CHECK_FQN_SET_EQUALITY = False
+
 class PipeTests(TestCase):
-    @parametrize("ModelClass", [ExampleCode, MultiMLP])
+    @parametrize("ModelClass", [ExampleCode, MultiMLP, ModelWithParamAlias])
     def test_model_split(self, ModelClass):
         mod = ModelClass()
         x = torch.randn(batch_size, d_hid)
@@ -77,7 +89,7 @@ class PipeTests(TestCase):
             example_args=(x, y),
         )
 
-        assert pipe.num_stages == 4, f"nstages = {pipe.num_stages}, expect 4"
+        assert pipe.num_stages == EXPECTED_N_STAGES[ModelClass], f"nstages = {pipe.num_stages}, expect {EXPECTED_N_STAGES[ModelClass]}"
 
         ref_out = mod(x, y)
         out = pipe(x, y)[0]
@@ -90,14 +102,17 @@ class PipeTests(TestCase):
         new_names = set()
         for idx in range(pipe.num_stages):
             stage_mod = pipe.get_stage_module(idx)
-            new_names.update(stage_mod.state_dict().keys())
+            stage_fqns = set(stage_mod.state_dict().keys())
+            assert stage_fqns.issubset(old_names)
+            new_names.update(stage_fqns)
 
-        assert (
-            old_names == new_names
-        ), f"""
-        old names {old_names}
-        new names {new_names}
-        """
+        if CHECK_FQN_SET_EQUALITY:
+            assert (
+                old_names == new_names
+            ), f"""
+            old names {old_names}
+            new names {new_names}
+            """
         print("Qualname check passed")
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127094
* __->__ #126702
* #126653

Repro:
```
cd test/distributed/pipelining
TORCH_LOGS=pp python test_pipe.py -k PipeTests.test_model_split_ModelClass2
```

Error:
```
RuntimeError: Expected positional argument for parameter lin1_weight, but one was not passed in!

While executing %lin1_weight : [num_users=1] = placeholder[target=lin1_weight]
Original traceback:
None

While executing %submod_0 : [num_users=1] = call_module[target=submod_0](args = (%x, %y), kwargs = {})
Original traceback:
None
```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k