### PR TITLE
[AOTInductor] Automatic detection for buffer mutation and binary linking

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1212,9 +1212,8 @@ class AOTInductorTestsTemplate:
                 return self.foo + x
 
         example_inputs = (torch.rand(4, 4, device=self.device),)
-        with config.patch({"aot_inductor.allow_buffer_mutation": True}):
-            torch._export.aot_compile(Model(self.device), example_inputs)
-            self.check_model(Model(self.device), example_inputs)
+        torch._export.aot_compile(Model(self.device), example_inputs)
+        self.check_model(Model(self.device), example_inputs)
 
     def test_non_tensor_input(self):
         def fn(a, b, alpha=1.0):
@@ -1246,9 +1245,8 @@ class AOTInductorTestsTemplate:
                 self.foo[5] = self.bar[0]
                 return x + self.bar, x * self.foo
 
-        with config.patch({"aot_inductor.allow_buffer_mutation": True}):
-            example_inputs = (torch.randn(10, device=self.device),)
-            self.check_model(Model(self.device), example_inputs)
+        example_inputs = (torch.randn(10, device=self.device),)
+        self.check_model(Model(self.device), example_inputs)
 
     def test_buffer_mutation_3(self):
         class KVCache(torch.nn.Module):
@@ -1288,8 +1286,7 @@ class AOTInductorTestsTemplate:
             torch.randn(1, 6, 1, 48, device=self.device),
             torch.randn(1, 6, 1, 48, device=self.device),
         )
-        with config.patch({"aot_inductor.allow_buffer_mutation": True}):
-            self.check_model(Model(self.device), example_inputs)
+        self.check_model(Model(self.device), example_inputs)
 
     @requires_multigpu()
     def test_replicate_on_devices(self):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1924,10 +1924,14 @@ class AotCodeCompiler:
                 run_command_and_check(cmd)
             log.debug("aot constant binary command: %s", cmd)
 
-            if config.aot_inductor.allow_buffer_mutation:
+            if graph.buffer_mutation:
                 # .data section is between .text and .bss. When the size of .data is large,
                 # during the linking, the relocation of .text against .bss may overflow.
                 # Rename it to .ldata so that it won't be in between the .text and .bss section
+                if len(consts) > 2_000_000_000:
+                    raise ValueError(
+                        "Models with buffer mutation included doesn't support constants greater than 2GB!"
+                    )
                 rename_data = " .data=.ldata"
             else:
                 # if no buffer mutation is needed, we could instead set the data region

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -744,9 +744,6 @@ class aot_inductor:
     # rather than embedded into the data section. Needed to support 1B+ parameter models
     force_mmap_weights: bool = False
 
-    # flag to allow buffer mutation. This would remove the read-only property from buffers.
-    allow_buffer_mutation: bool = False
-
 
 class cuda:
     # CUDA arch to use for CUDA template kernel compilation.

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -350,6 +350,7 @@ class GraphLowering(torch.fx.Interpreter):
         self.device_idxs: Set[int] = const_module.device_idxs if const_module else set()
         self.cuda = False
         self.buffers: List[ir.Buffer] = []
+        self.buffer_mutation: bool = False
         self.const_output_index: Dict[str, int] = (
             const_output_index if const_output_index else {}
         )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5083,6 +5083,7 @@ def mutate_to(changed, val, unsafe_alias=False):
         changed_data.data = val.data
         return changed
 
+    V.graph.buffer_mutation = True
     ir.MutationLayoutSHOULDREMOVE.realize_into(
         val, changed_data, unsafe_alias=unsafe_alias
     )


### PR DESCRIPTION
Summary: Instead of a explicit config for users to determine buffer mutation, we automatically detect whether there's buffer mutation in the model and determine which section constants would be placed. If constants are too large and doesn't fit within section, we error out directly.

Test Plan: Existing tests for buffer mutation and large weight linking

Differential Revision: D57579800




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @ColinPeppler @amjames @desertfire @chauhang