### PR TITLE
Change run_test.py arg parsing to handle additional args better

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1266,8 +1266,8 @@ def parse_args():
     )
 
     args, extra = parser.parse_known_args()
-    if len(extra) > 0 and extra[0] == "--":
-        extra = extra[1:]
+    if "--" in extra:
+        extra.remove("--")
     args.additional_args = extra
     return args
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -29,7 +29,6 @@ from torch.testing._internal.common_utils import (
     IS_CI,
     IS_MACOS,
     IS_WINDOWS,
-    parser as common_parser,
     retry_shell,
     set_cwd,
     shell,

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -443,6 +443,9 @@ def run_test(
         # use the downloaded test cases configuration, not supported in pytest
         unittest_args.extend(ci_args)
 
+    if options.save_xml:
+        unittest_args.append(f"--save-xml={options.save_xml}")
+
     if test_file in PYTEST_SKIP_RETRIES:
         if not options.pytest:
             raise RuntimeError(


### PR DESCRIPTION
Do not inherit parser from common_utils
* I don't think we use any variables in run_test that depend on those, and I think all tests except doctests run in a subprocess so they will parse the args in common_utils and set the variables.  I don't think doctests wants any of those variables?  

Parse known args, add the extra args as extra, pass the extra ones along to the subprocess
Removes the first instance of `--`

I think I will miss run_test telling me if an arg is valid or not

cc @Flamefire 