### PR TITLE
[Docs] Add `str` type to `cuda.get_device_name()` and `cuda. get_device_capability()` function

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -420,7 +420,7 @@ def get_device_name(device: Optional[_device_t] = None) -> str:
     r"""Get the name of a device.
 
     Args:
-        device (torch.device, str or int, optional): device for which to return the
+        device (torch.device or int or str, optional): device for which to return the
             name. This function is a no-op if this argument is a negative
             integer. It uses the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -435,7 +435,7 @@ def get_device_capability(device: Optional[_device_t] = None) -> Tuple[int, int]
     r"""Get the cuda capability of a device.
 
     Args:
-        device (torch.device or int, optional): device for which to return the
+        device (torch.device or int or str, optional): device for which to return the
             device capability. This function is a no-op if this argument is
             a negative integer. It uses the current device, given by
             :func:`~torch.cuda.current_device`, if :attr:`device` is ``None``

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -420,7 +420,7 @@ def get_device_name(device: Optional[_device_t] = None) -> str:
     r"""Get the name of a device.
 
     Args:
-        device (torch.device or int, optional): device for which to return the
+        device (torch.device, str or int, optional): device for which to return the
             name. This function is a no-op if this argument is a negative
             integer. It uses the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).


### PR DESCRIPTION
Fixes #126400

The `get_device_name()` and `get_device_capability()` allow passing in a string, but it's not stated in the doc.
