### PR TITLE
Add micro-benchmark framework and multi_layer_norm as an example

### DIFF
--- a/benchmarks/gpt_fast/micro_benchmark.py
+++ b/benchmarks/gpt_fast/micro_benchmark.py
@@ -1,0 +1,103 @@
+import argparse
+import dataclasses
+import time
+
+import torch
+import torch.nn as nn
+
+
+@dataclasses.dataclass
+class Experiment:
+    name: str
+    metric: str
+    target: float
+    actual: float
+
+
+DEFAULT_OUTPUT_FILE = "micro_benchmark.csv"
+
+
+def do_inference(mod, x, num_samples: int = 5):
+    total_time = 0
+    start = -1
+
+    for i in range(start, num_samples):
+        torch.cuda.synchronize("cuda")
+
+        t0 = time.perf_counter()
+        mod(x)
+
+        if i == -1:
+            print(f"Compilation time: {time.perf_counter() - t0:.2f} seconds")
+            continue
+
+        torch.cuda.synchronize("cuda")
+        total_time += time.perf_counter() - t0
+
+    total_time = total_time / num_samples
+
+    return total_time
+
+
+def run_multi_layernorm():
+    class MultiLayerNorm(nn.Module):
+        def __init__(self, num_layers, normalized_shape, eps=1e-5, bias=True):
+            super().__init__()
+            self.num_layers = num_layers
+            self.norm_layers = nn.ModuleList(
+                [
+                    nn.LayerNorm(normalized_shape, eps=eps, bias=bias)
+                    for _ in range(num_layers)
+                ]
+            )
+
+        def forward(self, x):
+            for layer_norm in self.norm_layers:
+                x = layer_norm(x)
+            return x
+
+    mod = MultiLayerNorm(num_layers=8, normalized_shape=4096).to("cuda")
+    mod = torch.compile(mod)
+    input = torch.randn([512, 1024, 4096], dtype=torch.bfloat16, device="cuda")
+    inference_time = do_inference(mod, input)
+
+    memory_bandwidth = input.numel() * input.dtype.itemsize / inference_time / 1e9
+
+    return [
+        Experiment(
+            "multi_layer_norm", "memory_bandwidth(GB/s)", 92, f"{memory_bandwidth:.02f}"
+        )
+    ]
+
+
+all_experiments = {
+    run_multi_layernorm,
+}
+
+
+def main(output_file=DEFAULT_OUTPUT_FILE):
+    results = []
+
+    for func in all_experiments:
+        lst = func()
+        for x in lst:
+            results.append(dataclasses.astuple(x))
+
+    headers = [field.name for field in dataclasses.fields(Experiment)]
+
+    from benchmark import output_csv
+
+    for row in results:
+        output_csv(output_file, headers, row)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run experiments.")
+    parser.add_argument(
+        "--output",
+        default=DEFAULT_OUTPUT_FILE,
+        help="Set the output CSV file to save the benchmark results",
+    )
+    args = parser.parse_args()
+
+    main(output_file=args.output)


### PR DESCRIPTION
```micro_benchmark.py``` output csv example (all numbers are fake, just for demo)
```
name,metric,target,actual
multi_layer_norm,inference_time(s),20,19.87
multi_layer_norm,memory_bandwidth(GB/s),108,108.04
llama2-int8, token_per_sec,155,156
llama2-int8,memory_bandwidth(GB/s),92,92.7
```
Expected dashboard looks like:
```
| name             | metric                 | target | actual | change |
|------------------|------------------------|--------|--------|--------|
| multi_layer_norm | inference_time(s)      | 20     | 19.87  | 99%    |
|                  | memory_bandwidth(GB/s) | 108    | 108.04 | 101%   |
| llama2-int8      | token_per_sec          | 155    | 156    | 100%   |
|                  | memory_bandwidth(GB/s) | 92     | 92.7   | 101%   |


```

