### PR TITLE
Write dynamo benchmarks performance result to csv when throw exceptions

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
@@ -50,6 +50,30 @@ densenet121,pass,0
 
 
 
+detectron2_fasterrcnn_r_101_c4,pass,42
+
+
+
+detectron2_fasterrcnn_r_101_dc5,pass,42
+
+
+
+detectron2_fasterrcnn_r_101_fpn,pass,46
+
+
+
+detectron2_fasterrcnn_r_50_c4,pass,42
+
+
+
+detectron2_fasterrcnn_r_50_dc5,pass,42
+
+
+
+detectron2_fasterrcnn_r_50_fpn,pass,46
+
+
+
 detectron2_fcos_r_50_fpn,pass,23
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
@@ -74,30 +74,6 @@ detectron2_fasterrcnn_r_50_fpn,pass,46
 
 
 
-detectron2_fasterrcnn_r_101_c4,pass,42
-
-
-
-detectron2_fasterrcnn_r_101_dc5,pass,42
-
-
-
-detectron2_fasterrcnn_r_101_fpn,pass,46
-
-
-
-detectron2_fasterrcnn_r_50_c4,pass,42
-
-
-
-detectron2_fasterrcnn_r_50_dc5,pass,42
-
-
-
-detectron2_fasterrcnn_r_50_fpn,pass,46
-
-
-
 detectron2_fcos_r_50_fpn,pass,23
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
@@ -74,6 +74,30 @@ detectron2_fasterrcnn_r_50_fpn,pass,46
 
 
 
+detectron2_fasterrcnn_r_101_c4,pass,42
+
+
+
+detectron2_fasterrcnn_r_101_dc5,pass,42
+
+
+
+detectron2_fasterrcnn_r_101_fpn,pass,46
+
+
+
+detectron2_fasterrcnn_r_50_c4,pass,42
+
+
+
+detectron2_fasterrcnn_r_50_dc5,pass,42
+
+
+
+detectron2_fasterrcnn_r_50_fpn,pass,46
+
+
+
 detectron2_fcos_r_50_fpn,pass,23
 
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -143,6 +143,12 @@ CI_SKIP_DYNAMIC_BATCH_ONLY = {
     "pyhpc_equation_of_state",
     "pyhpc_turbulent_kinetic_energy",
     "detectron2_fcos_r_50_fpn",
+    "detectron2_fasterrcnn_r_101_c4",
+    "detectron2_fasterrcnn_r_101_dc5",
+    "detectron2_fasterrcnn_r_101_fpn",
+    "detectron2_fasterrcnn_r_50_c4",
+    "detectron2_fasterrcnn_r_50_dc5",
+    "detectron2_fasterrcnn_r_50_fpn",
     "hf_T5_generate",
 }
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2762,6 +2762,7 @@ class BenchmarkRunner:
                     peak_mem = percentage * total / 10**9
             except Exception:
                 log.exception("Backend %s failed in warmup()", mode)
+                write_csv_when_exception(self.args, current_name, "warmup_failed", current_device)
                 return sys.exit(-1)
             dynamo_stats = get_dynamo_stats()
             dynamo_stats.subtract(start_stats)

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2768,7 +2768,9 @@ class BenchmarkRunner:
                     peak_mem = percentage * total / 10**9
             except Exception:
                 log.exception("Backend %s failed in warmup()", mode)
-                write_csv_when_exception(self.args, current_name, "warmup_failed", current_device)
+                write_csv_when_exception(
+                    self.args, current_name, "warmup_failed", current_device
+                )
                 return sys.exit(-1)
             dynamo_stats = get_dynamo_stats()
             dynamo_stats.subtract(start_stats)


### PR DESCRIPTION
**Performance mode Issue**: When dynamo benchmarks performance warm-up failed, the result will be not written into csv file. But the accuracy will be written as `fail_to_run` even when dynamo pass failed. So the accuracy model number is not aligned with performance model number for each of their csv files.
![image](https://github.com/pytorch/pytorch/assets/84730719/9043d215-130b-46b4-a835-f148c225947c)

- **Fix**: The warm-up failed models will be recorded into csv file shown as following:
![image](https://github.com/pytorch/pytorch/assets/84730719/7907a3c2-c942-42bb-b31c-55424a0e8117)


**Accuracy mode issue**: `detectron2_fasterrcnn_r` models failed on accuracy mode, but was tested successfully on performance mode. The accuracy failure is same as PR https://github.com/pytorch/pytorch/commit/ee557d8f61bbe8a54742a82507a6edb2de3e5a89.
```
Dynamic Shape:
Traceback (most recent call last):
  File "benchmarks/dynamo/torchbench.py", line 449, in <module>
    torchbench_main()
  File "benchmarks/dynamo/torchbench.py", line 445, in torchbench_main
    main(TorchBenchmarkRunner(), original_dir)
  File "/workspace/pytorch/benchmarks/dynamo/common.py", line 3650, in main
    process_entry(0, runner, original_dir, args)
  File "/workspace/pytorch/benchmarks/dynamo/common.py", line 3582, in process_entry
    return run(runner, args, original_dir)
  File "/workspace/pytorch/benchmarks/dynamo/common.py", line 4163, in run
    assert marked, f"nothing in example_inputs had a dim with {batch_size}"
AssertionError: nothing in example_inputs had a dim with 4
```
![image](https://github.com/pytorch/pytorch/assets/84730719/f25392f0-f982-46c8-8e2c-a8a25d85a21a)

- **Fix**: same as PR https://github.com/pytorch/pytorch/commit/ee557d8f61bbe8a54742a82507a6edb2de3e5a89, the batch_size will be skipped to set as 4 when testing dynamic shapes.

Dynamic shapes passrate improved from 89% -> **95%**
| Comp Item | Compiler | suite      | before     | After fix  |
|-----------|----------|------------|------------|------------|
| Pass Rate | Inductor | torchbench | 89%, 73/82 | 95%, 79/83 |


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @mcarilli @ptrblck @leslie-fang-intel @jgong5 @voznesenskym @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire