### PR TITLE
Fix SobolEngine default dtype handling

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7492,10 +7492,13 @@ class TestTorch(TestCase):
     def test_sobolengine_default_dtype(self):
         with set_default_dtype(torch.float64):
             engine = torch.quasirandom.SobolEngine(dimension=3, scramble=True, seed=123456)
-            result = engine.draw(n=5)
-            self.assertEqual(result.dtype, torch.float64)
-            result = engine.draw(n=5, dtype=torch.float32)
-            self.assertEqual(result.dtype, torch.float32)
+            # Check that default dtype is correctly handled
+            self.assertEqual(engine.draw(n=5).dtype, torch.float64)
+            # Check that explicitly passed dtype is adhered to
+            self.assertEqual(engine.draw(n=5, dtype=torch.float32).dtype, torch.float32)
+            # Reinitialize the engine and check that first draw dtype is correctly handled
+            engine = torch.quasirandom.SobolEngine(dimension=3, scramble=True, seed=123456)
+            self.assertEqual(engine.draw(n=5, dtype=torch.float32).dtype, torch.float32)
 
     @skipIfTorchDynamo("np.float64 restored as float32 after graph break.")
     def test_sobolengine_distribution(self, scramble=False):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7489,6 +7489,14 @@ class TestTorch(TestCase):
     def test_sobolengine_fast_forward_scrambled(self):
         self.test_sobolengine_fast_forward(scramble=True)
 
+    def test_sobolengine_default_dtype(self):
+        with set_default_dtype(torch.float64):
+            engine = torch.quasirandom.SobolEngine(dimension=3, scramble=True, seed=123456)
+            result = engine.draw(n=5)
+            self.assertEqual(result.dtype, torch.float64)
+            result = engine.draw(n=5, dtype=torch.float32)
+            self.assertEqual(result.dtype, torch.float32)
+
     @skipIfTorchDynamo("np.float64 restored as float32 after graph break.")
     def test_sobolengine_distribution(self, scramble=False):
         d = 50

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7490,9 +7490,12 @@ class TestTorch(TestCase):
         self.test_sobolengine_fast_forward(scramble=True)
 
     def test_sobolengine_default_dtype(self):
+        engine = torch.quasirandom.SobolEngine(dimension=3, scramble=True, seed=123456)
+        # Check that default dtype is correctly handled
+        self.assertEqual(engine.draw(n=5).dtype, torch.float32)
         with set_default_dtype(torch.float64):
             engine = torch.quasirandom.SobolEngine(dimension=3, scramble=True, seed=123456)
-            # Check that default dtype is correctly handled
+            # Check that default dtype is correctly handled (when set to float64)
             self.assertEqual(engine.draw(n=5).dtype, torch.float64)
             # Check that explicitly passed dtype is adhered to
             self.assertEqual(engine.draw(n=5, dtype=torch.float32).dtype, torch.float32)

--- a/torch/quasirandom.py
+++ b/torch/quasirandom.py
@@ -69,7 +69,7 @@ class SobolEngine:
         self.num_generated = 0
 
     def draw(self, n: int = 1, out: Optional[torch.Tensor] = None,
-             dtype: torch.dtype = torch.float32) -> torch.Tensor:
+             dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         r"""
         Function to draw a sequence of :attr:`n` points from a Sobol sequence.
         Note that the samples are dependent on the previous samples. The size
@@ -81,8 +81,11 @@ class SobolEngine:
             out (Tensor, optional): The output tensor
             dtype (:class:`torch.dtype`, optional): the desired data type of the
                                                     returned tensor.
-                                                    Default: ``torch.float32``
+                                                    Default: ``None``
         """
+        if dtype is None:
+            dtype = torch.get_default_dtype()
+
         if self.num_generated == 0:
             if n == 1:
                 result = self._first_point.to(dtype)
@@ -90,7 +93,7 @@ class SobolEngine:
                 result, self.quasi = torch._sobol_engine_draw(
                     self.quasi, n - 1, self.sobolstate, self.dimension, self.num_generated, dtype=dtype,
                 )
-                result = torch.cat((self._first_point, result), dim=-2)
+                result = torch.cat((self._first_point.to(dtype), result), dim=-2)
         else:
             result, self.quasi = torch._sobol_engine_draw(
                 self.quasi, n, self.sobolstate, self.dimension, self.num_generated - 1, dtype=dtype,
@@ -105,7 +108,7 @@ class SobolEngine:
         return result
 
     def draw_base2(self, m: int, out: Optional[torch.Tensor] = None,
-                   dtype: torch.dtype = torch.float32) -> torch.Tensor:
+                   dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         r"""
         Function to draw a sequence of :attr:`2**m` points from a Sobol sequence.
         Note that the samples are dependent on the previous samples. The size

--- a/torch/quasirandom.py
+++ b/torch/quasirandom.py
@@ -119,7 +119,7 @@ class SobolEngine:
             out (Tensor, optional): The output tensor
             dtype (:class:`torch.dtype`, optional): the desired data type of the
                                                     returned tensor.
-                                                    Default: ``torch.float32``
+                                                    Default: ``None``
         """
         n = 2 ** m
         total_n = self.num_generated + n


### PR DESCRIPTION
- Change default dtype argument to `None` and fetch it value via `torch.get_default_dtype()` call if not defined
- Fix bug in first draw handling logic, that would ignore dtype in favor of default one due to type promotion
- Add regression tests

Fixes https://github.com/pytorch/pytorch/issues/126478