### PR TITLE
[Fix]: populate input parameter name when convert TorchScript to ExportedProgram

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -2,6 +2,10 @@
 # flake8: noqa
 import unittest
 
+from dataclasses import dataclass
+
+from typing import List, Dict, Tuple
+
 import torch
 import torch._dynamo
 from torch._dynamo.test_case import run_tests, TestCase
@@ -134,9 +138,50 @@ def forward(self, arg0_1, arg1_1):
         exported_module = _convert_ts_to_export_experimental(
             traced_module_by_torchscript, inps
         )
-        print(exported_module.graph)
 
         self.assertTrue(torch.allclose(exported_module(inps), model_to_trace(inps)))
+
+    def test_torchscript_module_export_various_inputs_with_annotated_input_names(self):
+
+        def _check_equality_and_annotations(m_func, inps):
+            # Original module.
+            model_to_trace = m_func()
+
+            # ExportedProgram from TorchScript module.
+            traced_module_by_torchscript = torch.jit.trace(m_func(), example_inputs=inps)
+            exported_module = _convert_ts_to_export_experimental(
+                traced_module_by_torchscript, inps
+            )
+
+            # ExportedProgram from original module.
+            original_exported_module = torch.export.export(m_func(), inps)
+
+            # Check whether input annotations are the same as tracing the original module.
+            orig_ph_name_list = [n.name for n in original_exported_module.graph.nodes if n.op == "placeholder"]
+            ph_name_list = [n.name for n in exported_module.graph.nodes if n.op == "placeholder"]
+            self.assertEqual(orig_ph_name_list, ph_name_list)
+
+            # Check results equality.
+            self.assertTrue(torch.allclose(exported_module(*inps), model_to_trace(*inps)))
+
+        # Tuple
+        class MTuple(torch.nn.Module):
+            def forward(self, x: Tuple[torch.Tensor]):
+                return x[0] + x[1]
+        _check_equality_and_annotations(MTuple, ((torch.randn(4), torch.randn(4)),))
+
+        # List
+        class MList(torch.nn.Module):
+            def forward(self, x: List[torch.Tensor]):
+                return x[0] + x[1]
+        _check_equality_and_annotations(MList, ([torch.randn(4), torch.randn(4)],))
+
+        # Dict
+        class MDict(torch.nn.Module):
+            def forward(self, x: Dict[str, torch.Tensor]):
+                return x["0"] + x["1"]
+        _check_equality_and_annotations(MDict, ({"0": torch.randn(4), "1": torch.randn(4)},))
+
 
 
 if __name__ == "__main__":

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -134,6 +134,7 @@ def forward(self, arg0_1, arg1_1):
         exported_module = _convert_ts_to_export_experimental(
             traced_module_by_torchscript, inps
         )
+        print(exported_module.graph)
 
         self.assertTrue(torch.allclose(exported_module(inps), model_to_trace(inps)))
 

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -2,10 +2,6 @@
 # flake8: noqa
 import unittest
 
-from collections import namedtuple
-
-from dataclasses import dataclass
-
 from typing import Dict, List, Tuple
 
 import torch

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -437,7 +437,8 @@ def _get_torch_jit_trace_forward_signature(mod: torch.nn.Module):
     ast_func_def = ast_mod.body[0]
 
     # Arguments type mappings. Used to map from AST to Python signature.
-    # FIXME: Currently, other arguments types are commentted out.
+    # FIXME: Based on my understanding, TorchScript only supports explicit arguments
+    # and it cannot take variable length arguments.
     arg_type_map = {
         # "posonlyargs": inspect._POSITIONAL_ONLY,
         "args": inspect._POSITIONAL_OR_KEYWORD,

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -507,8 +507,6 @@ def placeholder_naming_pass(
     name_map: Dict[str, str] = {}
 
     # map user input names with mod.forward() signature
-    from torch.jit._trace import TopLevelTracedModule
-
     sig = inspect.signature(mod.forward) if not _is_torch_jit_trace else _get_torch_jit_trace_forward_signature(mod)
     combined_args = (
         sig.bind(*fake_args, **fake_kwargs).arguments

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -456,7 +456,7 @@ def _get_torch_jit_trace_forward_signature(mod: torch.nn.Module):
     return inspect.Signature(parameters=param_list)
 
 
-def _get_placeholder_combined_args(mod, fake_args, fake_kwargs):
+def _bind_signature_to_inputs(mod, fake_args, fake_kwargs):
     if isinstance(mod, (torch.jit.ScriptModule, torch.jit.TracedModule)):
         sig = _get_torch_jit_trace_forward_signature(mod)
 
@@ -518,7 +518,7 @@ def placeholder_naming_pass(
     name_map: Dict[str, str] = {}
 
     # map user input names with mod.forward() signature
-    combined_args = _get_placeholder_combined_args(mod, fake_args, fake_kwargs)
+    combined_args = _bind_signature_to_inputs(mod, fake_args, fake_kwargs)
 
     flat_args_with_path, _ = tree_flatten_with_path(combined_args)
     user_input_names = [

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -698,18 +698,17 @@ def _export_to_aten_ir(
     constants = rewrite_script_object_meta(gm)
     constants.update(lift_constants_pass(gm, export_graph_signature, constant_attrs))
 
-    # FIXME: Skipping this because traced modules do not have signature yet
-    if not _is_torch_jit_trace:
-        # prettify names for placeholder nodes
-        placeholder_naming_pass(
-            gm,
-            export_graph_signature,
-            mod,
-            fake_args,
-            fake_kwargs,
-            fake_params_buffers,
-            constants,
-        )
+    # Prettify names for placeholder nodes.
+    placeholder_naming_pass(
+        gm,
+        export_graph_signature,
+        mod,
+        fake_args,
+        fake_kwargs,
+        fake_params_buffers,
+        constants,
+        _is_torch_jit_trace,
+    )
 
     return ExportedArtifact(
         gm,

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -707,7 +707,6 @@ def _export_to_aten_ir(
         fake_kwargs,
         fake_params_buffers,
         constants,
-        _is_torch_jit_trace,
     )
 
     return ExportedArtifact(


### PR DESCRIPTION
## Goal
As title

## Design
Based on the fact that each TorchScript module has a `code` property which provides the original source code for the `forward` function, I implemented a function to extrapolate `forward` function signature by using the AST parser. 

Some other tradeoff
* Directly parsing src code as string --> will be very buggy
* Directly using `compile` function in Python to get the function object --> raises a lot of exceptions because of missing packages or undefined variable names