### PR TITLE
Support tracing through _get_current_dispatch_mode_stack

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1606,6 +1606,24 @@ $0: f32[] = torch._ops.aten.empty.memory_format([], device=device(type='cpu'), p
             with A() as mode2:
                 self.assertEqual(_get_current_dispatch_mode_stack(), [mode1, mode2])
 
+    def test_get_mode_stack_compiling(self):
+        @torch.compile()
+        def f():
+            return _get_current_dispatch_mode_stack()
+
+        class A(TorchDispatchMode):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                pass
+
+        self.assertEqual(f(), [])
+
+        with A() as mode1:
+            self.assertEqual(f(), [])
+
+        with mode1:
+            with A() as mode2:
+                self.assertEqual(f(), [])
+
     def test_all_same_mode(self):
         x = LoggingTensorMode()
         y = LoggingTensorMode()

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -296,6 +296,7 @@ manual_torch_name_rule_map = {
     "torch._dynamo.mark_static": UserFunctionVariable,
     "torch.fx.experimental.symbolic_shapes.guard_size_oblivious": TorchInGraphFunctionVariable,
     "torch.cuda._get_device_properties": TorchInGraphFunctionVariable,
+    "torch.utils._python_dispatch._get_current_dispatch_mode_stack": UserFunctionVariable,
     "torch.utils.hooks.BackwardHook": TorchInGraphFunctionVariable,
     "torch.sparse_bsc_tensor": SkipFunctionVariable,
     "torch.sparse_bsr_tensor": SkipFunctionVariable,

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -155,7 +155,9 @@ def _disable_infra_mode(key):
             _push_mode(mode_unset)
 
 
-def _get_current_dispatch_mode_stack():
+def _get_current_dispatch_mode_stack() -> list:
+    if torch.compiler.is_compiling():
+        return []
     stack_len = _len_torch_dispatch_stack()
     return [_get_dispatch_stack_at(i) for i in range(stack_len)]
 


### PR DESCRIPTION
## Summary
Fixes #125694

This PR allow dynamo tracing through `_get_current_dispatch_mode_stack` but only returns a `[]` as per @ezyang's [comment](https://github.com/pytorch/pytorch/issues/125694#issuecomment-2101702541)

## Test Plan
Added tests for this, locally passing. CI should help too.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames