### PR TITLE
[AOTI] Fix unsupported type of output=s1

### DIFF
--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -98,7 +98,6 @@ if TEST_WITH_ROCM:
 if config.abi_compatible:
     xfail_list = [
         "test_profiler_mark_wrapper_call_cuda",
-        "test_scaled_dot_product_attention_cuda_dynamic_shapes",
     ]
     for test_name in xfail_list:
         test_failures_cuda_wrapper[test_name] = test_torchinductor.TestFailure(

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1225,6 +1225,10 @@ class CppWrapperCpu(WrapperCodeGen):
                 output_args.append(f"&{output_name}")
             elif output is None:
                 output_args.append("nullptr")
+            elif output.is_Symbol:
+                output_name = f"{output_name_base}_{idx}"
+                self.writeline(f"auto {output_name} = {output};")
+                output_args.append(f"&{output_name}")
             else:
                 raise NotImplementedError(f"unsupported type of {output=}")
         args = args + output_args

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1223,6 +1223,10 @@ class CppWrapperCpu(WrapperCodeGen):
                 output_name = f"{output_name_base}_{idx}"
                 self.writeline(f"int64_t {output_name} = {output};")
                 output_args.append(f"&{output_name}")
+            elif isinstance(output, sympy.Symbol):
+                output_name = f"{output_name_base}_{idx}"
+                self.writeline(f"auto {output_name} = {output};")
+                output_args.append(f"&{output_name}")
             elif output is None:
                 output_args.append("nullptr")
             elif output.is_Symbol:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1229,10 +1229,6 @@ class CppWrapperCpu(WrapperCodeGen):
                 output_args.append(f"&{output_name}")
             elif output is None:
                 output_args.append("nullptr")
-            elif output.is_Symbol:
-                output_name = f"{output_name_base}_{idx}"
-                self.writeline(f"auto {output_name} = {output};")
-                output_args.append(f"&{output_name}")
             else:
                 raise NotImplementedError(f"unsupported type of {output=}")
         args = args + output_args


### PR DESCRIPTION
Fixes #123036

In unit test `DynamicShapesCudaWrapperCudaTests.test_scaled_dot_product_attention_cuda_dynamic_shapes_cuda_wrapper`, computed buffer buf3 is compiled to a fallback kernel `aoti_torch_cuda__scaled_dot_product_flash_attention`. It has 9 outputs whose types are `[MultiOutput, MultiOutput, None, None, s1, s1, MultiOutput, MultiOutput,MultiOutput]`. The type `s1` here is passed from [generate_output](https://github.com/pytorch/pytorch/blob/acfe237a71af609e837a34bb38048aa8acb8eb4d/torch/_inductor/ir.py#L5658). 

They type check for Symbol is missing for fallback kernel output generation. This PR fixes this issue by checking `output.is_Symbol`. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang