### PR TITLE
[export] add nonstrict, retrace, serdes patching for _trace._export tests

### DIFF
--- a/test/export/test_export_nonstrict.py
+++ b/test/export/test_export_nonstrict.py
@@ -6,6 +6,7 @@ except ImportError:
     import test_export
     import testing
 from torch.export import export
+from torch.export._trace import _export
 
 test_classes = {}
 
@@ -17,6 +18,13 @@ def mocked_non_strict_export(*args, **kwargs):
     return export(*args, **kwargs, strict=False)
 
 
+def mocked_non_strict_private_export(*args, **kwargs):
+    # If user already specified strict, don't make it non-strict
+    if "strict" in kwargs:
+        return _export(*args, **kwargs)
+    return _export(*args, **kwargs, strict=False)
+
+
 def make_dynamic_cls(cls):
     cls_prefix = "NonStrictExport"
 
@@ -25,6 +33,7 @@ def make_dynamic_cls(cls):
         cls_prefix,
         test_export.NON_STRICT_SUFFIX,
         mocked_non_strict_export,
+        mocked_non_strict_private_export,
         xfail_prop="_expected_failure_non_strict",
     )
 

--- a/test/export/test_serdes.py
+++ b/test/export/test_serdes.py
@@ -9,12 +9,22 @@ except ImportError:
     import testing
 
 from torch.export import export, load, save
+from torch.export._trace import _export
 
 test_classes = {}
 
 
 def mocked_serder_export(*args, **kwargs):
     ep = export(*args, **kwargs)
+    buffer = io.BytesIO()
+    save(ep, buffer)
+    buffer.seek(0)
+    loaded_ep = load(buffer)
+    return loaded_ep
+
+
+def mocked_serder_private_export(*args, **kwargs):
+    ep = _export(*args, **kwargs)
     buffer = io.BytesIO()
     save(ep, buffer)
     buffer.seek(0)
@@ -32,6 +42,7 @@ def make_dynamic_cls(cls):
         cls_prefix,
         suffix,
         mocked_serder_export,
+        mocked_serder_private_export,
         xfail_prop="_expected_failure_serdes",
     )
 


### PR DESCRIPTION
Summary: Not sure if this is a good idea? Handful of new expected failures. But will be useful for a future diff

Test Plan: tests

Differential Revision: D57638904


