### PR TITLE
[pipelining] Retire PIPPY_VERBOSITY in favor of TORCH_LOGS=pp

### DIFF
--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -16,7 +16,6 @@ from torch.fx.node import map_aggregate
 from torch.fx.passes.split_module import split_module
 
 from ._backward import _null_coalesce_accumulate, stage_backward
-from ._debug import PIPPY_VERBOSITY
 from ._unflatten import _outline_submodules
 from ._utils import QualnameMapMixin
 from .microbatch import split_args_kwargs_into_chunks, TensorChunkSpec
@@ -687,9 +686,7 @@ class Pipe(QualnameMapMixin, torch.nn.Module):
             logger.info("Auto-splitting model")
             traced = split_policy(traced)  # type: ignore[arg-type]
 
-        if PIPPY_VERBOSITY == "DEBUG":
-            logger.debug("Traced original model:")
-            traced.print_readable()
+        logger.debug(traced.print_readable(print_output=False))
 
         # Deduplicate `get_attr` nodes that refer to the same parameter . Downstream code for moving
         # parameters relies on the invariant that parameter accesses happen once. This is not necessarily

--- a/torch/distributed/pipelining/_debug.py
+++ b/torch/distributed/pipelining/_debug.py
@@ -1,24 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-import logging
-import os
-
 import torch
-
-
-# PIPPY_VERBOSITY is an environment variable that controls the logging level.
-# It can be set to one of the following:
-#   - WARNING (default)
-#   - INFO
-#   - DEBUG
-PIPPY_VERBOSITY = os.getenv("PIPPY_VERBOSITY", "WARNING")
-if PIPPY_VERBOSITY not in ["WARNING", "INFO", "DEBUG"]:
-    print(f"Unsupported PIPPY_VERBOSITY level: {PIPPY_VERBOSITY}")
-    PIPPY_VERBOSITY = "WARNING"
-
-logging.getLogger("pippy").setLevel(PIPPY_VERBOSITY)
-# It seems we need to print something to make the level setting effective
-# for child loggers. Doing it here.
-print(f"Setting PiPPy logging level to: {PIPPY_VERBOSITY}")
 
 
 def friendly_debug_info(v):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126828

https://github.com/pytorch/pytorch/pull/126499/ established: 

`TORCH_LOGS=pp` --> info
`TORCH_LOGS=-pp` --> warn
`TORCH_LOGS=+pp` --> debug

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k