### PR TITLE
[CUDA Caching Allocator] Round to nearest 512 bytes boundary if number of divisions=1

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1778,12 +1778,11 @@ class DeviceCachingAllocator {
   // them, the values are 1024, 1280, 1536, and 1792. So the function will
   // return 1280 as the nearest ceiling of power-2 divison.
   static size_t roundup_power2_next_division(size_t size, size_t divisions) {
-    if (C10_UNLIKELY(size <= 4 || divisions <= 1)) {
-      return size;
-    }
     if (llvm::isPowerOf2_64(size)) {
       return size;
     }
+
+    TORCH_CHECK(divisions >= 2, "Only 2 or more divisions are supported");
 
     // divide the space between these 2's power into equal divisions
     // If division is zero, return the power-of-2 ceiling.
@@ -1803,7 +1802,7 @@ class DeviceCachingAllocator {
       return kMinBlockSize;
     } else {
       auto divisions = CUDAAllocatorConfig::roundup_power2_divisions(size);
-      if (divisions > 0 && size > (kMinBlockSize * divisions)) {
+      if (divisions > 1 && size > (kMinBlockSize * divisions)) {
         return roundup_power2_next_division(size, divisions);
       } else {
         return kMinBlockSize * ((size + kMinBlockSize - 1) / kMinBlockSize);


### PR DESCRIPTION
Summary: This diff fixes an issue when the number of divisions=1, resulting in unaligned memory accesses.

Reviewed By: 842974287

Differential Revision: D57648763


