### PR TITLE
Update dispatch stub to make SDPA routing cleaner

### DIFF
--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -92,7 +92,7 @@ CPUCapability get_cpu_capability() {
 }
 
 void* DispatchStubImpl::get_call_ptr(
-  DeviceType device_type
+  const DeviceType device_type
   , void *DEFAULT
 #ifdef HAVE_AVX512_CPU_DEFINITION
   , void *AVX512

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -131,7 +131,7 @@ struct DispatchStub<rT (*)(Args...), T> {
   DispatchStub& operator=(const DispatchStub&) = delete;
 
 private:
-  FnPtr get_call_ptr(c10::DeviceType device_type) {
+  FnPtr get_call_ptr(const c10::DeviceType device_type) {
     return reinterpret_cast<FnPtr>(
       impl.get_call_ptr(device_type
       , reinterpret_cast<void*>(DEFAULT)
@@ -173,6 +173,13 @@ public:
   void set_privateuse1_dispatch_ptr(FnPtr fn_ptr) {
     impl.privateuse1_dispatch_ptr = reinterpret_cast<void*>(fn_ptr);
   }
+
+  // Returns true if the dispatcher has a kernel registered for this device
+  // type.
+  bool is_device_supported(const c10::DeviceType device_type) {
+    FnPtr call_ptr = get_call_ptr(device_type);
+    return call_ptr != nullptr;
+  };
 
   static TORCH_API FnPtr DEFAULT;
 #ifdef HAVE_AVX512_CPU_DEFINITION

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -90,6 +90,12 @@ struct DispatchStub;
  * number of specialization of the DispatchStub<> class.
  */
 struct TORCH_API DispatchStubImpl {
+
+  // The DispatchStubImpl::try_get_call_ptr() method is used to get the call
+  // pointer for a given device type. If the call pointer is not found,
+  // DispatchStubImpl::try_get_call_ptr() returns an ErrorType.
+  // The main difference between try_get_call_ptr() and get_call_ptr() is that
+  // try_get_call_ptr() will return the ErrorType and not raise an exception.
   DispatchResult try_get_call_ptr(
     c10::DeviceType device_type
     , void *DEFAULT
@@ -106,6 +112,25 @@ struct TORCH_API DispatchStubImpl {
       , void *ZVECTOR
 #endif
   );
+
+  // Analogous to try_get_call_ptr(), but it will return the ErrorType and not
+  // raise an exception.
+  DispatchResult try_choose_cpu_impl(
+    void *DEFAULT
+#ifdef HAVE_AVX512_CPU_DEFINITION
+    , void *AVX512
+#endif
+#ifdef HAVE_AVX2_CPU_DEFINITION
+    , void *AVX2
+#endif
+#ifdef HAVE_VSX_CPU_DEFINITION
+    , void *VSX
+#endif
+#ifdef HAVE_ZVECTOR_CPU_DEFINITION
+    , void *ZVECTOR
+#endif
+  );
+
 
   void* get_call_ptr(
     c10::DeviceType device_type

--- a/c10/util/Array.h
+++ b/c10/util/Array.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <array>
 #include <utility>
 


### PR DESCRIPTION
# Summary

Adds a public method to dispatchstub to check if a fn has been registered for a device. We use this new function to clean up the dispatching logic for SDPA, as well as make the private use dispatching simpler:
#126392