### PR TITLE
Faster __getattr__ in nn.Module

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1693,18 +1693,22 @@ class Module:
     # See full discussion on the problems with returning `Union` here
     # https://github.com/microsoft/pyright/issues/4213
     def __getattr__(self, name: str) -> Any:
-        if '_parameters' in self.__dict__:
-            _parameters = self.__dict__['_parameters']
-            if name in _parameters:
-                return _parameters[name]
-        if '_buffers' in self.__dict__:
-            _buffers = self.__dict__['_buffers']
-            if name in _buffers:
-                return _buffers[name]
-        if '_modules' in self.__dict__:
-            modules = self.__dict__['_modules']
-            if name in modules:
-                return modules[name]
+        __dict__ = self.__dict__
+        _parameters = __dict__['_parameters']
+        if _parameters:
+            result = _parameters.get(name, None)
+            if result is not None:
+                return result
+        _buffers = __dict__['_buffers']
+        if _buffers:
+            result = _buffers.get(name, None)
+            if result is not None:
+                return result
+        _modules = __dict__['_modules']
+        if _modules:
+            result = _modules.get(name, None)
+            if result is not None:
+                return result
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     def __setattr__(self, name: str, value: Union[Tensor, 'Module']) -> None:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1694,20 +1694,25 @@ class Module:
     # https://github.com/microsoft/pyright/issues/4213
     def __getattr__(self, name: str) -> Any:
         __dict__ = self.__dict__
-        _parameters = __dict__['_parameters']
+        _parameters = __dict__.get('_parameters')
         if _parameters:
-            result = _parameters.get(name, None)
-            if result is not None:
+            # A param can be None so we use False instead to check if the key
+            # is in the _parameters dict once and only once.
+            # We use False but any non-None, non-Parameter value would do.
+            # The alternative `if name in _parameters: return _parameters[name]`
+            # accesses the value of `name` twice when only one is required
+            result = _parameters.get(name, False)
+            if result is not False:
                 return result
-        _buffers = __dict__['_buffers']
+        _buffers = __dict__.get('_buffers')
         if _buffers:
-            result = _buffers.get(name, None)
-            if result is not None:
+            result = _buffers.get(name, False)
+            if result is not False:
                 return result
-        _modules = __dict__['_modules']
+        _modules = __dict__.get('_modules')
         if _modules:
-            result = _modules.get(name, None)
-            if result is not None:
+            result = _modules.get(name, False)
+            if result is not False:
                 return result
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1723,7 +1723,7 @@ class Module:
                     if isinstance(d, dict):
                         del d[name]
                     else:
-                        d.dislcard(name)
+                        d.discard(name)
 
         __dict__ = self.__dict__
         params = __dict__.get('_parameters')

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1723,14 +1723,15 @@ class Module:
                     if isinstance(d, dict):
                         del d[name]
                     else:
-                        d.discard(name)
+                        d.dislcard(name)
 
-        params = self.__dict__.get('_parameters')
+        __dict__ = self.__dict__
+        params = __dict__.get('_parameters')
         if isinstance(value, Parameter):
             if params is None:
                 raise AttributeError(
                     "cannot assign parameters before Module.__init__() call")
-            remove_from(self.__dict__, self._buffers, self._modules, self._non_persistent_buffers_set)
+            remove_from(__dict__, __dict__["_buffers"], __dict__["_modules"], self._non_persistent_buffers_set)
             self.register_parameter(name, value)
         elif params is not None and name in params:
             if value is not None:
@@ -1739,12 +1740,12 @@ class Module:
                                 )
             self.register_parameter(name, value)
         else:
-            modules = self.__dict__.get('_modules')
+            modules = __dict__.get('_modules')
             if isinstance(value, Module):
                 if modules is None:
                     raise AttributeError(
                         "cannot assign module before Module.__init__() call")
-                remove_from(self.__dict__, self._parameters, self._buffers, self._non_persistent_buffers_set)
+                remove_from(__dict__, __dict__["_parameters"], __dict__["_buffers"], self._non_persistent_buffers_set)
                 for hook in _global_module_registration_hooks.values():
                     output = hook(self, name, value)
                     if output is not None:
@@ -1761,7 +1762,7 @@ class Module:
                         value = output
                 modules[name] = value
             else:
-                buffers = self.__dict__.get('_buffers')
+                buffers = __dict__.get('_buffers')
                 if buffers is not None and name in buffers:
                     if value is not None and not isinstance(value, torch.Tensor):
                         raise TypeError(f"cannot assign '{torch.typename(value)}' as buffer '{name}' "


### PR DESCRIPTION
Similar improvements could be done for __setattr__

```python
from torch import nn
import torch.utils.benchmark
import torch

class MyModule(nn.Module):
    def __init__(self, ):
        super().__init__()
        self.net = nn.ModuleList([])

mod = MyModule()

cmd = "mod.net"
print(torch.utils.benchmark.Timer(cmd, globals=globals()).adaptive_autorange())

```

Runs in 370ns with main, 264 ns with this PR
If the module has params:
292.25 ns (here) vs 360.81 ns (main)

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki