### PR TITLE
[decomp] Enable test test_compile_rrelu on Windows

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1126,13 +1126,15 @@ class HasDecompTest(TestCase):
         core_aten_ops = useful_decomps - core_decomps
         self.assertExpected("".join(sorted(op.name() + "\n" for op in core_aten_ops)))
 
-    @unittest.skipIf(IS_WINDOWS, "torch.compile not supported on windows")
     def test_compile_rrelu(self):
         def f(x):
             return torch.rrelu(x)
 
+        from torch._dynamo.testing import CompileCounter
+        cnt = CompileCounter()
+
         inp = torch.rand(1, 2, 3)
-        self.assertEqual(f(inp), torch.compile(f)(inp))
+        self.assertEqual(f(inp), torch.compile(backend=cnt)(f)(inp))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary:**
Provide the do nothing backend CompileCounter to enable test on Windows machines.

**TestPlan**
` python test/test_decomp.py -k test_compile_rrelu`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang