### PR TITLE
[WIP] fix calls to `super().__getattr__` nn.Module in dynamo

### DIFF
--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -215,7 +215,6 @@ class NNModuleVariable(VariableTracker):
 
         base = tx.output.get_submodule(self.module_key)
         base_dict = object.__getattribute__(base, "__dict__")
-
         object_member = True
         all_class_attribute_names = set()
         for x in inspect.getmro(base.__class__):

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -215,6 +215,7 @@ class NNModuleVariable(VariableTracker):
 
         base = tx.output.get_submodule(self.module_key)
         base_dict = object.__getattribute__(base, "__dict__")
+
         object_member = True
         all_class_attribute_names = set()
         for x in inspect.getmro(base.__class__):
@@ -223,7 +224,9 @@ class NNModuleVariable(VariableTracker):
         if not self.source:
             unimplemented("GETATTR with no source")
 
-        if name in base_dict:
+        if name == "__dict__":
+            subobj = base_dict
+        elif name in base_dict:
             subobj = base_dict[name]
         elif (
             "_modules" in base_dict


### PR DESCRIPTION
Currently, custom getattr in nn.Module subclass such as
```python
def __getattr__(self, name):
    try:
        super().__getattr__(name)
    except AttributeError:
        bla
```
will fail because `__getattr__` is [ignored altogether](https://github.com/pytorch/pytorch/blob/ed734178abc99bc1d83ad2c61d3a1e4d4f5d20c8/torch/_dynamo/utils.py#L1939-L1941)

The part of getattr that breaks is retreiving the `__dict__` from `self`, but this seems to be already retrieved in var_getattr. This PR just checks if the name is `__dict__` and behaves accordingly.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang