### PR TITLE
Add torchao nightly testing workflow

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -159,6 +159,13 @@ function install_torchvision() {
 }
 
 function install_torchao() {
+  # Set ARCH list so that we can build fp16 with SM75+, the logic is copied from
+  # pytorch/builder
+  # https://github.com/pytorch/ao/blob/main/packaging/env_var_script_linux.sh#L16C1-L19
+  TORCH_CUDA_ARCH_LIST="8.0;8.6"
+  if [[ ${CU_VERSION:-} == "cu124" ]]; then
+    TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST};9.0"
+  fi
   pip_install --no-use-pep517 --user "git+https://github.com/pytorch/ao.git"
 }
 

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -158,6 +158,10 @@ function install_torchvision() {
   fi
 }
 
+function install_torchao() {
+  pip_install --no-use-pep517 --user "git+https://github.com/pytorch/ao.git"
+}
+
 function install_tlparse() {
   pip_install --user "tlparse==0.3.7"
   PATH="$(python -m site --user-base)/bin:$PATH"

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1358,14 +1358,17 @@ elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
     PYTHONPATH=$(pwd)/torchbench test_dynamo_benchmark torchbench "$id"
   fi
 elif [[ "${TEST_CONFIG}" == *torchao_huggingface* ]]; then
+  install_torchao
   install_torchvision
   id=$((SHARD_NUMBER-1))
   test_torchao_benchmark huggingface "$id"
 elif [[ "${TEST_CONFIG}" == *torchao_timm* ]]; then
+  install_torchao
   install_torchvision
   id=$((SHARD_NUMBER-1))
   test_torchao_benchmark timm_models "$id"
 elif [[ "${TEST_CONFIG}" == *torchao_torchbench* ]]; then
+  install_torchao
   install_torchaudio cuda
   install_torchvision
   id=$((SHARD_NUMBER-1))

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -518,7 +518,7 @@ test_torchao_perf_for_dashboard() {
       for torchao_backend in "${torchao_backends[@]}"; do
         if [[ "$DASHBOARD_TAG" == *${torchao_backend}-true* ]]; then
           python "benchmarks/dynamo/$suite.py" \
-              "${target_flag[@]}" --"$mode" --"$dtype" --quantization ${torchao_backend} "$@" \
+              "${target_flag[@]}" --"$mode" --"$dtype" --quantization "${torchao_backend}" "$@" \
               --output "$TEST_REPORTS_DIR/${backend}_${torchao_backend}_${suite}_${dtype}_${mode}_cuda_${target}.csv"
         fi
       done

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -482,6 +482,89 @@ test_perf_for_dashboard() {
   done
 }
 
+test_torchao_perf_for_dashboard() {
+  TEST_REPORTS_DIR=$(pwd)/test/test-reports
+  mkdir -p "$TEST_REPORTS_DIR"
+
+  local suite="$1"
+  shift
+
+  local backend=torchao
+  local modes=()
+  if [[ "$DASHBOARD_TAG" == *training-true* ]]; then
+    modes+=(training)
+  fi
+  if [[ "$DASHBOARD_TAG" == *inference-true* ]]; then
+    modes+=(inference)
+  fi
+  # TODO: All the accuracy tests can be skipped once the CI accuracy checking is stable enough
+  local targets=(accuracy performance)
+  local torchao_backends=(noquant int8dynamic int8weightonly int4weightonly  autoquant)
+
+  for mode in "${modes[@]}"; do
+    if [[ "$mode" == "inference" ]]; then
+      dtype=bfloat16
+    elif [[ "$mode" == "training" ]]; then
+      dtype=amp
+    fi
+    for target in "${targets[@]}"; do
+      local target_flag=("--${target}")
+      if [[ "$target" == "performance" ]]; then
+        target_flag+=( --cold-start-latency)
+      elif [[ "$target" == "accuracy" ]]; then
+        target_flag+=( --no-translation-validation)
+      fi
+
+      for torchao_backend in "${torchao_backends[@]}"; do
+        if [[ "$DASHBOARD_TAG" == *${torchao_backend}-true* ]]; then
+          python "benchmarks/dynamo/$suite.py" \
+              "${target_flag[@]}" --"$mode" --"$dtype" --quantization ${torchao_backend} "$@" \
+              --output "$TEST_REPORTS_DIR/${backend}_${torchao_backend}_${suite}_${dtype}_${mode}_cuda_${target}.csv"
+        fi
+      done
+    done
+  done
+}
+
+test_single_torchao_benchmark() {
+  # Usage: test_single_torchao_benchmark <inference|training> huggingface 0 --args-for-script
+
+  # Use test-reports directory under test folder will allow the CI to automatically pick up
+  # the test reports and upload them to S3. Need to use full path here otherwise the script
+  # will bark about file not found later on
+  TEST_REPORTS_DIR=$(pwd)/test/test-reports
+  mkdir -p "$TEST_REPORTS_DIR"
+
+  local name="$1"
+  shift
+  local suite="$1"
+  shift
+  # shard id is mandatory, even if it is not passed
+  local shard_id="$1"
+  shift
+
+  local partition_flags=()
+  if [[ -n "$NUM_TEST_SHARDS" && -n "$shard_id" ]]; then
+    partition_flags=( --total-partitions "$NUM_TEST_SHARDS" --partition-id "$shard_id" )
+  fi
+
+  test_torchao_perf_for_dashboard "$suite" \
+    "${TORCHAO_BENCHMARK_FLAGS[@]}" "$@" "${partition_flags[@]}"
+
+}
+
+test_torchao_benchmark() {
+  # Usage: test_torchao_benchmark huggingface 0
+  TEST_REPORTS_DIR=$(pwd)/test/test-reports
+
+  local suite="$1"
+  shift
+  local shard_id="$1"
+  shift
+
+  test_single_torchao_benchmark "inference" "$suite" "$shard_id" --inference --bfloat16 "$@"
+}
+
 test_single_dynamo_benchmark() {
   # Usage: test_single_dynamo_benchmark inductor_inference huggingface 0 --args-for-script
 
@@ -1235,15 +1318,15 @@ elif [[ "${TEST_CONFIG}" == *inductor_distributed* ]]; then
   test_inductor_distributed
 elif [[ "${TEST_CONFIG}" == *inductor-micro-benchmark* ]]; then
   test_inductor_micro_benchmark
-elif [[ "${TEST_CONFIG}" == *huggingface* ]]; then
+elif [[ "${TEST_CONFIG}" == *inductor_huggingface* ]]; then
   install_torchvision
   id=$((SHARD_NUMBER-1))
   test_dynamo_benchmark huggingface "$id"
-elif [[ "${TEST_CONFIG}" == *timm* ]]; then
+elif [[ "${TEST_CONFIG}" == *inductor_timm* ]]; then
   install_torchvision
   id=$((SHARD_NUMBER-1))
   test_dynamo_benchmark timm_models "$id"
-elif [[ "${TEST_CONFIG}" == *torchbench* ]]; then
+elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
   if [[ "${TEST_CONFIG}" == *cpu_inductor* ]]; then
     install_torchaudio cpu
   else
@@ -1274,6 +1357,20 @@ elif [[ "${TEST_CONFIG}" == *torchbench* ]]; then
     fi
     PYTHONPATH=$(pwd)/torchbench test_dynamo_benchmark torchbench "$id"
   fi
+elif [[ "${TEST_CONFIG}" == *torchao_huggingface* ]]; then
+  install_torchvision
+  id=$((SHARD_NUMBER-1))
+  test_torchao_benchmark huggingface "$id"
+elif [[ "${TEST_CONFIG}" == *torchao_timm* ]]; then
+  install_torchvision
+  id=$((SHARD_NUMBER-1))
+  test_torchao_benchmark timm_models "$id"
+elif [[ "${TEST_CONFIG}" == *torchao_torchbench* ]]; then
+  install_torchaudio cuda
+  install_torchvision
+  id=$((SHARD_NUMBER-1))
+  checkout_install_torchbench
+  PYTHONPATH=$(pwd)/torchbench test_torchao_benchmark torchbench "$id"
 elif [[ "${TEST_CONFIG}" == *inductor_cpp_wrapper_abi_compatible* ]]; then
   install_torchvision
   test_inductor_cpp_wrapper_abi_compatible

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -18,6 +18,7 @@ ciflow_push_tags:
 - ciflow/unstable
 - ciflow/xpu
 - ciflow/torchbench
+- ciflow/torchao
 retryable_workflows:
 - pull
 - trunk

--- a/.github/workflows/torchao-perf-test-nightly.yml
+++ b/.github/workflows/torchao-perf-test-nightly.yml
@@ -1,0 +1,89 @@
+name: torchao-A100-perf-nightly
+
+on:
+  push:
+    tags:
+      - ciflow/torchao/*
+  # NB: GitHub has an upper limit of 10 inputs here, so before we can sort it
+  # out, let try to run torchao cudagraphs_low_precision as part of cudagraphs
+  workflow_dispatch:
+    inputs:
+      noquant:
+        description: Run noquant?
+        required: false
+        type: boolean
+        default: true
+      int8dynamic:
+        description: Run int8dynamic?
+        required: false
+        type: boolean
+        default: true
+      int8weightonly:
+        description: Run int8weightonly?
+        required: false
+        type: boolean
+        default: true
+      int4weightonly:
+        description: Run int4weightonly?
+        required: false
+        type: boolean
+        default: true
+      autoquant:
+        description: Run autoquant?
+        required: false
+        type: boolean
+        default: true
+      benchmark_configs:
+        description: The list of configs used the benchmark
+        required: false
+        type: string
+        default: torchao_huggingface_perf,torchao_timm_perf,torchao_torchbench_perf
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  linux-focal-cuda12_1-py3_10-gcc9-torchao-build:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks
+      cuda-arch-list: '8.0'
+      test-matrix: |
+        { include: [
+          { config: "torchao_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "torchao_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "torchao_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "torchao_timm_perf", shard: 1, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "torchao_timm_perf", shard: 2, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "torchao_timm_perf", shard: 3, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "torchao_timm_perf", shard: 4, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "torchao_timm_perf", shard: 5, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "torchao_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "torchao_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "torchao_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "torchao_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.gcp.a100.large" },
+        ]}
+      selected-test-configs: ${{ inputs.benchmark_configs }}
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-torchao-test-nightly:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-torchao-build
+    if: github.event.schedule == '0 7 * * 1-6'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      dashboard-tag: noquant-${{ inputs.noquant }}-int8dynamic-${{ inputs.int8dynamic }}-int8weightonly-${{ inputs.int8weightonly }}-int4weightonly-${{ inputs.int4weightonly }}-autoquant-${{ inputs.autoquant }}
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 720
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+

--- a/.github/workflows/torchao-perf-test-nightly.yml
+++ b/.github/workflows/torchao-perf-test-nightly.yml
@@ -80,10 +80,9 @@ jobs:
     with:
       build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
       dashboard-tag: noquant-${{ inputs.noquant }}-int8dynamic-${{ inputs.int8dynamic }}-int8weightonly-${{ inputs.int8weightonly }}-int4weightonly-${{ inputs.int4weightonly }}-autoquant-${{ inputs.autoquant }}
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-torchao-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-torchao-build.outputs.test-matrix }}
       use-gha: anything-non-empty-to-use-gha
       timeout-minutes: 720
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
-

--- a/.github/workflows/torchao.yml
+++ b/.github/workflows/torchao.yml
@@ -74,7 +74,6 @@ jobs:
     name: cuda12.1-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_1-py3_10-gcc9-torchao-build
-    if: github.event.schedule == '0 7 * * 1-6'
     with:
       build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
       dashboard-tag: noquant-${{ inputs.noquant }}-int8dynamic-${{ inputs.int8dynamic }}-int8weightonly-${{ inputs.int8weightonly }}-int4weightonly-${{ inputs.int4weightonly }}-autoquant-${{ inputs.autoquant }}

--- a/.github/workflows/torchao.yml
+++ b/.github/workflows/torchao.yml
@@ -1,11 +1,9 @@
-name: torchao-A100-perf-nightly
+name: torchao
 
 on:
   push:
     tags:
       - ciflow/torchao/*
-  # NB: GitHub has an upper limit of 10 inputs here, so before we can sort it
-  # out, let try to run torchao cudagraphs_low_precision as part of cudagraphs
   workflow_dispatch:
     inputs:
       noquant:
@@ -72,7 +70,7 @@ jobs:
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
-  linux-focal-cuda12_1-py3_10-gcc9-torchao-test-nightly:
+  linux-focal-cuda12_1-py3_10-gcc9-torchao-test:
     name: cuda12.1-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-focal-cuda12_1-py3_10-gcc9-torchao-build


### PR DESCRIPTION
Add and test torchao nightly testing workflow.

This workflow will be triggered under the following conditions:
1. If the PR has ciflow/torchao label
2. Manual trigger

It will run the torchao benchmark on torchbench/timm/huggingface model workloads with 5 configs (noquant, autoquant, int8dynamic, int8weightonly, int4weightonly). The output will be updated to the PT2 Dashboard: https://hud.pytorch.org/benchmark/compilers