### PR TITLE
[ONNX] Skip assertion nodes

### DIFF
--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -1577,7 +1577,6 @@ SKIP_XFAIL_SUBTESTS_WITH_MATCHER_AND_MODEL_TYPE: tuple[
         matcher=lambda sample: len(sample.input.shape) == 0
         and sample.kwargs.get("as_tuple", False) is False,
         reason="Output 'shape' do not match: torch.Size([0, 1]) != torch.Size([0, 0]).",
-        model_type=pytorch_test_common.TorchModelType.TORCH_NN_MODULE,
     ),
     xfail(
         "scatter_add",

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -653,10 +653,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             func, (torch.tensor([1]), torch.randn(3, 4))
         )
 
-    @pytorch_test_common.xfail_if_model_type_is_exportedprogram(
-        error_message="Unsupported FX nodes: {'call_function': ['aten._assert_async.msg']}",
-        reason="https://github.com/pytorch/pytorch/issues/112622",
-    )
     def test_operator_with_dynamic_output_shape(self):
         class Foo(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -314,6 +314,15 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         input = torch.randn(2)
         self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(Model(), (input,))
 
+    def test_assert_does_not_raise_unsupported_node_error(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                torch.ops.aten._assert_async.msg(torch.tensor(True), "assertion failed")
+                return x + x
+
+        input = torch.randn(2)
+        self.run_test_with_fx_to_onnx_exporter_and_onnx_runtime(Model(), (input,))
+
     @skip_if_no_torchvision
     def test_resnet18(self):
         # TODO(bowbao): Note [training vs eval in dynamo_export]

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -309,6 +309,7 @@ class TestPublicBindings(TestCase):
             "torch.onnx._internal.fx.op_validation",
             "torch.onnx._internal.fx.passes",
             "torch.onnx._internal.fx.passes._utils",
+            "torch.onnx._internal.fx.passes.assertion_removal",
             "torch.onnx._internal.fx.passes.decomp",
             "torch.onnx._internal.fx.passes.functionalization",
             "torch.onnx._internal.fx.passes.modularization",

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -309,7 +309,6 @@ class TestPublicBindings(TestCase):
             "torch.onnx._internal.fx.op_validation",
             "torch.onnx._internal.fx.passes",
             "torch.onnx._internal.fx.passes._utils",
-            "torch.onnx._internal.fx.passes.assertion_removal",
             "torch.onnx._internal.fx.passes.decomp",
             "torch.onnx._internal.fx.passes.functionalization",
             "torch.onnx._internal.fx.passes.modularization",

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -1560,6 +1560,9 @@ def common_pre_export_passes(
     # Insert type casts explicitly where needed.
     module = passes.InsertTypePromotion(diagnostic_context, module).run()
 
+    # TODO: Delete this after https://github.com/pytorch/pytorch/issues/112443 is done
+    module = passes.RemoveAssertions(diagnostic_context, module).run(*fx_module_args)
+
     analysis.UnsupportedFxNodesAnalysis(
         diagnostic_context, module, options.onnxfunction_dispatcher
     ).analyze(infra.levels.ERROR)

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -1561,7 +1561,7 @@ def common_pre_export_passes(
     module = passes.InsertTypePromotion(diagnostic_context, module).run()
 
     # TODO: Delete this after https://github.com/pytorch/pytorch/issues/112443 is done
-    module = passes.RemoveAssertions(diagnostic_context, module).run(*fx_module_args)
+    module = passes.RemoveAssertions(diagnostic_context, module).run()
 
     analysis.UnsupportedFxNodesAnalysis(
         diagnostic_context, module, options.onnxfunction_dispatcher

--- a/torch/onnx/_internal/fx/passes/__init__.py
+++ b/torch/onnx/_internal/fx/passes/__init__.py
@@ -12,7 +12,8 @@ __all__ = [
     "Functionalize",
     "Modularize",
     "MovePlaceholderToFront",
-    "RemoveAssertions," "RemoveInputMutation",
+    "RemoveAssertions",
+    "RemoveInputMutation",
     "RestoreParameterAndBufferNames",
     "ReplaceGetAttrWithPlaceholder",
 ]

--- a/torch/onnx/_internal/fx/passes/__init__.py
+++ b/torch/onnx/_internal/fx/passes/__init__.py
@@ -1,3 +1,4 @@
+from .assertion_removal import RemoveAssertions
 from .decomp import Decompose
 from .functionalization import Functionalize, RemoveInputMutation
 from .modularization import Modularize
@@ -11,7 +12,7 @@ __all__ = [
     "Functionalize",
     "Modularize",
     "MovePlaceholderToFront",
-    "RemoveInputMutation",
+    "RemoveAssertions," "RemoveInputMutation",
     "RestoreParameterAndBufferNames",
     "ReplaceGetAttrWithPlaceholder",
 ]

--- a/torch/onnx/_internal/fx/passes/assertion_removal.py
+++ b/torch/onnx/_internal/fx/passes/assertion_removal.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import torch
+from torch.onnx._internal import _beartype
+from torch.onnx._internal.fx import _pass
+
+
+class RemoveAssertions(_pass.Transform):
+    """This pass removes all assertion and check nodes from the FX graph."""
+
+    _ATEN_ASSERTION_TARGETS = {torch.ops.aten.sym_constrain_range_for_size.default, torch.ops.aten._assert_async.msg}
+
+    @_beartype.beartype
+    def _run(self, *args, **kwargs) -> torch.fx.GraphModule:
+        for node in self.module.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target in self._ATEN_ASSERTION_TARGETS
+            ):
+                self.module.graph.erase_node(node)
+        return self.module

--- a/torch/onnx/_internal/fx/passes/assertion_removal.py
+++ b/torch/onnx/_internal/fx/passes/assertion_removal.py
@@ -8,7 +8,10 @@ from torch.onnx._internal.fx import _pass
 class RemoveAssertions(_pass.Transform):
     """This pass removes all assertion and check nodes from the FX graph."""
 
-    _ATEN_ASSERTION_TARGETS = {torch.ops.aten.sym_constrain_range_for_size.default, torch.ops.aten._assert_async.msg}
+    _ATEN_ASSERTION_TARGETS = {
+        torch.ops.aten.sym_constrain_range_for_size.default,
+        torch.ops.aten._assert_async.msg,
+    }
 
     @_beartype.beartype
     def _run(self, *args, **kwargs) -> torch.fx.GraphModule:

--- a/torch/onnx/_internal/fx/passes/assertion_removal.py
+++ b/torch/onnx/_internal/fx/passes/assertion_removal.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
 import torch
-from torch.onnx._internal import _beartype
 from torch.onnx._internal.fx import _pass
 
 
 class RemoveAssertions(_pass.Transform):
     """This pass removes all assertion and check nodes from the FX graph."""
 
-    _ATEN_ASSERTION_TARGETS = {
-        torch.ops.aten.sym_constrain_range_for_size.default,
-        torch.ops.aten._assert_async.msg,
-    }
+    _ATEN_ASSERTION_TARGETS = frozenset(
+        {
+            torch.ops.aten.sym_constrain_range_for_size.default,
+            torch.ops.aten._assert_async.msg,
+        }
+    )
 
-    @_beartype.beartype
-    def _run(self, *args, **kwargs) -> torch.fx.GraphModule:
+    def _run(self) -> torch.fx.GraphModule:
         for node in self.module.graph.nodes:
             if (
                 node.op == "call_function"

--- a/torch/onnx/_internal/fx/torch_export_graph_extractor.py
+++ b/torch/onnx/_internal/fx/torch_export_graph_extractor.py
@@ -113,6 +113,9 @@ class TorchExport(exporter.FXGraphExtractor):
         # Insert type casts explicitly where needed.
         fx_module = passes.InsertTypePromotion(diagnostic_context, fx_module).run()
 
+        # TODO: Delete this after https://github.com/pytorch/pytorch/issues/112443 is done
+        fx_module = passes.RemoveAssertions(diagnostic_context, fx_module).run()
+
         analysis.UnsupportedFxNodesAnalysis(
             diagnostic_context, fx_module, options.onnxfunction_dispatcher
         ).analyze(infra.levels.ERROR)


### PR DESCRIPTION
Continue from #125930 

The PR addresses the common existence of unused assertion nodes in models. (workaround #112443)

Assertion ops does not return anything in the graph, so it's not even an no-op in ONNX:
https://github.com/pytorch/pytorch/blob/d4ec18bdad7cf94fa12da7ebbfabfec53655829f/aten/src/ATen/native/native_functions.yaml#L173
https://github.com/pytorch/pytorch/blob/d4ec18bdad7cf94fa12da7ebbfabfec53655829f/aten/src/ATen/native/native_functions.yaml#L200

This pass can be extended when we see more and more none-return ops in FX.
