### PR TITLE
Log export result of torch.jit.trace to scuba

### DIFF
--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -116,6 +116,17 @@ def log_torchscript_usage(api: str):
     return
 
 
+def check_if_torch_exportable():
+    return False
+
+
+def log_torch_jit_trace_exportability(
+    api: str, type_of_export: str, export_outcome: str, result: str
+):
+    _, _, _, _ = api, type_of_export, export_outcome, result
+    return
+
+
 def export_api_rollout_check() -> bool:
     return False
 

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -947,46 +947,95 @@ def _log_export_wrapper(fn):
     return wrapper
 
 
-def _convert_ts_to_export_experimental(traced_callable, args, kwargs=None):
+def _process_jit_trace_inputs_for_export(example_inputs, example_kwarg_inputs):
+    if not isinstance(example_inputs, (tuple, list, dict)):
+        example_inputs = (example_inputs,)
+
+    elif isinstance(example_inputs, list):
+        example_inputs = tuple(example_inputs)
+
+    elif (
+        isinstance(example_inputs, (torch.Tensor, dict))
+        and example_kwarg_inputs is None
+    ):
+        example_inputs = (example_inputs,)
+
+    if example_kwarg_inputs is None:
+        example_kwarg_inputs = {}
+    return example_inputs, example_kwarg_inputs
+
+
+@contextmanager
+def patch_forward(obj: torch.nn.Module, new_method):
+    """Helper method to make it easier to cleanly torch.export() a method on a
+    module that is not `forward`.
+    """
+    # Save the original method
+    original_method = obj.forward
+
+    # Patch the method
+    obj.forward = new_method.__get__(obj, obj.__class__)
+
+    try:
+        yield
+    finally:
+        # Restore the original method
+        obj.forward = original_method
+
+
+@contextmanager
+def _temp_disable_texpr_fuser():
+    original_state = torch._C._jit_texpr_fuser_enabled()
     torch._C._jit_set_texpr_fuser_enabled(False)
+    try:
+        yield
+    finally:
+        torch._C._jit_set_texpr_fuser_enabled(original_state)
 
-    def process_trace_inputs_for_export(example_inputs, example_kwarg_inputs):
-        if not isinstance(example_inputs, tuple):
-            example_inputs = (example_inputs,)
 
-        if example_kwarg_inputs is None:
-            example_kwarg_inputs = {}
-        return example_inputs, example_kwarg_inputs
+def _convert_ts_to_export_experimental(traced_callable, args, kwargs=None):
+    with _temp_disable_texpr_fuser():
 
-    class _WrapperModule(torch.nn.Module):
-        def __init__(self, f):
-            super().__init__()
-            self.f = f
+        class _WrapperModule(torch.nn.Module):
+            def __init__(self, f):
+                super().__init__()
+                self.f = f
 
-        def forward(self, *args, **kwargs):
-            return self.f(*args, **kwargs)
+            def forward(self, *args, **kwargs):
+                return self.f(*args, **kwargs)
 
-    from torch.jit._trace import TopLevelTracedModule
+        from torch.jit._trace import TopLevelTracedModule
 
-    export_args, export_kwargs = process_trace_inputs_for_export(args, kwargs)
+        export_args, export_kwargs = _process_jit_trace_inputs_for_export(args, kwargs)
 
-    if isinstance(traced_callable, TopLevelTracedModule):
-        return _export(
-            traced_callable,
-            export_args,
-            export_kwargs,
-            strict=False,
-            _is_torch_jit_trace=True,
-        ).module()
+        if isinstance(traced_callable, (TopLevelTracedModule, torch._C.ScriptModule)):  # type: ignore[operator]
+            return _export(
+                traced_callable,
+                export_args,
+                export_kwargs,
+                strict=False,
+                _is_torch_jit_trace=True,
+            ).module()
 
-    else:
-        return _export(
-            _WrapperModule(traced_callable),
-            export_args,
-            export_kwargs,
-            strict=False,
-            _is_torch_jit_trace=True,
-        ).module()
+        elif isinstance(traced_callable, torch.ScriptMethod) and isinstance(
+            traced_callable.owner(), (torch._C.ScriptModule, torch.nn.Module)  # type: ignore[operator]
+        ):
+            with patch_forward(traced_callable.owner(), traced_callable):  # type: ignore[operator]
+                return _export(
+                    traced_callable.owner(),  # type: ignore[operator]
+                    export_args,
+                    export_kwargs,
+                    strict=False,
+                    _is_torch_jit_trace=True,
+                ).module()
+        else:
+            return _export(
+                _WrapperModule(traced_callable),
+                export_args,
+                export_kwargs,
+                strict=False,
+                _is_torch_jit_trace=True,
+            ).module()
 
 
 def _strict_export(
@@ -1417,7 +1466,9 @@ def _export(
         ),
         len(export_graph_signature.input_specs),
     )
-    combined_args = _combine_args(mod, args, kwargs)
+    combined_args = _combine_args(
+        mod, args, kwargs, _is_torch_jit_trace=_is_torch_jit_trace
+    )
     range_constraints = make_constraints(
         fake_mode,
         gm,

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -16,6 +16,7 @@ import inspect
 import os
 import re
 import warnings
+from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set, TypeVar
 from typing_extensions import ParamSpec
 
@@ -26,7 +27,6 @@ from torch._jit_internal import (
     is_scripting,
 )
 
-from torch._utils_internal import log_torchscript_usage
 from torch.autograd import function
 from torch.jit._script import _CachedForward, script, ScriptModule
 
@@ -639,6 +639,182 @@ def wrap_check_inputs(check_inputs):
     return [{"forward": c} for c in check_inputs]
 
 
+def analyze_ts_result_with_export_result(export, trace):
+    import torch.utils._pytree as pytree
+
+    flat_export = pytree.tree_leaves(export)
+    flat_trace = pytree.tree_leaves(trace)
+
+    for orig, loaded in zip(flat_export, flat_trace):
+        if type(orig) != type(loaded):
+            return False
+
+        if isinstance(orig, torch.Tensor):
+            if not torch.allclose(orig, loaded):
+                return False
+        else:
+            if orig != loaded:
+                return False
+    return True
+
+
+def _trace_impl(
+    func,
+    example_inputs=None,
+    optimize=None,
+    check_trace=True,
+    check_inputs=None,
+    check_tolerance=1e-5,
+    strict=True,
+    _force_outplace=False,
+    _module_class=None,
+    _compilation_unit=_python_cu,
+    example_kwarg_inputs=None,
+    _store_inputs=True,
+):
+    if isinstance(func, torch.jit.ScriptModule):
+        # it is hard to trace it because the forward method on ScriptModule is already defined, so it
+        # would result in an error.
+        warnings.warn(
+            "The input to trace is already a ScriptModule, tracing it is a no-op. Returning the object as is."
+        )
+        return func
+
+    if isinstance(func, torch.nn.Module):
+        if example_inputs is None:
+            if isinstance(example_kwarg_inputs, dict):
+                example_inputs = example_kwarg_inputs
+            else:
+                raise RuntimeError("example_kwarg_inputs should be a dict")
+        return trace_module(
+            func,
+            {"forward": example_inputs},
+            None,
+            check_trace,
+            wrap_check_inputs(check_inputs),
+            check_tolerance,
+            strict,
+            _force_outplace,
+            _module_class,
+            example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
+            _store_inputs=_store_inputs,
+        )
+    if (
+        hasattr(func, "__self__")
+        and isinstance(func.__self__, torch.nn.Module)
+        and func.__name__ == "forward"
+    ):
+        if example_inputs is None:
+            if isinstance(example_kwarg_inputs, dict):
+                example_inputs = example_kwarg_inputs
+            else:
+                raise RuntimeError("example_kwarg_inputs should be a dict")
+        return trace_module(
+            func.__self__,
+            {"forward": example_inputs},
+            None,
+            check_trace,
+            wrap_check_inputs(check_inputs),
+            check_tolerance,
+            strict,
+            _force_outplace,
+            _module_class,
+            example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
+            _store_inputs=_store_inputs,
+        )
+
+    # Special case for common case of passing a single Tensor
+    if (
+        isinstance(example_inputs, (torch.Tensor, dict))
+        and example_kwarg_inputs is None
+    ):
+        example_inputs = (example_inputs,)
+    # done primarily so that weird iterables fail here and not pybind11 code
+    elif example_kwarg_inputs is None and not isinstance(example_inputs, tuple):
+        example_inputs = tuple(example_inputs)
+
+    var_lookup_fn = _create_interpreter_name_lookup_fn(0)
+
+    if hasattr(func, "__self__") and isinstance(func.__self__, torch.nn.Module):
+        raise AttributeError(
+            "trace doesn't support compiling individual module's functions.\n"
+            "Please use trace_module"
+        )
+
+    name = _qualified_name(func)
+    if isinstance(example_kwarg_inputs, dict):
+        example_inputs = example_kwarg_inputs
+        traced = torch._C._create_function_from_trace_with_dict(
+            name,
+            func,
+            example_kwarg_inputs,
+            var_lookup_fn,
+            strict,
+            _force_outplace,
+            get_callable_argument_names(func),
+        )
+    else:
+        traced = torch._C._create_function_from_trace(
+            name,
+            func,
+            example_inputs,
+            var_lookup_fn,
+            strict,
+            _force_outplace,
+            get_callable_argument_names(func),
+        )
+
+    # Check the trace against new traces created from user-specified inputs
+    if check_trace:
+        if check_inputs is not None:
+            _check_trace(
+                check_inputs,
+                func,
+                traced,
+                check_tolerance,
+                strict,
+                _force_outplace,
+                False,
+                _module_class,
+                example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
+            )
+        else:
+            _check_trace(
+                [example_inputs],
+                func,
+                traced,
+                check_tolerance,
+                strict,
+                _force_outplace,
+                False,
+                _module_class,
+                example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
+            )
+
+    # Allow torch.compile() to inline
+    traced._torchdynamo_inline = func  # type: ignore[attr-defined]
+    return traced
+
+
+class _ExportType(str, Enum):
+    DIRECT_EXPORT = "DIRECT_EXPORT"
+    TRACE_AND_EXPORT = "TRACE_AND_EXPORT"
+    SOURCE_TO_SOURCE = "SOURCE_TO_SOURCE"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class _ExportOutcome(str, Enum):
+    SUCCESS = "SUCCESS"
+    FAILED_TO_EXPORT = "FAILED_TO_EXPORT"
+    FAILED_TO_RUN = "FAILED_TO_RUN"
+    ACCURACY_ERROR = "ACCURACY_ERROR"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 def trace(
     func,
     example_inputs=None,
@@ -805,130 +981,110 @@ def trace(
             "`optimize` is deprecated and has no effect. Use `with torch.jit.optimized_execution() instead"
         )
 
+    from torch._utils_internal import (
+        check_if_torch_exportable,
+        log_torch_jit_trace_exportability,
+        log_torchscript_usage,
+    )
+
     log_torchscript_usage("trace")
+    traced_func = _trace_impl(
+        func,
+        example_inputs,
+        optimize,
+        check_trace,
+        check_inputs,
+        check_tolerance,
+        strict,
+        _force_outplace,
+        _module_class,
+        _compilation_unit,
+        example_kwarg_inputs,
+        _store_inputs,
+    )
 
-    if isinstance(func, torch.jit.ScriptModule):
-        # it is hard to trace it because the forward method on ScriptModule is already defined, so it
-        # would result in an error.
-        warnings.warn(
-            "The input to trace is already a ScriptModule, tracing it is a no-op. Returning the object as is."
-        )
-        return func
-
-    if isinstance(func, torch.nn.Module):
-        if example_inputs is None:
-            if isinstance(example_kwarg_inputs, dict):
-                example_inputs = example_kwarg_inputs
-            else:
-                raise RuntimeError("example_kwarg_inputs should be a dict")
-        return trace_module(
-            func,
-            {"forward": example_inputs},
-            None,
-            check_trace,
-            wrap_check_inputs(check_inputs),
-            check_tolerance,
-            strict,
-            _force_outplace,
-            _module_class,
-            example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
-            _store_inputs=_store_inputs,
-        )
-    if (
-        hasattr(func, "__self__")
-        and isinstance(func.__self__, torch.nn.Module)
-        and func.__name__ == "forward"
-    ):
-        if example_inputs is None:
-            if isinstance(example_kwarg_inputs, dict):
-                example_inputs = example_kwarg_inputs
-            else:
-                raise RuntimeError("example_kwarg_inputs should be a dict")
-        return trace_module(
-            func.__self__,
-            {"forward": example_inputs},
-            None,
-            check_trace,
-            wrap_check_inputs(check_inputs),
-            check_tolerance,
-            strict,
-            _force_outplace,
-            _module_class,
-            example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
-            _store_inputs=_store_inputs,
+    if check_if_torch_exportable():
+        from torch._export.converter import TS2EPConverter
+        from torch.export._trace import (
+            _convert_ts_to_export_experimental,
+            _process_jit_trace_inputs_for_export,
         )
 
-    # Special case for common case of passing a single Tensor
-    if (
-        isinstance(example_inputs, (torch.Tensor, dict))
-        and example_kwarg_inputs is None
-    ):
-        example_inputs = (example_inputs,)
-    # done primarily so that weird iterables fail here and not pybind11 code
-    elif example_kwarg_inputs is None and not isinstance(example_inputs, tuple):
-        example_inputs = tuple(example_inputs)
-
-    var_lookup_fn = _create_interpreter_name_lookup_fn(0)
-
-    if hasattr(func, "__self__") and isinstance(func.__self__, torch.nn.Module):
-        raise AttributeError(
-            "trace doesn't support compiling individual module's functions.\n"
-            "Please use trace_module"
+        export_args, _ = _process_jit_trace_inputs_for_export(
+            example_inputs, example_kwarg_inputs
         )
 
-    name = _qualified_name(func)
-    if isinstance(example_kwarg_inputs, dict):
-        example_inputs = example_kwarg_inputs
-        traced = torch._C._create_function_from_trace_with_dict(
-            name,
-            func,
-            example_kwarg_inputs,
-            var_lookup_fn,
-            strict,
-            _force_outplace,
-            get_callable_argument_names(func),
-        )
-    else:
-        traced = torch._C._create_function_from_trace(
-            name,
-            func,
-            example_inputs,
-            var_lookup_fn,
-            strict,
-            _force_outplace,
-            get_callable_argument_names(func),
-        )
+        def _log_exportability(func_to_export, export_func, export_args, export_type):
+            try:
+                ep_module = export_func(func_to_export, export_args)
+            except Exception as e:
+                log_torch_jit_trace_exportability(
+                    "trace",
+                    str(export_type),
+                    str(_ExportOutcome.FAILED_TO_EXPORT),
+                    str(e),
+                )
+                return
 
-    # Check the trace against new traces created from user-specified inputs
-    if check_trace:
-        if check_inputs is not None:
-            _check_trace(
-                check_inputs,
-                func,
-                traced,
-                check_tolerance,
-                strict,
-                _force_outplace,
-                False,
-                _module_class,
-                example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
-            )
-        else:
-            _check_trace(
-                [example_inputs],
-                func,
-                traced,
-                check_tolerance,
-                strict,
-                _force_outplace,
-                False,
-                _module_class,
-                example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
+            try:
+                export = ep_module(*export_args)
+            except Exception as e:
+                log_torch_jit_trace_exportability(
+                    "trace", str(export_type), str(_ExportOutcome.FAILED_TO_RUN), str(e)
+                )
+                return
+
+            try:
+                traced_result = traced_func(*export_args)
+            except Exception as e:
+                _ = e
+                log_torch_jit_trace_exportability(
+                    "trace", str(export_type), str(_ExportOutcome.SUCCESS), "succeeded"
+                )
+                return
+
+            if not analyze_ts_result_with_export_result(export, traced_result):
+                log_torch_jit_trace_exportability(
+                    "trace",
+                    str(export_type),
+                    str(_ExportOutcome.ACCURACY_ERROR),
+                    "accuracy error",
+                )
+                return
+
+            log_torch_jit_trace_exportability(
+                "trace", str(export_type), str(_ExportOutcome.SUCCESS), "succeeded"
             )
 
-    # Allow torch.compile() to inline
-    traced._torchdynamo_inline = func  # type: ignore[attr-defined]
-    return traced
+        def _direct_export_and_lower(func, export_args):
+            return torch.export.export(func, export_args, strict=False).module()
+
+        def _convert_ts_to_export_source_to_source(func, export_args):
+            return TS2EPConverter(func, export_args).convert().module()
+
+        # torch.jit.trace is noop when the original module is torch.jit.ScriptModule
+        if not isinstance(traced_func, torch.jit.ScriptModule):
+            _log_exportability(
+                traced_func,
+                _direct_export_and_lower,
+                export_args,
+                _ExportType.DIRECT_EXPORT,
+            )
+
+        _log_exportability(
+            traced_func,
+            _convert_ts_to_export_experimental,
+            export_args,
+            _ExportType.TRACE_AND_EXPORT,
+        )
+        _log_exportability(
+            traced_func,
+            _convert_ts_to_export_source_to_source,
+            export_args,
+            _ExportType.SOURCE_TO_SOURCE,
+        )
+
+    return traced_func
 
 
 _trace_module_map: Optional[Dict[Any, Any]] = None


### PR DESCRIPTION
Summary: We want to track how well torch.jit.trace can be converted to export in large scale. As a first step, we log all of torch.jit.trace unittests whether we can convert the traced module to export module OR we can export the model directly

Test Plan: CI

Differential Revision: D57629682


