### PR TITLE
[wip] add metadata of orig model parameter ID to aot_autograd FX nodes

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -181,6 +181,13 @@ def set_meta(proxy, val):
         proxy.node.meta['tensor_meta'] = _extract_tensor_metadata(val)
     elif isinstance(val, torch.Tensor) and not val.is_sparse:
         proxy.node.meta['tensor_meta'] = _extract_tensor_metadata(val)
+
+    maybe_parameter_python_obj_id = getattr(val, 'parameter_python_obj_id')
+    if maybe_parameter_python_obj_id is not None:
+        # TODO(before land): find a better place for storing this
+        proxy.node.meta['parameter_python_obj_id'] = \
+            maybe_parameter_python_obj_id
+
     return proxy
 
 def thunkify(f, *args, **kwargs):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -549,9 +549,13 @@ class CodeGen:
                 if isinstance(meta_val, FakeTensor):
                     stride_annotation = f"{stringify_shape(meta_val.stride())}" if include_stride else ""
                     device_annotation = f"{meta_val.device}" if include_device else ""
+                    maybe_parameter_python_obj_id = node.meta.get('parameter_python_obj_id')
+                    maybe_parameter_python_obj_id_annot = \
+                        f", param_id:{maybe_parameter_python_obj_id}" \
+                        if maybe_parameter_python_obj_id is not None else ""
                     maybe_type_annotation = \
                         f': "{dtype_abbrs[meta_val.dtype]}{stringify_shape(meta_val.shape)}' \
-                        f'{stride_annotation}{device_annotation}"'
+                        f'{stride_annotation}{device_annotation}{maybe_parameter_python_obj_id_annot}"'
                 elif isinstance(meta_val, py_sym_types):
                     maybe_type_annotation = f': "Sym({meta_val})"'
                 elif isinstance(meta_val, TensorMetadata):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #126926
* #126698
* #126573

Summary:

When I am looking at aot_autograd graphs, I want to know where in the model
these graphs are coming from. One useful detail here is attributing
graph inputs to model weights.

This PR starts tracking the Python object ID of the model parameters
in FakeTensor and saving it on the FX nodes created by aot_autograd.

Not ready for review yet as I want to use this for debugging a couple of
models and see if this is actually useful first.  For now I'm planning to
create a mapping of weight_id -> FQN manually and use it to match these
logs to model FQNs.

Test Plan:

```
// run a toy model with nn.Linear fw + bw through torch.compile, see
// these aot_autograd logs:

TRACED GRAPH
 ===== Joint graph 0 =====
 /data/users/vasiliy/pytorch/torch/fx/_lazy_graph_module.py class joint_helper(torch.nn.Module):
    def forward(self, primals, tangents):
        primals_1: "bf16[7168, 8192], param_id:140324665807248"; primals_2: "bf16[16384, 8192]"; tangents_1: "bf16[]";

        primals_1, primals_2, tangents_1, = fx_pytree.tree_flatten_spec([primals, tangents], self._in_spec)
	...
```

Reviewers:

Subscribers:

Tasks:

Tags: