### PR TITLE
[release/2.3] Fix miopenStatusInternalError caused in new ROCm6.0 CI docker images

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -84,11 +84,11 @@ install_ubuntu() {
     if [[ $(ver $ROCM_VERSION) -ge $(ver 6.0) ]]; then
         for kdb in /opt/rocm/share/miopen/db/*.kdb
         do
-	  # journal_mode=delete seems to work on some kdbs that have "wal" as initial journal_mode
-	  sqlite3 $kdb "PRAGMA journal_mode=delete; PRAGMA VACUUM;"
-	  JOURNAL_MODE=$(sqlite3 $kdb "PRAGMA journal_mode;")
-	  # Both "delete and "off" work in cases where user doesn't have write permissions to directory where kdbs are installed
-	  if [[ $JOURNAL_MODE != "delete" ]] && [[ $JOURNAL_MODE != "off" ]]; then echo "kdb journal_mode change failed" && exit 1; fi
+          # journal_mode=delete seems to work on some kdbs that have "wal" as initial journal_mode
+          sqlite3 $kdb "PRAGMA journal_mode=delete; PRAGMA VACUUM;"
+          JOURNAL_MODE=$(sqlite3 $kdb "PRAGMA journal_mode;")
+          # Both "delete and "off" work in cases where user doesn't have write permissions to directory where kdbs are installed
+          if [[ $JOURNAL_MODE != "delete" ]] && [[ $JOURNAL_MODE != "off" ]]; then echo "kdb journal_mode change failed" && exit 1; fi
         done
     fi
 
@@ -167,11 +167,11 @@ install_centos() {
   if [[ $(ver $ROCM_VERSION) -ge $(ver 6.0) ]]; then
       for kdb in /opt/rocm/share/miopen/db/*.kdb
       do
-	# journal_mode=delete seems to work on some kdbs that have "wal" as initial journal_mode
-	sqlite3 $kdb "PRAGMA journal_mode=delete; PRAGMA VACUUM;"
-	JOURNAL_MODE=$(sqlite3 $kdb "PRAGMA journal_mode;")
-	# Both "delete" and "off" work in cases where user doesn't have write permissions to directory where kdbs are installed
-	if [[ $JOURNAL_MODE != "delete" ]] && [[ $JOURNAL_MODE != "off" ]]; then echo "kdb journal_mode change failed" && exit 1; fi
+        # journal_mode=delete seems to work on some kdbs that have "wal" as initial journal_mode
+        sqlite3 $kdb "PRAGMA journal_mode=delete; PRAGMA VACUUM;"
+        JOURNAL_MODE=$(sqlite3 $kdb "PRAGMA journal_mode;")
+        # Both "delete" and "off" work in cases where user doesn't have write permissions to directory where kdbs are installed
+        if [[ $JOURNAL_MODE != "delete" ]] && [[ $JOURNAL_MODE != "off" ]]; then echo "kdb journal_mode change failed" && exit 1; fi
       done
   fi
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -11,11 +11,6 @@ on:
         required: true
         type: string
         description: Name of the base docker image to build with.
-      docker-image-tag:
-        required: false
-        type: string
-        description: Name of the base docker image tag
-        default: ""
       build-generates-artifacts:
         required: false
         type: boolean
@@ -74,7 +69,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 240
     outputs:
-      docker-image: ${{ steps.calculate-docker.outputs.docker-image }}
+      docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
       test-matrix: ${{ steps.filter.outputs.test-matrix }}
     steps:
       - name: Setup SSH (Click me for login details)
@@ -98,24 +93,10 @@ jobs:
         with:
           docker-image-name: ${{ inputs.docker-image-name }}
 
-      - name: Override docker image tag if pinned
-        id: calculate-docker
-        env:
-          ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
-        shell: bash
-        run: |
-          export NEW_TAG=${{ inputs.docker-image-tag }}
-          if [[ ${NEW_TAG} != '' ]]; then
-            IMAGE=${ECR_DOCKER_IMAGE%:*}
-            echo "docker-image=${IMAGE}:${NEW_TAG}" >> "${GITHUB_OUTPUT}"
-          else
-            echo "docker-image=${ECR_DOCKER_IMAGE}" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Use following to pull public copy of the image
         id: print-ghcr-mirror
         env:
-          ECR_DOCKER_IMAGE: ${{ steps.calculate-docker.outputs.docker-image }}
+          ECR_DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
         shell: bash
         run: |
           tag=${ECR_DOCKER_IMAGE##*/}
@@ -124,7 +105,7 @@ jobs:
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@release/2.3
         with:
-          docker-image: ${{ steps.calculate-docker.outputs.docker-image }}
+          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
 
       - name: Parse ref
         id: parse-ref
@@ -168,7 +149,7 @@ jobs:
           XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           TORCH_CUDA_ARCH_LIST: ${{ inputs.cuda-arch-list }}
-          DOCKER_IMAGE: ${{ steps.calculate-docker.outputs.docker-image }}
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
           XLA_CUDA: ${{ contains(inputs.build-environment, 'xla') && '0' || '' }}
           DEBUG: ${{ inputs.build-with-debug && '1' || '0' }}
           OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -22,7 +22,6 @@ jobs:
     with:
       build-environment: linux-focal-rocm6.0-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
-      docker-image-tag: cea4be730564c18dd285a12828c7c449490b10b9
       test-matrix: |
         { include: [
           { config: "inductor", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.2" },

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -215,7 +215,6 @@ jobs:
     with:
       build-environment: linux-focal-rocm6.0-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
-      docker-image-tag: cea4be730564c18dd285a12828c7c449490b10b9
       test-matrix: |
         { include: [
           { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -409,7 +409,6 @@ jobs:
     with:
       build-environment: linux-focal-rocm6.0-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
-      docker-image-tag: cea4be730564c18dd285a12828c7c449490b10b9
       sync-tag: rocm-build
       test-matrix: |
         { include: [

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -31,7 +31,6 @@ jobs:
     with:
       build-environment: linux-focal-rocm6.0-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
-      docker-image-tag: cea4be730564c18dd285a12828c7c449490b10b9
       sync-tag: rocm-build
       test-matrix: |
         { include: [

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -107,7 +107,6 @@ jobs:
     with:
       build-environment: linux-focal-rocm6.0-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
-      docker-image-tag: cea4be730564c18dd285a12828c7c449490b10b9
       test-matrix: |
         { include: [
           { config: "slow", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -196,7 +196,6 @@ jobs:
     with:
       build-environment: linux-focal-rocm6.0-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
-      docker-image-tag: cea4be730564c18dd285a12828c7c449490b10b9
       sync-tag: rocm-build
       test-matrix: |
         { include: [


### PR DESCRIPTION
Fixes [MIOpen sqlite error observed when trying to open database file](https://github.com/pytorch/pytorch/actions/runs/9098255481/job/25012119854#step:15:1724).
```
inductor/test_torchinductor.py::GPUTests::test_alexnet_prefix_cuda MIOpen Error: /long_pathname_so_that_rpms_can_package_the_debug_info/src/extlibs/MLOpen/src/sqlite_db.cpp:229: Internal error while accessing SQLite database: unable to open database file 
```

This was observed when [recent changes to bump the triton commit](https://github.com/pytorch/pytorch/commit/d114e0488cd9678ec6d160fa109ce8cb490f9ab7) triggered a rebuild of the CI base docker images. These errors were observed first during the ROCm 6.0 CI upgrade and a [workaround was put in place](https://github.com/pytorch/pytorch/pull/119495/files#diff-21e62c50df7c94e4a6526cb452b66cd3a16b33de7f972fc94cdb2cd0d5a07736R83).

However, it seems that workaround didn't work during the rebuild, so this PR attempts a (better?) workaround, essentially by trying to set `journal_mode` to `delete` instead of `off`. For some reason, this seems to work for the gfx90a and gfx908 kdbs which have `journal_mode` originally set to `wal` ([write-ahead logging](https://www.sqlite.org/pragma.html#pragma_journal_mode)) - which needs write permissions for the user invoking MIOpen (ie. jenkins). This PR also introduces logic to check that the final `journal_mode` is either `delete` or `off`, either of which should be sufficient to get around the permission error.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang