### PR TITLE
Optimize mask memory for flash attention

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -27,8 +27,15 @@ struct VecConvert {
   }
 };
 
+template <typename src_t>
+inline typename std::enable_if<std::is_same<src_t, src_t>::value, Vectorized<src_t>>::type
+convert(const Vectorized<src_t>& src) {
+  return src;
+}
+
 template <typename dst_t, typename src_t>
-inline Vectorized<dst_t> convert(const Vectorized<src_t>& src) {
+inline typename std::enable_if<!std::is_same<dst_t, src_t>::value, Vectorized<dst_t>>::type
+convert(const Vectorized<src_t>& src) {
   return VecConvert<dst_t, 1, src_t, 1>::apply(src);
 }
 

--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -27,8 +27,8 @@ struct VecConvert {
   }
 };
 
-template <typename src_t>
-inline typename std::enable_if<std::is_same<src_t, src_t>::value, Vectorized<src_t>>::type
+template <typename dst_t, typename src_t>
+inline typename std::enable_if<std::is_same<dst_t, src_t>::value, Vectorized<src_t>>::type
 convert(const Vectorized<src_t>& src) {
   return src;
 }
@@ -54,8 +54,10 @@ template <
     int dst_n,
     typename src_t,
     int src_n,
+    bool keep = false,
     std::enable_if_t<dst_n == 1, int> = 0>
-inline Vectorized<dst_t> convert(const VectorizedN<src_t, src_n>& src) {
+inline typename std::conditional<keep, VectorizedN<dst_t, 1>, Vectorized<dst_t>>::type
+convert(const VectorizedN<src_t, src_n>& src) {
   return VecConvert<dst_t, dst_n, src_t, src_n>::apply(src);
 }
 

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -21,6 +21,53 @@ namespace at::native {
 
 namespace {
 
+// out = val * a + b
+template <typename T1, typename T2>
+inline void _scale_attn_mask_fusion_kernel(
+    T1* a,
+    T2* b,
+    const int& size,
+    T1* out,
+    T1& val) {
+  auto vec_size = at::vec::Vectorized<T1>::size();
+  auto vec_scale = at::vec::Vectorized<T1>(val);
+  for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
+    auto tmp0 = at::vec::Vectorized<T1>::loadu(a + i);
+    auto tmp1 = at::vec::Vectorized<T2>::loadu(b + i);
+    auto tmp2 = at::vec::convert<T1>(tmp1);
+    auto tmp3 = tmp0 * vec_scale + tmp2;
+    _store(out + i, tmp3);
+  }
+  for (long i = vec_size * (size / vec_size); i < size; i++) {
+    auto tmp0 = a[i];
+    auto tmp1 = (T1) b[i];
+    out[i] = tmp0 * val + tmp1;
+  }
+}
+
+// out = val * a + b
+template <typename T1>
+inline void _scale_attn_mask_fusion_kernel(
+    T1* a,
+    T1* b,
+    const int& size,
+    T1* out,
+    T1& val) {
+  auto vec_size = at::vec::Vectorized<T1>::size();
+  auto vec_scale = at::vec::Vectorized<T1>(val);
+  for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
+    auto tmp0 = at::vec::Vectorized<T1>::loadu(a + i);
+    auto tmp1 = at::vec::Vectorized<T1>::loadu(b + i);
+    auto tmp2 = tmp0 * vec_scale + tmp1;
+    _store(out + i, tmp2);
+  }
+  for (long i = vec_size * (size / vec_size); i < size; i++) {
+    auto tmp0 = a[i];
+    auto tmp1 = b[i];
+    out[i] = tmp0 * val + tmp1;
+  }
+}
+
 // 1) out = exp(a - val)
 // 2) val = sum(out)
 template <typename T1, typename T2>
@@ -142,7 +189,7 @@ void reshape_attn_mask_to_4d(
                 .expand({attn_mask_size_0, attn_mask_size_1, qSize, kvSize});
 }
 
-template <typename scalar_t, int64_t q_split_size, int64_t kv_split_size>
+template <typename scalar_t, typename mask_t, int64_t q_split_size, int64_t kv_split_size>
 void cpu_flash_attention(
     const Tensor& output,
     const Tensor& logsumexp,
@@ -180,9 +227,6 @@ void cpu_flash_attention(
 
   bool has_attn_mask = attn_mask.has_value() && attn_mask.value().numel();
   if (has_attn_mask) {
-    if (is_reduced_type) {
-      attn_mask.value() = attn_mask.value().to(at::kFloat);
-    }
     reshape_attn_mask_to_4d(attn_mask.value(), batchSize, num_head, qSize, kvSize);
   }
 
@@ -235,8 +279,8 @@ void cpu_flash_attention(
   const scalar_t* q_data = query.const_data_ptr<scalar_t>();
   const scalar_t* k_data = key.const_data_ptr<scalar_t>();
   const scalar_t* v_data = value.const_data_ptr<scalar_t>();
-  const accum_t* mask_data = has_attn_mask
-      ? attn_mask.value().const_data_ptr<accum_t>()
+  mask_t* mask_data = has_attn_mask
+      ? attn_mask.value().data_ptr<mask_t>()
       : nullptr;
   scalar_t* out_data = output.data_ptr<scalar_t>();
   accum_t* lse_data = logsumexp.data_ptr<accum_t>();
@@ -298,15 +342,13 @@ void cpu_flash_attention(
         // qk <- qk * scaling + attn_mask
         if (has_attn_mask) {
           for (int64_t row = 0; row < qBlockSize; ++row) {
-            at::vec::map2<accum_t>(
-                [scaling_factor](Vec x, Vec y) {
-                  return x * Vec(scaling_factor) + y;
-                },
-                qk_data + row * kvBlockSize,
+            _scale_attn_mask_fusion_kernel(
                 qk_data + row * kvBlockSize,
                 mask_data + i * mStrideB + j * mStrideH +
-                    (m + row) * mStrideM + n,
-                kvBlockSize);
+                        (m + row) * mStrideM + n,
+                kvBlockSize,
+                qk_data + row * kvBlockSize,
+                scaling_factor);
           }
         }
         // Update coefficients with Softmax
@@ -387,7 +429,7 @@ void cpu_flash_attention(
 
 }
 
-template <typename scalar_t, int64_t q_split_size, int64_t kv_split_size>
+template <typename scalar_t, typename mask_t, int64_t q_split_size, int64_t kv_split_size>
 void cpu_flash_attention_backward(
     const at::Tensor& grad_q,
     const at::Tensor& grad_k,
@@ -422,9 +464,6 @@ void cpu_flash_attention_backward(
 
   bool has_attn_mask = attn_mask.has_value() && attn_mask.value().numel();
   if (has_attn_mask) {
-    if (is_reduced_type) {
-      attn_mask.value() = attn_mask.value().to(at::kFloat);
-    }
     reshape_attn_mask_to_4d(attn_mask.value(), batchSize, num_head, qSize, kvSize);
   }
 
@@ -497,8 +536,8 @@ void cpu_flash_attention_backward(
   const scalar_t* q_data = query.const_data_ptr<scalar_t>();
   const scalar_t* k_data = key.const_data_ptr<scalar_t>();
   const scalar_t* v_data = value.const_data_ptr<scalar_t>();
-  const accum_t* mask_data = has_attn_mask
-      ? attn_mask.value().const_data_ptr<accum_t>()
+  mask_t* mask_data = has_attn_mask
+      ? attn_mask.value().data_ptr<mask_t>()
       : nullptr;
   const scalar_t* out_data = out.const_data_ptr<scalar_t>();
   const accum_t* lse_data = logsumexp.const_data_ptr<accum_t>();
@@ -554,16 +593,15 @@ void cpu_flash_attention_backward(
             kvBlockSize);
           // attn <- attn + mask
           if (has_attn_mask) {
+            accum_t one = accum_t(1);
             for (const auto row : c10::irange(qBlockSize)) {
-              at::vec::map2<accum_t>(
-                  [](Vec x, Vec y) {
-                    return x + y;
-                  },
-                  attn_data + row * kvBlockSize,
+              _scale_attn_mask_fusion_kernel(
                   attn_data + row * kvBlockSize,
                   mask_data + i * mStrideB + j * mStrideH +
                       (m + row) * mStrideM + n,
-                  kvBlockSize);
+                  kvBlockSize,
+                  attn_data + row * kvBlockSize,
+                  one);
             }
           }
           // restore self attention after softmax from logsumexp
@@ -686,6 +724,21 @@ void cpu_flash_attention_backward(
   });
 }
 
+#define AT_DISPATCH_MASK_TYPES(TYPE, NAME, ...)            \
+  AT_DISPATCH_SWITCH(                                      \
+      TYPE,                                                \
+      NAME,                                                \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::Bool, mask_t, __VA_ARGS__)       \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::Float, mask_t, __VA_ARGS__)      \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::Double, mask_t, __VA_ARGS__)     \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::BFloat16, mask_t, __VA_ARGS__)   \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::Half, mask_t, __VA_ARGS__))
+
 void flash_attention_kernel_impl(
     const Tensor& output,
     const Tensor& logsumexp,
@@ -699,18 +752,36 @@ void flash_attention_kernel_impl(
   auto q_seq_len = query.size(2);
 
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, query.scalar_type(), "flash_attention", [&] {
-    if (q_seq_len >= 768) {
-      cpu_flash_attention<scalar_t, 256, 512>(
-        output, logsumexp, query, key, value,
-        dropout_p, is_causal, attn_mask, scale);
-    } else if (q_seq_len >= 192) {
-      cpu_flash_attention<scalar_t, 64, 512>(
-        output, logsumexp, query, key, value,
-        dropout_p, is_causal, attn_mask, scale);
+    if (!attn_mask.has_value()) {
+      if (q_seq_len >= 768) {
+        cpu_flash_attention<scalar_t, scalar_t, 256, 512>(
+          output, logsumexp, query, key, value,
+          dropout_p, is_causal, attn_mask, scale);
+      } else if (q_seq_len >= 192) {
+        cpu_flash_attention<scalar_t, scalar_t, 64, 512>(
+          output, logsumexp, query, key, value,
+          dropout_p, is_causal, attn_mask, scale);
+      } else {
+        cpu_flash_attention<scalar_t, scalar_t, 32, 512>(
+          output, logsumexp, query, key, value,
+          dropout_p, is_causal, attn_mask, scale);
+      }
     } else {
-      cpu_flash_attention<scalar_t, 32, 512>(
-        output, logsumexp, query, key, value,
-        dropout_p, is_causal, attn_mask, scale);
+      AT_DISPATCH_MASK_TYPES(attn_mask.value().scalar_type(), "flash_attention_mask", [&]() {
+        if (q_seq_len >= 768) {
+          cpu_flash_attention<scalar_t, mask_t, 256, 512>(
+            output, logsumexp, query, key, value,
+            dropout_p, is_causal, attn_mask, scale);
+        } else if (q_seq_len >= 192) {
+          cpu_flash_attention<scalar_t, mask_t, 64, 512>(
+            output, logsumexp, query, key, value,
+            dropout_p, is_causal, attn_mask, scale);
+        } else {
+          cpu_flash_attention<scalar_t, mask_t, 32, 512>(
+            output, logsumexp, query, key, value,
+            dropout_p, is_causal, attn_mask, scale);
+        }
+      });
     }
   });
 }
@@ -736,21 +807,42 @@ void flash_attention_backward_kernel_impl(
   auto q_seq_len = query.size(1);
 
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, query.scalar_type(), "flash_attention_backward", [&] {
-    if (q_seq_len >= 768) {
-      cpu_flash_attention_backward<scalar_t, 256, 512>(
-        grad_q, grad_k, grad_v, grad_out_contig,
-        query, key, value, out, logsumexp,
-        dropout_p, is_causal, attn_mask, scale);
-    } else if (q_seq_len >= 192) {
-      cpu_flash_attention_backward<scalar_t, 64, 512>(
-        grad_q, grad_k, grad_v, grad_out_contig,
-        query, key, value, out, logsumexp,
-        dropout_p, is_causal, attn_mask, scale);
+    if (!attn_mask.has_value()) {
+      if (q_seq_len >= 768) {
+        cpu_flash_attention_backward<scalar_t, scalar_t, 256, 512>(
+          grad_q, grad_k, grad_v, grad_out_contig,
+          query, key, value, out, logsumexp,
+          dropout_p, is_causal, attn_mask, scale);
+      } else if (q_seq_len >= 192) {
+        cpu_flash_attention_backward<scalar_t, scalar_t, 64, 512>(
+          grad_q, grad_k, grad_v, grad_out_contig,
+          query, key, value, out, logsumexp,
+          dropout_p, is_causal, attn_mask, scale);
+      } else {
+        cpu_flash_attention_backward<scalar_t, scalar_t, 32, 512>(
+          grad_q, grad_k, grad_v, grad_out_contig,
+          query, key, value, out, logsumexp,
+          dropout_p, is_causal, attn_mask, scale);
+      }
     } else {
-      cpu_flash_attention_backward<scalar_t, 32, 512>(
-        grad_q, grad_k, grad_v, grad_out_contig,
-        query, key, value, out, logsumexp,
-        dropout_p, is_causal, attn_mask, scale);
+      AT_DISPATCH_MASK_TYPES(attn_mask.value().scalar_type(), "flash_attention_mask_backward", [&]() {
+        if (q_seq_len >= 768) {
+          cpu_flash_attention_backward<scalar_t, mask_t, 256, 512>(
+            grad_q, grad_k, grad_v, grad_out_contig,
+            query, key, value, out, logsumexp,
+            dropout_p, is_causal, attn_mask, scale);
+        } else if (q_seq_len >= 192) {
+          cpu_flash_attention_backward<scalar_t, mask_t, 64, 512>(
+            grad_q, grad_k, grad_v, grad_out_contig,
+            query, key, value, out, logsumexp,
+            dropout_p, is_causal, attn_mask, scale);
+        } else {
+          cpu_flash_attention_backward<scalar_t, mask_t, 32, 512>(
+            grad_q, grad_k, grad_v, grad_out_contig,
+            query, key, value, out, logsumexp,
+            dropout_p, is_causal, attn_mask, scale);
+        }
+      });
     }
   });
 }

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -22,7 +22,38 @@ namespace at::native {
 namespace {
 
 // out = val * a + b
-template <typename T1, typename T2>
+template <typename T1, typename T2,
+          typename std::enable_if_t<std::is_same_v<T1, float> && is_reduced_floating_point<T2>::value, int> = 0>
+inline void _scale_attn_mask_fusion_kernel(
+    T1* a,
+    T2* b,
+    const int& size,
+    T1* out,
+    T1& val) {
+  auto vec_size1 = at::vec::Vectorized<T1>::size();
+  auto vec_size2 = at::vec::Vectorized<T2>::size();
+  auto vec_scale = at::vec::Vectorized<T1>(val);
+  int64_t i = 0;
+  for (; i < size - (size % vec_size2); i += vec_size2) {
+    auto a0 = at::vec::Vectorized<T1>::loadu(a + i);
+    auto a1 = at::vec::Vectorized<T1>::loadu(a + i + vec_size1);
+    auto b_tmp = at::vec::Vectorized<T2>::loadu(b + i);
+    auto [b0, b1] = convert_to_float<T2>(b_tmp);
+    auto res0 = a0 * vec_scale + b0;
+    auto res1 = a1 * vec_scale + b1;
+    res0.store(out + i);
+    res1.store(out + i + vec_size1);
+  }
+  for (; i < size; i++) {
+    auto tmp0 = a[i];
+    auto tmp1 = (T1) b[i];
+    out[i] = tmp0 * val + tmp1;
+  }
+}
+
+// out = val * a + b
+template <typename T1, typename T2,
+          typename std::enable_if_t<!(std::is_same_v<T1, float> && is_reduced_floating_point<T2>::value), int > = 0>
 inline void _scale_attn_mask_fusion_kernel(
     T1* a,
     T2* b,
@@ -31,14 +62,15 @@ inline void _scale_attn_mask_fusion_kernel(
     T1& val) {
   auto vec_size = at::vec::Vectorized<T1>::size();
   auto vec_scale = at::vec::Vectorized<T1>(val);
-  for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
+  int64_t i = 0;
+  for (; i < size - (size % vec_size); i += vec_size) {
     auto tmp0 = at::vec::Vectorized<T1>::loadu(a + i);
     auto tmp1 = at::vec::Vectorized<T2>::loadu(b + i);
     auto tmp2 = at::vec::convert<T1>(tmp1);
     auto tmp3 = tmp0 * vec_scale + tmp2;
     _store(out + i, tmp3);
   }
-  for (long i = vec_size * (size / vec_size); i < size; i++) {
+  for (; i < size; i++) {
     auto tmp0 = a[i];
     auto tmp1 = (T1) b[i];
     out[i] = tmp0 * val + tmp1;

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -807,19 +807,20 @@ void flash_attention_backward_kernel_impl(
   auto q_seq_len = query.size(1);
 
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, query.scalar_type(), "flash_attention_backward", [&] {
-    if (!attn_mask.has_value()) {
+    if (!attn_mask.has_value() || !attn_mask.value().defined()) {
+      using accum_t = at::opmath_type<scalar_t>;
       if (q_seq_len >= 768) {
-        cpu_flash_attention_backward<scalar_t, scalar_t, 256, 512>(
+        cpu_flash_attention_backward<scalar_t, accum_t, 256, 512>(
           grad_q, grad_k, grad_v, grad_out_contig,
           query, key, value, out, logsumexp,
           dropout_p, is_causal, attn_mask, scale);
       } else if (q_seq_len >= 192) {
-        cpu_flash_attention_backward<scalar_t, scalar_t, 64, 512>(
+        cpu_flash_attention_backward<scalar_t, accum_t, 64, 512>(
           grad_q, grad_k, grad_v, grad_out_contig,
           query, key, value, out, logsumexp,
           dropout_p, is_causal, attn_mask, scale);
       } else {
-        cpu_flash_attention_backward<scalar_t, scalar_t, 32, 512>(
+        cpu_flash_attention_backward<scalar_t, accum_t, 32, 512>(
           grad_q, grad_k, grad_v, grad_out_contig,
           query, key, value, out, logsumexp,
           dropout_p, is_causal, attn_mask, scale);

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -45,29 +45,6 @@ inline void _scale_attn_mask_fusion_kernel(
   }
 }
 
-// out = val * a + b
-template <typename T1>
-inline void _scale_attn_mask_fusion_kernel(
-    T1* a,
-    T1* b,
-    const int& size,
-    T1* out,
-    T1& val) {
-  auto vec_size = at::vec::Vectorized<T1>::size();
-  auto vec_scale = at::vec::Vectorized<T1>(val);
-  for (long i = 0; i < vec_size * (size / vec_size); i += vec_size) {
-    auto tmp0 = at::vec::Vectorized<T1>::loadu(a + i);
-    auto tmp1 = at::vec::Vectorized<T1>::loadu(b + i);
-    auto tmp2 = tmp0 * vec_scale + tmp1;
-    _store(out + i, tmp2);
-  }
-  for (long i = vec_size * (size / vec_size); i < size; i++) {
-    auto tmp0 = a[i];
-    auto tmp1 = b[i];
-    out[i] = tmp0 * val + tmp1;
-  }
-}
-
 // 1) out = exp(a - val)
 // 2) val = sum(out)
 template <typename T1, typename T2>


### PR DESCRIPTION
The PR optimizes the mask memory for flash attention. Instead of directly converting the whole mask to fp32, we do the conversion block-wisely. This can decrease the peak memory usage (we test in https://huggingface.co/microsoft/Phi-3-mini-128k-instruct, peak memory usage reduces ~50%) and have some performance improvements as well.

### Performance result
single socket in Intel (R) Xeon (R) CPU Max 9480
batch_size = 12, q_seq_len = 1030, kv_seq_len = 1179, n_head = 3, head_dim = 33, mask_dim = 4, bool_mask = 0
  | Forward speedup | Backward speedup
-- | -- | --
float64 | 0.82% | 3.76%
float32 | 2.2% | 3.9%
bfloat16 | 16.15% | 7.56%

**segment-anything-fast**
Follow https://github.com/pytorch-labs/segment-anything-fast/tree/main/experiments
Single socket in Intel (R) Xeon (R) CPU Max 9480
Dtype: bfloat16, models: vit_b and vit_h, test in `SDPA` and `Triton` commit https://github.com/pytorch-labs/segment-anything-fast/blob/main/experiments/run_experiments.py#L199-L200, select the time of 20th iteration.
  | vit_b |   | vit_h |  
-- | -- | -- | -- | --
  | attn_mask w/o   block-wise | attn_mask w/   block-wise | attn_mask w/o   block-wise | attn_mask w/   block-wise
SDPA| 10.95s/it | 6.59s/it | 19.93s/it | 12.33s/it
Triton | 10.66s/it | 7.12s/it | 19.87s/it | 12.26s/it


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10