### PR TITLE
[AMD] Fix deprecated amdsmi api

### DIFF
--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -62,7 +62,12 @@ def rocm_get_per_process_gpu_info(handle: Any) -> List[Dict[str, Any]]:
     processes = amdsmi.amdsmi_get_gpu_process_list(handle)
     per_process_info = []
     for p in processes:
-        proc_info = amdsmi.amdsmi_get_gpu_process_info(handle, p)
+        try:
+            proc_info = amdsmi.amdsmi_get_gpu_process_info(handle, p)
+        except AttributeError:
+            # https://github.com/ROCm/amdsmi/commit/c551c3caedbd903ba828e7fdffa5b56d475a15e7
+            # BC-breaking change that removes amdsmi_get_gpu_process_info API from amdsmi
+            proc_info = p
         info = {
             "pid": proc_info["pid"],
             "gpu_memory": proc_info["memory_usage"]["vram_mem"],

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -653,7 +653,12 @@ def list_gpu_processes(device: Union[Device, int] = None) -> str:
             mem = p.usedGpuMemory / (1024 * 1024)
             pid = p.pid
         else:
-            proc_info = amdsmi.amdsmi_get_gpu_process_info(handle, p)  # type: ignore[possibly-undefined]
+            try:
+                proc_info = amdsmi.amdsmi_get_gpu_process_info(handle, p)  # type: ignore[possibly-undefined]
+            except AttributeError:
+                # https://github.com/ROCm/amdsmi/commit/c551c3caedbd903ba828e7fdffa5b56d475a15e7
+                # is a BC-breaking change that removes amdsmi_get_gpu_process_info API from amdsmi
+                proc_info = p
             mem = proc_info["memory_usage"]["vram_mem"] / (1024 * 1024)
             pid = proc_info["pid"]
         lines.append(f"process {pid:>10d} uses {mem:>12.3f} MB GPU memory")


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/119182 uses an API that has already been deprecated by https://github.com/ROCm/amdsmi/commit/c551c3caedbd903ba828e7fdffa5b56d475a15e7. So fixing this in a backward compatible way

Differential Revision: D57711088


