### PR TITLE
[Docs] Add int type to the `device` paramepter of the `torch.set_default_device()`

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -688,7 +688,7 @@ def set_default_device(device):
         :func:`torch.from_numpy` and :func:`torch.frombuffer`
 
     Args:
-        device (device or string): the device to set as default
+        device (device or string or int): the device to set as default
 
     Example::
 
@@ -703,6 +703,9 @@ def set_default_device(device):
         >>> torch.get_default_device()
         device(type='cuda', index=1)
         >>> torch.set_default_device('cuda:1')
+        >>> torch.get_default_device()
+        device(type='cuda', index=1)
+        >>> torch.set_default_device(1)  # legacy
         >>> torch.get_default_device()
         device(type='cuda', index=1)
 


### PR DESCRIPTION
Fixes #126646
