### PR TITLE
[codemod][lowrisk] Remove extra semi colon from caffe2/caffe2/core/observer.h

### DIFF
--- a/caffe2/core/observer.h
+++ b/caffe2/core/observer.h
@@ -23,7 +23,7 @@ class ObserverBase {
     return "Not implemented.";
   }
 
-  virtual ~ObserverBase() noexcept {};
+  virtual ~ObserverBase() noexcept {}
 
   T* subject() const {
     return subject_;
@@ -32,7 +32,7 @@ class ObserverBase {
   virtual std::unique_ptr<ObserverBase<T>> rnnCopy(T* subject, int rnn_order)
       const {
     return nullptr;
-  };
+  }
 
  protected:
   T* subject_;


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: palmje

Differential Revision: D57632765


