### PR TITLE
Fix typo for input

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -432,7 +432,7 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         cloned_inputs = clone_inputs(inputs)
         self.optimizer_zero_grad(mod)
         with self.autocast(**self.autocast_arg):
-            if isinstance(clone_inputs, dict):
+            if isinstance(cloned_inputs, dict):
                 pred = mod(**cloned_inputs)
             else:
                 pred = mod(*cloned_inputs)


### PR DESCRIPTION
The variable name should be `cloned_inputs` rather than `clone_inputs`. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang