### PR TITLE
[DCP] Fix no_dist logic to consider if user provides a process_group

### DIFF
--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -132,7 +132,7 @@ def load(
         rank has an individual GPU, via ``torch.cuda.set_device()``.
     """
 
-    no_dist = not (dist.is_available() and dist.is_initialized())
+    no_dist = (not (dist.is_available() and dist.is_initialized())) or process_group is None
     if no_dist:
         warnings.warn(
             "torch.distributed is unavailable or uninitialized, assuming the intent is to load in a single process."

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -132,7 +132,10 @@ def load(
         rank has an individual GPU, via ``torch.cuda.set_device()``.
     """
 
-    no_dist = (not (dist.is_available() and dist.is_initialized())) or process_group is None
+    no_dist = (
+        not (dist.is_available() and dist.is_initialized())
+    ) or process_group is None
+
     if no_dist:
         warnings.warn(
             "torch.distributed is unavailable or uninitialized, assuming the intent is to load in a single process."

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -136,7 +136,7 @@ def save(
     """
     torch._C._log_api_usage_once("torch.distributed.checkpoint.save")
 
-    no_dist = not (dist.is_available() and dist.is_initialized())
+    no_dist = (not (dist.is_available() and dist.is_initialized())) or process_group is None
     if no_dist:
         warnings.warn(
             "torch.distributed is unavailable or uninitialized, assuming the intent is to save in a single process."

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -136,7 +136,10 @@ def save(
     """
     torch._C._log_api_usage_once("torch.distributed.checkpoint.save")
 
-    no_dist = (not (dist.is_available() and dist.is_initialized())) or process_group is None
+    no_dist = (
+        not (dist.is_available() and dist.is_initialized())
+    ) or process_group is None
+
     if no_dist:
         warnings.warn(
             "torch.distributed is unavailable or uninitialized, assuming the intent is to save in a single process."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127014

For single process save/load cases, user may not provide the process group; the no_dist logic still tries to execute process_group operations when it's explicitly not provided by user, example: https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/state_dict_loader.py#L149 (in this case the program stalls).


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @mhorowitz @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang