### PR TITLE
[dtensor][debug] add all_reduce_coalesced tracing to CommDebugMode

### DIFF
--- a/test/distributed/_tensor/debug/test_comm_mode.py
+++ b/test/distributed/_tensor/debug/test_comm_mode.py
@@ -90,14 +90,21 @@ class TestCommMode(TestCase):
         comm_mode = CommDebugMode()
         with comm_mode:
             model(torch.randn(20, 10, device=self.device_type))
+
+        comm_counts = comm_mode.get_comm_counts()
+        self.assertEqual(comm_mode.get_total_counts(), 3)
+        self.assertEqual(comm_counts[c10d_functional.all_reduce_coalesced], 1)
+        self.assertEqual(comm_counts[c10d_functional.all_gather_into_tensor], 1)
+        self.assertEqual(comm_counts[c10d_functional.reduce_scatter_tensor], 1)
+
+        with comm_mode:
             model2(torch.randn(20, 10, device=self.device_type))
 
         comm_counts = comm_mode.get_comm_counts()
-        self.assertEqual(comm_mode.get_total_counts(), 6)
-        self.assertEqual(comm_counts[c10d_functional.all_reduce_coalesced], 1)
+        self.assertEqual(comm_mode.get_total_counts(), 3)
         self.assertEqual(comm_counts[c10d_functional.all_reduce], 1)
-        self.assertEqual(comm_counts[c10d_functional.all_gather_into_tensor], 2)
-        self.assertEqual(comm_counts[c10d_functional.reduce_scatter_tensor], 2)
+        self.assertEqual(comm_counts[c10d_functional.all_gather_into_tensor], 1)
+        self.assertEqual(comm_counts[c10d_functional.reduce_scatter_tensor], 1)
 
     def test_comm_mode_with_dtensor(self):
         world_pg = self.world_pg

--- a/test/distributed/_tensor/debug/test_comm_mode.py
+++ b/test/distributed/_tensor/debug/test_comm_mode.py
@@ -59,6 +59,46 @@ class TestCommMode(TestCase):
         self.assertEqual(comm_counts[c10d_functional.all_gather_into_tensor], 1)
         self.assertEqual(comm_counts[c10d_functional.reduce_scatter_tensor], 1)
 
+    def test_comm_mode_coalesced(self):
+        world_pg = self.world_pg
+
+        class WrapperModelCoalesced(nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.model = MLPModule(device=device)
+
+            def forward(self, x):
+                x = funcol.all_gather_tensor(x, 0, world_pg)
+                x = funcol.reduce_scatter_tensor(x, "sum", 0, world_pg)
+                out = self.model(x)
+                return funcol.all_reduce_coalesced([out], "sum", world_pg)
+
+        class WrapperModel(nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.model = MLPModule(device=device)
+
+            def forward(self, x):
+                x = funcol.all_gather_tensor(x, 0, world_pg)
+                x = funcol.reduce_scatter_tensor(x, "sum", 0, world_pg)
+                out = self.model(x)
+                return funcol.all_reduce(out, "sum", world_pg)
+
+        model = WrapperModelCoalesced(self.device_type)
+        model2 = WrapperModel(self.device_type)
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            model(torch.randn(20, 10, device=self.device_type))
+            model2(torch.randn(20, 10, device=self.device_type))
+
+        comm_counts = comm_mode.get_comm_counts()
+        self.assertEqual(comm_mode.get_total_counts(), 6)
+        self.assertEqual(comm_counts[c10d_functional.all_reduce_coalesced], 1)
+        self.assertEqual(comm_counts[c10d_functional.all_reduce], 1)
+        self.assertEqual(comm_counts[c10d_functional.all_gather_into_tensor], 2)
+        self.assertEqual(comm_counts[c10d_functional.reduce_scatter_tensor], 2)
+
     def test_comm_mode_with_dtensor(self):
         world_pg = self.world_pg
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))

--- a/torch/distributed/_tensor/debug/comm_mode.py
+++ b/torch/distributed/_tensor/debug/comm_mode.py
@@ -15,6 +15,7 @@ NATIVE_TO_PY_MAPPING = {
     funcol_native.all_gather_into_tensor: funcol_py.all_gather_into_tensor,
     funcol_native.all_gather_into_tensor_coalesced: funcol_py.all_gather_into_tensor_coalesced,
     funcol_native.all_reduce: funcol_py.all_reduce,
+    funcol_native.all_reduce_coalesced: funcol_py.all_reduce_coalesced,
     funcol_native.all_to_all_single: funcol_py.all_to_all_single,
     funcol_native.broadcast: funcol_py.broadcast,
     funcol_native.reduce_scatter_tensor: funcol_py.reduce_scatter_tensor,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127040
* #127029
* __->__ #127025

**Summary**
Added all_reduce_coalesced tracing to CommDebugMode and added test case to test_comm_mode test suite.

**Test Plan**
pytest test/distributed/_tensor/debug/test_comm_mode.py 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k