### PR TITLE
[dtensor][debug] add c10d allreduce_coalesced_ tracing to CommDebugMode

### DIFF
--- a/test/distributed/_tensor/debug/test_comm_mode.py
+++ b/test/distributed/_tensor/debug/test_comm_mode.py
@@ -127,6 +127,26 @@ class TestCommMode(TestCase):
         self.assertEqual(comm_counts[c10d_ops._reduce_scatter_base_], 1)
         self.assertEqual(comm_counts[c10d_ops.broadcast_], 1)
 
+    def test_comm_mode_with_c10d_allreduce_coalesced(self):
+        world_pg = self.world_pg
+
+        inp = torch.rand(2, 8, 16).cuda()
+        all_gather_out = inp.new_empty(self.world_size * 2, 8, 16)
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            dist.all_reduce_coalesced(inp)
+            dist.all_gather_into_tensor(all_gather_out, inp)
+            dist.reduce_scatter_tensor(inp, all_gather_out)
+            dist.broadcast(inp, 0)
+
+        comm_counts = comm_mode.get_comm_counts()
+        self.assertEqual(comm_mode.get_total_counts(), 4)
+        self.assertEqual(comm_counts[c10d_ops.allreduce_coalesced_], 1)
+        self.assertEqual(comm_counts[c10d_ops._allgather_base_], 1)
+        self.assertEqual(comm_counts[c10d_ops._reduce_scatter_base_], 1)
+        self.assertEqual(comm_counts[c10d_ops.broadcast_], 1)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_tensor/debug/test_comm_mode.py
+++ b/test/distributed/_tensor/debug/test_comm_mode.py
@@ -127,6 +127,7 @@ class TestCommMode(TestCase):
         self.assertEqual(comm_counts[c10d_ops._reduce_scatter_base_], 1)
         self.assertEqual(comm_counts[c10d_ops.broadcast_], 1)
 
+    @requires_nccl()
     def test_comm_mode_with_c10d_allreduce_coalesced(self):
         world_pg = self.world_pg
 

--- a/torch/distributed/_tensor/debug/comm_mode.py
+++ b/torch/distributed/_tensor/debug/comm_mode.py
@@ -29,6 +29,7 @@ c10d_collective_ops = {
     c10d_ops._allgather_base_,
     c10d_ops._reduce_scatter_base_,
     c10d_ops.broadcast_,
+    c10d_ops.allreduce_coalesced_,
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127040
* #127029
* #127025

**Summary**
Added c10d all_reduce_coalesced tracing to CommDebugMode and added test case to test_comm_mode.py.

**Test Plan**
pytest test/distributed/_tensor/debug/test_comm_mode.py 


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k