### PR TITLE
HealthcheckNCCL

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -517,6 +517,7 @@ libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/Work.cpp",
     "torch/csrc/distributed/c10d/control_plane/Handlers.cpp",
     "torch/csrc/distributed/c10d/control_plane/WorkerServer.cpp",
+    "torch/csrc/distributed/c10d/Healthcheck.cpp",
 ]
 
 # These files are only supported on Linux (and others) but not on Windows.
@@ -687,6 +688,7 @@ libtorch_cuda_distributed_extra_sources = [
     "torch/csrc/distributed/c10d/Utils.cu",
     "torch/csrc/distributed/rpc/tensorpipe_cuda.cpp",
     "torch/csrc/distributed/c10d/quantization/quantization_gpu.cu",
+    "torch/csrc/distributed/c10d/HealthcheckNCCL.cpp",
 ]
 
 libtorch_cuda_distributed_sources = libtorch_cuda_distributed_base_sources + libtorch_cuda_distributed_extra_sources

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -933,6 +933,7 @@ elseif(USE_CUDA)
   torch_compile_options(torch_cuda)  # see cmake/public/utils.cmake
   target_compile_options_if_supported(torch_cuda "-Wno-deprecated-copy")  # see cmake/public/utils.cmake
   target_compile_definitions(torch_cuda PRIVATE USE_CUDA)
+  target_link_libraries(torch_cuda PRIVATE fmt::fmt-header-only)
 
   if(USE_CUSPARSELT)
       target_link_libraries(torch_cuda PRIVATE torch::cusparselt)
@@ -1324,6 +1325,7 @@ if(USE_ROCM)
   if(USE_MEM_EFF_ATTENTION)
     target_compile_definitions(torch_hip PRIVATE USE_MEM_EFF_ATTENTION)
   endif()
+  target_link_libraries(torch_hip PRIVATE fmt::fmt-header-only)
 endif()
 
 if(BUILD_LITE_INTERPRETER)

--- a/test/distributed/test_healthcheck.py
+++ b/test/distributed/test_healthcheck.py
@@ -1,0 +1,163 @@
+# Owner(s): ["oncall: distributed"]
+
+import multiprocessing as mp
+import os
+import time
+import unittest
+from datetime import timedelta
+
+# Disable rethrowing errors in the watchdog thread to avoid crashes on teardown.
+os.environ["TORCH_NCCL_RETHROW_CUDA_ERRORS"] = "0"
+
+import torch
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    skip_if_lt_x_gpu,
+    TestCase,
+)
+from torch.testing._internal.common_utils import run_tests, TEST_CUDA
+
+
+class HealthcheckNCCLMultiprocessTest(MultiProcessTestCase):
+    @property
+    def store_path(self) -> str:
+        return f"/tmp/{self.id()}.filestore"
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def setUp(self) -> None:
+        if os.path.exists(self.store_path):
+            print("removing file store!", self.store_path)
+            os.remove(self.store_path)
+
+        from torch._C._distributed_c10d import FileStore
+
+        store = FileStore(self.store_path, self.world_size)
+        store.set("warm", "up")
+
+        super().setUp()
+        self._spawn_processes()
+
+    @skip_if_lt_x_gpu(2)
+    def test_healthcheck_success(self) -> None:
+        from torch._C._distributed_c10d import FileStore, HealthcheckNCCL
+
+        torch.cuda.set_device(self.rank)
+
+        store = FileStore(self.store_path, self.world_size)
+
+        healthcheck = HealthcheckNCCL(
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            local_world_size=1,
+            exit_on_error=None,
+            interval=timedelta(seconds=1),
+            timeout=timedelta(seconds=60),
+        )
+        while healthcheck.num_failures == -1:
+            time.sleep(0.01)
+        self.assertEqual(healthcheck.num_failures, 0)
+
+        healthcheck.shutdown()
+
+    @skip_if_lt_x_gpu(2)
+    def test_healthcheck_timeout(self) -> None:
+        from torch._C._distributed_c10d import FileStore, HealthcheckNCCL
+
+        torch.cuda.set_device(self.rank)
+
+        store = FileStore(self.store_path, self.world_size)
+
+        healthcheck = HealthcheckNCCL(
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+            local_world_size=1,
+            exit_on_error=None,
+            interval=timedelta(seconds=1),
+            timeout=timedelta(milliseconds=1),
+        )
+        while healthcheck.num_failures == -1:
+            time.sleep(0.01)
+        self.assertEqual(healthcheck.num_failures, 2)
+
+        # NCCL may be in a bad state -- force a clean exit
+        os._exit(0)
+
+
+def healthcheck_exit() -> None:
+    from torch._C._distributed_c10d import HashStore, HealthcheckNCCL
+
+    store = HashStore()
+
+    healthcheck = HealthcheckNCCL(
+        store=store,
+        rank=0,
+        world_size=2,
+        local_world_size=1,
+        exit_on_error=123,
+        interval=timedelta(seconds=1),
+        timeout=timedelta(milliseconds=1),
+    )
+
+    time.sleep(1000)
+
+
+class HealthcheckNCCLTest(TestCase):
+    @unittest.skipIf(not TEST_CUDA, "requires cuda")
+    def test_healthcheck_exit(self) -> None:
+        mp_context = mp.get_context("spawn")
+        p = mp_context.Process(target=healthcheck_exit)
+        p.start()
+        p.join()
+
+        self.assertEqual(p.exitcode, 123)
+
+    def test_healthcheck_groups(self) -> None:
+        from torch._C._distributed_c10d import Healthcheck
+
+        world_size = 8
+        local_world_size = 2
+
+        expected = [
+            [
+                (0, 0, 4),
+                (0, 1, 4),
+                (0, 2, 4),
+                (0, 3, 4),
+                (1, 0, 4),
+                (1, 1, 4),
+                (1, 2, 4),
+                (1, 3, 4),
+            ],
+            [
+                (0, 0, 4),
+                (0, 1, 4),
+                (1, 2, 4),
+                (1, 3, 4),
+                (1, 0, 4),
+                (1, 1, 4),
+                (0, 2, 4),
+                (0, 3, 4),
+            ],
+        ]
+        for side, infos in enumerate(expected):
+            for rank in range(world_size):
+                info = Healthcheck.calculate_group_info(
+                    side=side,
+                    rank=rank,
+                    world_size=world_size,
+                    local_world_size=local_world_size,
+                )
+                self.assertEqual(info, infos[rank], f"{side} {rank} {info}")
+
+
+if __name__ == "__main__":
+    assert (
+        not torch.cuda._initialized
+    ), "test_distributed must not have initialized CUDA context on main process"
+
+    run_tests()

--- a/torch/csrc/distributed/c10d/Healthcheck.cpp
+++ b/torch/csrc/distributed/c10d/Healthcheck.cpp
@@ -1,0 +1,142 @@
+#include <exception>
+#include <future>
+#include <stdexcept>
+
+#include <c10/util/Exception.h>
+#include <torch/csrc/distributed/c10d/Healthcheck.hpp>
+#include <torch/csrc/distributed/c10d/logging.h>
+
+namespace c10d {
+
+Healthcheck::Healthcheck(
+    c10::optional<int> exitOnError,
+    std::chrono::milliseconds interval,
+    std::chrono::milliseconds timeout)
+    : exitOnError_(exitOnError), interval_(interval), timeout_(timeout) {
+  worker_ = std::async(std::launch::async, [this]() {
+    try {
+      runLoop();
+    } catch (const std::exception& e) {
+      C10D_ERROR("Healthcheck thread failed: {}", e.what());
+    } catch (...) {
+      C10D_ERROR("Healthcheck thread failed with unknown exception");
+    }
+  });
+}
+
+void Healthcheck::runLoop() {
+  C10D_INFO("Healthcheck setup...");
+  for (int side = 0; side < 2; side++) {
+    setup(side);
+  }
+
+  while (true) {
+    C10D_INFO("Running healthchecks...");
+
+    std::vector<std::future<void>> futures;
+    futures.reserve(2);
+
+    for (int side = 0; side < 2; side++) {
+      futures.emplace_back(std::async(
+          std::launch::async,
+          [](Healthcheck* self, int side) { self->runHealthcheck(side); },
+          this,
+          side));
+    }
+
+    // calculate deadline for the futures
+    std::chrono::time_point<std::chrono::system_clock> deadline =
+        std::chrono::system_clock::now() + timeout_;
+
+    int failures = 0;
+
+    // wait for futures to complete
+    for (auto& future : futures) {
+      auto status = future.wait_until(deadline);
+      if (status == std::future_status::timeout) {
+        failures += 1;
+        C10D_ERROR("Healthcheck timed out");
+        continue;
+      }
+      TORCH_INTERNAL_ASSERT(status == std::future_status::ready);
+
+      try {
+        future.get();
+        C10D_INFO("Healthcheck passed");
+      } catch (const std::exception& e) {
+        C10D_WARNING("Healthcheck failed: {}", e.what());
+        failures += 1;
+        continue;
+      } catch (...) {
+        C10D_WARNING("Healthcheck failed with unknown exception");
+        failures += 1;
+        continue;
+      }
+    }
+
+    if (failures > 0) {
+      C10D_WARNING("Healthchecks had {} failures", failures);
+    } else {
+      C10D_INFO("All healthchecks passed");
+    }
+    numFailures_ = failures;
+    if (failures == 2) {
+      C10D_ERROR("Current host identified as problematic!");
+      if (exitOnError_) {
+        C10D_ERROR("Exiting with code {}!", *exitOnError_);
+        std::quick_exit(*exitOnError_);
+      }
+      Healthcheck::shutdown();
+      return;
+    }
+
+    // wait for interval
+    waitFor(interval_);
+    if (isShutdown()) {
+      throw std::runtime_error("shutting down");
+    }
+  }
+}
+
+void Healthcheck::waitFor(std::chrono::milliseconds duration) {
+  std::unique_lock lock{shutdownM_};
+  if (shutdown_) {
+    return;
+  }
+  shutdownCv_.wait_for(lock, duration);
+}
+
+bool Healthcheck::isShutdown() {
+  std::unique_lock lock{shutdownM_};
+  return shutdown_;
+}
+
+void Healthcheck::shutdown() {
+  C10D_INFO("shutting down...");
+  {
+    std::unique_lock lock{shutdownM_};
+    shutdown_ = true;
+  }
+  shutdownCv_.notify_all();
+}
+
+void Healthcheck::wait() {
+  worker_.wait();
+}
+
+std::tuple<int, int, int> Healthcheck::calculateGroupInfo(
+    int side,
+    int rank,
+    int worldSize,
+    int localWorldSize) {
+  auto hostRank = rank / localWorldSize;
+  auto hostCount = worldSize / localWorldSize;
+
+  auto group = (hostRank + side) % hostCount / 2;
+  auto groupSize = 2 * localWorldSize;
+  auto groupRank = rank % groupSize;
+
+  return {group, groupRank, groupSize};
+}
+
+} // namespace c10d

--- a/torch/csrc/distributed/c10d/Healthcheck.hpp
+++ b/torch/csrc/distributed/c10d/Healthcheck.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <c10/macros/Export.h>
+#include <torch/custom_class.h>
+
+namespace c10d {
+
+class TORCH_API Healthcheck : public torch::CustomClassHolder {
+ public:
+  Healthcheck(
+      c10::optional<int> exportOnError = c10::nullopt,
+      std::chrono::milliseconds interval = std::chrono::seconds(10),
+      std::chrono::milliseconds timeout = std::chrono::seconds(10));
+  virtual ~Healthcheck() = default;
+
+  virtual void shutdown();
+  void wait();
+
+  int getNumFailures() {
+    return numFailures_;
+  }
+
+  // Calculate group rank and size information for the specific rank and world
+  // size for the specific side. Side must be 0 or 1. Returns: (group,
+  // groupRank, groupSize)
+  static std::tuple<int, int, int> calculateGroupInfo(
+      int side,
+      int rank,
+      int worldSize,
+      int localWorldSize);
+
+ protected:
+  void waitFor(std::chrono::milliseconds duration);
+  bool isShutdown();
+
+ private:
+  // Called to setup each side, this is run on the worker thread.
+  virtual void setup(int side) = 0;
+
+  // Called in an individual thread to run the healthcheck.
+  virtual void runHealthcheck(int side) = 0;
+
+  void runLoop();
+
+ protected:
+  const c10::optional<int> exitOnError_;
+  const std::chrono::milliseconds interval_;
+  const std::chrono::milliseconds timeout_;
+
+ private:
+  std::atomic<int> numFailures_{-1};
+  std::future<void> worker_{};
+
+  std::mutex shutdownM_;
+  std::condition_variable shutdownCv_;
+  bool shutdown_{false};
+};
+
+} // namespace c10d

--- a/torch/csrc/distributed/c10d/HealthcheckNCCL.cpp
+++ b/torch/csrc/distributed/c10d/HealthcheckNCCL.cpp
@@ -1,0 +1,140 @@
+#ifdef USE_C10D_NCCL
+
+#include <torch/csrc/distributed/c10d/HealthcheckNCCL.hpp>
+
+#include <fmt/format.h>
+
+#include <ATen/ATen.h>
+#include <c10/core/TensorImpl.h>
+#include <c10/core/TensorOptions.h>
+#include <c10/cuda/CUDAFunctions.h>
+#include <c10/cuda/CUDAStream.h>
+#include <c10/util/intrusive_ptr.h>
+#include <torch/csrc/distributed/c10d/Healthcheck.hpp>
+#include <torch/csrc/distributed/c10d/PrefixStore.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
+#include <torch/csrc/distributed/c10d/Types.hpp>
+#include <torch/csrc/distributed/c10d/logging.h>
+#include <ratio>
+
+namespace {
+int getDeviceIndex() {
+  int deviceIndex = c10::cuda::current_device();
+  if (deviceIndex < 0) {
+    C10D_WARNING("got invalid device index, using 0");
+    deviceIndex = 0;
+  }
+  return deviceIndex;
+}
+} // namespace
+
+namespace c10d {
+
+HealthcheckNCCL::HealthcheckNCCL(
+    const c10::intrusive_ptr<::c10d::Store>& store,
+    int rank,
+    int worldSize,
+    int localWorldSize,
+    c10::optional<int> exitOnError,
+    std::chrono::milliseconds interval,
+    std::chrono::milliseconds timeout)
+    : Healthcheck(exitOnError, interval, timeout),
+      rank_(rank),
+      worldSize_(worldSize),
+      localWorldSize_(localWorldSize),
+      deviceIndex_(getDeviceIndex()),
+      store_(store) {
+  if (worldSize % localWorldSize != 0) {
+    throw std::runtime_error(
+        "World size must be divisible by local world size");
+  }
+  if (rank >= worldSize) {
+    throw std::runtime_error("Rank must be less than world size");
+  }
+  if (worldSize / localWorldSize < 2) {
+    throw std::runtime_error("At least two hosts are required");
+  }
+
+  streams_.reserve(2);
+  processGroups_.reserve(2);
+}
+
+void HealthcheckNCCL::setup(int side) {
+  auto info =
+      Healthcheck::calculateGroupInfo(side, rank_, worldSize_, localWorldSize_);
+
+  auto group = std::get<0>(info);
+  auto groupRank = std::get<1>(info);
+  auto groupSize = std::get<2>(info);
+
+  auto storePrefix = fmt::format("/healthcheck/{}/{}", side, group);
+  auto store = c10::make_intrusive<PrefixStore>(storePrefix, store_);
+
+  auto deviceIndex = deviceIndex_;
+  if (deviceIndex < 0) {
+    C10D_WARNING("got invalid device index, using 0");
+    deviceIndex = 0;
+  }
+  C10D_WARNING(
+      "setting device index to {}, class {}", deviceIndex, deviceIndex_);
+  c10::cuda::set_device(deviceIndex);
+
+  cudaStream_t stream;
+  cudaStreamCreate(&stream);
+  streams_.emplace_back(c10::cuda::getStreamFromExternal(stream, deviceIndex_));
+
+  C10D_INFO(
+      "Creating process group for side side={}, group={}, rank={}, size={}, store={}",
+      side,
+      group,
+      groupRank,
+      groupSize,
+      storePrefix);
+
+  processGroups_.emplace_back(
+      c10::make_intrusive<ProcessGroupNCCL>(store, groupRank, groupSize));
+}
+
+void HealthcheckNCCL::runHealthcheck(int side) {
+  auto device = deviceIndex_;
+  c10::cuda::set_device(deviceIndex_);
+
+  at::cuda::setCurrentCUDAStream(streams_.at(side));
+  auto& pg = processGroups_.at(side);
+
+  at::Tensor t = at::ones(
+      {1},
+      at::TensorOptions{}
+          .device(at::Device(c10::DeviceType::CUDA, device))
+          .dtype(at::kFloat));
+  std::vector<at::Tensor> tensors{t};
+
+  AllreduceOptions opts;
+  opts.timeout = timeout_;
+  auto work = pg->allreduce(tensors, opts);
+
+  while (!work->isCompleted()) {
+    waitFor(std::chrono::milliseconds(10));
+    if (isShutdown()) {
+      throw std::runtime_error("shutting down");
+    }
+  }
+  work->wait();
+
+  if (t.item().to<double>() != 2.0 * localWorldSize_) {
+    throw std::runtime_error(
+        "Health check all reduce returned invalid results");
+  }
+}
+
+void HealthcheckNCCL::shutdown() {
+  Healthcheck::shutdown();
+  for (auto& group : processGroups_) {
+    group->abort();
+    group->shutdown();
+  }
+}
+
+} // namespace c10d
+
+#endif

--- a/torch/csrc/distributed/c10d/HealthcheckNCCL.hpp
+++ b/torch/csrc/distributed/c10d/HealthcheckNCCL.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#ifdef USE_C10D_NCCL
+
+#include <c10/cuda/CUDAStream.h>
+#include <c10/macros/Export.h>
+#include <torch/csrc/distributed/c10d/Backend.hpp>
+#include <torch/csrc/distributed/c10d/Healthcheck.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
+#include <torch/csrc/distributed/c10d/Store.hpp>
+
+namespace c10d {
+
+class TORCH_API HealthcheckNCCL : public Healthcheck {
+ public:
+  HealthcheckNCCL(
+      const c10::intrusive_ptr<Store>& store,
+      int rank,
+      int worldSize,
+      int localWorldSize,
+      c10::optional<int> exitOnError = c10::nullopt,
+      std::chrono::milliseconds interval = std::chrono::seconds(10),
+      std::chrono::milliseconds timeout = std::chrono::seconds(10));
+
+  void shutdown() override;
+
+ protected:
+  void setup(int side) override;
+  void runHealthcheck(int side) override;
+
+ private:
+  const int rank_;
+  const int worldSize_;
+  const int localWorldSize_;
+  const c10::DeviceIndex deviceIndex_;
+
+  const c10::intrusive_ptr<Store> store_;
+  std::vector<at::cuda::CUDAStream> streams_;
+  std::vector<c10::intrusive_ptr<::c10d::ProcessGroupNCCL>> processGroups_;
+};
+
+} // namespace c10d
+
+#endif


### PR DESCRIPTION
This adds a `HealthcheckNCCL` class which can be used to bisect hosts and detect when a host goes down. Ideally this can detect issues and pinpoint their location without requiring global information.

This uses two process groups on separate CUDA streams to make nccl requests. When both groups return an error this will abort and take down the current process.

Example usage:

```py
store = FileStore(self.store_path, self.world_size)
healthcheck = HealthcheckNCCL(
    store=store,
    rank=self.rank,
    world_size=self.world_size,
    local_world_size=8,
    abort_on_error=True,
    interval=timedelta(seconds=60),
    timeout=timedelta(milliseconds=10),
)
```

Test plan:

```
python test/distributed/test_healthcheck.py
```

https://gist.github.com/d4l3k/14ec506b81146977a5f40bc8771036dc

```
torchx run -s local_cwd dist.ddp -j1x4 --script train.py
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang