### PR TITLE
Disallow fusions of foreach and reductions

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1135,7 +1135,7 @@ class ForeachKernelSchedulerNode(FusedSchedulerNode):
 
             producer = typing.cast(ForeachKernelSchedulerNode, producer)
             producer_subnode = producer.get_producer_subnode_for(consumer)
-            if producer_subnode is not None and not producer_subnode.is_reduction():
+            if producer_subnode is not None:
                 return producer.scheduler.can_fuse(producer_subnode, consumer)
 
             why("candidate consumer has no dep in any foreach producer")


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/120857

This currently isn't supported until we enable foreach reduction kernels.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang