### PR TITLE
[1/N] Fix clang-tidy warnings in  aten/src/ATen/detail/

### DIFF
--- a/aten/src/ATen/detail/CPUGuardImpl.cpp
+++ b/aten/src/ATen/detail/CPUGuardImpl.cpp
@@ -1,8 +1,7 @@
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 
-namespace at {
-namespace detail {
+namespace at::detail {
 
 C10_REGISTER_GUARD_IMPL(CPU, c10::impl::NoOpDeviceGuardImpl<DeviceType::CPU>);
 
-}} // namespace at::detail
+} // namespace at::detail

--- a/aten/src/ATen/detail/CUDAHooksInterface.cpp
+++ b/aten/src/ATen/detail/CUDAHooksInterface.cpp
@@ -35,7 +35,8 @@ const CUDAHooksInterface& getCUDAHooks() {
 #if !defined C10_MOBILE
   static c10::once_flag once;
   c10::call_once(once, [] {
-    cuda_hooks = CUDAHooksRegistry()->Create("CUDAHooks", CUDAHooksArgs{}).release();
+    cuda_hooks =
+        CUDAHooksRegistry()->Create("CUDAHooks", CUDAHooksArgs{}).release();
     if (!cuda_hooks) {
       cuda_hooks = new CUDAHooksInterface();
     }

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -62,7 +62,7 @@ constexpr const char* CUDA_HELP =
 struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
   // This should never actually be implemented, but it is used to
   // squelch -Werror=non-virtual-dtor
-  virtual ~CUDAHooksInterface() override = default;
+  ~CUDAHooksInterface() override = default;
 
   // Initialize THCState and, transitively, the CUDA state
   virtual void initCUDA() const {
@@ -113,7 +113,7 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
     TORCH_CHECK(false, "NVRTC requires CUDA. ", CUDA_HELP);
   }
 
-  virtual bool hasPrimaryContext(DeviceIndex device_index) const override {
+  bool hasPrimaryContext(DeviceIndex device_index) const override {
     TORCH_CHECK(false, "Cannot call hasPrimaryContext(", device_index, ") without ATen_cuda library. ", CUDA_HELP);
   }
 

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -18,7 +18,7 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
   #define FAIL_MPSHOOKS_FUNC(func) \
     TORCH_CHECK(false, "Cannot execute ", func, "() without MPS backend.");
 
-  virtual ~MPSHooksInterface() override = default;
+  ~MPSHooksInterface() override = default;
 
   // Initialize the MPS library state
   virtual void initMPS() const {
@@ -87,7 +87,7 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
   virtual double elapsedTimeOfEvents(uint32_t start_event_id, uint32_t end_event_id) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual bool hasPrimaryContext(DeviceIndex device_index) const override {
+  bool hasPrimaryContext(DeviceIndex device_index) const override {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
   #undef FAIL_MPSHOOKS_FUNC

--- a/aten/src/ATen/detail/MTIAHooksInterface.h
+++ b/aten/src/ATen/detail/MTIAHooksInterface.h
@@ -27,7 +27,7 @@ struct TORCH_API MTIAHooksInterface : AcceleratorHooksInterface {
 #define FAIL_MTIAHOOKS_FUNC(func) \
   TORCH_CHECK(false, "Cannot execute ", func, "() without MTIA backend.");
 
-  virtual ~MTIAHooksInterface() override = default;
+  ~MTIAHooksInterface() override = default;
 
   virtual void initMTIA() const {
     // Avoid logging here, since MTIA needs init devices first then it will know
@@ -52,7 +52,7 @@ struct TORCH_API MTIAHooksInterface : AcceleratorHooksInterface {
     FAIL_MTIAHOOKS_FUNC(__func__);
   }
 
-  virtual bool hasPrimaryContext(DeviceIndex device_index) const override {
+  bool hasPrimaryContext(DeviceIndex device_index) const override {
     return false;
   }
 

--- a/aten/src/ATen/detail/MetaGuardImpl.cpp
+++ b/aten/src/ATen/detail/MetaGuardImpl.cpp
@@ -1,9 +1,8 @@
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/macros/Macros.h>
 
-namespace at {
-namespace detail {
+namespace at::detail {
 
 C10_REGISTER_GUARD_IMPL(Meta, c10::impl::NoOpDeviceGuardImpl<DeviceType::Meta>);
 
-}} // namespace at::detail
+} // namespace at::detail

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -9,7 +9,7 @@
 namespace at {
 
 struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
-  virtual ~PrivateUse1HooksInterface() override = default;
+  ~PrivateUse1HooksInterface() override = default;
   virtual const at::Generator& getDefaultGenerator(
       c10::DeviceIndex device_index) {
     TORCH_CHECK_NOT_IMPLEMENTED(
@@ -29,7 +29,7 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
         "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `getPinnedMemoryAllocator`.");
   }
 
-  virtual bool hasPrimaryContext(DeviceIndex device_index) const override {
+  bool hasPrimaryContext(DeviceIndex device_index) const override {
     TORCH_CHECK_NOT_IMPLEMENTED(
         false,
         "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `hasPrimaryContext`.");

--- a/aten/src/ATen/detail/XPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/XPUHooksInterface.cpp
@@ -7,7 +7,6 @@
 namespace at {
 namespace detail {
 
-
 const XPUHooksInterface& getXPUHooks() {
   static XPUHooksInterface* xpu_hooks = nullptr;
   static c10::once_flag once;

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -19,7 +19,7 @@ constexpr const char* XPU_HELP =
     "be loaded, EVEN IF you don't directly use any symbols from that!";
 
 struct TORCH_API XPUHooksInterface {
-  virtual ~XPUHooksInterface() {}
+  virtual ~XPUHooksInterface() = default;
 
   virtual void initXPU() const {
     TORCH_CHECK(


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
