### PR TITLE
print default value in FunctionSignature

### DIFF
--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1207,6 +1207,7 @@ void FunctionParameter::set_default_str(const std::string& str) {
   } else {
     throw std::runtime_error("unknown parameter type");
   }
+  default_value = str;
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
@@ -1280,7 +1281,6 @@ FunctionSignature::FunctionSignature(const std::string& fmt, int index)
 }
 
 std::string FunctionSignature::toString() const {
-  // TODO: consider printing more proper schema strings with defaults,
   // optionals, etc.
   std::ostringstream ss;
   bool keyword_already = false;
@@ -1295,6 +1295,9 @@ std::string FunctionSignature::toString() const {
       keyword_already = true;
     }
     ss << param.type_name() << " " << param.name;
+    if (param.optional) {
+      ss << " = " << param.default_value;
+    }
     i++;
   }
   ss << ")";

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -347,6 +347,7 @@ struct FunctionParameter {
     at::ScalarType default_scalartype;
     at::Layout default_layout;
   };
+  std::string default_value;
 };
 
 template <int N>


### PR DESCRIPTION
Fixes #[126758](https://github.com/pytorch/pytorch/issues/126758) and #[126759](https://github.com/pytorch/pytorch/issues/126759)

The output information in the issue is not accurate because `FunctionSignature::toString()` print the schema strings without default. 
https://github.com/pytorch/pytorch/blob/cb6ef68caa22c1a2f7a4e8583c0e7c923c8bfd17/torch/csrc/utils/python_arg_parser.cpp#L1282-L1283
This pr, by adding a `default_value` to save the default str ,which shoule be priented. Of course, can also add an new api to reverse `default_bool/default_int` to string, which is slightly more complicated.
result:
![image](https://github.com/pytorch/pytorch/assets/37650440/f58a4cbf-b0f4-4c81-9106-59f0d35c54ea)
