### PR TITLE
[User-Written Triton] Handle the `scf.for` and `scf.while` case

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -1925,6 +1925,126 @@ class MutationTests(torch._inductor.test_case.TestCase):
             ["O_ptr"],
         )
 
+    @make_mutation_test
+    def test_for_loop_arg_2():
+        @triton.jit
+        def fwd_kernel(
+            x_ptr,
+            o_ptr,
+            M,
+            N,
+            stride_m,
+            stride_n,
+            BLOCK_B: tl.constexpr,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            # Get program ids
+            pid_m = tl.program_id(0)
+            X_block_ptr = tl.make_block_ptr(
+                base=x_ptr,
+                shape=(M, N),
+                strides=(stride_m, stride_n),
+                offsets=(0, 0),
+                block_shape=(BLOCK_M, BLOCK_N),
+                order=(1, 0),
+            )
+            O_block_ptr = tl.make_block_ptr(
+                base=o_ptr,
+                shape=(M, N),
+                strides=(stride_m, stride_n),
+                offsets=(0, 0),
+                block_shape=(BLOCK_M, BLOCK_N),
+                order=(1, 0),
+            )
+
+            for _ in range(BLOCK_B):
+                x = tl.load(X_block_ptr)
+                tl.store(O_block_ptr, x)
+
+                X_block_ptr = tl.advance(X_block_ptr, (BLOCK_M, 0))
+                O_block_ptr = tl.advance(O_block_ptr, (BLOCK_M, 0))
+
+        t = torch.randn((32, 64, 128))
+        o = torch.empty_like(t)
+        B, M, N = t.shape
+        return (
+            fwd_kernel,
+            {
+                "x_ptr": t,
+                "o_ptr": o,
+                "M": M,
+                "N": N,
+                "stride_m": N,
+                "stride_n": 1,
+                "BLOCK_B": B,
+                "BLOCK_M": M,
+                "BLOCK_N": N,
+            },
+            ["o_ptr"],
+        )
+
+    @make_mutation_test
+    def test_while_loop():
+        @triton.jit
+        def fwd_kernel(
+            x_ptr,
+            o_ptr,
+            M,
+            N,
+            stride_m,
+            stride_n,
+            BLOCK_B: tl.constexpr,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            # Get program ids
+            pid_m = tl.program_id(0)
+            X_block_ptr = tl.make_block_ptr(
+                base=x_ptr,
+                shape=(M, N),
+                strides=(stride_m, stride_n),
+                offsets=(0, 0),
+                block_shape=(BLOCK_M, BLOCK_N),
+                order=(1, 0),
+            )
+            O_block_ptr = tl.make_block_ptr(
+                base=o_ptr,
+                shape=(M, N),
+                strides=(stride_m, stride_n),
+                offsets=(0, 0),
+                block_shape=(BLOCK_M, BLOCK_N),
+                order=(1, 0),
+            )
+
+            i = 0
+            while i < BLOCK_B:
+                x = tl.load(X_block_ptr)
+                tl.store(O_block_ptr, x)
+
+                X_block_ptr = tl.advance(X_block_ptr, (BLOCK_M, 0))
+                O_block_ptr = tl.advance(O_block_ptr, (BLOCK_M, 0))
+                i += 1
+
+        t = torch.randn((32, 64, 128))
+        o = torch.empty_like(t)
+        B, M, N = t.shape
+        return (
+            fwd_kernel,
+            {
+                "x_ptr": t,
+                "o_ptr": o,
+                "M": M,
+                "N": N,
+                "stride_m": N,
+                "stride_n": 1,
+                "BLOCK_B": B,
+                "BLOCK_M": M,
+                "BLOCK_N": N,
+            },
+            ["o_ptr"],
+        )
+
 
 if HAS_CUDA:
     t = torch.randn(4)

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -288,7 +288,27 @@ def ttir_to_functions(ttir_module) -> Dict[str, Dict[Intermediate, List[Op]]]:
                 # child block to return the block result
                 return_ops = []
                 for block_id in child_block_ids:
-                    if name.startswith("scf."):
+                    if name == "scf.for":
+                        # example:
+                        # %result = scf.for %iv = %lb to %ub step %step iter_args(%arg = %init) -> (i32) ...
+                        # block args: 2 (%iv, %arg)
+                        # op operands: 4 (%lb, %ub, %step, %init)
+                        # `%arg` is mapping to `%init`
+                        for i, idx in enumerate(block_id_to_block_arg_ids[block_id]):
+                            if i == 0:
+                                next_fake_intermediate -= 1
+                                replacements[idx] = Intermediate(next_fake_intermediate)
+                            else:
+                                replacements[idx] = Intermediate(operand_ids[i + 2])
+                    elif name == "scf.while":
+                        # example:
+                        # %3:3 = scf.while (%arg2 = %1, %arg3 = %2, %arg4 = %c0_i32_8) ...
+                        # block args: 3 (%arg2, %arg3, %arg4)
+                        # op operands: 3 (%1, %2, %c0_i32_8)
+                        # `%arg2` is mapping to `%1`, `%arg3` is mapping to `%2`, ...
+                        for i, idx in enumerate(block_id_to_block_arg_ids[block_id]):
+                            replacements[idx] = Intermediate(operand_ids[i])
+                    elif name == "scf.if":
                         # the scf block args are ignored by the pass. but, as they
                         # may be used as operands of the ops inside the block
                         # (and nested blocks inlined in the current block by now),


### PR DESCRIPTION
Summary:
This is the official fix of the issue, reported in https://fb.workplace.com/groups/1075192433118967/permalink/1427865377851669/

The root-cause is the MLIR mutation analyze doesn't find the mutated tensors, which made AOT autograd think there is no users of the Triton kernel and then removed it 😔

---

Triton IR: P1369315213
Wrong Analyze Graph: P1364305956
Right Analyze Graph: P1369324977

Test Plan:
buck2 run mode/opt scripts/liptds/domain_kernels:triton_dcpp_flash

unit tests

Differential Revision: D57606053




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang