### PR TITLE
Corrected parameter passed to sysconf

### DIFF
--- a/caffe2/utils/bench_utils.cc
+++ b/caffe2/utils/bench_utils.cc
@@ -97,7 +97,7 @@ uint32_t wipe_cache() {
       if (wipe_size <= 0) {
         wipe_size = sysconf(_SC_LEVEL2_CACHE_SIZE);
         if(wipe_size <= 0) {
-          wipe_size = sysconf(_SC_LEVEL1D_CACHE_SIZE);
+          wipe_size = sysconf(_SC_LEVEL1_DCACHE_SIZE);
         }
       }
     }


### PR DESCRIPTION
The parameter passed should have been `_SC_LEVEL1_DCACHE_SIZE` instead of `_SC_LEVEL1D_CACHE_SIZE`.

Fixes #127078
