### PR TITLE
Remove torch._constrain_as_value

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2044,14 +2044,6 @@ def get_device_module(device: Optional[Union[torch.device, str]] = None):
     return device_module
 
 
-def _constrain_as_value(symbol, min: Optional[builtins.int] = None, max: Optional[builtins.int] = None):
-    """
-    Add min/max constraint on the intermediate symbol at tracing time. If called in eager mode,
-    it will still check if the input value is within the specified range.
-    """
-    torch.sym_constrain_range(symbol, min=min, max=max)
-
-
 def _constrain_as_size(symbol, min: Optional[builtins.int] = None, max: Optional[builtins.int] = None):
     """
     This indicates that a given int is size-like, and can be used in any context where a size is expected.
@@ -2059,8 +2051,7 @@ def _constrain_as_size(symbol, min: Optional[builtins.int] = None, max: Optional
     which then need to be used as tensor constructors. Providing these assertions to PyTorch can help resolve
       GuardOnDataDependentSymNode errors upon export, since we cannot guard on unbacked SymInts.
 
-    This function has unusual semantics which distinguish it from
-    _constrain_as_value.  Specifically, in some circumstances in framework
+    This function has unusual semantics in some circumstances in framework
     code, we will treat this int as >= 2 (when we do a size-oblivious guard).
     This makes it easier to use the unbacked int in size contexts,
     as we will often attempt to guard on a size being zero/one

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -283,7 +283,6 @@ manual_torch_name_rule_map = {
     "torch._functorch.deprecated.vjp": UserFunctionVariable,
     #
     "torch._constrain_as_size": UserFunctionVariable,
-    "torch._constrain_as_value": UserFunctionVariable,
     "torch._tensor._convert": UserFunctionVariable,
     "torch.jit._unwrap_optional": UserFunctionVariable,
     "torch.backends.mha.get_fastpath_enabled": UserFunctionVariable,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1942,7 +1942,6 @@ def wrap_fx_proxy_cls(
         getattr(torch.distributed, "get_world_size", _missing),
         # This always wants to be in the graph, even if the constraint
         # results in a constant int
-        torch._constrain_as_value,
         torch._constrain_as_size,
     ]:
         set_example_value(proxy.node, example_value)

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -304,23 +304,13 @@ def insert_deferred_runtime_asserts(
                         except TypeError:
                             return None
 
-                    if export:
-                        graph.call_function(
-                            torch.ops.aten.sym_constrain_range.default,
-                            (symbol_to_proxy[i0].node,),
-                            {
-                                "min": convert(vr.lower),
-                                "max": convert(vr.upper),
-                            },
-                        )
-                    else:
-                        graph.call_function(
-                            torch._constrain_as_value,
-                            (
-                                symbol_to_proxy[i0].node,
-                                convert(vr.lower),
-                                convert(vr.upper),
-                            ),
-                        )
+                    graph.call_function(
+                        torch.ops.aten.sym_constrain_range.default,
+                        (symbol_to_proxy[i0].node,),
+                        {
+                            "min": convert(vr.lower),
+                            "max": convert(vr.upper),
+                        },
+                    )
 
                 add_runtime_asserts(ras)


### PR DESCRIPTION
Summary: This API doesn't do anything useful and should be subsumed by torch._check.

Test Plan: CI

Differential Revision: D57786740




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang