### PR TITLE
[Easy] fix typo for `usort` config in `pyproject.toml`: `kown` -> `known`

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -5,11 +5,11 @@ import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List, Literal, Set
+from typing_extensions import TypedDict  # Python 3.11+
 
 import generate_binary_build_matrix  # type: ignore[import]
 
 import jinja2
-from typing_extensions import TypedDict  # Python 3.11+
 
 Arch = Literal["windows", "linux", "macos"]
 

--- a/android/test_app/make_assets.py
+++ b/android/test_app/make_assets.py
@@ -1,5 +1,6 @@
-import torch
 from torchvision import models
+
+import torch
 
 print(torch.version.__version__)
 

--- a/android/test_app/make_assets_custom.py
+++ b/android/test_app/make_assets_custom.py
@@ -4,9 +4,10 @@ MobileNetV2 TorchScript model, and dumps root ops used by the model for custom
 build script to create a tailored build which only contains these used ops.
 """
 
-import torch
 import yaml
 from torchvision import models
+
+import torch
 
 # Download and trace the model.
 model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)

--- a/benchmarks/distributed/ddp/benchmark.py
+++ b/benchmarks/distributed/ddp/benchmark.py
@@ -18,11 +18,12 @@ import sys
 import time
 
 import numpy as np
+import torchvision
+
 import torch
 import torch.distributed as dist
 import torch.nn as nn
 import torch.optim as optim
-import torchvision
 
 
 def allgather_object(obj):

--- a/benchmarks/distributed/pipeline/pipe.py
+++ b/benchmarks/distributed/pipeline/pipe.py
@@ -3,10 +3,10 @@ import math
 import os
 import time
 
+from benchmark_dataset import BenchmarkLMDataset, collate_sentences_lm
+
 import torch
 import torch.nn as nn
-
-from benchmark_dataset import BenchmarkLMDataset, collate_sentences_lm
 from torch.distributed import rpc
 
 from torch.distributed.pipeline.sync import Pipe

--- a/benchmarks/distributed/rpc/parameter_server/launcher.py
+++ b/benchmarks/distributed/rpc/parameter_server/launcher.py
@@ -3,18 +3,10 @@ import json
 import os
 from pathlib import Path
 
-import torch
-import torch.distributed as c10d
-import torch.distributed.rpc as rpc
-import torch.multiprocessing as mp
-
 from data import data_map
 from metrics.ProcessedMetricsPrinter import ProcessedMetricsPrinter
 from models import model_map
 from server import server_map
-from torch.distributed.rpc import TensorPipeRpcBackendOptions
-from torch.futures import wait_all
-from torch.utils.data import DataLoader
 from trainer import (
     criterion_map,
     ddp_hook_map,
@@ -24,6 +16,14 @@ from trainer import (
     preprocess_data_map,
     trainer_map,
 )
+
+import torch
+import torch.distributed as c10d
+import torch.distributed.rpc as rpc
+import torch.multiprocessing as mp
+from torch.distributed.rpc import TensorPipeRpcBackendOptions
+from torch.futures import wait_all
+from torch.utils.data import DataLoader
 
 
 def get_name(rank, args):

--- a/benchmarks/distributed/rpc/parameter_server/server/server.py
+++ b/benchmarks/distributed/rpc/parameter_server/server/server.py
@@ -3,11 +3,11 @@ import threading
 import time
 from abc import ABC, abstractmethod
 
-import torch
-import torch.distributed.rpc as rpc
-
 from metrics.MetricsLogger import MetricsLogger
 from utils import sparse_rpc_format_to_tensor, sparse_tensor_to_rpc_format
+
+import torch
+import torch.distributed.rpc as rpc
 
 
 class ParameterServerBase(ABC):

--- a/benchmarks/distributed/rpc/parameter_server/trainer/hooks.py
+++ b/benchmarks/distributed/rpc/parameter_server/trainer/hooks.py
@@ -1,6 +1,7 @@
+from utils import process_bucket_with_remote_server
+
 import torch
 import torch.distributed as c10d
-from utils import process_bucket_with_remote_server
 
 
 def allreduce_hook(state, bucket):

--- a/benchmarks/distributed/rpc/parameter_server/trainer/trainer.py
+++ b/benchmarks/distributed/rpc/parameter_server/trainer/trainer.py
@@ -2,9 +2,9 @@ import functools
 import time
 from abc import ABC, abstractmethod
 
-import torch
-
 from metrics.MetricsLogger import MetricsLogger
+
+import torch
 
 
 class TrainerBase(ABC):

--- a/benchmarks/distributed/rpc/rl/coordinator.py
+++ b/benchmarks/distributed/rpc/rl/coordinator.py
@@ -2,11 +2,11 @@ import time
 
 import numpy as np
 
-import torch
-import torch.distributed.rpc as rpc
-
 from agent import AgentBase
 from observer import ObserverBase
+
+import torch
+import torch.distributed.rpc as rpc
 
 COORDINATOR_NAME = "coordinator"
 AGENT_NAME = "agent"

--- a/benchmarks/distributed/rpc/rl/launcher.py
+++ b/benchmarks/distributed/rpc/rl/launcher.py
@@ -4,10 +4,10 @@ import json
 import os
 import time
 
+from coordinator import CoordinatorBase
+
 import torch.distributed.rpc as rpc
 import torch.multiprocessing as mp
-
-from coordinator import CoordinatorBase
 
 COORDINATOR_NAME = "coordinator"
 AGENT_NAME = "agent"

--- a/benchmarks/distributed/rpc/rl/observer.py
+++ b/benchmarks/distributed/rpc/rl/observer.py
@@ -1,10 +1,10 @@
 import random
 import time
 
+from agent import AgentBase
+
 import torch
 import torch.distributed.rpc as rpc
-
-from agent import AgentBase
 from torch.distributed.rpc import rpc_sync
 
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -36,12 +36,9 @@ from typing import (
     Type,
     TYPE_CHECKING,
 )
-from unittest.mock import MagicMock
 
 from typing_extensions import Self
-
-if TYPE_CHECKING:
-    from torch.onnx._internal.fx import diagnostics
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -61,6 +58,8 @@ from torch._dynamo.testing import (
     reset_rng_state,
     same,
 )
+
+from tqdm.auto import tqdm, trange
 
 try:
     from torch._dynamo.utils import (
@@ -83,7 +82,6 @@ from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.utils import _pytree as pytree
 from torch.utils._pytree import tree_map, tree_map_only
 
-from tqdm.auto import tqdm, trange
 
 try:
     import torch_xla
@@ -94,6 +92,11 @@ try:
 except ImportError:
     # ignore the error if torch_xla is not installed
     pass
+
+
+if TYPE_CHECKING:
+    from torch.onnx._internal.fx import diagnostics
+
 
 log = logging.getLogger(__name__)
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -36,20 +36,21 @@ from typing import (
     Type,
     TYPE_CHECKING,
 )
-
 from typing_extensions import Self
 from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
 import psutil
+from scipy.stats import gmean, ttest_ind
+from tqdm.auto import tqdm, trange
+
 import torch
 import torch._dynamo
 import torch._dynamo.utils
 import torch._export
 import torch.distributed
 import torch.multiprocessing as mp
-from scipy.stats import gmean, ttest_ind
 from torch._C import _has_cuda as HAS_CUDA, _has_xpu as HAS_XPU
 from torch._dynamo.profiler import fx_insert_profiling, Profiler
 from torch._dynamo.testing import (
@@ -58,8 +59,6 @@ from torch._dynamo.testing import (
     reset_rng_state,
     same,
 )
-
-from tqdm.auto import tqdm, trange
 
 try:
     from torch._dynamo.utils import (
@@ -74,14 +73,13 @@ except ImportError:
         graph_break_reasons,
         maybe_enable_compiled_autograd,
     )
+
 import torch._functorch.config
 from torch._functorch.aot_autograd import set_model_name
 from torch._inductor import config as inductor_config, metrics
 from torch._subclasses.fake_tensor import FakeTensorMode
-
 from torch.utils import _pytree as pytree
 from torch.utils._pytree import tree_map, tree_map_only
-
 
 try:
     import torch_xla
@@ -2343,16 +2341,16 @@ class BenchmarkRunner:
 
     def get_fsdp_auto_wrap_policy(self, model_name: str):
         from diffusers.models.transformer_2d import Transformer2DModel
-
-        from torch.distributed.fsdp.wrap import (
-            ModuleWrapPolicy,
-            size_based_auto_wrap_policy,
-        )
         from torchbenchmark.models.nanogpt.model import Block
         from transformers.models.llama.modeling_llama import LlamaDecoderLayer
 
         from transformers.models.t5.modeling_t5 import T5Block
         from transformers.models.whisper.modeling_whisper import WhisperEncoderLayer
+
+        from torch.distributed.fsdp.wrap import (
+            ModuleWrapPolicy,
+            size_based_auto_wrap_policy,
+        )
 
         # handcrafted wrap policy
         MODEL_FSDP_WRAP = {

--- a/benchmarks/dynamo/huggingface.py
+++ b/benchmarks/dynamo/huggingface.py
@@ -7,8 +7,9 @@ import subprocess
 import sys
 import warnings
 
-import torch
 from common import BenchmarkRunner, download_retry_decorator, main, reset_rng_state
+
+import torch
 
 from torch._dynamo.testing import collect_results
 from torch._dynamo.utils import clone_inputs

--- a/benchmarks/dynamo/microbenchmarks/bench_mm_fusion.py
+++ b/benchmarks/dynamo/microbenchmarks/bench_mm_fusion.py
@@ -1,10 +1,11 @@
 # flake8: noqa
+import triton
+from prettytable import PrettyTable
+
 import torch
 
 import torch._dynamo
 import torch._inductor.config
-import triton
-from prettytable import PrettyTable
 
 # torch._inductor.config.debug = True
 torch._inductor.config.triton.dense_indexing = True

--- a/benchmarks/dynamo/microbenchmarks/inductor_bmm.py
+++ b/benchmarks/dynamo/microbenchmarks/inductor_bmm.py
@@ -1,9 +1,10 @@
+from benchmark_helper import time_with_torch_timer
+
 import torch
 
 import torch._dynamo
 import torch._dynamo.config
 import torch._inductor.config as config
-from benchmark_helper import time_with_torch_timer
 
 
 @torch._dynamo.optimize("inductor", nopython=True)

--- a/benchmarks/dynamo/microbenchmarks/inductor_cpu_atomic.py
+++ b/benchmarks/dynamo/microbenchmarks/inductor_cpu_atomic.py
@@ -1,8 +1,9 @@
 import itertools
 
+from benchmark_helper import time_with_torch_timer
+
 import torch
 import torch._dynamo
-from benchmark_helper import time_with_torch_timer
 
 
 @torch._dynamo.optimize("inductor", nopython=True)

--- a/benchmarks/dynamo/microbenchmarks/inductor_mm.py
+++ b/benchmarks/dynamo/microbenchmarks/inductor_mm.py
@@ -1,10 +1,11 @@
+import triton
+from benchmark_helper import time_with_torch_timer
+
 import torch
 
 import torch._dynamo
 import torch._dynamo.config
 import torch._inductor.config as config
-import triton
-from benchmark_helper import time_with_torch_timer
 
 # The flag below controls whether to allow TF32 on matmul. This flag defaults to True.
 torch.backends.cuda.matmul.allow_tf32 = True

--- a/benchmarks/dynamo/microbenchmarks/matmul_relu.py
+++ b/benchmarks/dynamo/microbenchmarks/matmul_relu.py
@@ -1,8 +1,9 @@
+from benchmark_helper import time_with_torch_timer
+
 import torch
 
 import torch._dynamo
 import torch._inductor.config as inductor_config
-from benchmark_helper import time_with_torch_timer
 
 inductor_config.triton.mm = "triton"
 

--- a/benchmarks/dynamo/microbenchmarks/microbench.py
+++ b/benchmarks/dynamo/microbenchmarks/microbench.py
@@ -5,6 +5,7 @@ import sys
 
 import numpy as np
 import tabulate
+
 import torch
 
 import torch._inductor

--- a/benchmarks/dynamo/microbenchmarks/operatorbench.py
+++ b/benchmarks/dynamo/microbenchmarks/operatorbench.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import click
 import numpy as np
-import torch
 from operator_inp_utils import OperatorInputsLoader
+
+import torch
 
 from torch._dynamo.backends.cudagraphs import cudagraphs_inner
 from torch._dynamo.testing import same

--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -47,12 +47,13 @@ import matplotlib.pyplot as plt
 
 import numpy as np
 import pandas as pd
-import torch
-
-import torch._dynamo
 from matplotlib import rcParams
 from scipy.stats import gmean
 from tabulate import tabulate
+
+import torch
+
+import torch._dynamo
 
 rcParams.update({"figure.autolayout": True})
 plt.rc("axes", axisbelow=True)

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -7,8 +7,9 @@ import subprocess
 import sys
 import warnings
 
-import torch
 from common import BenchmarkRunner, download_retry_decorator, main
+
+import torch
 
 from torch._dynamo.testing import collect_results, reduce_to_scalar_loss
 from torch._dynamo.utils import clone_inputs

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -10,8 +10,9 @@ import warnings
 from collections import namedtuple
 from os.path import abspath, exists
 
-import torch
 import yaml
+
+import torch
 
 try:
     from .common import BenchmarkRunner, main

--- a/benchmarks/dynamo/training_loss.py
+++ b/benchmarks/dynamo/training_loss.py
@@ -5,12 +5,13 @@ import sys
 import time
 from datetime import timedelta
 
+from datasets import load_dataset, load_metric
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
 import torch
 
 import torch._dynamo
-from datasets import load_dataset, load_metric
 from torch.utils.data import DataLoader
-from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 torch.backends.cuda.matmul.allow_tf32 = True
 

--- a/benchmarks/fastrnns/runner.py
+++ b/benchmarks/fastrnns/runner.py
@@ -1,8 +1,9 @@
 from collections import namedtuple
 from functools import partial
 
-import torch
 import torchvision.models as cnn
+
+import torch
 
 from .factory import (
     dropoutlstm_creator,

--- a/benchmarks/fastrnns/test_bench.py
+++ b/benchmarks/fastrnns/test_bench.py
@@ -1,4 +1,5 @@
 import pytest
+
 import torch
 
 from .fuser import set_fuser

--- a/benchmarks/framework_overhead_benchmark/C2Module.py
+++ b/benchmarks/framework_overhead_benchmark/C2Module.py
@@ -1,7 +1,8 @@
 import numpy as np
-from caffe2.python import core, workspace
 
 from utils import NUM_LOOP_ITERS
+
+from caffe2.python import core, workspace
 
 workspace.GlobalInit(["caffe2"])
 

--- a/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
+++ b/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
@@ -1,5 +1,6 @@
-import torch
 from utils import NUM_LOOP_ITERS
+
+import torch
 
 
 def add_tensors_loop(x, y):

--- a/benchmarks/functional_autograd_benchmark/audio_text_models.py
+++ b/benchmarks/functional_autograd_benchmark/audio_text_models.py
@@ -1,9 +1,9 @@
-import torch
-
 import torchaudio_models as models
-from torch import nn, Tensor
 
 from utils import check_for_functorch, extract_weights, GetterReturnType, load_weights
+
+import torch
+from torch import nn, Tensor
 
 
 has_functorch = check_for_functorch()

--- a/benchmarks/functional_autograd_benchmark/ppl_models.py
+++ b/benchmarks/functional_autograd_benchmark/ppl_models.py
@@ -1,8 +1,8 @@
+from utils import GetterReturnType
+
 import torch
 import torch.distributions as dist
 from torch import Tensor
-
-from utils import GetterReturnType
 
 
 def get_simple_regression(device: torch.device) -> GetterReturnType:

--- a/benchmarks/functional_autograd_benchmark/vision_models.py
+++ b/benchmarks/functional_autograd_benchmark/vision_models.py
@@ -1,10 +1,11 @@
 from typing import cast
 
-import torch
 import torchvision_models as models
-from torch import Tensor
 
 from utils import check_for_functorch, extract_weights, GetterReturnType, load_weights
+
+import torch
+from torch import Tensor
 
 has_functorch = check_for_functorch()
 

--- a/benchmarks/fuser/run_benchmarks.py
+++ b/benchmarks/fuser/run_benchmarks.py
@@ -4,6 +4,7 @@ import sys
 import time
 
 import click
+
 import torch
 
 torch.set_num_threads(1)

--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -6,14 +6,15 @@ import os
 import time
 from typing import Optional, Tuple
 
-import torch
-import torch._inductor.config
 from mixtral_moe_model import Transformer as MixtralMoE
 from mixtral_moe_quantize import (
     WeightOnlyInt8QuantHandler as MixtralMoEWeightOnlyInt8QuantHandler,
 )
 from model import Transformer as LLaMA
 from quantize import WeightOnlyInt8QuantHandler as LLaMAWeightOnlyInt8QuantHandler
+
+import torch
+import torch._inductor.config
 
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True

--- a/benchmarks/gpt_fast/mixtral_moe_quantize.py
+++ b/benchmarks/gpt_fast/mixtral_moe_quantize.py
@@ -1,9 +1,9 @@
 # flake8: noqa: E266, C417, B950
+from mixtral_moe_model import ConditionalFeedForward
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-from mixtral_moe_model import ConditionalFeedForward
 
 ##### Quantization Primitives ######
 

--- a/benchmarks/inference/server.py
+++ b/benchmarks/inference/server.py
@@ -187,8 +187,9 @@ class BackendWorker:
     def _setup(self):
         import time
 
-        import torch
         from torchvision.models.resnet import BasicBlock, ResNet
+
+        import torch
 
         # Create ResNet18 on meta device
         with torch.device("meta"):

--- a/benchmarks/instruction_counts/core/utils.py
+++ b/benchmarks/instruction_counts/core/utils.py
@@ -4,10 +4,10 @@ import shutil
 import textwrap
 from typing import List, Optional, Tuple
 
-from torch.utils.benchmark.utils.common import _make_temp_dir
-
 from core.api import GroupedBenchmark, TimerArgs
 from core.types import Definition, FlatIntermediateDefinition, Label
+
+from torch.utils.benchmark.utils.common import _make_temp_dir
 
 
 _TEMPDIR: Optional[str] = None

--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 import benchmark_utils
 from benchmark_test_generator import _register_test
+
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 
 import benchmark_utils
 import numpy as np
+
 import torch
 
 # needs to be imported after torch

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -2,6 +2,7 @@ import json
 import time
 
 import benchmark_cpp_extension  # noqa: F401
+
 import torch
 
 

--- a/benchmarks/operator_benchmark/c2/add_test.py
+++ b/benchmarks/operator_benchmark/c2/add_test.py
@@ -1,8 +1,8 @@
 import benchmark_caffe2 as op_bench_c2
 from benchmark_caffe2 import Caffe2BenchmarkBase  # noqa: F401
-from caffe2.python import core
 
 import operator_benchmark as op_bench
+from caffe2.python import core
 
 
 """Microbenchmarks for element-wise Add operator. Supports both Caffe2/PyTorch."""

--- a/benchmarks/operator_benchmark/c2/batch_box_cox_test.py
+++ b/benchmarks/operator_benchmark/c2/batch_box_cox_test.py
@@ -1,8 +1,8 @@
 import benchmark_caffe2 as op_bench_c2
 from benchmark_caffe2 import Caffe2BenchmarkBase  # noqa: F401
-from caffe2.python import core
 
 import operator_benchmark as op_bench
+from caffe2.python import core
 
 
 """Microbenchmarks for BatchBoxCox operator."""

--- a/benchmarks/operator_benchmark/c2/batch_gather_test.py
+++ b/benchmarks/operator_benchmark/c2/batch_gather_test.py
@@ -1,9 +1,9 @@
 import benchmark_caffe2 as op_bench_c2
 import numpy
 from benchmark_caffe2 import Caffe2BenchmarkBase  # noqa: F401
-from caffe2.python import core
 
 import operator_benchmark as op_bench
+from caffe2.python import core
 
 
 """Microbenchmarks for element-wise BatchGather operator."""

--- a/benchmarks/operator_benchmark/c2/clip_ranges_test.py
+++ b/benchmarks/operator_benchmark/c2/clip_ranges_test.py
@@ -1,8 +1,8 @@
 import benchmark_caffe2 as op_bench_c2
 from benchmark_caffe2 import Caffe2BenchmarkBase  # noqa: F401
-from caffe2.python import core, dyndep
 
 import operator_benchmark as op_bench
+from caffe2.python import core, dyndep
 
 dyndep.InitOpsLibrary("@/caffe2/caffe2/fb/operators:clip_ranges_op")
 

--- a/benchmarks/operator_benchmark/c2/concat_test.py
+++ b/benchmarks/operator_benchmark/c2/concat_test.py
@@ -2,9 +2,9 @@ import random
 
 import benchmark_caffe2 as op_bench_c2
 from benchmark_caffe2 import Caffe2BenchmarkBase  # noqa: F401
-from caffe2.python import core
 
 import operator_benchmark as op_bench
+from caffe2.python import core
 
 
 """Microbenchmarks for Concat operator. Supports both Caffe2/PyTorch."""

--- a/benchmarks/operator_benchmark/c2/matmul_test.py
+++ b/benchmarks/operator_benchmark/c2/matmul_test.py
@@ -1,8 +1,8 @@
 import benchmark_caffe2 as op_bench_c2
 from benchmark_caffe2 import Caffe2BenchmarkBase  # noqa: F401
-from caffe2.python import core
 
 import operator_benchmark as op_bench
+from caffe2.python import core
 
 """Microbenchmarks for MatMul operator"""
 

--- a/benchmarks/operator_benchmark/c2/quantile_op_test.py
+++ b/benchmarks/operator_benchmark/c2/quantile_op_test.py
@@ -1,8 +1,8 @@
 import benchmark_caffe2 as op_bench_c2
 from benchmark_caffe2 import Caffe2BenchmarkBase  # noqa: F401
-from caffe2.python import core
 
 import operator_benchmark as op_bench
+from caffe2.python import core
 
 
 """Microbenchmarks for QuantileOp operator."""

--- a/benchmarks/operator_benchmark/c2/replace_nan_test.py
+++ b/benchmarks/operator_benchmark/c2/replace_nan_test.py
@@ -1,8 +1,8 @@
 import benchmark_caffe2 as op_bench_c2
 from benchmark_caffe2 import Caffe2BenchmarkBase  # noqa: F401
-from caffe2.python import core
 
 import operator_benchmark as op_bench
+from caffe2.python import core
 
 
 """Microbenchmarks for element-wise ReplaceNaN operator."""

--- a/benchmarks/operator_benchmark/common/repeat_benchmark.py
+++ b/benchmarks/operator_benchmark/common/repeat_benchmark.py
@@ -1,6 +1,7 @@
 import time
 
 import numpy as np
+
 import torch
 
 """Microbenchmarks for Tensor repeat operator. Supports PyTorch."""

--- a/benchmarks/operator_benchmark/common/tests/add_ops_list_test.py
+++ b/benchmarks/operator_benchmark/common/tests/add_ops_list_test.py
@@ -1,4 +1,5 @@
 import operator_benchmark as op_bench
+
 import torch
 
 

--- a/benchmarks/operator_benchmark/common/tests/c2_cpu_gpu_forward_backward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/c2_cpu_gpu_forward_backward_test.py
@@ -1,4 +1,5 @@
 import operator_benchmark as op_bench
+
 from caffe2.python import core
 
 

--- a/benchmarks/operator_benchmark/common/tests/jit_forward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/jit_forward_test.py
@@ -1,4 +1,5 @@
 import operator_benchmark as op_bench
+
 import torch
 
 intraop_bench_configs = op_bench.config_list(

--- a/benchmarks/operator_benchmark/common/tests/pt_backward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/pt_backward_test.py
@@ -1,4 +1,5 @@
 import operator_benchmark as op_bench
+
 import torch
 
 

--- a/benchmarks/operator_benchmark/common/tests/pt_configs_list_test.py
+++ b/benchmarks/operator_benchmark/common/tests/pt_configs_list_test.py
@@ -1,4 +1,5 @@
 import operator_benchmark as op_bench
+
 import torch
 
 """Microbenchmarks for element-wise Add operator. Supports both Caffe2/PyTorch."""

--- a/benchmarks/operator_benchmark/common/tests/pt_cpu_gpu_forward_backward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/pt_cpu_gpu_forward_backward_test.py
@@ -1,4 +1,5 @@
 import operator_benchmark as op_bench
+
 import torch
 
 

--- a/benchmarks/operator_benchmark/common/tests/random_sample_test.py
+++ b/benchmarks/operator_benchmark/common/tests/random_sample_test.py
@@ -1,4 +1,5 @@
 import operator_benchmark as op_bench
+
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt/add_test.py
+++ b/benchmarks/operator_benchmark/pt/add_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 """Microbenchmarks for add_ operator. Supports both Caffe2/PyTorch."""
 

--- a/benchmarks/operator_benchmark/pt/ao_sparsifier_test.py
+++ b/benchmarks/operator_benchmark/pt/ao_sparsifier_test.py
@@ -1,9 +1,8 @@
+import operator_benchmark as op_bench
 import torch
 from torch import nn
 
 from torch.ao import pruning
-
-import operator_benchmark as op_bench
 
 
 """Microbenchmarks for sparsifier."""

--- a/benchmarks/operator_benchmark/pt/as_strided_test.py
+++ b/benchmarks/operator_benchmark/pt/as_strided_test.py
@@ -1,8 +1,8 @@
 from typing import List
 
-import torch
-
 import operator_benchmark as op_bench
+
+import torch
 
 
 """Microbenchmarks for as_strided operator"""

--- a/benchmarks/operator_benchmark/pt/batchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/batchnorm_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.nn.functional as F
-
-import operator_benchmark as op_bench
 
 
 """Microbenchmarks for batchnorm operator."""

--- a/benchmarks/operator_benchmark/pt/binary_test.py
+++ b/benchmarks/operator_benchmark/pt/binary_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for binary operators."""

--- a/benchmarks/operator_benchmark/pt/bmm_test.py
+++ b/benchmarks/operator_benchmark/pt/bmm_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 """Microbenchmarks for add_ operator. Supports both Caffe2/PyTorch."""
 

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -1,9 +1,9 @@
 import random
 from typing import List
 
-import torch
-
 import operator_benchmark as op_bench
+
+import torch
 
 
 """Microbenchmarks for Cat operator"""

--- a/benchmarks/operator_benchmark/pt/channel_shuffle_test.py
+++ b/benchmarks/operator_benchmark/pt/channel_shuffle_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for channel_shuffle operator."""

--- a/benchmarks/operator_benchmark/pt/chunk_test.py
+++ b/benchmarks/operator_benchmark/pt/chunk_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for Chunk operator"""

--- a/benchmarks/operator_benchmark/pt/clip_ranges_test.py
+++ b/benchmarks/operator_benchmark/pt/clip_ranges_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for ClipRanges operator."""

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -1,9 +1,8 @@
-import torch
-import torch.nn as nn
-
 from pt import configs
 
 import operator_benchmark as op_bench
+import torch
+import torch.nn as nn
 
 """
 Microbenchmarks for Conv1d and ConvTranspose1d operators.

--- a/benchmarks/operator_benchmark/pt/diag_test.py
+++ b/benchmarks/operator_benchmark/pt/diag_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for diag operator"""

--- a/benchmarks/operator_benchmark/pt/embeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/embeddingbag_test.py
@@ -1,8 +1,8 @@
 import numpy
-import torch
 from pt import configs
 
 import operator_benchmark as op_bench
+import torch
 
 """Embedding and EmbeddingBag Operator Benchmark"""
 

--- a/benchmarks/operator_benchmark/pt/fill_test.py
+++ b/benchmarks/operator_benchmark/pt/fill_test.py
@@ -1,8 +1,7 @@
+import operator_benchmark as op_bench
 import torch
 
 from torch.testing._internal.common_device_type import get_all_device_types
-
-import operator_benchmark as op_bench
 
 """Microbenchmark for Fill_ operator."""
 

--- a/benchmarks/operator_benchmark/pt/gather_test.py
+++ b/benchmarks/operator_benchmark/pt/gather_test.py
@@ -1,7 +1,7 @@
 import numpy
-import torch
 
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for gather operator."""

--- a/benchmarks/operator_benchmark/pt/gelu_test.py
+++ b/benchmarks/operator_benchmark/pt/gelu_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """

--- a/benchmarks/operator_benchmark/pt/groupnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/groupnorm_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.nn.functional as F
-
-import operator_benchmark as op_bench
 
 
 """Microbenchmarks for groupnorm operator."""

--- a/benchmarks/operator_benchmark/pt/hardsigmoid_test.py
+++ b/benchmarks/operator_benchmark/pt/hardsigmoid_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
-
-import operator_benchmark as op_bench
 
 
 """

--- a/benchmarks/operator_benchmark/pt/hardswish_test.py
+++ b/benchmarks/operator_benchmark/pt/hardswish_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
-
-import operator_benchmark as op_bench
 
 
 """

--- a/benchmarks/operator_benchmark/pt/index_select_test.py
+++ b/benchmarks/operator_benchmark/pt/index_select_test.py
@@ -1,7 +1,7 @@
 import numpy
-import torch
 
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for index_select operator."""

--- a/benchmarks/operator_benchmark/pt/instancenorm_test.py
+++ b/benchmarks/operator_benchmark/pt/instancenorm_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.nn.functional as F
-
-import operator_benchmark as op_bench
 
 
 """Microbenchmarks for instancenorm operator."""

--- a/benchmarks/operator_benchmark/pt/interpolate_test.py
+++ b/benchmarks/operator_benchmark/pt/interpolate_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 """Microbenchmarks for interpolate operator."""
 

--- a/benchmarks/operator_benchmark/pt/layernorm_test.py
+++ b/benchmarks/operator_benchmark/pt/layernorm_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.nn.functional as F
-
-import operator_benchmark as op_bench
 
 
 """Microbenchmarks for layernorm operator."""

--- a/benchmarks/operator_benchmark/pt/linear_prepack_fp16_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_prepack_fp16_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 """Microbenchmarks for linear_prepack_fp16_ operator. Supports both Caffe2/PyTorch."""
 

--- a/benchmarks/operator_benchmark/pt/linear_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_test.py
@@ -1,9 +1,8 @@
-import torch
-import torch.nn as nn
-
 from pt import configs
 
 import operator_benchmark as op_bench
+import torch
+import torch.nn as nn
 
 
 """Microbenchmarks for Linear operator."""

--- a/benchmarks/operator_benchmark/pt/linear_unpack_fp16_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_unpack_fp16_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 """Microbenchmarks for linear_unpack_fp16_ operator. Supports both Caffe2/PyTorch."""
 

--- a/benchmarks/operator_benchmark/pt/matmul_test.py
+++ b/benchmarks/operator_benchmark/pt/matmul_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 """Microbenchmarks for MatMul operator"""
 

--- a/benchmarks/operator_benchmark/pt/matrix_mult_test.py
+++ b/benchmarks/operator_benchmark/pt/matrix_mult_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 """
 Microbenchmarks for batch matrix mult with einsum and torch.bmm.

--- a/benchmarks/operator_benchmark/pt/nan_to_num_test.py
+++ b/benchmarks/operator_benchmark/pt/nan_to_num_test.py
@@ -1,8 +1,8 @@
 import math
 
-import torch
-
 import operator_benchmark as op_bench
+
+import torch
 
 
 """Microbenchmarks for torch.nan_to_num / nan_to_num_ operators"""

--- a/benchmarks/operator_benchmark/pt/pool_test.py
+++ b/benchmarks/operator_benchmark/pt/pool_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
-
-import operator_benchmark as op_bench
 
 """
 Microbenchmarks for MaxPool1d and AvgPool1d operators.

--- a/benchmarks/operator_benchmark/pt/qactivation_test.py
+++ b/benchmarks/operator_benchmark/pt/qactivation_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.ao.nn.quantized.functional as qF
-
-import operator_benchmark as op_bench
 
 r"""Microbenchmarks for the quantized activations."""
 

--- a/benchmarks/operator_benchmark/pt/qarithmetic_test.py
+++ b/benchmarks/operator_benchmark/pt/qarithmetic_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 from torch._ops import ops
-
-import operator_benchmark as op_bench
 
 qarithmetic_binary_configs = op_bench.cross_product_configs(
     N=(2, 8, 64, 512),

--- a/benchmarks/operator_benchmark/pt/qatembedding_ops_test.py
+++ b/benchmarks/operator_benchmark/pt/qatembedding_ops_test.py
@@ -1,10 +1,10 @@
 import numpy
-import torch
-import torch.ao.nn.qat as nnqat
 from pt import configs
-from torch.ao.quantization import default_embedding_qat_qconfig
 
 import operator_benchmark as op_bench
+import torch
+import torch.ao.nn.qat as nnqat
+from torch.ao.quantization import default_embedding_qat_qconfig
 
 """
 Microbenchmarks for QAT Embedding + EmbeddingBag operators.

--- a/benchmarks/operator_benchmark/pt/qbatchnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qbatchnorm_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for quantized batchnorm operator."""

--- a/benchmarks/operator_benchmark/pt/qcat_test.py
+++ b/benchmarks/operator_benchmark/pt/qcat_test.py
@@ -1,9 +1,9 @@
 from typing import List
 
+import operator_benchmark as op_bench
+
 import torch
 import torch.ao.nn.quantized as nnq
-
-import operator_benchmark as op_bench
 
 
 """Microbenchmarks for quantized Cat operator"""

--- a/benchmarks/operator_benchmark/pt/qcomparators_test.py
+++ b/benchmarks/operator_benchmark/pt/qcomparators_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 qcomparators_configs = op_bench.cross_product_configs(
     N=(8, 64),

--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -1,9 +1,8 @@
-import torch
-import torch.ao.nn.quantized as nnq
-
 from pt import configs
 
 import operator_benchmark as op_bench
+import torch
+import torch.ao.nn.quantized as nnq
 
 """
 Microbenchmarks for qConv operators.

--- a/benchmarks/operator_benchmark/pt/qembedding_bag_lookups_test.py
+++ b/benchmarks/operator_benchmark/pt/qembedding_bag_lookups_test.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
 import numpy as np
+
+import operator_benchmark as op_bench
 import torch
 
 from torch.testing._internal.common_quantization import lengths_to_offsets
-
-import operator_benchmark as op_bench
 
 torch.ops.load_library("//caffe2/torch/fb/sparsenn:sparsenn_operators")
 

--- a/benchmarks/operator_benchmark/pt/qembedding_pack_test.py
+++ b/benchmarks/operator_benchmark/pt/qembedding_pack_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 embeddingbag_conversion_short_configs = op_bench.cross_product_configs(
     num_embeddings=(80,), embedding_dim=(128, 256, 512), tags=("short",)

--- a/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
+++ b/benchmarks/operator_benchmark/pt/qembeddingbag_test.py
@@ -1,9 +1,9 @@
 import numpy
-import torch
-import torch.ao.nn.quantized as nnq
 from pt import configs
 
 import operator_benchmark as op_bench
+import torch
+import torch.ao.nn.quantized as nnq
 
 """
 Microbenchmarks for qEmbeddingBag operators.

--- a/benchmarks/operator_benchmark/pt/qgroupnorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qgroupnorm_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for quantized groupnorm operator."""

--- a/benchmarks/operator_benchmark/pt/qinstancenorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qinstancenorm_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for quantized instancenorm operator."""

--- a/benchmarks/operator_benchmark/pt/qinterpolate_test.py
+++ b/benchmarks/operator_benchmark/pt/qinterpolate_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 """Microbenchmarks for the quantized interpolate op.
 

--- a/benchmarks/operator_benchmark/pt/qlayernorm_test.py
+++ b/benchmarks/operator_benchmark/pt/qlayernorm_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for quantized layernorm operator."""

--- a/benchmarks/operator_benchmark/pt/qlinear_test.py
+++ b/benchmarks/operator_benchmark/pt/qlinear_test.py
@@ -1,10 +1,9 @@
-import torch
-import torch.ao.nn.quantized as nnq
-import torch.ao.nn.quantized.dynamic as nnqd
-
 from pt import configs
 
 import operator_benchmark as op_bench
+import torch
+import torch.ao.nn.quantized as nnq
+import torch.ao.nn.quantized.dynamic as nnqd
 
 """
 Microbenchmarks for Quantized Linear operators.

--- a/benchmarks/operator_benchmark/pt/qobserver_test.py
+++ b/benchmarks/operator_benchmark/pt/qobserver_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.ao.quantization.observer as obs
-
-import operator_benchmark as op_bench
 
 qobserver_short_configs_dict = {
     "attr_names": ("C", "M", "N", "dtype", "device"),

--- a/benchmarks/operator_benchmark/pt/qpool_test.py
+++ b/benchmarks/operator_benchmark/pt/qpool_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 # 2D pooling will have input matrix of rank 3 or 4
 qpool2d_long_configs = op_bench.config_list(

--- a/benchmarks/operator_benchmark/pt/qrnn_test.py
+++ b/benchmarks/operator_benchmark/pt/qrnn_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 from torch import nn
-
-import operator_benchmark as op_bench
 
 """
 Microbenchmarks for RNNs.

--- a/benchmarks/operator_benchmark/pt/qtensor_method_test.py
+++ b/benchmarks/operator_benchmark/pt/qtensor_method_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 # Configs for pointwise and reduction unary ops
 qmethods_configs_short = op_bench.config_list(

--- a/benchmarks/operator_benchmark/pt/quantization_test.py
+++ b/benchmarks/operator_benchmark/pt/quantization_test.py
@@ -1,9 +1,8 @@
+import operator_benchmark as op_bench
 import torch
 import torch.ao.nn.quantized as nnq
 import torch.ao.quantization as tq
 import torch.nn as nn
-
-import operator_benchmark as op_bench
 
 """Microbenchmarks for general quantization operations."""
 

--- a/benchmarks/operator_benchmark/pt/qunary_test.py
+++ b/benchmarks/operator_benchmark/pt/qunary_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for quantized unary operators (point-wise and reduction)."""

--- a/benchmarks/operator_benchmark/pt/remainder_test.py
+++ b/benchmarks/operator_benchmark/pt/remainder_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for remainder operators."""

--- a/benchmarks/operator_benchmark/pt/softmax_test.py
+++ b/benchmarks/operator_benchmark/pt/softmax_test.py
@@ -1,7 +1,6 @@
+import operator_benchmark as op_bench
 import torch
 import torch.nn as nn
-
-import operator_benchmark as op_bench
 
 
 """

--- a/benchmarks/operator_benchmark/pt/split_test.py
+++ b/benchmarks/operator_benchmark/pt/split_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for Split operator"""

--- a/benchmarks/operator_benchmark/pt/stack_test.py
+++ b/benchmarks/operator_benchmark/pt/stack_test.py
@@ -1,9 +1,9 @@
 import random
 from typing import List
 
-import torch
-
 import operator_benchmark as op_bench
+
+import torch
 
 
 """Microbenchmarks for Stack operator"""

--- a/benchmarks/operator_benchmark/pt/sum_test.py
+++ b/benchmarks/operator_benchmark/pt/sum_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 """Microbenchmarks for sum reduction operator."""
 

--- a/benchmarks/operator_benchmark/pt/tensor_to_test.py
+++ b/benchmarks/operator_benchmark/pt/tensor_to_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 tensor_conversion_short_configs = op_bench.cross_product_configs(
     M=(

--- a/benchmarks/operator_benchmark/pt/unary_test.py
+++ b/benchmarks/operator_benchmark/pt/unary_test.py
@@ -1,6 +1,5 @@
-import torch
-
 import operator_benchmark as op_bench
+import torch
 
 
 """Microbenchmarks for point-wise unary operator."""

--- a/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
+++ b/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
@@ -1,6 +1,7 @@
 import unittest
 
 import benchmark_cpp_extension  # noqa: F401
+
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt_extension/setup.py
+++ b/benchmarks/operator_benchmark/pt_extension/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+
 from torch.utils.cpp_extension import BuildExtension, CppExtension
 
 setup(

--- a/benchmarks/overrides_benchmark/bench.py
+++ b/benchmarks/overrides_benchmark/bench.py
@@ -1,9 +1,9 @@
 import argparse
 import time
 
-import torch
-
 from common import SubTensor, SubWithTorchFunction, WithTorchFunction
+
+import torch
 
 NUM_REPEATS = 1000
 NUM_REPEAT_OF_REPEATS = 1000

--- a/benchmarks/overrides_benchmark/pyspybench.py
+++ b/benchmarks/overrides_benchmark/pyspybench.py
@@ -1,7 +1,8 @@
 import argparse
 
-import torch
 from common import SubTensor, SubWithTorchFunction, WithTorchFunction  # noqa: F401
+
+import torch
 
 Tensor = torch.tensor
 

--- a/benchmarks/profiler_benchmark/resnet_memory_profiler.py
+++ b/benchmarks/profiler_benchmark/resnet_memory_profiler.py
@@ -1,7 +1,8 @@
+import torchvision.models as models
+
 import torch
 
 import torch.autograd.profiler as profiler
-import torchvision.models as models
 
 for with_cuda in [False, True]:
     model = models.resnet18()

--- a/benchmarks/serialization/simple_measurement.py
+++ b/benchmarks/serialization/simple_measurement.py
@@ -1,5 +1,6 @@
-import torch
 from pyarkbench import Benchmark, default_args, Timer
+
+import torch
 
 use_new = True
 

--- a/benchmarks/sparse/benchmark_semi_structured_sparsity.py
+++ b/benchmarks/sparse/benchmark_semi_structured_sparsity.py
@@ -2,11 +2,12 @@ import argparse
 import random
 
 import pandas as pd
+from tqdm import tqdm
+
 import torch
 import torch.utils.benchmark as benchmark
 from torch import nn
 from torch.sparse import SparseSemiStructuredTensor, to_sparse_semi_structured
-from tqdm import tqdm
 
 
 torch.set_printoptions(

--- a/benchmarks/sparse/dlmc/matmul_bench.py
+++ b/benchmarks/sparse/dlmc/matmul_bench.py
@@ -9,9 +9,10 @@ import argparse
 import os
 import sys
 
+from scipy.sparse import isspmatrix
+
 import torch
 import torch.utils.benchmark as benchmark_utils
-from scipy.sparse import isspmatrix
 
 from .utils import load_dlmc_dataset
 

--- a/benchmarks/sparse/dlmc/utils.py
+++ b/benchmarks/sparse/dlmc/utils.py
@@ -1,8 +1,9 @@
 import math
 from pathlib import Path
 
-import torch
 from scipy import sparse
+
+import torch
 
 
 def to_coo_scipy(x):

--- a/benchmarks/sparse/spmm.py
+++ b/benchmarks/sparse/spmm.py
@@ -1,8 +1,9 @@
 import argparse
 import sys
 
-import torch
 from utils import Event, gen_sparse_coo, gen_sparse_coo_and_csr, gen_sparse_csr
+
+import torch
 
 
 def test_sparse_csr(m, n, k, nnz, test_count):

--- a/benchmarks/sparse/triton_ops.py
+++ b/benchmarks/sparse/triton_ops.py
@@ -125,6 +125,7 @@ if __name__ == "__main__":
     import sys
 
     import triton
+
     from torch.testing import make_tensor
 
     torch.manual_seed(0)

--- a/benchmarks/sparse/utils.py
+++ b/benchmarks/sparse/utils.py
@@ -4,6 +4,7 @@ import random
 import time
 
 import numpy as np
+
 import torch
 
 

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -4,6 +4,7 @@ import os
 import time
 
 import numpy as np
+
 import torch
 
 from . import tensor_engine

--- a/benchmarks/tensorexpr/broadcast.py
+++ b/benchmarks/tensorexpr/broadcast.py
@@ -2,6 +2,7 @@ import itertools
 import operator
 
 import numpy as np
+
 import torch
 
 from . import benchmark

--- a/benchmarks/tensorexpr/concat.py
+++ b/benchmarks/tensorexpr/concat.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import torch
 
 from . import benchmark

--- a/benchmarks/tensorexpr/elementwise.py
+++ b/benchmarks/tensorexpr/elementwise.py
@@ -3,6 +3,7 @@ import operator
 
 import numpy as np
 import scipy.special
+
 import torch
 
 from . import benchmark

--- a/benchmarks/tensorexpr/microbenchmarks.py
+++ b/benchmarks/tensorexpr/microbenchmarks.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+
 import torch
 import torch._C._te as te
 

--- a/benchmarks/transformer/attention_bias_benchmarks.py
+++ b/benchmarks/transformer/attention_bias_benchmarks.py
@@ -4,14 +4,15 @@ from functools import partial
 from typing import Callable, List, Union
 
 import numpy as np
+from tabulate import tabulate
+from tqdm import tqdm
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.benchmark as benchmark
-from tabulate import tabulate
 from torch.nn.attention.bias import CausalBias, CausalVariant
 from torch.nn.parameter import Parameter
-from tqdm import tqdm
 
 
 def benchmark_torch_function_in_microseconds(func: Callable, *args, **kwargs) -> float:

--- a/benchmarks/transformer/better_transformer_vs_mha_functional.py
+++ b/benchmarks/transformer/better_transformer_vs_mha_functional.py
@@ -20,10 +20,11 @@ from pprint import pprint
 from typing import Optional
 
 import numpy as np
-import torch
 
 from prettytable import PrettyTable
 from tqdm import tqdm
+
+import torch
 
 warnings.filterwarnings("ignore")
 

--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -6,11 +6,12 @@ from functools import partial
 from typing import Callable, List, Optional, Tuple
 
 import numpy as np
+from tabulate import tabulate
+from tqdm import tqdm
+
 import torch
 import torch.nn.functional as F
-from tabulate import tabulate
 from torch.nn.attention._flex_attention import _flex_attention
-from tqdm import tqdm
 
 torch._dynamo.config.automatic_dynamic_shapes = False
 # Needed since changing args to function causes recompiles

--- a/benchmarks/transformer/sdp.py
+++ b/benchmarks/transformer/sdp.py
@@ -9,11 +9,12 @@ from pprint import pprint
 from typing import List, Optional
 
 import numpy as np
+from prettytable import PrettyTable
+from tqdm import tqdm
+
 import torch
 import torch.utils.benchmark as benchmark
-from prettytable import PrettyTable
 from torch.backends.cuda import sdp_kernel
-from tqdm import tqdm
 
 warnings.filterwarnings("ignore")
 

--- a/benchmarks/transformer/sdpa.py
+++ b/benchmarks/transformer/sdpa.py
@@ -4,12 +4,13 @@ from contextlib import nullcontext
 from dataclasses import asdict, dataclass
 from typing import Callable, List, Tuple
 
+from tabulate import tabulate
+from tqdm import tqdm
+
 import torch
 import torch.utils.benchmark as benchmark
-from tabulate import tabulate
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.nn.functional import scaled_dot_product_attention
-from tqdm import tqdm
 
 
 def benchmark_torch_function_in_microseconds(func: Callable, *args, **kwargs) -> float:

--- a/docs/source/scripts/build_activation_images.py
+++ b/docs/source/scripts/build_activation_images.py
@@ -7,9 +7,9 @@ online tutorials.
 from pathlib import Path
 
 import matplotlib
+from matplotlib import pyplot as plt
 
 import torch
-from matplotlib import pyplot as plt
 
 matplotlib.use("Agg")
 

--- a/docs/source/scripts/build_opsets.py
+++ b/docs/source/scripts/build_opsets.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import torch
 import torch._prims as prims
+
 from torchgen.gen import parse_native_yaml
 
 ROOT = Path(__file__).absolute().parent.parent.parent.parent

--- a/functorch/benchmarks/cse.py
+++ b/functorch/benchmarks/cse.py
@@ -1,5 +1,6 @@
 import torch
 import torch.fx as fx
+
 from functorch import make_fx
 
 from torch._functorch.compile_utils import fx_graph_cse

--- a/functorch/benchmarks/operator_authoring.py
+++ b/functorch/benchmarks/operator_authoring.py
@@ -3,7 +3,9 @@ from functools import partial
 
 import numpy as np
 import pandas as pd
+
 import torch
+
 from functorch.compile import pointwise_operator
 
 WRITE_CSV = False

--- a/functorch/benchmarks/per_sample_grads.py
+++ b/functorch/benchmarks/per_sample_grads.py
@@ -1,12 +1,13 @@
 import time
 
-import torch
-import torch.nn as nn
 import torchvision.models as models
-
-from functorch import grad, make_functional, vmap
 from opacus import PrivacyEngine
 from opacus.utils.module_modification import convert_batchnorm_modules
+
+import torch
+import torch.nn as nn
+
+from functorch import grad, make_functional, vmap
 
 device = "cuda"
 batch_size = 128

--- a/functorch/dim/__init__.py
+++ b/functorch/dim/__init__.py
@@ -2,9 +2,9 @@ import dis
 import inspect
 from typing import Sequence, Union
 
-import torch
-
 import functorch._C
+
+import torch
 from functorch._C import dim as _C
 from .tree_map import tree_flatten, tree_map
 from .wrap_type import wrap_type

--- a/functorch/examples/compilation/eager_fusion.py
+++ b/functorch/examples/compilation/eager_fusion.py
@@ -2,6 +2,7 @@ import time
 
 import torch
 import torch.utils
+
 from functorch.compile import aot_function, tvm_compile
 
 a = torch.randn(2000, 1, 4, requires_grad=True)

--- a/functorch/examples/compilation/fuse_module.py
+++ b/functorch/examples/compilation/fuse_module.py
@@ -2,6 +2,7 @@ import timeit
 
 import torch
 import torch.nn as nn
+
 from functorch.compile import compiled_module, tvm_compile
 
 

--- a/functorch/examples/compilation/linear_train.py
+++ b/functorch/examples/compilation/linear_train.py
@@ -8,6 +8,7 @@ import time
 
 import torch
 import torch.nn as nn
+
 from functorch import make_functional
 from functorch.compile import nnc_jit
 

--- a/functorch/examples/compilation/simple_function.py
+++ b/functorch/examples/compilation/simple_function.py
@@ -7,6 +7,7 @@
 import time
 
 import torch
+
 from functorch import grad, make_fx
 from functorch.compile import nnc_jit
 

--- a/functorch/examples/dp_cifar10/cifar10_opacus.py
+++ b/functorch/examples/dp_cifar10/cifar10_opacus.py
@@ -12,15 +12,16 @@ import sys
 from datetime import datetime, timedelta
 
 import numpy as np
-import torch
-import torch.nn as nn
-import torch.optim as optim
-import torch.utils.data
 import torchvision.transforms as transforms
 from opacus import PrivacyEngine
 from torchvision import models
 from torchvision.datasets import CIFAR10
 from tqdm import tqdm
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torch.utils.data
 
 
 logging.basicConfig(

--- a/functorch/examples/dp_cifar10/cifar10_transforms.py
+++ b/functorch/examples/dp_cifar10/cifar10_transforms.py
@@ -12,16 +12,17 @@ import sys
 from datetime import datetime, timedelta
 
 import numpy as np
+import torchvision.transforms as transforms
+from torchvision import models
+from torchvision.datasets import CIFAR10
+from tqdm import tqdm
+
 import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.utils.data
-import torchvision.transforms as transforms
 
 from torch.func import functional_call, grad_and_value, vmap
-from torchvision import models
-from torchvision.datasets import CIFAR10
-from tqdm import tqdm
 
 logging.basicConfig(
     format="%(asctime)s:%(levelname)s:%(message)s",

--- a/functorch/examples/maml_omniglot/maml-omniglot-higher.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-higher.py
@@ -36,10 +36,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import pandas as pd
+from support.omniglot_loaders import OmniglotNShot
+
 import torch
 import torch.nn.functional as F
 import torch.optim as optim
-from support.omniglot_loaders import OmniglotNShot
 from torch import nn
 
 mpl.use("Agg")

--- a/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
@@ -35,11 +35,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import pandas as pd
+from support.omniglot_loaders import OmniglotNShot
+
 import torch
 import torch.nn.functional as F
 import torch.optim as optim
+
 from functorch import make_functional_with_buffers
-from support.omniglot_loaders import OmniglotNShot
 from torch import nn
 
 mpl.use("Agg")

--- a/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
@@ -36,10 +36,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import pandas as pd
+from support.omniglot_loaders import OmniglotNShot
+
 import torch
 import torch.nn.functional as F
 import torch.optim as optim
-from support.omniglot_loaders import OmniglotNShot
 from torch import nn
 from torch.func import functional_call, grad, vmap
 

--- a/functorch/examples/maml_omniglot/support/omniglot_loaders.py
+++ b/functorch/examples/maml_omniglot/support/omniglot_loaders.py
@@ -22,11 +22,11 @@ import os
 import os.path
 
 import numpy as np
+import torchvision.transforms as transforms
+from PIL import Image
 
 import torch
 import torch.utils.data as data
-import torchvision.transforms as transforms
-from PIL import Image
 
 
 class Omniglot(data.Dataset):

--- a/functorch/examples/maml_regression/evjang.py
+++ b/functorch/examples/maml_regression/evjang.py
@@ -7,6 +7,7 @@ import math
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+
 import torch
 from torch.nn import functional as F
 

--- a/functorch/examples/maml_regression/evjang_transforms.py
+++ b/functorch/examples/maml_regression/evjang_transforms.py
@@ -7,6 +7,7 @@ import math
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+
 import torch
 from torch.func import grad, vmap
 from torch.nn import functional as F

--- a/functorch/examples/maml_regression/evjang_transforms_module.py
+++ b/functorch/examples/maml_regression/evjang_transforms_module.py
@@ -7,7 +7,9 @@ import math
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+
 import torch
+
 from functorch import grad, make_functional, vmap
 from torch import nn
 from torch.nn import functional as F

--- a/functorch/experimental/__init__.py
+++ b/functorch/experimental/__init__.py
@@ -1,6 +1,5 @@
 # PyTorch forward-mode is not mature yet
+from functorch import functionalize
 from torch._functorch.apis import chunk_vmap
 from torch._functorch.batch_norm_replacement import replace_all_batch_norm_modules_
 from torch._functorch.eager_transforms import hessian, jacfwd, jvp
-
-from functorch import functionalize

--- a/functorch/op_analysis/gen_data.py
+++ b/functorch/op_analysis/gen_data.py
@@ -1,8 +1,9 @@
 import csv
 from collections import defaultdict
 
-import torch
 import yaml
+
+import torch
 
 
 def get_ops_for_key(key):

--- a/ios/TestApp/benchmark/coreml_backend.py
+++ b/ios/TestApp/benchmark/coreml_backend.py
@@ -1,7 +1,8 @@
+from torchvision import models
+
 import torch
 
 from torch.backends._coreml.preprocess import CompileSpec, CoreMLComputeUnit, TensorSpec
-from torchvision import models
 
 
 def mobilenetv2_spec():

--- a/ios/TestApp/benchmark/trace_model.py
+++ b/ios/TestApp/benchmark/trace_model.py
@@ -1,6 +1,7 @@
+from torchvision import models
+
 import torch
 from torch.utils.mobile_optimizer import optimize_for_mobile
-from torchvision import models
 
 model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
 model.eval()

--- a/ios/TestApp/custom_build/custom_build.py
+++ b/ios/TestApp/custom_build/custom_build.py
@@ -1,6 +1,7 @@
-import torch
 import yaml
 from torchvision import models
+
+import torch
 
 model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
 model.eval()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,11 @@ lines_after_imports = 2
 multi_line_output = 3
 include_trailing_comma = true
 
+[tool.usort.known]
+standard_library = ["typing_extensions"]
 
 [tool.usort.kown]
 first_party = ["caffe2", "torch", "torchgen", "functorch", "tests"]
-standard_library = ["typing_extensions"]
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ target-version = ["py38", "py39", "py310", "py311"]
 
 
 [tool.isort]
-src_paths = ["caffe2", "torch", "torchgen", "functorch", "tests"]
+src_paths = ["caffe2", "torch", "torchgen", "functorch", "test"]
 extra_standard_library = ["typing_extensions"]
 skip_gitignore = true
 skip_glob = ["third_party/*"]
@@ -33,11 +33,11 @@ multi_line_output = 3
 include_trailing_comma = true
 
 [tool.usort.known]
-first_party = ["caffe2"]
+first_party = ["caffe2", "torchgen", "test"]
 standard_library = ["typing_extensions"]
 
 [tool.usort.kown]
-first_party = ["torch", "torchgen", "functorch", "tests"]
+first_party = ["torch", "functorch"]
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,11 @@ multi_line_output = 3
 include_trailing_comma = true
 
 [tool.usort.known]
+first_party = ["caffe2"]
 standard_library = ["typing_extensions"]
 
 [tool.usort.kown]
-first_party = ["caffe2", "torch", "torchgen", "functorch", "tests"]
+first_party = ["torch", "torchgen", "functorch", "tests"]
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ multi_line_output = 3
 include_trailing_comma = true
 
 [tool.usort.known]
-first_party = ["caffe2", "torchgen", "test"]
+first_party = ["caffe2", "torchgen", "functorch", "test"]
 standard_library = ["typing_extensions"]
 
 [tool.usort.kown]
-first_party = ["torch", "functorch"]
+first_party = ["torch"]
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,10 @@ lines_after_imports = 2
 multi_line_output = 3
 include_trailing_comma = true
 
-[tool.usort.known]
-first_party = ["caffe2", "torchgen", "functorch", "test"]
-standard_library = ["typing_extensions"]
 
-[tool.usort.kown]
-first_party = ["torch"]
+[tool.usort.known]
+first_party = ["caffe2", "torch", "torchgen", "functorch", "test"]
+standard_library = ["typing_extensions"]
 
 
 [tool.ruff]

--- a/scripts/export/update_schema.py
+++ b/scripts/export/update_schema.py
@@ -1,8 +1,9 @@
 import argparse
 import os
 
-from torch._export.serde import schema_check
 from yaml import dump, Dumper
+
+from torch._export.serde import schema_check
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog="update_schema")

--- a/scripts/model_zoo/update-models-from-caffe2.py
+++ b/scripts/model_zoo/update-models-from-caffe2.py
@@ -11,12 +11,14 @@ import tempfile
 from urllib.request import urlretrieve
 
 import boto3
-import caffe2.python.onnx.backend
-import caffe2.python.onnx.frontend
-import caffe2.python.workspace as c2_workspace
 import numpy as np
 import onnx
 import onnx.backend
+from onnx import numpy_helper
+
+import caffe2.python.onnx.backend
+import caffe2.python.onnx.frontend
+import caffe2.python.workspace as c2_workspace
 from caffe2.proto import caffe2_pb2
 
 from caffe2.python.models.download import (
@@ -24,7 +26,6 @@ from caffe2.python.models.download import (
     downloadFromURLToFile,
     getURLFromName,
 )
-from onnx import numpy_helper
 
 
 """A script converting Caffe2 models to ONNX, and updating ONNX model zoos.

--- a/scripts/release_notes/categorize.py
+++ b/scripts/release_notes/categorize.py
@@ -4,7 +4,6 @@ import textwrap
 from pathlib import Path
 
 import common
-import torch
 
 # Imports for working with classi
 from classifier import (
@@ -17,6 +16,8 @@ from classifier import (
 )
 from commitlist import CommitList
 from common import get_commit_data_cache, topics
+
+import torch
 
 
 class Categorizer:

--- a/scripts/release_notes/classifier.py
+++ b/scripts/release_notes/classifier.py
@@ -9,11 +9,12 @@ from typing import Dict, List
 
 import common
 import pandas as pd
-import torch
-import torch.nn as nn
 import torchtext
 from torchtext.functional import to_tensor
 from tqdm import tqdm
+
+import torch
+import torch.nn as nn
 
 
 XLMR_BASE = torchtext.models.XLMR_BASE_ENCODER

--- a/test/cpp_extensions/no_python_abi_suffix_test/setup.py
+++ b/test/cpp_extensions/no_python_abi_suffix_test/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+
 from torch.utils.cpp_extension import BuildExtension, CppExtension
 
 setup(

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -1,8 +1,9 @@
 import os
 import sys
 
-import torch.cuda
 from setuptools import setup
+
+import torch.cuda
 from torch.testing._internal.common_utils import IS_WINDOWS
 from torch.utils.cpp_extension import (
     BuildExtension,

--- a/test/custom_backend/test_custom_backend.py
+++ b/test/custom_backend/test_custom_backend.py
@@ -3,9 +3,9 @@
 import os
 import tempfile
 
-import torch
-
 from backend import get_custom_backend_library_path, Model, to_custom_backend
+
+import torch
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 

--- a/test/custom_operator/my_custom_ops.py
+++ b/test/custom_operator/my_custom_ops.py
@@ -1,5 +1,6 @@
-import torch
 from model import get_custom_op_library_path
+
+import torch
 
 torch.ops.load_library(get_custom_op_library_path())
 

--- a/test/custom_operator/my_custom_ops2.py
+++ b/test/custom_operator/my_custom_ops2.py
@@ -1,5 +1,6 @@
-import torch
 from model import get_custom_op_library_path
+
+import torch
 
 torch.ops.load_library(get_custom_op_library_path())
 

--- a/test/custom_operator/pointwise.py
+++ b/test/custom_operator/pointwise.py
@@ -1,5 +1,6 @@
-import torch
 from model import get_custom_op_library_path
+
+import torch
 
 torch.ops.load_library(get_custom_op_library_path())
 

--- a/test/custom_operator/test_custom_ops.py
+++ b/test/custom_operator/test_custom_ops.py
@@ -5,10 +5,10 @@ import sys
 import tempfile
 import unittest
 
+from model import get_custom_op_library_path, Model
+
 import torch
 import torch._library.utils as utils
-
-from model import get_custom_op_library_path, Model
 from torch import ops
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 

--- a/test/distributed/_tensor/test_dtensor.py
+++ b/test/distributed/_tensor/test_dtensor.py
@@ -1,9 +1,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 
+from numpy.testing import assert_array_equal
+
 import torch
 import torch.nn.functional as F
-from numpy.testing import assert_array_equal
 from torch.distributed._functional_collectives import AsyncCollectiveTensor
 
 from torch.distributed._tensor import (

--- a/test/distributed/_tensor/test_xla_integration.py
+++ b/test/distributed/_tensor/test_xla_integration.py
@@ -7,6 +7,7 @@ from functools import wraps
 from typing import Any, Callable, Dict, Tuple
 
 import numpy as np
+
 import torch
 from torch import nn
 from torch.distributed._tensor import (

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -10,6 +10,7 @@ import sys
 import unittest
 
 import etcd
+
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import (
     EtcdRendezvous,
     EtcdRendezvousHandler,

--- a/test/distributed/pipeline/sync/skip/test_gpipe.py
+++ b/test/distributed/pipeline/sync/skip/test_gpipe.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 import torch
 from torch import nn
 

--- a/test/distributed/pipeline/sync/skip/test_leak.py
+++ b/test/distributed/pipeline/sync/skip/test_leak.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 import torch
 from torch import nn
 

--- a/test/distributed/pipeline/sync/skip/test_portal.py
+++ b/test/distributed/pipeline/sync/skip/test_portal.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 import torch
 
 from torch.distributed.pipeline.sync.dependency import fork, join

--- a/test/distributed/pipeline/sync/skip/test_stash_pop.py
+++ b/test/distributed/pipeline/sync/skip/test_stash_pop.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 import torch
 from torch import nn
 

--- a/test/distributed/pipeline/sync/skip/test_tracker.py
+++ b/test/distributed/pipeline/sync/skip/test_tracker.py
@@ -10,6 +10,7 @@ import threading
 from queue import Queue
 
 import pytest
+
 import torch
 from torch import nn
 

--- a/test/distributed/pipeline/sync/skip/test_verify_skippables.py
+++ b/test/distributed/pipeline/sync/skip/test_verify_skippables.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 from torch import nn
 
 from torch.distributed.pipeline.sync.skip import Namespace, skippable, verify_skippables

--- a/test/distributed/pipeline/sync/test_balance.py
+++ b/test/distributed/pipeline/sync/test_balance.py
@@ -9,6 +9,7 @@
 import time
 
 import pytest
+
 import torch
 from torch import nn
 

--- a/test/distributed/pipeline/sync/test_bugs.py
+++ b/test/distributed/pipeline/sync/test_bugs.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 import torch
 import torch.nn.functional as F
 from torch import nn

--- a/test/distributed/pipeline/sync/test_checkpoint.py
+++ b/test/distributed/pipeline/sync/test_checkpoint.py
@@ -9,6 +9,7 @@
 from functools import partial
 
 import pytest
+
 import torch
 import torch.cuda
 from torch import nn

--- a/test/distributed/pipeline/sync/test_copy.py
+++ b/test/distributed/pipeline/sync/test_copy.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 import torch
 
 from torch.distributed.pipeline.sync.copy import Copy, Wait

--- a/test/distributed/pipeline/sync/test_deferred_batch_norm.py
+++ b/test/distributed/pipeline/sync/test_deferred_batch_norm.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from itertools import chain
 
 import pytest
+
 import torch
 from torch import nn, optim
 

--- a/test/distributed/pipeline/sync/test_dependency.py
+++ b/test/distributed/pipeline/sync/test_dependency.py
@@ -9,6 +9,7 @@
 import weakref
 
 import pytest
+
 import torch
 
 from torch.distributed.pipeline.sync.dependency import Fork, fork, Join, join

--- a/test/distributed/pipeline/sync/test_inplace.py
+++ b/test/distributed/pipeline/sync/test_inplace.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 import torch
 from torch import nn
 

--- a/test/distributed/pipeline/sync/test_microbatch.py
+++ b/test/distributed/pipeline/sync/test_microbatch.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 import torch
 import torch.cuda
 

--- a/test/distributed/pipeline/sync/test_pipe.py
+++ b/test/distributed/pipeline/sync/test_pipe.py
@@ -12,6 +12,7 @@ from collections import OrderedDict
 from copy import deepcopy
 
 import pytest
+
 import torch
 from torch import nn, Tensor
 

--- a/test/distributed/pipeline/sync/test_stream.py
+++ b/test/distributed/pipeline/sync/test_stream.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
 import torch
 
 from torch.distributed.pipeline.sync.stream import (

--- a/test/distributed/pipeline/sync/test_worker.py
+++ b/test/distributed/pipeline/sync/test_worker.py
@@ -9,6 +9,7 @@
 import threading
 
 import pytest
+
 import torch
 
 from torch.distributed.pipeline.sync.microbatch import Batch

--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -2,9 +2,9 @@
 # Owner(s): ["oncall: distributed"]
 import copy
 
-import torch
-
 from model_registry import MLPModule
+
+import torch
 from torch.distributed.pipelining._backward import stage_backward
 from torch.testing._internal.common_utils import run_tests, TestCase
 

--- a/test/distributed/pipelining/test_pipe.py
+++ b/test/distributed/pipelining/test_pipe.py
@@ -1,8 +1,8 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
-import torch
-
 from model_registry import MLPModule
+
+import torch
 from torch.distributed.pipelining import pipe_split, pipeline
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,

--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -5,10 +5,10 @@ import os
 import sys
 import tempfile
 
+from model_registry import ModelWithKwargs, MultiMLP
+
 import torch
 import torch.distributed as dist
-
-from model_registry import ModelWithKwargs, MultiMLP
 from torch.distributed.pipelining import (
     ManualPipelineStage,
     pipeline,

--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -4,10 +4,10 @@ import os
 import sys
 import tempfile
 
+from model_registry import ExampleCode, ModelWithKwargs, MultiMLP
+
 import torch
 import torch.distributed as dist
-
-from model_registry import ExampleCode, ModelWithKwargs, MultiMLP
 from torch.distributed.pipelining import (
     ManualPipelineStage,
     pipeline,

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -20,9 +20,6 @@ if not c10d.is_available() or not c10d.is_gloo_available():
     sys.exit(0)
 
 import test_c10d_common
-import torch.distributed as dist
-import torch.nn.functional as F
-import torch.testing._internal.common_utils as common
 from test_c10d_common import (
     gpus_for_rank,
     LOOPBACK,
@@ -30,6 +27,10 @@ from test_c10d_common import (
     SparseGradientModule,
     Task,
 )
+
+import torch.distributed as dist
+import torch.nn.functional as F
+import torch.testing._internal.common_utils as common
 from torch import nn
 from torch.distributed._shard.sharded_tensor import (
     init_from_local_shards,

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -28,12 +28,13 @@ if not c10d.is_available() or not c10d.is_nccl_available():
 from typing import Dict, List
 
 import test_c10d_common
+from test_c10d_common import ConvNet, DoubleGpuNet, gpus_for_rank, ModuleForDdpCommHook
+
 import torch.distributed as dist
 import torch.distributed.algorithms.ddp_comm_hooks.default_hooks as default
 import torch.distributed.algorithms.ddp_comm_hooks.powerSGD_hook as powerSGD
 import torch.nn.functional as F
 import torch.testing._internal.common_utils as common
-from test_c10d_common import ConvNet, DoubleGpuNet, gpus_for_rank, ModuleForDdpCommHook
 from torch import nn
 from torch._C._distributed_c10d import OpType
 from torch.nn.parallel import DistributedDataParallel

--- a/test/distributed/test_c10d_spawn_gloo.py
+++ b/test/distributed/test_c10d_spawn_gloo.py
@@ -6,10 +6,11 @@ import sys
 import tempfile
 
 import test_c10d_spawn
+from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
+
 import torch
 import torch.distributed as c10d
 import torch.nn as nn
-from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU
 from torch.testing._internal.common_distributed import (
     create_device,

--- a/test/distributed/test_c10d_spawn_nccl.py
+++ b/test/distributed/test_c10d_spawn_nccl.py
@@ -3,9 +3,10 @@
 import sys
 
 import test_c10d_spawn
+from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
+
 import torch
 import torch.distributed as c10d
-from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (

--- a/test/distributed/test_c10d_spawn_ucc.py
+++ b/test/distributed/test_c10d_spawn_ucc.py
@@ -3,9 +3,10 @@
 import sys
 
 import test_c10d_spawn
+from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
+
 import torch
 import torch.distributed as c10d
-from test_c10d_spawn import _torch_dist_nn_available, TestDistributedNNFunctions
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_distributed import requires_ucc, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (

--- a/test/distributed/test_c10d_ucc.py
+++ b/test/distributed/test_c10d_ucc.py
@@ -18,15 +18,16 @@ if not c10d.is_available() or not c10d.is_ucc_available():
     sys.exit(0)
 
 import test_c10d_common
-import torch.distributed as dist
-import torch.nn.functional as F
-import torch.testing._internal.common_utils as common
 from test_c10d_common import (
     gpus_for_rank,
     ModuleForDdpCommHook,
     SparseGradientModule,
     Task,
 )
+
+import torch.distributed as dist
+import torch.nn.functional as F
+import torch.testing._internal.common_utils as common
 from torch import nn
 from torch.nn.parallel import DistributedDataParallel
 from torch.testing._internal.common_distributed import (

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -10,6 +10,7 @@ from typing import List
 from unittest.mock import patch
 
 import numpy as np
+
 import torch
 import torch._dynamo
 import torch._dynamo.logging

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -35,9 +35,10 @@ from collections import namedtuple
 from itertools import product
 from random import shuffle
 
+from packaging import version
+
 import torch
 import torch.autograd.forward_ad as fwAD
-from packaging import version
 
 from torch import inf, nan
 from torch.autograd import grad

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -11,6 +11,7 @@ import torch._dynamo.test_case
 import torch._functorch.config
 import torch.distributed as dist
 import torch.utils.checkpoint
+
 from functorch.compile import min_cut_rematerialization_partition
 from torch._dynamo.backends.common import aot_autograd
 from torch._dynamo.testing import CompileCounterWithBackend

--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -15,6 +15,7 @@ from torch.testing._internal.triton_utils import HAS_CUDA, requires_cuda
 
 if HAS_CUDA:
     import triton
+
     from torch.testing._internal.triton_utils import add_kernel
 
 

--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -3,6 +3,7 @@
 import unittest
 
 import torch
+
 from functorch import make_fx
 from torch._dynamo import debug_utils
 from torch._dynamo.debug_utils import aot_graph_input_parser

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -17,6 +17,7 @@ import torch
 import torch._dynamo
 import torch._dynamo.test_case
 import torch._dynamo.testing
+
 from functorch.experimental.control_flow import cond
 from torch._dynamo import config
 from torch._dynamo.exc import UserError

--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -8,6 +8,7 @@ import torch
 import torch._dynamo
 import torch._dynamo.test_case
 import torch._dynamo.testing
+
 from functorch.compile import nop
 from torch._dynamo import compiled_autograd
 from torch._functorch.aot_autograd import aot_module_simplified

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -25,6 +25,7 @@ import weakref
 from unittest.mock import patch
 
 import numpy as np
+
 import torch
 import torch._dynamo.testing
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, Iterator, List, Tuple
 from unittest import mock
 
 import numpy as np
+
 import torch
 
 import torch._dynamo.test_case

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -4,6 +4,7 @@ import random
 import unittest
 
 import numpy as np
+
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -15,6 +15,7 @@ from typing import Dict, List
 import torch
 import torch._dynamo as torchdynamo
 import torch.nn.functional as F
+
 from functorch.experimental.control_flow import cond, map
 from torch import Tensor
 from torch._dynamo.test_case import TestCase

--- a/test/export/test_pass_infra.py
+++ b/test/export/test_pass_infra.py
@@ -3,6 +3,7 @@ import copy
 import unittest
 
 import torch
+
 from functorch.experimental import control_flow
 from torch._dynamo.eval_frame import is_dynamo_supported
 from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -11,6 +11,7 @@ from re import escape
 from typing import List, Set
 
 import torch
+
 from functorch.experimental.control_flow import cond
 from torch._dynamo.eval_frame import is_dynamo_supported
 from torch._export.non_strict_utils import (

--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -10,6 +10,7 @@ from typing import Any, List
 
 import torch
 import torch._dynamo as torchdynamo
+
 from functorch.experimental.control_flow import cond, map
 from torch import Tensor
 from torch._export.utils import (

--- a/test/export/test_verifier.py
+++ b/test/export/test_verifier.py
@@ -2,6 +2,7 @@
 import unittest
 
 import torch
+
 from functorch.experimental import control_flow
 from torch import Tensor
 from torch._dynamo.eval_frame import is_dynamo_supported

--- a/test/functorch/attn_ft.py
+++ b/test/functorch/attn_ft.py
@@ -6,6 +6,7 @@
 import math
 
 import torch
+
 from functorch.dim import cat, dimlists, dims, softmax
 from torch import nn
 

--- a/test/functorch/common_utils.py
+++ b/test/functorch/common_utils.py
@@ -9,10 +9,12 @@ import os
 import unittest
 from collections import namedtuple
 
+from functorch_additional_op_db import additional_op_db
+
 import torch
 import torch.utils._pytree as pytree
+
 from functorch import vmap
-from functorch_additional_op_db import additional_op_db
 from torch.testing._internal.autograd_function_db import autograd_function_db
 from torch.testing._internal.common_device_type import toleranceOverride
 from torch.testing._internal.common_methods_invocations import DecorateInfo, op_db

--- a/test/functorch/discover_coverage.py
+++ b/test/functorch/discover_coverage.py
@@ -7,9 +7,10 @@ from enum import Enum
 # Importing these files make modifications to the op_db that we need
 import test_ops  # noqa: F401
 import test_vmap  # noqa: F401
+from functorch_additional_op_db import additional_op_db
+
 import torch
 import torch._functorch.top_operators_github_usage as top_ops
-from functorch_additional_op_db import additional_op_db
 from torch.testing._internal.common_device_type import toleranceOverride
 from torch.testing._internal.common_methods_invocations import op_db
 

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -15,11 +15,13 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Union
 from unittest.mock import patch
 
+from common_utils import decorate, decorateForModules, skip, skipOps, xfail
+
 import torch
 import torch._dynamo as torchdynamo
 import torch.nn as nn
 import torch.utils._pytree as pytree
-from common_utils import decorate, decorateForModules, skip, skipOps, xfail
+
 from functorch import grad, jacrev, make_fx, vjp, vmap
 from functorch.compile import (
     aot_function,

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -5,6 +5,7 @@ import unittest
 
 import torch
 import torch.utils._pytree as pytree
+
 from functorch.experimental import control_flow
 from functorch.experimental.control_flow import cond, UnsupportedAliasMutationException
 from torch._higher_order_ops.while_loop import while_loop

--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -9,10 +9,10 @@ import gc
 
 from unittest import skip, skipIf
 
-import torch
-
 from attn_ft import BertSelfAttention as BertSelfAttentionA, Linear
 from attn_positional import BertSelfAttention as BertSelfAttentionB
+
+import torch
 
 from functorch._C import dim as _C
 from functorch.dim import (

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -15,15 +15,15 @@ import unittest
 import warnings
 from functools import partial, wraps
 
-import functorch
-
 # NB: numpy is a testing dependency!
 import numpy as np
+from common_utils import expectedFailureIf
+
+import functorch
 import torch
 import torch.autograd.forward_ad as fwAD
 import torch.nn as nn
 import torch.nn.functional as F
-from common_utils import expectedFailureIf
 from functorch import (
     combine_state_for_ensemble,
     grad,

--- a/test/functorch/test_memory_efficient_fusion.py
+++ b/test/functorch/test_memory_efficient_fusion.py
@@ -8,6 +8,7 @@ from typing import Callable
 import torch
 import torch.fx as fx
 import torch.nn as nn
+
 from functorch import make_fx
 from functorch.compile import memory_efficient_fusion
 from torch._functorch.compile_utils import fx_graph_cse

--- a/test/functorch/test_minifier.py
+++ b/test/functorch/test_minifier.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: functorch"]
 
 import torch
+
 from functorch import make_fx
 from functorch.compile import minifier
 from torch._functorch.compile_utils import get_outputs, get_placeholders

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -10,8 +10,6 @@ import functools
 import itertools
 import unittest
 
-import torch
-import torch.autograd.forward_ad as fwAD
 from common_utils import (
     check_vmap_fallback,
     decorate,
@@ -29,8 +27,12 @@ from common_utils import (
     tol2,
     xfail,
 )
-from functorch import grad, jacfwd, jacrev, vjp, vmap
 from functorch_additional_op_db import additional_op_db
+
+import torch
+import torch.autograd.forward_ad as fwAD
+
+from functorch import grad, jacfwd, jacrev, vjp, vmap
 from torch import Tensor
 from torch._functorch.eager_transforms import _as_tuple, jvp
 from torch.testing._internal.autograd_function_db import autograd_function_db

--- a/test/functorch/test_parsing.py
+++ b/test/functorch/test_parsing.py
@@ -34,6 +34,7 @@ from functorch.einops._parsing import (
     ParsedExpression,
     validate_rearrange_expressions,
 )
+
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 mock_anonymous_axis_eq: Callable[[AnonymousAxis, object], bool] = (

--- a/test/functorch/test_rearrange.py
+++ b/test/functorch/test_rearrange.py
@@ -28,7 +28,9 @@ SOFTWARE.
 from typing import List, Tuple
 
 import numpy as np
+
 import torch
+
 from functorch.einops import rearrange
 from torch.testing._internal.common_utils import run_tests, TestCase
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -18,9 +18,6 @@ from collections import namedtuple
 from typing import OrderedDict
 from unittest.case import skipIf
 
-import functorch
-import torch
-import torch.nn.functional as F
 from common_utils import (
     check_vmap_fallback,
     compute_quantities_for_vmap_test,
@@ -36,9 +33,14 @@ from common_utils import (
     tol1,
     xfail,
 )
+from functorch_additional_op_db import additional_op_db
+
+import functorch
+
+import torch
+import torch.nn.functional as F
 from functorch import grad, grad_and_value, jacfwd, jvp, vjp, vmap
 from functorch.experimental import chunk_vmap
-from functorch_additional_op_db import additional_op_db
 from torch import Tensor
 from torch._C._functorch import reshape_dim_into, reshape_dim_outof
 from torch._functorch.make_functional import functional_init_with_buffers

--- a/test/fx/test_gradual_type.py
+++ b/test/fx/test_gradual_type.py
@@ -3,6 +3,7 @@
 import unittest
 
 import sympy
+
 import torch
 from torch.fx import GraphModule, symbolic_trace
 from torch.fx.annotate import annotate

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -41,6 +41,7 @@ from torch.utils import _pytree as pytree
 
 if HAS_CUDA:
     import triton
+
     from torch.testing._internal.triton_utils import (
         add_kernel,
         add_kernel_2d_autotuned,

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -44,6 +44,7 @@ HAS_TRITON = has_triton()
 
 if HAS_TRITON:
     import triton
+
     from torch.testing._internal.triton_utils import add_kernel
 
 requires_gpu = functools.partial(unittest.skipIf, not HAS_GPU, "requires gpu")

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import numpy as np
 import sympy
+
 import torch
 from torch import nn
 from torch._C import FileCheck

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 from sympy import Symbol
+
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import sympy_subs
 

--- a/test/jit/fixtures_srcs/test_upgrader_models_generation.py
+++ b/test/jit/fixtures_srcs/test_upgrader_models_generation.py
@@ -1,9 +1,9 @@
 # Owner(s): ["oncall: mobile"]
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
 
 from test.jit.fixtures_srcs.generate_models import ALL_MODULES
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestUpgraderModelGeneration(TestCase):

--- a/test/jit/fixtures_srcs/test_upgrader_models_generation.py
+++ b/test/jit/fixtures_srcs/test_upgrader_models_generation.py
@@ -1,8 +1,9 @@
 # Owner(s): ["oncall: mobile"]
 
 import torch
-from test.jit.fixtures_srcs.generate_models import ALL_MODULES
 from torch.testing._internal.common_utils import run_tests, TestCase
+
+from test.jit.fixtures_srcs.generate_models import ALL_MODULES
 
 
 class TestUpgraderModelGeneration(TestCase):

--- a/test/jit/test_dataclasses.py
+++ b/test/jit/test_dataclasses.py
@@ -7,8 +7,9 @@ from dataclasses import dataclass, field, InitVar
 from enum import Enum
 from typing import List, Optional
 
-import torch
 from hypothesis import given, settings, strategies as st
+
+import torch
 from torch.testing._internal.jit_utils import JitTestCase
 
 

--- a/test/jit/test_decorator.py
+++ b/test/jit/test_decorator.py
@@ -7,9 +7,9 @@ from enum import Enum
 from typing import List, Optional
 
 import torch
-from torch.testing._internal.jit_utils import JitTestCase
 
 from jit.myfunction_a import my_function_a
+from torch.testing._internal.jit_utils import JitTestCase
 
 
 class TestDecorator(JitTestCase):

--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -8,13 +8,13 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.testing._internal.jit_utils
+
+from jit.test_module_interface import TestModuleInterface  # noqa: F401
 from torch import jit
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import freeze_rng_state
 
 from torch.testing._internal.jit_utils import JitTestCase, make_global, RUN_CUDA_HALF
-
-from jit.test_module_interface import TestModuleInterface  # noqa: F401
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/test/jit/test_python_ir.py
+++ b/test/jit/test_python_ir.py
@@ -3,6 +3,7 @@
 import unittest
 
 import numpy as np
+
 import torch
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import IS_MACOS

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -5,13 +5,13 @@ import re
 import sys
 import types
 import typing
+import typing_extensions
 from collections import OrderedDict
 from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.jit.frontend
 import torch.nn as nn
-import typing_extensions
 from torch import Tensor
 from torch.testing import FileCheck
 

--- a/test/jit/test_save_load_for_op_version.py
+++ b/test/jit/test_save_load_for_op_version.py
@@ -7,9 +7,9 @@ from itertools import product as product
 from typing import Union
 
 import hypothesis.strategies as st
+from hypothesis import example, given, settings
 
 import torch
-from hypothesis import example, given, settings
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -9,11 +9,11 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 import torch
 import torch.testing._internal.jit_utils
+
+from jit.test_module_interface import TestModuleInterface  # noqa: F401
 from torch.testing import FileCheck
 
 from torch.testing._internal.jit_utils import JitTestCase
-
-from jit.test_module_interface import TestModuleInterface  # noqa: F401
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/test/lazy/test_ts_opinfo.py
+++ b/test/lazy/test_ts_opinfo.py
@@ -7,13 +7,14 @@ import pathlib
 from typing import Sequence
 from unittest import skip
 
+import yaml
+
 import torch
 import torch._lazy
 import torch._lazy.config
 import torch._lazy.ir_cache
 import torch._lazy.metrics
 import torch._lazy.ts_backend
-import yaml
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     ops,

--- a/test/mobile/custom_build/prepare_model.py
+++ b/test/mobile/custom_build/prepare_model.py
@@ -4,9 +4,10 @@ MobileNetV2 TorchScript model, and dumps root ops used by the model for custom
 build script to create a tailored build which only contains these used ops.
 """
 
-import torch
 import yaml
 from torchvision import models
+
+import torch
 
 # Download and trace the model.
 model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)

--- a/test/mobile/model_test/gen_test_model.py
+++ b/test/mobile/model_test/gen_test_model.py
@@ -1,7 +1,6 @@
 import io
 import sys
 
-import torch
 import yaml
 from android_api_module import AndroidAPIModule
 from builtin_ops import TSBuiltinOpsModule, TSCollectionOpsModule
@@ -44,12 +43,14 @@ from tensor_ops import (
     TensorTypingOpsModule,
     TensorViewOpsModule,
 )
-from torch.jit.mobile import _load_for_lite_interpreter
 from torchvision_models import (
     MobileNetV2Module,
     MobileNetV2VulkanModule,
     Resnet18Module,
 )
+
+import torch
+from torch.jit.mobile import _load_for_lite_interpreter
 
 test_path_ios = "ios/TestApp/models/"
 test_path_android = "android/pytorch_android/src/androidTest/assets/"

--- a/test/mobile/model_test/torchvision_models.py
+++ b/test/mobile/model_test/torchvision_models.py
@@ -1,7 +1,8 @@
+from torchvision import models
+
 import torch
 from torch.utils.bundled_inputs import augment_model_with_bundled_inputs
 from torch.utils.mobile_optimizer import optimize_for_mobile
-from torchvision import models
 
 
 class MobileNetV2Module:

--- a/test/onnx/debug_embed_params.py
+++ b/test/onnx/debug_embed_params.py
@@ -1,12 +1,12 @@
 import sys
 
-import caffe2.python.onnx.backend as c2
-
 import onnx
 import pytorch_test_common
 import torch
 import torch.jit
 from torch.autograd import Variable
+
+import caffe2.python.onnx.backend as c2
 
 torch.set_default_tensor_type("torch.FloatTensor")
 try:

--- a/test/onnx/debug_embed_params.py
+++ b/test/onnx/debug_embed_params.py
@@ -2,11 +2,11 @@ import sys
 
 import onnx
 import pytorch_test_common
+
+import caffe2.python.onnx.backend as c2
 import torch
 import torch.jit
 from torch.autograd import Variable
-
-import caffe2.python.onnx.backend as c2
 
 torch.set_default_tensor_type("torch.FloatTensor")
 try:

--- a/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
+++ b/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
@@ -10,10 +10,10 @@ import unittest
 from typing import Tuple
 
 import onnxruntime
+from parameterized import parameterized
 
 import torch
 import torch._dynamo.backends.registry
-from parameterized import parameterized
 from torch import nn
 from torch.onnx import (
     _OrtBackend as OrtBackend,

--- a/test/onnx/dynamo/test_exporter_api.py
+++ b/test/onnx/dynamo/test_exporter_api.py
@@ -3,8 +3,9 @@ import io
 import os
 
 import onnx
-import torch
 from beartype import roar
+
+import torch
 from torch.onnx import dynamo_export, ExportOptions, ONNXProgram
 from torch.onnx._internal import exporter, io_adapter
 from torch.onnx._internal.exporter import (

--- a/test/onnx/dynamo/test_registry_dispatcher.py
+++ b/test/onnx/dynamo/test_registry_dispatcher.py
@@ -6,12 +6,12 @@ import operator
 from typing import TypeVar, Union
 
 import onnxscript  # type: ignore[import]
-
-import torch
-import torch.fx
 from onnxscript import BFLOAT16, DOUBLE, FLOAT, FLOAT16  # type: ignore[import]
 from onnxscript.function_libs.torch_lib import ops  # type: ignore[import]
 from onnxscript.onnx_opset import opset15 as op  # type: ignore[import]
+
+import torch
+import torch.fx
 from torch.onnx._internal.diagnostics import infra
 from torch.onnx._internal.fx import (
     analysis,

--- a/test/onnx/error_reproduction.py
+++ b/test/onnx/error_reproduction.py
@@ -14,6 +14,7 @@ import numpy as np
 import onnx
 import onnxruntime as ort
 import onnxscript
+
 import torch
 
 _MISMATCH_MARKDOWN_TEMPLATE = """\

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -30,6 +30,7 @@ import numpy as np
 import onnxruntime
 import pytest
 import pytorch_test_common
+
 import torch
 from torch import export as torch_export
 from torch.onnx import _constants, verification

--- a/test/onnx/pytorch_helper.py
+++ b/test/onnx/pytorch_helper.py
@@ -3,6 +3,7 @@ import io
 import onnx
 
 import torch.onnx
+
 from caffe2.python.core import BlobReference, Net
 from caffe2.python.onnx.backend import Caffe2Backend
 

--- a/test/onnx/test_autograd_funs.py
+++ b/test/onnx/test_autograd_funs.py
@@ -1,9 +1,9 @@
 # Owner(s): ["module: onnx"]
 
 import pytorch_test_common
+from onnx_test_common import run_model_test
 
 import torch
-from onnx_test_common import run_model_test
 from torch.onnx import OperatorExportTypes
 from torch.onnx._globals import GLOBALS
 from torch.onnx.utils import _model_to_graph

--- a/test/onnx/test_custom_ops.py
+++ b/test/onnx/test_custom_ops.py
@@ -2,6 +2,7 @@
 
 import onnx_test_common
 import pytorch_test_common
+
 import torch
 import torch.utils.cpp_extension
 from torch.onnx import symbolic_helper

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -56,9 +56,9 @@ import onnx_test_common
 import parameterized
 import pytest
 import pytorch_test_common
+from onnx_test_common import skip, skip_slow, xfail
 
 import torch
-from onnx_test_common import skip, skip_slow, xfail
 from torch.onnx._internal.diagnostics import _rules
 from torch.testing._internal import (
     common_device_type,

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -10,8 +10,9 @@ from typing import Mapping, Tuple
 import onnx
 import onnx.inliner
 import pytorch_test_common
-import torch
 import transformers  # type: ignore[import]
+
+import torch
 from torch import nn
 from torch._subclasses import fake_tensor
 from torch.nn import functional as F

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -14,10 +14,11 @@ import onnx_test_common
 import onnxruntime  # type: ignore[import]
 import parameterized  # type: ignore[import]
 import pytorch_test_common
-import torch
-import torch.onnx
 
 import transformers  # type: ignore[import]
+
+import torch
+import torch.onnx
 from torch import nn
 
 from torch._subclasses import fake_tensor

--- a/test/onnx/test_fx_type_promotion.py
+++ b/test/onnx/test_fx_type_promotion.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: onnx"]
 
 import pytorch_test_common
+
 from torch.onnx._internal.fx.passes import type_promotion
 from torch.testing._internal import common_utils
 

--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -3,8 +3,6 @@
 import unittest
 
 import pytorch_test_common
-
-import torch
 from model_defs.dcgan import _netD, _netG, bsz, imgsz, nz, weights_init
 from model_defs.emb_seq import EmbeddingNetwork1, EmbeddingNetwork2
 from model_defs.mnist import MNIST
@@ -13,11 +11,6 @@ from model_defs.squeezenet import SqueezeNet
 from model_defs.srresnet import SRResNet
 from model_defs.super_resolution import SuperResolutionNet
 from pytorch_test_common import skipIfUnsupportedMinOpsetVersion, skipScriptTest
-from torch.ao import quantization
-from torch.autograd import Variable
-from torch.onnx import OperatorExportTypes
-from torch.testing._internal import common_utils
-from torch.testing._internal.common_utils import skipIfNoLapack
 from torchvision.models import shufflenet_v2_x1_0
 from torchvision.models.alexnet import alexnet
 from torchvision.models.densenet import densenet121
@@ -30,6 +23,13 @@ from torchvision.models.segmentation import deeplabv3_resnet101, fcn_resnet101
 from torchvision.models.vgg import vgg16, vgg16_bn, vgg19, vgg19_bn
 from torchvision.models.video import mc3_18, r2plus1d_18, r3d_18
 from verify import verify
+
+import torch
+from torch.ao import quantization
+from torch.autograd import Variable
+from torch.onnx import OperatorExportTypes
+from torch.testing._internal import common_utils
+from torch.testing._internal.common_utils import skipIfNoLapack
 
 if torch.cuda.is_available():
 

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -10,12 +10,8 @@ import parameterized
 import PIL
 import pytorch_test_common
 import test_models
-
-import torch
 import torchvision
 from pytorch_test_common import skipIfUnsupportedMinOpsetVersion, skipScriptTest
-from torch import nn
-from torch.testing._internal import common_utils
 from torchvision import ops
 from torchvision.models.detection import (
     faster_rcnn,
@@ -26,6 +22,10 @@ from torchvision.models.detection import (
     rpn,
     transform,
 )
+
+import torch
+from torch import nn
+from torch.testing._internal import common_utils
 
 
 def exportTest(

--- a/test/onnx/test_models_quantized_onnxruntime.py
+++ b/test/onnx/test_models_quantized_onnxruntime.py
@@ -6,9 +6,9 @@ import unittest
 import onnx_test_common
 import parameterized
 import PIL
+import torchvision
 
 import torch
-import torchvision
 from torch import nn
 
 

--- a/test/onnx/test_onnxscript_no_runtime.py
+++ b/test/onnx/test_onnxscript_no_runtime.py
@@ -6,8 +6,9 @@ from typing import List
 
 import onnx
 import onnxscript
-import torch
 from onnxscript.onnx_types import FLOAT
+
+import torch
 from torch.onnx._internal import jit_utils
 from torch.testing._internal import common_utils
 

--- a/test/onnx/test_onnxscript_runtime.py
+++ b/test/onnx/test_onnxscript_runtime.py
@@ -5,8 +5,9 @@ from typing import List
 
 import onnx_test_common
 import onnxscript
-import torch
 from onnxscript.onnx_types import FLOAT
+
+import torch
 from torch.onnx._internal import jit_utils
 from torch.testing._internal import common_utils
 

--- a/test/onnx/test_op_consistency.py
+++ b/test/onnx/test_op_consistency.py
@@ -30,10 +30,10 @@ from typing import Optional, Tuple
 import onnx_test_common
 import parameterized
 
-import torch
-
 # For readability, these two are allowed to be imported as function
 from onnx_test_common import skip, xfail
+
+import torch
 from torch.testing._internal import (
     common_device_type,
     common_methods_invocations,

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -18,11 +18,6 @@ import tempfile
 # Full diff for expect files
 import unittest
 
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
-import torch.onnx
-
 from pytorch_test_common import (
     BATCH_SIZE,
     flatten,
@@ -30,6 +25,11 @@ from pytorch_test_common import (
     RNN_INPUT_SIZE,
     RNN_SEQUENCE_LENGTH,
 )
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.onnx
 from torch.autograd import Function, Variable
 from torch.nn import functional, Module
 from torch.onnx._internal import diagnostics

--- a/test/onnx/test_pytorch_jit_onnx.py
+++ b/test/onnx/test_pytorch_jit_onnx.py
@@ -1,9 +1,9 @@
 # Owner(s): ["module: onnx"]
 import onnxruntime
 import pytorch_test_common
+from pytorch_test_common import skipIfNoCuda
 
 import torch
-from pytorch_test_common import skipIfNoCuda
 from torch.onnx import verification
 from torch.onnx._globals import GLOBALS
 from torch.testing._internal import common_utils

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -15,7 +15,6 @@ import numpy as np
 import onnx
 import onnx_test_common
 import parameterized
-import torch
 import torchvision
 from model_defs import (
     lstm_flattening_result,
@@ -37,6 +36,8 @@ from pytorch_test_common import (
     skipShapeChecking,
     skipTraceTest,
 )
+
+import torch
 
 from torch import Tensor
 from torch.nn.utils import rnn as rnn_utils

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -6,8 +6,6 @@ import onnx_test_common
 
 import onnxruntime  # noqa: F401
 import parameterized
-
-import torch
 from onnx_test_common import MAX_ONNX_OPSET_VERSION, MIN_ONNX_OPSET_VERSION
 from pytorch_test_common import (
     skipIfNoBFloat16Cuda,
@@ -16,6 +14,8 @@ from pytorch_test_common import (
     skipScriptTest,
 )
 from test_pytorch_onnx_onnxruntime import _parameterized_class_attrs_and_values
+
+import torch
 from torch.cuda.amp import autocast
 from torch.testing._internal import common_utils
 

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -5,8 +5,9 @@ import io
 import numpy as np
 import onnx
 import pytorch_test_common
-import torch
 from pytorch_test_common import skipIfUnsupportedMinOpsetVersion
+
+import torch
 from torch.onnx import _constants, utils
 from torch.onnx._globals import GLOBALS
 from torch.onnx._internal import jit_utils

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -10,10 +10,6 @@ from typing import Callable
 import onnx
 import parameterized
 import pytorch_test_common
-
-import torch
-import torch.onnx
-import torch.utils.cpp_extension
 import torchvision
 from autograd_helper import CustomFunction as CustomFunction2
 from pytorch_test_common import (
@@ -21,12 +17,16 @@ from pytorch_test_common import (
     skipIfUnsupportedMaxOpsetVersion,
     skipIfUnsupportedMinOpsetVersion,
 )
+from verify import verify
+
+import torch
+import torch.onnx
+import torch.utils.cpp_extension
 from torch.onnx import _constants, OperatorExportTypes, TrainingMode, utils
 from torch.onnx._globals import GLOBALS
 from torch.onnx.symbolic_helper import _unpack_list, parse_args
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import skipIfNoCaffe2, skipIfNoLapack
-from verify import verify
 
 
 def _remove_test_environment_prefix_from_scope_name(scope_name: str) -> str:

--- a/test/onnx/test_verification.py
+++ b/test/onnx/test_verification.py
@@ -9,9 +9,9 @@ import numpy as np
 import onnx
 import parameterized
 import pytorch_test_common
+from packaging import version
 
 import torch
-from packaging import version
 from torch.onnx import _constants, _experimental, verification
 from torch.testing._internal import common_utils
 

--- a/test/onnx_caffe2/export_onnx_tests_generator.py
+++ b/test/onnx_caffe2/export_onnx_tests_generator.py
@@ -5,10 +5,10 @@ import traceback
 
 import onnx
 import onnx_test_common
-
-import torch
 from onnx import numpy_helper
 from test_nn import new_module_tests
+
+import torch
 from torch.autograd import Variable
 from torch.testing._internal.common_nn import module_tests
 

--- a/test/onnx_caffe2/test_caffe2_common.py
+++ b/test/onnx_caffe2/test_caffe2_common.py
@@ -3,11 +3,11 @@
 import glob
 import os
 
-import caffe2.python.onnx.backend as c2
-
 import numpy as np
 import onnx.backend.test
 from onnx import numpy_helper
+
+import caffe2.python.onnx.backend as c2
 
 
 def load_tensor_as_numpy_array(f):

--- a/test/onnx_caffe2/test_custom_ops.py
+++ b/test/onnx_caffe2/test_custom_ops.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: onnx"]
 
-import caffe2.python.onnx.backend as c2
 import numpy as np
 import onnx
 import pytorch_test_common
@@ -8,6 +7,8 @@ import torch
 import torch.utils.cpp_extension
 from test_pytorch_onnx_caffe2 import do_export
 from torch.testing._internal import common_utils
+
+import caffe2.python.onnx.backend as c2
 
 
 class TestCaffe2CustomOps(pytorch_test_common.ExportTestCase):

--- a/test/onnx_caffe2/test_custom_ops.py
+++ b/test/onnx_caffe2/test_custom_ops.py
@@ -3,12 +3,12 @@
 import numpy as np
 import onnx
 import pytorch_test_common
-import torch
-import torch.utils.cpp_extension
 from test_pytorch_onnx_caffe2 import do_export
-from torch.testing._internal import common_utils
 
 import caffe2.python.onnx.backend as c2
+import torch
+import torch.utils.cpp_extension
+from torch.testing._internal import common_utils
 
 
 class TestCaffe2CustomOps(pytorch_test_common.ExportTestCase):

--- a/test/onnx_caffe2/test_pytorch_helper.py
+++ b/test/onnx_caffe2/test_pytorch_helper.py
@@ -5,16 +5,16 @@ import unittest
 
 import numpy as np
 import pytorch_test_common
+from pytorch_helper import PyTorchModule
 
 import torch.nn.init as init
 import torch.onnx
-from pytorch_helper import PyTorchModule
-from torch import nn
-from torch.testing._internal import common_utils
-from torch.testing._internal.common_utils import skipIfNoLapack
 
 from caffe2.python.core import workspace
 from caffe2.python.model_helper import ModelHelper
+from torch import nn
+from torch.testing._internal import common_utils
+from torch.testing._internal.common_utils import skipIfNoLapack
 
 
 class TestCaffe2Backend(pytorch_test_common.ExportTestCase):

--- a/test/onnx_caffe2/test_pytorch_helper.py
+++ b/test/onnx_caffe2/test_pytorch_helper.py
@@ -8,12 +8,13 @@ import pytorch_test_common
 
 import torch.nn.init as init
 import torch.onnx
-from caffe2.python.core import workspace
-from caffe2.python.model_helper import ModelHelper
 from pytorch_helper import PyTorchModule
 from torch import nn
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import skipIfNoLapack
+
+from caffe2.python.core import workspace
+from caffe2.python.model_helper import ModelHelper
 
 
 class TestCaffe2Backend(pytorch_test_common.ExportTestCase):

--- a/test/onnx_caffe2/test_pytorch_onnx_caffe2.py
+++ b/test/onnx_caffe2/test_pytorch_onnx_caffe2.py
@@ -11,9 +11,6 @@ import model_defs.word_language_model as word_language_model
 import numpy as np
 import onnx
 import pytorch_test_common
-import torch.onnx
-import torch.onnx.operators
-import torch.utils.model_zoo as model_zoo
 import verify
 from debug_embed_params import run_embed_params
 from model_defs.lstm_flattening_result import LstmFlatteningResult
@@ -33,12 +30,6 @@ from pytorch_test_common import (
     skipIfUnsupportedMinOpsetVersion,
     skipIfUnsupportedOpsetVersion,
 )
-from torch import nn
-from torch.autograd import function, Variable
-from torch.nn.utils import rnn as rnn_utils
-from torch.onnx import ExportTypes
-from torch.testing._internal import common_utils
-from torch.testing._internal.common_utils import skipIfNoLapack
 
 # Import various models for testing
 from torchvision.models.alexnet import alexnet
@@ -48,10 +39,19 @@ from torchvision.models.resnet import resnet50
 from torchvision.models.vgg import vgg16, vgg16_bn, vgg19, vgg19_bn
 
 import caffe2.python.onnx.backend as c2
+import torch.onnx
+import torch.onnx.operators
+import torch.utils.model_zoo as model_zoo
 from caffe2.python.operator_test.torch_integration_test import (
     create_bbox_transform_inputs,
     generate_rois_rotated,
 )
+from torch import nn
+from torch.autograd import function, Variable
+from torch.nn.utils import rnn as rnn_utils
+from torch.onnx import ExportTypes
+from torch.testing._internal import common_utils
+from torch.testing._internal.common_utils import skipIfNoLapack
 
 skip = unittest.skip
 

--- a/test/onnx_caffe2/test_pytorch_onnx_caffe2.py
+++ b/test/onnx_caffe2/test_pytorch_onnx_caffe2.py
@@ -6,8 +6,6 @@ import sys
 import unittest
 from typing import Tuple
 
-import caffe2.python.onnx.backend as c2
-
 import model_defs.dcgan as dcgan
 import model_defs.word_language_model as word_language_model
 import numpy as np
@@ -17,10 +15,6 @@ import torch.onnx
 import torch.onnx.operators
 import torch.utils.model_zoo as model_zoo
 import verify
-from caffe2.python.operator_test.torch_integration_test import (
-    create_bbox_transform_inputs,
-    generate_rois_rotated,
-)
 from debug_embed_params import run_embed_params
 from model_defs.lstm_flattening_result import LstmFlatteningResult
 from model_defs.mnist import MNIST
@@ -52,6 +46,12 @@ from torchvision.models.densenet import densenet121
 from torchvision.models.inception import inception_v3
 from torchvision.models.resnet import resnet50
 from torchvision.models.vgg import vgg16, vgg16_bn, vgg19, vgg19_bn
+
+import caffe2.python.onnx.backend as c2
+from caffe2.python.operator_test.torch_integration_test import (
+    create_bbox_transform_inputs,
+    generate_rois_rotated,
+)
 
 skip = unittest.skip
 

--- a/test/onnx_caffe2/test_pytorch_onnx_caffe2_quantized.py
+++ b/test/onnx_caffe2/test_pytorch_onnx_caffe2_quantized.py
@@ -2,8 +2,6 @@
 
 import io
 
-import caffe2.python.onnx.backend as c2
-
 import numpy as np
 import onnx
 import pytorch_test_common
@@ -11,6 +9,8 @@ import torch.ao.nn.quantized as nnq
 import torch.nn as nn
 import torch.onnx
 from torch.testing._internal import common_utils
+
+import caffe2.python.onnx.backend as c2
 
 
 class TestQuantizedOps(pytorch_test_common.ExportTestCase):

--- a/test/onnx_caffe2/test_pytorch_onnx_caffe2_quantized.py
+++ b/test/onnx_caffe2/test_pytorch_onnx_caffe2_quantized.py
@@ -5,12 +5,12 @@ import io
 import numpy as np
 import onnx
 import pytorch_test_common
+
+import caffe2.python.onnx.backend as c2
 import torch.ao.nn.quantized as nnq
 import torch.nn as nn
 import torch.onnx
 from torch.testing._internal import common_utils
-
-import caffe2.python.onnx.backend as c2
 
 
 class TestQuantizedOps(pytorch_test_common.ExportTestCase):

--- a/test/onnx_caffe2/test_verify.py
+++ b/test/onnx_caffe2/test_verify.py
@@ -1,12 +1,12 @@
 # Owner(s): ["module: onnx"]
 
+from verify import verify
+
+import caffe2.python.onnx.backend as backend
 import torch
 from torch.autograd import Function
 from torch.nn import Module, Parameter
 from torch.testing._internal import common_utils
-from verify import verify
-
-import caffe2.python.onnx.backend as backend
 
 
 class TestVerify(common_utils.TestCase):

--- a/test/onnx_caffe2/test_verify.py
+++ b/test/onnx_caffe2/test_verify.py
@@ -1,11 +1,12 @@
 # Owner(s): ["module: onnx"]
 
-import caffe2.python.onnx.backend as backend
 import torch
 from torch.autograd import Function
 from torch.nn import Module, Parameter
 from torch.testing._internal import common_utils
 from verify import verify
+
+import caffe2.python.onnx.backend as backend
 
 
 class TestVerify(common_utils.TestCase):

--- a/test/package/test_trace_dep/__init__.py
+++ b/test/package/test_trace_dep/__init__.py
@@ -1,5 +1,6 @@
-import torch
 import yaml
+
+import torch
 
 
 class SumMod(torch.nn.Module):

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -32,6 +32,7 @@ from typing import List, Optional
 from unittest.mock import patch
 
 import expecttest
+
 import torch
 import torch.nn as nn
 import torch.optim

--- a/test/scripts/run_cuda_memcheck.py
+++ b/test/scripts/run_cuda_memcheck.py
@@ -20,8 +20,9 @@ import subprocess
 import sys
 
 import cuda_memcheck_common as cmc
-import torch
 import tqdm
+
+import torch
 
 ALL_TESTS = []
 GPUS = torch.cuda.device_count()

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -28,6 +28,7 @@ from ao.sparsity.test_structured_sparsifier import (  # noqa: F401  # noqa: F401
     TestFPGMPruner,
     TestSaliencyPruner,
 )
+
 from torch.testing._internal.common_utils import IS_ARM64, run_tests
 
 # Composability

--- a/test/test_autograd_fallback.py
+++ b/test/test_autograd_fallback.py
@@ -4,6 +4,7 @@ import contextlib
 import warnings
 
 import numpy as np
+
 import torch
 from torch.library import _scoped_library, Library
 from torch.testing._internal.common_utils import (

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -10,6 +10,7 @@ from itertools import chain, product
 from numbers import Number
 
 import numpy as np
+
 import torch
 
 import torch.autograd.forward_ad as fwAD

--- a/test/test_bundled_images.py
+++ b/test/test_bundled_images.py
@@ -4,6 +4,7 @@
 import io
 
 import cv2
+
 import torch
 import torch.utils.bundled_inputs
 from torch.testing._internal.common_utils import TestCase

--- a/test/test_compile_benchmark_util.py
+++ b/test/test_compile_benchmark_util.py
@@ -8,6 +8,7 @@ from torch.testing._internal.common_utils import run_tests, TEST_CUDA, TestCase
 
 try:
     import tabulate  # noqa: F401  # type: ignore[import]
+
     from torch.utils.benchmark.utils.compile import bench_all
 
     HAS_TABULATE = True

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -3,9 +3,6 @@
 
 import os
 
-import torch
-import torch.testing._internal.common_nn as common_nn
-import torch.testing._internal.common_utils as common
 from cpp_api_parity import (
     functional_impl_check,
     module_impl_check,
@@ -14,6 +11,10 @@ from cpp_api_parity import (
 )
 from cpp_api_parity.parity_table_parser import parse_parity_tracker_table
 from cpp_api_parity.utils import is_torch_nn_functional_test
+
+import torch
+import torch.testing._internal.common_nn as common_nn
+import torch.testing._internal.common_utils as common
 
 # NOTE: turn this on if you want to print source code of all C++ tests (e.g. for debugging purpose)
 PRINT_CPP_SOURCE = False

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -13,6 +13,7 @@ import torch._custom_ops as custom_ops
 
 import torch.testing._internal.optests as optests
 import torch.utils.cpp_extension
+
 from functorch import make_fx
 from torch import Tensor
 from torch._custom_op.impl import custom_op, CustomOp, infer_schema

--- a/test/test_determination.py
+++ b/test/test_determination.py
@@ -3,6 +3,7 @@
 import os
 
 import run_test
+
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -9,6 +9,7 @@ import operator
 import re
 
 import sympy
+
 import torch
 import torch.fx
 import torch.nn.functional as F
@@ -1490,6 +1491,7 @@ class TestDimConstraints(TestCase):
 
         from sympy import Symbol
         from sympy.solvers.inequalities import reduce_inequalities
+
         from torch._dynamo.source import (
             LocalSource,
             TensorProperty,
@@ -1521,6 +1523,7 @@ class TestDimConstraints(TestCase):
 
     def test_dim_constraints_solve_full(self):
         from sympy import Eq, Integer, Ne, Symbol
+
         from torch._dynamo.source import (
             LocalSource,
             TensorProperty,

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -8,6 +8,7 @@ import warnings
 from functools import reduce
 
 import numpy as np
+
 import torch
 from torch import tensor
 

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -6,6 +6,7 @@ from functools import partial
 from itertools import combinations, permutations, product
 
 import numpy as np
+
 import torch
 
 from torch.testing import make_tensor

--- a/test/torch_np/numpy_tests/core/test_dtype.py
+++ b/test/torch_np/numpy_tests/core/test_dtype.py
@@ -13,6 +13,7 @@ from unittest import skipIf as skipif
 
 import pytest
 from pytest import raises as assert_raises
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/torch_np/numpy_tests/core/test_einsum.py
+++ b/test/torch_np/numpy_tests/core/test_einsum.py
@@ -5,8 +5,9 @@ import itertools
 
 from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 
-import torch._numpy as np
 from pytest import raises as assert_raises
+
+import torch._numpy as np
 from torch._numpy.testing import (
     assert_,
     assert_allclose,

--- a/test/torch_np/numpy_tests/core/test_getlimits.py
+++ b/test/torch_np/numpy_tests/core/test_getlimits.py
@@ -13,6 +13,7 @@ from unittest import skipIf
 import numpy
 
 from pytest import raises as assert_raises
+
 from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_TORCHDYNAMO,

--- a/test/torch_np/numpy_tests/core/test_indexing.py
+++ b/test/torch_np/numpy_tests/core/test_indexing.py
@@ -13,6 +13,7 @@ from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 import pytest
 
 from pytest import raises as assert_raises
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/torch_np/numpy_tests/core/test_numeric.py
+++ b/test/torch_np/numpy_tests/core/test_numeric.py
@@ -21,6 +21,7 @@ from unittest import expectedFailure as xfail, skipIf as skipif, SkipTest
 from hypothesis import given, strategies as st
 from hypothesis.extra import numpy as hynp
 from pytest import raises as assert_raises
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/torch_np/numpy_tests/core/test_numerictypes.py
+++ b/test/torch_np/numpy_tests/core/test_numerictypes.py
@@ -7,6 +7,7 @@ import sys
 from unittest import skipIf as skipif
 
 from pytest import raises as assert_raises
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/torch_np/numpy_tests/core/test_scalar_methods.py
+++ b/test/torch_np/numpy_tests/core/test_scalar_methods.py
@@ -14,6 +14,7 @@ from unittest import skipIf as skipif, SkipTest
 import pytest
 
 from pytest import raises as assert_raises
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/torch_np/numpy_tests/lib/test_type_check.py
+++ b/test/torch_np/numpy_tests/lib/test_type_check.py
@@ -6,6 +6,7 @@ import functools
 from unittest import expectedFailure as xfail, skipIf as skipif
 
 from pytest import raises as assert_raises
+
 from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_TORCHDYNAMO,

--- a/test/torch_np/numpy_tests/linalg/test_linalg.py
+++ b/test/torch_np/numpy_tests/linalg/test_linalg.py
@@ -19,6 +19,7 @@ import pytest
 
 from numpy.linalg.linalg import _multi_dot_matrix_chain_order
 from pytest import raises as assert_raises
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -5,12 +5,13 @@ import inspect
 from unittest import expectedFailure as xfail, skipIf as skip
 
 import numpy as _np
+from pytest import raises as assert_raises
+
 import torch
 
 import torch._numpy as w
 import torch._numpy._ufuncs as _ufuncs
 import torch._numpy._util as _util
-from pytest import raises as assert_raises
 from torch._numpy.testing import assert_allclose, assert_equal
 
 from torch.testing._internal.common_cuda import TEST_CUDA

--- a/test/torch_np/test_ufuncs_basic.py
+++ b/test/torch_np/test_ufuncs_basic.py
@@ -14,6 +14,7 @@ import operator
 from unittest import skipIf as skip, SkipTest
 
 from pytest import raises as assert_raises
+
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,

--- a/test/typing/pass/creation_ops.py
+++ b/test/typing/pass/creation_ops.py
@@ -1,9 +1,9 @@
 # mypy: disable-error-code="possibly-undefined"
 # flake8: noqa
+from typing_extensions import assert_type
+
 import torch
 from torch.testing._internal.common_utils import TEST_NUMPY
-
-from typing_extensions import assert_type
 
 
 if TEST_NUMPY:

--- a/test/typing/pass/disabled_jit.py
+++ b/test/typing/pass/disabled_jit.py
@@ -1,10 +1,10 @@
 from enum import Enum
 from typing import Type, TypeVar
+from typing_extensions import assert_never, assert_type, ParamSpec
 
 import pytest
 
 from torch import jit, nn, ScriptDict, ScriptFunction, ScriptList
-from typing_extensions import assert_never, assert_type, ParamSpec
 
 P = ParamSpec("P")
 R = TypeVar("R", covariant=True)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -38,6 +38,7 @@ from collections import defaultdict
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import yaml
+
 from torchgen.api import cpp
 from torchgen.api.python import (
     arg_parser_output_exprs,

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from typing import Any, Counter, Dict, List, Match, Optional, Sequence, Set, Tuple
 
 import yaml
+
 from torchgen.api import cpp
 
 from torchgen.api.autograd import (

--- a/tools/code_analyzer/gen_operators_yaml.py
+++ b/tools/code_analyzer/gen_operators_yaml.py
@@ -10,6 +10,7 @@ from gen_op_registration_allowlist import (
     gen_transitive_closure,
     load_op_dep_graph,
 )
+
 from torchgen.selective_build.operator import (
     merge_operator_dicts,
     SelectiveBuildOperator,

--- a/tools/code_analyzer/gen_oplist.py
+++ b/tools/code_analyzer/gen_oplist.py
@@ -10,6 +10,7 @@ import yaml
 from tools.lite_interpreter.gen_selected_mobile_ops_header import (
     write_selected_mobile_ops,
 )
+
 from torchgen.selective_build.selector import (
     combine_selective_builders,
     SelectiveBuilder,

--- a/tools/extract_scripts.py
+++ b/tools/extract_scripts.py
@@ -5,9 +5,9 @@ import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
+from typing_extensions import TypedDict  # Python 3.11+
 
 import yaml
-from typing_extensions import TypedDict  # Python 3.11+
 
 Step = Dict[str, Any]
 

--- a/tools/lite_interpreter/gen_selected_mobile_ops_header.py
+++ b/tools/lite_interpreter/gen_selected_mobile_ops_header.py
@@ -4,6 +4,7 @@ import os
 from typing import Set
 
 import yaml
+
 from torchgen.code_template import CodeTemplate
 from torchgen.selective_build.selector import SelectiveBuilder
 

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -8,6 +8,12 @@ from typing import Dict, List, Sequence
 from unittest.mock import Mock, patch
 from warnings import warn
 
+from tools.autograd.gen_python_functions import (
+    group_overloads,
+    load_signatures,
+    should_generate_py_binding,
+)
+
 from torchgen.api.python import (
     PythonSignatureGroup,
     PythonSignatureNativeFunctionPair,
@@ -17,12 +23,6 @@ from torchgen.gen import parse_native_yaml, parse_tags_yaml
 
 from torchgen.model import _TorchDispatchModeKey, DispatchKey, Variant
 from torchgen.utils import FileManager
-
-from tools.autograd.gen_python_functions import (
-    group_overloads,
-    load_signatures,
-    should_generate_py_binding,
-)
 
 """
 This module implements generation of type stubs for PyTorch,

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -26,10 +26,9 @@ def generate_code(
     force_schema_registration: bool = False,
     operator_selector: Any = None,
 ) -> None:
-    from torchgen.selective_build.selector import SelectiveBuilder
-
     from tools.autograd.gen_annotated_fn_args import gen_annotated
     from tools.autograd.gen_autograd import gen_autograd, gen_autograd_python
+    from torchgen.selective_build.selector import SelectiveBuilder
 
     # Build ATen based Variable classes
     if install_dir is None:

--- a/tools/test/test_codegen.py
+++ b/tools/test/test_codegen.py
@@ -4,11 +4,11 @@ import unittest
 from collections import defaultdict
 from typing import Dict, List
 
-import torchgen.model
-
 import yaml
 
 from tools.autograd import gen_autograd_functions, load_derivatives
+
+import torchgen.model
 from torchgen import dest
 from torchgen.api.types import CppSignatureGroup, DispatcherSignature
 from torchgen.context import native_function_manager

--- a/tools/test/test_codegen_model.py
+++ b/tools/test/test_codegen_model.py
@@ -5,10 +5,10 @@ import unittest
 from typing import cast
 
 import expecttest
+import yaml
 
 import torchgen.dest as dest
 import torchgen.gen as gen
-import yaml
 from torchgen.gen import LineLoader, parse_native_yaml_struct
 from torchgen.model import (
     Annotation,

--- a/tools/test/test_gen_backend_stubs.py
+++ b/tools/test/test_gen_backend_stubs.py
@@ -6,6 +6,7 @@ import unittest
 from typing import Optional
 
 import expecttest
+
 from torchgen.gen import _GLOBAL_PARSE_NATIVE_YAML_CACHE  # noqa: F401
 
 from torchgen.gen_backend_stubs import run

--- a/torch/_C/_profiler.pyi
+++ b/torch/_C/_profiler.pyi
@@ -1,8 +1,8 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing_extensions import TypeAlias
 
 from torch._C import device, dtype, layout
-from typing_extensions import TypeAlias
 
 # defined in torch/csrc/profiler/python/init.cpp
 

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -5,9 +5,9 @@ import functools
 from importlib import import_module
 from typing import Any, List, Optional
 
-from functorch.compile import min_cut_rematerialization_partition
-
 import torch
+
+from functorch.compile import min_cut_rematerialization_partition
 from torch import _guards
 from torch._functorch import config as functorch_config
 from torch._functorch.compilers import ts_compile

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -2,7 +2,6 @@ import dataclasses
 import sys
 import types
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Protocol, Union
-
 from typing_extensions import TypeAlias
 
 

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from torchgen.model import FunctionSchema
-
 import torch
 import torch.export._trace
 
@@ -15,6 +13,8 @@ from torch.export.graph_signature import (
 )
 from torch.fx import subgraph_rewriter
 from torch.onnx.utils import _create_jit_graph
+
+from torchgen.model import FunctionSchema
 
 
 def inplace_optimize_sym_size_div(gm: torch.fx.GraphModule):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -11,10 +11,10 @@ from itertools import count
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 from unittest import mock
 
-from functorch.compile import min_cut_rematerialization_partition
-
 import torch.fx
 import torch.utils._pytree as pytree
+
+from functorch.compile import min_cut_rematerialization_partition
 from torch._dynamo import (
     compiled_autograd,
     config as dynamo_config,

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -14,9 +14,9 @@ import subprocess
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
-from functorch.compile import draw_graph, get_aot_graph_name, get_graph_being_compiled
-
 import torch
+
+from functorch.compile import draw_graph, get_aot_graph_name, get_graph_being_compiled
 from torch import fx as fx
 
 from torch._dynamo.repro.after_aot import save_graph_repro, wrap_compiler_debug

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -2,7 +2,6 @@ import itertools
 import logging
 import operator
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
-
 from typing_extensions import TypeAlias
 
 import torch

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -22,10 +22,9 @@ SymPy expressions yet, despite sympy.Min and sympy.Max existing.
 import itertools
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Literal, Optional, overload, Tuple, Union
+from typing_extensions import TypeAlias
 
 import sympy
-
-from typing_extensions import TypeAlias
 
 import torch
 from torch._prims_common import dtype_to_type, is_integer_dtype

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -10,10 +10,10 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import Protocol
 from unittest.mock import patch
 
 import sympy
-from typing_extensions import Protocol
 
 import torch
 import torch.utils._pytree as pytree

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -26,7 +26,6 @@ from typing import (
     Tuple,
     Union,
 )
-
 from typing_extensions import Self, TypeGuard
 
 import torch

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -39,10 +39,10 @@ from typing import (
     Union,
     ValuesView,
 )
+from typing_extensions import Concatenate, ParamSpec
 from unittest import mock
 
 import sympy
-from typing_extensions import Concatenate, ParamSpec
 
 import torch
 import torch._export

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -21,7 +21,6 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
-
 from typing_extensions import TypeAlias
 
 

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -17,7 +17,6 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
-
 from typing_extensions import TypeAlias
 
 import torch

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -7,7 +7,6 @@ import traceback
 import warnings
 from collections import defaultdict
 from typing import Any, Callable, DefaultDict, Generic, List, Optional
-
 from typing_extensions import ParamSpec
 
 import torch

--- a/torch/ao/quantization/experimental/adaround_loss.py
+++ b/torch/ao/quantization/experimental/adaround_loss.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 
 import numpy as np
+
 import torch
 from torch.nn import functional as F
 

--- a/torch/csrc/lazy/test_mnist.py
+++ b/torch/csrc/lazy/test_mnist.py
@@ -2,6 +2,8 @@
 
 import os
 
+from torchvision import datasets, transforms
+
 import torch
 import torch._lazy
 import torch._lazy.metrics
@@ -10,7 +12,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from torch.optim.lr_scheduler import StepLR
-from torchvision import datasets, transforms
 
 torch._lazy.ts_backend.init()
 

--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -1,7 +1,6 @@
 import functools
-from typing import Any, cast, Optional, Union
 
-import typing_extensions
+from typing import Any, cast, NoReturn, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -142,7 +141,7 @@ def fully_shard(
     return module
 
 
-def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> typing_extensions.Never:
+def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> NoReturn:
     raise AssertionError(
         "FSDP does not support deepcopy. Please use state dict for serialization."
     )

--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -1,7 +1,5 @@
 import weakref
-from typing import Any, cast, Dict, Iterable, List, Optional, Set, Tuple
-
-import typing_extensions
+from typing import Any, cast, Dict, Iterable, List, NoReturn, Optional, Set, Tuple
 
 import torch
 import torch.nn as nn
@@ -138,7 +136,7 @@ class _ReplicateState(_State):
         return self._ddp._post_forward(output)
 
 
-def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> typing_extensions.Never:
+def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> NoReturn:
     raise AssertionError(
         "DDP does not support deepcopy. Please use state dict for serialization."
     )

--- a/torch/distributed/_spmd/api.py
+++ b/torch/distributed/_spmd/api.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass
 from functools import partial, wraps
 from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple, Union
 
-from functorch import make_fx
-
 import torch
 import torch.distributed as dist
 
@@ -14,6 +12,8 @@ import torch.distributed as dist
 import torch.distributed._functional_collectives
 import torch.nn as nn
 import torch.utils._pytree as pytree
+
+from functorch import make_fx
 
 from torch import fx
 from torch._decomp.decompositions import native_layer_norm_backward

--- a/torch/distributed/_spmd/partial_lower.py
+++ b/torch/distributed/_spmd/partial_lower.py
@@ -6,9 +6,9 @@ import logging
 import operator
 from typing import Callable, List, Optional, Set, Tuple
 
-from functorch import make_fx
-
 import torch
+
+from functorch import make_fx
 
 from torch._inductor.compile_fx import compile_fx_inner
 from torch._inductor.decomposition import select_decomp_table

--- a/torch/distributed/_tensor/debug/op_coverage.py
+++ b/torch/distributed/_tensor/debug/op_coverage.py
@@ -1,11 +1,11 @@
 from operator import itemgetter
 from typing import List
 
-from functorch.compile import make_boxed_func
-
 import torch
 import torch.fx
 import torch.nn as nn
+
+from functorch.compile import make_boxed_func
 from torch._functorch.compilers import aot_module
 from torch._inductor.decomposition import select_decomp_table
 from torch.distributed._tensor import DTensor

--- a/torch/distributed/checkpoint/logger.py
+++ b/torch/distributed/checkpoint/logger.py
@@ -1,7 +1,6 @@
 import functools
 import time
 from typing import Any, Callable, Dict, List, TypeVar
-
 from typing_extensions import ParamSpec
 
 import torch.distributed.c10d_logger as c10d_logger

--- a/torch/distributed/checkpoint/staging.py
+++ b/torch/distributed/checkpoint/staging.py
@@ -1,5 +1,4 @@
 from typing import Optional, runtime_checkable
-
 from typing_extensions import Protocol
 
 from torch.distributed._state_dict_utils import (

--- a/torch/distributed/checkpoint/stateful.py
+++ b/torch/distributed/checkpoint/stateful.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, runtime_checkable, TypeVar
-
 from typing_extensions import Protocol
 
 

--- a/torch/fx/experimental/shape_inference/infer_symbol_values.py
+++ b/torch/fx/experimental/shape_inference/infer_symbol_values.py
@@ -4,6 +4,7 @@ from typing import Any, DefaultDict, Dict, List, Tuple, Union
 import numpy as np
 
 import sympy as sp
+
 import torch
 
 square_brackets_pattern = r"\[([^]]+)\]"

--- a/torch/jit/_script.pyi
+++ b/torch/jit/_script.pyi
@@ -12,9 +12,9 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import Never, TypeAlias
 
 from _typeshed import Incomplete
-from typing_extensions import Never, TypeAlias
 
 import torch
 from torch._classes import classes as classes

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -17,7 +17,6 @@ import os
 import re
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Set, TypeVar
-
 from typing_extensions import ParamSpec
 
 import torch

--- a/torch/nn/utils/rnn.pyi
+++ b/torch/nn/utils/rnn.pyi
@@ -9,7 +9,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 from typing_extensions import Self
 
 from torch import Tensor

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -30,7 +30,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 from typing_extensions import Self
 
 import torch

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -16,7 +16,6 @@ from typing import (
     Tuple,
     Union,
 )
-
 from typing_extensions import TypeAlias
 
 import torch

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -20,7 +20,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 from typing_extensions import ParamSpec, Self, TypeAlias
 
 import torch

--- a/torch/profiler/_memory_profiler.py
+++ b/torch/profiler/_memory_profiler.py
@@ -15,7 +15,6 @@ from typing import (
     Tuple,
     Union,
 )
-
 from typing_extensions import Literal
 
 import torch

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -7,9 +7,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
-from warnings import warn
-
 from typing_extensions import Self
+from warnings import warn
 
 import torch
 import torch.autograd.profiler as prof

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -11,8 +11,6 @@ from functools import partial
 from itertools import product
 from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 
-from torchgen.utils import dataclass_repr
-
 import torch
 from torch.testing import make_tensor
 from torch.testing._internal.common_device_type import (
@@ -35,6 +33,8 @@ from torch.testing._internal.common_utils import (
     TrackedInputIter,
 )
 from torch.testing._internal.opinfo import utils
+
+from torchgen.utils import dataclass_repr
 
 # Reasonable testing sizes for dimensions
 L = 20

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -16,10 +16,10 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import TypeGuard
 
 import sympy
 from sympy.logic.boolalg import Boolean as SympyBoolean, BooleanAtom
-from typing_extensions import TypeGuard
 
 import torch
 

--- a/torchgen/utils.py
+++ b/torchgen/utils.py
@@ -25,7 +25,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 from typing_extensions import Self
 
 from torchgen.code_template import CodeTemplate


### PR DESCRIPTION
All changes are generated by `lintrunner -a --take UFMT --all-files`.


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @LucasLLC