### PR TITLE
Add unsafe_allow_in_graph; deprecate allow_in_graph

### DIFF
--- a/docs/source/torch.compiler_api.rst
+++ b/docs/source/torch.compiler_api.rst
@@ -15,6 +15,7 @@ For a quick overview of ``torch.compiler``, see :ref:`torch.compiler_overview`.
 
      compile
      reset
+     unsafe_allow_in_graph
      allow_in_graph
      assume_constant_result
      list_backends

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -622,6 +622,16 @@ class MiscTests(torch._inductor.test_case.TestCase):
                 cleanup_op("mylib::a")
                 del lib
 
+    def test_allow_in_graph_deprecation(self):
+        def f(x):
+            return x
+
+        msg = "allow_in_graph is deprecated as of PyTorch 2.4"
+        with self.assertWarnsRegex(DeprecationWarning, msg):
+            torch._dynamo.allow_in_graph(f)
+        with self.assertWarnsRegex(DeprecationWarning, msg):
+            torch.compiler.allow_in_graph(f)
+
     def test_auto_functionalize(self):
         try:
             lib = torch.library.Library("mylib", "FRAGMENT")

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -16,6 +16,7 @@ from .decorators import (
     mark_static_address,
     maybe_mark_dynamic,
     run,
+    unsafe_allow_in_graph,
 )
 from .eval_frame import (
     _reset_guarded_backend_cache,
@@ -55,6 +56,7 @@ __all__ = [
     "register_backend",
     "list_backends",
     "lookup_backend",
+    "unsafe_allow_in_graph",
 ]
 
 if torch.manual_seed is torch.random.manual_seed:

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -72,7 +73,7 @@ def assume_constant_result(fn):
     return fn
 
 
-def allow_in_graph(fn):
+def unsafe_allow_in_graph(fn):
     """
     Tells the compiler frontend (Dynamo) to skip symbolic introspection of the function
     and instead directly write it to the graph when encountered.
@@ -130,6 +131,26 @@ def allow_in_graph(fn):
         trace_rules._disallowed_callable_ids.remove(id(fn))
         trace_rules._allowed_callable_ids.add(id(fn))
     return fn
+
+
+def allow_in_graph(fn):
+    """This function is deprecated in favor of :func:`unsafe_allow_in_graph()`
+
+    If you are trying to black-box a Python function for use with torch.compile
+    (aka something similar to torch.fx.wrap),
+    do not use this API. Instead, please create a custom operator:
+    https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit
+
+    :func:`unsafe_allow_in_graph()`/:func:`allow_in_graph()` are fairly difficult
+    to use correctly; please read the docs carefully.
+    """
+    warnings.warn(
+        "allow_in_graph is deprecated as of PyTorch 2.4 and will be removed "
+        "in a future version of PyTorch. Please use unsafe_allow_in_graph "
+        "instead.",
+        DeprecationWarning,
+    )
+    return unsafe_allow_in_graph(fn)
 
 
 def _disallow_in_graph_helper(throw_if_not_allowed):

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1,4 +1,5 @@
 import torch
+import warnings
 from typing import List
 
 __all__ = [
@@ -12,6 +13,7 @@ __all__ = [
     "wrap_numpy",
     "is_compiling",
     "is_dynamo_compiling",
+    "unsafe_allow_in_graph",
 ]
 
 def compile(*args, **kwargs):
@@ -30,7 +32,7 @@ def reset() -> None:
 
     torch._dynamo.reset()
 
-def allow_in_graph(fn):
+def unsafe_allow_in_graph(fn):
     """
     Tells the compiler frontend (Dynamo) to skip symbolic introspection of the function
     and instead directly write it to the graph when encountered.
@@ -69,7 +71,25 @@ def allow_in_graph(fn):
     """
     import torch._dynamo
 
-    return torch._dynamo.allow_in_graph(fn)
+    return torch._dynamo.unsafe_allow_in_graph(fn)
+
+
+def allow_in_graph(fn):
+    """This function is deprecated in favor of :func:`unsafe_allow_in_graph()`
+
+    If you are trying to black-box a Python function for use with torch.compile
+    (aka something similar to torch.fx.wrap),
+    do not use this API. Instead, please create a custom operator:
+    https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit
+
+    :func:`unsafe_allow_in_graph()`/:func:`allow_in_graph()` are fairly difficult
+    to use correctly; please read the docs carefully.
+    """
+    warnings.warn(
+        "allow_in_graph is deprecated as of PyTorch 2.4 and will be removed "
+        "in a future version of PyTorch. Please use unsafe_allow_in_graph "
+        "instead.", DeprecationWarning, stacklevel=2)
+    return unsafe_allow_in_graph(fn)
 
 
 def list_backends(exclude_tags=("debug", "experimental")) -> List[str]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127119
* __->__ #127118
* #127117

See https://github.com/pytorch/pytorch/issues/122189 for motivation

Coming next: codemod to change all existing instances of allow_in_graph to
unsafe_allow_in_graph.

Test Plan:
- new test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang