### PR TITLE
[1/N][Easy] fix typo for `usort` config in `pyproject.toml` (`kown` -> `known`): sort stdlib

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -5,11 +5,11 @@ import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List, Literal, Set
+from typing_extensions import TypedDict  # Python 3.11+
 
 import generate_binary_build_matrix  # type: ignore[import]
 
 import jinja2
-from typing_extensions import TypedDict  # Python 3.11+
 
 Arch = Literal["windows", "linux", "macos"]
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -36,12 +36,9 @@ from typing import (
     Type,
     TYPE_CHECKING,
 )
-from unittest.mock import MagicMock
 
 from typing_extensions import Self
-
-if TYPE_CHECKING:
-    from torch.onnx._internal.fx import diagnostics
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -61,6 +58,8 @@ from torch._dynamo.testing import (
     reset_rng_state,
     same,
 )
+
+from tqdm.auto import tqdm, trange
 
 try:
     from torch._dynamo.utils import (
@@ -83,7 +82,6 @@ from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.utils import _pytree as pytree
 from torch.utils._pytree import tree_map, tree_map_only
 
-from tqdm.auto import tqdm, trange
 
 try:
     import torch_xla
@@ -94,6 +92,11 @@ try:
 except ImportError:
     # ignore the error if torch_xla is not installed
     pass
+
+
+if TYPE_CHECKING:
+    from torch.onnx._internal.fx import diagnostics
+
 
 log = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,11 @@ lines_after_imports = 2
 multi_line_output = 3
 include_trailing_comma = true
 
+[tool.usort.known]
+standard_library = ["typing_extensions"]
 
 [tool.usort.kown]
 first_party = ["caffe2", "torch", "torchgen", "functorch", "tests"]
-standard_library = ["typing_extensions"]
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ lines_after_imports = 2
 multi_line_output = 3
 include_trailing_comma = true
 
+
 [tool.usort.known]
 standard_library = ["typing_extensions"]
 

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -5,13 +5,13 @@ import re
 import sys
 import types
 import typing
+import typing_extensions
 from collections import OrderedDict
 from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.jit.frontend
 import torch.nn as nn
-import typing_extensions
 from torch import Tensor
 from torch.testing import FileCheck
 

--- a/test/typing/pass/creation_ops.py
+++ b/test/typing/pass/creation_ops.py
@@ -1,9 +1,9 @@
 # mypy: disable-error-code="possibly-undefined"
 # flake8: noqa
+from typing_extensions import assert_type
+
 import torch
 from torch.testing._internal.common_utils import TEST_NUMPY
-
-from typing_extensions import assert_type
 
 
 if TEST_NUMPY:

--- a/test/typing/pass/disabled_jit.py
+++ b/test/typing/pass/disabled_jit.py
@@ -1,10 +1,10 @@
 from enum import Enum
 from typing import Type, TypeVar
+from typing_extensions import assert_never, assert_type, ParamSpec
 
 import pytest
 
 from torch import jit, nn, ScriptDict, ScriptFunction, ScriptList
-from typing_extensions import assert_never, assert_type, ParamSpec
 
 P = ParamSpec("P")
 R = TypeVar("R", covariant=True)

--- a/tools/extract_scripts.py
+++ b/tools/extract_scripts.py
@@ -5,9 +5,9 @@ import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
+from typing_extensions import TypedDict  # Python 3.11+
 
 import yaml
-from typing_extensions import TypedDict  # Python 3.11+
 
 Step = Dict[str, Any]
 

--- a/torch/_C/_profiler.pyi
+++ b/torch/_C/_profiler.pyi
@@ -1,8 +1,8 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing_extensions import TypeAlias
 
 from torch._C import device, dtype, layout
-from typing_extensions import TypeAlias
 
 # defined in torch/csrc/profiler/python/init.cpp
 

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -2,7 +2,6 @@ import dataclasses
 import sys
 import types
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Protocol, Union
-
 from typing_extensions import TypeAlias
 
 

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -2,7 +2,6 @@ import itertools
 import logging
 import operator
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
-
 from typing_extensions import TypeAlias
 
 import torch

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -22,10 +22,9 @@ SymPy expressions yet, despite sympy.Min and sympy.Max existing.
 import itertools
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Literal, Optional, overload, Tuple, Union
+from typing_extensions import TypeAlias
 
 import sympy
-
-from typing_extensions import TypeAlias
 
 import torch
 from torch._prims_common import dtype_to_type, is_integer_dtype

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -10,10 +10,10 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import Protocol
 from unittest.mock import patch
 
 import sympy
-from typing_extensions import Protocol
 
 import torch
 import torch.utils._pytree as pytree

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -26,7 +26,6 @@ from typing import (
     Tuple,
     Union,
 )
-
 from typing_extensions import Self, TypeGuard
 
 import torch

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -39,10 +39,10 @@ from typing import (
     Union,
     ValuesView,
 )
+from typing_extensions import Concatenate, ParamSpec
 from unittest import mock
 
 import sympy
-from typing_extensions import Concatenate, ParamSpec
 
 import torch
 import torch._export

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -21,7 +21,6 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
-
 from typing_extensions import TypeAlias
 
 

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -17,7 +17,6 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
-
 from typing_extensions import TypeAlias
 
 import torch

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -7,7 +7,6 @@ import traceback
 import warnings
 from collections import defaultdict
 from typing import Any, Callable, DefaultDict, Generic, List, Optional
-
 from typing_extensions import ParamSpec
 
 import torch

--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -1,7 +1,6 @@
 import functools
-from typing import Any, cast, Optional, Union
 
-import typing_extensions
+from typing import Any, cast, NoReturn, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -142,7 +141,7 @@ def fully_shard(
     return module
 
 
-def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> typing_extensions.Never:
+def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> NoReturn:
     raise AssertionError(
         "FSDP does not support deepcopy. Please use state dict for serialization."
     )

--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -1,7 +1,5 @@
 import weakref
-from typing import Any, cast, Dict, Iterable, List, Optional, Set, Tuple
-
-import typing_extensions
+from typing import Any, cast, Dict, Iterable, List, NoReturn, Optional, Set, Tuple
 
 import torch
 import torch.nn as nn
@@ -138,7 +136,7 @@ class _ReplicateState(_State):
         return self._ddp._post_forward(output)
 
 
-def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> typing_extensions.Never:
+def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> NoReturn:
     raise AssertionError(
         "DDP does not support deepcopy. Please use state dict for serialization."
     )

--- a/torch/distributed/checkpoint/logger.py
+++ b/torch/distributed/checkpoint/logger.py
@@ -1,7 +1,6 @@
 import functools
 import time
 from typing import Any, Callable, Dict, List, TypeVar
-
 from typing_extensions import ParamSpec
 
 import torch.distributed.c10d_logger as c10d_logger

--- a/torch/distributed/checkpoint/staging.py
+++ b/torch/distributed/checkpoint/staging.py
@@ -1,5 +1,4 @@
 from typing import Optional, runtime_checkable
-
 from typing_extensions import Protocol
 
 from torch.distributed._state_dict_utils import (

--- a/torch/distributed/checkpoint/stateful.py
+++ b/torch/distributed/checkpoint/stateful.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, runtime_checkable, TypeVar
-
 from typing_extensions import Protocol
 
 

--- a/torch/jit/_script.pyi
+++ b/torch/jit/_script.pyi
@@ -12,9 +12,9 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import Never, TypeAlias
 
 from _typeshed import Incomplete
-from typing_extensions import Never, TypeAlias
 
 import torch
 from torch._classes import classes as classes

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -17,7 +17,6 @@ import os
 import re
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Set, TypeVar
-
 from typing_extensions import ParamSpec
 
 import torch

--- a/torch/nn/utils/rnn.pyi
+++ b/torch/nn/utils/rnn.pyi
@@ -9,7 +9,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 from typing_extensions import Self
 
 from torch import Tensor

--- a/torch/onnx/_internal/exporter.py
+++ b/torch/onnx/_internal/exporter.py
@@ -30,7 +30,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 from typing_extensions import Self
 
 import torch

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -16,7 +16,6 @@ from typing import (
     Tuple,
     Union,
 )
-
 from typing_extensions import TypeAlias
 
 import torch

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -20,7 +20,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 from typing_extensions import ParamSpec, Self, TypeAlias
 
 import torch

--- a/torch/profiler/_memory_profiler.py
+++ b/torch/profiler/_memory_profiler.py
@@ -15,7 +15,6 @@ from typing import (
     Tuple,
     Union,
 )
-
 from typing_extensions import Literal
 
 import torch

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -7,9 +7,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
-from warnings import warn
-
 from typing_extensions import Self
+from warnings import warn
 
 import torch
 import torch.autograd.profiler as prof

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -16,10 +16,10 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing_extensions import TypeGuard
 
 import sympy
 from sympy.logic.boolalg import Boolean as SympyBoolean, BooleanAtom
-from typing_extensions import TypeGuard
 
 import torch
 

--- a/torchgen/utils.py
+++ b/torchgen/utils.py
@@ -25,7 +25,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 from typing_extensions import Self
 
 from torchgen.code_template import CodeTemplate


### PR DESCRIPTION
The `usort` config in `pyproject.toml` has no effect due to a typo. Fixing the typo make `usort` do more and generate the changes in the PR. Except `pyproject.toml`, all changes are generated by `lintrunner -a --take UFMT --all-files`.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127126
* #127125
* #127124
* #127123
* __->__ #127122



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @LucasLLC