### PR TITLE
[3/N][Easy] fix typo for `usort` config in `pyproject.toml` (`kown` -> `known`): sort torchgen

### DIFF
--- a/docs/source/scripts/build_opsets.py
+++ b/docs/source/scripts/build_opsets.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import torch
 import torch._prims as prims
+
 from torchgen.gen import parse_native_yaml
 
 ROOT = Path(__file__).absolute().parent.parent.parent.parent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ target-version = ["py38", "py39", "py310", "py311"]
 
 
 [tool.isort]
-src_paths = ["caffe2", "torch", "torchgen", "functorch", "tests"]
+src_paths = ["caffe2", "torch", "torchgen", "functorch", "test"]
 extra_standard_library = ["typing_extensions"]
 skip_gitignore = true
 skip_glob = ["third_party/*"]
@@ -33,11 +33,11 @@ multi_line_output = 3
 include_trailing_comma = true
 
 [tool.usort.known]
-first_party = ["caffe2"]
+first_party = ["caffe2", "torchgen", "test"]
 standard_library = ["typing_extensions"]
 
 [tool.usort.kown]
-first_party = ["torch", "torchgen", "functorch", "tests"]
+first_party = ["torch", "functorch"]
 
 
 [tool.ruff]

--- a/test/jit/fixtures_srcs/test_upgrader_models_generation.py
+++ b/test/jit/fixtures_srcs/test_upgrader_models_generation.py
@@ -1,8 +1,9 @@
 # Owner(s): ["oncall: mobile"]
 
 import torch
-from test.jit.fixtures_srcs.generate_models import ALL_MODULES
 from torch.testing._internal.common_utils import run_tests, TestCase
+
+from test.jit.fixtures_srcs.generate_models import ALL_MODULES
 
 
 class TestUpgraderModelGeneration(TestCase):

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -38,6 +38,7 @@ from collections import defaultdict
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import yaml
+
 from torchgen.api import cpp
 from torchgen.api.python import (
     arg_parser_output_exprs,

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from typing import Any, Counter, Dict, List, Match, Optional, Sequence, Set, Tuple
 
 import yaml
+
 from torchgen.api import cpp
 
 from torchgen.api.autograd import (

--- a/tools/code_analyzer/gen_operators_yaml.py
+++ b/tools/code_analyzer/gen_operators_yaml.py
@@ -10,6 +10,7 @@ from gen_op_registration_allowlist import (
     gen_transitive_closure,
     load_op_dep_graph,
 )
+
 from torchgen.selective_build.operator import (
     merge_operator_dicts,
     SelectiveBuildOperator,

--- a/tools/code_analyzer/gen_oplist.py
+++ b/tools/code_analyzer/gen_oplist.py
@@ -10,6 +10,7 @@ import yaml
 from tools.lite_interpreter.gen_selected_mobile_ops_header import (
     write_selected_mobile_ops,
 )
+
 from torchgen.selective_build.selector import (
     combine_selective_builders,
     SelectiveBuilder,

--- a/tools/lite_interpreter/gen_selected_mobile_ops_header.py
+++ b/tools/lite_interpreter/gen_selected_mobile_ops_header.py
@@ -4,6 +4,7 @@ import os
 from typing import Set
 
 import yaml
+
 from torchgen.code_template import CodeTemplate
 from torchgen.selective_build.selector import SelectiveBuilder
 

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -8,6 +8,12 @@ from typing import Dict, List, Sequence
 from unittest.mock import Mock, patch
 from warnings import warn
 
+from tools.autograd.gen_python_functions import (
+    group_overloads,
+    load_signatures,
+    should_generate_py_binding,
+)
+
 from torchgen.api.python import (
     PythonSignatureGroup,
     PythonSignatureNativeFunctionPair,
@@ -17,12 +23,6 @@ from torchgen.gen import parse_native_yaml, parse_tags_yaml
 
 from torchgen.model import _TorchDispatchModeKey, DispatchKey, Variant
 from torchgen.utils import FileManager
-
-from tools.autograd.gen_python_functions import (
-    group_overloads,
-    load_signatures,
-    should_generate_py_binding,
-)
 
 """
 This module implements generation of type stubs for PyTorch,

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -26,10 +26,9 @@ def generate_code(
     force_schema_registration: bool = False,
     operator_selector: Any = None,
 ) -> None:
-    from torchgen.selective_build.selector import SelectiveBuilder
-
     from tools.autograd.gen_annotated_fn_args import gen_annotated
     from tools.autograd.gen_autograd import gen_autograd, gen_autograd_python
+    from torchgen.selective_build.selector import SelectiveBuilder
 
     # Build ATen based Variable classes
     if install_dir is None:

--- a/tools/test/test_codegen.py
+++ b/tools/test/test_codegen.py
@@ -4,11 +4,11 @@ import unittest
 from collections import defaultdict
 from typing import Dict, List
 
-import torchgen.model
-
 import yaml
 
 from tools.autograd import gen_autograd_functions, load_derivatives
+
+import torchgen.model
 from torchgen import dest
 from torchgen.api.types import CppSignatureGroup, DispatcherSignature
 from torchgen.context import native_function_manager

--- a/tools/test/test_codegen_model.py
+++ b/tools/test/test_codegen_model.py
@@ -5,10 +5,10 @@ import unittest
 from typing import cast
 
 import expecttest
+import yaml
 
 import torchgen.dest as dest
 import torchgen.gen as gen
-import yaml
 from torchgen.gen import LineLoader, parse_native_yaml_struct
 from torchgen.model import (
     Annotation,

--- a/tools/test/test_gen_backend_stubs.py
+++ b/tools/test/test_gen_backend_stubs.py
@@ -6,6 +6,7 @@ import unittest
 from typing import Optional
 
 import expecttest
+
 from torchgen.gen import _GLOBAL_PARSE_NATIVE_YAML_CACHE  # noqa: F401
 
 from torchgen.gen_backend_stubs import run

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from torchgen.model import FunctionSchema
-
 import torch
 import torch.export._trace
 
@@ -15,6 +13,8 @@ from torch.export.graph_signature import (
 )
 from torch.fx import subgraph_rewriter
 from torch.onnx.utils import _create_jit_graph
+
+from torchgen.model import FunctionSchema
 
 
 def inplace_optimize_sym_size_div(gm: torch.fx.GraphModule):

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -11,8 +11,6 @@ from functools import partial
 from itertools import product
 from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 
-from torchgen.utils import dataclass_repr
-
 import torch
 from torch.testing import make_tensor
 from torch.testing._internal.common_device_type import (
@@ -35,6 +33,8 @@ from torch.testing._internal.common_utils import (
     TrackedInputIter,
 )
 from torch.testing._internal.opinfo import utils
+
+from torchgen.utils import dataclass_repr
 
 # Reasonable testing sizes for dimensions
 L = 20


### PR DESCRIPTION
The `usort` config in `pyproject.toml` has no effect due to a typo. Fixing the typo make `usort` do more and generate the changes in the PR. Except `pyproject.toml`, all changes are generated by `lintrunner -a --take UFMT --all-files`.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127126
* #127125
* __->__ #127124
* #127123

