### PR TITLE
[dtensor] add a wrapper to disable dynamo quicker

### DIFF
--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -224,3 +224,17 @@ def compute_local_stride(
     return tuple(
         global_stride[i] // stride_divisors[i] for i in range(len(global_stride))
     )
+
+
+def _disable_dynamo(fn=None, recursive=True):
+    """
+    This util is merely a wrapper on top of torch._disable_dynamo. torch._disable_dynamo
+    uses funtools wrap where it incurs high CPU overhead. This util is used to
+    avoid circular imports issues, and early exit if it's not in compiling.
+    """
+    import torch.compiler
+
+    if not torch.compiler.is_compiling():
+        return fn  # no-op if not compiling
+
+    return torch._disable_dynamo(fn, recursive)

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -9,7 +9,7 @@ import torch.distributed._tensor.dispatch as op_dispatch
 import torch.distributed._tensor.random as random
 import torch.nn as nn
 from torch.distributed._tensor._collective_utils import mesh_broadcast
-from torch.distributed._tensor._utils import compute_global_tensor_info
+from torch.distributed._tensor._utils import _disable_dynamo, compute_global_tensor_info
 from torch.distributed._tensor.placement_types import (
     _Partial,
     DTensorSpec,
@@ -198,7 +198,7 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
     _op_dispatcher: op_dispatch.OpDispatcher = op_dispatch.OpDispatcher()
 
     @staticmethod
-    @torch._disable_dynamo
+    @_disable_dynamo
     def __new__(
         cls,
         local_tensor: torch.Tensor,
@@ -289,7 +289,7 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         )
 
     @classmethod
-    @torch._disable_dynamo
+    @_disable_dynamo
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127133

torch._disable_dynamo suffers from high CPU overhead, if it's a one time
off overhead is fine, but the problem when using it in Tensor subclass
is that every torch_dispatch call and make_wrapper_subclass call would
incur the CPU overhead, which is too much.

This is to make sure we can early exit the functool wrapping and avoid
circul import issues when adding this logic directly in
torch._disable_dynamo

before:
27.72us

![442510361_781091004137836_3620295539499507069_n](https://github.com/pytorch/pytorch/assets/9443650/7d577af0-e8b1-4559-a8e9-76155c7e7d1f)

after:
16.25us
![Screenshot 2024-05-24 at 3 59 19 PM](https://github.com/pytorch/pytorch/assets/9443650/687d85ea-f0b0-4867-bafa-b1dc45eb2a12)





cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k