### PR TITLE
[2/N] Fix clang-tidy warnings in aten/src/ATen/detail/

### DIFF
--- a/aten/src/ATen/detail/FunctionTraits.h
+++ b/aten/src/ATen/detail/FunctionTraits.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <tuple>
 
 // Modified from https://stackoverflow.com/questions/7943525/is-it-possible-to-figure-out-the-parameter-type-and-return-type-of-a-lambda
@@ -44,13 +45,13 @@ struct function_traits<ReturnType(Args...)> {
   // arity is the number of arguments.
   enum { arity = sizeof...(Args) };
 
-  typedef std::tuple<Args...> ArgsTuple;
-  typedef ReturnType result_type;
+  using ArgsTuple = std::tuple<Args...>;
+  using result_type = ReturnType;
 
   template <size_t i>
   struct arg
   {
-      typedef typename std::tuple_element<i, std::tuple<Args...>>::type type;
+      using type = typename std::tuple_element<i, std::tuple<Args...>>::type;
       // the i-th argument is equivalent to the i-th tuple element of a tuple
       // composed of those arguments.
   };

--- a/aten/src/ATen/detail/HIPHooksInterface.cpp
+++ b/aten/src/ATen/detail/HIPHooksInterface.cpp
@@ -3,7 +3,6 @@
 #include <c10/util/CallOnce.h>
 #include <c10/util/Registry.h>
 
-#include <cstddef>
 #include <memory>
 
 namespace at {

--- a/aten/src/ATen/detail/HIPHooksInterface.h
+++ b/aten/src/ATen/detail/HIPHooksInterface.h
@@ -6,7 +6,6 @@
 
 #include <c10/util/Registry.h>
 
-#include <cstddef>
 #include <memory>
 
 namespace at {

--- a/aten/src/ATen/detail/MTIAHooksInterface.cpp
+++ b/aten/src/ATen/detail/MTIAHooksInterface.cpp
@@ -2,7 +2,6 @@
 
 #include <c10/util/CallOnce.h>
 
-#include <cstddef>
 #include <memory>
 
 namespace at {

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -5,10 +5,6 @@
 #include <ATen/core/Generator.h>
 #include <c10/util/Registry.h>
 
-#include <cstddef>
-#include <functional>
-#include <memory>
-
 namespace at {
 
 constexpr const char* XPU_HELP =


### PR DESCRIPTION
Following #127057
