### PR TITLE
[1/N] Fix clang-tidy warnings in aten/src/ATen/cuda/

### DIFF
--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -3,7 +3,6 @@
 #include <c10/util/CallOnce.h>
 
 #include <ATen/cuda/CUDAConfig.h>
-#include <mutex>
 #include <deque>
 #include <vector>
 
@@ -23,7 +22,7 @@ void initCUDAContextVectors() {
 }
 
 void initDeviceProperty(DeviceIndex device_index) {
-  cudaDeviceProp device_prop;
+  cudaDeviceProp device_prop{};
   AT_CUDA_CHECK(cudaGetDeviceProperties(&device_prop, device_index));
   device_properties[device_index] = device_prop;
 }

--- a/aten/src/ATen/cuda/CUDAEvent.h
+++ b/aten/src/ATen/cuda/CUDAEvent.h
@@ -32,8 +32,7 @@ struct TORCH_CUDA_CPP_API CUDAEvent {
   CUDAEvent(unsigned int flags) noexcept : flags_{flags} {}
 
   CUDAEvent(
-      DeviceIndex device_index, const cudaIpcEventHandle_t* handle) {
-      device_index_ = device_index;
+      DeviceIndex device_index, const cudaIpcEventHandle_t* handle) : device_index_(device_index) {
       CUDAGuard guard(device_index_);
 
       AT_CUDA_CHECK(cudaIpcOpenEventHandle(&event_, *handle));

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -39,8 +39,8 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   void debug_dump(const std::string& debug_path);
 
  protected:
-  cudaGraph_t graph_ = NULL;
-  cudaGraphExec_t graph_exec_ = NULL;
+  cudaGraph_t graph_ = nullptr;
+  cudaGraphExec_t graph_exec_ = nullptr;
 
   static std::atomic<int> pending_event_queries;
 

--- a/aten/src/ATen/cuda/CUDAGraphsUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAGraphsUtils.cuh
@@ -27,7 +27,7 @@ inline CaptureStatus currentStreamCaptureStatus() {
   }
 }
 
-inline void assertNotCapturing(std::string attempt) {
+inline void assertNotCapturing(const std::string& attempt) {
   auto status = currentStreamCaptureStatus();
   TORCH_CHECK(status == CaptureStatus::None,
               attempt,
@@ -37,7 +37,7 @@ inline void assertNotCapturing(std::string attempt) {
               status);
 }
 
-inline void errorIfCapturingCudnnBenchmark(std::string version_specific) {
+inline void errorIfCapturingCudnnBenchmark(const std::string& version_specific) {
   auto status = currentStreamCaptureStatus();
   TORCH_CHECK(status == CaptureStatus::None,
               "Current cudaStreamCaptureStatus: ",

--- a/aten/src/ATen/cuda/CUDASparseDescriptors.cpp
+++ b/aten/src/ATen/cuda/CUDASparseDescriptors.cpp
@@ -93,7 +93,7 @@ cusparseDnMatDescr_t createRawDnMatDescriptor(const Tensor& input, int64_t batch
   // NOTE: Ideally, in the const case, we would use cusparseConstDnMatDescr_t
   // and cusparseCreateConstDnMat, but those were introduced in CUDA 12, and we
   // still need to support CUDA 11
-  cusparseDnMatDescr_t raw_descriptor;
+  cusparseDnMatDescr_t raw_descriptor = nullptr;
   TORCH_CUDASPARSE_CHECK(cusparseCreateDnMat(
       &raw_descriptor,
       rows,
@@ -132,7 +132,7 @@ CuSparseDnVecDescriptor::CuSparseDnVecDescriptor(const Tensor& input) {
   cudaDataType value_type = ScalarTypeToCudaDataType(input.scalar_type());
   check_supported_cuda_type(value_type);
 
-  cusparseDnVecDescr_t raw_descriptor;
+  cusparseDnVecDescr_t raw_descriptor = nullptr;
   TORCH_CUDASPARSE_CHECK(cusparseCreateDnVec(
       &raw_descriptor, input.numel(), input.data_ptr(), value_type));
   descriptor_.reset(raw_descriptor);
@@ -169,7 +169,7 @@ CuSparseSpMatCsrDescriptor::CuSparseSpMatCsrDescriptor(const Tensor& input, int6
   auto values_batch_stride =
       values.dim() >= 2 && batch_offset >= 0 ? values_->stride(-2) : 0;
 
-  cusparseSpMatDescr_t raw_descriptor;
+  cusparseSpMatDescr_t raw_descriptor = nullptr;
   TORCH_CUDASPARSE_CHECK(cusparseCreateCsr(
       &raw_descriptor, // output descriptor
       rows,

--- a/aten/src/ATen/cuda/CUDASparseDescriptors.h
+++ b/aten/src/ATen/cuda/CUDASparseDescriptors.h
@@ -81,7 +81,7 @@ class TORCH_CUDA_CPP_API CuSparseMatDescriptor
     : public CuSparseDescriptor<cusparseMatDescr, &cusparseDestroyMatDescr> {
  public:
   CuSparseMatDescriptor() {
-    cusparseMatDescr_t raw_descriptor;
+    cusparseMatDescr_t raw_descriptor = nullptr;
     TORCH_CUDASPARSE_CHECK(cusparseCreateMatDescr(&raw_descriptor));
     descriptor_.reset(raw_descriptor);
   }
@@ -91,7 +91,7 @@ class TORCH_CUDA_CPP_API CuSparseMatDescriptor
         upper ? CUSPARSE_FILL_MODE_UPPER : CUSPARSE_FILL_MODE_LOWER;
     cusparseDiagType_t diag_type =
         unit ? CUSPARSE_DIAG_TYPE_UNIT : CUSPARSE_DIAG_TYPE_NON_UNIT;
-    cusparseMatDescr_t raw_descriptor;
+    cusparseMatDescr_t raw_descriptor = nullptr;
     TORCH_CUDASPARSE_CHECK(cusparseCreateMatDescr(&raw_descriptor));
     TORCH_CUDASPARSE_CHECK(cusparseSetMatFillMode(raw_descriptor, fill_mode));
     TORCH_CUDASPARSE_CHECK(cusparseSetMatDiagType(raw_descriptor, diag_type));
@@ -105,7 +105,7 @@ class TORCH_CUDA_CPP_API CuSparseBsrsv2Info
     : public CuSparseDescriptor<bsrsv2Info, &cusparseDestroyBsrsv2Info> {
  public:
   CuSparseBsrsv2Info() {
-    bsrsv2Info_t raw_descriptor;
+    bsrsv2Info_t raw_descriptor = nullptr;
     TORCH_CUDASPARSE_CHECK(cusparseCreateBsrsv2Info(&raw_descriptor));
     descriptor_.reset(raw_descriptor);
   }
@@ -115,7 +115,7 @@ class TORCH_CUDA_CPP_API CuSparseBsrsm2Info
     : public CuSparseDescriptor<bsrsm2Info, &cusparseDestroyBsrsm2Info> {
  public:
   CuSparseBsrsm2Info() {
-    bsrsm2Info_t raw_descriptor;
+    bsrsm2Info_t raw_descriptor = nullptr;
     TORCH_CUDASPARSE_CHECK(cusparseCreateBsrsm2Info(&raw_descriptor));
     descriptor_.reset(raw_descriptor);
   }
@@ -202,7 +202,7 @@ class TORCH_CUDA_CPP_API CuSparseSpMatCsrDescriptor
   explicit CuSparseSpMatCsrDescriptor(const Tensor& input, int64_t batch_offset = -1);
 
   std::tuple<int64_t, int64_t, int64_t> get_size() {
-    int64_t rows, cols, nnz;
+    int64_t rows = 0, cols = 0, nnz = 0;
     TORCH_CUDASPARSE_CHECK(cusparseSpMatGetSize(
         this->descriptor(),
         &rows,
@@ -254,7 +254,7 @@ class TORCH_CUDA_CPP_API CuSparseSpSVDescriptor
     : public CuSparseDescriptor<cusparseSpSVDescr, &cusparseSpSV_destroyDescr> {
  public:
   CuSparseSpSVDescriptor() {
-    cusparseSpSVDescr_t raw_descriptor;
+    cusparseSpSVDescr_t raw_descriptor = nullptr;
     TORCH_CUDASPARSE_CHECK(cusparseSpSV_createDescr(&raw_descriptor));
     descriptor_.reset(raw_descriptor);
   }
@@ -266,7 +266,7 @@ class TORCH_CUDA_CPP_API CuSparseSpSMDescriptor
     : public CuSparseDescriptor<cusparseSpSMDescr, &cusparseSpSM_destroyDescr> {
  public:
   CuSparseSpSMDescriptor() {
-    cusparseSpSMDescr_t raw_descriptor;
+    cusparseSpSMDescr_t raw_descriptor = nullptr;
     TORCH_CUDASPARSE_CHECK(cusparseSpSM_createDescr(&raw_descriptor));
     descriptor_.reset(raw_descriptor);
   }
@@ -277,7 +277,7 @@ class TORCH_CUDA_CPP_API CuSparseSpGEMMDescriptor
     : public CuSparseDescriptor<cusparseSpGEMMDescr, &cusparseSpGEMM_destroyDescr> {
  public:
   CuSparseSpGEMMDescriptor() {
-    cusparseSpGEMMDescr_t raw_descriptor;
+    cusparseSpGEMMDescr_t raw_descriptor = nullptr;
     TORCH_CUDASPARSE_CHECK(cusparseSpGEMM_createDescr(&raw_descriptor));
     descriptor_.reset(raw_descriptor);
   }

--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -161,7 +161,7 @@ struct CUDACachingHostAllocatorImpl
         cudaHostRegister((void*)ptr, (size_t)size, cudaHostRegisterDefault));
 
     // If host and device pointer don't match, give a warning and exit
-    void* devptr;
+    void* devptr = nullptr;
     AT_CUDA_CHECK(cudaHostGetDevicePointer(&devptr, (void*)ptr, 0));
     TORCH_CHECK(
         (void*)devptr == (void*)ptr,

--- a/aten/src/ATen/cuda/PeerToPeerAccess.cpp
+++ b/aten/src/ATen/cuda/PeerToPeerAccess.cpp
@@ -48,7 +48,7 @@ bool get_p2p_access(int dev, int dev_to_access) {
     return cache;
   }
 
-  int result;
+  int result = 0;
   C10_CUDA_CHECK(cudaDeviceCanAccessPeer(&result, dev, dev_to_access));
   cache = result ? 1 : 0;
   if (cache) {

--- a/aten/src/ATen/cuda/cub.h
+++ b/aten/src/ATen/cuda/cub.h
@@ -39,7 +39,7 @@ void radix_sort_pairs(
     const key_t *keys_in, key_t *keys_out,
     const value_t *values_in, value_t *values_out,
     int64_t n, bool descending=false, int64_t begin_bit=0, int64_t end_bit=sizeof(key_t)*8) {
-  static_assert(std::is_trivially_copyable<value_t>::value ||
+  static_assert(std::is_trivially_copyable_v<value_t> ||
                 AT_ROCM_ENABLED(),  // ROCm incorrectly fails this check for vector types
                 "radix_sort_pairs value type must be trivially copyable");
   // Make value type opaque, so all inputs of a certain size use the same template instantiation

--- a/aten/src/ATen/cuda/jiterator_impl.h
+++ b/aten/src/ATen/cuda/jiterator_impl.h
@@ -117,7 +117,7 @@ struct OffsetCalculatorVariant {
   }
 
  private:
-  OffsetCalculatorTypes v;
+  OffsetCalculatorTypes v{};
 };
 
 struct ArrayVariant {
@@ -182,7 +182,7 @@ struct TrivialOffsetCalculatorVariant {
   }
 
 private:
-  TrivialOffsetCalculatorTypes v;
+  TrivialOffsetCalculatorTypes v{};
 };
 
 struct LoadWithCastVariant {
@@ -211,7 +211,7 @@ struct LoadWithCastVariant {
   }
 
 private:
-  LoadWithCastPtr v;
+  LoadWithCastPtr v{};
 };
 
 struct StoreWithCastVariant {
@@ -240,7 +240,7 @@ struct StoreWithCastVariant {
   }
 
 private:
-  StoreWithCastPtr v;
+  StoreWithCastPtr v{};
 };
 
 } // namespace at::native


### PR DESCRIPTION
Fixes clang-tidy warnings
