### PR TITLE
[3/N] Enable clang-tidy in aten/src/ATen/detail/

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -193,6 +193,7 @@ include_patterns = [
     'aten/src/ATen/*.cpp',
     'aten/src/ATen/core/*.h',
     'aten/src/ATen/core/*.cpp',
+    'aten/src/ATen/detail/*',
     'aten/src/ATen/functorch/*.h',
     'aten/src/ATen/functorch/*.cpp',
     'c10/**/*.cpp',

--- a/aten/src/ATen/detail/MTIAHooksInterface.h
+++ b/aten/src/ATen/detail/MTIAHooksInterface.h
@@ -40,7 +40,7 @@ struct TORCH_API MTIAHooksInterface : AcceleratorHooksInterface {
     return false;
   }
 
-  virtual DeviceIndex deviceCount() const override {
+  DeviceIndex deviceCount() const override {
     return 0;
   }
 
@@ -56,21 +56,21 @@ struct TORCH_API MTIAHooksInterface : AcceleratorHooksInterface {
     return false;
   }
 
-  virtual void setCurrentDevice(DeviceIndex device) const override {
+  void setCurrentDevice(DeviceIndex device) const override {
     FAIL_MTIAHOOKS_FUNC(__func__);
   }
 
-  virtual DeviceIndex getCurrentDevice() const override {
-    FAIL_MTIAHOOKS_FUNC(__func__);
-    return -1;
-  }
-
-  virtual DeviceIndex exchangeDevice(DeviceIndex device) const override {
+  DeviceIndex getCurrentDevice() const override {
     FAIL_MTIAHOOKS_FUNC(__func__);
     return -1;
   }
 
-  virtual DeviceIndex maybeExchangeDevice(DeviceIndex device) const override {
+  DeviceIndex exchangeDevice(DeviceIndex device) const override {
+    FAIL_MTIAHOOKS_FUNC(__func__);
+    return -1;
+  }
+
+  DeviceIndex maybeExchangeDevice(DeviceIndex device) const override {
     FAIL_MTIAHOOKS_FUNC(__func__);
     return -1;
   }

--- a/aten/src/ATen/detail/XPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/XPUHooksInterface.cpp
@@ -2,8 +2,6 @@
 
 #include <c10/util/CallOnce.h>
 
-#include <memory>
-
 namespace at {
 namespace detail {
 


### PR DESCRIPTION
Following #127168
