### PR TITLE
Quick Fix on #126854, deepcopy `lr` and other possible `base_parameters`

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2416,8 +2416,6 @@ class TestLRScheduler(TestCase):
             partial(ExponentialLR, gamma=0.9),
             PolynomialLR,
             partial(CosineAnnealingLR, T_max=10),
-            partial(CyclicLR, base_lr=0.01, max_lr=0.1),
-            partial(OneCycleLR, max_lr=0.01, total_steps=10, anneal_strategy="linear"),
             partial(CosineAnnealingWarmRestarts, T_0=20),
         ],
     )
@@ -2432,8 +2430,10 @@ class TestLRScheduler(TestCase):
         for i in range(2):
             opt.step()
             sch.step(i)
+            lr.multiply_(0.1)
             for group, ori_group in zip(opt.param_groups, ori_param_groups):
                 self.assertEqual(group["initial_lr"], ori_group["initial_lr"])
+                self.assertEqual(sch.base_lrs, [0.1])
 
     def test_constant_initial_params_cyclelr(self):
         # Test that the initial learning rate is constant

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: optimizer", "module: LrScheduler" ]
+import copy
 import math
 import pickle
 import tempfile
@@ -2402,6 +2403,100 @@ class TestLRScheduler(TestCase):
             scheduler2 = LRClass(self.opt)
             scheduler2.load_state_dict(state_dict_loaded)
             self.assertEqual(scheduler2.state_dict(), state_dict)
+
+    @parametrize(
+        "LRClass",
+        [
+            partial(LambdaLR, lr_lambda=lambda e: e // 10),
+            partial(MultiplicativeLR, lr_lambda=lambda e: 0.95),
+            partial(StepLR, step_size=30),
+            partial(MultiStepLR, milestones=[30, 80]),
+            ConstantLR,
+            LinearLR,
+            partial(ExponentialLR, gamma=0.9),
+            PolynomialLR,
+            partial(CosineAnnealingLR, T_max=10),
+            partial(CyclicLR, base_lr=0.01, max_lr=0.1),
+            partial(OneCycleLR, max_lr=0.01, total_steps=10, anneal_strategy="linear"),
+            partial(CosineAnnealingWarmRestarts, T_0=20),
+        ],
+    )
+    def test_constant_initial_lr(self, LRClass):
+        # Test that the initial learning rate is constant
+        lr = torch.as_tensor(0.1)
+        opt = SGD([torch.nn.Parameter(torch.randn(1))], lr=lr)
+        sch = LRClass(opt)
+
+        ori_param_groups = copy.deepcopy(opt.param_groups)
+
+        for i in range(2):
+            opt.step()
+            sch.step(i)
+            for group, ori_group in zip(opt.param_groups, ori_param_groups):
+                self.assertEqual(group["initial_lr"], ori_group["initial_lr"])
+
+    def test_constant_initial_params_cyclelr(self):
+        # Test that the initial learning rate is constant
+        lr = torch.as_tensor(0.1)
+        max_lr = torch.as_tensor(0.2)
+        base_momentum = torch.as_tensor(0.8)
+        max_momentum = torch.as_tensor(0.9)
+        opt = SGD([torch.nn.Parameter(torch.randn(1))], lr=lr)
+        sch = CyclicLR(
+            opt,
+            base_lr=lr,
+            max_lr=max_lr,
+            base_momentum=base_momentum,
+            max_momentum=max_momentum,
+        )
+        ori_param_groups = copy.deepcopy(opt.param_groups)
+
+        for i in range(2):
+            lr.multiply_(0.5)
+            max_lr.multiply_(0.5)
+            base_momentum.multiply_(0.5)
+            max_momentum.multiply_(0.5)
+            opt.step()
+            sch.step(i)
+            for group, ori_group in zip(opt.param_groups, ori_param_groups):
+                self.assertEqual(group["initial_lr"], ori_group["initial_lr"])
+                self.assertEqual(group["max_momentum"], ori_group["max_momentum"])
+                self.assertEqual(group["base_momentum"], ori_group["base_momentum"])
+                self.assertEqual(sch.base_lrs, [0.1])
+                self.assertEqual(sch.max_lrs, [0.2])
+                self.assertEqual(group["max_momentum"], 0.9)
+                self.assertEqual(group["base_momentum"], 0.8)
+
+    def test_constant_initial_params_onecyclelr(self):
+        # Test that the initial learning rate is constant
+        lr = torch.as_tensor(0.1)
+        base_momentum = torch.as_tensor(0.85)
+        max_momentum = torch.as_tensor(0.95)
+        opt = SGD([torch.nn.Parameter(torch.randn(1))], lr=lr)
+        sch = OneCycleLR(
+            opt,
+            max_lr=lr,
+            total_steps=10,
+            base_momentum=base_momentum,
+            max_momentum=max_momentum,
+        )
+        ori_param_groups = copy.deepcopy(opt.param_groups)
+
+        for i in range(2):
+            lr.multiply_(0.5)
+            base_momentum.multiply_(0.5)
+            max_momentum.multiply_(0.5)
+            opt.step()
+            sch.step(i)
+
+            for group, ori_group in zip(opt.param_groups, ori_param_groups):
+                self.assertEqual(group["initial_lr"], ori_group["initial_lr"])
+                self.assertEqual(group["max_lr"], ori_group["max_lr"])
+                self.assertEqual(group["min_lr"], ori_group["min_lr"])
+                self.assertEqual(group["max_momentum"], ori_group["max_momentum"])
+                self.assertEqual(group["base_momentum"], ori_group["base_momentum"])
+                self.assertEqual(group["max_momentum"], 0.95)
+                self.assertEqual(group["base_momentum"], 0.85)
 
 
 instantiate_parametrized_tests(TestLRScheduler)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -78,7 +78,10 @@ class LRScheduler:
         # Initialize epoch and base learning rates
         if last_epoch == -1:
             for group in optimizer.param_groups:
-                group.setdefault("initial_lr", copy.deepcopy(group["lr"]))
+                initial_lr = group["lr"]
+                if isinstance(initial_lr, Tensor):
+                    initial_lr = initial_lr.clone().detach()
+                group.setdefault("initial_lr", initial_lr)
         else:
             for i, group in enumerate(optimizer.param_groups):
                 if "initial_lr" not in group:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -69,7 +69,7 @@ def _format_param(name: str, optimizer: Optimizer, param):
     """Return correctly formatted lr/momentum for each param group."""
 
     def _copy(_param):
-        return _param.clone().detach() if isinstance(_param, Tensor) else _param
+        return _param.clone() if isinstance(_param, Tensor) else _param
 
     if isinstance(param, (list, tuple)):
         if len(param) != len(optimizer.param_groups):
@@ -97,7 +97,7 @@ class LRScheduler:
             for group in optimizer.param_groups:
                 initial_lr = group["lr"]
                 if isinstance(initial_lr, Tensor):
-                    initial_lr = initial_lr.clone().detach()
+                    initial_lr = initial_lr.clone()
                 group.setdefault("initial_lr", initial_lr)
         else:
             for i, group in enumerate(optimizer.param_groups):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1565,7 +1565,7 @@ class CyclicLR(LRScheduler):
             self._scale_fn_ref = partial(self._exp_range_scale_fn, self.gamma)
             self.scale_mode = "iterations"
 
-    def _format_param(self, name, optimizer, param, deepcopy: bool = True):
+    def _format_param(self, name, optimizer, param, deep_copy: bool = True):
         """Return correctly formatted lr/momentum for each param group."""
         if isinstance(param, (list, tuple)):
             if len(param) != len(optimizer.param_groups):
@@ -1575,7 +1575,7 @@ class CyclicLR(LRScheduler):
         else:
             param = [param] * len(optimizer.param_groups)
 
-        return copy.deepcopy(param) if deepcopy else param
+        return copy.deepcopy(param) if deep_copy else param
 
     def scale_fn(self, x) -> float:
         if self._scale_fn_custom is not None:
@@ -2049,7 +2049,7 @@ class OneCycleLR(LRScheduler):
 
         super().__init__(optimizer, last_epoch, verbose)
 
-    def _format_param(self, name, optimizer, param, deepcopy: bool = True):
+    def _format_param(self, name, optimizer, param, deep_copy: bool = True):
         """Return correctly formatted lr/momentum for each param group."""
         if isinstance(param, (list, tuple)):
             if len(param) != len(optimizer.param_groups):
@@ -2059,7 +2059,7 @@ class OneCycleLR(LRScheduler):
         else:
             param = [param] * len(optimizer.param_groups)
 
-        return copy.deepcopy(param) if deepcopy else param
+        return copy.deepcopy(param) if deep_copy else param
 
     def _anneal_func(self, *args, **kwargs):
         if hasattr(self, "_anneal_func_type"):

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -413,6 +413,7 @@ class SWALR(LRScheduler):
     def _format_param(
         optimizer: Optimizer,
         swa_lrs: Union[float, List[float], Tuple[float, ...]],
+        deep_copy: bool = False,
     ) -> Union[List[float], Tuple[float, ...]]:
         if isinstance(swa_lrs, (list, tuple)):
             if len(swa_lrs) != len(optimizer.param_groups):
@@ -421,9 +422,10 @@ class SWALR(LRScheduler):
                     f"optimizer.param_groups: swa_lr has {len(swa_lrs)}, "
                     f"optimizer.param_groups has {len(optimizer.param_groups)}"
                 )
-            return swa_lrs
         else:
-            return [swa_lrs] * len(optimizer.param_groups)
+            swa_lrs = [swa_lrs] * len(optimizer.param_groups)
+
+        return deepcopy(swa_lrs) if deep_copy else swa_lrs
 
     @staticmethod
     def _linear_anneal(t):

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Iterable, List, Literal, Optional, Tuple, Unio
 import torch
 from torch import Tensor
 from torch.nn import Module
-from torch.optim.lr_scheduler import LRScheduler
+from torch.optim.lr_scheduler import _format_param, LRScheduler
 from torch.utils._foreach_utils import _get_foreach_kernels_supported_devices
 from .optimizer import Optimizer
 
@@ -390,7 +390,7 @@ class SWALR(LRScheduler):
         anneal_strategy: Literal["cos", "linear"] = "cos",
         last_epoch=-1,
     ):
-        swa_lrs = self._format_param(optimizer, swa_lr)
+        swa_lrs = _format_param("swa_lr", optimizer, swa_lr)
         for swa_lr, group in zip(swa_lrs, optimizer.param_groups):
             group["swa_lr"] = swa_lr
         if anneal_strategy not in ["cos", "linear"]:
@@ -408,24 +408,6 @@ class SWALR(LRScheduler):
             )
         self.anneal_epochs = anneal_epochs
         super().__init__(optimizer, last_epoch)
-
-    @staticmethod
-    def _format_param(
-        optimizer: Optimizer,
-        swa_lrs: Union[float, List[float], Tuple[float, ...]],
-        deep_copy: bool = True,
-    ) -> Union[List[float], Tuple[float, ...]]:
-        if isinstance(swa_lrs, (list, tuple)):
-            if len(swa_lrs) != len(optimizer.param_groups):
-                raise ValueError(
-                    "swa_lr must have the same length as "
-                    f"optimizer.param_groups: swa_lr has {len(swa_lrs)}, "
-                    f"optimizer.param_groups has {len(optimizer.param_groups)}"
-                )
-        else:
-            swa_lrs = [swa_lrs] * len(optimizer.param_groups)
-
-        return deepcopy(swa_lrs) if deep_copy else swa_lrs
 
     @staticmethod
     def _linear_anneal(t):

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -413,7 +413,7 @@ class SWALR(LRScheduler):
     def _format_param(
         optimizer: Optimizer,
         swa_lrs: Union[float, List[float], Tuple[float, ...]],
-        deep_copy: bool = False,
+        deep_copy: bool = True,
     ) -> Union[List[float], Tuple[float, ...]]:
         if isinstance(swa_lrs, (list, tuple)):
             if len(swa_lrs) != len(optimizer.param_groups):


### PR DESCRIPTION
* Apply `deepcopy` to every base parameters (`initial_lr`, `max_lr`) when instantiating `LRScheduler`.

Fixes #126854
