### PR TITLE
Update triton-xpu commit pin merge rules for XPU

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -245,6 +245,7 @@
   - torch/xpu/**
   - test/xpu/**
   - third_party/xpu.txt
+  - .ci/docker/ci_commit_pins/triton-xpu.txt
   approved_by:
   - EikanWang
   - jgong5


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127203

Add the ".ci/docker/ci_commit_pins/triton-xpu.txt" to the XPU merge rules.
