### PR TITLE
[Inductor] FlexAttention backward kernel optimization

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -147,9 +147,9 @@ class TestFlexAttention(InductorTestCase):
         if compiled_error > ref_error * fudge_factor:
             name = tensor_name if tensor_name is not None else ""
             msg = f"{name} Compiled error {compiled_error} is greater than ref error {ref_error} by more than {fudge_factor}X."
-            # self.assertTrue(False, msg)
-            print(name)
-            print(msg)
+            self.assertTrue(False, msg)
+            # print(name)
+            # print(msg)
 
     def run_test(
         self,
@@ -326,7 +326,7 @@ class TestFlexAttention(InductorTestCase):
         self.assertEqual(torch._dynamo.utils.counters["frames"]["ok"], 2)
 
     @supported_platform
-    @common_utils.parametrize("dtype", test_dtypes_fast)
+    @common_utils.parametrize("dtype", test_dtypes)
     @common_utils.parametrize("score_mod", test_score_mods)
     def test_builtin_score_mods(self, dtype: torch.dtype, score_mod: Callable):
         self.run_test(score_mod, dtype)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -19,7 +19,10 @@ from torch.nn.attention._flex_attention import (
     _causal,
     _compose,
     _flex_attention,
+    _generate_alibi_bias,
     _identity,
+    _rel_bias,
+    _rel_causal,
 )
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
@@ -96,13 +99,13 @@ def _trig2(score, b, h, m, n):
 
 test_score_mods = [
     _identity,
-    # _times_two,
-    # _squared,
-    # _causal,
-    # _inverse_causal,
-    # _rel_bias,
-    # _rel_causal,
-    # _generate_alibi_bias(8),
+    _times_two,
+    _squared,
+    _causal,
+    _inverse_causal,
+    _rel_bias,
+    _rel_causal,
+    _generate_alibi_bias(8),
 ]
 
 captured_buffers_map = {

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -19,10 +19,7 @@ from torch.nn.attention._flex_attention import (
     _causal,
     _compose,
     _flex_attention,
-    _generate_alibi_bias,
     _identity,
-    _rel_bias,
-    _rel_causal,
 )
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
@@ -99,13 +96,13 @@ def _trig2(score, b, h, m, n):
 
 test_score_mods = [
     _identity,
-    _times_two,
-    _squared,
-    _causal,
-    _inverse_causal,
-    _rel_bias,
-    _rel_causal,
-    _generate_alibi_bias(8),
+    # _times_two,
+    # _squared,
+    # _causal,
+    # _inverse_causal,
+    # _rel_bias,
+    # _rel_causal,
+    # _generate_alibi_bias(8),
 ]
 
 captured_buffers_map = {
@@ -324,24 +321,24 @@ class TestFlexAttention(InductorTestCase):
         self.assertEqual(torch._dynamo.utils.counters["frames"]["ok"], 2)
 
     @supported_platform
-    @common_utils.parametrize("dtype", test_dtypes)
+    @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.parametrize("score_mod", test_score_mods)
     def test_builtin_score_mods(self, dtype: torch.dtype, score_mod: Callable):
         self.run_test(score_mod, dtype)
 
-    @supported_platform
-    @common_utils.parametrize("dtype", test_dtypes)
-    @common_utils.parametrize("score_mod", test_score_mods)
-    def test_builtin_score_mods_dynamic(self, dtype: torch.dtype, score_mod: Callable):
-        self.run_dynamic_test(score_mod, dtype)
+    # @supported_platform
+    # @common_utils.parametrize("dtype", test_dtypes)
+    # @common_utils.parametrize("score_mod", test_score_mods)
+    # def test_builtin_score_mods_dynamic(self, dtype: torch.dtype, score_mod: Callable):
+    #     self.run_dynamic_test(score_mod, dtype)
 
-    @supported_platform
-    @common_utils.parametrize("dtype", test_dtypes)
-    @common_utils.parametrize("score_mod", test_score_mods)
-    def test_builtin_score_mods_automatic_dynamic(
-        self, dtype: torch.dtype, score_mod: Callable
-    ):
-        self.run_automatic_dynamic_test(score_mod, dtype)
+    # @supported_platform
+    # @common_utils.parametrize("dtype", test_dtypes)
+    # @common_utils.parametrize("score_mod", test_score_mods)
+    # def test_builtin_score_mods_automatic_dynamic(
+    #     self, dtype: torch.dtype, score_mod: Callable
+    # ):
+    #     self.run_automatic_dynamic_test(score_mod, dtype)
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -144,7 +144,9 @@ class TestFlexAttention(InductorTestCase):
         if compiled_error > ref_error * fudge_factor:
             name = tensor_name if tensor_name is not None else ""
             msg = f"{name} Compiled error {compiled_error} is greater than ref error {ref_error} by more than {fudge_factor}X."
-            self.assertTrue(False, msg)
+            # self.assertTrue(False, msg)
+            print(name)
+            print(msg)
 
     def run_test(
         self,

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -144,12 +144,12 @@ class TestFlexAttention(InductorTestCase):
     ):
         compiled_error = (golden_out - compiled_out).abs().mean()
         ref_error = (golden_out - ref_out).abs().mean()
+        if torch.isnan(compiled_error).any() and torch.isnan(ref_error).any():
+            self.assertTrue(False, "Output/Grad with NaN")
         if compiled_error > ref_error * fudge_factor:
             name = tensor_name if tensor_name is not None else ""
             msg = f"{name} Compiled error {compiled_error} is greater than ref error {ref_error} by more than {fudge_factor}X."
             self.assertTrue(False, msg)
-            # print(name)
-            # print(msg)
 
     def run_test(
         self,
@@ -331,19 +331,19 @@ class TestFlexAttention(InductorTestCase):
     def test_builtin_score_mods(self, dtype: torch.dtype, score_mod: Callable):
         self.run_test(score_mod, dtype)
 
-    # @supported_platform
-    # @common_utils.parametrize("dtype", test_dtypes)
-    # @common_utils.parametrize("score_mod", test_score_mods)
-    # def test_builtin_score_mods_dynamic(self, dtype: torch.dtype, score_mod: Callable):
-    #     self.run_dynamic_test(score_mod, dtype)
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    @common_utils.parametrize("score_mod", test_score_mods)
+    def test_builtin_score_mods_dynamic(self, dtype: torch.dtype, score_mod: Callable):
+        self.run_dynamic_test(score_mod, dtype)
 
-    # @supported_platform
-    # @common_utils.parametrize("dtype", test_dtypes)
-    # @common_utils.parametrize("score_mod", test_score_mods)
-    # def test_builtin_score_mods_automatic_dynamic(
-    #     self, dtype: torch.dtype, score_mod: Callable
-    # ):
-    #     self.run_automatic_dynamic_test(score_mod, dtype)
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    @common_utils.parametrize("score_mod", test_score_mods)
+    def test_builtin_score_mods_automatic_dynamic(
+        self, dtype: torch.dtype, score_mod: Callable
+    ):
+        self.run_automatic_dynamic_test(score_mod, dtype)
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -191,7 +191,7 @@ class TestFlexAttention(InductorTestCase):
             self._check_equal(
                 q_gold.grad, q_ref.grad, q.grad, q_fudge_factor, "Grad_Query"
             )
-            k_fudge_factor = 8 * fudge_factor
+            k_fudge_factor = 4 * fudge_factor
             self._check_equal(
                 k_gold.grad, k_ref.grad, k.grad, k_fudge_factor, "Grad_Key"
             )

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -193,11 +193,11 @@ class TestFlexAttention(InductorTestCase):
             self._check_equal(
                 q_gold.grad, q_ref.grad, q.grad, q_fudge_factor, "Grad_Query"
             )
-            k_fudge_factor = 4 * fudge_factor
+            k_fudge_factor = 8 * fudge_factor
             self._check_equal(
                 k_gold.grad, k_ref.grad, k.grad, k_fudge_factor, "Grad_Key"
             )
-            v_fudge_factor = 8 * fudge_factor
+            v_fudge_factor = 4 * fudge_factor
             self._check_equal(
                 v_gold.grad, v_ref.grad, v.grad, v_fudge_factor, "Grad_Value"
             )

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -144,8 +144,6 @@ class TestFlexAttention(InductorTestCase):
     ):
         compiled_error = (golden_out - compiled_out).abs().mean()
         ref_error = (golden_out - ref_out).abs().mean()
-        if torch.isnan(compiled_error).any() and torch.isnan(ref_error).any():
-            self.assertTrue(False, "Output/Grad with NaN")
         if compiled_error > ref_error * fudge_factor:
             name = tensor_name if tensor_name is not None else ""
             msg = f"{name} Compiled error {compiled_error} is greater than ref error {ref_error} by more than {fudge_factor}X."

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -31,7 +31,10 @@ from torch.utils._triton import has_triton
 
 # Skip tests if Triton is not available
 supported_platform = skipUnless(
-    torch.cuda.is_available() and has_triton() and torch.version.hip is None,
+    torch.cuda.is_available()
+    and has_triton()
+    and torch.version.hip is None
+    and torch.cuda.get_device_capability() >= (8, 0),
     "Requires CUDA and Triton",
 )
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -144,6 +144,8 @@ class TestFlexAttention(InductorTestCase):
     ):
         compiled_error = (golden_out - compiled_out).abs().mean()
         ref_error = (golden_out - ref_out).abs().mean()
+        if torch.isnan(compiled_error).any() and not torch.isnan(ref_error).any():
+            self.assertTrue(False, "Output/Grad with NaN")
         if compiled_error > ref_error * fudge_factor:
             name = tensor_name if tensor_name is not None else ""
             msg = f"{name} Compiled error {compiled_error} is greater than ref error {ref_error} by more than {fudge_factor}X."

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -690,6 +690,8 @@ flex_attention_backward_template = TritonTemplate(
             kT = tl.load(kT_ptrs)
             vT = tl.load(vT_ptrs)
             qk = tl.dot(q, kT)
+            if not SCORE_MOD_IS_LINEAR:
+                qk *= 1.44269504
             p = tl.math.exp2(qk - m_)
             # Autoregressive masking.
             # if MASK:

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -478,8 +478,10 @@ flex_attention_backward_template = TritonTemplate(
     # M: Number of queries, N: Number of keys/values, D: Model dimension
     # z: Batch size, h: Number of heads, m: Number of queries per head, k: Number of keys per head
     # (Modifiable) Config options:
-    # BLOCK_M
-    # BLOCK_N
+    # BLOCK_M1: when calculating DK & DV, iterate over BLOCK_M1 across the seqlen dim of Q in each thread block.
+    # BLOCK_N1: when calculating DK & DV, the thread block size across the seqlen dim of K/V.
+    # BLOCK_M2: when calculating DQ, the thread block size across the seqlen dim of Q.
+    # BLOCK_N2: when calculating DQ, iterate over BLOCK_N2 across the seqlen dim of K/V in each thread block.
     # SCORE_MOD_IS_LINEAR: Is the score modifier linear? If so, we can lift the
     # change of base out of the loop
 

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -625,10 +625,10 @@ flex_attention_backward_template = TritonTemplate(
             lse = tl.load(LSE + offs_m1)
             qkT = tl.dot(k, qT)
             # ~~~~~~~~~~~~~~~~~~~ Apply score modification  ~~~~~~~~~~~~~~~~~~~
-            pre_mod_scores = qkT
             m = offs_m1[:, None]
             n = offs_n1[None, :]
             qk = tl.trans(qkT)
+            pre_mod_scores = qk
             {{ modification(
                 subgraph_number=0,
                 output_name="post_mod_scores",

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -780,7 +780,7 @@ def flex_attention_backward(*args, **kwargs):
             BLOCK_M1=BLOCK_M,
             BLOCK_N1=BLOCK_N,
             BLOCK_M2=BLOCK_N,
-            BLOCK_N2=BLOCK_N,
+            BLOCK_N2=BLOCK_M,
             BLOCK_DMODEL=query.get_size()[-1],
             # For now, we always assume the "sound" option
             SCORE_MOD_IS_LINEAR=False,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -158,7 +158,7 @@ class TritonTemplateKernel(TritonKernel):
 
     @contextlib.contextmanager
     def create_subgraph_body(self, body_name: str):
-        assert body_name not in self.subgraph_bodies
+        # assert body_name not in self.subgraph_bodies
         self.subgraph_bodies[body_name] = IndentedBuffer()
         with self.set_subgraph_body(body_name):
             yield

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -158,7 +158,7 @@ class TritonTemplateKernel(TritonKernel):
 
     @contextlib.contextmanager
     def create_subgraph_body(self, body_name: str):
-        # assert body_name not in self.subgraph_bodies
+        assert body_name not in self.subgraph_bodies
         self.subgraph_bodies[body_name] = IndentedBuffer()
         with self.set_subgraph_body(body_name):
             yield
@@ -310,7 +310,10 @@ class TritonTemplateKernel(TritonKernel):
         Args:
             subgraph_number (int): The index of the subgraph in self.subgraphs
         """
-        with self.create_subgraph_body(f"modification_{subgraph_number}"):
+        num = 0
+        while f"mod_{subgraph_number}_{num}" in self.subgraph_bodies:
+            num += 1
+        with self.create_subgraph_body(f"mod_{subgraph_number}_{num}"):
             assert isinstance(subgraph_number, int)
             assert isinstance(self.subgraphs, list)
             assert (


### PR DESCRIPTION
BWD Speedups (before this PR):
```
| Type    |   Speedup | shape             | score_mod     | dtype          |
|---------|-----------|-------------------|---------------|----------------|
| Average |     0.211 |                   |               |                |
| Max     |     0.364 | (16, 16, 512, 64) | relative_bias | torch.bfloat16 |
| Min     |     0.044 | (2, 16, 4096, 64) | causal_mask   | torch.bfloat16 |
```
BWD Speedups (after this PR, though not optimizing block size yet):
```
| Type    |   Speedup | shape              | score_mod     | dtype          |
|---------|-----------|--------------------|---------------|----------------|
| Average |     0.484 |                    |               |                |
| Max     |     0.626 | (2, 16, 512, 256)  | head_bias     | torch.bfloat16 |
| Min     |     0.355 | (8, 16, 4096, 128) | relative_bias | torch.bfloat16 |
```

There are a few things need to do as follow-ups:
* Optimized default block size on A100/H100.
* Support different seqlen for Q and K/V.
* Support dynamic shapes for backward.
* Enhance unit tests to check there is no ```nan``` value in any grad. I think we should make some changes to ```test_padded_dense_causal``` because it has invalid inputs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang