### PR TITLE
[DSD] Fix to remove non_persistent buffer in distributed state dict (#125337)

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -566,7 +566,6 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         ddp_model = DDP(copy.deepcopy(model))
         set_model_state_dict(ddp_model, get_model_state_dict(ddp_model))
         self.assertEqual(model.state_dict(), get_model_state_dict(ddp_model))
-    
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_fsdp_root_not_initialized(self) -> None:

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -566,6 +566,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         ddp_model = DDP(copy.deepcopy(model))
         set_model_state_dict(ddp_model, get_model_state_dict(ddp_model))
         self.assertEqual(model.state_dict(), get_model_state_dict(ddp_model))
+
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_fsdp_root_not_initialized(self) -> None:

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -555,6 +555,17 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
         self.assertEqual(original_keys, new_keys)
 
+    @with_comms
+    @skip_if_lt_x_gpu(1)
+    def test_non_persistent_buffers(self) -> None:
+        model = CompositeParamModel(device=torch.device("cuda"))
+        model.register_buffer(
+            "dont_save_me", torch.rand(100, device="cuda"), persistent=False
+        )
+        ddp_model = DDP(copy.deepcopy(model))
+        set_model_state_dict(ddp_model, get_model_state_dict(ddp_model))
+        self.assertEqual(model.state_dict(), get_model_state_dict(ddp_model))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -215,6 +215,8 @@ def _iterate_valid_model_state(model):
         for name, obj in chain(
             module.named_buffers(recurse=False), module.named_parameters(recurse=False)
         ):
+            if name in module._non_persistent_buffers_set:
+                continue
             new_fqn = f"{curr_fqn}{name}"
             yield new_fqn, obj
 


### PR DESCRIPTION
PR for 2.3.1 cherry-picking. ⚠️  https://github.com/pytorch/pytorch/pull/126567 must be merged before

[DSD] Fix to remove non_persistent buffer in distributed state dict (#125337)

Summary:
Fixes #122792

state_dict includes only persistent buffers, while named_buffers() would
include non_persistent buffers.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/125337
Approved by: https://github.com/awgu
ghstack dependencies: #125333, #125501, #125334, #125335, #125336

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC @atalman 