### PR TITLE
Add float16 and bfloat16 to support grid_sample CPU kernels

### DIFF
--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -1184,7 +1184,10 @@ void grid_sampler_2d_cpu_kernel_impl(
     return;                                                                    \
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "grid_sampler_2d_cpu_kernel_impl", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half,
+                                  at::ScalarType::BFloat16,
+                                  input.scalar_type(),
+                                  "grid_sampler_2d_cpu_kernel_impl", [&] {
     auto out_acc = output.accessor<scalar_t, 4>();
     auto inp_acc = input.accessor<const scalar_t, 4>();
     auto grid_acc = grid.accessor<const scalar_t, 4>();
@@ -1272,7 +1275,10 @@ void grid_sampler_2d_backward_cpu_kernel_impl(
     return;                                                                 \
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "grid_sampler_2d_backward_cpu_kernel_impl", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half,
+                                  at::ScalarType::BFloat16,
+                                  input.scalar_type(),
+                                  "grid_sampler_2d_backward_cpu_kernel_impl", [&] {
     auto gGrid_acc = grad_grid.accessor<scalar_t, 4>();
     auto inp_acc = input.accessor<const scalar_t, 4>();
     auto grid_acc = grid.accessor<const scalar_t, 4>();

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -1184,7 +1184,7 @@ void grid_sampler_2d_cpu_kernel_impl(
     return;                                                                    \
   }
 
-  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "grid_sampler_2d_cpu_kernel_impl", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "grid_sampler_2d_cpu_kernel_impl", [&] {
     auto out_acc = output.accessor<scalar_t, 4>();
     auto inp_acc = input.accessor<const scalar_t, 4>();
     auto grid_acc = grid.accessor<const scalar_t, 4>();
@@ -1272,7 +1272,7 @@ void grid_sampler_2d_backward_cpu_kernel_impl(
     return;                                                                 \
   }
 
-  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "grid_sampler_2d_backward_cpu_kernel_impl", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "grid_sampler_2d_backward_cpu_kernel_impl", [&] {
     auto gGrid_acc = grad_grid.accessor<scalar_t, 4>();
     auto inp_acc = input.accessor<const scalar_t, 4>();
     auto grid_acc = grid.accessor<const scalar_t, 4>();

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10356,7 +10356,6 @@ class TestNNDeviceType(NNTestCase):
             small_image.grad.zero_()
             large_view.grad.zero_()
 
-    @onlyCUDA
     def test_grid_sample_half_precision(self):
         def helper(shape_in, shape_out, align_corners):
             for mode in ('bilinear', 'nearest', 'bicubic'):
@@ -10376,7 +10375,6 @@ class TestNNDeviceType(NNTestCase):
         helper((32, 64, 16, 16), (32, 8, 8, 2), False)
         helper((32, 64, 16, 16, 16), (32, 8, 8, 8, 3), False)
 
-    @onlyCUDA
     def test_grid_sample_bfloat16_precision(self):
         def helper(shape_in, shape_out, align_corners):
             for mode in ('bilinear', 'nearest', 'bicubic'):


### PR DESCRIPTION
Fixes #127224 Adds float16/bfloat16 support to CPU grid_sampler

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10