### PR TITLE
Use hidden visibility in OBJECTCXX files

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -479,7 +479,9 @@ function(torch_compile_options libname)
     # templated classes crossing library boundary get duplicated (but identical)
     # definitions. It's easier to just disable it.
     target_compile_options(${libname} PRIVATE
-        $<$<COMPILE_LANGUAGE:CXX>: -fvisibility=hidden>)
+        $<$<COMPILE_LANGUAGE:CXX>: -fvisibility=hidden>
+        $<$<COMPILE_LANGUAGE:OBJC>: -fvisibility=hidden>
+        $<$<COMPILE_LANGUAGE:OBJCXX>: -fvisibility=hidden>)
   endif()
 
   # Use -O2 for release builds (-O3 doesn't improve perf, and -Os results in perf regression)


### PR DESCRIPTION
Since it can eliminate some linker warnings on MacOS
