### PR TITLE
[Inductor] support masked vectorization for the tail_loop for float16 datatype

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2840,6 +2840,7 @@ class CppVecKernelChecker(CppVecKernel):
         self.supported_dtypes_for_masked_vec: List[torch.dtype] = [
             torch.float,
             torch.bfloat16,
+            torch.float16,
         ]
 
     def disable_vec(self, msg=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127274
* #126526



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang