### PR TITLE
add xpu for amp

### DIFF
--- a/docs/source/amp.rst
+++ b/docs/source/amp.rst
@@ -276,7 +276,6 @@ please file an issue.
 XPU Ops that can autocast to ``float16``
 """"""""""""""""""""""""""""""""""""""""
 
-``__matmul__``,
 ``addbmm``,
 ``addmm``,
 ``addmv``,
@@ -297,7 +296,6 @@ XPU Ops that can autocast to ``float16``
 ``matmul``,
 ``mm``,
 ``mv``,
-``prelu``,
 ``RNNCell``
 
 XPU Ops that can autocast to ``float32``
@@ -309,9 +307,7 @@ XPU Ops that can autocast to ``float32``
 ``__rtruediv__``,
 ``binary_cross_entropy_with_logits``,
 ``cosine_embedding_loss``,
-``cdist``,
 ``cosine_similarity``,
-``cross_entropy``,
 ``cumsum``,
 ``dist``,
 ``exp``,
@@ -323,10 +319,8 @@ XPU Ops that can autocast to ``float32``
 ``log``,
 ``log_softmax``,
 ``margin_ranking_loss``,
-``multilabel_margin_loss``,
 ``nll_loss``,
 ``normalize``,
-``pdist``,
 ``poisson_nll_loss``,
 ``pow``,
 ``reciprocal``,

--- a/docs/source/amp.rst
+++ b/docs/source/amp.rst
@@ -19,8 +19,8 @@ are much faster in ``lower_precision_fp``. Other ops, like reductions, often req
 range of ``float32``.  Mixed precision tries to match each op to its appropriate datatype.
 
 Ordinarily, "automatic mixed precision training" with datatype of ``torch.float16`` uses :class:`torch.autocast` and
-:class:`torch.amp.GradScaler` together, as shown in the :ref:`CUDA Automatic Mixed Precision examples<amp-examples>`
-and `CUDA Automatic Mixed Precision recipe <https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html>`_.
+:class:`torch.amp.GradScaler` together, as shown in the :ref:`Automatic Mixed Precision examples<amp-examples>`
+and `Automatic Mixed Precision recipe <https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html>`_.
 However, :class:`torch.autocast` and :class:`torch.GradScaler` are modular, and may be used separately if desired.
 As shown in the CPU example section of :class:`torch.autocast`, "automatic mixed precision training/inference" on CPU with
 datatype of ``torch.bfloat16`` only uses :class:`torch.autocast`.
@@ -29,7 +29,7 @@ datatype of ``torch.bfloat16`` only uses :class:`torch.autocast`.
     ``torch.cuda.amp.autocast(args...)`` and ``torch.cpu.amp.autocast(args...)`` will be deprecated. Please use ``torch.autocast("cuda", args...)`` or ``torch.autocast("cpu", args...)`` instead.
     ``torch.cuda.amp.GradScaler(args...)`` and ``torch.cpu.amp.GradScaler(args...)`` will be deprecated. Please use ``torch.GradScaler("cuda", args...)`` or ``torch.GradScaler("cpu", args...)`` instead.
 
-:class:`torch.autocast` and :class:`torch.cpu.amp.autocast` are new in version `1.10`.
+:class:`torch.autocast` are new in version `1.10`. :class:`torch.cpu.amp.autocast` and :class:`torch.cuda.amp.autocast` will be deprecated. 
 
 .. contents:: :local:
 
@@ -248,6 +248,141 @@ Prefer ``binary_cross_entropy_with_logits`` over ``binary_cross_entropy``
 The backward passes of :func:`torch.nn.functional.binary_cross_entropy` (and :mod:`torch.nn.BCELoss`, which wraps it)
 can produce gradients that aren't representable in ``float16``.  In autocast-enabled regions, the forward input
 may be ``float16``, which means the backward gradient must be representable in ``float16`` (autocasting ``float16``
+forward inputs to ``float32`` doesn't help, because that cast must be reversed in backward).
+Therefore, ``binary_cross_entropy`` and ``BCELoss`` raise an error in autocast-enabled regions.
+
+Many models use a sigmoid layer right before the binary cross entropy layer.
+In this case, combine the two layers using :func:`torch.nn.functional.binary_cross_entropy_with_logits`
+or :mod:`torch.nn.BCEWithLogitsLoss`.  ``binary_cross_entropy_with_logits`` and ``BCEWithLogits``
+are safe to autocast.
+
+.. _autocast-xpu-op-reference:
+
+XPU Op-Specific Behavior
+------------------------
+The following lists describe the behavior of eligible ops in autocast-enabled regions.
+These ops always go through autocasting whether they are invoked as part of a :class:`torch.nn.Module`,
+as a function, or as a :class:`torch.Tensor` method. If functions are exposed in multiple namespaces,
+they go through autocasting regardless of the namespace.
+
+Ops not listed below do not go through autocasting.  They run in the type
+defined by their inputs.  However, autocasting may still change the type
+in which unlisted ops run if they're downstream from autocasted ops.
+
+If an op is unlisted, we assume it's numerically stable in ``bfloat16``.
+If you believe an unlisted op is numerically unstable in ``bfloat16``,
+please file an issue.
+
+XPU Ops that can autocast to ``bfloat16``
+""""""""""""""""""""""""""""""""""""""""
+
+``__matmul__``,
+``addbmm``,
+``addmm``,
+``addmv``,
+``addr``,
+``baddbmm``,
+``bmm``,
+``chain_matmul``,
+``multi_dot``,
+``conv1d``,
+``conv2d``,
+``conv3d``,
+``conv_transpose1d``,
+``conv_transpose2d``,
+``conv_transpose3d``,
+``GRUCell``,
+``linear``,
+``LSTMCell``,
+``matmul``,
+``mm``,
+``mv``,
+``prelu``,
+``RNNCell``
+
+XPU Ops that can autocast to ``float32``
+""""""""""""""""""""""""""""""""""""""""
+
+``__pow__``,
+``__rdiv__``,
+``__rpow__``,
+``__rtruediv__``,
+``acos``,
+``asin``,
+``binary_cross_entropy_with_logits``,
+``cosh``,
+``cosine_embedding_loss``,
+``cdist``,
+``cosine_similarity``,
+``cross_entropy``,
+``cumprod``,
+``cumsum``,
+``dist``,
+``erfinv``,
+``exp``,
+``expm1``,
+``group_norm``,
+``hinge_embedding_loss``,
+``kl_div``,
+``l1_loss``,
+``layer_norm``,
+``log``,
+``log_softmax``,
+``log10``,
+``log1p``,
+``log2``,
+``margin_ranking_loss``,
+``mse_loss``,
+``multilabel_margin_loss``,
+``multi_margin_loss``,
+``nll_loss``,
+``norm``,
+``normalize``,
+``pdist``,
+``poisson_nll_loss``,
+``pow``,
+``prod``,
+``reciprocal``,
+``rsqrt``,
+``sinh``,
+``smooth_l1_loss``,
+``soft_margin_loss``,
+``softmax``,
+``softmin``,
+``softplus``,
+``sum``,
+``renorm``,
+``tan``,
+``triplet_margin_loss``
+
+XPU Ops that promote to the widest input type
+"""""""""""""""""""""""""""""""""""""""""""""
+These ops don't require a particular dtype for stability, but take multiple inputs
+and require that the inputs' dtypes match.  If all of the inputs are
+``bfloat16``, the op runs in ``bfloat16``.  If any of the inputs is ``float32``,
+autocast casts all inputs to ``float32`` and runs the op in ``float32``.
+
+``addcdiv``,
+``addcmul``,
+``atan2``,
+``bilinear``,
+``cross``,
+``dot``,
+``grid_sample``,
+``index_put``,
+``scatter_add``,
+``tensordot``
+
+Some ops not listed here (e.g., binary ops like ``add``) natively promote
+inputs without autocasting's intervention.  If inputs are a mixture of ``bfloat16``
+and ``float32``, these ops run in ``float32`` and produce ``float32`` output,
+regardless of whether autocast is enabled.
+
+Prefer ``binary_cross_entropy_with_logits`` over ``binary_cross_entropy``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The backward passes of :func:`torch.nn.functional.binary_cross_entropy` (and :mod:`torch.nn.BCELoss`, which wraps it)
+can produce gradients that aren't representable in ``bfloat16``.  In autocast-enabled regions, the forward input
+may be ``bfloat16``, which means the backward gradient must be representable in ``bfloat16`` (autocasting ``bfloat16``
 forward inputs to ``float32`` doesn't help, because that cast must be reversed in backward).
 Therefore, ``binary_cross_entropy`` and ``BCELoss`` raise an error in autocast-enabled regions.
 

--- a/docs/source/amp.rst
+++ b/docs/source/amp.rst
@@ -258,8 +258,8 @@ are safe to autocast.
 
 .. _autocast-xpu-op-reference:
 
-XPU Op-Specific Behavior
-------------------------
+XPU Op-Specific Behavior (Experimental)
+---------------------------------------
 The following lists describe the behavior of eligible ops in autocast-enabled regions.
 These ops always go through autocasting whether they are invoked as part of a :class:`torch.nn.Module`,
 as a function, or as a :class:`torch.Tensor` method. If functions are exposed in multiple namespaces,

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -80,7 +80,7 @@ class autocast:
             loss.backward()
             optimizer.step()
 
-    See the :ref:`CUDA Automatic Mixed Precision examples<amp-examples>` for usage (along with gradient scaling)
+    See the :ref:`Automatic Mixed Precision examples<amp-examples>` for usage (along with gradient scaling)
     in more complex scenarios (e.g., gradient penalty, multiple models/losses, custom autograd functions).
 
     :class:`autocast` can also be used as a decorator, e.g., on the ``forward`` method of your model::


### PR DESCRIPTION
As support for Intel GPU has been upstreamed, this PR is to add the XPU-related contents to AMP doc.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5