### PR TITLE
add xpu to torch.compile

### DIFF
--- a/docs/source/torch.compiler.rst
+++ b/docs/source/torch.compiler.rst
@@ -22,7 +22,7 @@ written in Python and it marks the transition of PyTorch from C++ to Python.
 * **TorchInductor** is the default ``torch.compile`` deep learning compiler
   that generates fast code for multiple accelerators and backends. You
   need to use a backend compiler to make speedups through ``torch.compile``
-  possible. For NVIDIA and AMD GPUs, it leverages OpenAI Triton as the key
+  possible. For NVIDIA, AMD and Intel GPUs, it leverages OpenAI Triton as the key
   building block.
 
 * **AOT Autograd** captures not only the user-level code, but also backpropagation,

--- a/docs/source/torch.compiler_get_started.rst
+++ b/docs/source/torch.compiler_get_started.rst
@@ -15,7 +15,8 @@ understanding of how you can use ``torch.compile`` in your own programs.
 .. note::
    To run this script, you need to have at least one GPU on your machine.
    If you do not have a GPU, you can remove the ``.to(device="cuda:0")`` code
-   in the snippet below and it will run on CPU.
+   in the snippet below and it will run on CPU. You can also set device to
+   ``xpu:0`` to run on Intel® GPUs.
 
 .. code:: python
 


### PR DESCRIPTION
As support for Intel GPU has been upstreamed, this PR is to add the XPU-related contents to torch.compile doc.