### PR TITLE
add xpu to torch.tensors

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -779,4 +779,5 @@ Tensor class reference
     Tensor.where
     Tensor.xlogy
     Tensor.xlogy_
+    Tensor.xpu
     Tensor.zero_


### PR DESCRIPTION
As support for Intel GPU has been upstreamed, this PR is to add the XPU-related contents to torch.tensors doc.