### PR TITLE
Better graph break msg (and warning) on Dynamo x Python C++ extension

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -634,9 +634,19 @@ class SkipFunctionVariable(VariableTracker):
         else:
             try:
                 path = inspect.getfile(self.value)
+                msg = f"'skip function {self.value.__qualname__} in file {path}'"
             except TypeError:
-                path = f"Builtin {self.value.__name__}"
-            msg = f"'skip function {self.value.__qualname__} in file {path}'"
+                msg = (
+                    f"Unsupported builtin {self.value.__qualname__}. "
+                    f"This function is either a Python builtin (e.g. functools.partial) "
+                    f"or a third-party C/C++ Python extension (perhaps created with pybind). "
+                    f"If it is a Python builtin, please file an issue on GitHub "
+                    f"so the PyTorch team can add support for it and see the next case for a workaround. "
+                    f"If it is a third-party C/C++ Python extension, please "
+                    f"wrap it into a PyTorch-understood custom operator "
+                    f"(see https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU "
+                    f"for more details)"
+                )
             msg += f"', {self.reason}'" if self.reason else ""
             unimplemented(msg)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127117
* __->__ #127301
* #127423
* #127400
* #127292
* #127291

Dynamo graph breaks on Python C/C++ extensions (e.g. pybinded
functions). The usual way to handle this is to turn those extensions
into custom ops. This PR adds a nicer graph break message and also
changes it to unconditionally warn on this graph break (because graph
break messages are usually not visible).

Fixes https://github.com/pytorch/pytorch/issues/126799

Test Plan:
- new test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang