### PR TITLE
Back out "Prevent partitioner from ever saving views (#126446)"

### DIFF
--- a/test/distributed/_composable/test_replicate_with_compiler.py
+++ b/test/distributed/_composable/test_replicate_with_compiler.py
@@ -279,16 +279,12 @@ class ReplicateTest(MultiProcessTestCase):
         self.assertEqual(counters["inductor"]["ddp_buckets"], 3)
         return code
 
-    @torch._inductor.config.patch(
-        _fuse_ddp_communication_passes=[
+    def test_bucketing_coalesced_op(self):
+        torch._inductor.config._fuse_ddp_communication_passes = [
             "fuse_ddp_with_coalesced_op",
             "schedule_comm_wait",
         ]
-    )
-    # todo: This pass mucks things up since Inductor thinks its inference
-    # and can apply this. Should turn off these passes in compiled autograd
-    @torch._inductor.config.patch(reorder_for_locality=False)
-    def test_bucketing_coalesced_op(self):
+
         # Gradient is None
         code = self._test_bucketing()
         self.assertEqual(counters["inductor"]["ddp_buckets"], 3)
@@ -315,16 +311,12 @@ class ReplicateTest(MultiProcessTestCase):
 
         fc.run(code)
 
-    @torch._inductor.config.patch(
-        _fuse_ddp_communication_passes=[
+    def test_bucketing_concat_op(self):
+        torch._inductor.config._fuse_ddp_communication_passes = [
             "fuse_ddp_with_concat_op",
             "schedule_comm_wait",
         ]
-    )
-    # todo: This pass mucks things up since Inductor thinks its inference
-    # and can apply this. Should turn off these passes in compiled autograd
-    @torch._inductor.config.patch(reorder_for_locality=False)
-    def test_bucketing_concat_op(self):
+
         # Gradient is None
         code = self._test_bucketing()
         self.assertEqual(counters["inductor"]["ddp_buckets"], 3)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4713,7 +4713,8 @@ def forward(self, primals_1, primals_2):
     _foreach_copy = torch.ops.aten._foreach_copy.default([primals_1], [primals_2]);  primals_1 = primals_2 = None
     getitem = _foreach_copy[0];  _foreach_copy = None
     mm = torch.ops.aten.mm.default(getitem, getitem)
-    return [mm, getitem]""",
+    t_1 = torch.ops.aten.t.default(getitem);  getitem = None
+    return [mm, t_1]""",
         )
         self.assertEqual(out_ref, out_test)
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -960,13 +960,7 @@ class GraphModule(torch.nn.Module):
             joint_graph,
             """\
 class GraphModule(torch.nn.Module):
-    def forward(self, primals_1: "f64[2, 2, 8, 4]", primals_2: "f64[2, 2, 8, 4]", primals_3: "f64[2, 2, 8, 4]", getitem: "f64[2, 2, 8, 4]", getitem_1: "f32[2, 2, 8]", tangents_1: "f64[2, 2, 8, 4]"):
-        alias: "f64[2, 2, 8, 4]" = torch.ops.aten.alias.default(getitem);  getitem = None
-        alias_2: "f64[2, 2, 8, 4]" = torch.ops.aten.alias.default(alias);  alias = None
-        alias_3: "f64[2, 2, 8, 4]" = torch.ops.aten.alias.default(alias_2);  alias_2 = None
-        alias_1: "f32[2, 2, 8]" = torch.ops.aten.alias.default(getitem_1);  getitem_1 = None
-        alias_4: "f32[2, 2, 8]" = torch.ops.aten.alias.default(alias_1);  alias_1 = None
-        alias_5: "f32[2, 2, 8]" = torch.ops.aten.alias.default(alias_4);  alias_4 = None
+    def forward(self, primals_1: "f64[2, 2, 8, 4]", primals_2: "f64[2, 2, 8, 4]", primals_3: "f64[2, 2, 8, 4]", alias_3: "f64[2, 2, 8, 4]", alias_5: "f32[2, 2, 8]", tangents_1: "f64[2, 2, 8, 4]"):
         fw_graph = self.fw_graph
         joint_graph = self.joint_graph
         flex_attention_backward = torch.ops.higher_order.flex_attention_backward(primals_1, primals_2, primals_3, alias_3, alias_5, tangents_1, fw_graph, joint_graph);  primals_1 = primals_2 = primals_3 = alias_3 = alias_5 = tangents_1 = fw_graph = joint_graph = None

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -533,13 +533,12 @@ def reordering_to_mimic_autograd_engine(gm: fx.GraphModule) -> fx.GraphModule:
 
     # Populate depth for the nodes. Depth is the distance from the inputs.
     depths = {}
+    output_node = next(iter(gm.graph.find_nodes(op="output")))
     for node in gm.graph.nodes:
         if node.op == "placeholder":
             depths[node] = 0
         else:
-            depths[node] = (
-                max((depths[arg] for arg in node.all_input_nodes), default=0) + 1
-            )
+            depths[node] = max([depths[arg] for arg in node.all_input_nodes], default=0)
 
     def insert_node_in_graph(node):
         if node in env:
@@ -803,8 +802,6 @@ def get_saved_values(
             return False
         if node.target == operator.getitem:
             return False
-        if op_types.is_view(node):
-            return False
         if node.target in [aten.lift_fresh_copy.default, aten.lift_fresh.default]:
             return False
         # NB: "recompute" == 0 means that must save this node.
@@ -857,14 +854,6 @@ def get_saved_values(
 
     def get_node_weight(node) -> float:
         mem_sz = _size_of(node)
-        if op_types.is_view(node):
-            # We never choose to save views, since views are free to recompute.
-            # It makes it a bit simpler to analyze
-            # NB: If they're not free to recompute (e.g. nested tensors)... I
-            # think we should modify checks for view_ops to `is_view` and check
-            # that. Basically, with nested tensors, `aten.view` is not a "view
-            # op".
-            return math.inf
 
         if isinstance(node.meta["val"], py_sym_types):
             # We never want to save symfloats


### PR DESCRIPTION
Summary: Revert "Prevent partitioner from ever saving views (#126446)" due to a torchinductor failure on CU Training Framework tests.

Reviewed By: Chillee

Differential Revision: D57868343




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire