### PR TITLE
[export] Fix fake mode detection with empty inputs.

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -3665,6 +3665,19 @@ graph():
 
         check_device_and_fake_mode()
 
+    @testing.expectedFailureSerDer
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_empty_input(self):
+        class M(torch.nn.Module):
+            def forward(self):
+                x = torch.ones(1)
+                y = x.item()
+                return x + y
+
+        ep = export(M(), ())
+        res = ep.module()()
+        self.assertEqual(res, 2)
+
     def test_run_decomposition_supports_user_input_mutation(self):
         class SingleOp(torch.nn.Module):
             def __init__(self):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1211,6 +1211,7 @@ def export(
         graph_captured_input = None
         graph_captured_result: Optional[Tuple[torch.Tensor, ...]] = None
         fake_mode = None
+        ambient_fake_mode = None
 
         def guard_export_print(guards: _guards.GuardsSet):
             nonlocal out_guards
@@ -1242,6 +1243,7 @@ def export(
             def result_capturing_wrapper(*graph_inputs):
                 nonlocal graph_captured_result
                 nonlocal graph_captured_input
+                nonlocal ambient_fake_mode
 
                 graph_captured_input = graph_inputs
                 assert graph is not None
@@ -1436,6 +1438,7 @@ def export(
             if constraints
             else []
         )
+        graph.meta["ambient_fake_mode"] = ambient_fake_mode
 
         return ExportResult(graph, out_guards)
 


### PR DESCRIPTION
Summary:
Instead of detecting fake mode from inputs, directly pass down the original fake mode used in dynamo.

Fixing issue https://github.com/pytorch/pytorch/issues/126770

Test Plan: buck test mode/opt caffe2/test:test_export -- -r test_empty_input

Reviewed By: pianpwk

Differential Revision: D57865606




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang