### PR TITLE
[pipelining] rewrite interleaved 1f1b

### DIFF
--- a/torch/distributed/pipelining/PipelineSchedule.py
+++ b/torch/distributed/pipelining/PipelineSchedule.py
@@ -724,14 +724,16 @@ class ScheduleInterleaved1F1B(PipelineScheduleMulti):
         # cooldown_ops should encompass the remaining backwards
         cooldown_ops = microbatch_ops - fwd_bwd_ops
         # total ops encompass both forward and backward ops
-        total_ops = 2 * microbatch_ops
+        total_ops = warmup_ops + fwd_bwd_ops + cooldown_ops
+        assert warmup_ops + fwd_bwd_ops * 2 + cooldown_ops == microbatch_ops * 2
 
         logger.debug(
-            "rank %s, warmup_ops %s, 1f1b %s, cooldown_ops %s",
+            "rank %s, warmup_ops %s, 1f1b %s, cooldown_ops %s total_ops %s",
             rank,
             warmup_ops,
             fwd_bwd_ops,
             cooldown_ops,
+            total_ops
         )
 
         # Calculates the stage index based on step and pp_group_size

--- a/torch/distributed/pipelining/PipelineSchedule.py
+++ b/torch/distributed/pipelining/PipelineSchedule.py
@@ -725,7 +725,7 @@ class ScheduleInterleaved1F1B(PipelineScheduleMulti):
         cooldown_ops = microbatch_ops - fwd_bwd_ops
         # total ops encompass both forward and backward ops
         total_ops = warmup_ops + fwd_bwd_ops + cooldown_ops
-        assert warmup_ops + fwd_bwd_ops * 2 + cooldown_ops == microbatch_ops * 2
+        # warmup_ops + fwd_bwd_ops * 2 + cooldown_ops == microbatch_ops * 2
 
         logger.debug(
             "rank %s, warmup_ops %s, 1f1b %s, cooldown_ops %s total_ops %s",
@@ -733,7 +733,7 @@ class ScheduleInterleaved1F1B(PipelineScheduleMulti):
             warmup_ops,
             fwd_bwd_ops,
             cooldown_ops,
-            total_ops
+            total_ops,
         )
 
         # Calculates the stage index based on step and pp_group_size


### PR DESCRIPTION
## Context

Interleaved 1F1B has multiple points in the schedule where communication is both criss-crossed across ranks leading to hangs due to 1. looped nature of schedules, 2. batched nature of forward + backward in 1f1b phase.

<img width="1370" alt="image" src="https://github.com/pytorch/pytorch/assets/14858254/a07c2b1d-8a99-420b-9ba3-32a0115d228b">

In the current implementation, it is difficult to fix these hangs since it requires `dist.recv` from a prior point in time, but each rank operates on its own step schedule and does not have knowledge of other ranks operations to perform the `recv` prior to their own `send`.

## New implementation

The new implementation is split into 2 parts:

1. Creating the pipeline order.

Each rank will create the timestep normalized ordering of all schedule actions across all ranks. This is created once during the initialization of the schedule class. The timestep between each rank is normalized as each rank can only have 1 computation action (forward or backward) during that timestep.

<img width="1065" alt="image" src="https://github.com/pytorch/pytorch/assets/14858254/196f2347-7ff4-49cf-903b-d8db97d1156f">

3. Executing the pipeline order.

Once the pipeline order is determined, execution is simple because as each rank will perform its send to its peer (based on whether they did forward and backward). Now that each rank has a global understanding of the schedule, they can check their previous and next neighbor ranks to see if they need to recv any activations/gradients from them. Therefore, during execution, each rank is aligned and executing the same time step.

## Benefits

- Implementation is faster since 1f1b computation can now be split up in two time steps, 1 for forward and 1 for backward.
- Debugging is easier since we can now determine which timestep each rank is hung on
- Testing is easier since we can just validate the pipeline order, without running the schedule. This allows us to test on large amount of ranks without actually needing the GPUs.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127796
* #127559
* __->__ #127332
* #127084



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k 