### PR TITLE
Change default threads on Mac to one less than number of perf cores

### DIFF
--- a/aten/src/ATen/ParallelCommon.cpp
+++ b/aten/src/ATen/ParallelCommon.cpp
@@ -115,8 +115,9 @@ int intraop_default_num_threads() {
     size_t num_cores_len = sizeof(num_cores);
     if (sysctlbyname("hw.perflevel0.physicalcpu", &num_cores, &num_cores_len, nullptr, 0) == 0) {
       if (num_cores > 1) {
-        nthreads = num_cores;
-        return num_cores;
+        // Experiments on M1 mac suggest num_cores-1 works better than num_cores
+        nthreads = num_cores-1;
+        return nthreads;
       }
     }
 #endif


### PR DESCRIPTION
Changes the number of threads on Mac to one less than the number of performant cores.  Experiments with LLMs suggest this leads to better perf on M1 mac.

Specifically, I see an 11% perf improvement in llama2 perf on torchchat AOTI with this change on my M1 mac (https://fb.workplace.com/groups/pytorch.edge2.team/posts/982404176348768/?comment_id=985013399421179&reply_comment_id=985082682747584).