### PR TITLE
[dtensor] make Partial placement public

### DIFF
--- a/torch/distributed/_tensor/__init__.py
+++ b/torch/distributed/_tensor/__init__.py
@@ -8,7 +8,12 @@ import torch.distributed._tensor.random as random
 from torch.distributed._tensor._utils import compute_local_shape
 from torch.distributed._tensor.api import distribute_module, distribute_tensor, DTensor
 from torch.distributed._tensor.ops.utils import normalize_to_torch_size
-from torch.distributed._tensor.placement_types import Placement, Replicate, Shard
+from torch.distributed._tensor.placement_types import (
+    Partial,
+    Placement,
+    Replicate,
+    Shard,
+)
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
 from torch.optim.optimizer import (
     _foreach_supported_types as _optim_foreach_supported_types,
@@ -27,6 +32,7 @@ __all__ = [
     "init_device_mesh,",
     "Shard",
     "Replicate",
+    "Partial",
 ]
 
 

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -367,7 +367,7 @@ class Replicate(Placement):
 
 
 @dataclass(frozen=True)
-class _Partial(Placement):
+class Partial(Placement):
     # This is a default _Partial placement with element-wise reduce op
     # _Partial define three contracts:
     # 1. _reduce_value: reduce the value of the tensor on the mesh dimension
@@ -426,6 +426,10 @@ class _Partial(Placement):
         human readable representation of the Partial placement
         """
         return "P"
+
+
+# We keep the old _Partial name for a while for BC reason
+_Partial = Partial
 
 
 class TensorMeta(NamedTuple):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127340
* #127339
* __->__ #127338

As titled, partial placement is standardized right now and I think we
would want to expose this as a public API to allow user to annotate the
the sharding layout easier. Given that we already have use cases
internal/externally that uses Partial

Keeping the old _Partial name for a while for BC reason

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k