### PR TITLE
[Inductor]: Use new device-agnostic libdevice import from triton.language

### DIFF
--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -16,15 +16,21 @@ except ImportError:
 
 # In the latest triton, math functions were shuffled around into different modules:
 # https://github.com/openai/triton/pull/3172
-if hasattr(tl.extra, "cuda") and hasattr(tl.extra.cuda, "libdevice"):
-    libdevice = tl.extra.cuda.libdevice
+try:
+    from triton.language.extra import libdevice
+
+    libdevice = tl.extra.libdevice  # noqa: F811
     math = tl.math
-elif hasattr(tl.extra, "intel") and hasattr(tl.extra.intel, "libdevice"):
-    libdevice = tl.extra.intel.libdevice
-    math = tl.math
-else:
-    libdevice = tl.math
-    math = tl
+except ImportError:
+    if hasattr(tl.extra, "cuda") and hasattr(tl.extra.cuda, "libdevice"):
+        libdevice = tl.extra.cuda.libdevice
+        math = tl.math
+    elif hasattr(tl.extra, "intel") and hasattr(tl.extra.intel, "libdevice"):
+        libdevice = tl.extra.intel.libdevice
+        math = tl.math
+    else:
+        libdevice = tl.math
+        math = tl
 
 
 @triton.jit


### PR DESCRIPTION
Triton refactored `libdevice` in https://github.com/triton-lang/triton/commit/5e6952d8c529770ff0321c8ded633c32af0ff9ea 

While both imports still appear to work under CUDA, this change is required to pull the correct libdevice variants under the Intel XPU backend. I am working on developing a test that catches this behavior. The easiest path would be to enable `test/inductor/test_triton_kernels.py` under the XPU backend, but a different group at Intel manages that test and I need to see if they already have an enabling plan. 

I am not sure the double `libdevice` import (see line 22 where I have the nolint flag) is really necessary but have yet to find a conclusive test case. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang