### PR TITLE
[Functorch][cuDNN] Bump tolerances for `test_vmapjvpvjp`

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2034,7 +2034,8 @@ class TestOperators(TestCase):
             ),
             tol1(
                 "nn.functional.conv_transpose2d",
-                {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
+                {torch.float32: tol(atol=5e-04, rtol=5e-04)}
+            ),
             tol1("svd", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
             tol1("matrix_exp", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
         ),

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2032,7 +2032,9 @@ class TestOperators(TestCase):
             tol2(
                 "linalg.pinv", "hermitian", {torch.float32: tol(atol=5e-04, rtol=5e-04)}
             ),
-            tol1("nn.functional.conv_transpose2d", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
+            tol1(
+                "nn.functional.conv_transpose2d",
+                {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
             tol1("svd", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
             tol1("matrix_exp", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
         ),

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2032,6 +2032,7 @@ class TestOperators(TestCase):
             tol2(
                 "linalg.pinv", "hermitian", {torch.float32: tol(atol=5e-04, rtol=5e-04)}
             ),
+            tol1("nn.functional.conv_transpose2d", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
             tol1("svd", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
             tol1("matrix_exp", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
         ),

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2034,7 +2034,7 @@ class TestOperators(TestCase):
             ),
             tol1(
                 "nn.functional.conv_transpose2d",
-                {torch.float32: tol(atol=5e-04, rtol=5e-04)}
+                {torch.float32: tol(atol=5e-04, rtol=5e-04)},
             ),
             tol1("svd", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
             tol1("matrix_exp", {torch.float32: tol(atol=5e-04, rtol=5e-04)}),


### PR DESCRIPTION
cuDNN can select a winograd kernel for this case which slightly affects tolerances...

cc @csarofeen @ptrblck @xwang233 @zou3519 @Chillee @samdow @kshitij12345 @janeyx99