### PR TITLE
[1/N] Replace exceptions with static_assert(false) in some templates 

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -48,7 +48,7 @@ private:
 
 template <typename Dtype>
 inline void gemm(CUDABLAS_GEMM_ARGTYPES(Dtype)) {
-  AT_ERROR("at::cuda::blas::gemm: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),"at::cuda::blas::gemm: not implemented");
 }
 
 template <>
@@ -66,7 +66,7 @@ void gemm<at::BFloat16>(CUDABLAS_GEMM_ARGTYPES(at::BFloat16));
 
 template <typename Dtype>
 inline void gemm_internal(CUDABLAS_GEMM_ARGTYPES(Dtype)) {
-  AT_ERROR("at::cuda::blas::gemm_internal: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),"at::cuda::blas::gemm_internal: not implemented");
 }
 
 template <>
@@ -154,7 +154,7 @@ void scaled_gemm(
 
 template <typename Dtype>
 inline void bgemm(CUDABLAS_BGEMM_ARGTYPES(Dtype)) {
-  AT_ERROR("at::cuda::blas::bgemm: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),"at::cuda::blas::bgemm: not implemented");
 }
 
 template <>
@@ -172,7 +172,7 @@ void bgemm<at::BFloat16>(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16));
 
 template <typename Dtype>
 inline void bgemm_internal(CUDABLAS_BGEMM_ARGTYPES(Dtype)) {
-  AT_ERROR("at::cuda::blas::bgemm_internal: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),"at::cuda::blas::bgemm_internal: not implemented");
 }
 
 template <>
@@ -195,7 +195,7 @@ void bgemm_internal<at::BFloat16>(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16));
 
 template <typename Dtype>
 inline void trsm(CUDABLAS_TRSM_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::blas::trsm: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::blas::trsm: not implemented");
 }
 
 template <>
@@ -215,10 +215,7 @@ TORCH_CUDA_CU_API void trsm<c10::complex<double>>(CUDABLAS_TRSM_ARGTYPES(c10::co
 
 template <typename Dtype>
 inline void trsmBatched(CUDABLAS_TRSM_BATCHED_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::blas::trsmBatched: not implemented for ",
-      typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::blas::trsmBatched: not implemented");
 }
 
 template <>
@@ -238,7 +235,7 @@ TORCH_CUDA_CU_API void trsmBatched<c10::complex<double>>(CUDABLAS_TRSM_BATCHED_A
 
 template <typename Dtype>
 inline void gemv(CUDABLAS_GEMV_ARGTYPES(Dtype)) {
-  AT_ERROR("at::cuda::blas::gemv: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::blas::gemv: not implemented");
 }
 
 template <>
@@ -262,7 +259,7 @@ void gemv<at::BFloat16>(CUDABLAS_GEMV_ARGTYPES(at::BFloat16));
 
 template <typename Dtype>
 inline void dot(CUDABLAS_DOT_ARGTYPES(Dtype)) {
-  AT_ERROR("at::cuda::blas::dot: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),"at::cuda::blas::dot: not implemented");
 }
 
 template <>
@@ -280,7 +277,7 @@ void dot<c10::complex<float>>(CUDABLAS_DOT_ARGTYPES(c10::complex<float>));
 
 template <typename Dtype>
 inline void vdot(CUDABLAS_DOT_ARGTYPES(Dtype)) {
-  AT_ERROR("at::cuda::blas::vdot: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),"at::cuda::blas::vdot: not implemented");
 }
 
 template <>
@@ -295,8 +292,7 @@ void vdot<c10::complex<double>>(CUDABLAS_DOT_ARGTYPES(c10::complex<double>));
 
 template<class Dtype>
 void getrsBatched(CUDABLAS_GETRS_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::blas::getrsBatched: not implemented for ",
-    typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),"at::cuda::blas::getrsBatched: not implemented");
 }
 template<>
 TORCH_CUDA_CU_API void getrsBatched<float>(CUDABLAS_GETRS_ARGTYPES(float));
@@ -313,10 +309,7 @@ TORCH_CUDA_CU_API void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_ARGTYPE
 
 template <class Dtype>
 void geqrfBatched(CUDABLAS_GEQRF_BATCHED_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::blas::geqrfBatched: not implemented for ",
-      typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::blas::geqrfBatched: not implemented");
 }
 template <>
 TORCH_CUDA_CU_API void geqrfBatched<float>(CUDABLAS_GEQRF_BATCHED_ARGTYPES(float));
@@ -334,7 +327,7 @@ TORCH_CUDA_CU_API void geqrfBatched<c10::complex<float>>(
 
 template<class Dtype>
 void getrfBatched(CUDABLAS_GETRF_ARGTYPES(Dtype)) {
-  TORCH_CHECK(false, "at::cuda::blas::getrfBatched: not implemented for ", typeid(Dtype).name());
+  TORCH_CHECK(false, "at::cuda::blas::getrfBatched: not implemented");
 }
 template<>
 TORCH_CUDA_CU_API void getrfBatched<float>(CUDABLAS_GETRF_ARGTYPES(float));
@@ -350,7 +343,7 @@ TORCH_CUDA_CU_API void getrfBatched<c10::complex<float>>(CUDABLAS_GETRF_ARGTYPES
 
 template <class Dtype>
 void gelsBatched(CUDABLAS_GELS_BATCHED_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::blas::gelsBatched: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),"at::cuda::blas::gelsBatched: not implemented");
 }
 
 template<>

--- a/aten/src/ATen/cuda/CUDADataType.h
+++ b/aten/src/ATen/cuda/CUDADataType.h
@@ -9,7 +9,8 @@ namespace at::cuda {
 
 template <typename scalar_t>
 cudaDataType getCudaDataType() {
-  TORCH_INTERNAL_ASSERT(false, "Cannot convert type ", typeid(scalar_t).name(), " to cudaDataType.")
+  static_assert(false && sizeof(scalar_t), "Cannot convert type to cudaDataType.");
+  return {};
 }
 
 template<> inline cudaDataType getCudaDataType<at::Half>() {

--- a/aten/src/ATen/native/BlasKernel.cpp
+++ b/aten/src/ATen/native/BlasKernel.cpp
@@ -559,12 +559,14 @@ template <typename scalar_t>
 inline void scal(int64_t n, scalar_t a, scalar_t *x, int64_t incx)
 {
   if (n == 1) incx = 1;
+#if AT_BUILD_WITH_BLAS()
   if (blas_impl::scal_use_fast_path<scalar_t>(n, incx)) {
     int i_n = (int)n;
     int i_incx = (int)incx;
     blas_impl::scal_fast_path<scalar_t>(&i_n, &a, x, &i_incx);
     return;
   }
+#endif
   for (const auto i : c10::irange(n)) {
     if (a == scalar_t(0)) {
       x[i * incx] = 0;
@@ -578,6 +580,7 @@ template<typename scalar_t>
 void gemv(char trans, int64_t m, int64_t n, scalar_t alpha, const scalar_t *a, int64_t lda, const scalar_t *x, int64_t incx, scalar_t beta, scalar_t *y, int64_t incy) {
   if(n == 1) lda = m;
 
+#if AT_BUILD_WITH_BLAS()
   if (blas_impl::gemv_use_fast_path<scalar_t>(m, n, lda, incx, incy)) {
     TORCH_CHECK(lda >= std::max<int64_t>(1L, m), "lda should be at least max(1,", m, "), but have ", lda);
     int i_m = (int)m;
@@ -588,6 +591,7 @@ void gemv(char trans, int64_t m, int64_t n, scalar_t alpha, const scalar_t *a, i
     blas_impl::gemv_fast_path<scalar_t>(&trans, &i_m, &i_n, &alpha, a, &i_lda, x, &i_incx, &beta, y, &i_incy);
     return;
   }
+#endif
 
   using opmath_t = at::opmath_type<scalar_t>;
   if ((trans == 'T') || (trans == 't')) {

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -655,7 +655,7 @@ std::pair<K*, V*> radix_sort_parallel(
     const int64_t elements_count,
     const int64_t max_value) {
   TORCH_INTERNAL_ASSERT(false, "radix_sort_parallel: ATen not compiled with FBGEMM support");
-  std::make_pair(nullptr, nullptr);
+  return std::make_pair(nullptr, nullptr);
 }
 
 }

--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -327,7 +327,7 @@ void random_from_to_kernel(TensorIteratorBase& iter, uint64_t range, int64_t bas
 template<typename RNG>
 void random_full_64_bits_range_kernel(TensorIteratorBase& iter, RNG gen) {
   AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::BFloat16, iter.dtype(), "random_full_64_bits_range_kernel_cuda", [&] {
-    if constexpr (std::is_same<scalar_t, int64_t>::value ||
+    if (std::is_same<scalar_t, int64_t>::value ||
         std::is_same<scalar_t, double>::value ||
         std::is_same<scalar_t, float>::value ||
         std::is_same<scalar_t, at::BFloat16>::value) {

--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -327,7 +327,7 @@ void random_from_to_kernel(TensorIteratorBase& iter, uint64_t range, int64_t bas
 template<typename RNG>
 void random_full_64_bits_range_kernel(TensorIteratorBase& iter, RNG gen) {
   AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::BFloat16, iter.dtype(), "random_full_64_bits_range_kernel_cuda", [&] {
-    if (std::is_same<scalar_t, int64_t>::value ||
+    if constexpr (std::is_same<scalar_t, int64_t>::value ||
         std::is_same<scalar_t, double>::value ||
         std::is_same<scalar_t, float>::value ||
         std::is_same<scalar_t, at::BFloat16>::value) {

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.h
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.h
@@ -18,7 +18,7 @@ namespace solver {
 
 template<class Dtype>
 void getrf(CUDASOLVER_GETRF_ARGTYPES(Dtype)) {
-  TORCH_CHECK(false, "at::cuda::solver::getrf: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::getrf: not implemented");
 }
 template<>
 void getrf<float>(CUDASOLVER_GETRF_ARGTYPES(float));
@@ -35,7 +35,7 @@ void getrf<c10::complex<float>>(CUDASOLVER_GETRF_ARGTYPES(c10::complex<float>));
 
 template<class Dtype>
 void getrs(CUDASOLVER_GETRS_ARGTYPES(Dtype)) {
-  TORCH_CHECK(false, "at::cuda::solver::getrs: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::getrs: not implemented");
 }
 template<>
 void getrs<float>(CUDASOLVER_GETRS_ARGTYPES(float));
@@ -51,10 +51,8 @@ void getrs<c10::complex<float>>(CUDASOLVER_GETRS_ARGTYPES(c10::complex<float>));
 
 template <class Dtype>
 void sytrf_bufferSize(CUDASOLVER_SYTRF_BUFFER_ARGTYPES(Dtype)) {
-  TORCH_CHECK(
-      false,
-      "at::cuda::solver::sytrf_bufferSize: not implemented for ",
-      typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),
+      "at::cuda::solver::sytrf_bufferSize: not implemented");
 }
 template <>
 void sytrf_bufferSize<float>(CUDASOLVER_SYTRF_BUFFER_ARGTYPES(float));
@@ -73,10 +71,8 @@ void sytrf_bufferSize<c10::complex<float>>(
 
 template <class Dtype>
 void sytrf(CUDASOLVER_SYTRF_ARGTYPES(Dtype)) {
-  TORCH_CHECK(
-      false,
-      "at::cuda::solver::sytrf: not implemented for ",
-      typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),
+      "at::cuda::solver::sytrf: not implemented");
 }
 template <>
 void sytrf<float>(CUDASOLVER_SYTRF_ARGTYPES(float));
@@ -93,7 +89,7 @@ void sytrf<c10::complex<float>>(CUDASOLVER_SYTRF_ARGTYPES(c10::complex<float>));
 
 template<class Dtype>
 void gesvd_buffersize(CUDASOLVER_GESVD_BUFFERSIZE_ARGTYPES()) {
-  TORCH_CHECK(false, "at::cuda::solver::gesvd_buffersize: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::gesvd_buffersize: not implemented");
 }
 template<>
 void gesvd_buffersize<float>(CUDASOLVER_GESVD_BUFFERSIZE_ARGTYPES());
@@ -111,7 +107,7 @@ void gesvd_buffersize<c10::complex<double>>(CUDASOLVER_GESVD_BUFFERSIZE_ARGTYPES
 
 template<class Dtype, class Vtype>
 void gesvd(CUDASOLVER_GESVD_ARGTYPES(Dtype, Vtype)) {
-  TORCH_CHECK(false, "at::cuda::solver::gesvd: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::gesvd: not implemented");
 }
 template<>
 void gesvd<float>(CUDASOLVER_GESVD_ARGTYPES(float, float));
@@ -129,7 +125,7 @@ void gesvd<c10::complex<double>>(CUDASOLVER_GESVD_ARGTYPES(c10::complex<double>,
 
 template<class Dtype, class Vtype>
 void gesvdj_buffersize(CUDASOLVER_GESVDJ_BUFFERSIZE_ARGTYPES(Dtype, Vtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::gesvdj_buffersize: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::gesvdj_buffersize: not implemented");
 }
 template<>
 void gesvdj_buffersize<float>(CUDASOLVER_GESVDJ_BUFFERSIZE_ARGTYPES(float, float));
@@ -147,7 +143,7 @@ void gesvdj_buffersize<c10::complex<double>>(CUDASOLVER_GESVDJ_BUFFERSIZE_ARGTYP
 
 template<class Dtype, class Vtype>
 void gesvdj(CUDASOLVER_GESVDJ_ARGTYPES(Dtype, Vtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::gesvdj: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::gesvdj: not implemented");
 }
 template<>
 void gesvdj<float>(CUDASOLVER_GESVDJ_ARGTYPES(float, float));
@@ -165,7 +161,7 @@ void gesvdj<c10::complex<double>>(CUDASOLVER_GESVDJ_ARGTYPES(c10::complex<double
 
 template<class Dtype, class Vtype>
 void gesvdjBatched(CUDASOLVER_GESVDJ_BATCHED_ARGTYPES(Dtype, Vtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::gesvdj: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::gesvdj: not implemented");
 }
 template<>
 void gesvdjBatched<float>(CUDASOLVER_GESVDJ_BATCHED_ARGTYPES(float, float));
@@ -183,7 +179,7 @@ void gesvdjBatched<c10::complex<double>>(CUDASOLVER_GESVDJ_BATCHED_ARGTYPES(c10:
 
 template<class Dtype, class Vtype>
 void gesvdaStridedBatched_buffersize(CUDASOLVER_GESVDA_STRIDED_BATCHED_BUFFERSIZE_ARGTYPES(Dtype, Vtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::gesvdaStridedBatched_buffersize: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::gesvdaStridedBatched_buffersize: not implemented");
 }
 template<>
 void gesvdaStridedBatched_buffersize<float>(CUDASOLVER_GESVDA_STRIDED_BATCHED_BUFFERSIZE_ARGTYPES(float, float));
@@ -203,7 +199,7 @@ void gesvdaStridedBatched_buffersize<c10::complex<double>>(CUDASOLVER_GESVDA_STR
 
 template<class Dtype, class Vtype>
 void gesvdaStridedBatched(CUDASOLVER_GESVDA_STRIDED_BATCHED_ARGTYPES(Dtype, Vtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::gesvdaStridedBatched: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::gesvdaStridedBatched: not implemented");
 }
 template<>
 void gesvdaStridedBatched<float>(CUDASOLVER_GESVDA_STRIDED_BATCHED_ARGTYPES(float, float));
@@ -220,7 +216,7 @@ void gesvdaStridedBatched<c10::complex<double>>(CUDASOLVER_GESVDA_STRIDED_BATCHE
 
 template<class Dtype>
 void potrf(CUDASOLVER_POTRF_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::potrf: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::potrf: not implemented");
 }
 template<>
 void potrf<float>(CUDASOLVER_POTRF_ARGTYPES(float));
@@ -237,7 +233,7 @@ void potrf<c10::complex<double>>(CUDASOLVER_POTRF_ARGTYPES(c10::complex<double>)
 
 template<class Dtype>
 void potrf_buffersize(CUDASOLVER_POTRF_BUFFERSIZE_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::potrf_buffersize: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::potrf_buffersize: not implemented");
 }
 template<>
 void potrf_buffersize<float>(CUDASOLVER_POTRF_BUFFERSIZE_ARGTYPES(float));
@@ -254,7 +250,7 @@ void potrf_buffersize<c10::complex<double>>(CUDASOLVER_POTRF_BUFFERSIZE_ARGTYPES
 
 template<class Dtype>
 void potrfBatched(CUDASOLVER_POTRF_BATCHED_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::potrfBatched: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::potrfBatched: not implemented");
 }
 template<>
 void potrfBatched<float>(CUDASOLVER_POTRF_BATCHED_ARGTYPES(float));
@@ -270,10 +266,8 @@ void potrfBatched<c10::complex<double>>(CUDASOLVER_POTRF_BATCHED_ARGTYPES(c10::c
 
 template <class scalar_t>
 void geqrf_bufferSize(CUDASOLVER_GEQRF_BUFFERSIZE_ARGTYPES(scalar_t)) {
-  TORCH_CHECK(
-      false,
-      "at::cuda::solver::geqrf_bufferSize: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::geqrf_bufferSize: not implemented");
 }
 template <>
 void geqrf_bufferSize<float>(CUDASOLVER_GEQRF_BUFFERSIZE_ARGTYPES(float));
@@ -292,10 +286,8 @@ void geqrf_bufferSize<c10::complex<double>>(
 
 template <class scalar_t>
 void geqrf(CUDASOLVER_GEQRF_ARGTYPES(scalar_t)) {
-  TORCH_CHECK(
-      false,
-      "at::cuda::solver::geqrf: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::geqrf: not implemented");
 }
 template <>
 void geqrf<float>(CUDASOLVER_GEQRF_ARGTYPES(float));
@@ -312,7 +304,7 @@ void geqrf<c10::complex<double>>(
 
 template<class Dtype>
 void potrs(CUDASOLVER_POTRS_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::potrs: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::potrs: not implemented");
 }
 template<>
 void potrs<float>(CUDASOLVER_POTRS_ARGTYPES(float));
@@ -329,7 +321,7 @@ void potrs<c10::complex<double>>(CUDASOLVER_POTRS_ARGTYPES(c10::complex<double>)
 
 template<class Dtype>
 void potrsBatched(CUDASOLVER_POTRS_BATCHED_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(false, "at::cuda::solver::potrsBatched: not implemented for ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::potrsBatched: not implemented");
 }
 template<>
 void potrsBatched<float>(CUDASOLVER_POTRS_BATCHED_ARGTYPES(float));
@@ -347,10 +339,7 @@ void potrsBatched<c10::complex<double>>(CUDASOLVER_POTRS_BATCHED_ARGTYPES(c10::c
 
 template <class Dtype>
 void orgqr_buffersize(CUDASOLVER_ORGQR_BUFFERSIZE_ARGTYPES(Dtype)) {
-  TORCH_CHECK(
-      false,
-      "at::cuda::solver::orgqr_buffersize: not implemented for ",
-      typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::orgqr_buffersize: not implemented");
 }
 template <>
 void orgqr_buffersize<float>(CUDASOLVER_ORGQR_BUFFERSIZE_ARGTYPES(float));
@@ -368,10 +357,7 @@ void orgqr_buffersize<c10::complex<double>>(CUDASOLVER_ORGQR_BUFFERSIZE_ARGTYPES
 
 template <class Dtype>
 void orgqr(CUDASOLVER_ORGQR_ARGTYPES(Dtype)) {
-  TORCH_CHECK(
-      false,
-      "at::cuda::solver::orgqr: not implemented for ",
-      typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "at::cuda::solver::orgqr: not implemented");
 }
 template <>
 void orgqr<float>(CUDASOLVER_ORGQR_ARGTYPES(float));
@@ -389,10 +375,8 @@ void orgqr<c10::complex<double>>(CUDASOLVER_ORGQR_ARGTYPES(c10::complex<double>)
 
 template <class Dtype>
 void ormqr_bufferSize(CUDASOLVER_ORMQR_BUFFERSIZE_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::ormqr_bufferSize: not implemented for ",
-      typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),
+      "at::cuda::solver::ormqr_bufferSize: not implemented");
 }
 template <>
 void ormqr_bufferSize<float>(CUDASOLVER_ORMQR_BUFFERSIZE_ARGTYPES(float));
@@ -412,10 +396,8 @@ void ormqr_bufferSize<c10::complex<double>>(
 
 template <class Dtype>
 void ormqr(CUDASOLVER_ORMQR_ARGTYPES(Dtype)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::ormqr: not implemented for ",
-      typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype),
+      "at::cuda::solver::ormqr: not implemented");
 }
 template <>
 void ormqr<float>(CUDASOLVER_ORMQR_ARGTYPES(float));
@@ -431,7 +413,8 @@ void ormqr<c10::complex<double>>(
 
 template<class Dtype>
 cudaDataType get_cusolver_datatype() {
-  TORCH_CHECK(false, "cusolver doesn't support data type ", typeid(Dtype).name());
+  static_assert(false&&sizeof(Dtype), "cusolver doesn't support data type");
+  return {};
 }
 template<> cudaDataType get_cusolver_datatype<float>();
 template<> cudaDataType get_cusolver_datatype<double>();
@@ -459,10 +442,8 @@ void xpotrs(
 
 template <class scalar_t, class value_t = scalar_t>
 void syevd_bufferSize(CUDASOLVER_SYEVD_BUFFERSIZE_ARGTYPES(scalar_t, value_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::syevd_bufferSize: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::syevd_bufferSize: not implemented");
 }
 
 template <>
@@ -485,10 +466,8 @@ void syevd_bufferSize<c10::complex<double>, double>(
 
 template <class scalar_t, class value_t = scalar_t>
 void syevd(CUDASOLVER_SYEVD_ARGTYPES(scalar_t, value_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::syevd: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::syevd: not implemented");
 }
 
 template <>
@@ -509,10 +488,8 @@ void syevd<c10::complex<double>, double>(
 
 template <class scalar_t, class value_t = scalar_t>
 void syevj_bufferSize(CUDASOLVER_SYEVJ_BUFFERSIZE_ARGTYPES(scalar_t, value_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::syevj_bufferSize: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::syevj_bufferSize: not implemented");
 }
 
 template <>
@@ -535,10 +512,7 @@ void syevj_bufferSize<c10::complex<double>, double>(
 
 template <class scalar_t, class value_t = scalar_t>
 void syevj(CUDASOLVER_SYEVJ_ARGTYPES(scalar_t, value_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::syevj: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t), "at::cuda::solver::syevj: not implemented");
 }
 
 template <>
@@ -560,10 +534,8 @@ void syevj<c10::complex<double>, double>(
 template <class scalar_t, class value_t = scalar_t>
 void syevjBatched_bufferSize(
     CUDASOLVER_SYEVJ_BATCHED_BUFFERSIZE_ARGTYPES(scalar_t, value_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::syevjBatched_bufferSize: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::syevjBatched_bufferSize: not implemented");
 }
 
 template <>
@@ -586,10 +558,8 @@ void syevjBatched_bufferSize<c10::complex<double>, double>(
 
 template <class scalar_t, class value_t = scalar_t>
 void syevjBatched(CUDASOLVER_SYEVJ_BATCHED_ARGTYPES(scalar_t, value_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::syevjBatched: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::syevjBatched: not implemented");
 }
 
 template <>
@@ -612,10 +582,8 @@ void syevjBatched<c10::complex<double>, double>(
 
 template <class scalar_t>
 void xgeqrf_bufferSize(CUDASOLVER_XGEQRF_BUFFERSIZE_ARGTYPES(scalar_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::xgeqrf_bufferSize: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::xgeqrf_bufferSize: not implemented");
 }
 
 template <>
@@ -637,10 +605,7 @@ void xgeqrf_bufferSize<c10::complex<double>>(
 
 template <class scalar_t>
 void xgeqrf(CUDASOLVER_XGEQRF_ARGTYPES(scalar_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::xgeqrf: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t), "at::cuda::solver::xgeqrf: not implemented");
 }
 
 template <>
@@ -663,10 +628,8 @@ void xgeqrf<c10::complex<double>>(
 template <class scalar_t, class value_t = scalar_t>
 void xsyevd_bufferSize(
     CUDASOLVER_XSYEVD_BUFFERSIZE_ARGTYPES(scalar_t, value_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::xsyevd_bufferSize: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::xsyevd_bufferSize: not implemented");
 }
 
 template <>
@@ -691,10 +654,8 @@ void xsyevd_bufferSize<c10::complex<double>, double>(
 
 template <class scalar_t, class value_t = scalar_t>
 void xsyevd(CUDASOLVER_XSYEVD_ARGTYPES(scalar_t, value_t)) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      "at::cuda::solver::xsyevd: not implemented for ",
-      typeid(scalar_t).name());
+  static_assert(false&&sizeof(scalar_t),
+      "at::cuda::solver::xsyevd: not implemented");
 }
 
 template <>

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cpp
@@ -204,7 +204,7 @@ void csrmm2(
   T alpha, T *csrvala, int *csrrowptra, int *csrcolinda,
   T *b, int64_t ldb, T beta, T *c, int64_t ldc)
 {
-  TORCH_INTERNAL_ASSERT(false, "cusparse csr MM only supports data type of float, double, cfloat and cdouble.");
+  static_assert(false&&sizeof(T), "cusparse csr MM only supports data type of float, double, cfloat and cdouble.");
 }
 
 template<> void csrmm2<float>(
@@ -381,7 +381,7 @@ void csrmm2(
   T alpha, T *csrvala, int *csrrowptra, int *csrcolinda,
   T *b, int64_t ldb, T beta, T *c, int64_t ldc)
 {
-  TORCH_INTERNAL_ASSERT(false, "cusparse csr MM only supports data type of float, double, cfloat and cdouble.");
+  static_assert(false&&sizeof(T), "cusparse csr MM only supports data type of float, double, cfloat and cdouble.");
 }
 
 template<> void csrmm2<float>(

--- a/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
@@ -387,7 +387,7 @@ struct CusparseMatrixMultiplyOp {
       Tensor &output_values,
       Tensor &output_indices)
   {
-    TORCH_INTERNAL_ASSERT(false, "cusparse csr sparse-sparse MM only supports data type of float and double.");
+    static_assert(false&&sizeof(scalar_t), "cusparse csr sparse-sparse MM only supports data type of float and double.");
   }
 };
 


### PR DESCRIPTION
This PR tries to report some failures at build time. Once the build fails, it generally indicates that we can wrap the code inside some conditional macros, and it is a hint to further reduce the built code size. The sizeof operations were used to ensure that the assertion dependents on specific template instantiations.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10