### PR TITLE
[DSD] Make distributed state_dict support torch.distributed is not initialized case

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -42,6 +42,7 @@ from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
+    MultiProcessTestCase,
     with_comms,
 )
 from torch.testing._internal.distributed.common_state_dict import VerifyStateDictMixin
@@ -676,6 +677,23 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             fsdp_model, optimizers=fsdp_optim2, optim_state_dict=osd1
         )
         self.assertEqual(fsdp_optim.state_dict(), fsdp_optim2.state_dict())
+
+
+class TestNOComm(MultiProcessTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._spawn_processes()
+
+    @skip_if_lt_x_gpu(1)
+    def test_no_dist(self) -> None:
+        model = CompositeParamModel(device=torch.device("cuda"))
+        optim = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+        self.assertFalse(dist.is_initialized())
+        self.assertEqual(model.state_dict(), get_model_state_dict(model))
+        set_model_state_dict(model, model.state_dict())
+        osd = get_optimizer_state_dict(model, optim)
+        set_optimizer_state_dict(model, optim, optim.state_dict())
 
 
 if __name__ == "__main__":

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -606,7 +606,6 @@ def _flatten_optim_state_dict(state_dict: OptimizerStateType) -> Dict[str, Value
     this API won't flattent it.
     """
 
-
     def _raise_if_type_not_supported(v):
         if not isinstance(v, (torch.Tensor, int, float)):
             raise NotImplementedError(
@@ -764,6 +763,14 @@ def _split_optim_state_dict(
     pg_state: ListDictValueType = []
     return_osd: OptimizerStateType = {STATE: state, PG: pg_state}
     pg_mapping: Dict[int, int] = {}
+
+    if all(
+        [
+            isinstance(k, int)
+            for k in cast(DictValueType, optim_state_dict[STATE]).keys()
+        ]
+    ):
+        return optim_state_dict
 
     for param_group in optim.param_groups:
         pg_state.append({PARAMS: []})

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -407,6 +407,24 @@ def _state_dict_fn(obj: Union[nn.Module, torch.optim.Optimizer], api: str) -> Ca
     return call
 
 
+def _maybe_full_or_cpu_state_dict(
+    state_dict: Dict[str, Any], info: _StateDictInfo
+) -> Dict[str, Any]:
+    if info.full_state_dict:
+        ranks_only = (
+            tuple()
+            if (not info.cpu_offload or not torch.distributed.is_initialized())
+            else (0,)
+        )
+        return _gather_state_dict(
+            state_dict, cpu_offload=info.cpu_offload, ranks_only=ranks_only
+        )
+    elif info.cpu_offload:
+        return _offload_state_dict_to_cpu(state_dict)
+    else:
+        return state_dict
+
+
 def _get_model_state_dict(
     model: nn.Module, info: _StateDictInfo
 ) -> Dict[str, ValueType]:
@@ -471,15 +489,7 @@ def _get_model_state_dict(
         if torch.is_tensor(p) and p.is_meta:
             state_dict.pop(key)
 
-    if info.full_state_dict:
-        ranks_only = tuple() if not info.cpu_offload else (0,)
-        return _gather_state_dict(
-            state_dict, cpu_offload=info.cpu_offload, ranks_only=ranks_only
-        )
-    elif info.cpu_offload:
-        return _offload_state_dict_to_cpu(state_dict)
-    else:
-        return state_dict
+    return _maybe_full_or_cpu_state_dict(state_dict, info)
 
 
 def _load_model_state_dict(
@@ -733,15 +743,7 @@ def _get_optim_state_dict(
             OptimizerStateType, _flatten_optim_state_dict(optim_state_dict)
         )
 
-    if info.full_state_dict:
-        ranks_only = tuple() if not info.cpu_offload else (0,)
-        return _gather_state_dict(
-            optim_state_dict, cpu_offload=info.cpu_offload, ranks_only=ranks_only
-        )
-    elif info.cpu_offload:
-        return _offload_state_dict_to_cpu(optim_state_dict)
-    else:
-        return optim_state_dict
+    return _maybe_full_or_cpu_state_dict(optim_state_dict, info)
 
 
 def _split_optim_state_dict(
@@ -771,10 +773,7 @@ def _split_optim_state_dict(
     pg_mapping: Dict[int, int] = {}
 
     if all(
-        [
-            isinstance(k, int)
-            for k in cast(DictValueType, optim_state_dict[STATE]).keys()
-        ]
+        isinstance(k, int) for k in cast(DictValueType, optim_state_dict[STATE]).keys()
     ):
         return optim_state_dict
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127604
* __->__ #127385
* #127384
* #127071
* #127070

Fixes https://github.com/pytorch/pytorch/issues/124942

Summary:
Allow DSD to support loading the regular optimizer state_dict and can be used when torch.distributed.is_initialized() is False.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC