### PR TITLE
[from RFC #122468] Implement autoload device extension mechanism 

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2090,3 +2090,22 @@ def import_device_backends():
 
 from . import _logging
 _logging._init_logs()
+
+def import_device_backends():
+    if sys.version_info < (3, 10):
+        from importlib_metadata import entry_points
+    else:
+        from importlib.metadata import entry_points
+
+    for backend in entry_points(group='torch.backends'):
+        try:
+            backend_hook = backend.load()
+        except IndexError:
+            pass
+
+def is_device_backend_autoload_enabled() -> bool:
+    var = os.getenv("TORCH_DISABLE_DEVICE_BACKEND_AUTOLOAD")
+    return var is None or not var.upper() in ('1', 'TRUE', 'YES')
+
+if is_device_backend_autoload_enabled():
+    import_device_backends()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2065,29 +2065,6 @@ def _constrain_as_size(symbol, min: Optional[builtins.int] = None, max: Optional
     """
     torch.sym_constrain_range_for_size(symbol, min=min, max=max)
 
-def import_device_backends():
-    if sys.version_info < (3, 10):
-            from importlib_metadata import entry_points
-    else:
-        from importlib.metadata import entry_points
-
-    for backend in entry_points(group='torch.backends'):
-        try:
-            backend_hook = backend.load() 
-            if not hasattr(backend_hook, 'init_custom_backend'):
-                print(f"No explicit backend init function for \'{backend_hook.__name__}\' has been found, custom backend can't be loaded.")
-                continue
-            backend_hook.init_custom_backend()
-        except IndexError:
-            pass
-
-    def is_device_backend_autoload_enabled() -> bool:
-        var = os.getenv("TORCH_DISABLE_DEVICE_BACKEND_AUTOLOAD")
-        return not var in (1, 'True', 'true', 'Yes', 'yes')
-    
-    if is_device_backend_autoload_enabled():
-        import_device_backends()
-
 from . import _logging
 _logging._init_logs()
 
@@ -2099,7 +2076,7 @@ def import_device_backends():
 
     for backend in entry_points(group='torch.backends'):
         try:
-            backend_hook = backend.load()
+            backend.load()
         except IndexError:
             pass
 


### PR DESCRIPTION
This is a recast of PR #127228.

**Desc:**
These changes refer to RFC from https://github.com/pytorch/pytorch/issues/122468 issue. Early testing has been done against habana_frameworks extension, with the entry point exported according to the RFC discussion.
Things to do:

Documentation
Unit tests (we are open for suggestions)
More in-depth testing (in progress)
Looking forward for your review.