### PR TITLE
Cover clang-tidy to torch/csrc/onnx/init.cpp

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -235,7 +235,6 @@ exclude_patterns = [
     'torch/csrc/jit/serialization/import_legacy.cpp',
     'torch/csrc/jit/serialization/export.cpp',
     'torch/csrc/lazy/**/*',
-    'torch/csrc/onnx/init.cpp',
     'torch/csrc/mps/**/*',
 ]
 init_command = [


### PR DESCRIPTION
Enabling it will not cause issues.
