### PR TITLE
[pipelining] Fix block comments for doc rendering

### DIFF
--- a/torch/distributed/pipelining/PipelineStage.py
+++ b/torch/distributed/pipelining/PipelineStage.py
@@ -1067,6 +1067,7 @@ class ManualPipelineStage(_PipelineStageBase):
     as opposed to the PipelineStage class that is outputed from pipeline().
     This class extends the `_PipelineStageBase` class and can similarly be used
     in `PipelineScheule`.
+
     Args:
         submodule (nn.Module): The PyTorch module wrapped by this stage.
         stage_index (int): The ID of this stage.

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -323,13 +323,13 @@ def pipe_split():
     no-op if your annotated module is run eagerly.
 
     Example:
-    >>> # xdoctest: +SKIP
-    >>> def forward(self, x):
-    >>>     x = torch.mm(x, self.mm_param)
-    >>>     x = torch.relu(x)
-    >>>     pipe_split()
-    >>>     x = self.lin(x)
-    >>>     return x
+        >>> # xdoctest: +SKIP
+        >>> def forward(self, x):
+        >>>     x = torch.mm(x, self.mm_param)
+        >>>     x = torch.relu(x)
+        >>>     pipe_split()
+        >>>     x = self.lin(x)
+        >>>     return x
 
     The above example will be split into two stages.
     """
@@ -1269,15 +1269,16 @@ def pipeline(
         )
 
 
-# Context manager for setting `args_chunk_spec` during creation of Pipe
 class ArgsChunkSpec:
     """
+    Context manager for setting `args_chunk_spec` during creation of Pipe
+
     Example:
-    >>> # xdoctest: +SKIP
-    >>> # There are three positional arguments to the model, and
-    >>> # we are chunking them along dimension 0, 0 and 1, respectively
-    >>> with ArgsChunkSpec((0, 0, 1)):
-    >>>     pipe = pipeline(model, num_chunks, example_args)
+        >>> # xdoctest: +SKIP
+        >>> # There are three positional arguments to the model, and
+        >>> # we are chunking them along dimension 0, 0 and 1, respectively
+        >>> with ArgsChunkSpec((0, 0, 1)):
+        >>>     pipe = pipeline(model, num_chunks, example_args)
     """
 
     def __init__(
@@ -1299,14 +1300,15 @@ class ArgsChunkSpec:
         Pipe.args_chunk_spec = None
 
 
-# Context manager for setting `kwargs_chunk_spec` during creation of Pipe
 class KwargsChunkSpec:
     """
+    Context manager for setting `kwargs_chunk_spec` during creation of Pipe
+
     Example:
-    >>> # xdoctest: +SKIP
-    >>> # Chunk dimension 0 for the "id" argument, 1 for the "mask" argument
-    >>> with KwargsChunkSpec({"id": 0, "mask": 1}):
-    >>>     pipe = pipeline(model, num_chunks, (), example_kwargs)
+        >>> # xdoctest: +SKIP
+        >>> # Chunk dimension 0 for the "id" argument, 1 for the "mask" argument
+        >>> with KwargsChunkSpec({"id": 0, "mask": 1}):
+        >>>     pipe = pipeline(model, num_chunks, (), example_kwargs)
     """
 
     def __init__(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127418

Previous:
<img width="915" alt="image" src="https://github.com/pytorch/pytorch/assets/14858254/14626937-7d79-4a7a-9d0b-3fcfe64b4667">
<img width="926" alt="image" src="https://github.com/pytorch/pytorch/assets/14858254/58ab009c-3f93-46d7-a04f-499a2a0ba390">

New:
https://docs-preview.pytorch.org/pytorch/pytorch/127418/distributed.pipelining.html

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k