### PR TITLE
[export] provide parsing and refine function for automatically accepting dynamic shapes suggested fixes

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -5,6 +5,7 @@ import dataclasses
 import io
 import logging
 import re
+import sys
 import unittest
 import warnings
 from contextlib import contextmanager
@@ -1968,6 +1969,113 @@ class TestExport(TestCase):
         _dx = Dim("_dx", min=2, max=12)
         dynamic_shapes = {"x": (3 * _dx - 1,), "y": (3 * _dx,), "z": (3 * _dx + 2,)}
         export(Foo(), inputs, dynamic_shapes=dynamic_shapes)
+
+    def test_parse_and_refine_suggested_fixes(self):
+        from torch.export.dynamic_shapes import parse_and_refine_suggested_fixes
+
+        def helper(model, inputs, dynamic_shapes):
+            # export, fail, parse & refine suggested fixes, re-export
+            try:
+                export(Foo(), inps, dynamic_shapes=dynamic_shapes)
+                raise Exception("should have raised constraint violation error")
+            except torch._dynamo.exc.UserError as exc:
+                new_shapes = parse_and_refine_suggested_fixes(exc.msg, dynamic_shapes)
+                export(Foo(), inps, dynamic_shapes=new_shapes)
+                return new_shapes
+
+        # specialize dims + derived dims
+        class Foo(torch.nn.Module):
+            def forward(self, x, y, z):
+                x0 = x + y[1:] + z[2:]
+                x1 = x @ torch.randn(4, 4)
+                return x0, x1
+
+        inps = (torch.randn(4,), torch.randn(5,), torch.randn(6,))
+        dx = Dim("dx", max=16)
+        dynamic_shapes = {"x": (dx,), "y": (dx+1,), "z": (dx+2,)}
+        new_shapes = helper(Foo(), inps, dynamic_shapes)
+        self.assertEqual(new_shapes["x"][0], 4)
+        self.assertEqual(new_shapes["z"][0], 6)
+
+        # refine lower, upper bound
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                if x.shape[0] >= 6 and y.shape[0] <= 16:
+                    return x * 2.0, y + 1
+
+        inps = (torch.randn(16), torch.randn(12))
+        dynamic_shapes = {"x": (Dim("dx"),), "y": (Dim("dy"),)}
+        new_shapes = helper(Foo(), inps, dynamic_shapes)
+        self.assertEqual(new_shapes["x"][0].min, 6)
+        self.assertEqual(new_shapes["y"][0].max, 16)
+
+        # divisiblity, will introduce new root
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                if x.shape[0] >= 9:
+                    return x.reshape([-1, 3])
+
+        inps = (torch.randn(15,),)
+        dynamic_shapes = ((Dim("dx"),),)
+        new_shapes = helper(Foo(), inps, dynamic_shapes)
+        dim = new_shapes[0][0]
+        root = dim.root
+        self.assertEqual(dim.fn(2), 6)
+        self.assertEqual(root.min, 3)
+
+        # turn dim into derived dim/relation
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y[4:]
+
+        inps = (torch.randn(6, 4), torch.randn(10, 4))
+        dynamic_shapes = {
+            "x": (Dim("dx0"), Dim("dx1")),
+            "y": (Dim("dy0"), Dim("dy1")),
+        }
+        new_shapes = helper(Foo(), inps, dynamic_shapes)
+        self.assertEqual(new_shapes["x"][0], new_shapes["y"][0].root)  # dy0 = dx0 + 4
+        self.assertEqual(new_shapes["y"][0].fn(5), 9)
+        self.assertEqual(new_shapes["x"][1], new_shapes["y"][1])  # dx1 = dy1
+
+        # nested dynamic shapes spec
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                x0 = x[0]["data"] + x[1] + x[2][2:]
+                x1 = y["a"] @ torch.randn(4, 4)
+                x2 = y["b"] @ torch.randn(6, 6)
+                return x0, x1, x2
+
+        inps = (
+            [
+                {"data": torch.randn(4, 4)},
+                torch.randn(4, 4),
+                torch.randn(6, 4),
+            ],
+            {
+                "a": torch.randn(8, 4),
+                "b": torch.randn(9, 6),
+            }
+        )
+        dynamic_shapes = {
+            "x": [
+                {"data": (Dim("dx00"), Dim("dx01"))},
+                (Dim("dx10"), Dim("dx11")),
+                (Dim("dx20"), Dim("dx21")),
+            ],
+            "y": {
+                "a": (Dim("dya0"), Dim("dya1")),
+                "b": (Dim("dyb0"), Dim("dyb1")),
+            }
+        }
+        new_shapes = helper(Foo(), inps, dynamic_shapes)
+        self.assertEqual(new_shapes["x"][0]["data"][0], new_shapes["x"][1][0])  # dx10 = dx00
+        self.assertEqual(new_shapes["x"][2][0].root, new_shapes["x"][0]["data"][0])  # dx20 = dx00 + 2
+        self.assertEqual(new_shapes["x"][2][0].fn(10), 12)
+        self.assertEqual(new_shapes["x"][0]["data"][1], new_shapes["x"][1][1])  # dx11 = dx01
+        self.assertEqual(new_shapes["y"]["a"][1], 4)
+        self.assertEqual(new_shapes["y"]["b"][1], 6)
+        self.assertEqual(new_shapes["y"]["b"][0].__name__, "dyb0")  # unchanged
 
     def test_dynamic_shapes_spec_with_pytree(self):
         from torch.export import Dim, export

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -2,13 +2,22 @@ import builtins
 import dataclasses
 import inspect
 import math
+import re
 import sys
 import weakref
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
+
+import sympy
 
 import torch
-from torch.utils._pytree import _get_node_type, BUILTIN_TYPES, SUPPORTED_NODES, tree_map
+from torch.utils._pytree import (
+    _get_node_type,
+    BUILTIN_TYPES,
+    SUPPORTED_NODES,
+    tree_flatten,
+    tree_map,
+)
 
 from .exported_program import ExportedProgram
 
@@ -896,3 +905,181 @@ def _process_dynamic_shapes(
                 constraints.append(primary)
 
     return constraints  # type: ignore[return-value]
+
+
+def get_dim_name_mapping(
+    dynamic_shapes: Union[Dict[str, Any], Tuple[Any], List[Any], None]
+):
+    name_to_dim = {}
+    for dim in tree_flatten(
+        dynamic_shapes,
+        is_leaf=lambda x: isinstance(x, _Dim),
+    )[0]:
+        if dim is None or isinstance(dim, int):
+            continue
+        name_to_dim[dim.__name__] = dim
+        if isinstance(dim, _DerivedDim):
+            name_to_dim[dim.root.__name__] = dim.root  # type: ignore[attr-defined]
+    return name_to_dim
+
+
+def parse_and_refine_suggested_fixes(
+    msg: str, dynamic_shapes: Union[Dict[str, Any], Tuple[Any], List[Any]],
+) -> Union[Dict[str, Any], Tuple[Any], List[Any]]:
+    """
+    For working with export's dynamic shapes suggested fixes, and/or automatic dynamic shapes.
+    Refines the given dynamic shapes spec, given a ConstraintViolation error message and the original dynamic shapes.
+    Does this by parsing the suggested fixes and building an intermediate mapping suggested_fixes.
+
+    suggested_fixes is a dictionary mapping from dim names to either:
+    - integers (specialized values)
+    - Dims or DerivedDims
+    - strings representing valid derived dim expressions (a * x + b, where x is a Dim)
+
+    Finally returns the original dynamic shapes spec, but refined with the suggested fixes.
+
+    Some notes on behavior:
+    - Keys in suggested_fixes will be existing dim names (exists in original dynamic_shapes spec),
+      or newly introduced roots. The latter case is typically via suggested fixes to handle divisiblity
+      guard, e.g. if x % 2 == 0: -> Eq(Mod(x, 2), 0) -> dx = 2*_dx
+    - For refining derived dims, unless a value is explicitly provided for the derived dim name,
+      the root value provided in suggested_fixes is used to derive the new value.
+      For example:
+            dx = Dim("dx", max=2048); shapes = (dx, dx + 1, dx + 2);  #
+            suggested_fixes = {"dx": Dim("dx": max=16)} -> shapes[2] now has max = 18
+            suggested_fixes = {"dx": 16} -> shapes[2] is specialized to 18
+            suggested_fixes = {"dx": Dim("dx": max=16), "dx + 2": 18}
+                -> shapes[1] has max = 17, shapes[2] is specialized to 18
+                Keep in mind this case will actually fail export, since dx and dx + 1 should also be specialized.
+                Export's suggested fixes will never suggest this, but the flexibility is provided to the user.
+    """
+
+    from torch._dynamo.exc import UserError, UserErrorType
+    from torch.fx.experimental.symbolic_shapes import _is_supported_equivalence
+
+    try:
+        suggested_fixes_msg = msg.split("Suggested fixes:")[1].strip()
+    except:
+        raise UserError(
+            UserErrorType.INVALID_INPUT,
+            "Suggested fixes not found in error message given to parse_suggested_fixes()",
+        )
+
+    # build suggested_fixes dictionary
+    suggested_fixes = {}
+    for fix in suggested_fixes_msg.split("\n"):
+        fix = fix.strip()
+        if match := re.match(r"(.*) = Dim\('(.*)'.*\)", fix):
+            name = match.group(1)
+            _min, _max = None, None
+            if match_min := re.match(r".* = Dim\('.*', min\=([0-9]+).*\)", fix):
+                _min = int(match_min.group(1))
+            if match_max := re.match(r".* = Dim\('.*'.*max\=([0-9]+)\)", fix):
+                _max = int(match_max.group(1))
+            suggested_fixes[name] = Dim(name, min=_min, max=_max)
+        else:
+            name, expr = fix.split(" = ")
+            expr = sympy.sympify(expr)
+            if isinstance(expr, sympy.Number):
+                suggested_fixes[name] = int(expr)  # static, integer
+            else:
+                suggested_fixes[name] = str(expr)  # relation or derived dim
+
+    name_to_dim = get_dim_name_mapping(dynamic_shapes)
+
+    # track derived dim roots
+    roots: Set[str] = set()
+    for k, c in suggested_fixes.items():
+        if not isinstance(
+            c, (int, _Dim, _DerivedDim, str)
+        ):  # check derived dim expression
+            raise UserError(
+                UserErrorType.INVALID_INPUT,
+                (
+                    "Dictionary values to refine_with_suggested_fixes() must be integers, Dims, DerivedDims, "
+                    f"or strings representing derived dims, but instead found {c} of type {type(c)}"
+                ),
+            )
+        if isinstance(c, int) and not (
+            c >= 0 and c <= sys.maxsize - 1
+        ):  # check integer range
+            raise UserError(
+                UserErrorType.INVALID_INPUT,
+                (
+                    f"Integer values to refine_with_suggested_fixes() must be in the range [0, {sys.maxsize - 1}], "
+                    f"but instead found {c}"
+                ),
+            )
+        if isinstance(c, str):  # check dim/derived dim expression
+            expr = sympy.sympify(c)
+            if not _is_supported_equivalence(expr):
+                raise UserError(
+                    UserErrorType.INVALID_INPUT,
+                    (
+                        "String inputs to refine_with_suggested_fixes() must be supported derived dim expressions "
+                        f"of the form a * x + b, but instead found {expr}"
+                    ),
+                )
+            suggested_fixes[k] = expr  # replace strings with sympy.Exprs
+            roots.add(str(list(expr.free_symbols)[0]))
+        if isinstance(c, _DerivedDim):
+            roots.add(c.root.__name__)  # type: ignore[arg-type]
+
+    # check keys are existing dims or new roots
+    for k, c in suggested_fixes.items():
+        if not (k in name_to_dim or k in roots):
+            raise UserError(
+                UserErrorType.INVALID_INPUT,
+                (
+                    f"Key {k}: {c} in refine_with_suggested_fixes() does not correspond to an existing dim "
+                    "or an introduced root in the new spec"
+                ),
+            )
+
+    # cache so we don't produce multiple derived dim objects
+    derived_dim_cache: Dict[str, _DerivedDim] = {}
+
+    def apply_fixes(dim, dummy):
+        if dim is None or isinstance(dim, int):  # not dynamic
+            return dim
+        elif dim.__name__ in suggested_fixes:  # directly fix
+            fix = suggested_fixes[dim.__name__]
+            if isinstance(fix, sympy.Expr):  # now derived or related
+                if str(fix) in derived_dim_cache:
+                    return derived_dim_cache[str(fix)]
+                else:
+                    symbol = list(fix.free_symbols)[0]
+                    # try to locate symbol
+                    if symbol.name in suggested_fixes:
+                        root = suggested_fixes[symbol.name]
+                    elif symbol.name in name_to_dim:
+                        root = name_to_dim[symbol.name]
+                    else:
+                        raise UserError(
+                            UserErrorType.INVALID_INPUT,
+                            (
+                                f"Dim or derived dim expression {fix} with symbol {symbol} was specified, "
+                                f"but {symbol} was not found in original shapes spec or new spec."
+                            ),
+                        )
+                    # figure out value of fix
+                    modulus, remainder = sympy.polys.polytools.div(fix, symbol)
+                    dim = root
+                    if modulus != 1:
+                        dim = int(modulus) * dim
+                    if remainder != 0:
+                        dim = dim + int(remainder)
+                    derived_dim_cache[str(fix)] = dim
+                    return dim
+            else:
+                return fix
+        elif isinstance(dim, _DerivedDim) and dim.root.__name__ in suggested_fixes:
+            if dim.__name__ in derived_dim_cache:
+                return derived_dim_cache[dim.__name__]
+            else:  # evaluate new derived value based on root
+                _dim = dim.fn(suggested_fixes[dim.root.__name__])
+                derived_dim_cache[dim.__name__] = _dim
+                return _dim
+        return dim  # unchanged dim
+
+    return _tree_map(apply_fixes, dynamic_shapes, dynamic_shapes)


### PR DESCRIPTION
Summary:
Part of the work helping export's automatic dynamic shapes / dynamic shapes refining based on suggested fixes. 

Introduces a util function parse_and_refine_suggested_fixes() that takes the error message from a ConstraintViolationError message containing suggested dynamic shapes fixes, along with the original dynamic shapes spec, and returns the new spec. Written so that the suggested fixes from export can be directly parsed and used.

Example usage for the automatic dynamic shapes workflow:
```
# export, fail, parse & refine suggested fixes, re-export
try:
    export(model, inps, dynamic_shapes=dynamic_shapes)
except torch._dynamo.exc.UserError as exc:
    new_shapes = parse_and_refine_suggested_fixes(exc.msg, dynamic_shapes)
    export(model, inps, dynamic_shapes=new_shapes)
```

For examples of behavior, see the added test and docstring. Will take suggestions for renaming the function to something else 😅

Test Plan: test_export tests

Differential Revision: D57409142


