### PR TITLE
Add back private function torch.cuda.amp.autocast_mode._cast

### DIFF
--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -48,6 +48,9 @@ class autocast(torch.amp.autocast_mode.autocast):
             return func
         return super().__call__(func)
 
+# Preserved only for BC reasons
+def _cast(value, dtype):
+    return torch.amp.autocast_mode._cast(value, "cuda", dtype)
 
 def custom_fwd(fwd=None, *, cast_inputs=None):
     """

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -48,9 +48,11 @@ class autocast(torch.amp.autocast_mode.autocast):
             return func
         return super().__call__(func)
 
+
 # Preserved only for BC reasons
 def _cast(value, dtype):
     return torch.amp.autocast_mode._cast(value, "cuda", dtype)
+
 
 def custom_fwd(fwd=None, *, cast_inputs=None):
     """


### PR DESCRIPTION
This is unfortunately used in a few places in the wild: https://github.com/search?q=torch.cuda.amp.autocast_mode._cast&type=code