### PR TITLE
Fix delete old branches workflow

### DIFF
--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -267,7 +267,7 @@ def delete_branches() -> None:
     print(f"To delete ({len(delete)}):")
     for branch in delete:
         print(f"About to delete branch {branch}")
-        delete_branch(git_repo, branch)
+        # delete_branch(git_repo, branch)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -267,7 +267,7 @@ def delete_branches() -> None:
     print(f"To delete ({len(delete)}):")
     for branch in delete:
         print(f"About to delete branch {branch}")
-        # delete_branch(git_repo, branch)
+        delete_branch(git_repo, branch)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/delete_old_branches.yml
+++ b/.github/workflows/delete_old_branches.yml
@@ -7,6 +7,7 @@ on:
     # Run daily.
     - cron: 30 1 * * *
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: delete-old-branches
@@ -29,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
           architecture: x64
           check-latest: false
 

--- a/.github/workflows/delete_old_branches.yml
+++ b/.github/workflows/delete_old_branches.yml
@@ -7,7 +7,6 @@ on:
     # Run daily.
     - cron: 30 1 * * *
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: delete-old-branches


### PR DESCRIPTION
The ubuntu runner started using 2.45.1 (prev 2.43.2), which includes https://github.com/git/git/commit/1f49f7506f0d840e048ba78f7e0544c407568b58 (changes +00:00 timezone to Z)

Python versions prior to 3.11 do not support Z when parsing isoformat, so update the workflow to use 3.11
