### PR TITLE
Use less A100.large shards for torchao perf benchmark

### DIFF
--- a/.github/workflows/torchao.yml
+++ b/.github/workflows/torchao.yml
@@ -53,18 +53,9 @@ jobs:
       cuda-arch-list: '8.0'
       test-matrix: |
         { include: [
-          { config: "torchao_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "torchao_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "torchao_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "torchao_timm_perf", shard: 1, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "torchao_timm_perf", shard: 2, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "torchao_timm_perf", shard: 3, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "torchao_timm_perf", shard: 4, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "torchao_timm_perf", shard: 5, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "torchao_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "torchao_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "torchao_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "torchao_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "torchao_huggingface_perf", shard: 1, num_shards: 1, runner: "linux.gcp.a100.large" },
+          { config: "torchao_timm_perf", shard: 1, num_shards: 1, runner: "linux.gcp.a100.large" },
+          { config: "torchao_torchbench_perf", shard: 1, num_shards: 1, runner: "linux.gcp.a100.large" },
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
     secrets:

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -2,7 +2,7 @@ name: Upload torch dynamo performance stats
 
 on:
   workflow_run:
-    workflows: [inductor-A100-perf-nightly]
+    workflows: [inductor-A100-perf-nightly, torchao]
     types:
       - completed
 


### PR DESCRIPTION
Looking at the initial run on https://github.com/pytorch/pytorch/actions/runs/9226991392/job/25517416753, all `torchao` benchmark jobs are relatively quick and all could finish within 2.5 hour threshold for PyTorch CI.  So, a quick way to make the scheduling more efficient is to reduce the number of A100.large we need to only one for each test suites.  Finding 3 A100 runners is going to be easier than finding 12 of them.  This helps with the queue.

This's also adding torchao workflow into the upload workflow to get its CSV output ingested into Rockset.