### PR TITLE
[Intel GPU]Enable fp64 GEMM

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -62,10 +62,10 @@ Tensor& addmm_out(
       " but got:",
       self.sizes());
 
-  // complex/double case
-  if (mat1.is_complex() || mat1.scalar_type() == ScalarType::Double) {
+  // complex case
+  if (mat1.is_complex()) {
     AT_ERROR(
-        "Double and complex datatype matmul is not supported in oneDNN");
+        "Complex datatype matmul is not supported in oneDNN");
   }
 
   // general case
@@ -139,9 +139,9 @@ Tensor& mm_out(const Tensor& self, const Tensor& mat2, Tensor& result) {
     return result;
   }
 
-  if (self.is_complex() || self.scalar_type() == ScalarType::Double) {
+  if (self.is_complex()) {
     AT_ERROR(
-        "Double and complex datatype matmul is not supported in oneDNN");
+        "Complex datatype matmul is not supported in oneDNN");
   }
 
   onednn::matmul(result, self, mat2, Tensor(), true, onednn::Attr());
@@ -193,10 +193,10 @@ Tensor& baddbmm_out(
       " but got:",
       input.sizes());
 
-  // complex and double case
-  if (batch1.is_complex() || batch2.scalar_type() == ScalarType::Double) {
+  // complex case
+  if (batch1.is_complex()) {
     AT_ERROR(
-        "Double and complex datatype matmul is not supported in oneDNN");
+        "Complex datatype matmul is not supported in oneDNN");
   }
 
   // general case
@@ -320,9 +320,9 @@ Tensor& bmm_out(const Tensor& self, const Tensor& batch2, Tensor& result) {
     return result;
   }
 
-  if (self.is_complex() || self.scalar_type() == ScalarType::Double) {
+  if (self.is_complex()) {
     AT_ERROR(
-        "Double and complex datatype matmul is not supported in oneDNN");
+        "Complex datatype matmul is not supported in oneDNN");
   }
   onednn::matmul(result, self, batch2, at::Tensor(), true, onednn::Attr());
   return result;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -103,9 +103,9 @@ sycl::event matmul(
   b = b.contiguous(); // avoid reorder 2 times
 
   // xpu matmul support both ab/ba shape for m2 tensor, we don't check any more
-  auto m1_usr_dt = get_onednn_dtype(m1);
-  auto m2_usr_dt = get_onednn_dtype(m2);
-  auto dst_usr_dt = get_onednn_dtype(dst);
+  auto m1_usr_dt = get_onednn_dtype_include_double(m1);
+  auto m2_usr_dt = get_onednn_dtype_include_double(m2);
+  auto dst_usr_dt = get_onednn_dtype_include_double(dst);
 
   auto m1_dt = m1_usr_dt;
   auto m2_dt = m2_usr_dt;
@@ -157,7 +157,7 @@ sycl::event matmul(
 
   if (with_bias) {
     bias_dims = get_onednn_dims(b);
-    bias_dt = get_onednn_dtype(b);
+    bias_dt = get_onednn_dtype_include_double(b);
     bias_strides = get_onednn_strides(b);
   }
 

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -130,9 +130,10 @@ class TestBasicGEMM(TestCase):
         {
             torch.float: 1e-4,
             torch.half: 1e-1,
+            torch.double: 1e-8
         }
     )
-    @dtypes(torch.float32, torch.half)
+    @dtypes(torch.float32, torch.half, torch.double)
     def test_addmm(self, device, dtype):
         self._test_addmm_impl(torch.addmm, None, device, dtype)
 
@@ -183,6 +184,7 @@ class TestBasicGEMM(TestCase):
     @dtypes(
         torch.half,
         torch.float32,
+        torch.float64,
     )
     def test_mm(self, device, dtype):
         def _test_mm(n, m, p, dtype, genf):
@@ -285,7 +287,7 @@ class TestBasicGEMM(TestCase):
             _test_mm(n, m, p, dtype, genf)
 
     @precisionOverride({torch.half: 0.05, torch.bfloat16: 0.05})
-    @dtypes(torch.float32, torch.bfloat16, torch.half)
+    @dtypes(torch.float32, torch.bfloat16, torch.half, torch.float64)
     def test_bmm(self, device, dtype):
         batch_sizes = [1, 10]
         M, N, O = 23, 15, 12
@@ -401,7 +403,7 @@ class TestBasicGEMM(TestCase):
         self.assertEqual(res7, ref)
 
     @precisionOverride({torch.half: 0.05, torch.bfloat16: 0.05})
-    @dtypes(torch.float32, torch.bfloat16, torch.half)
+    @dtypes(torch.float64, torch.float32, torch.bfloat16, torch.half)
     def test_addbmm(self, device, dtype):
         num_batches = 2
         M, N, O = 16, 17, 18
@@ -521,7 +523,7 @@ class TestBasicGEMM(TestCase):
             self._test_addbmm_baddbmm("addbmm", b1, b2, ref, out_tensor)
 
     @precisionOverride({torch.half: 0.1, torch.bfloat16: 0.5})
-    @dtypes(torch.float32, torch.bfloat16, torch.half)
+    @dtypes(torch.float64, torch.float32, torch.bfloat16, torch.half)
     def test_baddbmm(self, device, dtype):
         num_batches = 10
         M, N, O = 12, 8, 50
@@ -618,7 +620,7 @@ class TestBasicGEMM(TestCase):
         )
         self.assertEqual(a, an)
 
-    @dtypes(torch.float)
+    @dtypes(torch.float, torch.double)
     @precisionOverride({torch.float32: 1e-4})
     def test_1_sized_with_0_strided(self, device, dtype):
         a = make_tensor((8, 1, 64), dtype=dtype, device=device)
@@ -707,7 +709,7 @@ class TestBasicGEMM(TestCase):
             r1 = fntorch(t0_full, t1, t2)
             self.assertEqual(r0, r1)
 
-    @dtypes(torch.float32)
+    @dtypes(torch.float32, torch.float64)
     def test_strided_mm_bmm(self, device, dtype):
         # Tests strided view case with stride smaller than corresponding dimension size
         x = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=dtype, device=device)
@@ -781,7 +783,7 @@ class TestBasicGEMM(TestCase):
                 y = torch.baddbmm(input, mat1, mat2, beta=0.0, out=out)
                 self.assertEqual(y_ref, y)
 
-    @dtypes(torch.float)
+    @dtypes(torch.float, torch.double)
     def test_addmm_sizes(self, device, dtype):
         for m in [0, 1, 25]:
             for n in [0, 1, 10]:
@@ -812,7 +814,7 @@ class TestBasicGEMM(TestCase):
             torch.cdouble: 1e-8,
         }
     )
-    @dtypes(torch.float32, torch.bfloat16, torch.half)
+    @dtypes(torch.double, torch.float32, torch.bfloat16, torch.half)
     def test_addmm_gelu(self, device, dtype):
         self._test_addmm_impl(torch._addmm_activation, "gelu", device, dtype)
 
@@ -826,11 +828,11 @@ class TestBasicGEMM(TestCase):
             torch.cdouble: 1e-8,
         }
     )
-    @dtypes(torch.float32, torch.bfloat16, torch.half)
+    @dtypes(torch.double, torch.float32, torch.bfloat16, torch.half)
     def test_addmm_relu(self, device, dtype):
         self._test_addmm_impl(torch._addmm_activation, "relu", device, dtype)
 
-    @dtypes(torch.float, torch.bfloat16, torch.half)
+    @dtypes(torch.float, torch.bfloat16, torch.half, torch.double)
     def test_addmv_rowmajor_colmajor_incx_incy_lda(self, device, dtype):
         # tests (o, s)*(s).  o is output size, s is summed size.
         o = 5
@@ -876,7 +878,7 @@ class TestBasicGEMM(TestCase):
             torch.cdouble: 1e-8,
         }
     )
-    @dtypes(torch.bfloat16, torch.half, torch.float32)
+    @dtypes(torch.double, torch.bfloat16, torch.half, torch.float32)
     def test_corner_cases_of_cublasltmatmul(self, device, dtype):
         # common case
         M = torch.randn(128, device=device).to(dtype)


### PR DESCRIPTION
# Motivation
oneDNN library has added support of double datatype GEMM in release v3.5. This PR unleashes the double limitation in XPU GEMM oneDNN integration code, accompanied with the UT change.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127507



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @EikanWang @fengyuan14 @guangyey