### PR TITLE
Validate file and handle exceptions for weights_only unpickler

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1069,8 +1069,8 @@ class TestSerialization(TestCase, SerializationMixin):
 
         # Check execptions are handled for corrupted ops unpickling
         data_corrupted_ops = (b'\x80\x02\x8a\x0a\x6c\xfc\x9c\x46\xf9\x20\x6a\xa8\x50\x19\x2e\x80'
-                             b'\x02\x4d\xe9\x03\x2e\x80\x02\x75\x78\x0b\x00\x03\x50\x4b\x03\x04'
-                             b'\x0a\x00\x00\x40\x00\x00\x2a')
+                              b'\x02\x4d\xe9\x03\x2e\x80\x02\x75\x78\x0b\x00\x03\x50\x4b\x03\x04'
+                              b'\x0a\x00\x00\x40\x00\x00\x2a')
         buf = io.BytesIO(data_corrupted_ops)
         with self.assertRaisesRegex(pickle.UnpicklingError, "Unable to unpickle file due to error: pop from empty list"):
             torch.load(buf, weights_only=True)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1060,6 +1060,21 @@ class TestSerialization(TestCase, SerializationMixin):
         _test_save_load_attr(t)
         _test_save_load_attr(torch.nn.Parameter(t))
 
+    def test_weights_only_unpickler(self):
+        # Check validation for too short files for unpickler
+        data_too_short = b'\x80\x02\x8a\x0a\x6c\xfc\x9c\x46\xf9\x20\x6a\xa8\x50\x19\x2e\x80'
+        buf = io.BytesIO(data_too_short)
+        with self.assertRaisesRegex(pickle.UnpicklingError, "file is too short: corrupt file?"):
+            torch.load(buf, weights_only=True)
+
+        # Check execptions are handled for corrupted ops unpickling
+        data_corrupted_ops = (b'\x80\x02\x8a\x0a\x6c\xfc\x9c\x46\xf9\x20\x6a\xa8\x50\x19\x2e\x80'
+                             b'\x02\x4d\xe9\x03\x2e\x80\x02\x75\x78\x0b\x00\x03\x50\x4b\x03\x04'
+                             b'\x0a\x00\x00\x40\x00\x00\x2a')
+        buf = io.BytesIO(data_corrupted_ops)
+        with self.assertRaisesRegex(pickle.UnpicklingError, "Unable to unpickle file due to error: pop from empty list"):
+            torch.load(buf, weights_only=True)
+
     def test_weights_only_assert(self):
         class HelloWorld:
             def __reduce__(self):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1060,7 +1060,7 @@ class TestSerialization(TestCase, SerializationMixin):
         _test_save_load_attr(t)
         _test_save_load_attr(torch.nn.Parameter(t))
 
-    def test_weights_only_unpickler(self):
+    def test_weights_only_unpickler_error_handling(self):
         # Check validation for too short files for unpickler
         data_too_short = b'\x80\x02\x8a\x0a\x6c\xfc\x9c\x46\xf9\x20\x6a\xa8\x50\x19\x2e\x80'
         buf = io.BytesIO(data_too_short)

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -415,4 +415,7 @@ class Unpickler:
 
 
 def load(file, *, encoding: str = "ASCII"):
-    return Unpickler(file, encoding=encoding).load()
+    try:
+        return Unpickler(file, encoding=encoding).load()
+    except Exception as e:
+        raise RuntimeError(f"Unable to unpickle file due to error: {e}")

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -418,4 +418,4 @@ def load(file, *, encoding: str = "ASCII"):
     try:
         return Unpickler(file, encoding=encoding).load()
     except Exception as e:
-        raise RuntimeError(f"Unable to unpickle file due to error: {e}")
+        raise RuntimeError(f"Unable to unpickle file due to error: {e}") from e

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1528,6 +1528,16 @@ def _legacy_load(f, map_location, pickle_module, **pickle_load_args):
             "functionality."
         )
 
+    start = f.tell()
+    f.seek(0, 2)
+    file_size = f.tell()
+    # Check that file is long enough to contain magic number and
+    # protocol version: 10 bytes for MAGIC_NUMBER, 2 bytes for
+    # PROTOCOL_VERSION, 8 bytes for unpickling operators.
+    if file_size < 20:
+        raise RuntimeError(f"{f.name} is too short: corrupt file?")
+    f.seek(start)
+
     magic_number = pickle_module.load(f, **pickle_load_args)
     if magic_number != MAGIC_NUMBER:
         raise RuntimeError("Invalid magic number; corrupt file?")

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1535,7 +1535,7 @@ def _legacy_load(f, map_location, pickle_module, **pickle_load_args):
     # protocol version: 10 bytes for MAGIC_NUMBER, 2 bytes for
     # PROTOCOL_VERSION, 8 bytes for unpickling operators.
     if file_size < 20:
-        raise RuntimeError(f"{f.name} is too short: corrupt file?")
+        raise RuntimeError("file is too short: corrupt file?")
     f.seek(start)
 
     magic_number = pickle_module.load(f, **pickle_load_args)


### PR DESCRIPTION
Fixing a lot of unhandled exceptions raised from weights_only model loading:

 - Validate file size to be able to contain at least magic number and protocol version
 - Also catch all exceptions from unpickler due to inconsistent operators interpretation.

Fixes #127525
