### PR TITLE
[ROCm] Fix error in torch.cuda initialisation if amdsmi is not available

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -629,7 +629,7 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
 
 
 def _raw_device_count_amdsmi() -> int:
-    if not _HAS_PYNVML: # If amdsmi is not available
+    if not _HAS_PYNVML:  # If amdsmi is not available
         return -1
     try:
         amdsmi.amdsmi_init()
@@ -660,8 +660,8 @@ def _raw_device_count_nvml() -> int:
 
 def _raw_device_uuid_amdsmi() -> Optional[List[str]]:
     from ctypes import byref, c_int, c_void_p, CDLL, create_string_buffer
-    
-    if not _HAS_PYNVML: # If amdsmi is not available
+
+    if not _HAS_PYNVML:  # If amdsmi is not available
         return None
     try:
         amdsmi.amdsmi_init()

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -629,6 +629,8 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
 
 
 def _raw_device_count_amdsmi() -> int:
+    if not _HAS_PYNVML: # If amdsmi is not available
+        return -1
     try:
         amdsmi.amdsmi_init()
     except amdsmi.AmdSmiException as e:
@@ -658,7 +660,9 @@ def _raw_device_count_nvml() -> int:
 
 def _raw_device_uuid_amdsmi() -> Optional[List[str]]:
     from ctypes import byref, c_int, c_void_p, CDLL, create_string_buffer
-
+    
+    if not _HAS_PYNVML: # If amdsmi is not available
+        return None
     try:
         amdsmi.amdsmi_init()
     except amdsmi.AmdSmiException:


### PR DESCRIPTION
Reported in https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15874 

When nvml_count is set via https://github.com/pytorch/pytorch/blob/9f73c65b8f644d599ff3ff53927b738cfbb7d191/torch/cuda/__init__.py#L834

If amdsmi is not available this will throw an error
```
File "python3.10/site-packages/torch/cuda/__init__.py", line 634, in _raw_device_count_amdsmi
    except amdsmi.AmdSmiException as e:
NameError: name 'amdsmi' is not defined
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang