### PR TITLE
[RFC] Introduce CheckpointableTensor for DCP

### DIFF
--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -28,6 +28,7 @@ __all__ = [
     "LoadPlan",
     "SavePlanner",
     "LoadPlanner",
+    "CheckpointableTensor",
 ]
 
 
@@ -424,5 +425,33 @@ class LoadPlanner:
         copying it back to the one in the state_dict.
 
         The contents of tensor will follow its device synchronization model.
+        """
+        pass
+
+
+class CheckpointableTensor(abc.ABC):
+    """
+    Interface for checkpointable tensors.
+    This is to allow arbitrary tensor subclasses to hook into DCP seamlessly through implementing the interface.
+    """
+
+    @abc.abstractmethod
+    def _create_write_items(self, fqn: str, *args, **kwargs) -> List[WriteItem]:
+        """
+        Return a list of WriteItems based on object's contents.
+        """
+        pass
+
+    @abc.abstractmethod
+    def _create_chunk_list(self, *args, **kwargs) -> List[ChunkStorageMetadata]:
+        """
+        Return a list of `ChunkStorageMetadata` based on object's contents.
+        """
+        pass
+
+    @abc.abstractmethod
+    def find_tensor_shard(self, index: MetadataIndex, *args, **kwargs) -> torch.Tensor:
+        """
+        Return a 'torch.Tensor' shard based on 'MetadataIndex'.
         """
         pass

--- a/torch/distributed/checkpoint/utils.py
+++ b/torch/distributed/checkpoint/utils.py
@@ -14,6 +14,7 @@ import torch.distributed as dist
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharded_tensor.shard import Shard
 from torch.distributed._tensor import DTensor
+from torch.distributed.checkpoint.planner import CheckpointableTensor
 
 from .api import (
     _is_wrapped_exception,
@@ -301,7 +302,9 @@ def _find_shard(tensor: ShardedTensor, index: MetadataIndex) -> Shard:
 
 
 def find_tensor_shard(tensor: torch.Tensor, index: MetadataIndex) -> torch.Tensor:
-    if isinstance(tensor, DTensor):
+    if isinstance(tensor, CheckpointableTensor):
+        return tensor.find_tensor_shard(index)
+    elif isinstance(tensor, DTensor):
         return tensor.to_local()
     if isinstance(tensor, ShardedTensor):
         return _find_shard(tensor, index).tensor


### PR DESCRIPTION
Summary:
# Introduce CheckpointableTensor interface for DCP to support arbitrary tensor subclasses for checkpointing

**Authors:**
* zainhuda

## **Summary**
This diff adds a CheckpointableTensor interface to allow for future compatibility for any tensor subclass with DCP in a clean and maintainable way.

## **Motivation**
For TorchRec sharding migration from ShardedTensor to DTensor, we create a tensor subclass that is stored by DTensor to support TorchRec's sharding schemes (ex, empty shards, multiple shards on a rank).

## **Proposed Implementation**
View the CheckpointableTensor interface implementation, in which, we introduce the minimal set of methods needed to be compatible with DCP. These methods are expected to implemented by any tensor subclasses and as such are then checkpointable by DCP.

## **Drawbacks**
No drawbacks, it extends functionality in a clean and maintainable way.

## **Alternatives**
Alternative design was creating paths for checking for certain attributes in tensor subclasses which can get messy and hard to maintain/understand why it was there in the first place.

Test Plan: Sandcastle

Differential Revision: D57970603




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC