### PR TITLE
Handle aten::__contains__ during TorchScript to ExportedProgram conversion

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1,7 +1,7 @@
 # Owner(s): ["oncall: export"]
 
 import unittest
-from typing import Tuple, Dict
+from typing import Dict, Tuple
 
 import torch
 
@@ -273,7 +273,6 @@ class TestConverter(TestCase):
             def forward(self, x: torch.Tensor):
                 return x.dtype in [-1]
 
-        
         class MTensorIn(torch.nn.Module):
             def forward(self, x: torch.Tensor, x_dict: Dict[torch.Tensor, str]):
                 return x in x_dict
@@ -286,6 +285,7 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(MTensorIn(), inp)
         inp = (torch.tensor(1), {torch.tensor(4): "foo"})
         self._check_equal_ts_ep_converter(MTensorIn(), inp)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1,7 +1,7 @@
 # Owner(s): ["oncall: export"]
 
 import unittest
-from typing import Tuple
+from typing import Tuple, Dict
 
 import torch
 
@@ -273,10 +273,19 @@ class TestConverter(TestCase):
             def forward(self, x: torch.Tensor):
                 return x.dtype in [-1]
 
+        
+        class MTensorIn(torch.nn.Module):
+            def forward(self, x: torch.Tensor, x_dict: Dict[torch.Tensor, str]):
+                return x in x_dict
+
         inp = (torch.tensor(4),)
         self._check_equal_ts_ep_converter(MIn(), inp)
         self._check_equal_ts_ep_converter(MNotIn(), inp)
 
+        inp = (torch.tensor(4), {torch.tensor(4): "foo"})
+        self._check_equal_ts_ep_converter(MTensorIn(), inp)
+        inp = (torch.tensor(1), {torch.tensor(4): "foo"})
+        self._check_equal_ts_ep_converter(MTensorIn(), inp)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -264,6 +264,19 @@ class TestConverter(TestCase):
         inp = ((torch.zeros(1, 4), torch.ones(1, 4)),)
         self._check_equal_ts_ep_converter(MUnpackTuple(), inp)
 
+    def test_ts2ep_converter_contains(self):
+        class MIn(torch.nn.Module):
+            def forward(self, x: torch.Tensor):
+                return x.dtype in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+        class MNotIn(torch.nn.Module):
+            def forward(self, x: torch.Tensor):
+                return x.dtype in [-1]
+
+        inp = (torch.tensor(4),)
+        self._check_equal_ts_ep_converter(MIn(), inp)
+        self._check_equal_ts_ep_converter(MNotIn(), inp)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -55,6 +55,7 @@ kind_to_standard_operators = {
     "aten::__is__": operator.is_,
     "aten::__isnot__": operator.is_not,
     "aten::__not__": operator.not_,
+    "aten::__contains__": operator.contains,
 }
 
 
@@ -362,15 +363,6 @@ class TS2FXGraphConverter:
     def convert_prim_CreateObject(self, node: torch._C.Node):
         output_name = node.output().debugName()
         self.attribute_map[output_name] = ""
-
-    def convert_aten___contains__(self, node: torch._C.Node):
-        inp_list = [inp for inp in node.inputs()]
-        assert len(inp_list) == 2, "aten::__contains__ assumes 2 inputs"
-
-        container, ele = inp_list
-        container = self.get_fx_value(container)
-        ele = self.get_fx_value(ele)
-        self.name_to_node[node.output().debugName()] = ele in container
 
     def convert_aten__convolution(self, node: torch._C.Node):
         # converts aten::_convolution as aten.convolution, since aten::_convolution

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -363,6 +363,15 @@ class TS2FXGraphConverter:
         output_name = node.output().debugName()
         self.attribute_map[output_name] = ""
 
+    def convert_aten___contains__(self, node: torch._C.Node):
+        inp_list = [inp for inp in node.inputs()]
+        assert len(inp_list) == 2, "aten::__contains__ assumes 2 inputs"
+
+        container, ele = inp_list
+        container = self.get_fx_value(container)
+        ele = self.get_fx_value(ele)
+        self.name_to_node[node.output().debugName()] = ele in container
+
     def convert_aten__convolution(self, node: torch._C.Node):
         # converts aten::_convolution as aten.convolution, since aten::_convolution
         # doesn't have a meta function
@@ -506,7 +515,6 @@ class TS2FXGraphConverter:
 
     def convert_node(self, node: torch._C.Node):
         node_kind = node.kind()
-        node_kind_split = node_kind.split("::")
 
         # Get handler based on namespace and operator name.
         # Provide a default node handler as well in case we don't find


### PR DESCRIPTION
#### Description
Add support for converting `prim::__contains__` from TorchScript IR to ExportedProgram, e.g.,
```python
class MIn(torch.nn.Module):
    def forward(self, x: torch.Tensor):
        return x.dtype in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
```
#### Test Plan
* Add test cases to cover both contains IR resulted from primitive types or Tensor. `pytest test/export/test_converter.py -s -k test_ts2ep_converter_contains`