### PR TITLE
[easy] Fix lint in test/test_custom_ops.py

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: custom-operators"]
+# Owner(s): ["module: custom operators"]
 
 from torch.testing._internal.common_utils import *  # noqa: F403
 from torch.testing._internal.common_device_type import *  # noqa: F403


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127548

For some reason this completely unrelated TESTOWNERS lint showed up in my other PR #127545 , so fixing it. No idea why it never showed up earlier
Repro:
Run TESTOWNERS lint on this file, see that it passes now, but not before