### PR TITLE
Add a GH action to autolabel docathon PRs

### DIFF
--- a/.github/scripts/docathon-label-sync.py
+++ b/.github/scripts/docathon-label-sync.py
@@ -1,0 +1,44 @@
+import os
+from github import Github
+import sys
+import re
+
+def main():
+    token = os.environ.get('GITHUB_TOKEN')
+
+    repo_owner = "pytorch"
+    repo_name = "pytorch"
+    pull_request_number = int(sys.argv[1])
+
+    g = Github(token)
+    repo = g.get_repo(f'{repo_owner}/{repo_name}')
+    pull_request = repo.get_pull(pull_request_number)
+    pull_request_body = pull_request.body
+    # PR without description
+    if pull_request_body is None:
+        return
+
+    # get issue number from the PR body
+    if not re.search(r'#\d{1,6}', pull_request_body):
+        print("The pull request does not mention an issue.")
+        return
+    issue_number = int(re.findall(r'#(\d{1,6})', pull_request_body)[0])
+    issue = repo.get_issue(issue_number)
+    issue_labels = issue.labels
+    docathon_label_present = any(label.name == 'docathon-h1-2024' for label in issue_labels)
+
+    # if the issue has a docathon label, add all labels from the issue to the PR.
+    if not docathon_label_present:
+        print("The 'docathon-h1-2024' label is not present in the issue.")
+        return
+    pull_request_labels = pull_request.get_labels()
+    issue_label_names = [label.name for label in issue_labels]
+    labels_to_add = [label for label in issue_label_names if label not in pull_request_labels]
+    if not labels_to_add:
+        print("The pull request already has the same labels.")
+        return
+    pull_request.add_to_labels(*labels_to_add)
+    print("Labels added to the pull request!")
+
+if __name__  == "__main__":
+    main()

--- a/.github/scripts/docathon-label-sync.py
+++ b/.github/scripts/docathon-label-sync.py
@@ -36,9 +36,10 @@ def main() -> None:
         print("The 'docathon-h1-2024' label is not present in the issue.")
         return
     pull_request_labels = pull_request.get_labels()
+    pull_request_label_names = [label.name for label in pull_request_labels]
     issue_label_names = [label.name for label in issue_labels]
     labels_to_add = [
-        label for label in issue_label_names if label not in pull_request_labels
+        label for label in issue_label_names if label not in pull_request_label_names
     ]
     if not labels_to_add:
         print("The pull request already has the same labels.")

--- a/.github/scripts/docathon-label-sync.py
+++ b/.github/scripts/docathon-label-sync.py
@@ -1,17 +1,19 @@
 import os
-from github import Github
-import sys
 import re
+import sys
 
-def main():
-    token = os.environ.get('GITHUB_TOKEN')
+from github import Github
+
+
+def main() -> None:
+    token = os.environ.get("GITHUB_TOKEN")
 
     repo_owner = "pytorch"
     repo_name = "pytorch"
     pull_request_number = int(sys.argv[1])
 
     g = Github(token)
-    repo = g.get_repo(f'{repo_owner}/{repo_name}')
+    repo = g.get_repo(f"{repo_owner}/{repo_name}")
     pull_request = repo.get_pull(pull_request_number)
     pull_request_body = pull_request.body
     # PR without description
@@ -19,13 +21,15 @@ def main():
         return
 
     # get issue number from the PR body
-    if not re.search(r'#\d{1,6}', pull_request_body):
+    if not re.search(r"#\d{1,6}", pull_request_body):
         print("The pull request does not mention an issue.")
         return
-    issue_number = int(re.findall(r'#(\d{1,6})', pull_request_body)[0])
+    issue_number = int(re.findall(r"#(\d{1,6})", pull_request_body)[0])
     issue = repo.get_issue(issue_number)
     issue_labels = issue.labels
-    docathon_label_present = any(label.name == 'docathon-h1-2024' for label in issue_labels)
+    docathon_label_present = any(
+        label.name == "docathon-h1-2024" for label in issue_labels
+    )
 
     # if the issue has a docathon label, add all labels from the issue to the PR.
     if not docathon_label_present:
@@ -33,12 +37,15 @@ def main():
         return
     pull_request_labels = pull_request.get_labels()
     issue_label_names = [label.name for label in issue_labels]
-    labels_to_add = [label for label in issue_label_names if label not in pull_request_labels]
+    labels_to_add = [
+        label for label in issue_label_names if label not in pull_request_labels
+    ]
     if not labels_to_add:
         print("The pull request already has the same labels.")
         return
     pull_request.add_to_labels(*labels_to_add)
     print("Labels added to the pull request!")
 
-if __name__  == "__main__":
+
+if __name__ == "__main__":
     main()

--- a/.github/workflows/docathon-sync-label.yml
+++ b/.github/workflows/docathon-sync-label.yml
@@ -3,6 +3,7 @@ name: Docathon Labels Sync
 on:
   pull_request_target:
     types: [opened, synchronize, edited]
+    branches: [main]
 
 jobs:
   check-labels:

--- a/.github/workflows/docathon-sync-label.yml
+++ b/.github/workflows/docathon-sync-label.yml
@@ -1,0 +1,29 @@
+name: Docathon Labels Sync
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, edited]
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          pip install requests
+          pip install PyGithub
+      - name: Run Python script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python ./.github/scripts/docathon-label-sync.py ${{ github.event.pull_request.number }}

--- a/.github/workflows/docathon-sync-label.yml
+++ b/.github/workflows/docathon-sync-label.yml
@@ -22,8 +22,8 @@ jobs:
           python-version: 3.x
       - name: Install dependencies
         run: |
-          pip install requests
-          pip install PyGithub
+          pip install requests==2.32.3
+          pip install PyGithub==2.3.0
       - name: Run Python script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To ease oncall burden for the docathon PR reviewers and ensure all PRs are correctly labeled, adding this GH action that will look for the issue number in the PR and if that issue has a docathon-h1-2024 label, then it would propagate the labels from the issues into the PR. It should not conflict with the existing labelers because we use ``pull_request.add_to_labels`` - credit @kit1980. 

cc @brycebortree @seemethere @malfet @pytorch/pytorch-dev-infra