### PR TITLE
Use freshly traced jit-traced module to be used in export analysis

### DIFF
--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -999,17 +999,17 @@ def _temp_disable_texpr_fuser():
         torch._C._jit_set_texpr_fuser_enabled(original_state)
 
 
+class _WrapperModule(torch.nn.Module):
+    def __init__(self, f):
+        super().__init__()
+        self.f = f
+
+    def forward(self, *args, **kwargs):
+        return self.f(*args, **kwargs)
+
+
 def _convert_ts_to_export_experimental(traced_callable, args, kwargs=None):
     with _temp_disable_texpr_fuser():
-
-        class _WrapperModule(torch.nn.Module):
-            def __init__(self, f):
-                super().__init__()
-                self.f = f
-
-            def forward(self, *args, **kwargs):
-                return self.f(*args, **kwargs)
-
         from torch.jit._trace import TopLevelTracedModule
 
         export_args, export_kwargs = _process_jit_trace_inputs_for_export(args, kwargs)
@@ -1034,6 +1034,7 @@ def _convert_ts_to_export_experimental(traced_callable, args, kwargs=None):
                     strict=False,
                     _is_torch_jit_trace=True,
                 ).module()
+
         else:
             return _export(
                 _WrapperModule(traced_callable),

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -646,6 +646,11 @@ def analyze_ts_result_with_export_result(export, trace):
     flat_trace = pytree.tree_leaves(trace)
 
     for orig, loaded in zip(flat_export, flat_trace):
+        if orig.layout != loaded.layout:
+            return False
+        # mkldnn is not supported for torch.allclose
+        if orig.layout == torch._mkldnn:  # type: ignore[attr-defined]
+            return True
         if type(orig) != type(loaded):
             return False
 
@@ -1012,6 +1017,21 @@ def trace(
             _process_jit_trace_inputs_for_export,
         )
 
+        traced_func_for_export = _trace_impl(
+            func,
+            example_inputs=example_inputs,
+            optimize=optimize,
+            check_trace=False,
+            check_inputs=check_inputs,
+            check_tolerance=check_tolerance,
+            strict=strict,
+            _force_outplace=_force_outplace,
+            _module_class=_module_class,
+            _compilation_unit=_compilation_unit,
+            example_kwarg_inputs=example_kwarg_inputs,
+            _store_inputs=_store_inputs,
+        )
+
         export_args, _ = _process_jit_trace_inputs_for_export(
             example_inputs, example_kwarg_inputs
         )
@@ -1037,7 +1057,7 @@ def trace(
                 return
 
             try:
-                traced_result = traced_func(*export_args)
+                traced_result = func_to_export(*export_args)
             except Exception as e:
                 _ = e
                 log_torch_jit_trace_exportability(
@@ -1065,22 +1085,22 @@ def trace(
             return TS2EPConverter(func, export_args).convert().module()
 
         # torch.jit.trace is noop when the original module is torch.jit.ScriptModule
-        if not isinstance(traced_func, torch.jit.ScriptModule):
+        if not isinstance(traced_func_for_export, torch.jit.ScriptModule):
             _log_exportability(
-                traced_func,
+                traced_func_for_export,
                 _direct_export_and_lower,
                 export_args,
                 _ExportType.DIRECT_EXPORT,
             )
 
         _log_exportability(
-            traced_func,
+            traced_func_for_export,
             _convert_ts_to_export_experimental,
             export_args,
             _ExportType.TRACE_AND_EXPORT,
         )
         _log_exportability(
-            traced_func,
+            traced_func_for_export,
             _convert_ts_to_export_source_to_source,
             export_args,
             _ExportType.SOURCE_TO_SOURCE,


### PR DESCRIPTION
Summary: When we export already traced module, it seems to be modifying some global state causing the traced modules to fail to run. For now, we are only logging for test cases, so it is probs ok to trace fresh copy to be used in export for now.

Test Plan: CI

Differential Revision: D57983518


