### PR TITLE
Handle custom op during TorchScript to ExportedProgram conversion

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -18,11 +18,7 @@ requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "requires cuda")
 class TestConverter(TestCase):
     def _check_equal_ts_ep_converter(self, mod, inp) -> ExportedProgram:
         ts_model = torch.jit.script(mod)
-        print(ts_model.graph)
         ep = TS2EPConverter(ts_model, inp).convert()
-        print(ep.graph)
-        print(ep.module()(*inp))
-        print(mod(*inp))
         ep_out, _ = pytree.tree_flatten(ep.module()(*inp))
         orig_out, _ = pytree.tree_flatten(mod(*inp))
         self.assertEqual(len(ep_out), len(orig_out))
@@ -329,21 +325,13 @@ class TestConverter(TestCase):
                     )
 
                 def forward(self, x):
-                    return torch.ops.mylib.foo(torch.nn.functional.linear(x, self.weight, bias=self.bias))
-                    # return torch.ops.mylib.foo(x)
+                    return torch.ops.mylib.foo(
+                        torch.nn.functional.linear(x, self.weight, bias=self.bias)
+                    )
 
             inp = (torch.randn(3, 3),)
-            mod = M(3, 3)
-
-            ts_model = torch.jit.script(mod)
-            print(ts_model.graph)
-            ep = TS2EPConverter(ts_model, inp).convert()
-            print(ep.graph)
-            print(ep.module()(*inp))
-            print(mod(*inp))
-            ep_out, _ = pytree.tree_flatten(ep.module()(*inp))
-
-            # self._check_equal_ts_ep_converter(m, inp)
+            m = M(3, 3)
+            self._check_equal_ts_ep_converter(m, inp)
 
 
 if __name__ == "__main__":

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -315,22 +315,11 @@ class TestConverter(TestCase):
                 return x + x
 
             class M(torch.nn.Module):
-                def __init__(self, in_features, out_features):
-                    super().__init__()
-                    self.weight = torch.nn.Parameter(
-                        torch.randn(out_features, in_features), requires_grad=True
-                    )
-                    self.bias = torch.nn.Parameter(
-                        torch.randn(out_features), requires_grad=True
-                    )
-
                 def forward(self, x):
-                    return torch.ops.mylib.foo(
-                        torch.nn.functional.linear(x, self.weight, bias=self.bias)
-                    )
+                    return torch.ops.mylib.foo(x)
 
             inp = (torch.randn(3, 3),)
-            m = M(3, 3)
+            m = M()
             self._check_equal_ts_ep_converter(m, inp)
 
 

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -75,7 +75,7 @@ def get_op_overload(node: torch._C.Node):
     except Exception as e:
         raise RuntimeError(
             f"Unable to find operator {node.kind()} with schema {node.schema}"
-        )
+        ) from e
 
     return op_overload
 

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -403,7 +403,7 @@ class TS2FXGraphConverter:
                     self.name_to_node[output_name] = fx_node
                     return
 
-        self.convert_aten_op(node)
+        self.convert_call_function_op(node)
 
     def convert_aten___getitem__(self, node: torch._C.Node):
         input_container, index = tuple(

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -503,16 +503,6 @@ class TS2FXGraphConverter:
         output_name = node.output().debugName()
         self.name_to_node[output_name] = fx_node
 
-    def convert_custom_op(self, node: torch._C.Node):
-        target = get_op_overload(node)
-
-        args, kwargs = self.get_args_kwargs(node, target._schema)
-
-        fx_node = self.fx_graph.call_function(target, args, kwargs)
-
-        output_name = node.output().debugName()
-        self.name_to_node[output_name] = fx_node
-
     def convert_node(self, node: torch._C.Node):
         node_kind = node.kind()
 

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -65,12 +65,19 @@ def get_op_overload(node: torch._C.Node):
     ns, op_name = str(schema.name.name).split("::")
     override = schema.name.overload_name
 
-    op_overload_mod = getattr(torch.ops, ns)
-    op_overload_packet = getattr(op_overload_mod, op_name)
-    if override:
-        op_overload = getattr(op_overload_packet, override)
-    else:
-        op_overload = op_overload_packet.default
+    try:
+        op_overload_mod = getattr(torch.ops, ns)
+        op_overload_packet = getattr(op_overload_mod, op_name)
+        if override:
+            op_overload = getattr(op_overload_packet, override)
+        else:
+            op_overload = op_overload_packet.default
+    except Exception as e:
+        msg = f"Finding operator overload for {node.kind()}"
+        if override:
+            msg += f" with override {override}"
+        msg += f" fail due to: {e}"
+        raise RuntimeError(msg)
 
     return op_overload
 

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -73,7 +73,9 @@ def get_op_overload(node: torch._C.Node):
         else:
             op_overload = op_overload_packet.default
     except Exception as e:
-        raise RuntimeError(f"Unable to find operator {node.kind()} with schema {node.schema}")
+        raise RuntimeError(
+            f"Unable to find operator {node.kind()} with schema {node.schema}"
+        )
 
     return op_overload
 

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -164,6 +164,13 @@ class TS2FXGraphConverter:
             name = graph_input.debugName()
             normalized_name = normalize_name(name)
 
+            fx_node = self.fx_graph.placeholder(normalized_name)
+
+            # fx_node.meta["val"] = FakeTensor()
+            # TODO: set fx_node.meta["val"]
+
+            self.name_to_node[name] = fx_node
+
             if name in self.param_names:
                 self.input_specs.append(
                     InputSpec(
@@ -172,7 +179,6 @@ class TS2FXGraphConverter:
                         target=name,
                     )
                 )
-                fx_node = self.fx_graph.get_attr(qualified_name=normalized_name)
             elif name in self.buffer_names:
                 self.input_specs.append(
                     InputSpec(
@@ -182,7 +188,6 @@ class TS2FXGraphConverter:
                         persistent=True,
                     )
                 )
-                fx_node = self.fx_graph.get_attr(qualified_name=normalized_name)
             else:
                 self.input_specs.append(
                     InputSpec(
@@ -191,12 +196,6 @@ class TS2FXGraphConverter:
                         target=name,
                     )
                 )
-                fx_node = self.fx_graph.placeholder(normalized_name)
-
-            self.name_to_node[name] = fx_node
-
-            # fx_node.meta["val"] = FakeTensor()
-            # TODO: set fx_node.meta["val"]
 
     def convert_prim_Constant(self, node: torch._C.Node):
         name = node.output().debugName()
@@ -503,6 +502,7 @@ class TS2FXGraphConverter:
         fx_node = self.fx_graph.call_function(target, args)
         output_name = node.output().debugName()
         self.name_to_node[output_name] = fx_node
+
     def convert_custom_op(self, node: torch._C.Node):
         target = get_op_overload(node)
 


### PR DESCRIPTION
#### Description
Handle custom ops during TorchScript to ExportedProgram covnersion
```python
torch.library.define(
    "mylib::foo",
    "(Tensor x) -> Tensor",
    lib=lib,
)

# PyTorch custorm op implementation
@torch.library.impl(
    "mylib::foo",
    "CompositeExplicitAutograd",
    lib=lib,
)
def foo_impl(x):
    return x + x

# Meta function of the custom op.
@torch.library.impl_abstract(
    "mylib::foo",
    lib=lib,
)
def foo_meta(x):
    return x + x

class M(torch.nn.Module):
    def forward(self, x):
        return torch.ops.mylib.foo(x)
```

#### Test Plan
* Add a test case where custom op is called and converted. `pytest test/export/test_converter.py -s -k test_ts2ep_converter_custom_op`