### PR TITLE
[Inductor][CPP] Support more than one LocalBuffer

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1993,26 +1993,30 @@ class CppKernel(Kernel):
                 ):
                     # Allocate local buffer
                     local_buffers = V.local_buffer_scope.local_buffers
-                    assert len(local_buffers.items()) == 1
-                    local_buffer = next(iter(local_buffers.items()))[1]
+                    # assert len(local_buffers.items()) == 1
+                    # local_buffer = next(iter(local_buffers.items()))[1]
 
-                    # Checked in try_outer_loop_fusion_with_local_buf by assuming last dim size and contiguous
-                    assert len(local_buffer.get_layout().size) == 1
-                    # For dynamic size, rename s to ks
-                    local_buf_size = self.rename_indexing(
-                        local_buffer.get_layout().size[-1]
-                    )
-                    local_buf_dtype = DTYPE_TO_CPP[local_buffer.get_layout().dtype]
-                    allocate = (
-                        f"std::make_unique<{local_buf_dtype} []>({local_buf_size})"
-                    )
-                    code.splice(
-                        f"std::unique_ptr<{local_buf_dtype} []> local_buffer = {allocate};"
-                    )
-                    local_buffer_name = local_buffer.get_name()
-                    code.splice(
-                        f"{local_buf_dtype}* {local_buffer_name} = local_buffer.get();"
-                    )
+                    for index in range(len(list(local_buffers.items()))):
+
+                        local_buffer = list(local_buffers.items())[index][1]
+
+                        # Checked in try_outer_loop_fusion_with_local_buf by assuming last dim size and contiguous
+                        assert len(local_buffer.get_layout().size) == 1
+                        # For dynamic size, rename s to ks
+                        local_buf_size = self.rename_indexing(
+                            local_buffer.get_layout().size[-1]
+                        )
+                        local_buf_dtype = DTYPE_TO_CPP[local_buffer.get_layout().dtype]
+                        allocate = (
+                            f"std::make_unique<{local_buf_dtype} []>({local_buf_size})"
+                        )
+                        code.splice(
+                            f"std::unique_ptr<{local_buf_dtype} []> local_buffer_{index} = {allocate};"
+                        )
+                        local_buffer_name = local_buffer.get_name()
+                        code.splice(
+                            f"{local_buf_dtype}* {local_buffer_name} = local_buffer_{index}.get();"
+                        )
                 gen_loops(loop_nest.root)
             else:
                 gen_kernel(loop_nest.kernel)
@@ -3459,7 +3463,18 @@ class CppKernelProxy(CppKernel):
                 def localize_fn(self, name, index):
                     scheduler_nodes = V.graph.scheduler.name_to_node.get(name).get_nodes()  # type: ignore[union-attr]
                     # Rename buffer name to Local Buffer
-                    name = self.local_buf.get_name()
+                    global_buf = None
+                    local_buf = None                    
+                    for loca_buf_pair in self.local_buf_pairs:
+                        if name == loca_buf_pair.global_buf.get_name():
+                            global_buf = loca_buf_pair.global_buf
+                            local_buf = loca_buf_pair.local_buf
+                            break
+                    
+                    assert local_buf is not None
+                    assert global_buf is not None
+                    name = local_buf.get_name()
+
                     # Use the last dim
                     _, (group, reduction_group) = max(
                         scheduler_nodes, key=lambda x: int(x.is_reduction())
@@ -3474,16 +3489,22 @@ class CppKernelProxy(CppKernel):
                             replacements[x] = sympy.core.numbers.Zero()
                     index = sympy_subs(index, replacements)  # type: ignore[arg-type]
                     return name, index
+                
+                from .cpp_utils import LocalBufferPair
+
+                local_buf_pairs = []
+                for index in range(len(V.local_buffer_scope.local_nodes.items())):
+                    local_buf_pairs.append(
+                        LocalBufferPair(
+                            list(V.local_buffer_scope.local_nodes.items())[index][1].node,
+                            list(V.local_buffer_scope.local_buffers.items())[index][1],
+                        )
+                    )
 
                 ctx = V.set_ops_handler(
                     LocalizeBufferHandler(
                         V.get_ops_handler(),
-                        global_buf=next(iter(V.local_buffer_scope.local_nodes.items()))[
-                            1
-                        ].node,
-                        local_buf=next(
-                            iter(V.local_buffer_scope.local_buffers.items())
-                        )[1],
+                        local_buf_pairs=local_buf_pairs,
                         localize_fn=localize_fn,
                     )
                 )
@@ -3853,29 +3874,31 @@ class CppScheduling(BaseScheduling):
                         global_buffer_layout.size[-1:],
                         global_buffer_layout.stride[-1:],
                     )
+                    prefix = "local_buffer_data"
                     local_buffers.append(
                         LocalBuffer(
                             local_buf=ir.Buffer(
-                                "local_buffer_data", local_buffer_layout
+                                f"{prefix}_{len(local_buffers)}", local_buffer_layout
                             ),
                             global_snode=scheduler_node,
                         )
                     )
-                    # At most 1 node with local buf for each OuterLoopFusedSchedulerNode
-                    break
+                    # # At most 1 node with local buf for each OuterLoopFusedSchedulerNode
+                    # break
             if len(local_buffers) == 0:
                 # No local buffer found
                 return False
-            assert len(local_buffers) == 1
+            # assert len(local_buffers) == 1
             for _node in node.get_outer_nodes():
                 assert isinstance(_node, (FusedSchedulerNode, SchedulerNode))
                 cpp_kernel_proxy = CppKernelProxy(kernel_group)
 
                 with LocalBufferScope(cpp_kernel_proxy) as scope:
-                    assert len(local_buffers) == 1
-                    scope.add_local_buffer(
-                        local_buffers[0].local_buf, local_buffers[0].global_snode
-                    )
+                    # assert len(local_buffers) == 1
+                    for local_buffer in local_buffers:
+                        scope.add_local_buffer(
+                            local_buffer.local_buf, local_buffer.global_snode
+                        )
                     cpp_kernel_proxy.codegen_nodes(_node.get_nodes())  # type: ignore[arg-type]
                 cpp_kernel_proxy_list.append(cpp_kernel_proxy)
                 nodes_list.append(_node.get_nodes())  # type: ignore[arg-type]
@@ -3898,10 +3921,10 @@ class CppScheduling(BaseScheduling):
                 # Also need the local buffer inform in codegen loop
                 # which is used to allocate the local buffer.
                 if local_buffers:
-                    assert len(local_buffers) == 1
-                    scope.add_local_buffer(
-                        local_buffers[0].local_buf, local_buffers[0].global_snode
-                    )
+                    for local_buffer in local_buffers:
+                        scope.add_local_buffer(
+                            local_buffer.local_buf, local_buffer.global_snode
+                        )
                 kernel_group.finalize_kernel(
                     outer_fusion_cpp_kernel_proxy,
                     [_node for _nodes in nodes_list for _node in _nodes],

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -255,23 +255,27 @@ def value_to_cpp(value, cpp_type):
         return f"static_cast<{cpp_type}>({repr(value)})"
 
 
+LocalBufferPair = namedtuple("LocalBufferPair", ["global_buf", "local_buf"])
+
+
 class LocalizeBufferHandler(V.WrapperHandler):  # type: ignore[name-defined]
     def __init__(
         self,
         inner,
-        global_buf=None,
-        local_buf=None,
+        # global_buf=None,
+        local_buf_pairs: Optional[List[LocalBufferPair]] = None,
         localize_fn: Optional[
             Callable[["LocalizeBufferHandler", str, sympy.Expr], Any]
         ] = None,
     ):
         super().__init__(inner)
-        self.global_buf = global_buf
-        self.local_buf = local_buf
+        # self.global_buf = global_buf
+        # self.local_buf = local_buf
         self.localize_fn = localize_fn
+        self.local_buf_pairs = local_buf_pairs
 
     def localize(self, name: str, index: sympy.Expr):
-        if self.global_buf and name == self.global_buf.get_name():
+        if self.local_buf_pair and name in [loca_buf_pair.global_buf.get_name() for loca_buf_pair in self.local_buf_pairs]:
             assert self.localize_fn is not None
             name, index = self.localize_fn(self, name, index)
         return name, index
@@ -283,8 +287,8 @@ class LocalizeBufferHandler(V.WrapperHandler):  # type: ignore[name-defined]
         local_buffer_name, local_buffer_index = self.localize(name, index)
         res = self._inner.store(local_buffer_name, local_buffer_index, value, mode)
         if (
-            self.global_buf
-            and name == self.global_buf.get_name()
+            self.local_buf_pairs
+            and name in [loca_buf_pair.global_buf.get_name() for loca_buf_pair in self.local_buf_pairs]
             and isinstance(V.kernel, Kernel)
         ):
             # Remove name of local buffer from Kernel.store_buffer_names
@@ -408,7 +412,20 @@ class LocalBufferScope:
         def inner_fn_wrapper(inner_fn):
             def inner(index):
                 def localize_fn(self, name, index):
-                    name = self.local_buf.get_name()
+                    # name = self.local_buf.get_name()
+                    global_buf = None
+                    local_buf = None
+
+                    for loca_buf_pair in self.local_buf_pairs:
+                        if name == loca_buf_pair.global_buf.get_name():
+                            global_buf = loca_buf_pair.global_buf
+                            local_buf = loca_buf_pair.local_buf
+                            break
+                    
+                    assert local_buf is not None
+                    assert global_buf is not None
+                    name = local_buf.get_name()
+                    
                     index_vars = sorted(
                         [
                             s
@@ -417,14 +434,17 @@ class LocalBufferScope:
                         ],
                         key=str,
                     )
-                    index = self.local_buf.layout.make_indexer()(index_vars)
+                    index = local_buf.layout.make_indexer()(index_vars)
                     return name, index
+                
+                from .cpp_utils import LocalBufferPair
 
                 with V.set_ops_handler(
                     LocalizeBufferHandler(
                         V.get_ops_handler(),
-                        global_buf,
-                        local_buf,
+                        [LocalBufferPair(global_buf=global_buf, local_buf=local_buf),],
+                        # [global_buf,],
+                        # [local_buf,],
                         localize_fn=localize_fn,
                     )
                 ):

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -262,20 +262,20 @@ class LocalizeBufferHandler(V.WrapperHandler):  # type: ignore[name-defined]
     def __init__(
         self,
         inner,
-        # global_buf=None,
-        local_buf_pairs: Optional[List[LocalBufferPair]] = None,
+        local_buf_pairs: List[LocalBufferPair],
         localize_fn: Optional[
             Callable[["LocalizeBufferHandler", str, sympy.Expr], Any]
         ] = None,
     ):
         super().__init__(inner)
-        # self.global_buf = global_buf
-        # self.local_buf = local_buf
-        self.localize_fn = localize_fn
         self.local_buf_pairs = local_buf_pairs
+        self.localize_fn = localize_fn
 
     def localize(self, name: str, index: sympy.Expr):
-        if self.local_buf_pair and name in [loca_buf_pair.global_buf.get_name() for loca_buf_pair in self.local_buf_pairs]:
+        if self.local_buf_pair and name in [
+            loca_buf_pair.global_buf.get_name()
+            for loca_buf_pair in self.local_buf_pairs
+        ]:
             assert self.localize_fn is not None
             name, index = self.localize_fn(self, name, index)
         return name, index
@@ -288,7 +288,11 @@ class LocalizeBufferHandler(V.WrapperHandler):  # type: ignore[name-defined]
         res = self._inner.store(local_buffer_name, local_buffer_index, value, mode)
         if (
             self.local_buf_pairs
-            and name in [loca_buf_pair.global_buf.get_name() for loca_buf_pair in self.local_buf_pairs]
+            and name
+            in [
+                loca_buf_pair.global_buf.get_name()
+                for loca_buf_pair in self.local_buf_pairs
+            ]
             and isinstance(V.kernel, Kernel)
         ):
             # Remove name of local buffer from Kernel.store_buffer_names
@@ -412,20 +416,14 @@ class LocalBufferScope:
         def inner_fn_wrapper(inner_fn):
             def inner(index):
                 def localize_fn(self, name, index):
-                    # name = self.local_buf.get_name()
-                    global_buf = None
                     local_buf = None
-
                     for loca_buf_pair in self.local_buf_pairs:
                         if name == loca_buf_pair.global_buf.get_name():
-                            global_buf = loca_buf_pair.global_buf
                             local_buf = loca_buf_pair.local_buf
                             break
-                    
                     assert local_buf is not None
-                    assert global_buf is not None
                     name = local_buf.get_name()
-                    
+
                     index_vars = sorted(
                         [
                             s
@@ -436,15 +434,13 @@ class LocalBufferScope:
                     )
                     index = local_buf.layout.make_indexer()(index_vars)
                     return name, index
-                
-                from .cpp_utils import LocalBufferPair
 
                 with V.set_ops_handler(
                     LocalizeBufferHandler(
                         V.get_ops_handler(),
-                        [LocalBufferPair(global_buf=global_buf, local_buf=local_buf),],
-                        # [global_buf,],
-                        # [local_buf,],
+                        [
+                            LocalBufferPair(global_buf=global_buf, local_buf=local_buf),
+                        ],
                         localize_fn=localize_fn,
                     )
                 ):

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -272,7 +272,7 @@ class LocalizeBufferHandler(V.WrapperHandler):  # type: ignore[name-defined]
         self.localize_fn = localize_fn
 
     def localize(self, name: str, index: sympy.Expr):
-        if self.local_buf_pair and name in [
+        if self.local_buf_pairs and name in [
             loca_buf_pair.global_buf.get_name()
             for loca_buf_pair in self.local_buf_pairs
         ]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127598
* #126967

**Summary**
Extend the LocalBuffer to support more than 1 in OuterLoopFusion.

**TestPlan**
```
python -u -m pytest -s -v test/inductor/test_cpu_repro.py -k test_two_local_buffer_in_outer_loop_fusion
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang