### PR TITLE
[CI] disable td for xpu ci test by default

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1200,6 +1200,7 @@ def parse_args():
         and not IS_SLOW
         and not TEST_WITH_ROCM
         and not IS_MACOS
+        and "xpu" not in BUILD_ENVIRONMENT
         and "onnx" not in BUILD_ENVIRONMENT
         and "debug" not in BUILD_ENVIRONMENT
         and "parallelnative" not in BUILD_ENVIRONMENT,


### PR DESCRIPTION
Due to the xpu ci test has been enabled td by default, a lot of test cases (75%) have been skipped in CI tests. It caused some ci failures escaped from the ci tests, for example issue #127539. This PR depends on PR #127595 landed. Link to #114850