### PR TITLE
[BE][Ez]: Update ruff to 0.4.6

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2120,7 +2120,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.4.5',
+    'ruff==0.4.6',
 ]
 is_formatter = true
 


### PR DESCRIPTION
Update ruff linter to 0.4.6. Uneventful PR that fixes bugs and reduces false positives.