### PR TITLE
[caffe2][be][2/n] migrate gloabl  static initializer

### DIFF
--- a/aten/src/ATen/core/Dimname.cpp
+++ b/aten/src/ATen/core/Dimname.cpp
@@ -4,7 +4,10 @@
 
 namespace at {
 
-static Symbol kWildcard = Symbol::dimname("*");
+Symbol& getWildcard() {
+  static Symbol wildcard = Symbol::dimname("*");
+  return wildcard;
+}
 
 std::ostream& operator<<(std::ostream& out, const Dimname& dimname) {
   if (dimname.type() == NameType::WILDCARD) {
@@ -45,7 +48,7 @@ static void check_valid_identifier(const std::string& name) {
 
 Dimname Dimname::fromSymbol(Symbol name) {
   TORCH_INTERNAL_ASSERT(name.is_dimname());
-  if (name == kWildcard) {
+  if (name == getWildcard()) {
     return Dimname::wildcard();
   }
   check_valid_identifier(name.toUnqualString());
@@ -53,7 +56,7 @@ Dimname Dimname::fromSymbol(Symbol name) {
 }
 
 Dimname Dimname::wildcard() {
-  static Dimname result(kWildcard, NameType::WILDCARD);
+  static Dimname result(getWildcard(), NameType::WILDCARD);
   return result;
 }
 

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.cpp
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.cpp
@@ -3,10 +3,15 @@
 namespace at {
 
 static PrivateUse1HooksInterface* privateuse1_hooks = nullptr;
-static std::mutex _hooks_mutex_lock;
+
+std::mutex& getHooksMutexLock() {
+  static std::mutex hooks_mutex_lock;
+  return hooks_mutex_lock;
+}
 
 TORCH_API void RegisterPrivateUse1HooksInterface(at::PrivateUse1HooksInterface* hook_) {
-  std::lock_guard<std::mutex> lock(_hooks_mutex_lock);
+  auto& hooksMutexLock = getHooksMutexLock();
+  std::lock_guard<std::mutex> lock(hooksMutexLock);
   TORCH_CHECK(privateuse1_hooks == nullptr, "PrivateUse1HooksInterface only could be registered once.");
   privateuse1_hooks = hook_;
 }
@@ -26,7 +31,7 @@ namespace detail {
 
 TORCH_API const at::PrivateUse1HooksInterface& getPrivateUse1Hooks() {
   TORCH_CHECK(
-      privateuse1_hooks != nullptr,
+            privateuse1_hooks != nullptr,
       "Please register PrivateUse1HooksInterface by `RegisterPrivateUse1HooksInterface` first.");
   return *privateuse1_hooks;
 }

--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -10,7 +10,7 @@
 
 namespace at {
 
-extern const std::string kParamCommsCallName = "record_param_comms";
+static constexpr char kRecordParamComms[] = "record_param_comms";
 
 namespace {
 
@@ -714,7 +714,7 @@ uint64_t RecordFunction::currentThreadId() {
 void RecordFunction::before(const char* name, int64_t sequence_nr) {
   fn_ = name;
   sequence_nr_ = sequence_nr;
-  is_nccl_meta_ = (std::strcmp(name, kParamCommsCallName.c_str()) == 0);
+  is_nccl_meta_ = (std::strcmp(name, kRecordParamComms.c_str()) == 0);
 
 #ifndef NDEBUG
     inputs_valid_ = true;
@@ -724,7 +724,7 @@ void RecordFunction::before(const char* name, int64_t sequence_nr) {
 }
 
 void RecordFunction::before(std::string name, int64_t sequence_nr) {
-  is_nccl_meta_ = (name == kParamCommsCallName);
+  is_nccl_meta_ = (name == kRecordParamComms.c_str());
   fn_ = std::move(name);
   sequence_nr_ = sequence_nr;
 
@@ -740,7 +740,7 @@ void RecordFunction::before(
     int64_t sequence_nr) {
   sequence_nr_ = sequence_nr;
   fn_ = schema;
-  is_nccl_meta_ = (schema.get().name() == kParamCommsCallName);
+  is_nccl_meta_ = (schema.get().name() == kRecordParamComms.c_str());
 
 #ifndef NDEBUG
     inputs_valid_ = true;

--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -194,13 +194,16 @@ REGISTER_ALLOCATOR(DeviceType::CPU, &g_mobile_cpu_allocator);
 #else
 
 // Global default CPU Allocator
-static DefaultCPUAllocator g_cpu_alloc;
-
-at::Allocator* GetDefaultCPUAllocator() {
-  return &g_cpu_alloc;
+DefaultCPUAllocator& getCpuAlloc() {
+  static DefaultCPUAllocator cpuAlloc;
+  return cpuAlloc;
 }
 
-REGISTER_ALLOCATOR(DeviceType::CPU, &g_cpu_alloc);
+at::Allocator* GetDefaultCPUAllocator() {
+  return &getCpuAlloc();
+}
+
+REGISTER_ALLOCATOR(DeviceType::CPU, &getCpuAlloc());
 
 #endif /* C10_Mobile */
 


### PR DESCRIPTION
Summary:
Caffe2 lib has 200+ global static initializer usage, which are papar-cut reference to startup perf. Detail in this post https://fb.workplace.com/groups/arglassesperf/permalink/623909116287154.
Kick off a stack to migirate all usage of global static initializer in caffe2.

Test Plan: CI

Differential Revision: D57758185


