### PR TITLE
Old branch deletion script to also delete old ciflow tags

### DIFF
--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -1,8 +1,8 @@
 # Delete old branches
-from functools import lru_cache
 import os
 import re
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Set
 
@@ -208,9 +208,7 @@ def get_branches_with_magic_label_or_open_pr() -> Set[str]:
         lambda res: res["data"]["repository"]["label"]["pullRequests"]["pageInfo"],
     )
 
-    pr_infos.extend(
-        get_open_prs()
-    )
+    pr_infos.extend(get_open_prs())
 
     # Get the most recent PR for each branch base (group gh together)
     branch_bases = set()
@@ -282,13 +280,14 @@ def delete_old_ciflow_tags() -> None:
     # created, so we can't check how old they are.  The script just assumes that
     # ciflow tags should be deleted regardless of creation date.
     git_repo = GitRepo(str(REPO_ROOT), "origin", debug=True)
-    def delete_tag(tag):
+
+    def delete_tag(tag: str) -> None:
         print(f"Deleting tag {tag}")
         ESTIMATED_TOKENS[0] += 1
         delete_branch(git_repo, f"refs/tags/{tag}")
 
     tags = git_repo._run_git("tag").splitlines()
-    open_pr_numbers = [x['number'] for x in get_open_prs()]
+    open_pr_numbers = [x["number"] for x in get_open_prs()]
 
     for tag in tags:
         try:

--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -273,7 +273,10 @@ def delete_branches() -> None:
 
 
 def delete_old_ciflow_tags() -> None:
-    # Deletes ciflow tags if they are associated with a closed PR or a specific commit
+    # Deletes ciflow tags if they are associated with a closed PR or a specific
+    # commit.  Lightweight tags don't have information about the date they were
+    # created, so we can't check how old they are.  The script just assumes that
+    # ciflow tags should be deleted.
     github_token = os.environ.get("GITHUB_TOKEN")
     headers = {
         "Authorization": f"token {github_token}",
@@ -286,6 +289,7 @@ def delete_old_ciflow_tags() -> None:
         #     f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/git/refs/tags/{tag}",
         #     headers=headers
         # )
+        ESTIMATED_TOKENS[0] += 1
 
     git_repo = GitRepo(str(REPO_ROOT), "origin", debug=True)
     tags = git_repo._run_git("tag").splitlines()
@@ -293,8 +297,8 @@ def delete_old_ciflow_tags() -> None:
         try:
             if not tag.startswith("ciflow/"):
                 continue
-            re_match_pr = re.match(r"^ciflow/[^\d]+/(\d+){5,6}$", tag)
-            re_match_sha = re.match(r"^ciflow/[^\d]+/([0-9a-f]{40})$", tag)
+            re_match_pr = re.match(r"^ciflow\/.*\/(\d{5,6})$", tag)
+            re_match_sha = re.match(r"^ciflow\/.*\/([0-9a-f]{40})$", tag)
             if re_match_pr:
                 pr_number = int(re_match_pr.group(1))
                 state = requests.request(

--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -6,8 +6,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Set
 
-import requests
-
 from github_utils import gh_fetch_json_dict, gh_graphql
 from gitutils import GitRepo
 

--- a/.github/scripts/delete_old_branches.py
+++ b/.github/scripts/delete_old_branches.py
@@ -285,7 +285,7 @@ def delete_old_ciflow_tags() -> None:
     def delete_tag(tag):
         print(f"Deleting tag {tag}")
         ESTIMATED_TOKENS[0] += 1
-        # delete_branch(git_repo, f"refs/tags/{tag}")
+        delete_branch(git_repo, f"refs/tags/{tag}")
 
     tags = git_repo._run_git("tag").splitlines()
     open_pr_numbers = [x['number'] for x in get_open_prs()]
@@ -311,5 +311,5 @@ def delete_old_ciflow_tags() -> None:
 
 
 if __name__ == "__main__":
-    # delete_branches()
+    delete_branches()
     delete_old_ciflow_tags()

--- a/.github/workflows/delete_old_branches.yml
+++ b/.github/workflows/delete_old_branches.yml
@@ -35,6 +35,8 @@ jobs:
           check-latest: false
 
       - name: Delete old branches
-        run: python .github/scripts/delete_old_branches.py
+        run: |
+          pip install requests==2.32.2
+          python .github/scripts/delete_old_branches.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete_old_branches.yml
+++ b/.github/workflows/delete_old_branches.yml
@@ -7,6 +7,7 @@ on:
     # Run daily.
     - cron: 30 1 * * *
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: delete-old-branches

--- a/.github/workflows/delete_old_branches.yml
+++ b/.github/workflows/delete_old_branches.yml
@@ -35,8 +35,6 @@ jobs:
           check-latest: false
 
       - name: Delete old branches
-        run: |
-          pip install requests==2.32.2
-          python .github/scripts/delete_old_branches.py
+        run: python .github/scripts/delete_old_branches.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete_old_branches.yml
+++ b/.github/workflows/delete_old_branches.yml
@@ -7,7 +7,6 @@ on:
     # Run daily.
     - cron: 30 1 * * *
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: delete-old-branches


### PR DESCRIPTION
Change branch deletion script to also delete left over ciflow tags that the bot doesn't get to, as well as the one created by triggering a workflow on HUD

Example run https://github.com/pytorch/pytorch/actions/runs/9322082915/job/25662376463?pr=127625
(didn't actually delete the tag, but lists what tags it would delete)