### PR TITLE
[ATen][Native] fixes sparse SPMV on aarch64

### DIFF
--- a/aten/src/ATen/native/Blas.cpp
+++ b/aten/src/ATen/native/Blas.cpp
@@ -122,7 +122,7 @@ Tensor &mv_out(const Tensor &self, const Tensor &vec, Tensor& result) {
 }
 
 Tensor mv(const Tensor &self, const Tensor &vec) {
-  Tensor result = at::empty({self.size(0)}, vec.options());
+  Tensor result = at::zeros({self.size(0)}, vec.options());
   //inplace version is more efficient if we can use it
   return at::addmv_(result, self, vec, 0, 1);
 }

--- a/aten/src/ATen/native/Blas.cpp
+++ b/aten/src/ATen/native/Blas.cpp
@@ -122,7 +122,7 @@ Tensor &mv_out(const Tensor &self, const Tensor &vec, Tensor& result) {
 }
 
 Tensor mv(const Tensor &self, const Tensor &vec) {
-  Tensor result = at::zeros({self.size(0)}, vec.options());
+  Tensor result = at::empty({self.size(0)}, vec.options());
   //inplace version is more efficient if we can use it
   return at::addmv_(result, self, vec, 0, 1);
 }

--- a/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
@@ -313,6 +313,14 @@ void addmv_sparse_csr(
     const scalar_t beta,
     scalar_t* result,
     const size_t result_stride) {
+  if(Scalar(beta).toComplexDouble() == 0.) {
+    at::parallel_for(0, mat_rows, 0, [&](int64_t rstart, int64_t rend) {
+      for(const auto row: c10::irange(rstart, rend)) {
+        result[row * result_stride] = 0.0;
+      }
+    });
+  }
+
   at::parallel_for(0, mat_rows, 0, [&](int64_t rstart, int64_t rend) {
     for(const auto row: c10::irange(rstart, rend)) {
       scalar_t acc(0);
@@ -338,6 +346,13 @@ void addmv_sparse_bsr(
     const scalar_t beta,
     scalar_t* result,
     const size_t result_stride) {
+  if(Scalar(beta).toComplexDouble() == 0.) {
+    at::parallel_for(0, mat_rows, 0, [&](int64_t rstart, int64_t rend) {
+      for(const auto row: c10::irange(rstart, rend)) {
+        result[row * result_stride] = 0.0;
+      }
+    });
+  }
   at::parallel_for(0, mat_rows, 0, [&](int64_t rstart, int64_t rend) {
     for(const auto row: c10::irange(rstart, rend)) {
       const auto block_row = row / blocksize_rows;

--- a/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
@@ -320,7 +320,6 @@ void addmv_sparse_csr(
       }
     });
   }
-
   at::parallel_for(0, mat_rows, 0, [&](int64_t rstart, int64_t rend) {
     for(const auto row: c10::irange(rstart, rend)) {
       scalar_t acc(0);


### PR DESCRIPTION
Fixes #127491
In #127491 result was allocated as `result = at::empty(...)`, which does not guarantee `result` being filled by zeros, therefore `torch.mv` was producing non-finite values. This happened mainly because the corner case (`beta = 0`) of `addmv` was not taken care of, as it should be just like in any other `addmv`/`addmm`:
https://github.com/pytorch/pytorch/blob/923edef31c7f3e98a14625724f2019b1422dcb26/aten/src/ATen/native/mkl/SparseBlasImpl.cpp#L307-L311