### PR TITLE
Relax Symbol check on debug_compile mode

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -330,7 +330,7 @@ class CppWrapperCpu(WrapperCodeGen):
                     )
                 else:
                     assert isinstance(
-                        d, sympy.Symbol
+                        d, (sympy.Symbol, sympy.core.add.Add)
                     ), f"dimention at {dim_idx=} for tensor {name=} must be a sympy.Symbol"
                     sym_range = V.graph.sizevars.shape_env.var_to_range.get(d, None)
                     if sym_range is None:


### PR DESCRIPTION
Summary:
as tile, there miht be case where the dim size is
sympy.Symbol -> e.g. s0
sympy.Integer -> e.g. 765
sympy.core.add.Add-> e.g. s0 + 1

Otherwise assertion will fail if we have s0 + 1

Test Plan:
```
hg co e958783f3

AOT_INDUCTOR_DEBUG_COMPILE=1 buck2 run mode/{opt,amd-gpu,inplace} -c fbcode.triton_backend=amd -c fbcode.enable_gpu_sections=true //aiplatform/modelstore/model_generation/gpu_lowering_service:gpu_lowering_cli -- --model_input_path="ads_storage_fblearner/tree/user/facebook/fblearner/predictor/936383960/0/gpu_lowering/input.merge" --model_output_path="ads_storage_fblearner/tree/user/facebook/fblearner/predictor/936383960/0/gpu_lowering/mi300_inductor_output.merge" --lowering_backend AOT_INDUCTOR --is_ads_model False --aot_inductor_lowering_settings_json='{"use_scripting":true,"preset_lowerer":"standalone_hstu_cint;disable_new_lowering_weights;disable_dper_passes:passes=fuse_parallel_linear_no_weight_change","precision":4,"output_precision":4, "remove_unexpected_type_cast":false, "sample_input_tile_factor":32}' 2>&1 | tee local_benchmark_log.txt
```

checked output cpp file: https://www.internalfb.com/phabricator/paste/view/P1387289145

Differential Revision: D58038791




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang