### PR TITLE
Ack codecvt_utf8_utf16 as a deprecated func in C++17

### DIFF
--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -43,8 +43,8 @@ std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString);
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-// TODO (huydhn) https://en.cppreference.com/w/cpp/header/codecvt has been deprecated
-// in C++17 but there is no alternative yet, so I just ack it
+// TODO (huydhn) https://en.cppreference.com/w/cpp/header/codecvt has been
+// deprecated in C++17 but there is no alternative yet, so I just ack it
 std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString) {
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   return _str(ss, converter.to_bytes(wString));

--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -41,10 +41,15 @@ std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString);
 
 #ifndef _WIN32
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// TODO (huydhn) https://en.cppreference.com/w/cpp/header/codecvt has been deprecated
+// in C++17 but there is no alternative yet, so I just ack it
 std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString) {
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   return _str(ss, converter.to_bytes(wString));
 }
+#pragma GCC diagnostic pop
 
 #else // #ifndef _WIN32
 // The WIN32 implementation of wstring_convert leaks memory; see


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/header/codecvt.  This starts to fail on MacOS after migrating it to MacOS 14 with a newer toolchain.  For example https://hud.pytorch.org/pytorch/pytorch/commit/57baae9c9b43fd31199dedd3f0fd5ed67faf5769.

As there is no clear alternative to the deprecated function yet, I just ack the warning to fix the build and complete the migration https://github.com/pytorch/pytorch/issues/127490