### PR TITLE
Allow symint inputs to aten.expand_copy and aten.view_copy

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -895,6 +895,38 @@ class FakeTensorTest(TestCase):
 
         self.assertEqual(t.shape[0], torch.ops.aten.unsqueeze_copy(t, 1).shape[0])
 
+    def test_expand_copy(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv, StatelessSymbolicContext, DimDynamic
+
+        shape_env = ShapeEnv()
+        t1 = torch.ones(2, 3, 10)
+        with FakeTensorMode(shape_env=shape_env) as fake_mode:
+            t = fake_mode.from_tensor(
+                t1,
+                symbolic_context=StatelessSymbolicContext(
+                    dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.DYNAMIC, DimDynamic.DYNAMIC],
+                )
+            )
+
+        self.assertEqual(torch.ops.aten.expand(t, t.shape).shape, torch.ops.aten.expand_copy(t, t.shape).shape)
+
+    def test_view_copy(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv, StatelessSymbolicContext, DimDynamic
+
+        shape_env = ShapeEnv()
+        t1 = torch.ones(2, 3, 10)
+        with FakeTensorMode(shape_env=shape_env) as fake_mode:
+            t = fake_mode.from_tensor(
+                t1,
+                symbolic_context=StatelessSymbolicContext(
+                    dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.DYNAMIC, DimDynamic.DYNAMIC],
+                )
+            )
+
+        self.assertEqual(torch.ops.aten.view(t, t.shape).shape, torch.ops.aten.view_copy(t, t.shape).shape)
+
     def test_alias_call(self):
         fwAD = torch.autograd.forward_ad
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -255,6 +255,7 @@ __all__ = [
     "dsplit",
     "dstack",
     "expand",
+    "expand_copy",
     "expand_as",
     "flatten",
     "flip",
@@ -289,6 +290,7 @@ __all__ = [
     "unsqueeze",
     "view",
     "view_as",
+    "view_copy",
     "vsplit",
     "vstack",
     "view_as_complex",
@@ -2952,6 +2954,11 @@ def expand_as(a: Tensor, b: Tensor) -> Tensor:
     return a.expand(b.shape)
 
 
+@register_decomposition(aten.expand_copy)
+def expand_copy(self: Tensor, size, *, implicit=False):
+    return expand(self, size).clone()
+
+
 def chunk(a: TensorLikeType, chunks: int, dim: int = 0) -> Tuple[TensorLikeType, ...]:
     if chunks <= 0:
         msg = f"Expected at least one chunk, but got {chunks}!"
@@ -4554,6 +4561,11 @@ def view(a: TensorLikeType, *shape: ShapeType) -> TensorLikeType:
 # CompositeImplicitAutograd - don't register decomp
 def view_as(self: TensorLikeType, other: TensorLikeType) -> TensorLikeType:
     return self.view(other.size())
+
+
+@register_decomposition(aten.view_copy.default)
+def view_copy(a: TensorLikeType, *shape: ShapeType) -> TensorLikeType:
+    return view(a, *shape).clone()
 
 
 # CompositeImplicitAutograd - don't register decomp


### PR DESCRIPTION
Without this change, we would run into the following error:
```
Traceback (most recent call last):
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/verification/arg_validator.py", line 47, in run_node
    ret = super().run_node(n)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/fx/interpreter.py", line 202, in run_node
    return getattr(self, n.op)(n.target, args, kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/verification/arg_validator.py", line 129, in call_function
    return super().call_function(target, args, kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/fx/interpreter.py", line 274, in call_function
    return target(*args, **kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/dialects/edge/_ops.py", line 333, in __call__
    return self._op(*args, **kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_ops.py", line 666, in __call__
    return self_._op(*args, **kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/utils/_stats.py", line 20, in wrapper
    return fn(*args, **kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_subclasses/fake_tensor.py", line 721, in __torch_dispatch__
    return func(*args, **kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_ops.py", line 666, in __call__
    return self_._op(*args, **kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/utils/_stats.py", line 20, in wrapper
    return fn(*args, **kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_subclasses/fake_tensor.py", line 1058, in __torch_dispatch__
    return self.dispatch(func, types, args, kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_subclasses/fake_tensor.py", line 1447, in dispatch
    return self._cached_dispatch_impl(func, types, args, kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_subclasses/fake_tensor.py", line 1150, in _cached_dispatch_impl
    output = self._dispatch_impl(func, types, args, kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_subclasses/fake_tensor.py", line 1754, in _dispatch_impl
    r = func(*args, **kwargs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_ops.py", line 666, in __call__
    return self_._op(*args, **kwargs)
RuntimeError: buck-out/v2/gen/fbcode/0f542de562e0bd82/caffe2/__gen_aten__/out/RegisterCompositeExplicitAutograd.cpp:1248: SymIntArrayRef expected to contain only concrete integers

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/program/test/test_program.py", line 321, in test_issue_3659
    to_edge(
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/program/_program.py", line 1020, in to_edge
    edge_programs[name] = _generate_edge_program(name, config, program)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/program/_program.py", line 704, in _generate_edge_program
    edge_program = ExportedProgram(
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/export/exported_program.py", line 242, in __init__
    self.verifier().check(self)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_export/verifier.py", line 153, in check
    self._check_graph_module(ep.graph_module)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/_export/verifier.py", line 263, in _check_graph_module
    self.check_additional(gm)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/verification/verifier.py", line 235, in check_additional
    _check_tensor_args_matching_op_allowed_dtype(gm)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/verification/verifier.py", line 150, in _check_tensor_args_matching_op_allowed_dtype
    validator.run(*inputs)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/torch/fx/interpreter.py", line 145, in run
    self.env[node] = self.run_node(node)
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/verification/arg_validator.py", line 52, in run_node
    raise InternalError(str(e)) from e
executorch.exir.error.InternalError: buck-out/v2/gen/fbcode/0f542de562e0bd82/caffe2/__gen_aten__/out/RegisterCompositeExplicitAutograd.cpp:1248: SymIntArrayRef expected to contain only concrete integers

While executing %aten_expand_copy_default : [num_users=1] = call_function[target=executorch.exir.dialects.edge._ops.aten.expand_copy.default](args = (%x, [1, %sym_size, %sym_size_1]), kwargs = {})
Original traceback:
  File "/data/users/angelayi/fbsource/buck-out/v2/gen/fbcode/0f542de562e0bd82/executorch/exir/program/test/__test_program__/test_program#link-tree/executorch/exir/program/test/test_program.py", line 282, in forward
    return torch.matmul(x, y)
```