### PR TITLE
[BE][Ez]: Apply PYI059 - Generic always come last

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -2423,7 +2423,7 @@ class TestFunctionalMapDataPipe(TestCase):
 _generic_namedtuple_allowed = sys.version_info >= (3, 7) and sys.version_info < (3, 9)
 if _generic_namedtuple_allowed:
 
-    class InvalidData(Generic[T_co], NamedTuple):
+    class InvalidData(NamedTuple, Generic[T_co]):
         name: str
         data: T_co
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -390,7 +390,7 @@ P = ParamSpec("P")
 RV = TypeVar("RV", covariant=True)
 
 
-class CachedMethod(Generic[P, RV], Protocol):
+class CachedMethod(Protocol, Generic[P, RV]):
     @staticmethod
     def clear_cache(self) -> None:
         ...

--- a/torch/onnx/_internal/registration.py
+++ b/torch/onnx/_internal/registration.py
@@ -61,7 +61,7 @@ _K = TypeVar("_K")
 _V = TypeVar("_V")
 
 
-class OverrideDict(Generic[_K, _V], Collection[_K]):
+class OverrideDict(Collection[_K], Generic[_K, _V]):
     """A dictionary that merges built-in and custom symbolic functions.
 
     It supports overriding and un-overriding built-in symbolic functions with custom


### PR DESCRIPTION
Generic baseclass should always be last or unexpected issues can occur, especially in non-stub files (such as with MRO). Applies autofixes from the preview PYI059 rule to fix the issues in the codebase.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang