### PR TITLE
Define PY_SSIZE_T_CLEAN before #include <Python.h>

### DIFF
--- a/torch/csrc/python_headers.h
+++ b/torch/csrc/python_headers.h
@@ -9,6 +9,7 @@
 #undef _XOPEN_SOURCE
 #undef _POSIX_C_SOURCE
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <frameobject.h>
 #include <structseq.h>


### PR DESCRIPTION
See https://docs.python.org/3/c-api/intro.html#include-files

Fixes #38019
