### PR TITLE
[Inductor] Enable inductor performance test for CPU

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -492,6 +492,12 @@ test_perf_for_dashboard() {
           "$TEST_REPORTS_DIR/${backend}_cudagraphs_low_precision_${suite}_quant_${mode}_cuda_${target}.csv"
       fi
       if [[ "$DASHBOARD_TAG" == *inductor_cpu-true* ]]; then
+        dtype=float32
+        python "benchmarks/dynamo/$suite.py" \
+            "${target_flag[@]}" --"$mode" --"$dtype" --backend "$backend" -dcpu "$@" --freezing \
+            --output "$TEST_REPORTS_DIR/${backend}_cpu_${suite}_${dtype}_${mode}_${target}.csv"
+
+        dtype=amp
         python "benchmarks/dynamo/$suite.py" \
             "${target_flag[@]}" --"$mode" --"$dtype" --backend "$backend" -dcpu "$@" --freezing \
             --output "$TEST_REPORTS_DIR/${backend}_cpu_${suite}_${dtype}_${mode}_${target}.csv"

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -491,6 +491,11 @@ test_perf_for_dashboard() {
         cp "$TEST_REPORTS_DIR/${backend}_with_cudagraphs_${suite}_${dtype}_${mode}_cuda_${target}.csv" \
           "$TEST_REPORTS_DIR/${backend}_cudagraphs_low_precision_${suite}_quant_${mode}_cuda_${target}.csv"
       fi
+      if [[ "$DASHBOARD_TAG" == *inductor_cpu-true* ]]; then
+        python "benchmarks/dynamo/$suite.py" \
+            "${target_flag[@]}" --"$mode" --"$dtype" --backend "$backend" -dcpu "$@" --freezing \
+            --output "$TEST_REPORTS_DIR/${backend}_cpu_${suite}_${dtype}_${mode}_${target}.csv"
+      fi
     done
   done
 }

--- a/.github/workflows/inductor-perf-test-nightly-cpu.yml
+++ b/.github/workflows/inductor-perf-test-nightly-cpu.yml
@@ -1,4 +1,4 @@
-name: inductor-A100-perf-nightly
+name: inductor-CPU-perf-nightly
 
 on:
   schedule:
@@ -9,50 +9,20 @@ on:
   workflow_dispatch:
     inputs:
       training:
-        description: Run training (on by default)?
+        description: Run training (off by default)?
         required: false
         type: boolean
-        default: true
+        default: false
       inference:
-        description: Run inference (off by default)?
-        required: false
-        type: boolean
-        default: false
-      default:
-        description: Run inductor_default?
-        required: false
-        type: boolean
-        default: false
-      dynamic:
-        description: Run inductor_dynamic_shapes?
-        required: false
-        type: boolean
-        default: false
-      cudagraphs:
-        description: Run inductor_cudagraphs?
+        description: Run inference (on by default)?
         required: false
         type: boolean
         default: true
-      freezing_cudagraphs:
-        description: Run inductor_cudagraphs with freezing for inference?
+      inductor_cpu:
+        description: Run inductor_cpu?
         required: false
         type: boolean
-        default: false
-      freeze_autotune_cudagraphs:
-        description: Run inductor_cudagraphs with freezing and max autotune for inference?
-        required: false
-        type: boolean
-        default: false
-      aotinductor:
-        description: Run aot_inductor for inference?
-        required: false
-        type: boolean
-        default: false
-      maxautotune:
-        description: Run inductor_max_autotune?
-        required: false
-        type: boolean
-        default: false
+        default: true
       benchmark_configs:
         description: The list of configs used the benchmark
         required: false
@@ -66,72 +36,71 @@ concurrency:
 permissions: read-all
 
 jobs:
-  linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
-    name: cuda12.1-py3.10-gcc9-sm80
+  linux-focal-cpu-py3_10-gcc9-inductor-build:
+    name: cpu-py3.10-gcc9
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
-      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks
-      cuda-arch-list: '8.0'
+      build-environment: linux-focal-cpu-py3.10-gcc9
+      docker-image-name: pytorch-linux-focal-py3.8-gcc9
       test-matrix: |
         { include: [
-          { config: "inductor_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "inductor_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "inductor_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 1, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 2, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 3, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 4, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_timm_perf", shard: 5, num_shards: 5, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.gcp.a100.large" },
-          { config: "inductor_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "inductor_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf", shard: 1, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf", shard: 2, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf", shard: 3, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf", shard: 4, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf", shard: 5, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.24xl.spr-metal" },
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
   linux-focal-cuda12_1-py3_10-gcc9-inductor-test-nightly:
-    name: cuda12.1-py3.10-gcc9-sm80
+    name: cpu-py3.10-gcc9
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    needs: linux-focal-cpu-py3_10-gcc9-inductor-build
     if: github.event.schedule == '0 7 * * 1-6'
     with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
-      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true-cudagraphs_low_precision-true
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      build-environment: linux-focal-cpu-py3.10-gcc9
+      dashboard-tag: training-true-inference-true-inductor_cpu-true
+      docker-image: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.test-matrix }}
       use-gha: anything-non-empty-to-use-gha
       timeout-minutes: 720
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
   linux-focal-cuda12_1-py3_10-gcc9-inductor-test-weekly:
-    name: cuda12.1-py3.10-gcc9-sm80
+    name: cpu-py3.10-gcc9
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    needs: linux-focal-cpu-py3_10-gcc9-inductor-build
     if: github.event.schedule == '0 7 * * 0'
     with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
-      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true-cudagraphs_low_precision-true
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      build-environment: linux-focal-cpu-py3.10-gcc9
+      dashboard-tag: training-true-inference-true-inductor_cpu-true
+      docker-image: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.test-matrix }}
       use-gha: anything-non-empty-to-use-gha
       timeout-minutes: 1440
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
   linux-focal-cuda12_1-py3_10-gcc9-inductor-test:
-    name: cuda12.1-py3.10-gcc9-sm80
+    name: cpu-py3.10-gcc9
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    needs: linux-focal-cpu-py3_10-gcc9-inductor-build
     if: github.event_name == 'workflow_dispatch'
     with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
-      dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-false-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}-cudagraphs_low_precision-${{ inputs.cudagraphs }}
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      build-environment: linux-focal-cpu-py3.10-gcc9
+      dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-inductor_cpu-${{ inputs.inductor_cpu }}
+      docker-image: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.test-matrix }}
       use-gha: anything-non-empty-to-use-gha
       timeout-minutes: 720
     secrets:

--- a/.github/workflows/inductor-perf-test-nightly-cpu.yml
+++ b/.github/workflows/inductor-perf-test-nightly-cpu.yml
@@ -1,0 +1,138 @@
+name: inductor-A100-perf-nightly
+
+on:
+  schedule:
+    - cron: 0 7 * * 1-6
+    - cron: 0 7 * * 0
+  # NB: GitHub has an upper limit of 10 inputs here, so before we can sort it
+  # out, let try to run torchao cudagraphs_low_precision as part of cudagraphs
+  workflow_dispatch:
+    inputs:
+      training:
+        description: Run training (on by default)?
+        required: false
+        type: boolean
+        default: true
+      inference:
+        description: Run inference (off by default)?
+        required: false
+        type: boolean
+        default: false
+      default:
+        description: Run inductor_default?
+        required: false
+        type: boolean
+        default: false
+      dynamic:
+        description: Run inductor_dynamic_shapes?
+        required: false
+        type: boolean
+        default: false
+      cudagraphs:
+        description: Run inductor_cudagraphs?
+        required: false
+        type: boolean
+        default: true
+      freezing_cudagraphs:
+        description: Run inductor_cudagraphs with freezing for inference?
+        required: false
+        type: boolean
+        default: false
+      freeze_autotune_cudagraphs:
+        description: Run inductor_cudagraphs with freezing and max autotune for inference?
+        required: false
+        type: boolean
+        default: false
+      aotinductor:
+        description: Run aot_inductor for inference?
+        required: false
+        type: boolean
+        default: false
+      maxautotune:
+        description: Run inductor_max_autotune?
+        required: false
+        type: boolean
+        default: false
+      benchmark_configs:
+        description: The list of configs used the benchmark
+        required: false
+        type: string
+        default: inductor_huggingface_perf,inductor_timm_perf,inductor_torchbench_perf
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn8-py3-gcc9-inductor-benchmarks
+      cuda-arch-list: '8.0'
+      test-matrix: |
+        { include: [
+          { config: "inductor_huggingface_perf", shard: 1, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_huggingface_perf", shard: 2, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_huggingface_perf", shard: 3, num_shards: 3, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 1, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 2, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 3, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 4, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 5, num_shards: 5, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf", shard: 1, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf", shard: 2, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf", shard: 3, num_shards: 4, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf", shard: 4, num_shards: 4, runner: "linux.gcp.a100.large" },
+        ]}
+      selected-test-configs: ${{ inputs.benchmark_configs }}
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-nightly:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    if: github.event.schedule == '0 7 * * 1-6'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true-cudagraphs_low_precision-true
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 720
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-weekly:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    if: github.event.schedule == '0 7 * * 0'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true-cudagraphs_low_precision-true
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 1440
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+
+  linux-focal-cuda12_1-py3_10-gcc9-inductor-test:
+    name: cuda12.1-py3.10-gcc9-sm80
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-cuda12_1-py3_10-gcc9-inductor-build
+    if: github.event_name == 'workflow_dispatch'
+    with:
+      build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
+      dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-default-${{ inputs.default }}-dynamic-${{ inputs.dynamic }}-cudagraphs-${{ inputs.cudagraphs }}-cppwrapper-false-aotinductor-${{ inputs.aotinductor }}-maxautotune-${{ inputs.maxautotune }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs }}-cudagraphs_low_precision-${{ inputs.cudagraphs }}
+      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      use-gha: anything-non-empty-to-use-gha
+      timeout-minutes: 720
+    secrets:
+      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}

--- a/.github/workflows/inductor-perf-test-nightly-cpu.yml
+++ b/.github/workflows/inductor-perf-test-nightly-cpu.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: 0 7 * * 1-6
     - cron: 0 7 * * 0
-  # NB: GitHub has an upper limit of 10 inputs here, so before we can sort it
-  # out, let try to run torchao cudagraphs_low_precision as part of cudagraphs
   workflow_dispatch:
     inputs:
       training:
@@ -36,11 +34,11 @@ concurrency:
 permissions: read-all
 
 jobs:
-  linux-focal-cpu-py3_10-gcc9-inductor-build:
-    name: cpu-py3.10-gcc9
+  linux-focal-cpu-py3_8-gcc9-inductor-build:
+    name: cpu-py3.8-gcc9
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-cpu-py3.10-gcc9
+      build-environment: linux-focal-cpu-py3.8-gcc9
       docker-image-name: pytorch-linux-focal-py3.8-gcc9
       test-matrix: |
         { include: [
@@ -61,46 +59,46 @@ jobs:
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
-  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-nightly:
-    name: cpu-py3.10-gcc9
+  linux-focal-cpu-py3_8-gcc9-inductor-test-nightly:
+    name: cpu-py3.8-gcc9
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cpu-py3_10-gcc9-inductor-build
+    needs: linux-focal-cpu-py3_8-gcc9-inductor-build
     if: github.event.schedule == '0 7 * * 1-6'
     with:
-      build-environment: linux-focal-cpu-py3.10-gcc9
+      build-environment: linux-focal-cpu-py3.8-gcc9
       dashboard-tag: training-true-inference-true-inductor_cpu-true
-      docker-image: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.test-matrix }}
       use-gha: anything-non-empty-to-use-gha
       timeout-minutes: 720
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
-  linux-focal-cuda12_1-py3_10-gcc9-inductor-test-weekly:
-    name: cpu-py3.10-gcc9
+  linux-focal-cpu-py3_8-gcc9-inductor-test-weekly:
+    name: cpu-py3.8-gcc9
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cpu-py3_10-gcc9-inductor-build
+    needs: linux-focal-cpu-py3_8-gcc9-inductor-build
     if: github.event.schedule == '0 7 * * 0'
     with:
-      build-environment: linux-focal-cpu-py3.10-gcc9
+      build-environment: linux-focal-cpu-py3.8-gcc9
       dashboard-tag: training-true-inference-true-inductor_cpu-true
-      docker-image: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.test-matrix }}
       use-gha: anything-non-empty-to-use-gha
       timeout-minutes: 1440
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
-  linux-focal-cuda12_1-py3_10-gcc9-inductor-test:
-    name: cpu-py3.10-gcc9
+  linux-focal-cpu-py3_8-gcc9-inductor-test:
+    name: cpu-py3.8-gcc9
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cpu-py3_10-gcc9-inductor-build
+    needs: linux-focal-cpu-py3_8-gcc9-inductor-build
     if: github.event_name == 'workflow_dispatch'
     with:
-      build-environment: linux-focal-cpu-py3.10-gcc9
+      build-environment: linux-focal-cpu-py3.8-gcc9
       dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-inductor_cpu-${{ inputs.inductor_cpu }}
-      docker-image: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cpu-py3_10-gcc9-inductor-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.test-matrix }}
       use-gha: anything-non-empty-to-use-gha
       timeout-minutes: 720
     secrets:

--- a/.github/workflows/inductor-perf-test-nightly-cpu.yml
+++ b/.github/workflows/inductor-perf-test-nightly-cpu.yml
@@ -66,7 +66,7 @@ jobs:
     if: github.event.schedule == '0 7 * * 1-6'
     with:
       build-environment: linux-focal-cpu-py3.8-gcc9
-      dashboard-tag: training-true-inference-true-inductor_cpu-true
+      dashboard-tag: training-false-inference-true-inductor_cpu-true
       docker-image: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.test-matrix }}
       use-gha: anything-non-empty-to-use-gha

--- a/.github/workflows/inductor-perf-test-nightly-cpu.yml
+++ b/.github/workflows/inductor-perf-test-nightly-cpu.yml
@@ -73,33 +73,3 @@ jobs:
       timeout-minutes: 720
     secrets:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
-
-  linux-focal-cpu-py3_8-gcc9-inductor-test-weekly:
-    name: cpu-py3.8-gcc9
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cpu-py3_8-gcc9-inductor-build
-    if: github.event.schedule == '0 7 * * 0'
-    with:
-      build-environment: linux-focal-cpu-py3.8-gcc9
-      dashboard-tag: training-true-inference-true-inductor_cpu-true
-      docker-image: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.test-matrix }}
-      use-gha: anything-non-empty-to-use-gha
-      timeout-minutes: 1440
-    secrets:
-      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
-
-  linux-focal-cpu-py3_8-gcc9-inductor-test:
-    name: cpu-py3.8-gcc9
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cpu-py3_8-gcc9-inductor-build
-    if: github.event_name == 'workflow_dispatch'
-    with:
-      build-environment: linux-focal-cpu-py3.8-gcc9
-      dashboard-tag: training-${{ inputs.training }}-inference-${{ inputs.inference }}-inductor_cpu-${{ inputs.inductor_cpu }}
-      docker-image: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cpu-py3_8-gcc9-inductor-build.outputs.test-matrix }}
-      use-gha: anything-non-empty-to-use-gha
-      timeout-minutes: 720
-    secrets:
-      HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -2,7 +2,7 @@ name: Upload torch dynamo performance stats
 
 on:
   workflow_run:
-    workflows: [inductor-A100-perf-nightly]
+    workflows: [inductor-A100-perf-nightly, inductor-CPU-perf-nightly]
     types:
       - completed
 


### PR DESCRIPTION
Enable inductor benchmark performance test for CPU. Test scope is aligned with A100 performance test: nightly, weekly and self-defined benchmark test.