### PR TITLE
Added hpu backend support in fsdp utils 

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -817,6 +817,16 @@ def _get_device_from_device_id(
             "index as the `device_id` argument."
         )
         device = torch.device("cuda", torch.cuda.current_device())
+    if device == torch.device("hpu"):
+        warnings.warn(
+            f"FSDP got the argument `device_id` {device_id} on rank "
+            f"{rank}, which does not have an explicit index. "
+            f"FSDP will use the current device {torch.hpu.current_device()}. "
+            "If this is incorrect, please explicitly call `torch.hpu.set_device()` "
+            "before FSDP initialization or pass in the explicit device "
+            "index as the `device_id` argument."
+        )
+        device = torch.device("hpu", torch.hpu.current_device())
     return device
 
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -818,7 +818,7 @@ def _get_device_from_device_id(
             "before FSDP initialization or pass in the explicit device "
             "index as the `device_id` argument."
         )
-        device = torch.device(f"{device.type}:{device_idx}")
+        device = torch.device(device.type, device_idx)
     return device
 
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -807,22 +807,18 @@ def _get_device_from_device_id(
     device = (
         device_id if isinstance(device_id, torch.device) else torch.device(device_id)
     )
-    backend_devices = [
-        ("cuda", lambda: torch.cuda.current_device()),
-        ("hpu", lambda: torch.hpu.current_device()),
-    ]
-
-    for device_type, device_idx in backend_devices:
-        if device == torch.device(device_type):
-            warnings.warn(
-                f"FSDP got the argument `device_id` {device_id} on rank "
-                f"{rank}, which does not have an explicit index. "
-                f"FSDP will use the current device {device_idx()}. "
-                "If this is incorrect, please explicitly call torch.{device_type}.set_device() "
-                "before FSDP initialization or pass in the explicit device "
-                "index as the `device_id` argument."
-            )
-            device = torch.device(f"{device_type}:{device_idx()}")
+    if device.type in ["cuda", "hpu"]:
+        backend = getattr(torch, device.type)
+        device_idx = backend.current_device()
+        warnings.warn(
+            f"FSDP got the argument `device_id` {device_id} on rank "
+            f"{rank}, which does not have an explicit index. "
+            f"FSDP will use the current device {device_idx}. "
+            "If this is incorrect, please explicitly call torch.{device_type}.set_device() "
+            "before FSDP initialization or pass in the explicit device "
+            "index as the `device_id` argument."
+        )
+        device = torch.device(f"{device.type}:{device_idx}")
     return device
 
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -807,7 +807,7 @@ def _get_device_from_device_id(
     device = (
         device_id if isinstance(device_id, torch.device) else torch.device(device_id)
     )
-    if device.type in ["cuda", "hpu"]:
+    if device in [torch.device("cuda"), torch.device("hpu")]:
         backend = getattr(torch, device.type)
         device_idx = backend.current_device()
         warnings.warn(


### PR DESCRIPTION
In fsdp init_utils, adding support for hpu backend device on _get_device API.


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang @rohan-varma
