### PR TITLE
Revert "correct BLAS input (#126200)"

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -147,21 +147,13 @@ set(AT_MKLDNN_ACL_ENABLED 0)
 set(AT_MKLDNN_ENABLED 0)
 set(AT_MKL_ENABLED 0)
 # setting default preferred BLAS options if not already present.
-if(NOT DEFINED BLAS)
-  if(NOT INTERN_BUILD_MOBILE)
-    set(BLAS "MKL" CACHE STRING "Selected BLAS library")
-  else()
-    set(BLAS "Eigen" CACHE STRING "Selected BLAS library")
-  endif()
-elseif(NOT BLAS STREQUAL "MKL")
-    if(USE_MKLDNN)
-      message(WARNING
-        "You explicitly chose with BLAS to not use MKL, so disabling USE_MKLDNN. Suppress this warning with "
-        "-DUSE_MKLDNN=OFF.")
-      set(USE_MKLDNN OFF)
-    endif()
+if(NOT INTERN_BUILD_MOBILE)
+  set(BLAS "MKL" CACHE STRING "Selected BLAS library")
+else()
+  set(BLAS "Eigen" CACHE STRING "Selected BLAS library")
+  set(AT_MKLDNN_ENABLED 0)
+  set(AT_MKL_ENABLED 0)
 endif()
-
 set_property(CACHE BLAS PROPERTY STRINGS "ATLAS;BLIS;Eigen;FLAME;Generic;MKL;OpenBLAS;vecLib")
 message(STATUS "Trying to find preferred BLAS backend of choice: " ${BLAS})
 


### PR DESCRIPTION
This reverts commit ea13e9a097aaa875a2b404822579b7f8b62ea291.

Looks like this could have caused: https://github.com/pytorch/pytorch/actions/runs/9346105069/job/25722431775#step:17:984

Aarch64 tests failures:
```
+ echo 'Checking that MKLDNN is available on aarch64'
Checking that MKLDNN is available on aarch64
+ pushd /tmp
/tmp /
+ python -c 'import torch; exit(0 if torch.backends.mkldnn.is_available() else 1)'
Error: Process completed with exit code 1.
```