### PR TITLE
[torch/jit-runtime] Add explicit include of <chrono> to torch/jit/run…

### DIFF
--- a/torch/csrc/jit/runtime/logging.h
+++ b/torch/csrc/jit/runtime/logging.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <mutex>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Added an explicit include to `<chrono>` in `jit/runtime/logging.h` since `std::chrono::time_point<std::chrono::high_resolution_clock>` is directly referenced in the header.