### PR TITLE
Fix FakeQuantize scale and zero_point device

### DIFF
--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -194,6 +194,9 @@ class FakeQuantize(FakeQuantizeBase):
         return self.activation_post_process.calculate_qparams()
 
     def forward(self, X):
+        # Change the device of scale and zero_point to match X.device
+        self.scale = self.scale.to(X.device)
+        self.zero_point = self.zero_point.to(X.device)
         if self.observer_enabled[0] == 1:
             self.activation_post_process(X.detach())
             _scale, _zero_point = self.calculate_qparams()


### PR DESCRIPTION
During 
```
class FakeQuantize(FakeQuantizeBase):
    def __init__(self, ..):
        self.register_buffer('scale', torch.tensor([1.0], dtype=torch.float))
        self.register_buffer('zero_point', torch.tensor([0], dtype=zero_point_dtype))


    def forward(self, X):
          ...         
```
`scale` and `zero_point` will be default to `cpu` device`. However, if we want to run ptq with CUDA, `X` will be cuda while `scale` and `zero_point` will be in cpu and it erros out:

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument scale in method wrapper_CUDA___fake_quantize_per_tensor_affine_cachemask_tensor_qparams)
```

Changing device during inference can be slow though, maybe there is a better way to handle this.