### PR TITLE
Disable foreach tests on sm86 jobs too 

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -201,8 +201,8 @@ class TestForeach(TestCase):
         ),
     )
     @unittest.skipIf(
-        torch.cuda.is_available() and not torch.cuda.get_device_capability(0) == (8, 6),
-        "failing flakily on non sm86 cuda jobs",
+        torch.cuda.is_available(),
+        "failing flakily on cuda jobs",
     )
     def test_parity(self, device, dtype, op, noncontiguous, inplace):
         if inplace:
@@ -580,8 +580,8 @@ class TestForeach(TestCase):
         dtypes=OpDTypes.supported,
     )
     @unittest.skipIf(
-        torch.cuda.is_available() and not torch.cuda.get_device_capability(0) == (8, 6),
-        "failing flakily on non sm86 cuda jobs, ex https://github.com/pytorch/pytorch/issues/125035",
+        torch.cuda.is_available(),
+        "failing flakily on cuda jobs, ex https://github.com/pytorch/pytorch/issues/125035",
     )
     def test_binary_op_list_error_cases(self, device, dtype, op):
         foreach_op, foreach_op_, ref, ref_ = (
@@ -674,8 +674,8 @@ class TestForeach(TestCase):
         dtypes=OpDTypes.supported,
     )
     @unittest.skipIf(
-        torch.cuda.is_available() and not torch.cuda.get_device_capability(0) == (8, 6),
-        "failing flakily on non sm86 cuda jobs, ex https://github.com/pytorch/pytorch/issues/125775",
+        torch.cuda.is_available(),
+        "failing flakily on cuda jobs, ex https://github.com/pytorch/pytorch/issues/125775",
     )
     def test_binary_op_list_slow_path(self, device, dtype, op):
         foreach_op, native_op, foreach_op_, native_op_ = self._get_funcs(op)
@@ -792,8 +792,8 @@ class TestForeach(TestCase):
         dtypes=floating_types_and(torch.half, torch.bfloat16),
     )
     @unittest.skipIf(
-        torch.cuda.is_available() and not torch.cuda.get_device_capability(0) == (8, 6),
-        "failing flakily on non sm86 cuda jobs",
+        torch.cuda.is_available(),
+        "failing flakily on cuda jobs",
     )
     def test_binary_op_float_inf_nan(self, device, dtype, op):
         inputs = (
@@ -861,8 +861,8 @@ class TestForeach(TestCase):
     @onlyCUDA
     @ops(filter(lambda op: op.supports_out, foreach_binary_op_db))
     @unittest.skipIf(
-        torch.cuda.is_available() and not torch.cuda.get_device_capability(0) == (8, 6),
-        "failing flakily on non sm86 cuda jobs",
+        torch.cuda.is_available(),
+        "failing flakily on cuda jobs",
     )
     def test_binary_op_tensors_on_different_devices(self, device, dtype, op):
         # `tensors1`: ['cuda', 'cpu']


### PR DESCRIPTION
Also fails on sm86 https://github.com/pytorch/pytorch/actions/runs/9353689322/job/25746584581, but possibly at a lower frequency