### PR TITLE
[dynamo] Unspec nn module when global backward hooks are present

### DIFF
--- a/torch/_dynamo/mutation_guard.py
+++ b/torch/_dynamo/mutation_guard.py
@@ -7,7 +7,7 @@ import torch.nn
 from torch.nn import Module
 from . import config
 
-from .utils import ExactWeakKeyDictionary, is_lazy_module
+from .utils import ExactWeakKeyDictionary, is_lazy_module, nn_module_has_global_hooks
 
 
 class MutationTracker:
@@ -108,6 +108,9 @@ def is_dynamic_nn_module(obj, is_export):
         and config.inline_inbuilt_nn_modules
         and not is_export
     ):
+        return True
+
+    if isinstance(obj, torch.nn.Module) and nn_module_has_global_hooks():
         return True
     dyn = GenerationTracker.dynamic_classes.get(type(obj)) or GenerationTracker.check(
         obj

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2027,6 +2027,14 @@ state_dict_hook_names = [
 all_hook_names = forward_hook_names + backward_hook_names + state_dict_hook_names
 
 
+def nn_module_has_global_hooks():
+    # This is limited to backward hooks for now because NNModuleVariable
+    # supports fwd hooks underneath.
+    return len(torch.nn.modules.module._global_backward_hooks) or len(
+        torch.nn.modules.module._global_backward_pre_hooks
+    )
+
+
 def nn_module_get_all_hooks(
     mod,
     check_forward_hooks=False,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #127721
* #126578
* #127823
* #127806
* __->__ #127802
* #127785



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang