### PR TITLE
[inductor][ez] fix loop ordering test

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -7,6 +7,9 @@ from torch._inductor import config as inductor_config, metrics
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
+if HAS_CUDA:
+    torch.set_default_device("cuda")
+
 
 @inductor_config.patch(
     {
@@ -53,5 +56,4 @@ class LoopOrderingTest(TestCase):
 
 if __name__ == "__main__":
     if HAS_CUDA:
-        torch.set_default_device("cuda")
         run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #127807

I didn't realize that the main block is not being run when inductor tests are being run in FBCode via remote GPUs. This is a quick fix. I've tested it in both OSS and FBCode.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang