### PR TITLE
Typo fixes: et al.

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -856,7 +856,7 @@ namespace {
 /**
  * @brief Computes the optimal matrix chain multiplication order
  *
- * Follows the dynamic programming algorithm from Cormen et al,
+ * Follows the dynamic programming algorithm from Cormen et al.,
  * "Introduction to Algorithms, Third Edition", Chapter 15.2,
  * p. 370-378. Note that the book uses 1-based indexing.
  *

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -2,9 +2,9 @@
 // Licensed under the BSD-3-Clause license
 // This is the CPU implementation of the Connectionist Temporal Loss.
 // We mostly follow Graves.
-// 1. Graves et al: http://www.cs.toronto.edu/~graves/icml_2006.pdf
+// 1. Graves et al.: http://www.cs.toronto.edu/~graves/icml_2006.pdf
 // We use the equations from above link, but note that [1] has 1-based indexing and we (of course) use 0-based.
-// Graves et al call the probabilities y, we use log_probs (also calling them inputs)
+// Graves et al. call the probabilities y, we use log_probs (also calling them inputs)
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 
 #include <ATen/core/Tensor.h>

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -508,7 +508,7 @@ static inline C10_HOST_DEVICE scalar_t calc_polygamma(scalar_t x, int n) {
 
 /* References
  * [igam1] "The Digital Library of Mathematical Functions", dlmf.nist.gov
- * [igam2] Maddock et. al., "Incomplete Gamma Functions",
+ * [igam2] Maddock et al., "Incomplete Gamma Functions",
  *     https://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/sf_gamma/igamma.html
  */
 

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -2,9 +2,9 @@
 // Licensed under the BSD-3-Clause license
 // This is the GPU implementation of the Connectionist Temporal Loss.
 // We mostly follow Graves.
-// 1. Graves et al: http://www.cs.toronto.edu/~graves/icml_2006.pdf
+// 1. Graves et al.: http://www.cs.toronto.edu/~graves/icml_2006.pdf
 // We use the equations from above link, but note that [1] has 1-based indexing and we (of course) use 0-based.
-// Graves et al call the probabilities y, we use log_probs (also calling them inputs)
+// Graves et al. call the probabilities y, we use log_probs (also calling them inputs)
 // A few optimizations (similar to those here, but also some I didn't take) are described in
 // 2. Minmin Sun: http://on-demand.gputechconf.com/gtc/2016/presentation/s6383-minmin-sun-speech-recognition.pdf
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5426,7 +5426,7 @@
   autogen: slice_backward.out
 
 # NB: This op exists to back the implementation of reverse view_funcs for various views (chunk,
-# slice.Tensor, split_with_sizes, et. al.). Currently, these are only used during fake-ification
+# slice.Tensor, split_with_sizes, et al.). Currently, these are only used during fake-ification
 # of PT2 graph input subclass instances that are views. This means:
 # * This op shouldn't really show up in eager mode (so e.g. XLA shouldn't have to implement it)
 # * This op shouldn't show up in a PT2 graph (so a PT2 backend shouldn't have to implement it)

--- a/benchmarks/functional_autograd_benchmark/torchaudio_models.py
+++ b/benchmarks/functional_autograd_benchmark/torchaudio_models.py
@@ -219,7 +219,7 @@ class BatchRNN(nn.Module):
 
 
 class Lookahead(nn.Module):
-    # Wang et al 2016 - Lookahead Convolution Layer for Unidirectional Recurrent Neural Networks
+    # Wang et al., 2016 - Lookahead Convolution Layer for Unidirectional Recurrent Neural Networks
     # input shape - sequence, batch, feature - TxNxH
     # output shape - same as input
     def __init__(self, n_features, context):

--- a/third_party/valgrind-headers/valgrind.h
+++ b/third_party/valgrind-headers/valgrind.h
@@ -21,16 +21,16 @@
    1. Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
 
-   2. The origin of this software must not be misrepresented; you must
-      not claim that you wrote the original software.  If you use this
-      software in a product, an acknowledgment in the product
+   2. The origin of this software must not be misrepresented; you must 
+      not claim that you wrote the original software.  If you use this 
+      software in a product, an acknowledgment in the product 
       documentation would be appreciated but is not required.
 
    3. Altered source versions must be plainly marked as such, and must
       not be misrepresented as being the original software.
 
-   4. The name of the author may not be used to endorse or promote
-      products derived from this software without specific prior written
+   4. The name of the author may not be used to endorse or promote 
+      products derived from this software without specific prior written 
       permission.
 
    THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
@@ -52,13 +52,13 @@
    the terms of the GNU General Public License, version 2.  See the
    COPYING file in the source distribution for details.
 
-   ----------------------------------------------------------------
+   ---------------------------------------------------------------- 
 */
 
 
 /* This file is for inclusion into client (your!) code.
 
-   You can use these macros to manipulate and query Valgrind's
+   You can use these macros to manipulate and query Valgrind's 
    execution inside your own programs.
 
    The resulting executables will still run without Valgrind, just a
@@ -232,8 +232,8 @@
    this is executed not under Valgrind.  Args are passed in a memory
    block, and so there's no intrinsic limit to the number that could
    be passed, but it's currently five.
-
-   The macro args are:
+   
+   The macro args are: 
       _zzq_rlval    result lvalue
       _zzq_default  default value (result returned when running on real CPU)
       _zzq_request  request code
@@ -261,7 +261,7 @@
     ||  defined(PLAT_x86_solaris)
 
 typedef
-   struct {
+   struct { 
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -326,7 +326,7 @@ typedef
 #if defined(PLAT_x86_win32) && !defined(__GNUC__)
 
 typedef
-   struct {
+   struct { 
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -401,7 +401,7 @@ valgrind_do_client_request_expr(uintptr_t _zzq_default, uintptr_t _zzq_request,
     ||  (defined(PLAT_amd64_win64) && defined(__GNUC__))
 
 typedef
-   struct {
+   struct { 
       unsigned long int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -473,7 +473,7 @@ typedef
 #if defined(PLAT_ppc32_linux)
 
 typedef
-   struct {
+   struct { 
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -542,7 +542,7 @@ typedef
 #if defined(PLAT_ppc64be_linux)
 
 typedef
-   struct {
+   struct { 
       unsigned long int nraddr; /* where's the code? */
       unsigned long int r2;  /* what tocptr do we need? */
    }
@@ -698,7 +698,7 @@ typedef
 #if defined(PLAT_arm_linux)
 
 typedef
-   struct {
+   struct { 
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -766,7 +766,7 @@ typedef
 #if defined(PLAT_arm64_linux)
 
 typedef
-   struct {
+   struct { 
       unsigned long int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -912,7 +912,7 @@ typedef
 #if defined(PLAT_mips32_linux)
 
 typedef
-   struct {
+   struct { 
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -926,7 +926,7 @@ typedef
                      "srl $0, $0, 29\n\t"       \
                      "srl $0, $0, 3\n\t"        \
                      "srl $0, $0, 19\n\t"
-
+                    
 #define VALGRIND_DO_CLIENT_REQUEST_EXPR(                          \
        _zzq_default, _zzq_request,                                \
        _zzq_arg1, _zzq_arg2, _zzq_arg3, _zzq_arg4, _zzq_arg5)     \
@@ -2246,7 +2246,7 @@ typedef
 #define VALGRIND_RESTORE_STACK             \
       "mr 1,28\n\t"
 
-/* These CALL_FN_ macros assume that on ppc32-linux,
+/* These CALL_FN_ macros assume that on ppc32-linux, 
    sizeof(unsigned long) == 4. */
 
 #define CALL_FN_W_v(lval, orig)                                   \
@@ -4771,7 +4771,7 @@ typedef
       "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7"
 #endif
 
-/* Nb: Although r11 is modified in the asm snippets below (inside
+/* Nb: Although r11 is modified in the asm snippets below (inside 
    VALGRIND_CFI_PROLOGUE) it is not listed in the clobber section, for
    two reasons:
    (1) r11 is restored in VALGRIND_CFI_EPILOGUE, so effectively it is not
@@ -5221,7 +5221,7 @@ typedef
 #endif /* PLAT_s390x_linux */
 
 /* ------------------------- mips32-linux ----------------------- */
-
+ 
 #if defined(PLAT_mips32_linux)
 
 /* These regs are trashed by the hidden call. */
@@ -6615,7 +6615,7 @@ typedef
 #define VG_IS_TOOL_USERREQ(a, b, v) \
    (VG_USERREQ_TOOL_BASE(a,b) == ((v) & 0xffff0000))
 
-/* !! ABIWARNING !! ABIWARNING !! ABIWARNING !! ABIWARNING !!
+/* !! ABIWARNING !! ABIWARNING !! ABIWARNING !! ABIWARNING !! 
    This enum comprises an ABI exported by Valgrind to programs
    which use client requests.  DO NOT CHANGE THE NUMERIC VALUES OF THESE
    ENTRIES, NOR DELETE ANY -- add new ones at the end of the most
@@ -6648,7 +6648,7 @@ typedef
           VG_USERREQ__CLO_CHANGE = 0x1203,
 
           /* These are useful and can be interpreted by any tool that
-             tracks malloc() et al., by using vg_replace_malloc.c. */
+             tracks malloc() et al, by using vg_replace_malloc.c. */
           VG_USERREQ__MALLOCLIKE_BLOCK = 0x1301,
           VG_USERREQ__RESIZEINPLACE_BLOCK = 0x130b,
           VG_USERREQ__FREELIKE_BLOCK   = 0x1302,
@@ -6768,7 +6768,7 @@ VALGRIND_PRINTF(const char *format, ...)
    _qzz_res = VALGRIND_DO_CLIENT_REQUEST_EXPR(0,
                               VG_USERREQ__PRINTF_VALIST_BY_REF,
                               (unsigned long)format,
-                              (unsigned long)&vargs,
+                              (unsigned long)&vargs, 
                               0, 0, 0);
 #endif
    va_end(vargs);
@@ -6807,7 +6807,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    _qzz_res = VALGRIND_DO_CLIENT_REQUEST_EXPR(0,
                               VG_USERREQ__PRINTF_BACKTRACE_VALIST_BY_REF,
                               (unsigned long)format,
-                              (unsigned long)&vargs,
+                              (unsigned long)&vargs, 
                               0, 0, 0);
 #endif
    va_end(vargs);
@@ -6818,7 +6818,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* These requests allow control to move from the simulated CPU to the
    real CPU, calling an arbitrary function.
-
+   
    Note that the current ThreadId is inserted as the first argument.
    So this call:
 
@@ -6835,7 +6835,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    there's a high chance Valgrind will crash.  Generally, your prospects of
    these working are made higher if the called function does not refer to
    any global variables, and does not refer to any libc or other functions
-   (printf et al.).  Any kind of entanglement with libc or dynamic linking is
+   (printf et al).  Any kind of entanglement with libc or dynamic linking is
    likely to have a bad outcome, for tricky reasons which we've grappled
    with a lot in the past.
 */
@@ -6904,7 +6904,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    - It marks the block as being addressable and undefined (if 'is_zeroed' is
      not set), or addressable and defined (if 'is_zeroed' is set).  This
      controls how accesses to the block by the program are handled.
-
+   
    'addr' is the start of the usable block (ie. after any
    redzone), 'sizeB' is its size.  'rzB' is the redzone size if the allocator
    can apply redzones -- these are blocks of padding at the start and end of
@@ -6912,7 +6912,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    Valgrind will spot block overruns.  `is_zeroed' indicates if the memory is
    zeroed (or filled with another predictable value), as is the case for
    calloc().
-
+   
    VALGRIND_MALLOCLIKE_BLOCK should be put immediately after the point where a
    heap block -- that will be used by the client program -- is allocated.
    It's best to put it at the outermost level of the allocator if possible;
@@ -7000,8 +7000,8 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Create a memory pool with some flags specifying extended behaviour.
    When flags is zero, the behaviour is identical to VALGRIND_CREATE_MEMPOOL.
-
-   The flag VALGRIND_MEMPOOL_METAPOOL specifies that the pieces of memory
+   
+   The flag VALGRIND_MEMPOOL_METAPOOL specifies that the pieces of memory 
    associated with the pool using VALGRIND_MEMPOOL_ALLOC  will be used
    by the application as superblocks to dole out MALLOC_LIKE blocks using
    VALGRIND_MALLOCLIKE_BLOCK. In other words, a meta pool is a "2 levels"

--- a/third_party/valgrind-headers/valgrind.h
+++ b/third_party/valgrind-headers/valgrind.h
@@ -21,16 +21,16 @@
    1. Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
 
-   2. The origin of this software must not be misrepresented; you must 
-      not claim that you wrote the original software.  If you use this 
-      software in a product, an acknowledgment in the product 
+   2. The origin of this software must not be misrepresented; you must
+      not claim that you wrote the original software.  If you use this
+      software in a product, an acknowledgment in the product
       documentation would be appreciated but is not required.
 
    3. Altered source versions must be plainly marked as such, and must
       not be misrepresented as being the original software.
 
-   4. The name of the author may not be used to endorse or promote 
-      products derived from this software without specific prior written 
+   4. The name of the author may not be used to endorse or promote
+      products derived from this software without specific prior written
       permission.
 
    THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
@@ -52,13 +52,13 @@
    the terms of the GNU General Public License, version 2.  See the
    COPYING file in the source distribution for details.
 
-   ---------------------------------------------------------------- 
+   ----------------------------------------------------------------
 */
 
 
 /* This file is for inclusion into client (your!) code.
 
-   You can use these macros to manipulate and query Valgrind's 
+   You can use these macros to manipulate and query Valgrind's
    execution inside your own programs.
 
    The resulting executables will still run without Valgrind, just a
@@ -232,8 +232,8 @@
    this is executed not under Valgrind.  Args are passed in a memory
    block, and so there's no intrinsic limit to the number that could
    be passed, but it's currently five.
-   
-   The macro args are: 
+
+   The macro args are:
       _zzq_rlval    result lvalue
       _zzq_default  default value (result returned when running on real CPU)
       _zzq_request  request code
@@ -261,7 +261,7 @@
     ||  defined(PLAT_x86_solaris)
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -326,7 +326,7 @@ typedef
 #if defined(PLAT_x86_win32) && !defined(__GNUC__)
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -401,7 +401,7 @@ valgrind_do_client_request_expr(uintptr_t _zzq_default, uintptr_t _zzq_request,
     ||  (defined(PLAT_amd64_win64) && defined(__GNUC__))
 
 typedef
-   struct { 
+   struct {
       unsigned long int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -473,7 +473,7 @@ typedef
 #if defined(PLAT_ppc32_linux)
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -542,7 +542,7 @@ typedef
 #if defined(PLAT_ppc64be_linux)
 
 typedef
-   struct { 
+   struct {
       unsigned long int nraddr; /* where's the code? */
       unsigned long int r2;  /* what tocptr do we need? */
    }
@@ -698,7 +698,7 @@ typedef
 #if defined(PLAT_arm_linux)
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -766,7 +766,7 @@ typedef
 #if defined(PLAT_arm64_linux)
 
 typedef
-   struct { 
+   struct {
       unsigned long int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -912,7 +912,7 @@ typedef
 #if defined(PLAT_mips32_linux)
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -926,7 +926,7 @@ typedef
                      "srl $0, $0, 29\n\t"       \
                      "srl $0, $0, 3\n\t"        \
                      "srl $0, $0, 19\n\t"
-                    
+
 #define VALGRIND_DO_CLIENT_REQUEST_EXPR(                          \
        _zzq_default, _zzq_request,                                \
        _zzq_arg1, _zzq_arg2, _zzq_arg3, _zzq_arg4, _zzq_arg5)     \
@@ -2246,7 +2246,7 @@ typedef
 #define VALGRIND_RESTORE_STACK             \
       "mr 1,28\n\t"
 
-/* These CALL_FN_ macros assume that on ppc32-linux, 
+/* These CALL_FN_ macros assume that on ppc32-linux,
    sizeof(unsigned long) == 4. */
 
 #define CALL_FN_W_v(lval, orig)                                   \
@@ -4771,7 +4771,7 @@ typedef
       "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7"
 #endif
 
-/* Nb: Although r11 is modified in the asm snippets below (inside 
+/* Nb: Although r11 is modified in the asm snippets below (inside
    VALGRIND_CFI_PROLOGUE) it is not listed in the clobber section, for
    two reasons:
    (1) r11 is restored in VALGRIND_CFI_EPILOGUE, so effectively it is not
@@ -5221,7 +5221,7 @@ typedef
 #endif /* PLAT_s390x_linux */
 
 /* ------------------------- mips32-linux ----------------------- */
- 
+
 #if defined(PLAT_mips32_linux)
 
 /* These regs are trashed by the hidden call. */
@@ -6615,7 +6615,7 @@ typedef
 #define VG_IS_TOOL_USERREQ(a, b, v) \
    (VG_USERREQ_TOOL_BASE(a,b) == ((v) & 0xffff0000))
 
-/* !! ABIWARNING !! ABIWARNING !! ABIWARNING !! ABIWARNING !! 
+/* !! ABIWARNING !! ABIWARNING !! ABIWARNING !! ABIWARNING !!
    This enum comprises an ABI exported by Valgrind to programs
    which use client requests.  DO NOT CHANGE THE NUMERIC VALUES OF THESE
    ENTRIES, NOR DELETE ANY -- add new ones at the end of the most
@@ -6648,7 +6648,7 @@ typedef
           VG_USERREQ__CLO_CHANGE = 0x1203,
 
           /* These are useful and can be interpreted by any tool that
-             tracks malloc() et al, by using vg_replace_malloc.c. */
+             tracks malloc() et al., by using vg_replace_malloc.c. */
           VG_USERREQ__MALLOCLIKE_BLOCK = 0x1301,
           VG_USERREQ__RESIZEINPLACE_BLOCK = 0x130b,
           VG_USERREQ__FREELIKE_BLOCK   = 0x1302,
@@ -6768,7 +6768,7 @@ VALGRIND_PRINTF(const char *format, ...)
    _qzz_res = VALGRIND_DO_CLIENT_REQUEST_EXPR(0,
                               VG_USERREQ__PRINTF_VALIST_BY_REF,
                               (unsigned long)format,
-                              (unsigned long)&vargs, 
+                              (unsigned long)&vargs,
                               0, 0, 0);
 #endif
    va_end(vargs);
@@ -6807,7 +6807,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    _qzz_res = VALGRIND_DO_CLIENT_REQUEST_EXPR(0,
                               VG_USERREQ__PRINTF_BACKTRACE_VALIST_BY_REF,
                               (unsigned long)format,
-                              (unsigned long)&vargs, 
+                              (unsigned long)&vargs,
                               0, 0, 0);
 #endif
    va_end(vargs);
@@ -6818,7 +6818,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* These requests allow control to move from the simulated CPU to the
    real CPU, calling an arbitrary function.
-   
+
    Note that the current ThreadId is inserted as the first argument.
    So this call:
 
@@ -6835,7 +6835,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    there's a high chance Valgrind will crash.  Generally, your prospects of
    these working are made higher if the called function does not refer to
    any global variables, and does not refer to any libc or other functions
-   (printf et al).  Any kind of entanglement with libc or dynamic linking is
+   (printf et al.).  Any kind of entanglement with libc or dynamic linking is
    likely to have a bad outcome, for tricky reasons which we've grappled
    with a lot in the past.
 */
@@ -6904,7 +6904,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    - It marks the block as being addressable and undefined (if 'is_zeroed' is
      not set), or addressable and defined (if 'is_zeroed' is set).  This
      controls how accesses to the block by the program are handled.
-   
+
    'addr' is the start of the usable block (ie. after any
    redzone), 'sizeB' is its size.  'rzB' is the redzone size if the allocator
    can apply redzones -- these are blocks of padding at the start and end of
@@ -6912,7 +6912,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    Valgrind will spot block overruns.  `is_zeroed' indicates if the memory is
    zeroed (or filled with another predictable value), as is the case for
    calloc().
-   
+
    VALGRIND_MALLOCLIKE_BLOCK should be put immediately after the point where a
    heap block -- that will be used by the client program -- is allocated.
    It's best to put it at the outermost level of the allocator if possible;
@@ -7000,8 +7000,8 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* Create a memory pool with some flags specifying extended behaviour.
    When flags is zero, the behaviour is identical to VALGRIND_CREATE_MEMPOOL.
-   
-   The flag VALGRIND_MEMPOOL_METAPOOL specifies that the pieces of memory 
+
+   The flag VALGRIND_MEMPOOL_METAPOOL specifies that the pieces of memory
    associated with the pool using VALGRIND_MEMPOOL_ALLOC  will be used
    by the application as superblocks to dole out MALLOC_LIKE blocks using
    VALGRIND_MALLOCLIKE_BLOCK. In other words, a meta pool is a "2 levels"

--- a/torch/_lowrank.py
+++ b/torch/_lowrank.py
@@ -21,7 +21,7 @@ def get_approximate_basis(
     of the size of :math:`A` or :math:`M`.
 
     .. note:: The implementation is based on the Algorithm 4.4 from
-              Halko et al, 2009.
+              Halko et al., 2009.
 
     .. note:: For an adequate approximation of a k-rank matrix
               :math:`A`, where k is not known in advance but could be
@@ -94,7 +94,7 @@ def svd_lowrank(
     SVD is computed for the matrix :math:`A - M`.
 
     .. note:: The implementation is based on the Algorithm 5.1 from
-              Halko et al, 2009.
+              Halko et al., 2009.
 
     .. note:: For an adequate approximation of a k-rank matrix
               :math:`A`, where k is not known in advance but could be
@@ -152,7 +152,7 @@ def _svd_lowrank(
     niter: Optional[int] = 2,
     M: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
-    # Algorithm 5.1 in Halko et al 2009
+    # Algorithm 5.1 in Halko et al., 2009
 
     q = 6 if q is None else q
     m, n = A.shape[-2:]

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -941,7 +941,7 @@ def choose(
     return choices[idx_list].squeeze(0)
 
 
-# ### unique et al ###
+# ### unique et al. ###
 
 
 def unique(
@@ -1021,7 +1021,7 @@ def resize(a: ArrayLike, new_shape=None):
     return reshape(a, new_shape)
 
 
-# ### diag et al ###
+# ### diag et al. ###
 
 
 def diagonal(a: ArrayLike, offset=0, axis1=0, axis2=1):

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -119,7 +119,7 @@ class OneHotCategoricalStraightThrough(OneHotCategorical):
     through gradient estimator from [1].
 
     [1] Estimating or Propagating Gradients Through Stochastic Neurons for Conditional Computation
-    (Bengio et al, 2013)
+    (Bengio et al., 2013)
     """
     has_rsample = True
 

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -30,10 +30,10 @@ class LogitRelaxedBernoulli(Distribution):
         logits (Number, Tensor): the log-odds of sampling `1`
 
     [1] The Concrete Distribution: A Continuous Relaxation of Discrete Random
-    Variables (Maddison et al, 2017)
+    Variables (Maddison et al., 2017)
 
     [2] Categorical Reparametrization with Gumbel-Softmax
-    (Jang et al, 2017)
+    (Jang et al., 2017)
     """
     arg_constraints = {"probs": constraints.unit_interval, "logits": constraints.real}
     support = constraints.real

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -26,10 +26,10 @@ class ExpRelaxedCategorical(Distribution):
         logits (Tensor): unnormalized log probability for each event
 
     [1] The Concrete Distribution: A Continuous Relaxation of Discrete Random Variables
-    (Maddison et al, 2017)
+    (Maddison et al., 2017)
 
     [2] Categorical Reparametrization with Gumbel-Softmax
-    (Jang et al, 2017)
+    (Jang et al., 2017)
     """
     arg_constraints = {"probs": constraints.simplex, "logits": constraints.real_vector}
     support = (

--- a/torch/nn/modules/pixelshuffle.py
+++ b/torch/nn/modules/pixelshuffle.py
@@ -16,7 +16,7 @@ class PixelShuffle(Module):
 
     See the paper:
     `Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network`_
-    by Shi et. al (2016) for more details.
+    by Shi et al. (2016) for more details.
 
     Args:
         upscale_factor (int): factor to increase spatial resolution by
@@ -69,7 +69,7 @@ class PixelUnshuffle(Module):
 
     See the paper:
     `Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network`_
-    by Shi et. al (2016) for more details.
+    by Shi et al. (2016) for more details.
 
     Args:
         downscale_factor (int): factor to decrease spatial resolution by

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -208,7 +208,7 @@ SGD.__doc__ = (
 
     .. note::
         The implementation of SGD with Momentum/Nesterov subtly differs from
-        Sutskever et. al. and implementations in some other frameworks.
+        Sutskever et al. and implementations in some other frameworks.
 
         Considering the specific case of Momentum, the update can be written as
 
@@ -221,7 +221,7 @@ SGD.__doc__ = (
         where :math:`p`, :math:`g`, :math:`v` and :math:`\mu` denote the
         parameters, gradient, velocity, and momentum respectively.
 
-        This is in contrast to Sutskever et. al. and
+        This is in contrast to Sutskever et al. and
         other frameworks which employ an update of the form
 
         .. math::

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3016,7 +3016,7 @@ def marginrankingloss_reference(input1, input2, target, margin=0, reduction='mea
     return output
 
 
-# this directly follows Graves et al's paper, in contrast to the production implementation, it does not use log-space
+# this directly follows Graves et al.'s paper, in contrast to the production implementation, it does not use log-space
 def ctcloss_reference(log_probs, targets, input_lengths, target_lengths, blank=0, reduction='mean'):
     input_lengths = torch.as_tensor(input_lengths, dtype=torch.long)
     target_lengths = torch.as_tensor(target_lengths, dtype=torch.long)


### PR DESCRIPTION
"et al." is short for _et alia_ and should be abbreviated with a period on the second word. Noticed this typo when reading through the SGD docs.