### PR TITLE
[ROCm] std::clamp work-around for hip-clang compiler

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -264,8 +264,9 @@ void index_put_kernel_quantized_cuda(TensorIterator& iter, const IntArrayRef ind
 #ifndef USE_ROCM
       qvalue = std::clamp(qvalue, qmin, qmax);
 #else
-      int64_t new_max = std::max<int64_t>(qmin, qvalue);
-      qvalue = std::min<int64_t>(qmax, new_max);
+      qvalue = (qvalue < qmin) ? qmin : (qmax < qvalue) ? qmax : qvalue;
+
+
 #endif
       *(scalar_t*)(out_data + offset) = static_cast<scalar_t>(qvalue);
     });

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -265,8 +265,6 @@ void index_put_kernel_quantized_cuda(TensorIterator& iter, const IntArrayRef ind
       qvalue = std::clamp(qvalue, qmin, qmax);
 #else
       qvalue = (qvalue < qmin) ? qmin : (qmax < qvalue) ? qmax : qvalue;
-
-
 #endif
       *(scalar_t*)(out_data + offset) = static_cast<scalar_t>(qvalue);
     });

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -265,6 +265,7 @@ void index_put_kernel_quantized_cuda(TensorIterator& iter, const IntArrayRef ind
       // The following replaces std::clamp(qvalue, qmin, qmax) and is a viable solution for
       // both CUDA and ROCm since std::clamp and this replacement generates the same PTX.
       // Using #ifdef USE_ROCM to differentiate caused Windows build failures.
+      // The replacement should generate the same PTX as std::clamp. See https://godbolt.org/z/Wde9KW3v4
       qvalue = (qvalue < qmin) ? qmin : (qmax < qvalue) ? qmax : qvalue;
       *(scalar_t*)(out_data + offset) = static_cast<scalar_t>(qvalue);
     });

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -260,12 +260,12 @@ void index_put_kernel_quantized_cuda(TensorIterator& iter, const IntArrayRef ind
     gpu_index_kernel(iter, index_size, index_stride, [inv_scale, zero_point, qmin, qmax]C10_DEVICE(char* const out_data, const char* const in_data, const int64_t offset) {
       int64_t qvalue = static_cast<int64_t>(zero_point + nearbyintf(*(float*)in_data * inv_scale));
       // See https://github.com/pytorch/pytorch/issues/127666
-      // hip-clang std::clamp __glibcxx_assert_fail host function when building on Fedora40/gcc14
-#ifndef USE_ROCM
-      qvalue = std::clamp(qvalue, qmin, qmax);
-#else
+      // and https://github.com/pytorch/pytorch/issues/128253.
+      // hip-clang std::clamp __glibcxx_assert_fail host function when building on Fedora40/gcc14.
+      // The following replaces std::clamp(qvalue, qmin, qmax) and is a viable solution for
+      // both CUDA and ROCm since std::clamp and this replacement generates the same PTX.
+      // Using #ifdef USE_ROCM to differentiate caused Windows build failures.
       qvalue = (qvalue < qmin) ? qmin : (qmax < qvalue) ? qmax : qvalue;
-#endif
       *(scalar_t*)(out_data + offset) = static_cast<scalar_t>(qvalue);
     });
   });


### PR DESCRIPTION
Fixes #127666.

Other std math functions are replaced with those in the global namespace during hipify. HIP does not claim to support every function in the C++ standard library. std::clamp is not yet supported and we have been relying on the std implementation. For Fedora 40 + gcc 14, a host-side assert is used which is not supported. Work-around this by replacing std::clamp with min and max.  Using #ifndef USE_ROCM to differentiate between CUDA using std::clamp and the ROCm replacement broke Windows builds. The replacement generates the same PTX as std::clamp, so using the replacement unconditionally. The replacement generates the same PTX as std::clamp. See https://godbolt.org/z/Wde9KW3v4 for a sample.

Original patch comes from @lamikr. Modified to improve efficiency.  

https://github.com/lamikr/rocm_sdk_builder/pull/37

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang