### PR TITLE
Add comments about runner labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,9 +1,12 @@
 self-hosted-runner:
   labels:
+    # GitHub hosted x86 Linux runners
     - linux.20_04.4x
     - linux.20_04.16x
-    - linux.large
+    # Repo-specific LF hosted ARC runners
     - linux.large.arc
+    # Organization-wide AWS Linux Runners
+    - linux.large
     - linux.2xlarge
     - linux.4xlarge
     - linux.12xlarge
@@ -13,16 +16,22 @@ self-hosted-runner:
     - linux.8xlarge.nvidia.gpu
     - linux.16xlarge.nvidia.gpu
     - linux.g5.4xlarge.nvidia.gpu
+    # Repo-specific IBM hosted S390x runner
     - linux.s390x
+    # Organization wide AWS Windows runners
     - windows.4xlarge.nonephemeral
     - windows.8xlarge.nvidia.gpu
     - windows.8xlarge.nvidia.gpu.nonephemeral
     - windows.g5.4xlarge.nvidia.gpu
-    - bm-runner
+    # Repo-specific AMD hosted MI300 runners
     - linux.rocm.gpu
+    # Repo-specific Apple hosted M2 runners
+    - macos-m2-metal
+    # Org wise AWS `mac2.metal` runners (2020 Mac mini hardware powered by Apple silicon M1 processors)
     - macos-m1-stable
     - macos-m1-13
     - macos-m1-14
+    # GitHub-hosted MacOS runners
     - macos-latest-xlarge
     - macos-13-xlarge
     - macos-14-xlarge

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -23,10 +23,11 @@ self-hosted-runner:
     - windows.8xlarge.nvidia.gpu
     - windows.8xlarge.nvidia.gpu.nonephemeral
     - windows.g5.4xlarge.nvidia.gpu
-    # Repo-specific AMD hosted MI300 runners
+    # Organization-wide AMD hosted MI300 runners
     - linux.rocm.gpu
-    # Repo-specific Apple hosted M2 runners
-    - macos-m2-metal
+    # Repo-specific Apple hosted  runners
+    - macos-m1-ultra
+    - macos-m2-14
     # Org wise AWS `mac2.metal` runners (2020 Mac mini hardware powered by Apple silicon M1 processors)
     - macos-m1-stable
     - macos-m1-13


### PR DESCRIPTION
To distinguish between org-wide and repo-specific runners as well as highlight where they are hosted (by DevInfra, LF or various partners

Delete unused `bm-runner`
