### PR TITLE
Allow cpu scalar to be moved to HPU in masked_fill_decomposition

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5598,10 +5598,10 @@ def masked_fill(a: TensorLikeType, mask: TensorLikeType, value: TensorOrNumberLi
             value_ndim == 0,
             lambda: f"only supports a 0-dimensional value tensor, but got tensor with {value_ndim} dimension",
         )
-        # `masked_fill` allows cpu scalar to be moved to hpu, cuda and xpu but not otherwise.
+        # `masked_fill` allows cpu scalar to be moved to cuda, xpu and hpu but not otherwise.
         is_cpu_scalar = (
             a.device.type
-            in ["hpu", "cuda", "xpu", torch._C._get_privateuse1_backend_name()]
+            in ["cuda", "xpu", torch._C._get_privateuse1_backend_name(), "hpu"]
             and value.device.type == "cpu"
         )
         torch._check(

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5600,7 +5600,8 @@ def masked_fill(a: TensorLikeType, mask: TensorLikeType, value: TensorOrNumberLi
         )
         # `masked_fill` allows cpu scalar to be moved to hpu, cuda and xpu but not otherwise.
         is_cpu_scalar = (
-            a.device.type in ["hpu", "cuda", "xpu", torch._C._get_privateuse1_backend_name()]
+            a.device.type
+            in ["hpu", "cuda", "xpu", torch._C._get_privateuse1_backend_name()]
             and value.device.type == "cpu"
         )
         torch._check(

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5598,9 +5598,9 @@ def masked_fill(a: TensorLikeType, mask: TensorLikeType, value: TensorOrNumberLi
             value_ndim == 0,
             lambda: f"only supports a 0-dimensional value tensor, but got tensor with {value_ndim} dimension",
         )
-        # `masked_fill` allows cpu scalar to be moved to cuda and xpu but not otherwise.
+        # `masked_fill` allows cpu scalar to be moved to hpu, cuda and xpu but not otherwise.
         is_cpu_scalar = (
-            a.device.type in ["cuda", "xpu", torch._C._get_privateuse1_backend_name()]
+            a.device.type in ["hpu", "cuda", "xpu", torch._C._get_privateuse1_backend_name()]
             and value.device.type == "cpu"
         )
         torch._check(


### PR DESCRIPTION
Extension of the condition allowing the cpu scalar to be moved to specific devices.

This fixes an HPU specific error:
`torch._dynamo.exc.BackendCompilerFailed: backend='aot_hpu_training_backend' raised:
RuntimeError: Expected `value` to be on same device as `a`While executing %masked_fill : [num_users=1] = call_method[target=masked_fill](args = (%matmul, %expand_as, %tensor), kwargs = {})`

On the HPU in eager mode the problem doesn't occur because the pytorch's implementation is not used then.