### PR TITLE
Validate that node TK_ASSIGN have field initialized

### DIFF
--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -708,6 +708,7 @@ void SourceImporterImpl::importNamedTuple(
              "only attribute annotations are currently supported.");
     }
     const auto assign = Assign(statement);
+    TORCH_INTERNAL_ASSERT(assign.type().present());
 
     auto name = Var(Assign(statement).lhs()).name().name();
     std::optional<IValue> default_val;


### PR DESCRIPTION
Fixes segmentation fault during model load via C++ API.

An `Assign` statement (`TK_ASSIGN` type) have 3 fields: `lhs`, `rhs` and `type`. Field `type` is of type `Maybe`, which means it could be not presented. During model load in `import_source.cpp` field `type` is dereferenced without validation.

It is similar error that have been fixed in #106041.

Fixes #127877
