### PR TITLE
Add runtime dependency on setuptools for cpp_extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1137,6 +1137,9 @@ def main():
         'mkl>=2021.1.1,<=2021.4.0; platform_system == "Windows"',
     ]
 
+    if sys.version_info >= (3, 12, 0):
+        install_requires.append("setuptools")
+
     if BUILD_PYTHON_ONLY:
         install_requires.append(LIBTORCH_PKG_NAME)
 


### PR DESCRIPTION
As per title since this was removed from the builtin python binary in 3.12 and we use it `torch.utils.cpp_extension.*`.
