### PR TITLE
Harcode scale and zero point to double and long

### DIFF
--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -382,7 +382,7 @@ class UniformQuantizationObserverBase(ObserverBase):
                     [float(zero_point)], dtype=zero_point.dtype, device=device
                 )
 
-        return scale, zero_point
+        return scale.to(torch.float32), zero_point.to(torch.int64)
 
     @torch.jit.export
     def reset_min_max_vals(self):


### PR DESCRIPTION
Summary: Harcode scale and zero point to double and long so that we don't varying outputs of scale and zero points from this call. Currently these are sometimes outputting `floats` and `doubles` for scales, and `int` and `long` for zero point based on the input.

Test Plan: CI

Differential Revision: D58149278


