### PR TITLE
[Profiler] Fix usage of with_stack to not need ExperimentalConfig

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1048,11 +1048,7 @@ class TestProfiler(TestCase):
         self.assertEqual(KinetoStepTracker.current_step(), initial_step + 2 * niters)
 
     def test_export_stacks(self):
-        with _profile(
-            with_stack=True,
-            use_kineto=kineto_available(),
-            experimental_config=_ExperimentalConfig(verbose=True),
-        ) as p:
+        with _profile(with_stack=True, use_kineto=kineto_available()) as p:
             x = torch.randn(10, 10)
             y = torch.randn(10, 10)
             z = torch.mm(x, y)

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -428,8 +428,9 @@ struct KinetoThreadLocalState : public ProfilerStateBase {
             [this](ExtraFields<EventType::TorchOp>& i) { invokeCallback(i); },
             [this](ExtraFields<EventType::Backend>& i) { invokeCallback(i); },
             [](auto&) {}));
-
-        kineto_events_.emplace_back(e, config_.experimental_config.verbose);
+        bool enable_python_stack =
+            config_.experimental_config.verbose || config_.with_stack;
+        kineto_events_.emplace_back(e, enable_python_stack);
         AddTensorboardFields add_tb(e, kineto_events_.back());
         AddGenericMetadata add_generic(e, &config_);
 


### PR DESCRIPTION
Summary:
Many users have been complaining that with stack does not work on its own as described in the our pytorch tutorials. If used it returns an empty python stack. It only returns a stack if JIT is enabled.
https://github.com/pytorch/pytorch/issues/89406
https://github.com/pytorch/pytorch/issues/95238
https://github.com/pytorch/pytorch/issues/100253
https://github.com/pytorch/pytorch/issues/117515

Test Plan: Edited unit test to only contain with_stack

Differential Revision: D58149768


@diff-train-skip-merge
^ reverted internally