### PR TITLE
[test][custom_op] skip autograd.Function if no_grad

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2152,6 +2152,28 @@ class TestCustomOpAPI(TestCase):
         self.assertEqual(z, x + y)
         self.assertTrue(cpu_called)
 
+    def test_no_grad_skips_autograd(self):
+        @torch.library.custom_op("_torch_testing::add", mutates_args=())
+        def add(x: Tensor, y: float) -> Tensor:
+            x_np = x.numpy(force=True)
+            out_np = x_np + y
+            return torch.from_numpy(out_np).to(x.device)
+
+        called = False
+
+        def setup_context(ctx, inputs, output):
+            nonlocal called
+            called = True
+
+        def backward(ctx, grad):
+            raise AssertionError("should not be reached")
+
+        x = torch.randn(3, requires_grad=True)
+        with torch.no_grad():
+            y = add(x, 2.)
+        self.assertFalse(called)
+        self.assertEqual(y, x + 2.)
+
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_manual_schema(self):
         @torch.library.custom_op(

--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -25,6 +25,18 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
     saved_keyword_only_args = None
     has_kwarg_only_args = utils.has_kwarg_only_args(op._schema)
 
+    def forward_no_grad(ctx, *args):
+        with _C._AutoDispatchBelowAutograd():
+            nonlocal saved_keyset, saved_keyword_only_args
+            keyset = saved_keyset
+            assert keyset is not None, "Should have been set by autograd_impl"
+            saved_keyset = None
+            kwargs = saved_keyword_only_args
+            assert kwargs is not None, "Should have been set by autograd_impl"
+            saved_keyword_only_args = None
+            result = op.redispatch(keyset & _C._after_autograd_keyset, *args, **kwargs)
+            return result
+
     def forward(ctx, *args):
         with _C._AutoDispatchBelowAutograd():
             nonlocal saved_keyset, saved_keyword_only_args
@@ -93,7 +105,11 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
         saved_keyset = keyset
         assert saved_keyword_only_args is None
         saved_keyword_only_args = keyword_only_args
-        result = Generated.apply(*args)  # type: ignore[attr-defined]
+
+        if torch.is_grad_enabled(False):
+            result = Generated.apply(*args)  # type: ignore[attr-defined]
+        else:
+            result = forward_no_grad(*args)
         return result
 
     return autograd_impl


### PR DESCRIPTION
Summary: Skip autograd.Function if we're under torch.no_grad()

Test Plan: - new tests

Differential Revision: D58157291


