### PR TITLE
[Fix] Parameter un/lifting issues in the TorchScript to ExportedProgram converter

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -18,7 +18,6 @@ requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "requires cuda")
 class TestConverter(TestCase):
     def _check_equal_ts_ep_converter(self, mod, inp) -> ExportedProgram:
         ts_model = torch.jit.script(mod)
-        # print(ts_model.graph)
         ep = TS2EPConverter(ts_model, inp).convert()
         ep_out, _ = pytree.tree_flatten(ep.module()(*inp))
         orig_out, _ = pytree.tree_flatten(mod(*inp))

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -18,6 +18,7 @@ requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "requires cuda")
 class TestConverter(TestCase):
     def _check_equal_ts_ep_converter(self, mod, inp) -> ExportedProgram:
         ts_model = torch.jit.script(mod)
+        # print(ts_model.graph)
         ep = TS2EPConverter(ts_model, inp).convert()
         ep_out, _ = pytree.tree_flatten(ep.module()(*inp))
         orig_out, _ = pytree.tree_flatten(mod(*inp))

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -286,6 +286,8 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
+        # Super nested, parameters neeed to lifted
+        # multiple times.
         class SuperNestedM1(torch.nn.Module):
             def __init__(self, dim: int) -> None:
                 super().__init__()
@@ -299,33 +301,61 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
-        # # Basic module testing.
-        # inp = (torch.ones(3),)
-        # orig_m = M(3)
-        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        # t = inp[0]
-        # t -= 0.8
-        # torch.testing.assert_close(
-        #     ep.module()(*inp),
-        #     orig_m(*inp),
-        # )
+        # Super nested, even the input needs to be
+        # lifted recursively due to value propogation optimiztaion.
+        class SuperNestedM2(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.m1 = NestedM(dim)
+                self.m2 = NestedM(dim)
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x: torch.Tensor):
+                if torch.sum(x) > 1:
+                    return self.linear(self.m1(x))
+                else:
+                    return self.linear(self.m2(x))
+
+        # # Basic module testing.
+        inp = (torch.ones(3),)
+        orig_m = M(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
 
         # # Nested module testing.
-        # inp = (torch.ones(3),)
-        # orig_m = NestedM(3)
-        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        inp = (torch.ones(3),)
+        orig_m = NestedM(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        # t = inp[0]
-        # t -= 0.8
-        # torch.testing.assert_close(
-        #     ep.module()(*inp),
-        #     orig_m(*inp),
-        # )
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
+
+        # Super nested module testing.
+        inp = (torch.ones(3),)
+        orig_m = SuperNestedM1(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
 
         # Super nested module testing.
         # inp = (torch.ones(3),)
-        # orig_m = SuperNestedM1(3)
+        # orig_m = SuperNestedM2(3)
         # ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
         # t = inp[0]

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -264,7 +264,40 @@ class TestConverter(TestCase):
         inp = ((torch.zeros(1, 4), torch.ones(1, 4)),)
         self._check_equal_ts_ep_converter(MUnpackTuple(), inp)
         
-    def test_convert_nn_module_with_param(self):
+    def test_convert_nn_module_with_nested_param(self):
+        class M(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x: torch.Tensor):
+                return self.linear(x)
+
+        class NestedM(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(dim, dim)
+                self.m = M(dim)
+
+            def forward(self, x: torch.Tensor):
+                return self.linear(self.m(x))
+
+        class SuperNestedM(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(dim, dim)
+                self.m = NestedM(dim)
+
+            def forward(self, x: torch.Tensor):
+                return self.linear(self.m(x))
+
+        inp = (torch.ones(3),)
+        orig_m = NestedM(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        orig_m = SuperNestedM(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+    def test_convert_nn_module_with_nested_if_and_param(self):
         class M(torch.nn.Module):
             def __init__(self, dim: int) -> None:
                 super().__init__()
@@ -301,7 +334,6 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
-
         # Super nested, even the input needs to be
         # lifted recursively due to value propogation optimiztaion.
         class SuperNestedM2(torch.nn.Module):
@@ -317,7 +349,7 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
-        # # Basic module testing.
+        # Basic module testing.
         inp = (torch.ones(3),)
         orig_m = M(3)
         ep = self._check_equal_ts_ep_converter(orig_m, inp)
@@ -329,7 +361,7 @@ class TestConverter(TestCase):
             orig_m(*inp),
         )
 
-        # # Nested module testing.
+        # Nested module testing.
         inp = (torch.ones(3),)
         orig_m = NestedM(3)
         ep = self._check_equal_ts_ep_converter(orig_m, inp)
@@ -353,7 +385,7 @@ class TestConverter(TestCase):
             orig_m(*inp),
         )
 
-        # Super nested module testing.
+        # # Super nested module testing.
         # inp = (torch.ones(3),)
         # orig_m = SuperNestedM2(3)
         # ep = self._check_equal_ts_ep_converter(orig_m, inp)

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -287,8 +287,46 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
+        class SuperNestedM(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.m1 = NestedM(dim)
+                self.m2 = NestedM(dim)
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x: torch.Tensor):
+                if torch.sum(x) > 1:
+                    return self.linear(self.m1(x))
+                else:
+                    return self.linear(self.m2(x))
+
+        # Basic module testing.
+        inp = (torch.ones(3),)
+        orig_m = M(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
+
+        # Nested module testing.
         inp = (torch.ones(3),)
         orig_m = NestedM(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
+
+        # Super nested module testing.
+        inp = (torch.ones(3),)
+        orig_m = SuperNestedM(3)
         ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
         t = inp[0]

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -260,7 +260,6 @@ class TestConverter(TestCase):
         class MUnpackList(torch.nn.Module):
             def forward(self, x):
                 x, y = torch.split(x, 2)
-                # print(x, y)
                 return x + y
 
         class MUnpackTuple(torch.nn.Module):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -299,29 +299,29 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
-        # Basic module testing.
-        inp = (torch.ones(3),)
-        orig_m = M(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        # # Basic module testing.
+        # inp = (torch.ones(3),)
+        # orig_m = M(3)
+        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        t = inp[0]
-        t -= 0.8
-        torch.testing.assert_close(
-            ep.module()(*inp),
-            orig_m(*inp),
-        )
+        # t = inp[0]
+        # t -= 0.8
+        # torch.testing.assert_close(
+        #     ep.module()(*inp),
+        #     orig_m(*inp),
+        # )
 
-        # Nested module testing.
-        inp = (torch.ones(3),)
-        orig_m = NestedM(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        # # Nested module testing.
+        # inp = (torch.ones(3),)
+        # orig_m = NestedM(3)
+        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        t = inp[0]
-        t -= 0.8
-        torch.testing.assert_close(
-            ep.module()(*inp),
-            orig_m(*inp),
-        )
+        # t = inp[0]
+        # t -= 0.8
+        # torch.testing.assert_close(
+        #     ep.module()(*inp),
+        #     orig_m(*inp),
+        # )
 
         # Super nested module testing.
         inp = (torch.ones(3),)

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -260,6 +260,7 @@ class TestConverter(TestCase):
         class MUnpackList(torch.nn.Module):
             def forward(self, x):
                 x, y = torch.split(x, 2)
+                # print(x, y)
                 return x + y
 
         class MUnpackTuple(torch.nn.Module):
@@ -268,7 +269,7 @@ class TestConverter(TestCase):
                 x = x.cos()
                 return x + y
 
-        inp = torch.ones(1, 4)
+        inp = (torch.ones(4),)
         self._check_equal_ts_ep_converter(MUnpackList(), inp)
         inp = ((torch.zeros(1, 4), torch.ones(1, 4)),)
         self._check_equal_ts_ep_converter(MUnpackTuple(), inp)

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -21,6 +21,14 @@ class TestConverter(TestCase):
         ep = TS2EPConverter(ts_model, inp).convert()
         ep_out, _ = pytree.tree_flatten(ep.module()(*inp))
         orig_out, _ = pytree.tree_flatten(mod(*inp))
+
+        # Check module.
+        self.assertEqual(
+            ep.module().state_dict().keys(),
+            mod.state_dict().keys(),
+        )
+
+        # Check results.
         self.assertEqual(len(ep_out), len(orig_out))
         for ep_t, orig_t in zip(ep_out, orig_out):
             if isinstance(ep_t, torch.Tensor):
@@ -263,7 +271,7 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(MUnpackList(), inp)
         inp = ((torch.zeros(1, 4), torch.ones(1, 4)),)
         self._check_equal_ts_ep_converter(MUnpackTuple(), inp)
-        
+
     def test_convert_nn_module_with_nested_param(self):
         class M(torch.nn.Module):
             def __init__(self, dim: int) -> None:

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -375,7 +375,7 @@ class TestConverter(TestCase):
                     return self.w + self.m1(x)
                 else:
                     return self.w + self.m2(x)
-        
+
         # Super nested module testing.
         inp = (torch.ones(1),)
         orig_m = SuperNestedM()

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -464,5 +464,9 @@ class TestConverter(TestCase):
             self._check_equal_ts_ep_converter(m, inp)
 
 
+    def test_convert_func_without_param(self):
+        pass
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -263,6 +263,39 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(MUnpackList(), inp)
         inp = ((torch.zeros(1, 4), torch.ones(1, 4)),)
         self._check_equal_ts_ep_converter(MUnpackTuple(), inp)
+        
+    def test_convert_nn_module_with_param(self):
+        class M(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x: torch.Tensor):
+                return self.linear(x)
+
+        class NestedM(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.m1 = M(dim)
+                self.m2 = M(dim)
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x: torch.Tensor):
+                if torch.sum(x) > 1:
+                    return self.linear(self.m1(x))
+                else:
+                    return self.linear(self.m2(x))
+
+        inp = (torch.ones(3),)
+        orig_m = NestedM(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
 
     def test_ts2ep_converter_contains(self):
         class MIn(torch.nn.Module):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -286,7 +286,7 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
-        class SuperNestedM(torch.nn.Module):
+        class SuperNestedM1(torch.nn.Module):
             def __init__(self, dim: int) -> None:
                 super().__init__()
                 self.m1 = NestedM(dim)
@@ -294,7 +294,7 @@ class TestConverter(TestCase):
                 self.linear = torch.nn.Linear(dim, dim)
 
             def forward(self, x: torch.Tensor):
-                if torch.sum(x) > 1:
+                if torch.max(x) > 1:
                     return self.linear(self.m1(x))
                 else:
                     return self.linear(self.m2(x))
@@ -324,16 +324,16 @@ class TestConverter(TestCase):
         # )
 
         # Super nested module testing.
-        inp = (torch.ones(3),)
-        orig_m = SuperNestedM(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        # inp = (torch.ones(3),)
+        # orig_m = SuperNestedM1(3)
+        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        t = inp[0]
-        t -= 0.8
-        torch.testing.assert_close(
-            ep.module()(*inp),
-            orig_m(*inp),
-        )
+        # t = inp[0]
+        # t -= 0.8
+        # torch.testing.assert_close(
+        #     ep.module()(*inp),
+        #     orig_m(*inp),
+        # )
 
     def test_ts2ep_converter_contains(self):
         class MIn(torch.nn.Module):

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -708,7 +708,7 @@ class TS2EPConverter:
         # TODO: adjust input orders to match GraphSignature convention
         ep = torch.export._trace._export(
             gm,
-            tuple(self.sample_args),
+            self.sample_args,
             strict=False,
             pre_dispatch=True,
         )

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -196,6 +196,17 @@ class TS2FXGraphConverter:
 
         self.block_to_arguments = block_to_arguments
 
+        # Populate methods for the standard operators.
+        for k in kind_to_standard_operators.keys():
+            handler_func_name = ir_name_to_func_name(k)
+            # Create an indirect function call:
+            # convert_<namespace>_<opname> --> lambda node: _convert_standard_operator(node)
+            setattr(
+                self,
+                handler_func_name,
+                lambda node: self._convert_standard_operators(node),
+            )
+
     def add_subgraph(self, subgraph) -> str:
         name = f"subgraph_{len(self.subgraphs)}"
         self.subgraphs[name] = subgraph

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -524,21 +524,19 @@ class TS2FXGraphConverter:
         assert len(inputs) == 1
         predicate = self.get_fx_value(inputs[0])
 
-        def _dfs_build_lifted_arguments_for_input(entry):
-            arguments: Set[str] = set()
-            for block in entry.blocks():
-                for block_node in block.nodes():
-                    for block_node_in in block_node.inputs():
-                        if block_node_in.debugName() in self.name_to_node:
-                            debug_name = block_node_in.debugName()
-                            arguments.add(debug_name)
-                    arguments = arguments.union(
-                        _dfs_build_lifted_arguments_for_input(block_node)
-                    )
-            return arguments
+        # Get union of inputs to blocks
+        arguments = set()
+        for block in node.blocks():
+            block_args = set()
 
-        # # Find inputs.
-        arguments = _dfs_build_lifted_arguments_for_input(node)
+            # TODO: block.inputs(), not sure what theyre used for
+
+            for block_node in block.nodes():
+                for block_node_in in block_node.inputs():
+                    if block_node_in.debugName() in self.name_to_node:
+                        block_args.add(block_node_in.debugName())
+
+            arguments.update(block_args)
 
         # Lift parameters.
         for block in node.blocks():

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -47,6 +47,12 @@ def ir_name_to_func_name(name: str) -> str:
     return "convert_" + "_".join(name_list)
 
 
+def get_node_for_param_and_buffer(fx_graph, name, is_top_level_graph):
+    if is_top_level_graph:
+        return fx_graph.get_attr(name)
+    return fx_graph.placeholder(name)
+
+
 # Those operators will be automatically populated to a instance method
 # of TS2FXGraphConverter with name convert_<namespace>_<opname>().
 # Please check __init__ for method population implementations.
@@ -86,7 +92,8 @@ class TS2FXGraphConverter:
         ts_graph: Union[torch._C.Graph, torch._C.Block],
         param_names: Set[str],
         buffer_names: Set[str],
-        mod_attribute_map: Dict[str, Any],
+        mod_param_and_buffer_map: Dict[str, Any],
+        is_top_level_graph: bool = False,
     ):
         self.ts_graph = ts_graph
         self.param_names = param_names
@@ -105,8 +112,12 @@ class TS2FXGraphConverter:
 
         self.subgraphs: Dict[str, torch.fx.GraphModule] = {}
 
-        # Parameter name: parameter
-        self.mod_attribute_map = mod_attribute_map
+        # Parameter or buffer name -> parameter or buffer.
+        self.mod_param_and_buffer_map = mod_param_and_buffer_map
+
+        # Indicate whether we lift parameters and buffers as inputs.
+        # They are lifted only for the top level graph but not subgraphs.
+        self.is_top_level_graph = is_top_level_graph
 
     def add_subgraph(self, subgraph) -> str:
         name = f"subgraph_{len(self.subgraphs)}"
@@ -145,14 +156,12 @@ class TS2FXGraphConverter:
         self.convert_graph_inputs()
 
         for node in self.ts_graph.nodes():
-            # if node.kind() == "prim::GetAttr":
-            #     breakpoint()
-            #     pass
             self.convert_node(node)
 
         self.convert_graph_outputs()
 
-        gm = torch.fx.GraphModule({**self.subgraphs, **self.mod_attribute_map}, self.fx_graph)
+        # Pass parameter and buffer to the root for lookup.
+        gm = torch.fx.GraphModule({**self.subgraphs, **self.mod_param_and_buffer_map}, self.fx_graph)
 
         inplace_optimize_sym_size_div(gm)
 
@@ -173,7 +182,7 @@ class TS2FXGraphConverter:
                         target=name,
                     )
                 )
-                fx_node = self.fx_graph.placeholder(normalized_name)
+                fx_node = get_node_for_param_and_buffer(self.fx_graph, normalized_name, self.is_top_level_graph)
             elif name in self.buffer_names:
                 self.input_specs.append(
                     InputSpec(
@@ -183,7 +192,7 @@ class TS2FXGraphConverter:
                         persistent=True,
                     )
                 )
-                fx_node = self.fx_graph.getattr(normalized_name)
+                fx_node = get_node_for_param_and_buffer(self.fx_graph, normalized_name, self.is_top_level_graph)
             else:
                 self.input_specs.append(
                     InputSpec(
@@ -435,12 +444,14 @@ class TS2FXGraphConverter:
 
             arguments.update(block_args)
 
-        arguments = list(arguments)
+        # We lift parameters and buffers as inputs for the subgraphs.
+        arguments = list(arguments) + list(self.param_names) + list(self.buffer_names)
 
         # Convert blocks to subgraphs
         subgraph_nodes = []
         for block in node.blocks():
-            subgraph_converter = TS2FXGraphConverter(block, set(), set(), self.mod_attribute_map)
+            # Convert subgraph with always lifting.
+            subgraph_converter = TS2FXGraphConverter(block, set(), set(), dict(), False)
             subgraph_converter.constant_map = self.constant_map
             subgraph_converter.attribute_map = self.attribute_map
 
@@ -451,7 +462,6 @@ class TS2FXGraphConverter:
                 )
                 subgraph_converter.name_to_node[block_arg] = placeholder_node
 
-            breakpoint()
             subgraph = subgraph_converter.convert()
             subgraph_name = self.add_subgraph(subgraph)
             subgraph_nodes.append(self.fx_graph.get_attr(subgraph_name))
@@ -559,8 +569,6 @@ class TS2EPConverter:
     ):
         self.ts_model = ts_model
         self.ts_graph, self.params, _, _ = _create_jit_graph(ts_model, sample_args)
-        print(self.ts_graph)
-        breakpoint()
 
         self.sample_args = sample_args
         self.sample_kwargs = sample_kwargs
@@ -568,13 +576,16 @@ class TS2EPConverter:
         self.param_names: Set[str] = {name for name, _ in ts_model.named_parameters()}
         self.buffer_names: Set[str] = {name for name, _ in ts_model.named_buffers()}
 
-        self.mod_attribute_map = {
-            name: param for name, param in ts_model.named_parameters()
-        }
+        # Populate nn module parameters and buffers.
+        self.mod_param_and_buffer_map: Dict[str, Any]= dict()
+        for name, param in ts_model.named_parameters():
+            self.mod_param_and_buffer_map[normalize_name(name)] = param
+        for name, buffer in ts_model.named_buffers():
+            self.mod_param_and_buffer_map[normalize_name(name)] = buffer 
 
     def convert(self) -> ExportedProgram:
         graph_converter = TS2FXGraphConverter(
-            self.ts_graph, self.param_names, self.buffer_names, self.mod_attribute_map
+            self.ts_graph, self.param_names, self.buffer_names, self.mod_param_and_buffer_map, True 
         )
         gm = graph_converter.convert()
         ep = self.retrace_as_exported_program(gm, graph_converter.tensor_constants)
@@ -582,7 +593,7 @@ class TS2EPConverter:
 
     def retrace_as_exported_program(self, gm: torch.fx.GraphModule, tensor_constants):
         # TODO: adjust input orders to match GraphSignature convention
-        inputs = [*self.sample_args, *self.params, *tensor_constants.values()]
+        inputs = [*self.sample_args]
 
         ep = torch.export._trace._export(
             gm,

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -268,7 +268,7 @@ class TS2FXGraphConverter:
                     )
                 )
                 fx_node = get_node_for_param_and_buffer(
-                    self.fx_graph, normalized_name, self.is_top_level_graph
+                    self.fx_graph, name, self.is_top_level_graph
                 )
             elif name in self.buffer_names:
                 self.input_specs.append(
@@ -280,7 +280,7 @@ class TS2FXGraphConverter:
                     )
                 )
                 fx_node = get_node_for_param_and_buffer(
-                    self.fx_graph, normalized_name, self.is_top_level_graph
+                    self.fx_graph, name, self.is_top_level_graph
                 )
             else:
                 self.input_specs.append(
@@ -672,9 +672,9 @@ class TS2EPConverter:
         # Populate nn module parameters and buffers.
         self.mod_param_and_buffer_map: Dict[str, Any] = dict()
         for name, param in ts_model.named_parameters():
-            self.mod_param_and_buffer_map[normalize_name(name)] = param
+            self.mod_param_and_buffer_map[name] = param
         for name, buffer in ts_model.named_buffers():
-            self.mod_param_and_buffer_map[normalize_name(name)] = buffer
+            self.mod_param_and_buffer_map[name] = buffer
 
     def convert(self) -> ExportedProgram:
         blocks_to_lifted_attrs = get_block_lifted_args(self.ts_graph)

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -119,7 +119,9 @@ def get_block_lifted_args(graph: torch._C.Graph):
         for node in entry.nodes():
             for block in node.blocks():
                 # Recursively build.
-                arguments = arguments.union(_dfs_build_lifted_arguments_for_param(block))
+                arguments = arguments.union(
+                    _dfs_build_lifted_arguments_for_param(block)
+                )
             if node.kind() == "prim::GetAttr":
                 src_ir, dest_ir, cur_name = get_src_dest_and_cur(node)
                 # Skip for intermediate GetAttr, which will anyway not results a FQN.
@@ -517,21 +519,21 @@ class TS2FXGraphConverter:
                 for block_node in block.nodes():
                     for block_node_in in block_node.inputs():
                         if block_node_in.debugName() in self.name_to_node:
-                            arguments.add(block_node_in.debugName())
-                    arguments = arguments.union(_dfs_build_lifted_arguments_for_input(block_node))
+                            debug_name = block_node_in.debugName()
+                            arguments.add(debug_name)
+                    arguments = arguments.union(
+                        _dfs_build_lifted_arguments_for_input(block_node)
+                    )
             return arguments
 
-        # Lift inputs.
+        # # Find inputs.
         arguments = _dfs_build_lifted_arguments_for_input(node)
 
         # Lift parameters.
         for block in node.blocks():
             arguments = arguments.union(self.block_to_arguments[block])
 
-        # We lift parameters and buffers as inputs for the subgraphs.
-        # TODO: only pass down necessary parameters and buffers.
         arguments = list(arguments)
-        print(arguments)
 
         # Convert blocks to subgraphs
         subgraph_nodes = []
@@ -657,7 +659,6 @@ class TS2EPConverter:
     ):
         self.ts_model = ts_model
         self.ts_graph, self.params, _, _ = _create_jit_graph(ts_model, sample_args)
-        print(self.ts_graph)
 
         self.sample_args = sample_args
         self.sample_kwargs = sample_kwargs


### PR DESCRIPTION
This PR fixes issues related to parameters and inputs lifting in the converter.

#### Issue 1
```
> Graph[linear.weights, bias.weights, x.1]
%1 ...
%2 ...
%3 = CreateObject()

	> Block 0[]
        %linear.0 = GetAttr(linear)[%3]

	             > Block 0.0[]
	             %weight.0 = GetAttr(weights)[%linear.0]
	
	> Block 1[]
	...
```
* Model parameters for the top level module should be unlifted, while parameters from sub-blocks should be lifted.
#### Fixes
* Bottom-up traversal (i.e., start from the inner most block) to figure out which parameters to be lifted for sub-blocks.

#### Test Plan
* Add test cases for nested block without control flow `pytest test/export/test_converter.py -s -k test_convert_nn_module_with_nested_param`
* Add test cases for nested block with control flow `pytest test/export/test_converter.py -s -k test_convert_nn_module_with_nested_if_and_param`

#### Outcome
##### TorchScript
```
graph(%x.1 : Float(3, strides=[1], requires_grad=0, device=cpu),
      %m1.m1.linear.weight : Float(3, 3, strides=[3, 1], requires_grad=0, device=cpu),
      %m1.m1.linear.bias : Float(3, strides=[1], requires_grad=0, device=cpu),
      %m1.linear.weight : Float(3, 3, strides=[3, 1], requires_grad=0, device=cpu),
      %m1.linear.bias : Float(3, strides=[1], requires_grad=0, device=cpu),
      %m1.m2.linear.weight : Float(3, 3, strides=[3, 1], requires_grad=0, device=cpu),
      %m1.m2.linear.bias : Float(3, strides=[1], requires_grad=0, device=cpu),
      %linear.weight : Float(3, 3, strides=[3, 1], requires_grad=0, device=cpu),
      %linear.bias : Float(3, strides=[1], requires_grad=0, device=cpu),
      %m2.m1.linear.weight : Float(3, 3, strides=[3, 1], requires_grad=0, device=cpu),
      %m2.m1.linear.bias : Float(3, strides=[1], requires_grad=0, device=cpu),
      %m2.linear.weight : Float(3, 3, strides=[3, 1], requires_grad=0, device=cpu),
      %m2.linear.bias : Float(3, strides=[1], requires_grad=0, device=cpu),
      %m2.m2.linear.weight : Float(3, 3, strides=[3, 1], requires_grad=0, device=cpu),
      %m2.m2.linear.bias : Float(3, strides=[1], requires_grad=0, device=cpu)):
  %15 : __torch__.export.test_converter.___torch_mangle_14.SuperNestedM1 = prim::CreateObject()
  %16 : NoneType = prim::Constant(), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
  %17 : int = prim::Constant[value=1](), scope: export.test_converter.SuperNestedM1:: # /data/users/jiashenc/pytorch/test/export/test_converter.py:342:34
  %18 : Tensor = aten::max(%x.1), scope: export.test_converter.SuperNestedM1:: # /data/users/jiashenc/pytorch/test/export/test_converter.py:342:19
  %19 : Tensor = aten::gt(%18, %17), scope: export.test_converter.SuperNestedM1:: # /data/users/jiashenc/pytorch/test/export/test_converter.py:342:19
  %20 : bool = aten::Bool(%19), scope: export.test_converter.SuperNestedM1:: # /data/users/jiashenc/pytorch/test/export/test_converter.py:342:19
  %21 : Tensor = prim::If(%20), scope: export.test_converter.SuperNestedM1:: # /data/users/jiashenc/pytorch/test/export/test_converter.py:342:16
    block0():
      %linear.6 : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%15), scope: export.test_converter.SuperNestedM1::
      %m1.1 : __torch__.export.test_converter.___torch_mangle_15.NestedM = prim::GetAttr[name="m1"](%15), scope: export.test_converter.SuperNestedM1::
      %24 : Tensor = aten::sum(%x.1, %16), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1 # /data/users/jiashenc/pytorch/test/export/test_converter.py:327:19
      %25 : Tensor = aten::gt(%24, %17), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1 # /data/users/jiashenc/pytorch/test/export/test_converter.py:327:19
      %26 : bool = aten::Bool(%25), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1 # /data/users/jiashenc/pytorch/test/export/test_converter.py:327:19
      %27 : Tensor = prim::If(%26), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1 # /data/users/jiashenc/pytorch/test/export/test_converter.py:327:16
        block0():
          %linear.10 : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%m1.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %m1.3 : __torch__.export.test_converter.___torch_mangle_16.M = prim::GetAttr[name="m1"](%m1.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %linear.12 : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%m1.3), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %weight.4 : Tensor = prim::GetAttr[name="weight"](%linear.12), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %bias.4 : Tensor = prim::GetAttr[name="bias"](%linear.12), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %33 : Tensor = aten::linear(%x.1, %weight.4, %bias.4), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1 # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
          %weight.6 : Tensor = prim::GetAttr[name="weight"](%linear.10), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %bias.6 : Tensor = prim::GetAttr[name="bias"](%linear.10), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %36 : Tensor = aten::linear(%33, %weight.6, %bias.6), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1 # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
          -> (%36)
        block1():
          %linear.14 : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%m1.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %m2.3 : __torch__.export.test_converter.___torch_mangle_16.M = prim::GetAttr[name="m2"](%m1.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %linear.16 : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%m2.3), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %weight.8 : Tensor = prim::GetAttr[name="weight"](%linear.16), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %bias.8 : Tensor = prim::GetAttr[name="bias"](%linear.16), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %42 : Tensor = aten::linear(%x.1, %weight.8, %bias.8), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1 # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
          %weight.2 : Tensor = prim::GetAttr[name="weight"](%linear.14), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %bias.2 : Tensor = prim::GetAttr[name="bias"](%linear.14), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1
          %45 : Tensor = aten::linear(%42, %weight.2, %bias.2), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m1 # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
          -> (%45)
      %weight.10 : Tensor = prim::GetAttr[name="weight"](%linear.6), scope: export.test_converter.SuperNestedM1::/torch.nn.modules.linear.Linear::linear
      %bias.10 : Tensor = prim::GetAttr[name="bias"](%linear.6), scope: export.test_converter.SuperNestedM1::/torch.nn.modules.linear.Linear::linear
      %48 : Tensor = aten::linear(%27, %weight.10, %bias.10), scope: export.test_converter.SuperNestedM1::/torch.nn.modules.linear.Linear::linear # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
      -> (%48)
    block1():
      %linear.8 : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%15), scope: export.test_converter.SuperNestedM1::
      %m2.1 : __torch__.export.test_converter.___torch_mangle_15.NestedM = prim::GetAttr[name="m2"](%15), scope: export.test_converter.SuperNestedM1::
      %51 : Tensor = aten::sum(%x.1, %16), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2 # /data/users/jiashenc/pytorch/test/export/test_converter.py:327:19
      %52 : Tensor = aten::gt(%51, %17), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2 # /data/users/jiashenc/pytorch/test/export/test_converter.py:327:19
      %53 : bool = aten::Bool(%52), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2 # /data/users/jiashenc/pytorch/test/export/test_converter.py:327:19
      %54 : Tensor = prim::If(%53), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2 # /data/users/jiashenc/pytorch/test/export/test_converter.py:327:16
        block0():
          %linear.1 : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%m2.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %m1 : __torch__.export.test_converter.___torch_mangle_16.M = prim::GetAttr[name="m1"](%m2.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %linear.5 : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%m1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %weight.1 : Tensor = prim::GetAttr[name="weight"](%linear.5), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %bias.1 : Tensor = prim::GetAttr[name="bias"](%linear.5), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %60 : Tensor = aten::linear(%x.1, %weight.1, %bias.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2 # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
          %weight.3 : Tensor = prim::GetAttr[name="weight"](%linear.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %bias.3 : Tensor = prim::GetAttr[name="bias"](%linear.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %63 : Tensor = aten::linear(%60, %weight.3, %bias.3), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2 # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
          -> (%63)
        block1():
          %linear.3 : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%m2.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %m2 : __torch__.export.test_converter.___torch_mangle_16.M = prim::GetAttr[name="m2"](%m2.1), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %linear : __torch__.torch.nn.modules.linear.___torch_mangle_17.Linear = prim::GetAttr[name="linear"](%m2), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %weight.5 : Tensor = prim::GetAttr[name="weight"](%linear), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %bias.5 : Tensor = prim::GetAttr[name="bias"](%linear), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %69 : Tensor = aten::linear(%x.1, %weight.5, %bias.5), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2 # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
          %weight.12 : Tensor = prim::GetAttr[name="weight"](%linear.3), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %bias.12 : Tensor = prim::GetAttr[name="bias"](%linear.3), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2
          %72 : Tensor = aten::linear(%69, %weight.12, %bias.12), scope: export.test_converter.SuperNestedM1::/export.test_converter.NestedM::m2 # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
          -> (%72)
      %weight : Tensor = prim::GetAttr[name="weight"](%linear.8), scope: export.test_converter.SuperNestedM1::/torch.nn.modules.linear.Linear::linear
      %bias : Tensor = prim::GetAttr[name="bias"](%linear.8), scope: export.test_converter.SuperNestedM1::/torch.nn.modules.linear.Linear::linear
      %75 : Tensor = aten::linear(%54, %weight, %bias), scope: export.test_converter.SuperNestedM1::/torch.nn.modules.linear.Linear::linear # /data/users/jiashenc/pytorch/torch/nn/modules/linear.py:116:15
      -> (%75)
  return (%21)
```
##### ExportedProgram
```
ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, p_linear_weight: "f32[3, 3]", p_linear_bias: "f32[3]", p_m1_linear_weight: "f32[3, 3]", p_m1_linear_bias: "f32[3]", p_m1_m1_linear_weight: "f32[3, 3]", p_m1_m1_linear_bias: "f32[3]", p_m1_m2_linear_weight: "f32[3, 3]", p_m1_m2_linear_bias: "f32[3]", p_m2_linear_weight: "f32[3, 3]", p_m2_linear_bias: "f32[3]", p_m2_m1_linear_weight: "f32[3, 3]", p_m2_m1_linear_bias: "f32[3]", p_m2_m2_linear_weight: "f32[3, 3]", p_m2_m2_linear_bias: "f32[3]", x_1: "f32[3]"):
            # No stacktrace found for following nodes
            max_1: "f32[]" = torch.ops.aten.max.default(x_1)
            gt: "b8[]" = torch.ops.aten.gt.Scalar(max_1, 1);  max_1 = None

            # File: <eval_with_key>.137:23 in forward, code: cond = torch.ops.higher_order.cond(l_args_0_, cond_true_2, cond_false_2, [l_args_3_0_, l_args_3_13_, l_args_3_5_, l_args_3_12_, l_args_3_14_, l_args_3_1_, l_args_3_3_, l_args_3_4_, l_args_3_7_, l_args_3_10_, l_args_3_11_, l_args_3_2_, l_args_3_6_, l_args_3_8_, l_args_3_9_]);  l_args_0_ = cond_true_2 = cond_false_2 = l_args_3_0_ = l_args_3_13_ = l_args_3_5_ = l_args_3_12_ = l_args_3_14_ = l_args_3_1_ = l_args_3_3_ = l_args_3_4_ = l_args_3_7_ = l_args_3_10_ = l_args_3_11_ = l_args_3_2_ = l_args_3_6_ = l_args_3_8_ = l_args_3_9_ = None
            true_graph_0 = self.true_graph_0
            false_graph_0 = self.false_graph_0
            conditional = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, [p_linear_weight, p_linear_bias, x_1, p_m1_linear_weight, p_m1_m1_linear_bias, p_m1_linear_bias, p_m1_m2_linear_weight, p_m1_m2_linear_bias, p_m1_m1_linear_weight, p_m2_m2_linear_bias, p_m2_m1_linear_weight, p_m2_linear_weight, p_m2_m1_linear_bias, p_m2_m2_linear_weight, p_m2_linear_bias]);  gt = true_graph_0 = false_graph_0 = p_linear_weight = p_linear_bias = x_1 = p_m1_linear_weight = p_m1_m1_linear_bias = p_m1_linear_bias = p_m1_m2_linear_weight = p_m1_m2_linear_bias = p_m1_m1_linear_weight = p_m2_m2_linear_bias = p_m2_m1_linear_weight = p_m2_linear_weight = p_m2_m1_linear_bias = p_m2_m2_linear_weight = p_m2_linear_bias = None
            getitem: "f32[3]" = conditional[0];  conditional = None
            return (getitem,)

        class <lambda>(torch.nn.Module):
            def forward(self, p_linear_weight: "f32[3, 3]", p_linear_bias: "f32[3]", x_1: "f32[3]", p_m1_linear_weight: "f32[3, 3]", p_m1_m1_linear_bias: "f32[3]", p_m1_linear_bias: "f32[3]", p_m1_m2_linear_weight: "f32[3, 3]", p_m1_m2_linear_bias: "f32[3]", p_m1_m1_linear_weight: "f32[3, 3]", p_m2_m2_linear_bias: "f32[3]", p_m2_m1_linear_weight: "f32[3, 3]", p_m2_linear_weight: "f32[3, 3]", p_m2_m1_linear_bias: "f32[3]", p_m2_m2_linear_weight: "f32[3, 3]", p_m2_linear_bias: "f32[3]"):
                # File: <eval_with_key>.134:8 in forward, code: sum_default = torch.ops.aten.sum.default(l_args_3_5__1, dtype = None)
                sum_1: "f32[]" = torch.ops.aten.sum.default(x_1)

                # File: <eval_with_key>.134:9 in forward, code: gt_scalar = torch.ops.aten.gt.Scalar(sum_default, 1);  sum_default = None
                gt: "b8[]" = torch.ops.aten.gt.Scalar(sum_1, 1);  sum_1 = None

                # File: <eval_with_key>.134:12 in forward, code: cond = torch.ops.higher_order.cond(gt_scalar, cond_true_0, cond_false_0, [l_args_3_12__true_branch, l_args_3_1__true_branch, l_args_3_5__1, l_args_3_14__true_branch, l_args_3_7__true_branch, l_args_3_3__true_branch, l_args_3_4__true_branch]);  gt_scalar = cond_true_0 = cond_false_0 = l_args_3_12__true_branch = l_args_3_1__true_branch = l_args_3_5__1 = l_args_3_14__true_branch = l_args_3_7__true_branch = l_args_3_3__true_branch = l_args_3_4__true_branch = None
                true_graph_0 = self.true_graph_0
                false_graph_0 = self.false_graph_0
                conditional = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, [p_m1_linear_weight, p_m1_linear_bias, x_1, p_m1_m1_linear_bias, p_m1_m1_linear_weight, p_m1_m2_linear_weight, p_m1_m2_linear_bias]);  gt = true_graph_0 = false_graph_0 = p_m1_linear_weight = p_m1_linear_bias = x_1 = p_m1_m1_linear_bias = p_m1_m1_linear_weight = p_m1_m2_linear_weight = p_m1_m2_linear_bias = None
                getitem: "f32[3]" = conditional[0];  conditional = None

                # File: <eval_with_key>.134:14 in forward, code: linear_default = torch.ops.aten.linear.default(getitem, l_args_3_0__1, l_args_3_13__1);  getitem = l_args_3_0__1 = l_args_3_13__1 = None
                linear: "f32[3]" = torch.ops.aten.linear.default(getitem, p_linear_weight, p_linear_bias);  getitem = p_linear_weight = p_linear_bias = None
                return (linear,)

            class <lambda>(torch.nn.Module):
                def forward(self, p_m1_linear_weight: "f32[3, 3]", p_m1_linear_bias: "f32[3]", x_1: "f32[3]", p_m1_m1_linear_bias: "f32[3]", p_m1_m1_linear_weight: "f32[3, 3]", p_m1_m2_linear_weight: "f32[3, 3]", p_m1_m2_linear_bias: "f32[3]"):
                    # File: <eval_with_key>.130:8 in forward, code: linear_default = torch.ops.aten.linear.default(l_args_3_5__1, l_args_3_7__true_branch, l_args_3_14__true_branch);  l_args_3_5__1 = l_args_3_7__true_branch = l_args_3_14__true_branch = None
                    linear: "f32[3]" = torch.ops.aten.linear.default(x_1, p_m1_m1_linear_weight, p_m1_m1_linear_bias);  x_1 = p_m1_m1_linear_weight = p_m1_m1_linear_bias = None

                    # File: <eval_with_key>.130:9 in forward, code: linear_default_1 = torch.ops.aten.linear.default(linear_default, l_args_3_12__1, l_args_3_1__1);  linear_default = l_args_3_12__1 = l_args_3_1__1 = None
                    linear_1: "f32[3]" = torch.ops.aten.linear.default(linear, p_m1_linear_weight, p_m1_linear_bias);  linear = p_m1_linear_weight = p_m1_linear_bias = None
                    return (linear_1,)

            class <lambda>(torch.nn.Module):
                def forward(self, p_m1_linear_weight: "f32[3, 3]", p_m1_linear_bias: "f32[3]", x_1: "f32[3]", p_m1_m1_linear_bias: "f32[3]", p_m1_m1_linear_weight: "f32[3, 3]", p_m1_m2_linear_weight: "f32[3, 3]", p_m1_m2_linear_bias: "f32[3]"):
                    # File: <eval_with_key>.131:8 in forward, code: linear_default = torch.ops.aten.linear.default(l_args_3_5__1, l_args_3_3__false_branch, l_args_3_4__false_branch);  l_args_3_5__1 = l_args_3_3__false_branch = l_args_3_4__false_branch = None
                    linear: "f32[3]" = torch.ops.aten.linear.default(x_1, p_m1_m2_linear_weight, p_m1_m2_linear_bias);  x_1 = p_m1_m2_linear_weight = p_m1_m2_linear_bias = None

                    # File: <eval_with_key>.131:9 in forward, code: linear_default_1 = torch.ops.aten.linear.default(linear_default, l_args_3_12__1, l_args_3_1__1);  linear_default = l_args_3_12__1 = l_args_3_1__1 = None
                    linear_1: "f32[3]" = torch.ops.aten.linear.default(linear, p_m1_linear_weight, p_m1_linear_bias);  linear = p_m1_linear_weight = p_m1_linear_bias = None
                    return (linear_1,)

        class <lambda>(torch.nn.Module):
            def forward(self, p_linear_weight: "f32[3, 3]", p_linear_bias: "f32[3]", x_1: "f32[3]", p_m1_linear_weight: "f32[3, 3]", p_m1_m1_linear_bias: "f32[3]", p_m1_linear_bias: "f32[3]", p_m1_m2_linear_weight: "f32[3, 3]", p_m1_m2_linear_bias: "f32[3]", p_m1_m1_linear_weight: "f32[3, 3]", p_m2_m2_linear_bias: "f32[3]", p_m2_m1_linear_weight: "f32[3, 3]", p_m2_linear_weight: "f32[3, 3]", p_m2_m1_linear_bias: "f32[3]", p_m2_m2_linear_weight: "f32[3, 3]", p_m2_linear_bias: "f32[3]"):
                # File: <eval_with_key>.135:8 in forward, code: sum_default = torch.ops.aten.sum.default(l_args_3_5__1, dtype = None)
                sum_1: "f32[]" = torch.ops.aten.sum.default(x_1)

                # File: <eval_with_key>.135:9 in forward, code: gt_scalar = torch.ops.aten.gt.Scalar(sum_default, 1);  sum_default = None
                gt: "b8[]" = torch.ops.aten.gt.Scalar(sum_1, 1);  sum_1 = None

                # File: <eval_with_key>.135:12 in forward, code: cond = torch.ops.higher_order.cond(gt_scalar, cond_true_1, cond_false_1, [l_args_3_2__false_branch, l_args_3_5__1, l_args_3_9__false_branch, l_args_3_11__false_branch, l_args_3_6__false_branch, l_args_3_10__false_branch, l_args_3_8__false_branch]);  gt_scalar = cond_true_1 = cond_false_1 = l_args_3_2__false_branch = l_args_3_5__1 = l_args_3_9__false_branch = l_args_3_11__false_branch = l_args_3_6__false_branch = l_args_3_10__false_branch = l_args_3_8__false_branch = None
                true_graph_0 = self.true_graph_0
                false_graph_0 = self.false_graph_0
                conditional = torch.ops.higher_order.cond(gt, true_graph_0, false_graph_0, [p_m2_linear_weight, x_1, p_m2_linear_bias, p_m2_m1_linear_weight, p_m2_m1_linear_bias, p_m2_m2_linear_bias, p_m2_m2_linear_weight]);  gt = true_graph_0 = false_graph_0 = p_m2_linear_weight = x_1 = p_m2_linear_bias = p_m2_m1_linear_weight = p_m2_m1_linear_bias = p_m2_m2_linear_bias = p_m2_m2_linear_weight = None
                getitem: "f32[3]" = conditional[0];  conditional = None

                # File: <eval_with_key>.135:14 in forward, code: linear_default = torch.ops.aten.linear.default(getitem, l_args_3_0__1, l_args_3_13__1);  getitem = l_args_3_0__1 = l_args_3_13__1 = None
                linear: "f32[3]" = torch.ops.aten.linear.default(getitem, p_linear_weight, p_linear_bias);  getitem = p_linear_weight = p_linear_bias = None
                return (linear,)

            class <lambda>(torch.nn.Module):
                def forward(self, p_m2_linear_weight: "f32[3, 3]", x_1: "f32[3]", p_m2_linear_bias: "f32[3]", p_m2_m1_linear_weight: "f32[3, 3]", p_m2_m1_linear_bias: "f32[3]", p_m2_m2_linear_bias: "f32[3]", p_m2_m2_linear_weight: "f32[3, 3]"):
                    # File: <eval_with_key>.132:8 in forward, code: linear_default = torch.ops.aten.linear.default(l_args_3_5__1, l_args_3_11__true_branch, l_args_3_6__true_branch);  l_args_3_5__1 = l_args_3_11__true_branch = l_args_3_6__true_branch = None
                    linear: "f32[3]" = torch.ops.aten.linear.default(x_1, p_m2_m1_linear_weight, p_m2_m1_linear_bias);  x_1 = p_m2_m1_linear_weight = p_m2_m1_linear_bias = None

                    # File: <eval_with_key>.132:9 in forward, code: linear_default_1 = torch.ops.aten.linear.default(linear_default, l_args_3_2__1, l_args_3_9__1);  linear_default = l_args_3_2__1 = l_args_3_9__1 = None
                    linear_1: "f32[3]" = torch.ops.aten.linear.default(linear, p_m2_linear_weight, p_m2_linear_bias);  linear = p_m2_linear_weight = p_m2_linear_bias = None
                    return (linear_1,)

            class <lambda>(torch.nn.Module):
                def forward(self, p_m2_linear_weight: "f32[3, 3]", x_1: "f32[3]", p_m2_linear_bias: "f32[3]", p_m2_m1_linear_weight: "f32[3, 3]", p_m2_m1_linear_bias: "f32[3]", p_m2_m2_linear_bias: "f32[3]", p_m2_m2_linear_weight: "f32[3, 3]"):
                    # File: <eval_with_key>.133:8 in forward, code: linear_default = torch.ops.aten.linear.default(l_args_3_5__1, l_args_3_8__false_branch, l_args_3_10__false_branch);  l_args_3_5__1 = l_args_3_8__false_branch = l_args_3_10__false_branch = None
                    linear: "f32[3]" = torch.ops.aten.linear.default(x_1, p_m2_m2_linear_weight, p_m2_m2_linear_bias);  x_1 = p_m2_m2_linear_weight = p_m2_m2_linear_bias = None

                    # File: <eval_with_key>.133:9 in forward, code: linear_default_1 = torch.ops.aten.linear.default(linear_default, l_args_3_2__1, l_args_3_9__1);  linear_default = l_args_3_2__1 = l_args_3_9__1 = None
                    linear_1: "f32[3]" = torch.ops.aten.linear.default(linear, p_m2_linear_weight, p_m2_linear_bias);  linear = p_m2_linear_weight = p_m2_linear_bias = None
                    return (linear_1,)

Graph signature: ExportGraphSignature(input_specs=[InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_linear_weight'), target='linear.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_linear_bias'), target='linear.bias', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m1_linear_weight'), target='m1.linear.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m1_linear_bias'), target='m1.linear.bias', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m1_m1_linear_weight'), target='m1.m1.linear.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m1_m1_linear_bias'), target='m1.m1.linear.bias', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m1_m2_linear_weight'), target='m1.m2.linear.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m1_m2_linear_bias'), target='m1.m2.linear.bias', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m2_linear_weight'), target='m2.linear.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m2_linear_bias'), target='m2.linear.bias', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m2_m1_linear_weight'), target='m2.m1.linear.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m2_m1_linear_bias'), target='m2.m1.linear.bias', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m2_m2_linear_weight'), target='m2.m2.linear.weight', persistent=None), InputSpec(kind=<InputKind.PARAMETER: 2>, arg=TensorArgument(name='p_m2_m2_linear_bias'), target='m2.m2.linear.bias', persistent=None), InputSpec(kind=<InputKind.USER_INPUT: 1>, arg=TensorArgument(name='x_1'), target=None, persistent=None)], output_specs=[OutputSpec(kind=<OutputKind.USER_OUTPUT: 1>, arg=TensorArgument(name='getitem'), target=None)])
Range constraints: {}
```