### PR TITLE
[Doc] disable cpp guards to see guards in Python

### DIFF
--- a/docs/source/torch.compiler_dynamo_overview.rst
+++ b/docs/source/torch.compiler_dynamo_overview.rst
@@ -57,6 +57,8 @@ Dynamo optimization:
 
    from typing import List
    import torch
+   # disable cpp guard so that we can see guards easily in Python
+   torch._dynamo.config.enable_cpp_guard_manager = False
    from torch import _dynamo as torchdynamo
    def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
        print("my_compiler() called with FX graph:")


### PR DESCRIPTION
Since the introduction of cpp guards, `guard.code_parts` will be an empty list, and the documentation (tutorial) is incorrect.

In the documentation, it is better to disable cpp guards, so that users can easily see all the guards.

cc @anijain2305 