### PR TITLE
[export] apply CSE pass in _export_to_aten_ir() for deduplication

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -5292,8 +5292,8 @@ def forward(self, x, y):
         for _strict in [True, False]:
             inputs = (torch.randn(8, 4), torch.randn(4))
             dynamic_shapes = {
-                "x": (Dim("dx0"), Dim("dx1")),
-                "y": (Dim("dy"),)
+                "x": (Dim("dx0", max=4096), Dim("dx1", max=4096)),
+                "y": (Dim("dy", max=4096),)
             }
             ep = torch.export._trace._export(
                 Foo(),

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -36,7 +36,7 @@ from torch._export.passes.lift_constants_pass import (
     lift_constants_pass,
     rewrite_script_object_meta,
 )
-from torch._export.utils import placeholder_naming_pass, placeholder_prefixes
+from torch._export.utils import cse_pass, placeholder_naming_pass, placeholder_prefixes
 from torch._export.verifier import SpecViolationError
 from torch._export.wrappers import _wrap_submodules
 from torch._functorch.aot_autograd import aot_export_module
@@ -708,6 +708,9 @@ def _export_to_aten_ir(
 
     constants = rewrite_script_object_meta(gm)
     constants.update(lift_constants_pass(gm, export_graph_signature, constant_attrs))
+
+    # run CSE pass to remove redundant nodes
+    gm = cse_pass(gm)
 
     # Prettify names for placeholder nodes.
     placeholder_naming_pass(

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -36,7 +36,6 @@ from torch.fx._compatibility import compatibility
 
 from torch.fx._utils import first_call_function_nn_module_stack
 from torch.fx.experimental.proxy_tensor import maybe_disable_fake_tensor_mode
-
 from torch.fx.passes.infra.pass_base import PassResult
 from torch.fx.passes.infra.pass_manager import PassManager
 from torch.fx.passes.runtime_assert import insert_deferred_runtime_asserts
@@ -667,6 +666,7 @@ class ExportedProgram:
             _node_metadata_hook,
             _set_node_metadata_hook,
         )
+        from torch._export.utils import cse_pass
 
         stack_trace = (
             'File "torch/fx/passes/runtime_assert.py", line 24, '
@@ -683,6 +683,9 @@ class ExportedProgram:
                     f"exported program: {first_call_function_nn_module_stack(gm.graph)}",
                     export=True,
                 )
+
+            # run CSE pass to remove redundant nodes
+            gm = cse_pass(gm)
 
         exported_program = ExportedProgram(
             root=gm,

--- a/torch/fx/passes/dialect/common/cse_pass.py
+++ b/torch/fx/passes/dialect/common/cse_pass.py
@@ -83,7 +83,13 @@ class CSEPass(PassBase):
         for n in graph_module.graph.nodes:
             # The placeholder, output, and get_attr nodes are copied to the new graph without change
             # do not CSE away random operations
-            if n.op == 'placeholder' or n.op == 'output' or n.op == 'get_attr' or get_aten_target(n) in self.banned_ops:
+            if (
+                n.op == 'placeholder'
+                or n.op == 'output'
+                or n.op == 'get_attr'
+                or get_aten_target(n) in self.banned_ops
+                or n.target in self.banned_ops
+            ):
                 new_node = new_graph.node_copy(n, lambda x: env[x])
                 if self.force_copy_name:
                     new_node.name = n.name


### PR DESCRIPTION
Summary:
Run common subexpression elimination pass in export(), mainly to handle deduplication for runtime asserts (but runs on all nodes). The pass dedups and substitutes groups of nodes that perform the same computation, and affects a lot of existing test cases.

Currently only applied at the top-level graph, not on higher order op subgraphs, since runtime asserts only exist there. Modifies the pass with some custom arguments for deduplicating runtime asserts.

Also changed the hashing, while debugging the pass' use of `hash()` led to a hash collision between hash(node, -1) and hash(node, -2), taking forever to debug.
 {F1671130486} 

Follow up work: currently this only handles computational redundancy. Future work for runtime asserts to handle logical redundancy (e.g. x > 0 & x > 1, Eq(x, 2) & Eq(2*x, 4))

Test Plan: export test counting # of nodes

Differential Revision: D58165606


