### PR TITLE
WorkerServer: add support for binding to TCP

### DIFF
--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -81,6 +81,17 @@ class WorkerServerTest(TestCase):
             self.assertEqual(resp.status, 200)
             out = pickle.loads(resp.data)
 
+    def test_tcp(self) -> None:
+        import requests
+
+        from torch._C._distributed_c10d import _WorkerServer
+
+        server = _WorkerServer("", 1234)
+        out = requests.get("http://localhost:1234/handler/")
+        self.assertEqual(out.status_code, 200)
+
+        server.shutdown()
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/distributed/c10d/control_plane/WorkerServer.hpp
+++ b/torch/csrc/distributed/c10d/control_plane/WorkerServer.hpp
@@ -14,7 +14,7 @@ namespace control_plane {
 
 class TORCH_API WorkerServer : public c10::intrusive_ptr_target {
  public:
-  WorkerServer(const std::string& socketFile);
+  WorkerServer(const std::string& hostOrFile, int port = -1);
   ~WorkerServer();
 
   void shutdown();

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3170,11 +3170,12 @@ such as `dist.all_reduce(tensor, async_op=True)`.
       module, "_WorkerServer", R"(
 )")
       .def(
-          py::init([](const std::string& socketPath) {
+          py::init([](const std::string& hostOrFile, int port) {
             return c10::make_intrusive<::c10d::control_plane::WorkerServer>(
-                socketPath);
+                hostOrFile, port);
           }),
-          py::arg("socket_path"))
+          py::arg("host_or_file"),
+          py::arg("port") = -1)
       .def("shutdown", &::c10d::control_plane::WorkerServer::shutdown);
   Py_RETURN_TRUE;
 }


### PR DESCRIPTION
This adds support for the WorkerServer binding to TCP as well as the existing unix socket support.

```py
server = _WorkerServer("", 1234)
```

Test plan:

Added unit test

```
python test/distributed/elastic/test_control_plane.py
```


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang