### PR TITLE
Update _learnable_fake_quantize.py

### DIFF
--- a/torch/ao/quantization/_learnable_fake_quantize.py
+++ b/torch/ao/quantization/_learnable_fake_quantize.py
@@ -9,8 +9,7 @@ class _LearnableFakeQuantize(torch.ao.quantization.FakeQuantizeBase):
 
     This is an extension of the FakeQuantize module in fake_quantize.py, which
     supports more generalized lower-bit quantization and support learning of the scale
-    and zero point parameters through backpropagation. For literature references,
-    please see the class _LearnableFakeQuantizePerTensorOp.
+    and zero point parameters through backpropagation.
 
     In addition to the attributes in the original FakeQuantize module, the _LearnableFakeQuantize
     module also includes the following attributes to support quantization parameter learning.

--- a/torch/ao/quantization/_learnable_fake_quantize.py
+++ b/torch/ao/quantization/_learnable_fake_quantize.py
@@ -8,7 +8,7 @@ class _LearnableFakeQuantize(torch.ao.quantization.FakeQuantizeBase):
     r"""Generalized extension of the FakeQuantize module in fake_quantize.py.
 
     This is an extension of the FakeQuantize module in fake_quantize.py, which
-    supports more generalized lower-bit quantization and support learning of the scale
+    supports more generalized lower-bit quantization and supports learning of the scale
     and zero point parameters through backpropagation.
 
     In addition to the attributes in the original FakeQuantize module, the _LearnableFakeQuantize


### PR DESCRIPTION
Remove sentence "For literature references, please see the class _LearnableFakeQuantizePerTensorOp." and add "s" to "support"

(Possibly) Fixes #99107 (But not sure, sorry)


cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel