### PR TITLE
[BE] Fix missing-prototypes errors in Metal backend

### DIFF
--- a/aten/src/ATen/native/metal/MetalAten.mm
+++ b/aten/src/ATen/native/metal/MetalAten.mm
@@ -6,10 +6,9 @@
 #include <torch/script.h>
 
 namespace at {
-namespace native {
-namespace metal {
+namespace native::metal {
 
-at::Tensor& copy_from_metal_(at::Tensor& dst, const at::Tensor& src) {
+static Tensor& copy_from_metal_(Tensor& dst, const Tensor& src) {
   TORCH_INTERNAL_ASSERT(
       src.device().type() == DeviceType::Metal,
       "copy_from_metal input tensor's device is not metal");
@@ -34,7 +33,7 @@ at::Tensor& copy_from_metal_(at::Tensor& dst, const at::Tensor& src) {
   return dst;
 }
 
-at::Tensor& copy_to_metal_(at::Tensor& dst, const at::Tensor& src) {
+static Tensor& copy_to_metal_(Tensor& dst, const Tensor& src) {
   TORCH_INTERNAL_ASSERT(
       dst.device().type() == DeviceType::Metal,
       "copy_to_metal_ output tensor's device is not metal");
@@ -54,7 +53,7 @@ at::Tensor& copy_to_metal_(at::Tensor& dst, const at::Tensor& src) {
   return dst;
 }
 
-at::Tensor& metal_copy_impl_(at::Tensor& dst, const at::Tensor& src) {
+static Tensor& metal_copy_impl_(Tensor& dst, const Tensor& src) {
   if (src.device().type() == at::kMetal && dst.device().type() == at::kCPU) {
     return copy_from_metal_(dst, src);
   }
@@ -69,7 +68,7 @@ at::Tensor& metal_copy_impl_(at::Tensor& dst, const at::Tensor& src) {
 
 #pragma mark - ATen Ops
 
-Tensor empty(
+static Tensor empty(
     c10::SymIntArrayRef sym_size,
     optional<ScalarType> dtype,
     optional<Layout> layout,
@@ -88,7 +87,7 @@ Tensor empty(
       std::move(mt), at::device(at::kMetal).dtype(dtype));
 };
 
-at::Tensor empty_strided(
+static Tensor empty_strided(
     IntArrayRef size,
     IntArrayRef stride,
     optional<ScalarType> dtype,
@@ -109,8 +108,7 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::empty_strided"), TORCH_FN(empty_strided));
 }
 
-} // namespace metal
-} // namespace native
+} // namespace native::metal
 
 struct MetalImpl : public at::metal::MetalInterface {
   bool is_metal_available() const override {

--- a/aten/src/ATen/native/metal/MetalConvParams.h
+++ b/aten/src/ATen/native/metal/MetalConvParams.h
@@ -3,9 +3,7 @@
 
 #include <c10/util/ArrayRef.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 struct Conv2DParams final {
   Conv2DParams() {}
@@ -46,8 +44,6 @@ struct Conv2DParams final {
   int64_t OH; // output height
 };
 
-} // namespace metal
-} // namespace native
-} // namespace at
+} // namespace at::native::metal
 
 #endif /* MetalConvParams_h */

--- a/aten/src/ATen/native/metal/MetalDevice.h
+++ b/aten/src/ATen/native/metal/MetalDevice.h
@@ -5,9 +5,7 @@
 
 #include <string>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 struct MetalDeviceInfo {
   std::string name;
@@ -42,8 +40,6 @@ static inline MetalDeviceInfo createDeviceInfo(id<MTLDevice> device) {
   return device_info;
 }
 
-}
-}
-}
+} // namespace at::native::metal
 
 #endif

--- a/aten/src/ATen/native/metal/MetalNeuronType.h
+++ b/aten/src/ATen/native/metal/MetalNeuronType.h
@@ -6,9 +6,7 @@
 
 #include <ATen/ATen.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 enum class NeuronType {
   None,
@@ -66,8 +64,6 @@ static inline MPSNNNeuronDescriptor* neuronDescriptor(NeuronType type) {
   }
 }
 
-}
-}
-}
+} // namespace at::native::metal
 
 #endif /* MetalNeuronType_h */

--- a/aten/src/ATen/native/metal/MetalPrepackOpContext.h
+++ b/aten/src/ATen/native/metal/MetalPrepackOpContext.h
@@ -3,9 +3,7 @@
 #include <ATen/Tensor.h>
 #include <torch/custom_class.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 using SerializationTypeConv2dPrePack = std::tuple<
     Tensor,
@@ -197,6 +195,4 @@ class LinearOpContext : public torch::jit::CustomClassHolder {
   std::function<void(void*)> releaseCallback_ = nullptr;
 };
 
-} // namespace metal
-} // namespace native
-} // namespace at
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/MetalPrepackOpRegister.cpp
+++ b/aten/src/ATen/native/metal/MetalPrepackOpRegister.cpp
@@ -3,11 +3,9 @@
 #include <ATen/native/metal/MetalPrepackOpContext.h>
 #include <c10/util/accumulate.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
-c10::intrusive_ptr<Conv2dOpContext> unpack(
+static c10::intrusive_ptr<Conv2dOpContext> unpack(
     Tensor&& weight,
     std::optional<Tensor>&& bias,
     std::vector<int64_t>&& stride,
@@ -28,7 +26,7 @@ c10::intrusive_ptr<Conv2dOpContext> unpack(
       output_max);
 }
 
-c10::intrusive_ptr<LinearOpContext> unpack(
+static c10::intrusive_ptr<LinearOpContext> unpack(
     Tensor&& weight,
     std::optional<Tensor>&& bias,
     const std::optional<Scalar>& output_min,
@@ -94,7 +92,7 @@ TORCH_LIBRARY(metal_prepack, m) {
       TORCH_SELECTIVE_SCHEMA("metal_prepack::linear_run(Tensor X, __torch__.torch.classes.metal.LinearOpContext W_prepack) -> Tensor Y"));
 }
 
-c10::intrusive_ptr<Conv2dOpContext> conv2d_prepack(
+static c10::intrusive_ptr<Conv2dOpContext> conv2d_prepack(
     Tensor&& weight,
     std::optional<Tensor>&& bias,
     std::vector<int64_t>&& stride,
@@ -115,7 +113,7 @@ c10::intrusive_ptr<Conv2dOpContext> conv2d_prepack(
       output_max);
 }
 
-c10::intrusive_ptr<LinearOpContext> linear_prepack(
+static c10::intrusive_ptr<LinearOpContext> linear_prepack(
     Tensor&& weight,
     std::optional<Tensor>&& bias,
     const std::optional<Scalar>& output_min,
@@ -129,6 +127,4 @@ TORCH_LIBRARY_IMPL(metal_prepack, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("metal_prepack::linear_prepack"), TORCH_FN(linear_prepack));
 }
 
-} // namespace metal
-} // namespace native
-} // namespace at
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/MetalTensorImplStorage.h
+++ b/aten/src/ATen/native/metal/MetalTensorImplStorage.h
@@ -1,9 +1,7 @@
 #include <ATen/Tensor.h>
 #include <c10/util/ArrayRef.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 class MPSImageWrapper;
 class MetalTensorImplStorage final {
@@ -42,6 +40,4 @@ class MetalTensorImplStorage final {
   std::shared_ptr<Impl> _impl;
 };
 
-} // namespace metal
-} // namespace native
-} // namespace at
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/MetalTensorUtils.h
+++ b/aten/src/ATen/native/metal/MetalTensorUtils.h
@@ -10,9 +10,7 @@ typedef float16_t fp16_t;
 typedef uint16_t fp16_t;
 #endif
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 uint32_t batchSize(const Tensor& tensor);
 uint32_t channelsSize(const Tensor& tensor);
@@ -70,6 +68,4 @@ static inline MetalCommandBuffer* getCommandBuffer(
   return cmdBuffer;
 }
 
-} // namespace metal
-} // namespace native
-} // namespace at
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNUtils.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNUtils.h
@@ -20,10 +20,7 @@
     }                                                                            \
   } while (false)
 
-namespace at {
-namespace native {
-namespace metal {
-namespace mpscnn {
+namespace at::native::metal::mpscnn {
 
 struct LaunchParams {
   MTLSize threadsPerThreadgroup;
@@ -71,7 +68,4 @@ static inline int computeMPSAlignOffset(int kernel, int pad) {
   return mps_offset - pt_offset;
 }
 
-}
-} // namespace metal
-} // namespace native
-} // namespace at
+} // namespace at::native::metal::mpscnn

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNUtils.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNUtils.mm
@@ -1,11 +1,8 @@
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 
-namespace at {
-namespace native {
-namespace metal {
-namespace mpscnn {
+namespace at::native::metal::mpscnn {
 
-auto divRoundUp(uint x, uint y) -> uint {
+static auto divRoundUp(uint x, uint y) -> uint {
   return (x + y - 1) / y;
 }
 
@@ -14,7 +11,7 @@ LaunchParams spatialPointwiseKernelLaunchParams(
     MPSImage* im) {
   return spatialPointwiseKernelLaunchParams(
       pipeline, im.numberOfImages, im.featureChannels, im.height, im.width);
-};
+}
 
 LaunchParams spatialPointwiseKernelLaunchParams(
     id<MTLComputePipelineState> pipeline,
@@ -33,9 +30,6 @@ LaunchParams spatialPointwiseKernelLaunchParams(
   const auto threadsPerGrid = MTLSizeMake(
       width, height, numberOfImages * divRoundUp(featureChannels, 4));
   return {threadsPerThreadgroup, threadgroupsPerGrid, threadsPerGrid};
-};
+}
 
-}
-}
-}
-}
+} // namespace at::native::metal::mpscnn

--- a/aten/src/ATen/native/metal/ops/MetalAddmm.mm
+++ b/aten/src/ATen/native/metal/ops/MetalAddmm.mm
@@ -12,12 +12,10 @@
 
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor addmm(
+static Tensor addmm(
     const Tensor& bias,
     const Tensor& input,
     const Tensor& weight,
@@ -63,7 +61,7 @@ Tensor addmm(
 
 namespace prepack {
 
-Tensor linear(const Tensor& input, LinearOpContext& context) {
+static Tensor linear(const Tensor& input, LinearOpContext& context) {
   TORCH_CHECK(input.is_metal());
   TORCH_CHECK(context.get_weight().device() == kCPU);
   TORCH_CHECK(context.get_weight().dim() == 4);
@@ -126,7 +124,7 @@ Tensor linear(const Tensor& input, LinearOpContext& context) {
   return output;
 }
 
-Tensor linear_run(
+static Tensor linear_run(
     const Tensor& input,
     const c10::intrusive_ptr<LinearOpContext>& op_context) {
   return linear(input, *op_context);
@@ -142,6 +140,4 @@ TORCH_LIBRARY_IMPL(metal_prepack, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("metal_prepack::linear_run"), TORCH_FN(prepack::linear_run));
 }
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalBinaryElementwise.mm
+++ b/aten/src/ATen/native/metal/ops/MetalBinaryElementwise.mm
@@ -10,9 +10,7 @@
 #include <ATen/Tensor.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 using MetalTensorImpl = at::MetalTensorImpl<MetalTensorImplStorage>;
 
@@ -58,7 +56,7 @@ static inline void checkInputs(const Tensor& input1, const Tensor& input2) {
   }
 }
 
-Tensor binaryElementwiseShaderKernel(
+static Tensor binaryElementwiseShaderKernel(
     const Tensor& input1,
     const Tensor& input2,
     const std::string& arrayKernel,
@@ -98,7 +96,7 @@ Tensor binaryElementwiseShaderKernel(
   return output;
 }
 
-Tensor& binaryElementwiseShaderKernel_(
+static Tensor& binaryElementwiseShaderKernel_(
     Tensor& input1,
     const Tensor& input2,
     const std::string& arrayKernel,
@@ -208,7 +206,7 @@ Tensor& binaryElementwiseMPSCNNKernel_(Tensor& input1, const Tensor& input2) {
   return input1;
 }
 
-Tensor add_Tensor(const Tensor& input1, const Tensor& input2, const Scalar& alpha) {
+static Tensor add_Tensor(const Tensor& input1, const Tensor& input2, const Scalar& alpha) {
   TORCH_CHECK(input1.is_metal());
   auto input2_ = input2.is_metal() ? input2 : input2.metal();
   if (@available(iOS 11.3, *)) {
@@ -219,7 +217,7 @@ Tensor add_Tensor(const Tensor& input1, const Tensor& input2, const Scalar& alph
   }
 }
 
-Tensor& add__Tensor(Tensor& input1, const Tensor& input2, const Scalar& alpha) {
+static Tensor& add__Tensor(Tensor& input1, const Tensor& input2, const Scalar& alpha) {
   TORCH_CHECK(input1.is_metal());
   auto input2_ = input2.is_metal() ? input2 : input2.metal();
   if (@available(iOS 11.3, *)) {
@@ -230,7 +228,7 @@ Tensor& add__Tensor(Tensor& input1, const Tensor& input2, const Scalar& alpha) {
   }
 }
 
-Tensor sub_Tensor(const Tensor& input1, const Tensor& input2, const Scalar& alpha) {
+static Tensor sub_Tensor(const Tensor& input1, const Tensor& input2, const Scalar& alpha) {
   TORCH_CHECK(input1.is_metal());
   auto input2_ = input2.is_metal() ? input2 : input2.metal();
   if (@available(iOS 11.3, *)) {
@@ -241,7 +239,7 @@ Tensor sub_Tensor(const Tensor& input1, const Tensor& input2, const Scalar& alph
   }
 }
 
-Tensor& sub__Tensor(Tensor& input1, const Tensor& input2, const Scalar& alpha) {
+static Tensor& sub__Tensor(Tensor& input1, const Tensor& input2, const Scalar& alpha) {
   TORCH_CHECK(input1.is_metal());
   auto input2_ = input2.is_metal() ? input2 : input2.metal();
   if (@available(iOS 11.3, *)) {
@@ -252,7 +250,7 @@ Tensor& sub__Tensor(Tensor& input1, const Tensor& input2, const Scalar& alpha) {
   }
 }
 
-Tensor mul_Tensor(const Tensor& input1, const Tensor& input2) {
+static Tensor mul_Tensor(const Tensor& input1, const Tensor& input2) {
   TORCH_CHECK(input1.is_metal());
   auto input2_ = input2.is_metal() ? input2 : input2.metal();
   if (@available(iOS 11.3, *)) {
@@ -263,7 +261,7 @@ Tensor mul_Tensor(const Tensor& input1, const Tensor& input2) {
   }
 }
 
-Tensor& mul__Tensor(Tensor& input1, const Tensor& input2) {
+static Tensor& mul__Tensor(Tensor& input1, const Tensor& input2) {
   TORCH_CHECK(input1.is_metal());
   auto input2_ = input2.is_metal() ? input2 : input2.metal();
   if (@available(iOS 11.3, *)) {
@@ -274,7 +272,7 @@ Tensor& mul__Tensor(Tensor& input1, const Tensor& input2) {
   }
 }
 
-Tensor div_Tensor(const Tensor& input1, const Tensor& input2) {
+static Tensor div_Tensor(const Tensor& input1, const Tensor& input2) {
   TORCH_CHECK(input1.is_metal());
   auto input2_ = input2.is_metal() ? input2 : input2.metal();
   if (@available(iOS 11.3, *)) {
@@ -285,7 +283,7 @@ Tensor div_Tensor(const Tensor& input1, const Tensor& input2) {
   }
 }
 
-Tensor& div__Tensor(Tensor& input1, const Tensor& input2) {
+static Tensor& div__Tensor(Tensor& input1, const Tensor& input2) {
   TORCH_CHECK(input1.is_metal());
   auto input2_ = input2.is_metal() ? input2 : input2.metal();
   if (@available(iOS 11.3, *)) {
@@ -305,8 +303,6 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::sub_.Tensor"), TORCH_FN(sub__Tensor));
   m.impl(TORCH_SELECTIVE_NAME("aten::div.Tensor"), TORCH_FN(div_Tensor));
   m.impl(TORCH_SELECTIVE_NAME("aten::div_.Tensor"), TORCH_FN(div__Tensor));
-};
+}
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalChunk.mm
+++ b/aten/src/ATen/native/metal/ops/MetalChunk.mm
@@ -9,13 +9,11 @@
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 // Split the input tensor into two on channel dimension
 // TODO: [T87567124] Fully implement chunk in Metal shader
-std::vector<Tensor> chunk(const Tensor& input, int64_t chunks, int64_t dim) {
+static std::vector<Tensor> chunk(const Tensor& input, int64_t chunks, int64_t dim) {
   TORCH_CHECK(chunks == 2 && dim == 1);
   TORCH_CHECK(input.dim() == 4);
   TORCH_CHECK(input.size(0) == 1);
@@ -61,8 +59,6 @@ std::vector<Tensor> chunk(const Tensor& input, int64_t chunks, int64_t dim) {
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::chunk"), TORCH_FN(chunk));
-};
+}
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalClamp.mm
+++ b/aten/src/ATen/native/metal/ops/MetalClamp.mm
@@ -8,11 +8,9 @@
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
-Tensor& hardtanh_(Tensor& input, const Scalar& min_val, const Scalar& max_val) {
+static Tensor& hardtanh_(Tensor& input, const Scalar& min_val, const Scalar& max_val) {
   TORCH_CHECK(input.is_metal());
   MPSImage* X = imageFromTensor(input);
   MetalCommandBuffer* commandBuffer = getCommandBuffer(input);
@@ -29,7 +27,7 @@ Tensor& hardtanh_(Tensor& input, const Scalar& min_val, const Scalar& max_val) {
   return input;
 }
 
-Tensor hardtanh(
+static Tensor hardtanh(
     const Tensor& input,
     const Scalar& min_val,
     const Scalar& max_val) {
@@ -52,7 +50,7 @@ Tensor hardtanh(
   return output;
 }
 
-at::Tensor clamp(
+static at::Tensor clamp(
     const at::Tensor& input,
     const c10::optional<at::Scalar>& min,
     const c10::optional<at::Scalar>& max) {
@@ -64,8 +62,6 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::hardtanh_"), TORCH_FN(hardtanh_));
   m.impl(TORCH_SELECTIVE_NAME("aten::hardtanh"), TORCH_FN(hardtanh));
   m.impl(TORCH_SELECTIVE_NAME("aten::clamp"), TORCH_FN(clamp));
-};
+}
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalConcat.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConcat.mm
@@ -12,11 +12,9 @@
 #include <ATen/native/UpSample.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
-Tensor cat_batch(const Tensor& tensor, const ITensorListRef& tensors, MetalTensorImplStorage& mt) {
+static Tensor cat_batch(const Tensor& tensor, const ITensorListRef& tensors, MetalTensorImplStorage& mt) {
   MetalCommandBuffer* commandBuffer = getCommandBuffer(tensor);
   MPSImage* Y = mt.texture()->image();
   ushort cat_dim4_pointer = 0;
@@ -53,7 +51,7 @@ Tensor cat_batch(const Tensor& tensor, const ITensorListRef& tensors, MetalTenso
   return output;
 }
 
-Tensor cat_feature(const Tensor& tensor, const ITensorListRef& tensors, MetalTensorImplStorage& mt) {
+static Tensor cat_feature(const Tensor& tensor, const ITensorListRef& tensors, MetalTensorImplStorage& mt) {
   MetalCommandBuffer* commandBuffer = getCommandBuffer(tensor);
   MPSImage* Y = mt.texture()->image();
   ushort channel_offset = 0;
@@ -162,7 +160,7 @@ Tensor cat_feature(const Tensor& tensor, const ITensorListRef& tensors, MetalTen
   return output;
 }
 
-Tensor cat(const ITensorListRef& tensors, int64_t dim) {
+static Tensor cat(const ITensorListRef& tensors, int64_t dim) {
   TORCH_CHECK(
       dim == 0 || dim == 1,
       "Metal cat is implemented only for batch dimension");
@@ -203,6 +201,4 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::cat"), TORCH_FN(cat));
 }
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalConvolution.h
+++ b/aten/src/ATen/native/metal/ops/MetalConvolution.h
@@ -2,9 +2,7 @@
 #import <ATen/native/metal/MetalPrepackOpContext.h>
 #include <c10/util/ArrayRef.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 Tensor conv2d(
     const Tensor& input,
@@ -19,6 +17,4 @@ namespace prepack {
 Tensor conv2d(const Tensor& input, Conv2dOpContext& context);
 }
 
-} // namespace metal
-} // namespace native
-} // namespace at
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalConvolution.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConvolution.mm
@@ -9,9 +9,7 @@
 
 #import <ATen/ATen.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 using MetalTensorImpl = at::MetalTensorImpl<MetalTensorImplStorage>;
 Tensor conv2d(
@@ -97,7 +95,7 @@ Tensor conv2d(const Tensor& input, Conv2dOpContext& context) {
   return output;
 }
 
-Tensor conv2d_prepack_run(
+static Tensor conv2d_prepack_run(
     const Tensor& input,
     const c10::intrusive_ptr<Conv2dOpContext>& op_context) {
   return conv2d(input, *op_context);
@@ -115,6 +113,4 @@ TORCH_LIBRARY_IMPL(metal_prepack, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("metal_prepack::conv2d_run"), prepack::conv2d_prepack_run);
 }
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalCopy.h
+++ b/aten/src/ATen/native/metal/ops/MetalCopy.h
@@ -3,14 +3,10 @@
 
 #include <ATen/Tensor.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 Tensor copy_to_host(const Tensor& input);
 
-}
-} // namespace native
-} // namespace at
+} // namespace at::native::metal
 
 #endif

--- a/aten/src/ATen/native/metal/ops/MetalCopy.mm
+++ b/aten/src/ATen/native/metal/ops/MetalCopy.mm
@@ -9,11 +9,9 @@
 
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
-Tensor copy_to_host(const Tensor& input) {
+static Tensor copy_to_host(const Tensor& input) {
   TORCH_CHECK(input.is_metal());
   MPSImage* X = imageFromTensor(input);
   if (X && !X.isTemporaryImage) {
@@ -52,8 +50,6 @@ Tensor copy_to_host(const Tensor& input) {
 
 TORCH_LIBRARY_IMPL(metal, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("metal::copy_to_host"), TORCH_FN(copy_to_host));
-};
+}
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalHardshrink.mm
+++ b/aten/src/ATen/native/metal/ops/MetalHardshrink.mm
@@ -9,15 +9,13 @@
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 using MetalTensorImpl = at::MetalTensorImpl<MetalTensorImplStorage>;
 
 // NB: this is currently unused, but I've left it because in principle
 // it's useful
-Tensor& hardshrink_(Tensor& input, const at::Scalar& lambda=0.5) {
+static Tensor& hardshrink_(Tensor& input, const at::Scalar& lambda=0.5) {
   float l = lambda.toFloat();
   MPSImage* X = imageFromTensor(input);
   MetalCommandBuffer* commandBuffer = getCommandBuffer(input);
@@ -51,7 +49,7 @@ Tensor& hardshrink_(Tensor& input, const at::Scalar& lambda=0.5) {
   return input;
 }
 
-Tensor hardshrink(const at::Tensor& input, const at::Scalar& lambda=0.5) {
+static Tensor hardshrink(const at::Tensor& input, const at::Scalar& lambda=0.5) {
   float l = lambda.toFloat();
   MPSImage* X = imageFromTensor(input);
   IntArrayRef outputSize = input.sizes();
@@ -87,8 +85,6 @@ Tensor hardshrink(const at::Tensor& input, const at::Scalar& lambda=0.5) {
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::hardshrink"), TORCH_FN(hardshrink));
-};
+}
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalHardswish.mm
+++ b/aten/src/ATen/native/metal/ops/MetalHardswish.mm
@@ -9,13 +9,11 @@
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 using MetalTensorImpl = at::MetalTensorImpl<MetalTensorImplStorage>;
 
-Tensor& hardswish_(Tensor& input) {
+static Tensor& hardswish_(Tensor& input) {
   MPSImage* X = imageFromTensor(input);
   MetalCommandBuffer* commandBuffer = getCommandBuffer(input);
   IntArrayRef outputSize = input.sizes();
@@ -47,7 +45,7 @@ Tensor& hardswish_(Tensor& input) {
   return input;
 }
 
-Tensor hardswish(const at::Tensor& input) {
+static Tensor hardswish(const at::Tensor& input) {
   MPSImage* X = imageFromTensor(input);
   IntArrayRef outputSize = input.sizes();
   MetalTensorImplStorage mt{outputSize.vec()};
@@ -82,8 +80,6 @@ Tensor hardswish(const at::Tensor& input) {
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::hardswish_"), TORCH_FN(hardswish_));
   m.impl(TORCH_SELECTIVE_NAME("aten::hardswish"), TORCH_FN(hardswish));
-};
+}
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalLeakyReLU.mm
+++ b/aten/src/ATen/native/metal/ops/MetalLeakyReLU.mm
@@ -9,13 +9,11 @@
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 using MetalTensorImpl = at::MetalTensorImpl<MetalTensorImplStorage>;
 
-Tensor& leaky_relu_(Tensor& input, const Scalar& negative_slope_val) {
+static Tensor& leaky_relu_(Tensor& input, const Scalar& negative_slope_val) {
   MPSImage* X = imageFromTensor(input);
   MetalCommandBuffer* commandBuffer = getCommandBuffer(input);
   IntArrayRef outputSize = input.sizes();
@@ -49,7 +47,7 @@ Tensor& leaky_relu_(Tensor& input, const Scalar& negative_slope_val) {
   return input;
 }
 
-Tensor leaky_relu(const at::Tensor& input, const Scalar& negative_slope_val) {
+static Tensor leaky_relu(const at::Tensor& input, const Scalar& negative_slope_val) {
   MPSImage* X = imageFromTensor(input);
   IntArrayRef outputSize = input.sizes();
   MetalTensorImplStorage mt{outputSize.vec()};
@@ -86,8 +84,6 @@ Tensor leaky_relu(const at::Tensor& input, const Scalar& negative_slope_val) {
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::leaky_relu_"), TORCH_FN(leaky_relu_));
   m.impl(TORCH_SELECTIVE_NAME("aten::leaky_relu"), TORCH_FN(leaky_relu));
-};
+}
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalNeurons.mm
+++ b/aten/src/ATen/native/metal/ops/MetalNeurons.mm
@@ -9,13 +9,11 @@
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 using MetalTensorImpl = at::MetalTensorImpl<MetalTensorImplStorage>;
 
-Tensor neuronKernel(const Tensor& input, MPSCNNNeuron* neuron) {
+static Tensor neuronKernel(const Tensor& input, MPSCNNNeuron* neuron) {
   MPSImage* X = imageFromTensor(input);
   IntArrayRef outputSize = input.sizes();
   if(input.numel() == 0){
@@ -33,7 +31,7 @@ Tensor neuronKernel(const Tensor& input, MPSCNNNeuron* neuron) {
   return output;
 }
 
-Tensor& neuronKernel_(Tensor& input, MPSCNNNeuron* neuron) {
+static Tensor& neuronKernel_(Tensor& input, MPSCNNNeuron* neuron) {
   MPSImage* X = imageFromTensor(input);
   IntArrayRef outputSize = input.sizes();
   if(input.numel() == 0){
@@ -52,30 +50,30 @@ Tensor& neuronKernel_(Tensor& input, MPSCNNNeuron* neuron) {
 }
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor relu(const Tensor& input) {
+static Tensor relu(const Tensor& input) {
   TORCH_CHECK(input.is_metal());
   return neuronKernel(input, [MPSCNNNeuronOp relu]);
 }
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor& relu_(Tensor& input) {
+static Tensor& relu_(Tensor& input) {
   TORCH_CHECK(input.is_metal());
   return neuronKernel_(input, [MPSCNNNeuronOp relu]);
 }
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor sigmoid(const Tensor& input) {
+static Tensor sigmoid(const Tensor& input) {
   return neuronKernel(input, [MPSCNNNeuronOp sigmoid]);
 }
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor& hardsigmoid_(Tensor& input) {
+static Tensor& hardsigmoid_(Tensor& input) {
   TORCH_CHECK(input.is_metal());
   return neuronKernel_(input, [MPSCNNNeuronOp hardSigmoid]);
 }
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor tanh(const Tensor& input) {
+static Tensor tanh(const Tensor& input) {
   TORCH_CHECK(input.is_metal());
   return neuronKernel(input, [MPSCNNNeuronOp tanh]);
 }
@@ -86,8 +84,6 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::relu_"), TORCH_FN(relu_));
   m.impl(TORCH_SELECTIVE_NAME("aten::sigmoid"), TORCH_FN(sigmoid));
   m.impl(TORCH_SELECTIVE_NAME("aten::hardsigmoid_"), TORCH_FN(hardsigmoid_));
-};
+}
 
-}
-}
-}
+} // namepsace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalPadding.mm
+++ b/aten/src/ATen/native/metal/ops/MetalPadding.mm
@@ -9,12 +9,10 @@
 
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor reflection_pad2d(const Tensor& input, IntArrayRef padding) {
+static Tensor reflection_pad2d(const Tensor& input, IntArrayRef padding) {
   TORCH_CHECK(input.is_metal());
 
   const int pad_dim = padding.size();
@@ -87,8 +85,6 @@ Tensor reflection_pad2d(const Tensor& input, IntArrayRef padding) {
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::reflection_pad2d"), TORCH_FN(reflection_pad2d));
-};
+}
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalPooling.mm
+++ b/aten/src/ATen/native/metal/ops/MetalPooling.mm
@@ -11,12 +11,10 @@
 #include <ATen/native/Pool.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor max_pool2d(
+static Tensor max_pool2d(
     const Tensor& input,
     IntArrayRef kernel_size,
     IntArrayRef stride,
@@ -71,7 +69,7 @@ Tensor max_pool2d(
 }
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor adaptive_avg_pool2d(const Tensor& input, IntArrayRef output_size) {
+static Tensor adaptive_avg_pool2d(const Tensor& input, IntArrayRef output_size) {
   // averages across the width and height, and outputs a 1x1xC image.
   TORCH_CHECK(output_size[0] == 1 && output_size[1] == 1);
   TORCH_CHECK(input.is_metal());
@@ -108,6 +106,4 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::adaptive_avg_pool2d"), TORCH_FN(adaptive_avg_pool2d));
 }
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalReduce.mm
+++ b/aten/src/ATen/native/metal/ops/MetalReduce.mm
@@ -11,9 +11,7 @@
 #include <ATen/native/ReduceOpsUtils.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 API_AVAILABLE(ios(11.3), macos(10.13))
 static inline MPSNNReduceUnary* kernelForReducedDim(int dim) {
@@ -28,7 +26,7 @@ static inline MPSNNReduceUnary* kernelForReducedDim(int dim) {
   return nil;
 }
 
-Tensor wrapper_mean_dim(
+static Tensor wrapper_mean_dim(
     const Tensor& input,
     OptionalIntArrayRef opt_dims,
     bool keepdim,
@@ -82,6 +80,4 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::mean.dim"), TORCH_FN(wrapper_mean_dim));
 };
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalReshape.mm
+++ b/aten/src/ATen/native/metal/ops/MetalReshape.mm
@@ -11,12 +11,10 @@
 #include <ATen/TensorUtils.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 API_AVAILABLE(ios(11.0), macos(10.13))
-Tensor view(const Tensor& input, c10::SymIntArrayRef sym_size) {
+static Tensor view(const Tensor& input, c10::SymIntArrayRef sym_size) {
   auto size = C10_AS_INTARRAYREF_SLOW(sym_size);
   TORCH_CHECK(input.is_metal());
   auto inferred_size = at::infer_size(size, input.numel());
@@ -62,12 +60,12 @@ Tensor view(const Tensor& input, c10::SymIntArrayRef sym_size) {
   return output;
 }
 
-Tensor reshape(const Tensor& input, IntArrayRef shape) {
+static Tensor reshape(const Tensor& input, IntArrayRef shape) {
   TORCH_CHECK(input.is_metal());
   return view(input, c10::fromIntArrayRefSlow(shape));
 }
 
-Tensor flatten_using_ints(
+static Tensor flatten_using_ints(
     const Tensor& input,
     int64_t start_dim,
     int64_t end_dim) {
@@ -97,7 +95,7 @@ Tensor flatten_using_ints(
   return input.reshape(shape);
 }
 
-Tensor detach(const Tensor& input) {
+static Tensor detach(const Tensor& input) {
   TORCH_CHECK(input.is_metal());
   return input;
 }
@@ -107,8 +105,6 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::view"), TORCH_FN(view));
   m.impl(TORCH_SELECTIVE_NAME("aten::reshape"), TORCH_FN(reshape));
   m.impl(TORCH_SELECTIVE_NAME("aten::flatten.using_ints"), TORCH_FN(flatten_using_ints));
-};
+}
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalSoftmax.mm
+++ b/aten/src/ATen/native/metal/ops/MetalSoftmax.mm
@@ -10,9 +10,7 @@
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 template <typename T>
 Tensor mpscnn_softmax(
@@ -50,14 +48,14 @@ Tensor mpscnn_softmax(
   return output;
 }
 
-Tensor log_softmax_int(
+static Tensor log_softmax_int(
     const Tensor& input,
     int64_t dim,
     c10::optional<ScalarType> dtype) {
   return mpscnn_softmax<MPSCNNLogSoftMax>(input, dim, dtype);
 }
 
-Tensor softmax_int(
+static Tensor softmax_int(
     const Tensor& input,
     int64_t dim,
     c10::optional<ScalarType> dtype) {
@@ -69,6 +67,4 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::softmax.int"), TORCH_FN(metal::softmax_int));
 };
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalTranspose.mm
+++ b/aten/src/ATen/native/metal/ops/MetalTranspose.mm
@@ -10,9 +10,7 @@
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
 // TODO: Move this function to MetalContext
 template<typename T>
@@ -24,7 +22,7 @@ id<MTLBuffer> _makeMTLBuffer(const std::vector<T>& src) {
     return buffer;
 }
 
-Tensor transpose(const Tensor& input, int64_t dim0, int64_t dim1) {
+static Tensor transpose(const Tensor& input, int64_t dim0, int64_t dim1) {
   TORCH_CHECK(input.is_metal());
   auto ndims = input.dim();
   // Support maximum eight channels on mobile
@@ -87,7 +85,7 @@ Tensor transpose(const Tensor& input, int64_t dim0, int64_t dim1) {
   }
 }
 
-Tensor t(const Tensor& input) {
+static Tensor t(const Tensor& input) {
   TORCH_CHECK(input.is_metal());
   TORCH_CHECK(input.dim() == 2);
   return metal::transpose(input, 0, input.dim() < 2 ? 0 : 1);
@@ -98,6 +96,4 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::transpose.int"), TORCH_FN(transpose));
 };
 
-}
-}
-}
+} // namespace at::native::metal

--- a/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
+++ b/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
@@ -11,11 +11,9 @@
 #include <ATen/native/UpSample.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
-namespace metal {
+namespace at::native::metal {
 
-Tensor upsample_nearest2d_vec(
+static Tensor upsample_nearest2d_vec(
     const Tensor& input,
     at::OptionalIntArrayRef output_size,
     c10::optional<ArrayRef<double>> scale_factors) {
@@ -70,6 +68,4 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::upsample_nearest2d.vec"), TORCH_FN(upsample_nearest2d_vec));
 };
 
-}
-}
-}
+} // namespace at::native::metal

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -772,7 +772,7 @@ if(NOT MSVC)
   set_source_files_properties(${PROJECT_SOURCE_DIR}/torch/csrc/distributed/c10d/socket.cpp PROPERTIES COMPILE_OPTIONS "-Wno-error=deprecated")
 endif()
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND NOT USE_VULKAN AND NOT USE_IOS AND NOT USE_PYTORCH_METAL AND NOT USE_COREML_DELEGATE)
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND NOT USE_VULKAN AND NOT USE_IOS AND NOT USE_COREML_DELEGATE)
   target_compile_options_if_supported(torch_cpu "-Wmissing-prototypes")
   target_compile_options_if_supported(torch_cpu "-Werror=missing-prototypes")
   get_target_property(TORCH_CPU_SOURCES torch_cpu SOURCES)


### PR DESCRIPTION
By declaring a bunch of functions static. 
Removed `USE_PYTORCH_METAL` from list of flags that suppress `-Werror=missing-prototypes`. This  will prevent regressions like the ones reported in https://github.com/pytorch/pytorch/issues/127942 to sneak past CI, that builds PyTorch with Metal support.
Use nested namespaces
Remove spurious semicolon after TORCH_LIBRARY declaration.

