### PR TITLE
[GPT-fast benchmark] Add MLP, gather + gemv, gemv micro benchmark

### DIFF
--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -8,9 +8,13 @@ from triton.testing import do_bench
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
+from torch.utils.flop_counter import FlopCounterMode
 
 WARMUP_ITER = 5
+
+A100_80G_BF16_TFLOPS = 312
+
+torch._inductor.config.coordinate_descent_tuning = True
 
 
 @dataclasses.dataclass
@@ -24,28 +28,30 @@ class Experiment:
 class SimpleMLP(nn.Module):
     def __init__(self, input_dim, hidden_dim, output_dim, dtype):
         super().__init__()
-        self.fc1 = nn.Linear(input_dim, hidden_dim, dtype=dtype)
-        self.ln1 = nn.LayerNorm(hidden_dim, dtype=dtype)
-        self.fc2 = nn.Linear(hidden_dim, output_dim, dtype=dtype)
-        self.ln2 = nn.LayerNorm(output_dim, dtype=dtype)
+        self.layers = nn.ModuleList(
+            [
+                nn.Linear(input_dim, hidden_dim, dtype=dtype),
+                nn.LayerNorm(hidden_dim, dtype=dtype),
+                nn.Linear(hidden_dim, output_dim, dtype=dtype),
+                nn.LayerNorm(output_dim, dtype=dtype),
+            ]
+        )
 
     def forward(self, x):
-        x = self.fc1(x)
-        x = F.gelu(self.ln1(x))
-        x = self.fc2(x)
-        x = F.gelu(self.ln2(x))
+        for layer in self.layers:
+            x = layer(x)
         return x
 
 
 def run_mlp_layer_norm_gelu():
-    dtype_memory_bandwidth_map = {
-        torch.bfloat16: "1805",
+    dtype_flops_utilization_map = {
+        torch.bfloat16: "0.72",
     }
     input_shapes = [1024, 4096, 8192, 16384]
     intermediate_size = 14336
     results = []
-    for dtype, expected_memory_bandwidth in dtype_memory_bandwidth_map.items():
-        memory_bandwidth = 0
+    for dtype, expected_flops_utilization in dtype_flops_utilization_map.items():
+        flops_utilization = 0
         for D in input_shapes:
             mod = SimpleMLP(
                 input_dim=D, hidden_dim=intermediate_size, output_dim=D, dtype=dtype
@@ -53,24 +59,27 @@ def run_mlp_layer_norm_gelu():
 
             x = torch.randn(D, device="cuda", dtype=torch.bfloat16)
 
-            compiled_mod = torch.compile(mod)
+            with FlopCounterMode(display=False) as mode:
+                mod(x)
+
+            flops = mode.get_total_flops()
+
+            compiled_mod = torch.compile(mod, dynamic=False)
 
             for _ in range(WARMUP_ITER):
                 compiled_mod(x)
 
             us_per_iter = do_bench(lambda: compiled_mod(x)) * 1000
-            memory_bandwidth += (
-                (1e6 / us_per_iter) * 4 * D * intermediate_size * dtype.itemsize / 1e9
-            )
+            flops_utilization += us_per_iter * flops / 1e9 / A100_80G_BF16_TFLOPS
 
-        memory_bandwidth = memory_bandwidth / len(input_shapes)
+        flops_utilization = flops_utilization / len(input_shapes)
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
                 f"mlp_layer_norm_gelu_{dtype_str}",
-                "memory_bandwidth(GB/s)",
-                expected_memory_bandwidth,
-                f"{memory_bandwidth:.02f}",
+                "flops_utilization",
+                expected_flops_utilization,
+                f"{flops_utilization:.02f}",
             )
         )
     return results
@@ -90,7 +99,7 @@ def run_layer_norm():
 
             x = torch.randn(BS, D, device="cuda", dtype=dtype)
 
-            compiled_mod = torch.compile(mod)
+            compiled_mod = torch.compile(mod, dynamic=False)
 
             for _ in range(WARMUP_ITER):
                 compiled_mod(x)
@@ -112,6 +121,7 @@ def run_layer_norm():
 
 
 def run_gather_gemv():
+    torch._inductor.config.coordinate_descent_tuning = True
     E = 8
     dtype_memory_bandwidth_map = {
         torch.int8: "1195",
@@ -130,13 +140,13 @@ def run_gather_gemv():
             x = torch.randn(D, device="cuda", dtype=torch.bfloat16)
             score_idxs = torch.tensor([3, 5], device="cuda")
 
-            compiled_fn = torch.compile(gather_gemv)
+            compiled_fn = torch.compile(gather_gemv, dynamic=False)
 
             for _ in range(WARMUP_ITER):
                 compiled_fn(W, score_idxs, x)
 
             us_per_iter = do_bench(lambda: compiled_fn(W, score_idxs, x)) * 1000
-            memory_bandwidth += (1e6 / us_per_iter) * 4 * D * D * dtype.itemsize / 1e9
+            memory_bandwidth += (1e6 / us_per_iter) * 2 * D * D * dtype.itemsize / 1e9
 
         memory_bandwidth = memory_bandwidth / len(input_shapes)
         dtype_str = str(dtype).replace("torch.", "")
@@ -152,6 +162,7 @@ def run_gather_gemv():
 
 
 def run_gemv():
+    torch._inductor.config.coordinate_descent_tuning = True
     dtype_memory_bandwidth_map = {
         torch.int8: "1080",
         torch.bfloat16: "1750",
@@ -168,7 +179,7 @@ def run_gemv():
             W = torch.randn(D, D, device="cuda").to(dtype=dtype)
             x = torch.randn(D, device="cuda", dtype=torch.bfloat16)
 
-            compiled_fn = torch.compile(gemv)
+            compiled_fn = torch.compile(gemv, dynamic=False)
 
             for _ in range(WARMUP_ITER):
                 compiled_fn(W, x)

--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -14,8 +14,6 @@ WARMUP_ITER = 5
 
 A100_80G_BF16_TFLOPS = 312
 
-torch._inductor.config.coordinate_descent_tuning = True
-
 
 @dataclasses.dataclass
 class Experiment:

--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -45,7 +45,7 @@ class SimpleMLP(nn.Module):
 
 def run_mlp_layer_norm_gelu():
     dtype_flops_utilization_map = {
-        torch.bfloat16: "0.72",
+        torch.bfloat16: "0.71",
     }
     input_shapes = [1024, 4096, 8192, 16384]
     intermediate_size = 14336
@@ -87,7 +87,7 @@ def run_mlp_layer_norm_gelu():
 
 def run_layer_norm():
     dtype_memory_bandwidth_map = {
-        torch.bfloat16: "1050",
+        torch.bfloat16: "1017",
     }
     input_shapes = [1024, 4096, 8192, 16384]
     BS = 4096
@@ -120,12 +120,12 @@ def run_layer_norm():
     return results
 
 
+@torch._inductor.config.patch(coordinate_descent_tuning=True)
 def run_gather_gemv():
-    torch._inductor.config.coordinate_descent_tuning = True
     E = 8
     dtype_memory_bandwidth_map = {
-        torch.int8: "1195",
-        torch.bfloat16: "2180",
+        torch.int8: "1113",
+        torch.bfloat16: "1249",
     }
     input_shapes = [1024, 4096, 8192, 16384]
     results = []
@@ -161,11 +161,11 @@ def run_gather_gemv():
     return results
 
 
+@torch._inductor.config.patch(coordinate_descent_tuning=True)
 def run_gemv():
-    torch._inductor.config.coordinate_descent_tuning = True
     dtype_memory_bandwidth_map = {
-        torch.int8: "1080",
-        torch.bfloat16: "1750",
+        torch.int8: "1964",
+        torch.bfloat16: "2272",
     }
     input_shapes = [1024, 4096, 8192, 16384]
     results = []

--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -162,8 +162,8 @@ def run_gather_gemv():
 @torch._inductor.config.patch(coordinate_descent_tuning=True)
 def run_gemv():
     dtype_memory_bandwidth_map = {
-        torch.int8: "1964",
-        torch.bfloat16: "2272",
+        torch.int8: "990",
+        torch.bfloat16: "1137",
     }
     input_shapes = [1024, 4096, 8192, 16384]
     results = []
@@ -183,7 +183,7 @@ def run_gemv():
                 compiled_fn(W, x)
 
             us_per_iter = do_bench(lambda: compiled_fn(W, x)) * 1000
-            memory_bandwidth += (1e6 / us_per_iter) * 2 * D * D * dtype.itemsize / 1e9
+            memory_bandwidth += (1e6 / us_per_iter) * D * D * dtype.itemsize / 1e9
 
         memory_bandwidth = memory_bandwidth / len(input_shapes)
         dtype_str = str(dtype).replace("torch.", "")


### PR DESCRIPTION
Output example:
```
| name                         | metric                    | target  | actual  |
|------------------------------|---------------------------|---------|---------|
| layer_norm_bfloat16          | memory_bandwidth(GB/s)    | 1017    | 1000.01 |
| mlp_layer_norm_gelu_bfloat16 | flops_utilization         | 0.71    | 0.71    |
| gemv_int8                    | memory_bandwidth(GB/s)    | 990     | 984.06 |
| gemv_bfloat16                | memory_bandwidth(GB/s)    | 1137    | 1137.92 |
| gather_gemv_int8             | memory_bandwidth(GB/s)    | 1113    | 1111.09 |
| gather_gemv_bfloat16         | memory_bandwidth(GB/s)    | 1249    | 1248.15 |


```
