### PR TITLE
Change JK check in should_use_remote_fx_graph_cache

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -376,13 +376,8 @@ def should_use_remote_fx_graph_cache():
     if torch.version.hip is not None:
         return False
 
-    try:
-        from triton.runtime.fb_memcache import MEMCACHE_VERSION
-    except ModuleNotFoundError:
-        return False
-
-    return MEMCACHE_VERSION >= torch._utils_internal.justknobs_getval_int(
-        "pytorch/remote_cache:fx_graph_memcache_version"
+    return torch._utils_internal.justknobs_check(
+        "pytorch/remote_cache:fx_graph_remote_cache_enabled"
     )
 
 


### PR DESCRIPTION
fb-internal

memcache is not used for FX graph remote caching so we change its JK check with a new one, which can be turned on gradually like `jk.check("ads_training_p9e/dynamo_configs:cprofile")`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang