### PR TITLE
Pass backend meta info in view ops.

### DIFF
--- a/aten/src/ATen/native/ComplexHelper.h
+++ b/aten/src/ATen/native/ComplexHelper.h
@@ -27,6 +27,11 @@ inline Tensor view_tensor(
       c10::TensorImpl::VIEW, std::move(storage), key_set, scalarTypeToTypeMeta(dtype));
   auto * impl = new_tensor.unsafeGetTensorImpl();
   impl->set_sizes_and_strides(sizes, strides, offset);
+  // pass c10::BackendMeta
+  auto backend_meta = tensor.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr();
+  if (backend_meta != nullptr) {
+    impl->set_backend_meta(backend_meta);
+  }
   return new_tensor;
 }
 

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -788,6 +788,11 @@ Tensor view_dtype(const Tensor& self, ScalarType dtype) {
   auto new_tensor = detail::make_tensor<TensorImpl>(
       std::move(storage), self.key_set(), type_meta);
   auto* impl = new_tensor.unsafeGetTensorImpl();
+  // pass c10::BackendMeta
+  auto backend_meta = self.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr();
+  if (backend_meta != nullptr) {
+    impl->set_backend_meta(backend_meta);
+  }
 
   if (self_element_size == new_element_size) {
     impl->set_sizes_and_strides(self.sym_sizes(), self.sym_strides(), self.sym_storage_offset());

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1602,6 +1602,10 @@ Tensor alias_with_sizes_and_strides(
     self_tmp_->set_storage_offset(self.storage_offset());
     self_tmp_->set_sizes_and_strides(sizes, strides);
   }
+  auto backend_meta = self.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr();
+  if (backend_meta != nullptr) {
+    self_.unsafeGetTensorImpl()->set_backend_meta(backend_meta);
+  }
   namedinference::propagate_names(self_, self);
   return self_;
 }
@@ -1624,6 +1628,10 @@ Tensor alias_with_sizes_and_strides(
     self_ = at::detail::make_tensor<TensorImpl>(
     c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
     self_.unsafeGetTensorImpl()->set_sizes_and_strides(sizes, strides, self.sym_storage_offset());
+  }
+  auto backend_meta = self.unsafeGetTensorImpl()->get_backend_meta_intrusive_ptr();
+  if (backend_meta != nullptr) {
+    self_.unsafeGetTensorImpl()->set_backend_meta(backend_meta);
   }
   namedinference::propagate_names(self_, self);
   return self_;
@@ -3380,7 +3388,6 @@ inline Tensor view_impl(const Tensor& self, IntArrayRef size) {
     "not compatible with input tensor's size and stride (at least one dimension"
     " spans across two contiguous subspaces). Use .reshape(...) instead.");
   return alias_with_sizes_and_strides(self, inferred_size, *stride);
-
 }
 
 Tensor _unsafe_view(const Tensor& self, IntArrayRef size) {
@@ -3769,7 +3776,9 @@ Tensor view(const Tensor& self,
 }
 
 Tensor alias(const Tensor& self) {
-  return alias_with_sizes_and_strides(self, self.sym_sizes(), self.sym_strides());
+  auto self_ = self.as_strided_symint(self.sym_sizes(), self.sym_strides());
+  namedinference::propagate_names(self_, self);
+  return self_;
 }
 
 Tensor detach(const Tensor& self) {

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -701,6 +701,7 @@ class TestProfilerTree(TestCase):
                       <built-in function isinstance>
                       <built-in method as_subclass of Tensor object at 0xXXXXXXXXXXXX>
                         aten::alias
+                          aten::as_strided
                       <built-in function isinstance>
               torch/profiler/profiler.py(...): __exit__
                 torch/profiler/profiler.py(...): stop

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -449,6 +449,19 @@ class TestCppExtensionOpenRgistration(common.TestCase):
             # loads BackendMeta data correctly
             self.assertFalse(self.module.check_backend_meta(z2))
 
+    def test_open_device_pass_custom_backend_meta(self):
+        x = torch.empty(4, 4, 2, 3)
+        y = x.foo()
+        self.assertFalse(self.module.check_backend_meta(y))
+        self.module.custom_set_backend_meta(y)
+        self.assertTrue(self.module.check_backend_meta(y))
+
+        # test tensor pass backend_meta
+        y_alias = torch.ops.aten.alias(y)
+        self.assertTrue(self.module.check_backend_meta(y_alias))
+        y_permute = y.permute((0, 2, 3, 1))
+        self.assertTrue(self.module.check_backend_meta(y_permute))
+
     def test_open_device_storage_resize(self):
         cpu_tensor = torch.randn([8])
         foo_tensor = cpu_tensor.foo()


### PR DESCRIPTION
1）Open device using as stride to pass backend meta;
2）alias_with_sizes_and_strides, view_dtype and view_tensor function pass backend meta.
@ezyang @bdhirsh 
