### PR TITLE
Documenting the torch.cuda.nccl.version function

### DIFF
--- a/torch/cuda/nccl.py
+++ b/torch/cuda/nccl.py
@@ -32,6 +32,15 @@ def is_available(tensors):
 
 
 def version():
+    """
+    Returns the version of the NCCL.
+
+
+    This function returns a tuple containing the major, minor, and patch version numbers of the NCCL.
+    The suffix is also included in the tuple if a version suffix exists.
+    Returns:
+        tuple: The version information of the NCCL.
+    """
     ver = torch._C._nccl_version()
     major = ver >> 32
     minor = (ver >> 16) & 65535


### PR DESCRIPTION
Fixes #127892 

This PR adds docstring to the torch.cuda.nccl.version function


cc @svekars @brycebortree