### PR TITLE
Change lerp decomp to use aten.as_strided_copy instead of prims.copy_strided

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5014,7 +5014,11 @@ def lerp(start: Tensor, end: Tensor, weight: Union[Tensor, NumberType]):
     # make sure the decomposition output's stride is same as non-decomposition path.
     stride = utils.compute_elementwise_output_strides(*_maybe_broadcast(*inputs))
     if output.stride() != stride:
-        output = prims.copy_strided(output, stride)
+        output = torch.ops.aten.as_strided_copy(
+            output,
+            output.size(),
+            stride,
+        )
 
     return handle_noncontiguous_outputs(inputs, output)
 


### PR DESCRIPTION
aten.lerp decomposition causes prims::copy_strided to appear in the graph, which is not core aten.

Internal ref: https://fb.workplace.com/groups/pytorch.edge.users/permalink/1525644288305859/