### PR TITLE
Documenting `torch.onnx.operator.shape_as_tensor`

### DIFF
--- a/torch/onnx/operators.py
+++ b/torch/onnx/operators.py
@@ -13,6 +13,20 @@ import torch.onnx
 
 
 def shape_as_tensor(x):
+    """Get the shape of a tensor as a tensor.
+
+    Args:
+        x (Tensor): The input tensor.
+
+    Returns:
+        Tensor: A tensor of shape [len(x.shape)] containing the size of each dimension of x.
+
+    Example:
+        >>> x = torch.randn(2, 3)
+        >>> shape_as_tensor(x)
+        tensor([2, 3])
+
+    """
     return torch._shape_as_tensor(x)
 
 


### PR DESCRIPTION
Fixes #127890 

This PR adds docstring to the `torch.onnx.operator.shape_as_tensor` function.

cc @svekars @brycebortree