### PR TITLE
Avoid GPU syncs by reusing Pre-allocated Zero Tensor

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -522,7 +522,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         # implemented using post-save and pre-load hooks
         _init_state_dict_state(self)
         _register_all_state_dict_hooks(self)
-        self._zero_scalar = None 
+        self._zero_scalar = None
 
     @property
     def module(self) -> nn.Module:
@@ -1155,9 +1155,13 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 if param.grad is not None:
                     grads.append(param.grad)
         # Compute local norms (forced to be in FP32)
-        local_sharded_norm = _get_grad_norm(sharded_params, norm_type, self._zero_scalar, self.compute_device)
+        local_sharded_norm = _get_grad_norm(
+            sharded_params, norm_type, self._zero_scalar, self.compute_device
+        )
         local_nonsharded_norm = (
-            _get_grad_norm(nonsharded_params, norm_type, self._zero_scalar, self.compute_device)
+            _get_grad_norm(
+                nonsharded_params, norm_type, self._zero_scalar, self.compute_device
+            )
             if nonsharded_params
             else None
         )

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -522,7 +522,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         # implemented using post-save and pre-load hooks
         _init_state_dict_state(self)
         _register_all_state_dict_hooks(self)
-        self.zero = torch.tensor(0.0, device=self.compute_device)
+        self._zero_scalar = None 
 
     @property
     def module(self) -> nn.Module:
@@ -1114,6 +1114,8 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             raise RuntimeError(
                 "`clip_grad_norm_()` should only be called on the root FSDP instance"
             )
+        if self._zero_scalar is None:
+            self._zero_scalar = torch.tensor(0.0, device=self.compute_device)
         self._assert_state(TrainingState.IDLE)
         # If every FSDP instance uses `NO_SHARD`, then we can directly use
         # the normal `nn.utils` one targeting local gradients
@@ -1153,9 +1155,9 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 if param.grad is not None:
                     grads.append(param.grad)
         # Compute local norms (forced to be in FP32)
-        local_sharded_norm = _get_grad_norm(sharded_params, norm_type, self.zero, self.compute_device)
+        local_sharded_norm = _get_grad_norm(sharded_params, norm_type, self._zero_scalar, self.compute_device)
         local_nonsharded_norm = (
-            _get_grad_norm(nonsharded_params, norm_type, self.zero, self.compute_device)
+            _get_grad_norm(nonsharded_params, norm_type, self._zero_scalar, self.compute_device)
             if nonsharded_params
             else None
         )


### PR DESCRIPTION
This commit improves the FullyShardedDataParallel (FSDP) class in PyTorch by reducing unnecessary GPU synchronizations by reusing a pre-allocated zero tensor.



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang