### PR TITLE
Updating the `sigslot` license to Public Domain

### DIFF
--- a/third_party/LICENSES_BUNDLED.txt
+++ b/third_party/LICENSES_BUNDLED.txt
@@ -420,7 +420,7 @@ Files: third_party/python-peachpy
   For details, see: third_party/python-peachpy/LICENSE.rst
 
 Name: sigslot
-License: Apache-2.0
+License: Public Domain
 Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/sigslot
   For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/sigslot/LICENSE
 

--- a/third_party/build_bundled.py
+++ b/third_party/build_bundled.py
@@ -116,7 +116,7 @@ def identify_license(f, exception=''):
             return 'Apache-2.0'
         elif 'sigslot' in txt:
             # Used in opentelemetry-cpp/tools/vcpkg/ports/sigslot
-            return 'Apache-2.0'
+            return 'Public Domain'
         elif squeeze("Clarified Artistic License") in txt:
             return 'Clarified Artistic License'
         elif all([squeeze(m) in txt.lower() for m in bsd3_txt]):


### PR DESCRIPTION
It seems that Sigslot's license is Public Domain, not Apache 2. https://sigslot.sourceforge.net


