### PR TITLE
Share TCPStore by default when using c10d rdzv handler

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -12,12 +12,15 @@ import pickle
 import socket
 import threading
 import time
+
 from abc import ABC, abstractmethod
 from base64 import b64encode
 from datetime import datetime, timedelta
 from typing import Callable, cast, Optional, Tuple
 from unittest import TestCase
-from unittest.mock import call, MagicMock, Mock, patch
+from unittest.mock import call, MagicMock, Mock, patch, PropertyMock
+
+import torch.distributed as dist
 
 from torch.distributed import HashStore, Store
 from torch.distributed.elastic.rendezvous import (
@@ -26,6 +29,7 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousInfo,
     RendezvousParameters,
     RendezvousStateError,
+    RendezvousStoreInfo,
     RendezvousTimeoutError,
 )
 from torch.distributed.elastic.rendezvous.dynamic_rendezvous import (
@@ -1169,6 +1173,16 @@ class DynamicRendezvousHandlerTest(TestCase):
 
         self._state = self._state_holder.state
 
+        self._tcp_store_mock = DummyStore()
+
+        patcher = patch.object(
+            DynamicRendezvousHandler,
+            "_create_tcp_store_server",
+            return_value=self._tcp_store_mock,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def _create_handler(self) -> DynamicRendezvousHandler:
         settings = RendezvousSettings(
             run_id="dummy_run_id",
@@ -1188,6 +1202,36 @@ class DynamicRendezvousHandlerTest(TestCase):
         return DynamicRendezvousHandler(
             self._node, settings, "dummy_backend", self._store, self._state_holder
         )
+
+    def test_share_store_creates_tcp_store(self):
+        handler = self._create_handler()
+
+        shared_store_info = RendezvousStoreInfo("host", 54321)
+        with patch.object(RendezvousStoreInfo, "build", return_value=shared_store_info):
+            rdzv_info = handler.next_rendezvous()
+            self.assertEqual(rdzv_info.bootstrap_store_info.master_addr, "host")
+            self.assertEqual(rdzv_info.bootstrap_store_info.master_port, 54321)
+        self.assertEqual(handler._shared_tcp_store_server, self._tcp_store_mock)
+
+        rdzv_info = handler.next_rendezvous()
+        self.assertEqual(handler._shared_tcp_store_server, self._tcp_store_mock)
+
+    def test_share_store_when_tcp_store(self):
+        handler = self._create_handler()
+
+        with patch.object(dist, "PrefixStore", new=Mock):
+            handler._store = Mock(spec=dist.TCPStore)
+            type(handler._store).host = PropertyMock(return_value="host")
+            type(handler._store).port = PropertyMock(return_value=54321)
+            rdzv_info = handler.next_rendezvous()
+            self.assertEqual(rdzv_info.bootstrap_store_info.master_addr, "host")
+            self.assertEqual(rdzv_info.bootstrap_store_info.master_port, 54321)
+            self.assertEqual(handler._shared_tcp_store_server, handler._store)
+
+            rdzv_info = handler.next_rendezvous()
+            self.assertEqual(rdzv_info.bootstrap_store_info.master_addr, "host")
+            self.assertEqual(rdzv_info.bootstrap_store_info.master_port, 54321)
+            self.assertEqual(handler._shared_tcp_store_server, handler._store)
 
     @patch("torch.distributed.elastic.rendezvous.dynamic_rendezvous._delay")
     def test_next_rendezvous_skews_the_first_join_attempt(self, mock_delay) -> None:
@@ -1716,6 +1760,93 @@ class IntegrationTest(TestCase):
         _wait_for(
             lambda: len(pickle.loads(self._backend.get_state()[0]).wait_list) == 1
         )
+
+    def test_use_agent_store_is_true_by_default(self):
+        handler = self._create_handler(
+            min_nodes=1,
+            max_nodes=2,
+        )
+
+        self.assertTrue(handler.use_agent_store)
+
+    @patch.dict(os.environ, {"TORCH_DISABLE_SHARE_RDZV_TCP_STORE": "1"})
+    def test_use_agent_store_is_disabled(self):
+        handler = self._create_handler(
+            min_nodes=1,
+            max_nodes=2,
+        )
+
+        self.assertFalse(handler.use_agent_store)
+
+    @patch.object(dist, "PrefixStore")
+    def test_share_tcp_store_from_backend(self, prefix_store_class_mock):
+        prefix_store = Mock(spec=dist.PrefixStore)
+        prefix_store_class_mock.return_value = prefix_store
+
+        tcp_store = Mock(spec=dist.TCPStore)
+        expected_addr = "expected_address"
+        expected_port = 54321
+        type(tcp_store).host = PropertyMock(return_value=expected_addr)
+        type(tcp_store).port = PropertyMock(return_value=expected_port)
+        # this will be injected
+        self._store = tcp_store
+
+        handler1 = self._create_handler(min_nodes=2, max_nodes=2)
+        handler2 = self._create_handler(min_nodes=2, max_nodes=2)
+
+        handler1_thread = _CapturingThread(target=handler1.next_rendezvous)
+        handler2_thread = _CapturingThread(target=handler2.next_rendezvous)
+
+        handler1_thread.start()
+        handler2_thread.start()
+
+        rdzv_info1: RendezvousInfo = handler1_thread.join()
+        rdzv_info2: RendezvousInfo = handler2_thread.join()
+
+        self.assertEqual(rdzv_info1.store, prefix_store)
+        self.assertEqual(rdzv_info2.store, prefix_store)
+        prefix_store_class_mock.assert_called_with(
+            "torch.rendezvous.dummy_run_id.0", tcp_store
+        )
+
+        self.assertEqual(
+            rdzv_info1.bootstrap_store_info, rdzv_info2.bootstrap_store_info
+        )
+
+        self.assertEqual(rdzv_info1.bootstrap_store_info.master_addr, expected_addr)
+        self.assertEqual(rdzv_info1.bootstrap_store_info.master_port, expected_port)
+
+    @patch.dict(os.environ, {"TORCH_DISABLE_SHARE_RDZV_TCP_STORE": "1"})
+    @patch.object(dist, "PrefixStore")
+    def test_share_tcp_store_is_disabled(self, prefix_store_class_mock):
+        prefix_store = Mock()
+        prefix_store_class_mock.return_value = prefix_store
+
+        prefix_store.set.return_value = None
+        prefix_store.get.return_value = b"123"
+        tcp_store = Mock(spec=dist.TCPStore)
+        # this will be injected
+        self._store = tcp_store
+
+        handler1 = self._create_handler(min_nodes=2, max_nodes=2)
+        handler2 = self._create_handler(min_nodes=2, max_nodes=2)
+
+        handler1_thread = _CapturingThread(target=handler1.next_rendezvous)
+        handler2_thread = _CapturingThread(target=handler2.next_rendezvous)
+
+        handler1_thread.start()
+        handler2_thread.start()
+
+        rdzv_info1: RendezvousInfo = handler1_thread.join()
+        rdzv_info2: RendezvousInfo = handler2_thread.join()
+
+        self.assertEqual(rdzv_info1.store, prefix_store)
+        self.assertEqual(rdzv_info2.store, prefix_store)
+        prefix_store_class_mock.assert_called_with(
+            "torch.rendezvous.dummy_run_id.0", self._store
+        )
+        self.assertEqual(rdzv_info1.bootstrap_store_info.master_port, 123)
+        self.assertEqual(rdzv_info2.bootstrap_store_info.master_port, 123)
 
 
 class _InMemoryRendezvousBackend(RendezvousBackend):

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -159,6 +159,7 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
                 host,
                 port,
                 is_master=is_server,
+                multi_tenant=True,
                 timeout=timedelta(seconds=read_timeout),
                 use_libuv=use_libuv,
             )


### PR DESCRIPTION
Summary:
Number of features rely on TCP store as a control plane. By default TCPStore server is started on rank0 trainer and this can create a a race condition when rank0 may exit (error and graceful exit) and any other ranks reading/writing will fail. 

Solution: TCPStore server should outlive all the trainer processes. By moving the ownership TCPStore to torchelastic agent it naturally fixes the lifecycle of the server.

Static rendezvous in torchelastic does already support sharing of the TCPStore server. We are extending this to more commonly used c10d rendezvous handler.

Any handler would like to manage tcp store has to:
- Return true on `use_agent_store` property
- `RendezvousInfo`.`RendezvousStoreInfo`#[`master_addr/master_port`] values refer to managed TCPStore (those are returned on `next_rendezvous` call)

Note: in some instances users may want to use non-TCPStore based stores for the torchelastic rendezvous process, so the handler will need to create and hold a reference to TCPStore (as done in this change)

Test Plan:
`cat ~/workspace/dist-demo/stores.py`
~~~
import torch
import logging
import sys
import torch.distributed as dist
import torch

import os
import time

logger = logging.getLogger(__name__)
logger.addHandler(logging.StreamHandler(sys.stderr))
logger.setLevel(logging.INFO)


def _run_test(store):

    if dist.get_rank() == 1:
        logger.info("Rank %s is sleeping", dist.get_rank())
        time.sleep(5)
        key = "lookup_key"
        logger.info("Checking key %s in store on rank %s", key, dist.get_rank())
        store.check([key])
    else:
        logger.info("rank %s done", dist.get_rank())


def main() -> None:
    use_gpu = torch.cuda.is_available()
    dist.init_process_group(backend="nccl" if use_gpu else "gloo")
    dist.barrier()

    logger.info(f"Hello World from rank {dist.get_rank()}")

    host = os.environ['MASTER_ADDR']
    port = os.environ['MASTER_PORT']
    world_size = os.environ['WORLD_SIZE']

    logger.info("testing TCPStore")
    store = dist.TCPStore(
        host_name=host, port=int(port), world_size=int(world_size),
    )
    _run_test(store)


if __name__ == "__main__":
    main()
~~~

With the fix (TORCH_DISABLE_SHARE_RDZV_TCP_STORE=0 or just drop the option)
~~~
(pytorch_38) [kurman@devgpu011.cln5 ~/local/pytorch (main)]$ TORCH_DISABLE_SHARE_RDZV_TCP_STORE=0 python -m torch.distributed.run --rdzv-backend c10d --nproc-per-node 3 ~/workspace/dist-demo/stores.py
master_addr is only used for static rdzv_backend and when rdzv_endpoint is not specified.
WARNING:__main__:
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
*****************************************
Hello World from rank 1
Hello World from rank 2
Hello World from rank 0
testing TCPStore
testing TCPStore
testing TCPStore
rank 2 done
Rank 1 is sleeping
rank 0 done
Checking key lookup_key in store on rank 1
~~~


TORCH_DISABLE_SHARE_RDZV_TCP_STORE=1
~~~
(pytorch_38) [kurman@devgpu011.cln5 ~/local/pytorch (main)]$ TORCH_DISABLE_SHARE_RDZV_TCP_STORE=1 python -m torch.distributed.run --rdzv-backend c10d --npro
c-per-node 3 ~/workspace/dist-demo/stores.py
master_addr is only used for static rdzv_backend and when rdzv_endpoint is not specified.
WARNING:__main__:
*****************************************

Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
*****************************************
Hello World from rank 0
Hello World from rank 2
Hello World from rank 1
testing TCPStore
testing TCPStore
testing TCPStore
rank 0 done
rank 2 done
Rank 1 is sleeping
Checking key lookup_key in store on rank 1
[rank1]: Traceback (most recent call last):
[rank1]:   File "/home/kurman/workspace/dist-demo/stores.py", line 46, in <module>
[rank1]:     main()
[rank1]:   File "/home/kurman/workspace/dist-demo/stores.py", line 42, in main
[rank1]:     _run_test(store)
[rank1]:   File "/home/kurman/workspace/dist-demo/stores.py", line 22, in _run_test
[rank1]:     store.check([key])
[rank1]: torch.distributed.DistNetworkError: Connection reset by peer
E0605 17:40:22.853277 140249136719680 torch/distributed/elastic/multiprocessing/api.py:832] failed (exitcode: 1) local_rank: 1 (pid: 2279237) of binary: /home/kurman/.conda/envs/pytorch_38/bin/python
Traceback (most recent call last):
  File "/home/kurman/.conda/envs/pytorch_38/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/kurman/.conda/envs/pytorch_38/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/data/users/kurman/pytorch/torch/distributed/run.py", line 904, in <module>
    main()
  File "/data/users/kurman/pytorch/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 347, in wrapper
    return f(*args, **kwargs)
  File "/data/users/kurman/pytorch/torch/distributed/run.py", line 900, in main
    run(args)
  File "/data/users/kurman/pytorch/torch/distributed/run.py", line 891, in run
    elastic_launch(
  File "/data/users/kurman/pytorch/torch/distributed/launcher/api.py", line 132, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
  File "/data/users/kurman/pytorch/torch/distributed/launcher/api.py", line 263, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError:
============================================================
/home/kurman/workspace/dist-demo/stores.py FAILED
------------------------------------------------------------
Failures:
  <NO_OTHER_FAILURES>
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2024-06-05_17:40:22
  host      : devgpu011.cln5.facebook.com
  rank      : 1 (local_rank: 1)
  exitcode  : 1 (pid: 2279237)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
============================================================
~~~

Differential Revision: D58180193




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k