### PR TITLE
[Traceable FSDP2] Return early from _register_post_backward_hook when compile

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -410,6 +410,9 @@ class FSDPParamGroup:
     def _register_post_backward_hook(
         self, args: Tuple[Any, ...], kwargs: Dict[str, Any]
     ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        # Compile relies on `root_post_backward_callback` to call each ParamGroup's post_backward.
+        if torch._dynamo.compiled_autograd.compiled_autograd_enabled:
+            return args, kwargs
         if not torch.is_grad_enabled():
             return args, kwargs
         args_list, args_spec = tree_flatten(args)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #128104
* #128103
* #128110
* #128109
* #128108
* #128107
* __->__ #128106
* #128105

