### PR TITLE
[dtensor] reuse DTensorSpec as much as possible

### DIFF
--- a/test/distributed/_tensor/test_dtensor_compile.py
+++ b/test/distributed/_tensor/test_dtensor_compile.py
@@ -220,7 +220,7 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
         x = torch.randn(32, requires_grad=True)
         spec = DTensorSpec(
             mesh,
-            (Replicate()),
+            (Replicate(),),
             tensor_meta=TensorMeta(shape=torch.Size([32]), stride=(1,), dtype=x.dtype),
         )
 

--- a/test/distributed/_tensor/test_dtensor_compile.py
+++ b/test/distributed/_tensor/test_dtensor_compile.py
@@ -21,6 +21,7 @@ from torch.distributed._tensor import (
     Replicate,
     Shard,
 )
+from torch.distributed._tensor.placement_types import DTensorSpec, TensorMeta
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper,
     CheckpointImpl,
@@ -193,41 +194,45 @@ class TestDTensorCompile(torch._dynamo.test_case.TestCase):
 
     def test_dtensor_constructor_w_graph_break(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        x = torch.randn(64, 32, requires_grad=True)
+        spec = DTensorSpec(
+            mesh,
+            (Replicate(), Shard(0)),
+            tensor_meta=TensorMeta(
+                shape=torch.Size([128, 32]), stride=(32, 1), dtype=x.dtype
+            ),
+        )
 
         # test passing in DTensor as inputs/outputs and run some tensor computation
         def fn(x):
             print("graph break!")
             return DTensor(
                 x,
-                mesh,
-                (Replicate(), Shard(0)),
-                shape=[128, 32],
-                dtype=x.dtype,
+                spec,
                 requires_grad=x.requires_grad,
-                stride=[32, 1],
             )
 
-        x = torch.randn(64, 32, requires_grad=True)
         out = fn(x)
         out2 = torch.compile(fn, backend="eager")(x)
 
     def test_dtensor_constructor_w_dynamo_disable(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        x = torch.randn(32, requires_grad=True)
+        spec = DTensorSpec(
+            mesh,
+            (Replicate()),
+            tensor_meta=TensorMeta(shape=torch.Size([32]), stride=(1,), dtype=x.dtype),
+        )
 
         @torch._dynamo.disable(recursive=False)
         def fn(x):
             print("foo")
             return DTensor(
                 x,
-                mesh,
-                (Replicate(),),
-                shape=torch.Size([32]),
-                dtype=x.dtype,
+                spec,
                 requires_grad=x.requires_grad,
-                stride=(1,),
             )
 
-        x = torch.randn(32, requires_grad=True)
         out = fn(x)
         out2 = torch.compile(fn, backend="eager")(x)
         self.assertEqual(out, out2)

--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -10,7 +10,12 @@ from torch.distributed._tensor._utils import (
 )
 
 from torch.distributed._tensor.debug import CommDebugMode
-from torch.distributed._tensor.placement_types import Replicate, Shard
+from torch.distributed._tensor.placement_types import (
+    DTensorSpec,
+    Replicate,
+    Shard,
+    TensorMeta,
+)
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 from torch.testing._internal.common_utils import run_tests
@@ -185,14 +190,20 @@ class Test2DStridedLocalShard(DTensorTestBase):
             chunks = list(torch.chunk(dtensor_tp.to_local(), 2, dim=0))
             shard_rank = 0 if self.rank // 2 == 0 else 1
             sharded_param = chunks[shard_rank]
+            spec_2d = DTensorSpec(
+                mesh=mesh_2d,
+                placements=(Shard(0), Shard(0)),
+                tensor_meta=TensorMeta(
+                    global_tensor.size(),
+                    global_tensor.stride(),
+                    global_tensor.dtype,
+                ),
+            )
+
             dtensor_2d = DTensor(
                 sharded_param,
-                mesh_2d,
-                [Shard(0), Shard(0)],
-                shape=global_tensor.size(),
-                dtype=global_tensor.dtype,
+                spec_2d,
                 requires_grad=False,
-                stride=global_tensor.stride(),
             )
 
             self.assertEqual(

--- a/torch/distributed/_tensor/__init__.py
+++ b/torch/distributed/_tensor/__init__.py
@@ -52,6 +52,8 @@ def _dtensor_init_helper(
     placements=None,
     **kwargs,
 ) -> DTensor:
+    from torch.distributed._tensor.placement_types import DTensorSpec, TensorMeta
+
     # if device_mesh is None, use the one from mesh resources
     device_mesh = device_mesh or _mesh_resources.get_current_mesh()
     kwargs["device"] = device_mesh.device_type
@@ -76,8 +78,6 @@ def _dtensor_init_helper(
     elif init_op == torch.rand or init_op == torch.randn:
         # this tensor meta is not used except `shape`
         dtype = kwargs.get("dtype", torch.get_default_dtype())
-
-        from torch.distributed._tensor.placement_types import DTensorSpec, TensorMeta
 
         tensor_meta = TensorMeta(size, (0,), dtype)
         spec = DTensorSpec(device_mesh, placements, tensor_meta=tensor_meta)

--- a/torch/distributed/_tensor/__init__.py
+++ b/torch/distributed/_tensor/__init__.py
@@ -91,13 +91,19 @@ def _dtensor_init_helper(
     else:
         local_tensor = init_op(local_shape, **kwargs)
 
+    spec = DTensorSpec(
+        device_mesh,
+        tuple(placements),
+        tensor_meta=TensorMeta(
+            size,
+            torch_stride,
+            local_tensor.dtype,
+        ),
+    )
+
     return DTensor(
-        local_tensor=local_tensor,
-        device_mesh=device_mesh,
-        placements=tuple(placements),
-        shape=size,
-        dtype=local_tensor.dtype,
-        stride=torch_stride,
+        local_tensor,
+        spec,
         requires_grad=kwargs["requires_grad"],
     )
 

--- a/torch/distributed/_tensor/_dispatch.py
+++ b/torch/distributed/_tensor/_dispatch.py
@@ -395,16 +395,7 @@ class OpDispatcher:
                 assert isinstance(
                     spec, DTensorSpec
                 ), f"output spec does not match with output! Expected DTensorSpec, got {spec}."
-                assert spec.tensor_meta is not None
-                return dtensor.DTensor(
-                    res,
-                    spec.mesh,
-                    spec.placements,
-                    shape=spec.tensor_meta.shape,
-                    dtype=spec.tensor_meta.dtype,
-                    requires_grad=res.requires_grad,
-                    stride=spec.tensor_meta.stride,
-                )
+                return dtensor.DTensor(res, spec, requires_grad=res.requires_grad)
             else:
                 # if output does not have a DTensorSpec due to specific ops, it must be a scalar tensor
                 assert res.ndim == 0, "output tensor should be scalar!"

--- a/torch/distributed/_tensor/_redistribute.py
+++ b/torch/distributed/_tensor/_redistribute.py
@@ -12,6 +12,7 @@ from torch.distributed._tensor.placement_types import (
     Placement,
     Replicate,
     Shard,
+    TensorMeta,
 )
 
 
@@ -283,15 +284,12 @@ class Redistribute(torch.autograd.Function):
         else:
             # use the same local tensor if placements are the same.
             output = input._local_tensor
+            target_spec = current_spec
 
         return dtensor.DTensor(
             output,
-            device_mesh,
-            placements,
-            shape=input.shape,
-            dtype=input.dtype,
+            target_spec,
             requires_grad=input.requires_grad,
-            stride=input.stride(),
         )
 
     @staticmethod
@@ -316,14 +314,20 @@ class Redistribute(torch.autograd.Function):
                 normalized_placements.append(Replicate())
             else:
                 normalized_placements.append(previous_placement)
+
+        spec = DTensorSpec(
+            previous_spec.device_mesh,
+            tuple(normalized_placements),
+            tensor_meta=TensorMeta(
+                shape=grad_output.shape,
+                stride=grad_output.stride(),
+                dtype=grad_output.dtype,
+            ),
+        )
         output_dtensor = dtensor.DTensor(
             output,
-            previous_spec.mesh,
-            tuple(normalized_placements),
-            shape=grad_output.shape,
-            dtype=grad_output.dtype,
+            spec,
             requires_grad=grad_output.requires_grad,
-            stride=grad_output.stride(),
         )
 
         return (

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -86,16 +86,21 @@ class _ToTorchTensor(torch.autograd.Function):
         )
         tensor_stride = tuple(tensor_stride)
         grad_placements = grad_placements or dtensor_spec.placements
+        grad_spec = DTensorSpec(
+            mesh,
+            grad_placements,
+            tensor_meta=TensorMeta(
+                shape=dtensor_meta.shape,
+                stride=tensor_stride,
+                dtype=dtensor_meta.dtype,
+            ),
+        )
 
         return (
             DTensor(
                 grad_output,
-                mesh,
-                grad_placements,
-                shape=dtensor_meta.shape,
-                dtype=dtensor_meta.dtype,
+                grad_spec,
                 requires_grad=grad_output.requires_grad,
-                stride=tensor_stride,
             ),
             None,
         )
@@ -146,17 +151,23 @@ class _FromTorchTensor(torch.autograd.Function):
                     input = input.contiguous()
                     mesh_broadcast(input, device_mesh, mesh_dim=idx)
 
+        dist_spec = DTensorSpec(
+            device_mesh,
+            placements,
+            tensor_meta=TensorMeta(
+                tensor_shape,
+                tensor_stride,
+                input.dtype,
+            ),
+        )
+
         # We want a fresh Tensor object that shares memory with the input tensor
         dist_tensor = DTensor(
             input.view_as(input),
-            device_mesh,
-            placements,
-            shape=tensor_shape,
-            dtype=input.dtype,
+            dist_spec,
             # requires_grad of the dist tensor depends on if input
             # requires_grad or not
             requires_grad=input.requires_grad,
-            stride=tensor_stride,
         )
         return dist_tensor
 
@@ -202,13 +213,9 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
     def __new__(
         cls,
         local_tensor: torch.Tensor,
-        device_mesh: DeviceMesh,
-        placements: Tuple[Placement, ...],
+        spec: DTensorSpec,
         *,
-        shape: torch.Size,
-        dtype: torch.dtype,
         requires_grad: bool,
-        stride: Tuple[int, ...],
     ) -> "DTensor":
         """
         Construct a DTensor from a local tensor, device mesh, and placement and
@@ -228,19 +235,18 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
 
         # new method instruct wrapper tensor from local_tensor and add
         # placement spec, it does not do actual distribution
+        assert spec.tensor_meta is not None, "TensorMeta should not be None!"
         r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
             cls,
-            shape,
-            strides=stride,
-            dtype=dtype,
+            spec.tensor_meta.shape,
+            strides=spec.tensor_meta.stride,
+            dtype=spec.tensor_meta.dtype,
             device=local_tensor.device,
             layout=local_tensor.layout,
             requires_grad=requires_grad,
         )
 
-        tensor_meta = TensorMeta(shape, stride, dtype)
-        # deepcopy and set spec
-        r._spec = DTensorSpec(device_mesh, placements, tensor_meta=tensor_meta)
+        r._spec = spec
         r._local_tensor = local_tensor
         return r
 
@@ -264,14 +270,20 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         ), "Expecting spec to be not None from `__tensor_flatten__` return value!"
         local_tensor = inner_tensors["_local_tensor"]
         spec, requires_grad = flatten_spec
-        return DTensor(
-            local_tensor,
+        unflatten_tensor_meta = TensorMeta(
+            shape=outer_size,
+            stride=outer_stride,
+            dtype=spec.tensor_meta.dtype,
+        )
+        unflatten_spec = DTensorSpec(
             spec.mesh,
             spec.placements,
-            shape=outer_size,
-            dtype=spec.tensor_meta.dtype,
+            tensor_meta=unflatten_tensor_meta,
+        )
+        return DTensor(
+            local_tensor,
+            unflatten_spec,
             requires_grad=requires_grad,
-            stride=outer_stride,
         )
 
     def __coerce_tangent_metadata__(self):
@@ -638,14 +650,19 @@ def distribute_tensor(
     assert local_tensor is not None, "distributing a tensor should not be None"
     # detach the local tensor passed to DTensor since after the construction
     # of DTensor, autograd would work on top of DTensor instead of local tensor
+    spec = DTensorSpec(
+        mesh=device_mesh,
+        placements=placements,
+        tensor_meta=TensorMeta(
+            shape=tensor.size(),
+            stride=tensor.stride(),
+            dtype=tensor.dtype,
+        ),
+    )
     return DTensor(
         local_tensor.requires_grad_(tensor.requires_grad),
-        device_mesh,
-        placements,
-        shape=tensor.size(),
-        dtype=tensor.dtype,
+        spec,
         requires_grad=tensor.requires_grad,
-        stride=tensor.stride(),
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #128117
* #128145
* __->__ #128112

as titled, given that our DTensorSpec is immutable, we can always reuse
the spec if the input/output have the same tensor metadata. this helps two fold:
1. We don't need to re-calculate the hash everytime we produce a
   DTensorSpec, reduce runtime operator overhead
2. reduce the DTensor construction overhead.

Some local benchmark on a 800 parameter clip_grad_norm shows that for
foreach_norm the CPU overhead reduces from 11ms -> 7.8ms (around 30% improvement)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k