### PR TITLE
Update torch.nanmean() docstring to mention input dtype requirement

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7009,6 +7009,7 @@ add_docstr(
 nanmean(input, dim=None, keepdim=False, *, dtype=None, out=None) -> Tensor
 
 Computes the mean of all `non-NaN` elements along the specified dimensions.
+Input must be floating point or complex.
 
 This function is identical to :func:`torch.mean` when there are no `NaN` values
 in the :attr:`input` tensor. In the presence of `NaN`, :func:`torch.mean` will
@@ -7018,7 +7019,7 @@ propagate the `NaN` to the output whereas :func:`torch.nanmean` will ignore the
 {keepdim_details}
 
 Args:
-    {input}
+    input (Tensor): the input tensor, either of floating point or complex dtype
     {opt_dim}
     {keepdim}
 


### PR DESCRIPTION
Fixes #120570 

## Description
Update torch.nanmean() docstring to mention input dtype requirement as either floating point type or complex. 
Previously, the torch.mean() docstring had been updated in #120208 in a similar manner, but the torch.nanmean() docstring was not updated.

## Checklist

- [X] The issue that is being fixed is referred in the description.
- [X] Only one issue is addressed in this pull request.
- [x] Labels from the issue that this PR is fixing are added to this pull request.
- [X] No unnecessary issues are included into this pull request.

cc: @janeyx99 @svekars 


cc @svekars @brycebortree