### PR TITLE
Manipulate triton_hash_with_backend so that it doesn't contain any keywords

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1996,8 +1996,7 @@ class TritonKernel(SIMDKernel):
     @staticmethod
     def inductor_meta_common():
         inductor_meta = {
-            # Hash is upper case so that it can't contain any Python keywords.
-            "backend_hash": torch.utils._triton.triton_hash_with_backend().upper(),
+            "backend_hash": torch.utils._triton.triton_hash_with_backend(),
             "are_deterministic_algorithms_enabled": torch.are_deterministic_algorithms_enabled(),
             "assert_indirect_indexing": config.assert_indirect_indexing,
             "autotune_local_cache": config.autotune_local_cache,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1996,7 +1996,8 @@ class TritonKernel(SIMDKernel):
     @staticmethod
     def inductor_meta_common():
         inductor_meta = {
-            "backend_hash": torch.utils._triton.triton_hash_with_backend(),
+            # Hash is upper case so that it can't contain any Python keywords.
+            "backend_hash": torch.utils._triton.triton_hash_with_backend().upper(),
             "are_deterministic_algorithms_enabled": torch.are_deterministic_algorithms_enabled(),
             "assert_indirect_indexing": config.assert_indirect_indexing,
             "autotune_local_cache": config.autotune_local_cache,

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -61,7 +61,9 @@ def triton_hash_with_backend():
 
     backend = triton_backend()
     key = f"{triton_key()}-{backend.hash()}"
-    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+    # Hash is upper case so that it can't contain any Python keywords.
+    return hashlib.sha256(key.encode("utf-8")).hexdigest().upper()
 
 
 def dtype_to_string(dtype):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128159

Summary: See https://github.com/pytorch/pytorch/issues/127637 where "def" appears in the backend_hash and causes a problem.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang