### PR TITLE
Use write_record_metadata in torch.save under certain conditions

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4023,6 +4023,7 @@ class TestSerialization(TestCase, SerializationMixin):
     @parametrize('dtype', (torch.complex32, torch.float32))  # test both rebuild_v2 and rebuild_v3 dtypes
     @unittest.skipIf(IS_WINDOWS, "NamedTemporaryFile on windows")
     @unittest.skipIf(IS_FBCODE, "miniz version differs between fbcode and oss")
+    @unittest.skipIf(not torch.cuda.is_available())
     def test_filewriter_metadata_writing(self, filename, device, dtype):
         '''
         Using a FakeTensorMode and annotating untyped_storage with `_serialize` will

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -25,6 +25,7 @@ class _StorageBase:
     is_sparse: bool = False
     is_sparse_csr: bool = False
     device: torch.device
+    _serialize: bool = True
 
     def __init__(self, *args, **kwargs): ...  # noqa: E704
     def __len__(self) -> int: ...  # type: ignore[empty-body] # noqa: E704
@@ -547,6 +548,10 @@ class TypedStorage:
         """Returns the file name associated with this storage if the storage was memory mapped from a file.
            or ``None`` if the storage was not created by memory mapping a file."""
         return self._untyped_storage.filename
+
+    @property
+    def _serialize(self) -> bool:
+        return self._untyped_storage._serialize
 
     def fill_(self, value):
         _warn_typed_storage_removal()


### PR DESCRIPTION
Add a flag `._serialize` to Storage, for FakeTensor(plain Tensor) with this set, the FakeTensor will be serialized as if it were the real tensor, storage will be serialized

e.g. you can do 

```python
with FakeTensorMode():
    m = nn.Linear(3, 5, dtype=torch.float16, device='cuda')

sd = m.state_dict()
for v in sd.values():
    v.untyped_storage()._serialize = False
    
torch.save(sd, 'bla.pt')
print(torch.load('bla.pt')
# OrderedDict([('weight', tensor([[0., 0., 0.],
#        [0., 0., 0.],
#        [0., 0., 0.],
#        [0., 0., 0.],
#        [0., 0., 0.]], device='cuda:0', dtype=torch.float16)), ('bias', tensor([0., 0., 0., 0., 0.], device='cuda:0', dtype=torch.float16))])
```

recall that `FakeTensor` has its storage on meta device so there is some hackery to make sure the storage is aware of its own device.

**The alternative here is to add a subclass that overrides `__reduce_ex__` that can be used for this purpose**

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128162

