### PR TITLE
Run read_data() directly without all_gather the exceptions

### DIFF
--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -227,7 +227,7 @@ def _load_state_dict(
         all_reads.wait()
         return None
 
-    _ = distW.all_gather("read", read_data)
+    read_data()
 
 
 def _load_state_dict_from_keys(

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -228,6 +228,7 @@ def _load_state_dict(
         return None
 
     read_data()
+    dist.barrier()
 
 
 def _load_state_dict_from_keys(


### PR DESCRIPTION
To solve this issue: https://github.com/pytorch/pytorch/issues/122529, remove the all_gather, so that it can immediately raise any error in read_data()

Fixes #122529


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang