### PR TITLE
commented introductory version for torch.Tensor classes in docs' tensor_attributes

### DIFF
--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -14,7 +14,7 @@ torch.dtype
 
 .. class:: dtype
 
-.. versions:: 0.4.0 +
+Introductory version: 0.4.0 +
 
 A :class:`torch.dtype` is an object that represents the data type of a
 :class:`torch.Tensor`. PyTorch has twelve different data types:
@@ -138,7 +138,7 @@ torch.device
 
 .. class:: device
 
-.. versions:: 0.4.0 +
+Introductory version: 0.4.0 +
 
 A :class:`torch.device` is an object representing the device on which a :class:`torch.Tensor` is
 or will be allocated.
@@ -254,7 +254,7 @@ torch.layout
 
 .. class:: layout
 
-.. versions:: 0.4.0+
+Introductory version: 0.4.0+
 
 .. warning::
   The ``torch.layout`` class is in beta and subject to change.
@@ -288,7 +288,7 @@ torch.memory_format
 
 .. class:: memory_format
 
-.. versions:: 1.5.0+
+Introductory version: 1.5.0+
 
 A :class:`torch.memory_format` is an object representing the memory format on which a :class:`torch.Tensor` is
 or will be allocated.

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -5,7 +5,7 @@
 Tensor Attributes
 =================
 
-Each ``torch.Tensor`` has a :class:`torch.dtype`, :class:`torch.device`, and :class:`torch.layout`.
+Each ``torch.Tensor`` has a :class:`torch.dtype`, :class:`torch.device`, :class:`torch.layout`, and :class:`torch.memory_format`.
 
 .. _dtype-doc:
 
@@ -13,6 +13,8 @@ torch.dtype
 -----------
 
 .. class:: dtype
+
+.. versions:: 0.4.0 +
 
 A :class:`torch.dtype` is an object that represents the data type of a
 :class:`torch.Tensor`. PyTorch has twelve different data types:
@@ -136,6 +138,8 @@ torch.device
 
 .. class:: device
 
+.. versions:: 0.4.0 +
+
 A :class:`torch.device` is an object representing the device on which a :class:`torch.Tensor` is
 or will be allocated.
 
@@ -250,6 +254,8 @@ torch.layout
 
 .. class:: layout
 
+.. versions:: 0.4.0+
+
 .. warning::
   The ``torch.layout`` class is in beta and subject to change.
 
@@ -281,6 +287,8 @@ torch.memory_format
 -------------------
 
 .. class:: memory_format
+
+.. versions:: 1.5.0+
 
 A :class:`torch.memory_format` is an object representing the memory format on which a :class:`torch.Tensor` is
 or will be allocated.


### PR DESCRIPTION
Added first version available for torch.dtype, torch.device, torch.layout, and torch.memory_format. I determined this by manually going through http://pytorch.org/docs/versions.html.

Also updated top comment that does not mention the existence of the torch.memory_format class. 

First contribution towards issue. Need feedback on format standardization and the appropriate amount of information. Will expand this update to other docs after feedback/approval.

Fixes #105460 
