### PR TITLE
Wrap output with FakeTensor if input FakeTensor is not preserved

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2117,7 +2117,11 @@ def _to_copy(
         x = torch._prims.convert_element_type(x, dtype)
         dtype_converted = True
 
-    if dtype_converted and input_is_fake and not isinstance(x, torch._subclasses.FakeTensor):
+    if (
+        dtype_converted
+        and input_is_fake
+        and not isinstance(x, torch._subclasses.FakeTensor)
+    ):
         x = wrap_output_with_input_device_(x, common_device)
     if memory_format is not None:  # no ref/prim for memory format
         return torch.clone(x, memory_format=memory_format)


### PR DESCRIPTION
Fixes #128202

For cases that the input is a FakeTensor with "meta" device, the output may not preserve its fakeness and come out as Tensor (see _convert_element_type_meta). In this case, the original device type is lost in the output.

This PR pick up the work from #104689 and apply the check of the input and output fakeness originally showing in #119868.