### PR TITLE
[C10D] Ensure gil is not released when calling toPyBytes

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1017,9 +1017,9 @@ Example::
                  const std::string& desired_value) -> py::bytes {
                 std::vector<uint8_t> value;
                 {
-                    py::call_guard<py::gil_scoped_release>();
-                    value = store.compareSet(
-                        key, toVec8(expected_value), toVec8(desired_value));
+                  py::call_guard<py::gil_scoped_release>();
+                  value = store.compareSet(
+                      key, toVec8(expected_value), toVec8(desired_value));
                 }
                 return toPyBytes(value);
               },

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1015,11 +1015,14 @@ Example::
                  const std::string& key,
                  const std::string& expected_value,
                  const std::string& desired_value) -> py::bytes {
-                auto value = store.compareSet(
-                    key, toVec8(expected_value), toVec8(desired_value));
+                std::vector<uint8_t> value;
+                {
+                    py::call_guard<py::gil_scoped_release>();
+                    value = store.compareSet(
+                        key, toVec8(expected_value), toVec8(desired_value));
+                }
                 return toPyBytes(value);
               },
-              py::call_guard<py::gil_scoped_release>(),
               R"(
 Inserts the key-value pair into the store based on the supplied ``key`` and
 performs comparison between ``expected_value`` and ``desired_value`` before inserting. ``desired_value``

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1015,12 +1015,11 @@ Example::
                  const std::string& key,
                  const std::string& expected_value,
                  const std::string& desired_value) -> py::bytes {
-                std::vector<uint8_t> value;
-                {
-                  py::call_guard<py::gil_scoped_release>();
-                  value = store.compareSet(
+                auto value = [&]() {
+                  py::gil_scoped_release guard;
+                  return store.compareSet(
                       key, toVec8(expected_value), toVec8(desired_value));
-                }
+                }();
                 return toPyBytes(value);
               },
               R"(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128212



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225 @chauhang @d4l3k