### PR TITLE
[BE]: Update ruff to 0.4.8

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -2079,7 +2079,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.4.6',
+    'ruff==0.4.8',
 ]
 is_formatter = true
 


### PR DESCRIPTION
Updates ruff to 0.4.8. Some minor fixes, but noticably is 10% faster on microbenchmark and should further reduce local and CI runtime of the linter. Also includes a few bugfixes.