### PR TITLE
Better doc for non_blocking arguments

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1228,9 +1228,16 @@ different device.
 
 Args:
     src (Tensor): the source tensor to copy from
-    non_blocking (bool): if ``True`` and this copy is between CPU and GPU,
-        the copy may occur asynchronously with respect to the host. For other
-        cases, this argument has no effect.
+    non_blocking (bool): if ``True`` the source is on a different device than the
+        destination, the copy may occur asynchronously with respect to the host.
+        For other cases, this argument has no effect. Defaults to ``False``.
+
+.. warning:: When ``non_blocking=True``, a subsequent access to the tensor data
+    after a device to CUDA transfer will trigger a CUDA stream synchronization.
+    In all other cases (CUDA to CPU or other device transfer) a call to ``synchronize``
+    is required for safe data access. Not calling ``torch.<device>.synchronize()``
+    will result in silent errors.
+
 """,
 )
 
@@ -1400,9 +1407,10 @@ then no copy is performed and the original object is returned.
 Args:
     device (:class:`torch.device`): The destination GPU device.
         Defaults to the current CUDA device.
-    non_blocking (bool): If ``True`` and the source is in pinned memory,
-        the copy will be asynchronous with respect to the host.
-        Otherwise, the argument has no effect. Default: ``False``.
+    non_blocking (bool): If ``True`` and the source and destination are on different
+        devices, the copy will be asynchronous with respect to the host. Otherwise,
+        the argument has no effect. This call doesn't require an explicit call to
+        :func:`~torch.cuda.synchronize`. Defaults to ``False``.
     {memory_format}
 """.format(
         **common_args
@@ -1422,10 +1430,16 @@ then no copy is performed and the original object is returned.
 Args:
     device (:class:`torch.device`): The destination IPU device.
         Defaults to the current IPU device.
-    non_blocking (bool): If ``True`` and the source is in pinned memory,
-        the copy will be asynchronous with respect to the host.
-        Otherwise, the argument has no effect. Default: ``False``.
+    non_blocking (bool): if ``True`` the source is on a different device than the
+        destination, the copy may occur asynchronously with respect to the host.
+        For other cases, this argument has no effect. Defaults to ``False``.
     {memory_format}
+
+.. warning:: When ``non_blocking=True``, a subsequent access to the tensor data
+    after a device to CUDA transfer will trigger a CUDA stream synchronization.
+    In all other cases (CUDA to CPU or other device transfer) a call to ``synchronize``
+    is required for safe data access. Not calling ``torch.<device>.synchronize()``
+    will result in silent errors.
 """.format(
         **common_args
     ),
@@ -1444,10 +1458,16 @@ then no copy is performed and the original object is returned.
 Args:
     device (:class:`torch.device`): The destination XPU device.
         Defaults to the current XPU device.
-    non_blocking (bool): If ``True`` and the source is in pinned memory,
-        the copy will be asynchronous with respect to the host.
-        Otherwise, the argument has no effect. Default: ``False``.
+    non_blocking (bool): if ``True`` the source is on a different device than the
+        destination, the copy may occur asynchronously with respect to the host.
+        For other cases, this argument has no effect. Defaults to ``False``.
     {memory_format}
+
+.. warning:: When ``non_blocking=True``, a subsequent access to the tensor data
+    after a device to CUDA transfer will trigger a CUDA stream synchronization.
+    In all other cases (CUDA to CPU or other device transfer) a call to ``synchronize``
+    is required for safe data access. Not calling ``torch.<device>.synchronize()``
+    will result in silent errors.
 """.format(
         **common_args
     ),
@@ -6004,12 +6024,17 @@ original object is returned.
 
 Args:
     dtype (dtype or string): The desired type
-    non_blocking (bool): If ``True``, and the source is in pinned memory
-        and destination is on the GPU or vice versa, the copy is performed
-        asynchronously with respect to the host. Otherwise, the argument
-        has no effect.
+    non_blocking (bool): if ``True`` the source is on a different device than the
+        destination, the copy may occur asynchronously with respect to the host.
+        For other cases, this argument has no effect. Defaults to ``False``.
     **kwargs: For compatibility, may contain the key ``async`` in place of
         the ``non_blocking`` argument. The ``async`` arg is deprecated.
+
+.. warning:: When ``non_blocking=True``, a subsequent access to the tensor data
+    after a device to CUDA transfer will trigger a CUDA stream synchronization.
+    In all other cases (CUDA to CPU or other device transfer) a call to ``synchronize``
+    is required for safe data access. Not calling ``torch.<device>.synchronize()``
+    will result in silent errors.
 """,
 )
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -21,10 +21,16 @@ def _type(self, dtype=None, non_blocking=False, **kwargs):
 
     Args:
         dtype (type or string): The desired type
-        non_blocking (bool): If ``True``, and the source is in pinned memory
-            and destination is on the GPU or vice versa, the copy is performed
-            asynchronously with respect to the host. Otherwise, the argument
-            has no effect.
+        non_blocking (bool): If ``True``, and source and destination are on
+            different devices, the copy is performed asynchronously with
+            respect to the host. Otherwise, the argument has no effect.
+
+            .. warning:: When ``non_blocking=True``, subsequent access to the tensor data
+                after a device to CUDA transfer will trigger a CUDA stream synchronization.
+                In all other cases (CUDA to CPU or other device transfer) a call to ``synchronize``
+                is required for safe data access. Not calling ``torch.<device>.synchronize()``
+                will result in silent errors.
+
         **kwargs: For compatibility, may contain the key ``async`` in place of
             the ``non_blocking`` argument. The ``async`` arg is deprecated.
     """
@@ -60,9 +66,15 @@ def _to(self, device, non_blocking=False):
 
     Args:
         device (int): The destination device.
-        non_blocking (bool): If ``True`` and the source is in pinned memory,
-            the copy will be asynchronous with respect to the host. Otherwise,
-            the argument has no effect.
+        non_blocking (bool): if ``True`` the source is on a different device than the
+            destination, the copy may occur asynchronously with respect to the host.
+            For other cases, this argument has no effect.
+
+    .. warning:: When ``non_blocking=True``, subsequent access to the tensor data
+        after a device to CUDA transfer will trigger a CUDA stream synchronization.
+        In all other cases (CUDA to CPU or other device transfer) a call to ``synchronize``
+        is required for safe data access. Not calling ``torch.<device>.synchronize()``
+        will result in silent errors.
     """
     if self.device == device:
         return self

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -106,12 +106,13 @@ def _iterate_state_dict(
         companion_obj (Any): A companion object to the state dict. If this object
             is supplied, we attempt to copy the tensor to the companion object.
         ranks_only (Tuple[int, ...]): if this tuple is empty, all ranks will
-            have the same state_dicts. Otherwise only ranks that in ``ranks_only``
+            have the same state_dicts. Otherwise, only ranks that in ``ranks_only``
             have the same state_dicts. Other ranks will get empty state_dicts.
         type_check (bool): check if the instance data type is a supported type
             that can be saved by DCP.  The current supported data types are
             torch.Tensor, DTensor, int, float, str, list, dict, None.
         non_blocking (bool): whether to use non-blocking copy when copying to the companion object.
+            Check :meth:`~torch.Tensor.to` for more context. Defaults to ``True``.
     """
     # TODO: should we use pytree?
     cpu_device = torch.device("cpu")

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -47,9 +47,11 @@ class _StorageBase:
 
         Args:
             device (int): The destination GPU id. Defaults to the current device.
-            non_blocking (bool): If ``True`` and the source is in pinned memory,
-                the copy will be asynchronous with respect to the host. Otherwise,
-                the argument has no effect.
+            non_blocking (bool): If ``True`` and the source and destination are on different
+                devices, the copy will be asynchronous with respect to the host. Otherwise,
+                the argument has no effect. This call doesn't require an explicit call to
+                :func:`~torch.cuda.synchronize`. Defaults to ``False``.
+
         """
         device2 = torch.device('cuda', device) if device else torch.device('cuda')
         return self.to(device=device2, non_blocking=non_blocking)
@@ -62,9 +64,16 @@ class _StorageBase:
 
         Args:
             device (int): The destination HPU id. Defaults to the current device.
-            non_blocking (bool): If ``True`` and the source is in pinned memory,
-                the copy will be asynchronous with respect to the host. Otherwise,
-                the argument has no effect.
+            non_blocking (bool): If ``True``, and source and destination are on
+                different devices, the copy is performed asynchronously with
+                respect to the host. Otherwise, the argument has no effect.
+                Defaults to ``False``.
+
+                .. warning:: When ``non_blocking=True``, subsequent access to the tensor data
+                    after a device to CUDA transfer will trigger a CUDA stream synchronization.
+                    In all other cases (CUDA to CPU or other device transfer) a call to ``synchronize``
+                    is required for safe data access. Not calling ``torch.<device>.synchronize()``
+                    will result in silent errors.
         """
         device2 = torch.device('hpu', device) if device else torch.device('hpu')
         return self.to(device=device2, non_blocking=non_blocking)

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -136,9 +136,15 @@ def _generate_tensor_methods_for_privateuse1_backend(custom_backend_name: str) -
 
         Args:
             device (int, optional): if specified, all parameters will be copied to that device
-            non_blocking (bool): If ``True`` and the source is in pinned memory,
-                the copy will be asynchronous with respect to the host. Otherwise,
-                the argument has no effect.
+            non_blocking (bool): If ``True``, and source and destination are on
+                different devices, the copy is performed asynchronously with
+                respect to the host. Otherwise, the argument has no effect.
+
+                .. warning:: When ``non_blocking=True``, subsequent access to the tensor data
+                    after a device to CUDA transfer will trigger a CUDA stream synchronization.
+                    In all other cases (CUDA to CPU or other device transfer) a call to ``synchronize``
+                    is required for safe data access. Not calling ``torch.<device>.synchronize()``
+                    will result in silent errors.
             **kwargs (dict): For compatibility, may contain the key ``memory_format`` argument.
         """
         if has_torch_function_unary(self):
@@ -241,9 +247,15 @@ def _generate_storage_methods_for_privateuse1_backend(custom_backend_name: str,
 
         Args:
             device (int): The destination device id. Defaults to the current device.
-            non_blocking (bool): If ``True`` and the source is in pinned memory,
-            the copy will be asynchronous with respect to the host. Otherwise,
-            the argument has no effect.
+            non_blocking (bool): If ``True``, and source and destination are on
+                different devices, the copy is performed asynchronously with
+                respect to the host. Otherwise, the argument has no effect.
+
+                .. warning:: When ``non_blocking=True``, subsequent access to the tensor data
+                    after a device to CUDA transfer will trigger a CUDA stream synchronization.
+                    In all other cases (CUDA to CPU or other device transfer) a call to ``synchronize``
+                    is required for safe data access. Not calling ``torch.<device>.synchronize()``
+                    will result in silent errors.
         """
         # There should be a judgment related to storage device and a judgment related to storage type,
         # but it depends on the extended function, so this part is temporarily omitted in the automatic generation.


### PR DESCRIPTION
Improves the doc of non_blocking arguments.

We want to
- make it clear that cpu -> cuda is safe, but everything else isn't if a synchronize has not been called
- remove the mention of `pin_memory`: if the tensor is already in pin_memory it'll be faster but 
  - with other devices (mps) non_blocking can still be used although pin_memory fails
  - it's still faster to call non_blocking=True even without pin_memory. The only difference AFAIU is that no explicit call to `pin_memory` will call some version of that under the hood. If a memory buffer can be placed in pin_memory it might be good to use that to move data to cuda but it isn't a strong requirement.

Not sure it makes that much sense for IPU / HPU?

Also for `type()` I edited the `non_blocking` arg (which involved a "source" that is not part of the args!)  but it seems that this has no effect (at least for `tensor.type(smth, non_blocking=whatever)` and for storages... well we have only untyped storages no?) Should we just say that it has no effect?



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang