### PR TITLE
[GenAi-MTIA] Add float8_e4m3fn datatype to the compiler flow.

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -843,6 +843,7 @@ ANY_DTYPE_ORDER = (
     torch.complex128,
     torch.float16,
     torch.bfloat16,
+    torch.float8_e4m3fn,
     torch.long,
     torch.int32,
     torch.int16,


### PR DESCRIPTION
Summary: Reference add kernel with float 8. Float8 support is not available.

Test Plan:
To run the command follow the doc to run athena amodel: https://docs.google.com/document/d/1W7jSMvIECtLWtwUyIsDEYYaaVm7YGRB_po1QXI1pS6U/edit?usp=sharing

add_ref_fp8 works with;
```
mtiavm ssh -- env TRITON_DISABLE_JUSTKNOBS=1 BACKEND_NAME=athena1 MTIA_TARGET_ARCH=MTIA_ARCH_ATHENA AFG_COMPILE_TARGET=athena1 AFG_EXEC_TILE_SIZE=4x4 CONFIGERATOR_PRETEND_NOT_PROD=1 AFG_USE_REF_KERNELS=all AFG_JOB_TIMEOUT_MS=10000 FBA_USE_FW_STREAM=0 FBA_USE_FW_P2P=0 AFG_USE_CPU_PRINTF=1 $(buck2 run @//mode/opt //glow/fba/tests:run_kernel --emit-shell -- --kernel "add" --config "input=2,3;dtype=fp8" --cmp none)
```

try add_fp8 and add_fp32 with;
```
mtiavm ssh -- env TRITON_DISABLE_JUSTKNOBS=1 BACKEND_NAME=athena1 MTIA_TARGET_ARCH=MTIA_ARCH_ATHENA AFG_COMPILE_TARGET=athena1 AFG_EXEC_TILE_SIZE=4x4 CONFIGERATOR_PRETEND_NOT_PROD=1 AFG_JOB_TIMEOUT_MS=10000 FBA_USE_FW_STREAM=0 FBA_USE_FW_P2P=0 AFG_USE_CPU_PRINTF=1 $(buck2 run @//mode/opt -c mtia.codename=athena1 //glow/fba/tests:run_kernel --emit-shell -- --kernel "add" --config "input=2,3;dtype=fp8" --cmp none)
```

```
mtiavm ssh -- env TRITON_DISABLE_JUSTKNOBS=1 BACKEND_NAME=athena1 MTIA_TARGET_ARCH=MTIA_ARCH_ATHENA AFG_COMPILE_TARGET=athena1 AFG_EXEC_TILE_SIZE=4x4 CONFIGERATOR_PRETEND_NOT_PROD=1 AFG_JOB_TIMEOUT_MS=10000 FBA_USE_FW_STREAM=0 FBA_USE_FW_P2P=0 AFG_USE_CPU_PRINTF=1 $(buck2 run @//mode/opt -c mtia.codename=athena1 //glow/fba/tests:run_kernel --emit-shell -- --kernel "add" --config "input=2,3;dtype=fp32" --cmp none)
```

Differential Revision: D57980526
