### PR TITLE
[WIP][DTensor] Add a util to compute DTensor padding

### DIFF
--- a/test/distributed/_tensor/test_utils.py
+++ b/test/distributed/_tensor/test_utils.py
@@ -5,6 +5,7 @@ import itertools
 import torch
 from torch.distributed._tensor import distribute_tensor, DTensor
 from torch.distributed._tensor._utils import (
+    compute_global_padding,
     compute_local_shape,
     compute_local_shape_and_global_offset,
 )
@@ -126,6 +127,54 @@ class UtilTest(DTensorTestBase):
                     dtensor.to_local(),
                     global_tensor[dim0_start:dim0_end, dim1_start:dim1_end],
                 )
+
+    @with_comms
+    def test_compute_global_padding(self):
+        # 1D DTensor Scenario
+        mesh = init_device_mesh(self.device_type, (8,))
+
+        # when the original tensor is evenly shardable already
+        global_tensor = torch.randn(8, requires_grad=True)
+        padding = compute_global_padding(global_tensor.shape, mesh, [Shard(0)])
+        self.assertEqual(padding, [0])
+
+        # On 0th dim, num_shard = 8 > global_tensor.size(0) = 7
+        global_tensor = torch.randn(7, requires_grad=True)
+        padding = compute_global_padding(global_tensor.shape, mesh, [Shard(0)])
+        self.assertEqual(padding, [1])
+        self.assertEqual((padding[0] + global_tensor.shape[0]) % self.world_size, 0)
+
+        # On 0th dim, num_shard = 8 < global_tensor.size(0) = 9
+        global_tensor = torch.randn(9, requires_grad=True)
+        padding = compute_global_padding(global_tensor.shape, mesh, [Shard(0)])
+        self.assertEqual(padding, [7])
+        self.assertEqual((padding[0] + global_tensor.shape[0]) % self.world_size, 0)
+
+        # 2D DTensor Scenario
+        mesh = init_device_mesh(self.device_type, (4, self.world_size // 4))
+
+        # On 0th dim, total_num_shard = 8 > global_tensor.size(0) = 7
+        global_tensor = torch.randn(self.world_size - 1, 8, requires_grad=True)
+        padding = compute_global_padding(
+            global_tensor.shape, mesh, [Shard(0), Shard(0)]
+        )
+        self.assertEqual(padding, [1, 0])
+
+        # On 0th dim, total_num_shard= 8 < global_tensor.size(0) = 9
+        global_tensor = torch.randn(self.world_size + 1, 8, requires_grad=True)
+        padding = compute_global_padding(
+            global_tensor.shape, mesh, [Shard(0), Shard(0)]
+        )
+        self.assertEqual(padding, [7, 0])
+
+        # On both dim, tensor is not evenly shardable.
+        # On 0th dim, num_shard = 4 > global_tensor.size(0) = 3
+        # On 1st dim, num_shard = 2 < global_tensor.size(1) = 3
+        global_tensor = torch.randn(3, 3, requires_grad=True)
+        padding = compute_global_padding(
+            global_tensor.shape, mesh, [Shard(0), Shard(1)]
+        )
+        self.assertEqual(padding, [1, 1])
 
 
 class Test2DStridedLocalShard(DTensorTestBase):

--- a/torch/distributed/_tensor/_utils.py
+++ b/torch/distributed/_tensor/_utils.py
@@ -224,3 +224,40 @@ def compute_local_stride(
     return tuple(
         global_stride[i] // stride_divisors[i] for i in range(len(global_stride))
     )
+
+
+def compute_global_padding(
+    global_shape: ShapeType, mesh: DeviceMesh, placements: Sequence[Placement]
+) -> List[int]:
+    """
+    Compute the padding needed to make the tensor evenly shardable. It returns
+    a list of ints where pad_sizes[i] means tensor dim i needs to be padded by
+    pad_sizes[i] in order to make the tensor evenly shardable on the given mesh
+    and placements.
+
+    For example, we have a dist tensor with shape (5, 1) on
+    device_mesh([[0, 1],[2, 3]]) with placements [Shard(0), Shard(0)].
+    The pad_sizes would be [3, 0]. This means, to make the tensor evenly shardable,
+    we need to pad the tensor on dim 0 by 5 elements and no padding is needed on dim 1.
+    """
+    num_shard_by_dim = [1 for _ in range(len(global_shape))]
+    for mesh_idx, placement in enumerate(placements):
+        if placement.is_shard():
+            tensor_shard_dim = placement.dim  # type: ignore[attr-defined]
+            mesh_dim_size = mesh.size(mesh_idx)
+            num_shard_by_dim[tensor_shard_dim] *= mesh_dim_size
+
+    pad_sizes = []
+    for tensor_dim, num_shard in enumerate(num_shard_by_dim):
+        tensor_dim_size = global_shape[tensor_dim]
+        if num_shard == 1 or num_shard == tensor_dim_size:
+            pad_sizes.append(0)
+        elif tensor_dim_size > num_shard:
+            padded_tensor_dim_size = (
+                tensor_dim_size + num_shard - (tensor_dim_size % num_shard)
+            )
+            pad_sizes.append(padded_tensor_dim_size - tensor_dim_size)
+        elif tensor_dim_size < num_shard:
+            pad_sizes.append(num_shard - tensor_dim_size)
+
+    return pad_sizes


### PR DESCRIPTION
Currently, we are doing dynamic padding on DTensor, but we want to explore static sharding for performance purposes, which means we want to do padding before any sharding happens. 

This PR to add a a util to compute the padding needed on each tensor dim on a global level. 

For example, let's say we have:
```
world_size = 6
mesh_shape = (3, 2)
placements = (Shard(0), Shard(0))
tensor = ([0, 1, 2, 3, 4, 5, 6])
```

With the current dynamic padding, we have the following sharding result:
```
tensor: [0, 1, 2, 3, 4, 5, 6]

rank0: [0, 1], rank1: [2]
rank2: [3, 4], rank3: [5]
rank4: [6], rank5: []
```

With static padding, we will decide the padding size needed for each tensor dimension instead of mesh dimension before sharding happens. 
```
# This PR calculates the padding required on the tensor dimension based on mesh_shape and placements.
# Padding is [5], which means we need to pad 5 elements on the 0th dimension of the given tensor.
tensor: [0, 1, 2, 3, 4, 5, 6, #, #, #, #, #]

rank0: [0, 1], rank1: [2, 3]
rank2: [4, 5], rank3: [6, #]
rank4: [#, #], rank5: [#, #]
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang