### PR TITLE
Fix docstring in many different files

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -1,8 +1,8 @@
 # mypy: allow-untyped-defs
 """
-``torch.autograd`` provides classes and functions implementing automatic
-differentiation of arbitrary scalar valued functions. It requires minimal
-changes to the existing code - you only need to declare :class:`Tensor` s
+``torch.autograd`` provides classes and functions implementing automatic differentiation of arbitrary scalar valued functions.
+
+It requires minimal changes to the existing code - you only need to declare :class:`Tensor` s
 for which gradients should be computed with the ``requires_grad=True`` keyword.
 As of now, we only support autograd for floating point :class:`Tensor` types (
 half, float, double and bfloat16) and complex :class:`Tensor` types (cfloat, cdouble).
@@ -188,8 +188,7 @@ def backward(
     grad_variables: Optional[_TensorOrTensors] = None,
     inputs: Optional[_TensorOrTensorsOrGradEdge] = None,
 ) -> None:
-    r"""Computes the sum of gradients of given tensors with respect to graph
-    leaves.
+    r"""Compute the sum of gradients of given tensors with respect to graph leaves.
 
     The graph is differentiated using the chain rule. If any of ``tensors``
     are non-scalar (i.e. their data has more than one element) and require
@@ -308,8 +307,7 @@ def grad(
     is_grads_batched: bool = False,
     materialize_grads: bool = False,
 ) -> Tuple[torch.Tensor, ...]:
-    r"""Computes and returns the sum of gradients of outputs with respect to
-    the inputs.
+    r"""Compute and return the sum of gradients of outputs with respect to the inputs.
 
     ``grad_outputs`` should be a sequence of length matching ``output``
     containing the "vector" in vector-Jacobian product, usually the pre-computed
@@ -476,7 +474,7 @@ def _is_checkpoint_valid():
     return Variable._execution_engine.is_checkpoint_valid()
 
 
-def variable(*args, **kwargs):
+def variable(*args, **kwargs):  # noqa: D103
     raise RuntimeError(
         "torch.autograd.variable(...) is deprecated, use torch.tensor(...) instead"
     )

--- a/torch/autograd/anomaly_mode.py
+++ b/torch/autograd/anomaly_mode.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""Autograd anomaly mode."""
 import warnings
 
 import torch
@@ -22,7 +23,6 @@ class detect_anomaly:
         will slow down your program execution.
 
     Example:
-
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_ANOMALY)
         >>> import torch
         >>> from torch import autograd
@@ -73,7 +73,7 @@ class detect_anomaly:
 
     """
 
-    def __init__(self, check_nan=True) -> None:
+    def __init__(self, check_nan=True) -> None:  # noqa: D107
         self.prev = torch.is_anomaly_enabled()
         self.check_nan = check_nan
         self.prev_check_nan = torch.is_anomaly_check_nan_enabled()
@@ -84,10 +84,10 @@ class detect_anomaly:
             stacklevel=2,
         )
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> None:  # noqa: D105
         torch.set_anomaly_enabled(True, self.check_nan)
 
-    def __exit__(self, *args: object) -> None:
+    def __exit__(self, *args: object) -> None:  # noqa: D105
         torch.set_anomaly_enabled(self.prev, self.prev_check_nan)
 
 
@@ -108,13 +108,13 @@ class set_detect_anomaly:
 
     """
 
-    def __init__(self, mode: bool, check_nan: bool = True) -> None:
+    def __init__(self, mode: bool, check_nan: bool = True) -> None:  # noqa: D107
         self.prev = torch.is_anomaly_enabled()
         self.prev_check_nan = torch.is_anomaly_check_nan_enabled()
         torch.set_anomaly_enabled(mode, check_nan)
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> None:  # noqa: D105
         pass
 
-    def __exit__(self, *args: object) -> None:
+    def __exit__(self, *args: object) -> None:  # noqa: D105
         torch.set_anomaly_enabled(self.prev, self.prev_check_nan)

--- a/torch/optim/_multi_tensor/__init__.py
+++ b/torch/optim/_multi_tensor/__init__.py
@@ -1,5 +1,5 @@
-"""
-:mod:`torch.optim._multi_tensor` is a package implementing various optimization algorithms.
+""":mod:`torch.optim._multi_tensor` is a package implementing various optimization algorithms.
+
 Most commonly used methods are already supported, and the interface is general
 enough, so that more sophisticated ones can be also easily integrated in the
 future.
@@ -9,7 +9,7 @@ from functools import partialmethod
 from torch import optim
 
 
-def partialclass(cls, *args, **kwargs):
+def partialclass(cls, *args, **kwargs):  # noqa: D103
     class NewCls(cls):
         __init__ = partialmethod(cls.__init__, *args, **kwargs)
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""Learning Rate Scheduler."""
 import math
 import types
 import warnings
@@ -55,7 +56,7 @@ EPOCH_DEPRECATION_WARNING = (
 
 
 def _check_verbose_deprecated_warning(verbose):
-    """Raises a warning when verbose is not the default value."""
+    """Raise a warning when verbose is not the default value."""
     if verbose != "deprecated":
         warnings.warn(
             "The verbose parameter is deprecated. Please use get_last_lr() "
@@ -85,9 +86,13 @@ def _format_param(name: str, optimizer: Optimizer, param):
 
 
 class LRScheduler:
+    r"""Initialize and adjust the learning rate based epoch numbers."""
+
     _get_lr_called_within_step: bool = False
 
-    def __init__(self, optimizer: Optimizer, last_epoch=-1, verbose="deprecated"):
+    def __init__(
+        self, optimizer: Optimizer, last_epoch=-1, verbose="deprecated"
+    ):  # noqa: D107
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
@@ -139,12 +144,12 @@ class LRScheduler:
         self._initial_step()
 
     def _initial_step(self):
-        """Initialize step counts and performs a step"""
+        """Initialize step counts and performs a step."""
         self._step_count = 0
         self.step()
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -154,7 +159,7 @@ class LRScheduler:
         }
 
     def load_state_dict(self, state_dict: Dict[str, Any]):
-        """Loads the schedulers state.
+        """Load the schedulers state.
 
         Args:
             state_dict (dict): scheduler state. Should be an object returned
@@ -167,7 +172,7 @@ class LRScheduler:
         return self._last_lr
 
     def get_lr(self) -> List[float]:
-        # Compute learning rate using chainable form of the scheduler
+        """Compute learning rate using chainable form of the scheduler."""
         raise NotImplementedError
 
     def print_lr(
@@ -199,6 +204,7 @@ class LRScheduler:
                 )
 
     def step(self, epoch: Optional[int] = None):
+        """Perform a step."""
         # Raise a warning if old pattern is detected
         # https://github.com/pytorch/pytorch/issues/20124
         if self._step_count == 1:
@@ -278,7 +284,9 @@ class _enable_get_lr_call:
 
 
 class LambdaLR(LRScheduler):
-    """Sets the learning rate of each parameter group to the initial lr
+    """Set the initial learning rate.
+
+    The learning rate of each parameter group is set to the initial lr
     times a given function. When last_epoch=-1, sets initial lr as lr.
 
     Args:
@@ -312,7 +320,7 @@ class LambdaLR(LRScheduler):
         lr_lambda: Union[Callable[[int], float], List[Callable[[int], float]]],
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.optimizer = optimizer
 
         self.lr_lambdas: List[Callable[[int], float]]
@@ -327,7 +335,7 @@ class LambdaLR(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -336,7 +344,6 @@ class LambdaLR(LRScheduler):
 
         When saving or loading the scheduler, please make sure to also save or load the state of the optimizer.
         """
-
         state_dict = {
             key: value
             for key, value in self.__dict__.items()
@@ -351,7 +358,7 @@ class LambdaLR(LRScheduler):
         return state_dict
 
     def load_state_dict(self, state_dict):
-        """Loads the schedulers state.
+        """Load the schedulers state.
 
         When saving or loading the scheduler, please make sure to also save or load the state of the optimizer.
 
@@ -359,7 +366,6 @@ class LambdaLR(LRScheduler):
             state_dict (dict): scheduler state. Should be an object returned
                 from a call to :meth:`state_dict`.
         """
-
         lr_lambdas = state_dict.pop("lr_lambdas")
         self.__dict__.update(state_dict)
         # Restore state_dict keys in order to prevent side effects
@@ -371,6 +377,7 @@ class LambdaLR(LRScheduler):
                 self.lr_lambdas[idx].__dict__.update(fn)
 
     def get_lr(self):
+        """Compute learning rate."""
         _warn_get_lr_called_within_step(self)
 
         return [
@@ -380,8 +387,9 @@ class LambdaLR(LRScheduler):
 
 
 class MultiplicativeLR(LRScheduler):
-    """Multiply the learning rate of each parameter group by the factor given
-    in the specified function. When last_epoch=-1, sets initial lr as lr.
+    """Multiply the learning rate of each parameter group by the factor given in the specified function.
+
+    When last_epoch=-1, sets initial lr as lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -412,7 +420,7 @@ class MultiplicativeLR(LRScheduler):
         lr_lambda: Union[Callable[[int], float], List[Callable[[int], float]]],
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.optimizer = optimizer
 
         self.lr_lambdas: List[Callable[[int], float]]
@@ -427,7 +435,7 @@ class MultiplicativeLR(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -448,7 +456,7 @@ class MultiplicativeLR(LRScheduler):
         return state_dict
 
     def load_state_dict(self, state_dict):
-        """Loads the schedulers state.
+        """Load the schedulers state.
 
         Args:
             state_dict (dict): scheduler state. Should be an object returned
@@ -465,6 +473,7 @@ class MultiplicativeLR(LRScheduler):
                 self.lr_lambdas[idx].__dict__.update(fn)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch > 0:
@@ -477,8 +486,9 @@ class MultiplicativeLR(LRScheduler):
 
 
 class StepLR(LRScheduler):
-    """Decays the learning rate of each parameter group by gamma every
-    step_size epochs. Notice that such decay can happen simultaneously with
+    """Decays the learning rate of each parameter group by gamma every step_size epochs.
+
+    Notice that such decay can happen simultaneously with
     other changes to the learning rate from outside this scheduler. When
     last_epoch=-1, sets initial lr as lr.
 
@@ -516,12 +526,13 @@ class StepLR(LRScheduler):
         gamma=0.1,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.step_size = step_size
         self.gamma = gamma
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if (self.last_epoch == 0) or (self.last_epoch % self.step_size != 0):
@@ -536,10 +547,10 @@ class StepLR(LRScheduler):
 
 
 class MultiStepLR(LRScheduler):
-    """Decays the learning rate of each parameter group by gamma once the
-    number of epoch reaches one of the milestones. Notice that such decay can
-    happen simultaneously with other changes to the learning rate from outside
-    this scheduler. When last_epoch=-1, sets initial lr as lr.
+    """Decays the learning rate of each parameter group by gamma once the number of epoch reaches one of the milestones.
+
+    Notice that such decay can happen simultaneously with other changes to the learning rate
+    from outside this scheduler. When last_epoch=-1, sets initial lr as lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -574,12 +585,13 @@ class MultiStepLR(LRScheduler):
         gamma=0.1,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.milestones = Counter(milestones)
         self.gamma = gamma
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch not in self.milestones:
@@ -598,8 +610,9 @@ class MultiStepLR(LRScheduler):
 
 
 class ConstantLR(LRScheduler):
-    """Multiply the learning rate of each parameter group by a small constant factor until the
-    number of epoch reaches a pre-defined milestone: total_iters.
+    """Multiply the learning rate of each parameter group by a small constant factor.
+
+    The multiplication is done until the number of epoch reaches a pre-defined milestone: total_iters.
     Notice that such multiplication of the small constant factor can
     happen simultaneously with other changes to the learning rate from outside this scheduler.
     When last_epoch=-1, sets initial lr as lr.
@@ -639,7 +652,7 @@ class ConstantLR(LRScheduler):
         total_iters=5,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if factor > 1.0 or factor < 0:
             raise ValueError(
                 "Constant multiplicative factor expected to be between 0 and 1."
@@ -650,6 +663,7 @@ class ConstantLR(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0:
@@ -671,8 +685,9 @@ class ConstantLR(LRScheduler):
 
 
 class LinearLR(LRScheduler):
-    """Decays the learning rate of each parameter group by linearly changing small
-    multiplicative factor until the number of epoch reaches a pre-defined milestone: total_iters.
+    """Decays the learning rate of each parameter group by linearly changing small multiplicative factor.
+
+    The multiplicatino is done until the number of epoch reaches a pre-defined milestone: total_iters.
     Notice that such decay can happen simultaneously with other changes to the learning rate
     from outside this scheduler. When last_epoch=-1, sets initial lr as lr.
 
@@ -716,7 +731,7 @@ class LinearLR(LRScheduler):
         total_iters=5,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if start_factor > 1.0 or start_factor <= 0:
             raise ValueError(
                 "Starting multiplicative factor expected to be greater than 0 and less or equal to 1."
@@ -733,6 +748,7 @@ class LinearLR(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0:
@@ -771,6 +787,7 @@ class LinearLR(LRScheduler):
 
 class ExponentialLR(LRScheduler):
     """Decays the learning rate of each parameter group by gamma every epoch.
+
     When last_epoch=-1, sets initial lr as lr.
 
     Args:
@@ -787,11 +804,12 @@ class ExponentialLR(LRScheduler):
 
     def __init__(
         self, optimizer: Optimizer, gamma: float, last_epoch=-1, verbose="deprecated"
-    ):
+    ):  # noqa: D107
         self.gamma = gamma
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0:
@@ -803,7 +821,9 @@ class ExponentialLR(LRScheduler):
 
 
 class SequentialLR(LRScheduler):
-    """Receives the list of schedulers that is expected to be called sequentially during
+    """Receives the list of schedulers.
+
+    These schedulers are expected to be called sequentially during
     optimization process and milestone points that provides exact intervals to reflect
     which scheduler is supposed to be called at a given epoch.
 
@@ -842,7 +862,7 @@ class SequentialLR(LRScheduler):
         milestones: List[int],
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if len(schedulers) < 1:
             raise ValueError(
                 f"{self.__class__.__name__} expects at least one scheduler, but got no scheduler."
@@ -892,6 +912,7 @@ class SequentialLR(LRScheduler):
         self._last_lr = schedulers[0].get_last_lr()
 
     def step(self):
+        """Perform a step."""
         self.last_epoch += 1
         idx = bisect_right(self._milestones, self.last_epoch)
         scheduler = self._schedulers[idx]
@@ -903,7 +924,7 @@ class SequentialLR(LRScheduler):
         self._last_lr = scheduler.get_last_lr()
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -922,7 +943,7 @@ class SequentialLR(LRScheduler):
         return state_dict
 
     def load_state_dict(self, state_dict):
-        """Loads the schedulers state.
+        """Load the schedulers state.
 
         Args:
             state_dict (dict): scheduler state. Should be an object returned
@@ -939,8 +960,9 @@ class SequentialLR(LRScheduler):
 
 
 class PolynomialLR(LRScheduler):
-    """Decays the learning rate of each parameter group using a polynomial function
-    in the given total_iters. When last_epoch=-1, sets initial lr as lr.
+    """Decays the learning rate of each parameter group using a polynomial function in the given total_iters.
+
+    When last_epoch=-1, sets initial lr as lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -975,12 +997,13 @@ class PolynomialLR(LRScheduler):
         power=1.0,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.total_iters = total_iters
         self.power = power
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0 or self.last_epoch > self.total_iters:
@@ -1004,8 +1027,9 @@ class PolynomialLR(LRScheduler):
 
 
 class CosineAnnealingLR(LRScheduler):
-    r"""Set the learning rate of each parameter group using a cosine annealing
-    schedule, where :math:`\eta_{max}` is set to the initial lr and
+    r"""Set the learning rate of each parameter group using a cosine annealing schedule.
+
+    The :math:`\eta_{max}` is set to the initial lr and
     :math:`T_{cur}` is the number of epochs since the last restart in SGDR:
 
     .. math::
@@ -1054,12 +1078,13 @@ class CosineAnnealingLR(LRScheduler):
         eta_min=0,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.T_max = T_max
         self.eta_min = eta_min
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Receive the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0:
@@ -1097,9 +1122,10 @@ class CosineAnnealingLR(LRScheduler):
 
 
 class ChainedScheduler(LRScheduler):
-    """Chains list of learning rate schedulers. It takes a sequence of chainable learning
-    rate schedulers and performs consecutive step() functions belonging to them by just
-    one call.
+    """Chains list of learning rate schedulers.
+
+    It takes a sequence of chainable learning rate schedulers and performs consecutive step()
+    functions belonging to them by just one call.
 
     Args:
         schedulers (sequence): sequence of chained schedulers.
@@ -1124,7 +1150,7 @@ class ChainedScheduler(LRScheduler):
 
     def __init__(
         self, schedulers: Sequence[LRScheduler], optimizer: Optional[Optimizer] = None
-    ):
+    ):  # noqa: D107
         if len(schedulers) < 1:
             raise ValueError(
                 f"{self.__class__.__name__} expects at least one scheduler to be chained, but got no scheduler."
@@ -1155,6 +1181,7 @@ class ChainedScheduler(LRScheduler):
         ]
 
     def step(self):
+        """Perform a step."""
         for scheduler in self._schedulers:
             scheduler.step()
         self._last_lr = [
@@ -1162,7 +1189,7 @@ class ChainedScheduler(LRScheduler):
         ]
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -1181,7 +1208,7 @@ class ChainedScheduler(LRScheduler):
         return state_dict
 
     def load_state_dict(self, state_dict):
-        """Loads the schedulers state.
+        """Load the schedulers state.
 
         Args:
             state_dict (dict): scheduler state. Should be an object returned
@@ -1199,6 +1226,7 @@ class ChainedScheduler(LRScheduler):
 
 class ReduceLROnPlateau(LRScheduler):
     """Reduce learning rate when a metric has stopped improving.
+
     Models often benefit from reducing the learning rate by a factor
     of 2-10 once learning stagnates. This scheduler reads a metrics
     quantity and if no improvement is seen for a 'patience' number
@@ -1269,7 +1297,7 @@ class ReduceLROnPlateau(LRScheduler):
         min_lr: Union[List[float], float] = 0,
         eps=1e-8,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if factor >= 1.0:
             raise ValueError("Factor should be < 1.0.")
         self.factor = factor
@@ -1308,12 +1336,13 @@ class ReduceLROnPlateau(LRScheduler):
         self._reset()
 
     def _reset(self):
-        """Resets num_bad_epochs counter and cooldown counter."""
+        """Reset num_bad_epochs counter and cooldown counter."""
         self.best = self.mode_worse
         self.cooldown_counter = 0
         self.num_bad_epochs = 0
 
     def step(self, metrics: SupportsFloat, epoch=None):  # type: ignore[override]
+        """Receive learning rates for parameter groups."""
         # convert `metrics` to float, in case it's a zero-dim Tensor
         current = float(metrics)
         if epoch is None:
@@ -1347,10 +1376,10 @@ class ReduceLROnPlateau(LRScheduler):
                 param_group["lr"] = new_lr
 
     @property
-    def in_cooldown(self):
+    def in_cooldown(self):  # noqa: D102
         return self.cooldown_counter > 0
 
-    def is_better(self, a, best):
+    def is_better(self, a, best):  # noqa: D102
         if self.mode == "min" and self.threshold_mode == "rel":
             rel_epsilon = 1.0 - self.threshold
             return a < best * rel_epsilon
@@ -1380,12 +1409,13 @@ class ReduceLROnPlateau(LRScheduler):
         self.threshold = threshold
         self.threshold_mode = threshold_mode
 
-    def state_dict(self):
+    def state_dict(self):  # noqa: D102
         return {
             key: value for key, value in self.__dict__.items() if key != "optimizer"
         }
 
     def load_state_dict(self, state_dict):
+        """Update mode and threshold values."""
         self.__dict__.update(state_dict)
         self._init_is_better(
             mode=self.mode, threshold=self.threshold, threshold_mode=self.threshold_mode
@@ -1393,10 +1423,10 @@ class ReduceLROnPlateau(LRScheduler):
 
 
 class CyclicLR(LRScheduler):
-    r"""Sets the learning rate of each parameter group according to
-    cyclical learning rate policy (CLR). The policy cycles the learning
-    rate between two boundaries with a constant frequency, as detailed in
-    the paper `Cyclical Learning Rates for Training Neural Networks`_.
+    r"""Sets the learning rate of each parameter group according to cyclical learning rate policy (CLR).
+
+    The policy cycles the learning rate between two boundaries with a constant frequency,
+    as detailed in the paper `Cyclical Learning Rates for Training Neural Networks`_.
     The distance between the two boundaries can be scaled on a per-iteration
     or per-cycle basis.
 
@@ -1507,7 +1537,7 @@ class CyclicLR(LRScheduler):
         max_momentum=0.9,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
@@ -1585,6 +1615,7 @@ class CyclicLR(LRScheduler):
             self.scale_mode = "iterations"
 
     def scale_fn(self, x) -> float:
+        """Receive scaling policy."""
         if self._scale_fn_custom is not None:
             return self._scale_fn_custom(x)
         else:
@@ -1603,13 +1634,13 @@ class CyclicLR(LRScheduler):
         return gamma**x
 
     def get_lr(self):
-        """Calculates the learning rate at batch index. This function treats
-        `self.last_epoch` as the last batch index.
+        """Calculate the learning rate at batch index.
+
+        This function treats `self.last_epoch` as the last batch index.
 
         If `self.cycle_momentum` is ``True``, this function has a side effect of
         updating the optimizer's momentum.
         """
-
         _warn_get_lr_called_within_step(self)
 
         cycle = math.floor(1 + self.last_epoch / self.total_size)
@@ -1650,6 +1681,7 @@ class CyclicLR(LRScheduler):
         return lrs
 
     def state_dict(self):
+        """Receive initialized or updated scale function."""
         state = super().state_dict()
         # We are dropping the `_scale_fn_ref` attribute because it is a
         # `weakref.WeakMethod` and can't be pickled.
@@ -1664,6 +1696,7 @@ class CyclicLR(LRScheduler):
         return state
 
     def load_state_dict(self, state_dict):
+        """Update scale function if found, initialize otherwise."""
         fn = state_dict.pop("_scale_fn_custom")
         super().load_state_dict(state_dict)
         if fn is not None:
@@ -1672,8 +1705,9 @@ class CyclicLR(LRScheduler):
 
 
 class CosineAnnealingWarmRestarts(LRScheduler):
-    r"""Set the learning rate of each parameter group using a cosine annealing
-    schedule, where :math:`\eta_{max}` is set to the initial lr, :math:`T_{cur}`
+    r"""Set the learning rate of each parameter group using a cosine annealing schedule.
+
+    The :math:`\eta_{max}` is set to the initial lr, :math:`T_{cur}`
     is the number of epochs since the last restart and :math:`T_{i}` is the number
     of epochs between two warm restarts in SGDR:
 
@@ -1712,7 +1746,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         eta_min=0,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if T_0 <= 0 or not isinstance(T_0, int):
             raise ValueError(f"Expected positive integer T_0, but got {T_0}")
         if T_mult < 1 or not isinstance(T_mult, int):
@@ -1729,6 +1763,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the initial learning rate."""
         _warn_get_lr_called_within_step(self)
 
         return [
@@ -1740,7 +1775,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         ]
 
     def step(self, epoch=None):
-        """Step could be called after every batch update
+        """Step could be called after every batch update.
 
         Example:
             >>> # xdoctest: +SKIP("Undefined vars")
@@ -1766,7 +1801,6 @@ class CosineAnnealingWarmRestarts(LRScheduler):
             >>> scheduler.step(26)
             >>> scheduler.step() # scheduler.step(27), instead of scheduler(20)
         """
-
         if epoch is None and self.last_epoch < 0:
             epoch = 0
 
@@ -1814,11 +1848,11 @@ class _SchedulePhase(TypedDict):
 
 
 class OneCycleLR(LRScheduler):
-    r"""Sets the learning rate of each parameter group according to the
-    1cycle learning rate policy. The 1cycle policy anneals the learning
-    rate from an initial learning rate to some maximum learning rate and then
-    from that maximum learning rate to some minimum learning rate much lower
-    than the initial learning rate.
+    r"""Sets the learning rate of each parameter group according to the 1cycle learning rate policy.
+
+    The 1cycle policy anneals the learning rate from an initial learning rate to some maximum
+    learning rate and then from that maximum learning rate to some minimum learning rate much
+    lower than the initial learning rate.
     This policy was initially described in the paper `Super-Convergence:
     Very Fast Training of Neural Networks Using Large Learning Rates`_.
 
@@ -1937,7 +1971,7 @@ class OneCycleLR(LRScheduler):
         three_phase=False,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         # Validate optimizer
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
@@ -2068,16 +2102,17 @@ class OneCycleLR(LRScheduler):
 
     @staticmethod
     def _annealing_cos(start, end, pct):
-        "Cosine anneal from `start` to `end` as pct goes from 0.0 to 1.0."
+        """Cosine anneal from `start` to `end` as pct goes from 0.0 to 1.0."""
         cos_out = math.cos(math.pi * pct) + 1
         return end + (start - end) / 2.0 * cos_out
 
     @staticmethod
     def _annealing_linear(start, end, pct):
-        "Linearly anneal from `start` to `end` as pct goes from 0.0 to 1.0."
+        """Linearly anneal from `start` to `end` as pct goes from 0.0 to 1.0."""
         return (end - start) * pct + start
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         lrs = []

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""NAdam algorithm."""
 from typing import cast, List, Optional, Tuple, Union
 
 import torch
@@ -25,6 +26,8 @@ __all__ = ["NAdam", "nadam"]
 
 
 class NAdam(Optimizer):
+    r"""Implementation for the NAdam algorithm."""
+
     def __init__(
         self,
         params: ParamsT,
@@ -39,7 +42,7 @@ class NAdam(Optimizer):
         maximize: bool = False,
         capturable: bool = False,
         differentiable: bool = False,
-    ):
+    ):  # noqa: D107
         if not 0.0 <= lr:
             raise ValueError(f"Invalid learning rate: {lr}")
         if not 0.0 <= eps:
@@ -66,7 +69,7 @@ class NAdam(Optimizer):
         )
         super().__init__(params, defaults)
 
-    def __setstate__(self, state):
+    def __setstate__(self, state):  # noqa: D105
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("maximize", False)
@@ -148,7 +151,7 @@ class NAdam(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -594,7 +597,6 @@ def nadam(
 
     See :class:`~torch.optim.NAdam` for details.
     """
-
     if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError(
             "API has changed, `state_steps` argument must contain a list of singleton tensors"

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+"""Base optimizer."""
 import functools
 import math
 import warnings
@@ -267,9 +268,9 @@ _maximize_doc = r"""maximize (bool, optional): maximize the objective with respe
 
 
 def register_optimizer_step_pre_hook(hook: GlobalOptimizerPreHook) -> RemovableHandle:
-    r"""Register a pre hook common to all optimizers. The hook should have the following
-    signature::
+    r"""Register a pre hook common to all optimizers.
 
+    The hook should have the following signature::
         hook(optimizer, args, kwargs) -> None or modified args and kwargs
 
     Args:
@@ -286,8 +287,9 @@ def register_optimizer_step_pre_hook(hook: GlobalOptimizerPreHook) -> RemovableH
 
 
 def register_optimizer_step_post_hook(hook: GlobalOptimizerPostHook) -> RemovableHandle:
-    r"""Register a post hook common to all optimizers. The hook should have the following
-    signature::
+    r"""Register a post hook common to all optimizers.
+
+    The hook should have the following signature::
 
         hook(optimizer, args, kwargs) -> None
 
@@ -336,7 +338,7 @@ class Optimizer:
     _optimizer_load_state_dict_pre_hooks: 'OrderedDict[int, Callable[["Optimizer", StateDict], Optional[StateDict]]]'
     _optimizer_load_state_dict_post_hooks: 'OrderedDict[int, Callable[["Optimizer"], None]]'
 
-    def __init__(self, params: ParamsT, defaults: Dict[str, Any]) -> None:
+    def __init__(self, params: ParamsT, defaults: Dict[str, Any]) -> None:  # noqa: D107
         torch._C._log_api_usage_once("python.optimizer")
         self.defaults = defaults
         self._optimizer_step_pre_hooks = OrderedDict()
@@ -371,14 +373,14 @@ class Optimizer:
         # https://github.com/pytorch/pytorch/issues/72948
         self._warned_capturable_if_run_uncaptured = True
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> Dict[str, Any]:  # noqa: D105
         return {
             "defaults": self.defaults,
             "state": self.state,
             "param_groups": self.param_groups,
         }
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: Dict[str, Any]) -> None:  # noqa: D105
         self.__dict__.update(state)
         if "_optimizer_step_pre_hooks" not in self.__dict__:
             self._optimizer_step_pre_hooks = OrderedDict()
@@ -395,7 +397,7 @@ class Optimizer:
         self._patch_step_function()  # To support multiprocessing pickle/unpickle
         self.defaults.setdefault("differentiable", False)
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # noqa: D105
         format_string = self.__class__.__name__ + " ("
         for i, group in enumerate(self.param_groups):
             format_string += "\n"
@@ -460,7 +462,7 @@ class Optimizer:
         pass
 
     @staticmethod
-    def profile_hook_step(func: Callable[_P, R]) -> Callable[_P, R]:
+    def profile_hook_step(func: Callable[_P, R]) -> Callable[_P, R]:  # noqa: D102
         @functools.wraps(func)
         def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> R:
             self, *_ = args
@@ -503,7 +505,8 @@ class Optimizer:
         Dict[Tuple[None, None], Tuple[TensorListList, Indices]],
         Dict[Tuple[torch.device, torch.dtype], Tuple[TensorListList, Indices]],
     ]:
-        """Groups a list of lists of tensors by device and dtype.
+        """Group a list of lists of tensors by device and dtype.
+
         Skips this step if we are compiling since this will occur during inductor lowering.
         """
         if is_compiling():
@@ -521,8 +524,9 @@ class Optimizer:
             self.__class__.step.hooked = True  # type: ignore[attr-defined]
 
     def register_step_pre_hook(self, hook: OptimizerPreHook) -> RemovableHandle:
-        r"""Register an optimizer step pre hook which will be called before
-        optimizer step. It should have the following signature::
+        r"""Register an optimizer step pre hook which will be called before optimizer step.
+
+        It should have the following signature::
 
             hook(optimizer, args, kwargs) -> None or modified args and kwargs
 
@@ -544,6 +548,7 @@ class Optimizer:
 
     def register_step_post_hook(self, hook: OptimizerPostHook) -> RemovableHandle:
         r"""Register an optimizer step post hook which will be called after optimizer step.
+
         It should have the following signature::
 
             hook(optimizer, args, kwargs) -> None
@@ -565,9 +570,9 @@ class Optimizer:
     def register_state_dict_pre_hook(
         self, hook: Callable[["Optimizer"], None], prepend: bool = False
     ) -> RemovableHandle:
-        r"""Register a state dict pre-hook which will be called before
-        :meth:`~torch.optim.Optimizer.state_dict` is called. It should have the
-        following signature::
+        r"""Register a state dict pre-hook which will be called before :meth:`~torch.optim.Optimizer.state_dict` is called.
+
+        It should have the following signature::
 
             hook(optimizer) -> None
 
@@ -599,9 +604,9 @@ class Optimizer:
         hook: Callable[["Optimizer", StateDict], Optional[StateDict]],
         prepend: bool = False,
     ) -> RemovableHandle:
-        r"""Register a state dict post-hook which will be called after
-        :meth:`~torch.optim.Optimizer.state_dict` is called. It should have the
-        following signature::
+        r"""Register a state dict post-hook which will be called after :meth:`~torch.optim.Optimizer.state_dict` is called.
+
+        It should have the following signature::
 
             hook(optimizer, state_dict) -> state_dict or None
 
@@ -630,7 +635,7 @@ class Optimizer:
 
     @torch._disable_dynamo
     def state_dict(self) -> StateDict:
-        r"""Returns the state of the optimizer as a :class:`dict`.
+        r"""Return the state of the optimizer as a :class:`dict`.
 
         It contains two entries:
 
@@ -678,7 +683,6 @@ class Optimizer:
             }
 
         """
-
         for pre_hook in self._optimizer_state_dict_pre_hooks.values():
             pre_hook(self)
 
@@ -754,9 +758,11 @@ class Optimizer:
         hook: Callable[["Optimizer", StateDict], Optional[StateDict]],
         prepend: bool = False,
     ) -> RemovableHandle:
-        r"""Register a load_state_dict pre-hook which will be called before
-        :meth:`~torch.optim.Optimizer.load_state_dict` is called. It should have the
-        following signature::
+        r"""Register a load_state_dict pre-hook.
+
+        This hool will be called before :meth:`~torch.optim.Optimizer.load_state_dict` is called.
+
+        It should have the following signature::
 
             hook(optimizer, state_dict) -> state_dict or None
 
@@ -791,9 +797,11 @@ class Optimizer:
     def register_load_state_dict_post_hook(
         self, hook: Callable[["Optimizer"], None], prepend: bool = False
     ) -> RemovableHandle:
-        r"""Register a load_state_dict post-hook which will be called after
-        :meth:`~torch.optim.Optimizer.load_state_dict` is called. It should have the
-        following signature::
+        r"""Register a load_state_dict post-hook.
+
+        This hook will be called after :meth:`~torch.optim.Optimizer.load_state_dict` is called.
+
+        It should have the following signature::
 
             hook(optimizer) -> None
 
@@ -824,7 +832,7 @@ class Optimizer:
 
     @torch._disable_dynamo
     def load_state_dict(self, state_dict: StateDict) -> None:
-        r"""Loads the optimizer state.
+        r"""Load the optimizer state.
 
         Args:
             state_dict (dict): optimizer state. Should be an object returned
@@ -910,7 +918,7 @@ class Optimizer:
 
     @torch._disable_dynamo
     def zero_grad(self, set_to_none: bool = True) -> None:
-        r"""Resets the gradients of all optimized :class:`torch.Tensor` s.
+        r"""Reset the gradients of all optimized :class:`torch.Tensor` s.
 
         Args:
             set_to_none (bool): instead of setting to zero, set the grads to None.
@@ -972,7 +980,7 @@ class Optimizer:
         ...
 
     def step(self, closure: Optional[Callable[[], float]] = None) -> Optional[float]:
-        r"""Performs a single optimization step (parameter update).
+        r"""Perform a single optimization to update parameter.
 
         Args:
             closure (Callable): A closure that reevaluates the model and

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""NAdam algorithm."""
 from typing import cast, List, Optional, Tuple, Union
 
 import torch
@@ -25,6 +26,8 @@ __all__ = ["RAdam", "radam"]
 
 
 class RAdam(Optimizer):
+    r"""Implementation for the NAdam algorithm."""
+
     def __init__(
         self,
         params: ParamsT,
@@ -38,7 +41,7 @@ class RAdam(Optimizer):
         maximize: bool = False,
         capturable: bool = False,
         differentiable: bool = False,
-    ):
+    ):  # noqa: D107
         if not 0.0 <= lr:
             raise ValueError(f"Invalid learning rate: {lr}")
         if not 0.0 <= eps:
@@ -63,7 +66,7 @@ class RAdam(Optimizer):
         )
         super().__init__(params, defaults)
 
-    def __setstate__(self, state):
+    def __setstate__(self, state):  # noqa: D105
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("foreach", None)
@@ -120,7 +123,7 @@ class RAdam(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -560,7 +563,6 @@ def radam(
 
     See :class:`~torch.optim.RAdam` for details.
     """
-
     if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError(
             "API has changed, `state_steps` argument must contain a list of singleton tensors"

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""RMSprop algorithm."""
 from typing import List, Optional
 
 import torch
@@ -22,6 +23,8 @@ __all__ = ["RMSprop", "rmsprop"]
 
 
 class RMSprop(Optimizer):
+    r"""Implementation for the RMSprop algorithm."""
+
     def __init__(
         self,
         params: ParamsT,
@@ -35,7 +38,7 @@ class RMSprop(Optimizer):
         foreach: Optional[bool] = None,
         maximize: bool = False,
         differentiable: bool = False,
-    ):
+    ):  # noqa: D107
         if not 0.0 <= lr:
             raise ValueError(f"Invalid learning rate: {lr}")
         if not 0.0 <= eps:
@@ -61,7 +64,7 @@ class RMSprop(Optimizer):
         )
         super().__init__(params, defaults)
 
-    def __setstate__(self, state):
+    def __setstate__(self, state):  # noqa: D105
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("momentum", 0)
@@ -135,7 +138,7 @@ class RMSprop(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -464,6 +467,7 @@ def rmsprop(
     centered: bool,
 ):
     r"""Functional API that performs rmsprop algorithm computation.
+
     See :class:`~torch.optim.RMSProp` for details.
     """
     # this check is slow during compilation, so we skip it

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""Resilient backpropagation."""
 from typing import List, Optional, Tuple
 
 import torch
@@ -22,6 +23,8 @@ __all__ = ["Rprop", "rprop"]
 
 
 class Rprop(Optimizer):
+    r"""Implementation for the Resilient backpropagation."""
+
     def __init__(
         self,
         params: ParamsT,
@@ -33,7 +36,7 @@ class Rprop(Optimizer):
         foreach: Optional[bool] = None,
         maximize: bool = False,
         differentiable: bool = False,
-    ):
+    ):  # noqa: D107
         if not 0.0 <= lr:
             raise ValueError(f"Invalid learning rate: {lr}")
         if not 0.0 < etas[0] < 1.0 < etas[1]:
@@ -50,7 +53,7 @@ class Rprop(Optimizer):
         )
         super().__init__(params, defaults)
 
-    def __setstate__(self, state):
+    def __setstate__(self, state):  # noqa: D105
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("foreach", None)
@@ -109,7 +112,7 @@ class Rprop(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""Stochastic Gradient Descent optimizer."""
 from typing import List, Optional
 
 import torch
@@ -19,6 +20,8 @@ __all__ = ["SGD", "sgd"]
 
 
 class SGD(Optimizer):
+    r"""Implementation for the Stochastic Gradient Descent."""
+
     def __init__(
         self,
         params,
@@ -32,7 +35,7 @@ class SGD(Optimizer):
         foreach: Optional[bool] = None,
         differentiable: bool = False,
         fused: Optional[bool] = None,
-    ):
+    ):  # noqa: D107
         if lr < 0.0:
             raise ValueError(f"Invalid learning rate: {lr}")
         if momentum < 0.0:
@@ -73,7 +76,7 @@ class SGD(Optimizer):
             if foreach:
                 raise RuntimeError("`fused` and `foreach` cannot be `True` together.")
 
-    def __setstate__(self, state):
+    def __setstate__(self, state):  # noqa: D105
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("nesterov", False)
@@ -100,7 +103,7 @@ class SGD(Optimizer):
 
     @_use_grad_for_differentiable
     def step(self, closure=None):
-        """Performs a single optimization step.
+        """Perform a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
@@ -264,7 +267,6 @@ def sgd(
 
     See :class:`~torch.optim.SGD` for details.
     """
-
     # Respect when the user inputs False/True for foreach or fused. We only want to change
     # the default when neither have been user-specified. Note that we default to foreach
     # and pass False to use_fused. This is not a mistake--we want to give the fused impl

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""Stochastic Weight Averaging implementation."""
 import itertools
 import math
 import warnings
@@ -28,6 +29,8 @@ PARAM_LIST = Union[Tuple[Tensor, ...], List[Tensor]]
 
 
 def get_ema_multi_avg_fn(decay=0.999):
+    """Receive exponential moving average (EMA)."""
+
     @torch.no_grad()
     def ema_update(ema_param_list: PARAM_LIST, current_param_list: PARAM_LIST, _):
         # foreach lerp only handles float and complex
@@ -43,6 +46,8 @@ def get_ema_multi_avg_fn(decay=0.999):
 
 
 def get_swa_multi_avg_fn():
+    """Receive stochastic weight average."""
+
     @torch.no_grad()
     def swa_update(
         averaged_param_list: PARAM_LIST,
@@ -73,6 +78,8 @@ def get_swa_multi_avg_fn():
 
 
 def get_ema_avg_fn(decay=0.999):
+    """Receive exponential moving average."""
+
     @torch.no_grad()
     def ema_update(ema_param: Tensor, current_param: Tensor, num_averaged):
         return decay * ema_param + (1 - decay) * current_param
@@ -81,6 +88,8 @@ def get_ema_avg_fn(decay=0.999):
 
 
 def get_swa_avg_fn():
+    """Receive stochastic weight average."""
+
     @torch.no_grad()
     def swa_update(
         averaged_param: Tensor, current_param: Tensor, num_averaged: Union[Tensor, int]
@@ -91,8 +100,7 @@ def get_swa_avg_fn():
 
 
 class AveragedModel(Module):
-    r"""Implements averaged model for Stochastic Weight Averaging (SWA) and
-    Exponential Moving Average (EMA).
+    r"""Implements averaged model for Stochastic Weight Averaging (SWA) and Exponential Moving Average (EMA).
 
     Stochastic Weight Averaging was proposed in `Averaging Weights Leads to
     Wider Optima and Better Generalization`_ by Pavel Izmailov, Dmitrii
@@ -189,6 +197,7 @@ class AveragedModel(Module):
     .. _Polyak averaging:
         https://paperswithcode.com/method/polyak-averaging
     """
+
     n_averaged: Tensor
 
     def __init__(
@@ -200,7 +209,7 @@ class AveragedModel(Module):
             Callable[[PARAM_LIST, PARAM_LIST, Union[Tensor, int]], None]
         ] = None,
         use_buffers=False,
-    ):
+    ):  # noqa: D107
         super().__init__()
         assert (
             avg_fn is None or multi_avg_fn is None
@@ -216,9 +225,11 @@ class AveragedModel(Module):
         self.use_buffers = use_buffers
 
     def forward(self, *args, **kwargs):
+        """Forward pass."""
         return self.module(*args, **kwargs)
 
     def update_parameters(self, model: Module):
+        """Update model parameters."""
         self_param = (
             itertools.chain(self.module.parameters(), self.module.buffers())
             if self.use_buffers
@@ -287,7 +298,7 @@ def update_bn(
     model: Module,
     device: Optional[Union[int, torch.device]] = None,
 ):
-    r"""Updates BatchNorm running_mean, running_var buffers in the model.
+    r"""Update BatchNorm running_mean, running_var buffers in the model.
 
     It performs one pass over data in `loader` to estimate the activation
     statistics for BatchNorm layers in the model.
@@ -390,7 +401,7 @@ class SWALR(LRScheduler):
         anneal_epochs=10,
         anneal_strategy: Literal["cos", "linear"] = "cos",
         last_epoch=-1,
-    ):
+    ):  # noqa: D107
         swa_lrs = _format_param("swa_lr", optimizer, swa_lr)
         for swa_lr, group in zip(swa_lrs, optimizer.param_groups):
             group["swa_lr"] = swa_lr
@@ -425,6 +436,7 @@ class SWALR(LRScheduler):
         return (lr - alpha * swa_lr) / (1 - alpha)
 
     def get_lr(self):
+        """Compute learning rate."""
         # `_get_lr_called_within_step` is only available `_enable_get_lr_call`,
         # so we ignore the type error here. See `LRScheduler.step()` for more details.
         if not self._get_lr_called_within_step:  # type: ignore[attr-defined]


### PR DESCRIPTION
This PR takes care of over 150 docstring errors in about a dozen files to reduce errors to 0. This can be verified by running, `pydocstyle path-to-file --count` as below:

**BEFORE the PR:** 
`pydocstyle torch/optim/lr_scheduler.py --count `
92 
`pydocstyle torch/optim/nadam.py --count`
6
`pydocstyle torch/optim/radam.py  --count`
6
`pydocstyle torch/optim/sgd.py --count`
6
`pydocstyle torch/autograd/anomaly_mode.py --count`
8
`pydocstyle torch/autograd/__init__.py --count`
9
`pydocstyle torch/optim/rprop.py --count`
5
 `pydocstyle torch/optim/_multi_tensor/__init__.py --count`
2
`pydocstyle torch/optim/swa_utils.py --count`
14
`pydocstyle torch/optim/rmsprop.py --count`
6
`pydocstyle torch/optim/optimizer.py --count`
29

**AFTER the PR:** 
`pydocstyle torch/optim/lr_scheduler.py --count `
0
`pydocstyle torch/optim/nadam.py --count `
0
`pydocstyle torch/optim/radam.py  --count`
0
`pydocstyle torch/optim/sgd.py --count`
0
`pydocstyle torch/autograd/anomaly_mode.py --count`
0
`pydocstyle torch/autograd/__init__.py --count`
0
`pydocstyle torch/optim/rprop.py --count`
0
`pydocstyle orch/optim/_multi_tensor/__init__.py --count`
0
`pydocstyle torch/optim/swa_utils.py --count`
0
`pydocstyle torch/optim/rmsprop.py --count`
0
`pydocstyle torch/optim/optimizer.py --count`
0


Fixes #112593


cc @svekars @brycebortree @vincentqb @jbschlosser @albanD @janeyx99 @crcrpar