### PR TITLE
Fix bug in _update_process_group API

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -2375,7 +2375,7 @@ void Reducer::reset_state() {
   // Reset unused parameter accounting.
   // See Note [local_used_map_ -> local_used_map_dev copying]
   if (find_unused_parameters_) {
-    local_used_map_.fill_(0);
+    local_used_map_.zero_();
     local_used_map_reduced_ = false;
   }
 }

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -2374,8 +2374,10 @@ void Reducer::reset_state() {
 
   // Reset unused parameter accounting.
   // See Note [local_used_map_ -> local_used_map_dev copying]
-  local_used_map_.fill_(0);
-  local_used_map_reduced_ = false;
+  if (find_unused_parameters_) {
+    local_used_map_.fill_(0);
+    local_used_map_reduced_ = false;
+  }
 }
 
 } // namespace c10d

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -9938,6 +9938,20 @@ class DistributedTest:
             # Run ddp again.
             ddp(input, False).sum().backward()
 
+        @skip_if_lt_x_gpu(4)
+        @require_world_size(4)
+        @skip_but_pass_in_sandcastle_if(
+            BACKEND not in DistTestCases.backend_feature["ddp"],
+            f"The {BACKEND} backend does not support DistributedDataParallel",
+        )
+        def test_ddp_update_process_group_no_find_unused(self):
+            ddp = torch.nn.parallel.DistributedDataParallel(
+                torch.nn.Linear(10, 10).cuda(self.rank),
+                device_ids=[self.rank],
+                find_unused_parameters=False,
+            )
+            ddp._update_process_group(_get_default_group())
+
 
         @skip_if_lt_x_gpu(2)
         @skip_but_pass_in_sandcastle_if(


### PR DESCRIPTION
`local_used_map_` was undefined in case of `find_unused_parameters=False`, this resulted in an error when we ran `local_used_map_.fill_(0);`

Added a unit test as well

cc @mrshenli @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k