### PR TITLE
[cuDNN] Graph-capturable cuDNN CTCLoss

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -357,6 +357,15 @@ struct TORCH_CUDA_CPP_API CTCLossDescriptor
     AT_CUDNN_CHECK(
         cudnnSetCTCLossDescriptorEx(mut_desc(), datatype, normMode, gradMode));
   }
+  void set_v9(
+      cudnnDataType_t datatype,
+      cudnnLossNormalizationMode_t normMode,
+      cudnnCTCGradMode_t gradMode,
+      int maxLabelLength) {
+    AT_CUDNN_CHECK(
+        cudnnSetCTCLossDescriptor_v9(mut_desc(), datatype, normMode, gradMode, maxLabelLength));
+  }
+
 };
 
 struct TORCH_CUDA_CPP_API ActivationDescriptor

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -357,13 +357,22 @@ struct TORCH_CUDA_CPP_API CTCLossDescriptor
     AT_CUDNN_CHECK(
         cudnnSetCTCLossDescriptorEx(mut_desc(), datatype, normMode, gradMode));
   }
-  void set_v9(
+  void set_v8_v9(
       cudnnDataType_t datatype,
       cudnnLossNormalizationMode_t normMode,
-      cudnnCTCGradMode_t gradMode,
+      cudnnNanPropagation_t gradMode,
       int maxLabelLength) {
+#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 90000
+    auto gradModev9 = CUDNN_CTC_ZERO_OOB_GRADIENTS;
+    if (gradMode == cudnnNanPropagation_t::CUDNN_PROPAGATE_NAN) {
+      gradModev9 = CUDNN_CTC_SKIP_OOB_GRADIENTS;
+    }
     AT_CUDNN_CHECK(
-        cudnnSetCTCLossDescriptor_v9(mut_desc(), datatype, normMode, gradMode, maxLabelLength));
+        cudnnSetCTCLossDescriptor_v9(mut_desc(), datatype, normMode, gradModev9, maxLabelLength));
+#else
+    AT_CUDNN_CHECK(
+        cudnnSetCTCLossDescriptor_v8(mut_desc(), datatype, normMode, gradMode, maxLabelLength));
+#endif
   }
 
 };

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -91,8 +91,7 @@ bool _use_cudnn_ctc_loss(
   bool use_cudnn = ctx.userEnabledCuDNN() && (BLANK == 0) &&
       (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
       (targets.scalar_type() == at::kInt) &&
-      (log_probs.device().type() == at::kCUDA) &&
-      (targets.is_contiguous()) &&
+      (log_probs.device().type() == at::kCUDA) && (targets.is_contiguous()) &&
       (log_probs.dim() == 3);
 
   if (use_cudnn) {
@@ -123,8 +122,7 @@ bool _use_cudnn_ctc_loss_tensor(
   bool use_cudnn = ctx.userEnabledCuDNN() && (BLANK == 0) &&
       (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
       (targets.scalar_type() == at::kInt) &&
-      (log_probs.device().type() == at::kCUDA) &&
-      (targets.is_contiguous()) &&
+      (log_probs.device().type() == at::kCUDA) && (targets.is_contiguous()) &&
       (log_probs.dim() == 3);
 
   return use_cudnn;
@@ -261,7 +259,10 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss_tensor(
   // so the CuDNN gradient semantics have changed between 7.1 and 7.6,
   // this is CuDNN 7.6 only, see PyTorch 1.2 for older CuDNN.
   ctc_loss_desc.set_v9(
-      CUDNN_DATA_FLOAT, CUDNN_LOSS_NORMALIZATION_SOFTMAX, CUDNN_CTC_SKIP_OOB_GRADIENTS, 255);
+      CUDNN_DATA_FLOAT,
+      CUDNN_LOSS_NORMALIZATION_SOFTMAX,
+      CUDNN_CTC_SKIP_OOB_GRADIENTS,
+      255);
   TensorDescriptor log_probs_desc{log_probs_t};
   Tensor grad = at::empty_like(log_probs_t, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   TensorDescriptor grad_desc{grad};
@@ -292,9 +293,9 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss_tensor(
       grad.data_ptr(),
       workspace_size,
       workspace.data_ptr()
-      
-      ));
-   return std::make_tuple(costs, grad);
+
+          ));
+  return std::make_tuple(costs, grad);
 }
 
 } // namespace native

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -82,9 +82,9 @@ namespace at {
 namespace native {
 
 namespace {
-  // "cache" whether we've previously failed the target lengths check
-  static bool tensor_failed_target_lengths_check = false;
-}
+// "cache" whether we've previously failed the target lengths check
+static bool tensor_failed_target_lengths_check = false;
+} // namespace
 
 bool _use_cudnn_ctc_loss(
     const Tensor& log_probs,
@@ -98,8 +98,7 @@ bool _use_cudnn_ctc_loss(
       (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
       (targets.scalar_type() == at::kInt) &&
       (targets.device().type() == at::kCPU) && (targets.is_contiguous()) &&
-      (log_probs.device().type() == at::kCUDA) &&
-      (log_probs.dim() == 3);
+      (log_probs.device().type() == at::kCUDA) && (log_probs.dim() == 3);
 
   if (use_cudnn) {
     // we don't know that input_lengths and target_lengths have the same size
@@ -130,8 +129,8 @@ bool _use_cudnn_ctc_loss_tensor(
       (targets.dim() == 1) && (log_probs.scalar_type() == at::kFloat) &&
       (targets.scalar_type() == at::kInt) &&
       (log_probs.device().type() == at::kCUDA) && (targets.is_contiguous()) &&
-      (log_probs.dim() == 3) &&
-      (input_lengths.scalar_type() == at::kInt) && (target_lengths.scalar_type() == at::kInt);
+      (log_probs.dim() == 3) && (input_lengths.scalar_type() == at::kInt) &&
+      (target_lengths.scalar_type() == at::kInt);
 
   if (at::cuda::currentStreamCaptureStatus() == at::cuda::CaptureStatus::None) {
     Tensor tlc = target_lengths.to(Device(at::kCPU), at::kLong).contiguous();
@@ -143,8 +142,7 @@ bool _use_cudnn_ctc_loss_tensor(
       Tensor tlc = target_lengths.to(Device(at::kCPU), at::kLong).contiguous();
       IntArrayRef il(ilc.data_ptr<int64_t>(), ilc.numel());
       IntArrayRef tl(tlc.data_ptr<int64_t>(), tlc.numel());
-      use_cudnn = use_cudnn && (tl[b] < 256) &&
-          (tl[b] <= il[b]);
+      use_cudnn = use_cudnn && (tl[b] < 256) && (tl[b] <= il[b]);
       if (!use_cudnn) {
         tensor_failed_target_lengths_check = true;
         break;
@@ -153,9 +151,10 @@ bool _use_cudnn_ctc_loss_tensor(
   } else {
     use_cudnn = use_cudnn && !tensor_failed_target_lengths_check;
     if (tensor_failed_target_lengths_check) {
-      TORCH_WARN("cuDNN max target length restriction < 256 cannot be checked during graph capture,"
-                 " but target length >= 256 was observed previously e.g., during warmup, so we"
-                 " presume it is unsafe to dispatch to cuDNN ctc_loss.");
+      TORCH_WARN(
+          "cuDNN max target length restriction < 256 cannot be checked during graph capture,"
+          " but target length >= 256 was observed previously e.g., during warmup, so we"
+          " presume it is unsafe to dispatch to cuDNN ctc_loss.");
     }
   }
 
@@ -270,8 +269,10 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss_tensor(
   checkBackend(c, {*log_probs}, Backend::CUDA);
   checkBackend(c, {*targets}, Backend::CUDA);
   const auto batch_size = log_probs->size(1);
-  int64_t input_lengths_size = input_lengths.sizes().size() ? input_lengths.size(0) : 1;
-  int64_t target_lengths_size = target_lengths.sizes().size() ? target_lengths.size(0) : 1;
+  int64_t input_lengths_size =
+      input_lengths.sizes().size() ? input_lengths.size(0) : 1;
+  int64_t target_lengths_size =
+      target_lengths.sizes().size() ? target_lengths.size(0) : 1;
   TORCH_CHECK(
       input_lengths_size == batch_size,
       "input_lengths needs to have size to match batch_size");

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -147,7 +147,7 @@ bool _use_cudnn_ctc_loss_tensor(
           (tl[b] <= il[b]);
       if (!use_cudnn) {
         tensor_failed_target_lengths_check = true;
-	break;
+        break;
       }
     }
   } else {
@@ -155,7 +155,7 @@ bool _use_cudnn_ctc_loss_tensor(
     if (tensor_failed_target_lengths_check) {
       TORCH_WARN("cuDNN max target length restriction < 256 cannot be checked during graph capture,"
                  " but target length >= 256 was observed previously e.g., during warmup, so we"
-		 " presume it is unsafe to dispatch to cuDNN ctc_loss.");
+                 " presume it is unsafe to dispatch to cuDNN ctc_loss.");
     }
   }
 

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -236,11 +236,13 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss_tensor(
   checkBackend(c, {*log_probs}, Backend::CUDA);
   checkBackend(c, {*targets}, Backend::CUDA);
   const auto batch_size = log_probs->size(1);
+  int64_t input_lengths_size = input_lengths.sizes().size() ? input_lengths.size(0) : 1;
+  int64_t target_lengths_size = target_lengths.sizes().size() ? target_lengths.size(0) : 1;
   TORCH_CHECK(
-      static_cast<int64_t>(input_lengths.size(0)) == batch_size,
+      input_lengths_size == batch_size,
       "input_lengths needs to have size to match batch_size");
   TORCH_CHECK(
-      static_cast<int64_t>(target_lengths.size(0)) == batch_size,
+      target_lengths_size == batch_size,
       "target_lengths needs to have size to match batch_size");
 
   TORCH_CHECK(BLANK == 0, "blank must be label 0 for cudnn_ctc_loss");

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -63,7 +63,7 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss_tensor(
     int64_t BLANK,
     bool deterministic,
     bool zero_infinity) {
-  AT_ERROR("cudnn_ctc_loss: ATen not compiled with cuDNN >= 7 support");
+  AT_ERROR("cudnn_ctc_loss: ATen not compiled with cuDNN >= 8 support");
 }
 
 } // namespace native
@@ -293,12 +293,10 @@ std::tuple<Tensor, Tensor> _cudnn_ctc_loss_tensor(
 
   CTCLossDescriptor ctc_loss_desc;
 
-  // so the CuDNN gradient semantics have changed between 7.1 and 7.6,
-  // this is CuDNN 7.6 only, see PyTorch 1.2 for older CuDNN.
-  ctc_loss_desc.set_v9(
+  ctc_loss_desc.set_v8_v9(
       CUDNN_DATA_FLOAT,
       CUDNN_LOSS_NORMALIZATION_SOFTMAX,
-      CUDNN_CTC_SKIP_OOB_GRADIENTS,
+      CUDNN_PROPAGATE_NAN,
       255);
   TensorDescriptor log_probs_desc{log_probs_t};
   Tensor grad = at::empty_like(log_probs_t, LEGACY_CONTIGUOUS_MEMORY_FORMAT);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11155,8 +11155,11 @@ class TestNNDeviceType(NNTestCase):
         with torch.backends.cudnn.flags(enabled=False):
             loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
-        loss_cudnn = torch.nn.functional.ctc_loss(log_probs, targets.to('cuda', torch.int32),
-                                                  input_lengths.to('cuda', torch.int32), target_lengths.to('cuda', torch.int32), reduction='none')
+        loss_cudnn = torch.nn.functional.ctc_loss(log_probs,
+                                                  targets.to('cuda', torch.int32),
+                                                  input_lengths.to('cuda', torch.int32),
+                                                  target_lengths.to('cuda', torch.int32),
+                                                  reduction='none')
         self.assertTrue("Cudnn" in str(loss_cudnn.grad_fn))
         grad_cudnn, = torch.autograd.grad(loss_cudnn, log_probs, grad_out)
         self.assertEqual(grad_cudnn, grad_native, atol=1e-4, rtol=0)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11137,7 +11137,7 @@ class TestNNDeviceType(NNTestCase):
 
     @onlyCUDA
     @skipCUDAIfRocm(msg="skipped Cudnn test on ROCm")
-    @skipCUDAIfCudnnVersionLessThan(7600)
+    @skipCUDAIfCudnnVersionLessThan(8000)
     def test_ctc_loss_cudnn_tensor(self, device):
         batch_size = 16
         input_length = 30


### PR DESCRIPTION
cuDNN v8.x added a graph-capturable CTCLoss, which slots "neatly" into the `Tensor` variant

~~WIP as cuDNN has a restriction on the max target length (255), but this is not checkable in the graph-capture case, so the UX around warnings/error-messages here might need to be tuned...~~
Currently checks restriction on max target length during warmup run(s), and bails out during capture if this constraint was violated during warmup.

CC @ptrblck 

cc @csarofeen @ptrblck @xwang233 @mcarilli @ezyang @eellison @peterbell10