### PR TITLE
Add a config for enabling FSDP-2

### DIFF
--- a/torch/distributed/fsdp_common.py
+++ b/torch/distributed/fsdp_common.py
@@ -1,0 +1,13 @@
+# This file contains stuff that is shared between FSDP-1 and FSDP-2.
+
+import os  # noqa: C101
+
+from typing import Any
+
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP1
+from torch.distributed._composable.fsdp.fully_shard import FSDPModule as FSDP2
+
+use_fsdp2 = os.environ.get("FSDP_VERSION", "1") == "2"
+
+def fsdp_type() -> Any:
+    return FSDP2 if use_fsdp2 else FSDP1


### PR DESCRIPTION
Summary: A file that contains the config for enabling FSDP-2 (it is not yet enabled),

Test Plan: Not needed in this diff because this file is not used anywhere in the source yet.

Differential Revision: D58324715




cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang