### PR TITLE
Documenting the torch.fx.annotate.annotate function

### DIFF
--- a/torch/fx/annotate.py
+++ b/torch/fx/annotate.py
@@ -4,8 +4,18 @@ from ._compatibility import compatibility
 
 @compatibility(is_backward_compatible=False)
 def annotate(val, type):
-    # val could be either a regular value (not tracing)
-    # or fx.Proxy (tracing)
+    """
+    Annotates a Proxy object with a given type.
+
+    This function annotates a val with a given type if a type of the val is a torch.fx.Proxy object
+    Args:
+        val (object): An object to be annotated if its type is torch.fx.Proxy.
+        type (object): A type to be assigned to a given proxy object as val.
+    Returns:
+        The given val.
+    Raises:
+        RuntimeError: If a val already has a type in its node.
+    """
     if isinstance(val, Proxy):
         if val.node.type:
             raise RuntimeError(f"Tried to annotate a value that already had a type on it!"


### PR DESCRIPTION
Fixes #127903

This PR adds docstring to the `torch.fx.annotate.annotate` function.

cc @svekars @brycebortree @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv