### PR TITLE
[pytroch] update torch preprocess to support coremltools 7*

### DIFF
--- a/torch/backends/_coreml/preprocess.py
+++ b/torch/backends/_coreml/preprocess.py
@@ -101,7 +101,7 @@ def preprocess(script_module: torch._C.ScriptObject, compile_spec: Dict[str, Tup
         ml_type = _convert_to_mil_type(shape, dtype, name)
         mil_inputs.append(ml_type)
     model = torch.jit.RecursiveScriptModule._construct(script_module, lambda x: None)
-    mlmodel = ct.convert(model, inputs=mil_inputs)
+    mlmodel = ct.convert(model, inputs=mil_inputs, convert_to="neuralnetwork")
 
     if quantization_mode != CoreMLQuantizationMode.NONE:
         quant_model_spec = quantization_utils.quantize_weights(


### PR DESCRIPTION
Summary:
new version of coreml tools by default generates ml program instead of neural network, and even if that would be done properly, pytroch backend would not support this mlprogram correctly  on device, so in order to continue producing coreml models as we did, simply passing neural network as "convert_to" param, like it was by default in versions 5.x
https://github.com/apple/coremltools/blob/main/coremltools/converters/_converters_entry.py

Test Plan: run convert for some dummy model, test converted model on device

Differential Revision: D58385253
