### PR TITLE
[inductor] Fix nested indirect indexing case for index_propagation

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1239,6 +1239,26 @@ class CommonTemplate:
         actual = _run_and_assert_no_indirect_indexing(self, copy_opt, x)
         self.assertEqual(expect, actual)
 
+    @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
+    @config.patch(implicit_fallbacks=True)
+    def test_index_propagation_nested_indirect_indexing(self):
+        def nested(x, repeats):
+            rank = torch.arange(repeats.numel(), device=x.device)
+            index = rank.repeat_interleave(repeats, dim=0)
+            return torch.index_select(x, index=index, dim=0)
+
+        example_inputs = (
+            torch.randn((32, 64), device=self.device),
+            repeats := torch.tensor([5, 10, 15], device=self.device),
+        )
+        torch._dynamo.mark_dynamic(repeats, 0)  # create backed symint
+
+        nested_opt = torch._dynamo.optimize("inductor")(nested)
+
+        expect = nested(*example_inputs)
+        actual = nested_opt(*example_inputs)
+        self.assertEqual(expect, actual)
+
     def test_index_propagation_flip(self):
         def flip(x):
             i = torch.arange(x.size(0) - 1, -1, -1, device=x.device)

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -29,8 +29,8 @@ import sympy
 import torch
 from torch._prims_common import dtype_to_type, is_integer_dtype
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Where
-from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 from torch.utils._sympy.symbol import free_symbol_is_type, SymT
+from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 from .utils import generate_assert
 
 from .virtualized import V
@@ -345,7 +345,6 @@ class IndexPropagation:
                 -size <= expr
             )
             can_prove_upper = self.statically_true(expr < size)
-
             expr = wrap_expr(expr)
             if generate_assert(check):
                 self.fallback(

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -30,6 +30,7 @@ import torch
 from torch._prims_common import dtype_to_type, is_integer_dtype
 from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Where
 from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
+from torch.utils._sympy.symbol import free_symbol_is_type, SymT
 from .utils import generate_assert
 
 from .virtualized import V
@@ -322,6 +323,13 @@ class IndexPropagation:
 
             expr = sympy.sympify(index.value.expr)
 
+            if free_symbol_is_type(expr, SymT.INDIRECT):
+                # This is the nested indirect indexing case:
+                # a = ops.indirect_indexing(...)
+                # b = ops.index_expr(a, ...)
+                # c = ops.indirect_indexing(b, ...)
+                return Where(expr < 0, expr + size, expr)
+
             # TODO Perhaps move this logic to the simplify indexing pass
             def wrap_expr(expr):
                 # Positive, negative, mixed
@@ -337,6 +345,7 @@ class IndexPropagation:
                 -size <= expr
             )
             can_prove_upper = self.statically_true(expr < size)
+
             expr = wrap_expr(expr)
             if generate_assert(check):
                 self.fallback(

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -350,8 +350,11 @@ class IndexPropagation:
         indirect_var = self.fallback(
             "indirect_indexing", (index, size, check), {}
         ).value
-        if indirect_var not in self.var_to_range:
-            lower, upper = -upper_bound(size), upper_bound(size) - 1
-            indirect_range = (indirect_var, ValueRanges(lower, upper))
-            self.var_to_range = self.var_to_range + (indirect_range,)
+        assert (
+            indirect_var not in self.var_to_range
+        ), f"{indirect_var} should've been created in the fallback."
+
+        lower, upper = -upper_bound(size), upper_bound(size) - 1
+        indirect_range = (indirect_var, ValueRanges(lower, upper))
+        self.var_to_range = self.var_to_range + (indirect_range,)
         return indirect_var

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -353,8 +353,6 @@ class IndexPropagation:
         assert (
             indirect_var not in self.var_to_range
         ), f"{indirect_var} should've been created in the fallback."
-
-        lower, upper = -upper_bound(size), upper_bound(size) - 1
-        indirect_range = (indirect_var, ValueRanges(lower, upper))
+        indirect_range = (indirect_var, ValueRanges(0, upper_bound(size) - 1))
         self.var_to_range = self.var_to_range + (indirect_range,)
         return indirect_var

--- a/torch/_inductor/index_propagation.py
+++ b/torch/_inductor/index_propagation.py
@@ -352,6 +352,6 @@ class IndexPropagation:
         ).value
         if indirect_var not in self.var_to_range:
             lower, upper = -upper_bound(size), upper_bound(size) - 1
-            indirect_var_to_default_range = (indirect_var, ValueRanges(lower, upper))
-            self.var_to_range = self.var_to_range + (indirect_var_to_default_range,)
+            indirect_range = (indirect_var, ValueRanges(lower, upper))
+            self.var_to_range = self.var_to_range + (indirect_range,)
         return indirect_var

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8012,7 +8012,10 @@ class LoopBody:
         return name
 
     def add_indirect(self, size):
-        var = sympy_index_symbol_with_prefix(SymT.INDIRECT, len(self.indirect_vars))
+        from torch.utils._sympy.symbol import make_symbol
+
+        # Note: indirect index variables can be negative, positive or 0.
+        var = make_symbol(SymT.INDIRECT, len(self.indirect_vars), integer=True)
         self.indirect_vars.append(var)
         return var
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8012,10 +8012,7 @@ class LoopBody:
         return name
 
     def add_indirect(self, size):
-        from torch.utils._sympy.symbol import make_symbol
-
-        # Note: indirect index variables can be negative, positive or 0.
-        var = make_symbol(SymT.INDIRECT, len(self.indirect_vars), integer=True)
+        var = sympy_index_symbol_with_prefix(SymT.INDIRECT, len(self.indirect_vars))
         self.indirect_vars.append(var)
         return var
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4420,11 +4420,7 @@ class ShapeEnv:
                 # Skip var_ranges logic for SingletonInt which is only used
                 # for jagged layout NestedTensors today
                 continue
-            try:
-                vr = var_ranges[k]
-            except KeyError:
-                log.warning("%s is not in var_ranges, defaulting to unknown range.", k)
-                vr = self._default_unspecified_value_range()
+            vr = var_ranges[k]
             if size_oblivious and k in self.size_like:
                 lower = max(2, vr.lower)
                 # This is a bit dodgy: what this means is that there was a


### PR DESCRIPTION
Tries to fix #127677.

# Context

Just as @peterbell10 pointed out, we have the following scenario:
```
a = ops.indirect_indexing(...)
b = ops.index_expr(a, ...)
c = ops.indirect_indexing(b, ...)
```

We can repro this as:
```
def forward(self, arg0_1, arg1_1, arg2_1):
    iota = torch.ops.prims.iota.default(arg0_1, start = 0, step = 1, index=0),
    repeat_interleave = torch.ops.aten.repeat_interleave.Tensor(arg1_1);
    index = torch.ops.aten.index.Tensor(iota, [repeat_interleave]);
    index_1 = torch.ops.aten.index.Tensor(arg2_1, [index]);
    return (index_1,)
```

which should generate a JIT py file like this:
```
def triton_poi_fused_index_select_0(in_ptr0, in_ptr1, out_ptr0, ks0, xnumel, XBLOCK : tl.constexpr):
    ...
    tmp0 = tl.load(in_ptr0 + (x1), xmask, eviction_policy='evict_last')
    tmp1 = ks0
    tmp2 = tmp0 + tmp1
    tmp3 = tmp0 < 0
    tmp4 = tl.where(tmp3, tmp2, tmp0)
    # check_bounds()
    tl.device_assert(((0 <= tmp4) & (tmp4 < ks0)) | ~(xmask), "index out of bounds: 0 <= tmp4 < ks0")

def call():
  arg0_1, arg1_1, arg2_1 = args
  buf1 = aten.repeat_interleave.Tensor(arg1_1)
  buf4 = empty_strided_cuda((u0, 64), (64, 1))
  triton_poi_fused_index_select_0.run(
    buf1, arg2_1, buf4, s0, 
    triton_poi_fused_index_select_0_xnumel, 
    grid=grid(triton_poi_fused_index_select_0_xnumel), 
    stream=stream0)
```

# Issue
In our `IndexPropagation.indirect_indexing()` call we have `expr=indirect0` which is spawned in `LoopBodyBlock.indirect_indexing()`.
https://github.com/pytorch/pytorch/blob/3b555ba47713d489975a9bb6cb6c31975f805e3f/torch/_inductor/ir.py#L8154-L8160

When we try to see if we can prove its bounds, we fail because `indirect0` isn't in `var_ranges`.

# Approach
When creating `indirect` symbols from fallback, specify its range to be `[-size, size -1]` to avoid a lookup error with `indirectX`.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128378



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang