### PR TITLE
[AOTI] Codegen rocm C shim file name with hip

### DIFF
--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2436,8 +2436,11 @@ codegen to generate the correct cpp call for this op. Contact AOTInductor team f
                 extra_cuda_headers if is_cuda_dispatch_key(dispatch_key) else ""
             )
 
+            device = dispatch_key.lower()
+            if rocm and device == "cuda":
+                device = "hip"
             aoti_fm.write(
-                f"c_shim_{dispatch_key.lower()}.cpp",
+                f"c_shim_{device}.cpp",
                 lambda: gen_aoti_c_shim(
                     fallback_native_functions,
                     structured_func_group_dict,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128379

Summary: This will save one step to hipify the generated C shim cpp file.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang