### PR TITLE
[AOTI] Use runtime executor for aten fallback ops without C shim

### DIFF
--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -106,14 +106,6 @@ if config.abi_compatible:
         test_failures_cuda_wrapper[
             f"{test_name}_dynamic_shapes"
         ] = test_torchinductor.TestFailure(("cuda_wrapper",), is_skip=False)
-    skip_list = []
-    for test_name in skip_list:
-        test_failures_cuda_wrapper[test_name] = test_torchinductor.TestFailure(
-            ("cuda_wrapper",), is_skip=True
-        )
-        test_failures_cuda_wrapper[
-            f"{test_name}_dynamic_shapes"
-        ] = test_torchinductor.TestFailure(("cuda_wrapper",), is_skip=True)
 
 
 def make_test_case(
@@ -199,6 +191,7 @@ if RUN_CUDA:
         BaseTest("test_index_tensor"),
         BaseTest("test_inductor_layout_optimization_input_mutations"),
         BaseTest("test_insignificant_strides"),
+        BaseTest("test_kwargs"),
         BaseTest("test_layer_norm"),
         BaseTest("test_linear1"),
         BaseTest("test_linear2"),

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5551,15 +5551,20 @@ class FallbackKernel(ExternKernelAlloc):
             # Aten Fallback Ops
             assert isinstance(kernel, torch._ops.OpOverload)
             if V.graph.cpp_wrapper:
+                from torchgen.aoti.fallback_ops import inductor_fallback_ops
+
                 if (
                     config.is_fbcode()
                     and kernel not in has_c_shim
                     # C shim v2 is torchgen-ed, which should cover all aten ops.
                     # If you do hit a missed op, please update gen_aoti_c_shim.py.
                     and config.c_shim_version == "1"
+                ) or (
+                    str(kernel) not in inductor_fallback_ops
+                    and config.c_shim_version == "2"
                 ):
                     log.warning(
-                        "%s is missing a c-shim implementation, using proxy executor as fallback",
+                        "%s is missing a c-shim implementation, using runtime executor as fallback",
                         kernel,
                     )
                     self.use_runtime_dispatch = True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128382

Summary: torchgen/aoti/fallback_ops.py contains a list of aten fallback ops that we will generate C shim functions for. All other fallback aten ops will go through a runtime executor solution, Python dispatcher in the JIT mode and Proxy Executor in the AOT mode.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang