### PR TITLE
Clean up xpu ut to make CI happy

### DIFF
--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -344,8 +344,6 @@ class TestXpuAutocast(TestCase):
 
             # Try module.* variant, if requested:
             if module is not None and hasattr(module, op):
-                print(*args)
-                print(**add_kwargs)
                 output = getattr(module, op)(*args, **add_kwargs)
                 if isinstance(output, torch.Tensor):
                     self.assertTrue(

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -312,6 +312,11 @@ instantiate_device_type_tests(TestXpu, globals(), only_for="xpu")
 
 
 class TestXpuAutocast(TestCase):
+    # These operators are not implemented on XPU backend and we can NOT fall back
+    # them to CPU. So we have to skip them at this moment.
+    # TODO: remove these operators from skip list when they are implemented on XPU backend.
+    skip_list = ["gru_cell"]
+
     def setUp(self):
         super().setUp()
         self.autocast_lists = AutocastTestLists(torch.device("xpu"))
@@ -407,6 +412,8 @@ class TestXpuAutocast(TestCase):
         for op_with_args in self.autocast_lists.torch_fp16:
             skip_test = False
             op, args = op_with_args[0], op_with_args[1]
+            if op in self.skip_list:
+                skip_test = True  # skip unsupported op
             if len(op_with_args) == 3:
                 skip_test = True  # skip cudnn op
             if not skip_test:
@@ -416,6 +423,8 @@ class TestXpuAutocast(TestCase):
         for op_with_args in self.autocast_lists.torch_fp16:
             skip_test = False
             op, args = op_with_args[0], op_with_args[1]
+            if op in self.skip_list:
+                skip_test = True  # skip unsupported op
             if len(op_with_args) == 3:
                 skip_test = True  # skip cudnn op
             if not skip_test:

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -413,7 +413,7 @@ class TestXpuAutocast(TestCase):
             skip_test = False
             op, args = op_with_args[0], op_with_args[1]
             if op in self.skip_list:
-                skip_test = True  # skip unsupported op
+                skip_test = True  # skip unimplemented op
             if len(op_with_args) == 3:
                 skip_test = True  # skip cudnn op
             if not skip_test:
@@ -424,7 +424,7 @@ class TestXpuAutocast(TestCase):
             skip_test = False
             op, args = op_with_args[0], op_with_args[1]
             if op in self.skip_list:
-                skip_test = True  # skip unsupported op
+                skip_test = True  # skip unimplemented op
             if len(op_with_args) == 3:
                 skip_test = True  # skip cudnn op
             if not skip_test:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128383

# Motivation
Before #127611 merged, the xpu-specific UT `test/test_xpu.py` was skipped temporarily. This PR aims to fix the UT bug introduced by #127741.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10