### PR TITLE
[Fix] Correctly identifying arguments for sub-blocks with renaming logic during TorchScript to ExportedProgram conversion

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -454,29 +454,29 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
-        # Basic module testing.
-        inp = (torch.ones(3),)
-        orig_m = M(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        # # Basic module testing.
+        # inp = (torch.ones(3),)
+        # orig_m = M(3)
+        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        t = inp[0]
-        t -= 0.8
-        torch.testing.assert_close(
-            ep.module()(*inp),
-            orig_m(*inp),
-        )
+        # t = inp[0]
+        # t -= 0.8
+        # torch.testing.assert_close(
+        #     ep.module()(*inp),
+        #     orig_m(*inp),
+        # )
 
-        # Nested module testing.
-        inp = (torch.ones(3),)
-        orig_m = NestedM(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        # # Nested module testing.
+        # inp = (torch.ones(3),)
+        # orig_m = NestedM(3)
+        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        t = inp[0]
-        t -= 0.8
-        torch.testing.assert_close(
-            ep.module()(*inp),
-            orig_m(*inp),
-        )
+        # t = inp[0]
+        # t -= 0.8
+        # torch.testing.assert_close(
+        #     ep.module()(*inp),
+        #     orig_m(*inp),
+        # )
 
     def test_convert_nn_module_with_nested_param(self):
         class M(torch.nn.Module):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -448,9 +448,9 @@ class TestConverter(TestCase):
 
         inp = (torch.ones(3),)
         orig_m = NestedM(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        self._check_equal_ts_ep_converter(orig_m, inp)
         orig_m = SuperNestedM(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        self._check_equal_ts_ep_converter(orig_m, inp)
 
     def test_convert_nn_module_with_nested_buffer(self):
         class M(torch.nn.Module):
@@ -955,6 +955,7 @@ class TestConverter(TestCase):
         # Cannot script variable length inputs.
         self._check_equal_ts_ep_converter(func2, tuple(values), ["trace"])
         
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -418,6 +418,39 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(MUnpackList(), inp)
         inp = ((torch.zeros(1, 4), torch.ones(1, 4)),)
         self._check_equal_ts_ep_converter(MUnpackTuple(), inp)
+        
+    def test_convert_nn_module_with_param(self):
+        class M(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x: torch.Tensor):
+                return self.linear(x)
+
+        class NestedM(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.m1 = M(dim)
+                self.m2 = M(dim)
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x: torch.Tensor):
+                if torch.sum(x) > 1:
+                    return self.linear(self.m1(x))
+                else:
+                    return self.linear(self.m2(x))
+
+        inp = (torch.ones(3),)
+        orig_m = NestedM(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
 
     def test_convert_nn_module_with_nested_param(self):
         class M(torch.nn.Module):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -418,7 +418,7 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(MUnpackList(), inp)
         inp = ((torch.zeros(1, 4), torch.ones(1, 4)),)
         self._check_equal_ts_ep_converter(MUnpackTuple(), inp)
-        
+
     def test_convert_nn_module_with_nested_param(self):
         class M(torch.nn.Module):
             def __init__(self, dim: int) -> None:
@@ -470,6 +470,7 @@ class TestConverter(TestCase):
 
             def forward(self, x: torch.Tensor):
                 if torch.sum(x) > 1:
+                    y = x
                     return self.linear(self.m1(x))
                 else:
                     return self.linear(self.m2(x))
@@ -757,12 +758,12 @@ class TestConverter(TestCase):
         # orig_m = SuperNestedM2(3)
         # ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        # t = inp[0]
-        # t -= 0.8
-        # torch.testing.assert_close(
-        #     ep.module()(*inp),
-        #     orig_m(*inp),
-        # )
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
 
     def test_ts2ep_converter_contains(self):
         class MIn(torch.nn.Module):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -954,7 +954,6 @@ class TestConverter(TestCase):
         values = [empty] + [torch.randn(M, N) for N in Ns]
         # Cannot script variable length inputs.
         self._check_equal_ts_ep_converter(func2, tuple(values), ["trace"])
-        
 
 
 if __name__ == "__main__":

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -633,14 +633,16 @@ class TestConverter(TestCase):
         # Super nested module testing.
         inp = (torch.ones(3),)
         orig_m = SuperNestedM2(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        # TODO: fix trace: state_dict is not equal.
+        ep_list = self._check_equal_ts_ep_converter(orig_m, inp, ["script"])
 
         t = inp[0]
         t -= 0.8
-        torch.testing.assert_close(
-            ep.module()(*inp),
-            orig_m(*inp),
-        )
+        for ep in ep_list:
+            torch.testing.assert_close(
+                ep.module()(*inp),
+                orig_m(*inp),
+            )
 
     def test_ts2ep_converter_contains(self):
         class MIn(torch.nn.Module):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -441,6 +441,32 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
+        class SuperNestedM(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.m1 = NestedM(dim)
+                self.m2 = NestedM(dim)
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x: torch.Tensor):
+                if torch.sum(x) > 1:
+                    return self.linear(self.m1(x))
+                else:
+                    return self.linear(self.m2(x))
+
+        # Basic module testing.
+        inp = (torch.ones(3),)
+        orig_m = M(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
+
+        # Nested module testing.
         inp = (torch.ones(3),)
         orig_m = NestedM(3)
         ep = self._check_equal_ts_ep_converter(orig_m, inp)

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -452,129 +452,6 @@ class TestConverter(TestCase):
         orig_m = SuperNestedM(3)
         ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-    def test_convert_nn_module_with_nested_if_and_param(self):
-        class M(torch.nn.Module):
-            def __init__(self, dim: int) -> None:
-                super().__init__()
-                self.linear = torch.nn.Linear(dim, dim)
-
-            def forward(self, x: torch.Tensor):
-                return self.linear(x)
-
-        class NestedM(torch.nn.Module):
-            def __init__(self, dim: int) -> None:
-                super().__init__()
-                self.m1 = M(dim)
-                self.m2 = M(dim)
-                self.linear = torch.nn.Linear(dim, dim)
-
-            def forward(self, x: torch.Tensor):
-                if torch.sum(x) > 1:
-                    y = x
-                    return self.linear(self.m1(x))
-                else:
-                    return self.linear(self.m2(x))
-
-        # Super nested, parameters neeed to lifted
-        # multiple times.
-        class SuperNestedM1(torch.nn.Module):
-            def __init__(self, dim: int) -> None:
-                super().__init__()
-                self.m1 = NestedM(dim)
-                self.m2 = NestedM(dim)
-                self.linear = torch.nn.Linear(dim, dim)
-
-            def forward(self, x: torch.Tensor):
-                if torch.max(x) > 1:
-                    return self.linear(self.m1(x))
-                else:
-                    return self.linear(self.m2(x))
-
-        # Super nested, even the input needs to be
-        # lifted recursively due to value propogation optimiztaion.
-        class SuperNestedM2(torch.nn.Module):
-            def __init__(self, dim: int) -> None:
-                super().__init__()
-                self.m1 = NestedM(dim)
-                self.m2 = NestedM(dim)
-                self.linear = torch.nn.Linear(dim, dim)
-
-            def forward(self, x: torch.Tensor):
-                if torch.sum(x) > 1:
-                    return self.linear(self.m1(x))
-                else:
-                    return self.linear(self.m2(x))
-
-        # Basic module testing.
-        inp = (torch.ones(3),)
-        orig_m = M(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
-
-        t = inp[0]
-        t -= 0.8
-        torch.testing.assert_close(
-            ep.module()(*inp),
-            orig_m(*inp),
-        )
-
-        # Nested module testing.
-        inp = (torch.ones(3),)
-        orig_m = NestedM(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
-
-        t = inp[0]
-        t -= 0.8
-        torch.testing.assert_close(
-            ep.module()(*inp),
-            orig_m(*inp),
-        )
-
-        # Super nested module testing.
-        inp = (torch.ones(3),)
-        orig_m = SuperNestedM1(3)
-        ep = self._check_equal_ts_ep_converter(orig_m, inp)
-
-        t = inp[0]
-        t -= 0.8
-        torch.testing.assert_close(
-            ep.module()(*inp),
-            orig_m(*inp),
-        )
-
-    def test_convert_nn_module_with_nested_param(self):
-        class M(torch.nn.Module):
-            def __init__(self, dim: int) -> None:
-                super().__init__()
-                self.linear = torch.nn.Linear(dim, dim)
-
-            def forward(self, x: torch.Tensor):
-                return self.linear(x)
-
-        class NestedM(torch.nn.Module):
-            def __init__(self, dim: int) -> None:
-                super().__init__()
-                self.linear = torch.nn.Linear(dim, dim)
-                self.m = M(dim)
-
-            def forward(self, x: torch.Tensor):
-                return self.linear(self.m(x))
-
-        class SuperNestedM(torch.nn.Module):
-            def __init__(self, dim: int) -> None:
-                super().__init__()
-                self.linear = torch.nn.Linear(dim, dim)
-                self.m = NestedM(dim)
-
-            def forward(self, x: torch.Tensor):
-                return self.linear(self.m(x))
-
-        inp = (torch.ones(3),)
-        orig_m = NestedM(3)
-        self._check_equal_ts_ep_converter(orig_m, inp)
-
-        orig_m = SuperNestedM(3)
-        self._check_equal_ts_ep_converter(orig_m, inp)
-
     def test_convert_nn_module_with_nested_buffer(self):
         class M(torch.nn.Module):
             def __init__(self) -> None:
@@ -753,10 +630,10 @@ class TestConverter(TestCase):
                 orig_m(*inp),
             )
 
-        # # Super nested module testing.
-        # inp = (torch.ones(3),)
-        # orig_m = SuperNestedM2(3)
-        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        # Super nested module testing.
+        inp = (torch.ones(3),)
+        orig_m = SuperNestedM2(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
         t = inp[0]
         t -= 0.8

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -441,6 +441,8 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
+        # Super nested, parameters neeed to lifted
+        # multiple times.
         class SuperNestedM1(torch.nn.Module):
             def __init__(self, dim: int) -> None:
                 super().__init__()
@@ -454,29 +456,57 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
-        # # Basic module testing.
-        # inp = (torch.ones(3),)
-        # orig_m = M(3)
-        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        # t = inp[0]
-        # t -= 0.8
-        # torch.testing.assert_close(
-        #     ep.module()(*inp),
-        #     orig_m(*inp),
-        # )
+        # Super nested, even the input needs to be
+        # lifted recursively due to value propogation optimiztaion.
+        class SuperNestedM2(torch.nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.m1 = NestedM(dim)
+                self.m2 = NestedM(dim)
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x: torch.Tensor):
+                if torch.sum(x) > 1:
+                    return self.linear(self.m1(x))
+                else:
+                    return self.linear(self.m2(x))
+
+        # # Basic module testing.
+        inp = (torch.ones(3),)
+        orig_m = M(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
 
         # # Nested module testing.
-        # inp = (torch.ones(3),)
-        # orig_m = NestedM(3)
-        # ep = self._check_equal_ts_ep_converter(orig_m, inp)
+        inp = (torch.ones(3),)
+        orig_m = NestedM(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
 
-        # t = inp[0]
-        # t -= 0.8
-        # torch.testing.assert_close(
-        #     ep.module()(*inp),
-        #     orig_m(*inp),
-        # )
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
+
+        # Super nested module testing.
+        inp = (torch.ones(3),)
+        orig_m = SuperNestedM1(3)
+        ep = self._check_equal_ts_ep_converter(orig_m, inp)
+
+        t = inp[0]
+        t -= 0.8
+        torch.testing.assert_close(
+            ep.module()(*inp),
+            orig_m(*inp),
+        )
 
     def test_convert_nn_module_with_nested_param(self):
         class M(torch.nn.Module):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -441,7 +441,7 @@ class TestConverter(TestCase):
                 else:
                     return self.linear(self.m2(x))
 
-        class SuperNestedM(torch.nn.Module):
+        class SuperNestedM1(torch.nn.Module):
             def __init__(self, dim: int) -> None:
                 super().__init__()
                 self.m1 = NestedM(dim)
@@ -449,7 +449,7 @@ class TestConverter(TestCase):
                 self.linear = torch.nn.Linear(dim, dim)
 
             def forward(self, x: torch.Tensor):
-                if torch.sum(x) > 1:
+                if torch.max(x) > 1:
                     return self.linear(self.m1(x))
                 else:
                     return self.linear(self.m2(x))

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -296,6 +296,8 @@ class TS2FXGraphConverter:
     def is_top_level_graph(self):
         return isinstance(self.ts_graph, torch._C.Graph)
 
+        self.block_to_arguments = block_to_arguments
+
     def add_subgraph(self, subgraph) -> str:
         name = f"subgraph_{len(self.subgraphs)}"
         self.subgraphs[name] = subgraph
@@ -661,7 +663,7 @@ class TS2FXGraphConverter:
                 for block_node_in in block_node.inputs():
                     if block_node_in.debugName() in self.name_to_node:
                         block_args.add(block_node_in.debugName())
-            
+
             arguments.update(block_args)
 
         # Lift parameters as inputs.

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -658,11 +658,14 @@ class TS2FXGraphConverter:
                 for block_node in block.nodes():
                     for block_node_in in block_node.inputs():
                         if block_node_in.debugName() in self.name_to_node:
-                            arguments.add(block_node_in.debugName())
-                    arguments = arguments.union(_dfs_build_lifted_arguments_for_input(block_node))
+                            debug_name = block_node_in.debugName()
+                            arguments.add(debug_name)
+                    arguments = arguments.union(
+                        _dfs_build_lifted_arguments_for_input(block_node)
+                    )
             return arguments
 
-        # Lift inputs.
+        # # Find inputs.
         arguments = _dfs_build_lifted_arguments_for_input(node)
 
         # Lift parameters as inputs.

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -42,7 +42,7 @@ def inplace_optimize_sym_size_div(gm: torch.fx.GraphModule):
 
 def is_valid_for_codegen(name):
     if len(name) == 0:
-        raise RuntimeError(f"Invalid name '{name}' for codegen")
+        raise RuntimeError("Empty argument name for codegen")
     if name[0].isdigit():
         return False
     return True

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -298,6 +298,17 @@ class TS2FXGraphConverter:
 
         self.block_to_arguments = block_to_arguments
 
+        # Populate methods for the standard operators.
+        for k in kind_to_standard_operators.keys():
+            handler_func_name = ir_name_to_func_name(k)
+            # Create an indirect function call:
+            # convert_<namespace>_<opname> --> lambda node: _convert_standard_operator(node)
+            setattr(
+                self,
+                handler_func_name,
+                lambda node: self._convert_standard_operators(node),
+            )
+
     def add_subgraph(self, subgraph) -> str:
         name = f"subgraph_{len(self.subgraphs)}"
         self.subgraphs[name] = subgraph

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -711,9 +711,7 @@ class TS2FXGraphConverter:
         arguments_renamed = []
         for i, argument in enumerate(arguments_orig):
             if not is_valid_for_codegen(argument):
-                prefix = self.name_to_node[
-                    argument
-                ].name  # type: ignore[union-attr]
+                prefix = self.name_to_node[argument].name  # type: ignore[union-attr]
                 argument_renamed = f"{prefix}_{argument}"
                 self.renaming_map[
                     argument

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -391,6 +391,8 @@ class TS2FXGraphConverter:
                     self.fx_graph, name, self.is_top_level_graph()
                 )
             else:
+                if not is_valid_for_codegen(normalized_name):
+                    normalized_name = f"input_{normalized_name}"
                 self.input_specs.append(
                     InputSpec(
                         InputKind.USER_INPUT,

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -661,7 +661,7 @@ class TS2FXGraphConverter:
                 for block_node_in in block_node.inputs():
                     if block_node_in.debugName() in self.name_to_node:
                         block_args.add(block_node_in.debugName())
-
+            
             arguments.update(block_args)
 
         # Lift parameters as inputs.
@@ -928,11 +928,11 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionaly
         self.lift_tensor_constants_to_buffer()
 
         # Populate nn module parameters and buffers.
-        self.mod_param_and_buffer_map: Dict[str, Any]= dict()
+        self.mod_param_and_buffer_map: Dict[str, Any] = dict()
         for name, param in ts_model.named_parameters():
             self.mod_param_and_buffer_map[normalize_name(name)] = param
         for name, buffer in ts_model.named_buffers():
-            self.mod_param_and_buffer_map[normalize_name(name)] = buffer 
+            self.mod_param_and_buffer_map[normalize_name(name)] = buffer
 
     def convert(self) -> ExportedProgram:
         blocks_to_lifted_attrs = get_block_to_lifted_attrs(self.ts_graph)

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -113,6 +113,14 @@ def construct_fqn(ir, ref_map, name_map):
     return ".".join(reversed(name_list))
 
 
+def is_valid_for_codegen(name):
+    if len(name) == 0:
+        return False
+    if name[0].isdigit():
+        return False
+    return True
+
+
 def get_block_to_lifted_attrs(graph: torch._C.Graph) -> Dict[torch._C.Block, Set[str]]:
     """
     Perform two passes to get a mapping of blocks to a set of FQNs of its lifted attributes.
@@ -281,6 +289,7 @@ class TS2FXGraphConverter:
         self.subgraphs: Dict[str, torch.fx.GraphModule] = {}
 
         self.blocks_to_lifted_attrs = blocks_to_lifted_attrs
+        self.renaming_map = renaming_map
 
         # Populate methods for the standard operators.
         for k in kind_to_standard_operators.keys():
@@ -295,21 +304,6 @@ class TS2FXGraphConverter:
 
     def is_top_level_graph(self):
         return isinstance(self.ts_graph, torch._C.Graph)
-
-        self.block_to_arguments = block_to_arguments
-
-        self.renaming_map = renaming_map
-
-        # Populate methods for the standard operators.
-        for k in kind_to_standard_operators.keys():
-            handler_func_name = ir_name_to_func_name(k)
-            # Create an indirect function call:
-            # convert_<namespace>_<opname> --> lambda node: _convert_standard_operator(node)
-            setattr(
-                self,
-                handler_func_name,
-                lambda node: self._convert_standard_operators(node),
-            )
 
     def add_subgraph(self, subgraph) -> str:
         name = f"subgraph_{len(self.subgraphs)}"
@@ -670,11 +664,16 @@ class TS2FXGraphConverter:
         assert len(inputs) == 1
         predicate = self.get_fx_value(inputs[0])
 
-        def _dfs_build_lifted_arguments_for_input(entry):
+        def _identify_inputs_as_arguments(entry):
             """
-            Bottom-up finding inputs that should be lifted. This is needed
+            Identify inputs from the innermost sub-block. This is needed
             for nested sub-blocks when the input is hidden in the nested sub-block.
-            We need a DFS to extrapolate the hidden input arguments.
+            E.g., example IR of input is hidden in the nested sub-block.
+            Graph[x.1]
+            %1 = ...
+                Block[]
+                    Block[x.1]
+                        %2 = x.1 ...
             """
             arguments: Set[str] = set()
             for block in entry.blocks():
@@ -687,7 +686,12 @@ class TS2FXGraphConverter:
                             # will cause error when it is embedded into a codegen function
                             # (invalid argument name). We rename if the name is not valid for
                             # code generation.
-                            if not is_legal_for_codegen(debug_name):
+                            # E.g.,
+                            #     Graph[x.1]                 Graph[x.1]
+                            #     %1 = ...          -->      %1 = ... // name_to_node["n_1"] = name_to_node["1"]
+                            #         Block[%1]                  Block[%n_1]
+                            #         %2 = %1 ...                %2 = %1 ... // renaming_map["1"] = "n_1"
+                            if not is_valid_for_codegen(debug_name):
                                 prefix = self.name_to_node[
                                     debug_name
                                 ].name  # type: ignore[union-attr]
@@ -702,12 +706,12 @@ class TS2FXGraphConverter:
 
                             arguments.add(debug_name)
                     arguments = arguments.union(
-                        _dfs_build_lifted_arguments_for_input(block_node)
+                        _identify_inputs_as_arguments(block_node)
                     )
             return arguments
 
         # Find inputs.
-        arguments = _dfs_build_lifted_arguments_for_input(node)
+        arguments = _identify_inputs_as_arguments(node)
 
         # Lift parameters as inputs.
         for block in node.blocks():
@@ -971,13 +975,6 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionaly
         self.name_to_non_tensor_attributes: Dict[str, Any] = {}
 
         self.lift_tensor_constants_to_buffer()
-
-        # Populate nn module parameters and buffers.
-        self.mod_param_and_buffer_map: Dict[str, Any] = dict()
-        for name, param in ts_model.named_parameters():
-            self.mod_param_and_buffer_map[normalize_name(name)] = param
-        for name, buffer in ts_model.named_buffers():
-            self.mod_param_and_buffer_map[normalize_name(name)] = buffer
 
     def convert(self) -> ExportedProgram:
         blocks_to_lifted_attrs = get_block_to_lifted_attrs(self.ts_graph)

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -326,6 +326,9 @@ class TS2FXGraphConverter:
         self.convert_graph_inputs()
 
         for node in self.ts_graph.nodes():
+            # if node.kind() == "prim::GetAttr":
+            #     breakpoint()
+            #     pass
             self.convert_node(node)
 
         self.convert_graph_outputs()
@@ -686,6 +689,7 @@ class TS2FXGraphConverter:
                 )
                 subgraph_converter.name_to_node[block_arg] = placeholder_node
 
+            breakpoint()
             subgraph = subgraph_converter.convert()
             subgraph_name = self.add_subgraph(subgraph)
             subgraph_nodes.append(self.fx_graph.get_attr(subgraph_name))
@@ -908,6 +912,7 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionaly
         self.ts_model = ts_model
         self.ts_graph, self.params, _, _ = _create_jit_graph(ts_model, sample_args)
         log.info(f"TorchScript graph\n\n{self.ts_graph}\n")  # noqa: G004
+        breakpoint()
 
         self.sample_args = sample_args
         self.sample_kwargs = sample_kwargs
@@ -925,6 +930,10 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionaly
         self.name_to_non_tensor_attributes: Dict[str, Any] = {}
 
         self.lift_tensor_constants_to_buffer()
+
+        self.mod_attribute_map = {
+            name: param for name, param in ts_model.named_parameters()
+        }
 
     def convert(self) -> ExportedProgram:
         blocks_to_lifted_attrs = get_block_to_lifted_attrs(self.ts_graph)

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -326,9 +326,6 @@ class TS2FXGraphConverter:
         self.convert_graph_inputs()
 
         for node in self.ts_graph.nodes():
-            # if node.kind() == "prim::GetAttr":
-            #     breakpoint()
-            #     pass
             self.convert_node(node)
 
         self.convert_graph_outputs()
@@ -689,7 +686,6 @@ class TS2FXGraphConverter:
                 )
                 subgraph_converter.name_to_node[block_arg] = placeholder_node
 
-            breakpoint()
             subgraph = subgraph_converter.convert()
             subgraph_name = self.add_subgraph(subgraph)
             subgraph_nodes.append(self.fx_graph.get_attr(subgraph_name))
@@ -931,9 +927,12 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionaly
 
         self.lift_tensor_constants_to_buffer()
 
-        self.mod_attribute_map = {
-            name: param for name, param in ts_model.named_parameters()
-        }
+        # Populate nn module parameters and buffers.
+        self.mod_param_and_buffer_map: Dict[str, Any]= dict()
+        for name, param in ts_model.named_parameters():
+            self.mod_param_and_buffer_map[normalize_name(name)] = param
+        for name, buffer in ts_model.named_buffers():
+            self.mod_param_and_buffer_map[normalize_name(name)] = buffer 
 
     def convert(self) -> ExportedProgram:
         blocks_to_lifted_attrs = get_block_to_lifted_attrs(self.ts_graph)


### PR DESCRIPTION
#### Issue
Fix two issues related to inputs lifting when there are sub-blocks.
* Some inputs may appear in the nested sub-blocks, which need a recursive search to identify which arguments need to be lifted / passed in the top-level block.
* Some inputs to the sub-block are intermediate results, meaning their names are only number. This will cause issue during code generation (i.e., invalid argument name). We rename those to valid names. 

#### Test Plan
* `pytest test/export/test_converter.py -s -k test_convert_nn_module_with_nested_if_and_param`
* `test/export/test_converter.py -s -k test_hidden_input_name`
