### PR TITLE
Torchbind call method + effects support

### DIFF
--- a/test/export/test_torchbind.py
+++ b/test/export/test_torchbind.py
@@ -182,10 +182,12 @@ def forward(self, x, n):
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, obj_attr, x, n):
-    call_torchbind = torch.ops.higher_order.call_torchbind(obj_attr, 'add_tensor', x);  obj_attr = None
-    add = torch.ops.aten.add.Tensor(x, call_torchbind);  x = call_torchbind = None
-    return (add,)""",
+def forward(self, token, obj_attr, x, n):
+    with_effects = torch._higher_order_ops.effects.with_effects(token, torch.ops.higher_order.call_torchbind, obj_attr, 'add_tensor', x);  token = obj_attr = None
+    getitem = with_effects[0]
+    getitem_1 = with_effects[1];  with_effects = None
+    add = torch.ops.aten.add.Tensor(x, getitem_1);  x = getitem_1 = None
+    return (getitem, add)""",  # noqa: B950
         )
 
     def test_method_schema(self):
@@ -227,10 +229,12 @@ def forward(self, x):
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, obj_attr, x):
-    call_torchbind = torch.ops.higher_order.call_torchbind(obj_attr, 'add_tensor', x);  obj_attr = None
-    add = torch.ops.aten.add.Tensor(x, call_torchbind);  x = call_torchbind = None
-    return (add,)""",
+def forward(self, token, obj_attr, x):
+    with_effects = torch._higher_order_ops.effects.with_effects(token, torch.ops.higher_order.call_torchbind, obj_attr, 'add_tensor', x);  token = obj_attr = None
+    getitem = with_effects[0]
+    getitem_1 = with_effects[1];  with_effects = None
+    add = torch.ops.aten.add.Tensor(x, getitem_1);  x = getitem_1 = None
+    return (getitem, add)""",  # noqa: B950
         )
 
     @parametrize("pre_dispatch", [True, False])
@@ -293,10 +297,12 @@ def forward(self, x, cc):
         self.assertExpectedInline(
             ep.graph_module.code.strip(),
             """\
-def forward(self, x, cc):
-    call_torchbind = torch.ops.higher_order.call_torchbind(cc, 'add_tensor', x);  cc = None
-    add = torch.ops.aten.add.Tensor(x, call_torchbind);  x = call_torchbind = None
-    return (add,)""",
+def forward(self, token, x, cc):
+    with_effects = torch._higher_order_ops.effects.with_effects(token, torch.ops.higher_order.call_torchbind, cc, 'add_tensor', x);  token = cc = None
+    getitem = with_effects[0]
+    getitem_1 = with_effects[1];  with_effects = None
+    add = torch.ops.aten.add.Tensor(x, getitem_1);  x = getitem_1 = None
+    return (getitem, add)""",  # noqa: B950
         )
         # aot_export_function runs the program twice
         # in run_functionalized_fw_and_collect_metadata and create_aot_dispatcher_function

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -898,7 +898,7 @@ class GraphModuleSerializer(metaclass=Final):
             return Argument.create(
                 as_custom_obj=CustomObjArgument(custom_obj_name, class_fqn)
             )
-        elif isinstance(arg, torch._ops.OpOverload):
+        elif isinstance(arg, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)):
             return Argument.create(as_operator=self.serialize_operator(arg))
         else:
             raise SerializeError(f"Unsupported argument type: {type(arg)}")

--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 from enum import Enum
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 import torch.utils._pytree as pytree
@@ -12,19 +12,26 @@ from torch.fx.experimental.proxy_tensor import (
     ProxyTorchDispatchMode,
     track_tensor_tree,
 )
+from .torchbind import call_torchbind
 
 
 class _EffectType(Enum):
     ORDERED = "Ordered"
 
 
-SIDE_EFFECTS: Dict[torch._ops.OpOverload, _EffectType] = {
+OpType = Union[torch._ops.HigherOrderOperator, torch._ops.OpOverload]
+
+
+SIDE_EFFECTS: Dict[OpType, _EffectType] = {
     torch.ops.aten._print.default: _EffectType.ORDERED,
+    call_torchbind: _EffectType.ORDERED,
 }
 
 
-def _register_effectful_op(op: torch._ops.OpOverload, effect: _EffectType):
-    assert isinstance(op, torch._ops.OpOverload) and not has_aliasing(op)
+def _register_effectful_op(op: OpType, effect: _EffectType):
+    assert isinstance(
+        op, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)
+    ) and not has_aliasing(op)
     if op in SIDE_EFFECTS and SIDE_EFFECTS[op] != effect:
         raise RuntimeError(
             f"Already registered effect type {SIDE_EFFECTS[op]} to op {op}, "
@@ -53,11 +60,11 @@ class WithEffects(HigherOrderOperator):
     def __call__(
         self,
         token,
-        op: torch._ops.OpOverload,
+        op: OpType,
         *args: Tuple[Any, ...],
         **kwargs: Dict[str, Any],
     ) -> Tuple[Any, ...]:
-        assert isinstance(op, torch._ops.OpOverload)
+        assert isinstance(op, (torch._ops.HigherOrderOperator, torch._ops.OpOverload))
         assert not has_aliasing(op), "Ops with aliasing is not supported"
         assert has_effects(op, args, kwargs)
         assert isinstance(kwargs, dict)
@@ -67,7 +74,11 @@ class WithEffects(HigherOrderOperator):
 with_effects = WithEffects()
 
 
-def has_aliasing(op: torch._ops.OpOverload):
+def has_aliasing(op: OpType):
+    # NOT FOR PUBLIC USE
+    if isinstance(op, torch._ops.HigherOrderOperator):
+        return op not in SIDE_EFFECTS
+
     for arg in op._schema.arguments:
         if arg.alias_info is not None:
             return True
@@ -84,7 +95,7 @@ def has_effects(op, args, kwargs) -> bool:
         return False
 
     return (
-        isinstance(op, torch._ops.OpOverload)
+        isinstance(op, (torch._ops.HigherOrderOperator, torch._ops.OpOverload))
         and not has_aliasing(op)
         and get_effect_key(op, args, kwargs) is not None
     )
@@ -163,10 +174,19 @@ with_effects.fallthrough(DispatchKey.AutogradCPU)
 with_effects.fallthrough(DispatchKey.AutogradCUDA)
 
 
+def _get_schema(op, args) -> torch.FunctionSchema:
+    if isinstance(op, torch._ops.OpOverload):
+        return op._schema
+    elif op == call_torchbind:
+        return getattr(args[0], args[1]).schema
+    else:
+        raise RuntimeError(f"Unable to get schema for op {op}")
+
+
 def handle_effects(
     allow_token_discovery: bool,
     tokens: Dict[_EffectType, torch.Tensor],
-    op: torch._ops.OpOverload,
+    op: OpType,
     args: Tuple[Any, ...],
     kwargs: Dict[str, Any],
 ) -> Any:
@@ -207,14 +227,15 @@ def handle_effects(
             unwrapped_token, op, *unwrapped_args, **unwrapped_kwargs  # type: ignore[arg-type]
         )
 
-    if len(op._schema.returns) == 0:
+    schema = _get_schema(op, unwrapped_args)
+    if len(schema.returns) == 0:
         assert unwrapped_outs[0] is None
         unwrapped_outs = None  # type: ignore[assignment]
-    elif len(op._schema.returns) == 1:
+    elif len(schema.returns) == 1:
         assert len(unwrapped_outs) == 1
         unwrapped_outs = unwrapped_outs[0]
     else:
-        assert len(unwrapped_outs) == len(op._schema.returns)
+        assert len(unwrapped_outs) == len(schema.returns)
 
     # Add the newly created token into the tokens map for a following call to
     # use this token.

--- a/torch/_higher_order_ops/torchbind.py
+++ b/torch/_higher_order_ops/torchbind.py
@@ -114,6 +114,8 @@ call_torchbind.py_impl(DispatchKey.Autograd)(
 
 @call_torchbind.py_functionalize_impl
 def call_torchbind_func(ctx, *args, **kwargs):
-    args = ctx.unwrap_tensors(args)
-    with ctx.redispatch_to_next():
-        return ctx.wrap_tensors(call_torchbind(*args, **kwargs))
+    from torch._higher_order_ops.effects import handle_effects
+
+    return handle_effects(
+        ctx.mode._allow_token_discovery, ctx.mode._tokens, call_torchbind, args, kwargs
+    )

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -382,6 +382,9 @@ class HigherOrderOperator(OperatorBase):
     def __str__(self):
         return f"{self.name()}"
 
+    # def __repr__(self):
+    #     return f"torch.ops._higher_order_ops.{self._name}"
+
     def name(self):
         return self._name
 

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1940,6 +1940,15 @@ void initJITBindings(PyObject* module) {
             ss << self;
             return ss.str();
           })
+      .def(py::pickle(
+          [](const FunctionSchema& self) { // __getstate__
+            std::stringstream ss;
+            ss << self;
+            return py::str(ss.str());
+          },
+          [](py::str schema) { // __setstate__, note: no `self` argument
+            return parseSchema(schema);
+          }))
       .def_property_readonly(
           "is_mutable", [](FunctionSchema& self) { return self.is_mutable(); });
   py::class_<Argument>(m, "Argument")

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -612,7 +612,9 @@ def _export_to_aten_ir(
         elif isinstance(val, torch.ScriptObject):
             return CustomObjArgument(name=node.name, class_fqn=val._type().qualified_name())  # type: ignore[attr-defined]
         elif isinstance(val, FakeScriptObject):
-            return CustomObjArgument(name=node.name, class_fqn=val.script_class_name)
+            return CustomObjArgument(
+                name=node.name, class_fqn=val.script_class_name, fake_val=val
+            )
         elif isinstance(val, (int, bool, str, float, type(None))):
             return ConstantArgument(name=node.name, value=val)
         else:

--- a/torch/export/graph_signature.py
+++ b/torch/export/graph_signature.py
@@ -3,6 +3,8 @@ import dataclasses
 from enum import auto, Enum
 from typing import Collection, Dict, List, Mapping, Optional, Set, Tuple, Union
 
+from torch._library.fake_class_registry import FakeScriptObject
+
 
 __all__ = [
     "ConstantArgument",
@@ -37,6 +39,7 @@ class SymIntArgument:
 class CustomObjArgument:
     name: str
     class_fqn: str
+    fake_val: Optional[FakeScriptObject] = None
 
 
 @dataclasses.dataclass

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -23,6 +23,9 @@ from torch.export.exported_program import (
 from torch.fx._symbolic_trace import is_fx_tracing
 from torch.utils._pytree import GetAttrKey, SequenceKey
 
+from ._remove_effect_tokens_pass import _remove_effect_tokens
+
+
 __all__ = ["InterpreterModule", "UnflattenedModule", "unflatten", "FlatArgsAdapter"]
 
 
@@ -485,6 +488,7 @@ def unflatten(
         An instance of :class:`UnflattenedModule`, which has the same module
         hierarchy as the original eager module pre-export.
     """
+    module = _remove_effect_tokens(module)
     return UnflattenedModule(module, flat_args_adapter)
 
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -459,7 +459,7 @@ class CodeGen:
                 qualified_name = _get_qualified_name(type(arg))
                 global_name = add_global(qualified_name, type(arg))
                 return f"{global_name}{repr(tuple(arg))}"
-            elif isinstance(arg, torch._ops.OpOverload):
+            elif isinstance(arg, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)):
                 qualified_name = _get_qualified_name(arg)
                 global_name = add_global(qualified_name, arg)
                 return f"{global_name}"

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -282,7 +282,7 @@ class TracerBase:
         elif isinstance(a, range):
             return range(self.create_arg(a.start), self.create_arg(a.stop), self.create_arg(a.step))
 
-        elif isinstance(a, torch._ops.OpOverload):
+        elif isinstance(a, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)):
             return a
 
         if isinstance(a, Proxy):


### PR DESCRIPTION
Adds effect token support to torchbind method calls by allowing `with_effects` to take in `torch.ops._higher_order_ops.call_torchbind` as an input.

Here is the print from `TORCH_LOGS="aot" python test/export/test_torchbind.py -k test_compile_obj_torchbind_op`:
```python
def forward(self, arg0_1: "f32[0]", arg1_1: "f32[2]", arg2_1):
    # File: /data/users/angelayi/pytorch2/test/export/test_torchbind.py:1266 in f, code: torch.ops._TorchScriptTesting.queue_push(tq, x.cos())
    cos: "f32[2]" = torch.ops.aten.cos.default(arg1_1)
    with_effects = torch._higher_order_ops.effects.with_effects(arg0_1, torch.ops._TorchScriptTesting.queue_push.default, arg2_1, cos);  arg0_1 = cos = None
    getitem: "f32[0]" = with_effects[0];  with_effects = None

    # File: /data/users/angelayi/pytorch2/test/export/test_torchbind.py:1267 in f, code: torch.ops._TorchScriptTesting.queue_push(tq, x.cos() + 1)
    cos_1: "f32[2]" = torch.ops.aten.cos.default(arg1_1)
    add: "f32[2]" = torch.ops.aten.add.Tensor(cos_1, 1);  cos_1 = None
    with_effects_1 = torch._higher_order_ops.effects.with_effects(getitem, torch.ops._TorchScriptTesting.queue_push.default, arg2_1, add);  getitem = add = None
    getitem_2: "f32[0]" = with_effects_1[0];  with_effects_1 = None

    # File: /data/users/angelayi/pytorch2/test/export/test_torchbind.py:1268 in f, code: torch.ops._TorchScriptTesting.queue_pop(tq)
    with_effects_2 = torch._higher_order_ops.effects.with_effects(getitem_2, torch.ops._TorchScriptTesting.queue_pop.default, arg2_1);  getitem_2 = None
    getitem_4: "f32[0]" = with_effects_2[0];  with_effects_2 = None

    # File: /data/users/angelayi/pytorch2/test/export/test_torchbind.py:1269 in f, code: torch.ops._TorchScriptTesting.queue_push(tq, x.sin())
    sin: "f32[2]" = torch.ops.aten.sin.default(arg1_1);  arg1_1 = None
    with_effects_3 = torch._higher_order_ops.effects.with_effects(getitem_4, torch.ops._TorchScriptTesting.queue_push.default, arg2_1, sin);  getitem_4 = sin = None
    getitem_6: "f32[0]" = with_effects_3[0];  with_effects_3 = None

    # File: /data/users/angelayi/pytorch2/test/export/test_torchbind.py:1270 in f, code: return tq.pop(), tq.pop() + tq.size(), tq
    with_effects_4 = torch._higher_order_ops.effects.with_effects(getitem_6, torch.ops._higher_order_ops.call_torchbind, arg2_1, 'pop');  getitem_6 = None
    getitem_8: "f32[0]" = with_effects_4[0]
    getitem_9: "f32[2]" = with_effects_4[1];  with_effects_4 = None
    with_effects_5 = torch._higher_order_ops.effects.with_effects(getitem_8, torch.ops._higher_order_ops.call_torchbind, arg2_1, 'pop');  getitem_8 = None
    getitem_10: "f32[0]" = with_effects_5[0]
    getitem_11: "f32[2]" = with_effects_5[1];  with_effects_5 = None
    with_effects_6 = torch._higher_order_ops.effects.with_effects(getitem_10, torch.ops._higher_order_ops.call_torchbind, arg2_1, 'size');  getitem_10 = arg2_1 = None
    getitem_12: "f32[0]" = with_effects_6[0];  with_effects_6 = None
    add_1: "f32[2]" = torch.ops.aten.add.Tensor(getitem_11, 0);  getitem_11 = None
    return (getitem_12, getitem_9, add_1)
```

In order to support this, this PR makes the following changes:
* Adds `FakeScriptObject` to `CustomObjArgument`, which will be put on the `meta["val"]` of nodes representing torchbind objects.
* Adds pickle/deepcopy support to FunctionSchema.