### PR TITLE
Errors when 0-dim tensor of complex or bool type passed to aminmax.

### DIFF
--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -1,4 +1,4 @@
-#include "c10/core/ScalarType.h"
+#include <c10/core/ScalarType.h>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
 #include <ATen/native/ReduceOps.h>
@@ -179,7 +179,7 @@ static void aminmax_kernel(
     " but got ", min_result.scalar_type(), " and ", max_result.scalar_type());
 
   if (self.numel() == 1 && self.ndimension() == 0) {
-    TORCH_CHECK(!self.is_complex() && self.scalar_type() != ScalarType::Bool, "aminmax not implemented for ", self.scalar_type());
+    TORCH_CHECK(!self.is_complex(), "aminmax not implemented for ", self.scalar_type());
     min_result.resize_({});
     max_result.resize_({});
     min_result.fill_(self);

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -179,8 +179,7 @@ static void aminmax_kernel(
     " but got ", min_result.scalar_type(), " and ", max_result.scalar_type());
 
   if (self.numel() == 1 && self.ndimension() == 0) {
-    TORCH_CHECK(!self.is_complex(), "Complex dtype not supported by aminmax.");
-    TORCH_CHECK(self.scalar_type() != ScalarType::Bool, "Boolean dtype not supported by aminmax.");
+    TORCH_CHECK(!self.is_complex() && self.scalar_type() != ScalarType::Bool, self.scalar_type(), " dtype not supported by aminmax.");
     min_result.resize_({});
     max_result.resize_({});
     min_result.fill_(self);

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -179,7 +179,7 @@ static void aminmax_kernel(
     " but got ", min_result.scalar_type(), " and ", max_result.scalar_type());
 
   if (self.numel() == 1 && self.ndimension() == 0) {
-    TORCH_CHECK(!self.is_complex() && self.scalar_type() != ScalarType::Bool, self.scalar_type(), " dtype not supported by aminmax.");
+    TORCH_CHECK(!self.is_complex() && self.scalar_type() != ScalarType::Bool, "aminmax not implemented for ", self.scalar_type());
     min_result.resize_({});
     max_result.resize_({});
     min_result.fill_(self);

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -1,3 +1,4 @@
+#include "c10/core/ScalarType.h"
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
 #include <ATen/native/ReduceOps.h>
@@ -178,6 +179,8 @@ static void aminmax_kernel(
     " but got ", min_result.scalar_type(), " and ", max_result.scalar_type());
 
   if (self.numel() == 1 && self.ndimension() == 0) {
+    TORCH_CHECK(!self.is_complex(), "Complex dtype not supported by aminmax.");
+    TORCH_CHECK(self.scalar_type() != ScalarType::Bool, "Boolean dtype not supported by aminmax.");
     min_result.resize_({});
     max_result.resize_({});
     min_result.fill_(self);

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -15,7 +15,7 @@ from torch import inf, nan
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import (
     all_types_and_complex_and, get_all_math_dtypes, integral_types, complex_types, floating_types_and,
-    integral_types_and, floating_and_complex_types_and, all_types_and, all_types,
+    integral_types_and, floating_and_complex_types_and, all_types_and, all_types, complex_types_and,
 )
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, skipIfNoSciPy, slowTest, torch_to_numpy_dtype_dict,
@@ -1227,6 +1227,17 @@ class TestReductions(TestCase):
 
         self._test_minmax_helper(_amin_wrapper, np.amin, device, dtype)
         self._test_minmax_helper(_amax_wrapper, np.amax, device, dtype)
+    
+    @onlyNativeDeviceTypes
+    @dtypes(*complex_types_and(torch.bool))
+    def test_invalid_0dim_aminmax(self, device, dtype):
+
+        with self.assertRaisesRegex(RuntimeError, 'not implemented'):
+            if dtype is bool:
+                torch.aminmax(torch.tensor(1, dtype=dtype, device=device), dim=0) 
+            else:
+                torch.aminmax(torch.tensor(1, dtype=dtype, device=device), dim=0)
+            
 
     # TODO: bincount isn't a classic reduction -- maybe this test suite is
     #   reductions and summary ops?

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1232,7 +1232,7 @@ class TestReductions(TestCase):
     @dtypes(*complex_types())
     def test_invalid_0dim_aminmax(self, device, dtype):
         with self.assertRaisesRegex(RuntimeError, 'not implemented'):
-            torch.aminmax(torch.tensor(True, dtype=dtype, device=device), dim=0)
+            torch.aminmax(torch.tensor(1., dtype=dtype, device=device), dim=0)
 
     # TODO: bincount isn't a classic reduction -- maybe this test suite is
     #   reductions and summary ops?

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -15,7 +15,7 @@ from torch import inf, nan
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import (
     all_types_and_complex_and, get_all_math_dtypes, integral_types, complex_types, floating_types_and,
-    integral_types_and, floating_and_complex_types_and, all_types_and, all_types, complex_types_and,
+    integral_types_and, floating_and_complex_types_and, all_types_and, all_types,
 )
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, skipIfNoSciPy, slowTest, torch_to_numpy_dtype_dict,
@@ -1227,17 +1227,12 @@ class TestReductions(TestCase):
 
         self._test_minmax_helper(_amin_wrapper, np.amin, device, dtype)
         self._test_minmax_helper(_amax_wrapper, np.amax, device, dtype)
-    
-    @onlyNativeDeviceTypes
-    @dtypes(*complex_types_and(torch.bool))
-    def test_invalid_0dim_aminmax(self, device, dtype):
 
+    @onlyNativeDeviceTypes
+    @dtypes(*complex_types())
+    def test_invalid_0dim_aminmax(self, device, dtype):
         with self.assertRaisesRegex(RuntimeError, 'not implemented'):
-            if dtype is bool:
-                torch.aminmax(torch.tensor(1, dtype=dtype, device=device), dim=0) 
-            else:
-                torch.aminmax(torch.tensor(1, dtype=dtype, device=device), dim=0)
-            
+            torch.aminmax(torch.tensor(True, dtype=dtype, device=device), dim=0)
 
     # TODO: bincount isn't a classic reduction -- maybe this test suite is
     #   reductions and summary ops?


### PR DESCRIPTION
Fixes #126742 

Added errors for the case of 0-dim tensors of complex or bool types passed to aminmax.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10