### PR TITLE
Disable fast path in `TransformerEncoderLayer` when there are forward (pre-)hooks attached to modules

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -347,7 +347,6 @@ class TestTransformers(NNTestCase):
         # remove hook
         handle.remove()
 
-    @tf32_on_and_off(0.001)
     @parametrize("use_torchscript", [False])
     @parametrize("enable_nested_tensor", [True, False])
     @parametrize("use_autocast", [True, False])

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -315,6 +315,39 @@ class TestTransformers(NNTestCase):
         with torch.no_grad():
             model(src, src_mask=src_mask)
 
+    @parametrize("nhead", [3, 4])
+    def test_transformerencoderlayer_no_fastpath_with_hooks(self, device, nhead):
+        batch_size = 2
+        seqlen = 4
+        d_model = 12
+
+        model = torch.nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=nhead,
+            dim_feedforward=d_model,
+            batch_first=True).to(device).eval()
+        src = torch.rand(batch_size, seqlen, d_model).to(device)  # bs, seqlen, d_model
+
+        cache = []
+
+        # forward hook to save output
+        def hook(module, inputs, output):
+            cache.append(output[0].detach())
+
+        # register hook to get the output of the self-attention layer
+        handle = model.self_attn.register_forward_hook(hook)
+
+        # forward pass
+        with torch.inference_mode():
+            model(src)
+
+        # output of the self-attention layer
+        assert len(cache) == 1, f"Expected 1 output, got {len(cache)}"
+
+        # remove hook
+        handle.remove()
+
+    @tf32_on_and_off(0.001)
     @parametrize("use_torchscript", [False])
     @parametrize("enable_nested_tensor", [True, False])
     @parametrize("use_autocast", [True, False])

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -819,7 +819,7 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "num_head is odd"
         elif torch.is_autocast_enabled():
             why_not_sparsity_fast_path = "autocast is enabled"
-        elif any([len(m._forward_hooks) + len(m._forward_pre_hooks) for m in self.modules()]):
+        elif any([len(getattr(m, "_forward_hooks", {})) + len(getattr(m, "_forward_pre_hooks", {})) for m in self.modules()]):
             why_not_sparsity_fast_path = "forward pre-/hooks are attached to the module"
         if not why_not_sparsity_fast_path:
             tensor_args = (

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -819,6 +819,8 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "num_head is odd"
         elif torch.is_autocast_enabled():
             why_not_sparsity_fast_path = "autocast is enabled"
+        elif sum([len(m._forward_hooks) + len(m._forward_pre_hooks) for m in self.modules()]) > 0:
+            why_not_sparsity_fast_path = "forward pre-/hooks are attached to the module"
         if not why_not_sparsity_fast_path:
             tensor_args = (
                 src,

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -819,7 +819,11 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "num_head is odd"
         elif torch.is_autocast_enabled():
             why_not_sparsity_fast_path = "autocast is enabled"
-        elif any(len(getattr(m, "_forward_hooks", {})) + len(getattr(m, "_forward_pre_hooks", {})) for m in self.modules()):
+        elif any(
+            len(getattr(m, "_forward_hooks", {}))
+            + len(getattr(m, "_forward_pre_hooks", {}))
+            for m in self.modules()
+        ):
             why_not_sparsity_fast_path = "forward pre-/hooks are attached to the module"
         if not why_not_sparsity_fast_path:
             tensor_args = (

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -819,7 +819,7 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "num_head is odd"
         elif torch.is_autocast_enabled():
             why_not_sparsity_fast_path = "autocast is enabled"
-        elif any([len(getattr(m, "_forward_hooks", {})) + len(getattr(m, "_forward_pre_hooks", {})) for m in self.modules()]):
+        elif any(len(getattr(m, "_forward_hooks", {})) + len(getattr(m, "_forward_pre_hooks", {})) for m in self.modules()):
             why_not_sparsity_fast_path = "forward pre-/hooks are attached to the module"
         if not why_not_sparsity_fast_path:
             tensor_args = (

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -819,7 +819,7 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "num_head is odd"
         elif torch.is_autocast_enabled():
             why_not_sparsity_fast_path = "autocast is enabled"
-        elif sum([len(m._forward_hooks) + len(m._forward_pre_hooks) for m in self.modules()]) > 0:
+        elif any([len(m._forward_hooks) + len(m._forward_pre_hooks) for m in self.modules()]):
             why_not_sparsity_fast_path = "forward pre-/hooks are attached to the module"
         if not why_not_sparsity_fast_path:
             tensor_args = (


### PR DESCRIPTION
Fixes #128413 

Disable fast-path if there are forward hooks or pre-hooks.

Example failure case given in the issue.