### PR TITLE
Allow setting `PYTHON_LIB_REL_PATH` via environment variable

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -230,6 +230,7 @@ class CMake:
                     "SELECTED_OP_LIST",
                     "TORCH_CUDA_ARCH_LIST",
                     "TRACING_BASED",
+                    "PYTHON_LIB_REL_PATH",
                 )
             }
         )


### PR DESCRIPTION
This allows builds to customize the location where caffe2's Python modules are installed to.

Fixes #ISSUE_NUMBER
