### PR TITLE
[Fix] Check tensor dtype before using torch.allclose in _trace log

### DIFF
--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -656,6 +656,8 @@ def analyze_ts_result_with_export_result(export, trace):
             return False
 
         if isinstance(orig, torch.Tensor):
+            if orig.dtype != loaded.dtype:
+                return False
             if not torch.allclose(orig, loaded):
                 return False
         else:


### PR DESCRIPTION
#### Issue
`torch.allclose` errors out during logging due to different dtypes.

#### Test
* `pytest test/test_jit.py`