### PR TITLE
Created docs for make_fx in torch.fx.experimental.proxy_tensor

### DIFF
--- a/docs/source/fx.experimental.rst
+++ b/docs/source/fx.experimental.rst
@@ -51,3 +51,14 @@ torch.fx.experimental.symbolic_shapes
     compute_unbacked_bindings
     rebind_unbacked
     resolve_unbacked_bindings
+
+torch.fx.experimental.proxy_tensor
+-------------------------------------
+.. currentmodule:: torch.fx.experimental.proxy_tensor
+.. automodule:: torch.fx.experimental.proxy_tensor
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    make_fx

--- a/docs/source/fx.rst
+++ b/docs/source/fx.rst
@@ -1143,7 +1143,6 @@ API Reference
 .. py:module:: torch.fx.experimental.normalize
 .. py:module:: torch.fx.experimental.optimization
 .. py:module:: torch.fx.experimental.partitioner_utils
-.. py:module:: torch.fx.experimental.proxy_tensor
 .. py:module:: torch.fx.experimental.recording
 .. py:module:: torch.fx.experimental.refinement_types
 .. py:module:: torch.fx.experimental.rewriter


### PR DESCRIPTION
Fixes #127886

## Description

Created docs to document the make_fx function to solve the issue #127886. 
The variable names were pretty descriptive so I added what would be the functionality of some of them. The way this function seems to be used across users is always initializing it with a call, so that is why in the Return section I added what will be the return when called.

My logic for the examples was to demonstrate in Example 1 the raw functionality and Example 2 an actual usage of the function. Let me know if you think Example 1 is not necesary.  

### Summary of Changes

- Added docs for torch.fx.experimental.proxy_tensor.make_fx
- Added the proxy_tensor.make_fx function in the autosummary of docs/source/fx.experimental.rst

## Checklist 
- [X] The issue that is being fixed is referred in the description
- [X] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [X] No unnecesary issues are included into this pull request

cc @svekars @brycebortree @sekyondaMeta @AlannaBurke @ezyang @SherlockNoMad @EikanWang @jgong5 @wenzhe-nrv