### PR TITLE
[c10d] fix OSS commSplit bug

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<NCCLComm> NCCLComm::split(
           source->ncclComm_, color_id, rank, &(comm->ncclComm_), &config),
       c10::nullopt);
   ++source->ncclCommSplitCounter_;
-  ncclCommUserRank(comm->ncclComm_, &comm->rank_);
+  comm->rank_ = rank;
   return comm;
 }
 #endif


### PR DESCRIPTION
Summary:
D56907877 modified OSS commSplit. However, commSplit requires every rank being called even though it is no-color. ncclCommSplit will not create a communicator for nocolor ranks hence this line of code will potentially throw error like `NCCL WARN CommUserRank : comm argument is NULL`

Revert this change from D56907877

Test Plan: CI

Differential Revision: D58436088


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k