### PR TITLE
[NOT NEEDED][Traceable FSDP2] Improve __bool__ and __len__ access on UserDefinedObjectVariable

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -416,9 +416,11 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
                     self.push(value)
                 self.jump(inst)
         elif isinstance(value, UserDefinedObjectVariable):
-            x = value.var_getattr(self, "__bool__")
+            x = None
+            if hasattr(value, "__bool__"):
+                x = value.var_getattr(self, "__bool__")
             # if __bool__ is missing, trying __len__ to infer a truth value.
-            if isinstance(x, GetAttrVariable):
+            if (x is None or isinstance(x, GetAttrVariable)) and hasattr(value, "__len__"):
                 x = value.var_getattr(self, "__len__")
 
             # __bool__ or __len__ is function


### PR DESCRIPTION
Some `UserDefinedObjectVariable` might not have `__bool__` or `__len__`, and calling `var_getattr` to get those attributes would fail with error. This PR checks `hasattr` before calling `var_getattr` on those attributes.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128471



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang