### PR TITLE
Revert "Make torch_geometric models compatible with export (#123403)"…

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1184,12 +1184,14 @@ class AOTInductorModelCache:
             else:
                 _register_dataclass_output_as_pytree(example_outputs)
 
-            gm = torch.export._trace._export(
+            # TODO(angelayi): change this to predispatch
+            # https://github.com/pytorch/pytorch/issues/127513 needs to be fixed before changing
+            # to predispatch to avoid performance regressions
+            gm = torch.export._trace._export_to_torch_ir(
                 model,
                 example_args,
                 example_kwargs,
-                pre_dispatch=True,
-            ).module()
+            )
             with torch.no_grad():
                 so_path = torch._inductor.aot_compile(
                     gm, example_args, example_kwargs


### PR DESCRIPTION
… (#128377)

Cherry pick https://github.com/pytorch/pytorch/pull/128377 to release/2.4 branch.

Reverted on main to fix https://github.com/pytorch/pytorch/issues/127513: a regression issue that will impact the AOTI CPU performance on multiple CNN models in the dynamo benchmark.
The detailed impact are explained [here](https://github.com/pytorch/pytorch/issues/127513#issuecomment-2158159984).


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang