### PR TITLE
[ts_converter] Fix prim::dtype

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -491,11 +491,11 @@ class TestConverter(TestCase):
     def test_ts2ep_converter_contains(self):
         class MIn(torch.nn.Module):
             def forward(self, x: torch.Tensor):
-                return x.dtype in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                return x.dtype in [torch.float32, torch.float64]
 
         class MNotIn(torch.nn.Module):
             def forward(self, x: torch.Tensor):
-                return x.dtype in [-1]
+                return x.dtype in [torch.int8]
 
         class MTensorIn(torch.nn.Module):
             def forward(self, x: torch.Tensor, x_dict: Dict[torch.Tensor, str]):


### PR DESCRIPTION
Summary: prim::dtype has the signature `(Tensor a) -> int`, where it gets the dtype of the tensor and returns the integer corresponding to this dtype based on the enum in ScalarType.h. Previously we were converting prim::dtype by returning the actual dtype of the tensor (ex. torch.float32). This causes some incorrect control flow to behavior, specifically where it checks if `prim::dtype(tensor) in [3, 5, 7]`, where [3, 5, 7] correspond to torch.int32, torch.float16, torch.float64. This control flow would always returns False because we would be comparing torch.float32 against the integers [3, 5, 7], which is a type mismatch.

Test Plan: 7/22 internal models now are convertable and runnable in eager and sigmoid! P1410243909

Reviewed By: jiashenC

Differential Revision: D58469232
