### PR TITLE
[traced-graph][sparse] remove redundant assert in sparse prop test

### DIFF
--- a/test/export/test_sparse.py
+++ b/test/export/test_sparse.py
@@ -172,7 +172,6 @@ class TestSparseProp(TestCase):
                 if i == 0:
                     self.assertEqualMeta(meta, sparse_input)
                 elif i == 1:
-                    self.assertIsInstance(meta, FakeTensor)
                     self.assertEqualMeta(meta, result)
                 else:
                     self.assertEqual(meta, None)
@@ -218,7 +217,6 @@ class TestSparseProp(TestCase):
         for i, node in enumerate(prog.graph.nodes):
             meta = node.meta.get("val", None)
             if i <= 2:
-                self.assertIsInstance(meta, FakeTensor)
                 self.assertEqualMeta(meta, x[i])
             elif i <= 5:
                 self.assertEqualMeta(meta, result[i - 3])


### PR DESCRIPTION
The assertEqualMeta() method already tests that the first argument is a FakeTensor

https://github.com/pytorch/pytorch/issues/117188


