### PR TITLE
[CUDA] Fix more `DeviceIndex` printing

### DIFF
--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -46,7 +46,7 @@ cudaDeviceProp* getCurrentDeviceProperties() {
 cudaDeviceProp* getDeviceProperties(c10::DeviceIndex device) {
   c10::call_once(init_flag, initCUDAContextVectors);
   if (device == -1) device = c10::cuda::current_device();
-  AT_ASSERT(device >= 0 && device < num_gpus, "device=", device, ", num_gpus=", num_gpus);
+  AT_ASSERT(device >= 0 && device < num_gpus, "device=", static_cast<int>(device), ", num_gpus=", num_gpus);
   c10::call_once(device_flags[device], initDeviceProperty, device);
   return &device_properties[device];
 }
@@ -54,8 +54,8 @@ cudaDeviceProp* getDeviceProperties(c10::DeviceIndex device) {
 bool canDeviceAccessPeer(c10::DeviceIndex device, c10::DeviceIndex peer_device) {
   c10::call_once(init_flag, initCUDAContextVectors);
   if (device == -1) device = c10::cuda::current_device();
-  AT_ASSERT(device >= 0 && device < num_gpus, "device=", device, ", num_gpus=", num_gpus);
-  AT_ASSERT(peer_device >= 0 && peer_device < num_gpus, "peer_device=", peer_device, ", num_gpus=", num_gpus);
+  AT_ASSERT(device >= 0 && device < num_gpus, "device=", static_cast<int>(device), ", num_gpus=", num_gpus);
+  AT_ASSERT(peer_device >= 0 && peer_device < num_gpus, "peer_device=", static_cast<int>(peer_device), ", num_gpus=", num_gpus);
   int can_access = 0;
   AT_CUDA_CHECK(cudaDeviceCanAccessPeer(&can_access, device, peer_device));
   return can_access != 0;


### PR DESCRIPTION
Same `char` dtype causing device index `0` to be interpreted as a null-terminator, see also #123984

cc @ptrblck @msaroufim