### PR TITLE
Remove global variable SIZE, and fix linter warning

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3730,7 +3730,8 @@ class TestNestedTensorSubclass(TestCase):
 
     def test_softmax(self, device):
         nt = random_nt_from_dims(
-            [3, None, 5], device=device, dtype=torch.float32, layout=torch.jagged)
+            [3, None, 5], device=device, dtype=torch.float32, layout=torch.jagged
+        )
 
         # operate on dim=2
         output = nt.softmax(dim=2)

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -32,9 +32,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 
-# TODO: remove this
-SIZE = 100
-
 
 class TestSortAndSelect(TestCase):
     def assertIsOrdered(self, order, x, mxx, ixx, task):
@@ -476,6 +473,7 @@ class TestSortAndSelect(TestCase):
             sortKVal, sortKInd = topKViaSort(t, k, dim, dir)
             compareTensors(t, sortKVal, sortKInd, topKVal, topKInd, dim)
 
+        SIZE = 100
         t = torch.rand(
             random.randint(1, SIZE),
             random.randint(1, SIZE),


### PR DESCRIPTION
- Resolve a TODO by removing global variable `SIZE`. 
- Fix a linter warning in `test/test_nestedtensor.py`.

`pytest pytorch/test/test_sort_and_select.py` and ` pytest test/test_nestedtensor.py` pass. 
