### PR TITLE
[experiment] Allocate all memory with cuMemCreate for zero-copy NCCL

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -33,6 +33,10 @@ class C10_CUDA_API CUDAAllocatorConfig {
 #endif
   }
 
+  static bool experimental_direct_rdma() {
+    return instance().m_experimental_direct_rdma;
+  }
+
   static bool release_lock_on_cudamalloc() {
     return instance().m_release_lock_on_cudamalloc;
   }
@@ -112,6 +116,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
   std::atomic<double> m_garbage_collection_threshold;
   std::atomic<size_t> m_pinned_num_register_threads;
   std::atomic<bool> m_expandable_segments;
+  std::atomic<bool> m_experimental_direct_rdma;
   std::atomic<bool> m_release_lock_on_cudamalloc;
   std::atomic<bool> m_pinned_use_cuda_host_register;
   std::string m_last_allocator_settings;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128573

Until NCCL can support expandable segments, we need a temporary way to
ensure all memory is allocated with cuMemCreate but not allocation spans
multiple cuMemCreate segments. This is a hack to do that which uses
the expandable segments pathway to do the memory allocation but
sets address_space_size == segment_size so the segments do not expand
and are a single cuMemCreate allocation.