### PR TITLE
Add MaskedTensor support to _is_any_true

### DIFF
--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -763,6 +763,45 @@ class TestReductions(TestCase):
         with self.assertRaisesRegex(RuntimeError, msg):
             masked_tensor(d, m, requires_grad=True)
 
+    def test_any_true_dtype(self):
+        mt = torch.masked.MaskedTensor(
+            torch.rand(2, 2),
+            torch.rand(2, 2) > 0.5
+        )
+        msg = "expected a boolean tensor"
+        with self.assertRaisesRegex(ValueError, msg):
+            mt._is_any_true()
+
+    def test__is_any_true(self):
+        mt = torch.masked.MaskedTensor(
+            torch.tensor([[True, True, False], [False, False, True]]),
+            torch.tensor([[True, False, False], [False, True, False]]),
+        )
+        _compare_mts(
+            masked_tensor(torch.tensor(True), torch.tensor(True)),
+            mt._is_any_true(),
+        )
+
+    def test__is_any_true_false(self):
+        mt = torch.masked.MaskedTensor(
+            torch.tensor([[True, True, False], [False, False, True]]),
+            torch.tensor([[False, False, False], [False, False, False]]),
+        )
+        _compare_mts(
+            masked_tensor(torch.tensor(False), torch.tensor(True),),
+            mt._is_any_true(),
+        )
+
+    def test_backward(self):
+        # See https://github.com/pytorch/pytorch/issues/128557
+        with torch.autograd.detect_anomaly():
+            mt = torch.masked.MaskedTensor(
+                torch.rand(2, 2),
+                torch.rand(2, 2) > 0.5,
+                requires_grad=True
+            )
+            mt.sum().backward()
+
 
 def is_unary(op):
     return op.name in UNARY_NAMES

--- a/torch/masked/maskedtensor/_ops_refs.py
+++ b/torch/masked/maskedtensor/_ops_refs.py
@@ -510,3 +510,22 @@ def _sparse_coo_tensor_with_dims_and_tensors(func, *args, **kwargs):
 def is_same_size(func, *args, **kwargs):
     _check_args_kwargs_length(args, kwargs, f"__torch_dispatch__, {func}", len_args=2)
     return _get_data(args[0]).is_same_size(_get_data(args[1]))
+
+
+@register_dispatch_func([torch.ops.aten._is_any_true])
+def _is_any_true(func, *args, **kwargs):
+    _check_args_kwargs_length(
+        args, kwargs, f"__torch_dispatch__, {func}", len_args=1, len_kwargs=0
+    )
+    data = _get_data(args[0])
+    mask = _maybe_get_mask(args[0])
+    if mask is None:
+        raise ValueError(
+            f"__torch_dispatch__, {func}: expected args[0] to be a MaskedTensor"
+        )
+    if data.dtype != torch.bool:
+        raise ValueError(f"__torch_dispatch__, {func}: expected a boolean tensor")
+    if data.is_sparse:
+        raise ValueError(f"MaskedTensors with sparse data do not have {func}")
+
+    return MaskedTensor(func(data & mask), torch.tensor(True))


### PR DESCRIPTION
Fixes #128557

If there is a better way to detect autograd anomalies consistently, feel free to share your ideas. This is a dirty check.