### PR TITLE
[dynamo][side effects] Raise assertion error if the object is already tracked for mutation

### DIFF
--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -219,10 +219,12 @@ class SideEffects:
     ):
         """Start tracking a new variable for mutation"""
         assert variable.source is not None
+        if id(item) in self.id_to_variable:
+            # If the object is already tracked, do not create a new variable
+            variable.mutable_local = self.id_to_variable[id(item)].mutable_local
+            return variable
+
         variable.mutable_local = mutable_cls(variable.source)
-        # TODO (anijain2305) - Right way is to check if it already exists in
-        # self.id_to_variable and return. But doing this to test for other
-        # places where we could probably replace with VariableBuilder.
         assert id(item) not in self.id_to_variable
         self.id_to_variable[id(item)] = variable
         self.keepalive.append(item)

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -220,6 +220,10 @@ class SideEffects:
         """Start tracking a new variable for mutation"""
         assert variable.source is not None
         variable.mutable_local = mutable_cls(variable.source)
+        # TODO (anijain2305) - Right way is to check if it already exists in
+        # self.id_to_variable and return. But doing this to test for other
+        # places where we could probably replace with VariableBuilder.
+        assert id(item) not in self.id_to_variable
         self.id_to_variable[id(item)] = variable
         self.keepalive.append(item)
         return variable


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128590
* #128269
* #128715

This issue was pointed out by @tombousso here - https://github.com/pytorch/pytorch/pull/128269#issuecomment-2163755792


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang