### PR TITLE
[EZ][ALI Migration] Add logging for workflow type determination

### DIFF
--- a/.github/scripts/get_workflow_type.py
+++ b/.github/scripts/get_workflow_type.py
@@ -53,14 +53,19 @@ def get_workflow_type(issue: Issue, username: str) -> str:
         user_list = issue.get_comments()[0].body.split()
 
         if user_list[0] == "!":
+            print("LF Workflows are disabled for everyone. Using meta runners.")
             return WORKFLOW_LABEL_META
         elif user_list[0] == "*":
+            print("LF Workflows are enabled for everyone. Using LF runners.")
             return WORKFLOW_LABEL_LF
         elif username in user_list:
+            print(f"LF Workflows are enabled for {username}. Using LF runners.")
             return WORKFLOW_LABEL_LF
         else:
+            print(f"LF Workflows are disabled for {username}. Using meta runners.")
             return WORKFLOW_LABEL_META
     except Exception as e:
+        print(f"Failed to get determine workflow type. Falling back to meta runners. Exception: {e}")
         return WORKFLOW_LABEL_META
 
 
@@ -68,6 +73,7 @@ def main() -> None:
     args = parse_args()
 
     if is_exception_branch(args.github_branch):
+        print(f"Exception branch: '{args.github_branch}', using meta runners")
         output = {LABEL_TYPE_KEY: WORKFLOW_LABEL_META}
     else:
         try:
@@ -77,6 +83,7 @@ def main() -> None:
 
             output = {LABEL_TYPE_KEY: get_workflow_type(issue, args.github_user)}
         except Exception as e:
+            print(f"Failed to get issue. Falling back to meta runners. Exception: {e}")
             output = {LABEL_TYPE_KEY: WORKFLOW_LABEL_META}
 
     json_output = json.dumps(output)

--- a/.github/scripts/get_workflow_type.py
+++ b/.github/scripts/get_workflow_type.py
@@ -65,7 +65,9 @@ def get_workflow_type(issue: Issue, username: str) -> str:
             print(f"LF Workflows are disabled for {username}. Using meta runners.")
             return WORKFLOW_LABEL_META
     except Exception as e:
-        print(f"Failed to get determine workflow type. Falling back to meta runners. Exception: {e}")
+        print(
+            f"Failed to get determine workflow type. Falling back to meta runners. Exception: {e}"
+        )
         return WORKFLOW_LABEL_META
 
 


### PR DESCRIPTION
To help figure out what went wrong when the wrong label appears to have been set