### PR TITLE
[inductor] Disable two tests on H100 due to a ptxas bug exposed by recent Triton pin update.

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -86,6 +86,7 @@ from torch.testing._internal.common_utils import (
     subtest,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
+    xfailIfSM90,
 )
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -5833,6 +5834,8 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn([2, 4, 37, 38, 39]),))
 
+    # Diabled for H100 due to a PTXAS optimizer bug
+    @xfailIfSM90
     def test_upsample_nearest2d_backward(self):
         func = torch.ops.aten.upsample_nearest2d_backward
 
@@ -7703,6 +7706,8 @@ class CommonTemplate:
             ],
         )
 
+    # Diabled for H100 due to a PTXAS optimizer bug
+    @xfailIfSM90
     def test_max_pool2d_with_indices_backward2(self):
         def fn(a, b, c):
             return aten.max_pool2d_with_indices_backward(

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1343,6 +1343,10 @@ def xpassIfTorchDynamo(func):
 def xfailIfTorchDynamo(func):
     return unittest.expectedFailure(func) if TEST_WITH_TORCHDYNAMO else func  # noqa: F821
 
+def xfailIfSM90(func):
+    is_cuda_90 = torch.device.startswith("cuda") and torch.cuda.get_device_capability() == (9, 0)
+    return unittest.expectedFailure(func) if is_cuda_90 else func
+
 
 def skipIfTorchDynamo(msg="test doesn't currently work with dynamo"):
     """


### PR DESCRIPTION
Summary: Recent Triton pin upgrade includes a LLVM pin update that exposes a PTXAS optimizer issue causing two tests failed. The tests pass with `DISABLE_PTXAS_OPT=1`.

Test Plan:
buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/inductor:test_inductor_cuda -- --exact 'caffe2/test/inductor:test_inductor_cuda - test_upsample_nearest2d_backward_cuda (caffe2.test.inductor.test_torchinductor.GPUTests)'

   buck2 test 'fbcode//mode/opt' fbcode//hammer/modules/sequential/encoders/tests:hstu_transducer_cint_tests -- --exact 'hammer/modules/sequential/encoders/tests:hstu_transducer_cint_tests - test_inference_fx_ts_compatibility (hammer.modules.sequential.encoders.tests.hstu_transducer_cint_tests.HSTUTransducerCIntFXTStest_0)'

Differential Revision: D58532831


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang