### PR TITLE
Fix manual licensing

### DIFF
--- a/test/test_license.py
+++ b/test/test_license.py
@@ -15,7 +15,7 @@ except ImportError:
     create_bundled = None
 
 license_file = "third_party/LICENSES_BUNDLED.txt"
-starting_txt = "The Pytorch repository and source distributions bundle"
+starting_txt = "The PyTorch repository and source distributions bundle"
 site_packages = os.path.dirname(os.path.dirname(torch.__file__))
 distinfo = glob.glob(os.path.join(site_packages, "torch-*dist-info"))
 

--- a/third_party/LICENSES_BUNDLED.txt
+++ b/third_party/LICENSES_BUNDLED.txt
@@ -1,4 +1,4 @@
-The Pytorch repository and source distributions bundle several libraries that are 
+The PyTorch repository and source distributions bundle several libraries that are 
 compatibly licensed.  We list these here.
 
 Name: DCGM
@@ -77,6 +77,11 @@ Name: colorama
 License: BSD-3-Clause
 Files: third_party/kineto/libkineto/third_party/dynolog/third_party/DCGM/testing/python3/libs_3rdparty/colorama
   For details, see: third_party/kineto/libkineto/third_party/dynolog/third_party/DCGM/testing/python3/libs_3rdparty/colorama/LICENSE.txt
+
+Name: cpp-httplib
+License: MIT
+Files: third_party/cpp-httplib
+  For details, see: third_party/cpp-httplib/LICENSE
 
 Name: cpplint
 License: BSD-3-Clause
@@ -168,12 +173,12 @@ Files: third_party/flatbuffers
 
 Name: fmt
 License: MIT with exception
-Files: third_party/fmt,
-     third_party/kineto/libkineto/third_party/dynolog/third_party/fmt,
-     third_party/kineto/libkineto/third_party/fmt
-  For details, see: third_party/fmt/LICENSE,
-     third_party/kineto/libkineto/third_party/dynolog/third_party/fmt/LICENSE.rst,
-     third_party/kineto/libkineto/third_party/fmt/LICENSE.rst
+Files: third_party/kineto/libkineto/third_party/dynolog/third_party/fmt,
+     third_party/kineto/libkineto/third_party/fmt,
+     third_party/fmt
+  For details, see: third_party/kineto/libkineto/third_party/dynolog/third_party/fmt/LICENSE.rst,
+     third_party/kineto/libkineto/third_party/fmt/LICENSE.rst,
+     third_party/fmt/LICENSE
 
 Name: foxi
 License: MIT
@@ -259,7 +264,7 @@ Files: third_party/fbgemm/third_party/hipify_torch
   For details, see: third_party/fbgemm/third_party/hipify_torch/LICENSE.txt
 
 Name: hungarian
-License: Apache-2.0
+License: Permissive (free to use)
 Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/hungarian
   For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/hungarian/LICENSE.txt
 
@@ -359,7 +364,7 @@ Files: third_party/opentelemetry-cpp/third_party/opentracing-cpp
   For details, see: third_party/opentelemetry-cpp/third_party/opentracing-cpp/LICENSE
 
 Name: pdcurses
-License: Apache-2.0
+License: Public Domain for core
 Files: third_party/opentelemetry-cpp/tools/vcpkg/ports/pdcurses
   For details, see: third_party/opentelemetry-cpp/tools/vcpkg/ports/pdcurses/LICENSE
 

--- a/third_party/build_bundled.py
+++ b/third_party/build_bundled.py
@@ -41,7 +41,7 @@ def create_bundled(d, outstream, include_files=False):
     """Write the information to an open outstream"""
     collected = collect_license(d)
     sorted_keys = sorted(collected.keys())
-    outstream.write('The Pytorch repository and source distributions bundle '
+    outstream.write('The PyTorch repository and source distributions bundle '
                     'several libraries that are \n')
     outstream.write('compatibly licensed.  We list these here.')
     files_to_include = []
@@ -107,10 +107,10 @@ def identify_license(f, exception=''):
             return 'Apache-2.0'
         elif 'libhungarian' in txt:
             # Used in opentelemetry-cpp/tools/vcpkg/ports/hungarian
-            return 'Apache-2.0'
+            return 'Permissive (free to use)'
         elif 'PDCurses' in txt:
             # Used in opentelemetry-cpp/tools/vcpkg/ports/pdcurses
-            return 'Apache-2.0'
+            return 'Public Domain for core'
         elif 'Copyright1999UniversityofNorthCarolina' in txt:
             # Used in opentelemetry-cpp/tools/vcpkg/ports/pqp
             return 'Apache-2.0'


### PR DESCRIPTION
It has come to my attention that some of our licenses are incorrect, so I attempted to rectify a few of them based on given recommendations for:
clog - BSD-3
eigen - MPL-2.0
ffnvcodec - LGPL-2.1
-> **hungarian - Permissive (free to use)**
irrlicht - The Irrlicht Engine License (zlib/libpng)
-> **pdcurses - Public Domain for core**
-> **sigslot - Public Domain**
test - BSD-3
Vulkan - Apache-2.0 or MIT
fb-only: more context is here https://fb.workplace.com/groups/osssupport/posts/26333256012962998/?comment_id=26333622989592967

This PR addressed the manual mismatches of licensing mentioned above (the two bolded, one is getting addressed in #128085, but as everything else is generated by pulling through other files, I did not address those. It is unclear what needs to be updated for the remaining to be accurate/if they're inaccurate today.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128630

