### PR TITLE
Use mv kernel for small M

### DIFF
--- a/aten/src/ATen/native/mps/operations/Quantized.mm
+++ b/aten/src/ATen/native/mps/operations/Quantized.mm
@@ -146,65 +146,6 @@ INSTANTIATE_INT4MM(bfloat, 128);
 INSTANTIATE_INT4MM(bfloat, 256);
 #endif
 
-template <typename T, unsigned blockSize=8>
-kernel void
-int8pack_mm(constant T *A [[buffer(0)]], constant char *B [[buffer(1)]],
-            constant T *scales [[buffer(2)]],
-            device T *outputData [[buffer(3)]],
-            constant int3 &sizes [[buffer(4)]],
-            uint2 group_index [[threadgroup_position_in_grid]],
-            uint2 threadgroup_index [[thread_position_in_threadgroup]]) {
-  using vecT = typename Vec4Type<T>::type;
-  const uint lda = sizes.y;
-  const uint ldc = sizes.z;
-  int out_idx = (group_index.x * blockSize + threadgroup_index.x) * 4;
-  int n = out_idx % sizes.z;
-  int m = out_idx / sizes.z;
-  // Offset pointers
-  A += m * lda;
-  B += n * lda;
-  outputData += m *ldc;
-
-  float4 rc = 0;
-  for (unsigned k = threadgroup_index.y * 4; k < sizes.y; k += 4 * blockSize) {
-    threadgroup_barrier(mem_flags::mem_none);
-    auto a_val = float4(*reinterpret_cast<constant vecT *>(A  + k));
-    float4x4 b_val;
-    for (int i = 0; i < 4; ++i) {
-      b_val[i] = float4(*reinterpret_cast<constant char4 *>(B + i * lda + k));
-    }
-    rc += transpose(b_val) * a_val;
-  }
-
-  // Accumulate results acorss SIMD group? (8 threads using vec4)
-  threadgroup float4 tgp_memory[blockSize][blockSize];
-  tgp_memory[threadgroup_index.x][threadgroup_index.y] = rc;
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-  if (threadgroup_index.y == 0) {
-    for (int i = 1; i < blockSize; i++) {
-      rc += tgp_memory[threadgroup_index.x][i];
-    }
-    *reinterpret_cast<device vecT *>(outputData + n) =
-        vecT(rc * float4(*reinterpret_cast<constant vecT *>(scales + n)));
-  }
-}
-
-#define INSTANTIATE_INT8MM(DTYPE)                                              \
-  template [[host_name("int8pack_mm_" #DTYPE)]] kernel void                    \
-  int8pack_mm<DTYPE>(                                                          \
-      constant DTYPE * A [[buffer(0)]], constant char *B [[buffer(1)]],        \
-      constant DTYPE *scales [[buffer(2)]],                                    \
-      device DTYPE *outputData [[buffer(3)]],                                  \
-      constant int3 &sizes [[buffer(4)]],                                      \
-      uint2 group_index [[threadgroup_position_in_grid]],                      \
-      uint2 threadgroup_index [[thread_position_in_threadgroup]]);
-
-INSTANTIATE_INT8MM(half);
-INSTANTIATE_INT8MM(float);
-#if __METAL_VERSION__ >= 310
-INSTANTIATE_INT8MM(bfloat);
-#endif
-
 // ------------------------------ For M >= 4 ------------------------------------
 /**
  * The following code is heavily inspired by llama.cpp (https://github.com/ggerganov/llama.cpp).
@@ -499,7 +440,7 @@ INSTANTIATE_MM(half, char, get_scale_zero_q8);
 #if __METAL_VERSION__ >= 310
 INSTANTIATE_MM(bfloat, char, get_scale_zero_q8);
 #endif
-/* Matrix vector multiplication
+/* Matrix vector multiplication, used for small M size for matrix multiplication as well.
 
                       for loop ->
                        1  1  1  1                                 1
@@ -749,10 +690,9 @@ Tensor _weight_int8pack_mm_mps(const Tensor& A, const Tensor& B, const Tensor& s
 #endif
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       std::string kernel;
-      if (M == 1) {
+      // heuristic, to use mv kernel for mm with small M. M = 10 is the performance tipping point.
+      if (M < 11) {
         kernel = fmt::format("int8pack_mv_{}", scalarToMetalTypeString(A));
-      } else if (M < 4) {
-        kernel = fmt::format("int8pack_mm_{}", scalarToMetalTypeString(A));
       } else {
         kernel = fmt::format("large_m_int8pack_mm_{}", scalarToMetalTypeString(A));
       }
@@ -763,12 +703,10 @@ Tensor _weight_int8pack_mm_mps(const Tensor& A, const Tensor& B, const Tensor& s
       mtl_setBuffer(computeEncoder, scales, 2);
       mtl_setBuffer(computeEncoder, C, 3);
       [computeEncoder setBytes:sizes.data() length:sizeof(uint32_t) * sizes.size() atIndex:4];
-      if (M == 1) {
+      if (M < 11) {
         [computeEncoder setThreadgroupMemoryLength:32 atIndex:0];
-        [computeEncoder dispatchThreadgroups:MTLSizeMake((N + 7) / 8, 1, 1)
+        [computeEncoder dispatchThreadgroups:MTLSizeMake((N + 7) / 8, M, 1)
                        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
-      } else if (M < 4) {
-        [computeEncoder dispatchThreads:MTLSizeMake(M * N / 4, 8, 1) threadsPerThreadgroup:MTLSizeMake(8, 8, 1)];
       } else {
         [computeEncoder setThreadgroupMemoryLength:12288 atIndex:0];
         [computeEncoder dispatchThreadgroups:MTLSizeMake((M + 31) / 32, (N + 63) / 64, 1)

--- a/aten/src/ATen/native/mps/operations/Quantized.mm
+++ b/aten/src/ATen/native/mps/operations/Quantized.mm
@@ -146,7 +146,7 @@ INSTANTIATE_INT4MM(bfloat, 128);
 INSTANTIATE_INT4MM(bfloat, 256);
 #endif
 
-// ------------------------------ For M >= 4 ------------------------------------
+// ------------------------------ int8 MM For M >= 10 ------------------------------------
 /**
  * The following code is heavily inspired by llama.cpp (https://github.com/ggerganov/llama.cpp).
  * The original code is under MIT License: https://github.com/ggerganov/llama.cpp/blob/master/LICENSE
@@ -440,6 +440,7 @@ INSTANTIATE_MM(half, char, get_scale_zero_q8);
 #if __METAL_VERSION__ >= 310
 INSTANTIATE_MM(bfloat, char, get_scale_zero_q8);
 #endif
+// ------------------------------ int8 MM For M < 10 ------------------------------------
 /* Matrix vector multiplication, used for small M size for matrix multiplication as well.
 
                       for loop ->

--- a/aten/src/ATen/native/mps/operations/Quantized.mm
+++ b/aten/src/ATen/native/mps/operations/Quantized.mm
@@ -146,7 +146,7 @@ INSTANTIATE_INT4MM(bfloat, 128);
 INSTANTIATE_INT4MM(bfloat, 256);
 #endif
 
-// ------------------------------ int8 MM For M >= 10 ------------------------------------
+// ------------------------------ int8 MM For M > 10 ------------------------------------
 /**
  * The following code is heavily inspired by llama.cpp (https://github.com/ggerganov/llama.cpp).
  * The original code is under MIT License: https://github.com/ggerganov/llama.cpp/blob/master/LICENSE
@@ -440,7 +440,7 @@ INSTANTIATE_MM(half, char, get_scale_zero_q8);
 #if __METAL_VERSION__ >= 310
 INSTANTIATE_MM(bfloat, char, get_scale_zero_q8);
 #endif
-// ------------------------------ int8 MM For M < 10 ------------------------------------
+// ------------------------------ int8 MM For M <= 10 ------------------------------------
 /* Matrix vector multiplication, used for small M size for matrix multiplication as well.
 
                       for loop ->


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128632

Previously we are using:
* mv kernel for M == 1
* mm kernel for 1 < M < 4
* llama.cpp inspired mm kernel for M >= 4

This PR consolidate it to only 2 kernels, use the same mv kernel for M <
12.

Benchmarked on https://github.com/malfet/llm_experiments/blob/main/metal-perf/int8mm.mm

Mac M1 Max, input size M x 4128 x 4096

![llama cpp shader and ATen shader (2)](https://github.com/pytorch/pytorch/assets/8188269/9e2e3024-c5ea-4303-88bf-ff3646296396)