### PR TITLE
Save DOT file of graph instead of SVG for GraphTranformObserver

### DIFF
--- a/test/fx/test_fx_xform_observer.py
+++ b/test/fx/test_fx_xform_observer.py
@@ -47,7 +47,7 @@ class TestGraphTransformObserver(TestCase):
             os.path.isfile(
                 os.path.join(
                     log_url,
-                    f"pass_{current_pass_count}_replace_neg_with_relu_input_graph.svg",
+                    f"pass_{current_pass_count}_replace_neg_with_relu_input_graph.dot",
                 )
             )
         )
@@ -55,7 +55,7 @@ class TestGraphTransformObserver(TestCase):
             os.path.isfile(
                 os.path.join(
                     log_url,
-                    f"pass_{current_pass_count}_replace_neg_with_relu_output_graph.svg",
+                    f"pass_{current_pass_count}_replace_neg_with_relu_output_graph.dot",
                 )
             )
         )

--- a/test/inductor/test_graph_transform_observer.py
+++ b/test/inductor/test_graph_transform_observer.py
@@ -58,9 +58,9 @@ class TestGraphTransformObserver(TestCase):
         found_output_svg = False
         for filepath_object in glob.glob(log_url + "/*"):
             if os.path.isfile(filepath_object):
-                if filepath_object.endswith("input_graph.svg"):
+                if filepath_object.endswith("input_graph.dot"):
                     found_input_svg = True
-                elif filepath_object.endswith("output_graph.svg"):
+                elif filepath_object.endswith("output_graph.dot"):
                     found_output_svg = True
 
         self.assertTrue(found_input_svg)

--- a/torch/fx/passes/graph_transform_observer.py
+++ b/torch/fx/passes/graph_transform_observer.py
@@ -58,10 +58,10 @@ class GraphTransformObserver:
                     e.obj_dict["attributes"]["fillcolor"] = "yellow"
                 else:
                     e.obj_dict["attributes"]["fillcolor"] = "grey"
-            self.input_dot_graph.write_svg(
+            self.input_dot_graph.write(
                 os.path.join(
                     self.log_url,
-                    f"pass_{GraphTransformObserver.__pass_count}_{self.passname}_input_graph.svg",
+                    f"pass_{GraphTransformObserver.__pass_count}_{self.passname}_input_graph.dot",
                 )
             )
 
@@ -76,10 +76,10 @@ class GraphTransformObserver:
                     e.obj_dict["attributes"]["fillcolor"] = "yellow"
                 else:
                     e.obj_dict["attributes"]["fillcolor"] = "grey"
-            output_dot_graph.write_svg(
+            output_dot_graph.write(
                 os.path.join(
                     self.log_url,
-                    f"pass_{GraphTransformObserver.__pass_count}_{self.passname}_output_graph.svg",
+                    f"pass_{GraphTransformObserver.__pass_count}_{self.passname}_output_graph.dot",
                 )
             )
 


### PR DESCRIPTION
Summary:
GraphTransformObserver saves the SVG file of the input/output graph in each inductor pass. In my test with CMF model, if the graph is large, GraphViz took forever to convert DOT to SVG. That is NOT acceptable.

This DIFF is to save DOT file instead of SVG file to speed it up. Also DOT file size is order of mangitude smaller than SVG.

To view these graphs, user can run dot -Txxx inpout.dot to convert DOT to any other format you want. User can control how many iterations to layout the graph properly. Refer to https://web.archive.org/web/20170507095019/http://graphviz.org/content/attrs#dnslimit for details.

Test Plan: buck2 test mode/dev-sand caffe2/test:fx --  fx.test_fx_xform_observer.TestGraphTransformObserver

Differential Revision: D58539182


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang