### PR TITLE
[POC] Split before autograd allow in graph

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -271,6 +271,8 @@ enforce_cond_guards_match = True
 # no optimization.
 optimize_ddp: Union[bool, str] = True
 
+preserve_allow_in_graph_via_splitting = True
+
 # By default, Dynamo emits runtime asserts (e.g. torch._check, torch._check_is_size) in the graph.
 # In some cases those asserts could be performance costly
 # E.g. torch._check(tensor[0].item() > 2) for tensor on cuda will require cuda sync.

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -95,6 +95,10 @@ register_artifact(
     "Only relevant for compiling DDP. DDP splits into multiple graphs to trigger comms early. This will print each individual graph here.",
 )
 register_artifact(
+    "split_graphs",
+    "TODO.",
+)
+register_artifact(
     "recompiles",
     "Prints the reason why we recompiled a graph. Very, very useful.",
     visible=True,

--- a/u.py
+++ b/u.py
@@ -1,0 +1,20 @@
+import torch
+import traceback
+from torch._subclasses.fake_tensor import maybe_get_fake_mode
+
+@torch.compiler.allow_in_graph
+def f(x):
+    if maybe_get_fake_mode(x):
+        print("fake")
+        return x
+    print("real")
+    return x
+
+f._dynamo_split_before_autograd = True
+
+@torch.compile(backend="aot_eager")
+def g(x):
+    return f(x + 1) + 1
+
+g(torch.randn(3))
+g(torch.randn(3))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128647

This POC shows how we could extend `allow_in_graph` to allow for almost arbitrary user code execution inside a torch.compile() region, without requiring graph breaks.

The intended UX here is:

1. User marks a function `allow_in_graph` with a special flag for this behavior (done manually in u.py for now)
2. They write a fake implementation inside (guarded on `detect_fake_mode`) which can be run at compile time with fake tensors. This could be done with the real dispatcher but for the POC I did a manual if statement
3. In the POC, you have to turn on `preserve_allow_in_graph_via_splitting`. We potentially could enable this by default however.

How the POC works is:

1. `allow_in_graph` lets us directly put the operator in the graph. Because the user has put in a fake tensor implementation, that's what gets used to propagate inputs to outputs during Dynamo tracing
2. I copy pasted DDPOptimizer into a new AllowInGraphSplitter. It splits the graph into segments that don't have allow in graph nodes and those that do. Then, we disable running the backend compiler on the allow in graph nodes

Running the test script, you see that the real user Python code is run twice, even though it is embedded in a single torch.compile region.

I do NOT plan on productionizing this POC, someone should take it.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec 