### PR TITLE
[inductor] Support mm decomps for matrices with unbacked sizes

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -1,16 +1,16 @@
 # Owner(s): ["module: inductor"]
 
+import functools
 import unittest
 
 import torch
-
 from torch._dynamo import config as dynamo_config
 from torch._inductor import config as inductor_config
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import is_big_gpu
 from torch.testing import make_tensor
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import IS_LINUX
+from torch.testing._internal.common_utils import IS_LINUX, parametrize
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CUDA, skipCUDAIf
 
 
@@ -213,6 +213,43 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+    @dynamo_config.patch({"capture_scalar_outputs": True})
+    @parametrize(
+        "torch_fn", [torch.mm, torch.bmm, torch.addmm], name_fn=lambda fn: fn.__name__
+    )
+    @parametrize("coordinate_descent_tuning", [True, False], name_fn=str)
+    def test_mm_and_friends(self, device, torch_fn, coordinate_descent_tuning):
+        if torch_fn == torch.addmm:
+            torch_fn = functools.partial(torch_fn, torch.ones(1, device=device))
+
+        def fn(x, w, repeats, is_bmm):
+            u0 = repeats.item()
+            torch._check_is_size(u0)
+
+            x_unbacked = x.expand(u0, 32)
+            w_unbacked = w.expand(32, u0)
+            if is_bmm:
+                # Make sure inputs are batched.
+                x_unbacked = x_unbacked.expand(10, *x_unbacked.shape)
+                w_unbacked = w_unbacked.expand(10, *w_unbacked.shape)
+
+            return torch_fn(x_unbacked, w_unbacked)
+
+        example_inputs = (
+            torch.randn(1, 32, device=device),
+            torch.randn(32, 1, device=device),
+            torch.tensor(100, device=device),
+            torch_fn == torch.bmm,
+        )
+        with inductor_config.patch(
+            {
+                "coordinate_descent_tuning": coordinate_descent_tuning,
+            }
+        ):
+            actual = torch.compile(fn, fullgraph=True)(*example_inputs)
+        expected = fn(*example_inputs)
+        torch.testing.assert_close(actual, expected)
 
 
 instantiate_device_type_tests(

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -244,6 +244,7 @@ class TestUnbackedSymints(InductorTestCase):
         )
         with inductor_config.patch(
             {
+                # coordinate_descent_tuning has its own path during decomp
                 "coordinate_descent_tuning": coordinate_descent_tuning,
             }
         ):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -28,6 +28,7 @@ from torch._prims_common import (
     ELEMENTWISE_TYPE_PROMOTION_KIND,
     type_to_dtype,
 )
+from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
 
 from . import config, inductor_prims
 from .utils import (
@@ -202,11 +203,15 @@ def round_dec(x, decimals=0):
 @pw_cast_for_opmath
 def bmm(self, batch2):
     if config.coordinate_descent_tuning:
-        if self.shape[1] == 1 or batch2.shape[2] == 1:
+        if guard_size_oblivious(self.shape[1] == 1) or guard_size_oblivious(
+            batch2.shape[2] == 1
+        ):
             out = (self.unsqueeze(-1) * batch2.unsqueeze(1)).sum(dim=2)
             return out
     if self.device.type == "cpu":
-        if self.size(1) == 1 and batch2.size(-1) == 1:
+        if guard_size_oblivious(self.size(1) == 1) and guard_size_oblivious(
+            batch2.size(-1) == 1
+        ):
             counters["inductor"]["decompose_bmm"] += 1
             return torch.sum(
                 self.squeeze(1) * batch2.squeeze(-1), dim=1, keepdim=True
@@ -218,13 +223,19 @@ def bmm(self, batch2):
 @pw_cast_for_opmath
 def addmm(self, mat1, mat2, beta=1, alpha=1):
     if self.device.type == "cpu":
-        if mat1.size(0) == 1 and mat2.size(-1) == 1:
+        if guard_size_oblivious(mat1.size(0) == 1) and guard_size_oblivious(
+            mat2.size(-1) == 1
+        ):
             counters["inductor"]["decompose_addmm"] += 1
             out = torch.sum(
                 mat1.squeeze(0) * mat2.squeeze(-1), dim=0, keepdim=True
             ).unsqueeze(0)
             return alpha * out + beta * self
-        if mat1.size(0) == 1 and mat2.size(0) <= 16 and mat2.size(1) <= 16:
+        if (
+            guard_size_oblivious(mat1.size(0) == 1)
+            and mat2.size(0) <= 16
+            and mat2.size(1) <= 16
+        ):
             counters["inductor"]["decompose_addmm"] += 1
             out = (mat1.T * mat2).sum(dim=0, keepdim=True)
             return alpha * out + beta * self
@@ -242,7 +253,9 @@ def mm(self, input2):
     # Our matrix vector multiplies only achieve peak bandwidth with coordinate descent tuning.
     # todo: Look into why and fix it (hopefully)
     if config.coordinate_descent_tuning:
-        if self.shape[0] == 1 or input2.shape[1] == 1:
+        if guard_size_oblivious(self.shape[0] == 1) or guard_size_oblivious(
+            input2.shape[1] == 1
+        ):
             return (self.unsqueeze(2) * input2.unsqueeze(0)).sum(dim=1)
     if self.device.type == "cpu":
         if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128655



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang