### PR TITLE
Fix docstring in autograd

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -1,8 +1,8 @@
 # mypy: allow-untyped-defs
 """
-``torch.autograd`` provides classes and functions implementing automatic
-differentiation of arbitrary scalar valued functions. It requires minimal
-changes to the existing code - you only need to declare :class:`Tensor` s
+``torch.autograd`` provides classes and functions implementing automatic differentiation of arbitrary scalar valued functions.
+
+It requires minimal changes to the existing code - you only need to declare :class:`Tensor` s
 for which gradients should be computed with the ``requires_grad=True`` keyword.
 As of now, we only support autograd for floating point :class:`Tensor` types (
 half, float, double and bfloat16) and complex :class:`Tensor` types (cfloat, cdouble).
@@ -188,8 +188,7 @@ def backward(
     grad_variables: Optional[_TensorOrTensors] = None,
     inputs: Optional[_TensorOrTensorsOrGradEdge] = None,
 ) -> None:
-    r"""Computes the sum of gradients of given tensors with respect to graph
-    leaves.
+    r"""Compute the sum of gradients of given tensors with respect to graph leaves.
 
     The graph is differentiated using the chain rule. If any of ``tensors``
     are non-scalar (i.e. their data has more than one element) and require
@@ -308,8 +307,7 @@ def grad(
     is_grads_batched: bool = False,
     materialize_grads: bool = False,
 ) -> Tuple[torch.Tensor, ...]:
-    r"""Computes and returns the sum of gradients of outputs with respect to
-    the inputs.
+    r"""Compute and return the sum of gradients of outputs with respect to the inputs.
 
     ``grad_outputs`` should be a sequence of length matching ``output``
     containing the "vector" in vector-Jacobian product, usually the pre-computed
@@ -476,7 +474,7 @@ def _is_checkpoint_valid():
     return Variable._execution_engine.is_checkpoint_valid()
 
 
-def variable(*args, **kwargs):
+def variable(*args, **kwargs):  # noqa: D103
     raise RuntimeError(
         "torch.autograd.variable(...) is deprecated, use torch.tensor(...) instead"
     )

--- a/torch/autograd/anomaly_mode.py
+++ b/torch/autograd/anomaly_mode.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""Autograd anomaly mode."""
 import warnings
 
 import torch
@@ -22,7 +23,6 @@ class detect_anomaly:
         will slow down your program execution.
 
     Example:
-
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_ANOMALY)
         >>> import torch
         >>> from torch import autograd
@@ -73,7 +73,7 @@ class detect_anomaly:
 
     """
 
-    def __init__(self, check_nan=True) -> None:
+    def __init__(self, check_nan=True) -> None:  # noqa: D107
         self.prev = torch.is_anomaly_enabled()
         self.check_nan = check_nan
         self.prev_check_nan = torch.is_anomaly_check_nan_enabled()
@@ -84,10 +84,10 @@ class detect_anomaly:
             stacklevel=2,
         )
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> None:  # noqa: D105
         torch.set_anomaly_enabled(True, self.check_nan)
 
-    def __exit__(self, *args: object) -> None:
+    def __exit__(self, *args: object) -> None:  # noqa: D105
         torch.set_anomaly_enabled(self.prev, self.prev_check_nan)
 
 
@@ -108,13 +108,13 @@ class set_detect_anomaly:
 
     """
 
-    def __init__(self, mode: bool, check_nan: bool = True) -> None:
+    def __init__(self, mode: bool, check_nan: bool = True) -> None:  # noqa: D107
         self.prev = torch.is_anomaly_enabled()
         self.prev_check_nan = torch.is_anomaly_check_nan_enabled()
         torch.set_anomaly_enabled(mode, check_nan)
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> None:  # noqa: D105
         pass
 
-    def __exit__(self, *args: object) -> None:
+    def __exit__(self, *args: object) -> None:  # noqa: D105
         torch.set_anomaly_enabled(self.prev, self.prev_check_nan)


### PR DESCRIPTION
Fix docstrings in autograd files. 

The fix can be verified by running pydocstyle path-to-file --count

Related #112593

**BEFORE the PR:** 
pydocstyle torch/autograd/anomaly_mode.py --count
8
pydocstyle torch/autograd/__init__.py --count
9

**AFTER the PR:** 
pydocstyle torch/autograd/anomaly_mode.py --count
0
pydocstyle torch/autograd/__init__.py --count
0



cc @svekars @brycebortree