### PR TITLE
Add missing #include <array> to thread_name.cpp

### DIFF
--- a/c10/util/thread_name.cpp
+++ b/c10/util/thread_name.cpp
@@ -1,6 +1,7 @@
 #include <c10/util/thread_name.h>
 
 #include <algorithm>
+#include <array>
 
 #ifndef __GLIBC_PREREQ
 #define __GLIBC_PREREQ(x, y) 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128664

I got local compile errors (using clang 14.0.6) due to this missing include after pulling the
latest pytorch main.  It's totally puzzling why CI appears to pass
without this fix.  Hopefully someone else will have an idea if we are
missing some CI coverage or if I am using a strange build setup locally.

The PR introducing the compile errors was https://github.com/pytorch/pytorch/pull/128448.

Differential Revision: [D58590678](https://our.internmc.facebook.com/intern/diff/D58590678)