### PR TITLE
[custom_op]Fix None return schema

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -575,23 +575,21 @@ class MiscTests(torch._inductor.test_case.TestCase):
         del lib
 
     def test_auto_functionalize_can_with_none_return(self):
-        lib = torch.library.Library("mylib", "FRAGMENT")
-        lib.define("foo(Tensor x, Tensor(a!) out) -> None")
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("foo(Tensor x, Tensor(a!) out) -> None")
 
-        def foo_impl(x, out):
-            out.copy_(x)
+            def foo_impl(x, out):
+                out.copy_(x)
 
-        lib.impl("foo", foo_impl, "CompositeExplicitAutograd")
-        x = torch.randn(3)
-        out = torch.zeros(3)
+            lib.impl("foo", foo_impl, "CompositeExplicitAutograd")
+            x = torch.randn(3)
+            out = torch.zeros(3)
 
-        @torch.compile
-        def f(x, out):
-            torch.ops.mylib.foo(x, out)
+            @torch.compile
+            def f(x, out):
+                torch.ops.mylib.foo(x, out)
 
-        f(x, out)
-        cleanup_op("mylib::foo")
-        del lib
+            f(x, out)
 
     def test_user_defined_setattr1(self):
         @torch.compile(backend="eager", fullgraph=True)

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -97,6 +97,9 @@ def can_auto_functionalize(op: torch._ops.OperatorBase) -> bool:
         # Tensor[], Tensor?[], Tensor[]?.
         return False
 
+    if len(schema.returns) == 1 and isinstance(schema.returns[0].type, torch.NoneType):
+        # Skip schema returns -> None
+        return True
     # The returns must not alias anything
     for ret in schema.returns:
         if ret.alias_info is None and type(ret.type) is torch.TensorType:

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -74,9 +74,9 @@ struct SchemaParser {
     L.expect(TK_ARROW);
     if (L.nextIf(TK_DOTS)) {
       is_varret = true;
-    } else if (L.cur().kind == TK_NONE){
+    } else if (L.cur().kind == TK_NONE) {
       L.expect(TK_NONE);
-    }else if (L.cur().kind == '(') {
+    } else if (L.cur().kind == '(') {
       parseList('(', ',', ')', [&] {
         if (is_varret) {
           throw ErrorReport(L.cur())

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -74,7 +74,9 @@ struct SchemaParser {
     L.expect(TK_ARROW);
     if (L.nextIf(TK_DOTS)) {
       is_varret = true;
-    } else if (L.cur().kind == '(') {
+    } else if (L.cur().kind == TK_NONE){
+      L.expect(TK_NONE);
+    }else if (L.cur().kind == '(') {
       parseList('(', ',', ')', [&] {
         if (is_varret) {
           throw ErrorReport(L.cur())

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -74,9 +74,7 @@ struct SchemaParser {
     L.expect(TK_ARROW);
     if (L.nextIf(TK_DOTS)) {
       is_varret = true;
-    } else if (L.cur().kind == TK_NONE){
-      L.expect(TK_NONE);
-    }else if (L.cur().kind == '(') {
+    } else if (L.cur().kind == '(') {
       parseList('(', ',', ')', [&] {
         if (is_varret) {
           throw ErrorReport(L.cur())

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -74,9 +74,9 @@ struct SchemaParser {
     L.expect(TK_ARROW);
     if (L.nextIf(TK_DOTS)) {
       is_varret = true;
-    } else if (L.cur().kind == TK_NONE) {
+    } else if (L.cur().kind == TK_NONE){
       L.expect(TK_NONE);
-    } else if (L.cur().kind == '(') {
+    }else if (L.cur().kind == '(') {
       parseList('(', ',', ')', [&] {
         if (is_varret) {
           throw ErrorReport(L.cur())


### PR DESCRIPTION
Fixes #125044

If users define a schema returns `None`, it will be parsed to a `torch.NoneType`.  Auto functionalization support the `()` as a empty return but not for `None`. So, `None` return fails the check for [`can_auto_functionalize`](https://github.com/pytorch/pytorch/blob/findhao/fix_none_return_functionalize/torch/_higher_order_ops/auto_functionalize.py#L71) even we can take this as a `()` return. This PR is a fix to skip the check for None return.

I hope it can be fixed in a [deeper level](https://github.com/pytorch/pytorch/pull/128667/commits/31e44c72ca424adeecc3ef022d79906e3b6b54db), but this fix breaks a lot of existing schemas. So it's better to fix this issue in the auto_functionalize.py at this moment.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang