### PR TITLE
Refactor c10::DataPtr by subclassing from c10::detail::UniqueVoidPtr

### DIFF
--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -23,90 +23,23 @@ namespace c10 {
 // nullptr DataPtrs can still have a nontrivial device; this allows
 // us to treat zero-size allocations uniformly with non-zero allocations.
 //
-class C10_API DataPtr {
+class C10_API DataPtr : public c10::detail::UniqueVoidPtr {
  private:
-  c10::detail::UniqueVoidPtr ptr_;
-  Device device_;
-
- public:
   // Choice of CPU here is arbitrary; if there's an "undefined" device
   // we could use that too
-  DataPtr() : ptr_(), device_(DeviceType::CPU) {}
-  DataPtr(void* data, Device device) : ptr_(data), device_(device) {}
+  Device device_{DeviceType::CPU};
+
+ public:
+  DataPtr() = default;
+  DataPtr(void* data, Device device)
+      : c10::detail::UniqueVoidPtr(data), device_(device) {}
   DataPtr(void* data, void* ctx, DeleterFnPtr ctx_deleter, Device device)
-      : ptr_(data, ctx, ctx_deleter), device_(device) {}
-  void* operator->() const {
-    return ptr_.get();
-  }
-  void clear() {
-    ptr_.clear();
-  }
-  void* get() const {
-    return ptr_.get();
-  }
+      : c10::detail::UniqueVoidPtr(data, ctx, ctx_deleter), device_(device) {}
   void* mutable_get() {
-    return ptr_.get();
-  }
-  void* get_context() const {
-    return ptr_.get_context();
-  }
-  void* release_context() {
-    return ptr_.release_context();
-  }
-  std::unique_ptr<void, DeleterFnPtr>&& move_context() {
-    return ptr_.move_context();
+    return get();
   }
   operator bool() const {
-    return static_cast<bool>(ptr_);
-  }
-  template <typename T>
-  T* cast_context(DeleterFnPtr expected_deleter) const {
-    return ptr_.cast_context<T>(expected_deleter);
-  }
-  DeleterFnPtr get_deleter() const {
-    return ptr_.get_deleter();
-  }
-  /**
-   * Compare the deleter in a DataPtr to expected_deleter.
-   * If it matches, replace the deleter with new_deleter
-   * and return true; otherwise, does nothing and returns
-   * false.
-   *
-   * In general, it is not safe to unconditionally set the
-   * deleter on a DataPtr, because you don't know what
-   * the deleter is, and thus will have a hard time properly
-   * disposing of the deleter without storing the original
-   * deleter (this is difficult to do, because DeleterFnPtr
-   * is not a closure, and because the context on DataPtr is
-   * only a single word, you generally don't have enough
-   * space to store both the original deleter and its context).
-   * However, in some cases, you know /exactly/ what the deleter
-   * is, and you have a new deleter that manually wraps
-   * the old one.  In this case, you can safely swap the deleter
-   * after asserting that the deleters line up.
-   *
-   * What are the requirements on new_deleter?  It must still
-   * properly dispose of the void* pointer passed in as its argument,
-   * where void* is whatever the context of the original deleter
-   * is.  So in general, you expect the new deleter to look something
-   * like this:
-   *
-   *      [](void* ptr) {
-   *        some_new_stuff(ptr);
-   *        get_orig_allocator()->raw_deleter(ptr);
-   *      }
-   *
-   * Note that it won't work to close over the original
-   * allocator; you don't have enough space to do that!  Also,
-   * it's unsafe to assume that the passed in pointer in
-   * question is the memory pointer in question; it might not
-   * be; be sure to read the source code of the Allocator
-   * in question to confirm this.
-   */
-  C10_NODISCARD bool compare_exchange_deleter(
-      DeleterFnPtr expected_deleter,
-      DeleterFnPtr new_deleter) {
-    return ptr_.compare_exchange_deleter(expected_deleter, new_deleter);
+    return c10::detail::UniqueVoidPtr::operator bool();
   }
   Device device() const {
     return device_;


### PR DESCRIPTION
That seems more reasonable and saves lots of delegated code.
