### PR TITLE
Remove caffe2 namespace from  c10/macros/Macros.h

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -157,13 +157,10 @@ namespace c10::cuda {}
 namespace c10::hip {}
 namespace c10::xpu {}
 
-// Since C10 is the core library for caffe2 (and aten), we will simply reroute
-// all abstractions defined in c10 to be available in caffe2 as well.
+// Since C10 is the core library for aten, we will simply reroute
+// all abstractions defined in c10 to be available in aten as well.
 // This is only for backwards compatibility. Please use the symbols from the
 // c10 namespace where possible.
-namespace caffe2 {
-using namespace c10;
-}
 namespace at {
 using namespace c10;
 }

--- a/c10/util/typeid.cpp
+++ b/c10/util/typeid.cpp
@@ -26,7 +26,7 @@ std::mutex& TypeMeta::getTypeMetaDatasLock() {
   return lock;
 }
 
-uint16_t TypeMeta::nextTypeIndex(NumScalarTypes);
+uint16_t TypeMeta::nextTypeIndex(c10::NumScalarTypes);
 
 // fixed length array of TypeMetaData instances
 detail::TypeMetaData* TypeMeta::typeMetaDatas() {
@@ -41,7 +41,7 @@ detail::TypeMetaData* TypeMeta::typeMetaDatas() {
       detail::_PickCopy<T>(),            \
       detail::_PickPlacementDelete<T>(), \
       detail::_PickDelete<T>(),          \
-      TypeIdentifier::Get<T>(),          \
+      c10::TypeIdentifier::Get<T>(),     \
       c10::util::get_fully_qualified_type_name<T>()),
       AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SCALAR_TYPE_META)
 #undef SCALAR_TYPE_META
@@ -52,7 +52,8 @@ detail::TypeMetaData* TypeMeta::typeMetaDatas() {
   return instances;
 }
 
-uint16_t TypeMeta::existingMetaDataIndexForType(TypeIdentifier identifier) {
+uint16_t TypeMeta::existingMetaDataIndexForType(
+    c10::TypeIdentifier identifier) {
   auto* metaDatas = typeMetaDatas();
   const auto end = metaDatas + nextTypeIndex;
   // MaxTypeIndex is not very large; linear search should be fine.

--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -190,7 +190,7 @@ void PyTorchStreamReader::init() {
       "pytorch.stream.reader.metadata",
       {{"serialization_id", serialization_id_},
        {"file_name", archive_name_},
-       {"file_size", str(mz_zip_get_archive_size(ar_.get()))}});
+       {"file_size", c10::str(mz_zip_get_archive_size(ar_.get()))}});
 
   // version check
   at::DataPtr version_ptr;
@@ -766,7 +766,7 @@ void PyTorchStreamWriter::writeEndOfFile() {
       "pytorch.stream.writer.metadata",
       {{"serialization_id", serialization_id_},
        {"file_name", archive_name_},
-       {"file_size", str(mz_zip_get_archive_size(ar_.get()))}});
+       {"file_size", c10::str(mz_zip_get_archive_size(ar_.get()))}});
   if (file_stream_.is_open()) {
     file_stream_.close();
   }

--- a/caffe2/serialize/inline_container_test.cc
+++ b/caffe2/serialize/inline_container_test.cc
@@ -390,7 +390,7 @@ TEST(PytorchStreamWriterAndReader, SkipDuplicateSerializationIdRecords) {
 TEST(PytorchStreamWriterAndReader, LogAPIUsageMetadata) {
   std::map<std::string, std::map<std::string, std::string>> logs;
 
-  SetAPIUsageMetadataLogger(
+  c10::SetAPIUsageMetadataLogger(
       [&](const std::string& context,
           const std::map<std::string, std::string>& metadata_map) {
         logs.insert({context, metadata_map});
@@ -411,16 +411,16 @@ TEST(PytorchStreamWriterAndReader, LogAPIUsageMetadata) {
       {"pytorch.stream.writer.metadata",
        {{"serialization_id", writer.serializationId()},
        {"file_name", "archive"},
-       {"file_size", str(oss.str().length())}}},
+       {"file_size", c10::str(oss.str().length())}}},
       {"pytorch.stream.reader.metadata",
        {{"serialization_id", writer.serializationId()},
        {"file_name", "archive"},
-       {"file_size", str(iss.str().length())}}}
+       {"file_size", c10::str(iss.str().length())}}}
   };
   ASSERT_EQ(expected_logs, logs);
 
   // reset logger
-  SetAPIUsageMetadataLogger(
+  c10::SetAPIUsageMetadataLogger(
       [&](const std::string& context,
           const std::map<std::string, std::string>& metadata_map) {});
 }

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -3,6 +3,7 @@
 #include <ATen/core/ivalue.h>
 #include <c10/core/impl/TorchDispatchModeTLS.h>
 #include <c10/util/flat_hash_map.h>
+#include <c10/util/typeid.h>
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/input_metadata.h>
 #include <torch/csrc/autograd/saved_variable.h>

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1033,7 +1033,7 @@ class ShapePropagator : public PropertyPropBase {
             if (isIntegralType(*first_scalar_type, false) &&
                 isFloatingType(*second_scalar_type)) {
               auto default_dtype =
-                  at::typeMetaToScalarType(caffe2::get_default_dtype());
+                  at::typeMetaToScalarType(c10::get_default_dtype());
               return {broadcast(*maybe_tensor_types, default_dtype)};
             }
             if (c10::ScalarType::Bool == *first_scalar_type &&
@@ -1915,8 +1915,7 @@ class ShapePropagator : public PropertyPropBase {
       }
       if (isIntegralType(*first_scalar_type, false) &&
           isFloatingType(*second_scalar_type)) {
-        auto default_dtype =
-            at::typeMetaToScalarType(caffe2::get_default_dtype());
+        auto default_dtype = at::typeMetaToScalarType(c10::get_default_dtype());
         auto type = tensor_types[0]->withScalarType(default_dtype);
         node->output()->setType(std::move(type));
         return true;


### PR DESCRIPTION
It's time to clean caffe2 namespaces.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec