### PR TITLE
put split memory block in the front of memory block set when stream and size equal.

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -627,6 +627,9 @@ static bool BlockComparatorSize(const Block* a, const Block* b) {
   if (a->size != b->size) {
     return a->size < b->size;
   }
+  if (a->is_split() != b->is_split()) {
+    return a->is_split() ? true : false;
+  }
   return (uintptr_t)a->ptr < (uintptr_t)b->ptr;
 }
 static bool BlockComparatorAddress(const Block* a, const Block* b) {


### PR DESCRIPTION
Using split memory block first and will reduce memory fragment.