### PR TITLE
Learning Rate Scheduler docstring fix

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+r"""Learning Rate Scheduler."""
 import math
 import types
 import warnings
@@ -55,7 +56,7 @@ EPOCH_DEPRECATION_WARNING = (
 
 
 def _check_verbose_deprecated_warning(verbose):
-    """Raises a warning when verbose is not the default value."""
+    """Raise a warning when verbose is not the default value."""
     if verbose != "deprecated":
         warnings.warn(
             "The verbose parameter is deprecated. Please use get_last_lr() "
@@ -85,9 +86,13 @@ def _format_param(name: str, optimizer: Optimizer, param):
 
 
 class LRScheduler:
+    r"""Adjusts the learning rate during optimization."""
+
     _get_lr_called_within_step: bool = False
 
-    def __init__(self, optimizer: Optimizer, last_epoch=-1, verbose="deprecated"):
+    def __init__(
+        self, optimizer: Optimizer, last_epoch=-1, verbose="deprecated"
+    ):  # noqa: D107
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
@@ -139,12 +144,12 @@ class LRScheduler:
         self._initial_step()
 
     def _initial_step(self):
-        """Initialize step counts and performs a step"""
+        """Initialize step counts and perform a step."""
         self._step_count = 0
         self.step()
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -154,7 +159,7 @@ class LRScheduler:
         }
 
     def load_state_dict(self, state_dict: Dict[str, Any]):
-        """Loads the schedulers state.
+        """Load the scheduler's state.
 
         Args:
             state_dict (dict): scheduler state. Should be an object returned
@@ -167,7 +172,7 @@ class LRScheduler:
         return self._last_lr
 
     def get_lr(self) -> List[float]:
-        # Compute learning rate using chainable form of the scheduler
+        """Compute learning rate using chainable form of the scheduler."""
         raise NotImplementedError
 
     def print_lr(
@@ -199,6 +204,7 @@ class LRScheduler:
                 )
 
     def step(self, epoch: Optional[int] = None):
+        """Perform a step."""
         # Raise a warning if old pattern is detected
         # https://github.com/pytorch/pytorch/issues/20124
         if self._step_count == 1:
@@ -278,7 +284,9 @@ class _enable_get_lr_call:
 
 
 class LambdaLR(LRScheduler):
-    """Sets the learning rate of each parameter group to the initial lr
+    """Sets the initial learning rate.
+
+    The learning rate of each parameter group is set to the initial lr
     times a given function. When last_epoch=-1, sets initial lr as lr.
 
     Args:
@@ -312,7 +320,7 @@ class LambdaLR(LRScheduler):
         lr_lambda: Union[Callable[[int], float], List[Callable[[int], float]]],
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.optimizer = optimizer
 
         self.lr_lambdas: List[Callable[[int], float]]
@@ -327,7 +335,7 @@ class LambdaLR(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -336,7 +344,6 @@ class LambdaLR(LRScheduler):
 
         When saving or loading the scheduler, please make sure to also save or load the state of the optimizer.
         """
-
         state_dict = {
             key: value
             for key, value in self.__dict__.items()
@@ -351,7 +358,7 @@ class LambdaLR(LRScheduler):
         return state_dict
 
     def load_state_dict(self, state_dict):
-        """Loads the schedulers state.
+        """Load the scheduler's state.
 
         When saving or loading the scheduler, please make sure to also save or load the state of the optimizer.
 
@@ -359,7 +366,6 @@ class LambdaLR(LRScheduler):
             state_dict (dict): scheduler state. Should be an object returned
                 from a call to :meth:`state_dict`.
         """
-
         lr_lambdas = state_dict.pop("lr_lambdas")
         self.__dict__.update(state_dict)
         # Restore state_dict keys in order to prevent side effects
@@ -371,6 +377,7 @@ class LambdaLR(LRScheduler):
                 self.lr_lambdas[idx].__dict__.update(fn)
 
     def get_lr(self):
+        """Compute learning rate."""
         _warn_get_lr_called_within_step(self)
 
         return [
@@ -380,8 +387,9 @@ class LambdaLR(LRScheduler):
 
 
 class MultiplicativeLR(LRScheduler):
-    """Multiply the learning rate of each parameter group by the factor given
-    in the specified function. When last_epoch=-1, sets initial lr as lr.
+    """Multiply the learning rate of each parameter group by the factor given in the specified function.
+
+    When last_epoch=-1, set initial lr as lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -412,7 +420,7 @@ class MultiplicativeLR(LRScheduler):
         lr_lambda: Union[Callable[[int], float], List[Callable[[int], float]]],
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.optimizer = optimizer
 
         self.lr_lambdas: List[Callable[[int], float]]
@@ -427,7 +435,7 @@ class MultiplicativeLR(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -448,7 +456,7 @@ class MultiplicativeLR(LRScheduler):
         return state_dict
 
     def load_state_dict(self, state_dict):
-        """Loads the schedulers state.
+        """Load the scheduler's state.
 
         Args:
             state_dict (dict): scheduler state. Should be an object returned
@@ -465,6 +473,7 @@ class MultiplicativeLR(LRScheduler):
                 self.lr_lambdas[idx].__dict__.update(fn)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch > 0:
@@ -477,10 +486,10 @@ class MultiplicativeLR(LRScheduler):
 
 
 class StepLR(LRScheduler):
-    """Decays the learning rate of each parameter group by gamma every
-    step_size epochs. Notice that such decay can happen simultaneously with
-    other changes to the learning rate from outside this scheduler. When
-    last_epoch=-1, sets initial lr as lr.
+    """Decays the learning rate of each parameter group by gamma every step_size epochs.
+
+    Notice that such decay can happen simultaneously with other changes to the learning rate
+    from outside this scheduler. When last_epoch=-1, sets initial lr as lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -516,12 +525,13 @@ class StepLR(LRScheduler):
         gamma=0.1,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.step_size = step_size
         self.gamma = gamma
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if (self.last_epoch == 0) or (self.last_epoch % self.step_size != 0):
@@ -536,10 +546,10 @@ class StepLR(LRScheduler):
 
 
 class MultiStepLR(LRScheduler):
-    """Decays the learning rate of each parameter group by gamma once the
-    number of epoch reaches one of the milestones. Notice that such decay can
-    happen simultaneously with other changes to the learning rate from outside
-    this scheduler. When last_epoch=-1, sets initial lr as lr.
+    """Decays the learning rate of each parameter group by gamma once the number of epoch reaches one of the milestones.
+
+    Notice that such decay can happen simultaneously with other changes to the learning rate
+    from outside this scheduler. When last_epoch=-1, sets initial lr as lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -574,12 +584,13 @@ class MultiStepLR(LRScheduler):
         gamma=0.1,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.milestones = Counter(milestones)
         self.gamma = gamma
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch not in self.milestones:
@@ -598,8 +609,9 @@ class MultiStepLR(LRScheduler):
 
 
 class ConstantLR(LRScheduler):
-    """Multiply the learning rate of each parameter group by a small constant factor until the
-    number of epoch reaches a pre-defined milestone: total_iters.
+    """Multiply the learning rate of each parameter group by a small constant factor.
+
+    The multiplication is done until the number of epoch reaches a pre-defined milestone: total_iters.
     Notice that such multiplication of the small constant factor can
     happen simultaneously with other changes to the learning rate from outside this scheduler.
     When last_epoch=-1, sets initial lr as lr.
@@ -639,7 +651,7 @@ class ConstantLR(LRScheduler):
         total_iters=5,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if factor > 1.0 or factor < 0:
             raise ValueError(
                 "Constant multiplicative factor expected to be between 0 and 1."
@@ -650,6 +662,7 @@ class ConstantLR(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0:
@@ -671,8 +684,9 @@ class ConstantLR(LRScheduler):
 
 
 class LinearLR(LRScheduler):
-    """Decays the learning rate of each parameter group by linearly changing small
-    multiplicative factor until the number of epoch reaches a pre-defined milestone: total_iters.
+    """Decays the learning rate of each parameter group by linearly changing small multiplicative factor.
+
+    The multiplication is done until the number of epoch reaches a pre-defined milestone: total_iters.
     Notice that such decay can happen simultaneously with other changes to the learning rate
     from outside this scheduler. When last_epoch=-1, sets initial lr as lr.
 
@@ -716,7 +730,7 @@ class LinearLR(LRScheduler):
         total_iters=5,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if start_factor > 1.0 or start_factor <= 0:
             raise ValueError(
                 "Starting multiplicative factor expected to be greater than 0 and less or equal to 1."
@@ -733,6 +747,7 @@ class LinearLR(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0:
@@ -771,6 +786,7 @@ class LinearLR(LRScheduler):
 
 class ExponentialLR(LRScheduler):
     """Decays the learning rate of each parameter group by gamma every epoch.
+
     When last_epoch=-1, sets initial lr as lr.
 
     Args:
@@ -787,11 +803,12 @@ class ExponentialLR(LRScheduler):
 
     def __init__(
         self, optimizer: Optimizer, gamma: float, last_epoch=-1, verbose="deprecated"
-    ):
+    ):  # noqa: D107
         self.gamma = gamma
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0:
@@ -803,9 +820,10 @@ class ExponentialLR(LRScheduler):
 
 
 class SequentialLR(LRScheduler):
-    """Receives the list of schedulers that is expected to be called sequentially during
-    optimization process and milestone points that provides exact intervals to reflect
-    which scheduler is supposed to be called at a given epoch.
+    """Contains a list of schedulers expected to be called sequentially during the optimization process.
+
+    Specifically, the schedulers will be called according to the milestone points, which should provide exact
+    intervals by which each scheduler should be called at a given epoch.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -842,7 +860,7 @@ class SequentialLR(LRScheduler):
         milestones: List[int],
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if len(schedulers) < 1:
             raise ValueError(
                 f"{self.__class__.__name__} expects at least one scheduler, but got no scheduler."
@@ -892,6 +910,7 @@ class SequentialLR(LRScheduler):
         self._last_lr = schedulers[0].get_last_lr()
 
     def step(self):
+        """Perform a step."""
         self.last_epoch += 1
         idx = bisect_right(self._milestones, self.last_epoch)
         scheduler = self._schedulers[idx]
@@ -903,7 +922,7 @@ class SequentialLR(LRScheduler):
         self._last_lr = scheduler.get_last_lr()
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -922,7 +941,7 @@ class SequentialLR(LRScheduler):
         return state_dict
 
     def load_state_dict(self, state_dict):
-        """Loads the schedulers state.
+        """Load the scheduler's state.
 
         Args:
             state_dict (dict): scheduler state. Should be an object returned
@@ -939,8 +958,9 @@ class SequentialLR(LRScheduler):
 
 
 class PolynomialLR(LRScheduler):
-    """Decays the learning rate of each parameter group using a polynomial function
-    in the given total_iters. When last_epoch=-1, sets initial lr as lr.
+    """Decays the learning rate of each parameter group using a polynomial function in the given total_iters.
+
+    When last_epoch=-1, sets initial lr as lr.
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
@@ -975,12 +995,13 @@ class PolynomialLR(LRScheduler):
         power=1.0,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.total_iters = total_iters
         self.power = power
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the learning rate."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0 or self.last_epoch > self.total_iters:
@@ -1004,8 +1025,9 @@ class PolynomialLR(LRScheduler):
 
 
 class CosineAnnealingLR(LRScheduler):
-    r"""Set the learning rate of each parameter group using a cosine annealing
-    schedule, where :math:`\eta_{max}` is set to the initial lr and
+    r"""Set the learning rate of each parameter group using a cosine annealing schedule.
+
+    The :math:`\eta_{max}` is set to the initial lr and
     :math:`T_{cur}` is the number of epochs since the last restart in SGDR:
 
     .. math::
@@ -1054,12 +1076,13 @@ class CosineAnnealingLR(LRScheduler):
         eta_min=0,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         self.T_max = T_max
         self.eta_min = eta_min
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Retrieve the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         if self.last_epoch == 0:
@@ -1097,9 +1120,10 @@ class CosineAnnealingLR(LRScheduler):
 
 
 class ChainedScheduler(LRScheduler):
-    """Chains list of learning rate schedulers. It takes a sequence of chainable learning
-    rate schedulers and performs consecutive step() functions belonging to them by just
-    one call.
+    """Chains a list of learning rate schedulers.
+
+    Takes in a sequence of chainable learning rate schedulers and calls their
+    step() functions consecutively in just one call to step().
 
     Args:
         schedulers (sequence): sequence of chained schedulers.
@@ -1124,7 +1148,7 @@ class ChainedScheduler(LRScheduler):
 
     def __init__(
         self, schedulers: Sequence[LRScheduler], optimizer: Optional[Optimizer] = None
-    ):
+    ):  # noqa: D107
         if len(schedulers) < 1:
             raise ValueError(
                 f"{self.__class__.__name__} expects at least one scheduler to be chained, but got no scheduler."
@@ -1155,6 +1179,7 @@ class ChainedScheduler(LRScheduler):
         ]
 
     def step(self):
+        """Perform a step."""
         for scheduler in self._schedulers:
             scheduler.step()
         self._last_lr = [
@@ -1162,7 +1187,7 @@ class ChainedScheduler(LRScheduler):
         ]
 
     def state_dict(self):
-        """Returns the state of the scheduler as a :class:`dict`.
+        """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in self.__dict__ which
         is not the optimizer.
@@ -1181,7 +1206,7 @@ class ChainedScheduler(LRScheduler):
         return state_dict
 
     def load_state_dict(self, state_dict):
-        """Loads the schedulers state.
+        """Load the scheduler's state.
 
         Args:
             state_dict (dict): scheduler state. Should be an object returned
@@ -1199,6 +1224,7 @@ class ChainedScheduler(LRScheduler):
 
 class ReduceLROnPlateau(LRScheduler):
     """Reduce learning rate when a metric has stopped improving.
+
     Models often benefit from reducing the learning rate by a factor
     of 2-10 once learning stagnates. This scheduler reads a metrics
     quantity and if no improvement is seen for a 'patience' number
@@ -1269,7 +1295,7 @@ class ReduceLROnPlateau(LRScheduler):
         min_lr: Union[List[float], float] = 0,
         eps=1e-8,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if factor >= 1.0:
             raise ValueError("Factor should be < 1.0.")
         self.factor = factor
@@ -1308,12 +1334,13 @@ class ReduceLROnPlateau(LRScheduler):
         self._reset()
 
     def _reset(self):
-        """Resets num_bad_epochs counter and cooldown counter."""
+        """Reset num_bad_epochs counter and cooldown counter."""
         self.best = self.mode_worse
         self.cooldown_counter = 0
         self.num_bad_epochs = 0
 
     def step(self, metrics: SupportsFloat, epoch=None):  # type: ignore[override]
+        """Perform a step."""
         # convert `metrics` to float, in case it's a zero-dim Tensor
         current = float(metrics)
         if epoch is None:
@@ -1347,10 +1374,10 @@ class ReduceLROnPlateau(LRScheduler):
                 param_group["lr"] = new_lr
 
     @property
-    def in_cooldown(self):
+    def in_cooldown(self):  # noqa: D102
         return self.cooldown_counter > 0
 
-    def is_better(self, a, best):
+    def is_better(self, a, best):  # noqa: D102
         if self.mode == "min" and self.threshold_mode == "rel":
             rel_epsilon = 1.0 - self.threshold
             return a < best * rel_epsilon
@@ -1380,12 +1407,13 @@ class ReduceLROnPlateau(LRScheduler):
         self.threshold = threshold
         self.threshold_mode = threshold_mode
 
-    def state_dict(self):
+    def state_dict(self):  # noqa: D102
         return {
             key: value for key, value in self.__dict__.items() if key != "optimizer"
         }
 
     def load_state_dict(self, state_dict):
+        """Load the scheduler's state."""
         self.__dict__.update(state_dict)
         self._init_is_better(
             mode=self.mode, threshold=self.threshold, threshold_mode=self.threshold_mode
@@ -1393,10 +1421,10 @@ class ReduceLROnPlateau(LRScheduler):
 
 
 class CyclicLR(LRScheduler):
-    r"""Sets the learning rate of each parameter group according to
-    cyclical learning rate policy (CLR). The policy cycles the learning
-    rate between two boundaries with a constant frequency, as detailed in
-    the paper `Cyclical Learning Rates for Training Neural Networks`_.
+    r"""Sets the learning rate of each parameter group according to cyclical learning rate policy (CLR).
+
+    The policy cycles the learning rate between two boundaries with a constant frequency,
+    as detailed in the paper `Cyclical Learning Rates for Training Neural Networks`_.
     The distance between the two boundaries can be scaled on a per-iteration
     or per-cycle basis.
 
@@ -1507,7 +1535,7 @@ class CyclicLR(LRScheduler):
         max_momentum=0.9,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
@@ -1585,6 +1613,7 @@ class CyclicLR(LRScheduler):
             self.scale_mode = "iterations"
 
     def scale_fn(self, x) -> float:
+        """Get the scaling policy."""
         if self._scale_fn_custom is not None:
             return self._scale_fn_custom(x)
         else:
@@ -1603,13 +1632,13 @@ class CyclicLR(LRScheduler):
         return gamma**x
 
     def get_lr(self):
-        """Calculates the learning rate at batch index. This function treats
-        `self.last_epoch` as the last batch index.
+        """Calculate the learning rate at batch index.
+
+        This function treats `self.last_epoch` as the last batch index.
 
         If `self.cycle_momentum` is ``True``, this function has a side effect of
         updating the optimizer's momentum.
         """
-
         _warn_get_lr_called_within_step(self)
 
         cycle = math.floor(1 + self.last_epoch / self.total_size)
@@ -1649,7 +1678,7 @@ class CyclicLR(LRScheduler):
 
         return lrs
 
-    def state_dict(self):
+    def state_dict(self):  # noqa: D102
         state = super().state_dict()
         # We are dropping the `_scale_fn_ref` attribute because it is a
         # `weakref.WeakMethod` and can't be pickled.
@@ -1664,6 +1693,7 @@ class CyclicLR(LRScheduler):
         return state
 
     def load_state_dict(self, state_dict):
+        """Load the scheduler's state."""
         fn = state_dict.pop("_scale_fn_custom")
         super().load_state_dict(state_dict)
         if fn is not None:
@@ -1672,8 +1702,9 @@ class CyclicLR(LRScheduler):
 
 
 class CosineAnnealingWarmRestarts(LRScheduler):
-    r"""Set the learning rate of each parameter group using a cosine annealing
-    schedule, where :math:`\eta_{max}` is set to the initial lr, :math:`T_{cur}`
+    r"""Set the learning rate of each parameter group using a cosine annealing schedule.
+
+    The :math:`\eta_{max}` is set to the initial lr, :math:`T_{cur}`
     is the number of epochs since the last restart and :math:`T_{i}` is the number
     of epochs between two warm restarts in SGDR:
 
@@ -1712,7 +1743,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         eta_min=0,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         if T_0 <= 0 or not isinstance(T_0, int):
             raise ValueError(f"Expected positive integer T_0, but got {T_0}")
         if T_mult < 1 or not isinstance(T_mult, int):
@@ -1729,6 +1760,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
+        """Compute the initial learning rate."""
         _warn_get_lr_called_within_step(self)
 
         return [
@@ -1740,7 +1772,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         ]
 
     def step(self, epoch=None):
-        """Step could be called after every batch update
+        """Step could be called after every batch update.
 
         Example:
             >>> # xdoctest: +SKIP("Undefined vars")
@@ -1766,7 +1798,6 @@ class CosineAnnealingWarmRestarts(LRScheduler):
             >>> scheduler.step(26)
             >>> scheduler.step() # scheduler.step(27), instead of scheduler(20)
         """
-
         if epoch is None and self.last_epoch < 0:
             epoch = 0
 
@@ -1814,11 +1845,11 @@ class _SchedulePhase(TypedDict):
 
 
 class OneCycleLR(LRScheduler):
-    r"""Sets the learning rate of each parameter group according to the
-    1cycle learning rate policy. The 1cycle policy anneals the learning
-    rate from an initial learning rate to some maximum learning rate and then
-    from that maximum learning rate to some minimum learning rate much lower
-    than the initial learning rate.
+    r"""Sets the learning rate of each parameter group according to the 1cycle learning rate policy.
+
+    The 1cycle policy anneals the learning rate from an initial learning rate to some maximum
+    learning rate and then from that maximum learning rate to some minimum learning rate much
+    lower than the initial learning rate.
     This policy was initially described in the paper `Super-Convergence:
     Very Fast Training of Neural Networks Using Large Learning Rates`_.
 
@@ -1937,7 +1968,7 @@ class OneCycleLR(LRScheduler):
         three_phase=False,
         last_epoch=-1,
         verbose="deprecated",
-    ):
+    ):  # noqa: D107
         # Validate optimizer
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
@@ -2068,16 +2099,17 @@ class OneCycleLR(LRScheduler):
 
     @staticmethod
     def _annealing_cos(start, end, pct):
-        "Cosine anneal from `start` to `end` as pct goes from 0.0 to 1.0."
+        """Cosine anneal from `start` to `end` as pct goes from 0.0 to 1.0."""
         cos_out = math.cos(math.pi * pct) + 1
         return end + (start - end) / 2.0 * cos_out
 
     @staticmethod
     def _annealing_linear(start, end, pct):
-        "Linearly anneal from `start` to `end` as pct goes from 0.0 to 1.0."
+        """Linearly anneal from `start` to `end` as pct goes from 0.0 to 1.0."""
         return (end - start) * pct + start
 
     def get_lr(self):
+        """Compute the learning rate of each parameter group."""
         _warn_get_lr_called_within_step(self)
 
         lrs = []


### PR DESCRIPTION
Fix docstrings in Learning Rate Scheduler.

The fix can be verified by running pydocstyle path-to-file --count

Related #112593

**BEFORE the PR:**
pydocstyle torch/optim/lr_scheduler.py --count 
92 

**AFTER the PR:**
pydocstyle torch/optim/lr_scheduler.py --count 
0

cc @svekars @brycebortree