### PR TITLE
Fix typo when using _check_tensor_list

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2335,7 +2335,7 @@ def all_reduce_coalesced(tensors, op=ReduceOp.SUM, group=None, async_op=False):
     """
     if isinstance(tensors, torch.Tensor):
         tensors = [tensors]
-    _check_tensor_list(tensors, "tensor")
+    _check_tensor_list(tensors, "tensors")
     _ensure_all_tensors_same_dtype(tensors)
     if _rank_not_in_group(group):
         _warn_not_in_group("all_reduce_coalesced")


### PR DESCRIPTION
`_check_tensor_list` is a helper function to check that the parameter ``param_name`` is a list of tensors. If `param` is not a list, it will raise a RuntimeError with ``param_name``. To better indicate to the user where the error occurred, we should keep `param_name` aligned with the variable name of `param`.

We can see that in other uses of `_check_tensor_list` (such as `all_gather` and `scatter`), `param_name` was kept aligned with the variable name of `param` while `all_reduce_coalesced` not. So I fix this.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang