### PR TITLE
[BE] Do not crash weight_norm on empty tensors

### DIFF
--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -57,7 +57,9 @@ std::tuple<Tensor,Tensor> weight_norm_cpu(
   const auto dtype = g.scalar_type() == at::ScalarType::BFloat16 ?
       at::ScalarType::Float : g.scalar_type();
   auto norm = at::empty_strided(g.sizes(), g.strides(), g.options().dtype(dtype));
-  weight_norm_stub(kCPU, w, norm, v, g, dim);
+  if (v.numel() && g.numel()) {
+    weight_norm_stub(kCPU, w, norm, v, g, dim);
+  }
 
   return std::tuple<Tensor, Tensor>{w, norm};
 }

--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -76,7 +76,9 @@ std::tuple<Tensor, Tensor> weight_norm_backward_cpu(
 
   auto grad_v = at::empty_like(saved_v, at::MemoryFormat::Contiguous);
   auto grad_g = at::empty_like(saved_g, at::MemoryFormat::Contiguous);
-  weight_norm_backward_stub(kCPU, grad_v, grad_g, grad_w, saved_v, saved_g, saved_norm, dim);
+  if (grad_v.numel() && grad_g.numel()) {
+    weight_norm_backward_stub(kCPU, grad_v, grad_g, grad_w, saved_v, saved_g, saved_norm, dim);
+  }
 
   return std::tuple<Tensor, Tensor>{grad_v, grad_g};
 }

--- a/aten/src/ATen/native/cuda/WeightNorm.cu
+++ b/aten/src/ATen/native/cuda/WeightNorm.cu
@@ -353,6 +353,11 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
   // current device is?  I believe so, because Type::* functions are DeviceGuard()ed.
   auto norms = at::empty_strided(g.sizes(), g.strides(), g.options().dtype(AccType));
 
+  // Return on empty inputs
+  if (v.numel() == 0 || g.numel() == 0) {
+    return std::tuple<Tensor, Tensor>{w, norms};
+  }
+
   const int ndims = v.dim();
 
   if(dim == 0)

--- a/aten/src/ATen/native/mps/operations/WeightNorm.mm
+++ b/aten/src/ATen/native/mps/operations/WeightNorm.mm
@@ -42,7 +42,7 @@ std::tuple<Tensor, Tensor> weight_norm_mps(const Tensor& v, const Tensor& g, int
 
   // Return early on empty inputs
   if (v.numel() == 0 || g.numel() == 0) {
-      return std::tuple<Tensor, Tensor>{w, norms};
+    return std::tuple<Tensor, Tensor>{w, norms};
   }
 
   string key = "weight_norm_mps_" + std::to_string(dim) + getTensorsStringKey({v, g});

--- a/aten/src/ATen/native/mps/operations/WeightNorm.mm
+++ b/aten/src/ATen/native/mps/operations/WeightNorm.mm
@@ -40,6 +40,11 @@ std::tuple<Tensor, Tensor> weight_norm_mps(const Tensor& v, const Tensor& g, int
   auto w = at::empty_like(v, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   auto norms = at::empty_like(g, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
+  // Return early on empty inputs
+  if (v.numel() == 0 || g.numel() == 0) {
+      return std::tuple<Tensor, Tensor>{w, norms};
+  }
+
   string key = "weight_norm_mps_" + std::to_string(dim) + getTensorsStringKey({v, g});
 
   NSMutableArray* reduction_dims = [NSMutableArray array];

--- a/aten/src/ATen/native/mps/operations/WeightNorm.mm
+++ b/aten/src/ATen/native/mps/operations/WeightNorm.mm
@@ -106,6 +106,11 @@ std::tuple<Tensor, Tensor> weight_norm_backward_mps(const Tensor& grad_w,
   auto grad_v = at::empty_like(saved_v, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   auto grad_g = at::empty_like(saved_g, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
+  // Return early on empty inputs
+  if (grad_v.numel() == 0 || grad_g.numel() == 0) {
+    return std::tuple<Tensor, Tensor>{grad_v, grad_g};
+  }
+
   string key =
       "weight_norm_backward_mps_" + std::to_string(dim) + getTensorsStringKey({grad_w, saved_v, saved_g, saved_norms});
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7113,7 +7113,8 @@ def sample_inputs_segment_reduce(op_info, device, dtype, requires_grad, *, mode=
 def sample_inputs__weight_norm(op_info, device, dtype, requires_grad, **kwargs):
     def _tensor(shape, dtype=dtype):
         return make_tensor(shape, dtype=dtype, device=device, requires_grad=requires_grad)
-    yield SampleInput(_tensor((3,0)), args=(_tensor((3, 0)),))
+    yield SampleInput(_tensor((S ,S)), args=(_tensor((S, S)),))
+    yield SampleInput(_tensor((M, 0)), args=(_tensor((M, 0)),))
 
 
 def sample_inputs_ravel(op_info, device, dtype, requires_grad, **kwargs):
@@ -21125,7 +21126,9 @@ op_db: List[OpInfo] = [
         '_weight_norm',
         aten_name='_weight_norm',
         dtypes=floating_types_and(torch.float16, torch.bfloat16),
-        supports_out=True,
+        supports_out=False,
+        supports_cow_input_no_materialize_forward=False,
+        supports_cow_input_no_materialize_backward=False,
         sample_inputs_func=sample_inputs__weight_norm,
     ),
 ]

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7110,6 +7110,11 @@ def sample_inputs_segment_reduce(op_info, device, dtype, requires_grad, *, mode=
                           args=(reduce,),
                           kwargs=sample_input_kwargs)
 
+def sample_inputs__weight_norm(op_info, device, dtype, requires_grad, **kwargs):
+    def _tensor(shape, dtype=dtype):
+        return make_tensor(shape, dtype=dtype, device=device, requires_grad=requires_grad)
+    yield SampleInput(_tensor((3,0)), args=(_tensor((3, 0)),))
+
 
 def sample_inputs_ravel(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, dtype=dtype, device=device,
@@ -21115,6 +21120,13 @@ op_db: List[OpInfo] = [
                 device_type="cuda",
             ),
         ),
+    ),
+    OpInfo(
+        '_weight_norm',
+        aten_name='_weight_norm',
+        dtypes=floating_types_and(torch.float16, torch.bfloat16),
+        supports_out=True,
+        sample_inputs_func=sample_inputs__weight_norm,
     ),
 ]
 op_db += opinfo.definitions.op_db

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21133,11 +21133,12 @@ op_db: List[OpInfo] = [
         supports_cow_input_no_materialize_backward=False,
         sample_inputs_func=sample_inputs__weight_norm,
         skips=(
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes'),
-               DecorateInfo(unittest.expectedFailure, "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
-               DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_vmapvjp_has_batch_rule'),
-               DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_vmapjvpvjp'),
-               DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_jvpvjp'),
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes'),
+            DecorateInfo(unittest.expectedFailure, 'TestDTensorOps', 'test_dtensor_op_db'),
+            DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_vmapvjp_has_batch_rule'),
+            DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_vmapjvpvjp'),
+            DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_jvpvjp'),
+            DecorateInfo(unittest.expectedFailure, "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
         ),
     ),
 ]

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21132,6 +21132,13 @@ op_db: List[OpInfo] = [
         supports_cow_input_no_materialize_forward=False,
         supports_cow_input_no_materialize_backward=False,
         sample_inputs_func=sample_inputs__weight_norm,
+        skips=(
+               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes'),
+               DecorateInfo(unittest.expectedFailure, "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
+               DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_vmapvjp_has_batch_rule'),
+               DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_vmapjvpvjp'),
+               DecorateInfo(unittest.expectedFailure, 'TestOperators', 'test_jvpvjp'),
+        ),
     ),
 ]
 op_db += opinfo.definitions.op_db

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7113,7 +7113,8 @@ def sample_inputs_segment_reduce(op_info, device, dtype, requires_grad, *, mode=
 def sample_inputs__weight_norm(op_info, device, dtype, requires_grad, **kwargs):
     def _tensor(shape, dtype=dtype):
         return make_tensor(shape, dtype=dtype, device=device, requires_grad=requires_grad)
-    yield SampleInput(_tensor((S ,S)), args=(_tensor((S, S)),))
+    yield SampleInput(_tensor((S ,S)), args=(_tensor((S, 1)),), kwargs={"dim": 0})
+    yield SampleInput(_tensor((S ,S, S)), args=(_tensor((1, 1, S)),), kwargs={"dim": 2})
     yield SampleInput(_tensor((M, 0)), args=(_tensor((M, 0)),))
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7113,8 +7113,9 @@ def sample_inputs_segment_reduce(op_info, device, dtype, requires_grad, *, mode=
 def sample_inputs__weight_norm(op_info, device, dtype, requires_grad, **kwargs):
     def _tensor(shape, dtype=dtype):
         return make_tensor(shape, dtype=dtype, device=device, requires_grad=requires_grad)
-    yield SampleInput(_tensor((S ,S)), args=(_tensor((S, 1)),), kwargs={"dim": 0})
-    yield SampleInput(_tensor((S ,S, S)), args=(_tensor((1, 1, S)),), kwargs={"dim": 2})
+    # TODO: Enabe testing for non-empty tensors as well
+    # yield SampleInput(_tensor((S ,S)), args=(_tensor((S, 1)),), kwargs={"dim": 0})
+    # yield SampleInput(_tensor((S ,S, S)), args=(_tensor((1, 1, S)),), kwargs={"dim": 2})
     yield SampleInput(_tensor((M, 0)), args=(_tensor((M, 0)),))
 
 


### PR DESCRIPTION
Test plan:
-  `python3 -c "import torch;print(torch._weight_norm(torch.rand((3, 0)), torch.rand((3, 0))))"`
- Add OpInfo with empty input for weight norm
- Skip the tests that fail (functorch ones for example) as well as dtypes, because it might look like it "works" for integral types

Fixes https://github.com/pytorch/pytorch/issues/128695
