### PR TITLE
fix the decomposition of aten.threshold

### DIFF
--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -876,7 +876,8 @@ def threshold(
     if inplace:
         raise NotImplementedError
 
-    return torch.where(a <= threshold, value, a)
+    python_type = utils.dtype_to_type(a.dtype)
+    return torch.where(a <= python_type(threshold), value, a)
 
 
 # CompositeImplicitAutograd - don't register decomp

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3353,6 +3353,9 @@ def sample_inputs_threshold(op_info, device, dtype, requires_grad, **kwargs):
     for x_size in sizes:
         # threshold and values args must be numbers
         yield SampleInput(make_arg(x_size), make_arg(()).item(), make_arg(()).item())
+    # additional test case for integral inputs
+    if dtype in integral_types() and dtype is not torch.uint8:
+        yield SampleInput(make_arg(x_size), -1.5, make_arg(()).item())
 
 def sample_inputs_unique(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)


### PR DESCRIPTION
Fixes #118642
fix the decomposition of `aten.threshold` to make its output consistent with eager mode when `input tensor` is intergral and `threshold` is a negative float.
