### PR TITLE
[GHF] Refuse merge to non-default branch

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -180,6 +180,9 @@ def mock_gh_get_info() -> Any:
     return {
         "closed": False,
         "isCrossRepository": False,
+        "headRefName": "foo",
+        "baseRefName": "bar",
+        "baseRepository": {"defaultBranchRef": { "name": "bar"}},
         "files": {"nodes": [], "pageInfo": {"hasNextPage": False}},
         "changedFiles": 0,
     }

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -182,7 +182,7 @@ def mock_gh_get_info() -> Any:
         "isCrossRepository": False,
         "headRefName": "foo",
         "baseRefName": "bar",
-        "baseRepository": {"defaultBranchRef": { "name": "bar"}},
+        "baseRepository": {"defaultBranchRef": {"name": "bar"}},
         "files": {"nodes": [], "pageInfo": {"hasNextPage": False}},
         "changedFiles": 0,
     }

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2335,7 +2335,7 @@ def main() -> None:
             org,
             project,
             args.pr_num,
-            f"PR targets {pr.base_ref()} rather than {pr.default_branch(), refusing merge request",
+            f"PR targets {pr.base_ref()} rather than {pr.default_branch()}, refusing merge request",
             dry_run=args.dry_run,
         )
         return

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -2330,6 +2330,15 @@ def main() -> None:
             dry_run=args.dry_run,
         )
         return
+    if not pr.is_ghstack_pr() and pr.base_ref() != pr.default_branch():
+        gh_post_pr_comment(
+            org,
+            project,
+            args.pr_num,
+            f"PR targets {pr.base_ref()} rather than {pr.default_branch(), refusing merge request",
+            dry_run=args.dry_run,
+        )
+        return
 
     if args.check_mergeability:
         if pr.is_ghstack_pr():


### PR DESCRIPTION
Unless PR is ghstack one

Test plan: 
```
% GITHUB_TOKEN=$(gh auth token)  python3 -c "from trymerge import GitHubPR; pr=GitHubPR('pytorch', 'pytorch', 128591); print(pr.base_ref(), pr.default_branch())"
release/2.4 main
```
Fixes: https://github.com/pytorch/test-infra/issues/5339
