### PR TITLE
Fix Storage.filename to not track the filename when storage was mmap-ed with MAP_PRIVATE

### DIFF
--- a/aten/src/ATen/MapAllocator.h
+++ b/aten/src/ATen/MapAllocator.h
@@ -55,6 +55,10 @@ class TORCH_API MapAllocator {
     return base_ptr_;
   }
 
+  int flags() const {
+    return flags_;
+  }
+
   static MapAllocator* fromDataPtr(const at::DataPtr&);
   static at::DataPtr makeDataPtr(
       c10::string_view filename,

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3177,18 +3177,19 @@ class TestTensorCreation(TestCase):
         dtype = torch.float64
         t = torch.randn(2, 5, dtype=dtype, device=device)
         with tempfile.NamedTemporaryFile() as f:
+            expected_filename = f.name if shared else None
             t.numpy().tofile(f)
             t_mapped = torch.from_file(f.name, shared=shared, size=t.numel(), dtype=dtype)
-            self.assertTrue(t_mapped.storage().filename == f.name)
+            self.assertTrue(t_mapped.untyped_storage().filename == expected_filename)
             self.assertEqual(torch.flatten(t), t_mapped)
 
             s = torch.UntypedStorage.from_file(f.name, shared, t.numel() * dtype.itemsize)
-            self.assertTrue(s.filename == f.name)
+            self.assertTrue(s.filename == expected_filename)
 
     @onlyCPU
     def test_storage_filename(self, device):
         t = torch.randn(2, 5, device=device)
-        self.assertIsNone(t.storage().filename)
+        self.assertIsNone(t.untyped_storage().filename)
 
 
 # Class for testing random tensor creation ops, like torch.randint

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -624,7 +624,8 @@ static PyObject* THPStorage__get_filename(PyObject* self, PyObject* noargs) {
   const c10::DataPtr& data_ptr = self_.data_ptr();
   at::MapAllocator* map_allocator = at::MapAllocator::fromDataPtr(data_ptr);
 
-  if (map_allocator == nullptr) {
+  if (map_allocator == nullptr ||
+      !(map_allocator->flags() & at::ALLOCATOR_MAPPED_SHARED)) {
     Py_RETURN_NONE;
   }
   std::string filename = map_allocator->filename();

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -363,8 +363,10 @@ class UntypedStorage(torch._C.StorageBase, _StorageBase):
 
     @property
     def filename(self) -> _Optional[str]:
-        """Returns the file name associated with this storage if the storage was memory mapped from a file.
-           or ``None`` if the storage was not created by memory mapping a file."""
+        """Returns the file name associated with this storage.
+
+        The file name will be a string if the storage is on CPU and was either created
+        via :meth:`~torch.from_file()` with ``shared`` as ``True``. This attribute is ``None`` otherwise."""
         return self._get_filename()
 
     @_share_memory_lock_protected

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -365,8 +365,8 @@ class UntypedStorage(torch._C.StorageBase, _StorageBase):
     def filename(self) -> _Optional[str]:
         """Returns the file name associated with this storage.
 
-        The file name will be a string if the storage is on CPU and was either created
-        via :meth:`~torch.from_file()` with ``shared`` as ``True``. This attribute is ``None`` otherwise."""
+        The file name will be a string if the storage is on CPU and was created via
+        :meth:`~torch.from_file()` with ``shared`` as ``True``. This attribute is ``None`` otherwise."""
         return self._get_filename()
 
     @_share_memory_lock_protected


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128725



cc @albanD