### PR TITLE
[CUDA][Convolution] Add missing launch bounds to `vol2col_kernel`

### DIFF
--- a/aten/src/ATen/native/cuda/vol2col.cuh
+++ b/aten/src/ATen/native/cuda/vol2col.cuh
@@ -14,6 +14,7 @@ using namespace at::cuda::detail;
 
 // Kernel for fast unfold+copy on volumes
 template <typename T>
+C10_LAUNCH_BOUNDS_1(1024)
 __global__ void vol2col_kernel(
     const int64_t n,
     const T* data_vol,


### PR DESCRIPTION
Fix "too many resources requested" that can happen with recent toolkits on V100.

cc @ptrblck @msaroufim