### PR TITLE
Kineto profiler: collecting observer traces from C++ child threads

### DIFF
--- a/test/profiler/test_cpp_thread.cpp
+++ b/test/profiler/test_cpp_thread.cpp
@@ -1,0 +1,109 @@
+
+#include <torch/csrc/autograd/profiler_kineto.h>
+#include <torch/torch.h>
+#include <string>
+
+using namespace torch::autograd::profiler;
+
+void blueprint(const std::string& text) {
+  printf("\33[94m%s\33[0m\n", text.c_str());
+}
+
+/**
+ * We're emulating a C++ training engine calling into Python to allow Python
+ * code controlling how profiling should be done.
+ */
+class ProfilerEventHandler
+    : public std::enable_shared_from_this<ProfilerEventHandler> {
+ public:
+  static std::shared_ptr<ProfilerEventHandler> Handler;
+  static void Register(const std::shared_ptr<ProfilerEventHandler>& handler) {
+    Handler = handler;
+  }
+
+ public:
+  virtual ~ProfilerEventHandler() {}
+  virtual void onIterationStart(int) {}
+  virtual void emulateTraining(int, int) {}
+};
+std::shared_ptr<ProfilerEventHandler> ProfilerEventHandler::Handler;
+
+class ProfilerEventHandlerTrampoline : public ProfilerEventHandler {
+ public:
+  virtual void onIterationStart(int iteration) override {
+    PYBIND11_OVERRIDE(void, ProfilerEventHandler, onIterationStart, iteration);
+  }
+  virtual void emulateTraining(int iteration, int thread_id) override {
+    PYBIND11_OVERRIDE(
+        void, ProfilerEventHandler, emulateTraining, iteration, thread_id);
+  }
+};
+
+/**
+ * This is the entry point for the C++ training engine.
+ */
+void start_threads(int thread_count, int iteration_count, bool attach) {
+  blueprint("start_cpp_threads called");
+
+  static std::atomic<int> barrier = 0;
+  barrier = 0;
+  thread_local bool enabled_in_main_thread = false;
+
+  std::vector<std::thread> threads;
+  for (int id = 0; id < thread_count; id++) {
+    blueprint("starting thread " + std::to_string(id));
+    threads.emplace_back([thread_count, iteration_count, id, attach]() {
+      for (int iteration = 0; iteration < iteration_count; iteration++) {
+        if (id == 0) {
+          ProfilerEventHandler::Handler->onIterationStart(iteration);
+        }
+
+        // this barrier makes sure all child threads will be turned on
+        // with profiling when main thread is enabled
+        ++barrier;
+        while (barrier % thread_count) {
+          std::this_thread::yield();
+        }
+
+        if (id > 0 && attach) {
+          bool enabled = isProfilerEnabledInMainThread();
+          if (enabled != enabled_in_main_thread) {
+            if (enabled) {
+              enableProfilerInChildThread();
+            } else {
+              disableProfilerInChildThread();
+            }
+            enabled_in_main_thread = enabled;
+          }
+        }
+
+        ProfilerEventHandler::Handler->emulateTraining(iteration, id);
+      }
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+PYBIND11_MODULE(profiler_test_cpp_thread_lib, m) {
+  py::class_<
+      ProfilerEventHandler,
+      ProfilerEventHandlerTrampoline,
+      std::shared_ptr<ProfilerEventHandler>>(m, "ProfilerEventHandler")
+      .def(py::init<>())
+      .def_static("Register", &ProfilerEventHandler::Register)
+      .def(
+          "onIterationStart",
+          &ProfilerEventHandler::onIterationStart,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
+          "emulateTraining",
+          &ProfilerEventHandler::emulateTraining,
+          py::call_guard<py::gil_scoped_release>());
+
+  m.def(
+      "start_threads",
+      &start_threads,
+      py::call_guard<py::gil_scoped_release>());
+};

--- a/test/profiler/test_cpp_thread.py
+++ b/test/profiler/test_cpp_thread.py
@@ -1,0 +1,206 @@
+# Owner(s): ["oncall: profiler"]
+
+import os
+import shutil
+import subprocess
+
+import torch
+import torch.utils.cpp_extension
+from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
+
+
+def remove_build_path():
+    default_build_root = torch.utils.cpp_extension.get_default_build_root()
+    if os.path.exists(default_build_root):
+        if IS_WINDOWS:
+            # rmtree returns permission error: [WinError 5] Access is denied
+            # on Windows, this is a word-around
+            subprocess.run(["rm", "-rf", default_build_root], stdout=subprocess.PIPE)
+        else:
+            shutil.rmtree(default_build_root)
+
+
+def is_fbcode():
+    return not hasattr(torch.version, "git_version")
+
+
+if is_fbcode():
+    import caffe2.test.profiler_test_cpp_thread_lib as cpp
+else:
+    # cpp extensions use relative paths. Those paths are relative to
+    # this file, so we'll change the working directory temporarily
+    old_working_dir = os.getcwd()
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    cpp = torch.utils.cpp_extension.load(
+        name="profiler_test_cpp_thread_lib",
+        sources=[
+            "test_cpp_thread.cpp",
+        ],
+        verbose=True,
+    )
+
+    # return the working directory (see setUp)
+    os.chdir(old_working_dir)
+
+
+KinetoProfiler = None
+IterationCount = 5
+ActivateIteration = 2
+
+
+def blueprint(text):
+    print(f"\33[34m{text}\33[0m")
+
+
+# onIterationStart() will be called by C++ training engine in cpp_thread_test_lib.cpp
+class PythonProfilerEventHandler(cpp.ProfilerEventHandler):
+    def onIterationStart(self, iteration: int) -> None:
+        global KinetoProfiler, IterationCount
+        # it is important to start the profiler on the same thread that step() is called
+        # and yes, onIterationStart() will always be called on the same thread
+        if iteration == 0:
+            # this also means step() starts on iteration 1, not 0
+            KinetoProfiler.start()
+            blueprint("starting kineto profiler")
+        elif iteration == IterationCount - 1:
+            KinetoProfiler.stop()
+            blueprint("stopping kineto profiler")
+        else:
+            blueprint("stepping kineto profiler")
+            KinetoProfiler.step()
+
+    def emulateTraining(self, iteration: int, thread_id: int) -> None:
+        # blueprint(f"training iteration {iteration} in thread {thread_id}")
+        device = torch.device("cuda")
+        # device = torch.device("cpu")
+        with torch.autograd.profiler.record_function("user_function"):
+            a = torch.ones(1, device=device)
+            b = torch.ones(1, device=device)
+            torch.add(a, b).cpu()
+            torch.cuda.synchronize()
+
+
+class CppThreadTest(TestCase):
+    ThreadCount = 20  # set to 2 for debugging
+    EventHandler = None
+    TraceObject = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(TestCase, cls).setUpClass()
+        CppThreadTest.EventHandler = PythonProfilerEventHandler()
+        cpp.ProfilerEventHandler.Register(CppThreadTest.EventHandler)
+
+    @classmethod
+    def tearDownClass(cls):
+        if not is_fbcode():
+            remove_build_path()
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("Test machine does not have cuda")
+
+        # this clears off events from initialization
+        self.start_profiler(False)
+        cpp.start_threads(1, IterationCount, False)
+
+    def start_profiler(self, profile_memory):
+        global KinetoProfiler
+        KinetoProfiler = torch.profiler.profile(
+            schedule=torch.profiler.schedule(
+                wait=1, warmup=1, active=ActivateIteration, repeat=1
+            ),
+            on_trace_ready=self.set_trace,
+            with_stack=True,
+            profile_memory=profile_memory,
+            record_shapes=True,
+        )
+
+    def set_trace(self, trace_obj) -> None:
+        CppThreadTest.TraceObject = trace_obj
+
+    def assert_text(self, condition, text, msg):
+        if condition:
+            print(f"\33[32m{text}\33[0m")
+        else:
+            print(f"\33[31m{text}\33[0m")
+        self.assertTrue(condition, msg)
+
+    def check_trace(self, expected, mem=False) -> None:
+        blueprint("verifying trace")
+        event_list = CppThreadTest.TraceObject.events()
+        for key, values in expected.items():
+            count = values[0]
+            min_count = count * (ActivateIteration - 1)
+            device = values[1]
+            filtered = filter(
+                lambda ev: ev.name == key
+                and str(ev.device_type) == f"DeviceType.{device}",
+                event_list,
+            )
+
+            if mem:
+                actual = 0
+                for ev in filtered:
+                    sev = str(ev)
+                    has_cuda_memory_usage = (
+                        sev.find("cuda_memory_usage=0 ") < 0
+                        and sev.find("cuda_memory_usage=") > 0
+                    )
+                    if has_cuda_memory_usage:
+                        actual += 1
+                self.assert_text(
+                    actual >= min_count,
+                    f"{key}: {actual} >= {min_count}",
+                    "not enough event with cuda_memory_usage set",
+                )
+            else:
+                actual = len(list(filtered))
+                if count == 1:  # test_without
+                    count *= ActivateIteration
+                    self.assert_text(
+                        actual == count,
+                        f"{key}: {actual} == {count}",
+                        "baseline event count incorrect",
+                    )
+                else:
+                    self.assert_text(
+                        actual >= min_count,
+                        f"{key}: {actual} >= {min_count}",
+                        "not enough event recorded",
+                    )
+
+    def test_with_enable_profiler_in_child_thread(self) -> None:
+        self.start_profiler(False)
+        cpp.start_threads(self.ThreadCount, IterationCount, True)
+        self.check_trace(
+            {
+                "aten::add": [self.ThreadCount, "CPU"],
+                "user_function": [self.ThreadCount, "CUDA"],
+            }
+        )
+
+    def test_without_enable_profiler_in_child_thread(self) -> None:
+        self.start_profiler(False)
+        cpp.start_threads(self.ThreadCount, IterationCount, False)
+        self.check_trace(
+            {
+                "aten::add": [1, "CPU"],
+                "user_function": [1, "CUDA"],
+            }
+        )
+
+    def test_profile_memory(self) -> None:
+        self.start_profiler(True)
+        cpp.start_threads(self.ThreadCount, IterationCount, True)
+        self.check_trace(
+            {
+                "aten::add": [self.ThreadCount, "CPU"],
+            },
+            mem=True,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -518,6 +518,12 @@ void pushProfilingCallbacks(const std::unordered_set<at::RecordScope>& scopes) {
   }
 }
 
+struct ProfilerStateInfo {
+  std::shared_ptr<KinetoThreadLocalState> state_ptr;
+  std::unordered_set<at::RecordScope> scopes;
+};
+std::shared_ptr<ProfilerStateInfo> profiler_state_info_ptr{nullptr};
+
 } // namespace
 
 void reportBackendEventToActiveKinetoProfiler(
@@ -650,8 +656,8 @@ void enableProfiler(
       has_cpu || !config.global(),
       "Ondemand profiling must enable CPU tracing");
 
-  KinetoThreadLocalState::push(
-      std::make_shared<KinetoThreadLocalState>(config, activities));
+  auto state_ptr = std::make_shared<KinetoThreadLocalState>(config, activities);
+  KinetoThreadLocalState::push(state_ptr);
 
   if (has_cpu) {
     config.global() ? pushProfilingCallbacks</*global=*/true>(scopes)
@@ -661,9 +667,42 @@ void enableProfiler(
   if (!config.global()) {
     torch::profiler::impl::kineto::startTrace();
   }
+
+  if (has_cpu) {
+    auto state_info_ptr = std::make_shared<ProfilerStateInfo>();
+    state_info_ptr->state_ptr = state_ptr;
+    state_info_ptr->scopes = scopes;
+    profiler_state_info_ptr = state_info_ptr;
+  }
+}
+
+bool isProfilerEnabledInMainThread() {
+  return profiler_state_info_ptr != nullptr;
+}
+
+void enableProfilerInChildThread() {
+  auto state_info_ptr = profiler_state_info_ptr;
+  TORCH_CHECK(state_info_ptr, "Profiler is not enabled in main thread.");
+  TORCH_CHECK(
+      KinetoThreadLocalState::get(/*global=*/false) == nullptr,
+      "Profiler is already enabled in this thread.");
+
+  KinetoThreadLocalState::push(state_info_ptr->state_ptr);
+  pushProfilingCallbacks</*global=*/false>(state_info_ptr->scopes);
+}
+
+void disableProfilerInChildThread() {
+  auto state_ptr = ProfilerStateBase::pop();
+  TORCH_CHECK(
+      state_ptr,
+      "Can't disable Kineto profiler when it's not running in this thread");
+  state_ptr->removeCallback();
 }
 
 std::unique_ptr<ProfilerResult> disableProfiler() {
+  // releasing to inform child threads to stop profiling
+  profiler_state_info_ptr = nullptr;
+
   auto state_ptr = ProfilerStateBase::pop();
   const auto& config = state_ptr->config();
   TORCH_CHECK(

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -177,6 +177,28 @@ TORCH_API void prepareProfiler(
     const torch::profiler::impl::ProfilerConfig& config,
     const std::set<torch::profiler::impl::ActivityType>& activities);
 
+/**
+ * When a C++ thread really has no control over how the profiler was enabled,
+ * for example, by some unreachable Python code, it can call these functions
+ * to test/join/unjoin itself into the collection set of a profiler, if any.
+ * Without calling these functions, the symptom may be "not seeing GPU events
+ * from some child C++ threads". This is an example on how to use them,
+ *
+ *    using namespace torch::autograd::profiler;
+ *    bool enabled = isProfilerEnabledInMainThread();
+ *    if (enabled != saved_enabled_state) {
+ *      if (enabled) {
+ *        enableProfilerInChildThread();
+ *      } else {
+ *        disableProfilerInChildThread();
+ *      }
+ *      saved_enabled_state = enabled;
+ *    }
+ */
+TORCH_API bool isProfilerEnabledInMainThread();
+TORCH_API void enableProfilerInChildThread();
+TORCH_API void disableProfilerInChildThread();
+
 } // namespace autograd::profiler
 
 namespace profiler::impl {


### PR DESCRIPTION
Summary:
In a C++ program, if we have child threads doing GPU work, it would be nice to get traces of those threads as well. The problem is, pushProfilingCallbacks() is not called on child threads, therefore, no observer traces are collected on these threads, entirely missing in the final output.

This diff provides a new API that a child thread may elect to call to register itself onto the profiler that was started in main thread (or whatever the Python thread that manages the profiler).

Test Plan:
```
buck2 test @mode/opt //caffe2/test:profiler_test_cpp_thread
```

Reviewed By: aaronenyeshi

Differential Revision: D56669942
