### PR TITLE
[TDB] Add function for getting new/removed tests

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -77,9 +77,15 @@ jobs:
           WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
           HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           echo "${WORKFLOW_URL}"
-          python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --head-branch "${HEAD_BRANCH}" --head-repository "${HEAD_REPOSITORY}"
+          python3 -m tools.stats.upload_test_stats \
+            --workflow-run-id "${WORKFLOW_RUN_ID}" \
+            --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" \
+            --head-branch "${HEAD_BRANCH}" \
+            --head-repository "${HEAD_REPOSITORY}" \
+            --head-sha "${WORKFLOW_HEAD_SHA}"
           python3 -m tools.stats.upload_sccache_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
 
       - name: Analyze disabled tests rerun

--- a/tools/stats/check_disabled_tests.py
+++ b/tools/stats/check_disabled_tests.py
@@ -9,10 +9,10 @@ from typing import Any, Dict, Generator, Tuple
 from tools.stats.upload_stats_lib import (
     download_s3_artifacts,
     is_rerun_disabled_tests,
+    process_xml_element,
     unzip,
     upload_workflow_stats_to_s3,
 )
-from tools.stats.upload_test_stats import process_xml_element
 
 TESTCASE_TAG = "testcase"
 SEPARATOR = ";"

--- a/tools/stats/test_dashboard.py
+++ b/tools/stats/test_dashboard.py
@@ -201,7 +201,6 @@ def get_new_removed_tests(
 def compare(
     job_summary: Dict[str, Any], base_job_summary: Dict[str, Any], base_job_id: int
 ) -> Dict[str, Any]:
-    # Compare the two summaries
     start = time.time()
     new, removed = get_new_removed_tests(job_summary, base_job_summary)
     print(f"Time taken to compare tests: {time.time() - start}")
@@ -246,18 +245,14 @@ def upload_wrapper(
 ) -> None:
     as_string = json.dumps(data)
     if len(as_string) > 1000000:
-        # data = [{"info": "Data too large to upload"}]
+        data = [{"info": "Data too large to upload"}]
         print("Data too large to upload")
-    print("uploaded")
-    with open("test/test-reports/" + name.replace("/", ".") + ".json", "w+") as f:
-        json.dump(data, f)
-    if False:
-        upload_workflow_stats_to_s3(
-            workflow_run_id,
-            workflow_run_attempt,
-            name,
-            [data],
-        )
+    upload_workflow_stats_to_s3(
+        workflow_run_id,
+        workflow_run_attempt,
+        name,
+        [data],
+    )
 
 
 def upload_additional_info(

--- a/tools/stats/test_dashboard.py
+++ b/tools/stats/test_dashboard.py
@@ -241,7 +241,11 @@ def get_base_id(sha: str, workflow_id: int) -> Optional[int]:
 
 
 def upload_wrapper(
-    workflow_run_id: int, workflow_run_attempt: int, name: str, data: Any, dry_run: bool = False
+    workflow_run_id: int,
+    workflow_run_attempt: int,
+    name: str,
+    data: Any,
+    dry_run: bool = False,
 ) -> None:
     as_string = json.dumps(data)
     if len(as_string) > 1000000:

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import sys
-import xml.etree.ElementTree as ET
 from multiprocessing import cpu_count, Pool
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -9,139 +8,10 @@ from typing import Any, Dict, List
 
 from tools.stats.test_dashboard import upload_additional_info
 from tools.stats.upload_stats_lib import (
-    download_s3_artifacts,
-    get_job_id,
-    unzip,
+    get_tests,
     upload_workflow_stats_to_s3,
+    parse_xml_report,
 )
-
-
-def parse_xml_report(
-    tag: str,
-    report: Path,
-    workflow_id: int,
-    workflow_run_attempt: int,
-) -> List[Dict[str, Any]]:
-    """Convert a test report xml file into a JSON-serializable list of test cases."""
-    print(f"Parsing {tag}s for test report: {report}")
-
-    job_id = get_job_id(report)
-    print(f"Found job id: {job_id}")
-
-    test_cases: List[Dict[str, Any]] = []
-
-    root = ET.parse(report)
-    for test_case in root.iter(tag):
-        case = process_xml_element(test_case)
-        case["workflow_id"] = workflow_id
-        case["workflow_run_attempt"] = workflow_run_attempt
-        case["job_id"] = job_id
-
-        # [invoking file]
-        # The name of the file that the test is located in is not necessarily
-        # the same as the name of the file that invoked the test.
-        # For example, `test_jit.py` calls into multiple other test files (e.g.
-        # jit/test_dce.py). For sharding/test selection purposes, we want to
-        # record the file that invoked the test.
-        #
-        # To do this, we leverage an implementation detail of how we write out
-        # tests (https://bit.ly/3ajEV1M), which is that reports are created
-        # under a folder with the same name as the invoking file.
-        case["invoking_file"] = report.parent.name
-        test_cases.append(case)
-
-    return test_cases
-
-
-def process_xml_element(element: ET.Element) -> Dict[str, Any]:
-    """Convert a test suite element into a JSON-serializable dict."""
-    ret: Dict[str, Any] = {}
-
-    # Convert attributes directly into dict elements.
-    # e.g.
-    #     <testcase name="test_foo" classname="test_bar"></testcase>
-    # becomes:
-    #     {"name": "test_foo", "classname": "test_bar"}
-    ret.update(element.attrib)
-
-    # The XML format encodes all values as strings. Convert to ints/floats if
-    # possible to make aggregation possible in Rockset.
-    for k, v in ret.items():
-        try:
-            ret[k] = int(v)
-        except ValueError:
-            pass
-        try:
-            ret[k] = float(v)
-        except ValueError:
-            pass
-
-    # Convert inner and outer text into special dict elements.
-    # e.g.
-    #     <testcase>my_inner_text</testcase> my_tail
-    # becomes:
-    #     {"text": "my_inner_text", "tail": " my_tail"}
-    if element.text and element.text.strip():
-        ret["text"] = element.text
-    if element.tail and element.tail.strip():
-        ret["tail"] = element.tail
-
-    # Convert child elements recursively, placing them at a key:
-    # e.g.
-    #     <testcase>
-    #       <foo>hello</foo>
-    #       <foo>world</foo>
-    #       <bar>another</bar>
-    #     </testcase>
-    # becomes
-    #    {
-    #       "foo": [{"text": "hello"}, {"text": "world"}],
-    #       "bar": {"text": "another"}
-    #    }
-    for child in element:
-        if child.tag not in ret:
-            ret[child.tag] = process_xml_element(child)
-        else:
-            # If there are multiple tags with the same name, they should be
-            # coalesced into a list.
-            if not isinstance(ret[child.tag], list):
-                ret[child.tag] = [ret[child.tag]]
-            ret[child.tag].append(process_xml_element(child))
-    return ret
-
-
-def get_tests(workflow_run_id: int, workflow_run_attempt: int) -> List[Dict[str, Any]]:
-    with TemporaryDirectory() as temp_dir:
-        print("Using temporary directory:", temp_dir)
-        os.chdir(temp_dir)
-
-        # Download and extract all the reports (both GHA and S3)
-        s3_paths = download_s3_artifacts(
-            "test-report", workflow_run_id, workflow_run_attempt
-        )
-        for path in s3_paths:
-            unzip(path)
-
-        # Parse the reports and transform them to JSON
-        test_cases = []
-        mp = Pool(cpu_count())
-        for xml_report in Path(".").glob("**/*.xml"):
-            test_cases.append(
-                mp.apply_async(
-                    parse_xml_report,
-                    args=(
-                        "testcase",
-                        xml_report,
-                        workflow_run_id,
-                        workflow_run_attempt,
-                    ),
-                )
-            )
-        mp.close()
-        mp.join()
-        test_cases = [tc.get() for tc in test_cases]
-        flattened = [item for sublist in test_cases for item in sublist]
-        return flattened
 
 
 def get_tests_for_circleci(
@@ -242,6 +112,11 @@ if __name__ == "__main__":
         action="store_true",
         help="If this is being run through circleci",
     )
+    parser.add_argument(
+        "--head-sha",
+        required=False,
+        help="Head sha of the workflow",
+    )
     args = parser.parse_args()
 
     print(f"Workflow id is: {args.workflow_run_id}")
@@ -288,4 +163,4 @@ if __name__ == "__main__":
             args.workflow_run_id, args.workflow_run_attempt, "test_run", test_cases
         )
 
-    upload_additional_info(args.workflow_run_id, args.workflow_run_attempt, test_cases)
+    upload_additional_info(args.workflow_run_id, args.workflow_run_attempt, args.head_sha, test_cases)

--- a/tools/stats/upload_test_stats_intermediate.py
+++ b/tools/stats/upload_test_stats_intermediate.py
@@ -22,6 +22,11 @@ if __name__ == "__main__":
         required=False,
         help="id of the workflow to get artifacts from",
     )
+    parser.add_argument(
+        "--dry-run",
+        required=False,
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
@@ -33,5 +38,5 @@ if __name__ == "__main__":
     sys.stdout.flush()
 
     upload_additional_info(
-        args.workflow_run_id, args.workflow_run_attempt, args.head_sha, test_cases
+        args.workflow_run_id, args.workflow_run_attempt, args.head_sha, test_cases, dry_run=args.dry_run
     )

--- a/tools/stats/upload_test_stats_intermediate.py
+++ b/tools/stats/upload_test_stats_intermediate.py
@@ -38,5 +38,9 @@ if __name__ == "__main__":
     sys.stdout.flush()
 
     upload_additional_info(
-        args.workflow_run_id, args.workflow_run_attempt, args.head_sha, test_cases, dry_run=args.dry_run
+        args.workflow_run_id,
+        args.workflow_run_attempt,
+        args.head_sha,
+        test_cases,
+        dry_run=args.dry_run,
     )

--- a/tools/stats/upload_test_stats_intermediate.py
+++ b/tools/stats/upload_test_stats_intermediate.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from tools.stats.test_dashboard import upload_additional_info
+from tools.stats.test_dashboard import get_base_id, upload_additional_info
 from tools.stats.upload_test_stats import get_tests
 
 if __name__ == "__main__":
@@ -17,6 +17,12 @@ if __name__ == "__main__":
         required=True,
         help="which retry of the workflow this is",
     )
+    parser.add_argument(
+        "--head-sha",
+        required=False,
+        help="id of the workflow to get artifacts from",
+    )
+
     args = parser.parse_args()
 
     print(f"Workflow id is: {args.workflow_run_id}")
@@ -26,4 +32,4 @@ if __name__ == "__main__":
     # Flush stdout so that any errors in Rockset upload show up last in the logs.
     sys.stdout.flush()
 
-    upload_additional_info(args.workflow_run_id, args.workflow_run_attempt, test_cases)
+    upload_additional_info(args.workflow_run_id, args.workflow_run_attempt, args.head_sha, test_cases)

--- a/tools/stats/upload_test_stats_intermediate.py
+++ b/tools/stats/upload_test_stats_intermediate.py
@@ -1,8 +1,8 @@
 import argparse
 import sys
 
-from tools.stats.test_dashboard import get_base_id, upload_additional_info
-from tools.stats.upload_test_stats import get_tests
+from tools.stats.test_dashboard import upload_additional_info
+from tools.stats.upload_stats_lib import get_tests
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Upload test stats to Rockset")
@@ -32,4 +32,6 @@ if __name__ == "__main__":
     # Flush stdout so that any errors in Rockset upload show up last in the logs.
     sys.stdout.flush()
 
-    upload_additional_info(args.workflow_run_id, args.workflow_run_attempt, args.head_sha, test_cases)
+    upload_additional_info(
+        args.workflow_run_id, args.workflow_run_attempt, args.head_sha, test_cases
+    )

--- a/tools/test/test_upload_test_stats.py
+++ b/tools/test/test_upload_test_stats.py
@@ -1,7 +1,8 @@
 import os
 import unittest
 
-from tools.stats.upload_test_stats import get_tests, summarize_test_cases
+from tools.stats.upload_stats_lib import get_tests
+from tools.stats.upload_test_stats import summarize_test_cases
 
 IN_CI = os.environ.get("CI")
 


### PR DESCRIPTION
Adds function for getting new and removed tests 
* Truncates list to 10 max per test class to prevent huge file size

Other
* Adds head sha as an input to calculate the base
  * Uses hud/pytorchbot to get the base
* Adds a way to get job ids for artifacts coming from jobs that failed to get the job id 
  * To do this, it queries github for the list of job ids and attempts to match based on the test report name
* Removes circleci + test xml related functions and arguments
* Adds dry run option to dashboard script that makes files in test/test-reports folder instead of uploading to aws so you can view the files without fear
* Moves functions from upload_test_stats to upload_stats_lib to prevent circular imports
