### PR TITLE
[ROCm] Check supported archs before setting preferred blas backend to hipblasLT

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -263,8 +263,7 @@ void Context::setLinalgPreferredBackend(at::LinalgBackend b) {
   }
 }
 
-at::BlasBackend Context::blasPreferredBackend() const {
-// Should this be called only once for performance reasons?
+at::BlasBackend Context::blasPreferredBackend() {
 #ifdef USE_ROCM
   if (blas_preferred_backend == at::BlasBackend::Cublaslt) {
     static const std::vector<std::string> archs = {"gfx90a", "gfx940", "gfx941", "gfx942"};
@@ -273,7 +272,7 @@ at::BlasBackend Context::blasPreferredBackend() const {
         TORCH_WARN_ONCE(
           "Attempting to use hipBLASLt on an unsupported architecture! "
           "Overriding blas backend to hipblas");
-        return at::BlasBackend::Cublas;
+        blas_preferred_backend = at::BlasBackend::Cublas;
       }
     }
   }

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -266,15 +266,19 @@ void Context::setLinalgPreferredBackend(at::LinalgBackend b) {
 at::BlasBackend Context::blasPreferredBackend() {
 #ifdef USE_ROCM
   if (blas_preferred_backend == at::BlasBackend::Cublaslt) {
-    static const std::vector<std::string> archs = {"gfx90a", "gfx940", "gfx941", "gfx942"};
-    for (auto index = 0; index < at::getNumGPUs(); index++) {
-      if (!detail::getCUDAHooks().isGPUArch(index, archs)) {
-        TORCH_WARN_ONCE(
-          "Attempting to use hipBLASLt on an unsupported architecture! "
-          "Overriding blas backend to hipblas");
-        blas_preferred_backend = at::BlasBackend::Cublas;
+    static const bool hipblaslt_unsupported = []() {
+      static const std::vector<std::string> archs = {"gfx90a", "gfx940", "gfx941", "gfx942"};
+      for (auto index = 0; index < at::getNumGPUs(); index++) {
+        if (!detail::getCUDAHooks().isGPUArch(index, archs)) {
+          TORCH_WARN_ONCE(
+            "Attempting to use hipBLASLt on an unsupported architecture! "
+            "Overriding blas backend to hipblas");
+	  return true;
+        }
       }
-    }
+      return false;
+    }();
+    if (hipblaslt_unsupported) blas_preferred_backend = at::BlasBackend::Cublas;
   }
 #endif
   return blas_preferred_backend;

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -273,7 +273,7 @@ at::BlasBackend Context::blasPreferredBackend() {
           TORCH_WARN_ONCE(
             "Attempting to use hipBLASLt on an unsupported architecture! "
             "Overriding blas backend to hipblas");
-	  return true;
+          return true;
         }
       }
       return false;

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -217,7 +217,7 @@ class TORCH_API Context {
   at::LinalgBackend linalgPreferredBackend() const;
   void setLinalgPreferredBackend(at::LinalgBackend);
 
-  at::BlasBackend blasPreferredBackend() const;
+  at::BlasBackend blasPreferredBackend();
   void setBlasPreferredBackend(at::BlasBackend);
 
   // Note [Enabling Deterministic Operations]

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -384,14 +384,15 @@ class TORCH_API Context {
       c10::utils::check_env("TORCH_LINALG_PREFER_CUSOLVER") == true
       ? at::LinalgBackend::Cusolver
       : at::LinalgBackend::Default;
+  static at::BlasBackend getBlasAcceptableBackend(at::BlasBackend b);
   at::BlasBackend blas_preferred_backend =
 #ifdef USE_ROCM
       (c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") != false)
 #else
       (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == true)
 #endif
-      ? at::BlasBackend::Cublaslt
-      : at::BlasBackend::Cublas;
+      ? getBlasAcceptableBackend(at::BlasBackend::Cublaslt)
+      : getBlasAcceptableBackend(at::BlasBackend::Cublas);
 #ifdef C10_MOBILE
   bool release_original_weights = true;
 #else

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -384,15 +384,14 @@ class TORCH_API Context {
       c10::utils::check_env("TORCH_LINALG_PREFER_CUSOLVER") == true
       ? at::LinalgBackend::Cusolver
       : at::LinalgBackend::Default;
-  static at::BlasBackend getBlasAcceptableBackend(at::BlasBackend b);
   at::BlasBackend blas_preferred_backend =
 #ifdef USE_ROCM
       (c10::utils::check_env("TORCH_BLAS_PREFER_HIPBLASLT") != false)
 #else
       (c10::utils::check_env("TORCH_BLAS_PREFER_CUBLASLT") == true)
 #endif
-      ? getBlasAcceptableBackend(at::BlasBackend::Cublaslt)
-      : getBlasAcceptableBackend(at::BlasBackend::Cublas);
+      ? at::BlasBackend::Cublaslt
+      : at::BlasBackend::Cublas;
 #ifdef C10_MOBILE
   bool release_original_weights = true;
 #else

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -440,6 +440,20 @@ int CUDAHooks::getNumGPUs() const {
   return at::cuda::device_count();
 }
 
+#ifdef USE_ROCM
+bool CUDAHooks::isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const {
+  hipDeviceProp_t* prop = at::cuda::getDeviceProperties(device_index);
+  std::string device_arch = prop->gcnArchName;
+  for (std::string arch : archs) {
+      size_t substring = device_arch.find(arch);
+      if (substring != std::string::npos) {
+          return true;
+      }
+  }
+  return false;
+}
+#endif
+
 void CUDAHooks::deviceSynchronize(DeviceIndex device_index) const {
   at::DeviceGuard device_guard(at::Device(at::DeviceType::CUDA, device_index));
   c10::cuda::device_synchronize();

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -49,6 +49,9 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   int64_t cuFFTGetPlanCacheSize(DeviceIndex device_index) const override;
   void cuFFTClearPlanCache(DeviceIndex device_index) const override;
   int getNumGPUs() const override;
+#ifdef USE_ROCM
+  bool isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const override;
+#endif
   void deviceSynchronize(DeviceIndex device_index) const override;
 };
 

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -186,6 +186,12 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
     return 0;
   }
 
+#ifdef USE_ROCM
+  virtual bool isGPUArch(DeviceIndex /*device_index*/, const std::vector<std::string>& /*archs*/) const {
+    TORCH_CHECK(false, "Cannot check GPU arch without ATen_cuda library. ", CUDA_HELP);
+  } 
+#endif
+
   virtual void deviceSynchronize(DeviceIndex /*device_index*/) const {
     TORCH_CHECK(false, "Cannot synchronize CUDA device without ATen_cuda library. ", CUDA_HELP);
   }

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -189,7 +189,7 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
 #ifdef USE_ROCM
   virtual bool isGPUArch(DeviceIndex /*device_index*/, const std::vector<std::string>& /*archs*/) const {
     TORCH_CHECK(false, "Cannot check GPU arch without ATen_cuda library. ", CUDA_HELP);
-  } 
+  }
 #endif
 
   virtual void deviceSynchronize(DeviceIndex /*device_index*/) const {


### PR DESCRIPTION
This PR is needed to resolve usability issues with PyTorch ROCm nightly wheels on non-gfx90a/gf94x architectures as a result of https://github.com/pytorch/pytorch/pull/127944.

Addresses https://github.com/pytorch/pytorch/issues/119081#issuecomment-2166504992

### With this PR's changes, I get the following on a gfx908 (unsupported by hipblasLT) architecture:
_Using setter function:_
```
>>> torch.backends.cuda.preferred_blas_library(backend="cublaslt")
[W617 19:58:58.286088851 Context.cpp:280] Warning: torch.backends.cuda.preferred_blas_library is an experimental feature. If you see any error or unexpected behavior when this flag is set please file an issue on GitHub. (function operator())
[W617 19:59:02.125161985 Context.cpp:291] Warning: Attempting to use hipBLASLt on an unsupported architecture! Overriding blas backend to hipblas (function operator())
<_BlasBackend.Cublas: 0>
```

_Using `TORCH_BLAS_PREFER_HIPBLASLT` env var:_
```
root@9d47bf40d4d4:/tmp/pytorch# TORCH_BLAS_PREFER_CUBLASLT=1 python
>>> import torch
>>> torch.backends.cuda.preferred_blas_library()
[W619 06:14:11.627715807 Context.cpp:274] Warning: Attempting to use hipBLASLt on an unsupported architecture! Overriding blas backend to hipblas (function operator())
<_BlasBackend.Cublas: 0>
```

### and the following on a gfx90a (supported by hipblasLT) architecture:
_Using setter function:_
```
>>> import torch
>>> torch.backends.cuda.preferred_blas_library()
<_BlasBackend.Cublaslt: 1>
>>> torch.backends.cuda.preferred_blas_library(backend="cublas")
<_BlasBackend.Cublas: 0>
>>> torch.backends.cuda.preferred_blas_library(backend="cublaslt")
[W620 18:38:29.404265518 Context.cpp:293] Warning: torch.backends.cuda.preferred_blas_library is an experimental feature. If you see any error or unexpected behavior when this flag is set please file an issue on GitHub. (function operator())
<_BlasBackend.Cublaslt: 1>
```

_Using `TORCH_BLAS_PREFER_HIPBLASLT` env var:_
```
root@9d47bf40d4d4:/tmp/pytorch# TORCH_BLAS_PREFER_HIPBLASLT=1 python
>>> import torch
>>> torch.backends.cuda.preferred_blas_library()
<_BlasBackend.Cublaslt: 1>
```
(Same result for _Using `TORCH_BLAS_PREFER_CUBLASLT` env var:_)

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang