### PR TITLE
[inductor] Parallel compile: handle crashes in subprocesses

### DIFF
--- a/torch/_inductor/compile_worker/__main__.py
+++ b/torch/_inductor/compile_worker/__main__.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import argparse
+import logging
 import os
 import sys
 import typing
@@ -8,6 +9,8 @@ from torch._inductor.async_compile import pre_fork_setup
 from torch._inductor.compile_worker.subproc_pool import Pipe, SubprocMain
 from torch._inductor.compile_worker.watchdog import _async_compile_initializer
 from torch._inductor.runtime.compile_tasks import _set_triton_ptxas_path
+
+log = logging.getLogger(__name__)
 
 _set_triton_ptxas_path()
 
@@ -20,25 +23,28 @@ except ImportError:
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--workers", type=int)
-    parser.add_argument("--parent", type=int)
-    args = parser.parse_args()
-    if os.getppid() != args.parent:
-        sys.exit(0)
-    write_fd = typing.cast(Pipe, os.fdopen(os.dup(sys.stdout.fileno()), "wb"))
-    read_fd = typing.cast(Pipe, os.fdopen(os.dup(sys.stdin.fileno()), "rb"))
+    try:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--workers", type=int)
+        parser.add_argument("--parent", type=int)
+        args = parser.parse_args()
+        if os.getppid() != args.parent:
+            sys.exit(0)
+        write_fd = typing.cast(Pipe, os.fdopen(os.dup(sys.stdout.fileno()), "wb"))
+        read_fd = typing.cast(Pipe, os.fdopen(os.dup(sys.stdin.fileno()), "rb"))
 
-    # nobody else should read stdin
-    sys.stdin.close()
+        # nobody else should read stdin
+        sys.stdin.close()
 
-    # redirect output of workers to stderr
-    os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
+        # redirect output of workers to stderr
+        os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
 
-    pre_fork_setup()
+        pre_fork_setup()
 
-    _async_compile_initializer(args.parent)
-    SubprocMain(args.workers, read_fd, write_fd).main()
+        _async_compile_initializer(args.parent)
+        SubprocMain(args.workers, read_fd, write_fd).main()
+    except Exception:
+        log.exception("Uncaught exception in compile_worker subprocess")
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import typing
 from concurrent.futures import Future, ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from typing import Any, Callable, Dict
 
 from torch._inductor import config
@@ -180,16 +181,20 @@ class SubprocMain:
         self.read_pipe = read_pipe
         self.write_pipe = write_pipe
         self.write_lock = threading.Lock()
-        self.pool = ProcessPoolExecutor(
+        self.nprocs = nprocs
+        self.pool = self._new_pool(nprocs, True)
+        self.running = True
+
+    def _new_pool(self, nprocs, warm):
+        pool = ProcessPoolExecutor(
             nprocs,
             mp_context=multiprocessing.get_context("fork"),
             initializer=functools.partial(_async_compile_initializer, os.getpid()),
         )
-        multiprocessing.util.Finalize(
-            None, self.pool.shutdown, exitpriority=sys.maxsize
-        )
-        self.running = True
-        _warm_process_pool(self.pool, nprocs)
+        multiprocessing.util.Finalize(None, pool.shutdown, exitpriority=sys.maxsize)
+        if warm:
+            _warm_process_pool(pool, nprocs)
+        return pool
 
     def main(self):
         while True:
@@ -210,6 +215,17 @@ class SubprocMain:
         self.pool.shutdown()
 
     def submit(self, job_id, data):
+        while True:
+            try:
+                self._submit_inner(job_id, data)
+                return
+            except BrokenProcessPool:
+                # If any subprocess in the pool crashes, we get a BrokenProcessPool
+                # exception and the whole pool becomes unusable. Handle crashes by
+                # recreating the pool and resubmitting.
+                self.pool = self._new_pool(self.nprocs, False)
+
+    def _submit_inner(self, job_id, data):
         future = self.pool.submit(functools.partial(SubprocMain.do_job, data))
 
         def callback(_):

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -215,7 +215,7 @@ class SubprocMain:
         self.pool.shutdown()
 
     def submit(self, job_id, data):
-        while True:
+        while self.running:
             try:
                 self._submit_inner(job_id, data)
                 return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128757

Summary: If any subprocess in the pool crashes, we get a BrokenProcessPool exception and the whole pool becomes unusable. Handle crashes by recreating the pool.

Test Plan:
* New unit test
* Started a long-running test (`test/inductor/test_torchinductor.py`), periodically killed subprocess manually, made sure the test run recovers and makes progress.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang