### PR TITLE
Change index_put on GPU to accept FP8 inputs

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1160,7 +1160,14 @@ class TestIndexing(TestCase):
         torch.cfloat, torch.cdouble, torch.float, torch.long, torch.bool, torch.bfloat16
     )
     @dtypesIfCUDA(
-        torch.cfloat, torch.cdouble, torch.half, torch.long, torch.bool, torch.bfloat16
+        torch.cfloat,
+        torch.cdouble,
+        torch.half,
+        torch.long,
+        torch.bool,
+        torch.bfloat16,
+        torch.float8_e5m2,
+        torch.float8_e4m3fn,
     )
     def test_index_put_src_datatype(self, device, dtype):
         src = torch.ones(3, 2, 4, device=device, dtype=dtype)


### PR DESCRIPTION
As the title says, this PR changes the dispatcher for the CUDA index_put_ kernel to accept FP8 inputs. This is useful for Transformers models where the KV cache is FP8 and has been pre-allocated.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10