### PR TITLE
[inductor] parallel compile: Print traceback detail when there's an exception in a sub-process

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -4,8 +4,8 @@ import os
 
 from torch._inductor.compile_worker.subproc_pool import (
     raise_testexc,
+    SubprocException,
     SubprocPool,
-    TestException,
 )
 
 from torch._inductor.test_case import TestCase
@@ -27,7 +27,10 @@ class TestCompileWorker(TestCase):
         pool = SubprocPool(2)
         try:
             a = pool.submit(raise_testexc)
-            with self.assertRaises(TestException):
+            with self.assertRaisesRegex(
+                SubprocException,
+                "torch._inductor.compile_worker.subproc_pool.TestException",
+            ):
                 a.result()
         finally:
             pool.shutdown()

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -9,6 +9,7 @@ import struct
 import subprocess
 import sys
 import threading
+import traceback
 import typing
 from concurrent.futures import Future, ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
@@ -72,6 +73,26 @@ def _get_ld_library_path():
             path = os.pathsep.join([lib_path, path]) if path else lib_path
 
     return path
+
+
+class _SubprocExceptionInfo:
+    """
+    Carries exception info from subprocesses across the wire. traceback
+    objects are not pickleable, so we store the trace as a string and
+    use it for the message in the exception thrown in the main process.
+    """
+
+    def __init__(self, details):
+        self.details = details
+
+
+class SubprocException(Exception):
+    """
+    Thrown when a job in a subprocess raises an Exception.
+    """
+
+    def __init__(self, details):
+        super().__init__(f"An exception occurred in a subprocess:\n\n{details}")
 
 
 class SubprocPool:
@@ -147,7 +168,13 @@ class SubprocPool:
                 with self.futures_lock:
                     if not self.running:
                         return
-                    if isinstance(result, Exception):
+                    if isinstance(result, _SubprocExceptionInfo):
+                        # An exception occurred in the submitted job
+                        self.pending_futures[job_id].set_exception(
+                            SubprocException(result.details)
+                        )
+                    elif isinstance(result, Exception):
+                        # An exception occurred in some of our subprocess machinery.
                         self.pending_futures[job_id].set_exception(result)
                     else:
                         self.pending_futures[job_id].set_result(result)
@@ -247,7 +274,10 @@ class SubprocMain:
     def do_job(data):
         # do the pickle/unpickle in the sub-subproc
         job = pickle.loads(data)
-        result = job()
+        try:
+            result = job()
+        except Exception as e:
+            result = _SubprocExceptionInfo(traceback.format_exc())
         return pickle.dumps(result, pickle.HIGHEST_PROTOCOL)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128775

Summary: We lose traceback info when an exception occurs in a subprocess because Python traceback objects don't pickle. In the subprocess-based parallel compile, we _are_ logging an exception in the subprocess, but a) those messages are easy to miss because they're not in the traceback output, and b) it seems that logging in the subproc is swallowed by default in internal builds. This PR captures the traceback in the subprocess and makes it available in the exception thrown in the main process. Users now see failures that look like this:

```
  ...
  File "/home/slarsen/.conda/envs/pytorch-3.10_3/lib/python3.10/concurrent/futures/_base.py", line 458, in result
    return self.__get_result()
  File "/home/slarsen/.conda/envs/pytorch-3.10_3/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
SubprocException: An exception occurred in a subprocess:

Traceback (most recent call last):
  File "/data/users/slarsen/pytorch-3.10_3/torch/_inductor/compile_worker/subproc_pool.py", line 270, in do_job
    result = SubprocMain.foo()
  File "/data/users/slarsen/pytorch-3.10_3/torch/_inductor/compile_worker/subproc_pool.py", line 263, in foo
    SubprocMain.bar()
  File "/data/users/slarsen/pytorch-3.10_3/torch/_inductor/compile_worker/subproc_pool.py", line 260, in bar
    SubprocMain.baz()
  File "/data/users/slarsen/pytorch-3.10_3/torch/_inductor/compile_worker/subproc_pool.py", line 257, in baz
    raise Exception("an error occurred")
Exception: an error occurred
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang