### PR TITLE
Remove dtype from gpt-fast micro benchmark experiments model name

### DIFF
--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -76,7 +76,7 @@ def run_mlp_layer_norm_gelu(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"mlp_layer_norm_gelu_{dtype_str}",
+                f"mlp_layer_norm_gelu",
                 "flops_utilization",
                 expected_flops_utilization,
                 f"{flops_utilization:.02f}",
@@ -113,7 +113,7 @@ def run_layer_norm(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"layer_norm_{dtype_str}",
+                f"layer_norm",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",
@@ -156,7 +156,7 @@ def run_gather_gemv(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"gather_gemv_{dtype_str}",
+                f"gather_gemv",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",
@@ -197,7 +197,7 @@ def run_gemv(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"gemv_{dtype_str}",
+                f"gemv",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",

--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -76,7 +76,7 @@ def run_mlp_layer_norm_gelu(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"mlp_layer_norm_gelu",
+                "mlp_layer_norm_gelu",
                 "flops_utilization",
                 expected_flops_utilization,
                 f"{flops_utilization:.02f}",
@@ -113,7 +113,7 @@ def run_layer_norm(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"layer_norm",
+                "layer_norm",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",
@@ -156,7 +156,7 @@ def run_gather_gemv(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"gather_gemv",
+                "gather_gemv",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",
@@ -197,7 +197,7 @@ def run_gemv(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"gemv",
+                "gemv",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",


### PR DESCRIPTION
Per comments on https://github.com/pytorch/test-infra/pull/5344, we already have a dtype column with the same information
