### PR TITLE
Doc (nn): improve doc-string of class Linear.

### DIFF
--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -59,7 +59,7 @@ class Linear(Module):
         out_features: size of each output sample
         bias: If set to ``False``, the layer will not learn an additive bias.
             Default: ``True``
-        device: device on which the weight and device tensors will be allocated.
+        device: device on which the weight and bias tensors will be allocated.
             ``None`` uses the default device.
         dtype: data type of the weight and bias tensors, must be differentiable (float or complex).
             ``None`` uses the default dtype.

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -3,10 +3,10 @@ import math
 from typing import Any
 
 import torch
-from torch import dtype, Tensor
+from torch import Tensor
 from torch.nn import functional as F, init
 from torch.nn.parameter import Parameter, UninitializedParameter
-from torch.types import Device
+from torch.types import Device, Dtype
 from .lazy import LazyModuleMixin
 from .module import Module
 
@@ -100,17 +100,16 @@ class Linear(Module):
         out_features: int,
         bias: bool = True,
         device: Device = None,
-        dtype: dtype = None
+        dtype: Dtype = None
     ) -> None:
-        factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
         self.weight = Parameter(
-            torch.empty((out_features, in_features), **factory_kwargs)
+            torch.empty((out_features, in_features), device=device, dtype=dtype)
         )
         if bias:
-            self.bias = Parameter(torch.empty(out_features, **factory_kwargs))
+            self.bias = Parameter(torch.empty(out_features, device=device, dtype=dtype))
         else:
             self.register_parameter("bias", None)
         self.reset_parameters()

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -3,10 +3,10 @@ import math
 from typing import Any
 
 import torch
-from torch import Tensor
+from torch import dtype, Tensor
 from torch.nn import functional as F, init
 from torch.nn.parameter import Parameter, UninitializedParameter
-
+from torch.types import Device
 from .lazy import LazyModuleMixin
 from .module import Module
 
@@ -59,6 +59,10 @@ class Linear(Module):
         out_features: size of each output sample
         bias: If set to ``False``, the layer will not learn an additive bias.
             Default: ``True``
+        device: device on which the weight and device tensors will be allocated.
+            ``None`` uses the default device.
+        dtype: data type of the weight and bias tensors, must be differentiable (float or complex).
+            ``None`` uses the default dtype.
 
     Shape:
         - Input: :math:`(*, H_{in})` where :math:`*` means any number of
@@ -95,8 +99,8 @@ class Linear(Module):
         in_features: int,
         out_features: int,
         bias: bool = True,
-        device=None,
-        dtype=None,
+        device: Device = None,
+        dtype: dtype = None
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()

--- a/torch/types.py
+++ b/torch/types.py
@@ -45,6 +45,10 @@ Number = Union[builtins.int, builtins.float, builtins.bool]
 Device = Optional[Union[_device, str, _int]]
 del Optional
 
+# Similar to Device, but for dtype.
+# None means default dtype (typically torch.float32)
+Dtype = _dtype | None
+
 # Storage protocol implemented by ${Type}StorageBase classes
 
 


### PR DESCRIPTION
Added type hint for device and dtype and a description for these. 

Explicitly stated that only differentiable dtypes (float and complex) can be used, which is not clear since dtype also encompasses types such as bool and int.

Also explicitly stated that None will use the 'default device' or 'default dtype' such that when people search for this in the docs, they will end up at the methods get_default_device() and similar. I am a machine learning engineer that regularly teaches trainees, and found that the meaning of the None value can cause confusion.

If this PR gets accepted, I might consider also updating some other doc strings in the same manner.
