### PR TITLE
Add hash function of std::string_view to torch/csrc/lazy/core/hash.h

### DIFF
--- a/torch/csrc/lazy/core/hash.h
+++ b/torch/csrc/lazy/core/hash.h
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace torch {
@@ -152,6 +153,10 @@ static inline hash_t Hash(const std::string& value) {
 }
 
 static inline hash_t Hash(const c10::string_view& value) {
+  return DataHash(value.data(), value.size());
+}
+
+static inline hash_t Hash(const std::string_view& value) {
   return DataHash(value.data(), value.size());
 }
 


### PR DESCRIPTION
For easier moving of c10::string_view to std::string_view in PyTorch/XLA.
