### PR TITLE
[ROCm] Tunableop record untuned

### DIFF
--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -82,8 +82,8 @@ fastest available implementation across both rocblas and hipblaslt.
 ### Motivation
 Basically it is used for workload with high-memory utilization where one might run out of memory with regular tuning.
 
-### Workflow 
-There are basically two steps: 
+### Workflow
+There are basically two steps:
 1) Set the environment variables to collect the untuned GEMM and this will generate `tunableop_untuned?.csv` ("?" is placeholder for the GPU ID), like:
 ```
 PYTORCH_TUNABLEOP_ENABLED=1

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -90,7 +90,7 @@ programmatically since the settings become fixed. Use the C++ or Python APIs ins
 | -------------------- | ----------- |
 | PYTORCH_TUNABLEOP_ENABLED | Default is 0. Set to 1 to enable. |
 | PYTORCH_TUNABLEOP_TUNING | Default is 1. Set to 0 to disable. |
-| PYTORCH_TUNABLEOP_RECORD_UNTUNED | Default is 1. Set to 0 to disable. |
+| PYTORCH_TUNABLEOP_RECORD_UNTUNED | Default is 0. Set to 1 to enable. |
 | PYTORCH_TUNABLEOP_UNTUNED_FILENAME | Default is 'tunableop_untuned.csv'. |
 | PYTORCH_TUNABLEOP_VERBOSE | Default is 0. Set to 1 to enable basic logging. 2 for basic tuning status. 3 for full trace. |
 | PYTORCH_TUNABLEOP_VERBOSE_FILENAME | Default is "err" for stderr. Set to "out" for stdout or a filename for capturing verbose logging. |
@@ -127,7 +127,7 @@ All python APIs exist in the `torch.cuda.tunable` module.
 | write_file_on_exit(val: bool) -> None | Default is True. |
 | write_file(filename: Optional[str] = None) -> None | If filename not given, it will call get_filename(). |
 | read_file(filename: Optional[str] = None) -> None | If filename not given, it will call get_filename(). |
-| tune_gemm_in_file(filename: str) -> None | read a untuned file and tune GEMMs in it. |
+| tune_gemm_in_file(filename: str) -> None | read an untuned file and tune GEMMs in it. |
 
 ### C++ Interface
 Example:

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -114,6 +114,8 @@ All python APIs exist in the `torch.cuda.tunable` module.
 | is_enabled() -> bool | |
 | tuning_enable(val: bool = True) -> None | Default is True. |
 | tuning_is_enabled() -> bool | |
+| record_untuned_enable(val: bool = True) -> None | Default is True. |
+| record_untuned_is_enabled() -> bool | |
 | set_max_tuning_duration(duration: int) -> None | |
 | get_max_tuning_duration() -> int | |
 | set_max_tuning_iterations(iterations: int) -> None | |

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -90,7 +90,7 @@ programmatically since the settings become fixed. Use the C++ or Python APIs ins
 | -------------------- | ----------- |
 | PYTORCH_TUNABLEOP_ENABLED | Default is 0. Set to 1 to enable. |
 | PYTORCH_TUNABLEOP_TUNING | Default is 1. Set to 0 to disable. |
-| PYTORCH_TUNABLEOP_RECORD_UNTUNED | Default is 0. Set to 1 to enable. |
+| PYTORCH_TUNABLEOP_RECORD_UNTUNED | Default is 1. Set to 0 to disable. |
 | PYTORCH_TUNABLEOP_UNTUNED_FILENAME | Default is 'tunableop_untuned.csv'. |
 | PYTORCH_TUNABLEOP_VERBOSE | Default is 0. Set to 1 to enable basic logging. 2 for basic tuning status. 3 for full trace. |
 | PYTORCH_TUNABLEOP_VERBOSE_FILENAME | Default is "err" for stderr. Set to "out" for stdout or a filename for capturing verbose logging. |

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -77,6 +77,31 @@ default, now called through TunableOp. Any call to at::cuda::blas::gemm() or ::b
 when enabled. Calling gemm() for a given set of input arguments (transa, transb, m, n, k) will attempt to use the
 fastest available implementation across both rocblas and hipblaslt.
 
+## Offline Tuning
+
+### Motivation
+Basically it is used for workload with high-memory utilization where one might run out of memory with regular tuning.
+
+### Workflow 
+There are basically two steps: 
+1) Set the environment variables to collect the untuned GEMM and this will generate `tunableop_untuned?.csv` ("?" is placeholder for the GPU ID), like:
+```
+PYTORCH_TUNABLEOP_ENABLED=1
+PYTORCH_TUNABLEOP_TUNING=0
+PYTORCH_TUNABLEOP_RECORD_UNTUNED=1
+...
+```
+2) Run a Python script that reads the `tunableop_untuned?.csv` and generates the `tunableop_results?.csv`, like:
+```
+import torch.cuda.tunable as tunable
+import os
+
+os.putenv('PYTORCH_TUNABLEOP_ENABLED', '1')
+os.putenv('PYTORCH_TUNABLEOP_TUNING', '1')
+os.putenv('PYTORCH_TUNABLEOP_RECORD_UNTUNED', '0')
+tunable.tune_gemm_in_file("tunableop_results?.csv")
+```
+
 ## Tuning Context
 The behavior of TunableOp is currently manipulated through environment variables, the C++ interface of
 at::cuda::tunable::getTuningContext(), or the `torch.cuda.tunable` python interfaces. The environment variables take

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -91,7 +91,7 @@ programmatically since the settings become fixed. Use the C++ or Python APIs ins
 | PYTORCH_TUNABLEOP_ENABLED | Default is 0. Set to 1 to enable. |
 | PYTORCH_TUNABLEOP_TUNING | Default is 1. Set to 0 to disable. |
 | PYTORCH_TUNABLEOP_RECORD_UNTUNED | Default is 0. Set to 1 to enable. |
-| PYTORCH_TUNABLEOP_UNTUNED_FILENAME | Default is 'untuned.csv'. |
+| PYTORCH_TUNABLEOP_UNTUNED_FILENAME | Default is 'tunableop_untuned.csv'. |
 | PYTORCH_TUNABLEOP_VERBOSE | Default is 0. Set to 1 to enable basic logging. 2 for basic tuning status. 3 for full trace. |
 | PYTORCH_TUNABLEOP_VERBOSE_FILENAME | Default is "err" for stderr. Set to "out" for stdout or a filename for capturing verbose logging. |
 | PYTORCH_TUNABLEOP_FILENAME | Default is 'tunableop_results.csv'. |

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -125,6 +125,7 @@ All python APIs exist in the `torch.cuda.tunable` module.
 | write_file_on_exit(val: bool) -> None | Default is True. |
 | write_file(filename: Optional[str] = None) -> None | If filename not given, it will call get_filename(). |
 | read_file(filename: Optional[str] = None) -> None | If filename not given, it will call get_filename(). |
+| tune_gemm_in_file(filename: str) -> None | read a untuned file and tune GEMMs in it. |
 
 ### C++ Interface
 Example:

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -90,6 +90,8 @@ programmatically since the settings become fixed. Use the C++ or Python APIs ins
 | -------------------- | ----------- |
 | PYTORCH_TUNABLEOP_ENABLED | Default is 0. Set to 1 to enable. |
 | PYTORCH_TUNABLEOP_TUNING | Default is 1. Set to 0 to disable. |
+| PYTORCH_TUNABLEOP_RECORD_UNTUNED | Default is 0. Set to 1 to enable. |
+| PYTORCH_TUNABLEOP_UNTUNED_FILENAME | Default is 'untuned.csv'. |
 | PYTORCH_TUNABLEOP_VERBOSE | Default is 0. Set to 1 to enable basic logging. 2 for basic tuning status. 3 for full trace. |
 | PYTORCH_TUNABLEOP_VERBOSE_FILENAME | Default is "err" for stderr. Set to "out" for stdout or a filename for capturing verbose logging. |
 | PYTORCH_TUNABLEOP_FILENAME | Default is 'tunableop_results.csv'. |

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -116,8 +116,7 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
   std::scoped_lock l{lock_};
   if (!untuned_file.good()) {
     TORCH_WARN_ONCE("failed to open file for writing; untuned gemm will not be saved");
-  }
-  else{
+  } else {
     bool isNew = false;
     auto it = untuned_results_.find(op_signature);
     if (it == untuned_results_.end()) {

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -114,7 +114,7 @@ void TuningResultsManager::Add(const std::string& op_signature, const std::strin
 
 void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std::string& op_signature, const std::string& params_signature) {
   std::scoped_lock l{lock_};
-  if (!untuned_file.good()){
+  if (!untuned_file.good()) {
     TORCH_WARN_ONCE("failed to open file for writing; untuned gemm will not be saved");
   }
   else{

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -125,8 +125,7 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
     }
 
     auto it_kernel_map = it->second.find(params_signature);
-    if (it_kernel_map == it->second.end())
-    {
+    if (it_kernel_map == it->second.end()) {
       it->second.insert(params_signature);
       isNew = true;
     }

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -130,7 +130,7 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
       isNew = true;
     }
 
-    if (isNew){
+    if (isNew) {
       std::string device = c10::str(int(c10::cuda::current_device()));
       untuned_file << op_signature << "," << params_signature << std::endl;
       TUNABLE_LOG3("Untuned,", op_signature, ",", params_signature);

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -116,6 +116,7 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
   std::scoped_lock l{lock_};
   if (!untuned_file.good()) {
     TORCH_WARN_ONCE("failed to open file for writing; untuned gemm will not be saved");
+    return;
   } else {
     bool isNew = false;
     auto it = untuned_results_.find(op_signature);
@@ -131,7 +132,6 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
     }
 
     if (isNew) {
-      std::string device = c10::str(int(c10::cuda::current_device()));
       untuned_file << op_signature << "," << params_signature << std::endl;
       TUNABLE_LOG3("Untuned,", op_signature, ",", params_signature);
     }

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -460,8 +460,7 @@ void TuningContext::EnableRecordUntuned(bool value) {
   record_untuned_enable_ = value;
   if (value) {
     TUNABLE_LOG1("Enable Record Untuned for TunableOp");
-  }
-  else {
+  } else {
     TUNABLE_LOG1("Disable Record Untuned for TunableOp");
   }
 }

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -482,8 +482,7 @@ bool TuningContext::IsRecordUntunedEnabled() const {
 }
 
 std::ofstream& TuningContext::GetUntunedFile(){
-  if (!untuned_file_.is_open())
-  {
+  if (!untuned_file_.is_open()) {
     const char *env = std::getenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME");
     std::string filename = (env == nullptr) ? "tunableop_untuned.csv" : env;
 

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -115,7 +115,7 @@ void TuningResultsManager::Add(const std::string& op_signature, const std::strin
 void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std::string& op_signature, const std::string& params_signature) {
   std::scoped_lock l{lock_};
   if (!untuned_file.good()){
-    TORCH_WARN("failed to open file for writing; untuned gemm will not be saved");
+    TORCH_WARN_ONCE("failed to open file for writing; untuned gemm will not be saved");
   }
   else{
     bool isNew = false;
@@ -134,7 +134,7 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
 
     if (isNew){
       std::string device = c10::str(int(c10::cuda::current_device()));
-      untuned_file << "Untuned GPU " <<device<<","<< op_signature << "," << params_signature << std::endl;
+      untuned_file << op_signature << "," << params_signature << std::endl;
       TUNABLE_LOG3("Untuned,", op_signature, ",", params_signature);
     }
   }
@@ -387,7 +387,7 @@ TuningStatus TuningResultsValidator::ValidatePyTorchVersion(const std::string& v
 TuningContext::TuningContext() :
     enable_{false},
     tuning_enable_{true},
-    record_untuned_enable_{true},
+    record_untuned_enable_{false},
     manager_initialized_{false},
     write_file_on_exit_{true},
     numerics_check_enable_{false},
@@ -478,8 +478,8 @@ bool TuningContext::IsTuningEnabled() const {
 
 bool TuningContext::IsRecordUntunedEnabled() const {
   static const char *env = std::getenv("PYTORCH_TUNABLEOP_RECORD_UNTUNED");
-  if (env != nullptr && strcmp(env, "0") == 0) {
-    return false;
+  if (env != nullptr && strcmp(env, "1") == 0) {
+    return true;
   }
   return record_untuned_enable_;
 }

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -124,12 +124,14 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
       it = untuned_results_.insert({op_signature, {}}).first;
       isNew = true;
     }
+
     auto it_kernel_map = it->second.find(params_signature);
     if (it_kernel_map == it->second.end())
     {
       it->second.insert(params_signature);
       isNew = true;
     }
+
     if (isNew){
       untuned_file << "Untuned," << op_signature << "," << params_signature << std::endl;
       TUNABLE_LOG3("Untuned,", op_signature, ",", params_signature);
@@ -471,7 +473,7 @@ bool TuningContext::IsRecordUntunedEnabled() const {
 }
 
 std::ofstream& TuningContext::GetUntunedFile(){
-  if (!untuned_file_.good())
+  if (!untuned_file_.is_open())
   {
     const char *env = std::getenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME");
     std::string filename = (env == nullptr) ? "untuned.csv" : env;

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -112,6 +112,31 @@ void TuningResultsManager::Add(const std::string& op_signature, const std::strin
   AddImpl(op_signature, params_signature, best, it->second);
 }
 
+void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std::string& op_signature, const std::string& params_signature) {
+  std::scoped_lock l{lock_};
+  if (!untuned_file.good()){
+    TORCH_WARN("failed to open file for writing; untuned gemm will not be saved");
+  }
+  else{
+    bool isNew = false;
+    auto it = untuned_results_.find(op_signature);
+    if (it == untuned_results_.end()) {
+      it = untuned_results_.insert({op_signature, {}}).first;
+      isNew = true;
+    }
+    auto it_kernel_map = it->second.find(params_signature);
+    if (it_kernel_map == it->second.end())
+    {
+      it->second.insert(params_signature);
+      isNew = true;
+    }
+    if (isNew){
+      untuned_file << "Untuned," << op_signature << "," << params_signature << std::endl;
+      TUNABLE_LOG3("Untuned,", op_signature, ",", params_signature);
+    }
+  }
+}
+
 void TuningResultsManager::Delete(const std::string& op_signature, const std::string& params_signature) {
   std::scoped_lock l{lock_};
 
@@ -369,6 +394,7 @@ TuningContext::TuningContext() :
     icache_flush_{true},
     rotating_buffer_size_{-1},
     filename_{},
+    untuned_file_{},
     results_count_from_input_file_{0}
 {
 }
@@ -393,6 +419,10 @@ TuningContext::~TuningContext() {
         TUNABLE_LOG1("failed to write file ", filename);
       }
     }
+  }
+
+  if (untuned_file_.good()) {
+    untuned_file_.close();
   }
 }
 
@@ -430,6 +460,24 @@ bool TuningContext::IsTuningEnabled() const {
     return false;
   }
   return tuning_enable_;
+}
+
+bool TuningContext::IsRecordUntunedEnabled() const {
+  static const char *env = std::getenv("PYTORCH_TUNABLEOP_RECORD_UNTUNED");
+  if (env != nullptr && strcmp(env, "1") == 0) {
+    return true;
+  }
+  return false;
+}
+
+std::ofstream& TuningContext::GetUntunedFile(){
+  if (!untuned_file_.good())
+  {
+    const char *env = std::getenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME");
+    std::string filename = (env == nullptr) ? "untuned.csv" : env;
+    untuned_file_ = std::ofstream(filename, std::ios::out | std::ios::trunc);
+  }
+  return untuned_file_;
 }
 
 void TuningContext::WriteFileOnExit(bool value) {

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -387,6 +387,7 @@ TuningStatus TuningResultsValidator::ValidatePyTorchVersion(const std::string& v
 TuningContext::TuningContext() :
     enable_{false},
     tuning_enable_{true},
+    record_untuned_enable_{true},
     manager_initialized_{false},
     write_file_on_exit_{true},
     numerics_check_enable_{false},
@@ -457,6 +458,16 @@ void TuningContext::EnableTuning(bool value) {
   }
 }
 
+void TuningContext::EnableRecordUntuned(bool value) {
+  record_untuned_enable_ = value;
+  if (value) {
+    TUNABLE_LOG1("Enable Record Untuned for TunableOp");
+  }
+  else {
+    TUNABLE_LOG1("Disable Record Untuned for TunableOp");
+  }
+}
+
 bool TuningContext::IsTuningEnabled() const {
   static const char *env = std::getenv("PYTORCH_TUNABLEOP_TUNING");
   if (env != nullptr && strcmp(env, "0") == 0) {
@@ -467,10 +478,10 @@ bool TuningContext::IsTuningEnabled() const {
 
 bool TuningContext::IsRecordUntunedEnabled() const {
   static const char *env = std::getenv("PYTORCH_TUNABLEOP_RECORD_UNTUNED");
-  if (env != nullptr && strcmp(env, "1") == 0) {
-    return true;
+  if (env != nullptr && strcmp(env, "0") == 0) {
+    return false;
   }
-  return false;
+  return record_untuned_enable_;
 }
 
 std::ofstream& TuningContext::GetUntunedFile(){

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -133,7 +133,8 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
     }
 
     if (isNew){
-      untuned_file << "Untuned," << op_signature << "," << params_signature << std::endl;
+      std::string device = c10::str(int(c10::cuda::current_device()));
+      untuned_file << "Untuned GPU " <<device<<","<< op_signature << "," << params_signature << std::endl;
       TUNABLE_LOG3("Untuned,", op_signature, ",", params_signature);
     }
   }
@@ -477,6 +478,17 @@ std::ofstream& TuningContext::GetUntunedFile(){
   {
     const char *env = std::getenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME");
     std::string filename = (env == nullptr) ? "untuned.csv" : env;
+
+    std::string device = c10::str(int(c10::cuda::current_device()));
+    std::size_t found = filename.rfind(".");
+    if (found != std::string::npos) {
+      filename.insert(found, device);
+    }
+    else {
+      // all else fails, just append
+      filename.append(device);
+    }
+
     untuned_file_ = std::ofstream(filename, std::ios::out | std::ios::trunc);
   }
   return untuned_file_;

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -477,7 +477,7 @@ std::ofstream& TuningContext::GetUntunedFile(){
   if (!untuned_file_.is_open())
   {
     const char *env = std::getenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME");
-    std::string filename = (env == nullptr) ? "untuned.csv" : env;
+    std::string filename = (env == nullptr) ? "tunableop_untuned.csv" : env;
 
     std::string device = c10::str(int(c10::cuda::current_device()));
     std::size_t found = filename.rfind(".");

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -618,7 +618,7 @@ TuningResultsManager& TuningContext::GetTuningResultsManager() {
       SetFilename(filename, true);
     }
     auto filename = GetFilename();
-    if (!filename.empty()) {
+    if (!filename.empty() && !IsRecordUntunedEnabled()) {
       ReadFile(filename);
       // attempt immediately to open file for writing to catch errors early
       std::ofstream file(filename, std::ios::out | std::ios::app);

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -490,8 +490,7 @@ std::ofstream& TuningContext::GetUntunedFile(){
     std::size_t found = filename.rfind(".");
     if (found != std::string::npos) {
       filename.insert(found, device);
-    }
-    else {
+    } else {
       // all else fails, just append
       filename.append(device);
     }

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -178,6 +178,7 @@ class TORCH_CUDA_CPP_API TuningContext {
     void EnableTuning(bool value);
     bool IsTuningEnabled() const;
 
+    void EnableRecordUntuned(bool value);
     bool IsRecordUntunedEnabled() const;
     std::ofstream& GetUntunedFile();
 
@@ -221,6 +222,7 @@ class TORCH_CUDA_CPP_API TuningContext {
   private:
     bool enable_;
     bool tuning_enable_;
+    bool record_untuned_enable_;
     bool manager_initialized_;
     bool write_file_on_exit_;
     bool numerics_check_enable_;

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -221,7 +221,6 @@ class TORCH_CUDA_CPP_API TuningContext {
   private:
     bool enable_;
     bool tuning_enable_;
-    bool record_untuned_;
     bool manager_initialized_;
     bool write_file_on_exit_;
     bool numerics_check_enable_;

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -87,6 +88,7 @@ class TORCH_CUDA_CPP_API ResultEntry {
 
 typedef std::unordered_map<std::string, ResultEntry> KernelMap;
 typedef std::unordered_map<std::string, KernelMap> ResultsMap;
+typedef std::unordered_map<std::string, std::unordered_set<std::string>> UntunedMap;
 
 struct TORCH_CUDA_CPP_API TuningResults {
   // Validates if these results are compatible with the libraries
@@ -129,9 +131,12 @@ class TORCH_CUDA_CPP_API TuningResultsManager {
 
     size_t GetSize();
 
+    void RecordUntuned( std::ofstream& untuned_file, const std::string& op_signature, const std::string& params_signature);
   private:
     std::mutex lock_;
     ResultsMap results_;
+    UntunedMap untuned_results_;
+
 };
 
 class TORCH_CUDA_CPP_API TuningResultsValidator {
@@ -173,6 +178,9 @@ class TORCH_CUDA_CPP_API TuningContext {
     void EnableTuning(bool value);
     bool IsTuningEnabled() const;
 
+    bool IsRecordUntunedEnabled() const;
+    std::ofstream& GetUntunedFile();
+
     void EnableNumericsCheck(bool value);
     bool IsNumericsCheckEnabled() const;
 
@@ -213,6 +221,7 @@ class TORCH_CUDA_CPP_API TuningContext {
   private:
     bool enable_;
     bool tuning_enable_;
+    bool record_untuned_;
     bool manager_initialized_;
     bool write_file_on_exit_;
     bool numerics_check_enable_;
@@ -226,6 +235,7 @@ class TORCH_CUDA_CPP_API TuningContext {
     mutable c10::once_flag manager_init_once_;
     TuningResultsValidator validator_;
     std::string filename_;
+    std::ofstream untuned_file_;
     size_t results_count_from_input_file_;
 };
 

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -54,12 +54,15 @@ class TunableOp {
         auto params_sig = params->Signature();
         result = mgr.Lookup(op_sig, params_sig);
         // If there is not previous tuning result been found, we do the tuning iff tuning is enabled
-        if (result == ResultEntry::Null() && ctx->IsTuningEnabled()) {
-          result = FindFastest(params);
-          mgr.Add(op_sig, params_sig, result);
-        }
-        else if (result == ResultEntry::Null() && ctx->IsRecordUntunedEnabled()) {
-          mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, params_sig);
+        if (result == ResultEntry::Null()) {
+          if (ctx->IsTuningEnabled()) {
+            result = FindFastest(params);
+            mgr.Add(op_sig, params_sig, result);
+          }
+          else if (ctx->IsRecordUntunedEnabled()) {
+            // or record the gemm into file
+            mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, params_sig);
+          }
         }
       }
       else {

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -58,6 +58,9 @@ class TunableOp {
           result = FindFastest(params);
           mgr.Add(op_sig, params_sig, result);
         }
+        else if (result == ResultEntry::Null() && ctx->IsRecordUntunedEnabled()){
+          mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, params_sig);
+        }
       }
       else {
         result = ResultEntry::Default();

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -58,7 +58,7 @@ class TunableOp {
           result = FindFastest(params);
           mgr.Add(op_sig, params_sig, result);
         }
-        else if (result == ResultEntry::Null() && ctx->IsRecordUntunedEnabled()){
+        else if (result == ResultEntry::Null() && ctx->IsRecordUntunedEnabled()) {
           mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, params_sig);
         }
       }

--- a/docs/source/cuda.tunable.rst
+++ b/docs/source/cuda.tunable.rst
@@ -19,6 +19,8 @@ API Reference
 .. autofunction:: is_enabled
 .. autofunction:: tuning_enable
 .. autofunction:: tuning_is_enabled
+.. autofunction:: record_untuned_enable
+.. autofunction:: record_untuned_is_enabled
 .. autofunction:: set_max_tuning_duration
 .. autofunction:: get_max_tuning_duration
 .. autofunction:: set_max_tuning_iterations
@@ -30,3 +32,4 @@ API Reference
 .. autofunction:: write_file_on_exit
 .. autofunction:: write_file
 .. autofunction:: read_file
+.. autofunction:: tune_gemm_in_file

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4602,7 +4602,7 @@ class TestLinalg(TestCase):
         assert len(torch.cuda.tunable.get_validators()) > 0
         assert len(torch.cuda.tunable.get_results()) > 0
         assert torch.cuda.tunable.write_file()
-        
+
         result_filename = f"tunableop_results{ordinal}.csv"
         assert os.path.exists(result_filename)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4833,7 +4833,6 @@ class TestLinalg(TestCase):
 
         # tuning the untuned GEMMs in file
         os.putenv('PYTORCH_TUNABLEOP_ENABLED', '1')
-        os.putenv('PYTORCH_TUNABLEOP_VERBOSE', '0')
         os.putenv('PYTORCH_TUNABLEOP_TUNING', '1')
         
         # set these to single iterations to keep it short but still exercise the code

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4865,48 +4865,6 @@ class TestLinalg(TestCase):
             except FileNotFoundError:
                 pass
 
-    @onlyCUDA
-    @dtypes(torch.half)
-    def test_matmul_offline_tunableop(self, device, dtype):
-        import os
-        torch.cuda.tunable.enable()
-        # record GEMM
-        torch.cuda.tunable.tuning_enable(False)
-        torch.cuda.tunable.record_untuned_enable(True)
-        assert torch.cuda.tunable.record_untuned_is_enabled(), "Record untuned should be on by default"
-
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-        for (size_x, size_y), nctg_x, nctg_y in product(self.gen_sizes_matmul(1), (True, False), (True, False)):
-            x = make_arg(size_x, noncontiguous=nctg_x)
-            y = make_arg(size_y, noncontiguous=nctg_y)
-            self.check_single_matmul(x, y)
-
-
-        assert torch.cuda.tunable.is_enabled()
-        assert torch.cuda.tunable.tuning_is_enabled() is False
-        ordinal = torch.cuda.current_device()
-        untuned_filename = f"tunableop_untuned{ordinal}.csv"
-        assert os.path.exists(untuned_filename)
-
-        # tuning the untuned GEMMs in file
-        torch.cuda.tunable.tuning_enable(True)
-        torch.cuda.tunable.record_untuned_enable(False)
-
-        # set these to single iterations to keep it short but still exercise the code
-        torch.cuda.tunable.set_max_tuning_duration(1)
-        torch.cuda.tunable.set_max_tuning_iterations(1)
-
-        torch.cuda.tunable.tune_gemm_in_file(untuned_filename)
-        result_filename = f"tunableop_results{ordinal}.csv"
-        assert os.path.exists(result_filename)
-        
-        # remove the files created above to avoid error 'Build left local git repository checkout dirty', ignore errors
-        for filename in [untuned_filename, result_filename]:
-            try:
-                os.remove(filename)
-            finally:
-                pass
-
     @dtypes(torch.float, torch.complex64)
     def test_matmul_out_kernel_errors_with_autograd(self, device, dtype):
         a = torch.empty((256, 512), device=device, dtype=dtype, requires_grad=True).unsqueeze(0)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4575,8 +4575,8 @@ class TestLinalg(TestCase):
         torch.cuda.tunable.enable()
         # record GEMM
         torch.cuda.tunable.tuning_enable(False)
-        assert torch.cuda.tunable.record_untuned_is_enabled() is False, "Record untuned should be off by default"
         torch.cuda.tunable.record_untuned_enable(True)
+        assert torch.cuda.tunable.record_untuned_is_enabled()
 
         make_arg = partial(make_tensor, device=device, dtype=dtype)
         for (size_x, size_y), nctg_x, nctg_y in product(self.gen_sizes_matmul(1), (True, False), (True, False)):
@@ -4615,6 +4615,7 @@ class TestLinalg(TestCase):
 
         # disables TunableOp, no file will be written, restore to default values
         torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.record_untuned_enable(False)
         torch.cuda.tunable.set_max_tuning_duration(30)
         torch.cuda.tunable.set_max_tuning_iterations(100)
         assert torch.cuda.tunable.is_enabled() is False, "TunableOp should be off after resetting"

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4811,6 +4811,47 @@ class TestLinalg(TestCase):
             except FileNotFoundError:
                 pass
 
+    @onlyCUDA
+    @dtypes(*floating_types_and(torch.half))
+    def test_matmul_offline_tunableop(self, device, dtype):
+        import os
+        # record GEMM
+        os.putenv('PYTORCH_TUNABLEOP_ENABLED', '1')
+        os.putenv('PYTORCH_TUNABLEOP_TUNING', '0')
+        os.putenv('PYTORCH_TUNABLEOP_RECORD_UNTUNED', '1')
+
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for (size_x, size_y), nctg_x, nctg_y in product(self.gen_sizes_matmul(1), (True, False), (True, False)):
+            x = make_arg(size_x, noncontiguous=nctg_x)
+            y = make_arg(size_y, noncontiguous=nctg_y)
+            self.check_single_matmul(x, y)
+
+        ordinal = torch.cuda.current_device()
+        untuned_filename = f"tunableop_untuned{ordinal}.csv"
+        assert os.path.exists(untuned_filename)
+
+        # tuning the untuned GEMMs in file
+        os.putenv('PYTORCH_TUNABLEOP_ENABLED', '1')
+        os.putenv('PYTORCH_TUNABLEOP_VERBOSE', '0')
+        os.putenv('PYTORCH_TUNABLEOP_TUNING', '1')
+        
+        # set these to single iterations to keep it short but still exercise the code
+        torch.cuda.tunable.set_max_tuning_duration(1)
+        torch.cuda.tunable.set_max_tuning_iterations(1)
+        
+        torch.cuda.tunable.tune_gemm_in_file(untuned_filename)
+        result_filename = f"tunableop_results{ordinal}.csv"
+        assert os.path.exists(result_filename)
+        
+        # remove the files created above to avoid error 'Build left local git repository checkout dirty', ignore errors
+        for filename in [untuned_filename, result_filename]:
+            try:
+                import os
+                os.remove(filename)
+            finally:
+                pass
+
     @dtypes(torch.float, torch.complex64)
     def test_matmul_out_kernel_errors_with_autograd(self, device, dtype):
         a = torch.empty((256, 512), device=device, dtype=dtype, requires_grad=True).unsqueeze(0)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4568,6 +4568,47 @@ class TestLinalg(TestCase):
         torch.cuda.tunable.enable(False)
 
     @onlyCUDA
+    @dtypes(torch.half)
+    def test_matmul_offline_tunableop(self, device, dtype):
+        import os
+        torch.cuda.tunable.enable()
+        # record GEMM
+        torch.cuda.tunable.tuning_enable(False)
+        torch.cuda.tunable.record_untuned_enable(True)
+        assert torch.cuda.tunable.record_untuned_is_enabled(), "Record untuned should be on by default"
+
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+        for (size_x, size_y), nctg_x, nctg_y in product(self.gen_sizes_matmul(1), (True, False), (True, False)):
+            x = make_arg(size_x, noncontiguous=nctg_x)
+            y = make_arg(size_y, noncontiguous=nctg_y)
+            self.check_single_matmul(x, y)
+
+        assert torch.cuda.tunable.is_enabled()
+        assert torch.cuda.tunable.tuning_is_enabled() is False
+        ordinal = torch.cuda.current_device()
+        untuned_filename = f"tunableop_untuned{ordinal}.csv"
+        assert os.path.exists(untuned_filename)
+
+        # tuning the untuned GEMMs in file
+        torch.cuda.tunable.tuning_enable(True)
+        torch.cuda.tunable.record_untuned_enable(False)
+
+        # set these to single iterations to keep it short but still exercise the code
+        torch.cuda.tunable.set_max_tuning_duration(1)
+        torch.cuda.tunable.set_max_tuning_iterations(1)
+
+        torch.cuda.tunable.tune_gemm_in_file(untuned_filename)
+        result_filename = f"tunableop_results{ordinal}.csv"
+        assert os.path.exists(result_filename)
+
+        # remove the files created above to avoid error 'Build left local git repository checkout dirty', ignore errors
+        for filename in [untuned_filename, result_filename]:
+            try:
+                os.remove(filename)
+            finally:
+                pass
+            
+    @onlyCUDA
     @skipCUDAIfNotRocm
     @dtypes(torch.float)
     def test_bmm_tunableop_rocm(self, device, dtype):

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1531,6 +1531,31 @@ PyObject* THCPModule_cuda_tunableop_tuning_is_enabled(
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THCPModule_cuda_record_untuned_enable(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPUtils_checkBool(arg),
+      "cuda_record_untuned_enable expects a bool, but got ",
+      THPUtils_typename(arg));
+  at::cuda::tunable::getTuningContext()->EnableRecordUntuned(THPUtils_unpackBool(arg));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THCPModule_cuda_record_untuned_is_enabled(
+    PyObject* _unused,
+    PyObject* noarg) {
+  HANDLE_TH_ERRORS
+  if (at::cuda::tunable::getTuningContext()->IsRecordUntunedEnabled()) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THCPModule_cuda_tunableop_write_file_on_exit(
     PyObject* _unused,
     PyObject* arg) {
@@ -1943,6 +1968,14 @@ static struct PyMethodDef _THCPModule_methods[] = {
      nullptr},
     {"_cuda_tunableop_tuning_is_enabled",
      THCPModule_cuda_tunableop_tuning_is_enabled,
+     METH_NOARGS,
+     nullptr},
+    {"_cuda_record_untuned_enable",
+     THCPModule_cuda_record_untuned_enable,
+     METH_O,
+     nullptr},
+    {"_cuda_record_untuned_is_enabled",
+     THCPModule_cuda_record_untuned_is_enabled,
      METH_NOARGS,
      nullptr},
     {"_cuda_tunableop_write_file_on_exit",

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1539,7 +1539,8 @@ PyObject* THCPModule_cuda_record_untuned_enable(
       THPUtils_checkBool(arg),
       "cuda_record_untuned_enable expects a bool, but got ",
       THPUtils_typename(arg));
-  at::cuda::tunable::getTuningContext()->EnableRecordUntuned(THPUtils_unpackBool(arg));
+  at::cuda::tunable::getTuningContext()->EnableRecordUntuned(
+      THPUtils_unpackBool(arg));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -115,7 +115,7 @@ C++ or Python APIs.
 from typing import Optional, Tuple
 
 import torch
-
+import warnings
 
 __all__ = [
     "enable",

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -273,27 +273,18 @@ def tune_gemm_in_file(filename: str) -> None:
                 transA = True if layout[0] == "T" else False
                 transB = True if layout[1] == "T" else False
 
-                dtype = torch.half
-                if data_type == "float":
-                    dtype = torch.float32
-                elif data_type == "double":
-                    dtype = torch.float64
-                elif data_type == "BFloat16":
-                    dtype = torch.bfloat16
-                elif data_type == "Half":
-                    dtype = torch.half
-                elif data_type == "Float8_e4m3fn":
-                    dtype = torch.float8_e4m3fn
-                elif data_type == "Float8_e5m2":
-                    dtype = torch.float8_e5m2
-                elif data_type == "Float8_e4m3fnuz":
-                    dtype = torch.float8_e4m3fnuz
-                elif data_type == "Float8_e5m2fnuz":
-                    dtype = torch.float8_e5m2fnuz
-                elif data_type == "c10::complex<double>":
-                    dtype = torch.complex128
-                elif data_type == "c10::complex<float>":
-                    dtype = torch.complex64
+                dtype = {
+                    "float": torch.float32,
+                    "double": torch.float64,
+                    "BFloat16": torch.bfloat16,
+                    "Half": torch.half,
+                    "c10::complex<double>": torch.complex128,
+                    "c10::complex<float>": torch.complex64,
+                    "Float8_e4m3fn": torch.float8_e4m3fn,
+                    "Float8_e5m2": torch.float8_e5m2,
+                    "Float8_e4m3fnuz": torch.float8_e4m3fnuz,
+                    "Float8_e5m2fnuz": torch.float8_e5m2fnuz,
+                }.get(data_type, torch.half)
 
                 if op_sig == "GemmTunableOp":
                     [n, m, k] = [int(g) for g in untuned_gemm[1].split("_")[1:]]

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -316,4 +316,4 @@ def tune_gemm_in_file(filename: str) -> None:
                     matB = matB.transpose(1, 2) if transA else matB
                     torch.bmm(matA, matB)
                 else:
-                    print("error: unkown op")
+                    warnings.warn(f"error: unkown op {op_sig}")

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -261,7 +261,7 @@ def tune_gemm_in_file(filename: str) -> None:
 
     with open(filename, 'r') as file:
         for line in file:
-            if line.startswith("Untuned"):
+            if line.startswith("Gemm"):
                 untuned_gemm = line.strip().split(',')[:]
                 [op_sig,data_type, layout] = untuned_gemm[0].split('_')
 

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -169,7 +169,7 @@ def record_untuned_enable(val: bool = True) -> None:
     torch._C._cuda_record_untuned_enable(val)  # type: ignore[attr-defined]
 
 def record_untuned_is_enabled() -> bool:
-    r"""Returns whether TunableOp implementations can be recorded."""
+    r"""Returns whether TunableOp operations are recorded for offline tuning."""
     return torch._C._cuda_record_untuned_is_enabled()  # type: ignore[attr-defined]
 
 def set_max_tuning_duration(duration: int) -> None:

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -155,11 +155,20 @@ def tuning_enable(val: bool = True) -> None:
     """
     torch._C._cuda_tunableop_tuning_enable(val)  # type: ignore[attr-defined]
 
-
 def tuning_is_enabled() -> bool:
     r"""Returns whether TunableOp implementations can be tuned."""
     return torch._C._cuda_tunableop_tuning_is_enabled()  # type: ignore[attr-defined]
 
+def record_untuned_enable(val: bool = True) -> None:
+    r"""Enable record untuned of TunableOp implementations.
+
+    When enabled, if a tuned entry isn't found, record the GEMM into file.
+    """
+    torch._C._cuda_record_untuned_enable(val)  # type: ignore[attr-defined]
+
+def record_untuned_is_enabled() -> bool:
+    r"""Returns whether TunableOp implementations can be recorded."""
+    return torch._C._cuda_record_untuned_is_enabled()  # type: ignore[attr-defined]
 
 def set_max_tuning_duration(duration: int) -> None:
     r"""Set max time in milliseconds to spend tuning a given solution.

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -285,8 +285,8 @@ def tune_gemm_in_file(filename: str) -> None:
                     torch.mm(matA, matB)
                 elif op_sig == "GemmStridedBatchedTunableOp":
                     [n,m,k,_,b] = untuned_gemm[1].split('_')[1:]
-                    matA = torch.rand(int(b),int(m),int(k), dtype=dtype, device='cuda')
-                    matB = torch.rand(int(b),int(k),int(n), dtype=dtype, device='cuda')
+                    matA = torch.rand(int(b),int(k),int(m), dtype=dtype, device='cuda') if transB else torch.rand(int(b),int(m),int(k), dtype=dtype, device='cuda')
+                    matB = torch.rand(int(b),int(n),int(k), dtype=dtype, device='cuda') if transA else torch.rand(int(b),int(k),int(n), dtype=dtype, device='cuda')
                     matA = matA.transpose(1,2) if transB else matA
                     matB = matB.transpose(1,2) if transA else matB
                     torch.bmm(matA, matB)

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -122,6 +122,8 @@ __all__ = [
     "is_enabled",
     "tuning_enable",
     "tuning_is_enabled",
+    "record_untuned_enable",
+    "record_untuned_is_enabled",
     "set_max_tuning_duration",
     "get_max_tuning_duration",
     "set_max_tuning_iterations",

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -162,9 +162,9 @@ def tuning_is_enabled() -> bool:
     return torch._C._cuda_tunableop_tuning_is_enabled()  # type: ignore[attr-defined]
 
 def record_untuned_enable(val: bool = True) -> None:
-    r"""Enable record untuned of TunableOp implementations.
+    r"""Enable recording untuned of TunableOp perations for offline tuning.
 
-    When enabled, if a tuned entry isn't found, record the GEMM into file.
+    When enabled, if a tuned entry isn't found, write it to the untuned file.
     """
     torch._C._cuda_record_untuned_enable(val)  # type: ignore[attr-defined]
 
@@ -262,7 +262,7 @@ def tune_gemm_in_file(filename: str) -> None:
     with open(filename, 'r') as file:
         for line in file:
             if line.startswith("Untuned"):
-                untuned_gemm = line.strip().split(',')[1:]
+                untuned_gemm = line.strip().split(',')[:]
                 [op_sig,data_type, layout] = untuned_gemm[0].split('_')
 
                 transA = True if layout[0] == 'T'  else False

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -112,10 +112,11 @@ environment variables take precedence over any setting you manipulate using the
 C++ or Python APIs.
 
 """
+import warnings
 from typing import Optional, Tuple
 
 import torch
-import warnings
+
 
 __all__ = [
     "enable",


### PR DESCRIPTION
When enable tunableop, It is easy to have OOM since APP usually needs large video memory size, such as running a LLM for inference.  So we need a offline mode to tune the GEMMs. This PR provide an offline mode for tunableOp:

- record untuned GEMMs to file.

- a python API named tune_gemm_in_file is added to read the untuned file and tune the GEMMs in file



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd