### PR TITLE
Fix negative value in profier dump table

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -127,11 +127,18 @@ class EventList(list):
                         # this can't be a parent
                         current_events.pop()
                     else:
-                        parent.append_cpu_child(event)
-                        assert (
-                            event.cpu_parent is None
-                        ), f"There is already a CPU parent event for {event.key}"
-                        event.set_cpu_parent(parent)
+                        is_contain = False
+                        for child in parent.cpu_children:
+                            if (child.time_range.end <= event.time_range.end and child.time_range.start >= event.time_range.start):
+                                is_contain = True
+                                break
+
+                        if not is_contain:
+                            parent.append_cpu_child(event)
+                            assert (
+                                event.cpu_parent is None
+                            ), f"There is already a CPU parent event for {event.key}"
+                            event.set_cpu_parent(parent)
                         break
 
                 current_events.append(event)


### PR DESCRIPTION
When using pytorch's profiler tool to view the performance of cpu op execution, negative numbers were observed in the performance data table of the dump, which only appeared in the "Self CPU %" and "Self CPU" columns. This is because all recursive children of a node are considered direct children of a parent node so there is double counting. This PR fixes the double counting
Fixes #128479
