### PR TITLE
Scale XBLOCK in triton reduction configs to avoid hitting max grid

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1747,6 +1747,7 @@ class CommonTemplate:
 
         self.common(fn, (torch.full((4,), float("-inf")),))
 
+    @requires_gpu
     def test_reduction_config_limit(self):
         """
         This unit-test tests whether we exceed cudaDeviceProperties.maxGridSize in

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1747,7 +1747,7 @@ class CommonTemplate:
 
         self.common(fn, (torch.full((4,), float("-inf")),))
 
-    @requires_gpu
+    @requires_gpu()
     def test_reduction_config_limit(self):
         """
         This unit-test tests whether we exceed cudaDeviceProperties.maxGridSize in

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1747,6 +1747,20 @@ class CommonTemplate:
 
         self.common(fn, (torch.full((4,), float("-inf")),))
 
+    def test_reduction_config_limit(self):
+        """
+        This unit-test tests whether we exceed cudaDeviceProperties.maxGridSize in
+        triton reduction configs for large size hints. #128826 introduced a scaling XBLOCK
+        feature to resolve the issue in reduction configs which may exceed the maxGridSize
+        """
+        from torch._inductor.runtime.runtime_utils import next_power_of_2
+        from torch._inductor.runtime.triton_heuristics import triton_config_reduction
+
+        size_hints = [67108864, 8192]
+        for i in range(4):
+            size_hints[0] = next_power_of_2(size_hints[0])
+            triton_config_reduction(size_hints, 1, 2048, 1, 8)
+
     def test_prod(self):
         def fn(a):
             return a.prod(0), a.prod(1), a.prod()

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1339,8 +1339,8 @@ def triton_config_reduction(size_hints, x, r, num_stages=1, num_warps=None) -> C
         if x >= TRITON_MAX_BLOCK["X"]:
             if num_warps == 1:
                 break  # If no more scaling possible then break
-            num_warps = int(
-                num_warps / 2
+            num_warps = (
+                num_warps // 2
             )  # If max XBLOCK then scale down warps as last resort
         x *= 2  # Scale up XBLOCK if grid exceeds limits
         num_blocks = num_blocks // 2

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1343,9 +1343,9 @@ def triton_config_reduction(size_hints, x, r, num_stages=1, num_warps=None) -> C
         x *= 2  # Scale up XBLOCK if grid exceeds limits
         num_blocks = int(num_blocks / 2)
     while conditional_product(x, r) > target: 
-        r = int(r / 2)
         if r == 1:
             break
+        r = int(r / 2)
 
     cfg = {"XBLOCK": x, "RBLOCK": r}
     check_config(cfg, xnumel=size_hints[0])

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1343,7 +1343,7 @@ def triton_config_reduction(size_hints, x, r, num_stages=1, num_warps=None) -> C
                 num_warps / 2
             )  # If max XBLOCK then scale down warps as last resort
         x *= 2  # Scale up XBLOCK if grid exceeds limits
-        num_blocks = int(num_blocks / 2)
+        num_blocks = num_blocks // 2
     while conditional_product(x, r) > target:
         if r == 1:
             break

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1347,7 +1347,7 @@ def triton_config_reduction(size_hints, x, r, num_stages=1, num_warps=None) -> C
     while conditional_product(x, r) > target:
         if r == 1:
             break
-        r = int(r / 2)
+        r = r // 2
 
     cfg = {"XBLOCK": x, "RBLOCK": r}
     check_config(cfg, xnumel=size_hints[0])

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1537,9 +1537,7 @@ def _reduction_configs(
     tiny_config = triton_config_reduction(
         size_hints, 2 * (256 // rnumel) if rnumel <= 256 else 1, min(rnumel, MAX_RBLOCK)
     )
-    import pdb
 
-    pdb.set_trace()
     if inductor_meta.get("max_autotune") or inductor_meta.get("max_autotune_pointwise"):
         pass  # skip all these cases
     elif reduction_hint == ReductionHint.INNER:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1537,7 +1537,6 @@ def _reduction_configs(
     tiny_config = triton_config_reduction(
         size_hints, 2 * (256 // rnumel) if rnumel <= 256 else 1, min(rnumel, MAX_RBLOCK)
     )
-
     if inductor_meta.get("max_autotune") or inductor_meta.get("max_autotune_pointwise"):
         pass  # skip all these cases
     elif reduction_hint == ReductionHint.INNER:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1323,7 +1323,6 @@ def triton_config_reduction(size_hints, x, r, num_stages=1, num_warps=None) -> C
     while r < size_hints[1] and conditional_product(x, r) < target:
         r *= 2
 
-    cfg = {"XBLOCK": x, "RBLOCK": r}
     if num_warps is None:
         num_warps = conditional_product(x, r) // 128
     # On AMD GPU each warp has 64 lanes which is double the size on NV GPU,
@@ -1331,6 +1330,24 @@ def triton_config_reduction(size_hints, x, r, num_stages=1, num_warps=None) -> C
     default_num_warps = 4 if torch.version.hip else 8
     min_num_warps = 1 if torch.version.hip else 2
     num_warps = next_power_of_2(min(max(num_warps, min_num_warps), default_num_warps))
+    
+    # Check if maxGridSize is exceeded - if so then must scale XBLOCK further 
+    max_grid_x = 4294967295 if torch.version.hip else 2147483647
+    warp_size = 64 if torch.version.hip else 32
+    num_blocks = int((size_hints[0] + x - 1) // x)
+    while(num_blocks * num_warps * warp_size) > max_grid_x:
+        if (x >= TRITON_MAX_BLOCK["X"]):
+            if num_warps == 1:
+                break  # If no more scaling possible then break
+            num_warps = int(num_warps / 2)  # If max XBLOCK then scale down warps as last resort
+        x *= 2  # Scale up XBLOCK if grid exceeds limits
+        num_blocks = int(num_blocks / 2)
+    while conditional_product(x, r) > target: 
+        r = int(r / 2)
+        if r == 1:
+            break
+
+    cfg = {"XBLOCK": x, "RBLOCK": r}
     check_config(cfg, xnumel=size_hints[0])
     assert r <= TRITON_MAX_BLOCK["R"], f"increase TRITON_MAX_BLOCK['r'] to {r}"
     return Config(cfg, num_warps=num_warps, num_stages=num_stages)


### PR DESCRIPTION
Scale XBLOCK size in triton_config_reduction to avoid hitting maxGridSize limits.

This issue was observed in gpt-fast examples with large sequence length:
Reproducer: https://gist.github.com/jataylo/8a0ba922fbf68e345d360a418b48b9f1

`RuntimeError: Triton Error [HIP]:  Code: 9, Messsage: invalid configuration argument`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang