### PR TITLE
[caffe2][be] [caffe2][be] migrate global static initializer - unused global initializer

### DIFF
--- a/torch/csrc/jit/mobile/promoted_prim_ops.cpp
+++ b/torch/csrc/jit/mobile/promoted_prim_ops.cpp
@@ -236,7 +236,8 @@ void dictIndex(Stack& stack) {
   push(stack, value->value());
 }
 
-static const C10_UNUSED std::array<mobile::prim_op_fn_register, 16> op_reg = {
+C10_UNUSED std::array<mobile::prim_op_fn_register, 16>& getOpReg() {
+  static C10_UNUSED std::array<mobile::prim_op_fn_register, 16> op_reg = {
     mobile::prim_op_fn_register("prim::TupleIndex", tupleIndex),
     mobile::prim_op_fn_register("aten::Bool.Tensor", boolTensor),
     mobile::prim_op_fn_register("aten::format", aten_format),
@@ -258,7 +259,9 @@ static const C10_UNUSED std::array<mobile::prim_op_fn_register, 16> op_reg = {
     // TODO: (@pavithran) size is overloaded with int[] and Tensor
     // so this throws error expecting int not Tensor
     // mobile::prim_op_fn_register("aten::size", size)
-};
+  };
+  return op_reg;
+}
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
Caffe2 lib has 200+ global static initializer usage, which are papar-cut reference to startup perf. Detail in this post https://fb.workplace.com/groups/arglassesperf/permalink/623909116287154.

Based on code search, https://fburl.com/code/608gvasc, it does not seem this variable is used in Caffe2?

Test Plan: CI

Differential Revision: D58643735
