### PR TITLE
Set bash shell on Windows

### DIFF
--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -89,7 +89,10 @@ jobs:
 
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        shell: bash
+        run: |
+          echo "${GITHUB_PATH}"
+          python3 .github/scripts/parse_ref.py
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -91,7 +91,6 @@ jobs:
         id: parse-ref
         shell: bash
         run: |
-          echo "${GITHUB_PATH}"
           python3 .github/scripts/parse_ref.py
 
       - name: Get workflow job id

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -47,6 +47,9 @@ jobs:
     timeout-minutes: 240
     outputs:
       test-matrix: ${{ steps.filter.outputs.test-matrix }}
+    defaults:
+      run:
+        shell: bash
     steps:
       # Duplicated in win-test because this MUST go before a checkout
       - name: Enable git symlinks on Windows and disable fsmonitor daemon

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -90,8 +90,7 @@ jobs:
       - name: Parse ref
         id: parse-ref
         shell: bash
-        run: |
-          python3 .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -92,7 +92,7 @@ jobs:
           retry_wait_seconds: 30
           command: |
             set -eu
-            python -m pip install rockset==1.0.3 'xdoctest>=1.1.0'
+            python3 -m pip install rockset==1.0.3 'xdoctest>=1.1.0'
 
       - name: Start monitoring script
         id: monitor-script
@@ -185,7 +185,7 @@ jobs:
         run: |
           pushd "${PYTORCH_FINAL_PACKAGE_DIR}"
           # shellcheck disable=SC2046,SC2102
-          python -mpip install $(echo *.whl)[opt-einsum,optree]
+          python3 -mpip install $(echo *.whl)[opt-einsum,optree]
           popd
 
           .ci/pytorch/win-test.sh
@@ -224,7 +224,8 @@ jobs:
 
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        shell: bash
+        run: python3 .github/scripts/parse_ref.py
 
       - name: Uninstall PyTorch
         if: always()
@@ -233,7 +234,7 @@ jobs:
         run: |
           # This step removes PyTorch installed by the test to give a clean slate
           # to the next job
-          python -mpip uninstall -y torch
+          python3 -mpip uninstall -y torch
 
       - name: Teardown Windows
         uses: ./.github/actions/teardown-win

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -92,7 +92,7 @@ jobs:
           retry_wait_seconds: 30
           command: |
             set -eu
-            python3 -m pip install rockset==1.0.3 'xdoctest>=1.1.0'
+            python -m pip install rockset==1.0.3 'xdoctest>=1.1.0'
 
       - name: Start monitoring script
         id: monitor-script
@@ -185,7 +185,7 @@ jobs:
         run: |
           pushd "${PYTORCH_FINAL_PACKAGE_DIR}"
           # shellcheck disable=SC2046,SC2102
-          python3 -mpip install $(echo *.whl)[opt-einsum,optree]
+          python -mpip install $(echo *.whl)[opt-einsum,optree]
           popd
 
           .ci/pytorch/win-test.sh
@@ -224,7 +224,7 @@ jobs:
 
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
 
       - name: Uninstall PyTorch
         if: always()
@@ -233,7 +233,7 @@ jobs:
         run: |
           # This step removes PyTorch installed by the test to give a clean slate
           # to the next job
-          python3 -mpip uninstall -y torch
+          python -mpip uninstall -y torch
 
       - name: Teardown Windows
         uses: ./.github/actions/teardown-win

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -41,6 +41,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.mem_leak_check == 'mem_leak_check' && 600 || inputs.timeout-minutes }}
+    defaults:
+      run:
+        shell: bash
     steps:
       # Duplicated in win-build because this MUST go before a checkout
       - name: Enable git symlinks on Windows and disable fsmonitor daemon


### PR DESCRIPTION
Attempt to fix the missing python3 command on the new Windows AMI https://github.com/pytorch/pytorch/actions/runs/9551494945/job/26325922503.  I added the logic to copy python to python3 to make the command available, it worked with the previous AMI, but start to fail now and the cause is not clear (maybe it's not the AMI, but a new GitHub runner version)