### PR TITLE
Remove circular import

### DIFF
--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -37,6 +37,3 @@ del rmsprop  # type: ignore[name-defined] # noqa: F821
 del optimizer  # type: ignore[name-defined] # noqa: F821
 del nadam  # type: ignore[name-defined] # noqa: F821
 del lbfgs  # type: ignore[name-defined] # noqa: F821
-
-
-import torch.optim._multi_tensor


### PR DESCRIPTION
Summary: A spurious import is causing circular dependency errors

Test Plan: phabricator signals

Differential Revision: D58685676
