### PR TITLE
Add packed layout to SDPA benchmark

### DIFF
--- a/benchmarks/transformer/sdpa.py
+++ b/benchmarks/transformer/sdpa.py
@@ -8,20 +8,31 @@ from tabulate import tabulate
 from tqdm import tqdm
 
 import torch
-import torch.utils.benchmark as benchmark
+from torch._inductor.utils import do_bench_using_profiling
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.nn.functional import scaled_dot_product_attention
 
 
-def benchmark_torch_function_in_microseconds(func: Callable, *args, **kwargs) -> float:
-    # warmup
-    for _ in range(5):
+def benchmark_cuda_function_in_microseconds(func: Callable, *args, **kwargs) -> float:
+    """Thin wrapper around do_bench_using_profiling"""
+
+    def no_args() -> None:
         func(*args, **kwargs)
-    t0 = benchmark.Timer(
-        stmt="func(*args, **kwargs)",
-        globals={"args": args, "kwargs": kwargs, "func": func},
-    )
-    return t0.adaptive_autorange(min_run_time=0.1).median * 1e6
+
+    time = do_bench_using_profiling(no_args)
+    return time * 1e3
+
+
+def get_tflops(flop_count: int, time_in_micro: float) -> float:
+    time_in_seconds = time_in_micro / 1e6
+    flops = flop_count / time_in_seconds
+    return flops / 1e12
+
+
+def flops(batch, headdim, seqlen_q, seq_len_kv, nheads, causal, mode="fwd"):
+    assert mode in ["fwd", "bwd", "fwd_bwd"]
+    f = 4 * batch * seqlen_q * seq_len_kv * nheads * headdim // (2 if causal else 1)
+    return f if mode == "fwd" else (2.5 * f if mode == "bwd" else 3.5 * f)
 
 
 @dataclass(frozen=True)
@@ -49,11 +60,46 @@ class ExperimentConfig:
 
 @dataclass(frozen=True)
 class ExperimentResults:
+    config: ExperimentConfig
     forward_time: float
     backward_time: float
 
+    @property
+    def tflops_forward(self):
+        config = self.config
+        total_flops = flops(
+            config.batch_size,
+            config.num_heads,
+            config.q_seq_len,
+            config.kv_seq_len,
+            config.head_dim,
+            config.is_causal,
+            mode="fwd",
+        )
+        tflops = get_tflops(flop_count=total_flops, time_in_micro=self.forward_time)
+        return tflops if self.config.is_causal is False else tflops / 2
+
+    @property
+    def tflops_backward(self):
+        config = self.config
+        total_flops = flops(
+            config.batch_size,
+            config.num_heads,
+            config.q_seq_len,
+            config.kv_seq_len,
+            config.head_dim,
+            config.is_causal,
+            mode="bwd",
+        )
+        return get_tflops(flop_count=total_flops, time_in_micro=self.backward_time)
+
     def asdict(self):
-        return asdict(self)
+        return {
+            "forward_time": self.forward_time,
+            "backward_time": self.backward_time,
+            "tflops_forward": self.tflops_forward,
+            "tflops_backward": self.tflops_backward,
+        }
 
 
 @dataclass(frozen=True)
@@ -63,7 +109,7 @@ class Experiment:
 
     def asdict(self):
         dict1 = asdict(self.config)
-        dict2 = asdict(self.results)
+        dict2 = self.results.asdict()
         return {**dict1, **dict2}
 
 
@@ -122,7 +168,7 @@ def run_single_experiment(config: ExperimentConfig) -> ExperimentResults:
         sdpa_kernel(config.backend) if config.backend is not None else nullcontext()
     )
     with context:
-        forward_time = benchmark_torch_function_in_microseconds(
+        forward_time = benchmark_cuda_function_in_microseconds(
             scaled_dot_product_attention,
             q,
             k,
@@ -134,11 +180,12 @@ def run_single_experiment(config: ExperimentConfig) -> ExperimentResults:
             q, k, v, is_causal=is_causal, attn_mask=None
         )
         dOut = torch.randn_like(out_torch)
-        backward_time = benchmark_torch_function_in_microseconds(
+        backward_time = benchmark_cuda_function_in_microseconds(
             out_torch.backward, dOut, retain_graph=True
         )
 
     return ExperimentResults(
+        config=config,
         forward_time=forward_time,
         backward_time=backward_time,
     )
@@ -147,17 +194,24 @@ def run_single_experiment(config: ExperimentConfig) -> ExperimentResults:
 def generate_experiment_configs() -> List[ExperimentConfig]:
     batch_sizes = [
         1,
-        8,
     ]
     num_heads = [16]
-    q_kv_seq_lens = [(128, 128), (256, 256), (512, 512), (1024, 1024)]
+    q_kv_seq_lens = [
+        (4096, 4096),
+        (8192, 8192),
+        (16384, 16384),
+        (32768, 32768),
+        (65536, 65536),
+    ]
     embed_dims = [2048]
-    backends = [SDPBackend.CUDNN_ATTENTION]  # If set to None, all backends are enabled
+    backends = [
+        None,
+    ]  # If set to None, all backends are enabled
     dtypes = [
         torch.bfloat16,
     ]
     is_causal = [True, False]
-    packed_layout = [True]
+    packed_layout = [False]
     all_configs = []
     for (
         bsz,


### PR DESCRIPTION
# Summary

Updates the sdpa benchmark to also measure the packed layout


On my H100 machine

```Shell
+------------+-----------+-----------+------------+-----------+-----------+---------------+----------------------------+---------------+--------------------+--------------------+--------------------+--------------------+
| batch_size | num_heads | q_seq_len | kv_seq_len | embed_dim | is_causal |     dtype     |          backend           | packed_layout |    forward_time    |   backward_time    |   tflops_forward   |  tflops_backward   |
+------------+-----------+-----------+------------+-----------+-----------+---------------+----------------------------+---------------+--------------------+--------------------+--------------------+--------------------+
|     1      |    16     |   4096    |    4096    |   2048    |   True    | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      | 334.3069322033899  | 962.5839729729724  | 102.77901849518268 | 178.47657624029836 |
|     1      |    16     |   4096    |    4096    |   2048    |   True    | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      | 181.82801449275445 | 712.4970413223137  | 188.96834167085504 | 241.12197226975303 |
|     1      |    16     |   4096    |    4096    |   2048    |   False   | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      | 457.07045251396613 | 1399.8640757575758 | 300.69533638865107 | 245.45053311268998 |
|     1      |    16     |   4096    |    4096    |   2048    |   False   | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      | 262.0925693430649  | 945.6711595744678  | 524.3908814984369  | 363.33706511110233 |
|     1      |    16     |   8192    |    8192    |   2048    |   True    | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      | 1123.874792682928  | 3069.263709677421  | 122.29027144910334 | 223.89564154857976 |
|     1      |    16     |   8192    |    8192    |   2048    |   True    | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      | 654.3218731343284  | 2154.3413181818178 | 210.04792765621733 | 318.9813803227644  |
|     1      |    16     |   8192    |    8192    |   2048    |   False   | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      | 1852.8493076923085 | 5253.537611111113  | 296.7083246358072  | 261.6122004748186  |
|     1      |    16     |   8192    |    8192    |   2048    |   False   | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      | 1079.1115999999997 | 3338.917000000003  | 509.45223264025714 | 411.6273434529815  |
|     1      |    16     |   16384   |   16384    |   2048    |   True    | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      | 4040.2861249999987 | 10587.775555555558 | 136.06853496990888 | 259.6181846712529  |
|     1      |    16     |   16384   |   16384    |   2048    |   True    | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      | 2404.2537749999988 | 7109.883384615387  | 228.65964466999756 | 386.61380514171356 |
|     1      |    16     |   16384   |   16384    |   2048    |   False   | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      | 7432.659769230769  | 20318.416500000003 | 295.85953397939323 | 270.5702060433695  |
|     1      |    16     |   16384   |   16384    |   2048    |   False   | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      | 4331.108090909089  | 12646.34971428571  | 507.7276321428474  | 434.71501762044323 |
|     1      |    16     |   32768   |   32768    |   2048    |   True    | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      | 15408.007166666666 | 40753.19350000001  | 142.71951146993993 | 269.7976608326412  |
|     1      |    16     |   32768   |   32768    |   2048    |   True    | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      | 9274.877699999997  | 26705.79799999999  | 237.09458244953467 | 411.71270290294274 |
|     1      |    16     |   32768   |   32768    |   2048    |   False   | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      | 29942.69366666667  | 80397.13200000004  | 293.76425247940006 | 273.5201120796198  |
|     1      |    16     |   32768   |   32768    |   2048    |   False   | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      | 17635.884599999998 | 48720.86349999999  | 498.7610897730642  | 451.3514534798835  |
|     1      |    16     |   65536   |   65536    |   2048    |   True    | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      | 67548.04500000001  | 181100.09299999996 | 130.2198016568503  | 242.85169809956977 |
|     1      |    16     |   65536   |   65536    |   2048    |   True    | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      |     37896.849      |     106951.693     | 232.10618440092472 | 411.2180357073918  |
|     1      |    16     |   65536   |   65536    |   2048    |   False   | torch.float16 | SDPBackend.FLASH_ATTENTION |     True      |     120982.844     | 314777.04499999987 | 290.8211687339074  | 279.43883335609826 |
|     1      |    16     |   65536   |   65536    |   2048    |   False   | torch.float16 | SDPBackend.CUDNN_ATTENTION |     True      |     70343.484      | 193589.19900000005 | 500.1795488098372  | 454.3689972191061  |
+------------+-----------+-----------+------------+-----------+-----------+---------------+----------------------------+---------------+--------------------+--------------------+--------------------+--------------
```