### PR TITLE
[RFC][Not Aim for landing now] Add a dummy pp hang case for flight recorder

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4040,7 +4040,6 @@ class PipelineParallelDumpOnTimeout(NCCLTraceTestDumpOnTimeoutBase):
     def test_pp_hello_world_timeout(self):
         os.environ["TORCH_NCCL_TRACE_BUFFER_SIZE"] = "1000"
         os.environ["TORCH_NCCL_DUMP_ON_TIMEOUT"] = "1"
-        
 
         if self.rank == self.MAIN_PROCESS_RANK:
             # wait for rank0 to crash before looking for its output file
@@ -4054,9 +4053,7 @@ class PipelineParallelDumpOnTimeout(NCCLTraceTestDumpOnTimeoutBase):
                 self.assertEqual(t[0]["p2p_seq_id"], 1)
                 self.assertEqual(t[0]["state"], "completed")
                 self.assertEqual(t[1]["p2p_seq_id"], 2)
-                self.assertEqual(
-                    t[1]["state"], "scheduled"
-                )
+                self.assertEqual(t[1]["state"], "scheduled")
 
             self.assertFalse(os.path.exists(self._trace_name(rank=0)))
             return
@@ -4074,7 +4071,7 @@ class PipelineParallelDumpOnTimeout(NCCLTraceTestDumpOnTimeoutBase):
                 pg.recv([b], 0, 0).wait()
 
             torch.cuda.synchronize(device=device)
-            
+
             if self.rank == 1:
                 pg.recv([b], 0, 0).wait()
 

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4051,9 +4051,9 @@ class PipelineParallelDumpOnTimeout(NCCLTraceTestDumpOnTimeoutBase):
                 t = pickle.load(f)
                 t = t["entries"]
                 self.assertEqual(len(t), 2)
-                self.assertEqual(t[0]["collective_seq_id"], 0)
+                self.assertEqual(t[0]["p2p_seq_id"], 1)
                 self.assertEqual(t[0]["state"], "completed")
-                self.assertEqual(t[1]["collective_seq_id"], 0)
+                self.assertEqual(t[1]["p2p_seq_id"], 2)
                 self.assertEqual(
                     t[1]["state"], "scheduled"
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128897

We are trying to create debug tools for pipeline parallel related collectives. We want to first start with some examples of pipeline parallel hangs so that we can think about design and solutions from some concrete examples. This PR is just using a simple hello-world style hang, e.g., we make one rank just wait here for a recv but no send is ever called. And then we want to what is given from the flight recorder.

To run the test, I need to manually override `DISTRIBUTED_TESTS_DEFAULT_TIMEOUT=20` to make the test timeout shorter otherwise, one needs to wait 300secs (5mins).

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k