### PR TITLE
Grouped Query Attention

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14709,21 +14709,21 @@
     CUDA, NestedTensorCUDA: native_multi_head_attention_cuda
   autogen: _native_multi_head_attention.out
 
-- func: scaled_dot_product_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None) -> Tensor
+- func: scaled_dot_product_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None, bool enable_gqa=False) -> Tensor
   python_module: nn
   variants: function
   autogen: scaled_dot_product_attention.out
   tags: nondeterministic_seeded
 
 # This aten function is kept so that we can test the choice function from Python
-- func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None) -> int
+- func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, *, float? scale=None, bool enable_gqa=False) -> int
   dispatch:
     Meta: _fused_sdp_choice_meta
     CPU, NestedTensorCPU: _fused_sdp_choice_cpp
     CUDA, NestedTensorCUDA: _fused_sdp_choice_cuda
   tags: nondeterministic_seeded
 
-- func: _scaled_dot_product_attention_math(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, Tensor? dropout_mask=None, *, float? scale=None) -> (Tensor, Tensor)
+- func: _scaled_dot_product_attention_math(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False, Tensor? dropout_mask=None, *, float? scale=None, bool enable_gqa=False) -> (Tensor, Tensor)
   variants: function
   tags: nondeterministic_seeded
 

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -625,8 +625,8 @@ std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
   if (all_equal){
     return std::make_tuple(key, value);
   }
-  auto repeat_key_shape = query.sym_size(1) / key.sym_size(1);
-  auto repeat_value_shape = query.sym_size(1) / value.sym_size(1);
+  auto repeat_key_shape = query.sym_size(-3) / key.sym_size(-3);
+  auto repeat_value_shape = query.sym_size(-3) / value.sym_size(-3);
   // std::cout << "Repeat key shape: " << repeat_key_shape << std::endl;
   // std::cout << "Repeat value shape: " << typeid(repeat_value_shape).name() << std::endl;
   at::Tensor key_repeated = key.repeat_interleave_symint(repeat_key_shape, -3);

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -513,19 +513,6 @@ inline void validate_sdpa_input(
       "Scaled_dot_product_attention: Nested tensors for query / key are not supported "
       "when an explicit attn_mask is set");
   }
-  // GQA/MQA handling
-  const auto q_num_heads = query_.size(1);
-  const auto k_num_heads = key.size(1);
-  const auto v_num_heads = value.size(1);
-
-  bool all_equal = q_num_heads == k_num_heads && k_num_heads == v_num_heads;
-  bool key_divisible = q_num_heads % k_num_heads == 0;
-  bool value_divisible = q_num_heads % v_num_heads == 0;
-
-  TORCH_CHECK(all_equal || (key_divisible && value_divisible),
-              "query, key, and value must have the same number of heads, or "
-              "the number of heads in query must be divisible by the number of "
-              "heads in key and value for grouped query attention");
   return;
 }
 // This function is used to produce an attn_mask
@@ -625,19 +612,25 @@ std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
     const at::Tensor& query,
     const at::Tensor& key,
     const at::Tensor& value) {
-  const auto q_num_heads = query.size(-3);
-  const auto k_num_heads = key.size(-3);
-  const auto v_num_heads = value.size(-3);
+  const auto q_num_heads = query.sym_size(-3);
+  const auto k_num_heads = key.sym_size(-3);
+  const auto v_num_heads = value.sym_size(-3);
 
   bool all_equal = q_num_heads == k_num_heads && k_num_heads == v_num_heads;
+  bool key_divisible = q_num_heads % k_num_heads == 0;
+  bool value_divisible = q_num_heads % v_num_heads == 0;
+  TORCH_CHECK(all_equal || (key_divisible && value_divisible),
+              "Number of heads in key and value must divide the number of heads in ");
 
   if (all_equal){
     return std::make_tuple(key, value);
   }
-  auto repeat_key_shape = query.size(-3) / key.size(-3);
-  auto repeat_value_shape = query.size(-3) / value.size(-3);
-  at::Tensor key_repeated = key.repeat_interleave(repeat_key_shape, -3);
-  at::Tensor value_repeated = value.repeat_interleave(repeat_value_shape, -3);
+  auto repeat_key_shape = query.sym_size(1) / key.sym_size(1);
+  auto repeat_value_shape = query.sym_size(1) / value.sym_size(1);
+  // std::cout << "Repeat key shape: " << repeat_key_shape << std::endl;
+  // std::cout << "Repeat value shape: " << typeid(repeat_value_shape).name() << std::endl;
+  at::Tensor key_repeated = key.repeat_interleave_symint(repeat_key_shape, -3);
+  at::Tensor value_repeated = value.repeat_interleave_symint(repeat_value_shape, -3);
   return std::make_tuple(std::move(key_repeated), std::move(value_repeated));
 }
 

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -790,7 +790,7 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
 
 
     // MQA/GQA handling
-    auto [key_expanded, value_expanded] = pre_process_group_query_attention_input(query_, key, value, enable_gqa);
+    auto [key_expanded, value_expanded] = pre_process_group_query_attention_input(query, key, value, enable_gqa);
     auto attn = at::matmul(query, key_expanded.transpose(-2, -1) * scaling_factor);
     if (attn_mask.has_value()) {
       if (at::areAnyTensorSubclassLike({attn, *attn_mask})) {

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -431,8 +431,8 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cpu(
 }
 
 int64_t _fused_sdp_choice_cpp(const Tensor& query_, const Tensor& key, const Tensor& value,
-        const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale){
-  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal};
+        const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale, bool enable_gqa){
+  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa};
   auto backend = sdp::select_sdp_backend_cpp(kernel_params);
   if (backend == sdp::SDPBackend::error) {
     TORCH_CHECK(
@@ -456,12 +456,13 @@ int64_t _fused_sdp_choice_meta(
     const std::optional<Tensor>& attn_mask_,
     double dropout_p,
     bool is_causal,
-    std::optional<double> scale) {
+    std::optional<double> scale,
+    bool enable_gqa) {
   auto query_key_set = query_.key_set();
 #if defined(USE_ROCM)
   bool has_rocm = query_key_set.has(c10::DispatchKey::HIP);
   if (has_rocm) {
-    auto choice_int = _fused_sdp_choice_stub(at::kHIP, query_, key, value, attn_mask_, dropout_p, is_causal, scale);
+    auto choice_int = _fused_sdp_choice_stub(at::kHIP, query_, key, value, attn_mask_, dropout_p, is_causal, scale, enable_gqa);
     return choice_int;
   }
 #else
@@ -475,7 +476,8 @@ int64_t _fused_sdp_choice_meta(
         attn_mask_,
         dropout_p,
         is_causal,
-        scale);
+        scale,
+        enable_gqa);
     return choice_int;
   }
 #endif
@@ -611,7 +613,12 @@ bool should_compute_logsumexp(const Tensor& query, const Tensor& key, const Tens
 std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
     const at::Tensor& query,
     const at::Tensor& key,
-    const at::Tensor& value) {
+    const at::Tensor& value,
+    const bool enable_gqa) {
+  
+  if (!enable_gqa) {
+    return std::make_tuple(key, value);
+  }
   const auto q_num_heads = query.sym_size(-3);
   const auto k_num_heads = key.sym_size(-3);
   const auto v_num_heads = value.sym_size(-3);
@@ -627,8 +634,7 @@ std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
   }
   auto repeat_key_shape = query.sym_size(-3) / key.sym_size(-3);
   auto repeat_value_shape = query.sym_size(-3) / value.sym_size(-3);
-  // std::cout << "Repeat key shape: " << repeat_key_shape << std::endl;
-  // std::cout << "Repeat value shape: " << typeid(repeat_value_shape).name() << std::endl;
+  
   at::Tensor key_repeated = key.repeat_interleave_symint(repeat_key_shape, -3);
   at::Tensor value_repeated = value.repeat_interleave_symint(repeat_value_shape, -3);
   return std::make_tuple(std::move(key_repeated), std::move(value_repeated));
@@ -672,12 +678,13 @@ Tensor scaled_dot_product_attention(
     const std::optional<Tensor>& attn_mask_,
     double dropout_p,
     bool is_causal,
-    std::optional<double> scale) {
+    std::optional<double> scale,
+    bool enable_gqa) {
   validate_sdpa_input(query_, key, value, attn_mask_, dropout_p, is_causal, scale);
   int64_t choice_int = static_cast<int64_t>(sdp::SDPBackend::math);
   if (_fused_sdp_choice_stub.is_device_supported(query_.device().type())) {
     choice_int = _fused_sdp_choice_stub(query_.device().type(),
-          query_, key, value, attn_mask_, dropout_p, is_causal, scale);
+          query_, key, value, attn_mask_, dropout_p, is_causal, scale, enable_gqa);
   }
   sdp::SDPBackend backend = static_cast<sdp::SDPBackend>(choice_int);
   std::optional<Tensor> attn_mask = convert_boolean_attn_mask(attn_mask_, query_.dtype());
@@ -739,8 +746,9 @@ Tensor scaled_dot_product_attention(
           attn_mask,
           dropout_p,
           is_causal,
-          std::nullopt, /*dropout_mask*/
-          scale));
+          c10::nullopt, /*dropout_mask*/
+          scale,
+          enable_gqa));
     default:
       TORCH_CHECK(
           false,
@@ -752,7 +760,7 @@ Tensor scaled_dot_product_attention(
 std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
         const Tensor& query_, const Tensor& key, const Tensor& value,
         const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal,
-        const std::optional<Tensor>& dropout_mask, std::optional<double> scale) {
+        const std::optional<Tensor>& dropout_mask, std::optional<double> scale, bool enable_gqa) {
   C10_LOG_API_USAGE_ONCE("torch.sdpa.math_fallback");
   if (query_.is_nested() || key.is_nested() || value.is_nested()) {
     TORCH_CHECK(
@@ -779,9 +787,9 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
         attn_mask = at::ones_symint({L, S}, query.options().dtype(at::kBool)).tril();
         attn_mask = convert_boolean_attn_mask(attn_mask, query.dtype());
     }
-
-    // MQA/GQA handling, HOW SHOULD WE HANDLE NESTED TENSORS?
-    auto [key_expanded, value_expanded] = pre_process_group_query_attention_input(query_, key, value);
+    
+    // MQA/GQA handling
+    auto [key_expanded, value_expanded] = pre_process_group_query_attention_input(query_, key, value, enable_gqa);
     auto attn = at::matmul(query, key_expanded.transpose(-2, -1) * scaling_factor);
     if (attn_mask.has_value()) {
       if (at::areAnyTensorSubclassLike({attn, *attn_mask})) {

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -615,7 +615,7 @@ std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
     const at::Tensor& key,
     const at::Tensor& value,
     const bool enable_gqa) {
-  
+
   if (!enable_gqa) {
     return std::make_tuple(key, value);
   }
@@ -634,7 +634,7 @@ std::tuple<at::Tensor, at::Tensor> pre_process_group_query_attention_input(
   }
   auto repeat_key_shape = query.sym_size(-3) / key.sym_size(-3);
   auto repeat_value_shape = query.sym_size(-3) / value.sym_size(-3);
-  
+
   at::Tensor key_repeated = key.repeat_interleave_symint(repeat_key_shape, -3);
   at::Tensor value_repeated = value.repeat_interleave_symint(repeat_value_shape, -3);
   return std::make_tuple(std::move(key_repeated), std::move(value_repeated));
@@ -787,7 +787,8 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
         attn_mask = at::ones_symint({L, S}, query.options().dtype(at::kBool)).tril();
         attn_mask = convert_boolean_attn_mask(attn_mask, query.dtype());
     }
-    
+
+
     // MQA/GQA handling
     auto [key_expanded, value_expanded] = pre_process_group_query_attention_input(query_, key, value, enable_gqa);
     auto attn = at::matmul(query, key_expanded.transpose(-2, -1) * scaling_factor);

--- a/aten/src/ATen/native/transformers/attention.h
+++ b/aten/src/ATen/native/transformers/attention.h
@@ -9,7 +9,7 @@ namespace at {
 namespace native {
 
 using fused_sdp_choice_fn = int64_t (*)(const Tensor& query_, const Tensor& key, const Tensor& value,
-        const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale);
+        const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale, bool enable_gqa);
 
 DECLARE_DISPATCH(fused_sdp_choice_fn, _fused_sdp_choice_stub);
 

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -868,8 +868,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _scaled_dot_product_efficient_attenti
 }
 
 int64_t _fused_sdp_choice_cuda(const Tensor& query_, const Tensor& key, const Tensor& value,
-        const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale){
-  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal};
+        const std::optional<Tensor>& attn_mask_, double dropout_p, bool is_causal, std::optional<double> scale, bool enable_gqa){
+  sdp::sdp_params kernel_params{query_, key, value, attn_mask_, dropout_p, is_causal, enable_gqa};
   auto backend = select_sdp_backend(kernel_params);
   if (backend == sdp::SDPBackend::error) {
     TORCH_CHECK(

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1029,8 +1029,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt> _efficient_
   TORCH_CHECK(key.size(1) == value.size(1));
 
   // Num heads
-  std::cout << "Print statements" << query.sizes();
-  std::cout << query.size(2) << key.size(2);
   TORCH_CHECK(query.size(2) == key.size(2));
   TORCH_CHECK(query.size(2) == value.size(2));
 

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1029,6 +1029,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt> _efficient_
   TORCH_CHECK(key.size(1) == value.size(1));
 
   // Num heads
+  std::cout << "Print statements" << query.sizes();
+  std::cout << query.size(2) << key.size(2);
   TORCH_CHECK(query.size(2) == key.size(2));
   TORCH_CHECK(query.size(2) == value.size(2));
 

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -599,7 +599,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
+        check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = false,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -582,7 +582,10 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_batch_size_and_num_heads_dense<true /*supports_grouped_query_attention=*/>
       );
   for (auto& constraint : general_constraints) {
+    std::cout << constraint << std::endl;
     if (!constraint(params, debug)) {
+      std::cout << "flash_attention_hardware_support check 1 failed" << std::endl;
+      std::cout << constraint << std::endl;
       return false;
     }
   }
@@ -594,6 +597,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
         check_for_seq_len_0_nested_tensor);
     for (auto& constraint : nested_constraints) {
       if (!constraint(params, debug)) {
+        std::cout << "flash_attention_hardware_support check 2 failed" << std::endl;
         return false;
       }
     }
@@ -605,6 +609,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
         check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {
       if (!constraint(params, debug)) {
+        std::cout << "flash_attention_hardware_support check 3 failed" << std::endl;
         return false;
       }
     }
@@ -657,9 +662,9 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense<false /*supports_grouped_query_attention=*/>,
         check_nonzero_sequence_lengths_dense,
-        check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim=*/>);
+        check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim=*/>,
+        check_batch_size_and_num_heads_dense<false /*supports_grouped_query_attention=*/>);
     for (auto& constraint : dense_constraints) {
       if (!constraint(params, debug)) {
         return false;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -582,10 +582,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_batch_size_and_num_heads_dense<true /*supports_grouped_query_attention=*/>
       );
   for (auto& constraint : general_constraints) {
-    std::cout << constraint << std::endl;
     if (!constraint(params, debug)) {
-      std::cout << "flash_attention_hardware_support check 1 failed" << std::endl;
-      std::cout << constraint << std::endl;
       return false;
     }
   }
@@ -597,7 +594,6 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
         check_for_seq_len_0_nested_tensor);
     for (auto& constraint : nested_constraints) {
       if (!constraint(params, debug)) {
-        std::cout << "flash_attention_hardware_support check 2 failed" << std::endl;
         return false;
       }
     }
@@ -609,7 +605,6 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
         check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {
       if (!constraint(params, debug)) {
-        std::cout << "flash_attention_hardware_support check 3 failed" << std::endl;
         return false;
       }
     }

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -578,8 +578,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_flash_attention_hardware_support,
       check_requires_grad_and_head_dim_gt192_constraints_on_sm86_89,
       check_flash_causal_non_square_seqlens,
-      check_dtypes_low_precision,
-      check_batch_size_and_num_heads_dense<true /*supports_grouped_query_attention=*/>
+      check_dtypes_low_precision
       );
   for (auto& constraint : general_constraints) {
     if (!constraint(params, debug)) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -579,7 +579,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_requires_grad_and_head_dim_gt192_constraints_on_sm86_89,
       check_flash_causal_non_square_seqlens,
       check_dtypes_low_precision,
-      check_batch_size_and_num_heads_dense<true> // supports_grouped_query_attention = true,
+      check_batch_size_and_num_heads_dense<true /*supports_grouped_query_attention=*/>
       );
   for (auto& constraint : general_constraints) {
     if (!constraint(params, debug)) {
@@ -600,7 +600,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
+        check_batch_size_and_num_heads_dense<true /*supports_grouped_query_attention=*/>,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -657,7 +657,7 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
+        check_batch_size_and_num_heads_dense<false /*supports_grouped_query_attention=*/>,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -578,8 +578,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_flash_attention_hardware_support,
       check_requires_grad_and_head_dim_gt192_constraints_on_sm86_89,
       check_flash_causal_non_square_seqlens,
-      check_dtypes_low_precision
-      );
+      check_dtypes_low_precision);
   for (auto& constraint : general_constraints) {
     if (!constraint(params, debug)) {
       return false;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -573,6 +573,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_runtime_disabled_flash,
       check_all_tensors_on_device,
       check_tensor_shapes,
+      check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
       check_for_attn_mask,
       check_head_dim_size_flash,
       check_flash_attention_hardware_support,
@@ -598,7 +599,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense,
+        check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {
@@ -655,7 +656,7 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense,
+        check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -631,6 +631,7 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
       check_runtime_disabled_mem_efficient,
       check_all_tensors_on_device,
       check_mem_efficient_hardware_support,
+      check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
       check_tensor_shapes,
       check_head_dim_size_mem_efficient);
   for (auto& constraint : general_constraints) {
@@ -645,6 +646,7 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
     return false;
 #endif
     constexpr auto nested_constraints = array_of<bool (*)(sdp_params const&, bool)>(
+        check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
         check_requires_grad_and_nested,
         check_batch_size_nested,
         check_for_seq_len_0_nested_tensor);
@@ -656,7 +658,7 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
+        check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -599,7 +599,7 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
   }
   if (has_only_dense_inputs(params)) {
     constexpr auto dense_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = false,
+        check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
         check_nonzero_sequence_lengths_dense,
         check_last_dim_stride_equals_1_dense<true /*ignore_singleton_dim=*/>);
     for (auto& constraint : dense_constraints) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -573,13 +573,14 @@ bool can_use_flash_attention(sdp_params const& params, bool debug) {
       check_runtime_disabled_flash,
       check_all_tensors_on_device,
       check_tensor_shapes,
-      check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
       check_for_attn_mask,
       check_head_dim_size_flash,
       check_flash_attention_hardware_support,
       check_requires_grad_and_head_dim_gt192_constraints_on_sm86_89,
       check_flash_causal_non_square_seqlens,
-      check_dtypes_low_precision);
+      check_dtypes_low_precision,
+      check_batch_size_and_num_heads_dense<true> // supports_grouped_query_attention = true,
+      );
   for (auto& constraint : general_constraints) {
     if (!constraint(params, debug)) {
       return false;
@@ -631,7 +632,6 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
       check_runtime_disabled_mem_efficient,
       check_all_tensors_on_device,
       check_mem_efficient_hardware_support,
-      check_batch_size_and_num_heads_dense<true>, // supports_grouped_query_attention = true,
       check_tensor_shapes,
       check_head_dim_size_mem_efficient);
   for (auto& constraint : general_constraints) {
@@ -646,7 +646,6 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
     return false;
 #endif
     constexpr auto nested_constraints = array_of<bool (*)(sdp_params const&, bool)>(
-        check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
         check_requires_grad_and_nested,
         check_batch_size_nested,
         check_for_seq_len_0_nested_tensor);

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
@@ -42,7 +42,7 @@ bool use_flash_attention_cpp(sdp_params const& params, bool debug) {
       check_nested_tensor,
       check_for_dropout,
       check_tensor_shapes,
-      check_batch_size_and_num_heads_dense,
+      check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
       check_attn_mask_shape,
       check_head_dim_size_cpp,
       check_nonzero_sequence_lengths_dense,

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
@@ -42,7 +42,7 @@ bool use_flash_attention_cpp(sdp_params const& params, bool debug) {
       check_nested_tensor,
       check_for_dropout,
       check_tensor_shapes,
-      check_batch_size_and_num_heads_dense<true /*supports_grouped_query_attention*/>,
+      check_batch_size_and_num_heads_dense<false /*supports_grouped_query_attention*/>,
       check_attn_mask_shape,
       check_head_dim_size_cpp,
       check_nonzero_sequence_lengths_dense,

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.cpp
@@ -42,7 +42,7 @@ bool use_flash_attention_cpp(sdp_params const& params, bool debug) {
       check_nested_tensor,
       check_for_dropout,
       check_tensor_shapes,
-      check_batch_size_and_num_heads_dense<false>, // supports_grouped_query_attention = false,
+      check_batch_size_and_num_heads_dense<true /*supports_grouped_query_attention*/>,
       check_attn_mask_shape,
       check_head_dim_size_cpp,
       check_nonzero_sequence_lengths_dense,

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -417,13 +417,6 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
 
   bool same_num_heads =
       q_num_heads == k_num_heads && q_num_heads == v_num_heads;
-  
-  if(params.enable_gqa && !supports_gqa){
-    TORCH_WARN(
-      "GQA is not supported for the kernel. Try with supported kernels, or set enable_gqa to false."
-    );
-  }
-
 
   if(params.enable_gqa && supports_gqa){
     return check_grouped_query_attention(params, debug);

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -359,7 +359,7 @@ inline bool check_grouped_query_attention(sdp_params const& params, bool debug) 
   const auto k_num_heads = params.key.sym_size(-3);
   const auto v_num_heads = params.value.sym_size(-3);
   const bool same_kv_heads = k_num_heads == v_num_heads;
-  
+
   if (!same_kv_heads){
     if (debug) {
       TORCH_WARN(
@@ -402,11 +402,11 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
 
   bool same_batch_size =
       q_batch_size == k_batch_size && q_batch_size == v_batch_size;
-  
+
   auto q_num_heads = params.query.sym_size(1);
   auto k_num_heads = params.key.sym_size(1);
   auto v_num_heads = params.value.sym_size(1);
-  
+
   if (!(same_batch_size)){
     if (debug) {
       TORCH_WARN(

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -355,30 +355,19 @@ inline bool check_safe_kv_broadcast(at::Tensor const& param, bool debug) {
 
 template <bool supports_gqa>
 inline bool check_grouped_query_attention(sdp_params const& params, bool debug) {
-  const auto q_num_heads = params.query.sym_size(1);
-  const auto k_num_heads = params.key.sym_size(1);
-  const auto v_num_heads = params.value.sym_size(1);
+  const auto q_num_heads = params.query.sym_size(-3);
+  const auto k_num_heads = params.key.sym_size(-3);
+  const auto v_num_heads = params.value.sym_size(-3);
   const bool same_kv_heads = k_num_heads == v_num_heads;
-  // Check nested tensor
-  if (params.query.is_nested() || params.key.is_nested() || params.value.is_nested()) {
-    if (debug) {
-      TORCH_WARN(
-          "Nested tensor not supported for grouped query attention,",
-          " got query.is_nested(): ", params.query.is_nested(),
-          ", key.is_nested(): ", params.key.is_nested(),
-          ", value.is_nested(): ", params.value.is_nested(),
-          " instead.");
-    }
-    return false;
-  }
+  
   if (!same_kv_heads){
     if (debug) {
       TORCH_WARN(
           "Both fused kernels require key and value to have the same num_heads but got: ",
-          "Key sizes(): ",
-          params.key.sizes(),
-          ", Value sizes(): ",
-          params.value.sizes(),
+          "Key heads: ",
+          params.key.size(-3),
+          ", Value heads: ",
+          params.value.size(-3),
           " instead.");
     }
     return false;
@@ -390,11 +379,11 @@ inline bool check_grouped_query_attention(sdp_params const& params, bool debug) 
       TORCH_WARN(
           "FlashAttentionV2 only supports grouped query attention, where the number of heads in key/value must divide number of heads in query.",
           "Got input Key sizes(): ",
-          params.key.sym_sizes(),
+          params.key.sym_size(-3),
           ", Value sizes(): ",
-          params.value.sym_sizes(),
+          params.value.sym_size(-3),
           ", Query sizes(): ",
-          params.query.sym_sizes(),
+          params.query.sym_size(-3),
           " instead.");
     }
     return false;
@@ -406,11 +395,11 @@ inline bool check_grouped_query_attention(sdp_params const& params, bool debug) 
       TORCH_WARN(
           "MemoryEfficient attention requires query, key and value to have the same num_heads but got: ",
           "Query.sizes(): ",
-          params.query.sym_sizes(),
+          params.query.sym_size(-3),
           ", Key sizes(): ",
-          params.key.sym_sizes(),
+          params.key.sym_size(-3),
           ", Value sizes(): ",
-          params.value.sym_sizes(),
+          params.value.sym_size(-3),
           " instead.");
     }
     return false;
@@ -429,25 +418,29 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
 
   bool same_batch_size =
       q_batch_size == k_batch_size && q_batch_size == v_batch_size;
-
-  auto q_num_heads = params.query.sym_size(-3);
-  auto k_num_heads = params.key.sym_size(-3);
-  auto v_num_heads = params.value.sym_size(-3);
+  
+  auto q_num_heads = params.query.sym_size(1);
+  auto k_num_heads = params.key.sym_size(1);
+  auto v_num_heads = params.value.sym_size(1);
+  
   if (!(same_batch_size)){
     if (debug) {
       TORCH_WARN(
-          "For dense inputs, both fused kernels require query, key and value to have the same batch_size and num_heads. ",
-          "Query.sizes(): ",
-          params.query.sym_sizes(),
-          ", Key sizes(): ",
-          params.key.sym_sizes(),
-          ", Value sizes(): ",
-          params.value.sym_sizes(),
+          "For dense inputs, both fused kernels require query, key and value to have the same batch_size. ",
+          "Query batch size: ",
+          params.query.size(0),
+          ", Key batch size: ",
+          params.key.size(0),
+          ", Value batch size: ",
+          params.value.size(0),
           " instead. To broadcast dense inputs, try using unsqueeze and expand_to before passing them into the kernel.");
     }
     return false;
   }
-  return check_grouped_query_attention<supports_gqa>(params, debug);
+  if(supports_gqa)
+  {
+    return check_grouped_query_attention<supports_gqa>(params, debug);
+  }
   // If all checks pass, return true
   return true;
 }

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -388,22 +388,6 @@ inline bool check_grouped_query_attention(sdp_params const& params, bool debug) 
     }
     return false;
   }
-  // If grouped query attention is not supported, ensure query and key have the
-  // same number of heads
-  else if (!supports_gqa && q_num_heads != k_num_heads) {
-    if (debug) {
-      TORCH_WARN(
-          "MemoryEfficient attention requires query, key and value to have the same num_heads but got: ",
-          "Query.sizes(): ",
-          params.query.sym_size(-3),
-          ", Key sizes(): ",
-          params.key.sym_size(-3),
-          ", Value sizes(): ",
-          params.value.sym_size(-3),
-          " instead.");
-    }
-    return false;
-  }
   return true;
 }
 
@@ -440,6 +424,22 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
   if(supports_gqa)
   {
     return check_grouped_query_attention<supports_gqa>(params, debug);
+  }
+  // If grouped query attention is not supported, ensure query and key have the
+  // same number of heads
+  else if (!supports_gqa && q_num_heads != k_num_heads) {
+    if (debug) {
+      TORCH_WARN(
+          "MemoryEfficient attention requires query, key and value to have the same num_heads but got: ",
+          "Query.sizes(): ",
+          params.query.sym_size(-3),
+          ", Key sizes(): ",
+          params.key.sym_size(-3),
+          ", Value sizes(): ",
+          params.value.sym_size(-3),
+          " instead.");
+    }
+    return false;
   }
   // If all checks pass, return true
   return true;

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -413,12 +413,10 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
   bool is_nested_input = params.query.is_nested() || params.key.is_nested() || params.value.is_nested();
 
   if(supports_gqa && same_batch_size && !is_nested_input){
-    std::cout << "Inside the gqa check" << std::endl;
     return check_grouped_query_attention<supports_gqa>(params, debug);
   }
 
-  if (!(same_batch_size && same_num_heads)){
-    std::cout << "Inside the batch size check" << std::endl;
+  if (!(same_batch_size && same_num_heads) && !(is_nested_input)){
     if (debug) {
       TORCH_WARN(
           "For dense inputs, both fused kernels require query, key and value to have the same batch_size. ",
@@ -432,7 +430,6 @@ inline bool check_batch_size_and_num_heads_dense(sdp_params const& params, bool 
     }
     return false;
   }
-  std::cout << "Returning true" << std::endl;
   // If all checks pass, return true
   return true;
 }

--- a/test/cpp_extensions/open_registration_extension.cpp
+++ b/test/cpp_extensions/open_registration_extension.cpp
@@ -128,7 +128,7 @@ void quantize_tensor_per_tensor_affine_privateuse1(
 }
 
 int64_t _fused_sdp_choice_privateuse1(const at::Tensor & query, const at::Tensor & key, const at::Tensor & value,
-    const c10::optional<at::Tensor> & attn_mask, double dropout_p, bool is_causal, c10::optional<double> scale){
+    const c10::optional<at::Tensor> & attn_mask, double dropout_p, bool is_causal, c10::optional<double> scale, bool enable_gqa){
   auto backend = sdp::SDPBackend::overrideable;
   return static_cast<int64_t>(backend);
 }

--- a/test/distributed/_tensor/test_matrix_ops.py
+++ b/test/distributed/_tensor/test_matrix_ops.py
@@ -303,7 +303,7 @@ class DistMatrixOpsTest(DTensorTestBase):
         #       Gaps include missing op support for aten.masked_fill_.Scalar.
         is_causal = True
         params = torch.backends.cuda.SDPAParams(
-            query, key, value, None, dropout_p, is_causal
+            query, key, value, None, dropout_p, is_causal, enable_gqa=False
         )
         if torch.backends.cuda.can_use_flash_attention(params, debug=False):
             available_backends.append(SDPBackend.FLASH_ATTENTION)

--- a/test/distributed/_tensor/test_matrix_ops.py
+++ b/test/distributed/_tensor/test_matrix_ops.py
@@ -302,8 +302,9 @@ class DistMatrixOpsTest(DTensorTestBase):
         # TODO: Add test cases where is_causal=False and an attention mask is provided.
         #       Gaps include missing op support for aten.masked_fill_.Scalar.
         is_causal = True
+        enable_gqa = False
         params = torch.backends.cuda.SDPAParams(
-            query, key, value, None, dropout_p, is_causal, enable_gqa=False
+            query, key, value, None, dropout_p, is_causal, enable_gqa
         )
         if torch.backends.cuda.can_use_flash_attention(params, debug=False):
             available_backends.append(SDPBackend.FLASH_ATTENTION)

--- a/test/dynamo/test_sdpa.py
+++ b/test/dynamo/test_sdpa.py
@@ -31,7 +31,7 @@ class TestSDPA(torch._dynamo.test_case.TestCase):
 
             @torch.compile(fullgraph=True, backend=counter)
             def fn(q, k, v, m):
-                return SDPAParams(q, k, v, m, 0.1, True)
+                return SDPAParams(q, k, v, m, 0.1, True, False)
 
             q = torch.randn(10)
             k = torch.randn(10)
@@ -39,7 +39,7 @@ class TestSDPA(torch._dynamo.test_case.TestCase):
             m = torch.randn(10)
             o = fn(q, k, v, m)
             self.assertTrue(isinstance(o, SDPAParams))
-            self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True))
+            self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True, False))
             self.assertEqual(counter.frame_count, 1)
 
     def test_graph_break_SDPAParams(self):
@@ -48,7 +48,7 @@ class TestSDPA(torch._dynamo.test_case.TestCase):
 
             @torch.compile(backend=counter)
             def fn(q, k, v, m):
-                z = SDPAParams(q, k, v, m, 0.1, True)
+                z = SDPAParams(q, k, v, m, 0.1, True, False)
                 torch._dynamo.graph_break()
                 return z, q + 1
 
@@ -58,7 +58,7 @@ class TestSDPA(torch._dynamo.test_case.TestCase):
             m = torch.randn(10)
             o, _ = fn(q, k, v, m)
             self.assertTrue(isinstance(o, SDPAParams))
-            self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True))
+            self.assert_ref_equals_params(o, SDPAParams(q, k, v, m, 0.1, True, False))
             self.assertEqual(counter.frame_count, 2)
 
     def test_input_SDPAParams(self):
@@ -74,7 +74,7 @@ class TestSDPA(torch._dynamo.test_case.TestCase):
             k = torch.randn(10)
             v = torch.randn(10)
             m = torch.randn(10)
-            s = SDPAParams(q, k, v, m, 0.1, True)
+            s = SDPAParams(q, k, v, m, 0.1, True, False)
             o, _ = fn(s, q)
             self.assertIs(o, s)
             self.assertEqual(counter.frame_count, 1)
@@ -86,7 +86,7 @@ class TestSDPA(torch._dynamo.test_case.TestCase):
             @torch.compile(fullgraph=True, backend=counter)
             def fn(q, k, v, m):
                 q += 1
-                z = SDPAParams(q, k, v, m, 0.1, True)
+                z = SDPAParams(q, k, v, m, 0.1, True, False)
                 a = z.query
                 return a + 1, z, q
 
@@ -95,7 +95,7 @@ class TestSDPA(torch._dynamo.test_case.TestCase):
             v = torch.randn(10)
             m = torch.randn(10)
             _, o, _ = fn(q, k, v, m)
-            expected = SDPAParams(q, k, v, m, 0.1, True)
+            expected = SDPAParams(q, k, v, m, 0.1, True, False)
             self.assert_ref_equals_params(o, expected)
             self.assertEqual(counter.frame_count, 1)
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -2529,6 +2529,7 @@ class TestNestedTensorDeviceType(TestCase):
         ):
             nt_noncont.narrow(dim=0, start=0, length=1)
 
+    @unittest.skip("Doesn't support the sdpa requirements")
     @parametrize("input_dim", [3, 4])
     def test_scaled_dot_product_attention(self, device, input_dim):
         def rand_tensor(*shape):
@@ -2553,14 +2554,14 @@ class TestNestedTensorDeviceType(TestCase):
             # Shape: (N, N', L, E); ragged N' and L
             query = torch.nested.nested_tensor(
                 [rand_tensor(2, 2, E), rand_tensor(3, 3, E), rand_tensor(4, 4, E)]
-            )
+            ).transpose(3, 1)
             # Shape: (N, N', S, E); ragged N' and S
             key = torch.nested.nested_tensor(
                 [rand_tensor(2, 3, E), rand_tensor(3, 4, E), rand_tensor(4, 5, E)]
-            )
+            ).transpose(3, 1)
             value = torch.nested.nested_tensor(
                 [rand_tensor(2, 3, E), rand_tensor(3, 4, E), rand_tensor(4, 5, E)]
-            )
+            ).transpose(3, 1)
         else:
             self.fail(f"Invalid input_dim {input_dim} encountered in SDP test")
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -2529,7 +2529,6 @@ class TestNestedTensorDeviceType(TestCase):
         ):
             nt_noncont.narrow(dim=0, start=0, length=1)
 
-    @unittest.skip("Doesn't support the sdpa requirements")
     @parametrize("input_dim", [3, 4])
     def test_scaled_dot_product_attention(self, device, input_dim):
         def rand_tensor(*shape):

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -2554,14 +2554,14 @@ class TestNestedTensorDeviceType(TestCase):
             # Shape: (N, N', L, E); ragged N' and L
             query = torch.nested.nested_tensor(
                 [rand_tensor(2, 2, E), rand_tensor(3, 3, E), rand_tensor(4, 4, E)]
-            ).transpose(3, 1)
+            )
             # Shape: (N, N', S, E); ragged N' and S
             key = torch.nested.nested_tensor(
                 [rand_tensor(2, 3, E), rand_tensor(3, 4, E), rand_tensor(4, 5, E)]
-            ).transpose(3, 1)
+            )
             value = torch.nested.nested_tensor(
                 [rand_tensor(2, 3, E), rand_tensor(3, 4, E), rand_tensor(4, 5, E)]
-            ).transpose(3, 1)
+            )
         else:
             self.fail(f"Invalid input_dim {input_dim} encountered in SDP test")
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3075,7 +3075,7 @@ class TestSDPACudaOnly(NNTestCase):
                 'out': 1.5,
                 'grad_query': 13.0,
                 'grad_key': 2.0,
-                'grad_value': 1.5,
+                'grad_value': 1.75,
             }
         )
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1562,6 +1562,18 @@ class TestSDPAFailureModes(NNTestCase):
                     q, k, v, None, 0.0, False))
 
     @onlyCUDA
+    @skipIfRocm  # Nested Tensor
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
+    def test_invalid_mem_efficient_kernel_grouped_query_attention(self, device, ):
+        rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            with self.assertRaisesRegex(RuntimeError, "No available kernel"):
+                F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+
+    @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not flash_attention fused scaled dot product attention")
     @parametrize("kernel", PLATFORM_SPECIFIC_SDPA)
     def test_invalid_fused_inputs_head_dim(self, device, kernel: SDPBackend):
@@ -3185,17 +3197,6 @@ class TestSDPACudaOnly(NNTestCase):
                     'grad_value': 2.0,
                 }
             )
-
-    @skipIfRocm  # Nested Tensor
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
-    def test_grouped_query_attention_error_case(self, device, ):
-        rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
-        rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
-        rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
-
-        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
-            with self.assertRaisesRegex(RuntimeError, "No available kernel"):
-                F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
 
 
     @skipIfRocm

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3199,34 +3199,84 @@ class TestSDPACudaOnly(NNTestCase):
         with sdpa_kernel(backends=[SDPBackend.MATH]):
             F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
 
-        # with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
-        #     F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            with self.assertRaisesRegex(RuntimeError, "No available kernel"):
+                F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+    
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
+    @unittest.skipIf(IS_JETSON, "causing sigkill on Jetson")
+    @parametrize("batch_size", [1, 8])
+    @parametrize("seq_len_q", [4, 8, 64, 143, 256, 512, 1024, 2048])
+    @parametrize("seq_len_k", [4, 8, 64, 128, 256, 587, 1024, 2048])
+    @parametrize("embedding_dim", [8, 16, 21, 32, 64, 72, 96, 128, 160, 192, 203, 256])
+    @parametrize("is_causal", [True, False])
+    @parametrize("dropout_p", [0.0, 0.22, 0.48])
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    @parametrize("n_heads", [[16, 8], [64, 8], [10, 2]])
+    def test_flash_attention_vs_math_ref_grads_grouped_query_attention(self, device, batch_size: int, seq_len_q: int, seq_len_k: int, 
+                                                                       embedding_dim: int, is_causal: bool, dropout_p: float, dtype: torch.dtype, n_heads: List):
+        # if isSM8XDevice and embedding_dim in range(193, 256 + 1):
+        #     self.skipTest("Flash attention on sm86, sm87, and sm89 for headdim > 192 currently disabled")
+        # if is_causal and seq_len_q != seq_len_k:
+        #     self.skipTest("Flash V2 does not accept is_casual when seq_len_q != seq_len_k")
+        # if TEST_WITH_ROCM and seq_len_q >= 1024 and seq_len_k >= 1024 and batch_size > 1:
+        #     torch.cuda.empty_cache()  # Prevent memory fragmentation
 
-    # def test_flash_gqa(self, device):
-    #     rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
-    #     rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
-    #     rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        query = torch.rand(batch_size, n_heads[0], seq_len_q, embedding_dim,
+                           device=device, dtype=dtype, requires_grad=True)
+        key = torch.rand(batch_size, n_heads[1], seq_len_k, embedding_dim, device=device,
+                         dtype=dtype, requires_grad=True)
+        value = torch.rand(batch_size, n_heads[1], seq_len_k, embedding_dim,
+                           device=device, dtype=dtype, requires_grad=True)
 
-    #     query_ref, key_ref, value_ref = query_key_value_clones(rand_query, rand_key, rand_value, dtype=rand_query.dtype)
+        # Run the math kernel on low precision references
+        query_ref_lp, key_ref_lp, value_ref_lp = query_key_value_clones(query, key, value, dtype=dtype)
 
-    #     with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-    #         out = F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+        higher_precision_dtype = torch.float64 if dtype == torch.float32 else torch.float32
+        query_ref, key_ref, value_ref = query_key_value_clones(query, key, value, dtype=higher_precision_dtype)
+        
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+            out = F.scaled_dot_product_attention(query, key, value, dropout_p=dropout_p, is_causal=is_causal)
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            # High Precision Math Reference
+            out_ref = F.scaled_dot_product_attention(
+                query_ref, key_ref, value_ref, is_causal=is_causal)
+            # Low Precision Math Reference
+            out_lp_ref = F.scaled_dot_product_attention(
+                query_ref_lp, key_ref_lp, value_ref_lp, is_causal=is_causal)
+        
 
-    #     with sdpa_kernel(backends=[SDPBackend.MATH]):
-    #         out_math = F.scaled_dot_product_attention(query_ref, key_ref, value_ref, dropout_p=0.0, is_causal=False)
+        upstream_grad = torch.rand_like(out, requires_grad=False)
 
-    #     with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
-    #         out_math = F.scaled_dot_product_attention(query_ref, key_ref, value_ref, dropout_p=0.0, is_causal=False)
+        # backward for flash attention on sm86, sm87, and sm89 for headdim >= 193 currently disabled
+        if isSM8XDevice and embedding_dim in range(193, 256):
+            self.assertRaises(RuntimeError, lambda: out.backward(upstream_grad))
+            return
+        out.backward(upstream_grad)
+        out_ref.backward(upstream_grad.to(out_ref.dtype))
+        out_lp_ref.backward(upstream_grad.to(out_lp_ref.dtype))
 
-    #     upstream_grad = torch.rand_like(out, requires_grad=False)
+        output_fudge_factor = 7  # if embedding_dim % 8 != 0 or TEST_WITH_ROCM else 1
+        output_ref_atol, output_ref_rtol = get_tolerances(out_ref, out_lp_ref, output_fudge_factor)
+        
+        query_fudge_factor = 7
+        grad_q_ref_atol, grad_q_ref_rtol = get_tolerances(query_ref.grad, query_ref_lp.grad, query_fudge_factor)
 
-    #     out.backward(upstream_grad)
-    #     out_math.backward(upstream_grad)
+        key_fudge_factor = 7
+        grad_k_ref_atol, grad_k_ref_rtol = get_tolerances(key_ref.grad, key_ref_lp.grad, key_fudge_factor)
 
-    #     torch.testing.assert_close(out, out_math, atol=1e-3, rtol=1e-2)
-    #     torch.testing.assert_close(rand_query.grad, query_ref.grad, atol=1e-3, rtol=1e-2)
-    #     torch.testing.assert_close(rand_key.grad, key_ref.grad, atol=1e-3, rtol=1e-2)
-    #     torch.testing.assert_close(rand_value.grad, value_ref.grad, atol=1e-3, rtol=1e-2)
+        value_fudge_factor = 7
+        grad_v_ref_atol, grad_v_ref_rtol = get_tolerances(value_ref.grad, value_ref_lp.grad, value_fudge_factor)
+
+        self.assertEqual(out, out_ref.to(out.dtype), atol=output_ref_atol, rtol=output_ref_rtol)
+        self.assertEqual(query.grad, query_ref.grad.to(query.grad.dtype),
+                         atol=grad_q_ref_atol, rtol=grad_q_ref_rtol)
+        self.assertEqual(key.grad, key_ref.grad.to(key.grad.dtype),
+                         atol=grad_k_ref_atol, rtol=grad_k_ref_rtol)
+        self.assertEqual(value.grad, value_ref.grad.to(value.grad.dtype),
+                         atol=grad_v_ref_atol, rtol=grad_v_ref_rtol)
+
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3186,6 +3186,31 @@ class TestSDPACudaOnly(NNTestCase):
             )
 
     @skipIfRocm  # Nested Tensor
+        @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
+    def test_flash_gqa(self, device):
+        rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        rand_key = torch.rand(8, 2, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        rand_value = torch.rand(8, 2, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+
+        query_ref, key_ref, value_ref = self.query_key_value_clones(rand_query, rand_key, rand_value, dtype=rand_query.dtype)
+
+        with sdp_kernel(**backend_map[SDPBackend.FLASH_ATTENTION]):
+            out = F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+
+        with sdp_kernel(**backend_map[SDPBackend.MATH]):
+            out_math = F.scaled_dot_product_attention(query_ref, key_ref, value_ref, dropout_p=0.0, is_causal=False)
+
+        upstream_grad = torch.rand_like(out, requires_grad=False)
+
+        out.backward(upstream_grad)
+        out_math.backward(upstream_grad)
+
+        torch.testing.assert_allclose(out, out_math, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_allclose(rand_query.grad, query_ref.grad, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_allclose(rand_key.grad, key_ref.grad, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_allclose(rand_value.grad, value_ref.grad, atol=1e-3, rtol=1e-2)
+
+        
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if
                  PLATFORM_SUPPORTS_FLASH_ATTENTION else [SDPBackend.EFFICIENT_ATTENTION])

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1699,7 +1699,7 @@ class TestSDPAFailureModes(NNTestCase):
         query = rand_nested_tensor(q_shape).transpose(1, 2)
         key = rand_nested_tensor(k_shape).transpose(1, 2)
         value = rand_nested_tensor(v_shape).transpose(1, 2)
-
+        
         with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 torch.nn.functional.scaled_dot_product_attention(
@@ -3188,7 +3188,7 @@ class TestSDPACudaOnly(NNTestCase):
 
     @skipIfRocm  # Nested Tensor
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
-    def test_flash_gqa(self, device, ):
+    def test_grouped_query_attention(self, device, ):
         rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
@@ -3199,8 +3199,8 @@ class TestSDPACudaOnly(NNTestCase):
         with sdpa_kernel(backends=[SDPBackend.MATH]):
             F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
 
-        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
-            F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+        # with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+        #     F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
 
     # def test_flash_gqa(self, device):
     #     rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
@@ -3339,7 +3339,7 @@ class TestSDPACudaOnly(NNTestCase):
         query = query.transpose(1, 2)
         key = key.transpose(1, 2)
         value = value.transpose(1, 2)
-
+        
         with sdpa_kernel(backends=[kernel]):
             actual = torch.nn.functional.scaled_dot_product_attention(
                 query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1805,7 +1805,7 @@ class TestSDPAFailureModes(NNTestCase):
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             with self.assertWarnsRegex(UserWarning, "Both fused kernels do not support training with broadcasted NT inputs"):
                 with self.assertRaisesRegex(RuntimeError, "No available kernel"):
-                    out = torch.nn.functional.scaled_dot_product_attention(
+                    torch.nn.functional.scaled_dot_product_attention(
                         query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False)
 
     @onlyCUDA
@@ -3217,8 +3217,9 @@ class TestSDPACudaOnly(NNTestCase):
             self.skipTest("Flash attention on sm86, sm87, and sm89 for headdim > 192 currently disabled")
         if is_causal and seq_len_q != seq_len_k:
             self.skipTest("Flash V2 does not accept is_casual when seq_len_q != seq_len_k")
-        if TEST_WITH_ROCM and seq_len_q >= 1024 and seq_len_k >= 1024 and batch_size > 1:
-            torch.cuda.empty_cache()  # Prevent memory fragmentation
+        if max(seq_len_q, seq_len_k) >= 2048 and torch.cuda.get_device_properties('cuda').total_memory < 40 * 2**30:
+            unittest.skip("Reference implementation OOM")
+            return
 
         query = torch.rand(batch_size, n_heads[0], seq_len_q, embedding_dim,
                            device=device, dtype=dtype, requires_grad=True)
@@ -3275,6 +3276,7 @@ class TestSDPACudaOnly(NNTestCase):
                          atol=grad_v_ref_atol, rtol=grad_v_ref_rtol)
 
 
+    @skipIfRocm  # Nested Tensor
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if
                  PLATFORM_SUPPORTS_FLASH_ATTENTION else [SDPBackend.EFFICIENT_ATTENTION])

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1573,8 +1573,8 @@ class TestSDPAFailureModes(NNTestCase):
 
         with sdpa_kernel(fused_kernel):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
-                with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, "
-                                           "key and value to have the same batch_size and num_heads"):
+                with self.assertWarnsRegex(UserWarning, "For dense inputs, both fused kernels require query, "
+                                           "key and value to have"):
                     F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0,
                                                    is_causal=False, enable_gqa=True)
 
@@ -1587,8 +1587,8 @@ class TestSDPAFailureModes(NNTestCase):
 
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
-                with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, "
-                                           "key and value to have the same batch_size and num_heads"):
+                with self.assertWarnsRegex(UserWarning, "For dense inputs, both fused kernels require query, "
+                                           "key and value to have"):
                     F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0,
                                                    is_causal=False, enable_gqa=True)
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1573,7 +1573,8 @@ class TestSDPAFailureModes(NNTestCase):
 
         with sdpa_kernel(fused_kernel):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
-                with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, key and value to have the same batch_size and num_heads"):
+                with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, "
+                                           "key and value to have the same batch_size and num_heads"):
                     F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False, enable_gqa=True)
 
     @onlyCPU
@@ -1586,7 +1587,8 @@ class TestSDPAFailureModes(NNTestCase):
 
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
-                with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, key and value to have the same batch_size and num_heads"):
+                with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, "
+                                           "key and value to have the same batch_size and num_heads"):
                     F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False, enable_gqa=True)
 
     @onlyCUDA

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3023,7 +3023,7 @@ class TestSDPACudaOnly(NNTestCase):
                     query_ref, key_ref, value_ref, is_causal=is_causal, scale=scale, enable_gqa=enable_gqa)
                 # Low Precision Math Reference
                 out_lp_ref = F.scaled_dot_product_attention(
-                    query_ref_lp, key_ref_lp, value_ref_lp, is_causal=is_causal, scale=scale, enable_gqa=enable_gqa)
+                    query, key, value, is_causal=is_causal, scale=scale, enable_gqa=enable_gqa)
         else:
             # Problem: We pad sizes in the composite region of the top level SDPA. But we need the
             # Debug mask when have dropout. So I am going to manualy pad up here when testing dropout
@@ -3054,7 +3054,7 @@ class TestSDPACudaOnly(NNTestCase):
                 scale=scale, dropout_mask=dropout_mask, enable_gqa=enable_gqa)[0]
             # Low Precision Math Reference
             out_lp_ref = torch.ops.aten._scaled_dot_product_attention_math(
-                query_ref_lp, key_ref_lp, value_ref_lp, dropout_p=dropout_p, is_causal=is_causal, scale=scale,
+                query, key, value, dropout_p=dropout_p, is_causal=is_causal, scale=scale,
                 dropout_mask=dropout_mask, enable_gqa=enable_gqa)[0]
 
         upstream_grad = torch.rand_like(out, requires_grad=False)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3210,13 +3210,12 @@ class TestSDPACudaOnly(NNTestCase):
         torch.testing.assert_close(rand_key.grad, key_ref.grad, atol=1e-3, rtol=1e-2)
         torch.testing.assert_close(rand_value.grad, value_ref.grad, atol=1e-3, rtol=1e-2)
 
-        
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if
                  PLATFORM_SUPPORTS_FLASH_ATTENTION else [SDPBackend.EFFICIENT_ATTENTION])
     def test_fused_kernels_seq_len_1_inputs(self, device, fused_kernel):
         rand_nested_tensor = partial(rand_sdpa_tensor, type="nested", device=device, dtype=torch.float16)
-        batch, num_heads, hequery_key_value_clonesad_dim = 32, 16, 64
+        batch, num_heads, head_dim = 32, 16, 64
         seq_lens = torch.randint(low=1, high=32, size=(batch,))
         # make sure some seq_lens are 1
         num_ones = 10

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1712,7 +1712,8 @@ class TestSDPAFailureModes(NNTestCase):
         seq_len_list = [2, 4, 5, 6, 7]
         shape = SdpaShape(5, 8, seq_len_list, 57)
         make_tensor = partial(rand_sdpa_tensor, shape=shape, type="nested", device=device, dtype=dtype)
-        q, k, v = make_tensor(), make_tensor(), make_tensor()
+        q, k, v = make_tensor().transpose(1, 2), make_tensor().transpose(1, 2), make_tensor().transpose(1, 2)
+
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             with self.assertWarnsRegex(UserWarning, "For NestedTensor inputs, Flash attention requires"):
                 self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
@@ -3187,28 +3188,45 @@ class TestSDPACudaOnly(NNTestCase):
 
     @skipIfRocm  # Nested Tensor
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
-    def test_flash_gqa(self, device):
+    def test_flash_gqa(self, device, ):
         rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
-        rand_key = torch.rand(8, 2, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
-        rand_value = torch.rand(8, 2, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
-
-        query_ref, key_ref, value_ref = query_key_value_clones(rand_query, rand_key, rand_value, dtype=rand_query.dtype)
+        rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
 
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-            out = F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+            F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
 
         with sdpa_kernel(backends=[SDPBackend.MATH]):
-            out_math = F.scaled_dot_product_attention(query_ref, key_ref, value_ref, dropout_p=0.0, is_causal=False)
+            F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
 
-        upstream_grad = torch.rand_like(out, requires_grad=False)
+        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+            F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
 
-        out.backward(upstream_grad)
-        out_math.backward(upstream_grad)
+    # def test_flash_gqa(self, device):
+    #     rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+    #     rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+    #     rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
 
-        torch.testing.assert_close(out, out_math, atol=1e-3, rtol=1e-2)
-        torch.testing.assert_close(rand_query.grad, query_ref.grad, atol=1e-3, rtol=1e-2)
-        torch.testing.assert_close(rand_key.grad, key_ref.grad, atol=1e-3, rtol=1e-2)
-        torch.testing.assert_close(rand_value.grad, value_ref.grad, atol=1e-3, rtol=1e-2)
+    #     query_ref, key_ref, value_ref = query_key_value_clones(rand_query, rand_key, rand_value, dtype=rand_query.dtype)
+
+    #     with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+    #         out = F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+
+    #     with sdpa_kernel(backends=[SDPBackend.MATH]):
+    #         out_math = F.scaled_dot_product_attention(query_ref, key_ref, value_ref, dropout_p=0.0, is_causal=False)
+
+    #     with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+    #         out_math = F.scaled_dot_product_attention(query_ref, key_ref, value_ref, dropout_p=0.0, is_causal=False)
+
+    #     upstream_grad = torch.rand_like(out, requires_grad=False)
+
+    #     out.backward(upstream_grad)
+    #     out_math.backward(upstream_grad)
+
+    #     torch.testing.assert_close(out, out_math, atol=1e-3, rtol=1e-2)
+    #     torch.testing.assert_close(rand_query.grad, query_ref.grad, atol=1e-3, rtol=1e-2)
+    #     torch.testing.assert_close(rand_key.grad, key_ref.grad, atol=1e-3, rtol=1e-2)
+    #     torch.testing.assert_close(rand_value.grad, value_ref.grad, atol=1e-3, rtol=1e-2)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("fused_kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2992,6 +2992,9 @@ class TestSDPACudaOnly(NNTestCase):
             self.skipTest("Flash V2 does not accept is_casual when seq_len_q != seq_len_k")
         if TEST_WITH_ROCM and seq_len_q >= 1024 and seq_len_k >= 1024 and batch_size > 1:
             torch.cuda.empty_cache()  # Prevent memory fragmentation
+        if max(seq_len_q, seq_len_k) >= 2048 and torch.cuda.get_device_properties('cuda').total_memory < 40 * 2**30:
+            unittest.skip("Reference implementation OOM")
+            return
 
         scale = scale if scale is None else (1 / head_dim)
         num_heads_q = num_heads_kv = 4

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1575,7 +1575,8 @@ class TestSDPAFailureModes(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, "
                                            "key and value to have the same batch_size and num_heads"):
-                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False, enable_gqa=True)
+                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0,
+                                                   is_causal=False, enable_gqa=True)
 
     @onlyCPU
     @skipIfRocm  # Nested Tensor
@@ -1589,7 +1590,8 @@ class TestSDPAFailureModes(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, "
                                            "key and value to have the same batch_size and num_heads"):
-                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False, enable_gqa=True)
+                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0,
+                                                   is_causal=False, enable_gqa=True)
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not flash_attention fused scaled dot product attention")

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1564,8 +1564,7 @@ class TestSDPAFailureModes(NNTestCase):
     @onlyCUDA
     @skipIfRocm  # Nested Tensor
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
-    @parametrize("fused_kernel", [SDPBackend.CUDNN_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if
-                 PLATFORM_SUPPORTS_CUDNN_ATTENTION else [SDPBackend.EFFICIENT_ATTENTION])
+    @parametrize("fused_kernel", [SDPBackend.EFFICIENT_ATTENTION])
     def test_invalid_sdpa_kernel_grouped_query_attention_cuda(self, device, fused_kernel):
         rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
@@ -2982,7 +2981,7 @@ class TestSDPACudaOnly(NNTestCase):
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     @parametrize("scale", [None, "l1"])
     @parametrize("enable_gqa", [True, False])
-    @parametrize("n_heads", [[16, 8], [64, 8], [10, 2]])
+    @parametrize("n_heads", [[16, 8], [10, 2]])
     def test_flash_attention_vs_math_ref_grads(self, device, batch_size: int, seq_len_q: int, seq_len_k: int,
                                                head_dim: int, is_causal: bool, dropout_p: float, dtype: torch.dtype,
                                                scale: str, enable_gqa: bool, n_heads: List[int]):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1699,7 +1699,7 @@ class TestSDPAFailureModes(NNTestCase):
         query = rand_nested_tensor(q_shape).transpose(1, 2)
         key = rand_nested_tensor(k_shape).transpose(1, 2)
         value = rand_nested_tensor(v_shape).transpose(1, 2)
-        
+
         with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 torch.nn.functional.scaled_dot_product_attention(
@@ -3188,21 +3188,16 @@ class TestSDPACudaOnly(NNTestCase):
 
     @skipIfRocm  # Nested Tensor
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
-    def test_grouped_query_attention(self, device, ):
+    def test_grouped_query_attention_error_case(self, device, ):
         rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
 
-        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-            F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
-
-        with sdpa_kernel(backends=[SDPBackend.MATH]):
-            F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
-
         with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
-    
+
+
     @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
     @unittest.skipIf(IS_JETSON, "causing sigkill on Jetson")
@@ -3214,14 +3209,15 @@ class TestSDPACudaOnly(NNTestCase):
     @parametrize("dropout_p", [0.0, 0.22, 0.48])
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     @parametrize("n_heads", [[16, 8], [64, 8], [10, 2]])
-    def test_flash_attention_vs_math_ref_grads_grouped_query_attention(self, device, batch_size: int, seq_len_q: int, seq_len_k: int, 
-                                                                       embedding_dim: int, is_causal: bool, dropout_p: float, dtype: torch.dtype, n_heads: List):
-        # if isSM8XDevice and embedding_dim in range(193, 256 + 1):
-        #     self.skipTest("Flash attention on sm86, sm87, and sm89 for headdim > 192 currently disabled")
-        # if is_causal and seq_len_q != seq_len_k:
-        #     self.skipTest("Flash V2 does not accept is_casual when seq_len_q != seq_len_k")
-        # if TEST_WITH_ROCM and seq_len_q >= 1024 and seq_len_k >= 1024 and batch_size > 1:
-        #     torch.cuda.empty_cache()  # Prevent memory fragmentation
+    def test_flash_attention_vs_math_ref_grads_grouped_query_attention(self, device, batch_size: int, seq_len_q: int,
+                                                                       seq_len_k: int, embedding_dim: int, is_causal: bool,
+                                                                       dropout_p: float, dtype: torch.dtype, n_heads: List):
+        if isSM8XDevice and embedding_dim in range(193, 256 + 1):
+            self.skipTest("Flash attention on sm86, sm87, and sm89 for headdim > 192 currently disabled")
+        if is_causal and seq_len_q != seq_len_k:
+            self.skipTest("Flash V2 does not accept is_casual when seq_len_q != seq_len_k")
+        if TEST_WITH_ROCM and seq_len_q >= 1024 and seq_len_k >= 1024 and batch_size > 1:
+            torch.cuda.empty_cache()  # Prevent memory fragmentation
 
         query = torch.rand(batch_size, n_heads[0], seq_len_q, embedding_dim,
                            device=device, dtype=dtype, requires_grad=True)
@@ -3235,17 +3231,17 @@ class TestSDPACudaOnly(NNTestCase):
 
         higher_precision_dtype = torch.float64 if dtype == torch.float32 else torch.float32
         query_ref, key_ref, value_ref = query_key_value_clones(query, key, value, dtype=higher_precision_dtype)
-        
+
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             out = F.scaled_dot_product_attention(query, key, value, dropout_p=dropout_p, is_causal=is_causal)
         with sdpa_kernel(backends=[SDPBackend.MATH]):
             # High Precision Math Reference
             out_ref = F.scaled_dot_product_attention(
-                query_ref, key_ref, value_ref, is_causal=is_causal)
+                query_ref, key_ref, value_ref, dropout_p=dropout_p, is_causal=is_causal)
             # Low Precision Math Reference
             out_lp_ref = F.scaled_dot_product_attention(
-                query_ref_lp, key_ref_lp, value_ref_lp, is_causal=is_causal)
-        
+                query_ref_lp, key_ref_lp, value_ref_lp, dropout_p=dropout_p, is_causal=is_causal)
+
 
         upstream_grad = torch.rand_like(out, requires_grad=False)
 
@@ -3259,7 +3255,7 @@ class TestSDPACudaOnly(NNTestCase):
 
         output_fudge_factor = 7  # if embedding_dim % 8 != 0 or TEST_WITH_ROCM else 1
         output_ref_atol, output_ref_rtol = get_tolerances(out_ref, out_lp_ref, output_fudge_factor)
-        
+
         query_fudge_factor = 7
         grad_q_ref_atol, grad_q_ref_rtol = get_tolerances(query_ref.grad, query_ref_lp.grad, query_fudge_factor)
 
@@ -3389,7 +3385,7 @@ class TestSDPACudaOnly(NNTestCase):
         query = query.transpose(1, 2)
         key = key.transpose(1, 2)
         value = value.transpose(1, 2)
-        
+
         with sdpa_kernel(backends=[kernel]):
             actual = torch.nn.functional.scaled_dot_product_attention(
                 query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1574,7 +1574,7 @@ class TestSDPAFailureModes(NNTestCase):
         with sdpa_kernel(fused_kernel):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, key and value to have the same batch_size and num_heads"):
-                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False, enable_gqa=True)
 
     @onlyCPU
     @skipIfRocm  # Nested Tensor
@@ -1587,7 +1587,7 @@ class TestSDPAFailureModes(NNTestCase):
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
                 with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, key and value to have the same batch_size and num_heads"):
-                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False, enable_gqa=True)
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not flash_attention fused scaled dot product attention")
@@ -3251,14 +3251,14 @@ class TestSDPACudaOnly(NNTestCase):
         query_ref, key_ref, value_ref = query_key_value_clones(query, key, value, dtype=higher_precision_dtype)
 
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-            out = F.scaled_dot_product_attention(query, key, value, dropout_p=dropout_p, is_causal=is_causal)
+            out = F.scaled_dot_product_attention(query, key, value, dropout_p=dropout_p, is_causal=is_causal, enable_gqa=True)
         with sdpa_kernel(backends=[SDPBackend.MATH]):
             # High Precision Math Reference
             out_ref = F.scaled_dot_product_attention(
-                query_ref, key_ref, value_ref, dropout_p=dropout_p, is_causal=is_causal)
+                query_ref, key_ref, value_ref, dropout_p=dropout_p, is_causal=is_causal, enable_gqa=True)
             # Low Precision Math Reference
             out_lp_ref = F.scaled_dot_product_attention(
-                query_ref_lp, key_ref_lp, value_ref_lp, dropout_p=dropout_p, is_causal=is_causal)
+                query_ref_lp, key_ref_lp, value_ref_lp, dropout_p=dropout_p, is_causal=is_causal, enable_gqa=True)
 
 
         upstream_grad = torch.rand_like(out, requires_grad=False)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -3186,18 +3186,18 @@ class TestSDPACudaOnly(NNTestCase):
             )
 
     @skipIfRocm  # Nested Tensor
-        @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
     def test_flash_gqa(self, device):
         rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_key = torch.rand(8, 2, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_value = torch.rand(8, 2, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
 
-        query_ref, key_ref, value_ref = self.query_key_value_clones(rand_query, rand_key, rand_value, dtype=rand_query.dtype)
+        query_ref, key_ref, value_ref = query_key_value_clones(rand_query, rand_key, rand_value, dtype=rand_query.dtype)
 
-        with sdp_kernel(**backend_map[SDPBackend.FLASH_ATTENTION]):
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             out = F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
 
-        with sdp_kernel(**backend_map[SDPBackend.MATH]):
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
             out_math = F.scaled_dot_product_attention(query_ref, key_ref, value_ref, dropout_p=0.0, is_causal=False)
 
         upstream_grad = torch.rand_like(out, requires_grad=False)
@@ -3205,10 +3205,10 @@ class TestSDPACudaOnly(NNTestCase):
         out.backward(upstream_grad)
         out_math.backward(upstream_grad)
 
-        torch.testing.assert_allclose(out, out_math, atol=1e-3, rtol=1e-2)
-        torch.testing.assert_allclose(rand_query.grad, query_ref.grad, atol=1e-3, rtol=1e-2)
-        torch.testing.assert_allclose(rand_key.grad, key_ref.grad, atol=1e-3, rtol=1e-2)
-        torch.testing.assert_allclose(rand_value.grad, value_ref.grad, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_close(out, out_math, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_close(rand_query.grad, query_ref.grad, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_close(rand_key.grad, key_ref.grad, atol=1e-3, rtol=1e-2)
+        torch.testing.assert_close(rand_value.grad, value_ref.grad, atol=1e-3, rtol=1e-2)
 
         
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION, "Fused SDPA was not built for this system")
@@ -3216,7 +3216,7 @@ class TestSDPACudaOnly(NNTestCase):
                  PLATFORM_SUPPORTS_FLASH_ATTENTION else [SDPBackend.EFFICIENT_ATTENTION])
     def test_fused_kernels_seq_len_1_inputs(self, device, fused_kernel):
         rand_nested_tensor = partial(rand_sdpa_tensor, type="nested", device=device, dtype=torch.float16)
-        batch, num_heads, head_dim = 32, 16, 64
+        batch, num_heads, hequery_key_value_clonesad_dim = 32, 16, 64
         seq_lens = torch.randint(low=1, high=32, size=(batch,))
         # make sure some seq_lens are 1
         num_ones = 10

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1580,7 +1580,6 @@ class TestSDPAFailureModes(NNTestCase):
 
     @onlyCPU
     @skipIfRocm  # Nested Tensor
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
     def test_invalid_sdpa_kernel_grouped_query_attention_cpu(self, device):
         rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2982,9 +2982,11 @@ class TestSDPACudaOnly(NNTestCase):
     @parametrize("dropout_p", [0.0, 0.22, 0.48])
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     @parametrize("scale", [None, "l1"])
+    @parametrize("enable_gqa", [True, False])
+    @parametrize("n_heads", [[16, 8], [64, 8], [10, 2]])
     def test_flash_attention_vs_math_ref_grads(self, device, batch_size: int, seq_len_q: int, seq_len_k: int,
                                                head_dim: int, is_causal: bool, dropout_p: float, dtype: torch.dtype,
-                                               scale: str):
+                                               scale: str, enable_gqa: bool, n_heads: List[int]):
         if isSM8XDevice and head_dim in range(193, 256 + 1):
             self.skipTest("Flash attention on sm86, sm87, and sm89 for headdim > 192 currently disabled")
         if is_causal and seq_len_q != seq_len_k:
@@ -2993,12 +2995,16 @@ class TestSDPACudaOnly(NNTestCase):
             torch.cuda.empty_cache()  # Prevent memory fragmentation
 
         scale = scale if scale is None else (1 / head_dim)
-        n_heads = 4
-        query = torch.rand(batch_size, n_heads, seq_len_q, head_dim,
+        num_heads_q = num_heads_kv = 4
+        if enable_gqa:
+            num_heads_q = n_heads[0]
+            num_heads_kv = n_heads[1]
+
+        query = torch.rand(batch_size, num_heads_q, seq_len_q, head_dim,
                            device=device, dtype=dtype, requires_grad=True)
-        key = torch.rand(batch_size, n_heads, seq_len_k, head_dim, device=device,
+        key = torch.rand(batch_size, num_heads_kv, seq_len_k, head_dim, device=device,
                          dtype=dtype, requires_grad=True)
-        value = torch.rand(batch_size, n_heads, seq_len_k, head_dim,
+        value = torch.rand(batch_size, num_heads_kv, seq_len_k, head_dim,
                            device=device, dtype=dtype, requires_grad=True)
 
         higher_precision_dtype = torch.float64 if dtype == torch.float32 else torch.float32
@@ -3008,14 +3014,15 @@ class TestSDPACudaOnly(NNTestCase):
 
         if not is_dropout:
             with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-                out = F.scaled_dot_product_attention(query, key, value, dropout_p=dropout_p, is_causal=is_causal, scale=scale)
+                out = F.scaled_dot_product_attention(
+                    query, key, value, dropout_p=dropout_p, is_causal=is_causal, scale=scale, enable_gqa=enable_gqa)
             with sdpa_kernel(backends=[SDPBackend.MATH]):
                 # High Precision Math Reference
                 out_ref = F.scaled_dot_product_attention(
-                    query_ref, key_ref, value_ref, is_causal=is_causal, scale=scale)
+                    query_ref, key_ref, value_ref, is_causal=is_causal, scale=scale, enable_gqa=enable_gqa)
                 # Low Precision Math Reference
                 out_lp_ref = F.scaled_dot_product_attention(
-                    query, key, value, is_causal=is_causal, scale=scale)
+                    query_ref_lp, key_ref_lp, value_ref_lp, is_causal=is_causal, scale=scale, enable_gqa=enable_gqa)
         else:
             # Problem: We pad sizes in the composite region of the top level SDPA. But we need the
             # Debug mask when have dropout. So I am going to manualy pad up here when testing dropout
@@ -3042,11 +3049,12 @@ class TestSDPACudaOnly(NNTestCase):
             dropout_mask = softmax_mask >= 0
             # High Precision Math Reference
             out_ref = torch.ops.aten._scaled_dot_product_attention_math(
-                query_ref, key_ref, value_ref, dropout_p=dropout_p, is_causal=is_causal, scale=scale, dropout_mask=dropout_mask)[0]
+                query_ref, key_ref, value_ref, dropout_p=dropout_p, is_causal=is_causal,
+                scale=scale, dropout_mask=dropout_mask, enable_gqa=enable_gqa)[0]
             # Low Precision Math Reference
             out_lp_ref = torch.ops.aten._scaled_dot_product_attention_math(
-                query, key, value, dropout_p=dropout_p, is_causal=is_causal, scale=scale,
-                dropout_mask=dropout_mask)[0]
+                query_ref_lp, key_ref_lp, value_ref_lp, dropout_p=dropout_p, is_causal=is_causal, scale=scale,
+                dropout_mask=dropout_mask, enable_gqa=enable_gqa)[0]
 
         upstream_grad = torch.rand_like(out, requires_grad=False)
 
@@ -3217,83 +3225,6 @@ class TestSDPACudaOnly(NNTestCase):
                     'grad_value': 2.0,
                 }
             )
-
-
-    @skipIfRocm
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
-    @unittest.skipIf(IS_JETSON, "causing sigkill on Jetson")
-    @parametrize("batch_size", [1, 8])
-    @parametrize("seq_len_q", [4, 8, 64, 143, 256, 512, 1024, 2048])
-    @parametrize("seq_len_k", [4, 8, 64, 128, 256, 587, 1024, 2048])
-    @parametrize("embedding_dim", [8, 16, 21, 32, 64, 72, 96, 128, 160, 192, 203, 256])
-    @parametrize("is_causal", [True, False])
-    @parametrize("dropout_p", [0.0, 0.22, 0.48])
-    @parametrize("dtype", [torch.float16, torch.bfloat16])
-    @parametrize("n_heads", [[16, 8], [64, 8], [10, 2]])
-    def test_flash_attention_vs_math_ref_grads_grouped_query_attention(self, device, batch_size: int, seq_len_q: int,
-                                                                       seq_len_k: int, embedding_dim: int, is_causal: bool,
-                                                                       dropout_p: float, dtype: torch.dtype, n_heads: List):
-        if isSM8XDevice and embedding_dim in range(193, 256 + 1):
-            self.skipTest("Flash attention on sm86, sm87, and sm89 for headdim > 192 currently disabled")
-        if is_causal and seq_len_q != seq_len_k:
-            self.skipTest("Flash V2 does not accept is_casual when seq_len_q != seq_len_k")
-        if max(seq_len_q, seq_len_k) >= 2048 and torch.cuda.get_device_properties('cuda').total_memory < 40 * 2**30:
-            unittest.skip("Reference implementation OOM")
-            return
-
-        query = torch.rand(batch_size, n_heads[0], seq_len_q, embedding_dim,
-                           device=device, dtype=dtype, requires_grad=True)
-        key = torch.rand(batch_size, n_heads[1], seq_len_k, embedding_dim, device=device,
-                         dtype=dtype, requires_grad=True)
-        value = torch.rand(batch_size, n_heads[1], seq_len_k, embedding_dim,
-                           device=device, dtype=dtype, requires_grad=True)
-
-        # Run the math kernel on low precision references
-        query_ref_lp, key_ref_lp, value_ref_lp = query_key_value_clones(query, key, value, dtype=dtype)
-
-        higher_precision_dtype = torch.float64 if dtype == torch.float32 else torch.float32
-        query_ref, key_ref, value_ref = query_key_value_clones(query, key, value, dtype=higher_precision_dtype)
-
-        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
-            out = F.scaled_dot_product_attention(query, key, value, dropout_p=dropout_p, is_causal=is_causal, enable_gqa=True)
-        with sdpa_kernel(backends=[SDPBackend.MATH]):
-            # High Precision Math Reference
-            out_ref = F.scaled_dot_product_attention(
-                query_ref, key_ref, value_ref, dropout_p=dropout_p, is_causal=is_causal, enable_gqa=True)
-            # Low Precision Math Reference
-            out_lp_ref = F.scaled_dot_product_attention(
-                query_ref_lp, key_ref_lp, value_ref_lp, dropout_p=dropout_p, is_causal=is_causal, enable_gqa=True)
-
-
-        upstream_grad = torch.rand_like(out, requires_grad=False)
-
-        # backward for flash attention on sm86, sm87, and sm89 for headdim >= 193 currently disabled
-        if isSM8XDevice and embedding_dim in range(193, 256):
-            self.assertRaises(RuntimeError, lambda: out.backward(upstream_grad))
-            return
-        out.backward(upstream_grad)
-        out_ref.backward(upstream_grad.to(out_ref.dtype))
-        out_lp_ref.backward(upstream_grad.to(out_lp_ref.dtype))
-
-        output_fudge_factor = 7  # if embedding_dim % 8 != 0 or TEST_WITH_ROCM else 1
-        output_ref_atol, output_ref_rtol = get_tolerances(out_ref, out_lp_ref, output_fudge_factor)
-
-        query_fudge_factor = 7
-        grad_q_ref_atol, grad_q_ref_rtol = get_tolerances(query_ref.grad, query_ref_lp.grad, query_fudge_factor)
-
-        key_fudge_factor = 7
-        grad_k_ref_atol, grad_k_ref_rtol = get_tolerances(key_ref.grad, key_ref_lp.grad, key_fudge_factor)
-
-        value_fudge_factor = 7
-        grad_v_ref_atol, grad_v_ref_rtol = get_tolerances(value_ref.grad, value_ref_lp.grad, value_fudge_factor)
-
-        self.assertEqual(out, out_ref.to(out.dtype), atol=output_ref_atol, rtol=output_ref_rtol)
-        self.assertEqual(query.grad, query_ref.grad.to(query.grad.dtype),
-                         atol=grad_q_ref_atol, rtol=grad_q_ref_rtol)
-        self.assertEqual(key.grad, key_ref.grad.to(key.grad.dtype),
-                         atol=grad_k_ref_atol, rtol=grad_k_ref_rtol)
-        self.assertEqual(value.grad, value_ref.grad.to(value.grad.dtype),
-                         atol=grad_v_ref_atol, rtol=grad_v_ref_rtol)
 
 
     @skipIfRocm  # Nested Tensor

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1563,15 +1563,31 @@ class TestSDPAFailureModes(NNTestCase):
 
     @onlyCUDA
     @skipIfRocm  # Nested Tensor
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
-    def test_invalid_mem_efficient_kernel_grouped_query_attention(self, device, ):
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
+    @parametrize("fused_kernel", [SDPBackend.CUDNN_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if
+                 PLATFORM_SUPPORTS_CUDNN_ATTENTION else [SDPBackend.EFFICIENT_ATTENTION])
+    def test_invalid_sdpa_kernel_grouped_query_attention_cuda(self, device, fused_kernel):
         rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
         rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
 
-        with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+        with sdpa_kernel(fused_kernel):
             with self.assertRaisesRegex(RuntimeError, "No available kernel"):
-                F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+                with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, key and value to have the same batch_size and num_heads"):
+                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
+
+    @onlyCPU
+    @skipIfRocm  # Nested Tensor
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support SDPA or pre-SM80 hardware")
+    def test_invalid_sdpa_kernel_grouped_query_attention_cpu(self, device):
+        rand_query = torch.rand(8, 8, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        rand_key = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+        rand_value = torch.rand(8, 4, 64, 64, device=device, dtype=torch.float16, requires_grad=True)
+
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+            with self.assertRaisesRegex(RuntimeError, "No available kernel"):
+                with self.assertWarnsRegex(UserWarning, "For dense inputs (not nested tensor), both fused kernels require query, key and value to have the same batch_size and num_heads"):
+                    F.scaled_dot_product_attention(rand_query, rand_key, rand_value, dropout_p=0.0, is_causal=False)
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not flash_attention fused scaled dot product attention")

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -466,6 +466,7 @@ def gen_nn_functional(fm: FileManager) -> None:
                             "dropout_p: float = 0.0",
                             "is_causal: bool = False",
                             "scale: Optional[float] = None",
+                            "enable_gqa: bool = False",
                         ]
                     )
                 )

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1956,6 +1956,7 @@ class _SDPAParams:
     attn_mask: Optional[Tensor]
     dropout: _float
     is_causal: _bool
+    enable_gqa: _bool
     def __init__(
         self,
         query: Tensor,
@@ -1963,7 +1964,8 @@ class _SDPAParams:
         value: Tensor,
         attn_mask: Optional[Tensor],
         dropout: _float,
-        is_causal: _bool) -> None: ...
+        is_causal: _bool,
+        enable_gqa: _bool) -> None: ...
 
 class _SDPBackend(Enum):
     ERROR = -1

--- a/torch/_dynamo/variables/sdpa.py
+++ b/torch/_dynamo/variables/sdpa.py
@@ -33,6 +33,9 @@ class SDPAParamsVariable(VariableTracker):
         is_causal_var = VariableBuilder(tx, AttrSource(source, "is_causal"))(
             value.is_causal
         )
+        enable_gqa_var = VariableBuilder(tx, AttrSource(source, "enable_gqa"))(
+            value.enable_gqa
+        )
         param_vars = [
             query_var,
             key_var,
@@ -40,6 +43,7 @@ class SDPAParamsVariable(VariableTracker):
             attn_mask_var,
             dropout_var,
             is_causal_var,
+            enable_gqa_var,
         ]
         return TorchInGraphFunctionVariable(SDPAParams).call_function(
             tx, param_vars, {}

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1953,16 +1953,18 @@ Call this whenever a new thread is created in order to propagate values from
                        at::Tensor const& value,
                        std::optional<at::Tensor> attn_mask,
                        double dropout,
-                       bool is_causal) {
+                       bool is_causal,
+                       bool enable_gqa) {
         return sdp::sdp_params{
-            query, key, value, std::move(attn_mask), dropout, is_causal};
+            query, key, value, std::move(attn_mask), dropout, is_causal, enable_gqa};
       }))
       .def_readonly("query", &sdp::sdp_params::query)
       .def_readonly("key", &sdp::sdp_params::key)
       .def_readonly("value", &sdp::sdp_params::value)
       .def_readonly("attn_mask", &sdp::sdp_params::attn_mask)
       .def_readonly("dropout", &sdp::sdp_params::dropout)
-      .def_readonly("is_causal", &sdp::sdp_params::is_causal);
+      .def_readonly("is_causal", &sdp::sdp_params::is_causal)
+      .def_readonly("enable_gqa", &sdp::sdp_params::enable_gqa);
 
   py::enum_<sdp::SDPBackend>(
       py_module,

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1956,7 +1956,13 @@ Call this whenever a new thread is created in order to propagate values from
                        bool is_causal,
                        bool enable_gqa) {
         return sdp::sdp_params{
-            query, key, value, std::move(attn_mask), dropout, is_causal, enable_gqa};
+            query,
+            key,
+            value,
+            std::move(attn_mask),
+            dropout,
+            is_causal,
+            enable_gqa};
       }))
       .def_readonly("query", &sdp::sdp_params::query)
       .def_readonly("key", &sdp::sdp_params::key)

--- a/torch/nn/attention/bias.py
+++ b/torch/nn/attention/bias.py
@@ -235,7 +235,6 @@ class CausalBias(torch.Tensor):
                     is_causal=True,  # TODO: Flash accepts causal = True and for this particular op it means lower right
                     return_debug_mask=False,
                     scale=og_scale,
-                    enable_gqa=enable_gqa,
                 )[0]
                 return _postprocess_flash_output(out, og_head_size)
             if can_use_efficient_attention(sdpa_params):

--- a/torch/nn/attention/bias.py
+++ b/torch/nn/attention/bias.py
@@ -218,7 +218,9 @@ class CausalBias(torch.Tensor):
             )
         elif attn_mask.variant == CausalVariant.LOWER_RIGHT:
             _validate_sdpa_input(query, key, value, None, dropout_p, is_causal, scale)
-            sdpa_params = SDPAParams(query, key, value, None, dropout_p, is_causal, enable_gqa)
+            sdpa_params = SDPAParams(
+                query, key, value, None, dropout_p, is_causal, enable_gqa
+            )
             if can_use_flash_attention(sdpa_params):
                 needs_padding = query.size(-1) % 8 != 0
                 og_head_size = query.size(-1)

--- a/torch/nn/attention/bias.py
+++ b/torch/nn/attention/bias.py
@@ -173,6 +173,7 @@ class CausalBias(torch.Tensor):
         dropout_p: float = 0.0,
         is_causal: bool = False,
         scale: Optional[float] = None,
+        enable_gqa: bool = False,
     ) -> torch.Tensor:
         r"""
         Handles the logic for computing attention with the specified causal bias.
@@ -189,6 +190,7 @@ class CausalBias(torch.Tensor):
                 are set.
             scale (optional float): Scaling factor applied prior to softmax. If None, the default value is set
                 to :math:`\frac{1}{\sqrt{E}}`.
+            enable_gqa (optional bool): If set to True, Grouped Query Attention (GQA) is enabled, by default it is set to False.
 
         Returns:
             output (Tensor): Attention output; shape :math:`(N, ..., L, Ev)`.
@@ -212,10 +214,11 @@ class CausalBias(torch.Tensor):
                 dropout_p=dropout_p,
                 is_causal=True,
                 scale=scale,
+                enable_gqa=enable_gqa,
             )
         elif attn_mask.variant == CausalVariant.LOWER_RIGHT:
             _validate_sdpa_input(query, key, value, None, dropout_p, is_causal, scale)
-            sdpa_params = SDPAParams(query, key, value, None, dropout_p, is_causal)
+            sdpa_params = SDPAParams(query, key, value, None, dropout_p, is_causal, enable_gqa)
             if can_use_flash_attention(sdpa_params):
                 needs_padding = query.size(-1) % 8 != 0
                 og_head_size = query.size(-1)
@@ -232,6 +235,7 @@ class CausalBias(torch.Tensor):
                     is_causal=True,  # TODO: Flash accepts causal = True and for this particular op it means lower right
                     return_debug_mask=False,
                     scale=og_scale,
+                    enable_gqa=enable_gqa,
                 )[0]
                 return _postprocess_flash_output(out, og_head_size)
             if can_use_efficient_attention(sdpa_params):
@@ -264,6 +268,7 @@ class CausalBias(torch.Tensor):
                     dropout_p=dropout_p,
                     is_causal=False,
                     scale=scale,
+                    enable_gqa=enable_gqa,
                 )
         else:
             raise ValueError(

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5618,7 +5618,7 @@ greater than 0.0 is specified. The optional scale argument can only be specified
 
     # Efficient implementation equivalent to the following:
     def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
-                                     is_causal=False, scale=None) -> torch.Tensor:
+                                     is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
         L, S = query.size(-2), key.size(-2)
         scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
         attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5617,7 +5617,8 @@ greater than 0.0 is specified. The optional scale argument can only be specified
 .. code-block:: python
 
     # Efficient implementation equivalent to the following:
-    def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
+    def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
+                                     is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
         L, S = query.size(-2), key.size(-2)
         scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
         attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
@@ -5746,7 +5747,7 @@ Examples:
     >>>     F.scaled_dot_product_attention(query,key,value)
 
 
-    >>> # Sample for GQA for llama3
+    >>> # Sample for GQA
     >>> query = torch.rand(32, 32, 128, 64, dtype=torch.float16, device="cuda")
     >>> key = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
     >>> value = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5606,9 +5606,7 @@ def _in_projection(
 
 scaled_dot_product_attention = _add_docstr(
     torch._C._nn.scaled_dot_product_attention,
-    r"""
-scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False,
-                             scale=None, enable_gqa=False) -> Tensor:
+    r"""scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False) -> Tensor:
 
 Computes scaled dot product attention on query, key and value tensors, using
 an optional attention mask if passed, and applying dropout if a probability
@@ -5656,112 +5654,153 @@ greater than 0.0 is specified. The optional scale argument can only be specified
 
     .. code-block:: python
 
-        class MyModel(nn.Module):
-            def __init__(self, p=0.5):
-                super().__init__()
-                self.p = p
+        # Efficient implementation equivalent to the following:
+        def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
+            L, S = query.size(-2), key.size(-2)
+            scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
+            attn_bias = torch.zeros(L, S, dtype=query.dtype)
+            if is_causal:
+                assert attn_mask is None
+                temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
+                attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
+                attn_bias.to(query.dtype)
 
-            def forward(self, ...):
-                return F.scaled_dot_product_attention(..., dropout_p=(self.p if self.training else 0.0))
+            if attn_mask is not None:
+                if attn_mask.dtype == torch.bool:
+                    attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
+                else:
+                    attn_bias += attn_mask
 
-Note:
+            if enable_gqa:
+                key = key.repeat_interleave(query.size(-3)//key.size(-3), -3)
+                value = value.repeat_interleave(query.size(-3)//value.size(-3), -3)
 
-    There are currently three supported implementations of scaled dot product attention:
+            attn_weight = query @ key.transpose(-2, -1) * scale_factor
+            attn_weight += attn_bias
+            attn_weight = torch.softmax(attn_weight, dim=-1)
+            attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
+            return attn_weight @ value
 
-        - `FlashAttention-2: Faster Attention with Better Parallelism and Work Partitioning`_
-        - `Memory-Efficient Attention`_
-        - A PyTorch implementation defined in C++ matching the above formulation
+    .. warning::
+        This function is beta and subject to change.
 
-    The function may call optimized kernels for improved performance when using the CUDA backend.
-    For all other backends, the PyTorch implementation will be used.
+    .. warning::
+        This function always applies dropout according to the specified ``dropout_p`` argument.
+        To disable dropout during evaluation, be sure to pass a value of ``0.0`` when the module
+        that makes the function call is not in training mode.
 
-    All implementations are enabled by default. Scaled dot product attention attempts to automatically select the
-    most optimal implementation based on the inputs. In order to provide more fine-grained control over what implementation
-    is used, the following functions are provided for enabling and disabling implementations.
-    The context manager is the preferred mechanism:
+        For example:
 
-        - :func:`torch.nn.attention.sdpa_kernel`: A context manager used to enable or disable any of the implementations.
-        - :func:`torch.backends.cuda.enable_flash_sdp`: Globally enables or disables FlashAttention.
-        - :func:`torch.backends.cuda.enable_mem_efficient_sdp`: Globally enables or disables  Memory-Efficient Attention.
-        - :func:`torch.backends.cuda.enable_math_sdp`: Globally enables or disables  the PyTorch C++ implementation.
+        .. code-block:: python
 
-    Each of the fused kernels has specific input limitations. If the user requires the use of a specific fused implementation,
-    disable the PyTorch C++ implementation using :func:`torch.nn.attention.sdpa_kernel`.
-    In the event that a fused implementation is not available, a warning will be raised with the
-    reasons why the fused implementation cannot run.
+            class MyModel(nn.Module):
+                def __init__(self, p=0.5):
+                    super().__init__()
+                    self.p = p
 
-    Due to the nature of fusing floating point operations, the output of this function may be different
-    depending on what backend kernel is chosen.
-    The c++ implementation supports torch.float64 and can be used when higher precision is required.
-    For more information please see :doc:`/notes/numerical_accuracy`
+                def forward(self, ...):
+                    return F.scaled_dot_product_attention(...,
+                        dropout_p=(self.p if self.training else 0.0))
 
-    Grouped Query Attention (GQA) is an experimental feature.
-    It currently works only for Flash_attention and math kernel on CUDA tensor, and does not support Nested tensor.
-    Constraints for GQA:
-        number_of_heads_query % number_of_heads_key_value == 0 and,
-        number_of_heads_key == number_of_heads_value
+    Note:
 
-Note:
-    {cudnn_reproducibility_note}
-""".format(
+        There are currently three supported implementations of scaled dot product attention:
+
+            - `FlashAttention-2: Faster Attention with Better Parallelism and Work Partitioning`_
+            - `Memory-Efficient Attention`_
+            - A PyTorch implementation defined in C++ matching the above formulation
+
+        The function may call optimized kernels for improved performance when using the CUDA backend.
+        For all other backends, the PyTorch implementation will be used.
+
+        All implementations are enabled by default. Scaled dot product attention attempts to automatically select the
+        most optimal implementation based on the inputs. In order to provide more fine-grained control over what implementation
+        is used, the following functions are provided for enabling and disabling implementations.
+        The context manager is the preferred mechanism:
+
+            - :func:`torch.nn.attention.sdpa_kernel`: A context manager used to enable or disable any of the implementations.
+            - :func:`torch.backends.cuda.enable_flash_sdp`: Globally enables or disables FlashAttention.
+            - :func:`torch.backends.cuda.enable_mem_efficient_sdp`: Globally enables or disables  Memory-Efficient Attention.
+            - :func:`torch.backends.cuda.enable_math_sdp`: Globally enables or disables  the PyTorch C++ implementation.
+
+        Each of the fused kernels has specific input limitations. If the user requires the use of a specific fused implementation,
+        disable the PyTorch C++ implementation using :func:`torch.nn.attention.sdpa_kernel`.
+        In the event that a fused implementation is not available, a warning will be raised with the
+        reasons why the fused implementation cannot run.
+
+        Due to the nature of fusing floating point operations, the output of this function may be different
+        depending on what backend kernel is chosen.
+        The c++ implementation supports torch.float64 and can be used when higher precision is required.
+        For more information please see :doc:`/notes/numerical_accuracy`
+
+        Grouped Query Attention (GQA) is an experimental feature. It currently works only for Flash_attention
+        and math kernel on CUDA tensor, and does not support Nested tensor.
+        Constraints for GQA:
+
+            - number_of_heads_query % number_of_heads_key_value == 0 and,
+            - number_of_heads_key == number_of_heads_value
+
+    Note:
+
+        {cudnn_reproducibility_note}
+    """.format(
         **reproducibility_notes
     )
     + r"""
-Args:
-    query (Tensor): Query tensor; shape :math:`(N, ..., Hq, L, E)`.
-    key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
-    value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
-    attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
-        which is :math:`(N,..., L, S)`. Two types of masks are supported.
-        A boolean mask where a value of True indicates that the element *should* take part in attention.
-        A float mask of the same type as query, key, value that is added to the attention score.
-    dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied
-    is_causal (bool): If set to true, the attention masking is a lower triangular matrix when the mask is a
-        square matrix. The attention masking has the form of the upper left causal bias due to the alignment
-        (see :class:`torch.nn.attention.bias.CausalBias`) when the mask is a non-square matrix.
-        An error is thrown if both attn_mask and is_causal are set.
-    scale (optional float, keyword-only): Scaling factor applied prior to softmax. If None, the default value is set
-        to :math:`\frac{1}{\sqrt{E}}`.
-    enable_gqa (bool): If set to True, Grouped Query Attention (GQA) is enabled, by default it is set to False.
+    Args:
+        query (Tensor): Query tensor; shape :math:`(N, ..., Hq, L, E)`.
+        key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
+        value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
+        attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
+            which is :math:`(N,..., L, S)`. Two types of masks are supported.
+            A boolean mask where a value of True indicates that the element *should* take part in attention.
+            A float mask of the same type as query, key, value that is added to the attention score.
+        dropout_p (float): Dropout probability; if greater than 0.0, dropout is applied
+        is_causal (bool): If set to true, the attention masking is a lower triangular matrix when the mask is a
+            square matrix. The attention masking has the form of the upper left causal bias due to the alignment
+            (see :class:`torch.nn.attention.bias.CausalBias`) when the mask is a non-square matrix.
+            An error is thrown if both attn_mask and is_causal are set.
+        scale (optional float, keyword-only): Scaling factor applied prior to softmax. If None, the default value is set
+            to :math:`\frac{1}{\sqrt{E}}`.
+        enable_gqa (bool): If set to True, Grouped Query Attention (GQA) is enabled, by default it is set to False.
+
+    Returns:
+        output (Tensor): Attention output; shape :math:`(N, ..., Hq, L, Ev)`.
+
+    Shape legend:
+        - :math:`N: \text{Batch size} ... : \text{Any number of other batch dimensions (optional)}`
+        - :math:`S: \text{Source sequence length}`
+        - :math:`L: \text{Target sequence length}`
+        - :math:`E: \text{Embedding dimension of the query and key}`
+        - :math:`Ev: \text{Embedding dimension of the value}`
+        - :math:`Hq: \text{Number of heads of query}`
+        - :math:`H: \text{Number of heads of key and value}`
+
+    Examples:
+
+        >>> # Optionally use the context manager to ensure one of the fused kernels is run
+        >>> query = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
+        >>> key = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
+        >>> value = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
+        >>> with torch.backends.cuda.sdp_kernel(enable_math=False):
+        >>>     F.scaled_dot_product_attention(query,key,value)
 
 
-Returns:
-    output (Tensor): Attention output; shape :math:`(N, ..., Hq, L, Ev)`.
-
-Shape legend:
-    - :math:`N: \text{Batch size} ... : \text{Any number of other batch dimensions (optional)}`
-    - :math:`S: \text{Source sequence length}`
-    - :math:`L: \text{Target sequence length}`
-    - :math:`E: \text{Embedding dimension of the query and key}`
-    - :math:`Ev: \text{Embedding dimension of the value}`
-    - :math:`Hq: \text{Number of heads of query}`
-    - :math:`H: \text{Number of heads of key and value}`
-
-Examples:
-
-    >>> # Optionally use the context manager to ensure one of the fused kernels is run
-    >>> query = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
-    >>> key = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
-    >>> value = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
-    >>> with torch.backends.cuda.sdp_kernel(enable_math=False):
-    >>>     F.scaled_dot_product_attention(query,key,value)
+        >>> # Sample for GQA for llama3
+        >>> query = torch.rand(32, 32, 128, 64, dtype=torch.float16, device="cuda")
+        >>> key = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
+        >>> value = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
+        >>> with sdpa_kernel(backends=[SDPBackend.MATH]):
+        >>>     F.scaled_dot_product_attention(query,key,value,enable_gqa=True)
 
 
-    >>> # Sample for GQA
-    >>> query = torch.rand(32, 32, 128, 64, dtype=torch.float16, device="cuda")
-    >>> key = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
-    >>> value = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
-    >>> with sdpa_kernel(backends=[SDPBackend.MATH]):
-    >>>     F.scaled_dot_product_attention(query,key,value,enable_gqa=True)
-
-
-.. _FlashAttention-2\: Faster Attention with Better Parallelism and Work Partitioning:
-    https://arxiv.org/abs/2307.08691
-.. _Memory-Efficient Attention:
-    https://github.com/facebookresearch/xformers
-.. _Grouped-Query Attention:
-    https://arxiv.org/pdf/2305.13245
-""",
+    .. _FlashAttention-2\: Faster Attention with Better Parallelism and Work Partitioning:
+        https://arxiv.org/abs/2307.08691
+    .. _Memory-Efficient Attention:
+        https://github.com/facebookresearch/xformers
+    .. _Grouped-Query Attention:
+        https://arxiv.org/pdf/2305.13245
+    """,
 )
 
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5606,56 +5606,18 @@ def _in_projection(
 
 scaled_dot_product_attention = _add_docstr(
     torch._C._nn.scaled_dot_product_attention,
-    r"""scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False) -> Tensor:
+    r"""scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
+        is_causal=False, scale=None, enable_gqa=False) -> Tensor:
 
-Computes scaled dot product attention on query, key and value tensors, using
-an optional attention mask if passed, and applying dropout if a probability
-greater than 0.0 is specified. The optional scale argument can only be specified as a keyword argument.
-
-.. code-block:: python
-
-    # Efficient implementation equivalent to the following:
-    def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
-                                     is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
-        L, S = query.size(-2), key.size(-2)
-        scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
-        attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
-        if is_causal:
-            assert attn_mask is None
-            temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
-            attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
-            attn_bias.to(query.dtype)
-
-        if attn_mask is not None:
-            if attn_mask.dtype == torch.bool:
-                attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
-            else:
-                attn_bias += attn_mask
-
-        if enable_gqa:
-            key = key.repeat_interleave(query.size(-3)//key.size(-3), -3)
-            value = value.repeat_interleave(query.size(-3)//value.size(-3), -3)
-
-        attn_weight = query @ key.transpose(-2, -1) * scale_factor
-        attn_weight += attn_bias
-        attn_weight = torch.softmax(attn_weight, dim=-1)
-        attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
-        return attn_weight @ value
-
-.. warning:: This function is beta and subject to change.
-
-.. warning::
-
-    This function always applies dropout according to the specified ``dropout_p`` argument.
-    To disable dropout during evaluation, be sure to pass a value of ``0.0`` when the module
-    that makes the function call is not in training mode.
-
-    For example:
+    Computes scaled dot product attention on query, key and value tensors, using an optional attention mask if passed,
+    and applying dropout if a probability greater than 0.0 is specified. The optional scale argument can only be
+    specified as a keyword argument.
 
     .. code-block:: python
 
         # Efficient implementation equivalent to the following:
-        def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
+        def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
+                is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
             L, S = query.size(-2), key.size(-2)
             scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
             attn_bias = torch.zeros(L, S, dtype=query.dtype)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5607,7 +5607,7 @@ def _in_projection(
 scaled_dot_product_attention = _add_docstr(
     torch._C._nn.scaled_dot_product_attention,
     r"""
-scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None) -> Tensor:
+scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False) -> Tensor:
 
 Computes scaled dot product attention on query, key and value tensors, using
 an optional attention mask if passed, and applying dropout if a probability
@@ -5630,7 +5630,12 @@ greater than 0.0 is specified. The optional scale argument can only be specified
             if attn_mask.dtype == torch.bool:
                 attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
             else:
-                attn_bias = attn_mask + attn_bias
+                attn_bias += attn_mask
+
+        if enable_gqa:
+            key = key.repeat_interleave(query.size(-3)//key.size(-3), -3)
+            value = value.repeat_interleave(query.size(-3)//value.size(-3), -3)
+
         attn_weight = query @ key.transpose(-2, -1) * scale_factor
         attn_weight += attn_bias
         attn_weight = torch.softmax(attn_weight, dim=-1)
@@ -5688,6 +5693,11 @@ Note:
     The c++ implementation supports torch.float64 and can be used when higher precision is required.
     For more information please see :doc:`/notes/numerical_accuracy`
 
+    Grouped Query Attention (GQA) is an experimental feature. It currently works only for Flash_attention and math kernel on CUDA tensor, and does not support Nested tensor.
+    Constraints for GQA: 
+        number_of_heads_query % number_of_heads_key_value == 0 and,
+        number_of_heads_key == number_of_heads_value
+
 Note:
     {cudnn_reproducibility_note}
 """.format(
@@ -5695,9 +5705,9 @@ Note:
     )
     + r"""
 Args:
-    query (Tensor): Query tensor; shape :math:`(N, ..., L, E)`.
-    key (Tensor): Key tensor; shape :math:`(N, ..., S, E)`.
-    value (Tensor): Value tensor; shape :math:`(N, ..., S, Ev)`.
+    query (Tensor): Query tensor; shape :math:`(N, ..., Hq, L, E)`.
+    key (Tensor): Key tensor; shape :math:`(N, ..., H, S, E)`.
+    value (Tensor): Value tensor; shape :math:`(N, ..., H, S, Ev)`.
     attn_mask (optional Tensor): Attention mask; shape must be broadcastable to the shape of attention weights,
         which is :math:`(N,..., L, S)`. Two types of masks are supported.
         A boolean mask where a value of True indicates that the element *should* take part in attention.
@@ -5709,10 +5719,11 @@ Args:
         An error is thrown if both attn_mask and is_causal are set.
     scale (optional float, keyword-only): Scaling factor applied prior to softmax. If None, the default value is set
         to :math:`\frac{1}{\sqrt{E}}`.
+    enable_gqa (bool): If set to True, Grouped Query Attention (GQA) is enabled, by default it is set to False.
 
 
 Returns:
-    output (Tensor): Attention output; shape :math:`(N, ..., L, Ev)`.
+    output (Tensor): Attention output; shape :math:`(N, ..., Hq, L, Ev)`.
 
 Shape legend:
     - :math:`N: \text{Batch size} ... : \text{Any number of other batch dimensions (optional)}`
@@ -5720,6 +5731,8 @@ Shape legend:
     - :math:`L: \text{Target sequence length}`
     - :math:`E: \text{Embedding dimension of the query and key}`
     - :math:`Ev: \text{Embedding dimension of the value}`
+    - :math:`Hq: \text{Number of heads of query}`
+    - :math:`H: \text{Number of heads of key and value}`
 
 Examples:
 
@@ -5731,11 +5744,20 @@ Examples:
     >>>     F.scaled_dot_product_attention(query,key,value)
 
 
+    >>> # Sample for GQA for llama3
+    >>> query = torch.rand(32, 32, 128, 64, dtype=torch.float16, device="cuda")
+    >>> key = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
+    >>> value = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
+    >>> with sdpa_kernel(backends=[SDPBackend.MATH]):
+    >>>     F.scaled_dot_product_attention(query,key,value, enable_gqa=True)
+
+
 .. _FlashAttention-2\: Faster Attention with Better Parallelism and Work Partitioning:
     https://arxiv.org/abs/2307.08691
 .. _Memory-Efficient Attention:
     https://github.com/facebookresearch/xformers
-
+.. _Grouped-Query Attention:
+    https://arxiv.org/pdf/2305.13245
 """,
 )
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5617,8 +5617,7 @@ greater than 0.0 is specified. The optional scale argument can only be specified
 .. code-block:: python
 
     # Efficient implementation equivalent to the following:
-    def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
-                                     is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
+    def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False) -> torch.Tensor:
         L, S = query.size(-2), key.size(-2)
         scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
         attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
@@ -5752,7 +5751,7 @@ Examples:
     >>> key = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
     >>> value = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
     >>> with sdpa_kernel(backends=[SDPBackend.MATH]):
-    >>>     F.scaled_dot_product_attention(query,key,value, enable_gqa=True)
+    >>>     F.scaled_dot_product_attention(query,key,value,enable_gqa=True)
 
 
 .. _FlashAttention-2\: Faster Attention with Better Parallelism and Work Partitioning:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5607,7 +5607,8 @@ def _in_projection(
 scaled_dot_product_attention = _add_docstr(
     torch._C._nn.scaled_dot_product_attention,
     r"""
-scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None, enable_gqa=False) -> Tensor:
+scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False,
+                             scale=None, enable_gqa=False) -> Tensor:
 
 Computes scaled dot product attention on query, key and value tensors, using
 an optional attention mask if passed, and applying dropout if a probability
@@ -5616,7 +5617,8 @@ greater than 0.0 is specified. The optional scale argument can only be specified
 .. code-block:: python
 
     # Efficient implementation equivalent to the following:
-    def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None) -> torch.Tensor:
+    def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
+                                     is_causal=False, scale=None) -> torch.Tensor:
         L, S = query.size(-2), key.size(-2)
         scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
         attn_bias = torch.zeros(L, S, dtype=query.dtype, device=query.device)
@@ -5693,8 +5695,9 @@ Note:
     The c++ implementation supports torch.float64 and can be used when higher precision is required.
     For more information please see :doc:`/notes/numerical_accuracy`
 
-    Grouped Query Attention (GQA) is an experimental feature. It currently works only for Flash_attention and math kernel on CUDA tensor, and does not support Nested tensor.
-    Constraints for GQA: 
+    Grouped Query Attention (GQA) is an experimental feature.
+    It currently works only for Flash_attention and math kernel on CUDA tensor, and does not support Nested tensor.
+    Constraints for GQA:
         number_of_heads_query % number_of_heads_key_value == 0 and,
         number_of_heads_key == number_of_heads_value
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8688,6 +8688,7 @@ def sample_inputs_scaled_mm(op_info, device, dtype, requires_grad, **kwargs):
 def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_grad, **kwargs):
     make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
     batch, seq_q, seq_kv, num_heads, head_dim = 4, 3, 6, 4, 8
+    num_heads_q_gqa, num_heads_kv_gqa = 32, 8
 
     dim_3_q_shape = (batch, seq_q, head_dim)
     dim_3_kv_shape = (batch, seq_kv, head_dim)
@@ -8695,8 +8696,9 @@ def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_
     dim_4_kv_shape = (batch, num_heads, seq_kv, head_dim)
 
     broadcast_tuple = ((num_heads, seq_q, head_dim), (batch, num_heads, seq_kv, head_dim))
+    gqa_tuple = ((batch, num_heads_q_gqa, seq_q, head_dim), (batch, num_heads_kv_gqa, seq_kv, head_dim))
 
-    qkv_shapes = [(dim_3_q_shape, dim_3_kv_shape), (dim_4_q_shape, dim_4_kv_shape), broadcast_tuple]
+    qkv_shapes = [(dim_3_q_shape, dim_3_kv_shape), (dim_4_q_shape, dim_4_kv_shape), broadcast_tuple, gqa_tuple]
     samples = []
     for qkv_shape, is_causal, dropout_p in product(
             qkv_shapes, [True, False], [0.0, 0.5]):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8700,15 +8700,16 @@ def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_
 
     qkv_shapes = [(dim_3_q_shape, dim_3_kv_shape), (dim_4_q_shape, dim_4_kv_shape), broadcast_tuple, gqa_tuple]
     samples = []
-    for qkv_shape, is_causal, dropout_p in product(
-            qkv_shapes, [True, False], [0.0, 0.5]):
+    for qkv_shape, is_causal, dropout_p, enable_gqa in product(
+            qkv_shapes, [True, False], [0.0, 0.5], [True, False]):
         shape_q, shape_kv = qkv_shape
         samples.append(SampleInput(
             make(shape_q),
             make(shape_kv),
             make(shape_kv),
             is_causal=is_causal,
-            dropout_p=dropout_p
+            dropout_p=dropout_p,
+            enable_gqa=enable_gqa,
         ))
 
     # Add non standard shapes

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8696,9 +8696,8 @@ def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_
     dim_4_kv_shape = (batch, num_heads, seq_kv, head_dim)
 
     broadcast_tuple = ((num_heads, seq_q, head_dim), (batch, num_heads, seq_kv, head_dim))
-    gqa_tuple = ((batch, num_heads_q_gqa, seq_q, head_dim), (batch, num_heads_kv_gqa, seq_kv, head_dim))
 
-    qkv_shapes = [(dim_3_q_shape, dim_3_kv_shape), (dim_4_q_shape, dim_4_kv_shape), broadcast_tuple, gqa_tuple]
+    qkv_shapes = [(dim_3_q_shape, dim_3_kv_shape), (dim_4_q_shape, dim_4_kv_shape), broadcast_tuple]
     samples = []
     for qkv_shape, is_causal, dropout_p, enable_gqa in product(
             qkv_shapes, [True, False], [0.0, 0.5], [True, False]):
@@ -8708,8 +8707,7 @@ def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_
             make(shape_kv),
             make(shape_kv),
             is_causal=is_causal,
-            dropout_p=dropout_p,
-            enable_gqa=enable_gqa,
+            dropout_p=dropout_p
         ))
 
     # Add non standard shapes
@@ -8730,6 +8728,15 @@ def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_
             attn_mask=make((seq_q, seq_kv)),
             is_causal=False,
             dropout_p=0.0)
+    )
+
+    samples.append(
+        SampleInput(
+            make((batch, num_heads_q_gqa, seq_q, head_dim)),
+            make((batch, num_heads_kv_gqa, seq_kv, head_dim)),
+            make((batch, num_heads_kv_gqa, seq_kv, head_dim)),
+            enable_gqa=True
+        )
     )
 
     yield from samples


### PR DESCRIPTION
### Approach: Using the current function declaration

**Constraint:** Q_Heads % KV_Heads == 0

**Major change:** 
- Added a new argument enable_gqa: bool to sdpa function call
- It adds a meaning to the last third dimension.

Sample use cases this would enable:
LLama3


```
# LLama3 8b call to SDPA
query = torch.rand(batch, 32, seq_len_q, D)
key = torch.rand(batch, 8, seq_len_kv, D)
value = torch.rand(batch, 8, seq_len_kv, D)

output = scaled_dot_product_attention(query, key, value, is_causal=True, enable_gqa=True)

# Output Shape
(batch, 32, seq_len_q, D)
```
	
### Design Choice: 

- Check if Query.size(-3) == Key.size(-3) == Value.size(-3) or, Query.size(-3) % Key.size(-3) == 0
- The function adjusts the key and value tensors to match the query tensor's head dimension by using repeat_interleave if their number of heads are not equal, facilitating correct and efficient computation in attention mechanisms.
- By default the enable_gqa flag is set to False, which ensures that regular sdpa functionality remains unchanged.

### Benchmarks:

- **sdpa.py: #130634** 
For different batch sizes enable_gqa=True shows a substansial improvement in the run_time of sdpa

 | batch_size | q_num_heads | kv_num_heads | q_seq_len | kv_seq_len | embed_dim | forward_time when enable_gqa=True   |   forward_time when enable_gqa=False    |
| ------------ | ------------- | -------------- | ----------- | ------------ | ----------- | ----------- | ---------------- |
|     1      |     32      |      8       |   2048    |    2048    |   2048    |   100.71  |  119.70  |
|     8      |     32      |      8       |   2048    |    2048    |   2048    |   539.78  |  628.83  |
|     16     |     32      |      8       |   2048    |    2048    |   2048    |   1056.81  |  1225.48  |
|     32      |     32      |      8       |   2048    |    2048    |   2048    |   2099.54  |  2440.45  |

![Screenshot 2024-07-25 at 9 07 40 PM](https://github.com/user-attachments/assets/a3e5f716-c39f-4096-9e6c-82a735e57b7b)



- **TorchTitan: https://github.com/pytorch/torchtitan/pull/458**


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames