### PR TITLE
[Fix]: Internal test failures when testing the exportability

### DIFF
--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1002,6 +1002,7 @@ def trace(
     )
 
     # Preserve a copy of module and inputs before tracing.
+    func_copy, example_inputs_copy, example_kwarg_inputs_copy = None, None, None
     if check_if_torch_exportable():
         func_copy = copy.deepcopy(func)
         example_inputs_copy = copy.deepcopy(example_inputs)

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1030,7 +1030,6 @@ def trace(
             _process_jit_trace_inputs_for_export,
         )
 
-
         traced_func_for_export = _trace_impl(
             func_copy,
             example_inputs=example_inputs_copy,

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1004,7 +1004,10 @@ def trace(
     # Preserve a copy of module and inputs before tracing.
     func_copy, example_inputs_copy, example_kwarg_inputs_copy = None, None, None
     if check_if_torch_exportable():
-        func_copy = copy.deepcopy(func)
+        if isinstance(func, torch.nn.Module):
+            func_copy = copy.deepcopy(func)
+        else:
+            func_copy = func
         example_inputs_copy = copy.deepcopy(example_inputs)
         example_kwarg_inputs_copy = copy.deepcopy(example_kwarg_inputs)
 


### PR DESCRIPTION
#### Issue
EP modifies the internal state of module / inputs. This PR sends a copy to log exportability instead.

#### Test Plan
* `pytest test/jit/test_tracer.py`