### PR TITLE
Fix hipify regular expression for AOTI wrapper

### DIFF
--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -1,0 +1,125 @@
+# Owner(s): ["module: inductor"]
+import torch
+
+from torch._inductor.codegen.aoti_hipify_utils import maybe_hipify_code_wrapper
+from torch._inductor.codegen.codegen_device_driver import cuda_kernel_driver
+
+from torch._inductor.test_case import run_tests, TestCase
+
+
+TEST_CODES = [
+    "CUresult code = EXPR;",
+    "CUfunction kernel = nullptr;",
+    "static CUfunction kernel = nullptr;",
+    "CUdeviceptr var = reinterpret_cast<CUdeviceptr>(arg.data_ptr());",
+    "at::cuda::CUDAStreamGuard guard(at::cuda::getStreamFromExternal());",
+    # Hipification should be idempotent, hipifying should be a no-op for already hipified files
+    "at::hip::HIPStreamGuardMasqueradingAsCUDA guard(at::hip::getStreamFromExternalMasqueradingAsCUDA());",
+]
+
+HIP_CODES = [
+    "hipError_t code = EXPR;",
+    "hipFunction_t kernel = nullptr;",
+    "static hipFunction_t kernel = nullptr;",
+    "hipDeviceptr_t var = reinterpret_cast<hipDeviceptr_t>(arg.data_ptr());",
+    "at::hip::HIPStreamGuardMasqueradingAsCUDA guard(at::hip::getStreamFromExternalMasqueradingAsCUDA());",
+    "at::hip::HIPStreamGuardMasqueradingAsCUDA guard(at::hip::getStreamFromExternalMasqueradingAsCUDA());",
+]
+
+
+class TestCppWrapperHipify(TestCase):
+    def test_hipify_basic_declaration(self) -> None:
+        assert len(TEST_CODES) == len(HIP_CODES)
+        for i in range(len(TEST_CODES)):
+            result = maybe_hipify_code_wrapper(TEST_CODES[i], True)
+            expected = HIP_CODES[i]
+            self.assertEqual(result, expected)
+
+    def test_hipify_aoti_driver_header(self) -> None:
+        header = cuda_kernel_driver()
+        expected = """
+            #define CUDA_DRIVER_CHECK(EXPR)                    \\
+            do {                                               \\
+                hipError_t code = EXPR;                          \\
+                const char *msg;                               \\
+                hipDrvGetErrorString(code, &msg);                  \\
+                if (code != hipSuccess) {                    \\
+                    throw std::runtime_error(                  \\
+                        std::string("CUDA driver error: ") +   \\
+                        std::string(msg));                     \\
+                }                                              \\
+            } while (0);
+
+            namespace {
+
+            struct Grid {
+                Grid(uint32_t x, uint32_t y, uint32_t z)
+                  : grid_x(x), grid_y(y), grid_z(z) {}
+                uint32_t grid_x;
+                uint32_t grid_y;
+                uint32_t grid_z;
+
+                bool is_non_zero() {
+                    return grid_x > 0 && grid_y > 0 && grid_z > 0;
+                }
+            };
+
+            }  // anonymous namespace
+
+            static inline hipFunction_t loadKernel(
+                    std::string filePath,
+                    const std::string &funcName,
+                    uint32_t sharedMemBytes,
+                    const std::optional<std::string> &cubinDir = std::nullopt) {
+                if (cubinDir) {
+                    std::filesystem::path p1{*cubinDir};
+                    std::filesystem::path p2{filePath};
+                    filePath = (p1 / p2.filename()).string();
+                }
+
+                hipModule_t mod;
+                hipFunction_t func;
+                CUDA_DRIVER_CHECK(hipModuleLoad(&mod, filePath.c_str()));
+                CUDA_DRIVER_CHECK(hipModuleGetFunction(&func, mod, funcName.c_str()));
+                if (sharedMemBytes > 0) {
+                    CUDA_DRIVER_CHECK(hipFuncSetAttribute(
+                        func,
+                        hipFuncAttributeMaxDynamicSharedMemorySize,
+                        sharedMemBytes
+                    ))
+                }
+                return func;
+            }
+
+            static inline void launchKernel(
+                    hipFunction_t func,
+                    uint32_t gridX,
+                    uint32_t gridY,
+                    uint32_t gridZ,
+                    uint32_t numWarps,
+                    uint32_t sharedMemBytes,
+                    void* args[],
+                    hipStream_t stream) {
+                CUDA_DRIVER_CHECK(hipModuleLaunchKernel(
+                    func, gridX, gridY, gridZ, 32*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
+                ));
+            }
+        """
+        if torch.version.hip is not None:
+            expected = expected.replace("32*numWarps", "64*numWarps")
+        result = maybe_hipify_code_wrapper(header, True)
+        self.assertEqual(result.rstrip(), expected.rstrip())
+
+    def test_hipify_cross_platform(self) -> None:
+        assert len(TEST_CODES) == len(HIP_CODES)
+        for i in range(len(TEST_CODES)):
+            hip_result = maybe_hipify_code_wrapper(TEST_CODES[i], True)
+            result = maybe_hipify_code_wrapper(TEST_CODES[i])
+            if torch.version.hip is not None:
+                self.assertEqual(result, hip_result)
+            else:
+                self.assertEqual(result, TEST_CODES[i])
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/codegen/aoti_hipify_utils.py
+++ b/torch/_inductor/codegen/aoti_hipify_utils.py
@@ -1,7 +1,9 @@
 # mypy: allow-untyped-defs
+import re
+
 import torch
 
-from torch.utils.hipify.hipify_python import PYTORCH_MAP, RE_PYTORCH_PREPROCESSOR
+from torch.utils.hipify.hipify_python import PYTORCH_MAP, PYTORCH_TRIE
 
 # It is not a good idea to directly apply hipify_torch to codegen, which will be vulnerable to cases like:
 #   "...
@@ -10,12 +12,21 @@ from torch.utils.hipify.hipify_python import PYTORCH_MAP, RE_PYTORCH_PREPROCESSO
 # In such cases, we do not need to hipify_torch the orignial class/file name in codegen/codecache
 
 
-def maybe_hipify_code_wrapper(source_codes: str) -> str:
-    if torch.version.hip is None:
+def maybe_hipify_code_wrapper(source_codes: str, force_hipify: bool = False) -> str:
+    if torch.version.hip is None and not force_hipify:
         return source_codes
 
     def c2_repl(m):
         return PYTORCH_MAP[m.group(0)]
+
+    # We need to redefine RE_PYTORCH_PREPROCESSOR here since in hipify_torch,
+    # it will apply positive lookbehind (?<=\W) to the pattern to avoid matching
+    # keyword at the beginning of code line. However, this can happen in codegen,
+    # which will cause the pattern to not match.
+
+    # Note that lookahead (?=\W) is still needed to keep hipification idomponent, for example
+    # we need to skip replacing "getStreamFromExternal" in "getStreamFromExternalMasqueradingAsCUDA"
+    RE_PYTORCH_PREPROCESSOR = re.compile(rf"({PYTORCH_TRIE.export_to_regex()})(?=\W)")
 
     source_codes = RE_PYTORCH_PREPROCESSOR.sub(c2_repl, source_codes)
     return source_codes


### PR DESCRIPTION
Summary: We need to redefine RE_PYTORCH_PREPROCESSOR here since in hipify_torch, it will apply positive lookbehind (?<=\W) and lookahead (?=\W) to the pattern to avoid matching keyword at the beginning and end of code line. However, this can  happen in codegen, which will cause the pattern to not match.

Test Plan:
```
buck2 run //caffe2/test/inductor:test_cpp_wrapper_hipify
```

```
File changed: fbcode//caffe2/test/inductor/test_cpp_wrapper_hipify.py
Buck UI: https://www.internalfb.com/buck2/395155fa-b2dc-4892-8c71-74e52c65fa2f
Note:    Using experimental modern dice
Network: Up: 0B  Down: 0B  (reSessionID-8fcfc520-755c-48f9-bacc-507c62f59231)
Jobs completed: 10947. Time elapsed: 0.5s.
Cache hits: 0%. Commands: 2 (cached: 0, remote: 0, local: 2)
BUILD SUCCEEDED
/data/users/zhuoran/fbsource/buck-out/v2/gen/fbcode/15b7034708b669be/caffe2/test/inductor/__test_cpp_wrapper_hipify__/test_cpp_wrapper_hipify#link-tree/torch/_utils_internal.py:282: NCCL_DEBUG env var is set to None
/data/users/zhuoran/fbsource/buck-out/v2/gen/fbcode/15b7034708b669be/caffe2/test/inductor/__test_cpp_wrapper_hipify__/test_cpp_wrapper_hipify#link-tree/torch/_utils_internal.py:300: NCCL_DEBUG is forced to WARN from None
test_hipify_aoti_driver_header (caffe2.test.inductor.test_cpp_wrapper_hipify.TestCppWrapperHipify) ... ok
test_hipify_basic_declaration (caffe2.test.inductor.test_cpp_wrapper_hipify.TestCppWrapperHipify) ... ok
test_hipify_cross_platform (caffe2.test.inductor.test_cpp_wrapper_hipify.TestCppWrapperHipify) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.262s

OK
```

e2e test:

```
TORCH_LOGS="output_code,graph_code" buck2 run mode/{opt,amd-gpu,inplace} -c fbcode.triton_backend=amd -c fbcode.enable_gpu_sections=true //aiplatform/modelstore/model_generation/gpu_lowering_service:gpu_lowering_cli -- --model_input_path="ads_storage_fblearner/tree/user/facebook/fblearner/predictor/936383960/0/gpu_lowering/input.merge" --model_output_path="ads_storage_fblearner/tree/user/facebook/fblearner/predictor/936383960/0/gpu_lowering/mi300_inductor_output.merge" --lowering_backend AOT_INDUCTOR --is_ads_model False --aot_inductor_lowering_settings_json='{"use_scripting":true,"preset_lowerer":"standalone_hstu_cint;disable_new_lowering_weights;disable_dper_passes:passes=fuse_parallel_linear_no_weight_change","precision":4,"output_precision":4, "remove_unexpected_type_cast":false, "sample_input_tile_factor":32}' 2>&1 | tee local_benchmark_log.txt
```

Differential Revision: D58705216


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang