### PR TITLE
Delete unused line

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1569,8 +1569,6 @@ class WelfordReduction(Reduction):
         for i in intermediates:
             i.realize()
 
-        i_loaders = [i.make_loader() for i in intermediates]
-
         def intermediate_loader_fn(index, reduction_index, loader):
             return loader([*index, *reduction_index])
 


### PR DESCRIPTION
Summary: i_loaders doesn't get used anywhere, and make_loader shouldn't change the internal state of the nodes its called on.

Test Plan: CI

Reviewed By: eellison, shunting314

Differential Revision: D58701582


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang