### PR TITLE
Add Strided Input test for flex attention

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -449,7 +449,7 @@ class TestFlexAttention(InductorTestCase):
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes_fast)
-    @common_utils.parametrize("q_s", test_input_strides)
+    @common_utils.parametrize("q_s", test_input_strides[:-2]) # TODO: fix layout for query braodcasting
     @common_utils.parametrize("k_s", test_input_strides)
     @common_utils.parametrize("v_s", test_input_strides)
     def test_strided_inputs(self, dtype: torch.dtype, q_s, k_s, v_s):

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -115,13 +115,6 @@ H = 8
 S = 2048
 D = 64
 
-test_input_strides = [
-    ((8*2048*64, 2048*64, 64, 1), 997),                    # offset
-    ((8*64, 64, 4*8*64, 1), 499),                          # transposed dimensions
-    ((2048*(64+1), 4*2048*(64+1), (64+1), 1), 293),        # additional buffer on one dim
-    ((1, 64, (4 + 1)*(8 + 1)*64, 1), 97),                  # additional buffer on multiple dim + shared dimension
-]
-
 
 def query_key_value_clones(
     query: torch.Tensor,
@@ -442,6 +435,14 @@ class TestFlexAttention(InductorTestCase):
         )
 
 
+    test_input_strides = [
+        ((B*S*D     ,S*D        ,D              ,1) ,997),                      # offset
+        ((H*D       ,D          ,B*H*D          ,1) ,499),                      # transposed dimensions
+        ((S*(D+1)   ,B*S*(D+1)  ,(D+1)          ,1) ,293),                      # additional buffer on one dim
+        ((1         ,D          ,(B+1)*(H+1)*D  ,1) ,97),                # additional buffer on multiple dim + shared dimension
+    ]
+
+
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.parametrize("q_s", test_input_strides)
@@ -460,14 +461,14 @@ class TestFlexAttention(InductorTestCase):
         q_strides, q_offset = q_s
         q_max = [ x*(y-1) for x, y in zip(q_strides, q_shape) ]
         assert sum(q_max) + q_offset < B*H*S*D*2
-        assert q_strides[-1] == 1    
+        assert q_strides[-1] == 1
         q = torch.as_strided(q1, q_shape, q_strides, q_offset)
 
 
-        k_strides, k_offset = k_s    
+        k_strides, k_offset = k_s
         k_max = [ x*(y-1) for x, y in zip(k_strides, k_shape) ]
         assert sum(k_max) + k_offset < B*H*S*D*2
-        assert k_strides[-1] == 1      
+        assert k_strides[-1] == 1
         k = torch.as_strided(k1, k_shape, k_strides, k_offset)
 
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -435,7 +435,7 @@ class TestFlexAttention(InductorTestCase):
         )
 
     test_input_strides = [
-        ((B * S * D, S * D, D, 1), 997),  # offset
+        ((H * S * D, S * D, D, 1), 997),  # offset
         ((H * D, D, B * H * D, 1), 499),  # transposed dimensions
         (
             (S * (D + 1), B * S * (D + 1), (D + 1), 1),

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -433,6 +433,54 @@ class TestFlexAttention(InductorTestCase):
             S,
             D,
         )
+    
+        
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    @common_utils.parametrize("score_mod", [_identity, _causal])
+    def test_strided_inputs(self, dtype: torch.dtype, score_mod: Callable):
+        q_shape = (B, S, H*D)
+        kv_shape = (B, S, H*D)
+        
+        make_q = functools.partial(
+            torch.rand, q_shape, device="cuda", dtype=dtype, requires_grad=False
+        )
+        make_kv = functools.partial(
+            torch.rand, kv_shape, device="cuda", dtype=dtype, requires_grad=False
+        )
+        
+        q = (
+            make_q()
+            .view(B, S, H, D)
+            .transpose(1, 2)
+        )
+        k = (
+            make_kv()
+            .view(B, S, H, D)
+            .transpose(1, 2)
+        )
+        v = (
+            make_kv()
+            .view(B, S, H, D)
+            .transpose(1, 2)
+        )
+
+        sdpa_partial = create_attention(score_mod)
+        compiled_sdpa = torch.compile(sdpa_partial)
+        golden_out = sdpa_partial(
+            q.to(torch.float64), k.to(torch.float64), v.to(torch.float64)
+        )
+        ref_out = sdpa_partial(q, k, v)
+        compiled_out = compiled_sdpa(q, k, v)
+
+        compiled_error = (golden_out - compiled_out).abs().mean()
+        ref_error = (golden_out - ref_out).abs().mean()
+        # Note, it seems like we really are less accurate
+        # likely due to the online softmax 
+        fudge_factor = 10.0
+        if compiled_error > ref_error * fudge_factor:
+            msg = f"Compiled error {compiled_error} is greater than ref error {ref_error} by more than {fudge_factor}X."
+            self.assertTrue(False, msg)
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -115,6 +115,13 @@ H = 8
 S = 2048
 D = 64
 
+test_input_strides = [
+    ((8*2048*64, 2048*64, 64, 1), 997),                    # offset
+    ((8*64, 64, 4*8*64, 1), 499),                          # transposed dimensions
+    ((2048*(64+1), 4*2048*(64+1), (64+1), 1), 293),        # additional buffer on one dim
+    ((1, 64, (4 + 1)*(8 + 1)*64, 1), 97),                  # additional buffer on multiple dim + shared dimension
+]
+
 
 def query_key_value_clones(
     query: torch.Tensor,
@@ -433,41 +440,44 @@ class TestFlexAttention(InductorTestCase):
             S,
             D,
         )
-    
-        
-    @supported_platform
-    @common_utils.parametrize("dtype", test_dtypes)
-    @common_utils.parametrize("score_mod", [_identity, _causal])
-    def test_strided_inputs(self, dtype: torch.dtype, score_mod: Callable):
-        q_shape = (B, S, H*D)
-        kv_shape = (B, S, H*D)
-        
-        make_q = functools.partial(
-            torch.rand, q_shape, device="cuda", dtype=dtype, requires_grad=False
-        )
-        make_kv = functools.partial(
-            torch.rand, kv_shape, device="cuda", dtype=dtype, requires_grad=False
-        )
-        
-        q = (
-            make_q()
-            .view(B, S, D, H)
-            .transpose(2, 3)
-            .transpose(1, 2)
-        )
-        k = (
-            make_kv()
-            .view(H, B, S, D)
-            .transpose(0, 1)
-        )
-        v = (
-            make_kv()
-            .view(B, S, D, H)
-            .transpose(2, 3)
-            .transpose(1, 2)
-        )
 
-        sdpa_partial = create_attention(score_mod)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    @common_utils.parametrize("q_s", test_input_strides)
+    @common_utils.parametrize("k_s", test_input_strides)
+    @common_utils.parametrize("v_s", test_input_strides)
+    def test_strided_inputs(self, dtype: torch.dtype, q_s, k_s, v_s):
+        q1 = torch.randn((B*H*S*D*2), dtype=dtype, device="cuda")
+        k1 = torch.randn((B*H*S*D*2), dtype=dtype, device="cuda")
+        v1 = torch.randn((B*H*S*D*2), dtype=dtype, device="cuda")
+
+        q_shape = (B, H, S//2, D)
+        k_shape = (B, H, S, D)
+        v_shape = (B, H, S, D)
+
+
+        q_strides, q_offset = q_s
+        q_max = [ x*(y-1) for x, y in zip(q_strides, q_shape) ]
+        assert sum(q_max) + q_offset < B*H*S*D*2
+        assert q_strides[-1] == 1    
+        q = torch.as_strided(q1, q_shape, q_strides, q_offset)
+
+
+        k_strides, k_offset = k_s    
+        k_max = [ x*(y-1) for x, y in zip(k_strides, k_shape) ]
+        assert sum(k_max) + k_offset < B*H*S*D*2
+        assert k_strides[-1] == 1      
+        k = torch.as_strided(k1, k_shape, k_strides, k_offset)
+
+
+        v_strides, v_offset = v_s
+        v_max = [ x*(y-1) for x, y in zip(v_strides, v_shape)]
+        assert sum(v_max) + v_offset < B*H*S*D*2
+        assert v_strides[-1] == 1
+        v = torch.as_strided(v1, v_shape, v_strides, v_offset)
+
+        sdpa_partial = create_attention(score_mod=_generate_alibi_bias(8))
         compiled_sdpa = torch.compile(sdpa_partial)
         ref_out = sdpa_partial(q, k, v)
         compiled_out = compiled_sdpa(q, k, v)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -449,7 +449,9 @@ class TestFlexAttention(InductorTestCase):
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes_fast)
-    @common_utils.parametrize("q_s", test_input_strides[:-2]) # TODO: fix layout for query braodcasting
+    @common_utils.parametrize(
+        "q_s", test_input_strides[:-2]
+    )  # TODO: fix layout for query braodcasting
     @common_utils.parametrize("k_s", test_input_strides)
     @common_utils.parametrize("v_s", test_input_strides)
     def test_strided_inputs(self, dtype: torch.dtype, q_s, k_s, v_s):

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -451,36 +451,29 @@ class TestFlexAttention(InductorTestCase):
         
         q = (
             make_q()
-            .view(B, S, H, D)
+            .view(B, S, D, H)
+            .transpose(2, 3)
             .transpose(1, 2)
         )
         k = (
             make_kv()
-            .view(B, S, H, D)
-            .transpose(1, 2)
+            .view(H, B, S, D)
+            .transpose(0, 1)
         )
         v = (
             make_kv()
-            .view(B, S, H, D)
+            .view(B, S, D, H)
+            .transpose(2, 3)
             .transpose(1, 2)
         )
 
         sdpa_partial = create_attention(score_mod)
         compiled_sdpa = torch.compile(sdpa_partial)
-        golden_out = sdpa_partial(
-            q.to(torch.float64), k.to(torch.float64), v.to(torch.float64)
-        )
         ref_out = sdpa_partial(q, k, v)
         compiled_out = compiled_sdpa(q, k, v)
 
-        compiled_error = (golden_out - compiled_out).abs().mean()
-        ref_error = (golden_out - ref_out).abs().mean()
-        # Note, it seems like we really are less accurate
-        # likely due to the online softmax 
-        fudge_factor = 10.0
-        if compiled_error > ref_error * fudge_factor:
-            msg = f"Compiled error {compiled_error} is greater than ref error {ref_error} by more than {fudge_factor}X."
-            self.assertTrue(False, msg)
+        tolerance = Tolerances(atol=2e-1, rtol=2e-1)
+        torch.testing.assert_close(ref_out, compiled_out, atol=tolerance.atol, rtol=tolerance.rtol)
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -434,14 +434,18 @@ class TestFlexAttention(InductorTestCase):
             D,
         )
 
-
     test_input_strides = [
-        ((B*S*D     ,S*D        ,D              ,1) ,997),                      # offset
-        ((H*D       ,D          ,B*H*D          ,1) ,499),                      # transposed dimensions
-        ((S*(D+1)   ,B*S*(D+1)  ,(D+1)          ,1) ,293),                      # additional buffer on one dim
-        ((1         ,D          ,(B+1)*(H+1)*D  ,1) ,97),                # additional buffer on multiple dim + shared dimension
+        ((B * S * D, S * D, D, 1), 997),  # offset
+        ((H * D, D, B * H * D, 1), 499),  # transposed dimensions
+        (
+            (S * (D + 1), B * S * (D + 1), (D + 1), 1),
+            293,
+        ),  # additional buffer on one dim
+        (
+            (1, D, (B + 1) * (H + 1) * D, 1),
+            97,
+        ),  # additional buffer on multiple dim + shared dimension
     ]
-
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes_fast)
@@ -449,32 +453,29 @@ class TestFlexAttention(InductorTestCase):
     @common_utils.parametrize("k_s", test_input_strides)
     @common_utils.parametrize("v_s", test_input_strides)
     def test_strided_inputs(self, dtype: torch.dtype, q_s, k_s, v_s):
-        q1 = torch.randn((B*H*S*D*2), dtype=dtype, device="cuda")
-        k1 = torch.randn((B*H*S*D*2), dtype=dtype, device="cuda")
-        v1 = torch.randn((B*H*S*D*2), dtype=dtype, device="cuda")
+        q1 = torch.randn((B * H * S * D * 2), dtype=dtype, device="cuda")
+        k1 = torch.randn((B * H * S * D * 2), dtype=dtype, device="cuda")
+        v1 = torch.randn((B * H * S * D * 2), dtype=dtype, device="cuda")
 
-        q_shape = (B, H, S//2, D)
+        q_shape = (B, H, S // 2, D)
         k_shape = (B, H, S, D)
         v_shape = (B, H, S, D)
 
-
         q_strides, q_offset = q_s
-        q_max = [ x*(y-1) for x, y in zip(q_strides, q_shape) ]
-        assert sum(q_max) + q_offset < B*H*S*D*2
+        q_max = [x * (y - 1) for x, y in zip(q_strides, q_shape)]
+        assert sum(q_max) + q_offset < B * H * S * D * 2
         assert q_strides[-1] == 1
         q = torch.as_strided(q1, q_shape, q_strides, q_offset)
 
-
         k_strides, k_offset = k_s
-        k_max = [ x*(y-1) for x, y in zip(k_strides, k_shape) ]
-        assert sum(k_max) + k_offset < B*H*S*D*2
+        k_max = [x * (y - 1) for x, y in zip(k_strides, k_shape)]
+        assert sum(k_max) + k_offset < B * H * S * D * 2
         assert k_strides[-1] == 1
         k = torch.as_strided(k1, k_shape, k_strides, k_offset)
 
-
         v_strides, v_offset = v_s
-        v_max = [ x*(y-1) for x, y in zip(v_strides, v_shape)]
-        assert sum(v_max) + v_offset < B*H*S*D*2
+        v_max = [x * (y - 1) for x, y in zip(v_strides, v_shape)]
+        assert sum(v_max) + v_offset < B * H * S * D * 2
         assert v_strides[-1] == 1
         v = torch.as_strided(v1, v_shape, v_strides, v_offset)
 
@@ -484,7 +485,9 @@ class TestFlexAttention(InductorTestCase):
         compiled_out = compiled_sdpa(q, k, v)
 
         tolerance = Tolerances(atol=2e-1, rtol=2e-1)
-        torch.testing.assert_close(ref_out, compiled_out, atol=tolerance.atol, rtol=tolerance.rtol)
+        torch.testing.assert_close(
+            ref_out, compiled_out, atol=tolerance.atol, rtol=tolerance.rtol
+        )
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes)


### PR DESCRIPTION
Test strided inputs to the flex_attention HOP. Similar to how inputs are generated in 
https://github.com/pytorch/pytorch/blob/main/benchmarks/transformer/score_mod.py. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang