### PR TITLE
[DON'T MERGE] Initial version of block sparse mask for flex attention

### DIFF
--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -188,7 +188,8 @@ flex_attention_template = TritonTemplate(
 
     Z = {{size("Q", 0)}}
     H = {{size("Q", 1)}}
-    N_CTX = {{size("Q", 2)}}
+    Q_LEN = {{size("Q", 2)}}
+    KV_LEN = {{size("K", 2)}}
 
     qk_scale = 1.0
     MATMUL_PRECISION = Q.dtype.element_ty
@@ -196,26 +197,27 @@ flex_attention_template = TritonTemplate(
     start_m = tl.program_id(0)
     off_hz = tl.program_id(1)
 
-    qkv_offset = off_hz * stride_qh
+    q_offset = off_hz * stride_qh
+    kv_offset = off_hz * stride_kh
     Q_block_ptr = tl.make_block_ptr(
-        base=Q + qkv_offset,
-        shape=(N_CTX, BLOCK_DMODEL),
+        base=Q + q_offset,
+        shape=(Q_LEN, BLOCK_DMODEL),
         strides=(stride_qm, stride_qk),
         offsets=(start_m * BLOCK_M, 0),
         block_shape=(BLOCK_M, BLOCK_DMODEL),
         order=(1, 0)
     )
     K_block_ptr = tl.make_block_ptr(
-        base=K + qkv_offset,
-        shape=(BLOCK_DMODEL, N_CTX),
+        base=K + kv_offset,
+        shape=(BLOCK_DMODEL, KV_LEN),
         strides=(stride_kk, stride_kn),
         offsets=(0, 0),
         block_shape=(BLOCK_DMODEL, BLOCK_N),
         order=(0, 1)
     )
     V_block_ptr = tl.make_block_ptr(
-        base=V + qkv_offset,
-        shape=(N_CTX, BLOCK_DMODEL),
+        base=V + kv_offset,
+        shape=(KV_LEN, BLOCK_DMODEL),
         strides=(stride_vk, stride_vn),
         offsets=(0, 0),
         block_shape=(BLOCK_N, BLOCK_DMODEL),
@@ -235,7 +237,7 @@ flex_attention_template = TritonTemplate(
     q = (q * qk_scale).to(MATMUL_PRECISION)
     # loop over k, v and update accumulator
     lo = 0
-    hi = N_CTX
+    hi = KV_LEN
     for start_n in range(lo, hi, BLOCK_N):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         m = offs_m[:, None]
@@ -318,7 +320,7 @@ flex_attention_template = TritonTemplate(
 
     # TODO dont want to write this if we dont require grad
     if OUTPUT_LOGSUMEXP:
-        l_ptrs = LSE + off_hz * N_CTX + offs_m
+        l_ptrs = LSE + off_hz * Q_LEN + offs_m
         lse = m_i + tl.math.log2(l_i)
         tl.store(l_ptrs, lse)
  """,


### PR DESCRIPTION
Before:
* score_mod = causal_mask

```
=========================================================FWD Speedups========================================================


| Type    |   Speedup | shape              | score_mod   | mask                                                                      | dtype          |
|---------|-----------|--------------------|-------------|---------------------------------------------------------------------------|----------------|
| Average |     0.226 |                    |             |                                                                           |                |
| Max     |     0.480 | (2, 16, 4096, 128) | causal_mask | <function generate_experiment_configs.<locals>.mask_fn at 0x7f16a7897c70> | torch.bfloat16 |
| Min     |     0.023 | (2, 16, 512, 64)   | causal_mask | <function generate_experiment_configs.<locals>.mask_fn at 0x7f16a7896200> | torch.bfloat16 |


=========================================================BWD Speedups========================================================


| Type    |   Speedup | shape             | score_mod   | mask                                                                      | dtype          |
|---------|-----------|-------------------|-------------|---------------------------------------------------------------------------|----------------|
| Average |     0.382 |                   |             |                                                                           |                |
| Max     |     0.693 | (2, 16, 512, 128) | causal_mask | <function generate_experiment_configs.<locals>.mask_fn at 0x7f16a7896200> | torch.bfloat16 |
| Min     |     0.220 | (2, 16, 512, 256) | causal_mask | <function generate_experiment_configs.<locals>.mask_fn at 0x7f16a7896200> | torch.bfloat16 |
```
After:
* score_mod = noop
* mask = causal

```
=========================================================FWD Speedups========================================================


| Type    |   Speedup | shape              | score_mod   | mask                                                                      | dtype          |
|---------|-----------|--------------------|-------------|---------------------------------------------------------------------------|----------------|
| Average |     0.217 |                    |             |                                                                           |                |
| Max     |     0.567 | (16, 16, 4096, 64) | noop        | <function generate_experiment_configs.<locals>.mask_fn at 0x7f4a7da96170> | torch.bfloat16 |
| Min     |     0.024 | (2, 16, 512, 64)   | noop        | <function generate_experiment_configs.<locals>.mask_fn at 0x7f4a7da97be0> | torch.bfloat16 |


=========================================================BWD Speedups========================================================


| Type    |   Speedup | shape              | score_mod   | mask                                                                      | dtype          |
|---------|-----------|--------------------|-------------|---------------------------------------------------------------------------|----------------|
| Average |     0.324 |                    |             |                                                                           |                |
| Max     |     0.928 | (2, 16, 1024, 128) | noop        | <function generate_experiment_configs.<locals>.mask_fn at 0x7f4a7da97be0> | torch.bfloat16 |
| Min     |     0.020 | (8, 16, 4096, 256) | noop        | <function generate_experiment_configs.<locals>.mask_fn at 0x7f4a7da96170> | torch.bfloat16 |
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang