### PR TITLE
Update tracker issues after successfully cherry-picking a PR

### DIFF
--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -3,7 +3,7 @@
 import json
 import os
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, cast, Dict, List, Optional
 
 from urllib.error import HTTPError
 
@@ -107,24 +107,20 @@ def cherry_pick(
 
     try:
         org, project = repo.gh_owner_and_name()
+
+        cherry_pick_pr = ""
         if not dry_run:
             cherry_pick_pr = submit_pr(repo, pr, cherry_pick_branch, onto_branch)
 
-            msg = f"The cherry pick PR is at {cherry_pick_pr}"
-            if fixes:
-                msg += f" and it is linked with issue {fixes}"
-            elif classification in REQUIRES_ISSUE:
-                msg += f" and it is recommended to link a {classification} cherry pick PR with an issue"
-
-            post_pr_comment(org, project, pr.pr_num, msg)
-
+        tracker_issues_comments = []
         tracker_issues = get_tracker_issues(org, project, onto_branch)
-        if not dry_run:
-            for issue in tracker_issues:
-                issue_number = int(str(issue.get("number", "0")))
-                if not issue_number:
-                    continue
+        for issue in tracker_issues:
+            issue_number = int(str(issue.get("number", "0")))
+            if not issue_number:
+                continue
 
+            res = cast(
+                Dict[str, Any],
                 post_tracker_issue_comment(
                     org,
                     project,
@@ -133,7 +129,26 @@ def cherry_pick(
                     cherry_pick_pr,
                     classification,
                     fixes,
-                )
+                    dry_run,
+                ),
+            )
+
+            comment_url = res.get("html_url", "")
+            if comment_url:
+                tracker_issues_comments.append(comment_url)
+
+        msg = f"The cherry pick PR is at {cherry_pick_pr}"
+        if fixes:
+            msg += f" and it is linked with issue {fixes}."
+        elif classification in REQUIRES_ISSUE:
+            msg += f" and it is recommended to link a {classification} cherry pick PR with an issue."
+
+        if tracker_issues_comments:
+            msg += " The following tracker issues are updated:\n"
+            for tracker_issues_comment in tracker_issues_comments:
+                msg += f"* {tracker_issues_comment}\n"
+
+        post_pr_comment(org, project, pr.pr_num, msg, dry_run)
 
     finally:
         if current_branch:
@@ -205,7 +220,9 @@ def submit_pr(
         raise RuntimeError(msg) from error
 
 
-def post_pr_comment(org: str, project: str, pr_num: int, msg: str) -> None:
+def post_pr_comment(
+    org: str, project: str, pr_num: int, msg: str, dry_run: bool = False
+) -> List[Dict[str, Any]]:
     """
     Post a comment on the PR itself to point to the cherry picking PR when success
     or print the error when failure
@@ -228,7 +245,7 @@ def post_pr_comment(org: str, project: str, pr_num: int, msg: str) -> None:
     comment = "\n".join(
         (f"### Cherry picking #{pr_num}", f"{msg}", "", f"{internal_debugging}")
     )
-    gh_post_pr_comment(org, project, pr_num, comment)
+    return gh_post_pr_comment(org, project, pr_num, comment, dry_run)
 
 
 def post_tracker_issue_comment(
@@ -239,7 +256,8 @@ def post_tracker_issue_comment(
     cherry_pick_pr: str,
     classification: str,
     fixes: str,
-) -> None:
+    dry_run: bool = False,
+) -> List[Dict[str, Any]]:
     """
     Post a comment on the tracker issue (if any) to record the cherry pick
     """
@@ -255,7 +273,7 @@ def post_tracker_issue_comment(
             " - ".join((classification.capitalize(), fixes.capitalize())),
         )
     )
-    gh_post_pr_comment(org, project, issue_num, comment)
+    return gh_post_pr_comment(org, project, issue_num, comment, dry_run)
 
 
 def main() -> None:

--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -82,7 +82,6 @@ def get_tracker_issues(
     if not tracker_issues:
         return []
 
-    print(f"LOOKING {version}")
     # Figure out the tracker issue from the list by looking at the title
     return [issue for issue in tracker_issues if version in issue.get("title", "")]
 

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -84,6 +84,7 @@ def gh_fetch_json(
         url += "?" + "&".join(
             f"{name}={quote(str(val))}" for name, val in params.items()
         )
+    print(f"==== {url}")
     return cast(
         List[Dict[str, Any]],
         gh_fetch_url(url, headers=headers, data=data, reader=json.load, method=method),
@@ -202,3 +203,12 @@ def gh_update_pr_state(org: str, repo: str, pr_num: int, state: str = "open") ->
             )
         else:
             raise
+
+
+def gh_query_issues_by_labels(
+    org: str, repo: str, labels: List[str], state: str = "open"
+) -> List[Dict[str, Any]]:
+    url = f"{GITHUB_API_URL}/repos/{org}/{repo}/issues"
+    return gh_fetch_json(
+        url, method="GET", params={"labels": ",".join(labels), "state": state}
+    )

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -84,7 +84,6 @@ def gh_fetch_json(
         url += "?" + "&".join(
             f"{name}={quote(str(val))}" for name, val in params.items()
         )
-    print(f"==== {url}")
     return cast(
         List[Dict[str, Any]],
         gh_fetch_url(url, headers=headers, data=data, reader=json.load, method=method),

--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -76,7 +76,7 @@ def run_mlp_layer_norm_gelu(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"mlp_layer_norm_gelu_{dtype_str}",
+                f"mlp_layer_norm_gelu",
                 "flops_utilization",
                 expected_flops_utilization,
                 f"{flops_utilization:.02f}",
@@ -113,7 +113,7 @@ def run_layer_norm(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"layer_norm_{dtype_str}",
+                f"layer_norm",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",
@@ -156,7 +156,7 @@ def run_gather_gemv(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"gather_gemv_{dtype_str}",
+                f"gather_gemv",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",
@@ -197,7 +197,7 @@ def run_gemv(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"gemv_{dtype_str}",
+                f"gemv",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",

--- a/benchmarks/gpt_fast/benchmark.py
+++ b/benchmarks/gpt_fast/benchmark.py
@@ -76,7 +76,7 @@ def run_mlp_layer_norm_gelu(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"mlp_layer_norm_gelu",
+                "mlp_layer_norm_gelu",
                 "flops_utilization",
                 expected_flops_utilization,
                 f"{flops_utilization:.02f}",
@@ -113,7 +113,7 @@ def run_layer_norm(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"layer_norm",
+                "layer_norm",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",
@@ -156,7 +156,7 @@ def run_gather_gemv(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"gather_gemv",
+                "gather_gemv",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",
@@ -197,7 +197,7 @@ def run_gemv(device: str = "cuda"):
         dtype_str = str(dtype).replace("torch.", "")
         results.append(
             Experiment(
-                f"gemv",
+                "gemv",
                 "memory_bandwidth(GB/s)",
                 expected_memory_bandwidth,
                 f"{memory_bandwidth:.02f}",


### PR DESCRIPTION
This extends the capacity of the cherry-pick bot to automatically update the tracker issue with the information.  For this to work, the tracker issue needs to be an open one with a `release tracker` label, i.e. https://github.com/pytorch/pytorch/issues/128436.  The version from the release branch, i.e. `release/2.4`, will be match with the title of the tracker issue, i.e. `[v.2.4.0] Release Tracker` or `[v.2.4.1] Release Tracker`

### Testing

`python cherry_pick.py --onto-branch release/2.4 --classification release --fixes "DEBUG DEBUG" --github-actor huydhn 128718`

* On the PR https://github.com/pytorch/pytorch/pull/128718#issuecomment-2174846771
* On the tracker issue https://github.com/pytorch/pytorch/issues/128436#issuecomment-2174846757
