### PR TITLE
[NOT NEEDED] [Traceable FSDP2] Improve FSDPParam._unsharded_param tracing

### DIFF
--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -329,11 +329,16 @@ class FSDPParam:
         2. Under compile, we always recreate `self.all_gather_outputs` per AllGather.
            This is to ensure the buffer creation is internal to the graph and
            avoid `self.all_gather_outputs` being captured as a graph input.
-        3. Under compile, at the end of `free_unsharded_param()`, we always clean up
-           `self.all_gather_outputs` and `self._unsharded_inner_tensors`,
+        3. Under compile, at the end of `init_unsharded_param()`, we always set
+           `self.all_gather_outputs` and `self._unsharded_inner_tensors` to empty list,
            to avoid them being captured as graph output.
+        4. Under compile, in `free_unsharded_param()`, we free up `self.unsharded_param` memory
+           by looking into its tensor storage and resizing it to 0, instead of relying on access
+           to `self.all_gather_outputs` and `self._unsharded_inner_tensors` (which are already emptied
+           at the end of `init_unsharded_param()` and thus can't be used as references to the underlying
+           storage tensors).
 
-        With these invariants, only these tensors will be inputs to the graph:
+        With these invariants, only these tensors will be inputs to the forward graph:
         - Sharded parameters
         - Placeholders for the `self._unsharded_param` nn.Parameter
         """
@@ -386,6 +391,8 @@ class FSDPParam:
             with torch.no_grad():
                 alloc_storage(self._unsharded_param)
                 self._unsharded_param.copy_(unsharded_param)
+            self.all_gather_outputs = []
+            self._unsharded_inner_tensors = []
         else:
             self._unsharded_param = nn.Parameter(
                 unsharded_param, requires_grad=self.sharded_param.requires_grad
@@ -520,8 +527,16 @@ class FSDPParam:
         ):
             free_storage(tensor)
         if ca.compiled_autograd_enabled:
-            self.all_gather_outputs = []
-            self._unsharded_inner_tensors = []
+            # Under compile, `self.all_gather_outputs` and `self._unsharded_inner_tensors` are emptied right after every AllGather.
+            # So we need to free `self.unsharded_param` memory by looking into its own tensor storage instead.
+            unsharded_param_data = self.unsharded_param.data  # Unpack nn.Parameter to get underlying tensor data
+            is_subclass = isinstance(unsharded_param_data, torch.Tensor) and type(unsharded_param_data) != torch.Tensor
+            if is_subclass:
+                attrs, ctx = unsharded_param_data.__tensor_flatten__()
+                for attr in attrs:
+                    free_storage(getattr(unsharded_param_data, attr))
+            else:
+                free_storage(unsharded_param_data)
 
     @property
     def all_gather_inputs(self) -> List[torch.Tensor]:  # 1D

--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -529,10 +529,15 @@ class FSDPParam:
         if ca.compiled_autograd_enabled:
             # Under compile, `self.all_gather_outputs` and `self._unsharded_inner_tensors` are emptied right after every AllGather.
             # So we need to free `self.unsharded_param` memory by looking into its own tensor storage instead.
-            unsharded_param_data = self.unsharded_param.data  # Unpack nn.Parameter to get underlying tensor data
-            is_subclass = isinstance(unsharded_param_data, torch.Tensor) and type(unsharded_param_data) != torch.Tensor
+            unsharded_param_data = (
+                self.unsharded_param.data
+            )  # Unpack nn.Parameter to get underlying tensor data
+            is_subclass = (
+                isinstance(unsharded_param_data, torch.Tensor)
+                and type(unsharded_param_data) != torch.Tensor
+            )
             if is_subclass:
-                attrs, ctx = unsharded_param_data.__tensor_flatten__()
+                attrs, ctx = unsharded_param_data.__tensor_flatten__()  # type: ignore[attr-defined]
                 for attr in attrs:
                     free_storage(getattr(unsharded_param_data, attr))
             else:

--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -527,8 +527,9 @@ class FSDPParam:
         ):
             free_storage(tensor)
         if ca.compiled_autograd_enabled:
-            # Under compile, `self.all_gather_outputs` and `self._unsharded_inner_tensors` are emptied right after every AllGather.
-            # So we need to free `self.unsharded_param` memory by looking into its own tensor storage instead.
+            # Under compile, `self.all_gather_outputs` and `self._unsharded_inner_tensors` are emptied
+            # right after every AllGather. So we need to free `self.unsharded_param` memory by
+            # looking into its own tensor storage instead.
             unsharded_param_data = (
                 self.unsharded_param.data
             )  # Unpack nn.Parameter to get underlying tensor data


### PR DESCRIPTION
Please see detailed changes in the code comment. This PR helps simplify the forward graph output by removing unnecessary tensors (e.g. `self.all_gather_outputs`) from it.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128927



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang @d4l3k