### PR TITLE
[inductor] Constant folding for dynamic shape node before pattern matching

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -395,9 +395,6 @@ compute_all_bounds = False
 # constant folding on the joint graph
 joint_graph_constant_folding = True
 
-# support dynamic shape derivation in constant_fold_uniform_value
-enable_dynamic_constant_fold_uniform_value = False
-
 # Enable indirect_indexing asserts for decompositions and lowerings
 debug_index_asserts = False
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -395,6 +395,9 @@ compute_all_bounds = False
 # constant folding on the joint graph
 joint_graph_constant_folding = True
 
+# support dynamic shape derivation in constant_fold_uniform_value
+enable_dynamic_constant_fold_uniform_value = False
+
 # Enable indirect_indexing asserts for decompositions and lowerings
 debug_index_asserts = False
 

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -60,14 +60,14 @@ class ConstantFolder(torch.fx.Interpreter):
         # is the output
         self.user_to_last_uses = self.node_to_last_non_output_use()
 
-        self.dynamic_node_substitute_values: Dict[torch.fx.Node, Any] = {}
         self.symint_nodes: Dict[str, torch.fx.Node] = {}
 
     def _support_dynamic_shape(self):
+        # ConstantFolder not support dynamic shape now
         return False
 
     def _deduce_value(self, node):
-        return self.unknown_value
+        return super().run_node(node)
 
     def is_impure(self, node: torch.fx.node.Node):
         if (
@@ -168,12 +168,9 @@ class ConstantFolder(torch.fx.Interpreter):
         ):
             return self.unknown_value
 
-        if self._support_dynamic_shape():
-            out = self._deduce_value(node)
-            if out == self.unknown_value:
-                return self.unknown_value
-        else:
-            out = super().run_node(node)
+        out = self._deduce_value(node)
+        if out == self.unknown_value:
+            return self.unknown_value
 
         if node.op != "get_attr" and isinstance(out, torch.Tensor):
             if out.device.type == "meta":
@@ -198,7 +195,6 @@ class ConstantFolder(torch.fx.Interpreter):
             for to_delete in self.user_to_last_uses.get(node, []):
                 if self.replaced_uses[to_delete] == len(to_delete.users):
                     self.node_replacements.pop(to_delete, None)
-                    self.dynamic_node_substitute_values.pop(to_delete, None)
 
         return out
 
@@ -217,10 +213,7 @@ class ConstantFolder(torch.fx.Interpreter):
                 and isinstance(n.meta["val"], torch.SymInt)
             ):
                 s = n.meta["val"]
-                env[n] = s
-                self.dynamic_node_substitute_values[n] = s.node.shape_env.size_hint(
-                    s.node.expr
-                )
+                env[n] = s.node.shape_env.size_hint(s.node.expr)
                 self.symint_nodes[str(s)] = n
             else:
                 env[n] = self.unknown_value

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -286,6 +286,10 @@ class UniformValueConstantFolder(ConstantFolder):
             if any(isinstance(inp, torch.SymInt) for inp in flattened_inputs):
                 return self.unknown_value
 
+            # we run the ops with dim 1, so remove memory_format to avoid error
+            kwargs = dict(kwargs)
+            kwargs.pop("memory_format", None)
+
             return node.target(*args, **kwargs)
 
         return self.unknown_value


### PR DESCRIPTION
Extend constant folding for dynamic shape node, only support pointwise op and some restricted ops 

We support dynamic shapes by limiting constant folding of ops that are guaranteed to have uniform values (`full`, pointwise ops, and views) and running these operators with tensors of shape 1. This also eliminates the possibility of memory overhead of constant folding.

Test plan:

```
python test/inductor/test_torchinductor_dynamic_shapes.py -k test_constant_fold_uniform_value_dynamic
```

Fixes #128387

@eellison 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @ezyang @bdhirsh @anijain2305