### PR TITLE
Update start_, end_  and retired only for the right entry when retire a work

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -779,6 +779,8 @@ struct NCCLTraceBuffer {
         startEvent = entry->start_;
         endEvent = entry->end_;
       }
+      entry->retired_ = true;
+      entry->start_ = entry->end_ = nullptr;
     }
 
     if (can_compute_duration) {
@@ -801,9 +803,6 @@ struct NCCLTraceBuffer {
         entry->duration_ = duration.value();
       }
     }
-
-    entry->retired_ = true;
-    entry->start_ = entry->end_ = nullptr;
   }
 
   const c10::List<c10::IValue> getCollectiveTrace(


### PR DESCRIPTION
Fixes #128805 
If the buffer size of NCCLTraceBuffer is 10 and the pg has recorded 11 works, the entry of the work 0 will have been overwritten by the work 10,  so when watchdog retire the work 0, the  start_ and end_  of the entry 0 shouldn't be set to nullptr. 

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k