### PR TITLE
Set correct output dtype for dequantize op during convert_pt2e in decomposed mode

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1243,7 +1243,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             node_list,
         )
 
-        def verify_quant_dequant_iotypes_new(m):
+        def verify_quant_dequant_iotypes(m):
             for node in m.graph.nodes:
                 if (
                     node.op == "call_function"
@@ -1272,7 +1272,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                             and quant_out_dtype == dequant_in_dtype
                         ), "quant dequant io dtype check failed!"
 
-        verify_quant_dequant_iotypes_new(m)
+        verify_quant_dequant_iotypes(m)
 
     def test_input_edge_sanity_check(self):
         class M(torch.nn.Module):

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -149,6 +149,12 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
     if hasattr(activation_post_process, "is_dynamic"):
         is_dynamic = activation_post_process.is_dynamic  # type: ignore[assignment]
 
+    def get_dq_out_dtype(input_node):
+        dq_out_dtype = torch.float32
+        if 'val' in input_node.meta:
+            dq_out_dtype = input_node.meta['val'].dtype
+        return dq_out_dtype
+
     if dtype in SUPPORTED_QDTYPES and (not is_dynamic):
         # TODO: probably should cleanup this condition check, it's hard
         # to reason about this if and the following elif
@@ -219,7 +225,7 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
             dequantized_node = graph.call_function(
                 dequantize_op,
                 tuple(dq_inputs),
-                {}
+                {"out_dtype": get_dq_out_dtype(input_node)}
             )
 
             node.replace_all_uses_with(dequantized_node)
@@ -322,7 +328,7 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
             dequantized_node = graph.call_function(
                 dequantize_op,
                 tuple(dq_inputs),
-                {}
+                {"out_dtype": get_dq_out_dtype(input_node)}
             )
 
             def remap_fn(x):

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -157,12 +157,6 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
                 dequantize_op_kwargs = {"out_dtype": dq_out_dtype}
         return dequantize_op_kwargs
 
-    def get_dq_out_dtype(input_node):
-        dq_out_dtype = torch.float32
-        if 'val' in input_node.meta:
-            dq_out_dtype = input_node.meta['val'].dtype
-        return dq_out_dtype
-
     if dtype in SUPPORTED_QDTYPES and (not is_dynamic):
         # TODO: probably should cleanup this condition check, it's hard
         # to reason about this if and the following elif

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1306,6 +1306,7 @@ class PT2EQuantizationTestCase(QuantizationTestCase):
             self.checkGraphModuleNodes(m_fx, expected_node_occurrence=node_occurrence)
             fx_quant_output = m_fx(*example_inputs)
             self.assertEqual(fx_quant_output, pt2_quant_output)
+        return m
 
     def _quantize(self, m, quantizer, example_inputs, is_qat: bool = False):
         # resetting dynamo cache


### PR DESCRIPTION
Earlier the signature of dequantize ops for decomposed quantized Tensor was changed for wider use-cases where the output dtype can be different from torch.float and needs to be passed during dequantization.
Please refer: https://github.com/pytorch/pytorch/pull/121450

However, setting of correct output dtype for dequantize ops was still missing in convert_pt2e flow.

This change enables the users to use PT2E quantization flow with non torch.float unquantized dtype, such as torch.bfloat16.
