### PR TITLE
[BE] Do not crash weight_norm on empty tensors

### DIFF
--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -57,7 +57,9 @@ std::tuple<Tensor,Tensor> weight_norm_cpu(
   const auto dtype = g.scalar_type() == at::ScalarType::BFloat16 ?
       at::ScalarType::Float : g.scalar_type();
   auto norm = at::empty_strided(g.sizes(), g.strides(), g.options().dtype(dtype));
-  weight_norm_stub(kCPU, w, norm, v, g, dim);
+  if (v.numel() && g.numel()) {
+    weight_norm_stub(kCPU, w, norm, v, g, dim);
+  }
 
   return std::tuple<Tensor, Tensor>{w, norm};
 }
@@ -74,7 +76,9 @@ std::tuple<Tensor, Tensor> weight_norm_backward_cpu(
 
   auto grad_v = at::empty_like(saved_v, at::MemoryFormat::Contiguous);
   auto grad_g = at::empty_like(saved_g, at::MemoryFormat::Contiguous);
-  weight_norm_backward_stub(kCPU, grad_v, grad_g, grad_w, saved_v, saved_g, saved_norm, dim);
+  if (grad_v.numel() && grad_g.numel()) {
+    weight_norm_backward_stub(kCPU, grad_v, grad_g, grad_w, saved_v, saved_g, saved_norm, dim);
+  }
 
   return std::tuple<Tensor, Tensor>{grad_v, grad_g};
 }

--- a/aten/src/ATen/native/cuda/WeightNorm.cu
+++ b/aten/src/ATen/native/cuda/WeightNorm.cu
@@ -353,6 +353,11 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
   // current device is?  I believe so, because Type::* functions are DeviceGuard()ed.
   auto norms = at::empty_strided(g.sizes(), g.strides(), g.options().dtype(AccType));
 
+  // Return on empty inputs
+  if (v.numel() == 0 || g.numel() == 0) {
+    return std::tuple<Tensor, Tensor>{w, norms};
+  }
+
   const int ndims = v.dim();
 
   if(dim == 0)

--- a/aten/src/ATen/native/mps/operations/WeightNorm.mm
+++ b/aten/src/ATen/native/mps/operations/WeightNorm.mm
@@ -40,6 +40,11 @@ std::tuple<Tensor, Tensor> weight_norm_mps(const Tensor& v, const Tensor& g, int
   auto w = at::empty_like(v, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   auto norms = at::empty_like(g, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
+  // Return early on empty inputs
+  if (v.numel() == 0 || g.numel() == 0) {
+    return std::tuple<Tensor, Tensor>{w, norms};
+  }
+
   string key = "weight_norm_mps_" + std::to_string(dim) + getTensorsStringKey({v, g});
 
   NSMutableArray* reduction_dims = [NSMutableArray array];
@@ -100,6 +105,11 @@ std::tuple<Tensor, Tensor> weight_norm_backward_mps(const Tensor& grad_w,
 
   auto grad_v = at::empty_like(saved_v, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   auto grad_g = at::empty_like(saved_g, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+
+  // Return early on empty inputs
+  if (grad_v.numel() == 0 || grad_g.numel() == 0) {
+    return std::tuple<Tensor, Tensor>{grad_v, grad_g};
+  }
 
   string key =
       "weight_norm_backward_mps_" + std::to_string(dim) + getTensorsStringKey({grad_w, saved_v, saved_g, saved_norms});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #128958
* __->__ #128957
* #128956
* #128955

Test plan:
 - `python3 -c "import torch;print(torch._weight_norm(torch.rand((3, 0)), torch.rand((3, 0))))"`
 - OpInfo tests added in https://github.com/pytorch/pytorch/pull/128958

Fixes https://github.com/pytorch/pytorch/issues/128695