### PR TITLE
fix dynamo isinstance inlining for nn.Parameter + subclasses

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1573,6 +1573,25 @@ class TestNestedTensor(torch._dynamo.test_case.TestCase):
 
         torch.compile(fn, fullgraph=True, backend="aot_eager")(nt)
 
+    # The test here: nn.Parameters that are secretly subclasses
+    # have a metaclass that overrides __isinstance__,
+    # that dynamo needs to respect when it inlines the if statement.
+    def test_param_subclass_isinstance_input(self):
+        x_inner = torch.randn(16, 16, requires_grad=True)
+        x = torch.nn.Parameter(TwoTensor(x_inner, x_inner))
+        m = torch.nn.Linear(16, 16)
+        m.weight = x
+
+        def fn():
+            if isinstance(m.weight, torch.nn.Parameter):
+                return m.weight + 1
+            else:
+                return m.weight + 2
+
+        out_ref = fn()
+        out_test = torch.compile(fn, backend="aot_eager")()
+        self.assertEqual(out_ref, out_test)
+
     def _input_view_test(self, nt_view_name):
         nt_view = VIEW_TEST_CASES[nt_view_name]()
 

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1392,7 +1392,11 @@ class BuiltinVariable(VariableTracker):
             def _tensor_isinstance(tensor_var, tensor_type):
                 def check_type(ty):
                     if ty not in tensortype_to_dtype:
-                        return issubclass(arg.python_type(), ty)
+                        example_val = arg.as_proxy().node.meta['example_value']
+                        # N.B: we are calling isinstance directly on the example value.
+                        # torch.nn.Parameter has a meta-class that overrides __isinstance__,
+                        # the isinstance check here allows us to invoke that logic.
+                        return isinstance(example_val, ty)
 
                     dtypes = tensortype_to_dtype[ty]
                     return arg.dtype in dtypes


### PR DESCRIPTION
Dynamo will incorrectly inline calls to `isinstance(x, torch.nn.Parameter)` when `x` is a parameter + subclass. This is because `nn.Parameter`'s handling for isinstance is... interesting:

(1) The parameter constructor sets an `_is_param` flag on the parameter ([code](https://github.com/pytorch/pytorch/blob/main/torch/nn/parameter.py#L55))

(2) `nn.Parameter` has a metaclass that overrides `__instancecheck__` to also check this flag, when determining if `isinstance(x, nn.Parameter)` should return True ([code](https://github.com/pytorch/pytorch/blob/main/torch/nn/parameter.py#L12))

The "proper" fix here is probably to carefully stare at the cpython implementation of `isinstance`. In this case though, I think the fix is a bit simpler: we can use `isinstance` in the dynamo impl, and run it directly on the `FakeTensor` example value. As long as we properly fakeified the nn parameter input to hold onto the `_is_param` flag, then we should be able to re-use the eager-mode machinery that has special handling for parameters.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #128331
* #128045
* __->__ #128981



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang