### PR TITLE
Evaluate symexprs on load path of cache not write

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2713,6 +2713,7 @@ coverage_ignore_classes = [
     "GuardOnDataDependentSymNode",
     "PendingUnbackedSymbolNotFound",
     "LoggingShapeGuardPrinter",
+    "SymExprPrinter",
     "RelaxedUnspecConstraint",
     "RuntimeAssert",
     "ShapeGuardPrinter",

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -1970,6 +1970,7 @@
     "EqualityConstraint",
     "GuardOnDataDependentSymNode",
     "LoggingShapeGuardPrinter",
+    "SymExprPrinter",
     "RelaxedUnspecConstraint",
     "RuntimeAssert",
     "ShapeGuardPrinter",

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -637,7 +637,7 @@ class TracingContext:
         # careful not to accidentally induce guards on the SymInt if
         # you ever do change this in aot_autograd.py; you should check
         # on permutations preferentially.)
-        self.output_strides: Optional[List[Optional[List[int]]]] = None
+        self.output_strides: Optional[List[Optional[Tuple[int, ...]]]] = None
         # When this is True, whenever we encounter an int in Dynamo tracing,
         # we will (1) force unspec it and (2) force it as a size-like unbacked
         # integer.  This is currently used when processing certain lists of

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -70,8 +70,6 @@ from torch.fx.experimental.symbolic_shapes import has_hint, hint_int, ShapeEnv
 if TYPE_CHECKING:
     from concurrent.futures import Future
 
-    import sympy
-
     from torch._inductor.graph import GraphLowering
     from torch._inductor.ir import ChoiceCaller
     from torch._inductor.runtime.hints import HalideMeta
@@ -1117,7 +1115,7 @@ class CompiledFxGraph:
     mutated_input_idxs: Set[int]
     constants: Dict[str, torch.Tensor]
     torchbind_constants: Dict[str, torch._C.ScriptObject]
-    output_strides: Optional[List[Optional[Tuple[sympy.Expr, ...]]]]
+    output_strides: Optional[List[Optional[Tuple[str, ...]]]]
     disabled_cudagraphs_reason: Optional[str]
     metrics_deltas: metrics.CachedMetricsDeltas
     # This is a string representation of an expression we serialize
@@ -1134,7 +1132,7 @@ class CompiledFxGraph:
         self,
         current_callable: Optional[Callable[..., Any]],
         graph: GraphLowering,
-        output_strides: List[Optional[Tuple[sympy.Expr, ...]]],
+        output_strides: List[Optional[Tuple[str, ...]]],
         disabled_cudagraphs_reason: Optional[str],
         metrics_deltas: metrics.CachedMetricsDeltas,
     ):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1117,7 +1117,7 @@ class CompiledFxGraph:
     mutated_input_idxs: Set[int]
     constants: Dict[str, torch.Tensor]
     torchbind_constants: Dict[str, torch._C.ScriptObject]
-    output_stride_exprs: Optional[List[Optional[Tuple[sympy.Expr, ...]]]]
+    output_strides: Optional[List[Optional[Tuple[sympy.Expr, ...]]]]
     disabled_cudagraphs_reason: Optional[str]
     metrics_deltas: metrics.CachedMetricsDeltas
     # This is a string representation of an expression we serialize
@@ -1134,7 +1134,7 @@ class CompiledFxGraph:
         self,
         current_callable: Optional[Callable[..., Any]],
         graph: GraphLowering,
-        output_stride_exprs: List[Optional[Tuple[sympy.Expr, ...]]],
+        output_strides: List[Optional[Tuple[sympy.Expr, ...]]],
         disabled_cudagraphs_reason: Optional[str],
         metrics_deltas: metrics.CachedMetricsDeltas,
     ):
@@ -1150,7 +1150,7 @@ class CompiledFxGraph:
         self.mutated_input_idxs = set(graph.mutated_input_idxs)
         self.constants = graph.constants
         self.torchbind_constants = graph.torchbind_constants
-        self.output_stride_exprs = output_stride_exprs
+        self.output_strides = output_strides
         self.disabled_cudagraphs_reason = disabled_cudagraphs_reason
         self.metrics_deltas = metrics_deltas
         self.guards_expr = None

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -46,6 +46,7 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
+from typing_extensions import TypeAlias
 
 import torch
 from torch._dynamo.utils import counters, dynamo_timed
@@ -1098,6 +1099,9 @@ class FxGraphCache:
             pass
 
 
+_StrideExprStr: TypeAlias = str
+
+
 @dataclasses.dataclass
 class CompiledFxGraph:
     """
@@ -1115,7 +1119,7 @@ class CompiledFxGraph:
     mutated_input_idxs: Set[int]
     constants: Dict[str, torch.Tensor]
     torchbind_constants: Dict[str, torch._C.ScriptObject]
-    output_strides: Optional[List[Optional[Tuple[str, ...]]]]
+    output_strides: Optional[List[Optional[Tuple[_StrideExprStr, ...]]]]
     disabled_cudagraphs_reason: Optional[str]
     metrics_deltas: metrics.CachedMetricsDeltas
     # This is a string representation of an expression we serialize
@@ -1132,7 +1136,7 @@ class CompiledFxGraph:
         self,
         current_callable: Optional[Callable[..., Any]],
         graph: GraphLowering,
-        output_strides: List[Optional[Tuple[str, ...]]],
+        output_strides: List[Optional[Tuple[_StrideExprStr, ...]]],
         disabled_cudagraphs_reason: Optional[str],
         metrics_deltas: metrics.CachedMetricsDeltas,
     ):

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -70,6 +70,8 @@ from torch.fx.experimental.symbolic_shapes import has_hint, hint_int, ShapeEnv
 if TYPE_CHECKING:
     from concurrent.futures import Future
 
+    import sympy
+
     from torch._inductor.graph import GraphLowering
     from torch._inductor.ir import ChoiceCaller
     from torch._inductor.runtime.hints import HalideMeta
@@ -1115,7 +1117,7 @@ class CompiledFxGraph:
     mutated_input_idxs: Set[int]
     constants: Dict[str, torch.Tensor]
     torchbind_constants: Dict[str, torch._C.ScriptObject]
-    output_strides: Optional[List[Optional[Tuple[int, ...]]]]
+    output_stride_exprs: Optional[List[Optional[Tuple[sympy.Expr, ...]]]]
     disabled_cudagraphs_reason: Optional[str]
     metrics_deltas: metrics.CachedMetricsDeltas
     # This is a string representation of an expression we serialize
@@ -1132,7 +1134,7 @@ class CompiledFxGraph:
         self,
         current_callable: Optional[Callable[..., Any]],
         graph: GraphLowering,
-        output_strides: List[Optional[Tuple[int, ...]]],
+        output_stride_exprs: List[Optional[Tuple[sympy.Expr, ...]]],
         disabled_cudagraphs_reason: Optional[str],
         metrics_deltas: metrics.CachedMetricsDeltas,
     ):
@@ -1148,7 +1150,7 @@ class CompiledFxGraph:
         self.mutated_input_idxs = set(graph.mutated_input_idxs)
         self.constants = graph.constants
         self.torchbind_constants = graph.torchbind_constants
-        self.output_strides = output_strides
+        self.output_stride_exprs = output_stride_exprs
         self.disabled_cudagraphs_reason = disabled_cudagraphs_reason
         self.metrics_deltas = metrics_deltas
         self.guards_expr = None

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -567,14 +567,12 @@ def compile_fx_inner(
     if context is not None and context.output_strides is not None:
         assert len(context.output_strides) == 0
         shape_env = _shape_env_from_inputs(example_inputs)
-        V.graph.sizevars = SizeVarAllocator(shape_env)
+        sizevars = SizeVarAllocator(shape_env)
         for exprs in compiled_graph.output_strides:
             if exprs is None:
                 context.output_strides.append(None)
             else:
-                context.output_strides.append(
-                    tuple(V.graph.sizevars.size_hint(s) for s in exprs)
-                )
+                context.output_strides.append([sizevars.size_hint(s) for s in exprs])
 
     if aot_mode:
         return compiled_graph

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -573,7 +573,7 @@ def compile_fx_inner(
                 context.output_strides.append(None)
             else:
                 context.output_strides.append(
-                    V.graph.sizevars.size_hint(s) for s in exprs
+                    tuple(V.graph.sizevars.size_hint(s) for s in exprs)
                 )
 
     if aot_mode:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -563,14 +563,14 @@ def compile_fx_inner(
                 context.output_strides.append(None)
             else:
                 context.output_strides.append(
-                    [
+                    tuple(
                         (
                             shape_env.evaluate_symexpr(e)
                             if shape_env is not None
                             else int(e)
                         )
                         for e in exprs
-                    ]
+                    )
                 )
 
     if aot_mode:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -558,7 +558,14 @@ def compile_fx_inner(
                 context.output_strides.append(None)
             else:
                 context.output_strides.append(
-                    [shape_env.evaluate_symexpr(e) for e in exprs]
+                    [
+                        (
+                            shape_env.evaluate_symexpr(e)
+                            if shape_env is not None
+                            else int(e)
+                        )
+                        for e in exprs
+                    ]
                 )
 
     if aot_mode:

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1555,7 +1555,7 @@ class GraphLowering(torch.fx.Interpreter):
             if tracing_context is not None and not isinstance(
                 V.real_inputs, NullHandler
             ):
-                if tracing_context.output_stride_exprs:
+                if tracing_context.output_strides:
                     tracing_context.output_strides.clear()
 
                 params_flat = [

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1555,7 +1555,7 @@ class GraphLowering(torch.fx.Interpreter):
             if tracing_context is not None and not isinstance(
                 V.real_inputs, NullHandler
             ):
-                if tracing_context.output_strides:
+                if tracing_context.output_stride_exprs:
                     tracing_context.output_strides.clear()
 
                 params_flat = [

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4239,6 +4239,13 @@ class ShapeEnv:
             return " and ".join(produced_guards)
         return None
 
+    def evaluate_symexpr(self, code):
+        """
+        To be used by compile_fx to evaluate symexprs
+        """
+        args = {str(e): val for e, val in self.var_to_val.items()}
+        return eval(code, SYMPY_INTERP, args)
+
     def evaluate_guards_expression(self, code, args):
         """
         Expected to be used with produce_guards_expression(). Evaluates an expression

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1470,6 +1470,11 @@ class RuntimeAssert:
     stack: str = field(repr=False)
 
 
+# Used for printing SymExprs in compile_fx
+class SymExprPrinter(StrPrinter):
+    pass
+
+
 class ShapeGuardPrinter(StrPrinter):
     def __init__(
         self,

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1475,7 +1475,7 @@ class SymExprPrinter(StrPrinter):
     pass
 
 
-class ShapeGuardPrinter(StrPrinter):
+class ShapeGuardPrinter(SymExprPrinter):
     def __init__(
         self,
         symbol_to_source,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #128997

When caching is enabled, an internal model fails with
```
assert_size_stride(bmm_9, (17, s0, 512), (54784, 512, 1))
AssertionError: expected size 17==17, stride 57344==54784 at dim=0
```
looking at this model, the exact problem is when the cache is hit on the forward graph, the generated code for backward fails since the strides of the outputs of forward, passed to backward as inputs, are not what we expected.

This PR changes the evaluation logic so that we defer evaluation of output stride exprs to load path as opposed to eagerly doing it on save path.

I have not been able to come up with a unit test repro for this problem.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang

Differential Revision: [D58796503](https://our.internmc.facebook.com/intern/diff/D58796503)