### PR TITLE
run_test: Unset cpp stacktraces after reruns

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -605,8 +605,6 @@ def run_test_retries(
             break  # Got to the end of the test suite successfully
         signal_name = f" ({SIGNALS_TO_NAMES_DICT[-ret_code]})" if ret_code < 0 else ""
         print_to_file(f"Got exit code {ret_code}{signal_name}")
-        if sc_command.startswith("--rs=") and ret_code == 0:
-            print_to_file("Test passed on retry, continuing to run rest of test suite")
 
         # Read what just failed/ran
         try:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -559,7 +559,7 @@ def try_set_cpp_stack_traces(env, command, set=True):
         IS_MACOS and len(command) >= 2 and command[2].startswith(INDUCTOR_TEST_PREFIX)
     ):
         env = env or {}
-        env["TORCH_SHOW_CPP_STACKTRACES"] = "1"
+        env["TORCH_SHOW_CPP_STACKTRACES"] = "1" if set else "0"
     return env
 
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -572,8 +572,9 @@ def run_test_retries(
     output,
     continue_through_error,
 ):
-    # Run the test with -x to stop at first failure. Repeat this test at most 2
-    # more times.  If it succeeds, the next subprocess will
+    # Run the test with -x to stop at first failure.  Rerun the test by itself.
+    # If it succeeds, move on to the rest of the tests in a new process.  If it
+    # still fails, see below
     #
     # If continue through error is not set, then we fail fast.
     #
@@ -1683,7 +1684,6 @@ def main():
 
     test_directory = str(REPO_ROOT / "test")
     selected_tests = get_selected_tests(options)
-    selected_tests = [x for x in selected_tests if x == "test_utils"]
 
     test_prioritizations = import_results()
     test_prioritizations.amend_tests(selected_tests)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -551,6 +551,20 @@ def run_test(
     return ret_code
 
 
+def try_set_cpp_stack_traces(env, command, set=True):
+    # Print full c++ stack traces during retries
+    # Don't do it for macos inductor tests as it makes them
+    # segfault for some reason
+    if not (
+        IS_MACOS
+        and len(command) >= 2
+        and command[2].startswith(INDUCTOR_TEST_PREFIX)
+    ):
+        env = env or {}
+        env["TORCH_SHOW_CPP_STACKTRACES"] = "1"
+    return env
+
+
 def run_test_retries(
     command,
     test_directory,
@@ -560,9 +574,8 @@ def run_test_retries(
     output,
     continue_through_error,
 ):
-    # Run the test with -x to stop at first failure. Try again, skipping the
-    # previously run tests, repeating this until there is a test that fails 3
-    # times (same number of rVetries we typically give).
+    # Run the test with -x to stop at first failure. Repeat this test at most 2
+    # more times.  If it succeeds, the next subprocess will
     #
     # If continue through error is not set, then we fail fast.
     #
@@ -590,12 +603,14 @@ def run_test_retries(
             retries=0,  # no retries here, we do it ourselves, this is because it handles timeout exceptions well
         )
         ret_code = 0 if ret_code == 5 else ret_code
-        if ret_code == 0:
+        if ret_code == 0 and not sc_command.startswith("--rs="):
             break  # Got to the end of the test suite successfully
         signal_name = f" ({SIGNALS_TO_NAMES_DICT[-ret_code]})" if ret_code < 0 else ""
         print_to_file(f"Got exit code {ret_code}{signal_name}")
+        if sc_command.startswith("--rs=") and ret_code == 0:
+            print_to_file("Test passed on retry, continuing to run rest of test suite")
 
-        # Read what just failed
+        # Read what just failed/ran
         try:
             with open(
                 REPO_ROOT / ".pytest_cache/v/cache/stepcurrent" / stepcurrent_key
@@ -608,25 +623,23 @@ def run_test_retries(
             )
             break
 
-        num_failures[current_failure] += 1
-        if num_failures[current_failure] >= 3:
+        env = try_set_cpp_stack_traces(env, command, set=False)
+        if ret_code != 0:
+            num_failures[current_failure] += 1
+
+        if ret_code == 0:
+            # Rerunning the previously failing test succeeded, so now we can
+            # skip it and move on
+            sc_command = f"--scs={stepcurrent_key}"
+        elif num_failures[current_failure] >= 3:
             if not continue_through_error:
                 print_to_file("Stopping at first consistent failure")
                 break
             sc_command = f"--scs={stepcurrent_key}"
         else:
-            sc_command = f"--sc={stepcurrent_key}"
+            env = try_set_cpp_stack_traces(env, command, set=True)
+            sc_command = f"--rs={stepcurrent_key}"
         print_to_file("Retrying...")
-        # Print full c++ stack traces during retries
-        # Don't do it for macos inductor tests as it makes them
-        # segfault for some reason
-        if not (
-            IS_MACOS
-            and len(command) >= 2
-            and command[2].startswith(INDUCTOR_TEST_PREFIX)
-        ):
-            env = env or {}
-            env["TORCH_SHOW_CPP_STACKTRACES"] = "1"
         print_items = []  # do not continue printing them, massive waste of space
 
     consistent_failures = [x[1:-1] for x in num_failures.keys() if num_failures[x] >= 3]
@@ -1667,6 +1680,7 @@ def main():
 
     test_directory = str(REPO_ROOT / "test")
     selected_tests = get_selected_tests(options)
+    selected_tests = [x for x in selected_tests if x == "test_utils"]
 
     test_prioritizations = import_results()
     test_prioritizations.amend_tests(selected_tests)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -556,9 +556,7 @@ def try_set_cpp_stack_traces(env, command, set=True):
     # Don't do it for macos inductor tests as it makes them
     # segfault for some reason
     if not (
-        IS_MACOS
-        and len(command) >= 2
-        and command[2].startswith(INDUCTOR_TEST_PREFIX)
+        IS_MACOS and len(command) >= 2 and command[2].startswith(INDUCTOR_TEST_PREFIX)
     ):
         env = env or {}
         env["TORCH_SHOW_CPP_STACKTRACES"] = "1"
@@ -631,17 +629,22 @@ def run_test_retries(
             # Rerunning the previously failing test succeeded, so now we can
             # skip it and move on
             sc_command = f"--scs={stepcurrent_key}"
-            print_to_file("Test succeeeded in new process, continuing with the rest of the tests")
+            print_to_file(
+                "Test succeeeded in new process, continuing with the rest of the tests"
+            )
         elif num_failures[current_failure] >= 3:
             if not continue_through_error:
                 print_to_file("Stopping at first consistent failure")
                 break
             sc_command = f"--scs={stepcurrent_key}"
-            print_to_file("Test failed consistently, continuing with the rest of the tests due to continue-through-error being set")
+            print_to_file(
+                "Test failed consistently, "
+                "continuing with the rest of the tests due to continue-through-error being set"
+            )
         else:
             env = try_set_cpp_stack_traces(env, command, set=True)
             sc_command = f"--rs={stepcurrent_key}"
-            print_to_file("Retrying...")
+            print_to_file("Retrying single test...")
         print_items = []  # do not continue printing them, massive waste of space
 
     consistent_failures = [x[1:-1] for x in num_failures.keys() if num_failures[x] >= 3]

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -631,15 +631,17 @@ def run_test_retries(
             # Rerunning the previously failing test succeeded, so now we can
             # skip it and move on
             sc_command = f"--scs={stepcurrent_key}"
+            print_to_file("Test succeeeded in new process, continuing with the rest of the tests")
         elif num_failures[current_failure] >= 3:
             if not continue_through_error:
                 print_to_file("Stopping at first consistent failure")
                 break
             sc_command = f"--scs={stepcurrent_key}"
+            print_to_file("Test failed consistently, continuing with the rest of the tests due to continue-through-error being set")
         else:
             env = try_set_cpp_stack_traces(env, command, set=True)
             sc_command = f"--rs={stepcurrent_key}"
-        print_to_file("Retrying...")
+            print_to_file("Retrying...")
         print_items = []  # do not continue printing them, massive waste of space
 
     consistent_failures = [x[1:-1] for x in num_failures.keys() if num_failures[x] >= 3]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -147,7 +147,7 @@ class TestCheckpoint(TestCase):
 
     def test_checkpoint_valid(self):
         import time
-        self.assertEqual(time.time() % 3, 0)
+        self.assertEqual(int(time.time()) % 3, 0)
         model = nn.Sequential(
             nn.Linear(100, 50),
             nn.ReLU(),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -146,8 +146,6 @@ class TestCheckpoint(TestCase):
                     self.assertEqual(m.counter, 1)
 
     def test_checkpoint_valid(self):
-        import time
-        self.assertEqual(int(time.time()) % 3, 0)
         model = nn.Sequential(
             nn.Linear(100, 50),
             nn.ReLU(),
@@ -1220,7 +1218,6 @@ def f(x):
             self.assertIn("HEYA", "".join(traceback.format_tb(e.__traceback__)))
 
     def test_format_traceback_short(self):
-        self.assertEqual(1, 2)
         try:
             raise RuntimeError
         except RuntimeError as e:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1219,6 +1219,7 @@ def f(x):
             self.assertIn("HEYA", "".join(traceback.format_tb(e.__traceback__)))
 
     def test_format_traceback_short(self):
+        self.assertEqual(1, 2)
         try:
             raise RuntimeError
         except RuntimeError as e:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -146,6 +146,7 @@ class TestCheckpoint(TestCase):
                     self.assertEqual(m.counter, 1)
 
     def test_checkpoint_valid(self):
+        self.assertEqual(1, 2)
         model = nn.Sequential(
             nn.Linear(100, 50),
             nn.ReLU(),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -146,7 +146,8 @@ class TestCheckpoint(TestCase):
                     self.assertEqual(m.counter, 1)
 
     def test_checkpoint_valid(self):
-        self.assertEqual(1, 2)
+        import time
+        self.assertEqual(time.time() % 3, 0)
         model = nn.Sequential(
             nn.Linear(100, 50),
             nn.ReLU(),


### PR DESCRIPTION
Rerun the failing test singly with the env var set.  If it succeeds, start a new process without the cpp stack traces env var

We don't want to waste time generating these if we don't have to

They can also show up in assertion errors, which may cause unexpected failures if a test wants to check these

Adds new --rs (run single) to be used the same way --scs and --sc are.  It will only run the single test in the step current file

https://hud.pytorch.org/pytorch/pytorch/pull/129004?sha=2c349d3557d399020bf1f6a8b7045e2e4957ba46 has some examples of logs

In the above:
* test_checkpoint_valid failed, then passed in another subprocess.  The testing continued in a different new subprocess from the test right after it (test_checkpointing_without_reentrant_early_free)
* test_format_traceback_short failed consistently, but it continued to run because keep-going was set
