### PR TITLE
Improved flexattention bwd perf + added configurations for benchmarks

### DIFF
--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -244,7 +244,7 @@ def print_results(results: List[Experiment]):
         print(tabulate(average_data, headers="keys", tablefmt="github", floatfmt=".3f"))
 
 
-def generate_score_mods() -> List[Callable]:
+def generate_score_mods(score_mods: List[str]) -> List[Callable]:
     def noop(score, b, h, m, n):
         return score
 
@@ -257,18 +257,21 @@ def generate_score_mods() -> List[Callable]:
     def head_bias(score, b, h, m, n):
         return score + 2 * h
 
-    return [noop, causal_mask, relative_bias, head_bias]
+    function_dict = {
+        'noop': noop,
+        'causal': causal_mask,
+        'rel': relative_bias,
+        'head_bias': head_bias
+    }
+    return [function_dict[name] for name in score_mods]
 
 
-def generate_experiment_configs(calculate_bwd: bool) -> List[ExperimentConfig]:
-    batch_sizes = [2, 8, 16]
-    num_heads = [16]
-    q_kv_seq_lens = [(512, 512), (1024, 1024), (4096, 4096)]
-    head_dims = [64, 128]
+def generate_experiment_configs(calculate_bwd: bool, batch_sizes: List[int], num_heads: List[int], seq_lens: List[int], head_dims: List[int], score_mods: List[str]) -> List[ExperimentConfig]:
+    q_kv_seq_lens = [(i, i) for i in seq_lens] # only testing q_len == kv_len
     dtypes = [
         torch.bfloat16,
     ]
-    score_mods = generate_score_mods()
+    score_mods = generate_score_mods(score_mods)
     all_configs = []
     for (
         bsz,
@@ -293,14 +296,14 @@ def generate_experiment_configs(calculate_bwd: bool) -> List[ExperimentConfig]:
     return all_configs
 
 
-def main(dynamic: bool, calculate_bwd: bool):
+def main(args):
     seed = 123
     np.random.seed(seed)
     torch.manual_seed(seed)
     results = []
-    for config in tqdm(generate_experiment_configs(calculate_bwd)):
+    for config in tqdm(generate_experiment_configs(args.calculate_bwd, args.b, args.nh, args.s, args.d, args.mods)):
         results.append(
-            Experiment(config, run_single_experiment(config, dynamic=dynamic))
+            Experiment(config, run_single_experiment(config, dynamic=args.dynamic))
         )
 
     print_results(results)
@@ -320,7 +323,13 @@ if __name__ == "__main__":
         "--calculate-bwd", action="store_true", help="Calculate backward pass times"
     )
 
+    parser.add_argument('-b', type=int, nargs='+', help='batch sizes', default=[2, 8, 16])
+    parser.add_argument('-nh', type=int, nargs='+', help='# of heads', default=[16])
+    parser.add_argument('-s', type=int, nargs='+', help='sequence lengths', default=[512, 1024, 4096])
+    parser.add_argument('-d', type=int, nargs='+', help='head dims', default=[64, 128])
+    parser.add_argument('-mods', type=str, nargs='+', help='score mods', default=['noop', 'causal', 'rel', 'head_bias'])
+
     # Parse arguments
     args = parser.parse_args()
 
-    main(args.dynamic, args.calculate_bwd)
+    main(args)

--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -258,16 +258,23 @@ def generate_score_mods(score_mods: List[str]) -> List[Callable]:
         return score + 2 * h
 
     function_dict = {
-        'noop': noop,
-        'causal': causal_mask,
-        'rel': relative_bias,
-        'head_bias': head_bias
+        "noop": noop,
+        "causal": causal_mask,
+        "rel": relative_bias,
+        "head_bias": head_bias,
     }
     return [function_dict[name] for name in score_mods]
 
 
-def generate_experiment_configs(calculate_bwd: bool, batch_sizes: List[int], num_heads: List[int], seq_lens: List[int], head_dims: List[int], score_mods: List[str]) -> List[ExperimentConfig]:
-    q_kv_seq_lens = [(i, i) for i in seq_lens] # only testing q_len == kv_len
+def generate_experiment_configs(
+    calculate_bwd: bool,
+    batch_sizes: List[int],
+    num_heads: List[int],
+    seq_lens: List[int],
+    head_dims: List[int],
+    score_mods: List[str],
+) -> List[ExperimentConfig]:
+    q_kv_seq_lens = [(i, i) for i in seq_lens]  # only testing q_len == kv_len
     dtypes = [
         torch.bfloat16,
     ]
@@ -301,7 +308,11 @@ def main(args):
     np.random.seed(seed)
     torch.manual_seed(seed)
     results = []
-    for config in tqdm(generate_experiment_configs(args.calculate_bwd, args.b, args.nh, args.s, args.d, args.mods)):
+    for config in tqdm(
+        generate_experiment_configs(
+            args.calculate_bwd, args.b, args.nh, args.s, args.d, args.mods
+        )
+    ):
         results.append(
             Experiment(config, run_single_experiment(config, dynamic=args.dynamic))
         )
@@ -323,11 +334,21 @@ if __name__ == "__main__":
         "--calculate-bwd", action="store_true", help="Calculate backward pass times"
     )
 
-    parser.add_argument('-b', type=int, nargs='+', help='batch sizes', default=[2, 8, 16])
-    parser.add_argument('-nh', type=int, nargs='+', help='# of heads', default=[16])
-    parser.add_argument('-s', type=int, nargs='+', help='sequence lengths', default=[512, 1024, 4096])
-    parser.add_argument('-d', type=int, nargs='+', help='head dims', default=[64, 128])
-    parser.add_argument('-mods', type=str, nargs='+', help='score mods', default=['noop', 'causal', 'rel', 'head_bias'])
+    parser.add_argument(
+        "-b", type=int, nargs="+", help="batch sizes", default=[2, 8, 16]
+    )
+    parser.add_argument("-nh", type=int, nargs="+", help="# of heads", default=[16])
+    parser.add_argument(
+        "-s", type=int, nargs="+", help="sequence lengths", default=[512, 1024, 4096]
+    )
+    parser.add_argument("-d", type=int, nargs="+", help="head dims", default=[64, 128])
+    parser.add_argument(
+        "-mods",
+        type=str,
+        nargs="+",
+        help="score mods",
+        default=["noop", "causal", "rel", "head_bias"],
+    )
 
     # Parse arguments
     args = parser.parse_args()

--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -276,7 +276,7 @@ def generate_experiment_configs(
 ) -> List[ExperimentConfig]:
     q_kv_seq_lens = [(i, i) for i in seq_lens]  # only testing q_len == kv_len
     dtypes = [
-        torch.bfloat16,
+        torch.float16,
     ]
     score_mods = generate_score_mods(score_mods)
     all_configs = []

--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -276,7 +276,7 @@ def generate_experiment_configs(
 ) -> List[ExperimentConfig]:
     q_kv_seq_lens = [(i, i) for i in seq_lens]  # only testing q_len == kv_len
     dtypes = [
-        torch.float16,
+        torch.bfloat16,
     ]
     score_mods = generate_score_mods(score_mods)
     all_configs = []

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -32,6 +32,7 @@ from torch.utils._triton import has_triton
 # Skip tests if Triton is not available
 supported_platform = skipUnless(
     torch.cuda.is_available()
+    and torch.hip.version is None
     and has_triton()
     and torch.cuda.get_device_capability() >= (8, 0),
     "Requires CUDA and Triton",
@@ -395,7 +396,6 @@ class TestFlexAttention(InductorTestCase):
         self.assertEqual(torch._dynamo.utils.counters["frames"]["ok"], 2)
 
     @supported_platform
-    @common_utils.skipIfRocm
     @common_utils.parametrize("dtype", test_dtypes)
     @common_utils.parametrize("score_mod", test_score_mods)
     def test_builtin_score_mods(self, dtype: torch.dtype, score_mod: Callable):

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -32,7 +32,7 @@ from torch.utils._triton import has_triton
 # Skip tests if Triton is not available
 supported_platform = skipUnless(
     torch.cuda.is_available()
-    and torch.hip.version is None
+    and torch.version.hip is None
     and has_triton()
     and torch.cuda.get_device_capability() >= (8, 0),
     "Requires CUDA and Triton",

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -395,6 +395,7 @@ class TestFlexAttention(InductorTestCase):
         self.assertEqual(torch._dynamo.utils.counters["frames"]["ok"], 2)
 
     @supported_platform
+    @common_utils.skipIfRocm
     @common_utils.parametrize("dtype", test_dtypes)
     @common_utils.parametrize("score_mod", test_score_mods)
     def test_builtin_score_mods(self, dtype: torch.dtype, score_mod: Callable):

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -277,7 +277,7 @@ def flex_attention_fake_tensor_mode(
         logsumexp = query.new_empty(
             batch_size, num_heads, seq_len_q, dtype=torch.float32
         )
-        return torch.empty_like(query, memory_format=torch.contiguous_format), logsumexp
+        return torch.empty_like(query), logsumexp
 
 
 # ---------------------------- Autograd Implementation ----------------------------
@@ -670,9 +670,9 @@ def flex_attention_backward_fake_tensor_mode(
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     with mode:
-        grad_query = torch.empty_like(query, memory_format=torch.contiguous_format)
-        grad_key = torch.empty_like(key, memory_format=torch.contiguous_format)
-        grad_value = torch.empty_like(value, memory_format=torch.contiguous_format)
+        grad_query = torch.empty_like(query)
+        grad_key = torch.empty_like(key)
+        grad_value = torch.empty_like(value)
         return grad_query, grad_key, grad_value
 
 

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -432,8 +432,8 @@ def flex_attention(*args, **kwargs):
             BLOCK_N=BLOCK_N,
             BLOCK_DMODEL=query.get_size()[-1],
             # For now, we always assume the "sound" option
-            SCORE_MOD_IS_LINEAR=False,
-            ROWS_GUARANTEED_SAFE=False,
+            SCORE_MOD_IS_LINEAR=True,
+            ROWS_GUARANTEED_SAFE=True,
             OUTPUT_LOGSUMEXP=True,
         )
     inputs_for_autotuning = [query, key, value, logsumexp] + list(other_buffers)

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -314,6 +314,9 @@ _h100_default_config = {
     (torch.bfloat16, 64): (128, 64, 4, 3),
     (torch.bfloat16, 128): (64, 32, 4, 3),
     (torch.bfloat16, 256): (64, 32, 4, 3),
+    (torch.float16, 64): (128, 64, 4, 3),
+    (torch.float16, 128): (64, 32, 4, 3),
+    (torch.float16, 256): (64, 32, 4, 3),
 }
 
 _a100_default_config = {
@@ -321,8 +324,11 @@ _a100_default_config = {
     (torch.float32, 128): (128, 32, 4, 3),
     (torch.float32, 256): (64, 16, 4, 3),
     (torch.bfloat16, 64): (128, 64, 4, 3),
-    (torch.bfloat16, 128): (128, 32, 4, 3),
+    (torch.bfloat16, 128): (128, 128, 8, 2),
     (torch.bfloat16, 256): (32, 64, 4, 3),
+    (torch.float16, 64): (128, 64, 4, 3),
+    (torch.float16, 128): (128, 128, 8, 2),
+    (torch.float16, 256): (32, 64, 4, 3),
 }
 
 

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -362,7 +362,7 @@ def _get_default_config_bwd(query) -> Tuple[int, int, int, int]:
         return (32, 128, 4, 3)
     elif torch.cuda.get_device_capability() >= (8, 0):  # A100
         if head_dim == 64:
-            return (32, 128, 4, 1)
+            return (32, 128, 4, 3)
         elif head_dim == 128:
             return (64, 128, 8, 3)
         else:

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -361,9 +361,8 @@ def _get_default_config_bwd(query) -> Tuple[int, int, int, int]:
             return (32, 64, 4, 1)
         return (32, 128, 4, 3)
     elif torch.cuda.get_device_capability() >= (8, 0):  # A100
-        return (64, 64, 4, 1)
         if head_dim == 64:
-            return (32, 128, 4, 3)
+            return (32, 128, 4, 1)
         elif head_dim == 128:
             return (64, 128, 8, 3)
         else:

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -103,6 +103,8 @@ class PartialRender:
         return self.code
 
 
+# This is used to store info needed for lowering each subgraph in triton
+# templates
 SubgraphInfo = namedtuple(
     "SubgraphInfo",
     [

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1597,7 +1597,7 @@ class AlgorithmSelectorCache(PersistentCache):
             result = timings[choice]
             if result:
                 sys.stderr.write(
-                    f"  {choice.name} {result:.4f} ms {best_time / result:.1%}\n"
+                    f"  {choice.name} {result:.4f} ms {best_time / result:.1%} {choice.debug_extra}\n"
                 )
             else:
                 sys.stderr.write(

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1596,8 +1596,11 @@ class AlgorithmSelectorCache(PersistentCache):
         for choice in top_k:
             result = timings[choice]
             if result:
+                kernel_info = (
+                    choice.debug_extra if hasattr(choice, "debug_extra") else ""
+                )
                 sys.stderr.write(
-                    f"  {choice.name} {result:.4f} ms {best_time / result:.1%} {choice.debug_extra}\n"
+                    f"  {choice.name} {result:.4f} ms {best_time / result:.1%} {kernel_info}\n"
                 )
             else:
                 sys.stderr.write(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129188
* __->__ #129013
* #128938

Before:
<img width="519" alt="image" src="https://github.com/pytorch/pytorch/assets/6355099/6f4a9b37-4aff-48d3-aaba-7e8e5a5bf0fb">


After:
<img width="541" alt="image" src="https://github.com/pytorch/pytorch/assets/6355099/423f179e-76f5-457b-8064-ee8a70247534">

After fixing strides:
![image](https://github.com/pytorch/pytorch/assets/6355099/58471587-404b-4bfc-b9b2-7546bdf53f54)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang