### PR TITLE
torch._inductor.config.joint_graph_constant_folding = False

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -392,7 +392,7 @@ assert_indirect_indexing = True
 compute_all_bounds = False
 
 # constant folding on the joint graph
-joint_graph_constant_folding = True
+joint_graph_constant_folding = False
 
 # Enable indirect_indexing asserts for decompositions and lowerings
 debug_index_asserts = False


### PR DESCRIPTION
Summary: Forward fix for feed model OOMs (like in f573527003)

Test Plan: f573858282 -- this gets us past the OOM and hits an unrelated error

Reviewed By: pushpakrajgautam

Differential Revision: D58744646


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang