### PR TITLE
fix add decomposition for complex numbers

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1097,6 +1097,26 @@ class CommonTemplate:
                 3,
             )
 
+    def test_add_complex5(self):
+        def fn(a, b, alpha):
+            return torch.add(a, b, alpha=alpha)
+
+        x = torch.tensor([[1 + 1j, -1 + 1j], [-2 + 2j, 3 - 3j]])
+        y = torch.tensor([[1 + 1j, -1 + 1j], [-2 + 2j, 3 - 3j]])
+
+        self.common(fn, (x, y, 2))
+
+    def test_add_complex6(self):
+        # Fix https://github.com/pytorch/pytorch/issues/125745.
+        # Add complex tensors with broadcasting.
+        def fn(a, b, alpha):
+            return torch.add(a, b, alpha=alpha)
+
+        x = torch.tensor([[1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j]])
+        y = torch.tensor([[1 + 1j]])
+
+        self.common(fn, (x, y, 2))
+
     def test_concat_add_inplace(self):
         def fn(x, y, z):
             return torch.cat([x, y], dim=1).add_(z)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -11180,11 +11180,9 @@ if HAS_GPU and not TEST_WITH_ASAN:
                 ),
                 (
                     fn3,
-                    (
-                        "triton_poi_fused_layer_norm_relu"
-                        if torch._dynamo.config.inline_inbuilt_nn_modules
-                        else "triton_poi_fused_LayerNorm_ReLU"
-                    ),
+                    "triton_poi_fused_layer_norm_relu"
+                    if torch._dynamo.config.inline_inbuilt_nn_modules
+                    else "triton_poi_fused_LayerNorm_ReLU",
                     (torch.randn(4, 4, device=GPU_TYPE),),
                 ),
             ]

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1117,36 +1117,6 @@ class CommonTemplate:
 
         self.common(fn, (x, y, 2))
 
-    def test_add_complex7(self):
-        # Add complex tensors and real tensors.
-        def fn(a, b, alpha):
-            return torch.add(a, b, alpha=alpha)
-
-        x = torch.tensor([[1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j]])
-        y = torch.tensor([[1]])
-
-        self.common(fn, (x, y, 2))
-
-    def test_add_complex8(self):
-        # Add complex tensors and real tensors.
-        def fn(a, b, alpha):
-            return torch.add(a, b, alpha=alpha)
-
-        x = torch.tensor([[1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j]])
-        y = torch.tensor([[1, 3, 4, 5]])
-
-        self.common(fn, (x, y, 2))
-
-    def test_add_complex9(self):
-        # Add complex tensors and real tensors.
-        def fn(a, b, alpha):
-            return torch.add(a, b, alpha=alpha)
-
-        x = torch.tensor([[1 + 1j]])
-        y = torch.tensor([[1, 3, 4, 5]])
-
-        self.common(fn, (x, y, 2))
-
     def test_concat_add_inplace(self):
         def fn(x, y, z):
             return torch.cat([x, y], dim=1).add_(z)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1117,6 +1117,36 @@ class CommonTemplate:
 
         self.common(fn, (x, y, 2))
 
+    def test_add_complex7(self):
+        # Add complex tensors and real tensors.
+        def fn(a, b, alpha):
+            return torch.add(a, b, alpha=alpha)
+
+        x = torch.tensor([[1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j]])
+        y = torch.tensor([[1]])
+
+        self.common(fn, (x, y, 2))
+
+    def test_add_complex8(self):
+        # Add complex tensors and real tensors.
+        def fn(a, b, alpha):
+            return torch.add(a, b, alpha=alpha)
+
+        x = torch.tensor([[1 + 1j, -1 + 1j, -2 + 2j, 3 - 3j]])
+        y = torch.tensor([[1, 3, 4, 5]])
+
+        self.common(fn, (x, y, 2))
+
+    def test_add_complex9(self):
+        # Add complex tensors and real tensors.
+        def fn(a, b, alpha):
+            return torch.add(a, b, alpha=alpha)
+
+        x = torch.tensor([[1 + 1j]])
+        y = torch.tensor([[1, 3, 4, 5]])
+
+        self.common(fn, (x, y, 2))
+
     def test_concat_add_inplace(self):
         def fn(x, y, z):
             return torch.cat([x, y], dim=1).add_(z)
@@ -11150,9 +11180,11 @@ if HAS_GPU and not TEST_WITH_ASAN:
                 ),
                 (
                     fn3,
-                    "triton_poi_fused_layer_norm_relu"
-                    if torch._dynamo.config.inline_inbuilt_nn_modules
-                    else "triton_poi_fused_LayerNorm_ReLU",
+                    (
+                        "triton_poi_fused_layer_norm_relu"
+                        if torch._dynamo.config.inline_inbuilt_nn_modules
+                        else "triton_poi_fused_LayerNorm_ReLU"
+                    ),
                     (torch.randn(4, 4, device=GPU_TYPE),),
                 ),
             ]

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -341,25 +341,28 @@ def add(x, y, *, alpha=None):
         z = alpha * y
     complex_type = torch.promote_types(x.dtype, y.dtype)
     if x_is_complex_tensor and y_is_complex_tensor:
-        # For complex typed `x`, `x.view(x.real.dtype)` doubles the last dimension and can cause problem 
+        # For complex typed `x`, `x.view(x.real.dtype)` doubles the last dimension and can cause problem
         # when broadcasting the add.
         def reshape_tensor(tensor):
-            """ Reshape tensor from [*initial_dims, last_dim] to *initial_dims, last_dim/2, 2]"""
+            """Reshape tensor from [*initial_dims, last_dim] to *initial_dims, last_dim/2, 2]"""
             # Get the current shape of the tensor
             *initial_dims, last_dim = tensor.shape
-     
-            # Check if the last dimension is even. We should never reach here since `x.view(x.real.dtype)` 
+
+            # Check if the last dimension is even. We should never reach here since `x.view(x.real.dtype)`
             # doubles the last dimension for complex numbers.
             if last_dim % 2 != 0:
-                raise ValueError("The size of the last dimension must be even to reshape it to [..., last_dim/2, 2]")
-      
+                raise ValueError(
+                    "The size of the last dimension must be even to reshape it to [..., last_dim/2, 2]"
+                )
+
             # Reshape the tensor
             new_shape = (*initial_dims, last_dim // 2, 2)
             reshaped_tensor = tensor.view(new_shape)
             return reshaped_tensor
+
         x_reshaped = reshape_tensor(x.view(x.real.dtype))
-        y_reshaped = reshape_tensor(y.view(y.real.dtype))
-        result = torch.flatten(x_reshaped + y_reshaped, start_dim=-2).view(complex_type)
+        z_reshaped = reshape_tensor(z.view(y.real.dtype))
+        result = torch.flatten(x_reshaped + z_reshaped, start_dim=-2).view(complex_type)
     else:
         result = (x.view(x.real.dtype) + z.view(y.real.dtype)).view(complex_type)
     return result
@@ -370,18 +373,6 @@ def conj_physical(self):
     assert not self.is_complex(), "TODO: implement this"
     return self
 
-
-# @register_decomposition([aten._conj])
-# def _conj(self):
-#     # assert not self.is_complex(), "TODO: implement this"
-#     if self.is_complex():
-#         print("complex")
-#         real = self.real
-#         imag = -self.imag
-#         print(real)
-#         print(imag)
-#         return real + imag
-#     return self
 
 @register_decomposition([aten.lift, aten.detach_])
 def lift(self):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -332,9 +332,10 @@ def angle(x):
 
 @register_decomposition([aten.add])
 def add(x, y, *, alpha=None):
-    if not torch.is_tensor(x) or not torch.is_tensor(y):
-        return NotImplemented
-    if not x.is_complex() and not y.is_complex():
+    # Require both x and y to be tensors and at least one of them is complex typed.
+    if (not torch.is_tensor(x) or not torch.is_tensor(y)) or (
+        not x.is_complex() and not y.is_complex()
+    ):
         return NotImplemented
     z = y
     if alpha is not None:

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -332,9 +332,9 @@ def angle(x):
 
 @register_decomposition([aten.add])
 def add(x, y, *, alpha=None):
-    x_is_complex_tensor = torch.is_tensor(x) and x.is_complex()
-    y_is_complex_tensor = torch.is_tensor(y) and y.is_complex()
-    if not x_is_complex_tensor and not y_is_complex_tensor:
+    if not torch.is_tensor(x) or not torch.is_tensor(y):
+        return NotImplemented
+    if not x.is_complex() and not y.is_complex():
         return NotImplemented
     z = y
     if alpha is not None:


### PR DESCRIPTION
Fixes #125745

Bug source: When addition requires broadcasting, adding complex numbers is not implemented correctly in `torch/_inductor/decomposition.py` because `x.view(x.real.dtype)` would multiply the last dimension by 2, and then broadcasting wouldn't work. 

Fix: re-shape the complex tensors after view and before broadcasting.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang