### PR TITLE
[Traceable FSDP2][Animesh's PR #125340] [dynamo][fsdp] Track FSDPNNModuleVariable for mutations

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -527,7 +527,7 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
             fsdp_m = torch.compile(fsdp_m, backend=prof, fullgraph=False)
             outputs = fsdp_m(inputs)
             self.assertTrue(same(correct_outputs, outputs))
-            FileCheck().check(
+            FileCheck().check_not(
                 "setattr(FSDPManagedNNModuleVariable(MutatingModel), state, ...)"
             ).run(prof.report())
 

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -527,9 +527,13 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
             fsdp_m = torch.compile(fsdp_m, backend=prof, fullgraph=False)
             outputs = fsdp_m(inputs)
             self.assertTrue(same(correct_outputs, outputs))
-            FileCheck().check_not(
+            FileCheck().check("Torchdynamo Profiler Report").check(
+                "Graph Breaks"
+            ).check_not(
                 "setattr(FSDPManagedNNModuleVariable(MutatingModel), state, ...)"
-            ).run(prof.report())
+            ).run(
+                prof.report()
+            )
 
     @skip_if_lt_x_gpu(1)
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -517,8 +517,7 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
             self.assertTrue(same(correct_outputs, outputs))
 
     @skip_if_lt_x_gpu(1)
-    @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
-    def test_setattr(self):
+    def test_fsdp_setattr(self):
         with _dynamo_dist_per_rank_init(self.rank, self.world_size):
             # Test with basic FSDP wrapping (outer wrap around whole model)
             m, inputs, correct_outputs = get_mutating_model(f"cuda:{self.rank}")
@@ -531,6 +530,8 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
                 "Graph Breaks"
             ).check_not(
                 "setattr(FSDPManagedNNModuleVariable(MutatingModel), state, ...)"
+            ).check_not(
+                "setattr(FSDPManagedNNModuleVariable(FullyShardedDataParallel), _is_root, ...)"
             ).run(
                 prof.report()
             )

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1222,12 +1222,11 @@ class VariableBuilder:
             # ID_MATCH is required to disambiguate cases as simple as a unit test that constructs 2 models and wraps
             # them differently with different FSDP configs.  (test_dynamo_distributed.py -k test_fsdp_aot_eager)
             self.install_guards(GuardBuilder.TYPE_MATCH, GuardBuilder.ID_MATCH)
-            # result = FSDPManagedNNModuleVariable(value, source=self.get_source())
-            # if not SideEffects.cls_supports_mutation_side_effects(type(value)):
-            #     # don't allow STORE_ATTR mutation with custom __setattr__
-            #     return result
-            # return self.tx.output.side_effects.track_object_existing(value, result)
-            return FSDPManagedNNModuleVariable(value, source=self.get_source())
+            result = FSDPManagedNNModuleVariable(value, source=self.get_source())
+            if not SideEffects.cls_supports_mutation_side_effects(type(value)):
+                # don't allow STORE_ATTR mutation with custom __setattr__
+                return result
+            return self.tx.output.side_effects.track_object_existing(value, result)
         else:
             return self.tx.output.register_attr_or_module(
                 value,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1222,11 +1222,12 @@ class VariableBuilder:
             # ID_MATCH is required to disambiguate cases as simple as a unit test that constructs 2 models and wraps
             # them differently with different FSDP configs.  (test_dynamo_distributed.py -k test_fsdp_aot_eager)
             self.install_guards(GuardBuilder.TYPE_MATCH, GuardBuilder.ID_MATCH)
-            result = FSDPManagedNNModuleVariable(value, source=self.get_source())
-            if not SideEffects.cls_supports_mutation_side_effects(type(value)):
-                # don't allow STORE_ATTR mutation with custom __setattr__
-                return result
-            return self.tx.output.side_effects.track_object_existing(value, result)
+            # result = FSDPManagedNNModuleVariable(value, source=self.get_source())
+            # if not SideEffects.cls_supports_mutation_side_effects(type(value)):
+            #     # don't allow STORE_ATTR mutation with custom __setattr__
+            #     return result
+            # return self.tx.output.side_effects.track_object_existing(value, result)
+            return FSDPManagedNNModuleVariable(value, source=self.get_source())
         else:
             return self.tx.output.register_attr_or_module(
                 value,

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -945,6 +945,11 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 ):
                     # Handle submodules
                     self.is_state_mutated = True
+                if (
+                    self.is_state_mutated
+                    and not tx.output.side_effects.is_attribute_mutation(self)
+                ):
+                    tx.output.side_effects.track_object_existing(self.value, self)
 
             if method is torch.nn.Module.__setattr__ and isinstance(
                 args[1], variables.DeletedVariable

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -945,11 +945,6 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 ):
                     # Handle submodules
                     self.is_state_mutated = True
-                if (
-                    self.is_state_mutated
-                    and not tx.output.side_effects.is_attribute_mutation(self)
-                ):
-                    tx.output.side_effects.track_object_existing(self.value, self)
 
             if method is torch.nn.Module.__setattr__ and isinstance(
                 args[1], variables.DeletedVariable


### PR DESCRIPTION
This is a copy of Animesh's work in https://github.com/pytorch/pytorch/pull/125340, with very small changes to the unit test. It's needed sooner for the Traceable FSDP2 work, so I copy it here and will work through landing it.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129045



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang @d4l3k @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng