### PR TITLE
[Traceable FSDP2] [Dynamo] Fix OptimizedModule._initialize to allow tracing into FSDP2 module hooks for module from user-defined module class

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -154,8 +154,9 @@ class OptimizedModule(torch.nn.Module):
         if isinstance(self.dynamo_ctx, DisableContext):
             # No need to check trace rules
             self.forward = self.dynamo_ctx(self._orig_mod.__call__)
-        elif isinstance(self._orig_mod.forward, types.MethodType) and trace_rules.check(
-            self._orig_mod.forward
+        elif isinstance(self._orig_mod.forward, types.MethodType) and (
+            trace_rules.check(self._orig_mod.forward)
+            or getattr(self._orig_mod, "_is_fsdp_managed_module", False)
         ):
             # This may be a torch.nn.* instance in trace_rules.py which
             # won't trigger a frame evaluation workaround to add an extra


### PR DESCRIPTION
This is a workaround to allow inplace fully-sharded module to still go into this branch:
https://github.com/pytorch/pytorch/blob/3a185778edb18abfbad155a87ff3b2d716e4c220/torch/_dynamo/eval_frame.py#L163
instead of the second branch:
https://github.com/pytorch/pytorch/blob/3a185778edb18abfbad155a87ff3b2d716e4c220/torch/_dynamo/eval_frame.py#L166


If we don't do this, `torch.compile(fully_shard(module_from_user_defined_module_class))` will ignore all module hooks which will break FSDP tracing.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129046



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang