### PR TITLE
Provide a method to unregister privateuse1

### DIFF
--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -128,7 +128,7 @@ std::string get_privateuse1_backend(bool lower_case) {
   auto name_registered =
       privateuse1_backend_name_set.load(std::memory_order_acquire);
   // Guaranteed that if the flag is set, then privateuse1_backend_name has been
-  // set, and will never be written to.
+  // set.
   auto backend_name =
       name_registered ? privateuse1_backend_name : "privateuseone";
   return backend_name;
@@ -143,9 +143,17 @@ void register_privateuse1_backend(const std::string& backend_name) {
       privateuse1_backend_name);
 
   privateuse1_backend_name = backend_name;
-  // Invariant: once this flag is set, privateuse1_backend_name is NEVER written
-  // to.
-  privateuse1_backend_name_set.store(true, std::memory_order_relaxed);
+  // Use unregister_privateuse1_backend to unregister privateuse1
+  privateuse1_backend_name_set.store(true, std::memory_order_release);
+}
+
+void unregister_privateuse1_backend() {
+  // Mutex is used here to prevent other threads from
+  // register_privateuse1_backend at this time, and Release is used to ensure
+  // the order with other Acquire.
+  std::lock_guard<std::mutex> guard(privateuse1_lock);
+  privateuse1_backend_name = "";
+  privateuse1_backend_name_set.store(false, std::memory_order_release);
 }
 
 bool is_privateuse1_backend_registered() {

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -102,6 +102,7 @@ C10_API bool isValidDeviceType(DeviceType d);
 C10_API std::ostream& operator<<(std::ostream& stream, DeviceType type);
 
 C10_API void register_privateuse1_backend(const std::string& backend_name);
+C10_API void unregister_privateuse1_backend();
 C10_API std::string get_privateuse1_backend(bool lower_case = true);
 
 C10_API bool is_privateuse1_backend_registered();

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -148,6 +148,13 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         ):
             torch.utils.rename_privateuse1_backend("dev")
 
+        # backend unregister
+        torch._C._unregister_privateuse1_backend()
+        torch.utils.rename_privateuse1_backend("dev")
+
+        torch._C._unregister_privateuse1_backend()
+        torch.utils.rename_privateuse1_backend("foo")
+
         # generator tensor and module can be registered only once
         with self.assertRaisesRegex(RuntimeError, "The custom device module of"):
             torch.utils.generate_methods_for_privateuse1_backend()

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -636,6 +636,15 @@ static PyObject* THModule_rename_privateuse1_backend(
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THModule_unregister_privateuse1_backend(
+    PyObject* _unused,
+    PyObject* arg) {
+  HANDLE_TH_ERRORS
+  c10::unregister_privateuse1_backend();
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject* THModule_get_privateuse1_backend_name(
     PyObject* _unused,
     PyObject* arg) {
@@ -1484,6 +1493,10 @@ static PyMethodDef TorchMethods[] = { // NOLINT
     {"_rename_privateuse1_backend",
      THModule_rename_privateuse1_backend,
      METH_O,
+     nullptr},
+    {"_unregister_privateuse1_backend",
+     THModule_unregister_privateuse1_backend,
+     METH_NOARGS,
      nullptr},
     {"_get_privateuse1_backend_name",
      THModule_get_privateuse1_backend_name,


### PR DESCRIPTION
In practical applications, users may want to use more than one accelerator at runtime, and these accelerators share the privateuse1 key. Therefore, this PR aims to provide a method for unregistering the privateuse1 backend.