### PR TITLE
[inductor] fix windows python module ext and func export declaration

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3964,8 +3964,8 @@ class KernelGroup:
         kernel_name = str(Placeholder.DESCRIPTIVE_NAME) if name is None else name
         arg_defs, _, _ = self.args.cpp_argdefs()
         arg_defs = ",\n".ljust(25).join(arg_defs)
-        func_export = self.get_export_declaration()
-        code.writeline(f'extern "C" {func_export} void {kernel_decl_name}({arg_defs})')
+        func_export_decl = self.get_export_declaration()
+        code.writeline(f'extern "C" {func_export_decl} void {kernel_decl_name}({arg_defs})')
 
         # 3. Function body
         with code.indent():

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -73,6 +73,7 @@ from .cpp_utils import (
     value_to_cpp,
 )
 
+_IS_WINDOWS = sys.platform == "win32"
 schedule_log = torch._logging.getArtifactLogger(__name__, "schedule")
 
 NATIVE_OMP_RTYPES = {"+", "*", "^", "||", "min", "max"}
@@ -3941,6 +3942,9 @@ class KernelGroup:
         args_num = len(arg_defs)
         return args_num
 
+    def get_export_declaration(self):
+        return "__declspec(dllexport)" if _IS_WINDOWS else ""
+
     def codegen_group(self, name=None) -> str:
         self.stack.close()
         if not self.scheduled_nodes:
@@ -3960,7 +3964,8 @@ class KernelGroup:
         kernel_name = str(Placeholder.DESCRIPTIVE_NAME) if name is None else name
         arg_defs, _, _ = self.args.cpp_argdefs()
         arg_defs = ",\n".ljust(25).join(arg_defs)
-        code.writeline(f'extern "C" void {kernel_decl_name}({arg_defs})')
+        func_export = self.get_export_declaration()
+        code.writeline(f'extern "C" {func_export} void {kernel_decl_name}({arg_defs})')
 
         # 3. Function body
         with code.indent():

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3965,7 +3965,9 @@ class KernelGroup:
         arg_defs, _, _ = self.args.cpp_argdefs()
         arg_defs = ",\n".ljust(25).join(arg_defs)
         func_export_decl = self.get_export_declaration()
-        code.writeline(f'extern "C" {func_export_decl} void {kernel_decl_name}({arg_defs})')
+        code.writeline(
+            f'extern "C" {func_export_decl} void {kernel_decl_name}({arg_defs})'
+        )
 
         # 3. Function body
         with code.indent():

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1006,11 +1006,11 @@ class CppBuilder:
             3. Final target file: output_dir/name.ext
     """
 
-    def get_shared_lib_ext(self) -> str:
-        SHARED_LIB_EXT = ".dll" if _IS_WINDOWS else ".so"
+    def __get_python_module_ext(self) -> str:
+        SHARED_LIB_EXT = ".pyd" if _IS_WINDOWS else ".so"
         return SHARED_LIB_EXT
 
-    def get_object_ext(self) -> str:
+    def __get_object_ext(self) -> str:
         EXT = ".obj" if _IS_WINDOWS else ".o"
         return EXT
 
@@ -1048,7 +1048,9 @@ class CppBuilder:
 
         self._compile_only = BuildOption.get_compile_only()
         file_ext = (
-            self.get_object_ext() if self._compile_only else self.get_shared_lib_ext()
+            self.__get_object_ext()
+            if self._compile_only
+            else self.__get_python_module_ext()
         )
         self._target_file = os.path.join(self._output_dir, f"{self._name}{file_ext}")
 
@@ -1156,17 +1158,6 @@ class CppBuilder:
 
     def get_target_file_path(self):
         return self._target_file
-
-    def convert_to_cpp_extension_args(self):
-        include_dirs = self._include_dirs_args
-        cflags = (
-            self._cflags_args
-            + self._definations_args
-            + self._passthough_parameters_args
-        )
-        ldflags = self._ldflags_args + self._libraries_args + self._libraries_dirs_args
-
-        return include_dirs, cflags, ldflags
 
     def build(self) -> Tuple[int, str]:
         """


### PR DESCRIPTION
I have run the first inductor case on Windows base on the exploration code: https://github.com/pytorch/pytorch/pull/128330 
Due to some fundamental PR still need pass `fb_code`: https://github.com/pytorch/pytorch/pull/128303 
This PR would land some part of exploration code:
1. Fix Windows python module ext type: pyd.
2. Add function export declaration for Windows.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht @iremyux @Blackhex @cristianPanaite @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang