### PR TITLE
re-export torch.optim._multi_tensor in torch/__init__.py

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1987,6 +1987,7 @@ from torch import (
     utils as utils,
     xpu as xpu,
 )
+import torch.optim._multi_tensor  # usort: skip
 from torch.signal import windows as windows
 
 # Quantized, sparse, AO, etc. should be last to get imported, as nothing


### PR DESCRIPTION
Summary:
- PR https://github.com/pytorch/pytorch/pull/127703 introduced a circular dependency
`torch/optim/__init__.py` imports `torch.optim._multi_tensor` and
`torch.optim._multi_tensor/_init__.py` imports `torch.optim`

  This seemed to work fine (green signals everywhere) but caused some internal test failures after it landed; an infinite recursion during import.

- PR https://github.com/pytorch/pytorch/pull/128875 attempted to fix this by removing the import from `torch/optim/__init__.py`.

This seemed to work fine: green signals everywhere and the failing tests started passing but a smaller number of tests started failing; unable to import `torch.optim._multi_tensor`

- This diff re-introduces the import but after `torch.optim` is fully initialized

Test Plan: CI signals

Differential Revision: D58792889
