### PR TITLE
[Traceable FSDP2][Dynamo] Fix related to __bool__ and __len__ access on user-defined object

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -422,15 +422,12 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
                     self.push(value)
                 self.jump(inst)
         elif isinstance(value, UserDefinedObjectVariable):
-            try:
+            x = None
+            if hasattr(value, "__bool__"):
                 x = value.var_getattr(self, "__bool__")
-            except exc.ObservedException:
-                # if __bool__ is missing, trying __len__ to infer a truth value.
+            # if __bool__ is missing, trying __len__ to infer a truth value.
+            if (x is None or isinstance(x, GetAttrVariable)) and hasattr(value, "__len__"):
                 x = value.var_getattr(self, "__len__")
-            else:
-                if isinstance(x, GetAttrVariable):
-                    # if __bool__ is missing, trying __len__ to infer a truth value.
-                    x = value.var_getattr(self, "__len__")
 
             # __bool__ or __len__ is function
             if isinstance(x, UserMethodVariable):
@@ -448,6 +445,10 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
                     )
             # __bool__ or __len__ is non-function or not existed in the user defined object
             else:
+                assert not (
+                    isinstance(x, UserDefinedClassVariable)
+                    and x.value is torch._dynamo.variables.user_defined.NO_SUCH_SUBOBJ
+                )
                 if truth_fn(True):
                     if push:
                         self.push(value)


### PR DESCRIPTION
With existing code, if neither `__bool__` nor `__len__` is found on the UserDefinedObjectVariable, `x` becomes `UserDefinedClassVariable(<class 'torch._dynamo.variables.user_defined.NO_SUCH_SUBOBJ'>)`, and we will somehow still guard on the `__len__` value (error log: https://gist.github.com/yf225/5c91e16ed42c699dce4129027802f499), even though this `x` is not used in downstream code.

This PR makes it so that when `__bool__` and `__len__` are not found on the UDOV, we set `x` to None instead, which fixes the error. (Again, we are not actually using `x` downstream, so I am also not sure why this fixes the error lol)

The user code where this happens:
```
from user code:
   File "/data/users/willfeng/pytorch_top/torch/_dynamo/external_utils.py", line 38, in inner
    return fn(*args, **kwargs)
  File "/data/users/willfeng/pytorch_top/torch/nn/modules/module.py", line 1698, in _call_impl
    args_kwargs_result = hook(self, args, kwargs)  # type: ignore[misc]
  File "/data/users/willfeng/pytorch_top/torch/distributed/_composable/fsdp/_fsdp_state.py", line 50, in fsdp_hook_wrapper
    return func(*args, **kwargs)
  File "/data/users/willfeng/pytorch_top/torch/distributed/_composable/fsdp/_fsdp_state.py", line 183, in _pre_forward
    if self._fsdp_param_group:
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129109



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang