### PR TITLE
[PT2][Observability] Change the string to dict type

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -790,7 +790,7 @@ def fx_codegen_and_compile(
         )
         if config.is_fbcode():
             log_optimus_to_scuba(
-                extra_logging={"pt2_configs": str(get_patched_config_dict())}
+                extra_logging={"pt2_configs": get_patched_config_dict()}
             )
 
     with V.set_fake_mode(fake_mode), maybe_disable_comprehensive_padding(

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -498,7 +498,7 @@ def should_pad_bench(
             multiplier = torch._inductor.config.post_grad_fusion_options[
                 "shape_padding_multiplier"
             ].get("value", 1.1)
-        counters["inductor"]["shape_padding_multiplier"] += 1
+            counters["inductor"]["shape_padding_multiplier"] += 1
         should_pad = _skip_do_bench_times or ori_time > pad_time * multiplier
         set_cached_should_pad(key, should_pad)
         return should_pad


### PR DESCRIPTION
Summary: The string type of extra_logging for PT2 is not the best for the followup diaquery to enable customized_optimus tracking, thus we change the type of logging to dict

Test Plan:
```
CUDA_VISIBLE_DEVICES=4 OC_CAUSE=1 buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode None --model_type "cmf_coffee" --flow_id 566577070
```

```
optimus parameter sent to the scuba: {'before_recompile_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GNGK2xb_dkYqdnYNAI8W8ZKNaPl3br0LAAAz', 'after_recompile_pre_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GKzKwhautBKZGBAEAGBNgYLJqgRobr0LAAAz', 'before_recompile_post_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GPGvzBa5FlOs0pUDAG3DWe989F1Ibr0LAAAz', 'after_recompile_post_grad': 'https://www.internalfb.com/intern/everpaste/?color=0&handle=GGuk1AiP4_dk8ucDAPk7Dh3mmSE6br0LAAAz', 'inductor': Counter({'pattern_matcher_nodes': 880, 'pattern_matcher_count': 869, 'extern_calls': 140}), 'graph_break': Counter(), 'model_type': None, 'global_rank': None, 'pt2_configs': {'TYPE_CHECKING': False, 'debug': True, 'disable_progress': True, 'verbose_progress': False, 'fx_graph_cache': False, 'fx_graph_remote_cache': None, 'autotune_local_cache': True, 'autotune_remote_cache': False, 'force_disable_caches': False, 'cpp_wrapper': False, 'abi_compatible': True, 'c_shim_version': '1', 'dce': False, 'static_weight_shapes': True, 'size_asserts': True, 'nan_asserts': False, 'pick_loop_orders': True, 'inplace_buffers': True, 'allow_buffer_reuse': True, 'memory_planning': False, 'memory_pool': 'intermediates', 'benchmark_harness': True, 'epilogue_fusion': True, 'epilogue_fusion_first': False, 'pattern_matcher': True, 'post_grad_custom_pre_pass': None, 'post_grad_custom_post_pass': None, 'joint_custom_pre_pass': None, 'joint_custom_post_pass': None, 'pre_grad_custom_pass': None, 'split_cat_fx_passes': True, 'efficient_conv_bn_eval_fx_passes': False, 'is_predispatch': False, 'group_fusion': False, 'batch_fusion': True, 'pre_grad_fusion_options': {}, 'post_grad_fusion_options': {}, 'reorder_for_locality': True, 'dynamic_scale_rblock': True, 'force_fuse_int_mm_with_mul': False, 'use_mixed_mm': True, 'fx_passes_numeric_check': {'pre_grad': True, 'precision': 0.0001, 'num_iterations': 1, 'requires_optimizer': True}, 'mixed_mm_choice': 'heuristic', 'reorder_for_compute_comm_overlap': False, 'reorder_for_compute_comm_overlap_passes': ['reorder_compute_for_overlap', 'sink_waits', 'raise_comms'], 'estimate_op_runtime': 'default', 'intra_node_bw': 300, 'inter_node_bw': 25, 'max_autotune': False, 'max_autotune_pointwise': False, 'max_autotune_gemm': False, 'force_same_precision': True, 'max_autotune_gemm_backends': 'ATEN,TRITON,CPP', 'max_autotune_gemm_search_space': 'DEFAULT', 'autotune_fallback_to_aten': True, 'unbacked_symint_fallback': 8192, 'search_autotune_cache': False, 'save_args': False, 'autotune_in_subproc': False, 'max_autotune_subproc_result_timeout_seconds': 60.0, 'max_autotune_subproc_graceful_timeout_seconds': 1.0, 'max_autotune_subproc_terminate_timeout_seconds': 2.0, 'autotune_multi_device': False, 'coordinate_descent_tuning': False, 'coordinate_descent_check_all_directions': False, 'coordinate_descent_search_radius': 1, 'layout_opt_default': '1', 'layout_optimization': True, 'force_layout_optimization': False, 'keep_output_stride': True, 'warn_mix_layout': False, 'realize_reads_threshold': 4, 'realize_opcount_threshold': 30, 'realize_acc_reads_threshold': 8, 'fallback_random': False, 'implicit_fallbacks': True, 'aggressive_fusion': False, 'debug_fusion': False, 'benchmark_fusion': False, 'enabled_metric_tables': '', 'benchmark_epilogue_fusion': True, 'max_epilogue_benchmarked_choices': 1, 'max_fusion_size': 64, 'max_pointwise_cat_inputs': 8, 'unroll_reductions_threshold': 8, 'comment_origin': False, 'conv_1x1_as_mm': False, 'split_reductions': True, 'benchmark_kernel': False, 'constant_and_index_propagation': True, 'always_keep_tensor_constants': False, 'assert_indirect_indexing': True, 'compute_all_bounds': False, 'joint_graph_constant_folding': True, 'debug_index_asserts': False, 'is_nightly_or_source': False, 'developer_warnings': True, 'worker_start_method': 'fork', '_fuse_ddp_communication': False, '_fuse_ddp_bucket_size': 25, '_fuse_ddp_communication_passes': ['fuse_ddp_with_concat_op', 'schedule_comm_wait'], '_micro_pipeline_tp': False, 'compile_threads': 1, 'global_cache_dir': None, 'kernel_name_max_ops': 10, 'shape_padding': True, 'comprehensive_padding': True, 'pad_channels_last': False, 'bw_outputs_user_visible': True, 'force_shape_pad': False, 'permute_fusion': False, 'profiler_mark_wrapper_call': False, 'generate_intermediate_hooks': False, 'debug_ir_traceback': False, '_raise_error_for_testing': False, '_profile_var': '', 'profile_bandwidth': False, 'profile_bandwidth_regex': '', 'profile_bandwidth_output': None, 'disable_cpp_codegen': False, 'freezing': False, 'freezing_discard_parameters': False, 'allow_stack_allocation': True, 'use_minimal_arrayref_interface': False, 'decompose_mem_bound_mm': False, 'assume_aligned_inputs': False, 'cpp.threads': -1, 'cpp.no_redundant_loops': True, 'cpp.dynamic_threads': False, 'cpp.simdlen': None, 'cpp.min_chunk_size': 4096, 'cpp.cxx': (None, 'g++'), 'cpp.enable_kernel_profile': False, 'cpp.weight_prepack': True, 'cpp.inject_relu_bug_TESTING_ONLY': None, 'cpp.inject_log1p_bug_TESTING_ONLY': None, 'cpp.vec_isa_ok': None, 'cpp.descriptive_names': 'original_aten', 'cpp.max_horizontal_fusion_size': 16, 'cpp.fallback_scatter_reduce_sum': True, 'cpp.enable_unsafe_math_opt_flag': False, 'cpp.enable_floating_point_contract_flag': False, 'triton.cudagraphs': False, 'triton.cudagraph_trees': True, 'triton.cudagraph_skip_dynamic_graphs': False, 'triton.slow_path_cudagraph_asserts': True, 'triton.cudagraph_trees_history_recording': False, 'triton.cudagraph_support_input_mutation': False, 'triton.force_cudagraph_sync': False, 'triton.force_cudagraphs_warmup': False, 'triton.fast_path_cudagraph_asserts': False, 'triton.skip_cudagraph_warmup': False, 'triton.debug_sync_graph': False, 'triton.debug_sync_kernel': False, 'triton.dense_indexing': False, 'triton.max_tiles': 2, 'triton.autotune_pointwise': True, 'triton.autotune_cublasLt': True, 'triton.tiling_prevents_pointwise_fusion': True, 'triton.tiling_prevents_reduction_fusion': True, 'triton.unique_kernel_names': False, 'triton.descriptive_names': 'original_aten', 'triton.persistent_reductions': True, 'triton.multi_kernel': 0, 'triton.divisible_by_16': True, 'triton.min_split_scan_rblock': 256, 'triton.store_cubin': False, 'triton.spill_threshold': 16, 'triton.use_block_ptr': False, 'triton.inject_relu_bug_TESTING_ONLY': None, 'aot_inductor.output_path': '', 'aot_inductor.debug_compile': False, 'aot_inductor.debug_dump_consts_bin': False, 'aot_inductor.serialized_in_spec': '', 'aot_inductor.serialized_out_spec': '', 'aot_inductor.use_runtime_constant_folding': False, 'aot_inductor.force_mmap_weights': False, 'cuda.arch': None, 'cuda.version': None, 'cuda.compile_opt_level': '-O1', 'cuda.enable_cuda_lto': False, 'cuda.enable_ptxas_info': False, 'cuda.enable_debug_info': False, 'cuda.use_fast_math': False, 'cuda.cutlass_dir': '/data/users/mengluy/fbsource/buck-out/v2/gen/fbcode/e197cdab6db07174/scripts/jackiexu0313/pt2/__local_model_with_pt2__/local_model_with_pt2-inplace#link-tree/third_party/cutlass', 'cuda.cutlass_max_profiling_configs': None, 'cuda.cuda_cxx': None, 'cuda.cutlass_backend_min_gemm_size': 1, 'cuda.generate_test_runner': True, 'cuda.cutlass_op_allowlist_regex': None, 'cuda.cutlass_op_denylist_regex': 'pingpong', 'trace.enabled': True, 'trace.debug_dir': None, 'trace.debug_log': False, 'trace.info_log': False, 'trace.fx_graph': True, 'trace.fx_graph_transformed': True, 'trace.ir_pre_fusion': True, 'trace.ir_post_fusion': True, 'trace.output_code': True, 'trace.graph_diagram': False, 'trace.draw_orig_fx_graph': False, 'trace.dot_graph_shape': None, 'trace.log_url_for_graph_xform': None, 'trace.compile_profile': False, 'trace.upload_tar': None, 'trace.log_autotuning_results': False, '_save_config_ignore': ['trace.upload_tar'], '_cache_config_ignore_prefix': ['trace', 'cuda.cutlass_dir', 'compile_threads']}}
```

Differential Revision: D58800633


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang