### PR TITLE
[compiled autograd] flatten runtime inputs with fast path

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2724,11 +2724,11 @@ def flatten_graph_inputs(gm: torch.fx.GraphModule, inputs, compile_gm):
 
     if torch._dynamo.compiled_autograd.in_compiled_autograd_region:
         # fast path, avoid pytree overhead
+        assert idx_to_steal == [0]
         def compiled_autograd_wrapper(*args):
             assert args and isinstance(args[0], list)
             flat_args = args[0] + list(args[1:])
-            for i in idx_to_steal:
-                args[i].clear()
+            args[0].clear()
             return compiled_fn(flat_args)
 
         return compiled_autograd_wrapper

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2725,6 +2725,7 @@ def flatten_graph_inputs(gm: torch.fx.GraphModule, inputs, compile_gm):
     if torch._dynamo.compiled_autograd.in_compiled_autograd_region:
         # fast path, avoid pytree overhead
         assert idx_to_steal == [0]
+
         def compiled_autograd_wrapper(*args):
             assert args and isinstance(args[0], list)
             flat_args = args[0] + list(args[1:])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129116
* #129181
* #128987
* #128982
* #128905
* #127960

covered by test_compiled_autograd.py and test_standalone_compile.py


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang