### PR TITLE
Fix typo in stack_module_state doc

### DIFF
--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -176,7 +176,7 @@ def stack_module_state(
         data = torch.randn(batch_size, 3)
 
         def wrapper(params, buffers, data):
-            return torch.func.functional_call(model[0], (params, buffers), data)
+            return torch.func.functional_call(models[0], (params, buffers), data)
 
         params, buffers = stack_module_state(models)
         output = vmap(wrapper, (0, 0, None))(params, buffers, data)


### PR DESCRIPTION
I think there is a typo in the first example of the `torch.func.stack_module_state` documentation. The first parameter in the function call in the `wrapper` return is missing an 's'.

