### PR TITLE
[BE] use relative backwards references in torch.optim._multi_tensor

### DIFF
--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -37,3 +37,6 @@ del rmsprop  # type: ignore[name-defined] # noqa: F821
 del optimizer  # type: ignore[name-defined] # noqa: F821
 del nadam  # type: ignore[name-defined] # noqa: F821
 del lbfgs  # type: ignore[name-defined] # noqa: F821
+
+
+import torch.optim._multi_tensor

--- a/torch/optim/_multi_tensor/__init__.py
+++ b/torch/optim/_multi_tensor/__init__.py
@@ -6,7 +6,19 @@ future.
 """
 from functools import partialmethod
 
-from torch import optim
+from .. import (
+    Adadelta as _Adadelta,
+    Adagrad as _Adagrad,
+    Adam as _Adam,
+    Adamax as _Adamax,
+    AdamW as _AdamW,
+    ASGD as _ASGD,
+    NAdam as _NAdam,
+    RAdam as _RAdam,
+    RMSprop as _RMSprop,
+    Rprop as _Rprop,
+    SGD as _SGD,
+)
 
 
 def partialclass(cls, *args, **kwargs):
@@ -16,14 +28,27 @@ def partialclass(cls, *args, **kwargs):
     return NewCls
 
 
-Adam = partialclass(optim.Adam, foreach=True)
-AdamW = partialclass(optim.AdamW, foreach=True)
-NAdam = partialclass(optim.NAdam, foreach=True)
-SGD = partialclass(optim.SGD, foreach=True)
-RAdam = partialclass(optim.RAdam, foreach=True)
-RMSprop = partialclass(optim.RMSprop, foreach=True)
-Rprop = partialclass(optim.Rprop, foreach=True)
-ASGD = partialclass(optim.ASGD, foreach=True)
-Adamax = partialclass(optim.Adamax, foreach=True)
-Adadelta = partialclass(optim.Adadelta, foreach=True)
-Adagrad = partialclass(optim.Adagrad, foreach=True)
+Adam = partialclass(_Adam, foreach=True)
+AdamW = partialclass(_AdamW, foreach=True)
+NAdam = partialclass(_NAdam, foreach=True)
+SGD = partialclass(_SGD, foreach=True)
+RAdam = partialclass(_RAdam, foreach=True)
+RMSprop = partialclass(_RMSprop, foreach=True)
+Rprop = partialclass(_Rprop, foreach=True)
+ASGD = partialclass(_ASGD, foreach=True)
+Adamax = partialclass(_Adamax, foreach=True)
+Adadelta = partialclass(_Adadelta, foreach=True)
+Adagrad = partialclass(_Adagrad, foreach=True)
+
+
+del _Adam
+del _AdamW
+del _NAdam
+del _SGD
+del _RAdam
+del _RMSprop
+del _Rprop
+del _ASGD
+del _Adamax
+del _Adadelta
+del _Adagrad


### PR DESCRIPTION
Summary:
This avoids some internal test failures caused by "infinite" recursion during import. Example: P1430048846

A bit of history:

- PR https://github.com/pytorch/pytorch/pull/127703 introduced a circular dependency
`torch/optim/__init__.py` imports `torch.optim._multi_tensor` and
`torch.optim._multi_tensor/_init__.py` imports `torch.optim`

  This seemed to work fine (green signals everywhere) but caused some internal test failures after it landed; an infinite recursion during import.

- PR https://github.com/pytorch/pytorch/pull/128875 attempted to fix this by removing the import from `torch/optim/__init__.py`.

This seemed to work fine: green signals everywhere and the failing tests started passing but a smaller number of tests started failing; unable to import `torch.optim._multi_tensor`

- This diff re-introduces the import but avoids the infinite recursion by using relative package paths

Differential Revision: D58815471
