### PR TITLE
Refine typing annotation for compile

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -30,9 +30,11 @@ from typing import (
     Tuple as _Tuple,
     Type as _Type,
     TYPE_CHECKING,
+    TypeVar as _TypeVar,
     Union as _Union,
+    overload,
 )
-from typing_extensions import TypeGuard as _TypeGuard
+from typing_extensions import ParamSpec as _ParamSpec, TypeGuard as _TypeGuard
 
 
 # multipy/deploy is setting this import before importing torch, this is the most
@@ -2190,6 +2192,38 @@ class _TorchCompileWrapper:
             self.compiler_fn.reset()
 
 
+_InputT = _ParamSpec("_InputT")
+_RetT = _TypeVar("_RetT")
+
+
+@overload
+def compile(
+    model: _Callable[_InputT, _RetT],
+    *,
+    fullgraph: builtins.bool = False,
+    dynamic: _Optional[builtins.bool] = None,
+    backend: _Union[str, _Callable] = "inductor",
+    mode: _Union[str, None] = None,
+    options: _Optional[_Dict[str, _Union[str, builtins.int, builtins.bool]]] = None,
+    disable: builtins.bool = False,
+) -> _Callable[_InputT, _RetT]:
+    ...
+
+
+@overload
+def compile(
+    model: None = None,
+    *,
+    fullgraph: builtins.bool = False,
+    dynamic: _Optional[builtins.bool] = None,
+    backend: _Union[str, _Callable] = "inductor",
+    mode: _Union[str, None] = None,
+    options: _Optional[_Dict[str, _Union[str, builtins.int, builtins.bool]]] = None,
+    disable: builtins.bool = False,
+) -> _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]]:
+    ...
+
+
 def compile(
     model: _Optional[_Callable] = None,
     *,
@@ -2199,7 +2233,10 @@ def compile(
     mode: _Union[str, None] = None,
     options: _Optional[_Dict[str, _Union[str, builtins.int, builtins.bool]]] = None,
     disable: builtins.bool = False,
-) -> _Callable:
+) -> (
+    _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]]
+    | _Callable[_InputT, _RetT]
+):
     """
     Optimizes given model/function using TorchDynamo and specified backend.
     If you are compiling an :class:`torch.nn.Module`, you can also use :meth:`torch.nn.Module.compile`
@@ -2291,7 +2328,7 @@ def compile(
     # Decorator mode
     if model is None:
 
-        def fn(model: _Callable):
+        def fn(model: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
             if model is None:
                 raise RuntimeError("Model can't be None")
             return compile(
@@ -2322,7 +2359,9 @@ def compile(
         nopython=fullgraph,
         dynamic=dynamic,
         disable=disable,
-    )(model)
+    )(
+        model
+    )  # type: ignore[return-value]
 
 
 def _register_device_module(device_type, module):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2233,10 +2233,10 @@ def compile(
     mode: _Union[str, None] = None,
     options: _Optional[_Dict[str, _Union[str, builtins.int, builtins.bool]]] = None,
     disable: builtins.bool = False,
-) -> (
-    _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]]
-    | _Callable[_InputT, _RetT]
-):
+) -> _Union[
+    _Callable[[_Callable[_InputT, _RetT]], _Callable[_InputT, _RetT]],
+    _Callable[_InputT, _RetT],
+]:
     """
     Optimizes given model/function using TorchDynamo and specified backend.
     If you are compiling an :class:`torch.nn.Module`, you can also use :meth:`torch.nn.Module.compile`

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -26,13 +26,13 @@ from typing import (
     Callable as _Callable,
     Dict as _Dict,
     Optional as _Optional,
+    overload,
     Set as _Set,
     Tuple as _Tuple,
     Type as _Type,
     TYPE_CHECKING,
     TypeVar as _TypeVar,
     Union as _Union,
-    overload,
 )
 from typing_extensions import ParamSpec as _ParamSpec, TypeGuard as _TypeGuard
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2328,7 +2328,7 @@ def compile(
     # Decorator mode
     if model is None:
 
-        def fn(model: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
+        def fn(model: _Callable[_InputT, _RetT]) -> _Callable[_InputT, _RetT]:
             if model is None:
                 raise RuntimeError("Model can't be None")
             return compile(

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -26,7 +26,7 @@ from typing import (
     Callable as _Callable,
     Dict as _Dict,
     Optional as _Optional,
-    overload,
+    overload as _overload,
     Set as _Set,
     Tuple as _Tuple,
     Type as _Type,
@@ -2196,7 +2196,7 @@ _InputT = _ParamSpec("_InputT")
 _RetT = _TypeVar("_RetT")
 
 
-@overload
+@_overload
 def compile(
     model: _Callable[_InputT, _RetT],
     *,
@@ -2210,7 +2210,7 @@ def compile(
     ...
 
 
-@overload
+@_overload
 def compile(
     model: None = None,
     *,


### PR DESCRIPTION
before
![image](https://github.com/pytorch/pytorch/assets/46243324/91372d0f-ad0e-4abe-9582-7fe892f99ec8)

after
![image](https://github.com/pytorch/pytorch/assets/46243324/175066ff-78f9-44a1-a3bb-5df809f7e86d)

cc @ezyang @anijain2305 @chauhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire