### PR TITLE
[inductor] fix linear_add_bias for autocast case

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -406,18 +406,21 @@ class TestPatternMatcher(TestPatternMatcherBase):
 
     def test_linear_add_bias(self):
         class M(torch.nn.Module):
-            def __init__(self, dtype, unary_fn):
+            def __init__(self, dtype, unary_fn, cast_bias):
                 super().__init__()
                 self.linear1 = torch.nn.Linear(10, 64, bias=False)
                 self.bias1 = torch.randn(64)
                 self.linear2 = torch.nn.Linear(10, 64, bias=False)
                 self.bias2 = torch.randn(64)
+                if cast_bias:
+                    self.bias1 = self.bias1.to(dtype=dtype)
+                    self.bias2 = self.bias2.to(dtype=dtype)
                 self.unary_fn = unary_fn
 
             def forward(self, x):
                 a = self.linear1(x) + self.bias1
                 b = self.linear2(x) + self.bias2
-                return self.unary_fn(a).to(dtype), self.unary_fn(b).to(dtype)
+                return self.unary_fn(a), self.unary_fn(b)
 
         dtypes = []
         if torch.ops.mkldnn._is_mkldnn_bf16_supported():
@@ -427,7 +430,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
         options = itertools.product(unary_list, dtypes)
         for unary_fn, dtype in options:
             metrics.reset()
-            mod = M(dtype, unary_fn).eval()
+            fold_mod = M(dtype, unary_fn, cast_bias=True).eval()
             v = torch.randn(2, 10)
             matcher_count = 3
             # Add 1 for weight packing pass, add 2 for bias folding pass per linear.
@@ -437,9 +440,20 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 matcher_nodes += 2
             # we have 2 linears, so we double the matcher_count/nodes
             self._test_common(
-                mod, (v,), matcher_count * 2, matcher_nodes * 2, check_autocast=dtype
+                fold_mod,
+                (v,),
+                matcher_count * 2,
+                matcher_nodes * 2,
+                check_autocast=dtype,
             )
             self.assertEqual(metrics.generated_kernel_count, 1)
+            # we won't fold the bias if bias is not same dtype with weight
+            # https://github.com/pytorch/pytorch/pull/129138
+            metrics.reset()
+            mod = M(dtype, unary_fn, cast_bias=False).eval()
+            self._test_common(mod, (v,), 2, 2, check_autocast=dtype)
+            # 1 kernel for "to_lowp", 2 kernels for unary ops
+            self.assertEqual(metrics.generated_kernel_count, 3)
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -409,15 +409,15 @@ class TestPatternMatcher(TestPatternMatcherBase):
             def __init__(self, dtype, unary_fn):
                 super().__init__()
                 self.linear1 = torch.nn.Linear(10, 64, bias=False)
-                self.bias1 = torch.randn(64).to(dtype=dtype)
+                self.bias1 = torch.randn(64)
                 self.linear2 = torch.nn.Linear(10, 64, bias=False)
-                self.bias2 = torch.randn(64).to(dtype=dtype)
+                self.bias2 = torch.randn(64)
                 self.unary_fn = unary_fn
 
             def forward(self, x):
                 a = self.linear1(x) + self.bias1
                 b = self.linear2(x) + self.bias2
-                return self.unary_fn(a), self.unary_fn(b)
+                return self.unary_fn(a).to(dtype), self.unary_fn(b).to(dtype)
 
         dtypes = []
         if torch.ops.mkldnn._is_mkldnn_bf16_supported():


### PR DESCRIPTION
Previously `linear_add_bias` only support the added tensor is `bfloat16`.

```
        class M(torch.nn.Module):
            def __init__(self, dtype):
                super().__init__()
                self.linear1 = torch.nn.Linear(10, 64, bias=False)
                self.bias1 = torch.randn(64).bfloat16()  # if the bias is not bf16, we will crash

            def forward(self, x):
                return self.linear1(x) + self.bias1
```
For `Autocast(bf16)` cases, `self.bias1` will not be converted to bf16. And we also not checked the dtype for weight and bias in the pattern matcher, this will lead to error if weight is bfl6 while bias is fp32.

We have 2 options to resolve this:
 - Check bias/weight dtype, only fold the bias when they are same dtype
 - We will fold them even they are not same dtype. By inserting to_dtypes for `bias node` to enforce it have same dtype with weight.

This PR chose option1, since we can't implicitly cast bias to bf16 here which would lose precision.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129138



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang