### PR TITLE
Fixes output_token not in output_token.names for call_torchbind operator

### DIFF
--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -147,11 +147,25 @@ def _sequential_split_and_maybe_inline_subgraphs(
             need_replacing = True
 
     if need_replacing:
+        # sequential_split returns a new graph module that could have different output
+        # args names. We need to fix the graph signature.
         new_gm = sequential_split(gm, _is_set_grad_enabled_node)
 
         replace_ctx = contextlib.nullcontext()
+        new_signature = None
         if graph_signature is not None:
-            replace_ctx = new_gm._set_replace_hook(graph_signature.get_replace_hook())  # type: ignore[assignment]
+            new_signature = copy.deepcopy(graph_signature)
+            new_gm_out_node = next(reversed(new_gm.graph.find_nodes(op="output")))
+            assert new_gm_out_node.op == "output" and len(
+                new_gm_out_node.args[0]
+            ) == len(new_signature.output_specs)
+            for arg_node, out_spec in zip(
+                new_gm_out_node.args[0], new_signature.output_specs
+            ):
+                if out_spec.arg.name != arg_node.name:
+                    out_spec.arg.name = arg_node.name
+
+            replace_ctx = new_gm._set_replace_hook(new_signature.get_replace_hook())  # type: ignore[assignment]
 
         with replace_ctx:
 
@@ -170,22 +184,24 @@ def _sequential_split_and_maybe_inline_subgraphs(
                 ),
             )
         new_gm.recompile()
-        return new_gm
+        return new_gm, new_signature
 
-    return gm
+    return gm, graph_signature
 
 
 def replace_set_grad_with_hop_pass(gm: torch.fx.GraphModule, graph_signature):
-    new_gm = _sequential_split_and_maybe_inline_subgraphs(gm, graph_signature)
+    new_gm, new_signature = _sequential_split_and_maybe_inline_subgraphs(
+        gm, graph_signature
+    )
     # recursively call
     for node in new_gm.graph.nodes:
         if node.op == "get_attr":
             subgm = getattr(new_gm, node.target)
             if not isinstance(subgm, torch.fx.GraphModule):
                 continue
-            new_subgm = replace_set_grad_with_hop_pass(subgm, None)
+            new_subgm, _ = replace_set_grad_with_hop_pass(subgm, None)
             setattr(new_gm, node.target, new_subgm)
 
     new_gm.recompile()
     new_gm.graph.lint()
-    return new_gm
+    return new_gm, new_signature

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -300,9 +300,9 @@ def get_lifted_tensor_constant(
 
 def sequential_split(gm: torch.fx.GraphModule, node_call_back) -> torch.fx.GraphModule:
     """
-    Splits the graph module into multiple submodules based on the node_call_back.
-    The node_call_back should return True if the node is a delimiter. Delimiter will be
-    the first node in the next submodule.
+    sequential_split creates a new graph module that splits the input graph module into multiple submodules
+    based on the node_call_back. It doesn't mutate the input graph module. The node_call_back should return
+    True if the node is a delimiter.  Delimiter will be the first node in the next submodule.
     """
     from torch.fx.passes.split_module import split_module
 

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -736,7 +736,9 @@ def _export_to_aten_ir(
             replace_set_grad_with_hop_pass,
         )
 
-        gm = replace_set_grad_with_hop_pass(gm, export_graph_signature)
+        gm, export_graph_signature = replace_set_grad_with_hop_pass(
+            gm, export_graph_signature
+        )
 
     # Remove nn_module_stack, stack_trace metadata from all placeholders/inputs nodes.
     for _mod in gm.modules():

--- a/torch/export/graph_signature.py
+++ b/torch/export/graph_signature.py
@@ -519,7 +519,7 @@ class ExportGraphSignature:
         """
         assert isinstance(old, str)
         assert isinstance(new, str)
-        arg_types = (TensorArgument, SymIntArgument, CustomObjArgument)
+        arg_types = (TensorArgument, SymIntArgument, CustomObjArgument, TokenArgument)
         for o in self.output_specs:
             if isinstance(o.arg, arg_types):
                 if o.arg.name == old:


### PR DESCRIPTION
Differential Revision: D58767610

We're getting an assertion error for `output_token not in output_token_names`. 

The error is pretty tricky:
1. in replace_set_grad_with_hop pass, the graph_signature doesn't change correctly according to the graph change of the pass. Related changes: replace_set_grad_with_hop_pass.py, graph_signature.py
2. _remove_effect_tokens pass collect the same call_torchbind operator twice. TODO is to support remove_effect_tokens in subgraphs. Related changes: _remove_effect_tokens_pass.py