### PR TITLE
[export] copy sym ops when respecting call module signature

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -794,6 +794,54 @@ class TestUnflatten(TestCase):
         unflattened = unflatten(ep)
         torch.testing.assert_close(unflattened(x), mod(x))
 
+    def test_dedup_sym_size(self):
+        # Here, sym_size & floor div are used in 3 subgraphs (top-level, m1, m2),
+        # but only one copy of sym_size is created in the initial export graph.
+        # For m1, sym_size & floordiv should be copied as recompute since we preserve the call signature,
+        # but for m2 floordiv should be passed in as a placeholder.
+        # Test that this is preserved, and the unflattened module runs correctly.
+        class M1(torch.nn.Module):
+            def forward(self, x, y):
+                d = x.size(0) // 2
+                return y[:d]
+
+        class M2(torch.nn.Module):
+            def forward(self, x, y):
+                d = x.size(0) // 2
+                return y[:d]
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.m1 = M1()
+                self.m2 = M2()
+
+            def forward(self, x, y):
+                d = x.size(0) // 2
+                m1_res = self.m1(x, y)
+                m2_res = self.m2(x, y)
+                return y[d:] + m1_res + m2_res
+
+        inputs = (torch.ones(10), torch.ones(10))
+        d_ = torch.export.Dim("foo", max=2048)
+        d = 2 * d_
+        ep = torch.export.export(
+            M(),
+            inputs,
+            dynamic_shapes=((d,), (d,)),
+            strict=False,
+            preserve_module_call_signature=("m1",),
+        )
+        unflat = unflatten(ep)
+        unflat(*inputs)
+
+        fn_count_sym_size = lambda graph: [node.target for node in graph.nodes].count(
+            torch.ops.aten.sym_size.int
+        )
+        self.assertEqual(fn_count_sym_size(unflat.graph), 1)
+        self.assertEqual(fn_count_sym_size(unflat.m1.graph), 1)
+        self.assertEqual(fn_count_sym_size(unflat.m2.graph), 0)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Summary:
Export, through AOTAutograd, [deduplicates](https://github.com/pytorch/pytorch/blob/11ff5345d249c27950a06a347cc70aa0047dd46e/torch/fx/experimental/proxy_tensor.py#L198) sym_size calls, which can cause issues during unflattening when the sym_size node is used in multiple submodules.

If preserve_call_module_signature is set, these nodes can't be passed between submodules as placeholders, so the calls (and any downstream un-duplicated nodes) must be copied. Adding this to unflattener

Test Plan: export unflatten test case

Reviewed By: TroyGarden, angelayi

Differential Revision: D58697231


