### PR TITLE
[Traceable FSDP2][Brian's PR #128981] fix dynamo isinstance inlining for nn.Parameter + subclasses

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -64,6 +64,7 @@ from .tensor import (
     UnspecializedPythonVariable,
 )
 from .user_defined import UserDefinedObjectVariable, UserDefinedVariable
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 log = logging.getLogger(__name__)
 
@@ -1392,8 +1393,8 @@ class BuiltinVariable(VariableTracker):
             def _tensor_isinstance(tensor_var, tensor_type):
                 def check_type(ty):
                     if ty not in tensortype_to_dtype:
-                        if ty is torch.nn.parameter.Parameter:
-                            example_val = arg.as_proxy().node.meta["example_value"]
+                        example_val = arg.as_proxy().node.meta["example_value"]
+                        if is_traceable_wrapper_subclass(example_val) and ty is torch.nn.parameter.Parameter:
                             # N.B: we are calling isinstance directly on the example value.
                             # torch.nn.Parameter has a meta-class that overrides __isinstance__,
                             # the isinstance check here allows us to invoke that logic.

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -13,6 +13,7 @@ from typing import Dict, List
 
 import torch
 from torch import sym_float, sym_int
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from .. import config, polyfill, variables
 from ..exc import (
@@ -64,7 +65,6 @@ from .tensor import (
     UnspecializedPythonVariable,
 )
 from .user_defined import UserDefinedObjectVariable, UserDefinedVariable
-from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 log = logging.getLogger(__name__)
 
@@ -1394,7 +1394,10 @@ class BuiltinVariable(VariableTracker):
                 def check_type(ty):
                     if ty not in tensortype_to_dtype:
                         example_val = arg.as_proxy().node.meta["example_value"]
-                        if is_traceable_wrapper_subclass(example_val) and ty is torch.nn.parameter.Parameter:
+                        if (
+                            is_traceable_wrapper_subclass(example_val)
+                            and ty is torch.nn.parameter.Parameter
+                        ):
                             # N.B: we are calling isinstance directly on the example value.
                             # torch.nn.Parameter has a meta-class that overrides __isinstance__,
                             # the isinstance check here allows us to invoke that logic.

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1392,7 +1392,14 @@ class BuiltinVariable(VariableTracker):
             def _tensor_isinstance(tensor_var, tensor_type):
                 def check_type(ty):
                     if ty not in tensortype_to_dtype:
-                        return issubclass(arg.python_type(), ty)
+                        if ty is torch.nn.parameter.Parameter:
+                            example_val = arg.as_proxy().node.meta["example_value"]
+                            # N.B: we are calling isinstance directly on the example value.
+                            # torch.nn.Parameter has a meta-class that overrides __isinstance__,
+                            # the isinstance check here allows us to invoke that logic.
+                            return isinstance(example_val, ty)
+                        else:
+                            return issubclass(arg.python_type(), ty)
 
                     dtypes = tensortype_to_dtype[ty]
                     return arg.dtype in dtypes


### PR DESCRIPTION
This is a copy of Brian's PR https://github.com/pytorch/pytorch/pull/128981, with very small changes to work around numpy related errors.

For discussions, please see Brian's original PR.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129162



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang