### PR TITLE
[AOTI] Fix test_cond_non_tensor_predicates

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3063,12 +3063,6 @@ CPU_TEST_FAILURES = {
     "test_zero_grid_with_backed_symbols": fail_with_and_without_stack_allocation(
         is_skip=True
     ),
-    # https://github.com/pytorch/pytorch/issues/122990
-    "test_cond_non_tensor_predicates_dynamic_False": fail_stack_allocation(
-        is_skip=True
-    ),
-    # same issue as https://github.com/pytorch/pytorch/issues/122990
-    "test_cond_non_tensor_predicates_dynamic_True": fail_stack_allocation(is_skip=True),
     # https://github.com/pytorch/pytorch/issues/122991
     "test_runtime_checks_complex": fail_with_and_without_stack_allocation(is_skip=True),
     "test_runtime_checks_fp8": fail_with_and_without_stack_allocation(is_skip=True),

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1617,7 +1617,9 @@ class CppWrapperCpu(WrapperCodeGen):
                     device_type,
                     device_idx,
                 ]
-                return f"ArrayRefTensor<{cpp_type}> {name}({', '.join(args)});"
+                self.wrapper_call.writeline(f"ArrayRefTensor<{cpp_type}> {name}_tensor({', '.join(args)});")
+                self.wrapper_call.writeline(f"AtenTensorHandle {name};")
+                return f"convert_output_to_handle({name}_tensor, {name});"
 
             args = [
                 str(len(shape)),

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1617,7 +1617,9 @@ class CppWrapperCpu(WrapperCodeGen):
                     device_type,
                     device_idx,
                 ]
-                self.wrapper_call.writeline(f"ArrayRefTensor<{cpp_type}> {name}_tensor({', '.join(args)});")
+                self.wrapper_call.writeline(
+                    f"ArrayRefTensor<{cpp_type}> {name}_tensor({', '.join(args)});"
+                )
                 self.wrapper_call.writeline(f"AtenTensorHandle {name};")
                 return f"convert_output_to_handle({name}_tensor, {name});"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129168
* __->__ #129166

Fix the issue mentioned in https://github.com/pytorch/pytorch/issues/122990
When we are able to do the stack allocation for inner output, need to wrap it before move assignment to outer_output.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang