### PR TITLE
[compiled autograd] move inputs to cuda with non_blocking=True

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -300,7 +300,7 @@ class AutogradCompilerInstance:
             try:
                 in_compiled_autograd_region = True
                 for i in runtime_inputs_to_move:
-                    inputs[i] = inputs[i].cuda()
+                    inputs[i] = inputs[i].pin_memory().cuda(non_blocking=True)
 
                 return compiled_fn(inputs, sizes, hooks)
             finally:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129116
* __->__ #129181
* #128987
* #128982
* #128905
* #127960

non_blocking=True requires first pinning, which shouldn't be a problem given that they are cpu scalars

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang