### PR TITLE
[CUDAGraph Trees] Enable input mutation support in OSS

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -661,7 +661,7 @@ class triton:
     cudagraph_trees_history_recording = False
 
     # Enable cudagraph support for mutated inputs from prior cudagraph pool
-    cudagraph_support_input_mutation = False
+    cudagraph_support_input_mutation = False if is_fbcode() else True
 
     # synchronize after cudagraph invocation
     force_cudagraph_sync = False


### PR DESCRIPTION
Summary: Enable input mutation support for cudagraph trees in OSS.

Test Plan: CI

Differential Revision: D58847850


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang