### PR TITLE
[bazel] fix --config=shell

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,7 +33,9 @@ build:cpu-only --@rules_cuda//cuda:enable_cuda=False
 
 # Definition of --config=shell
 # interactive shell immediately before execution
-build:shell --run_under="//tools/bazel_tools:shellwrap"
+# Need to be used like
+# cat /dev/tty | bazel run --config=shell //:target
+run:shell --run_under="//tools/bazel_tools:shellwrap"
 
 # Disable all warnings for external repositories. We don't care about
 # their warnings.

--- a/tools/bazel_tools/shellwrap.sh
+++ b/tools/bazel_tools/shellwrap.sh
@@ -5,9 +5,7 @@
 # This can provide a quick way to explore the sandbox directory and filesystem.
 # Typical use is with
 #
-#     bazel run --run_under=//tools/bazel:shell_wrapper //:target
-#     OR
-#     bazel run --config=shell //:target
+#     cat /dev/tty | bazel run --config=shell //:target
 
 shell='/bin/bash'
 rcfile='/tmp/pytorch_bazel_tools_shellwrap'
@@ -30,9 +28,12 @@ while [[ $# -gt 0 ]] ; do
     esac
 done
 
-if ! tty -s; then
-    echo 'A tty is not available.'
-    echo "Use \`bazel run\`, not \`bazel test\`."
+# Unfortunately vanilla bazel doesn't have good way to achive this so we relay on a weired way to execute this step
+# https://github.com/bazelbuild/bazel/issues/11371#issuecomment-628372628
+if tty -s; then
+    echo 'Detected un-redirected tty'
+    echo "Prefix your command with 'cat /dev/tty | '"
+    echo "For example: cat /dev/tty | bazel run --config=shell //:target"
     exit 1
 fi
 


### PR DESCRIPTION
Quality of life improvement for bazel dev.

Previously on recent bazel the `bazel --config=shell` was getting into a bad state where nothing can be typed and the shell cannot be halted, so it's worse then useless.

Unfortunately vanilla bazel doesn't have a good way to achieve the `--config=shell` intent, but with the `cat /dev/tty` is somewhat works (but no readline still).

So this is mostly fixing what is broken, but still not in the ideal shape.