### PR TITLE
[Inductor] FlexAttention supports block sparse mask

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -402,12 +402,14 @@ class TestFlexAttention(InductorTestCase):
     def test_builtin_score_mods(self, dtype: torch.dtype, score_mod: Callable):
         self.run_test(score_mod, dtype)
 
+    @expectedFailure  # TODO: supports block sparsity with dynamic shapes
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes)
     @common_utils.parametrize("score_mod", test_score_mods)
     def test_builtin_score_mods_dynamic(self, dtype: torch.dtype, score_mod: Callable):
         self.run_dynamic_test(score_mod, dtype)
 
+    @expectedFailure  # TODO: supports block sparsity with dynamic shapes
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes)
     @common_utils.parametrize("score_mod", test_score_mods)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1120,13 +1120,13 @@ class GraphModule(torch.nn.Module):
         l_args_1_ = L_args_1_
         l_args_2_ = L_args_2_
 
-        ones: "i32[1]" = torch.ones([1], dtype = torch.int32, device = device(type='cuda', index=0))
+        ones: "i32[1, 1, 1]" = torch.ones([1, 1, 1], dtype = torch.int32, device = device(type='cuda', index=0))
 
-        zeros: "i32[1, 1]" = torch.zeros([1, 1], dtype = torch.int32, device = device(type='cuda', index=0))
+        zeros: "i32[1, 1, 1, 1]" = torch.zeros([1, 1, 1, 1], dtype = torch.int32, device = device(type='cuda', index=0))
 
-        ones_1: "i32[1]" = torch.ones([1], dtype = torch.int32, device = device(type='cuda', index=0))
+        ones_1: "i32[1, 1, 1]" = torch.ones([1, 1, 1], dtype = torch.int32, device = device(type='cuda', index=0))
 
-        zeros_1: "i32[1, 1]" = torch.zeros([1, 1], dtype = torch.int32, device = device(type='cuda', index=0))
+        zeros_1: "i32[1, 1, 1, 1]" = torch.zeros([1, 1, 1, 1], dtype = torch.int32, device = device(type='cuda', index=0))
 
         new_empty: "f64[]" = l_args_0_.new_empty([], requires_grad = True)
         new_empty_1: "i32[]" = l_args_0_.new_empty([], dtype = torch.int32)
@@ -1165,7 +1165,7 @@ class GraphModule(torch.nn.Module):
             joint_graph,
             """\
 class GraphModule(torch.nn.Module):
-    def forward(self, primals_1: "f64[2, 2, 8, 4]", primals_2: "f64[2, 2, 8, 4]", primals_3: "f64[2, 2, 8, 4]", full_default: "i32[1]", full_default_1: "i32[1, 1]", getitem: "f64[2, 2, 8, 4]", getitem_1: "f32[2, 2, 8]", tangents_1: "f64[2, 2, 8, 4]"):
+    def forward(self, primals_1: "f64[2, 2, 8, 4]", primals_2: "f64[2, 2, 8, 4]", primals_3: "f64[2, 2, 8, 4]", full_default: "i32[1, 1, 1]", full_default_1: "i32[1, 1, 1, 1]", getitem: "f64[2, 2, 8, 4]", getitem_1: "f32[2, 2, 8]", tangents_1: "f64[2, 2, 8, 4]"):
         fw_graph = self.fw_graph
         joint_graph = self.joint_graph
         flex_attention_backward = torch.ops.higher_order.flex_attention_backward(primals_1, primals_2, primals_3, getitem, getitem_1, tangents_1, fw_graph, joint_graph, full_default, full_default_1, full_default, full_default_1, 8, 8);  primals_1 = primals_2 = primals_3 = getitem = getitem_1 = tangents_1 = fw_graph = joint_graph = full_default = full_default_1 = None

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1026,8 +1026,8 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
                 block_mask.kv_indices,
                 block_mask.q_num_blocks,
                 block_mask.q_indices,
-                block_mask.BLOCKSPARSE_KV,
-                block_mask.BLOCKSPARSE_Q,
+                block_mask.KV_BLOCK_SIZE,
+                block_mask.Q_BLOCK_SIZE,
             )
 
         @torch.compile(backend="aot_eager")
@@ -1045,8 +1045,8 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
                 block_mask.kv_indices,
                 block_mask.q_num_blocks,
                 block_mask.q_indices,
-                block_mask.BLOCKSPARSE_KV,
-                block_mask.BLOCKSPARSE_Q,
+                block_mask.KV_BLOCK_SIZE,
+                block_mask.Q_BLOCK_SIZE,
             )
 
         ref_out, ref_lse = eager_sdpa_hop(
@@ -1107,8 +1107,8 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
                 block_mask.kv_indices,
                 block_mask.q_num_blocks,
                 block_mask.q_indices,
-                block_mask.BLOCKSPARSE_KV,
-                block_mask.BLOCKSPARSE_Q,
+                block_mask.KV_BLOCK_SIZE,
+                block_mask.Q_BLOCK_SIZE,
             )
             lse_2 = lse * 2
             return lse_2
@@ -1140,8 +1140,8 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
                 block_mask.kv_indices,
                 block_mask.q_num_blocks,
                 block_mask.q_indices,
-                block_mask.BLOCKSPARSE_KV,
-                block_mask.BLOCKSPARSE_Q,
+                block_mask.KV_BLOCK_SIZE,
+                block_mask.Q_BLOCK_SIZE,
             )
             lse_2 = lse * 2
             return out, lse_2

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1092,7 +1092,7 @@ class GraphModule(torch.nn.Module):
         new_empty_3: "i32[]" = l_args_0_.new_empty([], dtype = torch.int32)
         new_empty_4: "i32[]" = l_args_0_.new_empty([], dtype = torch.int32)
         flex_attention_0 = self.flex_attention_0
-        flex_attention = torch.ops.higher_order.flex_attention(l_args_0_, l_args_1_, l_args_2_, flex_attention_0, ones, zeros, ones_1, zeros_1);  l_args_0_ = l_args_1_ = l_args_2_ = flex_attention_0 = ones = zeros = ones_1 = zeros_1 = None
+        flex_attention = torch.ops.higher_order.flex_attention(l_args_0_, l_args_1_, l_args_2_, flex_attention_0, ones, zeros, ones_1, zeros_1, 8, 8);  l_args_0_ = l_args_1_ = l_args_2_ = flex_attention_0 = ones = zeros = ones_1 = zeros_1 = None
         out: "f64[2, 2, 8, 4]" = flex_attention[0];  flex_attention = None
         return (out,)
 
@@ -1126,7 +1126,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f64[2, 2, 8, 4]", primals_2: "f64[2, 2, 8, 4]", primals_3: "f64[2, 2, 8, 4]", full_default: "i32[1]", full_default_1: "i32[1, 1]", getitem: "f64[2, 2, 8, 4]", getitem_1: "f32[2, 2, 8]", tangents_1: "f64[2, 2, 8, 4]"):
         fw_graph = self.fw_graph
         joint_graph = self.joint_graph
-        flex_attention_backward = torch.ops.higher_order.flex_attention_backward(primals_1, primals_2, primals_3, getitem, getitem_1, tangents_1, fw_graph, joint_graph, full_default, full_default_1, full_default, full_default_1);  primals_1 = primals_2 = primals_3 = getitem = getitem_1 = tangents_1 = fw_graph = joint_graph = full_default = full_default_1 = None
+        flex_attention_backward = torch.ops.higher_order.flex_attention_backward(primals_1, primals_2, primals_3, getitem, getitem_1, tangents_1, fw_graph, joint_graph, full_default, full_default_1, full_default, full_default_1, 8, 8);  primals_1 = primals_2 = primals_3 = getitem = getitem_1 = tangents_1 = fw_graph = joint_graph = full_default = full_default_1 = None
         getitem_2: "f64[2, 2, 8, 4]" = flex_attention_backward[0]
         getitem_3: "f64[2, 2, 8, 4]" = flex_attention_backward[1]
         getitem_4: "f64[2, 2, 8, 4]" = flex_attention_backward[2];  flex_attention_backward = None

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -549,9 +549,9 @@ class TestFlexAttention(InductorTestCase):
             return out
 
         _, code = run_and_get_code(func, q, k, v)
-        # Ensure _create_block_sparse_mask is compiled and generates 5 kernels,
+        # Ensure _create_block_sparse_mask is compiled and generates 3 kernels,
         # flex_attention generates 1 kernel.
-        FileCheck().check_count(".run(", 6, True).run(code[0])
+        FileCheck().check_count(".run(", 4, True).run(code[0])
 
     @supported_platform
     def test_block_sparse_mask_is_reused(self):
@@ -595,9 +595,9 @@ class TestFlexAttention(InductorTestCase):
             return out
 
         _, code = run_and_get_code(func, q, k, v, k2, v2)
-        # Ensure _create_block_sparse_mask is compiled and generates 5 kernels,
+        # Ensure _create_block_sparse_mask is compiled and generates 3 kernels,
         # 2 flex_attention generates 2 kernels.
-        FileCheck().check_count(".run(", 7, True).run(code[0])
+        FileCheck().check_count(".run(", 5, True).run(code[0])
 
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -503,7 +503,10 @@ class TestFlexAttention(InductorTestCase):
         assert v_strides[-1] == 1
         v = torch.as_strided(v1, v_shape, v_strides, v_offset)
 
-        sdpa_partial = create_attention(score_mod=_generate_alibi_bias(8))
+        block_mask = _create_empty_block_sparse_mask(q, k, v)
+        sdpa_partial = create_attention(
+            score_mod=_generate_alibi_bias(8), block_sparse_mask=block_mask
+        )
         compiled_sdpa = torch.compile(sdpa_partial)
         ref_out = sdpa_partial(q, k, v)
         compiled_out = compiled_sdpa(q, k, v)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1579,6 +1579,8 @@ class TemplatedAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
             sparse_mask_kv_indices,
             sparse_mask_q_num_blocks,
             sparse_mask_q_indices,
+            BLOCKSPARSE_KV,
+            BLOCKSPARSE_Q,
         ) = self.normalize_to_args(args, kwargs)
 
         p_args = self.create_wrapped_node(tx, query, score_mod)
@@ -1597,6 +1599,8 @@ class TemplatedAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
             ],
             {},
         )
+        BLOCKSPARSE_KV = BLOCKSPARSE_KV.as_python_constant()
+        BLOCKSPARSE_Q = BLOCKSPARSE_Q.as_python_constant()
 
         query_meta = query.as_proxy().node.meta["example_value"]
         logsumexp_shape = query_meta.size()[:-1]  # [B, H, M]
@@ -1612,7 +1616,11 @@ class TemplatedAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
             proxy=tx.output.create_proxy(
                 "call_function",
                 self.value,
-                args=inp_args + p_args[:1] + sparse_mask_args + p_args[1:],
+                args=inp_args
+                + p_args[:1]
+                + sparse_mask_args
+                + (BLOCKSPARSE_KV, BLOCKSPARSE_Q)
+                + p_args[1:],
                 kwargs={},
             ),
             example_value=example_value,

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1610,6 +1610,10 @@ class TemplatedAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
             lse_meta = query_meta.new_empty(logsumexp_shape, dtype=torch.float32)
         example_value = (out_meta, lse_meta)
 
+        # Compose the ordered HOO args from two parts:
+        # - inp_args: [query, key, value, sparse_kv_num_blocks, sparse_kv_indices,
+        #   sparse_q_num_blocks, sparse_q_indices, SPARSE_KV_BLOCK_SIZE, SPARSE_Q_BLOCK_SIZE]
+        # - p_args: [score_mod, *other_buffers]
         return wrap_fx_proxy(
             tx=tx,
             proxy=tx.output.create_proxy(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1575,12 +1575,12 @@ class TemplatedAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
             key,
             value,
             score_mod,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
         ) = self.normalize_to_args(args, kwargs)
 
         p_args = self.create_wrapped_node(tx, query, score_mod)
@@ -1588,12 +1588,12 @@ class TemplatedAttentionHigherOrderVariable(TorchHigherOrderOperatorVariable):
             query,
             key,
             value,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
         ]
 
         # Store the invocation as a call

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -490,11 +490,11 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
                 key,
                 value,
                 fw_graph,
-                *other_buffers,
                 sparse_mask_kv_num_blocks,
                 sparse_mask_kv_indices,
                 sparse_mask_q_num_blocks,
                 sparse_mask_q_indices,
+                 *other_buffers,
             )
 
         ctx.save_for_backward(

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -52,11 +52,25 @@ class FlexAttentionHOP(HigherOrderOperator):
         key: torch.Tensor,
         value: torch.Tensor,
         score_mod: Callable,
+        sparse_mask_kv_num_blocks: torch.Tensor,
+        sparse_mask_kv_indices: torch.Tensor,
+        sparse_mask_q_num_blocks: torch.Tensor,
+        sparse_mask_q_indices: torch.Tensor,
         *other_buffers: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if not all(isinstance(buf, torch.Tensor) for buf in other_buffers):
             raise RuntimeError("Other buffers must be tensors.")
-        return super().__call__(query, key, value, score_mod, *other_buffers)
+        return super().__call__(
+            query,
+            key,
+            value,
+            score_mod,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
+            *other_buffers,
+        )
 
 
 flex_attention = FlexAttentionHOP()
@@ -77,6 +91,10 @@ class FlexAttentionBackwardHOP(HigherOrderOperator):
         grad_out: torch.Tensor,
         fw_graph: Union[Callable, GraphModule],
         joint_graph: GraphModule,
+        sparse_mask_kv_num_blocks: torch.Tensor,
+        sparse_mask_kv_indices: torch.Tensor,
+        sparse_mask_q_num_blocks: torch.Tensor,
+        sparse_mask_q_indices: torch.Tensor,
         *other_buffers: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if not all(isinstance(buf, torch.Tensor) for buf in other_buffers):
@@ -90,6 +108,10 @@ class FlexAttentionBackwardHOP(HigherOrderOperator):
             grad_out,
             fw_graph,
             joint_graph,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
             *other_buffers,
         )
 
@@ -103,6 +125,10 @@ def math_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Eager implementation
@@ -153,9 +179,23 @@ def sdpa_dense(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    out, lse = math_attention(query, key, value, score_mod, *other_buffers)
+    out, lse = math_attention(
+        query,
+        key,
+        value,
+        score_mod,
+        sparse_mask_kv_num_blocks,
+        sparse_mask_kv_indices,
+        sparse_mask_q_num_blocks,
+        sparse_mask_q_indices,
+        *other_buffers,
+    )
     out = out.contiguous()
     return out, lse
 
@@ -166,6 +206,10 @@ def trace_flex_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Traces the flex_attention operator with the given score_mod function and other_buffers.
@@ -174,7 +218,17 @@ def trace_flex_attention(
     This will produce a GraphModule that will be stored on the root tracer as "sdpa_score". We
     access this graph module in inductor to inline the score_mod function to the triton template.
     """
-    example_out = flex_attention(query, key, value, score_mod, *other_buffers)
+    example_out = flex_attention(
+        query,
+        key,
+        value,
+        score_mod,
+        sparse_mask_kv_num_blocks,
+        sparse_mask_kv_indices,
+        sparse_mask_q_num_blocks,
+        sparse_mask_q_indices,
+        *other_buffers,
+    )
     example_vals = [
         torch.zeros((), dtype=query.dtype, requires_grad=query.requires_grad)
     ] + [torch.zeros((), dtype=torch.int) for _ in range(4)]
@@ -182,7 +236,17 @@ def trace_flex_attention(
         score_graph = reenter_make_fx(score_mod)(*example_vals, *other_buffers)
     qualname = proxy_mode.tracer.get_fresh_qualname("sdpa_score")
     proxy_mode.tracer.root.register_module(qualname, score_graph)
-    node_args = (query, key, value, score_graph, *other_buffers)
+    node_args = (
+        query,
+        key,
+        value,
+        score_graph,
+        sparse_mask_kv_num_blocks,
+        sparse_mask_kv_indices,
+        sparse_mask_q_num_blocks,
+        sparse_mask_q_indices,
+        *other_buffers,
+    )
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
     out_proxy = proxy_mode.tracer.create_proxy(
         "call_function", flex_attention, proxy_args, {}
@@ -199,13 +263,38 @@ def flex_attention_proxy_torch_dispatch_mode(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     assert mode is not None, "Mode should always be enabled for python fallback key"
     if mode.enable_tracing:
-        return trace_flex_attention(mode, query, key, value, score_mod, *other_buffers)
+        return trace_flex_attention(
+            mode,
+            query,
+            key,
+            value,
+            score_mod,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
+            *other_buffers,
+        )
     else:
-        return flex_attention(query, key, value, score_mod, *other_buffers)
+        return flex_attention(
+            query,
+            key,
+            value,
+            score_mod,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
+            *other_buffers,
+        )
 
 
 @flex_attention.py_functionalize_impl
@@ -215,6 +304,10 @@ def flex_attention_functionalize(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Defines the functionalization rules for the flex_attention operator.
@@ -226,6 +319,10 @@ def flex_attention_functionalize(
     query_unwrapped = ctx.unwrap_tensors(query)
     key_unwrapped = ctx.unwrap_tensors(key)
     value_unwrapped = ctx.unwrap_tensors(value)
+    sparse_mask_kv_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_mask_kv_num_blocks)
+    sparse_mask_kv_indices_unwrapped = ctx.unwrap_tensors(sparse_mask_kv_indices)
+    sparse_mask_q_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_mask_q_num_blocks)
+    sparse_mask_q_indices_unwrapped = ctx.unwrap_tensors(sparse_mask_q_indices)
     other_buffers_unwrapped = ctx.unwrap_tensors(other_buffers)
 
     # Appease the mypy overlords
@@ -257,6 +354,10 @@ def flex_attention_functionalize(
             key_unwrapped,
             value_unwrapped,
             functional_score_mod,
+            sparse_mask_kv_num_blocks_unwrapped,
+            sparse_mask_kv_indices_unwrapped,
+            sparse_mask_q_num_blocks_unwrapped,
+            sparse_mask_q_indices_unwrapped,
             *other_buffers_unwrapped,
         )
     return ctx.wrap_tensors(out)  # type: ignore[return-value, arg-type]
@@ -269,6 +370,10 @@ def flex_attention_fake_tensor_mode(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: Tuple[torch.Tensor, ...],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     with mode:
@@ -361,7 +466,17 @@ def create_fw_bw_graph(score_mod, index_values, other_buffers):
 class FlexAttentionAutogradOp(torch.autograd.Function):
     @staticmethod
     def forward(
-        ctx, query, key, value, fw_graph, joint_graph, *other_buffers
+        ctx,
+        query,
+        key,
+        value,
+        fw_graph,
+        joint_graph,
+        sparse_mask_kv_num_blocks: torch.Tensor,
+        sparse_mask_kv_indices: torch.Tensor,
+        sparse_mask_q_num_blocks: torch.Tensor,
+        sparse_mask_q_indices: torch.Tensor,
+        *other_buffers,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         any_buffer_requires_grad = any(buffer.requires_grad for buffer in other_buffers)
         assert (
@@ -370,19 +485,51 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
         ctx._fw_graph = fw_graph
         ctx._joint_graph = joint_graph
         with torch._C._AutoDispatchBelowAutograd():
-            out, logsumexp = flex_attention(query, key, value, fw_graph, *other_buffers)
+            out, logsumexp = flex_attention(
+                query,
+                key,
+                value,
+                fw_graph,
+                *other_buffers,
+                sparse_mask_kv_num_blocks,
+                sparse_mask_kv_indices,
+                sparse_mask_q_num_blocks,
+                sparse_mask_q_indices,
+            )
 
-        ctx.save_for_backward(query, key, value, out, logsumexp, *other_buffers)
+        ctx.save_for_backward(
+            query,
+            key,
+            value,
+            out,
+            logsumexp,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
+            *other_buffers,
+        )
         return out, logsumexp
 
     @staticmethod
     def backward(ctx, grad_out, logsumexp_grad):
         fw_args = ctx.saved_tensors
-        query, key, value, out, logsumexp, *other_buffers = fw_args
+        (
+            query,
+            key,
+            value,
+            out,
+            logsumexp,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
+            *other_buffers,
+        ) = fw_args
         fw_graph = ctx._fw_graph
         joint_graph = ctx._joint_graph
         # We have asserted that other_buffers do not require grad in the forward
-        none_grads = [None] * (2 + len(other_buffers))
+        none_grads = [None] * (6 + len(other_buffers))
         grad_query, grad_key, grad_value = flex_attention_backward(
             query,
             key,
@@ -392,6 +539,10 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
             grad_out,
             fw_graph,
             joint_graph,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
             *other_buffers,
         )
         return grad_query, grad_key, grad_value, *none_grads
@@ -403,6 +554,10 @@ def flex_attention_autograd(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: Tuple[torch.Tensor, ...],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     with TransformGetItemToIndex():
@@ -417,7 +572,16 @@ def flex_attention_autograd(
         else:
             fw_graph, bw_graph = score_mod, None
         out, logsumexp = FlexAttentionAutogradOp.apply(
-            query, key, value, fw_graph, bw_graph, *other_buffers
+            query,
+            key,
+            value,
+            fw_graph,
+            bw_graph,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
+            *other_buffers,
         )
     return out, logsumexp
 
@@ -435,6 +599,10 @@ def sdpa_dense_backward(
     grad_out: torch.Tensor,
     fw_graph: Callable,  # GraphModule type hint?
     joint_graph: Callable,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     working_precision = torch.float64 if query.dtype == torch.float64 else torch.float32
@@ -509,6 +677,10 @@ def trace_flex_attention_backward(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """We already have the forward graph and joint graph from the forward pass, so we create a proxy attach both graphs"""
@@ -521,6 +693,10 @@ def trace_flex_attention_backward(
         grad_out,
         fw_graph,
         joint_graph,
+        sparse_mask_kv_num_blocks,
+        sparse_mask_kv_indices,
+        sparse_mask_q_num_blocks,
+        sparse_mask_q_indices,
         *other_buffers,
     )
 
@@ -542,6 +718,10 @@ def trace_flex_attention_backward(
         grad_out,
         fw_graph,
         joint_graph,
+        sparse_mask_kv_num_blocks,
+        sparse_mask_kv_indices,
+        sparse_mask_q_num_blocks,
+        sparse_mask_q_indices,
         *other_buffers,
     )
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
@@ -568,6 +748,10 @@ def flex_attention_backward_proxy_torch_dispatch_mode(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert mode is not None, "Mode should always be enabled for python fallback key"
@@ -582,6 +766,10 @@ def flex_attention_backward_proxy_torch_dispatch_mode(
             grad_out,
             fw_graph,
             joint_graph,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
             *other_buffers,
         )
     else:
@@ -594,6 +782,10 @@ def flex_attention_backward_proxy_torch_dispatch_mode(
             grad_out,
             fw_graph,
             joint_graph,
+            sparse_mask_kv_num_blocks,
+            sparse_mask_kv_indices,
+            sparse_mask_q_num_blocks,
+            sparse_mask_q_indices,
             *other_buffers,
         )
 
@@ -609,6 +801,10 @@ def flex_attention_backward_functionalize(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Defines the functionalization rules for the flex_attention operator.
@@ -623,6 +819,10 @@ def flex_attention_backward_functionalize(
     out_unwrapped = ctx.unwrap_tensors(out)
     logsumexp_unwrapped = ctx.unwrap_tensors(logsumexp)
     grad_out_unwrapped = ctx.unwrap_tensors(grad_out)
+    sparse_mask_kv_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_mask_kv_num_blocks)
+    sparse_mask_kv_indices_unwrapped = ctx.unwrap_tensors(sparse_mask_kv_indices)
+    sparse_mask_q_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_mask_q_num_blocks)
+    sparse_mask_q_indices_unwrapped = ctx.unwrap_tensors(sparse_mask_q_indices)
     other_buffers_unwrapped = ctx.unwrap_tensors(other_buffers)
 
     # Appease the mypy overlords
@@ -648,6 +848,10 @@ def flex_attention_backward_functionalize(
             grad_out_unwrapped,
             functional_fw_graph,  # type: ignore[arg-type]
             functional_joint_graph,  # type: ignore[arg-type]
+            sparse_mask_kv_num_blocks_unwrapped,
+            sparse_mask_kv_indices_unwrapped,
+            sparse_mask_q_num_blocks_unwrapped,
+            sparse_mask_q_indices_unwrapped,
             *other_buffers_unwrapped,
         )
 
@@ -665,6 +869,10 @@ def flex_attention_backward_fake_tensor_mode(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
+    sparse_mask_kv_num_blocks: torch.Tensor,
+    sparse_mask_kv_indices: torch.Tensor,
+    sparse_mask_q_num_blocks: torch.Tensor,
+    sparse_mask_q_indices: torch.Tensor,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     with mode:

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -357,6 +357,10 @@ def flex_attention_functionalize(
     assert isinstance(query_unwrapped, torch.Tensor)
     assert isinstance(key_unwrapped, torch.Tensor)
     assert isinstance(value_unwrapped, torch.Tensor)
+    assert isinstance(sparse_mask_kv_num_blocks_unwrapped, torch.Tensor)
+    assert isinstance(sparse_mask_kv_indices_unwrapped, torch.Tensor)
+    assert isinstance(sparse_mask_q_num_blocks_unwrapped, torch.Tensor)
+    assert isinstance(sparse_mask_q_indices_unwrapped, torch.Tensor)
     assert isinstance(other_buffers_unwrapped, tuple)
     assert all(isinstance(item, torch.Tensor) for item in other_buffers_unwrapped)
 
@@ -894,6 +898,10 @@ def flex_attention_backward_functionalize(
     assert isinstance(out_unwrapped, torch.Tensor)
     assert isinstance(logsumexp_unwrapped, torch.Tensor)
     assert isinstance(grad_out_unwrapped, torch.Tensor)
+    assert isinstance(sparse_mask_kv_num_blocks_unwrapped, torch.Tensor)
+    assert isinstance(sparse_mask_kv_indices_unwrapped, torch.Tensor)
+    assert isinstance(sparse_mask_q_num_blocks_unwrapped, torch.Tensor)
+    assert isinstance(sparse_mask_q_indices_unwrapped, torch.Tensor)
     assert isinstance(other_buffers_unwrapped, tuple)
     assert all(isinstance(item, torch.Tensor) for item in other_buffers_unwrapped)
 

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -494,7 +494,7 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
                 sparse_mask_kv_indices,
                 sparse_mask_q_num_blocks,
                 sparse_mask_q_indices,
-                 *other_buffers,
+                *other_buffers,
             )
 
         ctx.save_for_backward(

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -52,12 +52,12 @@ class FlexAttentionHOP(HigherOrderOperator):
         key: torch.Tensor,
         value: torch.Tensor,
         score_mod: Callable,
-        sparse_mask_kv_num_blocks: torch.Tensor,
-        sparse_mask_kv_indices: torch.Tensor,
-        sparse_mask_q_num_blocks: torch.Tensor,
-        sparse_mask_q_indices: torch.Tensor,
-        BLOCKSPARSE_KV: int,
-        BLOCKSPARSE_Q: int,
+        sparse_kv_num_blocks: torch.Tensor,
+        sparse_kv_indices: torch.Tensor,
+        sparse_q_num_blocks: torch.Tensor,
+        sparse_q_indices: torch.Tensor,
+        SPARSE_KV_BLOCK_SIZE: int,
+        SPARSE_Q_BLOCK_SIZE: int,
         *other_buffers: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if not all(isinstance(buf, torch.Tensor) for buf in other_buffers):
@@ -67,12 +67,12 @@ class FlexAttentionHOP(HigherOrderOperator):
             key,
             value,
             score_mod,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers,
         )
 
@@ -95,12 +95,12 @@ class FlexAttentionBackwardHOP(HigherOrderOperator):
         grad_out: torch.Tensor,
         fw_graph: Union[Callable, GraphModule],
         joint_graph: GraphModule,
-        sparse_mask_kv_num_blocks: torch.Tensor,
-        sparse_mask_kv_indices: torch.Tensor,
-        sparse_mask_q_num_blocks: torch.Tensor,
-        sparse_mask_q_indices: torch.Tensor,
-        BLOCKSPARSE_KV: int,
-        BLOCKSPARSE_Q: int,
+        sparse_kv_num_blocks: torch.Tensor,
+        sparse_kv_indices: torch.Tensor,
+        sparse_q_num_blocks: torch.Tensor,
+        sparse_q_indices: torch.Tensor,
+        SPARSE_KV_BLOCK_SIZE: int,
+        SPARSE_Q_BLOCK_SIZE: int,
         *other_buffers: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if not all(isinstance(buf, torch.Tensor) for buf in other_buffers):
@@ -114,12 +114,12 @@ class FlexAttentionBackwardHOP(HigherOrderOperator):
             grad_out,
             fw_graph,
             joint_graph,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers,
         )
 
@@ -133,12 +133,12 @@ def math_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Eager implementation
@@ -189,12 +189,12 @@ def sdpa_dense(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     out, lse = math_attention(
@@ -202,12 +202,12 @@ def sdpa_dense(
         key,
         value,
         score_mod,
-        sparse_mask_kv_num_blocks,
-        sparse_mask_kv_indices,
-        sparse_mask_q_num_blocks,
-        sparse_mask_q_indices,
-        BLOCKSPARSE_KV,
-        BLOCKSPARSE_Q,
+        sparse_kv_num_blocks,
+        sparse_kv_indices,
+        sparse_q_num_blocks,
+        sparse_q_indices,
+        SPARSE_KV_BLOCK_SIZE,
+        SPARSE_Q_BLOCK_SIZE,
         *other_buffers,
     )
     out = out.contiguous()
@@ -220,12 +220,12 @@ def trace_flex_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Traces the flex_attention operator with the given score_mod function and other_buffers.
@@ -239,12 +239,12 @@ def trace_flex_attention(
         key,
         value,
         score_mod,
-        sparse_mask_kv_num_blocks,
-        sparse_mask_kv_indices,
-        sparse_mask_q_num_blocks,
-        sparse_mask_q_indices,
-        BLOCKSPARSE_KV,
-        BLOCKSPARSE_Q,
+        sparse_kv_num_blocks,
+        sparse_kv_indices,
+        sparse_q_num_blocks,
+        sparse_q_indices,
+        SPARSE_KV_BLOCK_SIZE,
+        SPARSE_Q_BLOCK_SIZE,
         *other_buffers,
     )
     example_vals = [
@@ -259,12 +259,12 @@ def trace_flex_attention(
         key,
         value,
         score_graph,
-        sparse_mask_kv_num_blocks,
-        sparse_mask_kv_indices,
-        sparse_mask_q_num_blocks,
-        sparse_mask_q_indices,
-        BLOCKSPARSE_KV,
-        BLOCKSPARSE_Q,
+        sparse_kv_num_blocks,
+        sparse_kv_indices,
+        sparse_q_num_blocks,
+        sparse_q_indices,
+        SPARSE_KV_BLOCK_SIZE,
+        SPARSE_Q_BLOCK_SIZE,
         *other_buffers,
     )
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
@@ -283,12 +283,12 @@ def flex_attention_proxy_torch_dispatch_mode(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     assert mode is not None, "Mode should always be enabled for python fallback key"
@@ -299,12 +299,12 @@ def flex_attention_proxy_torch_dispatch_mode(
             key,
             value,
             score_mod,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers,
         )
     else:
@@ -313,12 +313,12 @@ def flex_attention_proxy_torch_dispatch_mode(
             key,
             value,
             score_mod,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers,
         )
 
@@ -330,12 +330,12 @@ def flex_attention_functionalize(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Defines the functionalization rules for the flex_attention operator.
@@ -347,20 +347,20 @@ def flex_attention_functionalize(
     query_unwrapped = ctx.unwrap_tensors(query)
     key_unwrapped = ctx.unwrap_tensors(key)
     value_unwrapped = ctx.unwrap_tensors(value)
-    sparse_mask_kv_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_mask_kv_num_blocks)
-    sparse_mask_kv_indices_unwrapped = ctx.unwrap_tensors(sparse_mask_kv_indices)
-    sparse_mask_q_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_mask_q_num_blocks)
-    sparse_mask_q_indices_unwrapped = ctx.unwrap_tensors(sparse_mask_q_indices)
+    sparse_kv_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_kv_num_blocks)
+    sparse_kv_indices_unwrapped = ctx.unwrap_tensors(sparse_kv_indices)
+    sparse_q_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_q_num_blocks)
+    sparse_q_indices_unwrapped = ctx.unwrap_tensors(sparse_q_indices)
     other_buffers_unwrapped = ctx.unwrap_tensors(other_buffers)
 
     # Appease the mypy overlords
     assert isinstance(query_unwrapped, torch.Tensor)
     assert isinstance(key_unwrapped, torch.Tensor)
     assert isinstance(value_unwrapped, torch.Tensor)
-    assert isinstance(sparse_mask_kv_num_blocks_unwrapped, torch.Tensor)
-    assert isinstance(sparse_mask_kv_indices_unwrapped, torch.Tensor)
-    assert isinstance(sparse_mask_q_num_blocks_unwrapped, torch.Tensor)
-    assert isinstance(sparse_mask_q_indices_unwrapped, torch.Tensor)
+    assert isinstance(sparse_kv_num_blocks_unwrapped, torch.Tensor)
+    assert isinstance(sparse_kv_indices_unwrapped, torch.Tensor)
+    assert isinstance(sparse_q_num_blocks_unwrapped, torch.Tensor)
+    assert isinstance(sparse_q_indices_unwrapped, torch.Tensor)
     assert isinstance(other_buffers_unwrapped, tuple)
     assert all(isinstance(item, torch.Tensor) for item in other_buffers_unwrapped)
 
@@ -386,12 +386,12 @@ def flex_attention_functionalize(
             key_unwrapped,
             value_unwrapped,
             functional_score_mod,
-            sparse_mask_kv_num_blocks_unwrapped,
-            sparse_mask_kv_indices_unwrapped,
-            sparse_mask_q_num_blocks_unwrapped,
-            sparse_mask_q_indices_unwrapped,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks_unwrapped,
+            sparse_kv_indices_unwrapped,
+            sparse_q_num_blocks_unwrapped,
+            sparse_q_indices_unwrapped,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers_unwrapped,
         )
     return ctx.wrap_tensors(out)  # type: ignore[return-value, arg-type]
@@ -404,12 +404,12 @@ def flex_attention_fake_tensor_mode(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: Tuple[torch.Tensor, ...],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     with mode:
@@ -508,12 +508,12 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
         value,
         fw_graph,
         joint_graph,
-        sparse_mask_kv_num_blocks: torch.Tensor,
-        sparse_mask_kv_indices: torch.Tensor,
-        sparse_mask_q_num_blocks: torch.Tensor,
-        sparse_mask_q_indices: torch.Tensor,
-        BLOCKSPARSE_KV: int,
-        BLOCKSPARSE_Q: int,
+        sparse_kv_num_blocks: torch.Tensor,
+        sparse_kv_indices: torch.Tensor,
+        sparse_q_num_blocks: torch.Tensor,
+        sparse_q_indices: torch.Tensor,
+        SPARSE_KV_BLOCK_SIZE: int,
+        SPARSE_Q_BLOCK_SIZE: int,
         *other_buffers,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         any_buffer_requires_grad = any(buffer.requires_grad for buffer in other_buffers)
@@ -522,20 +522,20 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
         ), "Captured buffers that require grad are not yet supported."
         ctx._fw_graph = fw_graph
         ctx._joint_graph = joint_graph
-        ctx._BLOCKSPARSE_KV = BLOCKSPARSE_KV
-        ctx._BLOCKSPARSE_Q = BLOCKSPARSE_Q
+        ctx._SPARSE_KV_BLOCK_SIZE = SPARSE_KV_BLOCK_SIZE
+        ctx._SPARSE_Q_BLOCK_SIZE = SPARSE_Q_BLOCK_SIZE
         with torch._C._AutoDispatchBelowAutograd():
             out, logsumexp = flex_attention(
                 query,
                 key,
                 value,
                 fw_graph,
-                sparse_mask_kv_num_blocks,
-                sparse_mask_kv_indices,
-                sparse_mask_q_num_blocks,
-                sparse_mask_q_indices,
-                BLOCKSPARSE_KV,
-                BLOCKSPARSE_Q,
+                sparse_kv_num_blocks,
+                sparse_kv_indices,
+                sparse_q_num_blocks,
+                sparse_q_indices,
+                SPARSE_KV_BLOCK_SIZE,
+                SPARSE_Q_BLOCK_SIZE,
                 *other_buffers,
             )
 
@@ -545,10 +545,10 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
             value,
             out,
             logsumexp,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
             *other_buffers,
         )
         return out, logsumexp
@@ -562,16 +562,16 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
             value,
             out,
             logsumexp,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
             *other_buffers,
         ) = fw_args
         fw_graph = ctx._fw_graph
         joint_graph = ctx._joint_graph
-        BLOCKSPARSE_KV = ctx._BLOCKSPARSE_KV
-        BLOCKSPARSE_Q = ctx._BLOCKSPARSE_Q
+        SPARSE_KV_BLOCK_SIZE = ctx._SPARSE_KV_BLOCK_SIZE
+        SPARSE_Q_BLOCK_SIZE = ctx._SPARSE_Q_BLOCK_SIZE
         # We have asserted that other_buffers do not require grad in the forward
         none_grads = [None] * (8 + len(other_buffers))
         grad_query, grad_key, grad_value = flex_attention_backward(
@@ -583,12 +583,12 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
             grad_out,
             fw_graph,
             joint_graph,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers,
         )
         return grad_query, grad_key, grad_value, *none_grads
@@ -600,12 +600,12 @@ def flex_attention_autograd(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: Tuple[torch.Tensor, ...],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     with TransformGetItemToIndex():
@@ -625,12 +625,12 @@ def flex_attention_autograd(
             value,
             fw_graph,
             bw_graph,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers,
         )
     return out, logsumexp
@@ -649,12 +649,12 @@ def sdpa_dense_backward(
     grad_out: torch.Tensor,
     fw_graph: Callable,  # GraphModule type hint?
     joint_graph: Callable,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     working_precision = torch.float64 if query.dtype == torch.float64 else torch.float32
@@ -729,12 +729,12 @@ def trace_flex_attention_backward(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """We already have the forward graph and joint graph from the forward pass, so we create a proxy attach both graphs"""
@@ -747,12 +747,12 @@ def trace_flex_attention_backward(
         grad_out,
         fw_graph,
         joint_graph,
-        sparse_mask_kv_num_blocks,
-        sparse_mask_kv_indices,
-        sparse_mask_q_num_blocks,
-        sparse_mask_q_indices,
-        BLOCKSPARSE_KV,
-        BLOCKSPARSE_Q,
+        sparse_kv_num_blocks,
+        sparse_kv_indices,
+        sparse_q_num_blocks,
+        sparse_q_indices,
+        SPARSE_KV_BLOCK_SIZE,
+        SPARSE_Q_BLOCK_SIZE,
         *other_buffers,
     )
 
@@ -774,12 +774,12 @@ def trace_flex_attention_backward(
         grad_out,
         fw_graph,
         joint_graph,
-        sparse_mask_kv_num_blocks,
-        sparse_mask_kv_indices,
-        sparse_mask_q_num_blocks,
-        sparse_mask_q_indices,
-        BLOCKSPARSE_KV,
-        BLOCKSPARSE_Q,
+        sparse_kv_num_blocks,
+        sparse_kv_indices,
+        sparse_q_num_blocks,
+        sparse_q_indices,
+        SPARSE_KV_BLOCK_SIZE,
+        SPARSE_Q_BLOCK_SIZE,
         *other_buffers,
     )
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
@@ -806,12 +806,12 @@ def flex_attention_backward_proxy_torch_dispatch_mode(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV,
-    BLOCKSPARSE_Q,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE,
+    SPARSE_Q_BLOCK_SIZE,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert mode is not None, "Mode should always be enabled for python fallback key"
@@ -826,12 +826,12 @@ def flex_attention_backward_proxy_torch_dispatch_mode(
             grad_out,
             fw_graph,
             joint_graph,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers,
         )
     else:
@@ -844,12 +844,12 @@ def flex_attention_backward_proxy_torch_dispatch_mode(
             grad_out,
             fw_graph,
             joint_graph,
-            sparse_mask_kv_num_blocks,
-            sparse_mask_kv_indices,
-            sparse_mask_q_num_blocks,
-            sparse_mask_q_indices,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks,
+            sparse_kv_indices,
+            sparse_q_num_blocks,
+            sparse_q_indices,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers,
         )
 
@@ -865,12 +865,12 @@ def flex_attention_backward_functionalize(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Defines the functionalization rules for the flex_attention operator.
@@ -885,10 +885,10 @@ def flex_attention_backward_functionalize(
     out_unwrapped = ctx.unwrap_tensors(out)
     logsumexp_unwrapped = ctx.unwrap_tensors(logsumexp)
     grad_out_unwrapped = ctx.unwrap_tensors(grad_out)
-    sparse_mask_kv_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_mask_kv_num_blocks)
-    sparse_mask_kv_indices_unwrapped = ctx.unwrap_tensors(sparse_mask_kv_indices)
-    sparse_mask_q_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_mask_q_num_blocks)
-    sparse_mask_q_indices_unwrapped = ctx.unwrap_tensors(sparse_mask_q_indices)
+    sparse_kv_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_kv_num_blocks)
+    sparse_kv_indices_unwrapped = ctx.unwrap_tensors(sparse_kv_indices)
+    sparse_q_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_q_num_blocks)
+    sparse_q_indices_unwrapped = ctx.unwrap_tensors(sparse_q_indices)
     other_buffers_unwrapped = ctx.unwrap_tensors(other_buffers)
 
     # Appease the mypy overlords
@@ -898,10 +898,10 @@ def flex_attention_backward_functionalize(
     assert isinstance(out_unwrapped, torch.Tensor)
     assert isinstance(logsumexp_unwrapped, torch.Tensor)
     assert isinstance(grad_out_unwrapped, torch.Tensor)
-    assert isinstance(sparse_mask_kv_num_blocks_unwrapped, torch.Tensor)
-    assert isinstance(sparse_mask_kv_indices_unwrapped, torch.Tensor)
-    assert isinstance(sparse_mask_q_num_blocks_unwrapped, torch.Tensor)
-    assert isinstance(sparse_mask_q_indices_unwrapped, torch.Tensor)
+    assert isinstance(sparse_kv_num_blocks_unwrapped, torch.Tensor)
+    assert isinstance(sparse_kv_indices_unwrapped, torch.Tensor)
+    assert isinstance(sparse_q_num_blocks_unwrapped, torch.Tensor)
+    assert isinstance(sparse_q_indices_unwrapped, torch.Tensor)
     assert isinstance(other_buffers_unwrapped, tuple)
     assert all(isinstance(item, torch.Tensor) for item in other_buffers_unwrapped)
 
@@ -918,12 +918,12 @@ def flex_attention_backward_functionalize(
             grad_out_unwrapped,
             functional_fw_graph,  # type: ignore[arg-type]
             functional_joint_graph,  # type: ignore[arg-type]
-            sparse_mask_kv_num_blocks_unwrapped,
-            sparse_mask_kv_indices_unwrapped,
-            sparse_mask_q_num_blocks_unwrapped,
-            sparse_mask_q_indices_unwrapped,
-            BLOCKSPARSE_KV,
-            BLOCKSPARSE_Q,
+            sparse_kv_num_blocks_unwrapped,
+            sparse_kv_indices_unwrapped,
+            sparse_q_num_blocks_unwrapped,
+            sparse_q_indices_unwrapped,
+            SPARSE_KV_BLOCK_SIZE,
+            SPARSE_Q_BLOCK_SIZE,
             *other_buffers_unwrapped,
         )
 
@@ -941,12 +941,12 @@ def flex_attention_backward_fake_tensor_mode(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
-    sparse_mask_kv_num_blocks: torch.Tensor,
-    sparse_mask_kv_indices: torch.Tensor,
-    sparse_mask_q_num_blocks: torch.Tensor,
-    sparse_mask_q_indices: torch.Tensor,
-    BLOCKSPARSE_KV: int,
-    BLOCKSPARSE_Q: int,
+    sparse_kv_num_blocks: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    sparse_q_num_blocks: torch.Tensor,
+    sparse_q_indices: torch.Tensor,
+    SPARSE_KV_BLOCK_SIZE: int,
+    SPARSE_Q_BLOCK_SIZE: int,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     with mode:

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -61,32 +61,46 @@ def index_to_other_buffers(cnt: int, graph_type: SubgraphType) -> int:
         is_joint_graph (bool): Whether or not this subgraph represents the joint graph
     """
     # Current fwd_args = [
-    #   query, key, value, score_mod,
+    #   query,
+    #   key,
+    #   value,
+    #   score_mod,
     #   sparse_mask_kv_num_blocks,
     #   sparse_mask_kv_indices,
     #   sparse_mask_q_num_blocks,
     #   sparse_mask_q_indices,
+    #   BLOCKSPARSE_KV,
+    #   BLOCKSPARSE_Q,
     #   *other_buffers
     # ]
     # For fwd_graphs we have 5 dummy values this when the first lifted args
-    # is seen cnt = 5 and the start of the index_buffers is at args[8]
-    # thus we add 3 from the current cnt
+    # is seen cnt = 5 and the start of the index_buffers is at args[10]
+    # thus we add 5 from the current cnt
     if graph_type == SubgraphType.FWD:
         return cnt + 5
 
     # Current bwd_args = [
-    #   q, k, v, out, lse, grad_out, fw_graph, joint_graph,
+    #   q,
+    #   k,
+    #   v,
+    #   out,
+    #   lse,
+    #   grad_out,
+    #   fw_graph,
+    #   joint_graph,
     #   sparse_mask_kv_num_blocks,
     #   sparse_mask_kv_indices,
     #   sparse_mask_q_num_blocks,
     #   sparse_mask_q_indices,
+    #   BLOCKSPARSE_KV,
+    #   BLOCKSPARSE_Q,
     #   *other_buffers
     # ]
-    # We have 5 dummy values but the start of other_buffers is at index 12
+    # We have 5 dummy values but the start of other_buffers is at index 14
     if graph_type == SubgraphType.JOINT_FWD:
         return cnt + 9
 
-    # Same bwd args but now with 6 dummy values while other_buffers still start at 12
+    # Same bwd args but now with 6 dummy values while other_buffers still start at 14
     if graph_type == SubgraphType.JOINT_BWD:
         return cnt + 8
 

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -60,21 +60,35 @@ def index_to_other_buffers(cnt: int, graph_type: SubgraphType) -> int:
         cnt (int): The current index of the placeholder node
         is_joint_graph (bool): Whether or not this subgraph represents the joint graph
     """
-    # Current fwd_args = [query, key, value, score_mod, *other_buffers]
+    # Current fwd_args = [
+    #   query, key, value, score_mod,
+    #   sparse_mask_kv_num_blocks,
+    #   sparse_mask_kv_indices,
+    #   sparse_mask_q_num_blocks,
+    #   sparse_mask_q_indices,
+    #   *other_buffers
+    # ]
     # For fwd_graphs we have 5 dummy values this when the first lifted args
-    # is seen cnt = 5 and the start of the index_buffers is at args[4]
-    # thus we subtract 1 from the current cnt
+    # is seen cnt = 5 and the start of the index_buffers is at args[8]
+    # thus we add 3 from the current cnt
     if graph_type == SubgraphType.FWD:
-        return cnt - 1
-
-    # Current bwd_args = [q, k, v, out, lse, grad_out, fw_graph, joint_graph, *other_buffers]
-    # We have 5 dummy values but the start of other_buffers is at index 8
-    if graph_type == SubgraphType.JOINT_FWD:
         return cnt + 3
 
-    # Same bwd args but now with 6 dummy values while other_buffers still start at 8
+    # Current bwd_args = [
+    #   q, k, v, out, lse, grad_out, fw_graph, joint_graph,
+    #   sparse_mask_kv_num_blocks,
+    #   sparse_mask_kv_indices,
+    #   sparse_mask_q_num_blocks,
+    #   sparse_mask_q_indices,
+    #   *other_buffers
+    # ]
+    # We have 5 dummy values but the start of other_buffers is at index 12
+    if graph_type == SubgraphType.JOINT_FWD:
+        return cnt + 7
+
+    # Same bwd args but now with 6 dummy values while other_buffers still start at 12
     if graph_type == SubgraphType.JOINT_BWD:
-        return cnt + 2
+        return cnt + 6
 
 
 def build_subgraph_buffer(

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -295,12 +295,10 @@ flex_attention_template = TritonTemplate(
     hi = sparse_kv_num_blocks * BLOCKSPARSE_KV_MULTIPLE
 
     for start_n in range(0, hi):
-        # -- load k, v --
+        # -- load k --
         k = tl.load(K_block_ptr)
-        v = tl.load(V_block_ptr)
         # -- compute qk ---
-        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
-        qk = tl.dot(q, k.to(MATMUL_PRECISION), acc=qk)
+        qk = tl.dot(q, k)
         # ~~~~~~~~~~~~~~~~~~~ Apply score modification  ~~~~~~~~~~~~~~~~~~~
         m = offs_m[:, None]
         n = offs_n[None, :]

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -219,14 +219,21 @@ flex_attention_template = TritonTemplate(
     k_offset = off_z * stride_kz + off_h * stride_kh
     v_offset = off_z * stride_vz + off_h * stride_vh
 
+    SM_Z = {{size("SM_KV_NUM_BLKS", 0)}}
+    SM_H = {{size("SM_KV_NUM_BLKS", 1)}}
+
+    sm_idx_z = off_z % SM_Z
+    sm_idx_h = off_h % SM_H
+
     BLOCKSPARSE_Q_MULTIPLE: tl.constexpr = (BLOCKSPARSE_Q // BLOCK_M)
     BLOCKSPARSE_KV_MULTIPLE: tl.constexpr = (BLOCKSPARSE_KV // BLOCK_N)
 
-    # BLOCKSPARSE_Q_LEN: tl.constexpr = Q_LEN // BLOCKSPARSE_Q
+    BLOCKSPARSE_Q_LEN: tl.constexpr = Q_LEN // BLOCKSPARSE_Q
     BLOCKSPARSE_KV_LEN: tl.constexpr = KV_LEN // BLOCKSPARSE_KV
 
-    indices_offset = (start_m // BLOCKSPARSE_Q_MULTIPLE) * BLOCKSPARSE_KV_LEN
-    block_q_index = start_m // BLOCKSPARSE_Q_MULTIPLE
+    sm_hz_offset = sm_idx_z * SM_H + sm_idx_h
+    indices_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN * BLOCKSPARSE_KV_LEN + (start_m // BLOCKSPARSE_Q_MULTIPLE) * BLOCKSPARSE_KV_LEN
+    block_q_index = sm_hz_offset * BLOCKSPARSE_Q_LEN + start_m // BLOCKSPARSE_Q_MULTIPLE
     kv_indices = SM_KV_IDX + indices_offset
     kv_start = tl.load(kv_indices) * BLOCKSPARSE_KV # first kv block we're loading
     sbm_kv_num_blocks = tl.load(SM_KV_NUM_BLKS + block_q_index)
@@ -335,8 +342,6 @@ flex_attention_template = TritonTemplate(
 
     # Store output and logsumexp
     acc = acc / l_i[:, None]
-    idx_z = tl.program_id(1) // H
-    idx_h = tl.program_id(1) % H
     idx_m = offs_m[:, None]
     idx_d = tl.arange(0, BLOCK_DMODEL)[None, :]
 
@@ -616,6 +621,12 @@ flex_attention_backward_template = TritonTemplate(
     off_z = off_hz // H # batch idx
     off_h = off_hz % H # head idx
 
+    SM_Z = {{size("SM_KV_NUM_BLKS", 0)}}
+    SM_H = {{size("SM_KV_NUM_BLKS", 1)}}
+
+    sm_idx_z = off_z % SM_Z
+    sm_idx_h = off_h % SM_H
+
     off_chz = (off_hz * Q_LEN).to(tl.int64)
     q_adj = (stride_qh * (off_hz % H) + stride_qz * (off_hz // H)).to(tl.int64)
     k_adj = (stride_kh * (off_hz % H) + stride_kz * (off_hz // H)).to(tl.int64)
@@ -640,11 +651,12 @@ flex_attention_backward_template = TritonTemplate(
         BLOCKSPARSE_Q_MULTIPLE = (BLOCKSPARSE_Q // BLOCK_M2)
         BLOCKSPARSE_KV_MULTIPLE = (BLOCKSPARSE_KV // BLOCK_N2)
 
-        # BLOCKSPARSE_Q_LEN = Q_LEN // BLOCKSPARSE_Q
+        BLOCKSPARSE_Q_LEN = Q_LEN // BLOCKSPARSE_Q
         BLOCKSPARSE_KV_LEN = KV_LEN // BLOCKSPARSE_KV
 
-        indices_offset = (off_pid // BLOCKSPARSE_Q_MULTIPLE) * BLOCKSPARSE_KV_LEN
-        block_q_index = off_pid // BLOCKSPARSE_Q_MULTIPLE
+        sm_hz_offset = sm_idx_z * SM_H + sm_idx_h
+        indices_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN * BLOCKSPARSE_KV_LEN + (off_pid // BLOCKSPARSE_Q_MULTIPLE) * BLOCKSPARSE_KV_LEN
+        block_q_index = sm_hz_offset * BLOCKSPARSE_Q_LEN + off_pid // BLOCKSPARSE_Q_MULTIPLE
         kv_indices = SM_KV_IDX + indices_offset
         kv_start = tl.load(kv_indices) * BLOCKSPARSE_KV # first kv block we're loading
         sbm_kv_num_blocks = tl.load(SM_KV_NUM_BLKS + block_q_index)
@@ -739,8 +751,9 @@ flex_attention_backward_template = TritonTemplate(
         BLOCKSPARSE_Q_LEN = Q_LEN // BLOCKSPARSE_Q
         BLOCKSPARSE_KV_LEN = KV_LEN // BLOCKSPARSE_KV
 
-        indices_offset = (pid // BLOCKSPARSE_KV_MULTIPLE) * BLOCKSPARSE_Q_LEN
-        block_kv_index = pid // BLOCKSPARSE_KV_MULTIPLE
+        sm_hz_offset = sm_idx_z * SM_H + sm_idx_h
+        indices_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN * BLOCKSPARSE_KV_LEN + (pid // BLOCKSPARSE_KV_MULTIPLE) * BLOCKSPARSE_Q_LEN
+        block_kv_index = sm_hz_offset * BLOCKSPARSE_KV_LEN + pid // BLOCKSPARSE_KV_MULTIPLE
         q_indices = SM_Q_IDX + indices_offset
         q_start = tl.load(q_indices) * BLOCKSPARSE_Q # first q block we're loading
         sbm_q_num_blocks = tl.load(SM_Q_NUM_BLKS + block_kv_index)

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -356,6 +356,8 @@ flex_attention_template = TritonTemplate(
 
     # Store output and logsumexp
     acc = acc / l_i[:, None]
+    idx_z = tl.program_id(1) // H
+    idx_h = tl.program_id(1) % H
     idx_m = offs_m[:, None]
     idx_d = tl.arange(0, BLOCK_DMODEL)[None, :]
 

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -248,7 +248,7 @@ flex_attention_template = TritonTemplate(
     # SM_KV_IDX and SM_KV_NUM_BLKS are always contiguous.
     sm_hz_offset = sm_idx_z * SM_H + sm_idx_h
     sm_kv_num_blks_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN + start_m // BLOCKSPARSE_Q_MULTIPLE
-    sm_kv_idx_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN * BLOCKSPARSE_KV_LEN + (start_m // BLOCKSPARSE_Q_MULTIPLE) * BLOCKSPARSE_KV_LEN
+    sm_kv_idx_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN * BLOCKSPARSE_KV_LEN + (start_m // BLOCKSPARSE_Q_MULTIPLE) * BLOCKSPARSE_KV_LEN  # noqa: B950
     kv_indices = SM_KV_IDX + sm_kv_idx_offset
     kv_start = tl.load(kv_indices) * BLOCKSPARSE_KV # first kv block we're loading
     sm_kv_num_blocks = tl.load(SM_KV_NUM_BLKS + sm_kv_num_blks_offset)
@@ -673,7 +673,7 @@ flex_attention_backward_template = TritonTemplate(
         # SM_KV_IDX and SM_KV_NUM_BLKS are always contiguous.
         sm_hz_offset = sm_idx_z * SM_H + sm_idx_h
         sm_kv_num_blks_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN + off_pid // BLOCKSPARSE_Q_MULTIPLE
-        sm_kv_idx_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN * BLOCKSPARSE_KV_LEN + (off_pid // BLOCKSPARSE_Q_MULTIPLE) * BLOCKSPARSE_KV_LEN
+        sm_kv_idx_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN * BLOCKSPARSE_KV_LEN + (off_pid // BLOCKSPARSE_Q_MULTIPLE) * BLOCKSPARSE_KV_LEN  # noqa: B950
         kv_indices = SM_KV_IDX + sm_kv_idx_offset
         kv_start = tl.load(kv_indices) * BLOCKSPARSE_KV # first kv block we're loading
         sm_kv_num_blocks = tl.load(SM_KV_NUM_BLKS + sm_kv_num_blks_offset)
@@ -771,7 +771,7 @@ flex_attention_backward_template = TritonTemplate(
         # SM_Q_IDX and SM_Q_NUM_BLKS are always contiguous.
         sm_hz_offset = sm_idx_z * SM_H + sm_idx_h
         sm_q_num_blks_offset = sm_hz_offset * BLOCKSPARSE_KV_LEN + pid // BLOCKSPARSE_KV_MULTIPLE
-        sm_q_idx_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN * BLOCKSPARSE_KV_LEN + (pid // BLOCKSPARSE_KV_MULTIPLE) * BLOCKSPARSE_Q_LEN
+        sm_q_idx_offset = sm_hz_offset * BLOCKSPARSE_Q_LEN * BLOCKSPARSE_KV_LEN + (pid // BLOCKSPARSE_KV_MULTIPLE) * BLOCKSPARSE_Q_LEN  # noqa: B950
         q_indices = SM_Q_IDX + sm_q_idx_offset
         q_start = tl.load(q_indices) * BLOCKSPARSE_Q # first q block we're loading
         sm_q_num_blocks = tl.load(SM_Q_NUM_BLKS + sm_q_num_blks_offset)

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -532,7 +532,14 @@ def flex_attention(*args, **kwargs):
             BLOCKSPARSE_Q=BLOCKSPARSE_Q,
             BLOCKSPARSE_KV=BLOCKSPARSE_KV,
         )
-    inputs_for_autotuning = [query, key, value, logsumexp] + list(other_buffers)
+    inputs_for_autotuning = [
+        query,
+        key,
+        value,
+        logsumexp,
+        sparse_mask_kv_num_blocks,
+        sparse_mask_kv_indices,
+    ] + list(other_buffers)
     return (
         autotune_select_algorithm(
             "flex_attention", choices, inputs_for_autotuning, layout
@@ -984,6 +991,10 @@ def flex_attention_backward(*args, **kwargs):
         grad_out,
         grad_query,
         grad_value,
+        sparse_mask_kv_num_blocks,
+        sparse_mask_kv_indices,
+        sparse_mask_q_num_blocks,
+        sparse_mask_q_indices,
     ] + list(other_buffers)
 
     grad_key = autotune_select_algorithm(

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -438,7 +438,15 @@ def flex_attention(*args, **kwargs):
         sparse_mask_q_indices,
         *other_buffers,
     ) = args
-    for buf in [query, key, value]:
+    for buf in [
+        query,
+        key,
+        value,
+        sparse_mask_kv_num_blocks,
+        sparse_mask_kv_indices,
+        sparse_mask_q_num_blocks,
+        sparse_mask_q_indices,
+    ]:
         buf.realize()
     placeholder_inps = [
         create_placeholder(name, dtype, query.get_device())
@@ -850,7 +858,16 @@ def flex_attention_backward(*args, **kwargs):
         sparse_mask_q_indices,
         *other_buffers,
     ) = args
-    for buf in [query, key, value, grad_out]:
+    for buf in [
+        query,
+        key,
+        value,
+        grad_out,
+        sparse_mask_kv_num_blocks,
+        sparse_mask_kv_indices,
+        sparse_mask_q_num_blocks,
+        sparse_mask_q_indices,
+    ]:
         buf.realize()
 
     device = query.get_device()

--- a/torch/nn/attention/_flex_attention.py
+++ b/torch/nn/attention/_flex_attention.py
@@ -39,11 +39,69 @@ def _identity(
     return score
 
 
+class _SparseBlockMask:
+    kv_num_blocks: torch.Tensor
+    kv_indices: torch.Tensor
+    q_num_blocks: torch.Tensor
+    q_indices: torch.Tensor
+
+    def __init__(
+        self,
+        kv_num_blocks,
+        kv_indices,
+        q_num_blocks,
+        q_indices,
+    ):
+        self.kv_num_blocks = kv_num_blocks
+        self.kv_indices = kv_indices
+        self.q_num_blocks = q_num_blocks
+        self.q_indices = q_indices
+
+
+def _create_sparse_block_mask(
+    mask: torch.Tensor,
+    q_block_size: int,
+    kv_block_size: int,
+):
+    assert mask.dtype == torch.bool
+    q_len, kv_len = mask.shape
+    assert q_len % q_block_size == 0
+    assert kv_len % kv_block_size == 0
+    mask = mask.view(
+        q_len // q_block_size, q_block_size, kv_len // kv_block_size, kv_block_size
+    )
+
+    mask = mask.permute(0, 2, 1, 3)
+    block_mask = (mask.sum(dim=[-2, -1]) > 0).to("cpu")
+    kv_num_blocks = block_mask.sum(dim=1)
+    kv_indices = torch.argsort(block_mask, dim=1, descending=True, stable=True)
+    # kv_indices = torch.concat([kv_indices, kv_indices[:, -1][:, None]], dim=1)
+    q_num_blocks = block_mask.sum(dim=0)
+    q_indices = torch.argsort(block_mask, dim=0, descending=True, stable=True).t()
+    # q_indices = torch.concat([q_indices, q_indices[:, -1][:, None]], dim=1)
+    return _SparseBlockMask(
+        kv_num_blocks=kv_num_blocks.to(torch.int32).to(mask.device).contiguous(),
+        kv_indices=kv_indices.to(torch.int32).to(mask.device).contiguous(),
+        q_num_blocks=q_num_blocks.to(torch.int32).to(mask.device).contiguous(),
+        q_indices=q_indices.to(torch.int32).to(mask.device).contiguous(),
+    )
+
+
+def _create_empty_sparse_block_mask(device):
+    return _SparseBlockMask(
+        kv_num_blocks=torch.ones([1], dtype=torch.int32, device=device),
+        kv_indices=torch.zeros([1, 1], dtype=torch.int32, device=device),
+        q_num_blocks=torch.ones([1], dtype=torch.int32, device=device),
+        q_indices=torch.zeros([1, 1], dtype=torch.int32, device=device),
+    )
+
+
 def _flex_attention(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: _score_mod_signature = _identity,
+    sparse_block_mask: _SparseBlockMask = None,
 ) -> torch.Tensor:
     r"""This function implements scaled dot product attention with an arbitrary attention score modification function.
 
@@ -93,11 +151,22 @@ def _flex_attention(
 
     """
 
+    if sparse_block_mask is None:
+        sparse_block_mask = _create_empty_sparse_block_mask(query.device)
     if torch.compiler.is_dynamo_compiling():
         # mark head_dim always to be static
         for x in [query, key, value]:
             torch._dynamo.mark_static(x, -1)
-        out, _ = flex_attention_hop(query, key, value, score_mod)
+        out, _ = flex_attention_hop(
+            query,
+            key,
+            value,
+            score_mod,
+            sparse_block_mask.kv_num_blocks,
+            sparse_block_mask.kv_indices,
+            sparse_block_mask.q_num_blocks,
+            sparse_block_mask.q_indices,
+        )
         return out
 
     # Some basic input validation
@@ -113,7 +182,16 @@ def _flex_attention(
             with _temp_remove_pre_dispatch_torch_function_mode():
                 out, _ = torch.compile(
                     flex_attention_hop, backend="eager", fullgraph=True
-                )(query, key, value, score_mod)
+                )(
+                    query,
+                    key,
+                    value,
+                    score_mod,
+                    sparse_block_mask.kv_num_blocks,
+                    sparse_block_mask.kv_indices,
+                    sparse_block_mask.q_num_blocks,
+                    sparse_block_mask.q_indices,
+                )
                 return out
 
 

--- a/torch/nn/attention/_flex_attention.py
+++ b/torch/nn/attention/_flex_attention.py
@@ -69,8 +69,8 @@ class _BlockSparseMask:
 
 def _create_block_sparse_mask(
     mask: torch.Tensor,
-    BLOCKSPARSE_Q: int = _DEFAULT_BLOCKSPARSE_SIZE,
     BLOCKSPARSE_KV: int = _DEFAULT_BLOCKSPARSE_SIZE,
+    BLOCKSPARSE_Q: int = _DEFAULT_BLOCKSPARSE_SIZE,
 ):
     assert mask.dtype == torch.bool
     q_len, kv_len = mask.shape

--- a/torch/nn/attention/_flex_attention.py
+++ b/torch/nn/attention/_flex_attention.py
@@ -39,7 +39,7 @@ def _identity(
     return score
 
 
-_DEFAULT_BLOCKSPARSE_SIZE = 128
+_DEFAULT_SPARSE_BLOCK_SIZE = 128
 
 
 class _BlockSparseMask:
@@ -47,8 +47,8 @@ class _BlockSparseMask:
     kv_indices: torch.Tensor
     q_num_blocks: torch.Tensor
     q_indices: torch.Tensor
-    BLOCKSPARSE_KV: int
-    BLOCKSPARSE_Q: int
+    KV_BLOCK_SIZE: int
+    Q_BLOCK_SIZE: int
 
     def __init__(
         self,
@@ -56,15 +56,15 @@ class _BlockSparseMask:
         kv_indices,
         q_num_blocks,
         q_indices,
-        BLOCKSPARSE_KV=_DEFAULT_BLOCKSPARSE_SIZE,
-        BLOCKSPARSE_Q=_DEFAULT_BLOCKSPARSE_SIZE,
+        KV_BLOCK_SIZE=_DEFAULT_SPARSE_BLOCK_SIZE,
+        Q_BLOCK_SIZE=_DEFAULT_SPARSE_BLOCK_SIZE,
     ):
         self.kv_num_blocks = kv_num_blocks
         self.kv_indices = kv_indices
         self.q_num_blocks = q_num_blocks
         self.q_indices = q_indices
-        self.BLOCKSPARSE_KV = BLOCKSPARSE_KV
-        self.BLOCKSPARSE_Q = BLOCKSPARSE_Q
+        self.KV_BLOCK_SIZE = KV_BLOCK_SIZE
+        self.Q_BLOCK_SIZE = Q_BLOCK_SIZE
 
 
 def broadcast_to_dim(x, dim):
@@ -75,45 +75,45 @@ def broadcast_to_dim(x, dim):
 
 def _convert_mask_to_block_mask(
     mask,
-    BLOCKSPARSE_KV=_DEFAULT_BLOCKSPARSE_SIZE,
-    BLOCKSPARSE_Q=_DEFAULT_BLOCKSPARSE_SIZE,
+    KV_BLOCK_SIZE=_DEFAULT_SPARSE_BLOCK_SIZE,
+    Q_BLOCK_SIZE=_DEFAULT_SPARSE_BLOCK_SIZE,
 ):
     assert mask.dtype == torch.bool
     mask = broadcast_to_dim(mask, 4)
     B, H, Q, KV = mask.shape
-    assert Q % BLOCKSPARSE_Q == 0
-    assert KV % BLOCKSPARSE_KV == 0
+    assert Q % Q_BLOCK_SIZE == 0
+    assert KV % KV_BLOCK_SIZE == 0
     mask = mask.view(
-        B, H, Q // BLOCKSPARSE_Q, BLOCKSPARSE_Q, KV // BLOCKSPARSE_KV, BLOCKSPARSE_KV
-    )  # [B, H, Q//BLOCKSPARSE_Q, BLOCKSPARSE_Q, KV//BLOCKSPARSE_KV, BLOCKSPARSE_KV]
+        B, H, Q // Q_BLOCK_SIZE, Q_BLOCK_SIZE, KV // KV_BLOCK_SIZE, KV_BLOCK_SIZE
+    )  # [B, H, Q//Q_BLOCK_SIZE, Q_BLOCK_SIZE, KV//KV_BLOCK_SIZE, KV_BLOCK_SIZE]
     mask = mask.permute(
         0, 1, 2, 4, 3, 5
-    )  # [B, H, Q//BLOCKSPARSE_Q, KV//BLOCKSPARSE_KV, BLOCKSPARSE_Q, BLOCKSPARSE_KV]
-    mask = mask.sum(dim=[-2, -1]) > 0  # [B, H, Q//BLOCKSPARSE_Q, KV//BLOCKSPARSE_KV]
+    )  # [B, H, Q//Q_BLOCK_SIZE, KV//KV_BLOCK_SIZE, Q_BLOCK_SIZE, KV_BLOCK_SIZE]
+    mask = mask.sum(dim=[-2, -1]) > 0  # [B, H, Q//Q_BLOCK_SIZE, KV//KV_BLOCK_SIZE]
     return mask
 
 
 def _convert_block_mask_to_mask(
     block_mask,
-    BLOCKSPARSE_KV=_DEFAULT_BLOCKSPARSE_SIZE,
-    BLOCKSPARSE_Q=_DEFAULT_BLOCKSPARSE_SIZE,
+    KV_BLOCK_SIZE=_DEFAULT_SPARSE_BLOCK_SIZE,
+    Q_BLOCK_SIZE=_DEFAULT_SPARSE_BLOCK_SIZE,
 ):
     assert block_mask.dim() == 4
     B, H, Q, KV = block_mask.shape
-    block_mask = block_mask.expand(BLOCKSPARSE_Q, BLOCKSPARSE_KV, *block_mask.shape)
+    block_mask = block_mask.expand(Q_BLOCK_SIZE, KV_BLOCK_SIZE, *block_mask.shape)
     block_mask = block_mask.permute(2, 3, 4, 0, 5, 1).reshape(
-        B, H, Q * BLOCKSPARSE_Q, KV * BLOCKSPARSE_KV
+        B, H, Q * Q_BLOCK_SIZE, KV * KV_BLOCK_SIZE
     )
     return block_mask
 
 
 def _create_block_sparse_mask(
     mask: torch.Tensor,
-    BLOCKSPARSE_KV: int = _DEFAULT_BLOCKSPARSE_SIZE,
-    BLOCKSPARSE_Q: int = _DEFAULT_BLOCKSPARSE_SIZE,
+    KV_BLOCK_SIZE: int = _DEFAULT_SPARSE_BLOCK_SIZE,
+    Q_BLOCK_SIZE: int = _DEFAULT_SPARSE_BLOCK_SIZE,
 ):
     block_mask = _convert_mask_to_block_mask(
-        mask, BLOCKSPARSE_KV=BLOCKSPARSE_KV, BLOCKSPARSE_Q=BLOCKSPARSE_Q
+        mask, KV_BLOCK_SIZE=KV_BLOCK_SIZE, Q_BLOCK_SIZE=Q_BLOCK_SIZE
     )
     block_mask = block_mask.to(dtype=torch.int8)
     kv_num_blocks = block_mask.sum(dim=3)
@@ -127,8 +127,8 @@ def _create_block_sparse_mask(
         kv_indices=kv_indices.to(torch.int32).to(mask.device).contiguous(),
         q_num_blocks=q_num_blocks.to(torch.int32).to(mask.device).contiguous(),
         q_indices=q_indices.to(torch.int32).to(mask.device).contiguous(),
-        BLOCKSPARSE_KV=BLOCKSPARSE_KV,
-        BLOCKSPARSE_Q=BLOCKSPARSE_Q,
+        KV_BLOCK_SIZE=KV_BLOCK_SIZE,
+        Q_BLOCK_SIZE=Q_BLOCK_SIZE,
     )
 
 
@@ -149,8 +149,8 @@ def _create_empty_block_sparse_mask(query, key, value):
         kv_indices=torch.zeros([1, 1, 1, 1], dtype=torch.int32, device=device),
         q_num_blocks=torch.ones([1, 1, 1], dtype=torch.int32, device=device),
         q_indices=torch.zeros([1, 1, 1, 1], dtype=torch.int32, device=device),
-        BLOCKSPARSE_KV=kv_len,
-        BLOCKSPARSE_Q=q_len,
+        KV_BLOCK_SIZE=kv_len,
+        Q_BLOCK_SIZE=q_len,
     )
 
 
@@ -224,8 +224,8 @@ def _flex_attention(
             block_sparse_mask.kv_indices,
             block_sparse_mask.q_num_blocks,
             block_sparse_mask.q_indices,
-            block_sparse_mask.BLOCKSPARSE_KV,
-            block_sparse_mask.BLOCKSPARSE_Q,
+            block_sparse_mask.KV_BLOCK_SIZE,
+            block_sparse_mask.Q_BLOCK_SIZE,
         )
         return out
 
@@ -251,8 +251,8 @@ def _flex_attention(
                     block_sparse_mask.kv_indices,
                     block_sparse_mask.q_num_blocks,
                     block_sparse_mask.q_indices,
-                    block_sparse_mask.BLOCKSPARSE_KV,
-                    block_sparse_mask.BLOCKSPARSE_Q,
+                    block_sparse_mask.KV_BLOCK_SIZE,
+                    block_sparse_mask.Q_BLOCK_SIZE,
                 )
                 return out
 

--- a/torch/nn/attention/_flex_attention.py
+++ b/torch/nn/attention/_flex_attention.py
@@ -132,6 +132,14 @@ def _create_block_sparse_mask(
     )
 
 
+"""
+    The flex attention kernels are implemented using block sparsity,
+    where only the unmasked blocks are computed to get the best perf.
+    If users don't specify any block sparse mask info, we create this
+    empty block sparse mask with all blocks unmasked as the default one.
+"""
+
+
 def _create_empty_block_sparse_mask(query, key, value):
     device = query.device
     kv_len = key.size()[-2]

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -235,6 +235,8 @@ hop_db = [
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_pre_dispatch_export"),
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_serialize_export"),
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_retrace_export"),
+            DecorateInfo(unittest.expectedFailure, "TestProxyTensorOpInfo", "test_make_fx_symbolic_exhaustive"),
+            DecorateInfo(unittest.expectedFailure, "TestEagerFusionOpInfo", "test_aot_autograd_symbolic_exhaustive"),
         )
     ),
     OpInfo(
@@ -253,6 +255,8 @@ hop_db = [
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_pre_dispatch_export"),
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_serialize_export"),
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_retrace_export"),
+            DecorateInfo(unittest.expectedFailure, "TestProxyTensorOpInfo", "test_make_fx_symbolic_exhaustive"),
+            DecorateInfo(unittest.expectedFailure, "TestEagerFusionOpInfo", "test_aot_autograd_symbolic_exhaustive"),
         )
     )
 ]

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -10,6 +10,7 @@ from torch.testing._internal.opinfo.core import (
     SampleInput,
 )
 from torch.testing._internal.common_dtype import all_types_and, custom_types
+from torch.testing._internal.common_utils import IS_WINDOWS
 from torch.testing._internal.opinfo.core import DecorateInfo
 from torch.nn.attention._flex_attention import _flex_attention
 
@@ -235,9 +236,19 @@ hop_db = [
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_pre_dispatch_export"),
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_serialize_export"),
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_retrace_export"),
-            DecorateInfo(unittest.expectedFailure, "TestProxyTensorOpInfo", "test_make_fx_symbolic_exhaustive"),
-            DecorateInfo(unittest.expectedFailure, "TestEagerFusionOpInfo", "test_aot_autograd_symbolic_exhaustive"),
-        )
+            DecorateInfo(
+                unittest.expectedFailure,
+                "TestProxyTensorOpInfo",
+                "test_make_fx_symbolic_exhaustive",
+                active_if=not IS_WINDOWS,
+            ),
+            DecorateInfo(
+                unittest.expectedFailure,
+                "TestEagerFusionOpInfo",
+                "test_aot_autograd_symbolic_exhaustive",
+                active_if=not IS_WINDOWS,
+            ),
+        ),
     ),
     OpInfo(
         name="flex_attention_backward",
@@ -255,8 +266,18 @@ hop_db = [
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_pre_dispatch_export"),
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_serialize_export"),
             DecorateInfo(unittest.expectedFailure, "TestHOP", "test_retrace_export"),
-            DecorateInfo(unittest.expectedFailure, "TestProxyTensorOpInfo", "test_make_fx_symbolic_exhaustive"),
-            DecorateInfo(unittest.expectedFailure, "TestEagerFusionOpInfo", "test_aot_autograd_symbolic_exhaustive"),
-        )
+            DecorateInfo(
+                unittest.expectedFailure,
+                "TestProxyTensorOpInfo",
+                "test_make_fx_symbolic_exhaustive",
+                active_if=not IS_WINDOWS,
+            ),
+            DecorateInfo(
+                unittest.expectedFailure,
+                "TestEagerFusionOpInfo",
+                "test_aot_autograd_symbolic_exhaustive",
+                active_if=not IS_WINDOWS,
+            ),
+        ),
     )
 ]


### PR DESCRIPTION
Benchmark script (causal mask): https://gist.github.com/yanboliang/c2010a1fd081d4e8ca94fadec9eef286
Initial perf number:
* fwd speedup: 0.44 -> 0.72
* bwd speedup: 0.38 -> 0.71

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang