### PR TITLE
[codemod][lowrisk] Remove unused exception parameter from pytorch/genai-stable-import-prototype/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -198,7 +198,7 @@ class UvTcpServer : public UvTcpSocket {
           uv_strerror(uv_res));
 
       res->cacheSocketPort();
-    } catch (std::exception& ex) {
+    } catch (std::exception&) {
       res->close();
       throw;
     }
@@ -265,7 +265,7 @@ class UvTcpServer : public UvTcpSocket {
           uv_strerror(uv_res));
 
       res->cacheSocketPort();
-    } catch (std::exception& ex) {
+    } catch (std::exception&) {
       res->close();
       throw;
     }

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -320,7 +320,7 @@ void PyRRef::backwardOwnerRRef(
     py::object obj = torch::jit::toPyObject(value);
     try {
       value = torch::jit::toIValue(obj, c10::TensorType::get());
-    } catch (py::cast_error& e) {
+    } catch (py::cast_error&) {
       TORCH_CHECK(false, "RRef should contain a tensor for .backward()");
     }
   }

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -86,7 +86,7 @@ std::shared_ptr<Operator> matchBuiltinOp(
         opWithStack;
     try {
       opWithStack = torch::jit::getOpWithStack(c10OpsForSymbol, args, kwargs);
-    } catch (const std::runtime_error& e) {
+    } catch (const std::runtime_error&) {
       opWithStack = torch::jit::getOpWithStack(ops, args, kwargs);
     }
     matchedOperator = std::get<0>(opWithStack);
@@ -172,7 +172,7 @@ c10::intrusive_ptr<JitFuture> toPyJitFuture(
               e.restore();
               PyErr_Clear();
               return;
-            } catch (std::exception& e) {
+            } catch (std::exception&) {
               child->setErrorIfNeeded(std::current_exception());
               return;
             }

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -120,7 +120,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::runPythonFunction(
     e.restore();
     PyErr_Clear();
     return future;
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     return asFuture(std::current_exception());
   }
 

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -192,10 +192,10 @@ std::optional<c10::Device> SchemaTypeParser::tryToParseDeviceType() {
       std::string::size_type num_len;
       try {
         device_idx = std::stoi(num, &num_len);
-      } catch (const std::invalid_argument& e) {
+      } catch (const std::invalid_argument&) {
         throw ErrorReport(L.cur())
             << "Device index cannot be converted to integer";
-      } catch (const std::out_of_range& e) {
+      } catch (const std::out_of_range&) {
         throw ErrorReport(L.cur()) << "Device index is too long";
       }
     }
@@ -217,10 +217,10 @@ std::optional<bool> SchemaTypeParser::tryToParseRequiresGrad() {
 
   try {
     return (bool)std::stoi(num, &num_len);
-  } catch (const std::invalid_argument& e) {
+  } catch (const std::invalid_argument&) {
     throw ErrorReport(L.cur())
         << "Field requires_grad cannot be converted to integer";
-  } catch (const std::out_of_range& e) {
+  } catch (const std::out_of_range&) {
     throw ErrorReport(L.cur()) << "Field requires_grad is too long";
   }
 }
@@ -278,10 +278,10 @@ TypePtr SchemaTypeParser::parseRefinedTensor() {
           try {
             auto stride = std::stoll(num, &num_len);
             strides.push_back(stride);
-          } catch (const std::invalid_argument& e) {
+          } catch (const std::invalid_argument&) {
             throw ErrorReport(L.cur())
                 << "The stride value cannot be converted to int";
-          } catch (const std::out_of_range& e) {
+          } catch (const std::out_of_range&) {
             throw ErrorReport(L.cur()) << "The stride is too big";
           }
         });
@@ -317,9 +317,9 @@ TypePtr SchemaTypeParser::parseRefinedTensor() {
     int64_t dim = 0;
     try {
       dim = std::stoll(num, &num_len);
-    } catch (const std::invalid_argument& e) {
+    } catch (const std::invalid_argument&) {
       throw ErrorReport(L.cur()) << "The number can't be converted to int";
-    } catch (const std::out_of_range& e) {
+    } catch (const std::out_of_range&) {
       throw ErrorReport(L.cur()) << "Number is too big";
     }
     if (shape_symbol) {

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -195,10 +195,10 @@ ParsedLiteral IRParser::parseScalarLiteral(Node* n) {
         double imag = 0.0f;
         try {
           imag = std::stod(str.substr(0, str.size() - 1));
-        } catch (const std::invalid_argument& e) {
+        } catch (const std::invalid_argument&) {
           throw ErrorReport(token.range)
               << "Number cannot be converted to double";
-        } catch (const std::out_of_range& e) {
+        } catch (const std::out_of_range&) {
           throw ErrorReport(token.range)
               << "Number is too long to be represented in type double";
         }
@@ -209,10 +209,10 @@ ParsedLiteral IRParser::parseScalarLiteral(Node* n) {
         r.k = AttributeKind::f;
         try {
           r.f = std::stod(str);
-        } catch (const std::invalid_argument& e) {
+        } catch (const std::invalid_argument&) {
           throw ErrorReport(token.range)
               << "Number cannot be converted to double";
-        } catch (const std::out_of_range& e) {
+        } catch (const std::out_of_range&) {
           throw ErrorReport(token.range)
               << "Number is too long to be represented in type double";
         }
@@ -220,10 +220,10 @@ ParsedLiteral IRParser::parseScalarLiteral(Node* n) {
         r.k = AttributeKind::i;
         try {
           r.i = std::stoll(str);
-        } catch (const std::invalid_argument& e) {
+        } catch (const std::invalid_argument&) {
           throw ErrorReport(token.range)
               << "Number cannot be converted to integer";
-        } catch (const std::out_of_range& e) {
+        } catch (const std::out_of_range&) {
           throw ErrorReport(token.range) << "Number is too big";
         }
       }

--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -414,7 +414,7 @@ std::unique_ptr<mobile::Function> FlatbufferLoader::parseFunction(
           false /*is_varret*/);
 
       function->setSchema(std::move(schema));
-    } catch (const c10::Error& e) {
+    } catch (const c10::Error&) {
     }
   }
   return function;

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -178,7 +178,7 @@ std::shared_ptr<Graph> ToONNX(
         operator_export_type,
         env,
         values_in_env);
-  } catch (std::runtime_error& ex) {
+  } catch (std::runtime_error&) {
     ONNX_LOG(
         "ONNX graph being constructed during exception:\n",
         new_graph->toString());
@@ -446,7 +446,7 @@ void NodeToONNX(
       } else {
         outputs = py::cast<std::vector<Value*>>(raw_output);
       }
-    } catch (const std::exception& ex) {
+    } catch (const std::exception&) {
       std::ostringstream ss;
       ss << "Error casting results of symbolic for " << op_name
          << ": expected to return list of op nodes, instead received type ''"

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -61,7 +61,7 @@ void PropertyPropBase::propagateBlock(Block* block, bool insert_expands) {
   for (Node* node : block->nodes()) {
     try {
       propagateNode(node, insert_expands);
-    } catch (propagation_error& e) {
+    } catch (propagation_error&) {
       setUnshapedType(node);
     } catch (std::exception& e) {
       throw ErrorReport(node->sourceRange())

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -156,7 +156,7 @@ std::optional<IValue> toTypeInferredIValueOptional(py::handle input) {
   // on various object types, but we want it to work with all types.
   try {
     return toTypeInferredIValue(input);
-  } catch (const c10::Error& e) {
+  } catch (const c10::Error&) {
     return c10::nullopt;
   }
 }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Test Plan: Sandcastle

Reviewed By: dmm-fb

Differential Revision: D58830985


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang