### PR TITLE
[Memory Snapshot] Make recordAnnotations callback initialize lazily

### DIFF
--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <string>
 #include <utility>
 
 #include <c10/core/Device.h>

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -1,4 +1,5 @@
 #include <ATen/Context.h>
+#include <ATen/record_function.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <torch/csrc/cuda/memory_snapshot.h>
 #include <torch/csrc/jit/runtime/interpreter.h>
@@ -96,6 +97,34 @@ CapturedTraceback* getFromContext(
       "attempting to gather stack context from the wrong StackContext type.");
 }
 
+void _initRecordAnnotations() {
+  static c10::once_flag ra_init;
+  c10::call_once(ra_init, [&] {
+    // Save user annotations to CCA memory snapshot tool
+    at::addThreadLocalCallback(at::RecordFunctionCallback(
+        [](const at::RecordFunction& fn)
+            -> std::unique_ptr<at::ObserverContext> {
+          if (fn.scope() != at::RecordScope::USER_SCOPE) {
+            return nullptr; // only record user-defined scopes.
+          }
+          unwind::Frame frame{fn.name(), "START", 0};
+          auto r = std::make_shared<CapturedTraceback>();
+          r->recordUserDefinedFrame(frame);
+          c10::cuda::CUDACachingAllocator::recordAnnotation(r);
+          return nullptr;
+        },
+        [](const at::RecordFunction& fn, at::ObserverContext* ctx_ptr) {
+          if (fn.scope() != at::RecordScope::USER_SCOPE) {
+            return; // only record user-defined scopes.
+          }
+          unwind::Frame frame{fn.name(), "END", 0};
+          auto r = std::make_shared<CapturedTraceback>();
+          r->recordUserDefinedFrame(frame);
+          c10::cuda::CUDACachingAllocator::recordAnnotation(r);
+        }));
+  });
+}
+
 } // namespace
 
 void _record_memory_history(
@@ -117,6 +146,7 @@ void _record_memory_history(
     when = c10::cuda::CUDACachingAllocator::RecordContext::STATE;
   }
   at::globalContext().lazyInitCUDA();
+  _initRecordAnnotations();
   c10::cuda::CUDACachingAllocator::recordHistory(
       enabled, recorder, trace_alloc_max_entries, when);
 }
@@ -167,6 +197,7 @@ void _record_memory_history(
     }
   }
   at::globalContext().lazyInitCUDA();
+  _initRecordAnnotations();
   c10::cuda::CUDACachingAllocator::recordHistory(
       enabled.has_value(), recorder, max_entries, when);
 }


### PR DESCRIPTION
Summary: Make the recordAnnotations' Record function callback lazily initialize when record memory history starts. This will help reduce the impact on Time To First Batch metric.

Test Plan: CI and ran locally.

Differential Revision: D58875576

Pulled By: aaronenyeshi
