### PR TITLE
[BE] Runner determinator: Expect usernames to be prefixed with '@'

### DIFF
--- a/.github/scripts/get_workflow_type.py
+++ b/.github/scripts/get_workflow_type.py
@@ -51,7 +51,9 @@ def is_exception_branch(branch: str) -> bool:
 
 
 def get_workflow_type(issue: Issue, username: str) -> Tuple[str, str]:
-    formatted_username = "@" + username # Add the @ symbol to match the format in the issue body
+    formatted_username = (
+        "@" + username
+    )  # Add the @ symbol to match the format in the issue body
 
     try:
         user_list = issue.get_comments()[0].body.split()

--- a/.github/scripts/get_workflow_type.py
+++ b/.github/scripts/get_workflow_type.py
@@ -51,6 +51,8 @@ def is_exception_branch(branch: str) -> bool:
 
 
 def get_workflow_type(issue: Issue, username: str) -> Tuple[str, str]:
+    formatted_username = "@" + username # Add the @ symbol to match the format in the issue body
+
     try:
         user_list = issue.get_comments()[0].body.split()
 
@@ -60,7 +62,7 @@ def get_workflow_type(issue: Issue, username: str) -> Tuple[str, str]:
         elif user_list[0] == "*":
             MESSAGE = "LF Workflows are enabled for everyone. Using LF runners."
             return WORKFLOW_LABEL_LF, MESSAGE
-        elif username in user_list:
+        elif formatted_username in user_list:
             MESSAGE = f"LF Workflows are enabled for {username}. Using LF runners."
             return WORKFLOW_LABEL_LF, MESSAGE
         else:

--- a/.github/scripts/get_workflow_type.py
+++ b/.github/scripts/get_workflow_type.py
@@ -52,8 +52,8 @@ def is_exception_branch(branch: str) -> bool:
 
 def get_workflow_type(issue: Issue, username: str) -> Tuple[str, str]:
     formatted_username = (
-        "@" + username
-    )  # Add the @ symbol to match the format in the issue body
+        f"@{username}"  # Add the @ symbol to match the format in the issue body
+    )
 
     try:
         user_list = issue.get_comments()[0].body.split()

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -99,6 +99,8 @@ jobs:
 
 
           def get_workflow_type(issue: Issue, username: str) -> Tuple[str, str]:
+              formatted_username = "@" + username # Add the @ symbol to match the format in the issue body
+
               try:
                   user_list = issue.get_comments()[0].body.split()
 
@@ -108,7 +110,7 @@ jobs:
                   elif user_list[0] == "*":
                       MESSAGE = "LF Workflows are enabled for everyone. Using LF runners."
                       return WORKFLOW_LABEL_LF, MESSAGE
-                  elif username in user_list:
+                  elif formatted_username in user_list:
                       MESSAGE = f"LF Workflows are enabled for {username}. Using LF runners."
                       return WORKFLOW_LABEL_LF, MESSAGE
                   else:

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -100,8 +100,8 @@ jobs:
 
           def get_workflow_type(issue: Issue, username: str) -> Tuple[str, str]:
               formatted_username = (
-                  "@" + username
-              )  # Add the @ symbol to match the format in the issue body
+                  f"@{username}"  # Add the @ symbol to match the format in the issue body
+              )
 
               try:
                   user_list = issue.get_comments()[0].body.split()

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -99,7 +99,9 @@ jobs:
 
 
           def get_workflow_type(issue: Issue, username: str) -> Tuple[str, str]:
-              formatted_username = "@" + username # Add the @ symbol to match the format in the issue body
+              formatted_username = (
+                  "@" + username
+              )  # Add the @ symbol to match the format in the issue body
 
               try:
                   user_list = issue.get_comments()[0].body.split()


### PR DESCRIPTION
Expect the username in the runner rollover issue (https://github.com/pytorch/test-infra/issues/5132) to be prefixed with a "@".

This will make typos way less likely since github's autocomplete/autoformating will help out

For now, I've updated the issue to have usernames both with and without the @ while this change rolls out 

Testing:
Ran the script locally on both this issue and a new test issue and verified they both had the expected output:
```
(venv) (base) ➜  ~/pytorch git:(zainr/improve-get-workflow-type) 
python .github/scripts/get_workflow_type.py --github-token github_pat_***  --github-issue 5132 --github-user ZainRizvi --github-branch "zainr/stuff"
{"label_type": "lf.", "message": "LF Workflows are enabled for ZainRizvi. Using LF runners."}
```