### PR TITLE
Have torch_key hash entire torch directory

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -4,7 +4,6 @@ Utils for caching the outputs of AOTAutograd
 """
 from __future__ import annotations
 
-import functools
 import logging
 import os
 import pickle
@@ -25,7 +24,6 @@ from torch._inductor.codecache import (
     FxGraphCache,
     FxGraphCachePickler,
     FxGraphHashDetails,
-    get_code_hash,
     write_atomic,
 )
 
@@ -135,12 +133,6 @@ def check_node_safe(node: Node):
         raise BypassAOTAutogradCache(f"Unsupported node op {node.op}")
 
 
-@functools.lru_cache(None)
-def get_autograd_code_hash():
-    autograd_root = os.path.dirname(__file__)
-    return get_code_hash([autograd_root])
-
-
 def check_cacheable(gm: torch.fx.GraphModule):
     """
     Checks that the graph module only uses supported operators
@@ -180,7 +172,6 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
         self.grad_enabled = torch.is_grad_enabled()
         self.disable_amp = torch._C._is_any_autocast_enabled()
         self.deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
-        self.code_hash = get_autograd_code_hash()
         self.autograd_config = config.save_config()
         try:
             # We don't use FxGraphHashDetails to hash example_inputs because it expects


### PR DESCRIPTION
Summary:
Title. This way, both FXGraphCache and AOTAutogradCache use the same torch_key, and we don't need to only hash specific files. 

There's an argument to be made to only hash *.py and *.cpp files. Maybe we can fix the glob to do that.

We use a buck_filegroup because otherwise $SRCs gets too large. By using `$(location :torch_sources)`, we make the genrule implicitly depend on all files globbed by torch_sources.

Test Plan:
Unit tests still pass on OSS
For torch_key: 

```
buck2 build caffe2:src_hash.txt -v 2 --show-output
```
See the output, then make any change to any torch file. See that the hash changes.

Reviewed By: oulgen

Differential Revision: D58875785




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang