### PR TITLE
Inductor to fail gracefully on Voltas for bf16 tensors

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1634,26 +1634,29 @@ def handle_dynamo_export_graph(
 def _check_triton_bf16_support(graph: GraphLowering) -> None:
     def warn_and_skip(device) -> None:
         from torch._dynamo.exc import SkipFrame
+
         device_props = torch.cuda.get_device_properties(device)
-        warnings.warn(f"{device_props.name} does not support bfloat16 compilation natively, skipping")
+        warnings.warn(
+            f"{device_props.name} does not support bfloat16 compilation natively, skipping"
+        )
         raise SkipFrame("BF16 is not supported")
 
     for inp in graph.graph_inputs.values():
-       device = getattr(inp, "get_device", lambda: torch.device("meta"))()
-       if device.type != "cuda" or inp.get_dtype() != torch.bfloat16:
-           continue
-       # Print warning and skip frame if attempting to compile for bfloat16
-       # on device without hardware support for dtype
-       if torch.cuda.is_bf16_supported(including_emulation=False):
-          return
-       warn_and_skip(device)
+        device = getattr(inp, "get_device", lambda: torch.device("meta"))()
+        if device.type != "cuda" or inp.get_dtype() != torch.bfloat16:
+            continue
+        # Print warning and skip frame if attempting to compile for bfloat16
+        # on device without hardware support for dtype
+        if torch.cuda.is_bf16_supported(including_emulation=False):
+            return
+        warn_and_skip(device)
 
     for out in graph.graph_outputs:
-       device = getattr(out, "get_device", lambda: torch.device("meta"))()
-       if device.type != "cuda" or out.get_dtype() != torch.bfloat16:
-           continue
-       # Print warning and skip frame if attempting to compile for bfloat16
-       # on device without hardware support for dtype
-       if torch.cuda.is_bf16_supported(including_emulation=False):
-          return
-       warn_and_skip(device)
+        device = getattr(out, "get_device", lambda: torch.device("meta"))()
+        if device.type != "cuda" or out.get_dtype() != torch.bfloat16:
+            continue
+        # Print warning and skip frame if attempting to compile for bfloat16
+        # on device without hardware support for dtype
+        if torch.cuda.is_bf16_supported(including_emulation=False):
+            return
+        warn_and_skip(device)

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1639,7 +1639,7 @@ def _check_triton_bf16_support(graph: GraphLowering) -> None:
         raise SkipFrame("BF16 is not supported")
 
     for inp in graph.graph_inputs.values():
-       device = inp.get_device()
+       device = getattr(inp, "get_device", lambda: torch.device("meta"))()
        if device.type != "cuda" or inp.get_dtype() != torch.bfloat16:
            continue
        # Print warning and skip frame if attempting to compile for bfloat16
@@ -1649,7 +1649,7 @@ def _check_triton_bf16_support(graph: GraphLowering) -> None:
        warn_and_skip(device)
 
     for out in graph.graph_outputs:
-       device = out.get_device()
+       device = getattr(out, "get_device", lambda: torch.device("meta"))()
        if device.type != "cuda" or out.get_dtype() != torch.bfloat16:
            continue
        # Print warning and skip frame if attempting to compile for bfloat16

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -128,7 +128,7 @@ def is_available() -> bool:
         return torch._C._cuda_getDeviceCount() > 0
 
 
-def is_bf16_supported():
+def is_bf16_supported(including_emulation: bool = True):
     r"""Return a bool indicating if the current CUDA/ROCm device supports dtype bfloat16."""
     # Check for ROCm, if true return true, no ROCM_VERSION check required,
     # since it is supported on AMD GPU archs.
@@ -146,6 +146,9 @@ def is_bf16_supported():
         and torch.cuda.get_device_properties(device).major >= 8
     ):
         return True
+
+    if not including_emulation:
+        return False
 
     # Finally try to create a bfloat16 device.
     return _check_bf16_tensor_supported(device)


### PR DESCRIPTION
Volta(sm_7x) do not have a HW support for bfloat16 datatype, and while it is is emulated to ted in software, so PyTorch eager can use bfloat16 tensors, but not in Triton. So if graph with either CUDA bf16 input or output tensors is used, raise warnings and skip the frame.

Add optional parameter `including_emulation` to `torch.cuda.is_bf16_supported` method and call it from `torch._inductor.compile_fx. _check_triton_bf16_support`.

Test plan: Modify `is_bf16_supported` to return False and see that warning is generated

Fixes https://github.com/pytorch/pytorch/issues/118122 and https://github.com/pytorch/pytorch/issues/118581


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang