### PR TITLE
[2/N] Fix clang-tidy warnings in torch/csrc/jit/serialization

### DIFF
--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
@@ -6,7 +6,7 @@
 namespace torch::jit {
 
 namespace {
-const int64_t kInvalidSourceRangeTag = -1;
+constexpr int64_t kInvalidSourceRangeTag = -1;
 } // namespace
 
 c10::IValue InlinedCallStackSerializer::serialize(
@@ -209,7 +209,7 @@ std::optional<ModuleInstanceInfo> InlinedCallStackDeserializer::
 
 ska::flat_hash_map<int64_t, DebugInfoTuple> CallStackDebugInfoUnpickler::
     unpickle(
-        at::DataPtr&& data,
+        const at::DataPtr& data,
         size_t size,
         const ska::flat_hash_map<int64_t, SourceRange>& source_range_map,
         const std::shared_ptr<CompilationUnit>& cu) {

--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.h
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.h
@@ -77,7 +77,7 @@ class InlinedCallStackDeserializer {
 class TORCH_API CallStackDebugInfoUnpickler {
  public:
   ska::flat_hash_map<int64_t, DebugInfoTuple> unpickle(
-      at::DataPtr&& data,
+      const at::DataPtr& data,
       size_t size,
       const ska::flat_hash_map<int64_t, SourceRange>& source_range_map,
       const std::shared_ptr<CompilationUnit>& cu);

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -601,6 +601,7 @@ GraphEncoder::GraphEncoder(
   }
 }
 
+// NOLINTBEGIN(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 void GraphEncoder::TensorTypeToONNXType(
     const TensorTypePtr& tensor_type,
     const std::string& dim_name_prefix,
@@ -637,6 +638,7 @@ void GraphEncoder::TensorTypeToONNXType(
         ATenTypeToOnnxType(tensor_type->scalarType().value()));
   }
 }
+// NOLINTEND(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
 void GraphEncoder::EncodeValueInfoType(
     onnx::TypeProto* onnx_type,
@@ -1078,6 +1080,7 @@ void GraphEncoder::AddAttribute(
       ATenAttributeKindToOnnxAttributeType(node->kindOf(name), name));
   switch (node->kindOf(name)) {
     case AttributeKind::f:
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
       attr->set_f(node->f(name));
       break;
     case AttributeKind::fs:

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -1080,13 +1080,11 @@ void GraphEncoder::AddAttribute(
       ATenAttributeKindToOnnxAttributeType(node->kindOf(name), name));
   switch (node->kindOf(name)) {
     case AttributeKind::f:
-      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-      attr->set_f(node->f(name));
+      attr->set_f(static_cast<float>(node->f(name)));
       break;
     case AttributeKind::fs:
       for (auto& v : node->fs(name))
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-        attr->add_floats(v);
+        attr->add_floats(static_cast<float>(v));
       break;
     case AttributeKind::i:
       attr->set_i(node->i(name));

--- a/torch/csrc/jit/serialization/export_bytecode.cpp
+++ b/torch/csrc/jit/serialization/export_bytecode.cpp
@@ -395,6 +395,7 @@ mobile::Module jitModuleToMobile(
       backend_debug_info_map.begin(), backend_debug_info_map.end());
   m.setDebugTable(MobileDebugTable(
       debug_handle_cs_ptr_map.begin(), debug_handle_cs_ptr_map.end()));
+  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   m.set_min_operator_version(get_min_operator_version_from_version_map(m));
   m.set_bytecode_version(options.model_version);
   return m;

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -348,6 +348,7 @@ struct ModuleMethod {
   ModuleMethod(Module m, const GraphFunction& f, c10::QualifiedName n)
       : module(std::move(m)), function(f), exportName(std::move(n)) {}
   Module module;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const GraphFunction& function;
   c10::QualifiedName exportName;
 };
@@ -836,7 +837,8 @@ void ExportModule(
     bool save_mobile_debug_info,
     bool use_flatbuffer) {
   auto writer_func = [&](const void* buf, size_t nbytes) -> size_t {
-    out.write(static_cast<const char*>(buf), nbytes);
+    out.write(
+        static_cast<const char*>(buf), static_cast<std::streamsize>(nbytes));
     return !out ? 0 : nbytes;
   };
   ExportModule(

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -6,7 +6,6 @@
 
 #include <fstream>
 #include <functional>
-#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -6,8 +6,6 @@
 #include <caffe2/serialize/read_adapter_interface.h>
 
 #include <torch/csrc/jit/api/compilation_unit.h>
-#include <torch/csrc/jit/serialization/import.h>
-#include <torch/csrc/jit/serialization/source_range_serialization.h>
 
 #include <ATen/core/functional.h>
 #include <ATen/core/ivalue_inl.h>
@@ -21,6 +19,7 @@
 #include <torch/csrc/jit/operator_upgraders/upgraders_entry.h>
 #include <torch/csrc/jit/passes/shape_analysis.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include <torch/csrc/jit/serialization/import.h>
 #include <torch/csrc/jit/serialization/import_export_helpers.h>
 #include <torch/csrc/jit/serialization/import_read.h>
 #include <torch/csrc/jit/serialization/import_source.h>
@@ -31,7 +30,6 @@
 #include <fmt/format.h>
 
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/torch/csrc/jit/serialization/import_export_helpers.cpp
+++ b/torch/csrc/jit/serialization/import_export_helpers.cpp
@@ -10,11 +10,10 @@
 
 namespace torch::jit {
 
-static const std::string kExportSuffix = "py";
-
 std::string qualifierToArchivePath(
     const std::string& qualifier,
     const std::string& export_prefix) {
+  static const std::string kExportSuffix = "py";
   std::string path = qualifier;
   std::replace_if(
       path.begin(), path.end(), [](char c) { return c == '.'; }, '/');

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -312,7 +312,8 @@ void Pickler::pushStorageOfTensor(const at::Tensor& tensor) {
   // location
   pushString(tensor.device().str());
   // size
-  pushInt(tensor.storage().nbytes() / tensor.element_size());
+  pushInt(
+      static_cast<int64_t>(tensor.storage().nbytes() / tensor.element_size()));
 
   push<PickleOpCode>(PickleOpCode::TUPLE);
   push<PickleOpCode>(PickleOpCode::BINPERSID);
@@ -583,11 +584,11 @@ void Pickler::pushLong(const std::string& data) {
 void Pickler::pushTensorReference(const IValue& ivalue) {
   pushGlobal("torch.jit._pickle", "build_tensor_from_id");
   tensor_table_->push_back(ivalue.toTensor());
-  int64_t tensor_id = tensor_table_->size() - 1;
+  auto tensor_id = tensor_table_->size() - 1;
   // Reduce arguments are spread (e.g. `*args`) before calling the global,
   // so wrap in a tuple
   push<PickleOpCode>(PickleOpCode::MARK);
-  pushIValue(tensor_id);
+  pushIValue(static_cast<int64_t>(tensor_id));
   push<PickleOpCode>(PickleOpCode::TUPLE);
 
   push<PickleOpCode>(PickleOpCode::REDUCE);

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -231,7 +231,7 @@ class TORCH_API Pickler {
   }
 
   // Stream to write binary data to
-  // Code shouldn't call writer_ directly without first flush()ing.
+  // Code shouldn't call writer_ directly without first flushing.
   std::function<void(const char*, size_t)> writer_;
 
   // Buffer to avoid calling a writer_ on a per-byte basis.


### PR DESCRIPTION
Follows #129055