### PR TITLE
[aotinductor][UserDefinedTritonKernel] use appropriate expr printer when printing args

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1999,34 +1999,6 @@ class AOTInductorTestsTemplate:
         )
         self.check_model(Model(), inputs)
 
-    def test_triton_kernel_reinterpret_view(self):
-        if self.device != "cuda":
-            raise unittest.SkipTest("requires CUDA")
-
-        @triton.jit
-        def pass_kernel(x, y):
-            pass
-
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def forward(self, x):
-                out = torch.zeros_like(x[:, 4:])
-                # the slicing below creates two ReinterpretView
-                # instances: with offset=3 and offset=4
-                add_kernel[(10,)](
-                    in_ptr0=x[:, 3:-1],
-                    in_ptr1=x[:, 4:],
-                    out_ptr=out,
-                    n_elements=160,
-                    BLOCK_SIZE=16,
-                )
-                return out
-
-        example_inputs = (torch.randn(10, 20, device=self.device),)
-        self.check_model(Model(), example_inputs)
-
     def test_triton_kernel_with_none_input(self):
         if self.device != "cuda":
             raise unittest.SkipTest("requires CUDA")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1481,7 +1481,7 @@ class WrapperCodeGen(CodeGen):
             elif isinstance(arg, (int, float, bool, SymbolicCallArg)):
                 return str(arg)
             else:
-                return pexpr(V.graph.sizevars.simplify(arg))
+                return self.expr_printer(V.graph.sizevars.simplify(arg))
 
         call_args = [wrap_arg(arg) for arg in call_args]
 


### PR DESCRIPTION
Encountered the following C++ compile error.
```
Declared in this scope; did you mean ‘std::max’?
  619 |     auto var_5 = max(1, u0);
```

This PR will use the C++ printer when it's doing C++ codegen, before this PR it was using the Python printer even during C++ codegen.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129301



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang

Differential Revision: [D58913123](https://our.internmc.facebook.com/intern/diff/D58913123)