### PR TITLE
[aotinductor] Only autotune at compile time when enabled via config

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1300,7 +1300,7 @@ def compile_fx(
         with config.patch(
             {
                 "cpp_wrapper": False,
-                "triton.autotune_at_compile_time": True,
+                "triton.autotune_at_compile_time": config.triton.autotune_at_compile_time,
                 "triton.autotune_cublasLt": False,
                 "triton.cudagraphs": False,
                 "triton.store_cubin": True,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -697,7 +697,10 @@ class triton:
 
     # Tune the generated Triton kernels at compile time instead of first time they run
     autotune_at_compile_time = (
-        os.environ.get("TORCHINDUCTOR_TRITON_AUTOTUNE_AT_COMPILE_TIME", "0") == "1"
+        os.environ.get(
+            "TORCHINDUCTOR_TRITON_AUTOTUNE_AT_COMPILE_TIME", "0" if is_fbcode() else "1"
+        )
+        == "1"
     )
 
     # should we stop a fusion to allow better tiling?


### PR DESCRIPTION
Summary: ---

Test Plan: ci

Differential Revision: D58931057


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang

@diff-train-skip-merge