### PR TITLE
[MPS] Fused SGD optimizer

### DIFF
--- a/aten/src/ATen/native/cuda/FusedSgdKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedSgdKernel.cu
@@ -391,7 +391,7 @@ void _fused_sgd_kernel_cuda_(
   }
   TORCH_CHECK(
       lr.device() == params[0].device(),
-      "found_inf must be on the same GPU device as the params");
+      "lr must be on the same GPU device as the params");
   float* grad_scale_ptr =
       grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
   float* found_inf_ptr =

--- a/aten/src/ATen/native/mps/operations/FusedSgdKernel.mm
+++ b/aten/src/ATen/native/mps/operations/FusedSgdKernel.mm
@@ -1,9 +1,6 @@
-#include <ATen/Dispatch.h>
-#include <ATen/OpMathType.h>
-#include <ATen/core/Tensor.h>
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/ForeachUtils.h>
 #include <ATen/native/mps/operations/MultiTensorApply.h>
-#include <c10/util/Exception.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>

--- a/aten/src/ATen/native/mps/operations/FusedSgdKernel.mm
+++ b/aten/src/ATen/native/mps/operations/FusedSgdKernel.mm
@@ -53,7 +53,7 @@ static void _fused_sgd_with_momentum_kernel_mps_(at::TensorList params,
                                                  at::TensorList momentum_buffer_list,
                                                  const double weight_decay,
                                                  const double momentum,
-                                                 const Tensor lr_tensor,
+                                                 const at::Tensor& lr_tensor,
                                                  const double dampening,
                                                  const bool nesterov,
                                                  const bool maximize,
@@ -188,7 +188,7 @@ void _fused_sgd_kernel_mps_(at::TensorList params,
     TORCH_WARN_ONCE("`is_first_step` argument has no effect when `momentum_buffer_list` is empty");
   }
 
-  TORCH_CHECK(lr_tensor.device() == params[0].device(), "found_inf must be on the same GPU device as the params");
+  TORCH_CHECK(lr_tensor.device() == params[0].device(), "lr must be on the same GPU device as the params");
 
   std::vector<std::vector<at::Tensor>> tensor_lists{params.vec(), grads.vec()};
 

--- a/aten/src/ATen/native/mps/operations/FusedSgdKernel.mm
+++ b/aten/src/ATen/native/mps/operations/FusedSgdKernel.mm
@@ -1,0 +1,215 @@
+#include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/ForeachUtils.h>
+#include <ATen/native/mps/operations/MultiTensorApply.h>
+#include <c10/util/Exception.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_fused_sgd.h>
+#include <ATen/ops/_fused_sgd_native.h>
+#endif
+
+namespace at::native {
+
+namespace mps {
+
+static void _fused_sgd_with_momentum_kernel_mps_(at::TensorList params,
+                                                 at::TensorList grads,
+                                                 at::TensorList momentum_buffer_list,
+                                                 const double weight_decay,
+                                                 const double momentum,
+                                                 const double lr,
+                                                 const double dampening,
+                                                 const bool nesterov,
+                                                 const bool maximize,
+                                                 const bool is_first_step,
+                                                 const std::optional<at::Tensor>& grad_scale,
+                                                 const std::optional<at::Tensor>& found_inf) {
+  TORCH_CHECK_GT(momentum, 0);
+  TORCH_CHECK(at::native::check_fast_path_restrictions({params, grads, momentum_buffer_list}));
+
+  std::vector<std::vector<at::Tensor>> tensor_lists{params.vec(), grads.vec(), momentum_buffer_list.vec()};
+
+  const std::string kernel_name = "fused_sgd_momentum_" + scalarToMetalTypeString(params[0].scalar_type());
+
+  at::TensorList state_steps;
+
+  multi_tensor_apply_for_fused_optimizer<3, 512>(kernel_name,
+                                                 tensor_lists,
+                                                 state_steps,
+                                                 mps::FusedSgdEncodingFunctor(),
+                                                 weight_decay,
+                                                 momentum,
+                                                 lr,
+                                                 dampening,
+                                                 nesterov,
+                                                 maximize,
+                                                 is_first_step);
+}
+
+static void _fused_sgd_with_momentum_kernel_mps_(at::TensorList params,
+                                                 at::TensorList grads,
+                                                 at::TensorList momentum_buffer_list,
+                                                 const double weight_decay,
+                                                 const double momentum,
+                                                 const Tensor lr_tensor,
+                                                 const double dampening,
+                                                 const bool nesterov,
+                                                 const bool maximize,
+                                                 const bool is_first_step,
+                                                 const std::optional<at::Tensor>& grad_scale,
+                                                 const std::optional<at::Tensor>& found_inf) {
+  TORCH_CHECK_GT(momentum, 0);
+  TORCH_CHECK(at::native::check_fast_path_restrictions({params, grads, momentum_buffer_list}));
+
+  std::vector<std::vector<at::Tensor>> tensor_lists{params.vec(), grads.vec(), momentum_buffer_list.vec()};
+
+  const std::string kernel_name = "fused_sgd_momentum_" + scalarToMetalTypeString(params[0].scalar_type());
+
+  at::TensorList state_steps;
+
+  multi_tensor_apply_for_fused_optimizer<3, 512>(kernel_name,
+                                                 tensor_lists,
+                                                 state_steps,
+                                                 mps::FusedSgdEncodingFunctor(),
+                                                 weight_decay,
+                                                 momentum,
+                                                 lr_tensor,
+                                                 dampening,
+                                                 nesterov,
+                                                 maximize,
+                                                 is_first_step);
+}
+
+} // namespace mps
+
+void _fused_sgd_kernel_mps_(at::TensorList params,
+                            at::TensorList grads,
+                            at::TensorList momentum_buffer_list,
+                            const double weight_decay,
+                            const double momentum,
+                            const double lr,
+                            const double dampening,
+                            const bool nesterov,
+                            const bool maximize,
+                            const bool is_first_step,
+                            const std::optional<at::Tensor>& grad_scale,
+                            const std::optional<at::Tensor>& found_inf) {
+  TORCH_CHECK(!grad_scale.has_value() && !found_inf.has_value(), "grad_scale and found_inf are not supported on MPS");
+
+  if (!momentum_buffer_list.empty()) {
+    mps::_fused_sgd_with_momentum_kernel_mps_(params,
+                                              grads,
+                                              momentum_buffer_list,
+                                              weight_decay,
+                                              momentum,
+                                              lr,
+                                              dampening,
+                                              nesterov,
+                                              maximize,
+                                              is_first_step,
+                                              grad_scale,
+                                              found_inf);
+    return;
+  }
+  TORCH_CHECK_EQ(momentum, 0);
+  TORCH_CHECK(at::native::check_fast_path_restrictions({params, grads}));
+  if (is_first_step) {
+    TORCH_WARN_ONCE("`is_first_step` argument has no effect when `momentum_buffer_list` is empty");
+  }
+
+  std::vector<std::vector<at::Tensor>> tensor_lists{params.vec(), grads.vec()};
+
+  const std::string kernel_name = "fused_sgd_" + mps::scalarToMetalTypeString(params[0].scalar_type());
+
+  at::TensorList state_steps;
+
+  multi_tensor_apply_for_fused_optimizer<2, 512>(kernel_name,
+                                                 tensor_lists,
+                                                 state_steps,
+                                                 mps::FusedSgdEncodingFunctor(),
+                                                 weight_decay,
+                                                 momentum,
+                                                 lr,
+                                                 dampening,
+                                                 nesterov,
+                                                 maximize,
+                                                 is_first_step);
+}
+
+void _fused_sgd_kernel_mps_(at::TensorList params,
+                            at::TensorList grads,
+                            at::TensorList momentum_buffer_list,
+                            const double weight_decay,
+                            const double momentum,
+                            const at::Tensor& lr_tensor,
+                            const double dampening,
+                            const bool nesterov,
+                            const bool maximize,
+                            const bool is_first_step,
+                            const std::optional<at::Tensor>& grad_scale,
+                            const std::optional<at::Tensor>& found_inf) {
+  TORCH_CHECK(!grad_scale.has_value() && !found_inf.has_value(), "grad_scale and found_inf are not supported on MPS");
+
+  if (!momentum_buffer_list.empty()) {
+    mps::_fused_sgd_with_momentum_kernel_mps_(params,
+                                              grads,
+                                              momentum_buffer_list,
+                                              weight_decay,
+                                              momentum,
+                                              lr_tensor,
+                                              dampening,
+                                              nesterov,
+                                              maximize,
+                                              is_first_step,
+                                              grad_scale,
+                                              found_inf);
+    return;
+  }
+  if (lr_tensor.is_cpu()) {
+    _fused_sgd_kernel_mps_(params,
+                           grads,
+                           momentum_buffer_list,
+                           weight_decay,
+                           momentum,
+                           lr_tensor.item<double>(),
+                           dampening,
+                           nesterov,
+                           maximize,
+                           is_first_step,
+                           grad_scale,
+                           found_inf);
+    return;
+  }
+  TORCH_CHECK_EQ(momentum, 0);
+  TORCH_CHECK(at::native::check_fast_path_restrictions({params, grads}));
+  if (is_first_step) {
+    TORCH_WARN_ONCE("`is_first_step` argument has no effect when `momentum_buffer_list` is empty");
+  }
+
+  TORCH_CHECK(lr_tensor.device() == params[0].device(), "found_inf must be on the same GPU device as the params");
+
+  std::vector<std::vector<at::Tensor>> tensor_lists{params.vec(), grads.vec()};
+
+  const std::string kernel_name = "fused_sgd_" + mps::scalarToMetalTypeString(params[0].scalar_type());
+
+  at::TensorList state_steps;
+
+  multi_tensor_apply_for_fused_optimizer<2, 512>(kernel_name,
+                                                 tensor_lists,
+                                                 state_steps,
+                                                 mps::FusedSgdEncodingFunctor(),
+                                                 weight_decay,
+                                                 momentum,
+                                                 lr_tensor,
+                                                 dampening,
+                                                 nesterov,
+                                                 maximize,
+                                                 is_first_step);
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/MultiTensorApply.h
+++ b/aten/src/ATen/native/mps/operations/MultiTensorApply.h
@@ -51,6 +51,77 @@ struct FusedAdamEncodingFunctor {
   }
 };
 
+struct FusedSgdEncodingFunctor {
+  void operator()(
+    id<MTLComputeCommandEncoder>& computeEncoder,
+      id<MTLBuffer>& tensorArgumentBuffer,
+      const MetadataArguments& metadata_arguments,
+      const double weight_decay,
+      const double momentum,
+      const double lr,
+      const double dampening,
+      const bool nesterov,
+      const bool maximize,
+      const bool is_first_step
+    ) const {
+      float weight_decay_lv = weight_decay;
+      float momentum_lv = momentum;
+      float lr_lv = lr;
+      float dampening_lv = dampening;
+      uint8_t nesterov_lv = nesterov;
+      uint8_t maximize_lv = maximize;
+      uint8_t is_first_step_lv = is_first_step;
+
+      [computeEncoder setBuffer:tensorArgumentBuffer
+                                  offset:0
+                                  atIndex:0];
+      [computeEncoder setBytes:&metadata_arguments
+                                  length:sizeof(MetadataArguments)
+                                  atIndex:1];
+      [computeEncoder setBytes:&weight_decay_lv length:sizeof(float) atIndex:2];
+      [computeEncoder setBytes:&momentum_lv length:sizeof(float) atIndex:3];
+      [computeEncoder setBytes:&lr_lv length:sizeof(float) atIndex:4];
+      [computeEncoder setBytes:&dampening_lv length:sizeof(float) atIndex:5];
+      [computeEncoder setBytes:&nesterov_lv length:sizeof(uint8_t) atIndex:6];
+      [computeEncoder setBytes:&maximize_lv length:sizeof(uint8_t) atIndex:7];
+      [computeEncoder setBytes:&is_first_step_lv length:sizeof(uint8_t) atIndex:8];
+  }
+
+  void operator()(
+    id<MTLComputeCommandEncoder>& computeEncoder,
+      id<MTLBuffer>& tensorArgumentBuffer,
+      const MetadataArguments& metadata_arguments,
+      const double weight_decay,
+      const double momentum,
+      const Tensor lr_ptr,
+      const double dampening,
+      const bool nesterov,
+      const bool maximize,
+      const bool is_first_step
+    ) const {
+      float weight_decay_lv = weight_decay;
+      float momentum_lv = momentum;
+      float dampening_lv = dampening;
+      uint8_t nesterov_lv = nesterov;
+      uint8_t maximize_lv = maximize;
+      uint8_t is_first_step_lv = is_first_step;
+
+      [computeEncoder setBuffer:tensorArgumentBuffer
+                                  offset:0
+                                  atIndex:0];
+      [computeEncoder setBytes:&metadata_arguments
+                                  length:sizeof(MetadataArguments)
+                                  atIndex:1];
+      [computeEncoder setBytes:&weight_decay_lv length:sizeof(float) atIndex:2];
+      [computeEncoder setBytes:&momentum_lv length:sizeof(float) atIndex:3];
+      [computeEncoder setBuffer:getMTLBufferStorage(lr_ptr) offset:lr_ptr.storage_offset() * lr_ptr.element_size() atIndex:4];
+      [computeEncoder setBytes:&dampening_lv length:sizeof(float) atIndex:5];
+      [computeEncoder setBytes:&nesterov_lv length:sizeof(uint8_t) atIndex:6];
+      [computeEncoder setBytes:&maximize_lv length:sizeof(uint8_t) atIndex:7];
+      [computeEncoder setBytes:&is_first_step_lv length:sizeof(uint8_t) atIndex:8];
+  }
+};
+
 template <int depth, uint32_t kThreadGroupSize, typename encoder_func_t, typename... ArgTypes>
 static void multi_tensor_apply_for_fused_optimizer(
     const std::string& kernel_name,

--- a/aten/src/ATen/native/mps/operations/MultiTensorApply.h
+++ b/aten/src/ATen/native/mps/operations/MultiTensorApply.h
@@ -93,7 +93,7 @@ struct FusedSgdEncodingFunctor {
       const MetadataArguments& metadata_arguments,
       const double weight_decay,
       const double momentum,
-      const Tensor lr_ptr,
+      const at::Tensor& lr,
       const double dampening,
       const bool nesterov,
       const bool maximize,
@@ -114,7 +114,7 @@ struct FusedSgdEncodingFunctor {
                                   atIndex:1];
       [computeEncoder setBytes:&weight_decay_lv length:sizeof(float) atIndex:2];
       [computeEncoder setBytes:&momentum_lv length:sizeof(float) atIndex:3];
-      [computeEncoder setBuffer:getMTLBufferStorage(lr_ptr) offset:lr_ptr.storage_offset() * lr_ptr.element_size() atIndex:4];
+      [computeEncoder setBuffer:getMTLBufferStorage(lr) offset:lr.storage_offset() * lr.element_size() atIndex:4];
       [computeEncoder setBytes:&dampening_lv length:sizeof(float) atIndex:5];
       [computeEncoder setBytes:&nesterov_lv length:sizeof(uint8_t) atIndex:6];
       [computeEncoder setBytes:&maximize_lv length:sizeof(uint8_t) atIndex:7];

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -15613,6 +15613,7 @@
   dispatch:
     CPU: _fused_sgd_kernel_cpu_
     CUDA: _fused_sgd_kernel_cuda_
+    MPS: _fused_sgd_kernel_mps_
   autogen: _fused_sgd, _fused_sgd.out
 
 - func: _fused_sgd_.tensor_lr(Tensor(a!)[] self, Tensor(b!)[] grads, Tensor(c!)[] momentum_buffer_list, *, float weight_decay, float momentum, Tensor lr, float dampening, bool nesterov, bool maximize, bool is_first_step, Tensor? grad_scale=None, Tensor? found_inf=None) -> ()
@@ -15623,6 +15624,7 @@
   dispatch:
     CPU: _fused_sgd_kernel_cpu_
     CUDA: _fused_sgd_kernel_cuda_
+    MPS: _fused_sgd_kernel_mps_
   autogen: _fused_sgd.tensor_lr, _fused_sgd.tensor_lr_out
 
 - func: _fused_adagrad_(Tensor(a!)[] self, Tensor(b!)[] grads, Tensor(c!)[] state_sums, Tensor(d!)[] state_steps, *, float lr, float lr_decay, float weight_decay, float eps, bool maximize, Tensor? grad_scale=None, Tensor? found_inf=None) -> ()

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -188,7 +188,7 @@ Below is a table showing the available and default implementations of each algor
     :class:`RAdam`;foreach;yes;no
     :class:`RMSprop`;foreach;yes;no
     :class:`Rprop`;foreach;yes;no
-    :class:`SGD`;foreach;yes;yes (CPU and CUDA only)
+    :class:`SGD`;foreach;yes;yes
 
 Below table is showing the stability status for fused implementations:
 
@@ -209,7 +209,7 @@ Below table is showing the stability status for fused implementations:
     :class:`RAdam`;unsupported;unsupported;unsupported
     :class:`RMSprop`;unsupported;unsupported;unsupported
     :class:`Rprop`;unsupported;unsupported;unsupported
-    :class:`SGD`;beta;beta;unsupported
+    :class:`SGD`;beta;beta;beta
 
 How to adjust learning rate
 ---------------------------

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1759,6 +1759,7 @@ optim_db: List[OptimizerInfo] = [
         supports_fused_on=(
             "cpu",
             "cuda",
+            "mps",
         ),
         skips=(
             DecorateInfo(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129552
* #129451
* __->__ #129350

```
[-------------------------------------- Fused SGD --------------------------------------]
                                                          |  Fused: True  |  Fused: False
1 threads: ------------------------------------------------------------------------------
      numel: 1024, num_tensors: 100, momentum: True       |        2      |       15     
      numel: 1024, num_tensors: 100, momentum: False      |        2      |        5     
      numel: 65536, num_tensors: 100, momentum: True      |        3      |       16     
      numel: 65536, num_tensors: 100, momentum: False     |        2      |        5     
      numel: 1048576, num_tensors: 100, momentum: True    |       11      |       16     
      numel: 1048576, num_tensors: 100, momentum: False   |        8      |        6     
      numel: 1024, num_tensors: 500, momentum: True       |       29      |       70     
      numel: 1024, num_tensors: 500, momentum: False      |       20      |       24     
      numel: 65536, num_tensors: 500, momentum: True      |       33      |       76     
      numel: 65536, num_tensors: 500, momentum: False     |       22      |       26     
      numel: 1048576, num_tensors: 500, momentum: True    |       70      |       80     
      numel: 1048576, num_tensors: 500, momentum: False   |       43      |       40     
      numel: 1024, num_tensors: 1000, momentum: True      |      108      |      139     
      numel: 1024, num_tensors: 1000, momentum: False     |       72      |       48     
      numel: 65536, num_tensors: 1000, momentum: True     |      116      |      150     
      numel: 65536, num_tensors: 1000, momentum: False    |       77      |       52     
      numel: 1048576, num_tensors: 1000, momentum: True   |      190      |      170     
      numel: 1048576, num_tensors: 1000, momentum: False  |      120      |       50     
```

```python
def profile_fused_sgd():
    from torch.optim.sgd import sgd
    import torch.utils.benchmark as benchmark

    import itertools


    def profile(fn, params, grads, momentum_buffer_list, fused):
        fn(
            params,
            grads,
            momentum_buffer_list,
            momentum=True if len(momentum_buffer_list) > 0 else False,
            dampening=0.0,
            nesterov=False,
            foreach=False,
            fused=fused,
            lr=1e-3,
            weight_decay=.0,
            maximize=False,
            grad_scale=None,
            found_inf=None,
        )
        torch.mps.synchronize()

    device = "mps"
    
    results = []

    for num_tensors, numel, momentum in itertools.product([100, 500, 1000], [1024, 65536, 1048576], [True, False]):
        sublabel = f"numel: {numel}, num_tensors: {num_tensors}, momentum: {momentum}"
        print(sublabel)
        params, grads = [[torch.arange(numel, dtype=torch.float32, device=device) + (numel * i) for i in range(num_tensors)] for _ in range(2)]
        momentum_buffer_list = [torch.arange(numel, dtype=torch.float32, device=device) + (numel * i) for i in range(num_tensors)] if momentum else []
        fn = sgd

        for fused in [True, False]:

            t = benchmark.Timer(
                    stmt='profile(fn, params, grads, momentum_buffer_list, fused)',
                    label='Fused SGD',
                    sub_label=sublabel,
                    globals=locals(),
                    description= f"Fused: {fused}",
                ).blocked_autorange(min_run_time=5)
            results.append(t)

    compare = benchmark.Compare(results)
    compare.trim_significant_figures()
    compare.colorize(rowwise=True)
    compare.print()
```