### PR TITLE
make cached tensor more generic

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -738,6 +738,21 @@ class TestAutograd(TestCase):
         test(torch.randn(24, requires_grad=True), (3, 8), 7, 11)
         test(torch.randn(2, 3, 4, requires_grad=True), (6, 4), -1, 2)
 
+    def test_multiple_insert_removal_caching(self):
+        torch._C._set_cached_tensors_enabled(True)
+        try:
+            x = torch.rand([4])
+
+            torch._C._add_cached_tensor(x)
+            self.assertTrue(torch._C._is_cached_tensor(x))
+
+            torch._C._add_cached_tensor(x)
+            torch._C._remove_cached_tensor(x)
+
+            self.assertFalse(torch._C._is_cached_tensor(x))
+        finally:
+            torch._C._set_cached_tensors_enabled(False)
+
     def test_accumulate_grad(self):
         grad_output = torch.ones(5, 5)
 

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/python_headers.h>
 
+#include <ATen/CachedTensorUtils.h>
 #include <ATen/PythonTorchFunctionTLS.h>
 #include <ATen/SavedTensorHooks.h>
 #include <ATen/SequenceNumber.h>
@@ -586,6 +587,57 @@ static PyObject* is_autocast_available(
   auto r = parser.parse(args, kwargs, parsed_args);
   auto device_type = at::Device(r.string(0)).type();
   if (at::autocast::is_autocast_available(device_type)) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* set_cached_tensors_enabled(PyObject* _unused, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK_TYPE(
+      PyBool_Check(arg),
+      "set_cached_tensors_enabled expect a bool as input (got ",
+      Py_TYPE(arg)->tp_name,
+      ")");
+  at::caching::set_cached_tensors_enabled(arg == Py_True);
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* add_cached_tensor(PyObject* _unused, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPVariable_Check(arg),
+      "add_cached_tensor expect a Tensor as input (got ",
+      Py_TYPE(arg)->tp_name,
+      ")");
+  at::caching::add_cached_tensor(THPVariable_Unpack(arg));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* remove_cached_tensor(PyObject* _unused, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPVariable_Check(arg),
+      "remove_cached_tensor expect a Tensor as input (got ",
+      Py_TYPE(arg)->tp_name,
+      ")");
+  at::caching::remove_cached_tensor(THPVariable_Unpack(arg));
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* is_cached_tensor(PyObject* _unused, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      THPVariable_Check(arg),
+      "is_cached_tensor expect a Tensor as input (got ",
+      Py_TYPE(arg)->tp_name,
+      ")");
+  if (at::caching::is_cached_tensor((THPVariable_Unpack(arg)))) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;
@@ -1250,6 +1302,13 @@ static PyMethodDef methods[] = { // NOLINT
      castPyCFunctionWithKeywords(is_autocast_available),
      METH_VARARGS | METH_KEYWORDS,
      nullptr},
+    {"_set_cached_tensors_enabled",
+     set_cached_tensors_enabled,
+     METH_O,
+     nullptr},
+    {"_add_cached_tensor", add_cached_tensor, METH_O, nullptr},
+    {"_remove_cached_tensor", remove_cached_tensor, METH_O, nullptr},
+    {"_is_cached_tensor", is_cached_tensor, METH_O, nullptr},
     {"clear_autocast_cache", clear_autocast_cache, METH_NOARGS, nullptr},
     {"set_autocast_cpu_enabled", set_autocast_cpu_enabled, METH_O, nullptr},
     {"is_autocast_cpu_enabled", is_autocast_cpu_enabled, METH_NOARGS, nullptr},

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1,5 +1,4 @@
 #include <ATen/ATen.h>
-#include <ATen/CachedTensorUtils.h>
 #include <ATen/core/TensorBody.h>
 #include <ATen/cuda/CUDAConfig.h>
 #include <ATen/native/ConvUtils.h>
@@ -1171,22 +1170,6 @@ static void registerCudaPluggableAllocator(PyObject* module) {
     c10::StorageImpl* storage_impl = (c10::StorageImpl*)storage_impl_ptr;
     auto alloc = c10::cuda::CUDACachingAllocator::get();
     return (storage_impl->data_ptr().get_deleter() == alloc->raw_deleter());
-  });
-
-  m.def("_set_cached_tensors_enabled", [](bool enabled) {
-    at::caching::set_cached_tensors_enabled(enabled);
-  });
-
-  m.def("_add_cached_tensor", [](const at::Tensor& t) {
-    at::caching::add_cached_tensor(t);
-  });
-
-  m.def("_remove_cached_tensor", [](const at::Tensor& t) {
-    at::caching::remove_cached_tensor(t);
-  });
-
-  m.def("_is_cached_tensor", [](const at::Tensor& t) {
-    return at::caching::is_cached_tensor(t);
   });
 
   m.def("_storage_Use_Count", [](size_t storage_impl_ptr) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129357

# Motivation
solve https://github.com/pytorch/pytorch/issues/129027 to refactor cached tensor to be generic.

# Additional Context
No API name change. It is only decoupling with CUDA build option.