### PR TITLE
Chore (pyproject): match line length of black and isort to ruff (120 chars)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 
 
 [tool.black]
-line-length = 88
+line-length = 120
 target-version = ["py38", "py39", "py310", "py311"]
 
 
@@ -27,7 +27,7 @@ skip_glob = ["third_party/*"]
 atomic = true
 profile = "black"
 indent = 4
-line_length = 88
+line_length = 120
 lines_after_imports = 2
 multi_line_output = 3
 include_trailing_comma = true


### PR DESCRIPTION
There are 3 different line-length settings defined in pyproject.toml, i changed those of black and isort (88) to that of ruff (120)

Fixes #129410