### PR TITLE
inductor: dont decompose split_with_sizes_copy.out

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -83,7 +83,14 @@ inductor_decompositions = get_decompositions(
         quantized.linear_dynamic_fp16_unpacked_weight,
     ]
 )
+
+exclude_decomps = set(
+    [
+        aten.split_with_sizes_copy.out,
+    ]
+)
 decompositions = {**core_aten_decompositions(), **inductor_decompositions}
+decompositions = {k: v for k, v in decompositions.items() if k not in exclude_decomps}
 
 # Remove unwanted decompositions included via the core ATen decompositions from
 # the Inductor decomp table.


### PR DESCRIPTION
According to @yf225, we don't want to decompose the out= op in inductor. Especially now that we are not going to functinalize it, so we can just let the kernel fallback.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129407



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang