### PR TITLE
[aotinductor] only autotune at compile time when enabled via config

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1300,7 +1300,7 @@ def compile_fx(
         with config.patch(
             {
                 "cpp_wrapper": False,
-                "triton.autotune_at_compile_time": True,
+                "triton.autotune_at_compile_time": config.triton.autotune_at_compile_time,
                 "triton.autotune_cublasLt": False,
                 "triton.cudagraphs": False,
                 "triton.store_cubin": True,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1300,7 +1300,7 @@ def compile_fx(
         with config.patch(
             {
                 "cpp_wrapper": False,
-                "triton.autotune_at_compile_time": config.triton.autotune_at_compile_time,
+                "triton.autotune_at_compile_time": True,
                 "triton.autotune_cublasLt": False,
                 "triton.cudagraphs": False,
                 "triton.store_cubin": True,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1300,7 +1300,14 @@ def compile_fx(
         with config.patch(
             {
                 "cpp_wrapper": False,
-                "triton.autotune_at_compile_time": True,
+                # For triton.autotune_at_compile_time, disable by default for
+                # FBCode, but enabled by default for OSS.
+                "triton.autotune_at_compile_time": config.triton.autotune_at_compile_time
+                if config.is_fbcode()
+                else os.environ.get(
+                    "TORCHINDUCTOR_TRITON_AUTOTUNE_AT_COMPILE_TIME", "1"
+                )
+                == "1",
                 "triton.autotune_cublasLt": False,
                 "triton.cudagraphs": False,
                 "triton.store_cubin": True,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -696,9 +696,7 @@ class triton:
     autotune_cublasLt = True
 
     # Tune the generated Triton kernels at compile time instead of first time they run
-    autotune_at_compile_time = (
-        os.environ.get("TORCHINDUCTOR_TRITON_AUTOTUNE_AT_COMPILE_TIME", "0") == "1"
-    )
+    autotune_at_compile_time = False
 
     # should we stop a fusion to allow better tiling?
     tiling_prevents_pointwise_fusion = True

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -697,7 +697,10 @@ class triton:
 
     # Tune the generated Triton kernels at compile time instead of first time they run
     autotune_at_compile_time = (
-        os.environ.get("TORCHINDUCTOR_TRITON_AUTOTUNE_AT_COMPILE_TIME", "0") == "1"
+        os.environ.get(
+            "TORCHINDUCTOR_TRITON_AUTOTUNE_AT_COMPILE_TIME", "0" if is_fbcode() else "1"
+        )
+        == "1"
     )
 
     # should we stop a fusion to allow better tiling?

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -697,10 +697,7 @@ class triton:
 
     # Tune the generated Triton kernels at compile time instead of first time they run
     autotune_at_compile_time = (
-        os.environ.get(
-            "TORCHINDUCTOR_TRITON_AUTOTUNE_AT_COMPILE_TIME", "0" if is_fbcode() else "1"
-        )
-        == "1"
+        os.environ.get("TORCHINDUCTOR_TRITON_AUTOTUNE_AT_COMPILE_TIME", "0") == "1"
     )
 
     # should we stop a fusion to allow better tiling?


### PR DESCRIPTION
internal breakage when enabled.

Test Plan: CI

Differential Revision: D58965784


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang