### PR TITLE
[Traceable FSDP2] Don't decompose fsdp.split_with_sizes_copy

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -210,6 +210,15 @@ class TestFullyShardCompile(FSDPTest):
             *self._create_simple_mlp_factory_fns(), "aot_eager", fullgraph=True
         )
 
+    @skipIfRocm
+    @skip_if_lt_x_gpu(2)
+    def test_simple_mlp_fullgraph_backend_aot_eager_decomp_partition(self):
+        self._test_traceable_fsdp(
+            *self._create_simple_mlp_factory_fns(),
+            "aot_eager_decomp_partition",
+            fullgraph=True,
+        )
+
     @unittest.expectedFailure
     @skipIfRocm
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")

--- a/torch/_functorch/_aot_autograd/functional_utils.py
+++ b/torch/_functorch/_aot_autograd/functional_utils.py
@@ -416,7 +416,9 @@ def assert_functional_graph(fx_g: torch.fx.Graph) -> int:
                     ), f"n={str(n)}, n.args[0]={str(n.args[0])}, placeholders={str(placeholders)}, graph={str(fx_g)}"
                     placeholders.remove(n.args[0])
                 mutation_count += 1
-            elif n.target in [torch.ops.aten.split_with_sizes_copy.out]:
+            elif hasattr(torch.ops, "fsdp") and n.target in [
+                torch.ops.fsdp.split_with_sizes_copy.default
+            ]:
                 # These are mutation ops that can show up in the middle of the graph,
                 # because they are ops that we explicitly do **not** functinoalize
                 continue

--- a/torch/distributed/_composable/fsdp/_fsdp_collectives.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_collectives.py
@@ -112,9 +112,15 @@ def split_with_sizes_copy_functionalize(
 ) -> None:
     ag_output_elem = torch._from_functional_tensor(all_gather_output)
     out_elem = [torch._from_functional_tensor(x) for x in out]
-    torch.split_with_sizes_copy(
-        ag_output_elem, all_gather_input_split_sizes, dim=dim, out=out_elem
-    )
+    with torch._C._ExcludeDispatchKeyGuard(
+        torch._C.DispatchKeySet(torch._C.DispatchKey.Functionalize)
+    ):
+        torch.ops.fsdp.split_with_sizes_copy(
+            ag_output_elem, all_gather_input_split_sizes, dim=dim, out=out_elem
+        )
+
+
+torch.fx.node.has_side_effect(torch.ops.fsdp.split_with_sizes_copy.default)
 
 
 lib.define(

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -56,7 +56,6 @@ _side_effectful_functions: Set[Callable] = {
     _ops.profiler._record_function_enter_new,
     _ops.profiler._record_function_exit,
     _ops.inductor.accumulate_grad_.default,
-    _ops.aten.split_with_sizes_copy.out,
 } | _side_effectful_need_to_be_preserved_pre_dispatch
 if hasattr(_ops.inductor, "resize_storage_bytes_"):
     _side_effectful_functions.add(_ops.inductor.resize_storage_bytes_.default)


### PR DESCRIPTION
This makes it easier to do pattern-matching on `fsdp.split_with_sizes_copy` in Inductor passes.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129425
* #129422
* #127247
* __->__ #129414



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang @d4l3k