### PR TITLE
Flex Attention HOP: Add support for flex decoding

### DIFF
--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -1,0 +1,821 @@
+# Owner(s): ["module: inductor"]
+# flake8: noqa: B950
+
+import functools
+from collections import namedtuple
+from typing import Callable, Optional
+
+from unittest import expectedFailure, skip, skipUnless
+from unittest.mock import patch
+
+import torch
+
+from torch._higher_order_ops.flex_attention import flex_attention as flex_attention_hop
+from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.utils import run_and_get_code
+from torch.nn.attention._flex_attention import (
+    _causal,
+    _compose,
+    _create_empty_block_mask,
+    _flex_attention,
+    _generate_alibi_bias,
+    _identity,
+    _rel_bias,
+    _rel_causal,
+)
+from torch.testing import FileCheck
+from torch.testing._internal import common_utils
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_BF16
+from torch.utils._triton import has_triton
+
+# Skip tests if Triton is not available
+supported_platform = skipUnless(
+    torch.cuda.is_available()
+    and torch.version.hip is None
+    and has_triton()
+    and torch.cuda.get_device_capability() >= (8, 0),
+    "Requires CUDA and Triton",
+)
+
+Tolerances = namedtuple("Tolerances", ["atol", "rtol"])
+torch.set_float32_matmul_precision("high")
+
+index = torch.ops.aten.index
+
+
+def create_attention(score_mod, block_mask):
+    return functools.partial(
+        _flex_attention, score_mod=score_mod, block_mask=block_mask
+    )
+
+
+test_dtypes = (
+    [torch.float16, torch.bfloat16, torch.float32]
+    if PLATFORM_SUPPORTS_BF16
+    else [torch.float16, torch.float32]
+)
+
+test_dtypes_fast = [torch.float16]
+
+
+# --------- Useful score mod functions for testing ---------
+def _inverse_causal(score, b, h, m, n):
+    return torch.where(m <= n, score, float("-inf"))
+
+
+def _times_two(score, b, h, m, n):
+    """Joint graph needed for correctness"""
+    return score * 2
+
+
+def _squared(score, b, h, m, n):
+    """Joint graph needed for correctness"""
+    return score * score
+
+
+def _head_offset(dtype: torch.dtype):
+    """Captured Buffer"""
+    head_offset = torch.rand(Hkv, device="cuda", dtype=dtype)
+
+    def score_mod(score, b, h, m, n):
+        return score * head_offset[h]
+
+    return score_mod
+
+
+def _trig(score, b, h, m, n):
+    """Joint graph needed for correctness"""
+    return torch.sin(torch.cos(score)) + torch.tan(b)
+
+
+def _trig2(score, b, h, m, n):
+    """Branching joint graph"""
+    cos_score = torch.cos(score)
+    sin_score = torch.sin(score)
+    z = cos_score * sin_score + torch.tan(b)
+    return z
+
+
+test_score_mods = [
+    _identity,
+    _times_two,
+    _squared,
+    _causal,
+    _inverse_causal,
+    _rel_bias,
+    _rel_causal,
+    _generate_alibi_bias(8),
+]
+
+captured_buffers_map = {
+    "_head_offset": _head_offset,
+}
+
+B = 4
+S = 2048
+D = 64
+
+
+test_Hq_Hkv = [
+    (16, 1),
+    (8, 2),
+    (16, 16),
+    (32, 1),
+]
+
+(Hq, Hkv) = (16, 8)
+
+
+def query_key_value_clones(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    dtype: torch.dtype = None,
+):
+    """Clones the query, key, and value tensors and moves them to the specified dtype."""
+    if dtype is None:
+        dtype = query.dtype
+    query_ref = query.clone().detach().to(dtype).requires_grad_(query.requires_grad)
+    key_ref = key.clone().detach().to(dtype).requires_grad_(key.requires_grad)
+    value_ref = value.clone().detach().to(dtype).requires_grad_(value.requires_grad)
+    return query_ref, key_ref, value_ref
+
+
+class TestFlexAttention(InductorTestCase):
+    def _check_equal(
+        self,
+        golden_out: torch.Tensor,
+        ref_out: torch.Tensor,
+        compiled_out: torch.Tensor,
+        fudge_factor: float,
+        tensor_name: Optional[str] = None,
+    ):
+        compiled_error = (golden_out - compiled_out).abs().mean()
+        ref_error = (golden_out - ref_out).abs().mean()
+        if torch.isnan(compiled_error).any() and not torch.isnan(ref_error).any():
+            self.assertTrue(False, "Output/Grad with NaN")
+        if ref_error < (1e-4) * golden_out.abs().mean():
+            print(
+                "very small ref error of ",
+                (ref_error.to(torch.float64) * (1e5) / golden_out.abs().mean()),
+            )
+            tolerance = Tolerances(atol=2e-1, rtol=2e-1)
+            torch.testing.assert_close(
+                golden_out.to(dtype=compiled_out.dtype),
+                compiled_out,
+                atol=tolerance.atol,
+                rtol=tolerance.rtol,
+            )
+        elif compiled_error > ref_error * fudge_factor:
+            name = tensor_name if tensor_name is not None else ""
+            msg = f"{name} Compiled error {compiled_error} is greater than ref error {ref_error} by more than {fudge_factor}X."
+            self.assertTrue(False, msg)
+
+    def _check_out_and_grad(
+        self,
+        golden_out: torch.Tensor,
+        ref_out: torch.Tensor,
+        compiled_out: torch.Tensor,
+        q_gold: torch.Tensor,
+        q_ref: torch.Tensor,
+        q: torch.Tensor,
+        k_gold: torch.Tensor,
+        k_ref: torch.Tensor,
+        k: torch.Tensor,
+        v_gold: torch.Tensor,
+        v_ref: torch.Tensor,
+        v: torch.Tensor,
+    ):
+        dtype = ref_out.dtype
+        with torch.no_grad():
+            # Note, it seems like we really are less accurate than the float32
+            # computation, likely due to the online softmax
+            if dtype == torch.float32:
+                fudge_factor = 10.0
+            else:
+                fudge_factor = 1.1
+
+            # Checkout output
+            self._check_equal(golden_out, ref_out, compiled_out, fudge_factor, "Out")
+
+            # TODO: add backward support
+            # # Check gradients
+            # q_fudge_factor = 2.5 * fudge_factor
+            # self._check_equal(
+            #     q_gold.grad, q_ref.grad, q.grad, q_fudge_factor, "Grad_Query"
+            # )
+            # k_fudge_factor = 4 * fudge_factor
+            # self._check_equal(
+            #     k_gold.grad, k_ref.grad, k.grad, k_fudge_factor, "Grad_Key"
+            # )
+            # v_fudge_factor = 4 * fudge_factor
+            # self._check_equal(
+            #     v_gold.grad, v_ref.grad, v.grad, v_fudge_factor, "Grad_Value"
+            # )
+
+    def run_test(
+        self,
+        score_mod: Callable,
+        dtype: torch.dtype = torch.float16,
+        Q_B: int = B,
+        Q_H: int = Hq,
+        Q_S: int = 1,
+        Q_D: int = D,
+        KV_B: int = B,
+        KV_H: int = Hkv,
+        KV_S: int = S,
+        KV_D: int = D,
+    ):
+        assert Q_H % KV_H == 0
+
+        q = torch.randn(
+            (Q_B, KV_H, Q_S * (Q_H // KV_H), Q_D),
+            dtype=dtype,
+            device="cuda",
+            requires_grad=False,
+        )
+        k = torch.randn(
+            (KV_B, KV_H, KV_S, KV_D), dtype=dtype, device="cuda", requires_grad=False
+        )
+        v = torch.randn(
+            (KV_B, KV_H, KV_S, KV_D), dtype=dtype, device="cuda", requires_grad=False
+        )
+        q_ref, k_ref, v_ref = query_key_value_clones(q, k, v)
+        q_gold, k_gold, v_gold = query_key_value_clones(q, k, v, torch.float64)
+
+        block_mask = None
+        sdpa_partial = create_attention(score_mod, block_mask)
+        compiled_sdpa = torch.compile(sdpa_partial)
+        golden_out = sdpa_partial(q_gold, k_gold, v_gold)
+        ref_out = sdpa_partial(q_ref, k_ref, v_ref)
+        compiled_out = compiled_sdpa(q, k, v)
+
+        # TODO: Add backward support
+        # backward_grad = torch.randn(
+        #      (Q_B, KV_H, Q_S *(Q_H // KV_H), Q_D), dtype=dtype, device="cuda"
+        # )
+
+        # golden_out.backward(backward_grad.to(torch.float64))
+        # ref_out.backward(backward_grad)
+        # compiled_out.backward(backward_grad)
+
+        self._check_out_and_grad(
+            golden_out,
+            ref_out,
+            compiled_out,
+            q_gold,
+            q_ref,
+            q,
+            k_gold,
+            k_ref,
+            k,
+            v_gold,
+            v_ref,
+            v,
+        )
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    @common_utils.parametrize("score_mod", test_score_mods)
+    @common_utils.parametrize("head_dims", test_Hq_Hkv)
+    def test_builtin_score_mods(
+        self, dtype: torch.dtype, score_mod: Callable, head_dims
+    ):
+        Hq, Hkv = head_dims
+        assert Hq % Hkv == 0
+        self.run_test(score_mod, dtype, Q_H=Hq, KV_H=Hkv)
+
+    def input_strides_1(B, H, S, D):
+        return ((H * S * D, S * D, D, 1), 997)  # offset
+
+    def input_strides_2(B, H, S, D):
+        return ((H * D, D, B * H * D, 1), 499)  # transposed dimensions
+
+    def input_strides_3(B, H, S, D):
+        return ((S * (D + 1), B * S * (D + 1), (D + 1), 1), 293)  # additional buffer
+
+    def input_strides_4(B, H, S, D):
+        return ((1, D, (B + 1) * (H + 1) * D, 1), 97)  # shared dimension
+
+    test_input_strides = [
+        input_strides_1,
+        input_strides_2,
+        input_strides_3,
+        input_strides_4,
+    ]
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    @common_utils.parametrize("k_s", test_input_strides)
+    @common_utils.parametrize("v_s", test_input_strides)
+    @common_utils.parametrize("head_dims", test_Hq_Hkv)
+    def test_strided_inputs(self, dtype: torch.dtype, k_s, v_s, head_dims):
+        Hq, Hkv = head_dims
+        assert Hq % Hkv == 0
+        q1 = torch.randn((B * Hq * D), dtype=dtype, device="cuda")
+        k1 = torch.randn((B * Hkv * S * D * 4), dtype=dtype, device="cuda")
+        v1 = torch.randn((B * Hkv * S * D * 4), dtype=dtype, device="cuda")
+
+        k_shape = (B, Hkv, S, D)
+        v_shape = (B, Hkv, S, D)
+
+        q = q1.view(Hq // Hkv, Hkv, B, D).transpose(0, 2)
+
+        k_strides, k_offset = k_s(B, Hkv, S, D)
+        k_max = [x * (y - 1) for x, y in zip(k_strides, k_shape)]
+        assert sum(k_max) + k_offset < B * Hkv * S * D * 4
+        assert k_strides[-1] == 1
+        k = torch.as_strided(k1, k_shape, k_strides, k_offset)
+
+        v_strides, v_offset = v_s(B, Hkv, S, D)
+        v_max = [x * (y - 1) for x, y in zip(v_strides, v_shape)]
+        assert sum(v_max) + v_offset < B * Hkv * S * D * 4
+        assert v_strides[-1] == 1
+        v = torch.as_strided(v1, v_shape, v_strides, v_offset)
+
+        sdpa_partial = create_attention(
+            score_mod=_generate_alibi_bias(8), block_mask=None
+        )
+        compiled_sdpa = torch.compile(sdpa_partial)
+        ref_out = sdpa_partial(q, k, v)
+        compiled_out = compiled_sdpa(q, k, v)
+
+        tolerance = Tolerances(atol=2e-1, rtol=2e-1)
+        torch.testing.assert_close(
+            ref_out, compiled_out, atol=tolerance.atol, rtol=tolerance.rtol
+        )
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    def test_skip_odd_keys(self, dtype: torch.dtype):
+        def score_mod(score, b, h, q, kv):
+            return torch.where(kv % 2 == 0, score, float("-inf"))
+
+        self.run_test(score_mod, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    def test_function_composition(self, dtype: torch.dtype):
+        def score_mod_1(score, b, h, m, n):
+            return score + (m - n)
+
+        def score_mod_2(score, b, h, m, n):
+            return torch.where(m <= n, score, float("-inf"))
+
+        composed_score_mod = _compose(score_mod_1, score_mod_2)
+
+        self.run_test(composed_score_mod, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    def test_captured_buffers(self, dtype: torch.dtype):
+        head_offset = torch.rand(Hkv, device="cuda", dtype=dtype)
+
+        def score_mod(score, b, h, m, n):
+            return score + head_offset[h]
+
+        self.run_test(score_mod, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    def test_captured_buffers_all_dims(self, dtype: torch.dtype):
+        head_scale = torch.randn(Hkv, device="cuda")
+        batch_scale = torch.randn(B, device="cuda")
+        kv_scale = torch.randn(S, device="cuda")
+        q_scale = torch.randn(Hq // Hkv, device="cuda")
+        if q_scale.shape[-1] < 16:
+            q_scale = torch.nn.functional.pad(q_scale, (0, 16 - Hq // Hkv))
+
+        def all_bias(score, batch, head, token_q, token_kv):
+            score = score + kv_scale[token_kv]
+            score = score + q_scale[token_q]
+            score = score + head_scale[head]
+            return score
+
+        self.run_test(all_bias, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_seq_masking(self, dtype):
+        seq_idx = torch.zeros(S, device="cuda", dtype=torch.bool)
+        seq_idx[S // 2 :] = 1
+
+        def seq_mask_mod(score, b, h, q, kv):
+            return torch.where(seq_idx[q] == seq_idx[kv], score, float("-inf"))
+
+        self.run_test(seq_mask_mod, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_load_from_bias_seq_only(self, dtype):
+        bias = torch.randn(Hq // Hkv, S, device="cuda", dtype=dtype)
+        if bias.shape[-2] < 16:
+            bias = torch.nn.functional.pad(bias, (0, 16 - Hq // Hkv))
+
+        def bias_mod(score, b, h, q, kv):
+            return score + bias[q, kv]
+
+        self.run_test(bias_mod, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_load_from_bias_seq_batch(self, dtype):
+        bias = torch.randn(B, Hq // Hkv, S, device="cuda", dtype=dtype)
+
+        if bias.shape[-2] < 16:
+            bias = torch.nn.functional.pad(bias, (0, 16 - Hq // Hkv, 0, 0))
+
+        def bias_mod(score, b, h, q, kv):
+            return score + bias[b, q, kv]
+
+        self.run_test(bias_mod, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_load_from_bias_head_seq_batch(self, dtype):
+        bias = torch.randn(
+            B,
+            Hkv,
+            Hq // Hkv,
+            S,
+            device="cuda",
+            dtype=dtype,
+        )
+        if bias.shape[-2] < 16:
+            bias = torch.nn.functional.pad(bias, (0, 16 - Hq // Hkv, 0, 0))
+
+        def bias_mod(score, b, h, q, kv):
+            return score + bias[b, h, q, kv]
+
+        self.run_test(bias_mod, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_subgraph_respect_decompostion(self, dtype):
+        from torch._decomp import core_aten_decompositions
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def score_mod_func(score, b, h, q, kv):
+            return score - q // (1 + kv)
+
+        make_kv = functools.partial(
+            torch.randn,
+            (2, 2, 128, 4),
+            dtype=dtype,
+            device="cuda",
+            requires_grad=True,
+        )
+        make_q = functools.partial(
+            torch.randn,
+            (2, 2, 8, 4),
+            dtype=dtype,
+            device="cuda",
+            requires_grad=True,
+        )
+        query, key, value = make_q(), make_kv(), make_kv()
+        # floor_div is not decomposed in decompostion_table is empty
+        flex_attention = functools.partial(_flex_attention, score_mod=score_mod_func)
+        gm = make_fx(flex_attention, decomposition_table={})(query, key, value)
+        self.assertExpectedInline(
+            gm.sdpa_score0.code.strip(),
+            """\
+def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
+    add = torch.ops.aten.add.Tensor(arg4_1, 1);  arg4_1 = None
+    floor_divide = torch.ops.aten.floor_divide.default(arg3_1, add);  arg3_1 = add = None
+    sub = torch.ops.aten.sub.Tensor(arg0_1, floor_divide);  arg0_1 = floor_divide = None
+    return sub""",
+        )
+
+        # floor_div is decomposed for core_aten_decompositions
+        gm = make_fx(flex_attention, decomposition_table=core_aten_decompositions())(
+            query, key, value
+        )
+        self.assertExpectedInline(
+            gm.sdpa_score0.code.strip(),
+            """\
+def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
+    add = torch.ops.aten.add.Tensor(arg4_1, 1);  arg4_1 = None
+    div = torch.ops.aten.div.Tensor_mode(arg3_1, add, rounding_mode = 'floor');  arg3_1 = add = None
+    sub = torch.ops.aten.sub.Tensor(arg0_1, div);  arg0_1 = div = None
+    return sub""",
+        )
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_silu_on_score(self, dtype):
+        def silu_score(score, b, h, q, kv):
+            return torch.nn.functional.silu(score)
+
+        self.run_test(silu_score, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_padded_dense_causal(self, dtype):
+        seq_len = torch.arange(B, device="cuda", dtype=torch.int32) + 1
+
+        def create_padded_dense_wrapper(orig_score_mod):
+            def njt_score_mod(qk, b, h, q, kv):
+                return torch.where(
+                    qk <= seq_len[b], orig_score_mod(qk, b, h, q, kv), -float("inf")
+                )
+
+            return njt_score_mod
+
+        causal_njt = create_padded_dense_wrapper(_causal)
+
+        self.run_test(causal_njt, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_captured_scale(self, dtype):
+        scale = torch.ones((), device="cuda", dtype=torch.int32)
+
+        def score_mod_scale(qk, b, h, q, kv):
+            return qk + scale
+
+        self.run_test(score_mod_scale, dtype)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_recompile_changed_score_mod(self, dtype):
+        scale = torch.ones((), device="cuda", dtype=torch.int32)
+        ADD = True
+
+        def score_mod_scale(qk, b, h, q, kv):
+            if ADD:
+                return qk + scale
+            else:
+                return qk * scale
+
+        self.run_test(score_mod_scale, dtype)
+        ADD = False
+        self.run_test(score_mod_scale, dtype)
+
+    @supported_platform
+    @expectedFailure  # If we capture a tensor then we can perform a reduction on it, and that shouldn't be allowed
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    def test_captured_reduction(self, dtype):
+        scale = torch.randn((B, 8), device="cuda")
+
+        def score_mod_scale(qk, b, h, q, kv):
+            return qk + scale[b].sum(dim=-1)
+
+        self.run_test(score_mod_scale, dtype)
+
+    @supported_platform
+    def test_multiple_score_mod_calls(self):
+        query = torch.randn((1, 8, 4, 64), dtype=torch.float32, device="cuda")
+        keys = [
+            torch.randn((1, 8, 1024, 64), dtype=torch.float32, device="cuda")
+            for _ in range(2)
+        ]
+        values = [
+            torch.randn((1, 8, 1024, 64), dtype=torch.float32, device="cuda")
+            for _ in range(2)
+        ]
+
+        def scoremod_1(qk, b, h, q, kv):
+            return qk + (q - kv)
+
+        def scoremod_2(qk, b, h, q, kv):
+            return torch.where(q >= kv, qk, -float("inf"))
+
+        def f(q, k1, k2, v1, v2):
+            q2 = _flex_attention(q, k1, v1, score_mod=scoremod_1)
+            return _flex_attention(q2, k2, v2, score_mod=scoremod_2)
+
+        out = f(query, *keys, *values)
+        out2 = torch.compile(f)(query, *keys, *values)
+        tolerance = Tolerances(atol=2e-1, rtol=2e-1)
+        torch.testing.assert_close(out, out2, atol=tolerance.atol, rtol=tolerance.rtol)
+
+    @supported_platform
+    def test_multiple_score_mod_calls2(self):
+        query = torch.randn((1, 8, 4, 64), dtype=torch.float32, device="cuda")
+        keys = [
+            torch.randn((1, 8, 1024, 64), dtype=torch.float32, device="cuda")
+            for _ in range(3)
+        ]
+        values = [
+            torch.randn((1, 8, 1024, 64), dtype=torch.float32, device="cuda")
+            for _ in range(3)
+        ]
+
+        def scoremod_1(qk, b, h, q, kv):
+            return qk + (q - kv)
+
+        def scoremod_2(qk, b, h, q, kv):
+            return torch.where(q >= kv, qk, -float("inf"))
+
+        attention1 = functools.partial(_flex_attention, score_mod=scoremod_1)
+
+        def f(q, k1, k2, k3, v1, v2, v3):
+            q2 = attention1(q, k1, v1)
+            q3 = _flex_attention(q2, k2, v2, score_mod=scoremod_2)
+            return _flex_attention(q3, k3, v3, score_mod=scoremod_1)
+
+        out = f(query, *keys, *values)
+        out2 = torch.compile(f)(query, *keys, *values)
+        self.assertTrue((out - out2).abs().mean() < 1e-2)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    def test_njt_causal(self, dtype):
+        offsets = torch.tensor(
+            [0, 1024, 1024 + 512, S], device="cuda", dtype=torch.int32
+        )
+        seq_idx = torch.zeros(S, device="cuda", dtype=torch.int32)
+        for idx in range(len(offsets) - 1):
+            seq_idx[offsets[idx] : offsets[idx + 1]] = idx
+
+        def create_njt_wrapper(orig_score_mod, offsets, seq_idx):
+            def njt_score_mod(qk, b, h, q, kv):
+                q_nested = q - offsets[seq_idx[q]]
+                kv_nested = kv - offsets[seq_idx[kv]]
+                return orig_score_mod(qk, b, h, q_nested, kv_nested)
+
+            return njt_score_mod
+
+        causal_njt = create_njt_wrapper(_causal, offsets, seq_idx)
+
+        self.run_test(causal_njt, dtype)
+
+    @supported_platform
+    def test_mixed_dtypes_fails(self):
+        query = torch.randn((1, 1, 8, 64), dtype=torch.float32, device="cuda")
+        key = torch.randn((1, 1, 1024, 64), dtype=torch.float16, device="cuda")
+        value = torch.randn((1, 1, 1024, 64), dtype=torch.float16, device="cuda")
+        with self.assertRaisesRegex(
+            ValueError, "Expected query, key, and value to have the same dtype"
+        ):
+            _flex_attention(query, key, value, _identity)
+
+    @supported_platform
+    @patch.object(torch._inductor.config, "max_autotune", True)
+    def test_max_autotune(self):
+        def score_mod(score, b, h, m, n):
+            return score * 2
+
+        self.run_test(score_mod)
+
+    @supported_platform
+    @skip("TODO: Figure out why this is erroring")
+    @patch.object(torch._inductor.config, "max_autotune", True)
+    def test_max_autotune_with_captured(self):
+        head_scale = torch.randn(Hkv, device="cuda")
+        batch_scale = torch.randn(B, device="cuda")
+        tok_scale = torch.randn(S, device="cuda")
+        q_scale = torch.randn(Hq // Hkv, device="cuda")
+
+        def bias_mod(score, batch, head, token_q, token_kv):
+            score = score + tok_scale[token_kv]
+            score = score + q_scale[token_q]
+            score = score + batch_scale[batch]
+            score = score + head_scale[head]
+            return score
+
+        self.run_test(bias_mod)
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes)
+    @common_utils.parametrize("score_mod", [_identity, _causal])
+    def test_logsumexp_correctness(self, dtype, score_mod):
+        make_kv = functools.partial(
+            torch.randn,
+            (B, Hkv, S, D),
+            dtype=dtype,
+            device="cuda",
+            requires_grad=True,
+        )
+        make_q = functools.partial(
+            torch.randn,
+            (B, Hkv, Hq // Hkv, D),
+            dtype=dtype,
+            device="cuda",
+            requires_grad=True,
+        )
+        q, k, v = make_q(), make_kv(), make_kv()
+        block_mask = _create_empty_block_mask(q, k, v)
+
+        @torch.compile
+        def sdpa_hop(q, k, v, score_mod, block_mask):
+            return flex_attention_hop(
+                q,
+                k,
+                v,
+                score_mod,
+                block_mask.as_tuple(),
+            )
+
+        @torch.compile(backend="aot_eager")
+        def eager_sdpa_hop(q, k, v, score_mod, block_mask):
+            """The main entrypoint for FlexAttention doesnt return LSE.
+            Besides dropping LSE it also ensures that the hop is compiled with aot-eager
+            backend. We need to replicate this.
+            """
+            return flex_attention_hop(
+                q,
+                k,
+                v,
+                score_mod,
+                block_mask,
+            )
+
+        ref_out, ref_lse = eager_sdpa_hop(
+            q.to(torch.float64),
+            k.to(torch.float64),
+            v.to(torch.float64),
+            score_mod,
+            block_mask.as_tuple(),
+        )
+        compiled_out, compiled_lse = sdpa_hop(q, k, v, score_mod, block_mask)
+        # Comparing LSE for the ref and the compiled version
+        # The compiled uses a change of base trick to more efficiently compute the LSE
+        # this means that the base for the LSE computed by ref is e while for the compiled
+        # version it is 2. To compare we use the change of base formula
+        # log_2(x_compiled) = log_e(x_ref) * log_2(e) where
+        # x_ref      = sum(_i e^(scores[i]))
+        # x_compiled = sum(_i 2^(log2(e) * scores[i]))
+
+        self.assertTrue(ref_lse.dtype == torch.float64)
+        self.assertTrue(compiled_lse.dtype == torch.float32)
+        ref_lse = ref_lse * torch.log2(torch.tensor(torch.e))
+
+        tolerance = Tolerances(atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(
+            ref_out.to(dtype=torch.float32),
+            compiled_out.to(dtype=torch.float32),
+            atol=tolerance.atol,
+            rtol=tolerance.rtol,
+        )
+        torch.testing.assert_close(
+            ref_lse.to(dtype=torch.float32),
+            compiled_lse.to(dtype=torch.float32),
+            atol=tolerance.atol,
+            rtol=tolerance.rtol,
+        )
+
+    @supported_platform
+    def test_logsumexp_only_return(self):
+        make_tensor = functools.partial(
+            torch.randn,
+            (B, Hkv, Hq // Hkv, D),
+            dtype=torch.float32,
+            device="cuda",
+            requires_grad=True,
+        )
+
+        q, k, v = make_tensor(), make_tensor(), make_tensor()
+        block_mask = _create_empty_block_mask(q, k, v)
+
+        @torch.compile
+        def func(q, k, v, score_mod, block_mask):
+            _, lse = flex_attention_hop(
+                q,
+                k,
+                v,
+                score_mod,
+                block_mask.as_tuple(),
+            )
+            lse_2 = lse * 2
+            return lse_2
+
+        _, code = run_and_get_code(func, q, k, v, _identity, block_mask)
+        # Ensure that at least 3 kernels are generated
+        FileCheck().check_count(".run(", 3, False).run(code[0])
+
+    @supported_platform
+    def test_logsumexp_is_not_fused(self):
+        make_tensor = functools.partial(
+            torch.randn,
+            (B, Hkv, Hq // Hkv, D),
+            dtype=torch.float32,
+            device="cuda",
+            requires_grad=True,
+        )
+        q, k, v = make_tensor(), make_tensor(), make_tensor()
+        block_mask = _create_empty_block_mask(q, k, v)
+
+        @torch.compile
+        def func(q, k, v, score_mod, block_mask):
+            out, lse = flex_attention_hop(
+                q,
+                k,
+                v,
+                score_mod,
+                block_mask.as_tuple(),
+            )
+            lse_2 = lse * 2
+            return out, lse_2
+
+        _, code = run_and_get_code(func, q, k, v, _identity, block_mask)
+        # Ensure that at least 3 kernels are generated
+        FileCheck().check_count(".run(", 3, False).run(code[0])
+
+
+common_utils.instantiate_parametrized_tests(TestFlexAttention)
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()

--- a/torch/_inductor/kernel/flex_decoding.py
+++ b/torch/_inductor/kernel/flex_decoding.py
@@ -1,0 +1,380 @@
+# mypy: allow-untyped-defs
+""" Triton Implementation of the flex_attention Kernel for short query length (FlexDecoding)"""
+from typing import Any, List, Tuple
+
+import sympy
+
+import torch
+from torch._inductor.virtualized import V
+from ..ir import FixedLayout, FlexibleLayout
+from ..lowering import empty_strided, lowerings
+from ..runtime.runtime_utils import next_power_of_2
+from ..select_algorithm import autotune_select_algorithm, TritonTemplate
+
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+
+def flex_decoding_grid(batch_size, num_heads, n_keys, d_model, meta):
+    """How is this kernel parallelized?
+    We create a grid of (batch_size * num_heads, SPLIT_KV, 1)
+    Each block is responsible for iterating over blocks of keys and values calculating
+    the local output for their tile of keys and values over all full length of query.
+    groups of SPLIT_KV blocks then combine their output to produce the final result.
+    """
+
+    return (batch_size * num_heads, meta["SPLIT_KV"], 1)
+
+
+flex_decoding_template = TritonTemplate(
+    name="flex_decoding",
+    grid=flex_decoding_grid,
+    source=r"""
+    {{def_kernel("Q", "K", "V", "M", "L")}}
+    # Sub notation for this kernel:
+    # Q: Query, K: Key, V: Value
+    # reduction buffers: M rowmax across local KV split, L local sumexp across local KV split
+    # M: Number of queries, N: Number of keys/values, D(BLOCK_DMODEL): Model dimension
+    # BLOCK_M, BLOCK_DMODEL: M, and D dimemsion are always assigned to the same block
+    # z: Batch size, h: Number of heads, m: Number of queries per head, k: Number of keys per head t: Number of kv splits
+    # (Modifiable) Config options:
+    # SPLIT_KV: number of blocks K & V are split into
+    # TILE_KV: length of each local KV split
+    # BLOCK_M: block size that Q is padded along seqlen dim.
+    # BLOCK_N: block size of K & V along N dimension.
+    #
+    # change of base out of the loop
+    # ROWS_GUARANTEED_SAFE: Is it guaranteed that at least one value in each row
+    # is not masked out? If so, we can skip an extra safety check
+    # SAFE_M_BOUNDARY: Is Q seqlen a multiple of BLOCK_M? If so, we can skip an extra boundary check for loading query.
+    # SAFE_N_BOUNDARY: Is KV seqlen a multiple of BLOCK_N? If so, we can skip an extra boundary check for loading key/value.
+
+    # PRESCALE_QK: Whether to pre-scale QK by 1/sqrt(d) and change of base.
+    #
+    # Output: ACC output accumulated across local KV split.
+
+
+    # Define Q Strides
+    stride_qz = {{stride("Q", 0)}}
+    stride_qh = {{stride("Q", 1)}}
+    stride_qm = {{stride("Q", 2)}}
+    stride_qk = {{stride("Q", 3)}}
+    # Define K Strides
+    stride_kz = {{stride("K", 0)}}
+    stride_kh = {{stride("K", 1)}}
+    stride_kn = {{stride("K", 2)}}
+    stride_kk = {{stride("K", 3)}}
+    # Define V Strides
+    stride_vz = {{stride("V", 0)}}
+    stride_vh = {{stride("V", 1)}}
+    stride_vk = {{stride("V", 2)}}
+    stride_vn = {{stride("V", 3)}}
+    # Define M Strides
+    stride_mz = {{stride("M", 0)}}
+    stride_mh = {{stride("M", 1)}}
+    stride_mt = {{stride("M", 2)}}
+    stride_mm = {{stride("M", 3)}}
+    # Define L Strides
+    stride_lz = {{stride("L", 0)}}
+    stride_lh = {{stride("L", 1)}}
+    stride_lt = {{stride("L", 2)}}
+    stride_lm = {{stride("L", 3)}}
+
+
+    Z = {{size("Q", 0)}}
+    H = {{size("Q", 1)}}
+    Q_LEN = {{size("Q", 2)}}
+    KV_LEN = {{size("K", 2)}}
+    # Make sure each split is a multiple of BLOCK_N
+    TILE_KV_OG = tl.cdiv(KV_LEN, SPLIT_KV)
+    TILE_KV = tl.cdiv(TILE_KV_OG, BLOCK_N) * BLOCK_N
+
+    MATMUL_PRECISION = Q.dtype.element_ty
+
+    off_z = tl.program_id(0) // H
+    off_h = tl.program_id(0) % H
+    off_t = tl.program_id(1)
+    off_n = off_t * TILE_KV
+
+    q_offset = off_z * stride_qz + off_h * stride_qh
+    k_offset = off_z * stride_kz + off_h * stride_kh
+    v_offset = off_z * stride_vz + off_h * stride_vh
+    Q_block_ptr = tl.make_block_ptr(
+        base=Q + q_offset,
+        shape=(Q_LEN, BLOCK_DMODEL),        # (M, d)
+        strides=(stride_qm, stride_qk),
+        offsets=(0, 0),                     # No offset: one CTA per query
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
+        order=(1, 0)
+    )
+
+    K_block_ptr = tl.make_block_ptr(
+        base=K + k_offset,
+        shape=(BLOCK_DMODEL, KV_LEN),                # (d, N)
+        strides=(stride_kk, stride_kn),
+        offsets=(0, off_t * TILE_KV),
+        block_shape=(BLOCK_DMODEL, BLOCK_N),
+        order=(0, 1)
+    )
+    V_block_ptr = tl.make_block_ptr(
+        base=V + v_offset,
+        shape=(KV_LEN, BLOCK_DMODEL),
+        strides=(stride_vk, stride_vn),
+        offsets=(off_t * TILE_KV, 0),
+        block_shape=(BLOCK_N, BLOCK_DMODEL),
+        order=(1, 0)
+    )
+
+    m_offset = off_h * stride_mh + off_z * stride_mz
+    l_offset = off_h * stride_lh + off_z * stride_lz
+    M_block_ptr = tl.make_block_ptr(
+        base=M + m_offset,
+        shape=(SPLIT_KV, Q_LEN),                      # (T, M)
+        strides=(stride_mt, stride_mm),
+        offsets=(off_t, 0),
+        block_shape=(1, BLOCK_M),
+        order=(1, 0)
+    )
+    L_block_ptr = tl.make_block_ptr(
+        base=L + l_offset,
+        shape=(SPLIT_KV, Q_LEN),                      # (T, M)
+        strides=(stride_lt, stride_lm),
+        offsets=(off_t, 0),
+        block_shape=(1, BLOCK_M),
+        order=(1, 0)
+    )
+
+
+    # initialize offsets
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+
+    if SAFE_M_BOUNDARY:
+        q = tl.load(Q_block_ptr)
+    else:
+        q = tl.load(Q_block_ptr, boundary_check=(0, ))
+    RCP_LN2 = 1.44269504
+
+    if PRESCALE_QK:
+        q = (q * SM_SCALE * RCP_LN2).to(MATMUL_PRECISION)
+
+
+    # loop over k, v and update accumulator
+    lo = off_n
+    hi = tl.minimum(lo + TILE_KV, KV_LEN)
+    for start_n in range(lo, hi, BLOCK_N):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+        # -- load k, v --
+        k = tl.load(K_block_ptr).to(MATMUL_PRECISION)
+        v = tl.load(V_block_ptr)
+        # -- compute qk ---
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        qk = tl.dot(q, k, acc=qk)
+        if not PRESCALE_QK:
+            qk *= SM_SCALE
+
+        # ~~~~~~~~~~~~~~~~~~~ Apply score modification  ~~~~~~~~~~~~~~~~~~~
+        m = offs_m[:, None]
+        n = start_n + offs_n[None, :]
+        # TODO: Add load mask in modification when M/N Boundary is not safe
+        {{ modification(
+            subgraph_number=0,
+            output_name="post_mod_scores",
+            score="qk",
+            b="off_z",
+            h="off_h",
+            m="m",
+            n="n",
+            out="qk"
+        ) | indent_except_first(2) }}
+        # TODO: In the case that score_mod is linear, this can be LICMed
+        if not PRESCALE_QK:
+            post_mod_scores *= RCP_LN2
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+        # -- compute scaling constant ---
+        row_max = tl.max(post_mod_scores, 1)
+        m_i_new = tl.maximum(m_i, row_max)
+
+        alpha = tl.math.exp2(m_i - m_i_new)
+        p = tl.math.exp2(post_mod_scores - m_i_new[:, None])
+        if not ROWS_GUARANTEED_SAFE:
+            masked_out_rows = (m_i_new == float("-inf"))
+            alpha = tl.where(masked_out_rows, 0, alpha)
+            p = tl.where(masked_out_rows[:, None], 0, p)
+
+        # -- scale and update acc --
+        acc *= alpha[:, None]
+        acc = tl.dot(p.to(MATMUL_PRECISION), v.to(MATMUL_PRECISION), acc=acc)
+
+        # -- update m_i and l_i --
+        l_i = l_i * alpha + tl.sum(p, 1)
+        m_i = m_i_new
+        # update pointers
+        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+
+    # Store output, logsumexp and rowmax for cross CTA reduction. (all in float32, even when input data are in fp16)
+    if SAFE_M_BOUNDARY:
+        tl.store(M_block_ptr, m_i[None, :])
+        tl.store(L_block_ptr, l_i[None, :])
+    else:
+        tl.store(M_block_ptr, m_i[None, :], boundary_check=(1,))
+        tl.store(L_block_ptr, l_i[None, :], boundary_check=(1,))
+
+    # -- store output
+    idx_z = off_z
+    idx_h = off_h
+    idx_t = off_t
+    idx_m = offs_m[:, None]
+    idx_d = offs_d[None, :]
+    # TODO generalize and add proper mask support
+    mask = (idx_m < Q_LEN)
+    {{store_output(("idx_z", "idx_h", "idx_t", "idx_m", "idx_d"), "acc", "mask")}}
+ """,
+)
+
+
+MAX_SPLIT_KV = 64
+
+
+def get_split_k(B: int, H: int, Mk: int, SM: int = 128) -> int:
+    """Heuristic for the number of splits from xformer"""
+    bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
+    split_k = SM // bh  # Each SM should at least get one block.
+    split_k = max(split_k, 1)
+
+    return split_k
+
+
+def _get_decoding_default_config(key) -> Tuple[int, int, int]:
+    default_config = (64, 2, 3)
+
+    return default_config
+
+
+def create_flex_decoding_kernel(*args, **kwargs):
+    (subgraph_buffer, query, key, value, subgraph, scale, *other_buffers) = args
+    choices: List[Any] = []
+    configs: List[Tuple[int, int, int]] = []
+    configs.append(_get_decoding_default_config(key))
+    # Note: max_autotune is not supported yet. Causes error in lowering the dynamic shape in reduction ops.
+    # if config.max_autotune:
+    #     configs += [
+    #         (64, 2, 2),
+    #         (32, 2, 3),
+    #     ]
+    # TODO: fix autotuning.
+
+    SPLIT_KV = get_split_k(key.get_size()[0], key.get_size()[1], key.get_size()[2])
+    MAX_SPLIT_KV = SPLIT_KV
+    assert SPLIT_KV <= MAX_SPLIT_KV
+
+    # create config dependent intermediate buffers
+    buf_ML_shape = query.get_size()[:-2] + [
+        MAX_SPLIT_KV,
+        query.get_size()[-2],
+    ]  # [B, H, SPLIT_KV, M]
+    buf_M = empty_strided(
+        buf_ML_shape,
+        None,
+        dtype=torch.float32,  # The rowmax is always stored in fp32 regardless of the input dtype
+        device=query.get_device(),
+    )
+    buf_L = empty_strided(
+        buf_ML_shape,
+        None,
+        dtype=torch.float32,  # The intermediate sumexp is always stored in fp32 regardless of the input dtype
+        device=query.get_device(),
+    )
+
+    buf_ACC_shape = (
+        query.get_size()[:-2] + [MAX_SPLIT_KV] + query.get_size()[-2:]
+    )  # [B, H, SPLIT_KV, M, D]
+
+    layout_acc = FixedLayout(
+        query.get_device(),
+        torch.float32,
+        buf_ACC_shape,
+        FlexibleLayout.contiguous_strides(buf_ACC_shape),
+    )
+
+    m = query.get_size()[-2]
+    BLOCK_M = (
+        # m
+        # if V.graph.sizevars.evaluate_expr(sympy.Lt(query.get_size()[-2], 0))
+        # else  # Always use a BLOCK_M > 16 before Triton fix https://github.com/triton-lang/triton/pull/4061 is in pin
+        max(
+            next_power_of_2(
+                V.graph.sizevars.size_hint(
+                    m, fallback=torch._inductor.config.unbacked_symint_fallback  # type: ignore[arg-type]
+                )
+            ),
+            16,
+        )
+    )
+
+    V.graph.sizevars.guard_leq(m, sympy.Integer(BLOCK_M))
+
+    # Note, we don't need to pass in the captured buffers explicitly
+    # because they're implicitly added by the score_mod function
+    # We do need to explicitly pass it in for autotuning though.
+    for BLOCK_N, num_warps, num_stages in configs:
+        flex_decoding_template.maybe_append_choice(
+            choices=choices,
+            input_nodes=[query, key, value, buf_M, buf_L],
+            layout=layout_acc,
+            subgraphs=[
+                subgraph_buffer,
+            ],
+            mutated_inputs=[buf_M, buf_L],
+            num_stages=num_stages,
+            num_warps=num_warps,
+            call_sizes=query.get_size(),
+            BLOCK_M=BLOCK_M,
+            SPLIT_KV=SPLIT_KV,
+            BLOCK_DMODEL=query.get_size()[-1],
+            SM_SCALE=scale,
+            # Performance tuning
+            BLOCK_N=BLOCK_N,
+            # For now, we always assume the "sound" option
+            ROWS_GUARANTEED_SAFE=False,
+            SAFE_M_BOUNDARY=(query.get_size()[-2] % BLOCK_M) == 0,
+            SAFE_N_BOUNDARY=True,
+            PRESCALE_QK=False,
+        )
+
+    inputs_for_flex_decoding = [query, key, value, buf_M, buf_L] + list(other_buffers)
+    buf_ACC = autotune_select_algorithm(
+        "flex_decoding", choices, inputs_for_flex_decoding, layout_acc
+    )
+
+    # Reduction
+
+    g_M = lowerings[aten.max](buf_M, dim=-2, keepdim=True)[0]
+    adj_M = lowerings[aten.sub](buf_M, g_M)
+    alpha = lowerings[aten.exp2](adj_M)
+
+    buf_L = lowerings[aten.mul](buf_L, alpha)
+    g_L = lowerings[aten.sum](buf_L, axis=-2)
+    logsumexp = lowerings[aten.log2](g_L)
+    logsumexp = lowerings[aten.add](logsumexp, lowerings[aten.squeeze](g_M, dim=-2))
+
+    alpha_unseq = lowerings[aten.unsqueeze](alpha, 4)
+    buf_ACC = lowerings[aten.mul](buf_ACC, alpha_unseq)
+    output = lowerings[aten.sum](buf_ACC, axis=-3)
+    L_unseq = lowerings[aten.unsqueeze](g_L, 3)
+    output = lowerings[aten.div](output, L_unseq)
+    output = lowerings[prims.convert_element_type](output, query.get_dtype())
+
+    return (
+        output,
+        logsumexp,
+    )

--- a/torch/nn/attention/_flex_attention.py
+++ b/torch/nn/attention/_flex_attention.py
@@ -492,8 +492,11 @@ def flex_attention(
 
     # Some basic input validation
     _validate_sdpa_input(query, key, value)
-    if query.size(-2) % 128 != 0:
-        raise ValueError("NYI: S and L must be a multiple of 128")
+    if query.size(-2) >= 32:  # use Attention Kernel
+        if query.size(-2) >= 128 & query.size(-2) % 128 != 0:
+            raise ValueError("NYI: S must be <128 or a multiple of 128")
+    if key.size(-2) % 128 != 0:
+        raise ValueError("NYI: L must be a multiple of 128")
 
     if not torch._dynamo.is_dynamo_supported():
         raise RuntimeError("flex_attention requires dynamo support.")


### PR DESCRIPTION
# Flex Decoding
tl;dr This PR adds `flex_decoding` kernel to higher-order-op: `flex_attention` as the backend for multi-head attention decoding. 

Higher-order-op `flex_attention` was introduced in (https://github.com/pytorch/pytorch/pull/121845) to accept a user defined score modification callable (`score_mod`) and through `torch.compile`to create an efficient fused flash attention kernel instatiation. The `flex_attention` kernel is efficient for long queries (>512 tokens) attention. This PR introduces `flex_decoding` kernel as an alternative backend for `flex_attention` HOP to handle LLM inference where short queries (<32 tokens) attends to long key/value sequences.

### Details

LLM decoding iteratively attends each newly generated token ( query length = 1 ) to a long key/value context (up to 132k). `flex_attention` kernel only parallelizes attention along query length (M), batch size (B) and number of heads (H) dimension. LLM decoding lacks enough parallelism in the M dimension to fill up all SMs on the modern GPUs. 

`flex_decoding` adds parallelization along key/value sequence length (N). The key/value cache of a single head are split into multiple blocks and the query tokens attends to them in parallel. The results for the same head are then reduced across KV blocks to generate a global output. 


## Examples

Consider a Group Query Attention (GQA) decoding case, where a query token of 16 query heads (Hq) attends to 2 kv head (Hkv). Assume a batch size of 2 (B=2) and kv cache length of 4096 (N=4096). The attention kernel iteratively attends to newly generated query token (Mq = 1). 

We transform this problem into a Multiheaded Attention (MHA) problem by assuming a query length equal to number of query heads per kv heads, i.e. M=Hq//Hkv. 
The inputs to `flex_attention` HOP is thus a query of shape (B=2, H=Hkv=2, M=Hq//Hkv=8, D=64), key,value of shape (B=2, H=Hkv=2, N=4096, D=64, which lead to an intermediate attention score matrix of shape (2, 2, 8, 4096) and an output of shape (2, 2, 8, 64). 

```Python
import torch
from torch.nn.attention._flex_attention import _flex_attention as flex_attention

torch.manual_seed(0)

# Lets create some input tensors
# query of shape (B, Hkv, Hq//Hkv, D) 
# key/value of shape (B, Hkv, N, D) 
query = torch.randn(2, 2, 8, 64, device="cuda", dtype=torch.float32)
key = torch.randn(2, 2, 4096, 64, device="cuda", dtype=torch.float32)
value = torch.randn(2, 2, 4096, 64, device="cuda", dtype=torch.float32)

# Lets create a new score_modification checkerboard. 
def checkerboard(score, batch, head, token_q, token_kv):
    score = torch.where(torch.abs(token_kv - token_q) == 1, score * 0.5, score)
    score = torch.where(torch.abs(token_kv - token_q) == 2, score * 2.0, score)
    return score

# Lets call flex_attention with this new score modification for decoding. 
# The flex_attention HOP will chose flex_decoding as its backend since our query length (M) is only 8. 
output = flex_attention(query, key, value, score_mod=checkerboard)

compiled_flex_attention = torch.compile(flex_attention)
out_compiled = compiled_flex_attention (query, key, value, score_mod=checkerboard)

torch.testing.assert_close(output, out_compiled, atol=2e-2, rtol=2e-2)
```

## Future Plans 
- This PR does not implement load mask for score_mod function. This means if the score_mod functions takes a captured buffer along the M dimension , it must be padded to q length of 16, or next 2^n of query length if q_len > 16. 
i.e.
```python
q_scale = torch.randn(Hq//Hkv, device="cuda")
q_scale = torch.nn.functional.pad(q_scale, (0, 16-Hq//Hkv)) # Pad captured buffer
def bias_mod(score, batch, head, q, kv):
    score = score + q_scale[token_q]
    return score
```
- Backward path for short queries (<128 token) currently does not work because the `flex_attention_backward` kernel is lacking mask support and only takes query length of a multiple of 128. 
- Dynamic shape and max_autotuning is currently not working
- Add block sparse mask support (#129216 is a draft for flex_attention kernel) 
- Add explicit GQA support. (#130076 is a draft for GQA support on flex_attention kernel) 




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang