### PR TITLE
[export] match fake mode for _decompose_exported_program()

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -265,6 +265,26 @@ def forward(self, arg0_1, arg1_1):
         Range constraints: {}
         """
 
+    def test_joint_dynamic(self) -> None:
+        from torch.export import Dim
+
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.y = torch.nn.Parameter(torch.randn(3))
+
+            def forward(self, x):
+                x = torch.ones(x.shape[0], 3)
+                return (self.y + x).sum()
+
+        m = Module()
+        example_inputs = (torch.randn(3),)
+        m(*example_inputs)
+        ep = torch.export._trace._export(
+            m, example_inputs, pre_dispatch=True, dynamic_shapes={"x": {0: Dim("x0")}}
+        )
+        joint_ep = _export_forward_backward(ep)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Summary:
_decompose_exported_program() ran into an issue with trace_joint, where trace_joint() produces values with mismatching FakeModes. Adding fake mode context to aot_export_module() so this doesn't happen.

#thanks to tugsbayasgalan for the fix!

Test Plan: test_experimental

Differential Revision: D58977694


