### PR TITLE
[C10D] Separate deviceKey from streamKey in getNCCLComm

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -685,7 +685,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       at::Device& device,
       OpType opType,
       int p2pRank = 0,
-      bool isSendRecvSelf = false);
+      bool isSendRecvSelf = false,
+      std::optional<const std::string> streamKey = c10::nullopt);
 
   // Wrapper method which can be overridden for tests.
   virtual std::exception_ptr checkForNCCLErrors(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

The paves the way for a set of changes that would let us use the same
nccl communicator for collectives and p2p ops (and have that be eagerly
initialized instead of lazily initialized), but always use a dedicated
nccl stream for p2p operations with different ranks to ensure they can
overlap.

This PR only adds a new streamKey that defaults to the value of the
deviceKey, so should not affect runtime behavior at all.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @yf225 @chauhang @d4l3k