### PR TITLE
[C10D] Separate deviceKey from streamKey in getNCCLComm

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2184,14 +2184,15 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::getNCCLComm(
     C10D_NCCL_CHECK(ncclGroupStart(), c10::nullopt);
   }
 
-  ncclStreams_.emplace(streamKey, std::move(streamVal));
+  ncclStreams_.emplace(streamKey.value(), std::move(streamVal));
 
   // Note: these events are created with the (default) cudaEventDisableTiming
   // flag This flag provides the best performance when used with
   // cudaStreamWaitEvent() and cudaEventQuery(). Since we here don't measure the
   // performance using cudaEvent, this should be set.
   // TODO(kwen2501): is ncclEvents_ used anywhere else?
-  ncclEvents_.emplace(streamKey, at::cuda::CUDAEvent(cudaEventDisableTiming));
+  ncclEvents_.emplace(
+      streamKey.value(), at::cuda::CUDAEvent(cudaEventDisableTiming));
 
   // Record the communicators based on ncclUniqueId.
   ncclIdToCommMap_.emplace(buildNcclUniqueIdStr(ncclID), ncclComm);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -685,7 +685,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
       at::Device& device,
       OpType opType,
       int p2pRank = 0,
-      bool isSendRecvSelf = false);
+      bool isSendRecvSelf = false,
+      std::optional<const std::string> streamKey = c10::nullopt);
 
   // Wrapper method which can be overridden for tests.
   virtual std::exception_ptr checkForNCCLErrors(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129147
* __->__ #129435

The paves the way for a set of changes that would let us use the same
nccl communicator for collectives and p2p ops (and have that be eagerly
initialized instead of lazily initialized), but always use a dedicated
nccl stream for p2p operations with different ranks to ensure they can
overlap.

This PR only adds a new streamKey that defaults to the value of the
deviceKey, so should not affect runtime behavior at all.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @penguinwu @tianyu-l @yf225 @chauhang