### PR TITLE
[easy][DCP] Fix test_fsdp_ep.py for _MeshEnv.create_child_mesh API ch…

### DIFF
--- a/test/distributed/checkpoint/e2e/test_fsdp_ep.py
+++ b/test/distributed/checkpoint/e2e/test_fsdp_ep.py
@@ -73,7 +73,7 @@ class TestFSDPWithEP(DTensorTestBase, VerifyStateDictMixin):
             self.device_type, (2, 4), mesh_dim_names=("dp", "tp")
         )
         # TODO: we are using an internal API atm. Change to a publich API once it is ready.
-        mesh_fsdp_ep = _mesh_resources.create_child_mesh(mesh_fsdp_tp, 0, "dp")
+        mesh_fsdp_ep = _mesh_resources.create_child_mesh(mesh_fsdp_tp, ("dp",))
         del _mesh_resources.child_to_parent_mapping[mesh_fsdp_ep]
 
         mesh_fsdp = init_device_mesh(self.device_type, (8,))


### PR DESCRIPTION
…ange

Update test/distributed/checkpoint/e2e/test_fsdp_ep.py for #127465 change.
Failure info:
```bash
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664] Caught exception:                                                                                                                                                                                                                                                               
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664] Traceback (most recent call last):                                                                                                                                                                                                                                              
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]   File "/projs/framework/fooooo/code/pytorch_new/torch/testing/_internal/common_distributed.py", line 657, in run_test                                                                                                                                                      
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]     getattr(self, test_name)()                                                                                                                                                                                                                                                  
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]   File "/projs/framework/fooooo/code/pytorch_new/torch/testing/_internal/common_distributed.py", line 539, in wrapper                                                                                                                                                       
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]     fn()                                                                                                                                                                                                                                                                        
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]   File "/projs/framework/fooooo/code/pytorch_new/torch/testing/_internal/common_utils.py", line 2744, in wrapper                                                                                                                                                            
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]     method(*args, **kwargs)                                                                                                                                                                                                                                                     
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]   File "/projs/framework/fooooo/code/pytorch_new/torch/testing/_internal/distributed/_tensor/common_dtensor.py", line 369, in wrapper                                                                                                                                       
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]     func(self, *args, **kwargs)  # type: ignore[misc]                                                                                                                                                                                                                           
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]   File "/projs/framework/fooooo/code/pytorch_new/torch/testing/_internal/common_distributed.py", line 180, in wrapper                                                                                                                                                       
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]     return func(*args, **kwargs)                                                                                                                                                                                                                                                
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]   File "/projs/framework/fooooo/code/pytorch_new/torch/testing/_internal/distributed/checkpoint_utils.py", line 44, in wrapper                                                                                                                                              
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]     func(self, *args, **kwargs)                                                                                                                                                                                                                                                 
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]   File "/projs/framework/fooooo/code/pytorch_new/test/distributed/checkpoint/e2e/test_fsdp_ep.py", line 76, in test_e2e                                                                                                                                                     
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]     mesh_fsdp_ep = _mesh_resources.create_child_mesh(mesh_fsdp_tp, 0, "dp")                                                                                                                                                                                                     
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664] TypeError: _MeshEnv.create_child_mesh() takes 3 positional arguments but 4 were given                                                                                                                                                                                           
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]                                                                                                                                                                                                                                                                                 
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664] To execute this test, run the following from the base repo dir:                                                                                                                                                                                                                 
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]      python test/distributed/checkpoint/e2e/test_fsdp_ep.py -k TestFSDPWithEP.test_e2e                                                                                                                                                                                          
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664]                                                                                                                                                                                                                                                                                 
[rank4]:E0625 10:50:33.502000 140043309847744 torch/testing/_internal/common_distributed.py:664] This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0                                                                                                                                                                                                      

```

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @penguinwu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC @MeetVadakkanchery @mhorowitz