### PR TITLE
Fix static functions when using module in MSVC

### DIFF
--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -45,7 +45,7 @@ namespace torch::autograd {
 /// If you change this, update the doc at the top of the
 /// torch/autograd/__init__.py file and
 /// "test_set_requires_grad_only_for_continuous_types" in test/test_autograd.py
-static inline bool isDifferentiableType(at::ScalarType t) {
+inline bool isDifferentiableType(at::ScalarType t) {
   return isFloatingType(t) || isComplexType(t);
 }
 


### PR DESCRIPTION
If you try to use torch in c++ using modules then it will not compile due to static function not being supported in MSVC when using modules https://developercommunity.visualstudio.com/t/10323558.

Fixes #71309
Tested using the following code.
```c++
export module testModule;


import <torch/torch.h>;
import <memory>;
import <string>;
import <tuple>;
import <iostream>;

export namespace testModule 
{

    export void test()
    {
        torch::Tensor tensor1 = torch::rand({ 2, 3 });
        torch::Tensor tensor2 = torch::rand({ 3, 2 });
        // Perform tensor multiplication
        torch::Tensor result = torch::matmul(tensor1, tensor2);

        // Print the tensors
        std::cout << "Tensor 1: " << tensor1 << std::endl;
        std::cout << "Tensor 2: " << tensor2 << std::endl;
        std::cout << "Result of multiplication: " << result << std::endl;
    }
}
```
```cpp
import testModule;

int main()
{
	testModule::test();
	return 0;
}
```
I tried to use this builder https://github.com/mantaionut/builder/commits/module_test_windows/ for making a small build, however, it only works with VS2022 and since the CI is using VS2019 it still has 2 issues.
I've opened 2 issues in developer community https://developercommunity.visualstudio.com/t/10756123
https://developercommunity.visualstudio.com/t/10756126
