### PR TITLE
[Out of Date] switch CppCodeCache to new cpp_builder.

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -934,7 +934,7 @@ def get_cpp_torch_cuda_options(cuda: bool, aot_mode: bool = False):
     ):
         os.environ["CUDA_HOME"] = build_paths.cuda()
     """
-    from torch._inductor.codecache import _set_gpu_runtime_env, cpp_prefix_path
+    from torch._inductor.codecache import cpp_prefix_path
 
     _set_gpu_runtime_env()
     from torch.utils import cpp_extension

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -113,7 +113,7 @@ cdll.LoadLibrary("__lib_path__")
                 # Check if the output file exist, and compile when not.
                 output_path = x86_isa_help_builder.get_target_file_path()
                 if not os.path.isfile(output_path):
-                    status, target_file = x86_isa_help_builder.build()
+                    x86_isa_help_builder.build()
 
                 # Check build result
                 subprocess.check_call(


### PR DESCRIPTION
Original PRs is damaged by confilct and rebase: https://github.com/pytorch/pytorch/pull/128303, https://github.com/pytorch/pytorch/pull/129144

This PR just switch `CppCodeCache` to new cpp_builder, it need to be validated in `fb_code` environment. 


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht @iremyux @Blackhex @cristianPanaite @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang