### PR TITLE
Noise tensor using same size/stride with input to promote performance when channel last situation.

### DIFF
--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -70,7 +70,7 @@ Ctype<inplace> _dropout_impl(T& input, double p, bool train) {
   }
 
   at::Tensor b; // used for alpha_dropout only
-  auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  auto noise = feature_dropout ? make_feature_noise(input) : at::empty_like(input);
   noise.bernoulli_(1 - p);
   if (alpha_dropout) {
     constexpr double alpha = 1.7580993408473766;


### PR DESCRIPTION
All ops in _dropout_impl function are point-wise op. When input and output tensors are with same size and stride, those operators will get better performance. So i have remove memory in at::empty_like in make noise tensor.

@ezyang 

Test code:
```
import torch
 
input1 = torch.randn((50, 20, 50 ,30)).cuda()
input2 = torch.randn((50, 20, 50 ,30)).cuda().to(memory_format=torch.channels_last)
input3 = torch.randn((50, 20, 50 , 50)).cuda()[...,10:40]
dropout = torch.nn.Dropout(p=0.5, inplace=True)
 
# warmup:
for i in range(20):
    output = dropout(input1)
start_event = torch.cuda.Event(enable_timing=True)
end_event = torch.cuda.Event(enable_timing=True)
num = 10000
start_event.record()
for i in range(num):
    output = dropout(input1)
end_event.record()
end_event.synchronize()
time = start_event.elapsed_time(end_event)
print("input1 each time: {0}.".format(time * 1.0/num), flush =True)
 
start_event.record()
for i in range(num):
    output = dropout(input2)
end_event.record()
end_event.synchronize()
time = start_event.elapsed_time(end_event)
print("input2 each time: {0}.".format(time * 1.0/num), flush =True)
 
start_event.record()
for i in range(num):
    output = dropout(input3)
end_event.record()
end_event.synchronize()
time = start_event.elapsed_time(end_event)
print("input3 each time: {0}.".format(time * 1.0/num), flush =True)
```

Test result:

  | 算子名称 | 输入信息size / stride | empty是否携带连续性参数 | 耗时（ms） | 备注
-- | -- | -- | -- | -- | --
1 | dropout | (50, 20, 50 ,30) / (30000, 1500, 30, 1) | LEGACY_CONTIGUOUS_MEMORY_FORMAT | 0.0426735 |  
2 | dropout | (50, 20, 50 ,30) / (30000, 1, 600, 20) | LEGACY_CONTIGUOUS_MEMORY_FORMAT | 0.0461689 |  
3 | dropout | (50, 20, 50 ,30) / (50000, 2500, 50, 1) | LEGACY_CONTIGUOUS_MEMORY_FORMAT | 0.0512882 |  
4 | dropout | (50, 20, 50 ,30) / (30000, 1500, 30, 1) | 空，根据输入决定size/stride | 0.0426598 | 对比1,基本一致
5 | dropout | (50, 20, 50 ,30) / (30000, 1, 600, 20) | 空，根据输入决定size/stride | 0.0422751 | 对比2,提升8.4%左右
6 | dropout | (50, 20, 50 ,30) / (50000, 2500, 50, 1) | 空，根据输入决定size/stride | 0.0509037 | 对比3,基本一致






