### PR TITLE
[codemod] Fix deprecated dynamic exception in pytorch/FasterTransformer/FasterTransformer/tests/unittests/unittest_utils.h +5

### DIFF
--- a/aten/src/ATen/core/op_registration/op_allowlist.h
+++ b/aten/src/ATen/core/op_registration/op_allowlist.h
@@ -129,7 +129,7 @@ constexpr bool allowlist_contains(string_view allowlist, string_view item) {
 // and should be registered
 constexpr bool op_allowlist_check(string_view op_name) {
   assert(op_name.find("::") != string_view::npos);
-  // Use assert() instead of throw() due to a gcc bug. See:
+  // Use assert() instead of noexcept due to a gcc bug. See:
   // https://stackoverflow.com/questions/34280729/throw-in-constexpr-function
   // https://github.com/fmtlib/fmt/issues/682
   assert(op_name.find("(") == string_view::npos);


### PR DESCRIPTION
Summary:
LLVM has detected a violation of `-Wdeprecated-dynamic-exception-spec`. Dynamic exceptions were removed in C++17. This diff fixes the deprecated instance(s).

See [Dynamic exception specification](https://en.cppreference.com/w/cpp/language/except_spec) and [noexcept specifier](https://en.cppreference.com/w/cpp/language/noexcept_spec).

Test Plan: Sandcastle

Reviewed By: dmm-fb

Differential Revision: D58953076
