### PR TITLE
Add guard to use AMX for x86_64 only

### DIFF
--- a/aten/src/ATen/cpu/Utils.cpp
+++ b/aten/src/ATen/cpu/Utils.cpp
@@ -45,7 +45,7 @@ bool init_amx() {
     return false;
   }
 
-#if defined(__linux__) && !defined(__ANDROID__) && !defined(__s390x__)
+#if defined(__linux__) && !defined(__ANDROID__) && defined(__x86_64__)
 #define XFEATURE_XTILECFG 17
 #define XFEATURE_XTILEDATA 18
 #define XFEATURE_MASK_XTILECFG (1 << XFEATURE_XTILECFG)


### PR DESCRIPTION
Trying to mitigate aarch64 and s390 nightly failures as per this comment:
https://github.com/pytorch/pytorch/pull/127195#issuecomment-2189177949

Fixes https://github.com/pytorch/pytorch/issues/129443

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10