### PR TITLE
[ROCm] Use additional shard for inductor workflow to resolve timeouts

### DIFF
--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -24,7 +24,8 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "inductor", shard: 1, num_shards: 1, runner: "linux.rocm.gpu.2" },
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.2" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.2" },
         ]}
 
   linux-focal-rocm6_1-py3_8-inductor-test:


### PR DESCRIPTION
This will help timeouts on inductor workflow. The cuda equivalent job also moved to 2 shards since https://github.com/pytorch/pytorch/commit/e0aa992d73ce1c8e4e164fa50678af1f72b597c1

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang