### PR TITLE
Add reviewer to PyTorch Distributed

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -308,6 +308,7 @@
   - d4l3k
   - shuqiangzhang
   - weifengpy
+  - dsjohns2
   mandatory_checks_name:
   - EasyCLA
   - Lint


### PR DESCRIPTION
Summary: Add dsjohns2 as reviewer for pytorch distributed

Test Plan: none

Differential Revision: D59011196
