### PR TITLE
Add a check and error message for no support on MPS for conv with output_channels > 2^16

### DIFF
--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -161,13 +161,14 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
   }
   TensorArg output{output_t, "result", 0};
 
-  //TODO: MPS convolution kernel currently does not support output channels > 2^16
+  // TODO: MPS convolution kernel currently does not support output channels > 2^16
   for (auto elem : output_t.sizes()) {
-    TORCH_CHECK_NOT_IMPLEMENTED(elem <= (1 << 16), "Output channels > 65536 not supported at the MPS device. ",
-      "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` ",
-      "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
-      "on MPS."
-    );
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        elem <= (1 << 16),
+        "Output channels > 65536 not supported at the MPS device. ",
+        "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` ",
+        "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
+        "on MPS.");
   }
 
   convolution_shape_check(c, input, weight, output, padding, stride, dilation, groups);
@@ -355,13 +356,14 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
   using namespace mps;
   bool is3DConv = grad_output_t.dim() == 5;
 
-  //TODO: MPS convolution kernel currently does not support output channels > 2^16
+  // TODO: MPS convolution kernel currently does not support output channels > 2^16
   for (auto elem : grad_output_t.sizes()) {
-    TORCH_CHECK_NOT_IMPLEMENTED(elem <= (1 << 16), "Output channels > 65536 not supported at the MPS device. ",
-      "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` ",
-      "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
-      "on MPS."
-    );
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        elem <= (1 << 16),
+        "Output channels > 65536 not supported at the MPS device. ",
+        "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` ",
+        "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
+        "on MPS.");
   }
 
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -161,6 +161,15 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
   }
   TensorArg output{output_t, "result", 0};
 
+  //TODO: MPS convolution kernel currently does not support output channels > 2^16
+  for (auto elem : output_t.sizes()) {
+    TORCH_CHECK_NOT_IMPLEMENTED(elem <= (1 << 16), "Output channels > 65536 not supported at the MPS device. ",
+      "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` ",
+      "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
+      "on MPS."
+    );
+  }
+
   convolution_shape_check(c, input, weight, output, padding, stride, dilation, groups);
 
   // Derive from MPSCachedGraph
@@ -345,6 +354,15 @@ static Tensor mps_convolution_backward_input(IntArrayRef input_size,
   using namespace at::native::mps;
   using namespace mps;
   bool is3DConv = grad_output_t.dim() == 5;
+
+  //TODO: MPS convolution kernel currently does not support output channels > 2^16
+  for (auto elem : grad_output_t.sizes()) {
+    TORCH_CHECK_NOT_IMPLEMENTED(elem <= (1 << 16), "Output channels > 65536 not supported at the MPS device. ",
+      "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` ",
+      "to use the CPU as a fallback for this op. WARNING: this will be slower than running natively ",
+      "on MPS."
+    );
+  }
 
   TORCH_CHECK(isFloatingType(grad_output_t.scalar_type()), "Convolution is supported only for Floating types");
   CheckedFrom c = "mps_convolution_backward_input";

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1591,6 +1591,13 @@ class TestMPS(TestCaseMPS):
             a = torch.tensor(v, dtype=dtype, device="mps") * b
             self.compare_with_numpy(torch.exp, np.exp, a)
 
+    def test_conv_raises_error(self, device='mps', dtype=torch.float):
+        conv = nn.Conv1d(1, 65537, 3, padding=1).to('mps')
+
+        x = torch.ones([1, 1, 3])
+        with self.assertRaises(NotImplementedError):
+            y = conv(x.to("mps"))
+
     def test_triu_inf(self, device="mps", dtype=torch.float):
         for diag in [-1, 0, 1]:
             mask = torch.full((3, 6, 6), float("-inf"))


### PR DESCRIPTION

Fixes the silent correctness issue in #129207 by preventing the user from calling the convolution op on MPS device with an unsupported value.

The fix for the missing support is coming in later as that requires work on the kernel side so it'll take some more time.