### PR TITLE
Make categorize.py aware of missing categories

### DIFF
--- a/scripts/release_notes/categorize.py
+++ b/scripts/release_notes/categorize.py
@@ -48,7 +48,11 @@ class Categorizer:
         self.category = category
 
     def categorize(self):
+        existing_categories = {commit.category for commit in self.commits.commits}
+        common.categories += existing_categories - set(common.categories)
+
         commits = self.commits.filter(category=self.category)
+        # raise RuntimeError(f'categories {set(commit.category for commit in commits)}')
         total_commits = len(self.commits.commits)
         already_done = total_commits - len(commits)
         i = 0

--- a/scripts/release_notes/classifier.py
+++ b/scripts/release_notes/classifier.py
@@ -9,7 +9,7 @@ from typing import Dict, List
 
 import common
 import pandas as pd
-import torchtext
+import torchtext.models
 from torchtext.functional import to_tensor
 from tqdm import tqdm
 


### PR DESCRIPTION
Proposes changes in `categorize.py` to include categories (release notes tags) that occurred since the last release but were not listed in `common.categories`.

Example:
First uncategorized commit without these changes:
```
Test Plan: CI

Differential Revision: D54791087

Pull Request resolved: https://github.com/pytorch/pytorch/pull/121712
Approved by: https://github.com/ydwu4

Files changed: ['test/export/test_torchbind.py', 'torch/_ops.py']

Labels: ['fb-exported', 'Merged', 'ciflow/trunk']

Current category: Uncategorized

Select from: Uncategorized, lazy, hub, mobile, jit, visualization, onnx, caffe2, amd, rocm, cuda, cpu, cudnn, xla, benchmark, profiler, performance_as_product, package, dispatcher, releng, fx, code_coverage, vulkan, skip, composability, mps, intel, functorch, gnn, distributions, serialization, meta_frontend, nn_frontend, linalg_frontend, cpp_frontend, python_frontend, complex_frontend, vmap_frontend, autograd_frontend, build_frontend, memory_format_frontend, foreach_frontend, dataloader_frontend, sparse_frontend, nested tensor_frontend, optimizer_frontend, dynamo, inductor, quantization, distributed
```

With these changes:
```
Test Plan: CI

Differential Revision: D54791087

Pull Request resolved: https://github.com/pytorch/pytorch/pull/121712
Approved by: https://github.com/ydwu4

Files changed: ['test/export/test_torchbind.py', 'torch/_ops.py']

Labels: ['fb-exported', 'Merged', 'ciflow/trunk']

Current category: Uncategorized

Select from: Uncategorized, lazy, hub, mobile, jit, visualization, onnx, caffe2, amd, rocm, cuda, cpu, cudnn, xla, benchmark, profiler, performance_as_product, package, dispatcher, releng, fx, code_coverage, vulkan, skip, composability, mps, intel, functorch, gnn, distributions, serialization, meta_frontend, nn_frontend, linalg_frontend, cpp_frontend, python_frontend, complex_frontend, vmap_frontend, autograd_frontend, build_frontend, memory_format_frontend, foreach_frontend, dataloader_frontend, sparse_frontend, nested tensor_frontend, optimizer_frontend, dynamo, inductor, quantization, distributed, distributed (checkpoint), package/deploy, distributed (pipeline), distributed (dtensor), distributed (tools), xpu, export, distributed (fsdp2), distributed (torchelastic), optim
```
