### PR TITLE
RS migration - upload sccache stats to s3 instead of rockset

### DIFF
--- a/tools/stats/upload_sccache_stats.py
+++ b/tools/stats/upload_sccache_stats.py
@@ -5,7 +5,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
 
-from tools.stats.upload_stats_lib import download_s3_artifacts, upload_to_rockset
+from tools.stats.upload_stats_lib import (
+    download_s3_artifacts,
+    upload_workflow_stats_to_s3,
+)
 
 
 def get_sccache_stats(
@@ -41,4 +44,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     stats = get_sccache_stats(args.workflow_run_id, args.workflow_run_attempt)
-    upload_to_rockset("sccache_stats", stats)
+    upload_workflow_stats_to_s3(
+        args.workflow_run_id, args.workflow_run_attempt, "sccache_stats", stats
+    )


### PR DESCRIPTION
Upload sccache stats to s3 instead of rockset

I don't think we use these anywhere, so it's ok to cut off the ingest into rockset right now.

We should consider deleting this entirely if we don't plan on using it

I will work on copying existing data over from rockset to s3