### PR TITLE
[BE] Do not assert if the barrier is not created

### DIFF
--- a/test/distributed/test_distributed_spawn.py
+++ b/test/distributed/test_distributed_spawn.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-from os import path
 
 import torch
 import torch.distributed as dist

--- a/test/distributed/test_distributed_spawn.py
+++ b/test/distributed/test_distributed_spawn.py
@@ -39,7 +39,6 @@ if (
     "BACKEND" not in os.environ
     or "WORLD_SIZE" not in os.environ
     or "TEMP_DIR" not in os.environ
-    or not path.exists(path.join(os.environ["TEMP_DIR"], "barrier"))
 ):
     # TODO can we actually have `run_tests.py` emit the complete instructions when it prints a repro command?
     raise RuntimeError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129497

the foler will be created as long as TEMP_DIR is set and the program
has the write permission. This will ensure some test environment can run the
spawn tests.

Differential Revision: [D59020736](https://our.internmc.facebook.com/intern/diff/D59020736/)

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k