### PR TITLE
RS migration - trymerge to upload merge records to s3

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1163,7 +1163,6 @@ class GitHubPR:
             # Finally, upload the record to Rockset. The list of pending and failed
             # checks are at the time of the merge
             save_merge_record(
-                collection=ROCKSET_MERGES_COLLECTION,
                 comment_id=comment_id,
                 pr_num=self.pr_num,
                 owner=self.org,
@@ -1179,10 +1178,8 @@ class GitHubPR:
                 merge_base_sha=self.get_merge_base(),
                 merge_commit_sha=merge_commit_sha,
                 is_failed=False,
-                dry_run=dry_run,
                 skip_mandatory_checks=skip_mandatory_checks,
                 ignore_current=bool(ignore_current_checks),
-                workspace=ROCKSET_MERGES_WORKSPACE,
             )
         else:
             print("Missing comment ID or PR number, couldn't upload to Rockset")
@@ -2358,7 +2355,6 @@ def main() -> None:
             # list of pending and failed checks here, but they are not really
             # needed at the moment
             save_merge_record(
-                collection=ROCKSET_MERGES_COLLECTION,
                 comment_id=args.comment_id,
                 pr_num=args.pr_num,
                 owner=org,
@@ -2373,11 +2369,9 @@ def main() -> None:
                 last_commit_sha=pr.last_commit().get("oid", ""),
                 merge_base_sha=pr.get_merge_base(),
                 is_failed=True,
-                dry_run=args.dry_run,
                 skip_mandatory_checks=args.force,
                 ignore_current=args.ignore_current,
                 error=str(e),
-                workspace=ROCKSET_MERGES_WORKSPACE,
             )
         else:
             print("Missing comment ID or PR number, couldn't upload to Rockset")

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1533,6 +1533,9 @@ def save_merge_record(
             "skip_mandatory_checks": skip_mandatory_checks,
             "ignore_current": ignore_current,
             "error": error,
+            # This is a unique identifier for the record for deduping purposes
+            # in rockset.  Any unique string would work
+            "_id": f"{project}-{pr_num}-{comment_id}-{os.environ.get('GITHUB_RUN_ID')}",
         }
     ]
     repo_root = Path(__file__).resolve().parent.parent.parent

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -43,6 +43,7 @@ jobs:
           IGNORE_CURRENT: ${{ github.event.client_payload.ignore_current }}
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           DRCI_BOT_KEY: ${{ secrets.DRCI_BOT_KEY }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           set -x
           if [ -n "${REBASE}" ]; then
@@ -97,7 +98,7 @@ jobs:
         uses: seemethere/upload-artifact-s3@v5
         with:
           s3-bucket: ossci-raw-job-status
-          s3-prefix: merges/${{ github.repository }}/${{ github.event.client_payload.pr_num }}/${{ github.run_id }}
+          s3-prefix: merges/${{ github.repository }}/${{ github.event.client_payload.pr_num }}/${{ github.event.client_payload.comment_id }}/${{ github.run_id }}
           path: merge-record.json
 
 # We want newer merge commands to supercede old ones

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -88,7 +88,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v3
         continue-on-error: true
         with:
-          role-to-assume: arn:aws:iam::749337293305:role/upload_to_ossci_raw_job_status
+          role-to-assume: arn:aws:iam::308535385114:role/upload_to_ossci_raw_job_status
           aws-region: us-east-1
 
       - name: Upload merge record to s3

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -84,6 +84,21 @@ jobs:
           set -x
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::749337293305:role/upload_to_ossci_raw_job_status
+          aws-region: us-east-1
+
+      - name: Upload merge record to s3
+        if: always()
+        continue-on-error: true
+        uses: seemethere/upload-artifact-s3@v5
+        with:
+          s3-bucket: ossci-raw-job-status
+          s3-prefix: merges/${{ github.repository }}/${{ github.event.client_payload.pr_num }}/${{ github.run_id }}
+          path: merge-record.json
+
 # We want newer merge commands to supercede old ones
 concurrency:
   group: try-merge-${{ github.event.client_payload.pr_num }}

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -86,6 +86,7 @@ jobs:
 
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3
+        continue-on-error: true
         with:
           role-to-assume: arn:aws:iam::749337293305:role/upload_to_ossci_raw_job_status
           aws-region: us-east-1

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ env
 scripts/release_notes/*.json
 sccache-stats*.json
 lint.json
+merge_record.json
 
 # These files get copied over on invoking setup.py
 torchgen/packaged/*


### PR DESCRIPTION
Uploads merge records to to ossci-raw-job-status (public) bucket instead of directly to rockset

The runner used by trymerge is a GH runner, so it doesn't have access to s3.  Instead, I save the record as a json and upload the json to s3 in a different step that runs after the aws credentials are configured.

The role is defined [here](https://togithub.com/pytorch-labs/pytorch-gha-infra/pull/421) 

