### PR TITLE
Use CompositeExplicitAutograd for functional autograd collectives

### DIFF
--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -561,7 +561,7 @@ TORCH_LIBRARY(_c10d_functional_autograd, m) {
       "SymInt[] output_split_sizes, "
       "SymInt[] input_split_sizes, "
       "str group_name) -> Tensor",
-      torch::dispatch(c10::DispatchKey::Autograd, ::all_to_all_single_autograd),
+      torch::dispatch(c10::DispatchKey::CompositeExplicitAutograd, ::all_to_all_single_autograd),
       {at::Tag::pt2_compliant_tag});
   m.def(
       "reduce_scatter_tensor("
@@ -570,7 +570,7 @@ TORCH_LIBRARY(_c10d_functional_autograd, m) {
       "int group_size, "
       "str group_name) -> Tensor",
       torch::dispatch(
-          c10::DispatchKey::Autograd, ::reduce_scatter_tensor_autograd),
+          c10::DispatchKey::CompositeExplicitAutograd, ::reduce_scatter_tensor_autograd),
       {at::Tag::pt2_compliant_tag});
   m.def(
       "all_gather_into_tensor("
@@ -578,7 +578,7 @@ TORCH_LIBRARY(_c10d_functional_autograd, m) {
       "int group_size, "
       "str group_name) -> Tensor",
       torch::dispatch(
-          c10::DispatchKey::Autograd, ::all_gather_into_tensor_autograd),
+          c10::DispatchKey::CompositeExplicitAutograd, ::all_gather_into_tensor_autograd),
       {at::Tag::pt2_compliant_tag});
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129517
* #129516
* #129515
* #129514
* __->__ #129513
* #129512
* #129511
* #124961

Summary:
As title

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @tianyu-l @yf225 @chauhang