### PR TITLE
[inductor] Add Triton template for Conv3D

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -673,11 +673,11 @@ class TestMaxAutotune(TestCase):
     def test_conv3d(self):
         fn = torch.nn.functional.conv3d
         image = torch.randn([1, 3, 8, 16, 32])
-        filter = torch.randn([3, 3, 7, 7, 7])
+        filt = torch.randn([3, 3, 7, 7, 7])
 
         with config.patch({"max_autotune": True}):
-            expected = fn(image, filter)
-            actual = torch.compile(fn)(image, filter)
+            expected = fn(image, filt)
+            actual = torch.compile(fn)(image, filt)
             torch.testing.assert_close(actual, expected, atol=6e-5, rtol=0.001)
 
     def test_non_contiguous_input_mm(self):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -670,6 +670,16 @@ class TestMaxAutotune(TestCase):
             z = torch.randint(0, 10, (224,)).to(device="cuda")
             f(x, y, z)
 
+    def test_conv3d(self):
+        fn = torch.nn.functional.conv3d
+        image = torch.randn([1, 3, 8, 16, 32])
+        filter = torch.randn([3, 3, 7, 7, 7])
+
+        with config.patch({"max_autotune": True}):
+            expected = fn(image, filter)
+            actual = torch.compile(fn)(image, filter)
+            torch.testing.assert_close(actual, expected, atol=6e-5, rtol=0.001)
+
     def test_non_contiguous_input_mm(self):
         """
         Make sure the triton template can work with non-contiguous inputs without crash.

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3864,7 +3864,7 @@ class CommonTemplate:
         
     def test_conv3d(self):
         m = torch.nn.Sequential(
-            torch.nn.Conv3d(3, 3, kernel_size=7)
+            torch.nn.Conv3d(3, 3, kernel_size=7),
             ToTuple(),
         )
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3861,6 +3861,22 @@ class CommonTemplate:
             atol = 1e-05
             rtol = 1.3e-06
         self.common(fn, (x, w), atol=atol, rtol=rtol)
+        
+    def test_conv3d(self):
+        m = torch.nn.Sequential(
+            torch.nn.Conv3d(3, 3, kernel_size=7)
+            ToTuple(),
+        )
+
+        self.common(
+            m,
+            (
+                torch.randn([1, 3, 8, 16, 32]),
+                torch.randn([3, 3, 7, 7, 7]),
+            ),
+            atol=6e-5,
+            rtol=0.001,
+        )
 
     def test_conv2d_channels_last(self):
         if self.device == GPU_TYPE:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3873,6 +3873,10 @@ class CommonTemplate:
             (torch.randn([1, 3, 8, 16, 32]),),
             atol=6e-5,
             rtol=0.001,
+            # Make sure we compute also with fp16 in the reference. Otherwise,
+            # the reference will compute with fp32 and cast back to fp16, which
+            # causes numeric differences beyond tolerance.
+            reference_in_float=False if torch.version.hip else True,
         )
 
     def test_conv2d_channels_last(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3870,10 +3870,7 @@ class CommonTemplate:
 
         self.common(
             m,
-            (
-                torch.randn([1, 3, 8, 16, 32]),
-                torch.randn([3, 3, 7, 7, 7]),
-            ),
+            (torch.randn([1, 3, 8, 16, 32]),),
             atol=6e-5,
             rtol=0.001,
         )

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3861,7 +3861,7 @@ class CommonTemplate:
             atol = 1e-05
             rtol = 1.3e-06
         self.common(fn, (x, w), atol=atol, rtol=rtol)
-        
+
     def test_conv3d(self):
         m = torch.nn.Sequential(
             torch.nn.Conv3d(3, 3, kernel_size=7),

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -121,6 +121,7 @@ test_failures = {
     "test_arange6_dynamic_shapes": TestFailure(("cpu",)),
     "test_clamp_type_promotion_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv2d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
+    "test_conv3d": TestFailure(("cpu",)),
     "test_conv3d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
     "test_expand_dynamic_shapes": TestFailure(("cpu",)),
     "test_full_boolean_dynamic_shapes": TestFailure(("cpu",)),

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -121,7 +121,7 @@ test_failures = {
     "test_arange6_dynamic_shapes": TestFailure(("cpu",)),
     "test_clamp_type_promotion_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv2d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
-    "test_conv3d_dynamic_shapes": TestFailure(("cpu",))
+    "test_conv3d_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv3d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
     "test_expand_dynamic_shapes": TestFailure(("cpu",)),
     "test_full_boolean_dynamic_shapes": TestFailure(("cpu",)),

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -121,7 +121,7 @@ test_failures = {
     "test_arange6_dynamic_shapes": TestFailure(("cpu",)),
     "test_clamp_type_promotion_dynamic_shapes": TestFailure(("cpu",)),
     "test_conv2d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
-    "test_conv3d": TestFailure(("cpu",)),
+    "test_conv3d_dynamic_shapes": TestFailure(("cpu",))
     "test_conv3d_channels_last_dynamic_shapes": TestFailure(("cpu",)),
     "test_expand_dynamic_shapes": TestFailure(("cpu",)),
     "test_full_boolean_dynamic_shapes": TestFailure(("cpu",)),

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -47,12 +47,14 @@ def conv2d_grid(n, c, h, w, meta):
         meta["GROUPS"],
     )
 
+
 def conv3d_grid(n, c, d, h, w, meta):
     return (
         ceildiv(n * d * h * w, meta["BLOCK_M"]),
         ceildiv(c, meta["BLOCK_N"]),
         meta["GROUPS"],
     )
+
 
 # List of dictionaries to store the kernel configs. Configs that evaluate to true
 # will be utilised on the target platform

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -40,13 +40,19 @@ log = logging.getLogger(__name__)
 aten = torch.ops.aten
 
 
-def conv_grid(n, c, h, w, meta):
+def conv2d_grid(n, c, h, w, meta):
     return (
         ceildiv(n * h * w, meta["BLOCK_M"]),
         ceildiv(c, meta["BLOCK_N"]),
         meta["GROUPS"],
     )
 
+def conv3d_grid(n, c, d, h, w, meta):
+    return (
+        ceildiv(n * d * h * w, meta["BLOCK_M"]),
+        ceildiv(c, meta["BLOCK_N"]),
+        meta["GROUPS"],
+    )
 
 # List of dictionaries to store the kernel configs. Configs that evaluate to true
 # will be utilised on the target platform
@@ -79,7 +85,7 @@ conv_configs = functools.partial(
     configs=platform_configs,
 )
 
-LOOP_BODY = """
+LOOP_BODY_2D = """
         idx_x_h = i - PADDING_H + idx_y_h * STRIDE_H
         idx_x_w = j - PADDING_W + idx_y_w * STRIDE_W
         idx_x_c = tl.arange(0, BLOCK_K) + k
@@ -113,8 +119,8 @@ improved.  Many alternate conv versions can be found here:
 https://github.com/pytorch/torchdynamo/pull/971
 """
 conv2d_template = TritonTemplate(
-    name="convolution",
-    grid=conv_grid,
+    name="convolution2d",
+    grid=conv2d_grid,
     source=r"""
 {{def_kernel("X", "W")}}
     # Tensor dimensions
@@ -167,7 +173,7 @@ conv2d_template = TritonTemplate(
     j = {{j}}
     for k in range(0, GROUP_IN_C, BLOCK_K):
         """
-    + LOOP_BODY
+    + LOOP_BODY_2D
     + """
 {% endfor %}
 {% endfor %}
@@ -183,7 +189,7 @@ conv2d_template = TritonTemplate(
         i = ij // KERNEL_W
         j = ij % KERNEL_W
         """
-    + LOOP_BODY
+    + LOOP_BODY_2D
     + """
 {% endif %}
 
@@ -200,6 +206,144 @@ conv2d_template = TritonTemplate(
 
     # inductor generates a suffix
     {{store_output(("idx_n", "idx_c", "idx_h", "idx_w"), "acc", "mask")}}
+""",
+)
+
+LOOP_BODY_3D = """
+        idx_x_d = d - PADDING_D + idx_y_d * STRIDE_D
+        idx_x_h = i - PADDING_H + idx_y_h * STRIDE_H
+        idx_x_w = j - PADDING_W + idx_y_w * STRIDE_W
+        idx_x_c = tl.arange(0, BLOCK_K) + k
+
+        x_ptrs = x_base + (
+            (idx_x_d * stride_xd)[:, None]
+            + (idx_x_h * stride_xh)[:, None]
+            + (idx_x_w * stride_xw)[:, None]
+            + (idx_x_c * stride_xc)[None, :]
+        )
+        mask_x = (
+            (idx_n < BATCH)[:, None]
+            & (idx_x_d >= 0)[:, None]
+            & (idx_x_d < IN_D)[:, None]
+            & (idx_x_h >= 0)[:, None]
+            & (idx_x_h < IN_H)[:, None]
+            & (idx_x_w >= 0)[:, None]
+            & (idx_x_w < IN_W)[:, None]
+            & (idx_x_c < GROUP_IN_C)[None, :]
+        )
+        matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
+
+        w_ptrs = w_base + (
+            (idx_x_c * stride_wc_in)[:, None] +
+            (d * stride_wd) + (i * stride_wh) + (j * stride_ww)
+        )
+        mask_w = (idx_x_c[:, None] < GROUP_IN_C) & (idx_y_c[None, :] < GROUP_OUT_C)
+        matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
+        acc += tl.dot(matrix_x, matrix_w, allow_tf32=ALLOW_TF32)
+"""
+
+conv3d_template = TritonTemplate(
+    name="convolution3d",
+    grid=conv3d_grid,
+    source=r"""
+{{def_kernel("X", "W")}}
+    # Tensor dimensions
+    BATCH = {{size("X", 0)}}
+    IN_C = {{size("X", 1)}}
+    IN_D = {{size("X", 2)}}
+    IN_H = {{size("X", 3)}}
+    IN_W = {{size("X", 4)}}
+    OUT_C = {{size(None, 1)}}
+    OUT_D = {{size(None, 2)}}
+    OUT_H = {{size(None, 3)}}
+    OUT_W = {{size(None, 4)}}
+
+    # Strides:
+    stride_xn = {{stride("X", 0)}}
+    stride_xc = {{stride("X", 1)}}
+    stride_xd = {{stride("X", 2)}}
+    stride_xh = {{stride("X", 3)}}
+    stride_xw = {{stride("X", 4)}}
+    stride_wc_out = {{stride("W", 0)}}
+    stride_wc_in = {{stride("W", 1)}}
+    stride_wd = {{stride("W", 2)}}
+    stride_wh = {{stride("W", 3)}}
+    stride_ww = {{stride("W", 4)}}
+
+    ndhw = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    idx_y_w = ndhw % OUT_W
+    ndh = ndhw // OUT_W
+    idx_y_h = ndh % OUT_H
+    nd = ndh // OUT_H
+    idx_y_d = nd % OUT_D
+    idx_n = nd // OUT_D
+    idx_y_c = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+
+{% if GROUPS == 1 %}
+    group = 0
+    GROUP_IN_C = IN_C
+    GROUP_OUT_C = OUT_C
+{% else %}
+    group = tl.program_id(2)
+    GROUP_IN_C = IN_C // GROUPS
+    GROUP_OUT_C = OUT_C // GROUPS
+{% endif %}
+
+    x_base = X + (group * stride_xc * GROUP_IN_C + idx_n * stride_xn)[:, None]
+    w_base = (
+        W + (group * stride_wc_out * GROUP_OUT_C + idx_y_c * stride_wc_out)[None, :]
+    )
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+{% if UNROLL %}
+{% for d in range(KERNEL_D) %}
+{% for i in range(KERNEL_H) %}
+{% for j in range(KERNEL_W) %}
+    d = {{d}}
+    i = {{i}}
+    j = {{j}}
+    for k in range(0, GROUP_IN_C, BLOCK_K):
+        """
+    + LOOP_BODY_3D
+    + """
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% else %}
+    # Could be simplified, but slightly slower:
+    # for d in range(KERNEL_D):
+    #   for i in range(KERNEL_H):
+    #     for j in range(KERNEL_W):
+    #         for k in range(0, GROUP_IN_C, BLOCK_K):
+    BLOCK_K_COUNT = (GROUP_IN_C + BLOCK_K - 1) // BLOCK_K
+    for dijk in range(KERNEL_D * KERNEL_H * KERNEL_W * BLOCK_K_COUNT):
+        k = (dijk % BLOCK_K_COUNT) * BLOCK_K
+        dij = dijk // BLOCK_K_COUNT
+        j = dij % KERNEL_W
+        di = dij // KERNEL_W
+        i = di % KERNEL_H
+        d = di // KERNEL_H
+        """
+    + LOOP_BODY_3D
+    + """
+{% endif %}
+
+    mask = (
+        (idx_n < BATCH)[:, None]
+        & (idx_y_d < OUT_D)[:, None]
+        & (idx_y_h < OUT_H)[:, None]
+        & (idx_y_w < OUT_W)[:, None]
+        & (idx_y_c < GROUP_OUT_C)[None, :]
+    )
+    idx_n = idx_n[:, None]
+    idx_c = idx_y_c[None, :] + group * GROUP_OUT_C
+    idx_d = idx_y_d[:, None]
+    idx_h = idx_y_h[:, None]
+    idx_w = idx_y_w[:, None]
+
+    # inductor generates a suffix
+    {{store_output(("idx_n", "idx_c", "idx_d", "idx_h", "idx_w"), "acc", "mask")}}
 """,
 )
 
@@ -420,7 +564,6 @@ def convolution(
     if (
         use_triton_template(layout)
         # templates only support these:
-        and ndim == 2
         and is_ones(dilation)
         and not transposed
         and is_zeros(output_padding)
@@ -440,25 +583,49 @@ def convolution(
             out_chan,
             in_chan,
         ):
-            conv2d_template.maybe_append_choice(
-                choices,
-                input_nodes=(x, weight),
-                layout=layout,
-                KERNEL_H=kernel_shape[0],
-                KERNEL_W=kernel_shape[1],
-                STRIDE_H=stride[0],
-                STRIDE_W=stride[1],
-                PADDING_H=padding[0],
-                PADDING_W=padding[1],
-                GROUPS=groups,
-                # TODO(jansel): try unroll for bigger kernels once fixed:
-                #               https://github.com/openai/triton/issues/1254
-                UNROLL=is_ones(kernel_shape),
-                ALLOW_TF32=torch.backends.cudnn.allow_tf32,
-                num_stages=cfg.num_stages,
-                num_warps=cfg.num_warps,
-                **cfg.kwargs,
-            )
+            if ndim == 2:
+                conv2d_template.maybe_append_choice(
+                    choices,
+                    input_nodes=(x, weight),
+                    layout=layout,
+                    KERNEL_H=kernel_shape[0],
+                    KERNEL_W=kernel_shape[1],
+                    STRIDE_H=stride[0],
+                    STRIDE_W=stride[1],
+                    PADDING_H=padding[0],
+                    PADDING_W=padding[1],
+                    GROUPS=groups,
+                    # TODO(jansel): try unroll for bigger kernels once fixed:
+                    #               https://github.com/openai/triton/issues/1254
+                    UNROLL=is_ones(kernel_shape),
+                    ALLOW_TF32=torch.backends.cudnn.allow_tf32,
+                    num_stages=cfg.num_stages,
+                    num_warps=cfg.num_warps,
+                    **cfg.kwargs,
+                )
+            elif ndim == 3:
+                conv3d_template.maybe_append_choice(
+                    choices,
+                    input_nodes=(x, weight),
+                    layout=layout,
+                    KERNEL_D=kernel_shape[0],
+                    KERNEL_H=kernel_shape[1],
+                    KERNEL_W=kernel_shape[2],
+                    STRIDE_D=stride[0],
+                    STRIDE_H=stride[1],
+                    STRIDE_W=stride[2],
+                    PADDING_D=padding[0],
+                    PADDING_H=padding[1],
+                    PADDING_W=padding[2],
+                    GROUPS=groups,
+                    # TODO(jansel): try unroll for bigger kernels once fixed:
+                    #               https://github.com/openai/triton/issues/1254
+                    UNROLL=is_ones(kernel_shape),
+                    ALLOW_TF32=torch.backends.cudnn.allow_tf32,
+                    num_stages=cfg.num_stages,
+                    num_warps=cfg.num_warps,
+                    **cfg.kwargs,
+                )
 
     return autotune_select_algorithm("convolution", choices, args, layout)
 


### PR DESCRIPTION
This commit adds a Triton template for Conv3D ops,
by following the same logic like Conv2D. Conv3D
aren't as frequently used like Conv2D so they might
enjoy less optimizations in various libraries. So having
a Triton based inductor impl can improve performance
for cases.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang