### PR TITLE
Forward fix internal pyre failure from D58983461

### DIFF
--- a/torch/types.py
+++ b/torch/types.py
@@ -1,5 +1,7 @@
 # mypy: allow-untyped-defs
 
+import builtins
+
 # In some cases, these basic types are shadowed by corresponding
 # top-level values.  The underscore variants let us refer to these
 # types.  See https://github.com/python/mypy/issues/4146 for why these
@@ -36,16 +38,16 @@ _dtype = torch.dtype
 _device = torch.device
 _qscheme = torch.qscheme
 _layout = torch.layout
-_size = Union[torch.Size, List[_int], Tuple[_int, ...]]
-_dispatchkey = Union[_str, torch._C.DispatchKey]
+_size = Union[torch.Size, List[builtins.int], Tuple[builtins.int, ...]]
+_dispatchkey = Union[builtins.str, torch._C.DispatchKey]
 
 # Meta-type for "numeric" things; matches our docs
-Number = Union[_int, _float, _bool]
+Number = Union[builtins.int, builtins.float, builtins.bool]
 
 # Meta-type for "device-like" things.  Not to be confused with 'device' (a
 # literal device object).  This nomenclature is consistent with PythonArgParser.
 # None means use the default device (typically CPU)
-Device = Optional[Union[_device, _str, _int]]
+Device = Optional[Union[_device, builtins.str, builtins.int]]
 del Optional
 
 # Storage protocol implemented by ${Type}StorageBase classes


### PR DESCRIPTION
Summary: Somehow, using underscore alias of some builtin types breaks pyre

Test Plan:
All failed tests from D58983461 are passing:

```
buck2 test 'fbcode//mode/opt' fbcode//caffe2/torch/fb/training_toolkit/utils/tests:gpu_memory_utils_test-type-checking
buck2 test 'fbcode//mode/dev-nosan' fbcode//dper_lib/silvertorch/lib:device_util-type-checking
buck2 test 'fbcode//mode/dev-nosan' fbcode//dper_lib/silvertorch/lib:thompson_samplers_gpu-type-checking
buck2 test 'fbcode//mode/dev-nosan' fbcode//dper_lib/silvertorch/modules/retrieval/diversity/tests:combined_sampling_diversifier_test-type-checking
buck2 test 'fbcode//mode/dev-nosan' fbcode//dper_lib/silvertorch/modules/retrieval/diversity/tests:submodular_opt_test-type-checking
```

Differential Revision: D59029768
