### PR TITLE
[Profiler] Add Rank to NCCL Debug Info

### DIFF
--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -390,6 +390,9 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
   }
   auto& groupRanks = debugInfo->getGroupRanks();
   map.emplace(kGroupRanks, format_list(groupRanks, truncate));
+
+  auto rank = debugInfo->getRank();
+  map.emplace(kRank, std::to_string(rank));
 #endif // USE_DISTRIBUTED
   return map;
 }

--- a/torch/csrc/profiler/util.h
+++ b/torch/csrc/profiler/util.h
@@ -168,6 +168,7 @@ constexpr auto kGroupSize = "Group size";
 constexpr auto kProcessGroupName = "Process Group Name";
 constexpr auto kProcessGroupDesc = "Process Group Description";
 constexpr auto kGroupRanks = "Process Group Ranks";
+constexpr auto kRank = "Rank";
 #endif // USE_DISTRIBUTED
 
 } // namespace torch::profiler::impl


### PR DESCRIPTION
Summary: We need to add the Rank information to the NCCL debug data so that kineto can infer all the necessary process group info such that on-demand can create distributedInfo metadata. Kineto portion will be added in a follow up diff

Test Plan: Tested in D58736045, this diff just splits the kineto and profiler instances

Differential Revision: D59028819
