### PR TITLE
add _flash_attention_forward and _efficient_attention_forward to compute intensive ops in partitioner

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1259,6 +1259,8 @@ def get_default_op_list() -> OpTypes:
         aten.addmm,
         aten._scaled_dot_product_flash_attention,
         aten._scaled_dot_product_efficient_attention,
+        aten._flash_attention_forward,
+        aten._efficient_attention_forward,
         aten.upsample_bilinear2d,
     ]  # noqa: E501,B950
 


### PR DESCRIPTION
Avoid recompute of SDPA during the backward.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129533



cc @cpuhrsch @jbschlosser @bhosmer @drisspg @soulitzer