### PR TITLE
[cpu] Fix div with rounding_mode="floor" when division overflows

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -260,6 +260,10 @@ inline Vectorized<scalar_t> div_floor_floating_vec(
   const auto basic_div = a / b;
   floordiv = vec_t::blendv(floordiv, zero.copysign(basic_div), div == zero);
   floordiv = vec_t::blendv(floordiv, basic_div, b == zero);
+  vec_t inf(std::numeric_limits<scalar_t>::infinity());
+  // Sleef_fmod doesn't handle inf/nan well, so use basic_div for extremal values
+  auto nonfinite = basic_div.isnan() | (basic_div.abs() == inf);
+  floordiv = vec_t::blendv(floordiv, basic_div, nonfinite);
   return floordiv;
 };
 

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -251,6 +251,7 @@ inline Vectorized<scalar_t> div_floor_floating_vec(
   const auto basic_div = a / b;
   vec_t inf(std::numeric_limits<scalar_t>::infinity());
   auto mod = a.fmod(b);
+  // Fixup for a case that isn't properly handled by Sleef_fmod
   auto floor = vec_t::blendv(a - mod, a, (basic_div.abs() == inf) & (a.abs() != inf));
   auto div = floor / b;
   const auto zero = vec_t(0);

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -248,8 +248,11 @@ inline Vectorized<scalar_t> div_floor_floating_vec(
     const Vectorized<scalar_t>& a,
     const Vectorized<scalar_t>& b) {
   using vec_t = Vectorized<scalar_t>;
+  const auto basic_div = a / b;
+  vec_t inf(std::numeric_limits<scalar_t>::infinity());
   auto mod = a.fmod(b);
-  auto div = (a - mod) / b;
+  auto floor = vec_t::blendv(a - mod, a, (basic_div.abs() == inf) & (a.abs() != inf));
+  auto div = floor / b;
   const auto zero = vec_t(0);
   auto mask = (mod != zero) & ((b < zero) ^ (mod < zero));
   const auto one = vec_t(1);
@@ -257,13 +260,8 @@ inline Vectorized<scalar_t> div_floor_floating_vec(
   auto floordiv = div.floor();
   mask = (div - floordiv) > vec_t(0.5);
   floordiv = vec_t::blendv(floordiv, floordiv + one, mask);
-  const auto basic_div = a / b;
   floordiv = vec_t::blendv(floordiv, zero.copysign(basic_div), div == zero);
   floordiv = vec_t::blendv(floordiv, basic_div, b == zero);
-  vec_t inf(std::numeric_limits<scalar_t>::infinity());
-  // Sleef_fmod doesn't handle inf/nan well, so use basic_div for extremal values
-  auto nonfinite = basic_div.isnan() | (basic_div.abs() == inf);
-  floordiv = vec_t::blendv(floordiv, basic_div, nonfinite);
   return floordiv;
 };
 

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -969,6 +969,25 @@ class TestBinaryUfuncs(TestCase):
         d_ref = d_true.float() if rounding_unsupported else d_true
         self.assertEqual(d_trunc, d_ref.trunc().to(dtype))
 
+    @dtypes(*floating_types_and(torch.bfloat16, torch.float16))
+    def test_floor_div_extremal(self, device, dtype):
+        for num, denom, shape in itertools.product(
+                [torch.finfo(dtype).max * 0.7],
+                [0.5, -0.5, 0.],
+                [(), (32,)], # Scalar and vectorized
+        ):
+            a = torch.full(shape, num, dtype=dtype, device=device)
+            b = torch.full(shape, denom, dtype=dtype, device=device)
+
+            ref = np.floor_divide(num, denom).item()
+            if ref > torch.finfo(dtype).max:
+                ref = float('inf')
+            elif ref < torch.finfo(dtype).min:
+                ref = -float('inf')
+            expect = torch.full(shape, ref, dtype=dtype, device=device)
+            actual = torch.div(a, b, rounding_mode="floor")
+            self.assertEqual(expect, actual)
+
     @dtypes(torch.bfloat16, torch.half, torch.float32, torch.float64)
     def test_div_rounding_nonfinite(self, device, dtype):
         # Compare division of special floating point values against NumPy

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -972,18 +972,18 @@ class TestBinaryUfuncs(TestCase):
     @dtypes(*floating_types_and(torch.bfloat16, torch.float16))
     def test_floor_div_extremal(self, device, dtype):
         for num, denom, shape in itertools.product(
-                [torch.finfo(dtype).max * 0.7],
-                [0.5, -0.5, 0.],
-                [(), (32,)], # Scalar and vectorized
+            [torch.finfo(dtype).max * 0.7],
+            [0.5, -0.5, 0.0],
+            [(), (32,)],  # Scalar and vectorized
         ):
             a = torch.full(shape, num, dtype=dtype, device=device)
             b = torch.full(shape, denom, dtype=dtype, device=device)
 
             ref = np.floor_divide(num, denom).item()
             if ref > torch.finfo(dtype).max:
-                ref = float('inf')
+                ref = np.inf
             elif ref < torch.finfo(dtype).min:
-                ref = -float('inf')
+                ref = -np.inf
             expect = torch.full(shape, ref, dtype=dtype, device=device)
             actual = torch.div(a, b, rounding_mode="floor")
             self.assertEqual(expect, actual)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -994,6 +994,7 @@ class TestBinaryUfuncs(TestCase):
         num = torch.tensor(
             [1.0, -1.0, 0, 0.1, -0.1, np.pi, -np.pi, np.inf, -np.inf, np.nan],
             dtype=dtype,
+            device=device,
         )
         # Divide by zero is tested separately
         denom = num[num != 0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129536

Fixes #77742

`Sleef_fmod` returns NaN when the division overflows, where `libm` returns 0. In this narrow case we can drop the `fmod` from the calulation entirely.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10