### PR TITLE
[export] construct empty graph when there's no tensor computation 

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -81,6 +81,76 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         dynamo_result = out_graph()
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
+    def test_no_tensor_computation_fail(self):
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Failed to produce a graph",
+        ):
+            inp = [torch.randn(3)]
+            inp2 = 2
+            inps = [inp, inp2]
+
+            def func(x, y):
+                return x
+
+            exported = torch._dynamo.export(func, same_signature=False)(*inps)
+            
+    def test_no_tensor_computation(self):
+        inp = [torch.randn(3)]
+        inp2 = 2
+        inps = [inp, inp2]
+
+        def func(x, y):
+            return x
+
+        opt_func = torch._dynamo.optimize("eager", nopython=True, dynamic=True)(func)
+        real_result = opt_func(*inps)
+
+        torch._dynamo.reset()
+
+        exported = torch._dynamo.export(func)(*inps)
+        out_graph = exported[0]
+
+        dynamo_result = out_graph(*inps)
+
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result)) 
+        self.assertExpectedInline(
+                    out_graph.code.strip(),
+            """\
+def forward(self, x, y):
+    arg0, arg1, = fx_pytree.tree_flatten_spec(([x, y], {}), self._in_spec)
+    x = arg0
+    return pytree.tree_unflatten([x], self._out_spec)""",
+        )      
+
+    def test_no_tensor_computation_2(self):
+        inp = torch.randn(3)
+        inp2 = 2
+        inps = [inp, inp2]
+
+        def func(x, y):
+            return y
+
+        opt_func = torch._dynamo.optimize("eager", nopython=True, dynamic=True)(func)
+        real_result = opt_func(*inps)
+
+        torch._dynamo.reset()
+
+        exported = torch._dynamo.export(func)(*inps)
+        out_graph = exported[0]
+
+        dynamo_result = out_graph(*inps)
+
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result)) 
+        self.assertExpectedInline(
+                    out_graph.code.strip(),
+            """\
+def forward(self, x, y):
+    arg0, arg1, = fx_pytree.tree_flatten_spec(([x, y], {}), self._in_spec)
+    x = arg0
+    return pytree.tree_unflatten([2], self._out_spec)""",
+        )       
+
     def test_export_mismatched_out(self):
         def func(x):
             y = x + 1
@@ -607,6 +677,63 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         dynamo_result = out_graph()
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
+    
+    def test_export_no_tensor_computation_with_aten_graph(self):
+        inp = [torch.randn(3)]
+        inp2 = 2
+        inps = [inp, inp2]
+
+        def func(x, y):
+            return x
+
+        opt_func = torch._dynamo.optimize("eager", nopython=True, dynamic=True)(func)
+        real_result = opt_func(*inps)
+
+        torch._dynamo.reset()
+
+        exported = torch._dynamo.export(func, aten_graph=True)(*inps)
+        out_graph = exported[0]
+
+        dynamo_result = out_graph(*inps)
+
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result)) 
+        self.assertExpectedInline(
+                    out_graph.code.strip(),
+            """\
+def forward(self, x, y):
+    arg0, arg1, = fx_pytree.tree_flatten_spec(([x, y], {}), self._in_spec)
+    arg0_1 = arg0
+    _tensor_constant0 = self._tensor_constant0
+    return pytree.tree_unflatten([arg0_1], self._out_spec)""",
+        )   
+
+    def test_no_tensor_computation_2_with_aten_graph(self):
+        inp = torch.randn(3)
+        inp2 = 2
+        inps = [inp, inp2]
+
+        def func(x, y):
+            return y
+
+        opt_func = torch._dynamo.optimize("eager", nopython=True, dynamic=True)(func)
+        real_result = opt_func(*inps)
+
+        torch._dynamo.reset()
+
+        exported = torch._dynamo.export(func, aten_graph=True)(*inps)
+        out_graph = exported[0]
+
+        dynamo_result = out_graph(*inps)
+
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result)) 
+        self.assertExpectedInline(
+                    out_graph.code.strip(),
+            """\
+def forward(self, x, y):
+    arg0, arg1, = fx_pytree.tree_flatten_spec(([x, y], {}), self._in_spec)
+    arg0_1 = arg0
+    return pytree.tree_unflatten([2], self._out_spec)""",
+        )     
 
     def test_export_mismatched_out_with_aten_graph(self):
         def func(x):

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -94,7 +94,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
                 return x
 
             exported = torch._dynamo.export(func, same_signature=False)(*inps)
-            
+
     def test_no_tensor_computation(self):
         inp = [torch.randn(3)]
         inp2 = 2
@@ -113,15 +113,15 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         dynamo_result = out_graph(*inps)
 
-        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result)) 
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
         self.assertExpectedInline(
-                    out_graph.code.strip(),
+            out_graph.code.strip(),
             """\
 def forward(self, x, y):
     arg0, arg1, = fx_pytree.tree_flatten_spec(([x, y], {}), self._in_spec)
     x = arg0
     return pytree.tree_unflatten([x], self._out_spec)""",
-        )      
+        )
 
     def test_no_tensor_computation_2(self):
         inp = torch.randn(3)
@@ -141,15 +141,15 @@ def forward(self, x, y):
 
         dynamo_result = out_graph(*inps)
 
-        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result)) 
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
         self.assertExpectedInline(
-                    out_graph.code.strip(),
+            out_graph.code.strip(),
             """\
 def forward(self, x, y):
     arg0, arg1, = fx_pytree.tree_flatten_spec(([x, y], {}), self._in_spec)
     x = arg0
     return pytree.tree_unflatten([2], self._out_spec)""",
-        )       
+        )
 
     def test_export_mismatched_out(self):
         def func(x):
@@ -677,7 +677,7 @@ def forward(self, x, y):
 
         dynamo_result = out_graph()
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
-    
+
     def test_export_no_tensor_computation_with_aten_graph(self):
         inp = [torch.randn(3)]
         inp2 = 2
@@ -696,15 +696,15 @@ def forward(self, x, y):
 
         dynamo_result = out_graph(*inps)
 
-        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result)) 
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
         self.assertExpectedInline(
-                    out_graph.code.strip(),
+            out_graph.code.strip(),
             """\
 def forward(self, x, y):
     arg0, arg1, = fx_pytree.tree_flatten_spec(([x, y], {}), self._in_spec)
     arg0_1 = arg0
     return pytree.tree_unflatten([arg0_1], self._out_spec)""",
-        )   
+        )
 
     def test_no_tensor_computation_2_with_aten_graph(self):
         inp = torch.randn(3)
@@ -724,15 +724,15 @@ def forward(self, x, y):
 
         dynamo_result = out_graph(*inps)
 
-        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result)) 
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
         self.assertExpectedInline(
-                    out_graph.code.strip(),
+            out_graph.code.strip(),
             """\
 def forward(self, x, y):
     arg0, arg1, = fx_pytree.tree_flatten_spec(([x, y], {}), self._in_spec)
     arg0_1 = arg0
     return pytree.tree_unflatten([2], self._out_spec)""",
-        )     
+        )
 
     def test_export_mismatched_out_with_aten_graph(self):
         def func(x):

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -703,7 +703,6 @@ def forward(self, x, y):
 def forward(self, x, y):
     arg0, arg1, = fx_pytree.tree_flatten_spec(([x, y], {}), self._in_spec)
     arg0_1 = arg0
-    _tensor_constant0 = self._tensor_constant0
     return pytree.tree_unflatten([arg0_1], self._out_spec)""",
         )   
 

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -269,6 +269,34 @@ class TestExport(TestCase):
         inp = ([torch.ones(1, 3)], torch.ones(1, 3))
         self._test_export_same_as_eager(f, inp)
 
+
+    def test_no_tensor_computation(self):
+        class Module(torch.nn.Module):
+            def forward(self, x, y):
+                return y
+
+        f = Module()
+        inp = ([torch.ones(1, 3)], 1)
+        self._test_export_same_as_eager(f, inp)
+
+    def test_no_tensor_computation_2(self):
+        class Module(torch.nn.Module):
+            def forward(self, x, y):
+                return x
+
+        f = Module()
+        inp = (torch.randn(3), 1)
+        self._test_export_same_as_eager(f, inp)
+
+    def test_no_tensor_computation_3(self):
+        class Module(torch.nn.Module):
+            def forward(self, x, y):
+                return 5
+
+        f = Module()
+        inp = (2, 1)
+        self._test_export_same_as_eager(f, inp)
+
     # Errors because non-strict is not supported in training IR (T193692164)
     @testing.expectedFailureTrainingIRToRunDecomp
     def test_external_call_non_strict_real_tensor(self):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -277,7 +277,16 @@ class TestExport(TestCase):
 
         f = Module()
         inp = ([torch.ones(1, 3)], 1)
-        self._test_export_same_as_eager(f, inp)
+        ep = export(f, inp)
+        self.assertEqual(ep.module()(*inp), f(*inp))
+        self.assertExpectedInline(
+            str(ep.graph).strip(),
+            """\
+graph():
+    %x_0 : [num_users=0] = placeholder[target=x_0]
+    %y : [num_users=0] = placeholder[target=y]
+    return (1,)""",
+        )
 
     def test_no_tensor_computation_2(self):
         class Module(torch.nn.Module):
@@ -286,7 +295,16 @@ class TestExport(TestCase):
 
         f = Module()
         inp = (torch.randn(3), 1)
-        self._test_export_same_as_eager(f, inp)
+        ep = export(f, inp)
+        self.assertEqual(ep.module()(*inp), f(*inp))
+        self.assertExpectedInline(
+            str(ep.graph).strip(),
+            """\
+graph():
+    %x : [num_users=1] = placeholder[target=x]
+    %y : [num_users=0] = placeholder[target=y]
+    return (x,)""",
+        )
 
     def test_no_tensor_computation_3(self):
         class Module(torch.nn.Module):
@@ -295,7 +313,16 @@ class TestExport(TestCase):
 
         f = Module()
         inp = (2, 1)
-        self._test_export_same_as_eager(f, inp)
+        ep = export(f, inp)
+        self.assertEqual(ep.module()(*inp), f(*inp))
+        self.assertExpectedInline(
+            str(ep.graph).strip(),
+            """\
+graph():
+    %x : [num_users=0] = placeholder[target=x]
+    %y : [num_users=0] = placeholder[target=y]
+    return (5,)""",
+        )
 
 
     def test_no_tensor_computation_4(self):
@@ -305,7 +332,16 @@ class TestExport(TestCase):
 
         f = Module()
         inp = ([torch.randn(3)], 1)
-        self._test_export_same_as_eager(f, inp)
+        ep = export(f, inp)
+        self.assertEqual(ep.module()(*inp), f(*inp))
+        self.assertExpectedInline(
+            str(ep.graph).strip(),
+            """\
+graph():
+    %x_0 : [num_users=1] = placeholder[target=x_0]
+    %y : [num_users=0] = placeholder[target=y]
+    return (x_0,)""",
+        )
 
     # Errors because non-strict is not supported in training IR (T193692164)
     @testing.expectedFailureTrainingIRToRunDecomp

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -269,7 +269,6 @@ class TestExport(TestCase):
         inp = ([torch.ones(1, 3)], torch.ones(1, 3))
         self._test_export_same_as_eager(f, inp)
 
-
     def test_no_tensor_computation(self):
         class Module(torch.nn.Module):
             def forward(self, x, y):
@@ -323,7 +322,6 @@ graph():
     %y : [num_users=0] = placeholder[target=y]
     return (5,)""",
         )
-
 
     def test_no_tensor_computation_4(self):
         class Module(torch.nn.Module):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -305,6 +305,8 @@ graph():
     return (x,)""",
         )
 
+    # Errors because fake mode is not detected from non-tensor inputs
+    @testing.expectedFailureTrainingIRToRunDecomp
     def test_no_tensor_computation_3(self):
         class Module(torch.nn.Module):
             def forward(self, x, y):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -297,6 +297,16 @@ class TestExport(TestCase):
         inp = (2, 1)
         self._test_export_same_as_eager(f, inp)
 
+
+    def test_no_tensor_computation_4(self):
+        class Module(torch.nn.Module):
+            def forward(self, x, y):
+                return x
+
+        f = Module()
+        inp = ([torch.randn(3)], 1)
+        self._test_export_same_as_eager(f, inp)
+
     # Errors because non-strict is not supported in training IR (T193692164)
     @testing.expectedFailureTrainingIRToRunDecomp
     def test_external_call_non_strict_real_tensor(self):

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -991,9 +991,6 @@ class TestSchemaVersioning(TestCase):
 # We didn't set up kwargs input yet
 unittest.expectedFailure(TestDeserialize.test_exportdb_supported_case_fn_with_kwargs)
 
-# Failed to produce a graph during tracing. Tracing through 'f' must produce a single graph.
-unittest.expectedFailure(TestDeserialize.test_exportdb_supported_case_scalar_output)
-
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
 class TestSaveLoad(TestCase):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -906,7 +906,6 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
 
     def output(self, target, args, kwargs):
         dynamo_result_flat = args[0]
-        print(args)
         lookup = [*dynamo_result_flat, *self.new_args]
         new_results_flat = []
         for i in range(len(self.flat_results)):
@@ -1433,9 +1432,9 @@ def export(
             raise constraint_violation_error
 
         if graph is None:
-            graph_captured_input = []
             example_inputs = []
-            graph_captured_result = [] #result_traced
+            graph_captured_input = ()
+            graph_captured_result = ()
             fake_mode = torch._subclasses.FakeTensorMode(
                 shape_env=ShapeEnv(), export=True
             )
@@ -1451,11 +1450,11 @@ def export(
                     node.meta["val"] = fake_mode.from_tensor(
                         flat_args[i], static_shapes=True
                     )
-                    graph_captured_input.append(flat_args[i])
+                    graph_captured_input = graph_captured_input + (flat_args[i],)
                     example_inputs.append(flat_args[i])
             for r in pytree.tree_flatten(result_traced)[0]:
                 if torch.is_tensor(r):
-                    graph_captured_result.append(r)
+                    graph_captured_result = graph_captured_result + (r,)
             fx_graph.output(graph_captured_result)
             module = torch.nn.Module()
             graph = torch.fx.GraphModule(module, fx_graph)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1457,9 +1457,8 @@ def export(
                     )
                     graph_captured_input = graph_captured_input + (flat_args[i],)
                     example_inputs.append(flat_args[i])
-            for r in pytree.tree_flatten(result_traced)[0]:
-                if torch.is_tensor(r):
-                    graph_captured_result = graph_captured_result + (r,)
+            if torch.is_tensor(result_traced):
+                graph_captured_result = graph_captured_result + (result_traced,)
             fx_graph.output(graph_captured_result)
             module = torch.nn.Module()
             graph = torch.fx.GraphModule(module, fx_graph)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1443,7 +1443,7 @@ def export(
                 shape_env=ShapeEnv(), export=True
             )
             if out_guards is None:
-                our_guards = _guards.GuardsSet()
+                out_guards = _guards.GuardsSet()
             assert out_guards is not None  # suppress mypy error
             parameter_names = list(original_signature.parameters.keys())
             fx_graph = torch.fx.Graph()

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1457,8 +1457,6 @@ def export(
                     )
                     graph_captured_input = graph_captured_input + (flat_args[i],)
                     example_inputs.append(flat_args[i])
-            if torch.is_tensor(result_traced):
-                graph_captured_result = graph_captured_result + (result_traced,)
             fx_graph.output(graph_captured_result)
             module = torch.nn.Module()
             graph = torch.fx.GraphModule(module, fx_graph)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -341,9 +341,9 @@ class _TorchDynamoContext:
         # add context containing GraphModule to any GraphModule forward functions
         if isinstance(fn, GraphModule):
             # add context containing GraphModule to any GraphModule forward functions
-            code_context.get_context(fn.forward.__code__)["orig_graphmodule"] = (
-                weakref.ref(fn)
-            )
+            code_context.get_context(fn.forward.__code__)[
+                "orig_graphmodule"
+            ] = weakref.ref(fn)
 
         # Optimize the forward method of torch.nn.Module object
         if isinstance(fn, torch.nn.Module):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -341,9 +341,9 @@ class _TorchDynamoContext:
         # add context containing GraphModule to any GraphModule forward functions
         if isinstance(fn, GraphModule):
             # add context containing GraphModule to any GraphModule forward functions
-            code_context.get_context(fn.forward.__code__)["orig_graphmodule"] = (
-                weakref.ref(fn)
-            )
+            code_context.get_context(fn.forward.__code__)[
+                "orig_graphmodule"
+            ] = weakref.ref(fn)
 
         # Optimize the forward method of torch.nn.Module object
         if isinstance(fn, torch.nn.Module):
@@ -760,11 +760,9 @@ def _optimize(
         hooks,
         backend_ctx_ctor,
         dynamic=dynamic,
-        compiler_config=(
-            backend.get_compiler_config()
-            if hasattr(backend, "get_compiler_config")
-            else None
-        ),
+        compiler_config=backend.get_compiler_config()
+        if hasattr(backend, "get_compiler_config")
+        else None,
         rebuild_ctx=rebuild_ctx,
     )
 
@@ -878,11 +876,9 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
                         flat_args[i],
                         symbolic_context=StatelessSymbolicContext(
                             dynamic_sizes=[
-                                (
-                                    DimDynamic.DYNAMIC
-                                    if d in flat_args_dynamic_dims[i]
-                                    else DimDynamic.STATIC
-                                )
+                                DimDynamic.DYNAMIC
+                                if d in flat_args_dynamic_dims[i]
+                                else DimDynamic.STATIC
                                 for d in range(len(flat_args[i].shape))
                             ],
                             constraint_sizes=[None] * len(flat_args[i].shape),

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1432,6 +1432,7 @@ def export(
             raise constraint_violation_error
 
         if graph is None:
+            assert (same_signature), "Failed to produce a graph during tracing as no tensor operations were found and same_signature is False."
             # If the module does not contain any tensor computation, we would create a graph with inputs and outputs.
             # To be consitant with the graph traced by dynano, `graph` will have only tensor inputs as placeholders
             # and tensor outputs as output nodes. non-tensor inputs and outputs will be added when rewriting signature.

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1432,6 +1432,11 @@ def export(
             raise constraint_violation_error
 
         if graph is None:
+            # If the module does not contain any tensor computation, we would create a graph with inputs and outputs.
+            # To be consitant with the graph traced by dynano, `graph` will have only tensor inputs as placeholders
+            # and tensor outputs as output nodes. non-tensor inputs and outputs will be added when rewriting signature.
+            # We will also construct the `example_inputs`, `graph_captured_input`, and `graph_captured_result` corresponding
+            # to `graph`.
             example_inputs = []
             graph_captured_input = ()
             graph_captured_result = ()
@@ -1443,7 +1448,6 @@ def export(
             assert out_guards is not None  # suppress mypy error
             parameter_names = list(original_signature.parameters.keys())
             fx_graph = torch.fx.Graph()
-            # non-tensor inputs and outputs will be added when rewriting signature
             for i, name in enumerate(parameter_names):
                 if torch.is_tensor(flat_args[i]):
                     node = fx_graph.placeholder(name)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -760,11 +760,9 @@ def _optimize(
         hooks,
         backend_ctx_ctor,
         dynamic=dynamic,
-        compiler_config=(
-            backend.get_compiler_config()
-            if hasattr(backend, "get_compiler_config")
-            else None
-        ),
+        compiler_config=backend.get_compiler_config()
+        if hasattr(backend, "get_compiler_config")
+        else None,
         rebuild_ctx=rebuild_ctx,
     )
 
@@ -878,11 +876,9 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
                         flat_args[i],
                         symbolic_context=StatelessSymbolicContext(
                             dynamic_sizes=[
-                                (
-                                    DimDynamic.DYNAMIC
-                                    if d in flat_args_dynamic_dims[i]
-                                    else DimDynamic.STATIC
-                                )
+                                DimDynamic.DYNAMIC
+                                if d in flat_args_dynamic_dims[i]
+                                else DimDynamic.STATIC
                                 for d in range(len(flat_args[i].shape))
                             ],
                             constraint_sizes=[None] * len(flat_args[i].shape),

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -341,9 +341,9 @@ class _TorchDynamoContext:
         # add context containing GraphModule to any GraphModule forward functions
         if isinstance(fn, GraphModule):
             # add context containing GraphModule to any GraphModule forward functions
-            code_context.get_context(fn.forward.__code__)[
-                "orig_graphmodule"
-            ] = weakref.ref(fn)
+            code_context.get_context(fn.forward.__code__)["orig_graphmodule"] = (
+                weakref.ref(fn)
+            )
 
         # Optimize the forward method of torch.nn.Module object
         if isinstance(fn, torch.nn.Module):
@@ -760,9 +760,11 @@ def _optimize(
         hooks,
         backend_ctx_ctor,
         dynamic=dynamic,
-        compiler_config=backend.get_compiler_config()
-        if hasattr(backend, "get_compiler_config")
-        else None,
+        compiler_config=(
+            backend.get_compiler_config()
+            if hasattr(backend, "get_compiler_config")
+            else None
+        ),
         rebuild_ctx=rebuild_ctx,
     )
 
@@ -876,9 +878,11 @@ class FlattenInputOutputSignature(torch.fx.interpreter.Transformer):
                         flat_args[i],
                         symbolic_context=StatelessSymbolicContext(
                             dynamic_sizes=[
-                                DimDynamic.DYNAMIC
-                                if d in flat_args_dynamic_dims[i]
-                                else DimDynamic.STATIC
+                                (
+                                    DimDynamic.DYNAMIC
+                                    if d in flat_args_dynamic_dims[i]
+                                    else DimDynamic.STATIC
+                                )
                                 for d in range(len(flat_args[i].shape))
                             ],
                             constraint_sizes=[None] * len(flat_args[i].shape),
@@ -1432,7 +1436,9 @@ def export(
             raise constraint_violation_error
 
         if graph is None:
-            assert (same_signature), "Failed to produce a graph during tracing as no tensor operations were found and same_signature is False."
+            assert (
+                same_signature
+            ), "Failed to produce a graph during tracing as no tensor operations were found and same_signature is False."
             # If the module does not contain any tensor computation, we would create a graph with inputs and outputs.
             # To be consitant with the graph traced by dynano, `graph` will have only tensor inputs as placeholders
             # and tensor outputs as output nodes. non-tensor inputs and outputs will be added when rewriting signature.


### PR DESCRIPTION
Fixes [#127110](https://github.com/pytorch/pytorch/issues/127110). 

When input module does not contain any tensor computation, we would create a graph with inputs and outputs.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang