### PR TITLE
[DCP] Capture reader, writer and planner components in the DCP API logger

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -696,7 +696,7 @@ class FileSystemReader(StorageReader):
     @property
     def checkpoint_id(self) -> Union[str, os.PathLike]:
         """
-        return the checkpoint_id that will be used to save the checkpoint.
+        return the checkpoint_id that will be used to load the checkpoint.
         """
         return self.path
 

--- a/torch/distributed/checkpoint/logger.py
+++ b/torch/distributed/checkpoint/logger.py
@@ -26,6 +26,8 @@ def _msg_dict_from_dcp_method_args(*args, **kwargs) -> Dict[str, Any]:
     # checkpoint ID can be passed in through the serializer or through the checkpoint id directly
     storage_writer = kwargs.get("storage_writer", None)
     storage_reader = kwargs.get("storage_reader", None)
+    planner = kwargs.get("planner", None)
+
     checkpoint_id = kwargs.get("checkpoint_id", None)
     if not checkpoint_id and (serializer := storage_writer or storage_reader):
         checkpoint_id = getattr(serializer, "checkpoint_id", None)
@@ -33,6 +35,15 @@ def _msg_dict_from_dcp_method_args(*args, **kwargs) -> Dict[str, Any]:
     msg_dict["checkpoint_id"] = (
         str(checkpoint_id) if checkpoint_id is not None else checkpoint_id
     )
+
+    if storage_writer:
+        msg_dict["storage_writer"] = storage_writer.__class__.__name__
+
+    if storage_reader:
+        msg_dict["storage_reader"] = storage_reader.__class__.__name__
+
+    if planner:
+        msg_dict["planner"] = planner.__class__.__name__
 
     return msg_dict
 


### PR DESCRIPTION
Summary: Capture reader, writer and planner components in the DCP API logger

Test Plan:
logs can be found in scuba pytorch_dcp_logging

https://fburl.com/scuba/pytorch_dcp_logging/ruqez1ki

Differential Revision: D59040866


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @yf225 @chauhang @d4l3k @LucasLLC @MeetVadakkanchery @mhorowitz