### PR TITLE
switch to `torch.vmap`

### DIFF
--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -8,7 +8,7 @@ from typing_extensions import deprecated
 
 import torch
 import torch.testing
-from torch._vmap_internals import _vmap, vmap
+from torch._vmap_internals import _vmap
 from torch.overrides import is_tensor_like
 from torch.types import _TensorOrTensors
 
@@ -1151,7 +1151,7 @@ def _test_batched_grad(input, output, output_idx) -> bool:
         warnings.filterwarnings("ignore", message="There is a performance drop")
         warnings.filterwarnings("ignore", message="Please use torch.vmap")
         try:
-            result = vmap(vjp)(torch.stack(grad_outputs))
+            result = torch.vmap(vjp)(torch.stack(grad_outputs))
         except RuntimeError as ex:
             # It's OK that we're not raising the error at the correct callsite.
             # That's because the callsite is always going to inside the Python


### PR DESCRIPTION
following
```
FutureWarning: Please use `torch.vmap` instead of `torch._vmap_internals.vmap`.
  result = vmap(vjp)(torch.stack(grad_outputs))
```

and https://github.com/pytorch/pytorch/blob/610894e978953e34e4ee0607b4a4e19721361831/torch/_vmap_internals.py#L201-L209