### PR TITLE
Expose nholmann json to torch

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -762,6 +762,7 @@ cc_library(
         ":torch_headers",
         "@kineto",
         "@cpp-httplib",
+        "@nlohmann",
     ] + if_cuda([
         "@cuda//:nvToolsExt",
         "@cutlass",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -175,6 +175,12 @@ new_local_repository(
 )
 
 new_local_repository(
+    name = "nlohmann",
+    build_file = "//third_party:nlohmann.BUILD",
+    path = "third_party/nlohmann",
+)
+
+new_local_repository(
     name = "tensorpipe",
     build_file = "//third_party:tensorpipe.BUILD",
     path = "third_party/tensorpipe",

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -95,6 +95,7 @@ if(NOT BUILD_LIBTORCHLESS)
     target_link_libraries(c10 PUBLIC glog::glog)
   endif()
   target_link_libraries(c10 PRIVATE fmt::fmt-header-only)
+  target_link_libraries(c10 PRIVATE nlohmann)
 
   if(C10_USE_NUMA)
     message(STATUS "NUMA paths:")

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1193,6 +1193,9 @@ endif()
 target_include_directories(torch_cpu PRIVATE
   ${TORCH_ROOT}/third_party/cpp-httplib)
 
+target_include_directories(torch_cpu PRIVATE
+  ${TORCH_ROOT}/third_party/nlohmann/include)
+
 install(DIRECTORY "${TORCH_SRC_DIR}/csrc"
   DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch
   FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
@@ -1736,7 +1739,7 @@ if(BUILD_TEST)
         if(NOT MSVC)
           add_executable(${test_name}_${CPU_CAPABILITY} "${test_src}" ../aten/src/ATen/native/quantized/AffineQuantizerBase.cpp)
           # TODO: Get rid of c10 dependency (which is only needed for the implementation of AT_ERROR)
-          target_link_libraries(${test_name}_${CPU_CAPABILITY} c10 sleef gtest_main)
+          target_link_libraries(${test_name}_${CPU_CAPABILITY} c10 sleef gtest_main nlohmann)
           if(USE_FBGEMM)
             target_link_libraries(${test_name}_${CPU_CAPABILITY} fbgemm)
           endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1160,6 +1160,7 @@ if(USE_DISTRIBUTED AND USE_TENSORPIPE)
     add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/tensorpipe)
 
     list(APPEND Caffe2_DEPENDENCY_LIBS tensorpipe)
+    list(APPEND Caffe2_DEPENDENCY_LIBS nlohmann)
     if(USE_CUDA)
       list(APPEND Caffe2_CUDA_DEPENDENCY_LIBS tensorpipe_cuda)
     elseif(USE_ROCM)
@@ -1681,3 +1682,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/FlatBuffers.cmake)
 # Include cpp-httplib
 add_library(httplib INTERFACE IMPORTED)
 target_include_directories(httplib SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/third_party/cpp-httplib)
+
+# Include nlohmann-json
+add_library(nlohmann INTERFACE IMPORTED)
+include_directories(nlohmann SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/third_party/nlohmann/include)

--- a/third_party/nlohmann.BUILD
+++ b/third_party/nlohmann.BUILD
@@ -1,0 +1,20 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "nlohmann",
+    hdrs = glob(["include/**/*.hpp"]),
+    includes = [
+        "/",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "nlohmann_single_include",
+    hdrs = glob(["single_include/nlohmann/*.hpp"]),
+    includes = [
+        "/",
+    ],
+    visibility = ["//visibility:public"],
+)
+

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -69,6 +69,7 @@ set(TORCH_PYTHON_INCLUDE_DIRECTORIES
     ${TORCH_ROOT}/third_party/flatbuffers/include
     ${TORCH_ROOT}/third_party/kineto/libkineto/include
     ${TORCH_ROOT}/third_party/cpp-httplib
+    ${TORCH_ROOT}/third_party/nlohmann/include
 
     ${TORCH_SRC_DIR}/csrc
     ${TORCH_SRC_DIR}/csrc/api/include
@@ -82,6 +83,7 @@ set(TORCH_PYTHON_LINK_LIBRARIES
     pybind::pybind11
     opentelemetry::api
     httplib
+    nlohmann
     shm
     fmt::fmt-header-only
     ATEN_CPU_FILES_GEN_LIB)


### PR DESCRIPTION
Summary:



Expose nlohmann json library so that it can be used from inside Pytorch. The library already exists in the `third_party` directory. This PR is making `nlohmann/json.hpp` header available to be used from `torch.distributed`.
The next PR makes actual use of this header.

imported-using-ghimport

Test Plan: Imported from OSS

Reviewed By: malfet

Differential Revision: D59035246

Pulled By: c-p-i-o


