### PR TITLE
[codemod] Add `[[noreturn]]` to 2 files inc caffe2/c10/util/TypeCast.cpp

### DIFF
--- a/c10/util/TypeCast.cpp
+++ b/c10/util/TypeCast.cpp
@@ -2,7 +2,7 @@
 
 namespace c10 {
 
-void report_overflow(const char* name) {
+[[noreturn]] void report_overflow(const char* name) {
   std::ostringstream oss;
   oss << "value cannot be converted to type " << name << " without overflow";
   throw std::runtime_error(oss.str()); // rather than domain_error (issue 33562)

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -177,7 +177,7 @@ C10_HOST_DEVICE To convert(From f) {
 }
 
 // Define separately to avoid being inlined and prevent code-size bloat
-C10_API void report_overflow(const char* name);
+[[noreturn]] C10_API void report_overflow(const char* name);
 
 template <typename To, typename From>
 To checked_convert(From f, const char* name) {


### PR DESCRIPTION
Summary: LLVM-15 has a warning `-Wno-return` which can be used to identify functions that do not return. Qualifying these functions with `[[noreturn]]` is a perf optimization.

Test Plan: Sandcastle

Reviewed By: dmm-fb

Differential Revision: D59003594
