### PR TITLE
[inductor] optimize cpp builder configuration code

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -346,7 +346,7 @@ def _get_optimization_cflags() -> List[str]:
         if not config.cpp.enable_floating_point_contract_flag:
             cflags.append("ffp-contract=off")
 
-        if not sys.platform == "darwin":
+        if sys.platform != "darwin":
             # https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1
             # `-march=native` is unrecognized option on M1
             if not config.is_fbcode():

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -346,25 +346,14 @@ def _get_optimization_cflags() -> List[str]:
         if not config.cpp.enable_floating_point_contract_flag:
             cflags.append("ffp-contract=off")
 
-        if config.is_fbcode():
-            # FIXME: passing `-fopenmp` adds libgomp.so to the generated shared library's dependencies.
-            # This causes `ldopen` to fail in fbcode, because libgomp does not exist in the default paths.
-            # We will fix it later by exposing the lib path.
-            return cflags
-
-        if sys.platform == "darwin":
-            # Per https://mac.r-project.org/openmp/ right way to pass `openmp` flags to MacOS is via `-Xclang`
-            # Also, `-march=native` is unrecognized option on M1
-            cflags.append("Xclang")
-        else:
-            if platform.machine() == "ppc64le":
-                cflags.append("mcpu=native")
-            else:
-                cflags.append("march=native")
-
-        # Internal cannot find libgomp.so
-        if not config.is_fbcode():
-            cflags.append("fopenmp")
+        if not sys.platform == "darwin":
+            # https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1
+            # `-march=native` is unrecognized option on M1
+            if not config.is_fbcode():
+                if platform.machine() == "ppc64le":
+                    cflags.append("mcpu=native")
+                else:
+                    cflags.append("march=native")
 
         return cflags
 
@@ -575,13 +564,13 @@ def _get_build_args_of_chosen_isa(vec_isa: VecISA):
 
         build_flags = [vec_isa.build_arch_flags()]
 
-    if config.is_fbcode() and vec_isa != invalid_vec_isa:
-        cap = str(vec_isa).upper()
-        macros = [
-            f"CPU_CAPABILITY={cap}",
-            f"CPU_CAPABILITY_{cap}",
-            f"HAVE_{cap}_CPU_DEFINITION",
-        ]
+        if config.is_fbcode():
+            cap = str(vec_isa).upper()
+            macros = [
+                f"CPU_CAPABILITY={cap}",
+                f"CPU_CAPABILITY_{cap}",
+                f"HAVE_{cap}_CPU_DEFINITION",
+            ]
 
     return macros, build_flags
 
@@ -686,6 +675,10 @@ def _get_openmp_args(cpp_compiler):
     libs: List[str] = []
     passthough_args: List[str] = []
     if _IS_MACOS:
+        # Per https://mac.r-project.org/openmp/ right way to pass `openmp` flags to MacOS is via `-Xclang`
+        cflags.append("Xclang")
+        cflags.append("fopenmp")
+
         # only Apple builtin compilers (Apple Clang++) require openmp
         omp_available = not _is_apple_clang(cpp_compiler)
 
@@ -731,10 +724,8 @@ def _get_openmp_args(cpp_compiler):
         # /openmp, /openmp:llvm
         # llvm on Windows, new openmp: https://devblogs.microsoft.com/cppblog/msvc-openmp-update/
         # msvc openmp: https://learn.microsoft.com/zh-cn/cpp/build/reference/openmp-enable-openmp-2-0-support?view=msvc-170
-
         cflags.append("openmp")
         cflags.append("openmp:experimental")  # MSVC CL
-        libs = []
     else:
         if config.is_fbcode():
             include_dir_paths.append(build_paths.openmp())


### PR DESCRIPTION
Changes:
1. Combine choose isa condition dispatch code.
2. Unificate MacOS openmp configuration code.
3. Clean up useless code.

cc @malfet @albanD @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang