### PR TITLE
[Fix]: Convert operator that does specialization to its symbolic counterpart

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -799,14 +799,15 @@ class TestConverter(TestCase):
         ep_list = self._check_equal_ts_ep_converter(func6, inp)
 
         # TODO: Additional check once dynamic shape is supported.
-        # self.assertEqual(
-        #     ep_list[0].module()(
-        #         torch.randn([1, 1, 1]).to(torch.int8),
-        #         torch.randn([1, 1, 1]).to(torch.int32),
-        #         torch.randn([1, 1, 1]).to(torch.float32),
-        #         torch.randn([1, 1, 1]).to(torch.float64),
-        #     )[0], 1
-        # )
+        # for ep in ep_list:
+        #     self.assertEqual(
+        #         ep.module()(
+        #             torch.randn([1, 1, 1]).to(torch.int8),
+        #             torch.randn([1, 1, 1]).to(torch.int32),
+        #             torch.randn([1, 1, 1]).to(torch.float32),
+        #             torch.randn([1, 1, 1]).to(torch.float64),
+        #         )[0], 1
+        #     )
 
     def test_prim_tolist(self):
         class Module(torch.nn.Module):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -796,7 +796,17 @@ class TestConverter(TestCase):
             torch.randn([2, 3, 4]).to(torch.float32),
             torch.randn([2, 3, 4]).to(torch.float64),
         )
-        self._check_equal_ts_ep_converter(func6, inp)
+        ep_list = self._check_equal_ts_ep_converter(func6, inp)
+
+        # TODO: Additional check once dynamic shape is supported.
+        # self.assertEqual(
+        #     ep_list[0].module()(
+        #         torch.randn([1, 1, 1]).to(torch.int8),
+        #         torch.randn([1, 1, 1]).to(torch.int32),
+        #         torch.randn([1, 1, 1]).to(torch.float32),
+        #         torch.randn([1, 1, 1]).to(torch.float64),
+        #     )[0], 1
+        # )
 
     def test_prim_tolist(self):
         class Module(torch.nn.Module):

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -227,7 +227,9 @@ def get_op_overload(node: torch._C.Node):
 
         # To match the behavior of direct export, we replace specialized operator
         # with its symbolic counterpart if exists.
-        op_overload_packet = getattr(op_overload_mod, f"sym_{op_name}", op_overload_packet)
+        op_overload_packet = getattr(
+            op_overload_mod, f"sym_{op_name}", op_overload_packet
+        )
 
         if override:
             op_overload = getattr(op_overload_packet, override)

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -73,6 +73,14 @@ _TORCH_DTYPE_TO_ENUM = {
 }
 
 
+_TORCH_SPECIALIZED_OP_TO_SYMBOLIC_OP = {
+    torch.ops.aten.numel: torch.ops.aten.sym_numel,
+    torch.ops.aten.size: torch.ops.aten.sym_size,
+    torch.ops.aten.storage_offset: torch.ops.aten.sym_storage_offset,
+    torch.ops.aten.stride: torch.ops.aten.sym_stride,
+}
+
+
 def get_dtype_as_int(tensor):
     """
     prim::dtype has the signature "Tensor a) -> int", where it gets the dtype of
@@ -227,9 +235,10 @@ def get_op_overload(node: torch._C.Node):
 
         # To match the behavior of direct export, we replace specialized operator
         # with its symbolic counterpart if exists.
-        op_overload_packet = getattr(
-            op_overload_mod, f"sym_{op_name}", op_overload_packet
-        )
+        if op_overload_packet in _TORCH_SPECIALIZED_OP_TO_SYMBOLIC_OP:
+            op_overload_packet = _TORCH_SPECIALIZED_OP_TO_SYMBOLIC_OP[
+                op_overload_packet
+            ]
 
         if override:
             op_overload = getattr(op_overload_packet, override)

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -97,6 +97,7 @@ kind_to_standard_operators = {
     "prim::dtype": get_dtype_as_int,
     "aten::len": len,
     # Mapping from specialized op to its symbolic counterpart.
+    # They currently do not have any other overrides.
     "aten::numel": torch.ops.aten.sym_numel,
     "aten::size": torch.ops.aten.sym_size,
     "aten::storage_offset": torch.ops.aten.sym_storage_offset,

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -229,7 +229,6 @@ def get_op_overload(node: torch._C.Node):
     try:
         op_overload_mod = getattr(torch.ops, ns)
         op_overload_packet = getattr(op_overload_mod, op_name)
-
         if override:
             op_overload = getattr(op_overload_packet, override)
         else:
@@ -939,7 +938,6 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionaly
             self.name_to_non_tensor_attributes,
         )
         gm = graph_converter.convert()
-        print(gm)
         ep = self.retrace_as_exported_program(
             gm, graph_converter.name_to_tensor_constants
         )


### PR DESCRIPTION
#### Issue
During conversion, use symbolic operator when exist.

#### Test Plan
`pytest test/export/test_converter.py`