### PR TITLE
Make PyTorch argparser understand complex

### DIFF
--- a/torch/csrc/Dtype.h
+++ b/torch/csrc/Dtype.h
@@ -19,7 +19,7 @@ inline bool THPDtype_Check(PyObject* obj) {
 }
 
 inline bool THPPythonScalarType_Check(PyObject* obj) {
-  return obj == (PyObject*)(&PyFloat_Type) ||
+  return obj == (PyObject*)(&PyFloat_Type) || obj == (PyObject*)(&PyComplex_Type) ||
       obj == (PyObject*)(&PyBool_Type) || obj == (PyObject*)(&PyLong_Type);
 }
 

--- a/torch/csrc/Dtype.h
+++ b/torch/csrc/Dtype.h
@@ -19,8 +19,9 @@ inline bool THPDtype_Check(PyObject* obj) {
 }
 
 inline bool THPPythonScalarType_Check(PyObject* obj) {
-  return obj == (PyObject*)(&PyFloat_Type) || obj == (PyObject*)(&PyComplex_Type) ||
-      obj == (PyObject*)(&PyBool_Type) || obj == (PyObject*)(&PyLong_Type);
+  return obj == (PyObject*)(&PyFloat_Type) ||
+      obj == (PyObject*)(&PyComplex_Type) || obj == (PyObject*)(&PyBool_Type) ||
+      obj == (PyObject*)(&PyLong_Type);
 }
 
 TORCH_API PyObject* THPDtype_New(

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -755,6 +755,9 @@ inline at::ScalarType toScalarType(PyObject* obj) {
   if (obj == (PyObject*)&PyLong_Type) {
     return at::ScalarType::Long;
   }
+  if (obj == (PyObject*)&PyComplex_Type) {
+    return at::ScalarType::ComplexDouble;
+  }
   return reinterpret_cast<THPDtype*>(obj)->scalar_type;
 }
 


### PR DESCRIPTION
It understands float and int, so why not `complex`.

Test plan: `python -c "import torch;print(torch.rand(3, dtype=complex))"`

Fixes https://github.com/pytorch/pytorch/issues/126837


cc @albanD