### PR TITLE
[dynamo][compile-time] Manually trace torch.nn.Module.parameters

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -750,6 +750,27 @@ class ParametersModule3(ParametersModule1):
         return F.relu(self.linear1(x)) * self.scale + ones
 
 
+class ParametersModule4(ParametersModule1):
+    def forward(self, x):
+        ones = torch.ones(10, dtype=next(self.parameters(recurse=False)).dtype)
+        return F.relu(self.linear1(x)) * self.scale + ones
+
+
+class ParametersModule5(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear1 = torch.nn.Linear(10, 10)
+        self.scale = torch.nn.Parameter(torch.randn(10, 10))
+        self.scale_dup = self.scale
+
+    def forward(self, x):
+        counter = 0
+        for param in self.parameters():
+            counter += 1
+
+        return x * self.scale * counter
+
+
 class SuperModule(BasicModule):
     def forward(self, x):
         x = super().forward(x)
@@ -1160,6 +1181,8 @@ class NNModuleTests(torch._dynamo.test_case.TestCase):
     test_parameters1 = make_test(ParametersModule1())
     test_parameters2 = make_test(ParametersModule2())
     test_parameters3 = make_test(ParametersModule3(), expected_ops=5)
+    test_parameters4 = make_test(ParametersModule4())
+    test_parameters5 = make_test(ParametersModule5())
     test_hasattr = make_test(HasAttrModule())
     test_enumvalues = make_test(EnumValues())
     test_access_by_keys = make_test(AccessByKeys())

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -876,6 +876,60 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 tx, [self] + list(args), kwargs
             )
 
+    def trace_supported_methods(self, tx, method, name, args, kwargs):
+        def get_kwargs(*names):
+            fn = getattr(self.value, name)
+            bound_args = inspect.signature(fn).bind(
+                *([x.as_python_constant() for x in args]),
+                **{k: v.as_python_constant() for k, v in kwargs.items()},
+            )
+            bound_args.apply_defaults()
+            bound_args = bound_args.arguments
+            return {k: bound_args[k] for k in names}
+
+        def get_current_parameters(module_var):
+            params_dict = module_var.var_getattr(tx, "_parameters").realize().items
+            assert isinstance(params_dict, dict)
+            params_list = list(params_dict.values())
+            params_list = [param.realize() for param in params_list]
+            # Account for mod.param = None
+            params_list = [
+                param
+                for param in params_list
+                if isinstance(param, variables.TensorVariable)
+            ]
+            return params_list
+
+        def collect_parameters(module_var, recurse):
+            params_list = []
+            assert isinstance(module_var, UnspecializedNNModuleVariable)
+            params_list = get_current_parameters(module_var)
+            modules_dict = module_var.var_getattr(tx, "_modules").realize()
+            if recurse:
+                for submodule_var in modules_dict.items.values():
+                    assert isinstance(submodule_var, UnspecializedNNModuleVariable)
+                    params_list.extend(collect_parameters(submodule_var, recurse))
+            return params_list
+
+        if method is torch.nn.Module.parameters:
+            if self.source:
+                tx.output.guard_on_key_order.add(
+                    AttrSource(self.source, "_parameters").name()
+                )
+            recurse = get_kwargs("recurse")["recurse"]
+            params_list = collect_parameters(self, recurse=recurse)
+
+            # Account for duplicated params
+            deduplicated_params = list({param: None for param in params_list}.keys())
+
+            return variables.ListIteratorVariable(
+                deduplicated_params, mutable_local=MutableLocal()
+            )
+        else:
+            raise AssertionError(
+                "Discrepancy between is_supported_nn_module_method and trace_supported_methods"
+            )
+
     def call_method(
         self,
         tx,
@@ -899,6 +953,9 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
                 method = inspect.getattr_static(type(self.value), name)
             except AttributeError:
                 method = None
+
+            if self.is_supported_nn_module_method(method):
+                return self.trace_supported_methods(tx, method, name, args, kwargs)
 
             if isinstance(method, staticmethod):
                 source = AttrSource(

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -821,6 +821,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
         return key in self.value.__dict__
 
+    def is_supported_nn_module_method(self, method):
+        return method in (torch.nn.Module.parameters,)
+
     def var_getattr(self, tx, name):
         from .. import trace_rules
         from . import ConstantVariable
@@ -891,6 +894,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return variables.UserMethodVariable(
                 subobj.__get__.__func__, subobj_var, source=source
             ).call_function(tx, [self], {})
+        elif self.is_supported_nn_module_method(subobj):
+            return variables.GetAttrVariable(self, name, source=source)
         elif isinstance(subobj, staticmethod):
             func = subobj.__get__(self.value)
             if source is not None:

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -822,7 +822,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         return key in self.value.__dict__
 
     def is_supported_nn_module_method(self, method):
-        return method in (torch.nn.Module.parameters,)
+        return torch._dynamo.config.inline_inbuilt_nn_modules and method in (
+            torch.nn.Module.parameters,
+        )
 
     def var_getattr(self, tx, name):
         from .. import trace_rules

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -894,8 +894,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return variables.UserMethodVariable(
                 subobj.__get__.__func__, subobj_var, source=source
             ).call_function(tx, [self], {})
-        elif self.is_supported_nn_module_method(subobj):
-            return variables.GetAttrVariable(self, name, source=source)
         elif isinstance(subobj, staticmethod):
             func = subobj.__get__(self.value)
             if source is not None:
@@ -910,6 +908,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             isinstance(subobj, types.MethodType)
             and isinstance(self.value, torch.nn.Module)
         ):
+            if self.is_supported_nn_module_method(subobj):
+                return variables.GetAttrVariable(self, name, source=source)
+
             # Since we get subobj via self._getattr_static, which may not trigger dynamic lookup.
             # Static lookup can't tell us it's a method or function correctly,
             # so we trigger dynamic lookup here to get the correct type.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #128148
* #129610
* __->__ #129583

With this PR, we are not worse than no-inlining for Dynamo-only compilation time (there is a litte bit of noise, so outlier of 0.89 is probably ok here). For most of the models, we see positive numbers because of better caching in `UserDefinedObjectVariable`.

![image](https://github.com/pytorch/pytorch/assets/13822661/719d34fd-3e7f-4886-b7e0-1dbfc7141aa5)



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang