### PR TITLE
Add structured logging on FXGraphCache hit

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -902,6 +902,10 @@ class FxGraphCache:
             # Not expected, but in case the PyCodeCache entry is removed from
             # underneath us, treat it as a cache miss and recompile.
             log.error("Failed to load cached artifact: %s", artifact_path)
+            trace_structured(
+                "inductor_output_code",  # Omit filename when there's an error
+                payload_fn=lambda: code,
+            )
             return None
 
         # Now re-evaluate with the symints to add any guards to the current env.
@@ -923,6 +927,12 @@ class FxGraphCache:
 
         GraphLowering.save_output_code(code)
         output_code_log.debug("Output code: \n%s", code)
+        # On cache hit, use artifact path as filename
+        trace_structured(
+            "inductor_output_code",
+            lambda: {"filename": artifact_path},
+            payload_fn=lambda: code,
+        )
 
         return graph
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -902,10 +902,6 @@ class FxGraphCache:
             # Not expected, but in case the PyCodeCache entry is removed from
             # underneath us, treat it as a cache miss and recompile.
             log.error("Failed to load cached artifact: %s", artifact_path)
-            trace_structured(
-                "inductor_output_code",  # Omit filename when there's an error
-                payload_fn=lambda: code,
-            )
             return None
 
         # Now re-evaluate with the symints to add any guards to the current env.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129588


We'll also want to do this for AOTAutogradCache once that's ready 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang

Differential Revision: [D59144226](https://our.internmc.facebook.com/intern/diff/D59144226)