### PR TITLE
Fix compile error with Intel oneAPI compiler

### DIFF
--- a/aten/src/ATen/test/rng_test.h
+++ b/aten/src/ATen/test/rng_test.h
@@ -116,7 +116,7 @@ void test_random_from_to(const at::Device& device) {
   bool from_to_case_covered = false;
   bool from_case_covered = false;
   for (const int64_t from : froms) {
-    for (const ::std::optional<int64_t> to : tos) {
+    for (const ::std::optional<int64_t> & to : tos) {
       if (!to.has_value() || from < *to) {
         for (const uint64_t val : vals) {
           auto gen = at::make_generator<RNG>(val);


### PR DESCRIPTION
I am building PyTorch with the Intel oneAPI 2024.0.0 compiler, and encountered this compile error:
```
[ 85%] Building CXX object caffe2/CMakeFiles/cpu_rng_test.dir/__/aten/src/ATen/test/cpu_rng_test.cpp.o
In file included from /home/src/pytorch/aten/src/ATen/test/cpu_rng_test.cpp:2:
/home/src/pytorch/aten/src/ATen/test/rng_test.h:119:41: error: loop variable 'to' creates a copy from type 'const ::std::optional<int64_t>' (aka 'const optional<long>') [-Werror,-Wrange-loop-construct]
  119 |     for (const ::std::optional<int64_t> to : tos) {
      |                                         ^
/home/src/pytorch/aten/src/ATen/test/rng_test.h:119:10: note: use reference type 'const ::std::optional<int64_t> &' (aka 'const optional<long> &') to prevent copying
  119 |     for (const ::std::optional<int64_t> to : tos) {
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                         &
1 error generated.
```

This change makes the compiler happy.