### PR TITLE
[Fix] Let arg parser use default accelerator when device_type is not specified

### DIFF
--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -66,6 +66,7 @@
 #include <torch/csrc/utils/python_symnode.h>
 #include <torch/csrc/utils/six.h>
 
+#include <ATen/Context.h>
 #include <ATen/PythonTorchFunctionTLS.h>
 #include <ATen/core/Tensor.h>
 #include <c10/util/Exception.h>
@@ -814,7 +815,8 @@ inline at::Device toDevice(PyObject* obj) {
           static_cast<c10::DeviceIndex>(device_index));
     }
     return at::Device(
-        c10::DeviceType::CUDA, static_cast<c10::DeviceIndex>(device_index));
+        at::getAccelerator(true).value(),
+        static_cast<c10::DeviceIndex>(device_index));
   }
   const std::string& device_str = THPUtils_unpackString(obj);
   return at::Device(device_str);


### PR DESCRIPTION
Summary: As title.

Test Plan: OSS CIs

Differential Revision: D59063189
