### PR TITLE
fix: Prefix username_check strings with @

### DIFF
--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -193,7 +193,7 @@ jobs:
                           args.github_ref_type,
                           args.github_branch,
                       )
-                      label_type, message = get_workflow_type(issue, (args.github_issue_owner, username, ))
+                      label_type, message = get_workflow_type(issue, (f'@{args.github_issue_owner}', f'@{username}', ))
                       output = {
                           LABEL_TYPE_KEY: label_type,
                           MESSAGE_KEY: message,


### PR DESCRIPTION
We are expecting the username list to be prefixed with @ symbol so when passing in the set for username_check variable it should be preformatted with @.

