### PR TITLE
[torchbind] support tensor ops inside of __obj_flatten__

### DIFF
--- a/test/cpp/jit/test_custom_class_registrations.cpp
+++ b/test/cpp/jit/test_custom_class_registrations.cpp
@@ -380,6 +380,22 @@ struct ReLUClass : public torch::CustomClassHolder {
   }
 };
 
+struct FlattenWithTensorOp : public torch::CustomClassHolder {
+  explicit FlattenWithTensorOp(at::Tensor t) : t_(t) {}
+
+  at::Tensor get() {
+    return t_;
+  }
+
+  std::tuple<std::tuple<std::string, at::Tensor>> __obj_flatten__() {
+    return std::tuple(std::tuple("t", this->t_.sin()));
+  }
+
+ private:
+  at::Tensor t_;
+  ;
+};
+
 struct ContainsTensor : public torch::CustomClassHolder {
   explicit ContainsTensor(at::Tensor t) : t_(t) {}
 
@@ -446,6 +462,11 @@ TORCH_LIBRARY(_TorchScriptTesting, m) {
           [](std::vector<int64_t> state) { // __setstate__
             return c10::make_intrusive<Foo>(state[0], state[1]);
           });
+
+  m.class_<FlattenWithTensorOp>("_FlattenWithTensorOp")
+      .def(torch::init<at::Tensor>())
+      .def("get", &FlattenWithTensorOp::get)
+      .def("__obj_flatten__", &FlattenWithTensorOp::__obj_flatten__);
 
   m.def(
       "takes_foo(__torch__.torch.classes._TorchScriptTesting._Foo foo, Tensor x) -> Tensor");

--- a/torch/_library/fake_class_registry.py
+++ b/torch/_library/fake_class_registry.py
@@ -101,8 +101,14 @@ def _check_valid_flat_script_obj(flat_x):
 
 def to_fake_obj(fake_mode, x: torch.ScriptObject) -> FakeScriptObject:
     import torch.utils._pytree as pytree
+    from torch.utils._python_dispatch import _disable_current_modes
 
-    flat_x = x.__obj_flatten__()  # type: ignore[attr-defined]
+    # x.__obj_flatten__() could be calling some tensor operations inside but we don't
+    # want to call these ops in surrounding dispatch modes when executing it.
+    # Otherwise, for example, the fake tensor modes will error out when the tensors inside
+    # script obeject execute some operations like clone if allow_non_fake_input flag is set.
+    with _disable_current_modes():
+        flat_x = x.__obj_flatten__()  # type: ignore[attr-defined]
 
     _check_valid_flat_script_obj(flat_x)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129605


As titled. Previously, __obj_flatten__ can run in a fake tensor mode, e.g. in process_input of aot_autograd, which is surrounded by a fake tensor mode. This causes the tensor ops inside __obj_flatten__ to run under fake tensor mode. However, tensors inside of script obejct are real tensors, this causes the fake tensor mode to error out saying that we need to first fakify fall the tensors (because allow_non_fake_inputs is set to True).

In this PR, we disable all the dispatch modes when running to_fake_obj.

 Note that, the output of `__obj_flatten__` will be fakified and filled inside of the corresponding FakeScriptObject. So during traicng, we'll be using FakeScriptObject that has fake tensor contents.

Test Plan:
Add a new test: pytest test/export/test_torchbind.py -k test_compile_tensor_op_in_tensor_flatten
