### PR TITLE
[pytorch][cuda] Generate kernels for 5x5 filters on depth wise convolution backward

### DIFF
--- a/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
@@ -213,6 +213,9 @@ conv_depthwise2d_forward_kernel(
 }
 
 template <int kSize, int stride, typename scalar_t, typename index_t>
+#if !defined(USE_ROCM)
+C10_LAUNCH_BOUNDS_1(at::cuda::detail::CUDA_NUM_THREADS)
+#endif
 __global__ void conv_depthwise2d_backward_kernel(
     const PackedTensorAccessor32<const scalar_t, 4, DefaultPtrTraits> grad_output,
     PackedTensorAccessor32<scalar_t, 4, DefaultPtrTraits> grad_input,
@@ -245,19 +248,10 @@ __global__ void conv_depthwise2d_backward_kernel(
 
     acc_t value(0);
 
-#if !defined(USE_ROCM)
-#pragma unroll
-#endif
     for (int multiplier = 0; multiplier < depthwiseMultiplier; ++multiplier) {
       int och = (c * depthwiseMultiplier) + multiplier;
       int weightOffset = och * kernelHeight * kernelWidth;
-#if !defined(USE_ROCM)
-#pragma unroll
-#endif
       for (int kh = 0; kh < KH_LIMIT; ++kh) {
-#if defined(USE_ROCM)
-#pragma unroll
-#endif
         for (int kw = 0; kw < KW_LIMIT; ++kw) {
           int h_out = h + padHeight - kh * dilationHeight;
           int w_out = w + padWidth - kw * dilationWidth;
@@ -281,7 +275,6 @@ __global__ void conv_depthwise2d_backward_kernel(
     grad_input.data()[linearIndex] = static_cast<scalar_t>(value);
   }
 }
-
 
 template <typename scalar_t, typename index_t=unsigned>
 __global__ void conv_depthwise2d_grad_weight_kernel(
@@ -508,7 +501,24 @@ void conv_depthwise2d_backward_out(
     auto grad_input_a = grad_input.packed_accessor32<scalar_t, 4>();
     auto weight_a = weight.packed_accessor32<const scalar_t, 4>();
 
-    if (kW == 3 && kH == 3) {
+    if (kW == 5 && kH == 5) {
+      if (dW == 1 && dH == 1){
+        conv_depthwise2d_backward_kernel<5, 1><<<grid, block, 0, stream>>>(
+            grad_output_a, grad_input_a, weight_a, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+            height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      } else if (dW == 2 && dH == 2) {
+        conv_depthwise2d_backward_kernel<5, 2><<<grid, block, 0, stream>>>(
+            grad_output_a, grad_input_a, weight_a, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+            height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      } else {
+        conv_depthwise2d_backward_kernel<5, 0><<<grid, block, 0, stream>>>(
+            grad_output_a, grad_input_a, weight_a, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+            height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      }
+    } else if (kW == 3 && kH == 3) {
       if (dW == 1 && dH == 1){
         conv_depthwise2d_backward_kernel<3, 1><<<grid, block, 0, stream>>>(
             grad_output_a, grad_input_a, weight_a, n, inputChannels, depthwiseMultiplier, outputChannels, width,

--- a/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
@@ -252,6 +252,9 @@ __global__ void conv_depthwise2d_backward_kernel(
       int och = (c * depthwiseMultiplier) + multiplier;
       int weightOffset = och * kernelHeight * kernelWidth;
       for (int kh = 0; kh < KH_LIMIT; ++kh) {
+#if !defined(USE_ROCM)
+#pragma unroll
+#endif
         for (int kw = 0; kw < KW_LIMIT; ++kw) {
           int h_out = h + padHeight - kh * dilationHeight;
           int w_out = w + padWidth - kw * dilationWidth;


### PR DESCRIPTION
In #125362 we improved the default implementation of depth wise convolution 2D forward pass by precomputing boundaries of accessed slices instead of doing expensive edge checks in the inner loops. We also generated kernels for 5x5 filters as this is a common problem size.

In this PR we tried to applied the same strategy for the backward kernel but we only saw good gains just by generating code for 5x5 filters. We could also write a fallback implementation that precomputes access boundaries when filter size and stride are not known at compile time may bring some speedup but that kernel would very rarely be called.

This PR also hints the thread count at compile time and leaves only the unroll directive that seems to help performance.

Before:

```
         B      C      iH      iW    kH    kW  conv2d-backward (cuda)  conv2d-fp16-backward (cuda)
0      8.0   64.0  1024.0  1008.0   5.0   5.0               89.002686                    26.400480
1      8.0   64.0  1008.0  1008.0   5.0   5.0               88.885025                    25.995296
2      4.0   48.0   720.0   539.0   6.0   1.0                9.488832                     9.091136
3      4.0  120.0   379.0   283.0   6.0   1.0                4.194640                     3.844432
4      4.0   32.0   713.0   532.0   6.0   1.0                8.027296                     7.700064
5      4.0    3.0   712.0   542.0  31.0  31.0               15.618095                    15.097760
6      4.0  120.0   379.0   288.0   1.0   6.0                3.788224                     3.499648
7   1024.0  384.0     1.0   928.0   1.0   3.0               18.988289                    14.152768
8      4.0   24.0   687.0   512.0   6.0   1.0                6.902704                     6.685056
9     96.0   96.0   112.0   112.0   5.0   5.0               15.672400                     4.953984
10    96.0   80.0    56.0    56.0   5.0   5.0                3.261152                     1.250320
11    64.0  128.0    64.0    84.0   3.0   3.0                3.172192                     1.515648
12    16.0  960.0     7.0     7.0   5.0   5.0                0.197024                     0.072736
13    16.0   64.0   112.0   112.0   3.0   3.0                1.126240                     0.650304
```

After
```
conv2d-performance:
         B      C      iH      iW    kH    kW  conv2d-backward (cuda)  conv2d-fp16-backward (cuda)
0      8.0   64.0  1024.0  1008.0   5.0   5.0               76.278656                    26.418720
1      8.0   64.0  1008.0  1008.0   5.0   5.0               73.211617                    26.018433
2      4.0   48.0   720.0   539.0   6.0   1.0                8.901312                     9.322912
3      4.0  120.0   379.0   283.0   6.0   1.0                3.815616                     3.992208
4      4.0   32.0   713.0   532.0   6.0   1.0                7.753024                     8.032433
5      4.0    3.0   712.0   542.0  31.0  31.0               15.244144                    15.277296
6      4.0  120.0   379.0   288.0   1.0   6.0                3.503264                     3.552976
7   1024.0  384.0     1.0   928.0   1.0   3.0               16.682976                    14.167969
8      4.0   24.0   687.0   512.0   6.0   1.0                6.802576                     7.019040
9     96.0   96.0   112.0   112.0   5.0   5.0               12.713024                     4.958656
10    96.0   80.0    56.0    56.0   5.0   5.0                2.648352                     1.254752
11    64.0  128.0    64.0    84.0   3.0   3.0                3.213568                     1.517952
12    16.0  960.0     7.0     7.0   5.0   5.0                0.182208                     0.076256
13    16.0   64.0   112.0   112.0   3.0   3.0                1.139952                     0.652432
```