### PR TITLE
Fix runner determinator bug

### DIFF
--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -1,7 +1,6 @@
-import sys
 import json
 from argparse import ArgumentParser
-from typing import Any, Tuple, Iterable
+from typing import Any, Iterable, Tuple
 
 from github import Auth, Github
 from github.Issue import Issue
@@ -66,7 +65,10 @@ def get_workflow_type(issue: Issue, username_check: Iterable[str]) -> Tuple[str,
             return WORKFLOW_LABEL_LF, MESSAGE
         else:
             user_set = {
-                usr for usr in (usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split())
+                usr
+                for usr in (
+                    usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split()
+                )
             }
             if any(map(lambda uc: uc in user_set, username_check)):
                 MESSAGE = f"LF Workflows are enabled for {', '.join(username_check)}. Using LF runners."
@@ -93,7 +95,13 @@ def main() -> None:
             gh = get_gh_client(args.github_token)
             # The default issue we use - https://github.com/pytorch/test-infra/issues/5132
             issue = get_issue(gh, args.github_repo, args.github_issue)
-            label_type, message = get_workflow_type(issue, (args.github_issue_owner, args.github_actor, ))
+            label_type, message = get_workflow_type(
+                issue,
+                (
+                    args.github_issue_owner,
+                    args.github_actor,
+                ),
+            )
             output = {
                 LABEL_TYPE_KEY: label_type,
                 MESSAGE_KEY: message,

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -17,11 +17,17 @@ def parse_args() -> Any:
     parser = ArgumentParser("Get dynamic rollout settings")
     parser.add_argument("--github-token", type=str, required=True, help="GitHub token")
     parser.add_argument(
-        "--github-repo",
+        "--github-issue-repo",
         type=str,
         required=False,
         default="pytorch/test-infra",
         help="GitHub repo to get the issue",
+    )
+    parser.add_argument(
+        "--github-repo",
+        type=str,
+        required=True,
+        help="GitHub repo where CI is running",
     )
     parser.add_argument(
         "--github-issue", type=int, required=True, help="GitHub issue number"
@@ -33,7 +39,13 @@ def parse_args() -> Any:
         "--github-issue-owner", type=str, required=True, help="GitHub issue owner"
     )
     parser.add_argument(
-        "--github-branch", type=str, required=True, help="Current GitHub branch"
+        "--github-branch", type=str, required=True, help="Current GitHub branch or tag"
+    )
+    parser.add_argument(
+        "--github-ref-type",
+        type=str,
+        required=True,
+        help="Current GitHub ref type, branch or tag",
     )
 
     return parser.parse_args()
@@ -49,11 +61,39 @@ def get_issue(gh: Github, repo: str, issue_num: int) -> Issue:
     return repo.get_issue(number=issue_num)
 
 
+def get_potential_pr_author(
+    gh: Github, repo: str, username: str, ref_type: str, ref_name: str
+) -> str:
+    # If the trigger was a new tag added by a bot, this is a ciflow case
+    # Fetch the actual username from the original PR. The PR number is
+    # embedded in the tag name: ciflow/<name>/<pr-number>
+    if username == "pytorch-bot[bot]" and ref_type == "tag":
+        split_tag = ref_name.split("/")
+        if (
+            len(split_tag) == 3
+            and split_tag[0] == "ciflow"
+            and split_tag[2].isnumeric()
+        ):
+            pr_number = split_tag[2]
+            try:
+                repository = gh.get_repo(repo)
+                pull = repository.get_pull(number=int(pr_number))
+            except Exception as e:
+                raise Exception(  # noqa: TRY002
+                    f"issue with pull request {pr_number} from repo {repository}"
+                ) from e
+            return pull.user.login
+    # In all other cases, return the original input username
+    return username
+
+
 def is_exception_branch(branch: str) -> bool:
     return branch.split("/")[0] in {"main", "nightly", "release", "landchecks"}
 
 
-def get_workflow_type(issue: Issue, username_check: Iterable[str]) -> Tuple[str, str]:
+def get_workflow_type(
+    issue: Issue, workflow_requestors: Iterable[str]
+) -> Tuple[str, str]:
     try:
         first_comment = issue.get_comments()[0].body.strip("\n\t ")
 
@@ -64,17 +104,17 @@ def get_workflow_type(issue: Issue, username_check: Iterable[str]) -> Tuple[str,
             MESSAGE = "LF Workflows are enabled for everyone. Using LF runners."
             return WORKFLOW_LABEL_LF, MESSAGE
         else:
-            user_set = {
-                usr
-                for usr in (
-                    usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split()
-                )
+            all_opted_in_users = {
+                usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split()
             }
-            if any(map(lambda uc: uc in user_set, username_check)):
-                MESSAGE = f"LF Workflows are enabled for {', '.join(username_check)}. Using LF runners."
+            opted_in_requestors = {
+                usr for usr in workflow_requestors if usr in all_opted_in_users
+            }
+            if any(usr in all_opted_in_users for usr in workflow_requestors):
+                MESSAGE = f"LF Workflows are enabled for {', '.join(opted_in_requestors)}. Using LF runners."
                 return WORKFLOW_LABEL_LF, MESSAGE
             else:
-                MESSAGE = f"LF Workflows are disabled for {', '.join(username_check)}. Using meta runners."
+                MESSAGE = f"LF Workflows are disabled for {', '.join(workflow_requestors)}. Using meta runners."
                 return WORKFLOW_LABEL_META, MESSAGE
 
     except Exception as e:
@@ -85,7 +125,7 @@ def get_workflow_type(issue: Issue, username_check: Iterable[str]) -> Tuple[str,
 def main() -> None:
     args = parse_args()
 
-    if is_exception_branch(args.github_branch):
+    if args.github_ref_type == "branch" and is_exception_branch(args.github_branch):
         output = {
             LABEL_TYPE_KEY: WORKFLOW_LABEL_META,
             MESSAGE_KEY: f"Exception branch: '{args.github_branch}', using meta runners",
@@ -94,12 +134,19 @@ def main() -> None:
         try:
             gh = get_gh_client(args.github_token)
             # The default issue we use - https://github.com/pytorch/test-infra/issues/5132
-            issue = get_issue(gh, args.github_repo, args.github_issue)
+            issue = get_issue(gh, args.github_issue_repo, args.github_issue)
+            username = get_potential_pr_author(
+                gh,
+                args.github_repo,
+                args.github_actor,
+                args.github_ref_type,
+                args.github_branch,
+            )
             label_type, message = get_workflow_type(
                 issue,
                 (
                     args.github_issue_owner,
-                    args.github_actor,
+                    username,
                 ),
             )
             output = {

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -110,7 +110,7 @@ def get_workflow_type(
             opted_in_requestors = {
                 usr for usr in workflow_requestors if usr in all_opted_in_users
             }
-            if any(usr in all_opted_in_users for usr in workflow_requestors):
+            if opted_in_requestors:
                 MESSAGE = f"LF Workflows are enabled for {', '.join(opted_in_requestors)}. Using LF runners."
                 return WORKFLOW_LABEL_LF, MESSAGE
             else:

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -1,0 +1,112 @@
+import sys
+import json
+from argparse import ArgumentParser
+from typing import Any, Tuple, Iterable
+
+from github import Auth, Github
+from github.Issue import Issue
+
+
+WORKFLOW_LABEL_META = ""  # use meta runners
+WORKFLOW_LABEL_LF = "lf."  # use runners from the linux foundation
+LABEL_TYPE_KEY = "label_type"
+MESSAGE_KEY = "message"
+MESSAGE = ""  # Debug message to return to the caller
+
+
+def parse_args() -> Any:
+    parser = ArgumentParser("Get dynamic rollout settings")
+    parser.add_argument("--github-token", type=str, required=True, help="GitHub token")
+    parser.add_argument(
+        "--github-repo",
+        type=str,
+        required=False,
+        default="pytorch/test-infra",
+        help="GitHub repo to get the issue",
+    )
+    parser.add_argument(
+        "--github-issue", type=int, required=True, help="GitHub issue number"
+    )
+    parser.add_argument(
+        "--github-actor", type=str, required=True, help="GitHub triggering_actor"
+    )
+    parser.add_argument(
+        "--github-issue-owner", type=str, required=True, help="GitHub issue owner"
+    )
+    parser.add_argument(
+        "--github-branch", type=str, required=True, help="Current GitHub branch"
+    )
+
+    return parser.parse_args()
+
+
+def get_gh_client(github_token: str) -> Github:
+    auth = Auth.Token(github_token)
+    return Github(auth=auth)
+
+
+def get_issue(gh: Github, repo: str, issue_num: int) -> Issue:
+    repo = gh.get_repo(repo)
+    return repo.get_issue(number=issue_num)
+
+
+def is_exception_branch(branch: str) -> bool:
+    return branch.split("/")[0] in {"main", "nightly", "release", "landchecks"}
+
+
+def get_workflow_type(issue: Issue, username_check: Iterable[str]) -> Tuple[str, str]:
+    try:
+        first_comment = issue.get_comments()[0].body.strip("\n\t ")
+
+        if first_comment[0] == "!":
+            MESSAGE = "LF Workflows are disabled for everyone. Using meta runners."
+            return WORKFLOW_LABEL_META, MESSAGE
+        elif first_comment[0] == "*":
+            MESSAGE = "LF Workflows are enabled for everyone. Using LF runners."
+            return WORKFLOW_LABEL_LF, MESSAGE
+        else:
+            user_set = {
+                usr for usr in (usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split())
+            }
+            if any(map(lambda uc: uc in user_set, username_check)):
+                MESSAGE = f"LF Workflows are enabled for {', '.join(username_check)}. Using LF runners."
+                return WORKFLOW_LABEL_LF, MESSAGE
+            else:
+                MESSAGE = f"LF Workflows are disabled for {', '.join(username_check)}. Using meta runners."
+                return WORKFLOW_LABEL_META, MESSAGE
+
+    except Exception as e:
+        MESSAGE = f"Failed to get determine workflow type. Falling back to meta runners. Exception: {e}"
+        return WORKFLOW_LABEL_META, MESSAGE
+
+
+def main() -> None:
+    args = parse_args()
+
+    if is_exception_branch(args.github_branch):
+        output = {
+            LABEL_TYPE_KEY: WORKFLOW_LABEL_META,
+            MESSAGE_KEY: f"Exception branch: '{args.github_branch}', using meta runners",
+        }
+    else:
+        try:
+            gh = get_gh_client(args.github_token)
+            # The default issue we use - https://github.com/pytorch/test-infra/issues/5132
+            issue = get_issue(gh, args.github_repo, args.github_issue)
+            label_type, message = get_workflow_type(issue, (args.github_issue_owner, args.github_actor, ))
+            output = {
+                LABEL_TYPE_KEY: label_type,
+                MESSAGE_KEY: message,
+            }
+        except Exception as e:
+            output = {
+                LABEL_TYPE_KEY: WORKFLOW_LABEL_META,
+                MESSAGE_KEY: f"Failed to get issue. Falling back to meta runners. Exception: {e}",
+            }
+
+    json_output = json.dumps(output)
+    print(json_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -119,7 +119,9 @@ jobs:
               return repo.get_issue(number=issue_num)
 
 
-          def get_user(gh: Github, repo: str, username: str, ref_type: str, ref_name: str) -> str:
+          def get_potential_pr_author(
+              gh: Github, repo: str, username: str, ref_type: str, ref_name: str
+          ) -> str:
               # If the trigger was a new tag added by a bot, this is a ciflow case
               # Fetch the actual username from the original PR. The PR number is
               # embedded in the tag name: ciflow/<name>/<pr-number>
@@ -135,7 +137,9 @@ jobs:
                           repository = gh.get_repo(repo)
                           pull = repository.get_pull(number=int(pr_number))
                       except Exception as e:
-                          raise Exception(f"issue with pull request {pr_number} from repo {repository}") from e
+                          raise Exception(  # noqa: TRY002
+                              f"issue with pull request {pr_number} from repo {repository}"
+                          ) from e
                       return pull.user.login
               # In all other cases, return the original input username
               return username
@@ -145,7 +149,9 @@ jobs:
               return branch.split("/")[0] in {"main", "nightly", "release", "landchecks"}
 
 
-          def get_workflow_type(issue: Issue, username_check: Iterable[str]) -> Tuple[str, str]:
+          def get_workflow_type(
+              issue: Issue, workflow_requestors: Iterable[str]
+          ) -> Tuple[str, str]:
               try:
                   first_comment = issue.get_comments()[0].body.strip("\n\t ")
 
@@ -156,17 +162,17 @@ jobs:
                       MESSAGE = "LF Workflows are enabled for everyone. Using LF runners."
                       return WORKFLOW_LABEL_LF, MESSAGE
                   else:
-                      user_set = {
-                          usr
-                          for usr in (
-                              usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split()
-                          )
+                      all_opted_in_users = {
+                          usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split()
                       }
-                      if any(map(lambda uc: uc in user_set, username_check)):
-                          MESSAGE = f"LF Workflows are enabled for {', '.join(username_check)}. Using LF runners."
+                      opted_in_requestors = {
+                          usr for usr in workflow_requestors if usr in all_opted_in_users
+                      }
+                      if any(usr in all_opted_in_users for usr in workflow_requestors):
+                          MESSAGE = f"LF Workflows are enabled for {', '.join(opted_in_requestors)}. Using LF runners."
                           return WORKFLOW_LABEL_LF, MESSAGE
                       else:
-                          MESSAGE = f"LF Workflows are disabled for {', '.join(username_check)}. Using meta runners."
+                          MESSAGE = f"LF Workflows are disabled for {', '.join(workflow_requestors)}. Using meta runners."
                           return WORKFLOW_LABEL_META, MESSAGE
 
               except Exception as e:
@@ -187,14 +193,20 @@ jobs:
                       gh = get_gh_client(args.github_token)
                       # The default issue we use - https://github.com/pytorch/test-infra/issues/5132
                       issue = get_issue(gh, args.github_issue_repo, args.github_issue)
-                      username = get_user(
+                      username = get_potential_pr_author(
                           gh,
                           args.github_repo,
                           args.github_actor,
                           args.github_ref_type,
                           args.github_branch,
                       )
-                      label_type, message = get_workflow_type(issue, (args.github_issue_owner, username, ))
+                      label_type, message = get_workflow_type(
+                          issue,
+                          (
+                              args.github_issue_owner,
+                              username,
+                          ),
+                      )
                       output = {
                           LABEL_TYPE_KEY: label_type,
                           MESSAGE_KEY: message,
@@ -211,7 +223,6 @@ jobs:
 
           if __name__ == "__main__":
               main()
-
           EOF
 
           cat runner_determinator.py

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -52,10 +52,10 @@ jobs:
 
       # TODO: Remove the hardcoded step below
       # Hardcoding below is temporary for testing ALI runners
-      # This file below should match the script found in .github/scripts/get_workflow_type.py
+      # This file below should match the script found in .github/scripts/runner_determinator.py
       - name: Hardcode runner-determinator script
         run: |
-          cat <<EOF > get_workflow_type.py
+          cat <<EOF > runner_determinator.py
           import sys
           import json
           from argparse import ArgumentParser
@@ -157,9 +157,8 @@ jobs:
                       MESSAGE = "LF Workflows are enabled for everyone. Using LF runners."
                       return WORKFLOW_LABEL_LF, MESSAGE
                   else:
-                      user_w_at = first_comment.split()
                       user_set = {
-                          f"@{susr}" for susr in (usr.strip("\n\t ") for usr in first_comment.split())
+                          usr for usr in (usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split())
                       }
                       if any(map(lambda uc: uc in user_set, username_check)):
                           MESSAGE = f"LF Workflows are enabled for {', '.join(username_check)}. Using LF runners."
@@ -211,7 +210,8 @@ jobs:
           if __name__ == "__main__":
               main()
           EOF
-          cat get_workflow_type.py
+
+          cat runner_determinator.py
 
       - name: Install dependencies
         run: python3 -m pip install urllib3==1.26.18 PyGithub==2.3.0
@@ -223,7 +223,7 @@ jobs:
           curr_ref_type="${{ inputs.curr_ref_type }}"
           echo "Current branch is '$curr_branch'"
 
-          output="$(python3 get_workflow_type.py \
+          output="$(python3 runner_determinator.py \
             --github-token "$GITHUB_TOKEN" \
             --github-issue "$ISSUE_NUMBER" \
             --github-branch "$curr_branch" \

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -56,10 +56,9 @@ jobs:
       - name: Hardcode runner-determinator script
         run: |
           cat <<EOF > runner_determinator.py
-          import sys
           import json
           from argparse import ArgumentParser
-          from typing import Any, Tuple, Iterable
+          from typing import Any, Iterable, Tuple
 
           from github import Auth, Github
           from github.Issue import Issue
@@ -158,7 +157,10 @@ jobs:
                       return WORKFLOW_LABEL_LF, MESSAGE
                   else:
                       user_set = {
-                          usr for usr in (usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split())
+                          usr
+                          for usr in (
+                              usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split()
+                          )
                       }
                       if any(map(lambda uc: uc in user_set, username_check)):
                           MESSAGE = f"LF Workflows are enabled for {', '.join(username_check)}. Using LF runners."
@@ -209,6 +211,7 @@ jobs:
 
           if __name__ == "__main__":
               main()
+
           EOF
 
           cat runner_determinator.py

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -168,7 +168,7 @@ jobs:
                       opted_in_requestors = {
                           usr for usr in workflow_requestors if usr in all_opted_in_users
                       }
-                      if any(usr in all_opted_in_users for usr in workflow_requestors):
+                      if opted_in_requestors:
                           MESSAGE = f"LF Workflows are enabled for {', '.join(opted_in_requestors)}. Using LF runners."
                           return WORKFLOW_LABEL_LF, MESSAGE
                       else:


### PR DESCRIPTION
Currently the runner determinator is buggy and doesn't let anyone's workflows run against the LF runners (it prefixes a "@" to the user names in the issue instead of either stripping it or prefixing it to the incoming names)

This PR fixes the bug so that people opted in to using LF runners can actually use them. It also puts the python code back into the repo.  Even though the code isn't directly invoked, having it there makes testing and linting easier/possible

Also includes lint fixes

Note: if you just review the .yml file you'll see all the relevant diffs

### Testing:
#### Before
```
python .github/scripts/runner_determinator.py --github-token $GH_KEY --github-issue 5132 --github-actor ZainRizvi --github-issue-owner ZainRizvi --github-branch foo 
{"label_type": "", "message": "LF Workflows are disabled for ZainRizvi, ZainRizvi. Using meta runners."}
```

#### After
```
python .github/scripts/runner_determinator.py --github-token $GH_KEY --github-issue 5132 --github-actor ZainRizvi --github-issue-owner ZainRizvi --github-branch foo
{"label_type": "lf.", "message": "LF Workflows are enabled for ZainRizvi, ZainRizvi. Using LF runners."} 
```

Aside: updated test case after rebase:
```
python .github/scripts/runner_determinator.py --github-token $GH_KEY --github-issue 5132 --github-actor ZainRizvi --github-issue-owner ZainRizvi2 --github-branch foo  --github-repo python/pythonss --github-ref-type branch
{"label_type": "lf.", "message": "LF Workflows are enabled for ZainRizvi. Using LF runners."}
```