### PR TITLE
[custom ops] Add unknown arg

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -343,7 +343,8 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
 
     def test_opcheck_fails_basic(self, device):
         @custom_op(f"{self.test_ns}::foo")
-        def foo(x: torch.Tensor) -> torch.Tensor: ...
+        def foo(x: torch.Tensor) -> torch.Tensor: 
+            ...
 
         @foo.impl(["cpu", "cuda"])
         def foo_impl(x):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -343,7 +343,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
 
     def test_opcheck_fails_basic(self, device):
         @custom_op(f"{self.test_ns}::foo")
-        def foo(x: torch.Tensor) -> torch.Tensor: 
+        def foo(x: torch.Tensor) -> torch.Tensor:
             ...
 
         @foo.impl(["cpu", "cuda"])

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -343,8 +343,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
 
     def test_opcheck_fails_basic(self, device):
         @custom_op(f"{self.test_ns}::foo")
-        def foo(x: torch.Tensor) -> torch.Tensor:
-            ...
+        def foo(x: torch.Tensor) -> torch.Tensor: ...
 
         @foo.impl(["cpu", "cuda"])
         def foo_impl(x):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -343,8 +343,7 @@ class TestCustomOpTesting(CustomOpTestCaseBase):
 
     def test_opcheck_fails_basic(self, device):
         @custom_op(f"{self.test_ns}::foo")
-        def foo(x: torch.Tensor) -> torch.Tensor:
-            ...
+        def foo(x: torch.Tensor) -> torch.Tensor: ...
 
         @foo.impl(["cpu", "cuda"])
         def foo_impl(x):
@@ -2542,6 +2541,14 @@ class TestCustomOpAPI(TestCase):
             if prev is None and after is None:
                 continue
             self.assertGreater(after, prev)
+
+        with self.assertRaisesRegex(ValueError, "string"):
+
+            @torch.library.custom_op("_torch_testing::f3", mutates_args="x")
+            def f3(
+                x: Tensor,
+            ) -> None:
+                return
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     @parametrize("idx", [0, 1, 2, 3, 4, 5])

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -504,7 +504,6 @@ class CustomOpDef:
             )
 
     def __call__(self, *args, **kwargs):
-        print(args, kwargs)
         return self._opoverload(*args, **kwargs)
 
 

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -29,7 +29,7 @@ def custom_op(
     fn: Optional[Callable] = None,
     /,
     *,
-    mutates_args: Iterable[str],
+    mutates_args: Union[str, Iterable[str]],
     device_types: device_types_t = None,
     schema: Optional[str] = None,
 ) -> Callable:
@@ -51,7 +51,8 @@ def custom_op(
             To avoid name collisions, please use your project name as the namespace;
             e.g. all custom ops in pytorch/fbgemm use "fbgemm" as the namespace.
         mutates_args (Iterable[str]): The names of args that the function mutates.
-            This MUST be accurate, otherwise, the behavior is undefined.
+            This MUST be accurate, otherwise, the behavior is undefined. If "unknown",
+            it pessimistically assumes that all inputs to the operator are being mutates.
         device_types (None | str | Sequence[str]): The device type(s) the function
             is valid for. If no device type is provided, then the function
             is used as the default implementation for all device types.
@@ -503,6 +504,7 @@ class CustomOpDef:
             )
 
     def __call__(self, *args, **kwargs):
+        print(args, kwargs)
         return self._opoverload(*args, **kwargs)
 
 

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -50,9 +50,9 @@ def custom_op(
             in PyTorch subsystems (e.g. torch.export, FX graphs).
             To avoid name collisions, please use your project name as the namespace;
             e.g. all custom ops in pytorch/fbgemm use "fbgemm" as the namespace.
-        mutates_args (Iterable[str]): The names of args that the function mutates.
+        mutates_args (Iterable[str] or "unknown"): The names of args that the function mutates.
             This MUST be accurate, otherwise, the behavior is undefined. If "unknown",
-            it pessimistically assumes that all inputs to the operator are being mutates.
+            it pessimistically assumes that all inputs to the operator are being mutated.
         device_types (None | str | Sequence[str]): The device type(s) the function
             is valid for. If no device type is provided, then the function
             is used as the default implementation for all device types.
@@ -504,7 +504,6 @@ class CustomOpDef:
             )
 
     def __call__(self, *args, **kwargs):
-        print(args, kwargs)
         return self._opoverload(*args, **kwargs)
 
 

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -504,6 +504,7 @@ class CustomOpDef:
             )
 
     def __call__(self, *args, **kwargs):
+        print(args, kwargs)
         return self._opoverload(*args, **kwargs)
 
 

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -82,7 +82,8 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
         if type(mutates_args) == str:
             if mutates_args != UNKNOWN_MUTATES:
                 raise ValueError(
-                    "mutates_args must either be a sequence of the names of the arguments that are mutated or the string 'unknown'. "
+                    "mutates_args must either be a sequence of the names of "
+                    "the arguments that are mutated or the string 'unknown'. "
                 )
             if schema_type.startswith("Tensor"):
                 schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor'):]}"

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -79,7 +79,11 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
                 )
 
         schema_type = SUPPORTED_PARAM_TYPES[annotation_type]
-        if mutates_args == UNKNOWN_MUTATES:
+        if type(mutates_args) == str:
+            if mutates_args != UNKNOWN_MUTATES:
+                raise ValueError(
+                    "Argument mutates_args is a string {mutates_args}. mutates_args can only be 'unknown' when it is a string. "
+                )
             if schema_type.startswith("Tensor"):
                 schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor'):]}"
         elif name in mutates_args:

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -13,13 +13,15 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
     We make some assumptions to make our lives easier that correspond to how people
     write custom ops in real life:
     - none of the outputs alias any of the inputs or each other.
-    - only the args listed in mutates_args are being mutated.
+    - only the args listed in ``mutates_args`` are being mutated. If ``mutates_args`` is "unknown",
+      it assumes that all inputs to the operator are being mutates.
     - string type annotations "device, dtype, Tensor, types" without library specification
       are assumed to be torch.*. Similarly, string type annotations "Optional, List, Sequence, Union"
       without library specification are assumed to be typing.*.
 
     Callers (e.g. the custom ops API) are responsible for checking these assumptions.
     """
+    UNKNOWN_MUTATES = "unknown"
     sig = inspect.signature(prototype_function)
 
     def error_fn(what):
@@ -77,7 +79,10 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
                 )
 
         schema_type = SUPPORTED_PARAM_TYPES[annotation_type]
-        if name in mutates_args:
+        if mutates_args == UNKNOWN_MUTATES:
+            if schema_type.startswith("Tensor"):
+                schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor'):]}"
+        elif name in mutates_args:
             if not schema_type.startswith("Tensor"):
                 error_fn(
                     f"Parameter {name} is in mutable_args but only Tensors or collections of Tensors can be mutated"
@@ -103,14 +108,15 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
                     f"Please file an issue on GitHub so we can prioritize this."
                 )
             params.append(f"{schema_type} {name}={default_repr}")
-    mutates_args_not_seen = set(mutates_args) - seen_args
-    if len(mutates_args_not_seen) > 0:
-        error_fn(
-            f"{mutates_args_not_seen} in mutates_args were not found in "
-            f"the custom op's signature. "
-            f"mutates_args should contain the names of all args that the "
-            f"custom op mutates."
-        )
+    if mutates_args != UNKNOWN_MUTATES:
+        mutates_args_not_seen = set(mutates_args) - seen_args
+        if len(mutates_args_not_seen) > 0:
+            error_fn(
+                f"{mutates_args_not_seen} in mutates_args were not found in "
+                f"the custom op's signature. "
+                f"mutates_args should contain the names of all args that the "
+                f"custom op mutates."
+            )
     return_annotation = sig.return_annotation
     if type(return_annotation) == str:
         return_annotation = convert_type_string(return_annotation)

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -82,7 +82,7 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
         if type(mutates_args) == str:
             if mutates_args != UNKNOWN_MUTATES:
                 raise ValueError(
-                    "Argument mutates_args is a string {mutates_args}. mutates_args can only be 'unknown' when it is a string. "
+                    "mutates_args must either be a sequence of the names of the arguments that are mutated or the string 'unknown'. "
                 )
             if schema_type.startswith("Tensor"):
                 schema_type = f"Tensor(a{idx}!){schema_type[len('Tensor'):]}"
@@ -119,7 +119,7 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
                 f"{mutates_args_not_seen} in mutates_args were not found in "
                 f"the custom op's signature. "
                 f"mutates_args should contain the names of all args that the "
-                f"custom op mutates."
+                f"custom op mutates, or just the string 'unknown' if you don't know."
             )
     return_annotation = sig.return_annotation
     if type(return_annotation) == str:


### PR DESCRIPTION
Fixes #129372

Add a mutated_args="unknown" that pessimistically assumes that all inputs to the operator are being mutates. 