### PR TITLE
Add missing mapping between DLDevice and ATenDevice for MAIA

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -115,6 +115,9 @@ static DLDevice getDLDevice(const Tensor& tensor, c10::DeviceIndex device_id) {
       ctx.device_id =
           at::detail::getXPUHooks().getGlobalIdxFromDevice(tensor.device());
       break;
+    case DeviceType::MAIA:
+      ctx.device_type = DLDeviceType::kDLMAIA;
+      break;
     default:
       TORCH_CHECK(false, "Cannot pack tensors on " + tensor.device().str());
   }
@@ -141,6 +144,8 @@ static Device getATenDevice(const DLDevice& ctx, void* data) {
 #endif
     case DLDeviceType::kDLOneAPI:
       return at::detail::getXPUHooks().getDeviceFromPtr(data);
+    case DLDeviceType::kDLMAIA:
+      return at::Device(DeviceType::MAIA, ctx.device_id);
     default:
       TORCH_CHECK(
           false, "Unsupported device_type: ", std::to_string(ctx.device_type));

--- a/aten/src/ATen/dlpack.h
+++ b/aten/src/ATen/dlpack.h
@@ -89,6 +89,8 @@ typedef enum {
   kDLWebGPU = 15,
   /*! \brief Qualcomm Hexagon DSP */
   kDLHexagon = 16,
+  /*! \brief Microsoft AI Accelerator */
+  kDLMAIA = 17,
 } DLDeviceType;
 
 /*!


### PR DESCRIPTION
This PR adds missing mapping between the `DLDevice `and `ATenDevice `for MAIA device. These changes are necessary for `dlpack `support for `maia `tensors.

[MAIA is added to the DldeviceType enum in the dlpack repo](https://github.com/dmlc/dlpack/blob/bbd2f4d32427e548797929af08cfe2a9cbb3cf12/include/dlpack/dlpack.h#L120) already. 