### PR TITLE
Fix inductor benchmarks

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1291,6 +1291,7 @@ elif [[ "${TEST_CONFIG}" == *torchbench* ]]; then
   fi
   install_torchtext
   install_torchvision
+  TORCH_CUDA_ARCH_LIST="8.0;8.6" pip_install git+https://github.com/pytorch/ao.git
   id=$((SHARD_NUMBER-1))
   # https://github.com/opencv/opencv-python/issues/885
   pip_install opencv-python==4.8.0.74


### PR DESCRIPTION
By installing torchao explicitly, as torchao-0.3.0 that was release recently to pypi introduced hard dependency to torch-2.3.1, which results in following cryptic error: `RuntimeError: operator torchvision::nms does not exist`

TODOs:
 - Figure out what installs torchao from pypi rather than builds from source
 - Add proper CI pin for torchao