### PR TITLE
Add more dtypes to __cuda_array_interface__

### DIFF
--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -114,9 +114,13 @@ class TestNumbaIntegration(common.TestCase):
             torch.float64,
             torch.uint8,
             torch.int8,
+            torch.uint16,
             torch.int16,
+            torch.uint32,
             torch.int32,
+            torch.uint32,
             torch.int64,
+            torch.bool
         ]
 
         for dt in torch_dtypes:

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -118,9 +118,9 @@ class TestNumbaIntegration(common.TestCase):
             torch.int16,
             torch.uint32,
             torch.int32,
-            torch.uint32,
+            torch.uint64,
             torch.int64,
-            torch.bool
+            torch.bool,
         ]
 
         for dt in torch_dtypes:

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1159,14 +1159,19 @@ class Tensor(torch._C.TensorBase):
         typestr = {
             torch.complex64: "<c8",
             torch.complex128: "<c16",
+            torch.bfloat16: "<f2",
             torch.float16: "<f2",
             torch.float32: "<f4",
             torch.float64: "<f8",
             torch.uint8: "|u1",
             torch.int8: "|i1",
+            torch.uint16: "<u2",
             torch.int16: "<i2",
+            torch.uint32: "<u4",
             torch.int32: "<i4",
+            torch.uint64: "<u8",
             torch.int64: "<i8",
+            torch.bool: "|b1",
         }[self.dtype]
 
         itemsize = self.element_size()


### PR DESCRIPTION
`__cuda_array_interface__` was missing some unsigned integer dtypes as well as BF16.

numba doesn't support BF16 so I skip tests for that one.