### PR TITLE
[Inductor UT] Generalize device-bias code in newly added UT `test_scatter_optimization.py`

### DIFF
--- a/test/inductor/test_scatter_optimization.py
+++ b/test/inductor/test_scatter_optimization.py
@@ -2,6 +2,7 @@
 
 import copy
 import os
+import unittest
 
 import torch
 from torch import nn
@@ -9,7 +10,7 @@ from torch._dynamo.utils import counters, same
 from torch._inductor import metrics
 from torch._inductor.runtime.runtime_utils import do_bench_gpu as do_bench
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.inductor_utils import HAS_GPU
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
 
@@ -182,6 +183,10 @@ class TestScatterOpt(TestCase):
         self.check_metric()
 
         if DO_PERF_TEST:
+            if GPU_TYPE == "xpu":
+                raise unittest.SkipTest(
+                    "torch.xpu.reset_peak_memory_stats not implemented."
+                )
             torch.cuda.reset_peak_memory_stats()
             for _ in range(3):
                 opt_f(opt_model, x, label)
@@ -191,7 +196,7 @@ class TestScatterOpt(TestCase):
 
 
 if HAS_GPU:
-    torch.set_default_device("cuda")
+    torch.set_default_device(GPU_TYPE)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -859,7 +859,7 @@ class TestInductorDynamic(TestCase):
         f(torch.tensor([5], device=device))
 
     def test_sort_dynamic_shape_with_check(self, device):
-        if TEST_WITH_ROCM or torch.device(device).type != "cuda":
+        if TEST_WITH_ROCM or torch.device(device).type != GPU_TYPE:
 
             def check_count(n):
                 self.assertEqual(metrics.generated_kernel_count, 0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129622

[Inductor UT] Generalize device-bias code in newly added UT test_scatter_optimization.py and test_torchinductor_dynamic_shapes.py
Fix issue #129624 , #129642

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang