### PR TITLE
[inductor] Add size_hint to conv dilation

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3741,6 +3741,18 @@ class CommonTemplate:
             ),
         )
 
+    def test_convolution5(self):
+        def fn(x, w):
+            x = F.conv2d(x, w, dilation=[x.size(0)])
+            return x.sum()
+
+        x = torch.randn([2, 1, 16, 20])
+        w = torch.randn([1, 1, 5, 5])
+
+        torch._dynamo.mark_dynamic(x, 0)
+
+        self.common(fn, (x, w))
+
     def test_conv2d_channels_last(self):
         if self.device == GPU_TYPE:
             raise unittest.SkipTest("only support cpu conv2d channels_last")

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -249,7 +249,7 @@ def conv_layout(
             ir.ir_node_to_tensor(bias, guard_shape=True),
             V.graph.sizevars.size_hints(stride),  # type: ignore[arg-type]
             V.graph.sizevars.size_hints(padding),  # type: ignore[arg-type]
-            dilation,
+            V.graph.sizevars.size_hints(dilation),  # type: ignore[arg-type]
             transposed,
             V.graph.sizevars.size_hints(output_padding),  # type: ignore[arg-type]
             groups,


### PR DESCRIPTION
Summary: [Here](https://github.com/pytorch/pytorch/blob/ea588d7fd36131e2c79647983ac9c48a7dc6a107/torch/_inductor/kernel/conv.py#L252) in the `conv` lowering `dilation` is not `size_hint`-ed. This breaks if `dilation` is a symbolic expression (which we see in some internal models). The PR fixes it by adding a `size_hints`.

Test Plan:
```
$ python test/inductor/test_torchinductor.py -k test_convolution5
...
----------------------------------------------------------------------
Ran 2 tests in 7.329s

OK
```

Differential Revision: D59097019


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang