### PR TITLE
DSD for TorchTune LoRA

### DIFF
--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -911,7 +911,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         ptd_state_dict.set_model_state_dict(
             meta_model,
             model_state_dict=full_sd,
-            # 'aten.copy_.default: got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!',).
+            # 'aten.copy_.default: got mixed torch.Tensor and DTensor, need to convert all 
+            # torch.Tensor to DTensor before calling distributed operators!',).
             options=ptd_state_dict.StateDictOptions(
                 full_state_dict=True, strict=False
             )

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -910,7 +910,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         ptd_state_dict.set_model_state_dict(
             meta_model,
             model_state_dict=full_sd,
-            options=ptd_state_dict.StateDictOptions(full_state_dict=True, strict=False)
+            options=ptd_state_dict.StateDictOptions(full_state_dict=True, strict=False),
         )
 
 

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -895,6 +895,31 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
 
         self._test_save_load(init_model_optim)
 
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    def test_full_state_dict_with_fsdp(self) -> None:
+        device = "cuda"
+        torch.manual_seed(0)
+        with torch.device("meta"):
+            meta_model = nn.Sequential(*[nn.Linear(4, 4, bias=False) for _ in range(2)])
+            for layer in meta_model:
+                fully_shard(layer)
+            fully_shard(meta_model)
+        with torch.device("cpu"):
+            cpu_model = nn.Sequential(*[nn.Linear(4, 4, bias=False) for _ in range(2)])
+            full_sd = cpu_model.state_dict()
+        ptd_state_dict.set_model_state_dict(
+            meta_model,
+            model_state_dict=full_sd,
+            # 'aten.copy_.default: got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!',).
+            options=ptd_state_dict.StateDictOptions(
+                broadcast_from_rank0=True, full_state_dict=True, strict=False
+            )
+            # NotImplementedError: c10d::broadcast_: attempted to run this operator with Meta tensors
+            # options=ptd_state_dict.StateDictOptions(
+            #     broadcast_from_rank0=True, full_state_dict=True, strict=False
+            # )
+        )
 
 class TestNoComm(MultiProcessTestCase):
     def setUp(self) -> None:

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -913,7 +913,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             model_state_dict=full_sd,
             # 'aten.copy_.default: got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!',).
             options=ptd_state_dict.StateDictOptions(
-                broadcast_from_rank0=True, full_state_dict=True, strict=False
+                full_state_dict=True, strict=False
             )
             # NotImplementedError: c10d::broadcast_: attempted to run this operator with Meta tensors
             # options=ptd_state_dict.StateDictOptions(

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -910,13 +910,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         ptd_state_dict.set_model_state_dict(
             meta_model,
             model_state_dict=full_sd,
-            # 'aten.copy_.default: got mixed torch.Tensor and DTensor, need to convert all
-            # torch.Tensor to DTensor before calling distributed operators!',).
             options=ptd_state_dict.StateDictOptions(full_state_dict=True, strict=False)
-            # NotImplementedError: c10d::broadcast_: attempted to run this operator with Meta tensors
-            # options=ptd_state_dict.StateDictOptions(
-            #     broadcast_from_rank0=True, full_state_dict=True, strict=False
-            # )
         )
 
 

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -913,14 +913,13 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             model_state_dict=full_sd,
             # 'aten.copy_.default: got mixed torch.Tensor and DTensor, need to convert all 
             # torch.Tensor to DTensor before calling distributed operators!',).
-            options=ptd_state_dict.StateDictOptions(
-                full_state_dict=True, strict=False
-            )
+            options=ptd_state_dict.StateDictOptions(full_state_dict=True, strict=False)
             # NotImplementedError: c10d::broadcast_: attempted to run this operator with Meta tensors
             # options=ptd_state_dict.StateDictOptions(
             #     broadcast_from_rank0=True, full_state_dict=True, strict=False
             # )
         )
+        
 
 class TestNoComm(MultiProcessTestCase):
     def setUp(self) -> None:

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -898,7 +898,6 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_full_state_dict_with_fsdp(self) -> None:
-        device = "cuda"
         torch.manual_seed(0)
         with torch.device("meta"):
             meta_model = nn.Sequential(*[nn.Linear(4, 4, bias=False) for _ in range(2)])
@@ -911,7 +910,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         ptd_state_dict.set_model_state_dict(
             meta_model,
             model_state_dict=full_sd,
-            # 'aten.copy_.default: got mixed torch.Tensor and DTensor, need to convert all 
+            # 'aten.copy_.default: got mixed torch.Tensor and DTensor, need to convert all
             # torch.Tensor to DTensor before calling distributed operators!',).
             options=ptd_state_dict.StateDictOptions(full_state_dict=True, strict=False)
             # NotImplementedError: c10d::broadcast_: attempted to run this operator with Meta tensors
@@ -919,7 +918,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
             #     broadcast_from_rank0=True, full_state_dict=True, strict=False
             # )
         )
-        
+
 
 class TestNoComm(MultiProcessTestCase):
     def setUp(self) -> None:

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -944,8 +944,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         meta_model_dict = meta_model.state_dict()
         cpu_mocel_dict = get_model_state_dict(cpu_model)
         for key, value in cpu_mocel_dict.items():
-            self.assertEqual(len(meta_model_dict[key]), int(len(value) / 2))
-            self.assertEqual(meta_model_dict[key][0].size(), value[0].size())
+            self.assertEqual(len(meta_model_dict[key].to_local()), int(len(value) / 2))
+            self.assertEqual(meta_model_dict[key].to_local()[0].size(), value[0].size())
 
 
 class TestNoComm(MultiProcessTestCase):

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -944,8 +944,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         meta_model_dict = meta_model.state_dict()
         cpu_mocel_dict = get_model_state_dict(cpu_model)
         for key, value in cpu_mocel_dict.items():
-            self.assertEqual(len(meta_model_dict[key].to_local()), int(len(value) / 2))
-            self.assertEqual(meta_model_dict[key].to_local()[0].size(), value[0].size())
+            self.assertEqual(len(meta_model_dict[key]), len(value))
+            self.assertEqual(meta_model_dict[key][0].size(), value[0].size())
 
 
 class TestNoComm(MultiProcessTestCase):

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -918,8 +918,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @skip_if_lt_x_gpu(2)
     def test_setting_meta_device_model_broadcasting(self) -> None:
         # This test verifies that we can set model state dict by a meta device model
-        # With the correlated changes in state_dict, meta device model should be accepted 
-        # in broadcasting and get copied successfully. 
+        # With the correlated changes in state_dict, meta device model should be accepted
+        # in broadcasting and get copied successfully.
         torch.manual_seed(0)
         with torch.device("meta"):
             meta_model = nn.Sequential(*[nn.Linear(4, 4, bias=False) for _ in range(2)])

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -916,8 +916,9 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         meta_model_dict = meta_model.state_dict()
         cpu_mocel_dict = get_model_state_dict(cpu_model)
         for key, value in cpu_mocel_dict.items():
-            meta_model_list = meta_model_dict[key].tolist()
-            self.assertEqual(meta_model_list, value.tolist())
+            device = value.device
+            meta_model_change_device = meta_model_dict[key].to(device=device)
+            self.assertEqual(value, meta_model_change_device)
 
     @with_comms
     @skip_if_lt_x_gpu(2)
@@ -944,8 +945,9 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         meta_model_dict = meta_model.state_dict()
         cpu_mocel_dict = get_model_state_dict(cpu_model)
         for key, value in cpu_mocel_dict.items():
-            meta_model_list = meta_model_dict[key].tolist()
-            self.assertEqual(meta_model_list, value.tolist())
+            device = value.device
+            meta_model_change_device = meta_model_dict[key].to(device=device)
+            self.assertEqual(value, meta_model_change_device)
 
 
 class TestNoComm(MultiProcessTestCase):

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -898,6 +898,7 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_setting_meta_device_model(self) -> None:
+        # This test verifies that we can set model state dict by a meta device model
         torch.manual_seed(0)
         with torch.device("meta"):
             meta_model = nn.Sequential(*[nn.Linear(4, 4, bias=False) for _ in range(2)])
@@ -916,6 +917,9 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
     @with_comms
     @skip_if_lt_x_gpu(2)
     def test_setting_meta_device_model_broadcasting(self) -> None:
+        # This test verifies that we can set model state dict by a meta device model
+        # With the correlated changes in state_dict, meta device model should be accepted 
+        # in broadcasting and get copied successfully. 
         torch.manual_seed(0)
         with torch.device("meta"):
             meta_model = nn.Sequential(*[nn.Linear(4, 4, bias=False) for _ in range(2)])

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -916,8 +916,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         meta_model_dict = meta_model.state_dict()
         cpu_mocel_dict = get_model_state_dict(cpu_model)
         for key, value in cpu_mocel_dict.items():
-            self.assertEqual(len(meta_model_dict[key]), len(value))
-            self.assertEqual(meta_model_dict[key][0].size(), value[0].size())
+            meta_model_list = meta_model_dict[key].tolist()
+            self.assertEqual(meta_model_list, value.tolist())
 
     @with_comms
     @skip_if_lt_x_gpu(2)
@@ -944,8 +944,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         meta_model_dict = meta_model.state_dict()
         cpu_mocel_dict = get_model_state_dict(cpu_model)
         for key, value in cpu_mocel_dict.items():
-            self.assertEqual(len(meta_model_dict[key]), len(value))
-            self.assertEqual(meta_model_dict[key][0].size(), value[0].size())
+            meta_model_list = meta_model_dict[key].tolist()
+            self.assertEqual(meta_model_list, value.tolist())
 
 
 class TestNoComm(MultiProcessTestCase):

--- a/test/distributed/checkpoint/test_state_dict.py
+++ b/test/distributed/checkpoint/test_state_dict.py
@@ -917,11 +917,11 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         cpu_mocel_dict = get_model_state_dict(cpu_model)
         for key, value in cpu_mocel_dict.items():
             self.assertEqual(len(meta_model_dict[key]), len(value))
-            self.assertEqual(meta_model_dict[key][0].size(),  value[0].size())
+            self.assertEqual(meta_model_dict[key][0].size(), value[0].size())
 
     @with_comms
     @skip_if_lt_x_gpu(2)
-    def _test_setting_meta_device_model_broadcasting(self) -> None:
+    def test_setting_meta_device_model_broadcasting(self) -> None:
         # This test verifies that we can set model state dict by a meta device model
         # With the correlated changes in state_dict, meta device model should be accepted
         # in broadcasting and get copied successfully.
@@ -944,8 +944,8 @@ class TestStateDict(DTensorTestBase, VerifyStateDictMixin):
         meta_model_dict = meta_model.state_dict()
         cpu_mocel_dict = get_model_state_dict(cpu_model)
         for key, value in cpu_mocel_dict.items():
-            self.assertEqual(len(meta_model_dict[key]), int(len(value)/2))
-            self.assertEqual(meta_model_dict[key][0].size(),  value[0].size())
+            self.assertEqual(len(meta_model_dict[key]), int(len(value) / 2))
+            self.assertEqual(meta_model_dict[key][0].size(), value[0].size())
 
 
 class TestNoComm(MultiProcessTestCase):

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -563,7 +563,7 @@ def _load_model_state_dict(
         )
         for fqn, local_state in local_state_dict.items():
             state_dict[fqn] = local_state
-    elif info.fsdp_context() and info.full_state_dict:
+    elif info.full_state_dict:
         device = None
         for key, value in local_state_dict.items():
             if torch.is_tensor(value):

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -23,6 +23,7 @@ from typing import (
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+from torch._utils import _get_device_module
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._state_dict_utils import (
     _broadcast_state_dict,
@@ -557,6 +558,8 @@ def _load_model_state_dict(
                     device = value.device
                 else:
                     assert device == value.device
+        if device == torch.device("meta"):
+            device = dist.distributed_c10d._get_pg_default_device()
         assert device is not None
         _broadcast_state_dict(
             state_dict, local_state_dict, device=device, strict=info.strict

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -22,7 +22,6 @@ from typing import (
 
 import torch
 import torch.distributed as dist
-from torch._utils import _get_device_module
 import torch.nn as nn
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._state_dict_utils import (
@@ -549,10 +548,6 @@ def _load_model_state_dict(
             ) and fqn != fqn_with_prefix:
                 state_dict[fqn_with_prefix] = state_dict.pop(fqn)
             local_state_dict[fqn_with_prefix] = value
-            if value.device == torch.device("meta"):
-                meta_tensor = dist.checkpoint.planner_helpers._init_meta_tensor(value)
-                local_state_dict[fqn_with_prefix] = meta_tensor
-                local_state_dict[fqn_with_prefix].copy_(meta_tensor)
 
     if info.broadcast_from_rank0:
         device = None
@@ -564,6 +559,7 @@ def _load_model_state_dict(
                     assert device == value.device
         if device == torch.device("meta"):
             device = dist.distributed_c10d._get_pg_default_device()
+            model.to_empty(device=device)
         assert device is not None
         _broadcast_state_dict(
             state_dict, local_state_dict, device=device, strict=info.strict

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -549,7 +549,7 @@ def _load_model_state_dict(
                 state_dict[fqn_with_prefix] = state_dict.pop(fqn)
             local_state_dict[fqn_with_prefix] = value
 
-    if info.broadcast_from_rank0:
+    if info.broadcast_from_rank0 or info.full_state_dict:
         device = None
         for key, value in local_state_dict.items():
             if torch.is_tensor(value) and value.dim() > 0:
@@ -557,26 +557,16 @@ def _load_model_state_dict(
                     device = value.device
                 else:
                     assert device == value.device
+        assert device is not None
         if device == torch.device("meta"):
             device = dist.distributed_c10d._get_pg_default_device()
             model.to_empty(device=device)
-        assert device is not None
-        _broadcast_state_dict(
-            state_dict, local_state_dict, device=device, strict=info.strict
-        )
-        for fqn, local_state in local_state_dict.items():
-            state_dict[fqn] = local_state
-    elif info.full_state_dict:
-        device = None
-        for key, value in local_state_dict.items():
-            if torch.is_tensor(value):
-                if device is None:
-                    device = value.device
-                else:
-                    assert device == value.device
-        assert device is not None
-        _distribute_state_dict(state_dict, local_state_dict, device=device)
-        state_dict = {}
+        if info.broadcast_from_rank0:
+            _broadcast_state_dict(
+                state_dict, local_state_dict, device=device, strict=info.strict
+            )
+        elif info.full_state_dict:
+            _distribute_state_dict(state_dict, local_state_dict, device=device)
         for fqn, local_state in local_state_dict.items():
             state_dict[fqn] = local_state
 

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -549,7 +549,20 @@ def _load_model_state_dict(
                 state_dict[fqn_with_prefix] = state_dict.pop(fqn)
             local_state_dict[fqn_with_prefix] = value
 
-    if info.broadcast_from_rank0:
+    if info.fsdp_context() and info.full_state_dict and not info.broadcast_from_rank0:
+        device = None
+        for key, value in local_state_dict.items():
+            if torch.is_tensor(value):
+                if device is None:
+                    device = value.device
+                else:
+                    assert device == value.device
+        assert device is not None
+        _distribute_state_dict(state_dict, local_state_dict, device=device)
+        state_dict = {}
+        for fqn, local_state in local_state_dict.items():
+            state_dict[fqn] = local_state
+    elif info.broadcast_from_rank0:
         device = None
         for key, value in local_state_dict.items():
             if torch.is_tensor(value) and value.dim() > 0:

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -563,7 +563,7 @@ def _load_model_state_dict(
         )
         for fqn, local_state in local_state_dict.items():
             state_dict[fqn] = local_state
-    elif info.fsdp_context() and info.full_state_dic:
+    elif info.fsdp_context() and info.full_state_dict:
         device = None
         for key, value in local_state_dict.items():
             if torch.is_tensor(value):


### PR DESCRIPTION
Fixes #128745
Solve the issue with conflicts when users use full_state_dict while the model is FSDP.

Current solve the issue for `full_state_dict=True`, with error
`'aten.copy_.default: got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!',).`

TODO: for` broadcast_from_rank0=True, full_state_dict=True`, the error is
`NotImplementedError: c10d::broadcast_: attempted to run this operator with Meta tensors`


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @tianyu-l @yf225 @chauhang