### PR TITLE
[Simple FSDP] Add unit test for torch.compile + reparameterization + SAC

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -25,7 +25,6 @@ from torch.testing._internal.common_cuda import (
 from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm
 from torch.testing._internal.inductor_utils import HAS_CUDA
 from torch.testing._internal.two_tensor import TwoTensor
-
 from torch.utils.checkpoint import (
     checkpoint,
     CheckpointPolicy,

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -1009,6 +1009,7 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
                 def _custom_policy(ctx, func, *args, **kwargs):
                     to_recompute = func in {
                         torch.ops.aten.mul.Tensor,
+                        torch.ops.aten.sigmoid.default,
                     }
                     return (
                         CheckpointPolicy.MUST_RECOMPUTE
@@ -1064,7 +1065,10 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
         )
         bw_compiler = functools.partial(
             count_ops,
-            freqs=[1, 0],
+            freqs=[
+                2,  # 1 from mul recompute, 1 from mul backward
+                1,
+            ],
             ops=[torch.ops.aten.mul.Tensor, torch.ops.aten.sigmoid.default],
         )
 

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -11,6 +11,7 @@ import torch._dynamo.config
 import torch._dynamo.test_case
 import torch._functorch.config
 import torch.distributed as dist
+import torch.nn as nn
 import torch.utils.checkpoint
 
 from functorch.compile import min_cut_rematerialization_partition
@@ -24,6 +25,7 @@ from torch.testing._internal.common_cuda import (
 from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm
 from torch.testing._internal.inductor_utils import HAS_CUDA
 from torch.testing._internal.two_tensor import TwoTensor
+
 from torch.utils.checkpoint import (
     checkpoint,
     CheckpointPolicy,
@@ -1003,15 +1005,6 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
 
     @torch._dynamo.config.patch(inline_inbuilt_nn_modules=True)
     def test_compile_selective_checkpoint_reparameterization(self):
-        import torch
-        import torch.nn as nn
-
-        from torch.utils.checkpoint import (
-            checkpoint,
-            CheckpointPolicy,
-            create_selective_checkpoint_contexts,
-        )
-
         def sac_policy():
             def _recomp_policy():
                 def _custom_policy(ctx, func, *args, **kwargs):


### PR DESCRIPTION
This can reproduce the error in https://github.com/pytorch/pytorch/issues/129684. Adding a unit test so that we hold the line for torch.compile + reparameterization + SAC to always be working, to pave the path for Tianyu's intern's project.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129641



cc @soulitzer @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames