### PR TITLE
[ROCm] CUDA_VISIBLE_DEVICES fallback option for device_count

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3765,7 +3765,7 @@ print(f"{torch.cuda.device_count()}")
             {"CUDA_VISIBLE_DEVICES": None, "HIP_VISIBLE_DEVICES": "0"},
             {"CUDA_VISIBLE_DEVICES": "0,1,2,3", "HIP_VISIBLE_DEVICES": "0"},
         ]
-        
+
         for env_config in custom_envs:
             env = os.environ.copy()
             for key, value in env_config.items():
@@ -3779,7 +3779,7 @@ print(f"{torch.cuda.device_count()}")
                 .strip()
             )
             self.assertEqual("1", r)
-            
+
     @unittest.skipIf(not TEST_MULTIGPU, "requires multiple devices")
     def test_device_count_not_cached_pre_init(self):
         visible_devices = (

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3752,17 +3752,47 @@ exit(2)
             )
             self.assertEqual(rc, "3")
 
-    @unittest.skipIf(not TEST_MULTIGPU, "requires multiple devices")
-    @unittest.skipIf(TEST_WITH_ROCM, "too lazy to debug this on ROCm")
-    def test_device_count_not_cached_pre_init(self):
+    @unittest.skipIf(not TEST_WITH_ROCM, "not relevant for CUDA testing")
+    def test_hip_device_count(self):
+        """Validate device_count works with both CUDA/HIP visible devices"""
         test_script = """\
 import torch
 import os
+print(f"{torch.cuda.device_count()}")
+"""
+        custom_envs = [
+            {"CUDA_VISIBLE_DEVICES": "0", "HIP_VISIBLE_DEVICES": None},
+            {"CUDA_VISIBLE_DEVICES": None, "HIP_VISIBLE_DEVICES": "0"},
+            {"CUDA_VISIBLE_DEVICES": "0,1,2,3", "HIP_VISIBLE_DEVICES": "0"},
+        ]
+        
+        for env_config in custom_envs:
+            env = os.environ.copy()
+            for key, value in env_config.items():
+                if value is None:
+                    env.pop(key, None)
+                else:
+                    env[key] = value
+            r = (
+                subprocess.check_output([sys.executable, "-c", test_script], env=env)
+                .decode("ascii")
+                .strip()
+            )
+            self.assertEqual("1", r)
+            
+    @unittest.skipIf(not TEST_MULTIGPU, "requires multiple devices")
+    def test_device_count_not_cached_pre_init(self):
+        visible_devices = (
+            "HIP_VISIBLE_DEVICES" if torch.version.hip else "CUDA_VISIBLE_DEVICES"
+        )
+        test_script = f"""\
+import torch
+import os
 r1 = torch.cuda.device_count()
-os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+os.environ['{visible_devices}'] = '0'
 r2 = torch.cuda.device_count()
 torch.empty(10, device='cuda')
-print(f"{r1}, {r2}")
+print(f"{{r1}}, {{r2}}")
 """
 
         r = (

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -637,9 +637,11 @@ def set_stream(stream: Stream):
 
 def _parse_visible_devices() -> Union[List[int], List[str]]:
     r"""Parse CUDA_VISIBLE_DEVICES environment variable."""
-    var = os.getenv(
-        "CUDA_VISIBLE_DEVICES" if not torch.version.hip else "HIP_VISIBLE_DEVICES"
-    )
+    var = os.getenv("CUDA_VISIBLE_DEVICES")
+
+    if var is None and torch.version.hip:
+        var = os.getenv("HIP_VISIBLE_DEVICES")
+
     if var is None:
         return list(range(64))
 
@@ -1067,15 +1069,15 @@ def _get_amdsmi_handler(device: Optional[Union[Device, int]] = None):
 
 
 def _get_amdsmi_device_index(device: Optional[Union[int, Device]]) -> int:
-    r"""Return the amdsmi index of the device, taking HIP_VISIBLE_DEVICES into account."""
+    r"""Return the amdsmi index of the device, taking visible_devices into account."""
     idx = _get_device_index(device, optional=True)
     visible_devices = _parse_visible_devices()
     if type(visible_devices[0]) is str:
-        raise RuntimeError("HIP_VISIBLE_DEVICES should be indices and not strings")
+        raise RuntimeError("CUDA_VISIBLE_DEVICES should be indices and not strings")
     idx_map = dict(enumerate(cast(List[int], visible_devices)))
     if idx not in idx_map:
         raise RuntimeError(
-            f"device {idx} is not visible (HIP_VISIBLE_DEVICES={visible_devices})"
+            f"device {idx} is not visible (CUDA_VISIBLE_DEVICES={visible_devices})"
         )
     return idx_map[idx]
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -636,11 +636,13 @@ def set_stream(stream: Stream):
 
 
 def _parse_visible_devices() -> Union[List[int], List[str]]:
-    r"""Parse HIP_VISIBLE_DEVICES environment variable."""
-    var = os.getenv("HIP_VISIBLE_DEVICES")
+    r"""Parse CUDA_VISIBLE_DEVICES environment variable."""
+    var = os.getenv("CUDA_VISIBLE_DEVICES")
 
-    if var is None and torch.version.hip:
-        var = os.getenv("CUDA_VISIBLE_DEVICES")
+    if torch.version.hip:
+        hip_devices = os.getenv("HIP_VISIBLE_DEVICES")
+        if hip_devices is not None:
+            var = hip_devices
 
     if var is None:
         return list(range(64))

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -636,11 +636,11 @@ def set_stream(stream: Stream):
 
 
 def _parse_visible_devices() -> Union[List[int], List[str]]:
-    r"""Parse CUDA_VISIBLE_DEVICES environment variable."""
-    var = os.getenv("CUDA_VISIBLE_DEVICES")
+    r"""Parse HIP_VISIBLE_DEVICES environment variable."""
+    var = os.getenv("HIP_VISIBLE_DEVICES")
 
     if var is None and torch.version.hip:
-        var = os.getenv("HIP_VISIBLE_DEVICES")
+        var = os.getenv("CUDA_VISIBLE_DEVICES")
 
     if var is None:
         return list(range(64))
@@ -1073,11 +1073,11 @@ def _get_amdsmi_device_index(device: Optional[Union[int, Device]]) -> int:
     idx = _get_device_index(device, optional=True)
     visible_devices = _parse_visible_devices()
     if type(visible_devices[0]) is str:
-        raise RuntimeError("CUDA_VISIBLE_DEVICES should be indices and not strings")
+        raise RuntimeError("HIP_VISIBLE_DEVICES should be indices and not strings")
     idx_map = dict(enumerate(cast(List[int], visible_devices)))
     if idx not in idx_map:
         raise RuntimeError(
-            f"device {idx} is not visible (CUDA_VISIBLE_DEVICES={visible_devices})"
+            f"device {idx} is not visible (HIP_VISIBLE_DEVICES={visible_devices})"
         )
     return idx_map[idx]
 


### PR DESCRIPTION
Updating `_parse_visible_devices` to allow use of CUDA_VISIBLE_DEVICES if HIP_VISIBLE_DEVICES is unset, to avoid any unnecessary code changes in workloads that already rely on CUDA_VISIBLE_DEVICES.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang