### PR TITLE
Add XPU device architecture property

### DIFF
--- a/c10/xpu/XPUDeviceProp.h
+++ b/c10/xpu/XPUDeviceProp.h
@@ -126,6 +126,16 @@ namespace c10::xpu {
   /* the number of hardware threads per EU of GPU. */    \
   _(gpu_hw_threads_per_eu, 8)
 
+#define AT_FORALL_XPU_EXP_DEVICE_PROPERTIES(_)         \
+  /* the device architecture of this SYCL device.      \
+     0x9900000000000000 - should be unkown, but was    \
+     added only recentely at                           \
+     https://github.com/intel/llvm/pull/14077          \
+     In version before 2025 it represents x86_64       \
+     Use zero for now, since this is the default value \
+     for triton */                                     \
+  _(architecture, 0)
+
 #define AT_FORALL_XPU_DEVICE_ASPECT(_)                  \
   /* sycl::half is supported on device. */              \
   _(fp16)                                               \
@@ -148,6 +158,10 @@ namespace c10::xpu {
 #define DEFINE_EXT_DEVICE_PROP(property, ...) \
   _DEFINE_SYCL_PROP(sycl::ext::intel::info::device, property, property)
 
+#define DEFINE_EXP_DEVICE_PROP(property, ...) \
+  _DEFINE_SYCL_PROP(                          \
+      sycl::ext::oneapi::experimental::info::device, property, property)
+
 #define DEFINE_DEVICE_ASPECT(member) bool has_##member;
 
 struct C10_XPU_API DeviceProp {
@@ -157,6 +171,8 @@ struct C10_XPU_API DeviceProp {
   DEFINE_PLATFORM_PROP(name, platform_name);
 
   AT_FORALL_XPU_EXT_DEVICE_PROPERTIES(DEFINE_EXT_DEVICE_PROP);
+
+  AT_FORALL_XPU_EXP_DEVICE_PROPERTIES(DEFINE_EXP_DEVICE_PROP);
 
   AT_FORALL_XPU_DEVICE_ASPECT(DEFINE_DEVICE_ASPECT);
 };

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -86,6 +86,14 @@ void initDeviceProperties(DeviceProp* device_prop, int device) {
       ? raw_device.get_info<intel::info::device::property>()                 \
       : default_value;
 
+#define ASSIGN_EXP_DEVICE_PROP(property, default_value)                      \
+  try {                                                                      \
+    device_prop->property =                                                  \
+        raw_device.get_info<oneapi::experimental::info::device::property>(); \
+  } catch (...) {                                                            \
+    device_prop->property = oneapi::experimental::property(default_value);   \
+  }
+
 #define ASSIGN_DEVICE_ASPECT(member) \
   device_prop->has_##member = raw_device.has(sycl::aspect::member);
 
@@ -95,6 +103,8 @@ void initDeviceProperties(DeviceProp* device_prop, int device) {
       raw_device.get_info<device::platform>().get_info<platform::name>();
 
   AT_FORALL_XPU_EXT_DEVICE_PROPERTIES(ASSIGN_EXT_DEVICE_PROP);
+
+  AT_FORALL_XPU_EXP_DEVICE_PROPERTIES(ASSIGN_EXP_DEVICE_PROP);
 
   AT_FORALL_XPU_DEVICE_ASPECT(ASSIGN_DEVICE_ASPECT);
   return;

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -105,6 +105,9 @@ class TestXpu(TestCase):
         self.assertEqual(
             device_properties.driver_version, device_capability["driver_version"]
         )
+        self.assertEqual(
+            device_properties.device_arch, device_capability["device_arch"]
+        )
         self.assertEqual(device_properties.has_fp16, device_capability["has_fp16"])
         self.assertEqual(device_properties.has_fp64, device_capability["has_fp64"])
         self.assertEqual(

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2074,6 +2074,7 @@ def _xpu_emptyCache() -> None: ...
 class _XpuDeviceProperties:
     name: str
     platform_name: str
+    device_arch: _int
     vendor: str
     driver_version: str
     version: str

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -226,6 +226,9 @@ static void registerXpuDeviceProperties(PyObject* module) {
     }
     return stream.str();
   };
+  auto get_device_architecture = [](const DeviceProp& prop) {
+    return static_cast<uint64_t>(prop.architecture);
+  };
   auto gpu_subslice_count = [](const DeviceProp& prop) {
     return (prop.gpu_eu_count / prop.gpu_eu_count_per_subslice);
   };
@@ -247,12 +250,15 @@ static void registerXpuDeviceProperties(PyObject* module) {
       .def_readonly("has_fp64", &DeviceProp::has_fp64)
       .def_readonly("has_atomic64", &DeviceProp::has_atomic64)
       .def_property_readonly("type", get_device_type)
+      .def_property_readonly("device_arch", get_device_architecture)
       .def(
           "__repr__",
           [&get_device_type, &gpu_subslice_count](const DeviceProp& prop) {
             std::ostringstream stream;
             stream << "_XpuDeviceProperties(name='" << prop.name
-                   << "', platform_name='" << prop.platform_name << "', type='"
+                   << "', platform_name='" << prop.platform_name
+                   << "', device_arch='"
+                   << static_cast<uint64_t>(prop.architecture) << "', type='"
                    << get_device_type(prop) << "', driver_version='"
                    << prop.driver_version << "', total_memory="
                    << prop.global_mem_size / (1024ull * 1024)


### PR DESCRIPTION
Add `device_arch` property to `_XpuDeviceProperties` to match intel's IPEX `_DeviceProperties`: https://github.com/intel/intel-extension-for-pytorch/blob/fd4fce2ee30d95ee09c30aead96bc2be994057a7/intel_extension_for_pytorch/csrc/xpu/Module.cpp#L580-L582


Fixes https://github.com/intel/intel-xpu-backend-for-triton/issues/1496
