### PR TITLE
Dyn uniform value constant folding

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -157,24 +157,34 @@ class TestInductorDynamic(TestCase):
             a = a[:, None]
             return x * a
 
+        def full_mul_symint(x):
+            a = torch.full(x.shape, -1, dtype=x.dtype, device=x.device)
+            b = 2 + a
+            return b * x.shape[0]
+
         fns = (full_add_zero, full_mul_one, full_view_op)
 
         x = torch.randn((2, 4), device=device)
+        y = torch.randn((3, 4), device=device)
 
         for dynamic in [False, True]:
+            torch._dynamo.reset()
             for fn in fns:
                 ref = fn(x)
-                actual, source_codes = run_and_get_code(
-                    torch.compile(fn, dynamic=dynamic), x
-                )
+                fn_c = torch.compile(fn, dynamic=dynamic)
 
-                # due to constant folding, fn returns x directly.
-                if device == "cpu":
-                    FileCheck().check_not("cpp_fused").run(source_codes[0])
-                else:
-                    FileCheck().check_not("triton.jit").run(source_codes[0])
+                actual, source_codes = run_and_get_code(fn_c, x)
+
+                if fn is not full_mul_symint:
+                    # due to constant folding, fn returns x directly.
+                    if device == "cpu":
+                        FileCheck().check_not("cpp_fused").run(source_codes[0])
+                    else:
+                        FileCheck().check_not("triton.jit").run(source_codes[0])
 
                 self.assertEqual(ref, actual)
+                self.assertEqual(fn(x), fn_c(x))
+                self.assertEqual(fn(y), fn_c(y))
 
     def test_arange_dynamic(self, device):
         def fn(a):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -141,26 +141,40 @@ class TestInductorDynamic(TestCase):
         TestCase.tearDown(self)
         torch._dynamo.reset()
 
-    @torch._inductor.config.patch({"enable_dynamic_constant_fold_uniform_value": True})
     def test_constant_fold_uniform_value_dynamic(self, device):
-        def fn(x: torch.Tensor):
-            _, length = x.shape
-            mask = torch.ones((1, length), device=x.device, dtype=x.dtype)
-            mask = 1 - mask
-            return x + mask
+        def full_add_zero(x):
+            a = torch.full(x.shape, 1, dtype=x.dtype, device=x.device)
+            b = a - 1
+            return x + b
+
+        def full_mul_one(x):
+            a = torch.full(x.shape, -1, dtype=x.dtype, device=x.device)
+            b = 2 + a
+            return x * b
+
+        def full_view_op(x):
+            a = torch.ones([1], dtype=x.dtype, device=x.device)
+            a = a[:, None]
+            return x * a
+
+        fns = (full_add_zero, full_mul_one, full_view_op)
 
         x = torch.randn((2, 4), device=device)
 
-        ref = fn(x)
-        actual, source_codes = run_and_get_code(self.compile_fn(fn), x)
+        for dynamic in [False, True]:
+            for fn in fns:
+                ref = fn(x)
+                actual, source_codes = run_and_get_code(
+                    torch.compile(fn, dynamic=dynamic), x
+                )
 
-        # due to constant folding, fn returns x directly.
-        if device == "cpu":
-            FileCheck().check_not("cpp_fused").run(source_codes[0])
-        else:
-            FileCheck().check_not("triton.jit").run(source_codes[0])
+                # due to constant folding, fn returns x directly.
+                if device == "cpu":
+                    FileCheck().check_not("cpp_fused").run(source_codes[0])
+                else:
+                    FileCheck().check_not("triton.jit").run(source_codes[0])
 
-        self.assertEqual(ref, actual)
+                self.assertEqual(ref, actual)
 
     def test_arange_dynamic(self, device):
         def fn(a):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -17,7 +17,9 @@ from torch._inductor.codegen.common import device_codegens, register_backend_for
 from torch._inductor.codegen.cpp import CppScheduling
 from torch._inductor.codegen.wrapper import WrapperCodeGen
 from torch._inductor.test_case import TestCase
+from torch._inductor.utils import run_and_get_code
 from torch._inductor.virtualized import V
+from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
@@ -138,6 +140,27 @@ class TestInductorDynamic(TestCase):
         self._stack.close()
         TestCase.tearDown(self)
         torch._dynamo.reset()
+
+    @torch._inductor.config.patch({"enable_dynamic_constant_fold_uniform_value": True})
+    def test_constant_fold_uniform_value_dynamic(self, device):
+        def fn(x: torch.Tensor):
+            _, length = x.shape
+            mask = torch.ones((1, length), device=x.device, dtype=x.dtype)
+            mask = 1 - mask
+            return x + mask
+
+        x = torch.randn((2, 4), device=device)
+
+        ref = fn(x)
+        actual, source_codes = run_and_get_code(self.compile_fn(fn), x)
+
+        # due to constant folding, fn returns x directly.
+        if device == "cpu":
+            FileCheck().check_not("cpp_fused").run(source_codes[0])
+        else:
+            FileCheck().check_not("triton.jit").run(source_codes[0])
+
+        self.assertEqual(ref, actual)
 
     def test_arange_dynamic(self, device):
         def fn(a):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -394,9 +394,6 @@ compute_all_bounds = False
 # constant folding on the joint graph
 joint_graph_constant_folding = True
 
-# support dynamic shape derivation in constant_fold_uniform_value
-enable_dynamic_constant_fold_uniform_value = False
-
 # Enable indirect_indexing asserts for decompositions and lowerings
 debug_index_asserts = False
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -394,6 +394,9 @@ compute_all_bounds = False
 # constant folding on the joint graph
 joint_graph_constant_folding = True
 
+# support dynamic shape derivation in constant_fold_uniform_value
+enable_dynamic_constant_fold_uniform_value = False
+
 # Enable indirect_indexing asserts for decompositions and lowerings
 debug_index_asserts = False
 

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -60,14 +60,14 @@ class ConstantFolder(torch.fx.Interpreter):
         # is the output
         self.user_to_last_uses = self.node_to_last_non_output_use()
 
-        self.dynamic_node_substitute_values: Dict[torch.fx.Node, Any] = {}
         self.symint_nodes: Dict[str, torch.fx.Node] = {}
 
     def _support_dynamic_shape(self):
+        # ConstantFolder not support dynamic shape now
         return False
 
     def _deduce_value(self, node):
-        return self.unknown_value
+        return super().run_node(node)
 
     def is_impure(self, node: torch.fx.node.Node):
         if (
@@ -168,12 +168,9 @@ class ConstantFolder(torch.fx.Interpreter):
         ):
             return self.unknown_value
 
-        if self._support_dynamic_shape():
-            out = self._deduce_value(node)
-            if out == self.unknown_value:
-                return self.unknown_value
-        else:
-            out = super().run_node(node)
+        out = self._deduce_value(node)
+        if out == self.unknown_value:
+            return self.unknown_value
 
         if node.op != "get_attr" and isinstance(out, torch.Tensor):
             if out.device.type == "meta":
@@ -198,7 +195,6 @@ class ConstantFolder(torch.fx.Interpreter):
             for to_delete in self.user_to_last_uses.get(node, []):
                 if self.replaced_uses[to_delete] == len(to_delete.users):
                     self.node_replacements.pop(to_delete, None)
-                    self.dynamic_node_substitute_values.pop(to_delete, None)
 
         return out
 
@@ -217,10 +213,7 @@ class ConstantFolder(torch.fx.Interpreter):
                 and isinstance(n.meta["val"], torch.SymInt)
             ):
                 s = n.meta["val"]
-                env[n] = s
-                self.dynamic_node_substitute_values[n] = s.node.shape_env.size_hint(
-                    s.node.expr
-                )
+                env[n] = s.node.shape_env.size_hint(s.node.expr)
                 self.symint_nodes[str(s)] = n
             else:
                 env[n] = self.unknown_value


### PR DESCRIPTION
Extending https://github.com/pytorch/pytorch/pull/128937/files

Work from @imzhuhl & myself with commits form both.

We support dynamic shapes by limiting constant folding of ops that are guaranteed to have uniform values (full, pointwise ops, and views) and running these operators with tensors of shape 1. This also eliminates the possibility of memory overhead of constant folding during joint graph. It does mean in the joint graph we will no longer constant fold things like arange/sum, but those are unlikely to end up in a uniform value anyway. 



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang