### PR TITLE
doc - fix the `max_norm` value in a note

### DIFF
--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -56,7 +56,7 @@ class Embedding(Module):
         :attr:`max_norm` is not ``None``. For example::
 
             n, d, m = 3, 5, 7
-            embedding = nn.Embedding(n, d, max_norm=True)
+            embedding = nn.Embedding(n, d, max_norm=1.0)
             W = torch.randn((m, d), requires_grad=True)
             idx = torch.tensor([1, 2])
             a = embedding.weight.clone() @ W.t()  # weight must be cloned for this to be differentiable


### PR DESCRIPTION
`max_norm=True` is currently written in the note, but `max_norm` can be a `float`, NOT a `bool` (as the [docstring](https://github.com/pytorch/pytorch/blob/ec284d3a74ec1863685febd53687d491fd99a161/torch/nn/modules/sparse.py#L30) says).
That note was created in #45595 

The current pull request cleans it up.
The value `True` in the note can confuse the users to think it can be a boolean.

In fact, a counter-intuitive behavior will happen if users try to set it to `False`:
it will be interpreted as 0, so the values of the embedding will become 0 - not what the users were expecting by setting it to `False`.
