### PR TITLE
Upload test stats when workflow regardless of conclusion

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -28,7 +28,9 @@ jobs:
     if:
       github.repository_owner == 'pytorch' &&
       (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' ||
-      needs.get_workflow_conclusion.outputs.conclusion == 'success' || needs.get_workflow_conclusion.outputs.conclusion == 'failure')
+      github.event.workflow_run.conclusion == 'cancelled' ||
+      needs.get_workflow_conclusion.outputs.conclusion == 'success' || needs.get_workflow_conclusion.outputs.conclusion == 'failure' ||
+      needs.get_workflow_conclusion.outputs.conclusion == 'cancelled')
     runs-on: ubuntu-22.04
     environment: upload-stats
     name: Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -25,12 +25,7 @@ jobs:
 
   upload-test-stats:
     needs: get_workflow_conclusion
-    if:
-      github.repository_owner == 'pytorch' &&
-      (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' ||
-      github.event.workflow_run.conclusion == 'cancelled' ||
-      needs.get_workflow_conclusion.outputs.conclusion == 'success' || needs.get_workflow_conclusion.outputs.conclusion == 'failure' ||
-      needs.get_workflow_conclusion.outputs.conclusion == 'cancelled')
+    if: github.repository_owner == 'pytorch'
     runs-on: ubuntu-22.04
     environment: upload-stats
     name: Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}


### PR DESCRIPTION
Upload test stats when workflow always so that we can get status for cancelled workflows (especially ones that were cancelled manually)

There aren't that many workflow conclusions, so might as well as always run it, and we can see what happens

Undos [this old PR](https://togithub.com/pytorch/pytorch/pull/79180)

Notable pitfalls from the above:
Might cause noise if things can't be downloaded, but since this workflow doesn't show up on PRs, I think it's ok to slowly deal with what comes