### PR TITLE
Fix typo in lxml requirement

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -306,7 +306,7 @@ pywavelets==1.5.0 ; python_version >= "3.12"
 #Pinned versions: 1.4.1
 #test that import:
 
-lxml==5.0.0.
+lxml==5.0.0
 #Description: This is a requirement of unittest-xml-reporting
 
 # Python-3.9 binaries


### PR DESCRIPTION
Extra period at the end throws off pip:
```
root@f04177cab5af:/data/pytorch# pip install -r .ci/docker/requirements-ci.txt
ERROR: Invalid requirement: 'lxml==5.0.0.': Expected end or semicolon (after version specifier)
    lxml==5.0.0.
        ~~~~~~~^ (from line 309 of .ci/docker/requirements-ci.txt)
```

Not sure why CI docker builds do not have an issue with this period.

Typo comes from https://github.com/pytorch/pytorch/commit/f73b1b93883ad43b0dd675d3d4c638acb9bf4b8f