### PR TITLE
Fix nodes has more than one output users after replace_set_grad_with_hop pass

### DIFF
--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -624,7 +624,13 @@ class TestPasses(TestCase):
         _ExportPassBaseDeprecatedDoNotUse()(ep.graph_module)
 
     def test_predispatceh_set_grad(self):
+        def _check_node_users_in_the_same_graph(gm):
+            for node in gm.graph.nodes:
+                for user in node.users:
+                    self.assertTrue(user.graph is gm.graph)
+
         mod, args = self.SET_GRAD_ENABLED_TESTS["op"]
+        _check_node_users_in_the_same_graph(mod)
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -639,7 +645,9 @@ def forward(self, x):
     return pytree.tree_unflatten((add_1, sub), self._out_spec)
     """,
         )
+
         mod, args = self.SET_GRAD_ENABLED_TESTS["op_under_no_grad"]
+        _check_node_users_in_the_same_graph(mod)
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -656,6 +664,7 @@ def forward(self, x):
         )
 
         mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager"]
+        _check_node_users_in_the_same_graph(mod)
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -670,7 +679,9 @@ def forward(self, x):
     return pytree.tree_unflatten((add_1, sub), self._out_spec)
     """,
         )
+
         mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_under_no_grad"]
+        _check_node_users_in_the_same_graph(mod)
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -685,7 +696,9 @@ def forward(self, x):
     return pytree.tree_unflatten((add_1, sub), self._out_spec)
     """,
         )
+
         mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_multi_dep"]
+        _check_node_users_in_the_same_graph(mod)
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -705,7 +718,9 @@ def forward(self, x):
     return pytree.tree_unflatten((add_1, add_2, sub, sub_1), self._out_spec)
     """,  # noqa: B950
         )
+
         mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_multi_dep_no_grad"]
+        _check_node_users_in_the_same_graph(mod)
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\

--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -140,51 +140,48 @@ def _sequential_split_and_maybe_inline_subgraphs(
     For each subgraph, decides whether to construct a HOO subgraph, or inline the calls
     back into the parent graph module.
     """
-    # If there is no set_grad_enabled node, return the original graph module
-    need_replacing = False
-    for node in gm.graph.nodes:
-        if _is_set_grad_enabled_node(node):
-            need_replacing = True
+    need_replacing = any(_is_set_grad_enabled_node(node) for node in gm.graph.nodes)
+    if not need_replacing:
+        return gm, graph_signature
 
-    if need_replacing:
-        # sequential_split returns a new graph module that could have different output
-        # args names. We need to fix the graph signature.
-        new_gm = sequential_split(gm, _is_set_grad_enabled_node)
+    # sequential_split returns a new graph module that could have different output
+    # args names. We need to fix the graph signature.
+    new_gm = sequential_split(gm, _is_set_grad_enabled_node)
 
-        replace_ctx = contextlib.nullcontext()
-        new_signature = None
-        if graph_signature is not None:
-            new_signature = copy.deepcopy(graph_signature)
-            new_gm_out_node = next(reversed(new_gm.graph.find_nodes(op="output")))
-            assert new_gm_out_node.op == "output" and len(
-                new_gm_out_node.args[0]
-            ) == len(new_signature.output_specs)
-            for arg_node, out_spec in zip(
-                new_gm_out_node.args[0], new_signature.output_specs
-            ):
-                if out_spec.arg.name != arg_node.name:
-                    out_spec.arg.name = arg_node.name
+    replace_ctx = contextlib.nullcontext()
+    new_signature = None
+    if graph_signature is not None:
+        new_signature = copy.deepcopy(graph_signature)
+        new_gm_out_node = next(reversed(new_gm.graph.find_nodes(op="output")))
+        assert new_gm_out_node.op == "output" and len(new_gm_out_node.args[0]) == len(
+            new_signature.output_specs
+        )
+        for arg_node, out_spec in zip(
+            new_gm_out_node.args[0], new_signature.output_specs
+        ):
+            if out_spec.arg.name != arg_node.name:
+                out_spec.arg.name = arg_node.name
 
-            replace_ctx = new_gm._set_replace_hook(new_signature.get_replace_hook())  # type: ignore[assignment]
+        replace_ctx = new_gm._set_replace_hook(new_signature.get_replace_hook())  # type: ignore[assignment]
 
-        with replace_ctx:
+    with replace_ctx:
 
-            def _maybe_inline_or_replace_with_hop(node: torch.fx.Node):
-                if _is_set_grad_enabled_sub_mod(node, omit_if_same_with_ambient=True):
-                    _replace_with_hop(node)
-                else:
-                    _remove_set_grad_and_inline(node)
+        def _maybe_inline_or_replace_with_hop(node: torch.fx.Node):
+            if _is_set_grad_enabled_sub_mod(node, omit_if_same_with_ambient=True):
+                _replace_with_hop(node)
+            else:
+                _remove_set_grad_and_inline(node)
 
-            nodes_map(
-                list(new_gm.graph.nodes),
-                lambda node: (
-                    _maybe_inline_or_replace_with_hop(node)
-                    if node.op == "call_module"
-                    else node
-                ),
-            )
-        new_gm.recompile()
-        return new_gm, new_signature
+        nodes_map(
+            list(new_gm.graph.nodes),
+            lambda node: (
+                _maybe_inline_or_replace_with_hop(node)
+                if node.op == "call_module"
+                else node
+            ),
+        )
+    new_gm.recompile()
+    return new_gm, new_signature
 
     return gm, graph_signature
 

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -402,8 +402,16 @@ def node_inline_(call_mod_node: torch.fx.Node) -> None:
             new_output = output[0].args[0]
 
             if isinstance(new_output, torch.fx.Node):
+                # Clear the users of the output node and set
+                # the users to be the users of original call_module node.
+                new_output.users.clear()
                 node_replace_(call_mod_node, new_output, delete_old=True)
             elif isinstance(new_output, (list, tuple)):
+                # Clear the users of the output node and set
+                # the users to be the users of original call_module node.
+                for node in new_output:
+                    node.users.clear()
+
                 # Inline the get_item calls for the output node.
                 get_item_users = nodes_filter(
                     list(call_mod_node.users.keys()),


### PR DESCRIPTION
Summary: Previously, when we inline the subgraphs that doesn't have a different require_grad environment, we didn't clean up the nodes's users in subgraph and direcly used them to  to replace the output of  the call_modules. This records dead depencies in node.users. This PR fixes this.

Test Plan:
Added a new test.

Also see the torchrec tests:
Step 1:
buck run mode/dev-nosan //aimp/experimental/pt2:pt2_export -- --model-entity-id 934687114 --output /tmp/934687114.zip --use-torchrec-eager-mp --use-manifold

Step 2:
buck run mode/opt -c python.package_style=inplace -c fbcode.enable_gpu_sections=true aimp/cli:cli --  --platform=aps --template=disagg_gpu_aps_pt2 --pt2 --model-entity-id=934687114 non-request-only-tagging torchrec-shard-and-quantize gpu-disagg-split assign-device materialize-weights script-and-save

Differential Revision: D59132214
