### PR TITLE
Use setup-miniconda step from test-infra for llm retrival workflow

### DIFF
--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -36,33 +36,24 @@ jobs:
           ref: v0.0.2
           path: llm-target-determinator
 
-      - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v2.1.1
+      - name: Setup miniconda
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          miniconda-version: "py39_4.12.0"
-          python-version: 3.9
+          python-version: "3.9"
 
-      - name: Install Requirements
+      - name: Install requirements
         shell: bash -l {0}
         run: |
           set -euxo pipefail
-          conda create \
-            --yes \
-            --quiet \
-            --name "tdenv" \
-            "python=3.9"
-          conda activate tdenv
-          cd "${GITHUB_WORKSPACE}/llm-target-determinator"
-          pip install -r requirements.txt
-          cd ../codellama
-          pip install -e .
+          ${CONDA_RUN} pip install -r llm-target-determinator/requirements.txt
+          cd "${GITHUB_WORKSPACE}/codellama"
+          ${CONDA_RUN} pip install -e .
 
       - name: Fetch CodeLlama Checkpoint
         shell: bash -l {0}
         run: |
           set -euxo pipefail
-          conda activate tdenv
-          cd codellama/
+          cd "${GITHUB_WORKSPACE}/codellama"
           mkdir "CodeLlama-7b-Python"
           aws s3 cp "s3://target-determinator-assets/CodeLlama-7b-Python" "CodeLlama-7b-Python" --recursive --no-progress
 
@@ -75,7 +66,7 @@ jobs:
           shell: bash
           command: |
             set -euxo pipefail
-            python3 -m pip install awscli==1.29.40
+            ${CONDA_RUN} python -m pip install awscli==1.29.40
             cd "${GITHUB_WORKSPACE}"/llm-target-determinator/assets
             aws s3 cp "s3://target-determinator-assets/indexes/latest" . --recursive
 
@@ -88,9 +79,8 @@ jobs:
         shell: bash -l {0}
         run: |
           set -euxo pipefail
-          conda activate tdenv
           cd "${GITHUB_WORKSPACE}"/llm-target-determinator
-          torchrun \
+          ${CONDA_RUN} torchrun \
             --standalone \
             --nnodes=1 \
             --nproc-per-node=1 \

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -20,14 +20,12 @@ concurrency:
 permissions: read-all
 
 jobs:
-  # Often fails due to conda availability issues
-  # See https://github.com/pytorch/pytorch/issues/129717
-  # llm-td:
-  #  name: before-test
-  #  uses: ./.github/workflows/llm_td_retrieval.yml
-  #  permissions:
-  #    id-token: write
-  #    contents: read
+  llm-td:
+    name: before-test
+    uses: ./.github/workflows/llm_td_retrieval.yml
+    permissions:
+      id-token: write
+      contents: read
 
   target-determination:
     name: before-test

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -30,7 +30,7 @@ jobs:
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    # needs: llm-td
+    needs: llm-td
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -21,14 +21,12 @@ concurrency:
 permissions: read-all
 
 jobs:
-  # Often fails due to conda availability issues
-  # See https://github.com/pytorch/pytorch/issues/129717
-  # llm-td:
-  #   name: before-test
-  #   uses: ./.github/workflows/llm_td_retrieval.yml
-  #   permissions:
-  #     id-token: write
-  #     contents: read
+  llm-td:
+    name: before-test
+    uses: ./.github/workflows/llm_td_retrieval.yml
+    permissions:
+      id-token: write
+      contents: read
 
   target-determination:
     name: before-test

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -31,7 +31,7 @@ jobs:
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    # needs: llm-td
+    needs: llm-td
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -19,14 +19,12 @@ concurrency:
 permissions: read-all
 
 jobs:
-  # Often fails due to conda availability issues
-  # See https://github.com/pytorch/pytorch/issues/129717
-  # llm-td:
-  #  name: before-test
-  #  uses: ./.github/workflows/llm_td_retrieval.yml
-  #  permissions:
-  #    id-token: write
-  #    contents: read
+  llm-td:
+    name: before-test
+    uses: ./.github/workflows/llm_td_retrieval.yml
+    permissions:
+      id-token: write
+      contents: read
 
   target-determination:
     name: before-test

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -29,7 +29,7 @@ jobs:
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    # needs: llm-td
+    needs: llm-td
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Undo https://github.com/pytorch/pytorch/pull/129722

Use the setup-miniconda step in written in test-infra to install miniconda in the llm retrieval workflow.  It comes with a cache so we don't have to worry about hitting cache limits.  The llm retrieval job was failing due to too many requests https://github.com/pytorch/pytorch/issues/129718#issue-2379260544

https://github.com/pytorch/test-infra/blob/2aba8f107aca99710cca5cd97b6c16500eb808e2/.github/actions/setup-miniconda/action.yml#L1