### PR TITLE
[FSDP2] Ran reduce-scatter copy-in in default stream

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -247,7 +247,12 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
         group = fsdp_param_group.mesh_info.shard_process_group
         self.assertEqual(group.size(), self.world_size)
         all_reduce_stream = torch.cuda.Stream()
-        post_reduce_event, _ = foreach_reduce(
+        (
+            reduce_scatter_input,
+            reduce_scatter_event,
+            post_reduce_event,
+            _,
+        ) = foreach_reduce(
             fsdp_params,
             unsharded_grads,
             group,

--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -122,13 +122,13 @@ class TestFullyShardMemory(FSDPTest):
         loss.sum().backward()
         mem_mb = self._get_peak_active_memory_mb()
         if reshard_after_forward:
-            # 1x max unsharded block parameters (all-gather), 2x max
+            # 2x max unsharded block parameters (all-gather + copy-out), 2x max
             # unsharded block gradients (gradients, reduce-scatter input),
             # non-block parameters, and other
             # NOTE: Reduce-scatter output is counted as part of the 1x sharded
             # gradients below since the gradients view into the output
             expected_mem_mb = (
-                3 * max_unsharded_numel + non_block_numel
+                4 * max_unsharded_numel + non_block_numel
             ) * 4 / 1e6 + buffer_mb
             if not use_cpu_offload:
                 # 2x sharded parameters/gradients

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -274,8 +274,8 @@ class TestFullyShard1DTrainingCore(FSDPTest):
                 _optim.step()
             self.assertEqual(losses[0], losses[1])
 
-    # @skip_if_lt_x_gpu(2)
-    # @test_compiled_fsdp(compile_compute_on_module=Transformer)
+    @skip_if_lt_x_gpu(2)
+    @test_compiled_fsdp(compile_compute_on_module=Transformer)
     def test_train_parity_multi_group(self):
         """
         Tests train parity against DDP when using multiple parameter groups for

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -274,8 +274,8 @@ class TestFullyShard1DTrainingCore(FSDPTest):
                 _optim.step()
             self.assertEqual(losses[0], losses[1])
 
-    @skip_if_lt_x_gpu(2)
-    @test_compiled_fsdp(compile_compute_on_module=Transformer)
+    # @skip_if_lt_x_gpu(2)
+    # @test_compiled_fsdp(compile_compute_on_module=Transformer)
     def test_train_parity_multi_group(self):
         """
         Tests train parity against DDP when using multiple parameter groups for

--- a/torch/distributed/_composable/fsdp/_fsdp_collectives.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_collectives.py
@@ -273,19 +273,15 @@ def foreach_reduce(
     )
     reduce_scatter_input_numel = sum(s.numel() for s in padded_unsharded_sizes)
     reduce_scatter_output_numel = reduce_scatter_input_numel // world_size
+    reduce_scatter_input = torch.empty(
+        (reduce_scatter_input_numel,), dtype=reduce_dtype, device=device
+    )
+    foreach_reduce_scatter_copy_in(unsharded_grads, reduce_scatter_input, world_size)
     current_stream = torch.cuda.current_stream()
+    # Only after the copy-in finishes can we free the gradients
+    unsharded_grads.clear()
     reduce_scatter_stream.wait_stream(current_stream)
     with torch.cuda.stream(reduce_scatter_stream):
-        reduce_scatter_input = torch.empty(
-            (reduce_scatter_input_numel,), dtype=reduce_dtype, device=device
-        )
-        foreach_reduce_scatter_copy_in(
-            unsharded_grads, reduce_scatter_input, world_size
-        )
-        # Only after the copy-in finishes can we free the gradients, which were
-        # computed in the default stream
-        current_stream.wait_stream(reduce_scatter_stream)
-        unsharded_grads.clear()
         reduce_output = reduce_scatter_input.new_empty((reduce_scatter_output_numel,))
         _div_if_needed(reduce_scatter_input, predivide_factor)
         dist.reduce_scatter_tensor(
@@ -294,6 +290,7 @@ def foreach_reduce(
             group=reduce_scatter_group,
             op=ReduceOp.AVG if predivide_factor is None else ReduceOp.SUM,
         )
+        reduce_scatter_event = reduce_scatter_stream.record_event()
         post_reduce_stream = reduce_scatter_stream
         if all_reduce_group is not None:  # HSDP
             # Accumulations must run in the reduce-scatter stream
@@ -358,7 +355,7 @@ def foreach_reduce(
     # stream (for optimizer). To ensure its memory is not reused for later
     # RSs, we do not need extra synchronization since the sharded parameters
     # hold refs through the end of backward.
-    return post_reduce_event, None
+    return reduce_scatter_input, reduce_scatter_event, post_reduce_event, None
 
 
 def foreach_reduce_scatter_copy_in(

--- a/torch/distributed/_composable/fsdp/_fsdp_state.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_state.py
@@ -249,6 +249,7 @@ class FSDPState(_State):
                     state._finalize_backward()
             if self._state_ctx.is_last_backward:
                 self._comm_ctx.post_forward_order.clear()
+                self._comm_ctx.reduce_scatter_state = None
             self._state_ctx.post_backward_final_callback_queued = False
 
     def _finalize_backward(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129721

This PR runs the reduce-scatter copy-in in the default stream, allowing the reduce-scatter input (large allocation proportional to unsharded gradients) to be allocated in the default stream to avoid fragmenting that memory across stream memory pools.
- In general, minimizing memory usage spikes in non-default-stream memory pools helps because otherwise, that memory cannot be reused by the default stream outside of that spike. This reduce-scatter input allocation represents one such spike. The reduce-scatter outputs are still allocated in the separate `reduce_scatter` stream since they are small and have a non-spiky allocation/free pattern (we iteratively allocate them through backward and free them altogether after optimizer).
- This PR should not have any impact on overlap (I sanity checked Llama3-8B traces from torchtitan; plus we have the `test_fully_shard_overlap.py` unit tests). 


**Experiment**
**(Before)** Llama3-8B, 1D FSDP, 8 H100s, bf16/fp32 mixed precision, no AC, local batch size 1:
```
[rank0]:2024-06-27 16:38:56,620 - root - INFO - step:  1  loss: 12.2764  memory: 71.99GiB(75.75%)  wps: 1,436  mfu: 8.41%
[rank0]:2024-06-27 16:38:56,620 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:2024-06-27 16:38:57,943 - root - INFO - step:  2  loss: 12.1001  memory: 79.82GiB(83.98%)  wps: 6,195  mfu: 36.28%
[rank0]:2024-06-27 16:38:59,266 - root - INFO - step:  3  loss: 11.7697  memory: 79.82GiB(83.98%)  wps: 6,193  mfu: 36.27%
[rank0]:2024-06-27 16:39:00,587 - root - INFO - step:  4  loss: 11.2807  memory: 79.82GiB(83.98%)  wps: 6,203  mfu: 36.32%
[rank0]:2024-06-27 16:39:01,910 - root - INFO - step:  5  loss: 10.9494  memory: 79.82GiB(83.98%)  wps: 6,198  mfu: 36.30%
```

**(After)** Llama3-8B, 1D FSDP, 8 H100s, bf16/fp32 mixed precision, no AC, local batch size 1:
```
[rank0]:2024-06-27 16:41:12,106 - root - INFO - step:  1  loss: 12.2560  memory: 69.46GiB(73.08%)  wps: 1,158  mfu: 6.78%
[rank0]:2024-06-27 16:41:12,106 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:2024-06-27 16:41:13,502 - root - INFO - step:  2  loss: 12.0949  memory: 77.29GiB(81.32%)  wps: 5,870  mfu: 34.37%
[rank0]:2024-06-27 16:41:14,839 - root - INFO - step:  3  loss: 11.7770  memory: 77.29GiB(81.32%)  wps: 6,130  mfu: 35.90%
[rank0]:2024-06-27 16:41:16,154 - root - INFO - step:  4  loss: 11.3188  memory: 77.29GiB(81.32%)  wps: 6,230  mfu: 36.48%
[rank0]:2024-06-27 16:41:17,474 - root - INFO - step:  5  loss: 10.9443  memory: 77.29GiB(81.32%)  wps: 6,211  mfu: 36.37%
```
**2.53 GiB reduction in peak reserved memory.**



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang @d4l3k