### PR TITLE
Disable llm-td step

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -20,17 +20,19 @@ concurrency:
 permissions: read-all
 
 jobs:
-  llm-td:
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-    permissions:
-      id-token: write
-      contents: read
+  # Often fails due to conda availability issues
+  # See https://github.com/pytorch/pytorch/issues/129717
+  # llm-td:
+  #  name: before-test
+  #  uses: ./.github/workflows/llm_td_retrieval.yml
+  #  permissions:
+  #    id-token: write
+  #    contents: read
 
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
+    # needs: llm-td
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -21,17 +21,19 @@ concurrency:
 permissions: read-all
 
 jobs:
-  llm-td:
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-    permissions:
-      id-token: write
-      contents: read
+  # Often fails due to conda availability issues
+  # See https://github.com/pytorch/pytorch/issues/129717
+  # llm-td:
+  #   name: before-test
+  #   uses: ./.github/workflows/llm_td_retrieval.yml
+  #   permissions:
+  #     id-token: write
+  #     contents: read
 
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
+    # needs: llm-td
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -19,17 +19,19 @@ concurrency:
 permissions: read-all
 
 jobs:
-  llm-td:
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-    permissions:
-      id-token: write
-      contents: read
+  # Often fails due to conda availability issues
+  # See https://github.com/pytorch/pytorch/issues/129717
+  # llm-td:
+  #  name: before-test
+  #  uses: ./.github/workflows/llm_td_retrieval.yml
+  #  permissions:
+  #    id-token: write
+  #    contents: read
 
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
+    # needs: llm-td
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
As it often fails during conda install step with `Unexpected HTTP response: 429`
