### PR TITLE
[1/4] 3D Composability - move fsdp tests

### DIFF
--- a/.ci/pytorch/multigpu-test.sh
+++ b/.ci/pytorch/multigpu-test.sh
@@ -55,7 +55,7 @@ time python test/run_test.py --verbose -i distributed/_composable/fsdp/test_full
 time python test/run_test.py --verbose -i distributed/pipelining/test_composability.py
 
 # 3D composability tests
-time python test/run_test.py --verbose -i distributed/_composable/test_composability/test_fsdp_tp_dp_composable
+time python test/run_test.py --verbose -i distributed/_composable/test_composability/test_2d_composable
 
 # Other tests
 time python test/run_test.py --verbose -i test_cuda_primary_ctx

--- a/.ci/pytorch/multigpu-test.sh
+++ b/.ci/pytorch/multigpu-test.sh
@@ -54,6 +54,9 @@ time python test/run_test.py --verbose -i distributed/_composable/fsdp/test_full
 # Pipelining composability tests
 time python test/run_test.py --verbose -i distributed/pipelining/test_composability.py
 
+# 3D composability tests
+time python test/run_test.py --verbose -i distributed/_composable/test_composability/test_fsdp_tp_dp_composable
+
 # Other tests
 time python test/run_test.py --verbose -i test_cuda_primary_ctx
 time python test/run_test.py --verbose -i test_optim -- -k test_forloop_goes_right_direction_multigpu

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -5,11 +5,10 @@ import copy
 import functools
 import itertools
 import unittest
-from typing import Iterable, List, Tuple, Type, Union
+from typing import Iterable, List, Tuple, Union
 
 import torch
 import torch.distributed as dist
-import torch.distributed.checkpoint as dcp
 import torch.nn as nn
 from torch.distributed._composable import checkpoint, replicate
 from torch.distributed._composable.fsdp import (
@@ -25,10 +24,6 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     _CHECKPOINT_PREFIX,
     apply_activation_checkpointing,
     CheckpointWrapper,
-)
-from torch.distributed.checkpoint.state_dict import (
-    get_model_state_dict,
-    get_optimizer_state_dict,
 )
 from torch.distributed.device_mesh import DeviceMesh
 from torch.testing._internal.common_cuda import TEST_CUDA
@@ -46,7 +41,6 @@ from torch.testing._internal.common_fsdp import (
 from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     run_tests,
-    skipIfRocm,
     wrapSwapTensorsTest,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -54,7 +48,6 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     Transformer,
     TransformerBlock,
 )
-from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
 
 c10d_ops = torch.ops.c10d
 funcol = torch.ops.c10d_functional
@@ -953,232 +946,6 @@ class TestFullyShardGradientAccumulation(FSDPTest):
         check_sharded_parity(self, ref_model, model)
 
 
-class TestFullyShard2DTraining(FSDPTest):
-    @property
-    def world_size(self) -> int:
-        return min(4, torch.cuda.device_count())
-
-    def init_global_mesh(self) -> DeviceMesh:
-        # Prefer to test with >=4 GPUs, but for 2 GPUs, use 2-way TP
-        dp_size = 2 if self.world_size > 2 else 1
-        return init_device_mesh(
-            "cuda", (dp_size, self.world_size // dp_size), mesh_dim_names=("dp", "tp")
-        )
-
-    @skip_if_lt_x_gpu(2)
-    @skipIfRocm
-    def test_train_parity_2d_mlp(self):
-        global_mesh = self.init_global_mesh()
-        self.run_subtests(
-            {
-                "reshard_after_forward": [False, True],
-                "use_activation_checkpointing": [False, True],
-                "mlp_dim": [3, 16, 17],
-            },
-            functools.partial(self._test_train_parity_2d_mlp, global_mesh),
-        )
-
-    def _test_train_parity_2d_mlp(
-        self,
-        global_mesh: DeviceMesh,
-        reshard_after_forward: bool,
-        use_activation_checkpointing: bool,
-        mlp_dim: int,
-    ):
-        dp_mesh, tp_mesh = global_mesh["dp"], global_mesh["tp"]
-        dp_pg = dp_mesh.get_group()  # used for `replicate()`
-
-        torch.manual_seed(42)
-        model = MLPStack(mlp_dim)
-        ref_model = copy.deepcopy(model).cuda()
-        replicate(ref_model, device_ids=[self.rank], process_group=dp_pg)
-        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=False)
-        model.parallelize(
-            tp_mesh,
-            dp_mesh,
-            use_activation_checkpointing,
-            reshard_after_forward=reshard_after_forward,
-        )
-        optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=False)
-
-        torch.manual_seed(42 + dp_pg.rank() + 1)
-        device = torch.device("cuda")
-        for iter_idx in range(10):
-            inp = torch.randn((8, mlp_dim), device=device)
-            losses: List[torch.Tensor] = []
-            for _model, _optim in ((ref_model, ref_optim), (model, optim)):
-                _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
-                losses.append(_model(inp).sum())
-                losses[-1].backward()
-                _optim.step()
-            self.assertEqual(losses[0], losses[1])
-
-    @skip_if_lt_x_gpu(2)
-    @skipIfRocm
-    def test_tp_with_fsdp_offloading(self):
-        global_mesh = init_device_mesh(
-            "cuda", (1, self.world_size), mesh_dim_names=("dp", "tp")
-        )
-        dp_mesh, tp_mesh = global_mesh["dp"], global_mesh["tp"]
-        torch.manual_seed(42)
-        mlp_dim = 16
-        model = MLPStack(mlp_dim)
-        ref_model = copy.deepcopy(model).cuda()
-        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=False)
-        # Parallelize with N-way TP and 1-way FSDP
-        model.parallelize(
-            tp_mesh,
-            dp_mesh,
-            use_activation_checkpointing=False,
-            reshard_after_forward=True,
-            offload_policy=CPUOffloadPolicy(),
-        )
-        for param in model.parameters():
-            self.assertEqual(param.device.type, "cpu")
-        num_mlps = sum(isinstance(module, MLP) for module in model.modules())
-        optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=False)
-
-        # NOTE: We still see the FSDP all-gather/reduce-scatter c10d ops
-        # called, but they will just be no-ops without issuing any kernels.
-        # We prefer to keep the no-op check at the c10d level, not in FSDP.
-        inp = torch.randn((4, mlp_dim), device="cuda")  # same on all ranks
-        for iter_idx in range(10):
-            ref_optim.zero_grad()
-            optim.zero_grad()
-
-            with CommDebugMode() as fwd_comm_mode:
-                loss = model(inp).sum()
-
-            fwd_comm_counts = fwd_comm_mode.get_comm_counts()
-            self.assertEqual(len(fwd_comm_counts), 2)
-            self.assertEqual(fwd_comm_counts[funcol.all_reduce], num_mlps)
-            self.assertEqual(fwd_comm_counts[c10d_ops._allgather_base_], num_mlps)
-            ref_loss = ref_model(inp).sum()
-            self.assertEqual(loss, ref_loss)
-
-            with CommDebugMode() as bwd_comm_mode:
-                loss.backward()
-            bwd_comm_counts = bwd_comm_mode.get_comm_counts()
-            self.assertEqual(len(bwd_comm_counts), 3)
-            # First MLP's input gradient does not need to be all-reduced
-            self.assertEqual(bwd_comm_counts[funcol.all_reduce], num_mlps - 1)
-            self.assertEqual(bwd_comm_counts[c10d_ops._allgather_base_], num_mlps)
-            self.assertEqual(bwd_comm_counts[c10d_ops._reduce_scatter_base_], num_mlps)
-            ref_loss.backward()
-
-            optim.step()
-            ref_optim.step()
-
-    @skip_if_lt_x_gpu(2)
-    @with_temp_dir
-    def test_train_parity_2d_transformer_checkpoint_resume(self):
-        """
-        Tests train parity of a 2D transformer without checkpointing against a
-        2D transformer with a checkpoint save/load.
-        """
-        self.run_subtests(
-            {
-                "use_seq_parallel": [False, True],
-                # If reusing, then load into the same model/optimizer instance
-                # else construct new ones (requiring eager optim state init)
-                "reuse_model_optim": [False, True],
-                "optimizer_class": [torch.optim.Adam, torch.optim.AdamW],
-                # TODO: need to update `parallelize` before including foreach=True for testing
-                "foreach": [False],
-            },
-            self._test_train_parity_2d_transformer_checkpoint_resume,
-        )
-
-    def _test_train_parity_2d_transformer_checkpoint_resume(
-        self,
-        use_seq_parallel: bool,
-        reuse_model_optim: bool,
-        optimizer_class: Type[torch.optim.Optimizer],
-        foreach: bool,
-    ):
-        def train_step(
-            _model: nn.Module, _optim: torch.optim.Optimizer, _inp: torch.Tensor
-        ) -> torch.Tensor:
-            loss = _model(_inp).sum()
-            loss.backward()
-            _optim.step()
-            _optim.zero_grad()
-            return loss
-
-        def parallelize(_model: Transformer, mesh: DeviceMesh, use_seq_parallel: bool):
-            _model = Transformer.parallelize(_model, mesh["tp"], use_seq_parallel)
-            for layer in _model.layers:
-                fully_shard(layer, mesh=mesh["dp"])
-            fully_shard(_model, mesh=mesh["dp"])
-            return _model
-
-        global_mesh = self.init_global_mesh()
-        # Baseline: run two iterations without checkpointing
-        seed = 42
-        torch.manual_seed(seed)
-        model_args = ModelArgs(dropout_p=0.0)
-        model_no_cp = parallelize(
-            Transformer(model_args), global_mesh, use_seq_parallel
-        )
-        optim_no_cp = optimizer_class(
-            model_no_cp.parameters(), lr=1e-2, foreach=foreach
-        )
-
-        torch.manual_seed(42 + global_mesh["dp"].get_local_rank() + 1)
-        inp = torch.randint(0, model_args.vocab_size, (3, 16), device="cuda")
-        loss_no_cp1 = train_step(model_no_cp, optim_no_cp, inp)
-        loss_no_cp2 = train_step(model_no_cp, optim_no_cp, inp)
-
-        # Test: run one iteration, save checkpoint, zero states or init new
-        # model/optimizer, load checkpoint, and run another iteration
-        torch.manual_seed(seed)
-        model_cp = parallelize(Transformer(model_args), global_mesh, use_seq_parallel)
-        optim_cp = optimizer_class(model_cp.parameters(), lr=1e-2, foreach=foreach)
-
-        loss_cp1 = train_step(model_cp, optim_cp, inp)
-        self.assertEqual(loss_no_cp1, loss_cp1)
-
-        sharded_sd = {
-            "model": get_model_state_dict(model_cp),
-            # Use `get_optimizer_state_dict` to handle eager optim state init
-            # when constructing a new optimizer instance
-            "optim": get_optimizer_state_dict(model_cp, optim_cp),
-        }
-        dcp.save(
-            state_dict=sharded_sd,
-            storage_writer=dcp.FileSystemWriter(self.temp_dir),
-        )
-        if reuse_model_optim:
-            with torch.no_grad():
-                for param in model_cp.parameters():
-                    param.zero_()
-                optim_sd = optim_cp.state_dict()
-                for param_states in optim_sd["state"].values():
-                    for state_value in param_states.values():
-                        if torch.is_tensor(state_value):
-                            state_value.zero_()
-        else:
-            torch.manual_seed(seed + 1)  # different seed
-            model_cp = parallelize(
-                Transformer(model_args), global_mesh, use_seq_parallel
-            )
-            optim_cp = optimizer_class(model_cp.parameters(), lr=1e-2, foreach=foreach)
-        self.assertNotEqual(loss_no_cp2, train_step(model_cp, optim_cp, inp))
-
-        sharded_sd = {
-            "model": get_model_state_dict(model_cp),
-            "optim": get_optimizer_state_dict(model_cp, optim_cp),
-        }
-        dcp.load(
-            state_dict=sharded_sd,
-            storage_reader=dcp.FileSystemReader(self.temp_dir),
-        )
-        self.assertGreater(len(optim_cp.state_dict()["state"]), 0)
-
-        loss_cp2 = train_step(model_cp, optim_cp, inp)
-        self.assertEqual(loss_no_cp2, loss_cp2)
-
-
 class TestFullyShardNDTraining(FSDPTest):
     @property
     def world_size(self) -> int:
@@ -1253,78 +1020,6 @@ class TestFullyShardNDTraining(FSDPTest):
             self.assertEqual(p.device_mesh.ndim, 2)
             self.assertEqual(len(p.placements), 2)
             self.assertEqual(p.device_mesh.mesh_dim_names, ("dp", "tp"))
-
-
-class TestFullyShardHSDPTraining(FSDPTest):
-    @property
-    def world_size(self) -> int:
-        return min(4, torch.cuda.device_count())
-
-    @skip_if_lt_x_gpu(2)
-    def test_train_parity_hsdp(self):
-        shard_size = 2 if self.world_size > 2 else 1
-        replicate_size = self.world_size // shard_size
-        global_mesh = init_device_mesh(
-            "cuda", (replicate_size, shard_size), mesh_dim_names=("replicate", "shard")
-        )
-        self.run_subtests(
-            {
-                "reshard_after_forward": [False, True],
-                "use_activation_checkpointing": [False, True],
-                "mlp_dim": [3, 16, 17],
-                "sync_gradients_at_last_batch": [True, False],
-            },
-            functools.partial(self._test_train_parity_hsdp, global_mesh),
-        )
-
-    def _test_train_parity_hsdp(
-        self,
-        global_mesh: DeviceMesh,
-        reshard_after_forward: bool,
-        use_activation_checkpointing: bool,
-        mlp_dim: int,
-        sync_gradients_at_last_batch: bool,
-    ):
-        torch.manual_seed(42)
-        model = nn.Sequential(
-            nn.LayerNorm(mlp_dim, bias=False),
-            MLP(mlp_dim, dim_multiplier=3),
-            MLP(mlp_dim),
-            MLP(mlp_dim, dim_multiplier=3),
-        )
-        ref_model = copy.deepcopy(model).cuda()
-        replicate(ref_model, device_ids=[self.rank])
-        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
-        for mlp in model:
-            if use_activation_checkpointing:
-                checkpoint(mlp)
-            fully_shard(
-                mlp, mesh=global_mesh, reshard_after_forward=reshard_after_forward
-            )
-        fully_shard(
-            model, mesh=global_mesh, reshard_after_forward=reshard_after_forward
-        )
-        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
-        check_sharded_parity(self, ref_model, model)
-        torch.manual_seed(42 + self.rank + 1)
-        device = torch.device("cuda")
-        num_microbatches = 3
-        for iter_idx in range(5):
-            for microbatch_idx in range(num_microbatches):
-                is_last_microbatch = microbatch_idx == num_microbatches - 1
-                if sync_gradients_at_last_batch:
-                    model.set_requires_gradient_sync(is_last_microbatch)
-                inp = torch.randn((8, mlp_dim), device=device)
-                losses: List[torch.Tensor] = []
-                for _model, _optim in ((ref_model, ref_optim), (model, optim)):
-                    losses.append(_model(inp).sum())
-                    losses[-1].backward()
-                self.assertEqual(losses[0], losses[1])
-            check_sharded_parity(self, ref_model, model)
-            for _model, _optim in ((ref_model, ref_optim), (model, optim)):
-                _optim.step()
-                _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
-            check_sharded_parity(self, ref_model, model)
 
 
 class TestFullyShardCustomForwardMethod(FSDPTest):

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -1022,6 +1022,78 @@ class TestFullyShardNDTraining(FSDPTest):
             self.assertEqual(p.device_mesh.mesh_dim_names, ("dp", "tp"))
 
 
+class TestFullyShardHSDPTraining(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return min(4, torch.cuda.device_count())
+
+    @skip_if_lt_x_gpu(2)
+    def test_train_parity_hsdp(self):
+        shard_size = 2 if self.world_size > 2 else 1
+        replicate_size = self.world_size // shard_size
+        global_mesh = init_device_mesh(
+            "cuda", (replicate_size, shard_size), mesh_dim_names=("replicate", "shard")
+        )
+        self.run_subtests(
+            {
+                "reshard_after_forward": [False, True],
+                "use_activation_checkpointing": [False, True],
+                "mlp_dim": [3, 16, 17],
+                "sync_gradients_at_last_batch": [True, False],
+            },
+            functools.partial(self._test_train_parity_hsdp, global_mesh),
+        )
+
+    def _test_train_parity_hsdp(
+        self,
+        global_mesh: DeviceMesh,
+        reshard_after_forward: bool,
+        use_activation_checkpointing: bool,
+        mlp_dim: int,
+        sync_gradients_at_last_batch: bool,
+    ):
+        torch.manual_seed(42)
+        model = nn.Sequential(
+            nn.LayerNorm(mlp_dim, bias=False),
+            MLP(mlp_dim, dim_multiplier=3),
+            MLP(mlp_dim),
+            MLP(mlp_dim, dim_multiplier=3),
+        )
+        ref_model = copy.deepcopy(model).cuda()
+        replicate(ref_model, device_ids=[self.rank])
+        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
+        for mlp in model:
+            if use_activation_checkpointing:
+                checkpoint(mlp)
+            fully_shard(
+                mlp, mesh=global_mesh, reshard_after_forward=reshard_after_forward
+            )
+        fully_shard(
+            model, mesh=global_mesh, reshard_after_forward=reshard_after_forward
+        )
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
+        check_sharded_parity(self, ref_model, model)
+        torch.manual_seed(42 + self.rank + 1)
+        device = torch.device("cuda")
+        num_microbatches = 3
+        for iter_idx in range(5):
+            for microbatch_idx in range(num_microbatches):
+                is_last_microbatch = microbatch_idx == num_microbatches - 1
+                if sync_gradients_at_last_batch:
+                    model.set_requires_gradient_sync(is_last_microbatch)
+                inp = torch.randn((8, mlp_dim), device=device)
+                losses: List[torch.Tensor] = []
+                for _model, _optim in ((ref_model, ref_optim), (model, optim)):
+                    losses.append(_model(inp).sum())
+                    losses[-1].backward()
+                self.assertEqual(losses[0], losses[1])
+            check_sharded_parity(self, ref_model, model)
+            for _model, _optim in ((ref_model, ref_optim), (model, optim)):
+                _optim.step()
+                _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            check_sharded_parity(self, ref_model, model)
+
+
 class TestFullyShardCustomForwardMethod(FSDPTest):
     @property
     def world_size(self) -> int:

--- a/test/distributed/_composable/test_composability/test_fsdp_tp_dp_composability.py
+++ b/test/distributed/_composable/test_composability/test_fsdp_tp_dp_composability.py
@@ -1,0 +1,382 @@
+# Owner(s): ["oncall: distributed"]
+
+import copy
+import functools
+from typing import List, Type
+
+import torch
+import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
+import torch.nn as nn
+
+from torch.distributed._composable import checkpoint, replicate
+from torch.distributed._composable.fsdp import CPUOffloadPolicy
+from torch.distributed._composable.fsdp.fully_shard import fully_shard
+from torch.distributed._tensor import DeviceMesh, init_device_mesh
+from torch.distributed._tensor.debug.comm_mode import CommDebugMode
+from torch.distributed.checkpoint.state_dict import (
+    get_model_state_dict,
+    get_optimizer_state_dict,
+)
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    parallelize_module,
+    RowwiseParallel,
+)
+from torch.distributed.tensor.parallel.ddp import _pre_dp_module_transform
+
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import (
+    check_sharded_parity,
+    FSDPTest,
+    MLP,
+    MLPStack,
+)
+
+from torch.testing._internal.common_utils import run_tests, skipIfRocm
+
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    MLPModule,
+    ModelArgs,
+    Transformer,
+)
+from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
+
+
+# Tensor-Parallel degree
+TP_DEGREE = 2
+LR = 3e-5
+
+c10d_ops = torch.ops.c10d
+funcol = torch.ops.c10d_functional
+
+
+def init_model(device_type, model_parallel_size=TP_DEGREE):
+    torch.manual_seed(0)
+    model = MLPModule(device_type)
+    torch.manual_seed(0)
+    twod_model = MLPModule(device_type)
+    model = DDP(model)
+
+    # 2-D mesh is [dp, tp]
+    world_size = dist.get_world_size()
+    mesh_2d = init_device_mesh(
+        device_type,
+        (world_size // model_parallel_size, model_parallel_size),
+        mesh_dim_names=("dp", "tp"),
+    )
+
+    dp_pg = mesh_2d.get_group(mesh_dim=0)
+
+    parallelize_plan = {
+        "net1": ColwiseParallel(),
+        "net2": RowwiseParallel(),
+    }
+    twod_model = parallelize_module(twod_model, mesh_2d["tp"], parallelize_plan)
+    _pre_dp_module_transform(twod_model)
+    # TODO: Add tests when using gradient_as_bucket_view and static_graph for DDP.
+    twod_model = DDP(twod_model, process_group=dp_pg)
+    return model, twod_model, dp_pg
+
+
+class TestFullyShard2DTraining(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return min(4, torch.cuda.device_count())
+
+    def init_global_mesh(self) -> DeviceMesh:
+        # Prefer to test with >=4 GPUs, but for 2 GPUs, use 2-way TP
+        dp_size = 2 if self.world_size > 2 else 1
+        return init_device_mesh(
+            "cuda", (dp_size, self.world_size // dp_size), mesh_dim_names=("dp", "tp")
+        )
+
+    @skip_if_lt_x_gpu(2)
+    @skipIfRocm
+    def test_train_parity_2d_mlp(self):
+        global_mesh = self.init_global_mesh()
+        self.run_subtests(
+            {
+                "reshard_after_forward": [False, True],
+                "use_activation_checkpointing": [False, True],
+                "mlp_dim": [3, 16, 17],
+            },
+            functools.partial(self._test_train_parity_2d_mlp, global_mesh),
+        )
+
+    def _test_train_parity_2d_mlp(
+        self,
+        global_mesh: DeviceMesh,
+        reshard_after_forward: bool,
+        use_activation_checkpointing: bool,
+        mlp_dim: int,
+    ):
+        dp_mesh, tp_mesh = global_mesh["dp"], global_mesh["tp"]
+        dp_pg = dp_mesh.get_group()  # used for `replicate()`
+
+        torch.manual_seed(42)
+        model = MLPStack(mlp_dim)
+        ref_model = copy.deepcopy(model).cuda()
+        replicate(ref_model, device_ids=[self.rank], process_group=dp_pg)
+        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=False)
+        model.parallelize(
+            tp_mesh,
+            dp_mesh,
+            use_activation_checkpointing,
+            reshard_after_forward=reshard_after_forward,
+        )
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=False)
+
+        torch.manual_seed(42 + dp_pg.rank() + 1)
+        device = torch.device("cuda")
+        for iter_idx in range(10):
+            inp = torch.randn((8, mlp_dim), device=device)
+            losses: List[torch.Tensor] = []
+            for _model, _optim in ((ref_model, ref_optim), (model, optim)):
+                _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+                losses.append(_model(inp).sum())
+                losses[-1].backward()
+                _optim.step()
+            self.assertEqual(losses[0], losses[1])
+
+    @skip_if_lt_x_gpu(2)
+    @skipIfRocm
+    def test_tp_with_fsdp_offloading(self):
+        global_mesh = init_device_mesh(
+            "cuda", (1, self.world_size), mesh_dim_names=("dp", "tp")
+        )
+        dp_mesh, tp_mesh = global_mesh["dp"], global_mesh["tp"]
+        torch.manual_seed(42)
+        mlp_dim = 16
+        model = MLPStack(mlp_dim)
+        ref_model = copy.deepcopy(model).cuda()
+        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=False)
+        # Parallelize with N-way TP and 1-way FSDP
+        model.parallelize(
+            tp_mesh,
+            dp_mesh,
+            use_activation_checkpointing=False,
+            reshard_after_forward=True,
+            offload_policy=CPUOffloadPolicy(),
+        )
+        for param in model.parameters():
+            self.assertEqual(param.device.type, "cpu")
+        num_mlps = sum(isinstance(module, MLP) for module in model.modules())
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=False)
+
+        # NOTE: We still see the FSDP all-gather/reduce-scatter c10d ops
+        # called, but they will just be no-ops without issuing any kernels.
+        # We prefer to keep the no-op check at the c10d level, not in FSDP.
+        inp = torch.randn((4, mlp_dim), device="cuda")  # same on all ranks
+        for iter_idx in range(10):
+            ref_optim.zero_grad()
+            optim.zero_grad()
+
+            with CommDebugMode() as fwd_comm_mode:
+                loss = model(inp).sum()
+
+            fwd_comm_counts = fwd_comm_mode.get_comm_counts()
+            self.assertEqual(len(fwd_comm_counts), 2)
+            self.assertEqual(fwd_comm_counts[funcol.all_reduce], num_mlps)
+            self.assertEqual(fwd_comm_counts[c10d_ops._allgather_base_], num_mlps)
+            ref_loss = ref_model(inp).sum()
+            self.assertEqual(loss, ref_loss)
+
+            with CommDebugMode() as bwd_comm_mode:
+                loss.backward()
+            bwd_comm_counts = bwd_comm_mode.get_comm_counts()
+            self.assertEqual(len(bwd_comm_counts), 3)
+            # First MLP's input gradient does not need to be all-reduced
+            self.assertEqual(bwd_comm_counts[funcol.all_reduce], num_mlps - 1)
+            self.assertEqual(bwd_comm_counts[c10d_ops._allgather_base_], num_mlps)
+            self.assertEqual(bwd_comm_counts[c10d_ops._reduce_scatter_base_], num_mlps)
+            ref_loss.backward()
+
+            optim.step()
+            ref_optim.step()
+
+    @skip_if_lt_x_gpu(2)
+    @with_temp_dir
+    def test_train_parity_2d_transformer_checkpoint_resume(self):
+        """
+        Tests train parity of a 2D transformer without checkpointing against a
+        2D transformer with a checkpoint save/load.
+        """
+        self.run_subtests(
+            {
+                "use_seq_parallel": [False, True],
+                # If reusing, then load into the same model/optimizer instance
+                # else construct new ones (requiring eager optim state init)
+                "reuse_model_optim": [False, True],
+                "optimizer_class": [torch.optim.Adam, torch.optim.AdamW],
+                # TODO: need to update `parallelize` before including foreach=True for testing
+                "foreach": [False],
+            },
+            self._test_train_parity_2d_transformer_checkpoint_resume,
+        )
+
+    def _test_train_parity_2d_transformer_checkpoint_resume(
+        self,
+        use_seq_parallel: bool,
+        reuse_model_optim: bool,
+        optimizer_class: Type[torch.optim.Optimizer],
+        foreach: bool,
+    ):
+        def train_step(
+            _model: nn.Module, _optim: torch.optim.Optimizer, _inp: torch.Tensor
+        ) -> torch.Tensor:
+            loss = _model(_inp).sum()
+            loss.backward()
+            _optim.step()
+            _optim.zero_grad()
+            return loss
+
+        def parallelize(_model: Transformer, mesh: DeviceMesh, use_seq_parallel: bool):
+            _model = Transformer.parallelize(_model, mesh["tp"], use_seq_parallel)
+            for layer in _model.layers:
+                fully_shard(layer, mesh=mesh["dp"])
+            fully_shard(_model, mesh=mesh["dp"])
+            return _model
+
+        global_mesh = self.init_global_mesh()
+        # Baseline: run two iterations without checkpointing
+        seed = 42
+        torch.manual_seed(seed)
+        model_args = ModelArgs(dropout_p=0.0)
+        model_no_cp = parallelize(
+            Transformer(model_args), global_mesh, use_seq_parallel
+        )
+        optim_no_cp = optimizer_class(
+            model_no_cp.parameters(), lr=1e-2, foreach=foreach
+        )
+
+        torch.manual_seed(42 + global_mesh["dp"].get_local_rank() + 1)
+        inp = torch.randint(0, model_args.vocab_size, (3, 16), device="cuda")
+        loss_no_cp1 = train_step(model_no_cp, optim_no_cp, inp)
+        loss_no_cp2 = train_step(model_no_cp, optim_no_cp, inp)
+
+        # Test: run one iteration, save checkpoint, zero states or init new
+        # model/optimizer, load checkpoint, and run another iteration
+        torch.manual_seed(seed)
+        model_cp = parallelize(Transformer(model_args), global_mesh, use_seq_parallel)
+        optim_cp = optimizer_class(model_cp.parameters(), lr=1e-2, foreach=foreach)
+
+        loss_cp1 = train_step(model_cp, optim_cp, inp)
+        self.assertEqual(loss_no_cp1, loss_cp1)
+
+        sharded_sd = {
+            "model": get_model_state_dict(model_cp),
+            # Use `get_optimizer_state_dict` to handle eager optim state init
+            # when constructing a new optimizer instance
+            "optim": get_optimizer_state_dict(model_cp, optim_cp),
+        }
+        dcp.save(
+            state_dict=sharded_sd,
+            storage_writer=dcp.FileSystemWriter(self.temp_dir),
+        )
+        if reuse_model_optim:
+            with torch.no_grad():
+                for param in model_cp.parameters():
+                    param.zero_()
+                optim_sd = optim_cp.state_dict()
+                for param_states in optim_sd["state"].values():
+                    for state_value in param_states.values():
+                        if torch.is_tensor(state_value):
+                            state_value.zero_()
+        else:
+            torch.manual_seed(seed + 1)  # different seed
+            model_cp = parallelize(
+                Transformer(model_args), global_mesh, use_seq_parallel
+            )
+            optim_cp = optimizer_class(model_cp.parameters(), lr=1e-2, foreach=foreach)
+        self.assertNotEqual(loss_no_cp2, train_step(model_cp, optim_cp, inp))
+
+        sharded_sd = {
+            "model": get_model_state_dict(model_cp),
+            "optim": get_optimizer_state_dict(model_cp, optim_cp),
+        }
+        dcp.load(
+            state_dict=sharded_sd,
+            storage_reader=dcp.FileSystemReader(self.temp_dir),
+        )
+        self.assertGreater(len(optim_cp.state_dict()["state"]), 0)
+
+        loss_cp2 = train_step(model_cp, optim_cp, inp)
+        self.assertEqual(loss_no_cp2, loss_cp2)
+
+
+class TestFullyShardHSDPTraining(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return min(4, torch.cuda.device_count())
+
+    @skip_if_lt_x_gpu(2)
+    def test_train_parity_hsdp(self):
+        shard_size = 2 if self.world_size > 2 else 1
+        replicate_size = self.world_size // shard_size
+        global_mesh = init_device_mesh(
+            "cuda", (replicate_size, shard_size), mesh_dim_names=("replicate", "shard")
+        )
+        self.run_subtests(
+            {
+                "reshard_after_forward": [False, True],
+                "use_activation_checkpointing": [False, True],
+                "mlp_dim": [3, 16, 17],
+                "sync_gradients_at_last_batch": [True, False],
+            },
+            functools.partial(self._test_train_parity_hsdp, global_mesh),
+        )
+
+    def _test_train_parity_hsdp(
+        self,
+        global_mesh: DeviceMesh,
+        reshard_after_forward: bool,
+        use_activation_checkpointing: bool,
+        mlp_dim: int,
+        sync_gradients_at_last_batch: bool,
+    ):
+        torch.manual_seed(42)
+        model = nn.Sequential(
+            nn.LayerNorm(mlp_dim, bias=False),
+            MLP(mlp_dim, dim_multiplier=3),
+            MLP(mlp_dim),
+            MLP(mlp_dim, dim_multiplier=3),
+        )
+        ref_model = copy.deepcopy(model).cuda()
+        replicate(ref_model, device_ids=[self.rank])
+        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
+        for mlp in model:
+            if use_activation_checkpointing:
+                checkpoint(mlp)
+            fully_shard(
+                mlp, mesh=global_mesh, reshard_after_forward=reshard_after_forward
+            )
+        fully_shard(
+            model, mesh=global_mesh, reshard_after_forward=reshard_after_forward
+        )
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
+        check_sharded_parity(self, ref_model, model)
+        torch.manual_seed(42 + self.rank + 1)
+        device = torch.device("cuda")
+        num_microbatches = 3
+        for iter_idx in range(5):
+            for microbatch_idx in range(num_microbatches):
+                is_last_microbatch = microbatch_idx == num_microbatches - 1
+                if sync_gradients_at_last_batch:
+                    model.set_requires_gradient_sync(is_last_microbatch)
+                inp = torch.randn((8, mlp_dim), device=device)
+                losses: List[torch.Tensor] = []
+                for _model, _optim in ((ref_model, ref_optim), (model, optim)):
+                    losses.append(_model(inp).sum())
+                    losses[-1].backward()
+                self.assertEqual(losses[0], losses[1])
+            check_sharded_parity(self, ref_model, model)
+            for _model, _optim in ((ref_model, ref_optim), (model, optim)):
+                _optim.step()
+                _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            check_sharded_parity(self, ref_model, model)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
pytorch (fsdp, tp, pp) -> pytorch (composable)
Move (fsdp, tp, pp) tests under pytorch into a composable folder

FSDP:
test/distributed/_composable/fsdp/test_fully_shard_trainin.py
-TestFullyShard2DTraining
-TestFullyShardHSDPTraining
DP:
test/distributed/tensor/parallel/test_ddp_2d_parallel.py
TP:
**test/distributed/tensor/parallel/test_fsdp_2d_parallel.py**
PP:
test/distributed/pipelining/test_composability.py

=>
**distributed/_composable/test_composability/test_2d_composability.py**
distributed/_composable/test_composability/test_pp_composability.py

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129727
* #129726
* #129725
* __->__ #129724

