### PR TITLE
[2/4] 3D Composability - move pp tests

### DIFF
--- a/.ci/pytorch/multigpu-test.sh
+++ b/.ci/pytorch/multigpu-test.sh
@@ -51,11 +51,9 @@ time python test/run_test.py --verbose -i distributed/tensor/parallel/test_tp_ra
 # FSDP2 tests
 time python test/run_test.py --verbose -i distributed/_composable/fsdp/test_fully_shard_training -- -k test_2d_mlp_with_nd_mesh
 
-# Pipelining composability tests
-time python test/run_test.py --verbose -i distributed/pipelining/test_composability.py
-
 # 3D composability tests
 time python test/run_test.py --verbose -i distributed/_composable/test_composability/test_fsdp_tp_dp_composable
+time python test/run_test.py --verbose -i distributed/_composable/test_composability/test_pp_composable
 
 # Other tests
 time python test/run_test.py --verbose -i test_cuda_primary_ctx

--- a/test/distributed/_composable/test_composability/test_pp_composability.py
+++ b/test/distributed/_composable/test_composability/test_pp_composability.py
@@ -1,11 +1,8 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 import copy
 import os
 import sys
 import tempfile
-
-from model_registry import MLPModule
 
 import torch
 import torch.distributed as dist
@@ -34,6 +31,21 @@ from torch.testing._internal.common_utils import (
     parametrize,
     skip_but_pass_in_sandcastle_if,
 )
+
+
+# MLP Layer
+class MLPModule(torch.nn.Module):
+    def __init__(self, d_hid: int):
+        super().__init__()
+        self.net1 = torch.nn.Linear(d_hid, d_hid)
+        self.relu = torch.nn.ReLU()
+        self.net2 = torch.nn.Linear(d_hid, d_hid)
+
+    def forward(self, x):
+        x = self.net1(x)
+        x = self.relu(x)
+        x = self.net2(x)
+        return x
 
 
 class ComposabilityTest(MultiProcContinousTest):
@@ -215,7 +227,6 @@ if __name__ == "__main__":
 
     rank = int(os.getenv("RANK", -1))
     world_size = int(os.getenv("WORLD_SIZE", 4))
-
     if rank != -1:
         # Launched with torchrun or other multi-proc launchers. Directly run the test.
         ComposabilityTest.run_rank(rank, world_size)

--- a/test/distributed/_composable/test_composability/test_pp_composability.py
+++ b/test/distributed/_composable/test_composability/test_pp_composability.py
@@ -227,6 +227,7 @@ if __name__ == "__main__":
 
     rank = int(os.getenv("RANK", -1))
     world_size = int(os.getenv("WORLD_SIZE", 4))
+    
     if rank != -1:
         # Launched with torchrun or other multi-proc launchers. Directly run the test.
         ComposabilityTest.run_rank(rank, world_size)


### PR DESCRIPTION
pytorch (fsdp, tp, pp) -> pytorch (composable)
Move (fsdp, tp, pp) tests under pytorch into a composable folder

FSDP:
test/distributed/_composable/fsdp/test_fully_shard_trainin.py
-TestFullyShard2DTraining
-TestFullyShardHSDPTraining
DP:
test/distributed/tensor/parallel/test_ddp_2d_parallel.py
TP:
test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
**PP:
test/distributed/pipelining/test_composability.py**

=>
distributed/_composable/test_composability/test_fsdp_tp_dp_composability.py
**distributed/_composable/test_composability/test_pp_composability.py**



Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129727
* #129726
* __->__ #129725
* #129724

