### PR TITLE
[CMAKE] Look for `Development.Module` instead of `Development`

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -850,7 +850,7 @@ if(NOT Python_EXECUTABLE)
 endif()
 
 if(BUILD_PYTHON)
-  set(PYTHON_COMPONENTS Development)
+  set(PYTHON_COMPONENTS Development.Module)
   if(USE_NUMPY)
     list(APPEND PYTHON_COMPONENTS NumPy)
   endif()
@@ -870,7 +870,7 @@ endif()
 
 # ---[ Python + Numpy
 if(BUILD_PYTHON)
-  if(Python_Development_FOUND)
+  if(Python_Development.Module_FOUND)
     if(USE_NUMPY)
       if(NOT Python_NumPy_FOUND)
         message(WARNING "NumPy could not be found. Not building with NumPy. Suppress this warning with -DUSE_NUMPY=OFF")


### PR DESCRIPTION
Based on the [cmake issue](https://gitlab.kitware.com/cmake/cmake/-/issues/23716) and [manylinux issue](https://github.com/pypa/manylinux/issues/1347), when building a python module, it should find the `Development.Module` module, not `Development`, which includes `Development.Module` and `Development.Embed`, and will expect the shared python library only. After this PR and before #124613, pytorch could be built with a static libpython (e.g. in manylinux).

Cherry-pick of 953c6476bd75e3fa1d558204bb30ff5fc90ce4f1 into release/2.4