### PR TITLE
[Inductor] Remove bitwise_xor from boolean_ops

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -241,7 +241,6 @@ def boolean_ops():
     return (
         "is_inf",
         "is_nan",
-        "bitwise_xor",
         "logical_not",
         "signbit",
         "le",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129733
* __->__ #129738

**Summary** 
We add `bitwise_xor` into the `ops_to_bool` which means it returns dtype of `bool` in data type propagation. It seems wrong since according to this doc
https://pytorch.org/docs/stable/generated/torch.bitwise_xor.html, it should return the same integral with input and the below testcase failed due to this issue after following PR when we enable the vectorization of `bitwise_xor`.

**Test Plan**
```
python -u -m pytest -s -v test/inductor/test_torchinductor.py -k test_bitwise3
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang