### PR TITLE
Add a CI job to check runner det sync

### DIFF
--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -54,6 +54,7 @@ jobs:
       # Hardcoding below is temporary for testing ALI runners
       # This file below should match the script found in .github/scripts/runner_determinator.py
       - name: Hardcode runner-determinator script
+        id: hardcode-script
         run: |
           cat <<EOF > runner_determinator.py
           import json

--- a/.github/workflows/runner_determinator_script_sync.yaml
+++ b/.github/workflows/runner_determinator_script_sync.yaml
@@ -1,0 +1,42 @@
+name: runner-determinator
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/_runner-determinator.yaml
+      - .github/workflows/_runner_determinator_script_sync.yaml
+      - .github/workflows/scripts/runner_determinator.py
+
+jobs:
+  python-script-sync-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+
+      - name: Extract the script from runner_determinator
+        run: |
+            # Runner determinator files
+            RUNNER_DETERMINATOR_WORKFLOW_FILE=.github/workflows/_runner-determinator.yml
+            RUNNER_DETERMINATOR_PYTHON_SCRIPT_FILE=.github/scripts/runner_determinator.py
+
+            # Parse the job file, extract the script and run it, up to the final EOF,
+            # to generate the python file in the local folder
+            yq '.jobs.runner-determinator.steps[] | select(.id == "hardcode-script") | .run' \
+                "${RUNNER_DETERMINATOR_WORKFLOW_FILE}" | sed '/^EOF$/q' | bash
+
+            set +e
+            DIFF="$(diff "$(basename ${RUNNER_DETERMINATOR_PYTHON_SCRIPT_FILE})" ${RUNNER_DETERMINATOR_PYTHON_SCRIPT_FILE})"
+            IS_DIFF=$?
+            set -e
+            if [ $IS_DIFF -eq 0 ]; then
+                echo "Scripts are in sync! ^_^";
+            else
+                echo -e "Scripts are *NOT* in sync:\n ${DIFF}";
+                exit 1
+            fi


### PR DESCRIPTION
Add a new CI job that runs only when the runner determinator files are modified. The jobs checks that the runner_determinator.py script is in sync with the version embedded in _runner-determinator.yaml.

Fixes TBD
