### PR TITLE
[custom ops] add default value support for device types

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -678,6 +678,26 @@ class TestCustomOp(CustomOpTestCaseBase):
             """(Tensor(a0!) x, Tensor(a1!)[] y, Tensor(a2!)[] z, Tensor(a3!)?[] w) -> ()""",
         )
 
+        def h(
+            x: Tensor,
+            a: Optional[int] = None,
+            b: float = 3.14,
+            c: bool = True,
+            d: int = 3,
+            e: str = "foo",
+            f: torch.dtype = torch.float,
+            g: torch.dtype = torch.float32,
+            h: torch.dtype = torch.int,
+            i: torch.device = torch.device("cpu:0"),
+            j: torch.device = "cpu",
+        ) -> None:
+            pass
+
+        self.assertExpectedInline(
+            infer_schema(h),
+            """(Tensor x, SymInt? a=None, float b=3.14, bool c=True, SymInt d=3, str e="foo", ScalarType f=float32, ScalarType g=float32, ScalarType h=int32, Device i="cpu:0", Device j="cpu") -> ()""",
+        )
+
     def test_infer_schema_unsupported(self):
         with self.assertRaisesRegex(ValueError, "varargs"):
 

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2440,15 +2440,16 @@ class TestCustomOpAPI(TestCase):
             g: torch.dtype = torch.float32,
             h: torch.dtype = torch.int,
             i: torch.device = torch.device("cpu:0"),
+            j: torch.device = "cpu",
         ) -> Tensor:
-            defaults.extend([a, b, c, d, e, f, g, h, i])
+            defaults.extend([a, b, c, d, e, f, g, h, i, j])
             return x.clone()
 
         x = torch.randn(3)
         f(x)
         self.assertEqual(
             defaults,
-            [None, 3.14, True, 3, "foo", torch.float, torch.float32, torch.int, torch.device("cpu:0")],
+            [None, 3.14, True, 3, "foo", torch.float, torch.float32, torch.int, torch.device("cpu:0"), "cpu"],
         )
 
     def test_mutated_error(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2469,13 +2469,44 @@ class TestCustomOpAPI(TestCase):
         f(x)
         self.assertEqual(
             defaults,
-            [None, 3.14, True, 3, "foo", torch.float, torch.float32, torch.int, torch.device("cpu:0"), "cpu"],
+            [
+                None,
+                3.14,
+                True,
+                3,
+                "foo",
+                torch.float,
+                torch.float32,
+                torch.int,
+                torch.device("cpu:0"),
+                "cpu",
+            ],
         )
-        default_values = [arg.default_value for arg in torch.ops._torch_testing.f.default._schema.arguments]
+        default_values = [
+            arg.default_value
+            for arg in torch.ops._torch_testing.f.default._schema.arguments
+        ]
         print(default_values)
+        # enum values taken from c10/core/ScalarType.h
+        type_enum = {
+            "float": 6,
+            "int": 3,
+        }
         self.assertEqual(
             default_values,
-            [None, None, 3.14, True, 3, "foo", float, float, int, torch.device("cpu:0"), torch.device("cpu")],
+            [
+                None,
+                None,
+                3.14,
+                True,
+                3,
+                "foo",
+                type_enum["float"],
+                type_enum["float"],
+                type_enum["int"],
+                torch.device("cpu:0"),
+                torch.device("cpu"),
+            ],
         )
 
     def test_mutated_error(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2439,15 +2439,16 @@ class TestCustomOpAPI(TestCase):
             f: torch.dtype = torch.float,
             g: torch.dtype = torch.float32,
             h: torch.dtype = torch.int,
+            i: torch.device = torch.device("cpu:0"),
         ) -> Tensor:
-            defaults.extend([a, b, c, d, e, f, g, h])
+            defaults.extend([a, b, c, d, e, f, g, h, i])
             return x.clone()
 
         x = torch.randn(3)
         f(x)
         self.assertEqual(
             defaults,
-            [None, 3.14, True, 3, "foo", torch.float, torch.float32, torch.int],
+            [None, 3.14, True, 3, "foo", torch.float, torch.float32, torch.int, torch.device("cpu:0")],
         )
 
     def test_mutated_error(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2486,7 +2486,6 @@ class TestCustomOpAPI(TestCase):
             arg.default_value
             for arg in torch.ops._torch_testing.f.default._schema.arguments
         ]
-        print(default_values)
         # enum values taken from c10/core/ScalarType.h
         type_enum = {
             "float": 6,

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -695,8 +695,10 @@ class TestCustomOp(CustomOpTestCaseBase):
 
         self.assertExpectedInline(
             infer_schema(h),
-            ("""(Tensor x, SymInt? a=None, float b=3.14, bool c=True, SymInt d=3, str e="foo", """
-             """ScalarType f=float32, ScalarType g=float32, ScalarType h=int32, Device i="cpu:0", Device j="cpu") -> ()"""),
+            (
+                """(Tensor x, SymInt? a=None, float b=3.14, bool c=True, SymInt d=3, str e="foo", """
+                """ScalarType f=float32, ScalarType g=float32, ScalarType h=int32, Device i="cpu:0", Device j="cpu") -> ()"""
+            ),
         )
 
     def test_infer_schema_unsupported(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2471,6 +2471,12 @@ class TestCustomOpAPI(TestCase):
             defaults,
             [None, 3.14, True, 3, "foo", torch.float, torch.float32, torch.int, torch.device("cpu:0"), "cpu"],
         )
+        default_values = [arg.default_value for arg in torch.ops._torch_testing.f.default._schema.arguments]
+        print(default_values)
+        self.assertEqual(
+            default_values,
+            [None, None, 3.14, True, 3, "foo", float, float, int, torch.device("cpu:0"), torch.device("cpu")],
+        )
 
     def test_mutated_error(self):
         with self.assertRaisesRegex(

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -695,7 +695,8 @@ class TestCustomOp(CustomOpTestCaseBase):
 
         self.assertExpectedInline(
             infer_schema(h),
-            """(Tensor x, SymInt? a=None, float b=3.14, bool c=True, SymInt d=3, str e="foo", ScalarType f=float32, ScalarType g=float32, ScalarType h=int32, Device i="cpu:0", Device j="cpu") -> ()""",
+            ("""(Tensor x, SymInt? a=None, float b=3.14, bool c=True, SymInt d=3, str e="foo", """
+             """ScalarType f=float32, ScalarType g=float32, ScalarType h=int32, Device i="cpu:0", Device j="cpu") -> ()"""),
         )
 
     def test_infer_schema_unsupported(self):

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -100,7 +100,7 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
             default_repr = None
             if param.default is None or isinstance(param.default, (int, float, bool)):
                 default_repr = str(param.default)
-            elif isinstance(param.default, str):
+            elif isinstance(param.default, str) or isinstance(param.default, torch.device):
                 default_repr = f'"{param.default}"'
             elif isinstance(param.default, torch.dtype):
                 dtype_repr = str(param.default)

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -100,7 +100,7 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
             default_repr = None
             if param.default is None or isinstance(param.default, (int, float, bool)):
                 default_repr = str(param.default)
-            elif isinstance(param.default, str) or isinstance(param.default, torch.device):
+            elif isinstance(param.default, (str, torch.device)):
                 default_repr = f'"{param.default}"'
             elif isinstance(param.default, torch.dtype):
                 dtype_repr = str(param.default)


### PR DESCRIPTION
Fixes #129371

I think the first case in Issue #129371 is already supported in the current code? Since it takes care of string default values. This PR adds support for device type default values. 
