### PR TITLE
[cuDNN][functorch] Bump tolerances for `nn.functional.conv2d` in `test_vmap_autograd_grad`

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2387,6 +2387,11 @@ class TestOperators(TestCase):
                 "linalg.pinv", "hermitian", {torch.float32: tol(atol=5e-06, rtol=5e-06)}
             ),
             tol1("nn.functional.conv3d", {torch.float32: tol(atol=5e-04, rtol=9e-03)}),
+            tol1(
+                "nn.functional.conv2d",
+                {torch.float32: tol(atol=3e-05, rtol=5e-06)},
+                device_type="cuda",
+            ),
             tol1("svd_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),
             tol1("pca_lowrank", {torch.float32: tol(atol=5e-05, rtol=5e-05)}),
         ),


### PR DESCRIPTION
Newer versions of cuDNN can dispatch to a winograd kernel here on A100 which affects numerics a bit

cc @csarofeen @ptrblck @xwang233 @zou3519 @Chillee @samdow @kshitij12345 @janeyx99