### PR TITLE
Revert "[LLVM/TensorExpr] Update for an API change in LLVM 18."

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -2754,11 +2754,7 @@ void LLVMCodeGenImpl::optimize(llvm::Module& M) {
   // options.
   llvm::PassBuilder PB(&TM);
 
-#if LLVM_VERSION_MAJOR >= 18
-  TM.registerPassBuilderCallbacks(PB, false /* PopulateClassToPassNames */);
-#else
   TM.registerPassBuilderCallbacks(PB);
-#endif
 
   // Register all the basic analyses with the managers.
   PB.registerModuleAnalyses(MAM);


### PR DESCRIPTION
This reverts commit 20f394f10a389bcf13485929be8862f98ad4b322 (https://github.com/pytorch/pytorch/pull/117086) 

LLVM upstream changed the pass builder API again, so registerPassBuilderCallbacks no longer takes extra boolean for PopulateClassToPassNames. Update accordingly.

Relevant LLVM upstream change:
https://github.com/llvm/llvm-project/pull/96321
https://github.com/llvm/llvm-project/pull/96462




cc @EikanWang @jgong5