### PR TITLE
UFMT for test/test_masked.py  test/test_maskedtensor.py

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1080,8 +1080,6 @@ exclude_patterns = [
     'test/test_jiterator.py',
     'test/test_kernel_launch_checks.py',
     'test/test_linalg.py',
-    'test/test_masked.py',
-    'test/test_maskedtensor.py',
     'test/test_matmul_cuda.py',
     'test/test_meta.py',
     'test/test_metal.py',

--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -4,19 +4,26 @@
 """
 
 import itertools
-import torch
-from typing import List, Any
-from functools import wraps
 import unittest
-from torch.testing._internal.common_utils import skipIfTorchDynamo
+from functools import wraps
+from typing import Any, List
 
-
-from torch.testing._internal.common_utils import \
-    (TestCase, parametrize, suppress_warnings, _TestParametrizer, run_tests)
-from torch.testing._internal.common_methods_invocations import \
-    (op_db, SampleInput)
-from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, ops, onlyNativeDeviceTypes, precisionOverride)
+import torch
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyNativeDeviceTypes,
+    ops,
+    precisionOverride,
+)
+from torch.testing._internal.common_methods_invocations import op_db, SampleInput
+from torch.testing._internal.common_utils import (
+    _TestParametrizer,
+    parametrize,
+    run_tests,
+    skipIfTorchDynamo,
+    suppress_warnings,
+    TestCase,
+)
 
 
 def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
@@ -74,27 +81,27 @@ def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
       of masked operations.
     """
     # eliminate mask and dim_position keyword arguments:
-    mask = kwargs.pop('mask', None)
-    dim_pos = kwargs.pop('dim_position', 0)
+    mask = kwargs.pop("mask", None)
+    dim_pos = kwargs.pop("dim_position", 0)
 
-    dtype = kwargs.get('dtype', input.dtype)
+    dtype = kwargs.get("dtype", input.dtype)
     if input.ndim == 0:
         # scalar input is an elementary slice
         return op(input, *args, **kwargs).to(dtype=dtype)
 
     # eliminate keepdim keyword argument if specified:
-    keepdim = kwargs.pop('keepdim', False)
+    keepdim = kwargs.pop("keepdim", False)
 
     # eliminate dim argument that may appear both as args or kwargs
     # element:
     if dim_pos < len(args):
         # dim is specified in args
-        assert 'dim' not in kwargs, (args, kwargs)
+        assert "dim" not in kwargs, (args, kwargs)
         dim = args[dim_pos]
-        args0 = args[:dim_pos] + (None,) + args[dim_pos + 1:]
+        args0 = args[:dim_pos] + (None,) + args[dim_pos + 1 :]
     else:
         # dim may be specified in kwargs
-        dim = kwargs.pop('dim', None)
+        dim = kwargs.pop("dim", None)
         args0 = args
 
     # dimensions along which the reduction operation is applied:
@@ -112,7 +119,9 @@ def apply_masked_reduction_along_dim(op, input, *args, **kwargs):
             shape.append(input.shape[i])
 
     # keepdim=True version of the output, filled with nan or 0:
-    output = input.new_full(shape, float('nan') if dtype.is_floating_point else 0, dtype=dtype)
+    output = input.new_full(
+        shape, float("nan") if dtype.is_floating_point else 0, dtype=dtype
+    )
 
     # apply op to all elementary slices:
     if mask is None:
@@ -139,13 +148,13 @@ def apply_masked_normalization_along_dim(op, input, *args, **kwargs):
     """Applies normalization op along given dimension to strided x
     elements that are valid according to mask tensor.
     """
-    mask = kwargs.pop('mask', None)
-    dim_pos = kwargs.pop('dim_position', 0)
+    mask = kwargs.pop("mask", None)
+    dim_pos = kwargs.pop("dim_position", 0)
     if input.ndim == 0:  # scalar input
         return op(input, *args, **kwargs)
-    dtype = kwargs.get('dtype', input.dtype)
+    dtype = kwargs.get("dtype", input.dtype)
     dim = args[dim_pos]
-    args0 = args[:dim_pos] + (0,) + args[dim_pos + 1:]
+    args0 = args[:dim_pos] + (0,) + args[dim_pos + 1 :]
     output = torch.zeros_like(input, dtype=dtype)
     if mask is None:
         inpmask = input.new_ones([], dtype=torch.bool).expand(input.shape)
@@ -153,7 +162,7 @@ def apply_masked_normalization_along_dim(op, input, *args, **kwargs):
         inpmask = torch.masked._input_mask(input, mask=mask)
     dim_ = dim % input.ndim
     left_ranges = tuple(map(range, input.shape[:dim_]))
-    right_ranges = tuple(map(range, input.shape[dim_ + 1:]))
+    right_ranges = tuple(map(range, input.shape[dim_ + 1 :]))
     for s in itertools.product(*(left_ranges + ((slice(None),),) + right_ranges)):
         indices = inpmask[s].argwhere()
         output[s][indices] = op(input[s][indices], *args0, **kwargs)
@@ -161,19 +170,36 @@ def apply_masked_normalization_along_dim(op, input, *args, **kwargs):
 
 
 reference_functions = dict(
-    norm=lambda *args, **kwargs: apply_masked_reduction_along_dim(torch.linalg.vector_norm, *args, **dict(kwargs, dim_position=1)),
-    var=lambda *args, **kwargs: apply_masked_reduction_along_dim(torch.var, *args, **dict(kwargs, dim_position=0)),
-    std=lambda *args, **kwargs: apply_masked_reduction_along_dim(torch.std, *args, **dict(kwargs, dim_position=0)),
-    softmax=lambda *args, **kwargs: apply_masked_normalization_along_dim(torch.softmax, *args, **kwargs),
-    log_softmax=lambda *args, **kwargs: apply_masked_normalization_along_dim(torch.log_softmax, *args, **kwargs),
-    softmin=lambda *args, **kwargs: apply_masked_normalization_along_dim(torch.nn.functional.softmin, *args, **kwargs),
+    norm=lambda *args, **kwargs: apply_masked_reduction_along_dim(
+        torch.linalg.vector_norm, *args, **dict(kwargs, dim_position=1)
+    ),
+    var=lambda *args, **kwargs: apply_masked_reduction_along_dim(
+        torch.var, *args, **dict(kwargs, dim_position=0)
+    ),
+    std=lambda *args, **kwargs: apply_masked_reduction_along_dim(
+        torch.std, *args, **dict(kwargs, dim_position=0)
+    ),
+    softmax=lambda *args, **kwargs: apply_masked_normalization_along_dim(
+        torch.softmax, *args, **kwargs
+    ),
+    log_softmax=lambda *args, **kwargs: apply_masked_normalization_along_dim(
+        torch.log_softmax, *args, **kwargs
+    ),
+    softmin=lambda *args, **kwargs: apply_masked_normalization_along_dim(
+        torch.nn.functional.softmin, *args, **kwargs
+    ),
     normalize=lambda *args, **kwargs: apply_masked_normalization_along_dim(
-        torch.nn.functional.normalize, *args, **dict(kwargs, dim_position=1)),
+        torch.nn.functional.normalize, *args, **dict(kwargs, dim_position=1)
+    ),
 )
 
-masked_ops = [op for op in op_db if op.name.startswith('masked.')]
-masked_ops_with_references = [op for op in masked_ops if op.name.rsplit('.', 1)[-1] in reference_functions]
-masked_ops_with_non_strided_support = [op for op in masked_ops if op.supports_sparse or op.supports_sparse_csr]
+masked_ops = [op for op in op_db if op.name.startswith("masked.")]
+masked_ops_with_references = [
+    op for op in masked_ops if op.name.rsplit(".", 1)[-1] in reference_functions
+]
+masked_ops_with_non_strided_support = [
+    op for op in masked_ops if op.supports_sparse or op.supports_sparse_csr
+]
 
 
 def _tensor_to_strided(obj):
@@ -187,20 +213,17 @@ def _tensor_to_strided(obj):
 
 
 def to_strided(obj):
-    """Convert the tensor content of object to strided tensor content.
-    """
+    """Convert the tensor content of object to strided tensor content."""
     return torch.utils._pytree.tree_map(_tensor_to_strided, obj)
 
 
 def to_sparse_coo(obj):
-    """Convert the tensor content of object to sparse coo tensor content.
-    """
+    """Convert the tensor content of object to sparse coo tensor content."""
     return torch.utils._pytree.tree_map(torch.Tensor.to_sparse, obj)
 
 
 def to_sparse_csr(obj):
-    """Convert the tensor content of object to sparse csr tensor content.
-    """
+    """Convert the tensor content of object to sparse csr tensor content."""
     return torch.utils._pytree.tree_map(torch.Tensor.to_sparse_csr, obj)
 
 
@@ -210,28 +233,32 @@ class mask_layouts(_TestParametrizer):
     The sample_inputs generator provides samples with all supported
     layouts for the mask argument.
     """
-    def _parametrize_test(self, test, generic_cls, device_cls):
 
+    def _parametrize_test(self, test, generic_cls, device_cls):
         @wraps(test)
         def wrap(self, layout, device, dtype, op):
-            layout_name = str(layout).lstrip('torch.')
+            layout_name = str(layout).lstrip("torch.")
             if layout == torch.strided:
                 # strided layouts are always supported
                 sample_inputs_func = op.sample_inputs
             elif layout == torch.sparse_coo:
                 if not op.supports_sparse:
-                    raise unittest.SkipTest(f"{op.name} does not support inputs with {layout_name} layout")
+                    raise unittest.SkipTest(
+                        f"{op.name} does not support inputs with {layout_name} layout"
+                    )
                 sample_inputs_func = op.sample_inputs_sparse_coo
             elif layout == torch.sparse_csr:
                 if not op.supports_sparse_csr:
-                    raise unittest.SkipTest(f"{op.name} does not support inputs with {layout_name} layout")
+                    raise unittest.SkipTest(
+                        f"{op.name} does not support inputs with {layout_name} layout"
+                    )
                 sample_inputs_func = op.sample_inputs_sparse_csr
             else:
-                raise NotImplementedError(f'{layout}')
+                raise NotImplementedError(f"{layout}")
 
             def sample_inputs_generator():
                 for sample_input in sample_inputs_func(device, dtype):
-                    mask = sample_input.kwargs.get('mask')
+                    mask = sample_input.kwargs.get("mask")
                     if mask is None:
                         yield sample_input
                     else:
@@ -240,30 +267,39 @@ class mask_layouts(_TestParametrizer):
                         if layout != torch.strided:
                             sample_input_kwargs = sample_input.kwargs.copy()
                             sample_input_kwargs.update(mask=mask.to_dense())
-                            yield SampleInput(sample_input.input.clone(),
-                                              args=sample_input.args,
-                                              kwargs=sample_input_kwargs)
+                            yield SampleInput(
+                                sample_input.input.clone(),
+                                args=sample_input.args,
+                                kwargs=sample_input_kwargs,
+                            )
                         if layout != torch.sparse_coo and op.supports_sparse:
                             sample_input_kwargs = sample_input.kwargs.copy()
                             sample_input_kwargs.update(mask=mask.to_sparse())
-                            yield SampleInput(sample_input.input.clone(),
-                                              args=sample_input.args,
-                                              kwargs=sample_input_kwargs)
-                        if layout != torch.sparse_csr and op.supports_sparse_csr and sample_input.input.ndim == 2:
+                            yield SampleInput(
+                                sample_input.input.clone(),
+                                args=sample_input.args,
+                                kwargs=sample_input_kwargs,
+                            )
+                        if (
+                            layout != torch.sparse_csr
+                            and op.supports_sparse_csr
+                            and sample_input.input.ndim == 2
+                        ):
                             sample_input_kwargs = sample_input.kwargs.copy()
                             sample_input_kwargs.update(mask=mask.to_sparse_csr())
-                            yield SampleInput(sample_input.input.clone(),
-                                              args=sample_input.args,
-                                              kwargs=sample_input_kwargs)
+                            yield SampleInput(
+                                sample_input.input.clone(),
+                                args=sample_input.args,
+                                kwargs=sample_input_kwargs,
+                            )
 
             test(self, layout, device, dtype, op, sample_inputs_generator())
 
         for layout in (torch.strided, torch.sparse_coo, torch.sparse_csr):
-            yield (wrap, str(layout).lstrip('torch.'), {'layout': layout}, lambda _: [])
+            yield (wrap, str(layout).lstrip("torch."), {"layout": layout}, lambda _: [])
 
 
 class TestMasked(TestCase):
-
     def assertEqualMasked(self, actual, expected, mask):
         strided = to_strided(actual)
         if mask is not None:
@@ -276,17 +312,23 @@ class TestMasked(TestCase):
     @ops(masked_ops_with_references)
     @precisionOverride({torch.bfloat16: 5e-4, torch.float16: 5e-4})
     def test_reference_masked(self, device, dtype, op):
-        op_name = op.name.rsplit('.', 1)[-1]
+        op_name = op.name.rsplit(".", 1)[-1]
         ref_op = reference_functions[op_name]
         sample_inputs = op.sample_inputs(device, dtype)
         for sample_input in sample_inputs:
-            t_inp, t_args, t_kwargs = sample_input.input, sample_input.args, sample_input.kwargs
-            if op_name in {'var', 'std'} and not (t_inp.dtype.is_floating_point or t_inp.dtype.is_complex):
+            t_inp, t_args, t_kwargs = (
+                sample_input.input,
+                sample_input.args,
+                sample_input.kwargs,
+            )
+            if op_name in {"var", "std"} and not (
+                t_inp.dtype.is_floating_point or t_inp.dtype.is_complex
+            ):
                 # torch.var/torch.std does not support integer inputs
                 continue
             actual = op.op(t_inp, *t_args, **t_kwargs)
             expected = ref_op(t_inp, *t_args, **t_kwargs)
-            if t_kwargs.get('mask') is None:
+            if t_kwargs.get("mask") is None:
                 outmask = None
             else:
                 outmask = torch.masked._output_mask(op.op, t_inp, *t_args, **t_kwargs)
@@ -308,7 +350,7 @@ class TestMasked(TestCase):
             #  op(inp, mask).to_dense() == op(inp.to_dense(), mask.to_dense()) at outmask
             #
             r_inp, r_args, r_kwargs = to_strided((t_inp, t_args, t_kwargs))
-            if r_kwargs.get('mask') is None:
+            if r_kwargs.get("mask") is None:
                 outmask = None
             else:
                 outmask = torch.masked._output_mask(op.op, r_inp, *r_args, **r_kwargs)
@@ -316,14 +358,21 @@ class TestMasked(TestCase):
             self.assertEqualMasked(actual, expected, outmask)
 
     @skipIfTorchDynamo("https://github.com/pytorch/torchdynamo/issues/1992")
-    @parametrize("sparse_kind,fill_value", [('coo', 0), ('hybrid_coo', 0),
-                                            ('coo', 123), ('hybrid_coo', 123),
-                                            ('csr', 0), ('csr', 123)],
-                 name_fn=lambda sparse_kind, fill_value: f'{sparse_kind}_fill_value_{fill_value}')
+    @parametrize(
+        "sparse_kind,fill_value",
+        [
+            ("coo", 0),
+            ("hybrid_coo", 0),
+            ("coo", 123),
+            ("hybrid_coo", 123),
+            ("csr", 0),
+            ("csr", 123),
+        ],
+        name_fn=lambda sparse_kind, fill_value: f"{sparse_kind}_fill_value_{fill_value}",
+    )
     def test_where(self, sparse_kind, fill_value):
-
         is_hybrid = False
-        if sparse_kind == 'coo':
+        if sparse_kind == "coo":
 
             def to_sparse(dense):
                 return dense.to_sparse(2)
@@ -331,7 +380,7 @@ class TestMasked(TestCase):
             def set_values(sparse, index, value):
                 sparse._values()[index] = value
 
-        elif sparse_kind == 'hybrid_coo':
+        elif sparse_kind == "hybrid_coo":
             is_hybrid = True
 
             def to_sparse(dense):
@@ -340,7 +389,7 @@ class TestMasked(TestCase):
             def set_values(sparse, index, value):
                 sparse._values()[index] = value
 
-        elif sparse_kind == 'csr':
+        elif sparse_kind == "csr":
 
             def to_sparse(dense):
                 return dense.to_sparse_csr()
@@ -351,12 +400,16 @@ class TestMasked(TestCase):
         else:
             assert 0, sparse_kind
 
-        mask = torch.tensor([[1, 0, 1, 0, 0],
-                             [1, 1, 1, 1, 0],
-                             [0, 1, 0, 1, 0],
-                             [0, 0, 0, 0, 0],
-                             [0, 0, 1, 1, 0],
-                             [1, 1, 0, 0, 0]]).to(dtype=bool)
+        mask = torch.tensor(
+            [
+                [1, 0, 1, 0, 0],
+                [1, 1, 1, 1, 0],
+                [0, 1, 0, 1, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 0],
+                [1, 1, 0, 0, 0],
+            ]
+        ).to(dtype=bool)
         mask = to_sparse(mask)
         # make some specified mask elements as explicit masked-out masks:
         if is_hybrid:
@@ -366,12 +419,16 @@ class TestMasked(TestCase):
             set_values(mask, 3, False)
             set_values(mask, -3, False)
 
-        input = torch.tensor([[1, 0, 0, 0, -1],
-                              [2, 3, 0, 0, -2],
-                              [0, 4, 5, 0, -3],
-                              [0, 0, 6, 7, 0],
-                              [0, 8, 9, 0, -3],
-                              [10, 11, 0, 0, -5]])
+        input = torch.tensor(
+            [
+                [1, 0, 0, 0, -1],
+                [2, 3, 0, 0, -2],
+                [0, 4, 5, 0, -3],
+                [0, 0, 6, 7, 0],
+                [0, 8, 9, 0, -3],
+                [10, 11, 0, 0, -5],
+            ]
+        )
         input = to_sparse(input)
         # make specified input elements have zero values:
         if is_hybrid:
@@ -387,35 +444,52 @@ class TestMasked(TestCase):
         Z = 99
         # Z value corresponds to masked-in elements that are not
         # specified in the input and it will be replaced with a zero
-        tmp = torch.tensor([[1, F, Z, F, F],
-                            [2, F, Z, Z, F],
-                            [F, 4, F, Z, F],
-                            [0, 0, 0, 0, 0],
-                            [F, F, 9, F, F],
-                            [Z, 11, F, F, F]])
+        tmp = torch.tensor(
+            [
+                [1, F, Z, F, F],
+                [2, F, Z, Z, F],
+                [F, 4, F, Z, F],
+                [0, 0, 0, 0, 0],
+                [F, F, 9, F, F],
+                [Z, 11, F, F, F],
+            ]
+        )
         tmp = to_sparse(tmp)
 
-
-        sparse = torch.masked._where(mask, input,
-                                     torch.tensor(fill_value, dtype=input.dtype, device=input.device))
+        sparse = torch.masked._where(
+            mask,
+            input,
+            torch.tensor(fill_value, dtype=input.dtype, device=input.device),
+        )
 
         if tmp.layout == torch.sparse_coo:
             expected_sparse = torch.sparse_coo_tensor(
                 tmp.indices(),
-                torch.where(tmp.values() != Z, tmp.values(), tmp.values().new_full([], 0)),
-                input.shape)
-            outmask = torch.sparse_coo_tensor(sparse.indices(),
-                                              sparse.values().new_full(sparse.values().shape, 1).to(dtype=bool),
-                                              sparse.shape)._coalesced_(True)
+                torch.where(
+                    tmp.values() != Z, tmp.values(), tmp.values().new_full([], 0)
+                ),
+                input.shape,
+            )
+            outmask = torch.sparse_coo_tensor(
+                sparse.indices(),
+                sparse.values().new_full(sparse.values().shape, 1).to(dtype=bool),
+                sparse.shape,
+            )._coalesced_(True)
         elif tmp.layout == torch.sparse_csr:
             expected_sparse = torch.sparse_csr_tensor(
                 tmp.crow_indices(),
                 tmp.col_indices(),
-                torch.where(tmp.values() != Z, tmp.values(), tmp.values().new_full([], 0)),
-                input.shape)
-            outmask = torch.sparse_csr_tensor(sparse.crow_indices(), sparse.col_indices(),
-                                              sparse.values().new_full(sparse.values().shape, 1).to(dtype=bool),
-                                              sparse.shape)
+                torch.where(
+                    tmp.values() != Z, tmp.values(), tmp.values().new_full([], 0)
+                ),
+                input.shape,
+            )
+            outmask = torch.sparse_csr_tensor(
+                sparse.crow_indices(),
+                sparse.col_indices(),
+                sparse.values().new_full(sparse.values().shape, 1).to(dtype=bool),
+                sparse.shape,
+            )
         else:
             assert 0
 
@@ -424,12 +498,16 @@ class TestMasked(TestCase):
         # check invariance:
         #  torch.where(mask.to_dense(), input.to_dense(), fill_value)
         #    == where(mask, input, fill_value).to_dense(fill_value)
-        expected = torch.where(mask.to_dense(), input.to_dense(), torch.full(input.shape, F))
-        dense = torch.where(outmask.to_dense(), sparse.to_dense(), torch.full(sparse.shape, F))
+        expected = torch.where(
+            mask.to_dense(), input.to_dense(), torch.full(input.shape, F)
+        )
+        dense = torch.where(
+            outmask.to_dense(), sparse.to_dense(), torch.full(sparse.shape, F)
+        )
         self.assertEqual(dense, expected)
 
 
-instantiate_device_type_tests(TestMasked, globals(), except_for='meta')
+instantiate_device_type_tests(TestMasked, globals(), except_for="meta")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -1,31 +1,40 @@
 # Owner(s): ["module: masked operators"]
 
-import torch
+
 import unittest
-from torch.testing._internal.common_utils import (
-    decorateIf,
-    TestCase,
-    run_tests,
-    make_tensor,
-    parametrize,
-    instantiate_parametrized_tests,
+
+import torch
+from torch.masked import _combine_input_and_mask, as_masked_tensor, masked_tensor
+from torch.masked.maskedtensor.binary import (
+    BINARY_NAMES,
+    NATIVE_BINARY_FNS,
+    NATIVE_INPLACE_BINARY_FNS,
+)
+from torch.masked.maskedtensor.core import _masks_match, _tensors_match
+from torch.masked.maskedtensor.reductions import REDUCE_NAMES
+from torch.masked.maskedtensor.unary import (
+    NATIVE_INPLACE_UNARY_FNS,
+    NATIVE_UNARY_FNS,
+    UNARY_NAMES,
 )
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     ops,
 )
 from torch.testing._internal.common_methods_invocations import (
-    SampleInput,
     binary_ufuncs,
     reduction_ops,
+    SampleInput,
     unary_ufuncs,
 )
-
-from torch.masked import as_masked_tensor, masked_tensor, _combine_input_and_mask
-from torch.masked.maskedtensor.core import _masks_match, _tensors_match
-from torch.masked.maskedtensor.unary import NATIVE_INPLACE_UNARY_FNS, NATIVE_UNARY_FNS, UNARY_NAMES
-from torch.masked.maskedtensor.binary import NATIVE_BINARY_FNS, NATIVE_INPLACE_BINARY_FNS, BINARY_NAMES
-from torch.masked.maskedtensor.reductions import REDUCE_NAMES
+from torch.testing._internal.common_utils import (
+    decorateIf,
+    instantiate_parametrized_tests,
+    make_tensor,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
 
 def _compare_mt_t(mt_result, t_result, rtol=1e-05, atol=1e-05):
@@ -40,20 +49,25 @@ def _compare_mt_t(mt_result, t_result, rtol=1e-05, atol=1e-05):
     if not _tensors_match(a, b, exact=False, rtol=rtol, atol=atol):
         raise ValueError("The data in MaskedTensor a and Tensor b do not match")
 
+
 def _compare_mts(mt1, mt2, rtol=1e-05, atol=1e-08):
     mt_data1 = mt1.get_data()
     mt_data2 = mt2.get_data()
     if mt_data1.layout != mt_data2.layout:
-        raise ValueError("mt1's data and mt2's data do not have the same layout. "
-                         f"mt1.get_data().layout = {mt_data1.layout} while mt2.get_data().layout = {mt_data2.layout}")
+        raise ValueError(
+            "mt1's data and mt2's data do not have the same layout. "
+            f"mt1.get_data().layout = {mt_data1.layout} while mt2.get_data().layout = {mt_data2.layout}"
+        )
 
     mask = mt1.get_mask()
     mask2 = mt2.get_mask()
     if not _masks_match(mt1, mt2):
         raise ValueError("mt1 and mt2 must have matching masks")
     if mask.layout != mask2.layout:
-        raise ValueError("mt1's mask and mt2's mask do not have the same layout. "
-                         f"mt1.get_mask().layout = {mask.layout} while mt2.get_mask().layout = {mask2.layout}")
+        raise ValueError(
+            "mt1's mask and mt2's mask do not have the same layout. "
+            f"mt1.get_mask().layout = {mask.layout} while mt2.get_mask().layout = {mask2.layout}"
+        )
     if mask.layout in {torch.sparse_coo, torch.sparse_csr}:
         mask = mask.to_dense()
 
@@ -64,11 +78,14 @@ def _compare_mts(mt1, mt2, rtol=1e-05, atol=1e-08):
     b = mt_data2.detach().masked_fill_(~mask, 0)
 
     if not _tensors_match(a, b, exact=False, rtol=rtol, atol=atol):
-        raise ValueError("The data in MaskedTensor mt1 and MaskedTensor mt2 do not match")
+        raise ValueError(
+            "The data in MaskedTensor mt1 and MaskedTensor mt2 do not match"
+        )
 
 
 def _create_random_mask(shape, device):
     return make_tensor(shape, device=device, dtype=torch.bool)
+
 
 def _generate_sample_data(
     device="cpu", dtype=torch.float, requires_grad=True, layout=torch.strided
@@ -99,6 +116,7 @@ def _generate_sample_data(
         inputs.append(SampleInput(data, kwargs={"mask": mask}))
     return inputs
 
+
 def _fix_fn_name(fn_name):
     if fn_name[-1] == "_":
         fn_name = fn_name[:-1]
@@ -123,19 +141,25 @@ class TestBasics(TestCase):
     def test_diff_layouts(self, device):
         data = torch.randn((3, 4), device=device).to_sparse_coo()
         mask = _create_random_mask((3, 4), device=device)
-        with self.assertRaisesRegex(TypeError, "data and mask must have the same layout"):
+        with self.assertRaisesRegex(
+            TypeError, "data and mask must have the same layout"
+        ):
             masked_tensor(data, mask)
 
     def test_diff_dim(self, device):
         data = torch.randn((3, 4, 5), device=device)
         mask = _create_random_mask((3, 4), device=device)
-        with self.assertRaisesRegex(ValueError, "data.dim\\(\\) must equal mask.dim\\(\\)"):
+        with self.assertRaisesRegex(
+            ValueError, "data.dim\\(\\) must equal mask.dim\\(\\)"
+        ):
             masked_tensor(data, mask)
 
     def test_diff_sizes(self, device):
         data = torch.randn((3, 4), device=device)
         mask = _create_random_mask((3, 3), device=device)
-        with self.assertRaisesRegex(ValueError, "data.size\\(\\) must equal mask.size\\(\\)"):
+        with self.assertRaisesRegex(
+            ValueError, "data.size\\(\\) must equal mask.size\\(\\)"
+        ):
             masked_tensor(data, mask)
 
     def test_grad_warning(self, device):
@@ -152,7 +176,9 @@ class TestBasics(TestCase):
         m1 = masked_tensor(data, ~mask)
         with self.assertRaisesRegex(ValueError, "Input masks must match."):
             m0 + m1
-        _compare_mts(m0 + m0, masked_tensor(torch.tensor([0., 2, 0, 6, 0], device=device), mask))
+        _compare_mts(
+            m0 + m0, masked_tensor(torch.tensor([0.0, 2, 0, 6, 0], device=device), mask)
+        )
 
     def test_softmax(self, device):
         data = torch.randn((3, 4), device=device) * 0.1
@@ -162,7 +188,7 @@ class TestBasics(TestCase):
                 [False, True, False, True],
                 [True, True, False, False],
             ],
-            device=device
+            device=device,
         )
         mt = masked_tensor(data, mask, requires_grad=True)
         masked_res = torch.softmax(mt, -1)
@@ -175,7 +201,9 @@ class TestBasics(TestCase):
         _compare_mt_t(mt.grad, xinf.grad, atol=1e-06)
 
     def test_where(self, device):
-        data = torch.tensor([-10.0, -5, 0, 5, 10, 50, 60, 70, 80, 90, 100], device=device)
+        data = torch.tensor(
+            [-10.0, -5, 0, 5, 10, 50, 60, 70, 80, 90, 100], device=device
+        )
         mask = data < 0
 
         mx = masked_tensor(data, mask, requires_grad=True)
@@ -207,8 +235,7 @@ class TestBasics(TestCase):
 
     def test_to_dense(self, device):
         samples = _generate_sample_data(
-            device=device,
-            layout=torch.sparse_coo
+            device=device, layout=torch.sparse_coo
         ) + _generate_sample_data(device=device, layout=torch.sparse_csr)
         for sample in samples:
             data = sample.input
@@ -264,7 +291,9 @@ class TestBasics(TestCase):
     def test_invalid_sparse_layout(self, device):
         data = torch.randn((3, 4), device=device).to_sparse_csc()
         mask = _create_random_mask((3, 4), device=device).to_sparse_csc()
-        with self.assertRaisesRegex(TypeError, "data layout of torch.sparse_csc is not supported"):
+        with self.assertRaisesRegex(
+            TypeError, "data layout of torch.sparse_csc is not supported"
+        ):
             masked_tensor(data, mask)
 
     def test_invalid_sparse_coo_values(self, device):
@@ -273,7 +302,9 @@ class TestBasics(TestCase):
         i2 = torch.tensor([[0, 1, 1], [2, 1, 2]])
 
         t = torch.sparse_coo_tensor(i1, v, (2, 4), device=device)
-        mask = torch.sparse_coo_tensor(i2, torch.tensor([True, True, True]), (2, 4), device=device)
+        mask = torch.sparse_coo_tensor(
+            i2, torch.tensor([True, True, True]), (2, 4), device=device
+        )
 
         msg = "data and mask are both sparse COO tensors but do not have the same indices."
         with self.assertRaisesRegex(ValueError, msg):
@@ -292,7 +323,7 @@ class TestBasics(TestCase):
             torch.tensor(crow_indices1, dtype=torch.int64),
             torch.tensor(col_indices1, dtype=torch.int64),
             torch.tensor(values),
-            size=(2, 4)
+            size=(2, 4),
         )
         mask1 = torch.sparse_csr_tensor(
             torch.tensor(crow_indices2, dtype=torch.int64),
@@ -360,6 +391,7 @@ class TestBasics(TestCase):
         self.assertEqual(now_contiguous_mt.get_data().is_contiguous(), True)
         self.assertEqual(now_contiguous_mt.is_contiguous(), True)
 
+
 class TestUnary(TestCase):
     def _get_test_data(self, fn_name):
         data = torch.randn(10, 10)
@@ -423,6 +455,7 @@ class TestUnary(TestCase):
         t_result = fn(*t_args, **kwargs)
         _compare_mt_t(mt_result, t_result)
 
+
 class TestBinary(TestCase):
     def _get_test_data(self, fn_name):
         fn_name = _fix_fn_name(fn_name)
@@ -443,9 +476,9 @@ class TestBinary(TestCase):
         return kwargs
 
     def _yield_sample_args(self, fn_name, data0, data1, mask):
-        """ Returns two sets of Tensor and MaskedTensor args for a binary function to compute.
-            Tensor args are all the same (just the two provided data tensors),
-            while the MaskedTensor args tests both (MaskedTensor, MaskedTensor) and (MaskedTensor, Tensor)
+        """Returns two sets of Tensor and MaskedTensor args for a binary function to compute.
+        Tensor args are all the same (just the two provided data tensors),
+        while the MaskedTensor args tests both (MaskedTensor, MaskedTensor) and (MaskedTensor, Tensor)
         """
         fn_name = _fix_fn_name(fn_name)
         mt0 = masked_tensor(data0, mask)
@@ -466,7 +499,7 @@ class TestBinary(TestCase):
         data0, data1, mask = self._get_test_data(fn_name)
         kwargs = self._get_sample_kwargs(fn_name)
 
-        for (t_args, mt_args) in self._yield_sample_args(fn_name, data0, data1, mask):
+        for t_args, mt_args in self._yield_sample_args(fn_name, data0, data1, mask):
             mt_result = fn(*mt_args, **kwargs)
             t_result = fn(*t_args, **kwargs)
             _compare_mt_t(mt_result, t_result)
@@ -478,7 +511,7 @@ class TestBinary(TestCase):
         data0, data1, mask = self._get_test_data(fn_name)
         kwargs = self._get_sample_kwargs(fn_name)
 
-        for (t_args, mt_args) in self._yield_sample_args(fn_name, data0, data1, mask):
+        for t_args, mt_args in self._yield_sample_args(fn_name, data0, data1, mask):
             mt_result = fn(*mt_args, **kwargs)
             t_result = fn(*t_args, **kwargs)
             _compare_mt_t(mt_result, t_result)
@@ -500,6 +533,7 @@ class TestBinary(TestCase):
                 "Input masks must match. If you need support for this, please open an issue on Github."
                 == str(e)
             )
+
 
 class TestReductions(TestCase):
     def test_max_not_implemented(self):
@@ -592,46 +626,54 @@ class TestReductions(TestCase):
             will yield a RuntimeError of "element 0 of tensors does not require grad and does not have a grad_fn"
             as expected.
     """
+
     def test_mean_grad_case_1a(self):
-        """ values.requires_grad = True
-            mt = masked_tensor(values, mask, requires_grad=True)
+        """values.requires_grad = True
+        mt = masked_tensor(values, mask, requires_grad=True)
         """
         d = torch.tensor([[0, 1, 2], [3, 4, 5.0]], requires_grad=True)
         m = torch.tensor([[True, False, False], [False, True, False]])
-        with self.assertWarnsRegex(UserWarning, "It is not recommended to create a MaskedTensor"):
+        with self.assertWarnsRegex(
+            UserWarning, "It is not recommended to create a MaskedTensor"
+        ):
             mt = masked_tensor(d, m, requires_grad=True)
         mt.mean().backward()
         self.assertIsNone(d.grad)
-        _compare_mts(mt.grad, masked_tensor(torch.tensor([[0.5, 0, 0], [0, 0.5, 0]]), m))
+        _compare_mts(
+            mt.grad, masked_tensor(torch.tensor([[0.5, 0, 0], [0, 0.5, 0]]), m)
+        )
 
     def test_mean_grad_case_1b(self):
-        """ values.requires_grad = False
-            mt = masked_tensor(values, mask, requires_grad=True)
+        """values.requires_grad = False
+        mt = masked_tensor(values, mask, requires_grad=True)
         """
         d = torch.tensor([[0, 1, 2], [3, 4, 5.0]])
         m = torch.tensor([[True, False, False], [False, True, False]])
         mt = masked_tensor(d, m, requires_grad=True)
         mt.mean().backward()
         self.assertIsNone(d.grad)
-        _compare_mts(mt.grad, masked_tensor(torch.tensor([[0.5, 0, 0], [0, 0.5, 0]]), m))
+        _compare_mts(
+            mt.grad, masked_tensor(torch.tensor([[0.5, 0, 0], [0, 0.5, 0]]), m)
+        )
 
     def test_mean_grad_case_1c(self):
-        """ values.requires_grad = True
-            mt = masked_tensor(values, mask, requires_grad=False)
+        """values.requires_grad = True
+        mt = masked_tensor(values, mask, requires_grad=False)
         """
         d = torch.tensor([[0, 1, 2], [3, 4, 5.0]], requires_grad=True)
         m = torch.tensor([[True, False, False], [False, True, False]])
-        with self.assertWarnsRegex(UserWarning, "It is not recommended to create a MaskedTensor"):
+        with self.assertWarnsRegex(
+            UserWarning, "It is not recommended to create a MaskedTensor"
+        ):
             mt = masked_tensor(d, m, requires_grad=False)
         result = mt.mean()
         msg = "element 0 of tensors does not require grad and does not have a grad_fn"
         with self.assertRaisesRegex(RuntimeError, msg):
             result.backward()
 
-
     def test_mean_grad_case_1d(self):
-        """ values.requires_grad = False
-            mt = masked_tensor(values, mask, requires_grad=False)
+        """values.requires_grad = False
+        mt = masked_tensor(values, mask, requires_grad=False)
         """
         d = torch.tensor([[0, 1, 2], [3, 4, 5.0]])
         m = torch.tensor([[True, False, False], [False, True, False]])
@@ -642,8 +684,8 @@ class TestReductions(TestCase):
             result.backward()
 
     def test_mean_grad_case_1e(self):
-        """ values.requires_grad = True
-            mt = as_masked_tensor(values, mask)
+        """values.requires_grad = True
+        mt = as_masked_tensor(values, mask)
         """
         d = torch.tensor([[0, 1, 2], [3, 4, 5.0]], requires_grad=True)
         m = torch.tensor([[True, False, False], [False, True, False]])
@@ -655,8 +697,8 @@ class TestReductions(TestCase):
             self.assertIsNone(mt.grad)
 
     def test_mean_grad_case_1f(self):
-        """ values.requires_grad = False
-            mt = as_masked_tensor(values, mask)
+        """values.requires_grad = False
+        mt = as_masked_tensor(values, mask)
         """
         d = torch.tensor([[0, 1, 2], [3, 4, 5.0]])
         m = torch.tensor([[True, False, False], [False, True, False]])
@@ -671,7 +713,9 @@ class TestReductions(TestCase):
         m = torch.tensor([[True, True, False], [False, True, False]])
         mt = masked_tensor(d, m, requires_grad=True)
         mt.mean(1).sum().backward()
-        _compare_mts(mt.grad, masked_tensor(torch.tensor([[0.5, 0.5, 0], [0, 1, 0]]), m))
+        _compare_mts(
+            mt.grad, masked_tensor(torch.tensor([[0.5, 0.5, 0], [0, 1, 0]]), m)
+        )
 
     def test_amax(self):
         d = torch.tensor([[0, 1, 3, -3], [3, -4, 1.0, 3]])
@@ -767,11 +811,14 @@ class TestReductions(TestCase):
 def is_unary(op):
     return op.name in UNARY_NAMES
 
+
 def is_binary(op):
     return op.name in BINARY_NAMES
 
+
 def is_reduction(op):
     return op.name in REDUCE_NAMES and op.name not in {"all", "mean", "std", "var"}
+
 
 mt_unary_ufuncs = [op for op in unary_ufuncs if is_unary(op)]
 mt_binary_ufuncs = [op for op in binary_ufuncs if is_binary(op)]
@@ -782,6 +829,7 @@ MASKEDTENSOR_FLOAT_TYPES = {
     torch.float32,
     torch.float64,
 }
+
 
 class TestOperators(TestCase):
     def _convert_mt_args(self, args, mask, layout):
@@ -890,31 +938,31 @@ class TestOperators(TestCase):
     @decorateIf(
         unittest.expectedFailure,
         lambda params: (
-            params["op"].name == "add" and
-            params["dtype"] in [torch.float16, torch.float32] and
-            params["device"] == "cpu" and
-            params["layout"] == torch.sparse_csr
-        )
+            params["op"].name == "add"
+            and params["dtype"] in [torch.float16, torch.float32]
+            and params["device"] == "cpu"
+            and params["layout"] == torch.sparse_csr
+        ),
     )
     # Result is just wrong; production logic should be fixed
     @decorateIf(
         unittest.expectedFailure,
         lambda params: (
-            params["op"].name == "sub" and
-            params["dtype"] in [torch.float16, torch.float32] and
-            params["device"] == "cpu" and
-            params["layout"] == torch.sparse_csr
-        )
+            params["op"].name == "sub"
+            and params["dtype"] in [torch.float16, torch.float32]
+            and params["device"] == "cpu"
+            and params["layout"] == torch.sparse_csr
+        ),
     )
     # Result is just wrong; production logic should be fixed
     @decorateIf(
         unittest.expectedFailure,
         lambda params: (
-            params["op"].name == "eq" and
-            params["dtype"] == torch.float64 and
-            params["device"] == "cpu" and
-            params["layout"] == torch.sparse_csr
-        )
+            params["op"].name == "eq"
+            and params["dtype"] == torch.float64
+            and params["device"] == "cpu"
+            and params["layout"] == torch.sparse_csr
+        ),
     )
     def test_binary_core(self, device, dtype, op, layout):
         self._test_unary_binary_equality(device, dtype, op, layout)
@@ -937,5 +985,5 @@ instantiate_parametrized_tests(TestUnary)
 instantiate_parametrized_tests(TestBinary)
 instantiate_parametrized_tests(TestReductions)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Fixes #123062

Run lintrunner on files:

```bash
lintrunner

  FLAKE8 success!
  CLANGFORMAT success!
  MYPY success!
  MYPYSTRICT success!
  CLANGTIDY success!
  TYPEIGNORE success!
  TYPENOSKIP success!
  NOQA success!
  NEWLINE success!
  CONSTEXPR success!
  NATIVEFUNCTIONS success!
  SPACES success!
  INCLUDE success!
  TABS success!
  PYBIND11_INCLUDE success!
  ERROR_PRONE_ISINSTANCE success!
  PYBIND11_SPECIALIZATION success!
  PYPIDEP success!
  EXEC success!
  CUBINCLUDE success!
  RAWCUDA success!
  RAWCUDADEVICE success!
  ROOT_LOGGING success!
  DEPLOY_DETECTION success!
  CMAKE success!
  SHELLCHECK success!
  ACTIONLINT success!
  TESTOWNERS success!
  TEST_HAS_MAIN success!
  CALL_ONCE success!
  ONCE_FLAG success!
  WORKFLOWSYNC success!
  UFMT success!
  COPYRIGHT success!
  MERGE_CONFLICTLESS_CSV success!
  LINTRUNNER_VERSION success!
  BAZEL_LINTER success!
  RUFF success!
  ATEN_CPU_GPU_AGNOSTIC success!
ok No lint issues.
```