### PR TITLE
[inductor] unificate toolchain code.

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -23,7 +23,7 @@ from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 from torch.utils._sympy.value_ranges import bound_sympy, ValueRanges
 from ..._dynamo.utils import counters
 
-from .. import codecache, config, cpu_vec_isa, ir, metrics
+from .. import codecache, config, cpp_builder, cpu_vec_isa, ir, metrics
 from ..codegen.wrapper import WrapperCodeGen
 from ..optimize_indexing import range_expressable_in_32_bits
 from ..scheduler import (
@@ -2293,7 +2293,7 @@ class CppVecKernel(CppKernel):
                     load_mask = f"{self._load_mask}.is_masked({itervar_inner})"
                 else:
                     load_mask = f"{self._load_mask} != 0"
-            if codecache.is_gcc():
+            if cpp_builder.is_gcc():
                 code.writeline(f"#pragma GCC unroll {self.tiling_factor}")
             else:
                 code.writeline(f"#pragma unroll {self.tiling_factor}")
@@ -4207,7 +4207,7 @@ class LoopLevel:
             line1 = ""
         elif self.simd_omp:
             line1 = f"#pragma omp {simd}"
-        elif not self.is_reduction and codecache.is_gcc():
+        elif not self.is_reduction and cpp_builder.is_gcc():
             line1 = "#pragma GCC ivdep"
         else:
             line1 = ""

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -7,7 +7,7 @@ from sympy.parsing.sympy_parser import parse_expr
 
 import torch
 from torch.utils._sympy.symbol import SymT
-from .. import codecache, config, ir, lowering as L
+from .. import config, cpp_builder, ir, lowering as L
 
 from ..autotune_process import CppBenchmarkRequest
 from ..select_algorithm import PartialRender
@@ -174,7 +174,7 @@ class CppTemplateKernel(CppKernel):
             return ""
 
     def unroll_pragma(self, unroll):
-        if codecache.is_gcc():
+        if cpp_builder.is_gcc():
             return f"#pragma GCC unroll {unroll}"
         else:
             return f"#pragma unroll {unroll}"

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -5,6 +5,7 @@
 import copy
 import errno
 import functools
+import json
 import logging
 import os
 import platform
@@ -20,15 +21,6 @@ from typing import List, Sequence, Tuple, Union
 
 import torch
 from torch._inductor import config, exc
-
-# TODO: import below objects in function scope, in further optimization
-from torch._inductor.codecache import (
-    _get_python_include_dirs,
-    _LINKER_SCRIPT,
-    _transform_cuda_paths,
-    get_lock_dir,
-    LOCK_TIMEOUT,
-)
 from torch._inductor.cpu_vec_isa import invalid_vec_isa, VecISA
 from torch._inductor.runtime.runtime_utils import cache_dir
 
@@ -68,8 +60,11 @@ _IS_WINDOWS = sys.platform == "win32"
 log = logging.getLogger(__name__)
 
 
+# =============================== toolchain ===============================
 @functools.lru_cache(1)
 def cpp_compiler_search(search: str) -> str:
+    from torch._inductor.codecache import get_lock_dir, LOCK_TIMEOUT
+
     for cxx in search:
         try:
             if cxx is None:
@@ -92,7 +87,7 @@ def cpp_compiler_search(search: str) -> str:
             return cxx
         except (subprocess.SubprocessError, FileNotFoundError, ImportError):
             continue
-    raise exc.InvalidCxxCompiler()  # noqa: RSE102
+    raise exc.InvalidCxxCompiler
 
 
 def install_gcc_via_conda() -> str:
@@ -121,7 +116,7 @@ def install_gcc_via_conda() -> str:
     return cxx_path
 
 
-def _get_cpp_compiler() -> str:
+def get_cpp_compiler() -> str:
     if _IS_WINDOWS:
         compiler = os.environ.get("CXX", "cl")
     else:
@@ -135,36 +130,62 @@ def _get_cpp_compiler() -> str:
     return compiler
 
 
-def cpp_compiler() -> str:
-    return _get_cpp_compiler()
-
-
-def _is_gcc(cpp_compiler) -> bool:
-    return bool(re.search(r"(gcc|g\+\+)", cpp_compiler))
-
-
-def is_gcc() -> bool:
-    return _is_gcc(_get_cpp_compiler())
+@functools.lru_cache(None)
+def _is_apple_clang(cpp_compiler) -> bool:
+    version_string = subprocess.check_output([cpp_compiler, "--version"]).decode("utf8")
+    return "Apple" in version_string.splitlines()[0]
 
 
 def _is_clang(cpp_compiler) -> bool:
     # Mac OS apple clang maybe named as gcc, need check compiler info.
     if sys.platform == "darwin":
-        return is_apple_clang(cpp_compiler)
+        return _is_apple_clang(cpp_compiler)
     return bool(re.search(r"(clang|clang\+\+)", cpp_compiler))
 
 
-def is_clang() -> bool:
-    compiler = _get_cpp_compiler()
-    return _is_clang(compiler)
+def _is_gcc(cpp_compiler) -> bool:
+    if sys.platform == "darwin" and _is_apple_clang(cpp_compiler):
+        return False
+    return bool(re.search(r"(gcc|g\+\+)", cpp_compiler))
 
 
 @functools.lru_cache(None)
-def is_apple_clang(cpp_compiler) -> bool:
-    version_string = subprocess.check_output([cpp_compiler, "--version"]).decode("utf8")
-    return "Apple" in version_string.splitlines()[0]
+def is_gcc() -> bool:
+    return _is_gcc(get_cpp_compiler())
 
 
+@functools.lru_cache(None)
+def is_clang() -> bool:
+    return _is_clang(get_cpp_compiler())
+
+
+@functools.lru_cache(None)
+def is_apple_clang() -> bool:
+    return _is_apple_clang(get_cpp_compiler())
+
+
+def get_compiler_version_info(compiler: str) -> str:
+    SUBPROCESS_DECODE_ARGS = ("oem",) if _IS_WINDOWS else ()
+    env = os.environ.copy()
+    env["LC_ALL"] = "C"  # Don't localize output
+    try:
+        version_string = subprocess.check_output(
+            [compiler, "-v"], stderr=subprocess.STDOUT, env=env
+        ).decode(*SUBPROCESS_DECODE_ARGS)
+    except Exception as e:
+        try:
+            version_string = subprocess.check_output(
+                [compiler, "--version"], stderr=subprocess.STDOUT, env=env
+            ).decode(*SUBPROCESS_DECODE_ARGS)
+        except Exception as e:
+            return ""
+    # Mutiple lines to one line string.
+    version_string = version_string.replace("\r", "_")
+    version_string = version_string.replace("\n", "_")
+    return version_string
+
+
+# =============================== cpp builder ===============================
 def _append_list(dest_list: List[str], src_list: List[str]):
     for item in src_list:
         dest_list.append(copy.deepcopy(item))
@@ -358,7 +379,7 @@ def _get_shared_cflag(compile_only: bool) -> List[str]:
     else:
         if compile_only:
             return ["fPIC"]
-        if platform.system() == "Darwin" and "clang" in _get_cpp_compiler():
+        if platform.system() == "Darwin" and "clang" in get_cpp_compiler():
             # This causes undefined symbols to behave the same as linux
             return ["shared", "fPIC", "undefined dynamic_lookup"]
         else:
@@ -415,13 +436,13 @@ class CppOptions(BuildOptionsBase):
 
     def __init__(
         self,
-        compile_only: bool,
+        compile_only: bool = False,
         warning_all: bool = True,
         extra_flags: Sequence[str] = (),
         use_absolute_path: bool = False,
     ) -> None:
         super().__init__()
-        self._compiler = _get_cpp_compiler()
+        self._compiler = get_cpp_compiler()
         self._use_absolute_path = use_absolute_path
         self._compile_only = compile_only
 
@@ -496,6 +517,8 @@ def _setup_standard_sys_libs(
     aot_mode: bool,
     use_absolute_path: bool,
 ):
+    from torch._inductor.codecache import _LINKER_SCRIPT
+
     cflags: List[str] = []
     include_dirs: List[str] = []
     passthough_args: List[str] = []
@@ -592,6 +615,19 @@ def _get_torch_related_args(include_pytorch: bool, aot_mode: bool):
     return include_dirs, libraries_dirs, libraries
 
 
+def _get_python_include_dirs():
+    include_dir = Path(sysconfig.get_path("include"))
+    # On Darwin Python executable from a framework can return
+    # non-existing /Library/Python/... include path, in which case
+    # one should use Headers folder from the framework
+    if not include_dir.exists() and platform.system() == "Darwin":
+        std_lib = Path(sysconfig.get_path("stdlib"))
+        include_dir = (std_lib.parent.parent / "Headers").absolute()
+    if not (include_dir / "Python.h").exists():
+        warnings.warn(f"Can't find Python.h in {str(include_dir)}")
+    return [str(include_dir)]
+
+
 def _get_python_related_args():
     python_include_dirs = _get_python_include_dirs()
     python_include_path = sysconfig.get_path(
@@ -612,6 +648,36 @@ def _get_python_related_args():
     return python_include_dirs, python_lib_path
 
 
+@functools.lru_cache(None)
+def is_conda_llvm_openmp_installed() -> bool:
+    try:
+        command = "conda list llvm-openmp --json"
+        output = subprocess.check_output(command.split()).decode("utf8")
+        return len(json.loads(output)) > 0
+    except subprocess.SubprocessError:
+        return False
+
+
+@functools.lru_cache(None)
+def homebrew_libomp() -> Tuple[bool, str]:
+    try:
+        # check if `brew` is installed
+        subprocess.check_output(["which", "brew"])
+        # get the location of `libomp` if it is installed
+        # this is the location that `libomp` **would** be installed
+        # see https://github.com/Homebrew/brew/issues/10261#issuecomment-756563567 for details
+        libomp_path = (
+            subprocess.check_output(["brew", "--prefix", "libomp"])
+            .decode("utf8")
+            .strip()
+        )
+        # check if `libomp` is installed
+        omp_available = os.path.exists(libomp_path)
+        return omp_available, libomp_path
+    except subprocess.SubprocessError:
+        return False, ""
+
+
 def _get_openmp_args(cpp_compiler):
     cflags: List[str] = []
     ldflags: List[str] = []
@@ -620,13 +686,8 @@ def _get_openmp_args(cpp_compiler):
     libs: List[str] = []
     passthough_args: List[str] = []
     if _IS_MACOS:
-        from torch._inductor.codecache import (
-            homebrew_libomp,
-            is_conda_llvm_openmp_installed,
-        )
-
         # only Apple builtin compilers (Apple Clang++) require openmp
-        omp_available = not is_apple_clang(cpp_compiler)
+        omp_available = not _is_apple_clang(cpp_compiler)
 
         # check the `OMP_PREFIX` environment first
         omp_prefix = os.getenv("OMP_PREFIX")
@@ -850,6 +911,33 @@ class CppTorchOptions(CppOptions):
         _append_list(self._libraries, torch_libraries)
         _append_list(self._passthough_args, torch_passthough_args)
         self._remove_duplicate_options()
+
+
+def _set_gpu_runtime_env() -> None:
+    if (
+        config.is_fbcode()
+        and torch.version.hip is None
+        and "CUDA_HOME" not in os.environ
+        and "CUDA_PATH" not in os.environ
+    ):
+        os.environ["CUDA_HOME"] = build_paths.cuda()
+
+
+def _transform_cuda_paths(lpaths):
+    # This handles two cases:
+    # 1. Meta internal cuda-12 where libs are in lib/cuda-12 and lib/cuda-12/stubs
+    # 2. Linux machines may have CUDA installed under either lib64/ or lib/
+    for i, path in enumerate(lpaths):
+        if (
+            "CUDA_HOME" in os.environ
+            and path.startswith(os.environ["CUDA_HOME"])
+            and not os.path.exists(f"{path}/libcudart_static.a")
+        ):
+            for root, dirs, files in os.walk(path):
+                if "libcudart_static.a" in files:
+                    lpaths[i] = os.path.join(path, root)
+                    lpaths.append(os.path.join(lpaths[i], "stubs"))
+                    break
 
 
 def get_cpp_torch_cuda_options(cuda: bool, aot_mode: bool = False):


### PR DESCRIPTION
This PR is the implemention of https://github.com/pytorch/pytorch/issues/124245#issuecomment-2197778902 plan 2, and it is continued PR to https://github.com/pytorch/pytorch/pull/129789

Changes:
1. Unificate cpp builder's toolchain code.
2. Move all build related code to `cpp_builder.py`.
3. Optimize `codecache.py`, `cpp_builder.py` and `cpu_vec_isa.py` import logical follow: https://github.com/pytorch/pytorch/issues/124245#issuecomment-2197778902 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang