### PR TITLE
Fix names conflict when lifting

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -4,12 +4,14 @@ import copy
 import math
 
 from dataclasses import dataclass
+from typing import List
 
 import torch
 
 import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch._dynamo.utils
+from functorch.compile import aot_module_simplified
 from torch.testing._internal.triton_utils import HAS_CUDA, requires_cuda
 
 if HAS_CUDA:
@@ -221,6 +223,69 @@ class ModuleWithGradFunc(torch.nn.Module):
 
     def forward(self, x):
         return self.f(x)
+
+
+@torch.library.custom_op("mylib::custom_op_forward", mutates_args=())
+def custom_op_forward(
+    foo: torch.Tensor,
+    bar: torch.Tensor,
+    shape: List[int],
+) -> torch.Tensor:
+    return torch.ones_like(foo)
+
+
+@custom_op_forward.register_fake
+def _(foo, bar, weight):
+    return torch.empty_like(foo)
+
+
+@torch.library.custom_op("mylib::custom_op_backward", mutates_args=())
+def custom_op_backward(
+    grad_output: torch.Tensor,
+    foo: torch.Tensor,
+    bar: torch.Tensor,
+    shape: List[int],
+) -> torch.Tensor:
+    assert list(bar.shape) == shape
+    return torch.ones_like(bar)
+
+
+@custom_op_backward.register_fake
+def _(grad_output, foo, bar, shape):
+    return torch.empty_like(bar)
+
+
+class CustomOpFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input, weight, normalized_shape):
+        ctx.normalized_shape = normalized_shape
+        input_ = input.contiguous()
+        weight_ = weight.contiguous()
+        output = custom_op_forward(input_, weight_, ctx.normalized_shape)
+        ctx.save_for_backward(input_, weight_)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input_, weight_ = ctx.saved_tensors
+        # grad_weight = a_func(grad_output, input_, weight_, ctx.normalized_shape)
+        grad_weight = custom_op_backward(
+            grad_output.contiguous(),
+            input_,
+            weight_,
+            ctx.normalized_shape,
+        )
+        return None, grad_weight, None
+
+
+class CustomOpModule(torch.nn.Module):
+    def __init__(self, shape):
+        super().__init__()
+        self.shape = shape
+        self.weight = torch.nn.Parameter(torch.ones(self.shape))
+
+    def forward(self, x):
+        return CustomOpFunc.apply(x, self.weight, self.shape)
 
 
 class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
@@ -527,18 +592,29 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, ctx, x: "f32[]", z: "f32[]", l_weird_b: "f32[]", l_weird_c: "f32[]"):
-            mul: "f32[]" = l_weird_b * l_weird_c
-            clone: "f32[]" = x.clone();  x = None
+            ctx_1 = ctx
+            x_1 = x
+            z_1 = z
+            l_weird_b_1 = l_weird_b
+            l_weird_c_1 = l_weird_c
+
+            mul: "f32[]" = l_weird_b_1 * l_weird_c_1
+            clone: "f32[]" = x_1.clone();  x_1 = None
             mul_1: "f32[]" = mul * clone;  mul = clone = None
-            return (mul_1, [l_weird_b, l_weird_c])
+            return (mul_1, [l_weird_b_1, l_weird_c_1])
 
     class GraphModule(torch.nn.Module):
         def forward(self, ctx, grad: "f32[]", l_weird_b: "f32[]", l_weird_c: "f32[]"):
+            ctx_1 = ctx
+            grad_1 = grad
+            l_weird_b_1 = l_weird_b
+            l_weird_c_1 = l_weird_c
+
             _set_grad_enabled = torch._C._set_grad_enabled(False)
 
-            mul: "f32[]" = grad * l_weird_b;  l_weird_b = None
-            mul_1: "f32[]" = mul * l_weird_c;  mul = l_weird_c = None
-            mul_2: "f32[]" = grad * 2;  grad = None
+            mul: "f32[]" = grad_1 * l_weird_b_1;  l_weird_b_1 = None
+            mul_1: "f32[]" = mul * l_weird_c_1;  mul = l_weird_c_1 = None
+            mul_2: "f32[]" = grad_1 * 2;  grad_1 = None
 
             _set_grad_enabled_1 = torch._C._set_grad_enabled(True)
             return (mul_1, mul_2)
@@ -1102,6 +1178,22 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(x.grad.shape, shape)
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(cnt.op_count, 2)
+
+    def test_custom_op(self):
+        shape = [7]
+        x = torch.rand(128, shape[0])
+        model = CustomOpModule(shape)
+        out = model(x)
+
+        def backend(gm, example_inputs):
+            return aot_module_simplified(
+                gm, example_inputs, fw_compiler=lambda gm, _: gm
+            )
+
+        opt_model = torch.compile(model, backend=backend)
+        opt_out = opt_model(x)
+        opt_out.mean().backward()
+        self.assertEqual(out, opt_out)
 
     @requires_cuda
     def test_triton_kernel_basic(self):

--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -225,7 +225,7 @@ class ModuleWithGradFunc(torch.nn.Module):
         return self.f(x)
 
 
-@torch.library.custom_op("mylib::custom_op_forward", mutates_args=())
+@torch.library.custom_op("_torch_testing::custom_op_forward", mutates_args=())
 def custom_op_forward(
     foo: torch.Tensor,
     bar: torch.Tensor,
@@ -239,7 +239,7 @@ def _(foo, bar, weight):
     return torch.empty_like(foo)
 
 
-@torch.library.custom_op("mylib::custom_op_backward", mutates_args=())
+@torch.library.custom_op("_torch_testing::custom_op_backward", mutates_args=())
 def custom_op_backward(
     grad_output: torch.Tensor,
     foo: torch.Tensor,

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1894,16 +1894,16 @@ def forward(self, x):
                 out_graph.cond_true_0.code.strip(),
                 """\
 def forward(self, l_x_):
-    l_x__1 = l_x_
-    add = l_x__1 + l_x__1;  l_x__1 = None
+    l_x__2 = l_x_
+    add = l_x__2 + l_x__2;  l_x__2 = None
     return (add,)""",
             )
             self.assertExpectedInline(
                 out_graph.cond_false_0.code.strip(),
                 """\
 def forward(self, l_x_):
-    l_x__1 = l_x_
-    getitem = l_x__1[slice(None, 2, None)];  l_x__1 = None
+    l_x__2 = l_x_
+    getitem = l_x__2[slice(None, 2, None)];  l_x__2 = None
     return (getitem,)""",
             )
             with self.assertRaisesRegex(
@@ -3947,13 +3947,13 @@ def forward(self, pred, x):
             out_graph.cond_true_0.code.strip(),
             """\
 def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
-    a_1 = a
-    b_1 = b
-    l_x__1 = l_x_
-    add = l_x__1 + l_x__1;  l_x__1 = None
-    cos = a_1.cos();  a_1 = None
+    a_2 = a
+    b_2 = b
+    l_x__2 = l_x_
+    add = l_x__2 + l_x__2;  l_x__2 = None
+    cos = a_2.cos();  a_2 = None
     add_1 = add + cos;  add = cos = None
-    cos_1 = b_1.cos();  b_1 = None
+    cos_1 = b_2.cos();  b_2 = None
     add_2 = add_1 + cos_1;  add_1 = cos_1 = None
     cos_2 = d_true_branch.cos();  d_true_branch = None
     add_3 = add_2 + cos_2;  add_2 = cos_2 = None
@@ -3964,13 +3964,13 @@ def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
             out_graph.cond_false_0.code.strip(),
             """\
 def forward(self, a, b, l_x_, d_true_branch, c_false_branch):
-    a_1 = a
-    b_1 = b
-    l_x__1 = l_x_
-    mul = l_x__1 * l_x__1;  l_x__1 = None
-    sin = a_1.sin();  a_1 = None
+    a_2 = a
+    b_2 = b
+    l_x__2 = l_x_
+    mul = l_x__2 * l_x__2;  l_x__2 = None
+    sin = a_2.sin();  a_2 = None
     add = mul + sin;  mul = sin = None
-    sin_1 = b_1.sin();  b_1 = None
+    sin_1 = b_2.sin();  b_2 = None
     add_1 = add + sin_1;  add = sin_1 = None
     sin_2 = c_false_branch.sin();  c_false_branch = None
     add_2 = add_1 + sin_2;  add_1 = sin_2 = None

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -1973,6 +1973,7 @@ class GraphModule(torch.nn.Module):
                 """\
 class GraphModule(torch.nn.Module):
     def forward(self, s0: "Sym(s0)", L_lambda0_keywords_y_: "f32[s0, s0]"):
+        s0_1 = s0
         l_lambda0_keywords_y_ = L_lambda0_keywords_y_
 
         mul: "f32[s0, s0]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_
@@ -2021,6 +2022,7 @@ class GraphModule(torch.nn.Module):
                 """\
 class GraphModule(torch.nn.Module):
     def forward(self, s0: "Sym(s0)", L_lambda0_keywords_y_: "f32[s0, s0]"):
+        s0_1 = s0
         l_lambda0_keywords_y_ = L_lambda0_keywords_y_
 
         mul: "f32[s0, s0]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_
@@ -2072,6 +2074,7 @@ class GraphModule(torch.nn.Module):
                 """\
 class GraphModule(torch.nn.Module):
     def forward(self, s0: "Sym(s0)", L_lambda0_keywords_y_: "f32[s0, s0]"):
+        s0_1 = s0
         l_lambda0_keywords_y_ = L_lambda0_keywords_y_
 
         mul: "f32[s0, s0]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_
@@ -2120,6 +2123,7 @@ class GraphModule(torch.nn.Module):
                 """\
 class GraphModule(torch.nn.Module):
     def forward(self, s0: "Sym(s0)", L_x_: "f32[s0, s0]"):
+        s0_1 = s0
         l_x_ = L_x_
 
         mul: "f32[s0, s0]" = l_x_ * 4

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -334,10 +334,14 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_d_x_: "f32[]", l_d_y_0_: "f32[]", l_d_y_1_2_: "f32[]"):
-            sin: "f32[]" = l_d_x_.sin();  l_d_x_ = None
-            cos: "f32[]" = l_d_y_0_.cos();  l_d_y_0_ = None
+            l_d_x__1 = l_d_x_
+            l_d_y_0__1 = l_d_y_0_
+            l_d_y_1_2__1 = l_d_y_1_2_
+
+            sin: "f32[]" = l_d_x__1.sin();  l_d_x__1 = None
+            cos: "f32[]" = l_d_y_0__1.cos();  l_d_y_0__1 = None
             add: "f32[]" = sin + cos;  sin = cos = None
-            sin_1: "f32[]" = l_d_y_1_2_.sin();  l_d_y_1_2_ = None
+            sin_1: "f32[]" = l_d_y_1_2__1.sin();  l_d_y_1_2__1 = None
             sub: "f32[]" = add - sin_1;  add = sin_1 = None
             return (sub,)
 """,  # NOQA: B950
@@ -372,7 +376,9 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_: "f32[3, 1]"):
-            view: "f32[3]" = l_x_.view(3);  l_x_ = None
+            l_x__1 = l_x_
+
+            view: "f32[3]" = l_x__1.view(3);  l_x__1 = None
             add: "f32[3]" = view + 0.5;  view = None
             return (add,)
 """,
@@ -383,16 +389,20 @@ class GraphModule(torch.nn.Module):
                 """\
 class GraphModule(torch.nn.Module):
     def forward(self, s0: "Sym(s0)", L_x_: "f32[s0, 1]"):
+        s0_1 = s0
         l_x_ = L_x_
 
         wrap_body_0 = self.wrap_body_0
-        wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_x_, s0);  wrap_body_0 = l_x_ = s0 = None
+        wrap = torch._higher_order_ops.wrap.wrap(wrap_body_0, l_x_, s0_1);  wrap_body_0 = l_x_ = s0_1 = None
         getitem: "f32[s0]" = wrap[0];  wrap = None
         return (getitem,)
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_: "f32[s0, 1]", size: "Sym(s0)"):
-            view: "f32[s0]" = l_x_.view(size);  l_x_ = size = None
+            l_x__1 = l_x_
+            size_1 = size
+
+            view: "f32[s0]" = l_x__1.view(size_1);  l_x__1 = size_1 = None
             add: "f32[s0]" = view + 0.5;  view = None
             return (add,)
 """,
@@ -1194,9 +1204,11 @@ def forward(self, L_xs_ : torch.Tensor, L_y_ : torch.Tensor):
                 body_graph,
                 """\
 def forward(self, child, l_y_):
-    child_1 = child[0]
+    child_1 = child
+    l_y__1 = l_y_
+    child_2 = child_1[0]
     map_body_0 = self.map_body_0
-    map_impl = torch.ops.higher_order.map_impl(map_body_0, [child], [l_y_]);  map_body_0 = child = l_y_ = None
+    map_impl = torch.ops.higher_order.map_impl(map_body_0, [child_1], [l_y__1]);  map_body_0 = child_1 = l_y__1 = None
     getitem_1 = map_impl[0];  map_impl = None
     return (getitem_1,)""",
             )
@@ -1226,9 +1238,10 @@ def forward(self, L_x_ : torch.Tensor):
                 body_graph,
                 """\
 def forward(self, child):
-    child_1 = child.sin()
-    child_2 = child.sin();  child = None
-    return (child_1, child_2)""",
+    child_1 = child
+    child_2 = child_1.sin()
+    child_3 = child_1.sin();  child_1 = None
+    return (child_2, child_3)""",
             )
 
     def test_map_pytree_return(self):
@@ -1267,7 +1280,8 @@ def forward(self, L_x_ : torch.Tensor):
                 body_graph,
                 """\
 def forward(self, child):
-    return (child, child, child, child, child, child, child)""",
+    child_1 = child
+    return (child_1, child_1, child_1, child_1, child_1, child_1, child_1)""",
             )
 
     def test_map_kwargs(self):
@@ -1310,7 +1324,9 @@ def forward(self, L_x_ : torch.Tensor):
                 body_graph,
                 """\
 def forward(self, child, const_unused):
-    add = child + 3;  child = None
+    child_1 = child
+    const_unused_1 = const_unused
+    add = child_1 + 3;  child_1 = None
     sin = torch.sin(add);  add = None
     return (sin,)""",
             )
@@ -1344,7 +1360,9 @@ def forward(self, L_x_ : torch.Tensor):
                 body_graph,
                 """\
 def forward(self, child, const_unused):
-    add = child + 3;  child = None
+    child_1 = child
+    const_unused_1 = const_unused
+    add = child_1 + 3;  child_1 = None
     sin = torch.sin(add);  add = None
     return (sin,)""",
             )
@@ -1600,16 +1618,16 @@ def forward(self, L_x_ : torch.Tensor):
                 true_graph,
                 """\
 def forward(self, l_x_):
-    l_x__1 = l_x_
-    sin = torch.sin(l_x__1);  l_x__1 = None
+    l_x__2 = l_x_
+    sin = torch.sin(l_x__2);  l_x__2 = None
     return (sin,)""",
             )
             self.assertExpectedInline(
                 false_graph,
                 """\
 def forward(self, l_x_):
-    l_x__1 = l_x_
-    cos = torch.cos(l_x__1);  l_x__1 = None
+    l_x__2 = l_x_
+    cos = torch.cos(l_x__2);  l_x__2 = None
     return (cos,)""",
             )
 
@@ -1850,9 +1868,12 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_arg1_0_: "f32[3]", l_arg2_0_: "f32[3]"):
-            child: "f32[3]" = l_arg1_0_ + 1;  l_arg1_0_ = None
+            l_arg1_0__1 = l_arg1_0_
+            l_arg2_0__1 = l_arg2_0_
 
-            child_1: "f32[3]" = l_arg2_0_ + 1;  l_arg2_0_ = None
+            child: "f32[3]" = l_arg1_0__1 + 1;  l_arg1_0__1 = None
+
+            child_1: "f32[3]" = l_arg2_0__1 + 1;  l_arg2_0__1 = None
             return (child, child_1)
 """,
         )
@@ -2049,8 +2070,10 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_: "f32[2, 3]"):
-            child: "f32[2, 3]" = l_x_.sin()
-            child_1: "f32[2, 3]" = l_x_.cos();  l_x_ = None
+            l_x__1 = l_x_
+
+            child: "f32[2, 3]" = l_x__1.sin()
+            child_1: "f32[2, 3]" = l_x__1.cos();  l_x__1 = None
             return (child, child_1)
 """,
         )
@@ -2084,7 +2107,9 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_: "f32[3]"):
-            child: "f32[3]" = -l_x_;  l_x_ = None
+            l_x__1 = l_x_
+
+            child: "f32[3]" = -l_x__1;  l_x__1 = None
             return (child,)
 """,
         )

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4661,6 +4661,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             str(graph.code).strip(),
             """\
 def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
+    s0_1 = s0
+    s1_1 = s1
     l_x_ = L_x_
     getitem_2 = l_x_[0]
     sum_1 = getitem_2.sum();  getitem_2 = None

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1095,7 +1095,9 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_: "f32[3, 4]"):
-            add_: "f32[3, 4]" = l_x_.add_(1.0);  l_x_ = None
+            l_x__1 = l_x_
+
+            add_: "f32[3, 4]" = l_x__1.add_(1.0);  l_x__1 = None
             return (add_,)
 """,
         )
@@ -1119,7 +1121,9 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_):
-            add_ = l_x_.add_(1.0);  l_x_ = None
+            l_x__1 = l_x_
+
+            add_ = l_x__1.add_(1.0);  l_x__1 = None
             return (add_,)
 """,
         )
@@ -1149,7 +1153,9 @@ class GraphModule(torch.nn.Module):
 
     class GraphModule(torch.nn.Module):
         def forward(self, l_x_):
-            add_ = l_x_.add_(1.0);  l_x_ = None
+            l_x__1 = l_x_
+
+            add_ = l_x__1.add_(1.0);  l_x__1 = None
             return (add_,)
 """,
         )

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -733,7 +733,9 @@ def forward(self, L_iter_ : torch.Tensor, L_x_ : torch.Tensor):
                 gm.cond_fn_0.code.strip(),
                 """\
 def forward(self, l_iter_, l_x_, l__self___dec_cond_fn, l__self___linear_bias_body_fn, l__self___linear_weight_body_fn):
-    sub = l_iter_ - l__self___dec_cond_fn;  l_iter_ = l__self___dec_cond_fn = None
+    l_iter__1 = l_iter_
+    l_x__1 = l_x_
+    sub = l_iter__1 - l__self___dec_cond_fn;  l_iter__1 = l__self___dec_cond_fn = None
     gt = sub > 0;  sub = None
     return gt""",  # noqa: B950
             )
@@ -741,8 +743,10 @@ def forward(self, l_iter_, l_x_, l__self___dec_cond_fn, l__self___linear_bias_bo
                 gm.body_fn_0.code.strip(),
                 """\
 def forward(self, l_iter_, l_x_, l__self___dec_cond_fn, l__self___linear_bias_body_fn, l__self___linear_weight_body_fn):
-    child = l_iter_ - 1;  l_iter_ = None
-    child_1 = torch._C._nn.linear(l_x_, l__self___linear_weight_body_fn, l__self___linear_bias_body_fn);  l_x_ = l__self___linear_weight_body_fn = l__self___linear_bias_body_fn = None
+    l_iter__1 = l_iter_
+    l_x__1 = l_x_
+    child = l_iter__1 - 1;  l_iter__1 = None
+    child_1 = torch._C._nn.linear(l_x__1, l__self___linear_weight_body_fn, l__self___linear_bias_body_fn);  l_x__1 = l__self___linear_weight_body_fn = l__self___linear_bias_body_fn = None
     return (child, child_1)""",  # noqa: B950
             )
 
@@ -2695,11 +2699,11 @@ def forward(self, arg0_1):
             backend.graphs[0].cond_true_0.code.strip("\n"),
             """\
 def forward(self, l_inp_, l_tmp_):
-    l_inp__1 = l_inp_
-    l_tmp__1 = l_tmp_
-    a = l_inp__1.clone();  l_inp__1 = None
+    l_inp__2 = l_inp_
+    l_tmp__2 = l_tmp_
+    a = l_inp__2.clone();  l_inp__2 = None
     a_view = a.view(-1)
-    tmp = l_tmp__1.clone();  l_tmp__1 = None
+    tmp = l_tmp__2.clone();  l_tmp__2 = None
     _set_grad_enabled = torch._C._set_grad_enabled(False)
     set_ = a.set_(tmp)
     mul_ = a_view.mul_(2);  a_view = None

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1491,13 +1491,24 @@ class GraphModule(torch.nn.Module):
         return (out,)
 
     class GraphModule(torch.nn.Module):
-        def forward(self, child: "f64[]", child_1: "i32[]", child_2: "i32[]", child_3: "i32[]", child_4: "i32[]"):
-            mul: "f64[]" = child * child;  child = None
+        def forward(self, child: "f64[]", child_2: "i32[]", child_4: "i32[]", child_6: "i32[]", child_8: "i32[]"):
+            child_1 = child
+            child_3 = child_2
+            child_5 = child_4
+            child_7 = child_6
+            child_9 = child_8
+
+            mul: "f64[]" = child_1 * child_1;  child_1 = None
             return mul
 
     class GraphModule(torch.nn.Module):
-        def forward(self, child_5: "i32[]", child_6: "i32[]", child_7: "i32[]", child_8: "i32[]"):
-            ge: "b8[]" = child_7 >= child_8;  child_7 = child_8 = None
+        def forward(self, child_5: "i32[]", child_7: "i32[]", child_9: "i32[]", child_11: "i32[]"):
+            child_6 = child_5
+            child_8 = child_7
+            child_10 = child_9
+            child_12 = child_11
+
+            ge: "b8[]" = child_10 >= child_12;  child_10 = child_12 = None
             return ge
 """,  # noqa: B950
         )

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1869,6 +1869,9 @@ class SubgraphTracer(fx.Tracer):
             flat_args, tree_spec = pytree.tree_flatten((args, kwargs))
             new_flat_args = []
             for arg in flat_args:
+                if isinstance(arg, torch.fx.proxy.Proxy):
+                    self.graph._graph_namespace._used_names.add(arg.node.name)
+            for arg in flat_args:
                 maybe_new_arg = self.maybe_lift_tracked_freevar_to_input(arg)
                 new_flat_args.append(maybe_new_arg)
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2073,7 +2073,10 @@ class SubgraphTracer(fx.Tracer):
         if name in self.input_name_to_proxy or name in self.illegal_input_names:
             for i in itertools.count():
                 candidate_name = f"{name}_{i}"
-                if candidate_name not in self.input_name_to_proxy and candidate_name not in self.illegal_input_names:
+                if (
+                    candidate_name not in self.input_name_to_proxy
+                    and candidate_name not in self.illegal_input_names
+                ):
                     name = candidate_name
                     break
 


### PR DESCRIPTION
## Bug description
When pending args that are potentially to be lift [here](https://github.com/pytorch/pytorch/blob/58f346c874a8a982679b4d4f3876602cc05d66d4/torch/_dynamo/output_graph.py#L1866) having same base name, like `contiguous` and `contiguous_1`, the call into [create_graph_input](https://github.com/pytorch/pytorch/blob/58f346c874a8a982679b4d4f3876602cc05d66d4/torch/_dynamo/output_graph.py#L2081) can finally create a name ([here](https://github.com/pytorch/pytorch/blob/58f346c874a8a982679b4d4f3876602cc05d66d4/torch/fx/graph.py#L1008)) that overwrite args to lift. And thus causing a wrong output of graph.

## Reproducing
Below is an reproduceable example, 
```python
import logging
from typing import List

import torch
from functorch.compile import aot_module_simplified, make_boxed_func


@torch.library.custom_op("mylib::somefunc_forward", mutates_args=())
def somefunc_forward(
    input_: torch.Tensor,
    weight: torch.Tensor,
    shape: List[int],
) -> torch.Tensor:
    return torch.ones_like(input_)


@somefunc_forward.register_fake
def _(input_, shape, weight):
    return torch.empty_like(input_)


@torch.library.custom_op("mylib::somefunc_backward", mutates_args=())
def somefunc_backward(
    grad_output: torch.Tensor,
    input_: torch.Tensor,
    weight: torch.Tensor,
    shape: List[int],
) -> torch.Tensor:
    print(f"backward.{grad_output.shape=}")
    print(f"backward.{input_.shape=}")
    print(f"backward.{weight.shape=}")
    print(f"backward.{shape=}")
    assert list(weight.shape) == shape
    return torch.ones_like(weight)


@somefunc_backward.register_fake
def _(grad_output, input_, weight, shape):
    return torch.empty_like(weight)


def a_func(grad_output, input_, weight_, shape):
    return torch.ones_like(input_.sum() * weight_)


class SomeFunc(torch.autograd.Function):
    @staticmethod
    def forward(ctx, input, weight, normalized_shape):
        ctx.normalized_shape = normalized_shape
        input_ = input.contiguous()
        weight_ = weight.contiguous()
        output = somefunc_forward(input_, weight_, ctx.normalized_shape)
        ctx.save_for_backward(input_, weight_)
        return output

    @staticmethod
    def backward(ctx, grad_output):
        input_, weight_ = ctx.saved_tensors
        # grad_weight = a_func(grad_output, input_, weight_, ctx.normalized_shape)
        grad_weight = somefunc_backward(
            grad_output.contiguous(),
            input_,
            weight_,
            ctx.normalized_shape,
        )
        return None, grad_weight, None


class MyModel(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.weight = torch.nn.Parameter(torch.ones(7))

    def forward(self, x):
        return SomeFunc.apply(x, self.weight, [7])


model = MyModel()
torch._logging.set_logs(dynamo=logging.DEBUG, aot=logging.DEBUG, graph_code=True)


def aot_print_backend(gm, sample_inputs):
    # Forward compiler capture
    def fw(gm, sample_inputs):
        print(f"----- fw")
        gm.print_readable()
        return make_boxed_func(gm.forward)

    # Backward compiler capture
    def bw(gm, sample_inputs):
        print(f"----- bw")
        gm.print_readable()
        return make_boxed_func(gm.forward)

    # Call AOTAutograd
    gm_forward = aot_module_simplified(
        gm, sample_inputs, fw_compiler=fw, bw_compiler=bw
    )
    return gm_forward


model = torch.compile(
    model,
    backend=aot_print_backend,
    dynamic=False,
)
out = model(torch.rand((128, 4, 7)))
out.mean().backward()
```

I can see log that showing calling into create_graph_input like
```log
V0629 02:08:46.839914 8200981504 torch/_dynamo/output_graph.py:2042] [0/0] create_graph_input contiguous (none)
V0629 02:08:46.839998 8200981504 torch/_dynamo/output_graph.py:2042] [0/0] create_graph_input contiguous_1 (none)
```

And the backward graph generate will be like
```log
class GraphModule(torch.nn.Module):
    def forward(self, function_ctx, somefunc_forward_default: "f32[128, 4, 7]", contiguous: "f32[128, 4, 7]", contiguous_1: "f32[7]"):
        contiguous_1 = contiguous
        contiguous_2 = contiguous_1
        
        # No stacktrace found for following nodes
        _set_grad_enabled = torch._C._set_grad_enabled(False)
        
         # File: /Users/bytedance/testtorch/test_custom_op_bug.py:61 in backward, code: grad_output.contiguous(),
        contiguous: "f32[128, 4, 7]" = somefunc_forward_default.contiguous();  somefunc_forward_default = None
        
         # File: /opt/tiger/pytorch/torch/_library/custom_ops.py:506 in __call__, code: return self._opoverload(*args, **kwargs)
        somefunc_backward_default: "f32[7]" = torch.ops.mylib.somefunc_backward.default(contiguous, contiguous_1, contiguous_2, [7]);  contiguous = contiguous_1 = contiguous_2 = None
        
        # No stacktrace found for following nodes
        _set_grad_enabled_1 = torch._C._set_grad_enabled(True)
        return (None, somefunc_backward_default)
```

The original code of `somefunc_backward` takes a input list of `grad_output`, `input_`, `weight` and `shape`, where `weight` should be shape of `torch.Size([7])`. However, in the graph, `contiguous1` and `contiguous_2` are assigned with `contiguous`, this leads to assertion failure I added in `somefunc_backward`.

## Environment
```log
Collecting environment information...
PyTorch version: 2.5.0a0+git0b7e8df
Is debug build: False
CUDA used to build PyTorch: None
ROCM used to build PyTorch: N/A

OS: macOS 14.5 (arm64)
GCC version: Could not collect
Clang version: 15.0.0 (clang-1500.3.9.4)
CMake version: version 3.26.4
Libc version: N/A

Python version: 3.9.19 (main, May  6 2024, 14:39:30)  [Clang 14.0.6 ] (64-bit runtime)
Python platform: macOS-14.5-arm64-arm-64bit
Is CUDA available: False
CUDA runtime version: No CUDA
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: No CUDA
Nvidia driver version: No CUDA
cuDNN version: No CUDA
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True

CPU:
Apple M3 Pro

Versions of relevant libraries:
[pip3] numpy==2.0.0
[pip3] optree==0.11.0
[pip3] torch==2.5.0a0+git0b7e8df
[pip3] torchgraph==0.0.1
[conda] numpy                     2.0.0                    pypi_0    pypi
[conda] optree                    0.11.0                   pypi_0    pypi
[conda] torch                     2.5.0a0+git0b7e8df           dev_0    <develop>
[conda] torchgraph                0.0.1                     dev_0    <develop>
```

## How to fix?

I put a naive fix that add the potential args to lift into the used_names. This visits private variables, will fix that if this issue makes sense to you.

@zou3519 @oulgen 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @rec @peterbell10