### PR TITLE
[Inductor] Make FlexAttention block_mask argument as tuple

### DIFF
--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -52,12 +52,7 @@ class FlexAttentionHOP(HigherOrderOperator):
         key: torch.Tensor,
         value: torch.Tensor,
         score_mod: Callable,
-        sparse_kv_num_blocks: torch.Tensor,
-        sparse_kv_indices: torch.Tensor,
-        sparse_q_num_blocks: torch.Tensor,
-        sparse_q_indices: torch.Tensor,
-        SPARSE_KV_BLOCK_SIZE: int,
-        SPARSE_Q_BLOCK_SIZE: int,
+        block_mask: Tuple,
         *other_buffers: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if not all(isinstance(buf, torch.Tensor) for buf in other_buffers):
@@ -67,12 +62,7 @@ class FlexAttentionHOP(HigherOrderOperator):
             key,
             value,
             score_mod,
-            sparse_kv_num_blocks,
-            sparse_kv_indices,
-            sparse_q_num_blocks,
-            sparse_q_indices,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            block_mask,
             *other_buffers,
         )
 
@@ -95,12 +85,7 @@ class FlexAttentionBackwardHOP(HigherOrderOperator):
         grad_out: torch.Tensor,
         fw_graph: Union[Callable, GraphModule],
         joint_graph: GraphModule,
-        sparse_kv_num_blocks: torch.Tensor,
-        sparse_kv_indices: torch.Tensor,
-        sparse_q_num_blocks: torch.Tensor,
-        sparse_q_indices: torch.Tensor,
-        SPARSE_KV_BLOCK_SIZE: int,
-        SPARSE_Q_BLOCK_SIZE: int,
+        block_mask: Tuple,
         *other_buffers: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if not all(isinstance(buf, torch.Tensor) for buf in other_buffers):
@@ -114,12 +99,7 @@ class FlexAttentionBackwardHOP(HigherOrderOperator):
             grad_out,
             fw_graph,
             joint_graph,
-            sparse_kv_num_blocks,
-            sparse_kv_indices,
-            sparse_q_num_blocks,
-            sparse_q_indices,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            block_mask,
             *other_buffers,
         )
 
@@ -133,12 +113,7 @@ def math_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Eager implementation
@@ -189,12 +164,7 @@ def sdpa_dense(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     out, lse = math_attention(
@@ -202,12 +172,7 @@ def sdpa_dense(
         key,
         value,
         score_mod,
-        sparse_kv_num_blocks,
-        sparse_kv_indices,
-        sparse_q_num_blocks,
-        sparse_q_indices,
-        SPARSE_KV_BLOCK_SIZE,
-        SPARSE_Q_BLOCK_SIZE,
+        block_mask,
         *other_buffers,
     )
     out = out.contiguous()
@@ -220,12 +185,7 @@ def trace_flex_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Traces the flex_attention operator with the given score_mod function and other_buffers.
@@ -239,12 +199,7 @@ def trace_flex_attention(
         key,
         value,
         score_mod,
-        sparse_kv_num_blocks,
-        sparse_kv_indices,
-        sparse_q_num_blocks,
-        sparse_q_indices,
-        SPARSE_KV_BLOCK_SIZE,
-        SPARSE_Q_BLOCK_SIZE,
+        block_mask,
         *other_buffers,
     )
     example_vals = [
@@ -259,12 +214,7 @@ def trace_flex_attention(
         key,
         value,
         score_graph,
-        sparse_kv_num_blocks,
-        sparse_kv_indices,
-        sparse_q_num_blocks,
-        sparse_q_indices,
-        SPARSE_KV_BLOCK_SIZE,
-        SPARSE_Q_BLOCK_SIZE,
+        block_mask,
         *other_buffers,
     )
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
@@ -283,12 +233,7 @@ def flex_attention_proxy_torch_dispatch_mode(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     assert mode is not None, "Mode should always be enabled for python fallback key"
@@ -299,12 +244,7 @@ def flex_attention_proxy_torch_dispatch_mode(
             key,
             value,
             score_mod,
-            sparse_kv_num_blocks,
-            sparse_kv_indices,
-            sparse_q_num_blocks,
-            sparse_q_indices,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            block_mask,
             *other_buffers,
         )
     else:
@@ -313,12 +253,7 @@ def flex_attention_proxy_torch_dispatch_mode(
             key,
             value,
             score_mod,
-            sparse_kv_num_blocks,
-            sparse_kv_indices,
-            sparse_q_num_blocks,
-            sparse_q_indices,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            block_mask,
             *other_buffers,
         )
 
@@ -330,12 +265,7 @@ def flex_attention_functionalize(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Defines the functionalization rules for the flex_attention operator.
@@ -347,20 +277,14 @@ def flex_attention_functionalize(
     query_unwrapped = ctx.unwrap_tensors(query)
     key_unwrapped = ctx.unwrap_tensors(key)
     value_unwrapped = ctx.unwrap_tensors(value)
-    sparse_kv_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_kv_num_blocks)
-    sparse_kv_indices_unwrapped = ctx.unwrap_tensors(sparse_kv_indices)
-    sparse_q_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_q_num_blocks)
-    sparse_q_indices_unwrapped = ctx.unwrap_tensors(sparse_q_indices)
+    block_mask_unwrapped = ctx.unwrap_tensors(block_mask)
     other_buffers_unwrapped = ctx.unwrap_tensors(other_buffers)
 
     # Appease the mypy overlords
     assert isinstance(query_unwrapped, torch.Tensor)
     assert isinstance(key_unwrapped, torch.Tensor)
     assert isinstance(value_unwrapped, torch.Tensor)
-    assert isinstance(sparse_kv_num_blocks_unwrapped, torch.Tensor)
-    assert isinstance(sparse_kv_indices_unwrapped, torch.Tensor)
-    assert isinstance(sparse_q_num_blocks_unwrapped, torch.Tensor)
-    assert isinstance(sparse_q_indices_unwrapped, torch.Tensor)
+    assert isinstance(block_mask_unwrapped, tuple)
     assert isinstance(other_buffers_unwrapped, tuple)
     assert all(isinstance(item, torch.Tensor) for item in other_buffers_unwrapped)
 
@@ -386,12 +310,7 @@ def flex_attention_functionalize(
             key_unwrapped,
             value_unwrapped,
             functional_score_mod,
-            sparse_kv_num_blocks_unwrapped,
-            sparse_kv_indices_unwrapped,
-            sparse_q_num_blocks_unwrapped,
-            sparse_q_indices_unwrapped,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            block_mask_unwrapped,
             *other_buffers_unwrapped,
         )
     return ctx.wrap_tensors(out)  # type: ignore[return-value, arg-type]
@@ -404,12 +323,7 @@ def flex_attention_fake_tensor_mode(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: Tuple[torch.Tensor, ...],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     with mode:
@@ -508,12 +422,7 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
         value,
         fw_graph,
         joint_graph,
-        sparse_kv_num_blocks: torch.Tensor,
-        sparse_kv_indices: torch.Tensor,
-        sparse_q_num_blocks: torch.Tensor,
-        sparse_q_indices: torch.Tensor,
-        SPARSE_KV_BLOCK_SIZE: int,
-        SPARSE_Q_BLOCK_SIZE: int,
+        block_mask,
         *other_buffers,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         any_buffer_requires_grad = any(buffer.requires_grad for buffer in other_buffers)
@@ -522,20 +431,16 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
         ), "Captured buffers that require grad are not yet supported."
         ctx._fw_graph = fw_graph
         ctx._joint_graph = joint_graph
-        ctx._SPARSE_KV_BLOCK_SIZE = SPARSE_KV_BLOCK_SIZE
-        ctx._SPARSE_Q_BLOCK_SIZE = SPARSE_Q_BLOCK_SIZE
+        # KV_BLOCK_SIZE and Q_BLOCK_SIZE are integers, so can't use ctx.save_for_backward
+        ctx._KV_BLOCK_SIZE = block_mask[4]
+        ctx._Q_BLOCK_SIZE = block_mask[5]
         with torch._C._AutoDispatchBelowAutograd():
             out, logsumexp = flex_attention(
                 query,
                 key,
                 value,
                 fw_graph,
-                sparse_kv_num_blocks,
-                sparse_kv_indices,
-                sparse_q_num_blocks,
-                sparse_q_indices,
-                SPARSE_KV_BLOCK_SIZE,
-                SPARSE_Q_BLOCK_SIZE,
+                block_mask,
                 *other_buffers,
             )
 
@@ -545,10 +450,7 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
             value,
             out,
             logsumexp,
-            sparse_kv_num_blocks,
-            sparse_kv_indices,
-            sparse_q_num_blocks,
-            sparse_q_indices,
+            *block_mask[:4],
             *other_buffers,
         )
         return out, logsumexp
@@ -570,10 +472,10 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
         ) = fw_args
         fw_graph = ctx._fw_graph
         joint_graph = ctx._joint_graph
-        SPARSE_KV_BLOCK_SIZE = ctx._SPARSE_KV_BLOCK_SIZE
-        SPARSE_Q_BLOCK_SIZE = ctx._SPARSE_Q_BLOCK_SIZE
+        KV_BLOCK_SIZE = ctx._KV_BLOCK_SIZE
+        Q_BLOCK_SIZE = ctx._Q_BLOCK_SIZE
         # We have asserted that other_buffers do not require grad in the forward
-        none_grads = [None] * (8 + len(other_buffers))
+        none_grads = [None] * (3 + len(other_buffers))
         grad_query, grad_key, grad_value = flex_attention_backward(
             query,
             key,
@@ -583,12 +485,14 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
             grad_out,
             fw_graph,
             joint_graph,
-            sparse_kv_num_blocks,
-            sparse_kv_indices,
-            sparse_q_num_blocks,
-            sparse_q_indices,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            (
+                sparse_kv_num_blocks,
+                sparse_kv_indices,
+                sparse_q_num_blocks,
+                sparse_q_indices,
+                KV_BLOCK_SIZE,
+                Q_BLOCK_SIZE,
+            ),
             *other_buffers,
         )
         return grad_query, grad_key, grad_value, *none_grads
@@ -600,12 +504,7 @@ def flex_attention_autograd(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: Callable,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: Tuple[torch.Tensor, ...],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     with TransformGetItemToIndex():
@@ -625,12 +524,7 @@ def flex_attention_autograd(
             value,
             fw_graph,
             bw_graph,
-            sparse_kv_num_blocks,
-            sparse_kv_indices,
-            sparse_q_num_blocks,
-            sparse_q_indices,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            block_mask,
             *other_buffers,
         )
     return out, logsumexp
@@ -649,12 +543,7 @@ def sdpa_dense_backward(
     grad_out: torch.Tensor,
     fw_graph: Callable,  # GraphModule type hint?
     joint_graph: Callable,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     working_precision = torch.float64 if query.dtype == torch.float64 else torch.float32
@@ -729,12 +618,7 @@ def trace_flex_attention_backward(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """We already have the forward graph and joint graph from the forward pass, so we create a proxy attach both graphs"""
@@ -747,12 +631,7 @@ def trace_flex_attention_backward(
         grad_out,
         fw_graph,
         joint_graph,
-        sparse_kv_num_blocks,
-        sparse_kv_indices,
-        sparse_q_num_blocks,
-        sparse_q_indices,
-        SPARSE_KV_BLOCK_SIZE,
-        SPARSE_Q_BLOCK_SIZE,
+        block_mask,
         *other_buffers,
     )
 
@@ -774,12 +653,7 @@ def trace_flex_attention_backward(
         grad_out,
         fw_graph,
         joint_graph,
-        sparse_kv_num_blocks,
-        sparse_kv_indices,
-        sparse_q_num_blocks,
-        sparse_q_indices,
-        SPARSE_KV_BLOCK_SIZE,
-        SPARSE_Q_BLOCK_SIZE,
+        block_mask,
         *other_buffers,
     )
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, node_args)
@@ -806,12 +680,7 @@ def flex_attention_backward_proxy_torch_dispatch_mode(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE,
-    SPARSE_Q_BLOCK_SIZE,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert mode is not None, "Mode should always be enabled for python fallback key"
@@ -826,12 +695,7 @@ def flex_attention_backward_proxy_torch_dispatch_mode(
             grad_out,
             fw_graph,
             joint_graph,
-            sparse_kv_num_blocks,
-            sparse_kv_indices,
-            sparse_q_num_blocks,
-            sparse_q_indices,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            block_mask,
             *other_buffers,
         )
     else:
@@ -844,12 +708,7 @@ def flex_attention_backward_proxy_torch_dispatch_mode(
             grad_out,
             fw_graph,
             joint_graph,
-            sparse_kv_num_blocks,
-            sparse_kv_indices,
-            sparse_q_num_blocks,
-            sparse_q_indices,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            block_mask,
             *other_buffers,
         )
 
@@ -865,12 +724,7 @@ def flex_attention_backward_functionalize(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Defines the functionalization rules for the flex_attention operator.
@@ -885,10 +739,7 @@ def flex_attention_backward_functionalize(
     out_unwrapped = ctx.unwrap_tensors(out)
     logsumexp_unwrapped = ctx.unwrap_tensors(logsumexp)
     grad_out_unwrapped = ctx.unwrap_tensors(grad_out)
-    sparse_kv_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_kv_num_blocks)
-    sparse_kv_indices_unwrapped = ctx.unwrap_tensors(sparse_kv_indices)
-    sparse_q_num_blocks_unwrapped = ctx.unwrap_tensors(sparse_q_num_blocks)
-    sparse_q_indices_unwrapped = ctx.unwrap_tensors(sparse_q_indices)
+    block_mask_unwrapped = ctx.unwrap_tensors(block_mask)
     other_buffers_unwrapped = ctx.unwrap_tensors(other_buffers)
 
     # Appease the mypy overlords
@@ -898,10 +749,7 @@ def flex_attention_backward_functionalize(
     assert isinstance(out_unwrapped, torch.Tensor)
     assert isinstance(logsumexp_unwrapped, torch.Tensor)
     assert isinstance(grad_out_unwrapped, torch.Tensor)
-    assert isinstance(sparse_kv_num_blocks_unwrapped, torch.Tensor)
-    assert isinstance(sparse_kv_indices_unwrapped, torch.Tensor)
-    assert isinstance(sparse_q_num_blocks_unwrapped, torch.Tensor)
-    assert isinstance(sparse_q_indices_unwrapped, torch.Tensor)
+    assert isinstance(block_mask_unwrapped, tuple)
     assert isinstance(other_buffers_unwrapped, tuple)
     assert all(isinstance(item, torch.Tensor) for item in other_buffers_unwrapped)
 
@@ -918,12 +766,7 @@ def flex_attention_backward_functionalize(
             grad_out_unwrapped,
             functional_fw_graph,  # type: ignore[arg-type]
             functional_joint_graph,  # type: ignore[arg-type]
-            sparse_kv_num_blocks_unwrapped,
-            sparse_kv_indices_unwrapped,
-            sparse_q_num_blocks_unwrapped,
-            sparse_q_indices_unwrapped,
-            SPARSE_KV_BLOCK_SIZE,
-            SPARSE_Q_BLOCK_SIZE,
+            block_mask_unwrapped,
             *other_buffers_unwrapped,
         )
 
@@ -941,12 +784,7 @@ def flex_attention_backward_fake_tensor_mode(
     grad_out: torch.Tensor,
     fw_graph: Union[Callable, GraphModule],
     joint_graph: GraphModule,
-    sparse_kv_num_blocks: torch.Tensor,
-    sparse_kv_indices: torch.Tensor,
-    sparse_q_num_blocks: torch.Tensor,
-    sparse_q_indices: torch.Tensor,
-    SPARSE_KV_BLOCK_SIZE: int,
-    SPARSE_Q_BLOCK_SIZE: int,
+    block_mask: Tuple,
     *other_buffers: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     with mode:

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -69,8 +69,8 @@ def index_to_other_buffers(cnt: int, graph_type: SubgraphType) -> int:
     #   *other_buffers
     # ]
     # For fwd_graphs we have 5 dummy values this when the first lifted args
-    # is seen cnt = 5 and the start of the index_buffers is at args[10]
-    # thus we add 5 from the current cnt
+    # is seen cnt = 5 and the start of the index_buffers is at args[5]
+    # thus we add 0 from the current cnt
     if graph_type == SubgraphType.FWD:
         return cnt + 0
 
@@ -86,11 +86,11 @@ def index_to_other_buffers(cnt: int, graph_type: SubgraphType) -> int:
     #   block_mask,
     #   *other_buffers
     # ]
-    # We have 5 dummy values but the start of other_buffers is at index 14
+    # We have 5 dummy values but the start of other_buffers is at index 9
     if graph_type == SubgraphType.JOINT_FWD:
         return cnt + 4
 
-    # Same bwd args but now with 6 dummy values while other_buffers still start at 14
+    # Same bwd args but now with 6 dummy values while other_buffers still start at 9
     if graph_type == SubgraphType.JOINT_BWD:
         return cnt + 3
 

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -65,19 +65,14 @@ def index_to_other_buffers(cnt: int, graph_type: SubgraphType) -> int:
     #   key,
     #   value,
     #   score_mod,
-    #   sparse_kv_num_blocks,
-    #   sparse_kv_indices,
-    #   sparse_q_num_blocks,
-    #   sparse_q_indices,
-    #   SPARSE_KV_BLOCK_SIZE,
-    #   SPARSE_Q_BLOCK_SIZE,
+    #   block_mask,
     #   *other_buffers
     # ]
     # For fwd_graphs we have 5 dummy values this when the first lifted args
     # is seen cnt = 5 and the start of the index_buffers is at args[10]
     # thus we add 5 from the current cnt
     if graph_type == SubgraphType.FWD:
-        return cnt + 5
+        return cnt + 0
 
     # Current bwd_args = [
     #   q,
@@ -88,21 +83,16 @@ def index_to_other_buffers(cnt: int, graph_type: SubgraphType) -> int:
     #   grad_out,
     #   fw_graph,
     #   joint_graph,
-    #   sparse_kv_num_blocks,
-    #   sparse_kv_indices,
-    #   sparse_q_num_blocks,
-    #   sparse_q_indices,
-    #   SPARSE_KV_BLOCK_SIZE,
-    #   SPARSE_Q_BLOCK_SIZE,
+    #   block_mask,
     #   *other_buffers
     # ]
     # We have 5 dummy values but the start of other_buffers is at index 14
     if graph_type == SubgraphType.JOINT_FWD:
-        return cnt + 9
+        return cnt + 4
 
     # Same bwd args but now with 6 dummy values while other_buffers still start at 14
     if graph_type == SubgraphType.JOINT_BWD:
-        return cnt + 8
+        return cnt + 3
 
 
 def build_subgraph_buffer(
@@ -458,14 +448,17 @@ def flex_attention(*args, **kwargs):
         key,
         value,
         subgraph,
+        block_mask,
+        *other_buffers,
+    ) = args
+    (
         sparse_kv_num_blocks,
         sparse_kv_indices,
         sparse_q_num_blocks,
         sparse_q_indices,
         SPARSE_KV_BLOCK_SIZE,
         SPARSE_Q_BLOCK_SIZE,
-        *other_buffers,
-    ) = args
+    ) = block_mask
     for buf in [
         query,
         key,
@@ -897,14 +890,17 @@ def flex_attention_backward(*args, **kwargs):
         grad_out,
         fw_graph,
         joint_graph,
+        block_mask,
+        *other_buffers,
+    ) = args
+    (
         sparse_kv_num_blocks,
         sparse_kv_indices,
         sparse_q_num_blocks,
         sparse_q_indices,
         SPARSE_KV_BLOCK_SIZE,
         SPARSE_Q_BLOCK_SIZE,
-        *other_buffers,
-    ) = args
+    ) = block_mask
     for buf in [
         query,
         key,

--- a/torch/nn/attention/_flex_attention.py
+++ b/torch/nn/attention/_flex_attention.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 """This module implements the user facing API for flex_attention in PyTorch."""
 import functools
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 
 import torch
 from torch._higher_order_ops.flex_attention import flex_attention as flex_attention_hop
@@ -42,7 +42,7 @@ def _identity(
 _DEFAULT_SPARSE_BLOCK_SIZE = 128
 
 
-class _BlockSparseMask:
+class _BlockMask:
     kv_num_blocks: torch.Tensor
     kv_indices: torch.Tensor
     q_num_blocks: torch.Tensor
@@ -65,6 +65,16 @@ class _BlockSparseMask:
         self.q_indices = q_indices
         self.KV_BLOCK_SIZE = KV_BLOCK_SIZE
         self.Q_BLOCK_SIZE = Q_BLOCK_SIZE
+
+    def as_tuple(self):
+        return (
+            self.kv_num_blocks,
+            self.kv_indices,
+            self.q_num_blocks,
+            self.q_indices,
+            self.KV_BLOCK_SIZE,
+            self.Q_BLOCK_SIZE,
+        )
 
 
 def broadcast_to_dim(x, dim):
@@ -107,11 +117,11 @@ def _convert_block_mask_to_mask(
     return block_mask
 
 
-def _create_block_sparse_mask(
+def _create_block_mask(
     mask: torch.Tensor,
     KV_BLOCK_SIZE: int = _DEFAULT_SPARSE_BLOCK_SIZE,
     Q_BLOCK_SIZE: int = _DEFAULT_SPARSE_BLOCK_SIZE,
-):
+) -> Tuple:
     block_mask = _convert_mask_to_block_mask(
         mask, KV_BLOCK_SIZE=KV_BLOCK_SIZE, Q_BLOCK_SIZE=Q_BLOCK_SIZE
     )
@@ -122,14 +132,14 @@ def _create_block_sparse_mask(
     q_indices = torch.argsort(block_mask, dim=2, descending=True, stable=True).permute(
         0, 1, 3, 2
     )
-    return _BlockSparseMask(
+    return _BlockMask(
         kv_num_blocks=kv_num_blocks.to(torch.int32).to(mask.device).contiguous(),
         kv_indices=kv_indices.to(torch.int32).to(mask.device).contiguous(),
         q_num_blocks=q_num_blocks.to(torch.int32).to(mask.device).contiguous(),
         q_indices=q_indices.to(torch.int32).to(mask.device).contiguous(),
         KV_BLOCK_SIZE=KV_BLOCK_SIZE,
         Q_BLOCK_SIZE=Q_BLOCK_SIZE,
-    )
+    ).as_tuple()
 
 
 """
@@ -140,18 +150,18 @@ def _create_block_sparse_mask(
 """
 
 
-def _create_empty_block_sparse_mask(query, key, value):
+def _create_empty_block_mask(query, key, value) -> Tuple:
     device = query.device
     kv_len = key.size()[-2]
     q_len = query.size()[-2]
-    return _BlockSparseMask(
+    return _BlockMask(
         kv_num_blocks=torch.ones([1, 1, 1], dtype=torch.int32, device=device),
         kv_indices=torch.zeros([1, 1, 1, 1], dtype=torch.int32, device=device),
         q_num_blocks=torch.ones([1, 1, 1], dtype=torch.int32, device=device),
         q_indices=torch.zeros([1, 1, 1, 1], dtype=torch.int32, device=device),
         KV_BLOCK_SIZE=kv_len,
         Q_BLOCK_SIZE=q_len,
-    )
+    ).as_tuple()
 
 
 def _flex_attention(
@@ -159,7 +169,7 @@ def _flex_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     score_mod: _score_mod_signature = _identity,
-    block_sparse_mask: Optional[_BlockSparseMask] = None,
+    block_mask: Optional[Tuple] = None,
 ) -> torch.Tensor:
     r"""This function implements scaled dot product attention with an arbitrary attention score modification function.
 
@@ -209,8 +219,8 @@ def _flex_attention(
 
     """
 
-    if block_sparse_mask is None:
-        block_sparse_mask = _create_empty_block_sparse_mask(query, key, value)
+    if block_mask is None:
+        block_mask = _create_empty_block_mask(query, key, value)
     if torch.compiler.is_dynamo_compiling():
         # mark head_dim always to be static
         for x in [query, key, value]:
@@ -220,12 +230,7 @@ def _flex_attention(
             key,
             value,
             score_mod,
-            block_sparse_mask.kv_num_blocks,
-            block_sparse_mask.kv_indices,
-            block_sparse_mask.q_num_blocks,
-            block_sparse_mask.q_indices,
-            block_sparse_mask.KV_BLOCK_SIZE,
-            block_sparse_mask.Q_BLOCK_SIZE,
+            block_mask,
         )
         return out
 
@@ -247,12 +252,7 @@ def _flex_attention(
                     key,
                     value,
                     score_mod,
-                    block_sparse_mask.kv_num_blocks,
-                    block_sparse_mask.kv_indices,
-                    block_sparse_mask.q_num_blocks,
-                    block_sparse_mask.q_indices,
-                    block_sparse_mask.KV_BLOCK_SIZE,
-                    block_sparse_mask.Q_BLOCK_SIZE,
+                    block_mask,
                 )
                 return out
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129909
* #129859
* __->__ #129831


Re-organize ```block_mask``` related arguments a tuple to reduce the individual argument number. I was trying to use named tuple, but aot autograd doesn't work well with named tuple. The only downside of using tuple rather than named tuple is we need to use index to access its element. But we only need this at one place, it should be fine. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang