### PR TITLE
Bug fix for captuing execution trace grid function

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1759,7 +1759,7 @@ def grid(*numels):
             z_grid,
         )
 
-    setattr(grid_fn, "grid_fn_str", f"grid({numels})")  # noqa: B010
+    setattr(grid_fn, "grid_fn_str", f"grid{numels}")  # noqa: B010
 
     return grid_fn
 


### PR DESCRIPTION
Summary:
The inputs to grid function are varying argument, it can be one number, two numbers, or three  numbers. The current implementation captured it as a tuple. For example "grid((16,))". The fix is to change it to varying number of elements. In the previous example, it is changed to "grid(16,)".

PARAM et-replay code will be modified to reflect this change in a following up DIFF.

Test Plan: buck2 test  mode/dev-nosan caffe2/test:profiler -- -- test_execution_trace_with_pt2

Differential Revision: D59195933


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang