### PR TITLE
[AOTI] Fix test_dynamic_scalar_abi_compatible_cpu_with_stack_allocation_and_minimal_arrayref_interface

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3029,7 +3029,7 @@ CPU_TEST_FAILURES = {
     "test_dynamic_cat": fail_minimal_arrayref_interface(),
     # https://github.com/pytorch/pytorch/issues/129550
     # https://github.com/pytorch/pytorch/issues/123691
-    "test_dynamic_scalar": fail_stack_allocation(is_skip=True),
+    # "test_dynamic_scalar": fail_stack_allocation(is_skip=True),
     # https://github.com/pytorch/pytorch/issues/122980
     "test_fft_c2c": fail_stack_allocation(is_skip=True),
     # TODO: test_freezing_abi_compatible_cpu fails,

--- a/torch/_inductor/codegen/aoti_runtime/implementation.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/implementation.cpp
@@ -13,16 +13,23 @@ void convert_output_to_handle(
   handle = output.expensiveCopyToTensor();
 }
 
+void convert_output_to_handle(
+    const float& output,
+    AtenTensorHandle& handle) {
+  RAIIAtenTensorHandle scalar_to_tensor_0 = scalar_to_tensor_handle(output);
+  handle = scalar_to_tensor_0.release();
+}
+
 template <typename... Ts, std::size_t... Is>
 void convert_outputs_to_handles_helper(
-    const std::tuple<ArrayRefTensor<Ts>...>& outputs,
+    const std::tuple<Ts...>& outputs,
     AtenTensorHandle* output_handles,
     std::index_sequence<Is...>) {
   (convert_output_to_handle(std::get<Is>(outputs), output_handles[Is]), ...);
 }
 template <typename... Ts>
 void convert_outputs_to_handles(
-    const std::tuple<ArrayRefTensor<Ts>...>& outputs,
+    const std::tuple<Ts...>& outputs,
     AtenTensorHandle* output_handles) {
   convert_outputs_to_handles_helper(
       outputs, output_handles, std::make_index_sequence<sizeof...(Ts)>());

--- a/torch/_inductor/codegen/aoti_runtime/implementation.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/implementation.cpp
@@ -13,12 +13,15 @@ void convert_output_to_handle(
   handle = output.expensiveCopyToTensor();
 }
 
-void convert_output_to_handle(
-    const float& output,
-    AtenTensorHandle& handle) {
-  RAIIAtenTensorHandle scalar_to_tensor_0 = scalar_to_tensor_handle(output);
-  handle = scalar_to_tensor_0.release();
-}
+
+template<typename T,
+    typename = std::enable_if_t<std::is_scalar<T>::value>>
+    inline void convert_output_to_handle(
+      const T& output,
+      AtenTensorHandle& handle) {
+      RAIIAtenTensorHandle scalar_to_tensor_0 = scalar_to_tensor_handle(output);
+      handle = scalar_to_tensor_0.release();
+    }
 
 template <typename... Ts, std::size_t... Is>
 void convert_outputs_to_handles_helper(

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1008,11 +1008,16 @@ class CppWrapperCpu(WrapperCodeGen):
 
             if config.abi_compatible:
                 if isinstance(output_buffer, ir.ShapeAsConstantBuffer):
-                    # Need to wrap scalar into tensor as the main function returns a vector of tensors
-                    output_tensor = self.codegen_scalar_to_tensor(output)
-                    self.wrapper_call.writeline(
-                        f"output_handles[{idx}] = {output_tensor}.release();"
-                    )
+                    if config.use_minimal_arrayref_interface:
+                        self.wrapper_call.writeline(
+                            f"std::get<{idx}>(output_arrayref_tensors) = {output};"
+                        )
+                    else:
+                        # Need to wrap scalar into tensor as the main function returns a vector of tensors
+                        output_tensor = self.codegen_scalar_to_tensor(output)
+                        self.wrapper_call.writeline(
+                            f"output_handles[{idx}] = {output_tensor}.release();"
+                        )
                     continue
 
                 output_is_tensor_handle_expr = (


### PR DESCRIPTION
Fixes #129550

## Summary
Error 1:
```
  File "/home/yingzhaoseattle/pytorch/torch/_inductor/codegen/cpp_wrapper_cpu.py", line 401, in write_wrapper_decl
    output_arrayref_types = ", ".join(
                            ^^^^^^^^^^
  File "/home/yingzhaoseattle/pytorch/torch/_inductor/codegen/cpp_wrapper_cpu.py", line 402, in <genexpr>
    f"ArrayRefTensor<{DTYPE_TO_CPP[x.get_dtype()]}>"
                                   ^^^^^^^^^^^^^
  File "/home/yingzhaoseattle/pytorch/torch/_inductor/ir.py", line 318, in get_dtype
    return self.dtype
           ^^^^^^^^^^
AttributeError: 'ShapeAsConstantBuffer' object has no attribute 'dtype'
```
Fix: Add function get_output_cpp_type to handle the case when output is ShapeAsConstantBuffer, we use dtype of output.shape

Error 2: 
Return type AOTInductorModelOutputs = std::tuple<ArrayRefTensor<float>, double>; 
Fix: need specially handling when returning double

Error 3:
convert_outputs_to_handles template only accepts ArrayRefTensor, need to make it more generalized 

## Test Plan

```
python test/inductor/test_aot_inductor.py -k AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface.test_dynamic_scalar_abi_compatible_cpu_with_stack_allocation_and_minimal_arrayref_interface
```
```
stats [('calls_captured', 3), ('unique_graphs', 1)]
inductor [('extern_calls', 1)]
.
----------------------------------------------------------------------
Ran 1 test in 9.541s

OK
Segmentation fault (core dumped)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang