### PR TITLE
fix gcc10 build for cpu container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,10 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bi
 
 # Tools needed for llvm
 RUN sudo apt-get -y update
-RUN sudo apt install -y lsb-release wget software-properties-common gnupg
+RUN sudo apt install -y lsb-release wget software-properties-common gnupg 
+
+# Libraries needed for gcc build
+RUN sudo apt install -y libopenblas-dev liblapack-dev
 
 # Install CLANG if version is specified
 ARG CLANG_VERSION


### PR DESCRIPTION
add required libraries to Dockerfile to avoid linker errors for cpu based devcontainer
