### PR TITLE
Fixed nn.set_submodule()

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1446,8 +1446,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         net.set_submodule(target, l2)
         self.assertEqual(net.get_submodule(target), l2)
         self.assertRaises(ValueError, net.set_submodule, "", l)
-        self.assertRaises(AttributeError, net.set_submodule, "a.l", l)
-        self.assertRaises(AttributeError, net.set_submodule, "t.l.l2", l2)
 
     def test_module_to_argparse(self):
         net = nn.Sequential(nn.Linear(3, 3))

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -776,10 +776,10 @@ class Module:
                 )
 
             mod = getattr(mod, item)
-            
+
             if not isinstance(mod, torch.nn.Module):
                 raise AttributeError("`" + item + "` is not an nn.Module")
-            
+
         setattr(mod, name, module)
 
     def get_parameter(self, target: str) -> "Parameter":

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -776,9 +776,13 @@ class Module:
                 )
 
             mod = getattr(mod, item)
-
-            if type(mod) is not torch.nn.Module:
+            
+            if not isinstance(mod, torch.nn.Module):
                 raise AttributeError("`" + item + "` is not an nn.Module")
+
+        if type(mod) is not torch.nn.Module:
+                raise AttributeError("Type of `" + item + "` is not nn.Module")
+            
         setattr(mod, name, module)
 
     def get_parameter(self, target: str) -> "Parameter":

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -779,9 +779,6 @@ class Module:
             
             if not isinstance(mod, torch.nn.Module):
                 raise AttributeError("`" + item + "` is not an nn.Module")
-
-        if type(mod) is not torch.nn.Module:
-                raise AttributeError("Type of `" + item + "` is not nn.Module")
             
         setattr(mod, name, module)
 


### PR DESCRIPTION
nn.set_submodule() shouldn't check whether type is strictly only nn.Module.
Instead, it should allows the operation if all module in the path inherit from nn.Module.