### PR TITLE
[Traceable FSDP2] Mark inductor.resize_storage_bytes_ as mutation op

### DIFF
--- a/torch/csrc/inductor/resize_storage_bytes.cpp
+++ b/torch/csrc/inductor/resize_storage_bytes.cpp
@@ -50,7 +50,7 @@ static void resize_storage_bytes__functionalize(
 
 TORCH_LIBRARY_FRAGMENT(inductor, m) {
   m.def(
-      "resize_storage_bytes_(Tensor variable, SymInt new_size) -> ()",
+      "resize_storage_bytes_(Tensor(a!) variable, SymInt new_size) -> ()",
       dispatch(
           c10::DispatchKey::CompositeExplicitAutograd, resize_storage_bytes_),
       {at::Tag::pt2_compliant_tag});


### PR DESCRIPTION
Since `inductor.resize_storage_bytes_` is indeed a mutation op, it could be a good idea to mark it as so.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129852
* __->__ #129855

