### PR TITLE
Add deterministic support in nn.functional.interpolate for XPU

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4568,7 +4568,7 @@ def interpolate(  # noqa: F811
         # Two levels are necessary to prevent TorchScript from touching
         # are_deterministic_algorithms_enabled.
         if not torch.jit.is_scripting():
-            if torch.are_deterministic_algorithms_enabled() and input.is_cuda:
+            if torch.are_deterministic_algorithms_enabled() and (input.is_cuda or input.is_xpu):
                 # Use slow decomp whose backward will be in terms of index_put
                 # importlib is required because the import cannot be top level
                 # (cycle) and cannot be nested (TS doesn't support)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4568,7 +4568,9 @@ def interpolate(  # noqa: F811
         # Two levels are necessary to prevent TorchScript from touching
         # are_deterministic_algorithms_enabled.
         if not torch.jit.is_scripting():
-            if torch.are_deterministic_algorithms_enabled() and (input.is_cuda or input.is_xpu):
+            if torch.are_deterministic_algorithms_enabled() and (
+                input.is_cuda or input.is_xpu
+            ):
                 # Use slow decomp whose backward will be in terms of index_put
                 # importlib is required because the import cannot be top level
                 # (cycle) and cannot be nested (TS doesn't support)
@@ -5081,7 +5083,9 @@ def pad(
             torch.nn.functional.pad, (input,), input, pad, mode=mode, value=value
         )
     if not torch.jit.is_scripting():
-        if torch.are_deterministic_algorithms_enabled() and input.is_cuda:
+        if torch.are_deterministic_algorithms_enabled() and (
+            input.is_cuda or input.is_xpu
+        ):
             if mode == "replicate":
                 # Use slow decomp whose backward will be in terms of index_put.
                 # importlib is required because the import cannot be top level


### PR DESCRIPTION
Both for CUDA and XPU, there are no deterministic implementation at native in `aten::upsample_bilinear` and `aten::replication_pad`. CUDA leverage operator decomposition path in frontend hook `nn.functional.interpolate` as its deterministic implentation. XPU backend uses the same solution in this PR.

cc @frank-wei @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @EikanWang @fengyuan14 @guangyey