### PR TITLE
Correctly put mark_unbacked symbols in shape_env_to_source_to_symbol_cache

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -617,7 +617,7 @@ def forward(self):
         self.assertTrue(f(torch.empty(8)).item())
         self.assertFalse(f(torch.empty(13)).item())
 
-    @torch._dynamo.config.patch(error_on_recompile = True)
+    @torch._dynamo.config.patch(error_on_recompile=True)
     def test_mark_unbacked(self):
         class TestModel(torch.nn.Module):
             def __init__(

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -617,6 +617,33 @@ def forward(self):
         self.assertTrue(f(torch.empty(8)).item())
         self.assertFalse(f(torch.empty(13)).item())
 
+    @torch._dynamo.config.patch(error_on_recompile = False)
+    def test_mark_unbacked(self):
+        class TestModel(torch.nn.Module):
+            def __init__(
+                self,
+            ):
+                super().__init__()
+
+            def forward(self, x: torch.Tensor, val: int) -> torch.Tensor:
+                return x * 2
+
+        main_model = TestModel()
+        opt_model = torch.compile(main_model, mode="max-autotune", dynamic=True)
+
+        x1 = torch.rand(3, 5, 4, 8)
+        x2 = torch.rand(1, 5, 4, 8)
+
+        torch._dynamo.decorators.mark_unbacked(x1, 0)
+
+        o1_ref = main_model(x1, 2)
+        o1 = opt_model(x1, 2)
+        self.assertEqual(o1_ref, o1)
+
+        o1_2_ref = main_model(x2, 2)
+        o1_2 = opt_model(x2, 2)
+        self.assertEqual(o1_2_ref, o1_2)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -617,7 +617,7 @@ def forward(self):
         self.assertTrue(f(torch.empty(8)).item())
         self.assertFalse(f(torch.empty(13)).item())
 
-    @torch._dynamo.config.patch(error_on_recompile = False)
+    @torch._dynamo.config.patch(error_on_recompile = True)
     def test_mark_unbacked(self):
         class TestModel(torch.nn.Module):
             def __init__(

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3440,12 +3440,6 @@ class ShapeEnv:
     ) -> "sympy.Expr":
         """Create a new symbol which is tracked by this ShapeEnv
         """
-        if dynamic_dim is DimDynamic.SIZE_LIKE_UNBACKED:
-            r = self.create_unbacked_symint().node.expr
-            self._constrain_range_for_size(r)
-            # TODO: maybe put the hint somewhere
-            return r
-
         # check if constraint_dim is actually static integer
         if isinstance(constraint_dim, StrictMinMaxConstraint) and constraint_dim.vr.lower == constraint_dim.vr.upper:
             dynamic_dim = DimDynamic.STATIC
@@ -3469,6 +3463,14 @@ class ShapeEnv:
                 and source_name
                 and (source_name in symbolic_context.shape_env_to_source_to_symbol_cache[id(self)])):
             return symbolic_context.shape_env_to_source_to_symbol_cache[id(self)][source_name]
+
+        if dynamic_dim is DimDynamic.SIZE_LIKE_UNBACKED:
+            out = self.create_unbacked_symint().node.expr
+            self._constrain_range_for_size(out)
+            # TODO: maybe put the hint somewhere
+            if isinstance(symbolic_context, StatefulSymbolicContext) and source_name:
+                symbolic_context.shape_env_to_source_to_symbol_cache[id(self)][source_name] = out
+            return out
 
         if do_not_specialize_zero_one:
             specialize_zero_one = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #129677
* __->__ #129869

Internal xref:
https://www.internalfb.com/intern/anp/view/?source=version_selector&id=5534845

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang