### PR TITLE
Fix layout for *_like() factories on NJTs

### DIFF
--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -520,17 +520,33 @@ def _nested_jagged_to_strided(func, *args, **kwargs):
     )
 
 
-register_jagged_func(
+register_jagged_func(torch.ops.aten.detach.default, "self: jt_all")(
+    jagged_unary_pointwise
+)
+
+
+@register_jagged_func(
     [
         torch.ops.aten.empty_like.default,
         torch.ops.aten.ones_like.default,
         torch.ops.aten.zeros_like.default,
-        torch.ops.aten.empty_like.default,
         torch.ops.aten.randn_like.default,
-        torch.ops.aten.detach.default,
     ],
     "self: jt_all",
-)(jagged_unary_pointwise)
+)
+def like_factory_default(func, *args, **kwargs):
+    _, new_kwargs = normalize_function(
+        func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
+    )
+
+    inp = new_kwargs.pop("input")
+
+    # Default layout is technically torch.strided but only jagged is supported here.
+    # Rather than force users to specify the layout, assume jagged.
+    # This should be set to strided for redispatching on values.
+    new_kwargs["layout"] = torch.strided
+
+    return NestedTensor(func(inp._values, **new_kwargs), **extract_kwargs(inp))
 
 
 @register_jagged_func(torch.ops.aten.zero_.default, "self: jt_all")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129879

Background: this bug was triggering DEBUG=1 asserts in the backward for `unbind()`, which calls `empty_like()`. I found that the NJT implementation of `empty_like()` was redispatching on `values` while blindly passing along all kwargs. This resulted in `empty_like(values, ..., layout=torch.jagged)`, which is incorrect since `values` is strided, tripping the debug assert here:

https://github.com/pytorch/pytorch/blob/433b691f9823dc2e3404c90969df44ff5487a978/aten/src/ATen/EmptyTensor.cpp#L305

This PR explicitly sets `layout=torch.strided` when redispatching `*_like()` factories on `values`.