### PR TITLE
Don't mark conversion to float as is_integer = False

### DIFF
--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -502,7 +502,6 @@ class PowByNatural(sympy.Function):
 # base is assumed to be nonnegative, thereby prevent complex numbers from
 # occuring
 class FloatPow(sympy.Function):
-    is_integer = False
     is_real = True
 
     @classmethod
@@ -523,7 +522,6 @@ class FloatPow(sympy.Function):
 # In particular, sympy division is willing to simplify x/x == 1
 # where 1 is an integer, but this must be a float if x was float.
 class FloatTrueDiv(sympy.Function):
-    is_integer = False
     is_real = True
 
     @classmethod
@@ -547,7 +545,6 @@ class FloatTrueDiv(sympy.Function):
 # so just have a different operator
 # NB: Right now, Inductor codegen doesn't implement this correctly lol
 class IntTrueDiv(sympy.Function):
-    is_integer = False
     is_real = True
 
     @classmethod
@@ -633,7 +630,6 @@ class IsNonOverlappingAndDenseIndicator(sympy.Function):
 
 # NB: this is inconsistent with math.trunc in Python
 class TruncToFloat(sympy.Function):
-    is_integer = False
     is_real = True
 
     @classmethod
@@ -692,7 +688,6 @@ class RoundToInt(sympy.Function):
 
 # NB: Like Round, this only ever returns floats.  ndigits cannot be None
 class RoundDecimal(sympy.Function):
-    is_integer = False
     is_real = True
 
     @classmethod
@@ -704,7 +699,6 @@ class RoundDecimal(sympy.Function):
 
 
 class ToFloat(sympy.Function):
-    is_integer = False
     is_real = True
 
     @classmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #128327
* __->__ #129890

Zero is an integer, so if you say is_integer = False, you are also
saying the result cannot be zero, which is undesirable.

This is exercised by next PR in the stack.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10