### PR TITLE
Fixes for flaky test - test_flash_attention_vs_math_ref_grads

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2928,6 +2928,9 @@ class TestSDPACudaOnly(NNTestCase):
             self.skipTest("Flash V2 does not accept is_casual when seq_len_q != seq_len_k")
         if TEST_WITH_ROCM and seq_len_q >= 1024 and seq_len_k >= 1024 and batch_size > 1:
             torch.cuda.empty_cache()  # Prevent memory fragmentation
+        if max(seq_len_q, seq_len_k) >= 2048 and torch.cuda.get_device_properties('cuda').total_memory < 40 * 2**30:
+            unittest.skip("Reference implementation OOM")
+            return
 
         scale = scale if scale is None else (1 / head_dim)
         n_heads = 4


### PR DESCRIPTION
Fixes #128119 

Added a check to skip test if cuda memory is less than the required memory