### PR TITLE
[aoti] Add packaging solution

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -1,0 +1,133 @@
+# Owner(s): ["module: inductor"]
+import copy
+import sys
+import unittest
+
+import torch
+from torch._inductor import config
+from torch._inductor.package import load_package
+from torch._inductor.test_case import TestCase
+from torch.testing._internal import common_utils
+from torch.testing._internal.triton_utils import HAS_CUDA
+
+try:
+    try:
+        from .test_torchinductor import copy_tests
+    except ImportError:
+        from test_torchinductor import copy_tests
+except (unittest.SkipTest, ImportError) as e:
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise
+
+
+def compile(model, example_inputs, dynamic_shapes, options, device):
+    ep = torch.export.export(
+        model,
+        example_inputs,
+        dynamic_shapes=dynamic_shapes,
+        strict=False,
+    )
+    gm = ep.module()
+    package_path = torch._inductor.aot_compile(gm, example_inputs, options=options)  # type: ignore[arg-type]
+    compiled_model = load_package(package_path, device)
+    return compiled_model
+
+
+def check_model(
+    self: TestCase,
+    model,
+    example_inputs,
+    options=None,
+    dynamic_shapes=None,
+    disable_constraint_solver=False,
+    atol=None,
+    rtol=None,
+):
+    with torch.no_grad(), config.patch(
+        {
+            "aot_inductor.package": True,
+            # TODO: "aot_inductor.force_mmap_weights": True,
+        }
+    ):
+        torch.manual_seed(0)
+        model = model.to(self.device)
+        ref_model = copy.deepcopy(model)
+        ref_inputs = copy.deepcopy(example_inputs)
+        expected = ref_model(*ref_inputs)
+
+        torch.manual_seed(0)
+        compiled_model = compile(
+            model,
+            example_inputs,
+            dynamic_shapes,
+            options,
+            self.device,
+        )
+
+        actual = compiled_model(*example_inputs)
+
+    self.assertEqual(actual, expected, atol=atol, rtol=rtol)
+
+
+class AOTInductorTestsTemplate:
+    def test_add(self):
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        example_inputs = (
+            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=self.device),
+        )
+        self.check_model(Model(), example_inputs)
+
+    def test_linear(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+
+            def forward(self, x, y):
+                return x + self.linear(y)
+
+        example_inputs = (
+            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=self.device),
+        )
+        self.check_model(Model(), example_inputs)
+
+
+common_utils.instantiate_parametrized_tests(AOTInductorTestsTemplate)
+
+
+@unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
+class AOTInductorTestPackagedABICompatibleCuda(TestCase):
+    device = "cuda"
+    check_model = check_model
+
+
+copy_tests(
+    AOTInductorTestsTemplate,
+    AOTInductorTestPackagedABICompatibleCuda,
+    "packaged_abi_compatible_cuda",
+)
+
+
+class AOTInductorTestPackagedABICompatibleCpu(TestCase):
+    device = "cpu"
+    check_model = check_model
+
+
+copy_tests(
+    AOTInductorTestsTemplate,
+    AOTInductorTestPackagedABICompatibleCpu,
+    "packaged_abi_compatible_cpu",
+)
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    # cpp_extension N/A in fbcode
+    if HAS_CUDA or sys.platform == "darwin":
+        run_tests(needs="filelock")

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -8,6 +8,7 @@ from torch._inductor import config
 from torch._inductor.package import load_package
 from torch._inductor.test_case import TestCase
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_utils import IS_FBCODE
 from torch.testing._internal.triton_utils import HAS_CUDA
 
 try:
@@ -101,7 +102,7 @@ class AOTInductorTestsTemplate:
 common_utils.instantiate_parametrized_tests(AOTInductorTestsTemplate)
 
 
-@unittest.skipIf(sys.platform == "darwin", "No CUDA on MacOS")
+@unittest.skipIf(sys.platform == "darwin" or IS_FBCODE, "No CUDA on MacOS")
 class AOTInductorTestPackagedABICompatibleCuda(TestCase):
     device = "cuda"
     check_model = check_model
@@ -114,6 +115,7 @@ copy_tests(
 )
 
 
+@unittest.skipIf(IS_FBCODE, "This is for OSS only")
 class AOTInductorTestPackagedABICompatibleCpu(TestCase):
     device = "cpu"
     check_model = check_model

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1924,14 +1924,15 @@ class AotCodeCompiler:
 
                 from torch._inductor.package import package_aoti
 
-                package_constants = {
-                    name: graph.get_original_value_of_constant(name)
-                    for name in graph.constants.keys()
-                    if name not in graph.folded_constants
-                }
-                archive_path = package_aoti(
-                    os.path.split(input_path)[0], package_constants
-                )
+                if use_mmap_weights:
+                    weight_file = (
+                        os.path.splitext(input_path)[0] + "_serialized_weights.bin"
+                    )
+                    with open(weight_file, "wb") as f_weights:
+                        f_weights.write(serialized_weights)
+                        f_weights.write(struct.pack("q", magic_number))
+
+                archive_path = package_aoti(os.path.split(input_path)[0])
                 return archive_path
 
             # TODO: replace this with using the CppBuilder above

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -831,6 +831,8 @@ class aot_inductor:
     # rather than embedded into the data section. Needed to support 1B+ parameter models
     force_mmap_weights: bool = False
 
+    package: bool = False
+
 
 class cuda:
     # CUDA arch to use for CUDA template kernel compilation.

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -17,7 +17,7 @@ import sys
 import sysconfig
 import warnings
 from pathlib import Path
-from typing import List, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import torch
 from torch._inductor import config, exc
@@ -251,20 +251,33 @@ class BuildOptionsBase:
     and maintains the suitable args.
     """
 
-    def __init__(self) -> None:
-        self._compiler = ""
-        self._definations: List[str] = []
-        self._include_dirs: List[str] = []
-        self._cflags: List[str] = []
-        self._ldflags: List[str] = []
-        self._libraries_dirs: List[str] = []
-        self._libraries: List[str] = []
+    def __init__(
+        self,
+        compiler: str = "",
+        definitions: Optional[List[str]] = None,
+        include_dirs: Optional[List[str]] = None,
+        cflags: Optional[List[str]] = None,
+        ldflags: Optional[List[str]] = None,
+        libraries_dirs: Optional[List[str]] = None,
+        libraries: Optional[List[str]] = None,
+        passthrough_args: Optional[List[str]] = None,
+        aot_mode: bool = False,
+        use_absolute_path: bool = False,
+        compile_only: bool = False,
+    ) -> None:
+        self._compiler = compiler
+        self._definations: List[str] = definitions or []
+        self._include_dirs: List[str] = include_dirs or []
+        self._cflags: List[str] = cflags or []
+        self._ldflags: List[str] = ldflags or []
+        self._libraries_dirs: List[str] = libraries_dirs or []
+        self._libraries: List[str] = libraries or []
         # Some args is hard to abstract to OS compatable, passthough it directly.
-        self._passthough_args: List[str] = []
+        self._passthough_args: List[str] = passthrough_args or []
 
-        self._aot_mode: bool = False
-        self._use_absolute_path: bool = False
-        self._compile_only: bool = False
+        self._aot_mode: bool = aot_mode
+        self._use_absolute_path: bool = use_absolute_path
+        self._compile_only: bool = compile_only
 
     def _remove_duplicate_options(self):
         self._definations = _remove_duplication_in_list(self._definations)
@@ -307,6 +320,24 @@ class BuildOptionsBase:
 
     def get_compile_only(self) -> bool:
         return self._compile_only
+
+    def save_flags_to_file(self, file) -> None:
+        attrs = {
+            "compiler": self.get_compiler(),
+            "definitions": self.get_definations(),
+            "include_dirs": self.get_include_dirs(),
+            "cflags": self.get_cflags(),
+            "ldflags": self.get_ldflags(),
+            "libraries_dirs": self.get_libraries_dirs(),
+            "libraries": self.get_libraries(),
+            "passthrough_args": self.get_passthough_args(),
+            "aot_mode": self.get_aot_mode(),
+            "use_absolute_path": self.get_use_absolute_path(),
+            "compile_only": self.get_compile_only(),
+        }
+
+        with open(file, "w") as f:
+            json.dump(attrs, f)
 
 
 def _get_warning_all_cflag(warning_all: bool = True) -> List[str]:

--- a/torch/_inductor/package/__init__.py
+++ b/torch/_inductor/package/__init__.py
@@ -1,0 +1,1 @@
+from .package import load_package, package_aoti

--- a/torch/_inductor/package/build_package.py
+++ b/torch/_inductor/package/build_package.py
@@ -1,0 +1,15 @@
+build_package_contents = """
+import os
+from pathlib import Path
+
+from torch._inductor.package.package import compile_so
+
+curr_dir = Path(__file__).parent
+aoti_files = [
+    os.path.join(root, file)
+    for root, dirs, files in os.walk(curr_dir)
+    for file in files
+]
+
+output_so = compile_so(curr_dir, aoti_files, curr_dir)
+"""

--- a/torch/_inductor/package/package.py
+++ b/torch/_inductor/package/package.py
@@ -1,0 +1,247 @@
+import glob
+import json
+import os
+import shlex
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import torch
+import torch._inductor
+import torch.utils._pytree as pytree
+from torch._inductor import config, exc
+from torch._inductor.cpp_builder import BuildOptionsBase, CppBuilder
+from torch.export._tree_utils import reorder_kwargs
+from .build_package import build_package_contents
+from .pt2_archive_constants import AOTINDUCTOR_DIR, ARCHIVE_VERSION
+
+
+class PT2ArchiveWriter:
+    def __init__(self, archive_path: str):
+        self.archive_path: str = archive_path
+        self.archive_file: Optional[zipfile.ZipFile] = None
+
+    def __enter__(self) -> "PT2ArchiveWriter":
+        assert self.archive_file is None
+        self.archive_file = zipfile.ZipFile(
+            self.archive_path, "w", compression=zipfile.ZIP_STORED
+        )
+        self.writestr("version", str(ARCHIVE_VERSION))
+        self.writestr("archive_format", "pt2")
+        return self
+
+    def __exit__(self, *args) -> None:  # type: ignore[no-untyped-def]
+        assert self.archive_file is not None
+        self.archive_file.close()
+        self.archive_file = None
+        return None
+
+    def writestr(self, name: str, data: Union[bytes, str]) -> None:
+        assert self.archive_file is not None
+        self.archive_file.writestr(name, data)
+
+    def write_file(self, name: str, file_path: str) -> None:
+        """
+        Copy a file into the archive.
+        name: The destination file inside the archive.
+        file_path: The source file on disk.
+        """
+        assert Path(file_path).is_file(), f"{file_path} is not a valid file path"
+        assert self.archive_file is not None
+        self.archive_file.write(file_path, arcname=name)
+
+
+class PT2ArchiveReader:
+    def __init__(self, archive_path: str):
+        self.archive_path: str = archive_path
+        self.archive_file: Optional[zipfile.ZipFile] = None
+
+    def __enter__(self) -> "PT2ArchiveReader":
+        self.archive_file = zipfile.ZipFile(
+            self.archive_path, "r", compression=zipfile.ZIP_STORED
+        )
+        return self
+
+    def __exit__(self, *args) -> None:  # type: ignore[no-untyped-def]
+        if self.archive_file is not None:
+            self.archive_file.close()
+        return None
+
+    def read(self, name: str) -> bytes:
+        assert self.archive_file is not None
+        return self.archive_file.read(name)
+
+    def extract_to_path(self, member: str, path: str) -> str:
+        assert self.archive_file is not None
+        return self.archive_file.extract(member, path)
+
+    def extractall(self, path: str) -> None:
+        assert self.archive_file is not None
+        self.archive_file.extractall(path)
+
+    def get_file_names(self) -> List[str]:
+        assert self.archive_file is not None
+        return self.archive_file.namelist()
+
+
+def _run_command_and_check(cmd: str) -> None:
+    cmd = shlex.split(cmd)
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        raise exc.CppCompileError(cmd, e.output) from e
+
+
+def compile_so(aoti_dir: str, aoti_files: List[str], so_path: str) -> str:
+    def get_aoti_file_with_suffix(suffix: str) -> str:
+        for file in aoti_files:
+            if file.endswith(suffix):
+                return file
+        raise RuntimeError(f"Unable to find file with suffix {suffix}")
+
+    # Compile all the files into a .so
+    cpp_file = os.path.join(aoti_dir, get_aoti_file_with_suffix(".cpp"))
+    consts_o = os.path.join(aoti_dir, get_aoti_file_with_suffix(".o"))
+
+    file_name = os.path.splitext(cpp_file)[0]
+
+    # Parse compile flags and build the .o file
+    with open(file_name + "_compile_flags.json") as f:
+        compile_flags = json.load(f)
+
+    compile_options = BuildOptionsBase(**compile_flags)
+    object_builder = CppBuilder(
+        name=file_name,
+        sources=cpp_file,
+        BuildOption=compile_options,
+    )
+    compile_cmd = object_builder.get_command_line()
+    output_o = object_builder.get_target_file_path()
+
+    _run_command_and_check(compile_cmd)
+
+    # Parse linker flags and build the .so file
+    with open(file_name + "_linker_flags.json") as f:
+        linker_flags = json.load(f)
+
+    linker_options = BuildOptionsBase(**linker_flags)
+    so_builder = CppBuilder(
+        name=os.path.split(so_path)[-1],
+        sources=[output_o, consts_o],
+        BuildOption=linker_options,
+        output_dir=so_path,
+    )
+    link_cmd = so_builder.get_command_line()
+    output_so = so_builder.get_target_file_path()
+
+    _run_command_and_check(link_cmd)
+
+    # TODO: load constants w/ mmap
+    # tmp_file = os.path.join(tmp_dir, os.path.join(tmp_dir, CONSTANTS_DIR, "constants.pt"))
+    # constants = torch.load(tmp_file, mmap=True)
+    # print(constants.keys())
+
+    # serialized_weights = b"".join(
+    #     _to_bytes(constant) for constant in constants.values()
+    # )
+
+    # with open(output_so, "a+b") as f_so:
+    #     so_size = f_so.tell()
+    #     # Page align the weights
+    #     f_so.write(b" " * (16384 - so_size % 16384))
+    #     f_so.write(serialized_weights)
+    #     f_so.write(struct.pack("q", magic_number))
+
+    return output_so
+
+
+def package_aoti(aoti_output_dir: str, constants: Dict[str, Any]) -> str:
+    """
+    Saves the AOTInductor generated files to the PT2Archive format.
+    """
+
+    # Add a makefile and python script
+    build_package_filename = "build_package.py"
+    with open(os.path.join(aoti_output_dir, build_package_filename), "w") as f:
+        f.write(build_package_contents)
+
+    with open(os.path.join(aoti_output_dir, "Makefile"), "w") as f:
+        f.write(f"all:\n\tpython3 {build_package_filename}\n")
+
+    if config.aot_inductor.output_path.endswith(".so"):
+        raise RuntimeError(
+            "Unable to save package as a .so. It should be a .pt2 format or a directory."
+        )
+    elif config.aot_inductor.output_path.endswith(".pt2"):
+        # Save using the PT2 packaging format
+        # (https://docs.google.com/document/d/1jLPp8MN8Whs0-VW9PmJ93Yg02W85tpujvHrTa1pc5x8/edit#heading=h.v2y2jgnwc56a)
+        archive_path = config.aot_inductor.output_path
+
+        with PT2ArchiveWriter(archive_path) as archive_writer:
+            package_files = glob.glob(f"{aoti_output_dir}/*")
+
+            for path in package_files:
+                filename = os.path.basename(path)
+                archive_writer.write_file(f"{AOTINDUCTOR_DIR}{filename}", path)
+
+        # For saving constants for mmap
+        # buffer = io.BytesIO()
+        # torch.save(constants, buffer, _use_new_zipfile_serialization=True)
+        # archive_writer.writestr(
+        #     os.path.join(CONSTANTS_DIR, "constants.pt"), buffer.getvalue()
+        # )
+
+        return archive_path
+
+    else:
+        # Directly put the files into the directory, without any archiving
+        return aoti_output_dir
+
+
+def load_package(path: str, device: str) -> Callable:  # type: ignore[type-arg]
+    if path.endswith(".so"):
+        raise RuntimeError(
+            "Unable to load .so. It should be a .pt2 format or a directory."
+        )
+
+    elif path.endswith(".pt2"):
+        so_path = os.path.splitext(path)[0]
+        with PT2ArchiveReader(path) as archive_reader:
+            file_names = archive_reader.get_file_names()
+
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                archive_reader.extractall(tmp_dir)
+                file_names = archive_reader.get_file_names()
+                aoti_files = [
+                    file for file in file_names if file.startswith(AOTINDUCTOR_DIR)
+                ]
+
+                so_path = compile_so(tmp_dir, aoti_files, so_path)
+
+    else:
+        assert os.path.isdir(path), "Must specify a directory or a .pt2 file"
+        aoti_files = [
+            os.path.join(root, file)
+            for root, dirs, files in os.walk(path)
+            for file in files
+        ]
+        so_path = compile_so(path, aoti_files, path)
+
+    if device == "cpu":
+        runner = torch._C._aoti.AOTIModelContainerRunnerCpu(so_path, 1)  # type: ignore[call-arg]
+    elif device == "cuda" or device.startswith("cuda:"):
+        runner = torch._C._aoti.AOTIModelContainerRunnerCuda(so_path, 1, device)  # type: ignore[assignment, call-arg]
+    else:
+        raise RuntimeError("Unsupported device " + device)
+
+    def optimized(*args, **kwargs):  # type: ignore[no-untyped-def]
+        call_spec = runner.get_call_spec()  # type: ignore[attr-defined]
+        in_spec = pytree.treespec_loads(call_spec[0])
+        out_spec = pytree.treespec_loads(call_spec[1])
+        flat_inputs = pytree.tree_flatten((args, reorder_kwargs(kwargs, in_spec)))[0]
+        flat_outputs = runner.run(flat_inputs)  # type: ignore[attr-defined]
+        return pytree.tree_unflatten(flat_outputs, out_spec)
+
+    return optimized

--- a/torch/_inductor/package/pt2_archive_constants.py
+++ b/torch/_inductor/package/pt2_archive_constants.py
@@ -1,0 +1,16 @@
+ARCHIVE_ROOT_NAME = "package"
+ARCHIVE_FORMAT_PATH = "archive_format"
+MODELS_DIR = "models/"
+MODELS_FILENAME_FORMAT = "models/{}.json"
+AOTINDUCTOR_DIR = "data/aotinductor/"
+WEIGHTS_DIR = "data/weights/"
+WEIGHT_FILENAME_PREFIX = "weight_"
+CONSTANTS_DIR = "data/constants/"
+TENSOR_CONSTANT_FILENAME_PREFIX = "tensor_"
+CUSTOM_OBJ_FILENAME_PREFIX = "custom_obj_"
+SAMPLE_INPUTS_DIR = "data/sample_inputs/"
+SAMPLE_INPUTS_FILENAME_FORMAT = "data/sample_inputs/{}.pt"
+EXTRA_DIR = "extra/"
+MODULE_INFO_PATH = "extra/module_info.json"
+
+ARCHIVE_VERSION = 0


### PR DESCRIPTION
In this PR, I added support for packaging the AOTI generated files into a zipfile, and loading it in python.

`compile_so` takes the path to the package, a device, and a desired so_path location, and compiles package into a .so, and saves to the specified location.
`load_package` takes a path to the package and device, calls _extract_so, and then creates a callable to run the compiled model.

The zipfile generated looks like the following:
```
|- version
|- archive_format
|- data
   |- aotinductor
      |- cbtnafqaqrhvwztv7xudlal4xs6sofxa5oxccyuaqtrt6aozaklx.cubin  # AOTI cuda generated cubin files
      |- cskkqtna23bty2v3aq7g2q37cxrgufehlkuaaolhlgug5zg6fuwe.cpp  # AOTI generated cpp file
      |- cskkqtna23bty2v3aq7g2q37cxrgufehlkuaaolhlgug5zg6fuwe_compile_flags  # Flags for compiling the .o
      |- c6qqtnpgwfi3dv5nb76ai773kt45ezoxfwdmd7q37lvq6fs2tnoi.o  # AOTI saved const.o
      |- cskkqtna23bty2v3aq7g2q37cxrgufehlkuaaolhlgug5zg6fuwe_linker_flags  # Flags for linking the files to form the .so
   |- constants
      |- constants.pt  # Constants saved using torch.save, can be loaded using mmap
```

The workflow is something like:
```
with torch.no_grad():
    ep = torch.export.export(
        model,
        example_inputs,
        dynamic_shapes=dynamic_shapes,
        strict=False,
    )
    gm = ep.module()
    package_path = torch._inductor.aot_compile(
        gm, 
        example_inputs, 
        options= {
              "aot_inductor.output_path": "my_path.pt2",  # or a directory
              "aot_inductor.package": True,
        }
    )
compiled_model = torch._inductor.package.load_package(package_path, device)
return compiled_model
```

I tried turning on loading the weights using mmap by default, but had some trouble with it, so that is just left as a todo

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang