### PR TITLE
Do not create a ncclUniqueId and bcast it when using ncclCommSplit

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2116,21 +2116,22 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::getNCCLComm(
   // entry if it hasn't been yet rather than untangling the
   // conditions that might have resulted in a split above.
   if (!ncclComm) {
-    // For point-to-point communication, lower rank of the two will get unique id.
+    // For point-to-point communication, lower rank of the two will get unique
+    // id.
     if (rank_ == 0 || (singleP2POp && p2pRank == 0)) {
-        C10D_NCCL_CHECK(ncclGetUniqueId(&ncclID), c10::nullopt);
+      C10D_NCCL_CHECK(ncclGetUniqueId(&ncclID), c10::nullopt);
     }
 
     if (shouldBroadcastNCCLUniqueID(isSendRecvSelf)) {
-        // Broadcast so that each process can have a unique NCCL ID
-        auto timeStarted = std::chrono::steady_clock::now();
-        broadcastUniqueNCCLID(&ncclID, singleP2POp, deviceKey, p2pRank);
-        auto timerDeltaMs =
-            std::chrono::duration_cast<std::chrono::duration<double>>(
-                std::chrono::steady_clock::now() - timeStarted)
-                .count() *
-            1000;
-        LOG(INFO) << logPrefix()
+      // Broadcast so that each process can have a unique NCCL ID
+      auto timeStarted = std::chrono::steady_clock::now();
+      broadcastUniqueNCCLID(&ncclID, singleP2POp, deviceKey, p2pRank);
+      auto timerDeltaMs =
+          std::chrono::duration_cast<std::chrono::duration<double>>(
+              std::chrono::steady_clock::now() - timeStarted)
+              .count() *
+          1000;
+      LOG(INFO) << logPrefix()
                 << "ProcessGroupNCCL broadcast unique ID through store took "
                 << timerDeltaMs << " ms";
     }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2045,24 +2045,6 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::getNCCLComm(
   // For batch_isend_irecv, ncclGroupStart() would be called upfront
   bool batchP2P = ncclActiveGroupCounter_ > 0;
   bool singleP2POp = isP2POp(opType, batchP2P);
-  // For point-to-point communication, lower rank of the two will get unique id.
-  if (rank_ == 0 || (singleP2POp && p2pRank == 0)) {
-    C10D_NCCL_CHECK(ncclGetUniqueId(&ncclID), c10::nullopt);
-  }
-
-  if (shouldBroadcastNCCLUniqueID(isSendRecvSelf)) {
-    // Broadcast so that each process can have a unique NCCL ID
-    auto timeStarted = std::chrono::steady_clock::now();
-    broadcastUniqueNCCLID(&ncclID, singleP2POp, deviceKey, p2pRank);
-    auto timerDeltaMs =
-        std::chrono::duration_cast<std::chrono::duration<double>>(
-            std::chrono::steady_clock::now() - timeStarted)
-            .count() *
-        1000;
-    LOG(INFO) << logPrefix()
-              << "ProcessGroupNCCL broadcast unique ID through store took "
-              << timerDeltaMs << " ms";
-  }
 
   at::cuda::OptionalCUDAGuard gpuGuard;
 
@@ -2134,6 +2116,25 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::getNCCLComm(
   // entry if it hasn't been yet rather than untangling the
   // conditions that might have resulted in a split above.
   if (!ncclComm) {
+    // For point-to-point communication, lower rank of the two will get unique id.
+    if (rank_ == 0 || (singleP2POp && p2pRank == 0)) {
+        C10D_NCCL_CHECK(ncclGetUniqueId(&ncclID), c10::nullopt);
+    }
+
+    if (shouldBroadcastNCCLUniqueID(isSendRecvSelf)) {
+        // Broadcast so that each process can have a unique NCCL ID
+        auto timeStarted = std::chrono::steady_clock::now();
+        broadcastUniqueNCCLID(&ncclID, singleP2POp, deviceKey, p2pRank);
+        auto timerDeltaMs =
+            std::chrono::duration_cast<std::chrono::duration<double>>(
+                std::chrono::steady_clock::now() - timeStarted)
+                .count() *
+            1000;
+        LOG(INFO) << logPrefix()
+                << "ProcessGroupNCCL broadcast unique ID through store took "
+                << timerDeltaMs << " ms";
+    }
+
 #ifdef NCCL_HAS_COMM_NONBLOCKING
     ncclComm = NCCLComm::create(numRanks, rank, ncclID, options_->config);
 #else


### PR DESCRIPTION
Calling `ncclGetUniqueId(...)` will spawn a new thread and open a new port until the NCCL ID is used. If not used, thread is listening to the port for the lifespan of the application.
For ncclCommSplit code paths, we do not need to provide a ncclUniqueId, therefore we do not need to create one and do not need to broadcast it.
This PR moves the code around to only create an ID when `ncclCommInitRank` is used.
CC @wconstab @kwen2501 @eqy 

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @tianyu-l @chauhang