### PR TITLE
[MPS][BE] Introduce `mtl_setBytes`

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -380,7 +380,7 @@ static inline void mtl_setBytes(id<MTLComputeCommandEncoder> encoder, const T va
 }
 
 template<typename Container,
-         typename = std::enable_if_t<std::is_integral_v<typename Container::value_type>>>
+         typename = std::enable_if_t<std::is_integral_v<typename Container::size_type>>>
 static inline void mtl_setBytes(id<MTLComputeCommandEncoder> encoder, const Container& values, unsigned idx) {
   [encoder setBytes:values.data() length:sizeof(typename Container::value_type) * values.size() atIndex: idx];
 }

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -13,6 +13,7 @@
 #include <torch/library.h>
 #include <exception>
 #include <unordered_map>
+#include <vector>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -370,6 +371,18 @@ static inline void mtl_setBuffer(id<MTLComputeCommandEncoder> encoder, const Ten
   [encoder setBuffer:getMTLBufferStorage(t)
               offset:t.storage_offset() * t.element_size()
              atIndex:idx];
+}
+
+template<typename T,
+         typename = std::enable_if_t<std::is_integral_v<T> || std::is_same_v<T, float>>>
+static inline void mtl_setBytes(id<MTLComputeCommandEncoder> encoder, const T val, unsigned idx) {
+  [encoder setBytes:&val length:sizeof(T) atIndex: idx];
+}
+
+template<typename Container,
+         typename = std::enable_if_t<std::is_integral_v<typename Container::value_type>>>
+static inline void mtl_setBytes(id<MTLComputeCommandEncoder> encoder, const Container& values, unsigned idx) {
+  [encoder setBytes:values.data() length:sizeof(typename Container::value_type) * values.size() atIndex: idx];
 }
 
 static inline void mtl_dispatch1DJob(id<MTLComputeCommandEncoder> encoder,

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -146,7 +146,7 @@ static void handle_tensor_tensor_binary_op(const Tensor& self,
 
     [commandEncoder pushDebugGroup:[NSString stringWithFormat:@"Dispatch %s kernel", kernel_name.c_str()]];
     [commandEncoder setComputePipelineState:cplState];
-    [commandEncoder setBytes:&length length:sizeof(length) atIndex:0];
+    mtl_setBytes(commandEncoder, length, 0);
     mtl_setBuffer(commandEncoder, output, 1);
     mtl_setBuffer(commandEncoder, self, 2);
     mtl_setBuffer(commandEncoder, other, 3);
@@ -176,10 +176,10 @@ static void handle_tensor_scalar_binary_op(const Tensor& self,
 
     [commandEncoder pushDebugGroup:[NSString stringWithFormat:@"Dispatch %s kernel", kernel_name.c_str()]];
     [commandEncoder setComputePipelineState:cplState];
-    [commandEncoder setBytes:&length length:sizeof(length) atIndex:0];
+    mtl_setBytes(commandEncoder, length, 0);
     mtl_setBuffer(commandEncoder, output, 1);
     mtl_setBuffer(commandEncoder, self, 2);
-    [commandEncoder setBytes:&sval length:sizeof(sval) atIndex:3];
+    mtl_setBytes(commandEncoder, sval, 3);
     mtl_dispatch1DJob(commandEncoder, cplState, length);
 
     getMPSProfiler().endProfileKernel(cplState);
@@ -267,7 +267,7 @@ static void _bitwise_not_out_mps(const Tensor& self, const Tensor& output_) {
 
     [commandEncoder pushDebugGroup:@"Dispatch bitwise_not kernel"];
     [commandEncoder setComputePipelineState:cplState];
-    [commandEncoder setBytes:&length length:sizeof(length) atIndex:0];
+    mtl_setBytes(commandEncoder, length, 0);
     mtl_setBuffer(commandEncoder, output, 1);
     mtl_setBuffer(commandEncoder, self, 2);
     mtl_dispatch1DJob(commandEncoder, cplState, length);

--- a/aten/src/ATen/native/mps/operations/Bucketization.mm
+++ b/aten/src/ATen/native/mps/operations/Bucketization.mm
@@ -229,11 +229,11 @@ static void searchsorted_mps_contiguous(Tensor& result,
       mtl_setBuffer(computeEncoder, input, 0);
       mtl_setBuffer(computeEncoder, boundaries, 1);
       mtl_setBuffer(computeEncoder, result, 2);
-      [computeEncoder setBytes:&idim_in length:sizeof(int64_t) atIndex:3];
-      [computeEncoder setBytes:&idim_bd length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&numel_in length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&right_i64 length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&is_1d_boundaries length:sizeof(int64_t) atIndex:7];
+      mtl_setBytes(computeEncoder, idim_in, 3);
+      mtl_setBytes(computeEncoder, idim_bd, 4);
+      mtl_setBytes(computeEncoder, numel_in, 5);
+      mtl_setBytes(computeEncoder, right_i64, 6);
+      mtl_setBytes(computeEncoder, is_1d_boundaries, 7);
       if (sorter.defined())
         mtl_setBuffer(computeEncoder, sorter, 8);
 

--- a/aten/src/ATen/native/mps/operations/CrossKernel.mm
+++ b/aten/src/ATen/native/mps/operations/CrossKernel.mm
@@ -114,9 +114,9 @@ void cross_mps_impl(const Tensor& out, const Tensor& input, const Tensor& other,
       mtl_setBuffer(computeEncoder, other, 1);
       mtl_setBuffer(computeEncoder, out, 2);
       [computeEncoder setBuffer:kernelDataOffsets offset:0 atIndex:3];
-      [computeEncoder setBytes:&out_dim_stride length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&input_dim_stride length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&other_dim_stride length:sizeof(int64_t) atIndex:6];
+      mtl_setBytes(computeEncoder, out_dim_stride, 4);
+      mtl_setBytes(computeEncoder, input_dim_stride, 5);
+      mtl_setBytes(computeEncoder, other_dim_stride, 6);
       mtl_dispatch1DJob(computeEncoder, crossPSO, numThreads);
 
       getMPSProfiler().endProfileKernel(crossPSO);

--- a/aten/src/ATen/native/mps/operations/Gamma.mm
+++ b/aten/src/ATen/native/mps/operations/Gamma.mm
@@ -519,7 +519,7 @@ TORCH_IMPL_FUNC(polygamma_out_mps)(const int64_t order, const Tensor& self, cons
       mtl_setBuffer(computeEncoder, output, 1);
 
       if (func_name == "polygamma") {
-        [computeEncoder setBytes:&order length:sizeof(order) atIndex:2];
+        mtl_setBytes(computeEncoder, order, 2);
       }
 
       mtl_dispatch1DJob(computeEncoder, cplState, length);

--- a/aten/src/ATen/native/mps/operations/HistogramKernel.mm
+++ b/aten/src/ATen/native/mps/operations/HistogramKernel.mm
@@ -247,10 +247,10 @@ void histogramdd_kernel_impl(Tensor& hist_output,
       id<MTLComputePipelineState> stridedIndicesPSO = lib.getPipelineStateForFunc("kernel_index_offset");
 
       [computeEncoder setComputePipelineState:stridedIndicesPSO];
-      [computeEncoder setBytes:strides.data() length:sizeof(uint32_t) * nDim atIndex:0];
+      mtl_setBytes(computeEncoder, strides, 0);
       [computeEncoder setBuffer:stridedIndicesBuffer offset:0 atIndex:1];
-      [computeEncoder setBytes:inputShapeData.data() length:sizeof(uint32_t) * inputShape.size() atIndex:2];
-      [computeEncoder setBytes:&nDim length:sizeof(uint32_t) atIndex:3];
+      mtl_setBytes(computeEncoder, inputShapeData, 2);
+      mtl_setBytes(computeEncoder, nDim, 3);
 
       mtl_dispatch1DJob(computeEncoder, stridedIndicesPSO, stridedIndicesNumThreads);
 
@@ -267,16 +267,14 @@ void histogramdd_kernel_impl(Tensor& hist_output,
       }
       mtl_setBuffer(computeEncoder, thread_histograms, 2);
       [computeEncoder setBuffer:stridedIndicesBuffer offset:0 atIndex:3];
-      [computeEncoder setBytes:&D length:sizeof(int64_t) atIndex:4];
+      mtl_setBytes(computeEncoder, D, 4);
       [computeEncoder setBytes:bin_seq.data() length:sizeof(input_t) * bin_seq_offset atIndex:5];
-      [computeEncoder setBytes:num_bin_edges.data() length:sizeof(int64_t) * D atIndex:6];
-      [computeEncoder setBytes:leftmost_edge.data() length:sizeof(input_t) * D atIndex:7];
-      [computeEncoder setBytes:rightmost_edge.data() length:sizeof(input_t) * D atIndex:8];
-      [computeEncoder setBytes:thread_histograms.strides().data()
-                        length:sizeof(int64_t) * thread_hist_sizes.size()
-                       atIndex:9];
-      [computeEncoder setBytes:&bin_selection_algorithm length:sizeof(uint8_t) atIndex:10];
-      [computeEncoder setBytes:&has_weight length:sizeof(uint8_t) atIndex:11];
+      mtl_setBytes(computeEncoder, num_bin_edges, 6);
+      mtl_setBytes(computeEncoder, leftmost_edge, 7);
+      mtl_setBytes(computeEncoder, rightmost_edge, 8);
+      mtl_setBytes(computeEncoder, thread_histograms.strides(), 9);
+      mtl_setBytes(computeEncoder, bin_selection_algorithm, 10);
+      mtl_setBytes(computeEncoder, has_weight, 11);
 
       mtl_dispatch1DJob(computeEncoder, histogramPSO, numThreads);
 

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -145,15 +145,15 @@ static bool dispatchIndexKernel(TensorIteratorBase& iter,
 
       [computeEncoder setComputePipelineState:indexSelectPSO];
       [computeEncoder setBuffer:indexAB offset:0 atIndex:0];
-      [computeEncoder setBytes:index_size.data() length:sizeof(index_size[0]) * index_size.size() atIndex:1];
-      [computeEncoder setBytes:index_stride.data() length:sizeof(index_stride[0]) * index_stride.size() atIndex:2];
+      mtl_setBytes(computeEncoder, index_size, 1);
+      mtl_setBytes(computeEncoder, index_stride, 2);
       [computeEncoder setBuffer:kernelDataOffsets offset:0 atIndex:3];
       mtl_setBuffer(computeEncoder, inputTensor, 4);
       mtl_setBuffer(computeEncoder, outputTensor, 5);
-      [computeEncoder setBytes:&num_indices length:sizeof(uint32_t) atIndex:6];
+      mtl_setBytes(computeEncoder, num_indices, 6);
       MTLSize gridSize = MTLSizeMake(numThreads, 1, 1);
       if (serial_index_put) {
-        [computeEncoder setBytes:&numIters length:sizeof(numIters) atIndex:7];
+        mtl_setBytes(computeEncoder, numIters, 7);
         gridSize = MTLSizeMake(1, 1, 1);
         numThreads = 1;
       }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -97,8 +97,8 @@ Tensor& do_metal_mm(const Tensor& self, const Tensor& other, Tensor& output) {
       mtl_setBuffer(computeEncoder, self, 0);
       mtl_setBuffer(computeEncoder, other, 1);
       mtl_setBuffer(computeEncoder, output, 2);
-      [computeEncoder setBytes:strides.data() length:sizeof(uint64_t) * strides.size() atIndex:3];
-      [computeEncoder setBytes:sizes.data() length:sizeof(uint32_t) * sizes.size() atIndex:4];
+      mtl_setBytes(computeEncoder, strides, 3);
+      mtl_setBytes(computeEncoder, sizes, 4);
       mtl_dispatch1DJob(computeEncoder, matmulPSO, output.numel());
       getMPSProfiler().endProfileKernel(matmulPSO);
     }

--- a/aten/src/ATen/native/mps/operations/Quantized.mm
+++ b/aten/src/ATen/native/mps/operations/Quantized.mm
@@ -740,7 +740,7 @@ Tensor _convert_weight_to_int4pack_mps(const Tensor& in, int64_t innerKTiles) {
       [computeEncoder setComputePipelineState:quantizedPSO];
       mtl_setBuffer(computeEncoder, weight, 0);
       mtl_setBuffer(computeEncoder, weight_packed, 1);
-      [computeEncoder setBytes:sizes.data() length:sizeof(uint32_t) * sizes.size() atIndex:2];
+      mtl_setBytes(computeEncoder, sizes, 2);
       [computeEncoder dispatchThreads:MTLSizeMake(N, K / 2, 1) threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
 #if _CAPTURE_KERNEL
       if (getMPSProfiler().isCapturing()) {
@@ -799,7 +799,7 @@ Tensor _weight_int4pack_mm_mps(const Tensor& A, const Tensor& B, int64_t qGroupS
       mtl_setBuffer(computeEncoder, B, 1);
       mtl_setBuffer(computeEncoder, qScaleAndZeros, 2);
       mtl_setBuffer(computeEncoder, C, 3);
-      [computeEncoder setBytes:sizes.data() length:sizeof(uint32_t) * sizes.size() atIndex:4];
+      mtl_setBytes(computeEncoder, sizes, 4);
       [computeEncoder dispatchThreads:MTLSizeMake(N / 4 * 32, 1, M) threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
 #if _CAPTURE_KERNEL
       if (getMPSProfiler().isCapturing()) {
@@ -854,7 +854,7 @@ Tensor _weight_int8pack_mm_mps(const Tensor& A, const Tensor& B, const Tensor& s
       mtl_setBuffer(computeEncoder, B, 1);
       mtl_setBuffer(computeEncoder, scales, 2);
       mtl_setBuffer(computeEncoder, C, 3);
-      [computeEncoder setBytes:sizes.data() length:sizeof(uint32_t) * sizes.size() atIndex:4];
+      mtl_setBytes(computeEncoder, sizes, 4);
       if (M < 12) {
         [computeEncoder setThreadgroupMemoryLength:32 atIndex:0];
         [computeEncoder dispatchThreadgroups:MTLSizeMake((N + 7) / 8, M, 1)

--- a/aten/src/ATen/native/mps/operations/RenormKernel.mm
+++ b/aten/src/ATen/native/mps/operations/RenormKernel.mm
@@ -55,7 +55,6 @@ void renorm_out_mps(const Tensor& self, const Scalar& p, int64_t dim, const Scal
 
   Tensor norm = at::linalg_vector_norm(self, p.toDouble(), reduce_dims, /*keepdim=*/true);
   auto factor = at::empty(norm.sizes(), self.options());
-  auto maxnorm_f = maxnorm.to<float>();
 
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   id<MTLBuffer> normBuffer = getMTLBufferStorage(norm);
@@ -74,7 +73,7 @@ void renorm_out_mps(const Tensor& self, const Scalar& p, int64_t dim, const Scal
       [computeEncoder setComputePipelineState:renormPSO];
       mtl_setBuffer(computeEncoder, norm, 0);
       mtl_setBuffer(computeEncoder, factor, 1);
-      [computeEncoder setBytes:&maxnorm_f length:sizeof(float) atIndex:2];
+      mtl_setBytes(computeEncoder, maxnorm.to<float>(), 2);
       mtl_dispatch1DJob(computeEncoder, renormPSO, norm.numel());
 
       getMPSProfiler().endProfileKernel(renormPSO);

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -142,15 +142,8 @@ void computeRepeatIndices(const index_t* repeat_ptr,
       [computeEncoder setBuffer:repeatBuffer offset:0 atIndex:0];
       [computeEncoder setBuffer:cumsumBuffer offset:0 atIndex:1];
       [computeEncoder setBuffer:resultBuffer offset:0 atIndex:2];
-      [computeEncoder setBytes:&size length:sizeof(size) atIndex:3];
-      MTLSize gridSize = MTLSizeMake(size, 1, 1);
-      NSUInteger threadsPerThreadgroup_ = pipelineState.maxTotalThreadsPerThreadgroup;
-      if (threadsPerThreadgroup_ > static_cast<NSUInteger>(size)) {
-        threadsPerThreadgroup_ = size;
-      }
-      MTLSize threadsPerThreadgroup = MTLSizeMake(threadsPerThreadgroup_, 1, 1);
-
-      [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadsPerThreadgroup];
+      mps::mtl_setBytes(computeEncoder, size, 3);
+      mps::mtl_dispatch1DJob(computeEncoder, pipelineState, size);
 
       getMPSProfiler().endProfileKernel(pipelineState);
     }


### PR DESCRIPTION
Which for primitive types calls `[encoder setBytes:&val legnth:sizeof(val) index:idx];` and for container types passes number of elements equal to the size of the container
