### PR TITLE
[CI] Enable build with asserts

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -230,6 +230,10 @@ if [[ "${BUILD_ENVIRONMENT}" != *android* && "${BUILD_ENVIRONMENT}" != *cuda* ]]
   export BUILD_STATIC_RUNTIME_BENCHMARK=ON
 fi
 
+if [[ "$BUILD_ENVIRONMENT" == *-debug* ]]; then
+  export CMAKE_BUILD_TYPE=RelWithAssert
+fi
+
 # Do not change workspace permissions for ROCm CI jobs
 # as it can leave workspace with bad permissions for cancelled jobs
 if [[ "$BUILD_ENVIRONMENT" != *rocm* ]]; then

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -249,9 +249,7 @@ fi
 # This tests that the debug asserts are working correctly.
 if [[ "$BUILD_ENVIRONMENT" == *-debug* ]]; then
     echo "We are in debug mode: $BUILD_ENVIRONMENT. Expect the python assertion to fail"
-    # TODO: Enable the check after we setup the build to run debug asserts without having
-    #       to do a full (and slow) debug build
-    # (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_debug_asserts_fail(424242)")
+    (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_debug_asserts_fail(424242)")
 elif [[ "$BUILD_ENVIRONMENT" != *-bazel-* ]]; then
     # Noop when debug is disabled. Skip bazel jobs because torch isn't available there yet.
     echo "We are not in debug mode: $BUILD_ENVIRONMENT. Expect the assertion to pass"

--- a/aten/src/ATen/cuda/EmptyTensor.cpp
+++ b/aten/src/ATen/cuda/EmptyTensor.cpp
@@ -68,7 +68,9 @@ TensorBase empty_strided_cuda(
     std::optional<Device> device_opt,
     std::optional<bool> pin_memory_opt) {
   TORCH_CHECK(!pin_memory_opt.has_value() || !*pin_memory_opt, "Only dense CPU tensors can be pinned");
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(layout_or_default(layout_opt) == Layout::Strided);
+  // TODO: remove check for jagged, see https://github.com/pytorch/pytorch/issues/130073
+  const auto layout = layout_or_default(layout_opt);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(layout == Layout::Strided || layout == Layout::Jagged);
 
   const auto dtype = dtype_or_default(dtype_opt);
   return at::detail::empty_strided_cuda(size, stride, dtype, device_opt);

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -414,7 +414,8 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cpu(
   // Fuse transform_0213 inside
   auto proj = transform0213_gemm_nt_bias(
       attn_ctx, proj_weight, proj_bias, query);
-#ifndef NDEBUG
+// TODO: Remove me when https://github.com/pytorch/pytorch/issues/130073 is fixed
+#if !defined(NDEBUG) && 0
   debug_assert_shape(__LINE__, proj, {B, T, D});
 #endif
   if (need_weights && average_attn_weights) {

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -77,6 +77,12 @@ if TEST_WITH_ROCM:
     test_failures["test_unbacked_reduction"] = TestFailure(("cpu"), is_skip=True)
 
 
+if os.getenv("BUILD_ENVIRONMENT", "").endswith("-debug"):
+    # Fails with TORCH_INTERNAL_ASSERT(!is_heap_allocated()), see https://github.com/pytorch/pytorch/issues/130073
+    test_failures["test_resize_as_dynamic_shapes"] = TestFailure(("cpu", "cuda"))
+    test_failures["test_resize_dynamic_shapes"] = TestFailure(("cpu", "cuda"))
+
+
 def make_dynamic_cls(cls, xfail_prop="_expected_failure_dynamic"):
     return make_test_cls_with_patches(
         cls,

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -540,6 +540,8 @@ DONT_ENFORCE_SAME_TENSOR_IMPL_OR_STORAGE = {
     # These functions are expected to change impl or storage of input tensors
     "set_",
     "_cudnn_rnn_flatten_weight",
+    "_unsafe_masked_index",
+    "_unsafe_masked_index_put_accumulate",
 }
 DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     # These non-inplace, non-out functions return tensors with use_count > 1

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -419,6 +419,12 @@ if(BUILD_ONEDNN_GRAPH)
   endif()
 endif()
 
+if(${CMAKE_BUILD_TYPE} STREQUAL "RelWithAssert")
+   # Workaround numerous decret-without-a-gil warnings from JIT
+   # see https://github.com/pytorch/pytorch/issues/130073
+   target_compile_definitions(torch_python PRIVATE "-DPYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF")
+endif()
+
 if(NOT TORCH_PYTHON_LINK_FLAGS STREQUAL "")
     set_target_properties(torch_python PROPERTIES LINK_FLAGS ${TORCH_PYTHON_LINK_FLAGS})
 endif()

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -385,6 +385,10 @@ static void autogradNotImplementedFallbackImpl(
             // NJT components are expected to be reused; skip use_count() check
             op_name.rfind("aten::_nested_get", 0) == 0)
           return;
+        // Skip test_parallel_materialize
+        // For details see https://github.com/pytorch/pytorch/issues/130073
+        if (op_name == "aten::_test_parallel_materialize")
+          return;
         if (!is_inplace_output[idx_ret])
           TORCH_INTERNAL_ASSERT(
               t.use_count() <= 1, op_name); // Okay to return undefined tensor
@@ -395,7 +399,7 @@ static void autogradNotImplementedFallbackImpl(
         // where each element represents the norm of corresponding input Tensor,
         // here I want to return the same number of Tensors as the input
         // TensorList, see https://github.com/pytorch/pytorch/issues/93940
-        // Skip nattive_channel_shuffle as well
+        // Skip native_channel_shuffle as well as transformer_encoder
         // For details see https://github.com/pytorch/pytorch/issues/130073
         if (!is_aliased_output[idx_ret] && t.has_storage() &&
             op_name != "aten::_foreach_norm" &&

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -399,6 +399,7 @@ static void autogradNotImplementedFallbackImpl(
         // For details see https://github.com/pytorch/pytorch/issues/130073
         if (!is_aliased_output[idx_ret] && t.has_storage() &&
             op_name != "aten::_foreach_norm" &&
+            op_name != "aten::_transformer_encoder_layer_fwd" &&
             op_name != "aten::native_channel_shuffle")
           TORCH_INTERNAL_ASSERT(t.storage().use_count() == 1);
       },

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -392,8 +392,11 @@ static void autogradNotImplementedFallbackImpl(
         // where each element represents the norm of corresponding input Tensor,
         // here I want to return the same number of Tensors as the input
         // TensorList, see https://github.com/pytorch/pytorch/issues/93940
+        // Skip nattive_channel_shuffle as well
+        // For details see https://github.com/pytorch/pytorch/issues/130073
         if (!is_aliased_output[idx_ret] && t.has_storage() &&
-            op_name != "aten::_foreach_norm")
+            op_name != "aten::_foreach_norm" &&
+            op_name != "aten::native_channel_shuffle")
           TORCH_INTERNAL_ASSERT(t.storage().use_count() == 1);
       },
       stack,

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -364,11 +364,14 @@ static void autogradNotImplementedFallbackImpl(
 #ifndef NDEBUG
   _foreach_tensor(
       [&](size_t idx_tensor, size_t _, const at::Tensor& t) {
-        if (storage_saved.at(idx_tensor).has_value())
+        // Skip next two for chunk_cat, see
+        // https://github.com/pytorch/pytorch/issues/130073
+        if (storage_saved.at(idx_tensor).has_value() &&
+            op_name != "aten::_chunk_cat")
           TORCH_INTERNAL_ASSERT(
               storage_saved.at(idx_tensor).value().is_alias_of(t.storage()),
               op_name);
-        if (impl_saved.at(idx_tensor))
+        if (impl_saved.at(idx_tensor) && op_name != "aten::_chunk_cat")
           TORCH_INTERNAL_ASSERT(
               impl_saved.at(idx_tensor) == t.getIntrusivePtr(), op_name);
       },

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -387,7 +387,8 @@ static void autogradNotImplementedFallbackImpl(
           return;
         // Skip test_parallel_materialize
         // For details see https://github.com/pytorch/pytorch/issues/130073
-        if (op_name == "aten::_test_parallel_materialize")
+        if (op_name == "aten::_test_parallel_materialize" ||
+            op_name == "aten::_test_optional_intlist")
           return;
         if (!is_inplace_output[idx_ret])
           TORCH_INTERNAL_ASSERT(

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -388,7 +388,9 @@ static void autogradNotImplementedFallbackImpl(
         // Skip test_parallel_materialize
         // For details see https://github.com/pytorch/pytorch/issues/130073
         if (op_name == "aten::_test_parallel_materialize" ||
-            op_name == "aten::_test_optional_intlist")
+            op_name == "aten::_test_optional_intlist" ||
+            op_name == "aten::_test_optional_filled_intlist" ||
+            op_name == "aten::_test_optional_floatlist")
           return;
         if (!is_inplace_output[idx_ret])
           TORCH_INTERNAL_ASSERT(


### PR DESCRIPTION
Not a standard CMake config, as far as I can tell, but it introduces an important concept of optimized build without `NDEBUG`. Test by running `python -c "import torch; torch._C._crash_if_debug_asserts_fail(424242)"`, which is a no-op unless debug_assert_fail is enabled.

Add recently added `_unsafe_masked_index`/`_unsafe_masked_index_put_accumulate` to DONT_ENFORCE_SAME_TENSOR_IMPL_OR_STORAGE to avoid all test involving those ops to fail with internal assert 
Suppress number of internal asserts to make CI green, see https://github.com/pytorch/pytorch/issues/130073

Fixes https://github.com/pytorch/pytorch/issues/102105

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang