### PR TITLE
Add debug repr to SymNode

### DIFF
--- a/c10/core/SymNodeImpl.h
+++ b/c10/core/SymNodeImpl.h
@@ -206,6 +206,9 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
   virtual std::string str() {
     TORCH_CHECK(false, "NYI");
   };
+  virtual std::string _graph_repr() {
+    return str();
+  };
   virtual std::optional<int64_t> nested_int() {
     return std::nullopt;
   }

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -505,7 +505,7 @@ class SymInt:
         raise TypeError("type stub not overridden")
 
     def __repr__(self):
-        return str(self.node)
+        return self.node._graph_repr()
 
     def _sympy_(self):
         return self.node.expr

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -616,7 +616,7 @@ class SymFloat:
         raise TypeError("type stub not overridden")
 
     def __repr__(self):
-        return self.node.str()
+        return self.node._graph_repr()
 
     def _sympy_(self):
         return self.node.expr
@@ -684,7 +684,7 @@ class SymBool:
         raise TypeError("type stub not overridden")
 
     def __repr__(self):
-        return str(self.node)
+        return self.node._graph_repr()
 
     def _sympy_(self):
         return self.node.expr

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1285,6 +1285,9 @@ void initJITBindings(PyObject* module) {
           "__repr__",
           [](c10::SymNode a) { return a->str(); })
       .def(
+          "_graph_repr",
+          [](c10::SymNode a) { return a->_graph_repr(); })
+      .def(
           "is_constant",
           [](const c10::SymNode& node){
             return node->is_constant();

--- a/torch/csrc/utils/python_symnode.h
+++ b/torch/csrc/utils/python_symnode.h
@@ -155,6 +155,11 @@ class PythonSymNodeImpl : public c10::SymNodeImpl {
     return getPyObj().attr("str")().cast<std::string>();
   }
 
+  std::string _graph_repr() override {
+    py::gil_scoped_acquire acquire;
+    return getPyObj().attr("_graph_repr")().cast<std::string>();
+  }
+
   c10::SymNode dispatch_sym_ite_(
       const char* fname,
       const c10::SymNode& other,

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -234,14 +234,14 @@ class SymNode:
         return self.str()
 
     def __repr__(self):
-        return self.str()
-
-    def debug_repr(self):
-        # This method includes additional debugging information
         return (
             f"SymNode(expr={self.expr}, shape_env={self.shape_env}, "
             f"pytype={self.pytype}, hint={self._hint}, constant={self.constant})"
         )
+
+    def _graph_repr(self) -> str:
+        # Representation used by GraphModule to create a pythonic version of a graph
+        return self.str()
 
     # These methods call the metaprogrammed methods, they're hand written
     # here so we get good stack traces

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -227,23 +227,25 @@ class SymNode:
     def clone(self):
         return self
 
-    def str(self):
+    def _str(self):
         return f"{self.expr}"
 
     def __str__(self):
-        return self.str()
+        return self._str()
 
     def __repr__(self):
         rep = [
             f"SymNode({self.expr}, shape_env={self.shape_env}, pytype={self.pytype}",
-            *(f"hint={self._hint}" for _ in [None] if self._hint is not None),
-            *(f"constant={self.constant}" for _ in [None] if self.constant is not None),
         ]
+        if self._hint is not None:
+            rep.append(f"hint={self._hint}")
+        if self.constant is not None:
+            rep.append(f"constant={self.constant}")
         return ", ".join(rep) + ")"
 
-    def _graph_repr(self):
+    def _graph_repr(self) -> str:
         # Representation used by GraphModule to create a pythonic version of a graph
-        return self.str()
+        return self._str()
 
     # These methods call the metaprogrammed methods, they're hand written
     # here so we get good stack traces

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -234,12 +234,14 @@ class SymNode:
         return self.str()
 
     def __repr__(self):
-        return (
-            f"SymNode(expr={self.expr}, shape_env={self.shape_env}, "
-            f"pytype={self.pytype}, hint={self._hint}, constant={self.constant})"
-        )
+        rep = [
+            f"SymNode({self.expr}, shape_env={self.shape_env}, pytype={self.pytype}",
+            *(f"hint={self._hint}" for _ in [None] if self._hint is not None),
+            *(f"constant={self.constant}" for _ in [None] if self.constant is not None),
+        ]
+        return ", ".join(rep) + ")"
 
-    def _graph_repr(self) -> str:
+    def _graph_repr(self):
         # Representation used by GraphModule to create a pythonic version of a graph
         return self.str()
 

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -245,7 +245,7 @@ class SymNode:
             rep.append(f"fx_node={self.fx_node}")
         return ", ".join(rep) + ")"
 
-    def _graph_repr(self) -> str:  # type: ignore[valid-type]
+    def _graph_repr(self) -> builtins.str:
         # Representation used by GraphModule to create a pythonic version of a graph
         return self.str()
 

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -236,6 +236,13 @@ class SymNode:
     def __repr__(self):
         return self.str()
 
+    def debug_repr(self):
+        # This method includes additional debugging information
+        return (
+            f"SymNode(expr={self.expr}, shape_env={self.shape_env}, "
+            f"pytype={self.pytype}, hint={self._hint}, constant={self.constant})"
+        )
+
     # These methods call the metaprogrammed methods, they're hand written
     # here so we get good stack traces
     def abs(self) -> "SymNode":

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -241,6 +241,8 @@ class SymNode:
             rep.append(f"hint={self._hint}")
         if self.constant is not None:
             rep.append(f"constant={self.constant}")
+        if self.fx_node is not None:
+            rep.append(f"fx_node={self.fx_node}")
         return ", ".join(rep) + ")"
 
     def _graph_repr(self) -> str:

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -227,11 +227,11 @@ class SymNode:
     def clone(self):
         return self
 
-    def _str(self):
+    def str(self):
         return f"{self.expr}"
 
     def __str__(self):
-        return self._str()
+        return self.str()
 
     def __repr__(self):
         rep = [
@@ -245,9 +245,9 @@ class SymNode:
             rep.append(f"fx_node={self.fx_node}")
         return ", ".join(rep) + ")"
 
-    def _graph_repr(self) -> str:
+    def _graph_repr(self) -> str:  # type: ignore[valid-type]
         # Representation used by GraphModule to create a pythonic version of a graph
-        return self._str()
+        return self.str()
 
     # These methods call the metaprogrammed methods, they're hand written
     # here so we get good stack traces


### PR DESCRIPTION
Fixes #129403

Create a separate printing function to debug SymNode, since we can't easily change `__repr__` that is used by GraphModule.recompile() to create a pythonic version of a graph

This is my first contribution, please let me know if there is anything that I should look into in further details

Thank you for you guidance! 🙏 I hope to contribute more in the future!

@aorenste 