### PR TITLE
[export] add dynamic shapes argument and infer from graph nodes

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4437,6 +4437,19 @@ graph():
         self.assertEqual(a.size(), torch.Size([3, 4]))
         self.assertEqual(b.size(), torch.Size([3, 4]))
 
+        # Contains unbacked symint
+        class M(torch.nn.Module):
+            def forward(self):
+                full = torch.full((), 11)
+                i0 = full.item()
+                return (torch.full((i0,), 0.0),)
+
+        f = M()
+        ep = torch.export.export(f, ())
+        a = ep.module()()[0]
+        self.assertEqual(a.size(), torch.Size([11]))
+        self.assertEqual(a, torch.zeros(11))
+
     def test_pad_sequence(self):
         class Module(torch.nn.Module):
             def forward(self, x):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4432,7 +4432,7 @@ graph():
                 return torch.randn(3, 4), torch.randn(3, 4)
 
         f = Module()
-        ep = torch.export.export(f, ())
+        ep = export(f, ())
         a, b = ep.module()()
         self.assertEqual(a.size(), torch.Size([3, 4]))
         self.assertEqual(b.size(), torch.Size([3, 4]))
@@ -4445,7 +4445,7 @@ graph():
                 return (torch.full((i0,), 0.0),)
 
         f = M()
-        ep = torch.export.export(f, ())
+        ep = export(f, ())
         a = ep.module()()[0]
         self.assertEqual(a.size(), torch.Size([11]))
         self.assertEqual(a, torch.zeros(11))

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -4432,7 +4432,7 @@ graph():
                 return torch.randn(3, 4), torch.randn(3, 4)
 
         f = Module()
-        ep = export(f, ())
+        ep = torch.export.export(f, ())
         a, b = ep.module()()
         self.assertEqual(a.size(), torch.Size([3, 4]))
         self.assertEqual(b.size(), torch.Size([3, 4]))
@@ -4445,7 +4445,7 @@ graph():
                 return (torch.full((i0,), 0.0),)
 
         f = M()
-        ep = export(f, ())
+        ep = torch.export.export(f, ())
         a = ep.module()()[0]
         self.assertEqual(a.size(), torch.Size([11]))
         self.assertEqual(a, torch.zeros(11))

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4942,7 +4942,9 @@ def forward(self, arg0_1):
                 i0 = full.item()
                 return (torch.full((i0,), 0),)
 
-        gm, _ = aot_export_module(mod=M(), args=(), trace_joint=False)
+        gm, _ = aot_export_module(
+            mod=M(), args=(), trace_joint=False, dynamic_shapes=True
+        )
         self.assertExpectedInline(
             gm.code.strip(),
             """\

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4935,6 +4935,24 @@ def forward(self, arg0_1):
             aot_export_joint_simple(fn, [mod.p, inp], trace_joint=True)
             aot_export_module(mod, [inp], trace_joint=False)
 
+    def test_aot_export_unbacked_arg(self):
+        class M(torch.nn.Module):
+            def forward(self):
+                full = torch.full((), 11)
+                i0 = full.item()
+                return (torch.full((i0,), 0),)
+
+        gm, _ = aot_export_module(mod=M(), args=(), trace_joint=False)
+        self.assertExpectedInline(
+            gm.code.strip(),
+            """\
+def forward(self):
+    full = torch.ops.aten.full.default([], 11, device = device(type='cpu'), pin_memory = False)
+    _local_scalar_dense = torch.ops.aten._local_scalar_dense.default(full);  full = None
+    full_1 = torch.ops.aten.full.default([_local_scalar_dense], 0, device = device(type='cpu'), pin_memory = False);  _local_scalar_dense = None
+    return (full_1,)""",
+        )
+
 
 class TestPartitioning(AOTTestCase):
     @unittest.skipIf(not USE_NETWORKX, "networkx not available")

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4952,7 +4952,7 @@ def forward(self):
     full = torch.ops.aten.full.default([], 11, device = device(type='cpu'), pin_memory = False)
     _local_scalar_dense = torch.ops.aten._local_scalar_dense.default(full);  full = None
     full_1 = torch.ops.aten.full.default([_local_scalar_dense], 0, device = device(type='cpu'), pin_memory = False);  _local_scalar_dense = None
-    return (full_1,)""",
+    return (full_1,)""",  # noqa: B950
         )
 
 

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2707,7 +2707,12 @@ def canonicalize(ep: ExportedProgram) -> ExportedProgram:
     sorted_ins = sorted(
         enumerate(zip(graph.inputs, signature.input_specs)), key=rank_input
     )
-    sorted_inputs, input_specs = zip(*(i for idx, i in sorted_ins))  # type: ignore[assignment]
+
+    if len(sorted_ins) > 0:
+        sorted_inputs, input_specs = zip(*(i for idx, i in sorted_ins))  # type: ignore[assignment]
+    else:
+        sorted_inputs = ()
+        input_specs = ()
 
     sorted_outs = sorted(
         enumerate(zip(graph.outputs, signature.output_specs)), key=rank_output

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -3,7 +3,7 @@
 import itertools
 from contextlib import contextmanager, nullcontext
 from functools import partial, wraps
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from unittest.mock import patch
 
 import torch
@@ -1038,6 +1038,8 @@ def aot_export_module(
     # Your module can return multiple outputs, so you must specify which output the loss is.
     output_loss_index: Optional[int] = None,
     pre_dispatch: bool = False,
+    # If None, will be infered from inputs and mod.graph.nodes if mod is a graph module, but the inferred result might be wrong.
+    dynamic_shapes: Union[bool, None] = None,
     kwargs=None,
 ) -> Tuple[torch.fx.GraphModule, GraphSignature]:
     """
@@ -1167,6 +1169,7 @@ We require the output marked as the loss (at index {output_loss_index}) to be a 
             num_params_buffers=params_len,
             no_tangents=True,
             pre_dispatch=pre_dispatch,
+            dynamic_shapes=dynamic_shapes,
             kwargs=kwargs,
         )
     if trace_joint:
@@ -1344,6 +1347,8 @@ def _aot_export_function(
     # We don't know this info at trace time though, so we need to make it an explicit config.
     no_tangents: bool = False,
     pre_dispatch: bool = False,
+    # If None, `dynamic_shapes` will be infered from inputs, but the inferred result might be wrong.
+    dynamic_shapes: Union[bool, None] = None,
     kwargs=None,
 ) -> Tuple[torch.fx.GraphModule, ViewAndMutationMeta, pytree.TreeSpec, pytree.TreeSpec]:
     kwargs = kwargs or {}
@@ -1351,14 +1356,20 @@ def _aot_export_function(
     flat_fn, out_spec = create_tree_flattened_fn(func, args, kwargs)
     flat_args, in_spec = pytree.tree_flatten((args, kwargs))
 
-    dynamic_shapes = False
-    if len(flat_args) == 0:
-        dynamic_shapes = True
-    else:
-        for x in flat_args:
-            if isinstance(x, FakeTensor):
-                dynamic_shapes = x.fake_mode.shape_env is not None
-                break
+    if dynamic_shapes is None:
+        # Try to infer `dynamic_shapes from inputs and graph nodes
+        args_and_vals = flat_args.copy()
+        if hasattr(func, "_orig_mod") and isinstance(
+            func._orig_mod, torch.fx.GraphModule
+        ):
+            args_and_vals = args_and_vals + [
+                node.meta["val"]
+                for node in func._orig_mod.graph.nodes
+                if "val" in node.meta
+            ]
+
+        fake_mode = detect_fake_mode(args_and_vals)
+        dynamic_shapes = fake_mode is not None and fake_mode.shape_env is not None
 
     # The export use case doesn't care about several bits of AOTConfig
     # (1) compilers (we just export the graph)

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1353,7 +1353,7 @@ def _aot_export_function(
 
     dynamic_shapes = False
     if len(flat_args) == 0:
-        dynamic_shapes = FakeTensorMode()
+        dynamic_shapes = True
     else:
         for x in flat_args:
             if isinstance(x, FakeTensor):

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1352,10 +1352,13 @@ def _aot_export_function(
     flat_args, in_spec = pytree.tree_flatten((args, kwargs))
 
     dynamic_shapes = False
-    for x in flat_args:
-        if isinstance(x, FakeTensor):
-            dynamic_shapes = x.fake_mode.shape_env is not None
-            break
+    if len(flat_args) == 0:
+        dynamic_shapes = FakeTensorMode()
+    else:
+        for x in flat_args:
+            if isinstance(x, FakeTensor):
+                dynamic_shapes = x.fake_mode.shape_env is not None
+                break
 
     # The export use case doesn't care about several bits of AOTConfig
     # (1) compilers (we just export the graph)

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -204,6 +204,10 @@ def _convert_input_to_fake(gm, args, kwargs):
             fake_val = node.meta["val"]
             if fake_val is not None and isinstance(fake_val, torch.Tensor):
                 fake_inps.append(fake_val)
+        elif "example_value" in node.meta:
+            fake_val = node.meta["example_value"]
+            if fake_val is not None and isinstance(fake_val, torch.Tensor):
+                fake_inps.append(fake_val)
 
     if detected_fake_mode := detect_fake_mode(fake_inps):
         fake_mode = detected_fake_mode

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -199,17 +199,18 @@ def _rewrite_node(gm):
 def _convert_input_to_fake(gm, args, kwargs):
     params_buffers = _get_params_buffers(gm)
     fake_inps: List[torch.Tensor] = []
+    fake_vals: List[torch.Tensor] = []
     for node in gm.graph.nodes:
         if node.op == "placeholder" and "val" in node.meta:
             fake_val = node.meta["val"]
             if fake_val is not None and isinstance(fake_val, torch.Tensor):
                 fake_inps.append(fake_val)
-        elif "example_value" in node.meta:
+        elif len(fake_inps) == 0 and "example_value" in node.meta:
             fake_val = node.meta["example_value"]
             if fake_val is not None and isinstance(fake_val, torch.Tensor):
-                fake_inps.append(fake_val)
+                fake_vals.append(fake_val)
 
-    if detected_fake_mode := detect_fake_mode(fake_inps):
+    if detected_fake_mode := detect_fake_mode(fake_inps + fake_vals):
         fake_mode = detected_fake_mode
     else:
         fake_mode = FakeTensorMode(shape_env=ShapeEnv(), export=True)


### PR DESCRIPTION
Fixes the example in #118304 for `torch._functorch.aot_autograd.aot_export_module` and `torch.export.export`.

On a high level, the issue is caused by not detecting fake_mode when there's no input.

Change plan:

1) we add a  `dynamic_shapes: Union[bool, None] = None` arg to `aot_export_module` and `_aot_export_function`.

2) if the input is not a graph module, then we can only rely on this `dynamic_shapes` input arg. 

3) If the input is a graph module, then we can traverse the graph and check. 

4) So we check if the input mod is a graph module or just a module, and do 2) or 3) depending on the type.

Fixes #129927

Bug source: dynamo's fake_mode is not detected correctly in `_convert_input_to_fake` in `_traced.py` when there’s no input to the graph). So in ` _strict_export_lower_to_aten_ir`, we create another fake_mode. `dynamo_fake_mode` is not the same as the fake_mode used by dynamo.

Change plan:
check `gm_torch_level` graph's node meta "example_value" for fake mode in addition.
