### PR TITLE
[traced-graph][sparse] add relay override for layout_impl

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -514,6 +514,9 @@ c10::SymInt FunctionalTensorWrapper::sym_size_custom(int64_t d) const {
 c10::SymInt FunctionalTensorWrapper::sym_storage_offset_custom() const {
   return value_.unsafeGetTensorImpl()->sym_storage_offset();
 }
+c10::Layout FunctionalTensorWrapper::layout_impl() const {
+  return value_.unsafeGetTensorImpl()->layout();
+}
 
 namespace functionalization {
 namespace impl {

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -222,6 +222,7 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   c10::SymIntArrayRef sym_strides_custom() const override;
   c10::SymInt sym_storage_offset_custom() const override;
   c10::Device device_custom() const override;
+  c10::Layout layout_impl() const override;
 
  private:
   const char* tensorimpl_type_name() const override;


### PR DESCRIPTION
In the "layout()" method of "TensorImpl" defined in the file core/TensorImpl.h, the following code and documentation can be found:

```
  Layout layout() const {
  ...
  if .. {
  ...
  } else if (is_sparse_compressed()) {
      // Typically, the tensor dispatch keys define the tensor layout
      // uniquely. This allows using non-virtual layout method for
      // better performance. However, when tensor's layout depends,
      // say, on tensor attributes, one must use this execution path
      // where the corresponding tensor impl class overwrites virtual
      // layout_impl() method.
      return layout_impl();
    } else {
    ...
    }
  }

```
However, this override was never implemented. This PR put the override in place, to prepare for sparsity propagation in another PR.

https://github.com/pytorch/pytorch/issues/117188

