### PR TITLE
update the input `weight` of `_convert_weight_to_int4pack` to `[n][k / 2] uint8`

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3442,14 +3442,14 @@ Tensor _convert_weight_to_int4pack_cpu(
 
   TORCH_CHECK(in.dim() == 2,
       __func__, " : expect weight to be 2D tensor.");
-  TORCH_CHECK(in.dtype() == at::kInt,
-      __func__, " : expect weight to be kInt.");
+  TORCH_CHECK(in.dtype() == at::kByte,
+      __func__, " : expect weight to be kByte.");
   TORCH_CHECK(innerKTiles == 2 || innerKTiles == 4 || innerKTiles == 8,
       __func__, " : innerKTiles need to be 2, 4, or 8, got ", innerKTiles);
 
   auto weight = in.contiguous();
   auto N = weight.size(0);
-  auto K = weight.size(1);
+  auto K = weight.size(1) * 2;
 
   // Create fake shapes for cpu. The meta registration in dynamo requires
   // operator has the same output shape for each device. So creating a fake
@@ -3470,6 +3470,7 @@ Tensor _convert_weight_to_int4pack_cpu(
       at::TensorOptions().dtype(at::kInt));
 
   weight_to_int4pack_stub(kCPU, weight_packed, weight, N, K);
+  std::cout<<"stub end\n";
   return weight_packed;
 }
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3470,7 +3470,6 @@ Tensor _convert_weight_to_int4pack_cpu(
       at::TensorOptions().dtype(at::kInt));
 
   weight_to_int4pack_stub(kCPU, weight_packed, weight, N, K);
-  std::cout<<"stub end\n";
   return weight_packed;
 }
 

--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -614,25 +614,23 @@ void weight_to_int4pack_kernel(
   // 64 for avx512 and 32 for avx2/non-vectorized
   constexpr int BLOCK_N = vec::Vectorized<float>::size() * 4;
   const int NB =  (N + BLOCK_N - 1) / BLOCK_N;
+  int K_div_2 = K / 2;
 
-  std::cout<<"N "<<N<<" K "<<K <<"\n";
   // parallel on NB blocks
   at::parallel_for(0, NB, 0, [&](int begin, int end) {
     for (const auto i : c10::irange(begin, end)) {
       int nb_size = std::min(BLOCK_N, N - i * BLOCK_N);
-      std::cout<<"nb_size "<<nb_size<<"\n";
 
-      const uint8_t* src = weight_data + i * BLOCK_N * K / 2;
+      const uint8_t* src = weight_data + i * BLOCK_N * K_div_2;
       uint8_t* dst = weight_packed_data + i * K * BLOCK_N / 2;
-      for (const auto k : c10::irange(K / 2)) {
-        std::cout<<" k: "<<k<<"\n";
+      for (const auto k : c10::irange(K_div_2)) {
 #if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
         if (nb_size == BLOCK_N) {
           for (const auto d : c10::irange(16)) {
-            uint8_t val0 = src[(d +  0) * K / 2 + k];
-            uint8_t val1 = src[(d + 16) * K / 2 + k];
-            uint8_t val2 = src[(d + 32) * K / 2 + k];
-            uint8_t val3 = src[(d + 48) * K / 2 + k];
+            uint8_t val0 = src[(d + 0) * K_div_2 + k];
+            uint8_t val1 = src[(d + 16) * K_div_2 + k];
+            uint8_t val2 = src[(d + 32) * K_div_2 + k];
+            uint8_t val3 = src[(d + 48) * K_div_2 + k];
 
             uint8_t packed02_0 = (val2 & 0xF0) | ((val0 & 0xF0) >> 4);
             uint8_t packed13_0 = (val3 & 0xF0) | ((val1 & 0xF0) >> 4);
@@ -647,19 +645,11 @@ void weight_to_int4pack_kernel(
         } else {
           // for nb_size 16, 32, 48
           for (int n = 0; n < nb_size; n += 2) {
-            uint8_t val0 = src[n * K / 2 + k];
-            uint8_t val1 = src[n * K / 2 + K / 2 + k];
-            std::cout<<"val0"<<"\n";
-            printf("%x\n", val0);
-            std::cout<<"val1"<<"\n";
-            printf("%x\n", val1);
+            uint8_t val0 = src[n * K_div_2 + k];
+            uint8_t val1 = src[n * K_div_2 + K_div_2 + k];
 
             uint8_t packed_0 = ((val1 & 0xF0)) | ((val0 & 0xF0) >> 4);
             uint8_t packed_1 = ((val1 & 0xF) << 4) | (val0 & 0xF);
-            std::cout<<"packed_0"<<"\n";
-            printf("%x\n", packed_0);
-            std::cout<<"packed_1"<<"\n";
-            printf("%x\n", packed_1);
             dst[k * 2 * nb_size / 2 + n / 2] = packed_0;
             dst[(k * 2 + 1) * nb_size / 2 + n / 2] = packed_1;
           }
@@ -668,8 +658,8 @@ void weight_to_int4pack_kernel(
         if (nb_size == BLOCK_N) {
           // for nb_size 32
           for (const auto d : c10::irange(16)) {
-            uint8_t val0 = src[(d + 0) * K / 2 + k];
-            uint8_t val1 = src[(d + 16) * K / 2 + k];
+            uint8_t val0 = src[(d + 0) * K_div_2 + k];
+            uint8_t val1 = src[(d + 16) * K_div_2 + k];
 
             uint8_t packed01_0 = ((val1 & 0xF0) | ((val0 & 0xF0) >> 4));
             uint8_t packed01_1 = ((val1 & 0xF) << 4) | (val0 & 0xF);
@@ -679,30 +669,22 @@ void weight_to_int4pack_kernel(
         } else {
           // for nb_size 16
           for (int n = 0; n < nb_size; n += 2) {
-            int32_t val0 = src[n * K / 2 + k];
-            int32_t val1 = src[n * K / 2 + K / 2 + k];
+            int32_t val0 = src[n * K_div_2 + k];
+            int32_t val1 = src[n * K_div_2 + K_div_2 + k];
 
             uint8_t packed_0 = ((val1 & 0xF0)) | ((val0 & 0xF0) >> 4);
             uint8_t packed_1 = ((val1 & 0xF) << 4) | (val0 & 0xF);
-            std::cout<<"packed_0"<<"\n";
-            printf("%x\n", packed_0);
-            std::cout<<"packed_1"<<"\n";
-            printf("%x\n", packed_1);
             dst[k * 2 * nb_size / 2 + n / 2] = packed_0;
             dst[(k * 2 + 1) * nb_size / 2 + n / 2] = packed_1;
           }
         }
 #else
         for (int n = 0; n < nb_size; n += 2) {
-          uint8_t val0 = src[n * K / 2 + k];
-          uint8_t val1 = src[n * K / 2 + K / 2 + k];
+          uint8_t val0 = src[n * K_div_2 + k];
+          uint8_t val1 = src[n * K_div_2 + K_div_2 + k];
 
           uint8_t packed_0 = ((val1 & 0xF0)) | ((val0 & 0xF0) >> 4);
           uint8_t packed_1 = ((val1 & 0xF) << 4) | (val0 & 0xF);
-          std::cout<<"packed_0"<<"\n";
-          printf("%x\n", packed_0);
-          std::cout<<"packed_1"<<"\n";
-          printf("%x\n", packed_1);
           dst[k * 2 * nb_size / 2 + n / 2] = packed_0;
           dst[(k * 2 + 1) * nb_size / 2 + n / 2] = packed_1;
         }

--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -1014,8 +1014,6 @@ __global__ void matrix_to_m16n8k16_Bint4_layout(
   auto kOuterTile = blockIdx.x;
   auto nTile = blockIdx.y;
   auto t = threadIdx.x;
-  printf("%d %d %d\n", kOuterTile, nTile, t);
-  printf("InnerKTiles %d\n", InnerKTiles);
 
   // Two k-tiles are packed into an int32 at a time
 #pragma unroll
@@ -1050,9 +1048,6 @@ __global__ void matrix_to_m16n8k16_Bint4_layout(
     ks[3] = ks[2] + 4;
 #endif
 
-    // printf("%d %d: %d %d %d %d %d %d %d %d \n", n0, t, ks[0], ks[1], ks[2],
-    // ks[3], ks[4], ks[5], ks[6], ks[7]);
-    printf("%d %d: %d %d %d %d \n", n0, t, ks[0], ks[1], ks[2], ks[3]);
     auto pIn = &in[n0][0];
 
     uint8_t v[4];
@@ -1061,12 +1056,15 @@ __global__ void matrix_to_m16n8k16_Bint4_layout(
       v[i] = (n0Valid && ks[i] < in.size(1)) ? pIn[ks[i]] : uint8_t(0);
     }
 
-    // To clearly explain the packed result with 8 int4 values into one int32,
-    // we use the follow figure:
-    //[n][k]     int32: v[0] v[1] v[2] v[3] v[4] v[5] v[6] v[7]
-    //[n][k / 2] uint8:    v[0]     v[1]      v[2]      v[3]
-    // Packed result is consisted of v[7] v[5] v[3] v[1] v[6] v[4] v[2] v[0],
-    // which epuals to v[3]L v[2]L v[1]L v[0]L v[3]H v[2]H v[1]H v[0]H.
+    // To clearly explain the packed result with 8 int4 values (4 uint8)
+    // into one int32, we use the follow figure:
+    // [n][k]     int32: v[0] v[1] v[2] v[3] v[4] v[5] v[6] v[7]
+    // [n][k / 2] uint8:    v[0]     v[1]      v[2]      v[3]
+    // When using int32 weight as input, the packed result is consisted of
+    // v[7] | v[5] | v[3] | v[1] | v[6] | v[4] | v[2] | v[0],
+    // which epuals to
+    // v[3]L | v[2]L | v[1]L | v[0]L | v[3]H | v[2]H | v[1]H | v[0]H
+    // when using uint8 weight as input.
     int32_t pack = ((uint32_t)(v[3] & 0xF) << 28) |
         ((uint32_t)(v[2] & 0xF) << 24) | ((uint32_t)(v[1] & 0xF) << 20) |
         ((uint32_t)(v[0] & 0xF) << 16) | ((uint32_t)(v[3] & 0xF0) << 8) |

--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -994,8 +994,8 @@ void launch_tinygemm_kernel(
 // FIXME: parallelize better, smem staging etc?
 template <int InnerKTiles>
 __global__ void matrix_to_m16n8k16_Bint4_layout(
-    // size [n][k]
-    const at::PackedTensorAccessor32<int32_t, 2, at::RestrictPtrTraits> in,
+    // size [n][k / 2]
+    const at::PackedTensorAccessor32<uint8_t, 2, at::RestrictPtrTraits> in,
     // size [ceil(n / 8)][ceil(k / (InnerKTiles * 16))][32][InnerKTiles / 2]
     at::PackedTensorAccessor32<int32_t, 4, at::RestrictPtrTraits> out) {
   // int4 values are packed into int32 values, which require at least 8. Given
@@ -1014,6 +1014,8 @@ __global__ void matrix_to_m16n8k16_Bint4_layout(
   auto kOuterTile = blockIdx.x;
   auto nTile = blockIdx.y;
   auto t = threadIdx.x;
+  printf("%d %d %d\n", kOuterTile, nTile, t);
+  printf("InnerKTiles %d\n", InnerKTiles);
 
   // Two k-tiles are packed into an int32 at a time
 #pragma unroll
@@ -1027,44 +1029,49 @@ __global__ void matrix_to_m16n8k16_Bint4_layout(
 
     bool n0Valid = n0 < in.size(0);
 
-    int32_t ks[8];
+    // Four uint8 are packed into an int32
+    int32_t ks[4];
 
-    auto kBase0 = (kOuterTile * InnerKTiles + innerKTile) * kKTileSize;
+    auto kBase0 = (kOuterTile * InnerKTiles + innerKTile) * kKTileSize / 2;
 
 #if defined(USE_ROCM)
-    ks[0] = kBase0 + (t / kNTileSize) * 4;
+    ks[0] = kBase0 + (t / kNTileSize) * 2;
     ks[1] = ks[0] + 1;
-    ks[2] = ks[0] + 2;
-    ks[3] = ks[0] + 3;
 
-    auto kBase1 = kBase0 + kKTileSize;
-    ks[4] = kBase1 + (t / kNTileSize) * 4;
-    ks[5] = ks[4] + 1;
-    ks[6] = ks[4] + 2;
-    ks[7] = ks[4] + 3;
+    auto kBase1 = kBase0 + kKTileSize / 2;
+    ks[2] = kBase1 + (t / kNTileSize) * 2;
+    ks[3] = ks[4] + 1;
 #else
-    ks[0] = kBase0 + (t % 4) * 2;
-    ks[1] = ks[0] + 1;
-    ks[2] = ks[0] + 8;
-    ks[3] = ks[0] + 8 + 1;
+    ks[0] = kBase0 + t % 4;
+    ks[1] = ks[0] + 4;
 
-    auto kBase1 = kBase0 + kKTileSize;
-    ks[4] = kBase1 + (t % 4) * 2;
-    ks[5] = ks[4] + 1;
-    ks[6] = ks[4] + 8;
-    ks[7] = ks[4] + 8 + 1;
+    auto kBase1 = kBase0 + kKTileSize / 2;
+    ks[2] = kBase1 + t % 4;
+    ks[3] = ks[2] + 4;
 #endif
 
+    // printf("%d %d: %d %d %d %d %d %d %d %d \n", n0, t, ks[0], ks[1], ks[2],
+    // ks[3], ks[4], ks[5], ks[6], ks[7]);
+    printf("%d %d: %d %d %d %d \n", n0, t, ks[0], ks[1], ks[2], ks[3]);
     auto pIn = &in[n0][0];
 
-    uint32_t v[8];
+    uint8_t v[4];
 #pragma unroll
-    for (int i = 0; i < 8; ++i) {
-      v[i] = (n0Valid && ks[i] < in.size(1)) ? pIn[ks[i]] : uint32_t(0);
+    for (int i = 0; i < 4; ++i) {
+      v[i] = (n0Valid && ks[i] < in.size(1)) ? pIn[ks[i]] : uint8_t(0);
     }
 
-    int32_t pack = (v[7] << 28) | (v[5] << 24) | (v[3] << 20) | (v[1] << 16) |
-        (v[6] << 12) | (v[4] << 8) | (v[2] << 4) | v[0];
+    // To clearly explain the packed result with 8 int4 values into one int32,
+    // we use the follow figure:
+    //[n][k]     int32: v[0] v[1] v[2] v[3] v[4] v[5] v[6] v[7]
+    //[n][k / 2] uint8:    v[0]     v[1]      v[2]      v[3]
+    // Packed result is consisted of v[7] v[5] v[3] v[1] v[6] v[4] v[2] v[0],
+    // which epuals to v[3]L v[2]L v[1]L v[0]L v[3]H v[2]H v[1]H v[0]H.
+    int32_t pack = ((uint32_t)(v[3] & 0xF) << 28) |
+        ((uint32_t)(v[2] & 0xF) << 24) | ((uint32_t)(v[1] & 0xF) << 20) |
+        ((uint32_t)(v[0] & 0xF) << 16) | ((uint32_t)(v[3] & 0xF0) << 8) |
+        ((uint32_t)(v[2] & 0xF0) << 4) | ((uint32_t)(v[1] & 0xF0)) |
+        ((uint32_t)(v[0] & 0xF0) >> 4);
 
     // inner k-tiles pack two at a time
 #if defined(USE_ROCM)
@@ -1273,15 +1280,15 @@ at::Tensor _weight_int4pack_mm_cuda(
   return C_final;
 }
 
-// input is [n][k] (int32 dtype)
-// output is [n / 8][k / (InnerKTiles * 16)][32][innerKTiles / 2]
+// input is [n][k / 2] (uint8 dtype)
+// output is [n / 8][k / (InnerKTiles * 16)][32][innerKTiles / 2] (int32 dtype)
 at::Tensor _convert_weight_to_int4pack_cuda(
     const at::Tensor& in,
     int64_t innerKTiles) {
   c10::cuda::CUDAGuard g(in.device());
 
   TORCH_CHECK(in.dim() == 2);
-  TORCH_CHECK(in.dtype() == at::kInt);
+  TORCH_CHECK(in.dtype() == at::kByte);
   TORCH_CHECK(in.is_contiguous());
 
   // At least 2 k-tiles need to be packed back to back in the innermost
@@ -1315,9 +1322,9 @@ at::Tensor _convert_weight_to_int4pack_cuda(
 
   // k-tiles are packed back to back in the innermost dimension in order to
   // allow for 4/8/16 byte loads
-  TORCH_CHECK(isEvenDivisor(in.size(1), innerKTiles * kKTileSize));
+  TORCH_CHECK(isEvenDivisor(in.size(1) * 2, innerKTiles * kKTileSize));
   // kSuperTiles is the number of k-tiles assuming k is innerKTiles * kKTileSize
-  auto kSuperTiles = divUp(in.size(1), innerKTiles * kKTileSize);
+  auto kSuperTiles = divUp(in.size(1) * 2, innerKTiles * kKTileSize);
 
   // each block handles `innerKTiles` k-tiles.
   // 2 k-tiles are a single int32
@@ -1334,15 +1341,15 @@ at::Tensor _convert_weight_to_int4pack_cuda(
 
   if (innerKTiles == 2) {
     matrix_to_m16n8k16_Bint4_layout<2><<<grid, kWarpSize, 0, stream>>>(
-        in.packed_accessor32<int32_t, 2, at::RestrictPtrTraits>(),
+        in.packed_accessor32<uint8_t, 2, at::RestrictPtrTraits>(),
         out.packed_accessor32<int32_t, 4, at::RestrictPtrTraits>());
   } else if (innerKTiles == 4) {
     matrix_to_m16n8k16_Bint4_layout<4><<<grid, kWarpSize, 0, stream>>>(
-        in.packed_accessor32<int32_t, 2, at::RestrictPtrTraits>(),
+        in.packed_accessor32<uint8_t, 2, at::RestrictPtrTraits>(),
         out.packed_accessor32<int32_t, 4, at::RestrictPtrTraits>());
   } else if (innerKTiles == 8) {
     matrix_to_m16n8k16_Bint4_layout<8><<<grid, kWarpSize, 0, stream>>>(
-        in.packed_accessor32<int32_t, 2, at::RestrictPtrTraits>(),
+        in.packed_accessor32<uint8_t, 2, at::RestrictPtrTraits>(),
         out.packed_accessor32<int32_t, 4, at::RestrictPtrTraits>());
   }
 

--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -1038,7 +1038,7 @@ __global__ void matrix_to_m16n8k16_Bint4_layout(
 
     auto kBase1 = kBase0 + kKTileSize / 2;
     ks[2] = kBase1 + (t / kNTileSize) * 2;
-    ks[3] = ks[4] + 1;
+    ks[3] = ks[2] + 1;
 #else
     ks[0] = kBase0 + t % 4;
     ks[1] = ks[0] + 4;

--- a/aten/src/ATen/native/mps/operations/Quantized.mm
+++ b/aten/src/ATen/native/mps/operations/Quantized.mm
@@ -55,7 +55,7 @@ template <> struct Vec2Type<bfloat> {
 };
 #endif
 
-kernel void weight_to_int4pack(constant int *W [[buffer(0)]],
+kernel void weight_to_int4pack(constant uchar *W [[buffer(0)]],
                                device uchar *outputData [[buffer(1)]],
                                constant uint2 &sizes [[buffer(2)]],
                                uint2 thread_index [[thread_position_in_grid]]) {
@@ -63,8 +63,8 @@ kernel void weight_to_int4pack(constant int *W [[buffer(0)]],
   const uint Kdiv2 = sizes.y;
   const uint n = thread_index.x; // 0..N-1
   const uint k = thread_index.y; // 0..Kdiv2-1
-  uint8_t src_val = W[n * Kdiv2 + k];
-  outputData[n * Kdiv2 + k] = (src_val & 0xF << 4) | (src_val >> 4);
+  uchar src_val = W[n * Kdiv2 + k];
+  outputData[n * Kdiv2 + k] = ((src_val & 0xF) << 4) | (src_val >> 4);
 }
 
 /*

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6138,11 +6138,11 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         b_bf16 = torch.rand((k, n), dtype=torch.bfloat16, device=device)
 
         def convert_weight_to_int4pack(b):
-            b_int32, b_scales_and_zeros = _group_quantize_tensor(
+            b_uint8, b_scales_and_zeros = _group_quantize_tensor(
                 b, n_bit=4, q_group_size=q_group
             )
             b_int4pack = torch._convert_weight_to_int4pack(
-                b_int32, inner_k_tiles
+                b_uint8, inner_k_tiles
             )
 
             return b_int4pack, b_scales_and_zeros

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9178,8 +9178,10 @@ class TestLinalgMPS(TestCaseMPS):
 
         def convert_weight_to_int4pack(b):
             b_int32, b_scales_and_zeros = _group_quantize_tensor(
-                b, n_bit=4, q_group_size=q_group
+                b.to("cpu"), n_bit=4, q_group_size=q_group
             )
+            b_int32 = b_int32.to("mps")
+            b_scales_and_zeros = b_scales_and_zeros.to("mps")
             b_int4pack = torch._convert_weight_to_int4pack(
                 b_int32, inner_k_tiles
             )

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3260,22 +3260,30 @@ def meta__convert_weight_to_int4pack(w, inner_k_tiles):
     )
     n = w.size(0)
     k = w.size(1)
-    return w.new_empty((n, k), dtype=torch.uint8)
+    return w.new_empty(
+        (
+            n // 8,
+            k // (inner_k_tiles * 16),
+            32,
+            inner_k_tiles // 2,
+        ),
+        dtype=torch.int32,
+    )
 
 
 @register_meta([aten._weight_int4pack_mm])
 def meta__weight_int4pack_mm(x, w, q_group_size, q_scale_and_zeros):
     torch._check(x.dim() == 2, lambda: "x must be a 2D tensor")
-    torch._check(w.dim() == 2, lambda: "w must be a 2D tensor")
+    torch._check(w.dim() == 4, lambda: "w must be a 4D tensor")
     torch._check(
         x.dtype in [torch.float32, torch.float16, torch.bfloat16],
         lambda: f"expected x to be f32/f16/bf16, got {x.dtype}",
     )
     torch._check(
-        w.dtype is torch.uint8,
-        lambda: f"expected w to be uint8, got {w.dtype}",
+        w.dtype is torch.int32,
+        lambda: f"expected w to be int32, got {w.dtype}",
     )
-    return x.new_empty(x.size(0), w.size(0), dtype=x.dtype)
+    return x.new_empty(x.size(0), w.size(0) * 8, dtype=x.dtype)
 
 
 @register_meta([aten._weight_int8pack_mm])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3255,35 +3255,27 @@ def meta__int_mm(a, b):
 def meta__convert_weight_to_int4pack(w, inner_k_tiles):
     torch._check(w.dim() == 2, lambda: "w must be a 2D tensor")
     torch._check(
-        w.dtype is torch.int32,
+        w.dtype is torch.uint8,
         lambda: f"expected w to be int32, got {w.dtype}",
     )
     n = w.size(0)
     k = w.size(1)
-    return w.new_empty(
-        (
-            n // 8,
-            k // (inner_k_tiles * 16),
-            32,
-            inner_k_tiles // 2,
-        ),
-        dtype=torch.int32,
-    )
+    return w.new_empty((n, k), dtype=torch.uint8)
 
 
 @register_meta([aten._weight_int4pack_mm])
 def meta__weight_int4pack_mm(x, w, q_group_size, q_scale_and_zeros):
     torch._check(x.dim() == 2, lambda: "x must be a 2D tensor")
-    torch._check(w.dim() == 4, lambda: "w must be a 4D tensor")
+    torch._check(w.dim() == 2, lambda: "w must be a 2D tensor")
     torch._check(
         x.dtype in [torch.float32, torch.float16, torch.bfloat16],
         lambda: f"expected x to be f32/f16/bf16, got {x.dtype}",
     )
     torch._check(
-        w.dtype is torch.int32,
-        lambda: f"expected w to be int32, got {w.dtype}",
+        w.dtype is torch.uint8,
+        lambda: f"expected w to be uint8, got {w.dtype}",
     )
-    return x.new_empty(x.size(0), w.size(0) * 8, dtype=x.dtype)
+    return x.new_empty(x.size(0), w.size(0), dtype=x.dtype)
 
 
 @register_meta([aten._weight_int8pack_mm])

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -476,11 +476,7 @@ def _group_quantize_tensor(w, n_bit=4, q_group_size=16):
     assert torch.isnan(out).sum() == 0
 
     out = out.to(dtype=torch.int32).reshape(w.shape)
-
-    out_uint8 = torch.empty((w.shape[0], w.shape[1] // 2), dtype=torch.uint8, device=w.device)
-    for n in range(w.shape[0]):
-        for j in range(w.shape[1] // 2):
-            out_uint8[n][j] = out[n][j * 2] << 4 | out[n][j * 2 + 1]
+    out_uint8 = (out[::,::2] << 4 | out[::,1::2]).to(torch.uint8)
 
     # Scales and zeros for the same q-group should be contiguous, so we can
     # load as a 32-bit word

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -477,7 +477,7 @@ def _group_quantize_tensor(w, n_bit=4, q_group_size=16):
 
     out = out.to(dtype=torch.int32).reshape(w.shape)
 
-    out_uint8 = torch.empty((w.shape[0], w.shape[1] // 2), dtype=torch.uint8)
+    out_uint8 = torch.empty((w.shape[0], w.shape[1] // 2), dtype=torch.uint8, device=w.device)
     for n in range(w.shape[0]):
         for j in range(w.shape[1] // 2):
             out_uint8[n][j] = out[n][j * 2] << 4 | out[n][j * 2 + 1]

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -476,7 +476,7 @@ def _group_quantize_tensor(w, n_bit=4, q_group_size=16):
     assert torch.isnan(out).sum() == 0
 
     out = out.to(dtype=torch.int32).reshape(w.shape)
-    out_uint8 = (out[::,::2] << 4 | out[::,1::2]).to(torch.uint8)
+    out_uint8 = (out[::, ::2] << 4 | out[::, 1::2]).to(torch.uint8)
 
     # Scales and zeros for the same q-group should be contiguous, so we can
     # load as a 32-bit word


### PR DESCRIPTION
This PR is to update the input `weight` of `_convert_weight_to_int4pack` from `[n][k] int32` to `[n][k / 2] uint8`, both for CPU, CUDA and MPS, which can help decouple int4 model checkpoint with different ISAs and different platforms in `gpt-fast`. The advantage is int4 model checkpoint can be shared in different test machines, without re-generating in one certain platform. Meanwhile, the size of input `weight` can be reduced to `1 / 8`.

Before this PR, packed weight stored in CUDA specific layout: `[n/8][k/(InnerKTiles*16)][32][InnerKTiles/2]`, dtype int32, where InnerKTiles = 2, 4, 8. CPU packed weight viewed as the SAME shape but stored in different layout: `[n/64][k][32]`, dtype uint8. Weight is strongly coupled with platforms (CPU/CUDA) and ISAs (AVX512/AVX2/scalar). And users cannot use a generated weight in another different ISA or platform, because when loading weight into devices, the compute format is different.
![image](https://github.com/pytorch/pytorch/assets/61222868/64971c4b-29b9-42cf-9aeb-ffa01cea93dd)

Now, we use common serialized layout (`[n][k/2] uint8`) for different devices or ISAs as input `weight` of `_convert_weight_to_int4pack`, and each back chooses how to interpret as compute layout.
![image](https://github.com/pytorch/pytorch/assets/61222868/c7990761-c723-417b-aca2-7c60db7785c7)

### Performance
Intel (R) Xeon (R) CPU Max 9480, single socket (56 cores)
There is no obvious regression of this PR.
![image](https://github.com/pytorch/pytorch/assets/61222868/6046dcf4-920b-4c63-9ca3-1c8c3cafebde)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10