### PR TITLE
[inductor] Add missing config check for buffer reuse

### DIFF
--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -356,6 +356,7 @@ class BaseSchedulerNode:
         # hacky check for if V.kernel is a real kernel or NullHandler
         if (
             hasattr(V.kernel, "args")
+            and config.allow_buffer_reuse
             and self.get_name() in V.kernel.inplace_update_buffers
         ):
             V.graph.wrapper_code.codegen_inplace_reuse(


### PR DESCRIPTION
With `config.allow_buffer_reuse` being `False`, inductor still reuses some of the buffers, which is due to the missing check.

I did check desired effect manually by looking at `output_code.py` with and without the change, not sure if there is a way to have an automated test for this?


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang