### PR TITLE
[Update] Update note for Getting Started with PyTorch on Intel GPUs

### DIFF
--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -12,7 +12,7 @@ Hardware Prerequisite
      - Supported OS
    * - Intel® Data Center GPU Max Series
      - Linux
-   * - (Prototype Support) Intel® Core™ Ultra Processors with Intel® Arc™ Graphics (MTL-H)
+   * - (Prototype Support) Intel Client GPU
      - Windows/Linux
 
 

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -15,6 +15,7 @@ Hardware Prerequisite
    * - Intel Client GPU
      - Windows/Linux
 
+Intel GPUs support enhancement is ready in PyTorch* 2.5 to provide Beta quality for Intel® Data Center GPU Max Series and Intel® Client GPUs on both Linux and Windows, which brings Intel GPUs and the SYCL* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios, especially in AIPC scene. 
 
 Software Prerequisite
 ---------------------

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -32,20 +32,34 @@ Installation
 Binaries
 ^^^^^^^^
 
-Now we have all the required packages installed and environment activated. Use the following commands to install ``pytorch``, ``torchvision``, ``torchaudio``.
+Platform Linux
+""""""""""""""
+
+
+Now we have all the required packages installed and environment activated. Use the following commands to install ``pytorch``, ``torchvision``, ``torchaudio`` on Linux.
 
 .. code-block::
 
-    ## Linux
     pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
-    ## Windows: for torchvision/torchaudio, build it from source
-    pip3 install torch --index-url https://download.pytorch.org/whl/xpu
 
+
+Platform Windows
+""""""""""""""""
+
+Now we have all the required packages installed and environment activated. Use the following commands to install ``pytorch`` on Windows, build from source for ``torchvision`` and ``torchaudio``.
+
+.. code-block::
+
+    pip3 install torch --index-url https://download.pytorch.org/whl/xpu
 
 From Source
 ^^^^^^^^^^^
 
-Build from source refer to `PyTorch Installation Build from source <https://github.com/pytorch/pytorch?tab=readme-ov-file#from-source>`_.
+Build from source for ``torch`` refer to `PyTorch Installation Build from source <https://github.com/pytorch/pytorch?tab=readme-ov-file#from-source>`_.
+
+Build from source for ``torchvision`` refer to `Torchvision Installation Build from source <https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md#development-installation>`_.
+
+Build from source for ``torchaudio`` refert to `Torchaudio Installation Build from source <https://github.com/pytorch/audio/blob/main/CONTRIBUTING.md#building-torchaudio-from-source>`_.
 
 Check availability for Intel GPU
 --------------------------------

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -15,7 +15,7 @@ Hardware Prerequisite
    * - Intel Client GPU
      - Windows/Linux
 
-Intel GPUs support enhancement is ready in PyTorch* 2.5 to provide Beta quality for Intel® Data Center GPU Max Series and Intel® Client GPUs on both Linux and Windows, which brings Intel GPUs and the SYCL* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios, especially in AIPC scene.
+Intel GPUs support enhancement is ready in PyTorch* 2.5 for Intel® Data Center GPU Max Series and Intel® Client GPUs on both Linux and Windows, which brings Intel GPUs and the SYCL* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios.
 
 Software Prerequisite
 ---------------------

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -40,7 +40,7 @@ Now we have all the required packages installed and environment activated. Use t
 
 .. code-block::
 
-    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
+    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu
 
 
 Platform Windows
@@ -50,7 +50,7 @@ Now we have all the required packages installed and environment activated. Use t
 
 .. code-block::
 
-    pip3 install torch --index-url https://download.pytorch.org/whl/xpu
+    pip3 install torch --index-url https://download.pytorch.org/whl/nightly/xpu
 
 From Source
 ^^^^^^^^^^^

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -4,7 +4,7 @@ Getting Started on Intel GPU
 Hardware Prerequisite
 ---------------------
 
-.. list-table:: 
+.. list-table::
    :widths: 50 50
    :header-rows: 1
 
@@ -12,7 +12,7 @@ Hardware Prerequisite
      - Supported OS
    * - Intel® Data Center GPU Max Series
      - Linux
-   * - (Prototype Support) Intel® Core™ Ultra Processors with Intel® Arc™ Graphics (MTL-H) 
+   * - (Prototype Support) Intel® Core™ Ultra Processors with Intel® Arc™ Graphics (MTL-H)
      - Windows/Linux
 
 

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -8,7 +8,12 @@ This release only supports build from source for Intel GPUs.
 Prerequisites
 -------------
 
-To check hardware support, install Intel Data Center GPU drivers, install Intel support packages, and set up oneAPI environment variables, you would typically follow `PyTorch Installation Prerequisites for Intel GPUs <https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpus.html>`_.
+Visit `PyTorch Installation Prerequisites for Intel GPUs <https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpus.html>`_ for more detailed information regarding:
+
+#. Supported hardware.
+#. Intel GPU driver installation
+#. Intel support package installation
+#. compilation environment setup
 
 Build from source
 -----------------

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -12,7 +12,7 @@ Hardware Prerequisite
      - Supported OS
    * - Intel® Data Center GPU Max Series
      - Linux
-   * - (Prototype Support) Intel Client GPU
+   * - Intel Client GPU
      - Windows/Linux
 
 

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -5,36 +5,10 @@ The support for Intel GPUs is released alongside PyTorch v2.4.
 
 This release only supports build from source for Intel GPUs.
 
-Hardware Prerequisites
-----------------------
+Prerequisites
+-------------
 
-.. list-table::
-   :header-rows: 1
-
-   * - Supported Hardware
-     - Intel® Data Center GPU Max Series
-   * - Supported OS
-     - Linux
-
-
-PyTorch for Intel GPUs is compatible with Intel® Data Center GPU Max Series and only supports OS Linux with release 2.4.
-
-Software Prerequisites
-----------------------
-
-As a prerequisite, install the driver and required packages by following the `PyTorch Installation Prerequisites for Intel GPUs <https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpus.html>`_.
-
-Set up Environment
-------------------
-
-Before you begin, you need to set up the environment. This can be done by sourcing the ``setvars.sh`` script provided by the ``intel-for-pytorch-gpu-dev`` and  ``intel-pti-dev`` packages.
-
-.. code-block::
-
-   source ${ONEAPI_ROOT}/setvars.sh
-
-.. note::
-   The ``ONEAPI_ROOT`` is the folder you installed your ``intel-for-pytorch-gpu-dev`` and  ``intel-pti-dev`` packages. Typically, it is located at ``/opt/intel/oneapi/`` or ``~/intel/oneapi/``.
+To check hardware support, install Intel Data Center GPU drivers, install Intel support packages, and set up oneAPI environment variables, you would typically follow `PyTorch Installation Prerequisites for Intel GPUs <https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpus.html>`_.
 
 Build from source
 -----------------

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -15,7 +15,7 @@ Hardware Prerequisite
    * - Intel Client GPU
      - Windows/Linux
 
-Intel GPUs support enhancement is ready in PyTorch* 2.5 to provide Beta quality for Intel® Data Center GPU Max Series and Intel® Client GPUs on both Linux and Windows, which brings Intel GPUs and the SYCL* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios, especially in AIPC scene. 
+Intel GPUs support enhancement is ready in PyTorch* 2.5 to provide Beta quality for Intel® Data Center GPU Max Series and Intel® Client GPUs on both Linux and Windows, which brings Intel GPUs and the SYCL* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios, especially in AIPC scene.
 
 Software Prerequisite
 ---------------------

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -38,19 +38,34 @@ Platform Linux
 
 Now we have all the required packages installed and environment activated. Use the following commands to install ``pytorch``, ``torchvision``, ``torchaudio`` on Linux.
 
+For release wheels
+
 .. code-block::
 
-    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu
+    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
 
+For nightly wheels
+
+.. code-block::
+
+    pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu
 
 Platform Windows
 """"""""""""""""
 
 Now we have all the required packages installed and environment activated. Use the following commands to install ``pytorch`` on Windows, build from source for ``torchvision`` and ``torchaudio``.
 
+For release wheels
+
 .. code-block::
 
-    pip3 install torch --index-url https://download.pytorch.org/whl/nightly/xpu
+    pip3 install torch --index-url https://download.pytorch.org/whl/xpu
+
+For nightly wheels
+
+.. code-block::
+
+    pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/xpu
 
 From Source
 ^^^^^^^^^^^

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -15,7 +15,7 @@ Hardware Prerequisite
    * - Intel Client GPU
      - Windows/Linux
 
-Intel GPUs support enhancement is ready in PyTorch* 2.5 for Intel® Data Center GPU Max Series and Intel® Client GPUs on both Linux and Windows, which brings Intel GPUs and the SYCL* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios.
+Intel GPUs support enhancement is ready in PyTorch* 2.5 to provide Beta quality for Intel® Data Center GPU Max Series and Intel® Client GPUs on both Linux and Windows, which brings Intel GPUs and the SYCL* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios.
 
 Software Prerequisite
 ---------------------

--- a/docs/source/notes/get_start_xpu.rst
+++ b/docs/source/notes/get_start_xpu.rst
@@ -15,7 +15,7 @@ Hardware Prerequisite
    * - Intel Client GPU
      - Windows/Linux
 
-Intel GPUs support enhancement is ready in PyTorch* 2.5 to provide Beta quality for Intel® Data Center GPU Max Series and Intel® Client GPUs on both Linux and Windows, which brings Intel GPUs and the SYCL* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios.
+Intel GPUs support (Beta) is ready in PyTorch* 2.5 for Intel® Data Center GPU Max Series and Intel® Client GPUs on both Linux and Windows, which brings Intel GPUs and the SYCL* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios.
 
 Software Prerequisite
 ---------------------


### PR DESCRIPTION
remove the hardware and software prerequisites and set up env part.
keep the prerequisites section and link to pytorch prerequistes for intel gpus for driver install, intel support package install and env set up
https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpus.html
Update the support for Intel Client GPU MTL-H
Update inference & training examples
