### PR TITLE
appease custom ops spec for shard_dim_alltoall

### DIFF
--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -624,6 +624,7 @@ at::Tensor shard_dim_alltoall(
 
 // DTensor comm op registry
 TORCH_LIBRARY(_dtensor, m) {
+  m.set_python_module("torch.distributed._tensor._collective_utils");
   m.def(
       "shard_dim_alltoall(Tensor input, int gather_dim, int shard_dim, str group_name) -> Tensor",
       torch::dispatch(


### PR DESCRIPTION
Summary: this distributed op has a fake_impl in python, but it looks like nobody has tried to use it with compile up until now - it was missing a `m.set_python_module()` (the runtime error you get helpfully tells you exactly what to add)

Test Plan: CI

Reviewed By: zou3519, williamwen42

Differential Revision: D59254474


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @tianyu-l @chauhang