### PR TITLE
Issue warning with reference to user code rather than torch

### DIFF
--- a/torch/amp/grad_scaler.py
+++ b/torch/amp/grad_scaler.py
@@ -130,7 +130,8 @@ class GradScaler:
         if self._device == "cuda":
             if enabled and torch.cuda.amp.common.amp_definitely_not_available():
                 warnings.warn(
-                    "torch.cuda.amp.GradScaler is enabled, but CUDA is not available.  Disabling."
+                    "torch.cuda.amp.GradScaler is enabled, but CUDA is not available.  Disabling.",
+                    stacklevel=2,
                 )
                 self._enabled = False
 


### PR DESCRIPTION
Warning message before:
```
/home/admin/.local/share/hatch/env/virtual/toms-project-1/Qv9k_r_5/dev/lib/python3.10/site-packages/torch/cuda/amp/grad_scaler.py:120: UserWarning: torch.cuda.amp.GradScaler is enabled, but CUDA is not available.  Disabling.
```

Warning message after:
```
/path/to/my/code:91: UserWarning: torch.cuda.amp.GradScaler is enabled, but CUDA is not available.  Disabling.
```

Helps the user find where the issue stems from in their code. What do you think?

(Looks like "skip_file_prefixes" is not available until Python 3.12 minimum...)

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5