### PR TITLE
Raise error for use_local_synchronization=True and ncclCommSplit

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -672,6 +672,19 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_new_group_device_bound_local_sync_not_allowed(self):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        self._create_process_group_nccl(store, self.opts(), device_id=device)
+        with self.assertRaisesRegex(
+            ValueError,
+            "NCCL backend doesn't support use_local_synchronization=True "
+            "in sub-groups when device_id is used with init_process_group",
+        ):
+            c10d.new_group([0], use_local_synchronization=True)
+
+    @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_get_uid(self):
         store = c10d.FileStore(self.file_name, self.world_size)
         device = torch.device(f"cuda:{self.rank}")

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -4414,6 +4414,21 @@ def _new_group_with_tag(
             raise ValueError(
                 "MPI backend doesn't support use_local_synchronization=True"
             )
+        if backend == Backend.NCCL:
+            # When there is a device bound to the default group,
+            # 'ncclCommSplit' will be used instead of 'ncclCommInitRank'.
+            # The API 'ncclCommSplit' requires all the ranks from the parent
+            # communicator to participate.
+            # Ranks not part of this sub-group will call 'perform_nocolor_split'.
+            if (
+                is_initialized()
+                and _get_default_group().bound_device_id
+                and len(ranks) < _get_default_group().size()
+            ):
+                raise ValueError(
+                    "NCCL backend doesn't support use_local_synchronization=True "
+                    "in sub-groups when device_id is used with init_process_group"
+                )
         if ranks is not None and get_rank() not in ranks:
             return None
 


### PR DESCRIPTION
When there is a device bound to the default group, 'ncclCommSplit' will be used instead of 'ncclCommInitRank'.
The API 'ncclCommSplit' requires all the ranks from the parent communicator to participate.
Ranks not part of this sub-group cannot exit early, they need to call 'perform_nocolor_split' inside '_new_process_group_helper'.

Therefore, raise an error when 'use_local_synchronization=True' is set and ncclCommSplit path will be taken.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @tianyu-l @chauhang @eqy 