### PR TITLE
Back out "Pass device to is_pinned call inside TensorProperties.create_from_tensor"

### DIFF
--- a/test/distributed/checkpoint/test_utils.py
+++ b/test/distributed/checkpoint/test_utils.py
@@ -1,7 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
 import sys
-from unittest.mock import MagicMock
 
 import torch
 
@@ -122,14 +121,6 @@ class TestMedatadaIndex(TestCase):
 
         with self.assertRaisesRegex(ValueError, "Could not find shard"):
             find_state_dict_object(state_dict, MetadataIndex("st", [1]))
-
-
-class TestTensorProperties(TestCase):
-    def test_create_from_tensor_correct_device(self):
-        t = torch.randn([10, 2], device="cpu")
-        t.is_pinned = MagicMock(return_value=True)
-        TensorProperties.create_from_tensor(t)
-        t.is_pinned.assert_called_with(device=torch.device("cpu"))
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_shard/sharded_tensor/metadata.py
+++ b/torch/distributed/_shard/sharded_tensor/metadata.py
@@ -76,7 +76,7 @@ class TensorProperties:
             layout=tensor.layout,
             requires_grad=tensor.requires_grad,
             memory_format=torch.contiguous_format,
-            pin_memory=tensor.is_pinned(device=tensor.device),
+            pin_memory=tensor.is_pinned(),
         )
 
 

--- a/torch/distributed/checkpoint/metadata.py
+++ b/torch/distributed/checkpoint/metadata.py
@@ -105,7 +105,7 @@ class TensorProperties:
             layout=tensor.layout,
             requires_grad=tensor.requires_grad,
             memory_format=torch.contiguous_format,
-            pin_memory=tensor.is_pinned(device=tensor.device),
+            pin_memory=tensor.is_pinned(),
         )
 
 


### PR DESCRIPTION
Summary:
It turns out, the device used as a param in is_pinned is meant to be the accelerator device with the respect to which pinning is expected. Passing 'cpu' always makes the return value false, regardless of whether the actual tensor is a cpu tensor pinned to Cuda.

Besides, there is a PR https://github.com/pytorch/pytorch/pull/126376 about to be merged which automatically uses the correct accelerator device which obviates the need for users to pass any kind of explicit  device and doesn't create Cuda context for pure cpu tensors.

Note, https://www.internalfb.com/intern/test/844425019931542?ref_report_id=0 test is expected to be broken by this diff, but it should be fixed forward by https://github.com/pytorch/pytorch/pull/126376

Test Plan: Sandcastle.

Differential Revision: D59283190


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang @d4l3k @LucasLLC @MeetVadakkanchery @mhorowitz