### PR TITLE
[custom ops] Support factory function 

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2969,6 +2969,7 @@ Please use `add.register_fake` to add an fake impl.""",
         with self.assertRaisesRegex(RuntimeError, "may not alias"):
             numpy_sin_inplace(x)
 
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_factory_function(self):
         @torch.library.custom_op(
             "_torch_testing::f", mutates_args={}, device_types="cpu"

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2969,6 +2969,17 @@ Please use `add.register_fake` to add an fake impl.""",
         with self.assertRaisesRegex(RuntimeError, "may not alias"):
             numpy_sin_inplace(x)
 
+    def test_factory_function(self):
+        @torch.library.custom_op(
+            "_torch_testing::f", mutates_args={}, device_types="cpu"
+        )
+        def f(device: torch.device) -> Tensor:
+            return torch.ones(3)
+
+        result = f(device="cpu")
+        self.assertEqual(result.device, torch.device("cpu"))
+        self.assertEqual(result, torch.ones(3))
+
 
 class MiniOpTestOther(CustomOpTestCaseBase):
     test_ns = "mini_op_test"

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2989,6 +2989,17 @@ Please use `add.register_fake` to add an fake impl.""",
             )
             def f2() -> Tensor:
                 return torch.ones(3)
+        
+        with self.assertRaisesRegex(ValueError, "Functions without tensor inputs are required to have a `device: torch.device` argument"):
+            @torch.library.custom_op( "_torch_testing::f3", mutates_args={}, device_types="cpu" ) 
+            def f3() -> Tensor: 
+                raise NotImplementedError("NYI") 
+            
+            @f3.register_kernel("cpu") 
+            def _(): 
+                return torch.zeros(3) 
+        
+            result = f(x)
 
 class MiniOpTestOther(CustomOpTestCaseBase):
     test_ns = "mini_op_test"

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2980,6 +2980,15 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(result.device, torch.device("cpu"))
         self.assertEqual(result, torch.ones(3))
 
+        with self.assertRaisesRegex(RuntimeError, "f does not have a kernel registered for cuda"):
+            f("cuda")
+
+        with self.assertRaisesRegex(ValueError, "Functions without tensor inputs are required to have a `device: torch.device` argument"):
+            @torch.library.custom_op(
+                "_torch_testing::f2", mutates_args={}, device_types="cpu"
+            )
+            def f2() -> Tensor:
+                return torch.ones(3)
 
 class MiniOpTestOther(CustomOpTestCaseBase):
     test_ns = "mini_op_test"

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2980,26 +2980,39 @@ Please use `add.register_fake` to add an fake impl.""",
         self.assertEqual(result.device, torch.device("cpu"))
         self.assertEqual(result, torch.ones(3))
 
-        with self.assertRaisesRegex(RuntimeError, "f does not have a kernel registered for cuda"):
+        with self.assertRaisesRegex(
+            RuntimeError, "f does not have a kernel registered for cuda"
+        ):
             f("cuda")
 
-        with self.assertRaisesRegex(ValueError, "Functions without tensor inputs are required to have a `device: torch.device` argument"):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Functions without tensor inputs are required to have a `device: torch.device` argument",
+        ):
+
             @torch.library.custom_op(
                 "_torch_testing::f2", mutates_args={}, device_types="cpu"
             )
             def f2() -> Tensor:
                 return torch.ones(3)
-        
-        with self.assertRaisesRegex(ValueError, "Functions without tensor inputs are required to have a `device: torch.device` argument"):
-            @torch.library.custom_op( "_torch_testing::f3", mutates_args={}, device_types="cpu" ) 
-            def f3() -> Tensor: 
-                raise NotImplementedError("NYI") 
-            
-            @f3.register_kernel("cpu") 
-            def _(): 
-                return torch.zeros(3) 
-        
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Functions without tensor inputs are required to have a `device: torch.device` argument",
+        ):
+
+            @torch.library.custom_op(
+                "_torch_testing::f3", mutates_args={}, device_types="cpu"
+            )
+            def f3() -> Tensor:
+                raise NotImplementedError("NYI")
+
+            @f3.register_kernel("cpu")
+            def _():
+                return torch.zeros(3)
+
             result = f(x)
+
 
 class MiniOpTestOther(CustomOpTestCaseBase):
     test_ns = "mini_op_test"

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -3011,6 +3011,18 @@ Please use `add.register_fake` to add an fake impl.""",
 
             result = f(x)
 
+        @torch.library.custom_op("_torch_testing::f4", mutates_args={})
+        def f4(device: torch.device) -> Tensor:
+            raise NotImplementedError("NYI")
+
+        @f4.register_kernel("cpu")
+        def _(device: torch.device):
+            return torch.zeros(3)
+
+        result = f(device="cpu")
+        self.assertEqual(result.device, torch.device("cpu"))
+        self.assertEqual(result, torch.ones(3))
+
 
 class MiniOpTestOther(CustomOpTestCaseBase):
     test_ns = "mini_op_test"

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2996,16 +2996,14 @@ Please use `add.register_fake` to add an fake impl.""",
             def f2() -> Tensor:
                 return torch.ones(3)
 
+        @torch.library.custom_op("_torch_testing::f3", mutates_args={})
+        def f3() -> Tensor:
+            raise NotImplementedError("NYI")
+
         with self.assertRaisesRegex(
             ValueError,
             "Functions without tensor inputs are required to have a `device: torch.device` argument",
         ):
-
-            @torch.library.custom_op(
-                "_torch_testing::f3", mutates_args={}, device_types="cpu"
-            )
-            def f3() -> Tensor:
-                raise NotImplementedError("NYI")
 
             @f3.register_kernel("cpu")
             def _():

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -223,3 +223,32 @@ def tuple_to_list(tuple_type: typing.Type[typing.Tuple]) -> typing.Type[typing.L
         return typing.List[type_args[0]]  # type: ignore[valid-type]
     else:
         return typing.List[typing.Union[tuple(type_args)]]  # type: ignore[misc]
+
+
+# def has_tensor_arg(prototype_function: typing.Callable):
+#     sig = inspect.signature(prototype_function)
+#     for idx, (name, param) in enumerate(sig.parameters.items()):
+#         if "Tensor" in str(param.annotation):
+#             return True
+#     return False
+
+
+def has_tensor_arg(schema: str):
+    """
+    Given a schema string, returns True if the schema has a Tensor arg.
+    A Tensor arg is any arg with a type annotation that might involve Tensor.
+    """
+    inputs = schema.split("->")[0].split("(")[1].split(")")[0].split(",")
+    input_types = [input.strip().split(" ")[0] for input in inputs]
+    return any("Tensor" in s for s in input_types)
+
+def has_device_arg(schema: str):
+    """
+    Given a schema string, returns True if the schema has a device arg.
+    A device arg is any arg with a type annotation that might involve device.
+    """
+    print(schema)
+    inputs = schema.split("->")[0].split("(")[1].split(")")[0].split(",")
+    input_types = [input.strip().split(" ")[0] for input in inputs]
+    print(input_types)
+    return any("Device" in s for s in input_types)

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -225,7 +225,7 @@ def tuple_to_list(tuple_type: typing.Type[typing.Tuple]) -> typing.Type[typing.L
         return typing.List[typing.Union[tuple(type_args)]]  # type: ignore[misc]
 
 
-def has_tensor_arg(schema: str):
+def has_tensor_arg(schema: str) -> bool:
     """
     Given a schema string, returns True if the schema has a Tensor arg.
     A Tensor arg is any arg with a type annotation that might involve Tensor.
@@ -235,10 +235,11 @@ def has_tensor_arg(schema: str):
     return any("Tensor" in s for s in input_types)
 
 
-def has_device_arg(schema: str):
+def get_device_arg_id(schema: str) -> Union[int, None]:
     """
-    Given a schema string, returns True if the schema has a device: torch.device arg.
-    A device arg is any arg with a type annotation that might involve device.
+    Given a schema string, returns the id of the `device: torch.device` argument.
+    If it does not exist, returns None.
     """
     inputs = schema.split("->")[0].split("(")[1].split(")")[0].split(",")
-    return any("Device device" == s.strip() for s in inputs)
+
+    return next((i for i, s in enumerate(inputs) if "Device device" == s.strip()), None)

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -225,14 +225,6 @@ def tuple_to_list(tuple_type: typing.Type[typing.Tuple]) -> typing.Type[typing.L
         return typing.List[typing.Union[tuple(type_args)]]  # type: ignore[misc]
 
 
-# def has_tensor_arg(prototype_function: typing.Callable):
-#     sig = inspect.signature(prototype_function)
-#     for idx, (name, param) in enumerate(sig.parameters.items()):
-#         if "Tensor" in str(param.annotation):
-#             return True
-#     return False
-
-
 def has_tensor_arg(schema: str):
     """
     Given a schema string, returns True if the schema has a Tensor arg.
@@ -242,13 +234,11 @@ def has_tensor_arg(schema: str):
     input_types = [input.strip().split(" ")[0] for input in inputs]
     return any("Tensor" in s for s in input_types)
 
+
 def has_device_arg(schema: str):
     """
-    Given a schema string, returns True if the schema has a device arg.
+    Given a schema string, returns True if the schema has a device: torch.device arg.
     A device arg is any arg with a type annotation that might involve device.
     """
-    print(schema)
     inputs = schema.split("->")[0].split("(")[1].split(")")[0].split(",")
-    input_types = [input.strip().split(" ")[0] for input in inputs]
-    print(input_types)
-    return any("Device" in s for s in input_types)
+    return any("Device device" == s.strip() for s in inputs)

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -223,23 +223,3 @@ def tuple_to_list(tuple_type: typing.Type[typing.Tuple]) -> typing.Type[typing.L
         return typing.List[type_args[0]]  # type: ignore[valid-type]
     else:
         return typing.List[typing.Union[tuple(type_args)]]  # type: ignore[misc]
-
-
-def has_tensor_arg(schema: str) -> bool:
-    """
-    Given a schema string, returns True if the schema has a Tensor arg.
-    A Tensor arg is any arg with a type annotation that might involve Tensor.
-    """
-    inputs = schema.split("->")[0].split("(")[1].split(")")[0].split(",")
-    input_types = [input.strip().split(" ")[0] for input in inputs]
-    return any("Tensor" in s for s in input_types)
-
-
-def get_device_arg_id(schema: str) -> Union[int, None]:
-    """
-    Given a schema string, returns the id of the `device: torch.device` argument.
-    If it does not exist, returns None.
-    """
-    inputs = schema.split("->")[0].split("(")[1].split(")")[0].split(",")
-
-    return next((i for i, s in enumerate(inputs) if "Device device" == s.strip()), None)

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -257,19 +257,24 @@ def has_kwarg_only_tensors(schema: _C.FunctionSchema):
         return True
     return False
 
+
 def has_tensor_arg(schema: _C.FunctionSchema) -> bool:
     """
     Given a schema, returns True if the schema has a Tensor arg.
     A Tensor arg is any arg with a type annotation that might involve Tensor.
     """
-    return any((is_tensor_like_type(a.type) or is_tensorlist_like_type(a.type)) for a in schema.arguments)
+    return any(
+        (is_tensor_like_type(a.type) or is_tensorlist_like_type(a.type))
+        for a in schema.arguments
+    )
+
 
 def get_device_arg_id(schema: _C.FunctionSchema) -> Union[int, None]:
     """
     Given a schema, returns the id of the `device: torch.device` argument.
     If it does not exist, returns None.
     """
-    for (i, a) in enumerate(schema.arguments):
+    for i, a in enumerate(schema.arguments):
         if a.type is _C.DeviceObjType.get() and a.name == "device":
             return i
     return None

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -2,7 +2,7 @@
 import dataclasses
 import inspect
 import sys
-from typing import Any, Callable, Dict, Iterable, Tuple
+from typing import Any, Callable, Dict, Iterable, Tuple, Union
 
 import torch
 from torch import _C, _utils_internal
@@ -256,3 +256,20 @@ def has_kwarg_only_tensors(schema: _C.FunctionSchema):
             continue
         return True
     return False
+
+def has_tensor_arg(schema: _C.FunctionSchema) -> bool:
+    """
+    Given a schema, returns True if the schema has a Tensor arg.
+    A Tensor arg is any arg with a type annotation that might involve Tensor.
+    """
+    return any((is_tensor_like_type(a.type) or is_tensorlist_like_type(a.type)) for a in schema.arguments)
+
+def get_device_arg_id(schema: _C.FunctionSchema) -> Union[int, None]:
+    """
+    Given a schema, returns the id of the `device: torch.device` argument.
+    If it does not exist, returns None.
+    """
+    for (i, a) in enumerate(schema.arguments):
+        if a.type is _C.DeviceObjType.get() and a.name == "device":
+            return i
+    return None

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -269,12 +269,12 @@ def has_tensor_arg(schema: _C.FunctionSchema) -> bool:
     )
 
 
-def get_device_arg_id(schema: _C.FunctionSchema) -> Union[int, None]:
+def get_device_arg_index(schema: _C.FunctionSchema) -> Union[int, None]:
     """
     Given a schema, returns the id of the `device: torch.device` argument.
     If it does not exist, returns None.
     """
-    for i, a in enumerate(schema.arguments):
-        if a.type is _C.DeviceObjType.get() and a.name == "device":
-            return i
+    for index, arg in enumerate(schema.arguments):
+        if arg.type is _C.DeviceObjType.get() and arg.name == "device":
+            return index
     return None


### PR DESCRIPTION
Fixes #129389 

If a user registers a device-specific implementation for an operator that accepts no Tensors, then we require the operator to have a "device: torch.device argument"

We switch on the device argument to select the correct backend to dispatch to.
