### PR TITLE
[export] Update example inputs format for DB.

### DIFF
--- a/docs/source/scripts/exportdb/generate_example_rst.py
+++ b/docs/source/scripts/exportdb/generate_example_rst.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import torch
 import torch._dynamo as torchdynamo
 
-from torch._export.db.case import ExportCase, normalize_inputs
+from torch._export.db.case import ExportCase
 from torch._export.db.examples import all_examples
 from torch.export import export
 
@@ -41,8 +41,13 @@ def generate_example_rst(example_case: ExportCase):
         2,
     }, f"more than one @export_rewrite_case decorator in {source_code}"
 
+    more_arguments = ""
+    if example_case.example_kwargs:
+        more_arguments += ", example_kwargs"
+    if example_case.dynamic_shapes:
+        more_arguments += ", dynamic_shapes=dynamic_shapes"
+
     # Generate contents of the .rst file
-    # TODO(zhxchen17) Update template when we switch to example_args and example_kwargs.
     title = f"{example_case.name}"
     doc_contents = f"""{title}
 {'^' * (len(title))}
@@ -59,6 +64,8 @@ Original source code:
 
     {splitted_source_code[0]}
 
+    torch.export.export(model, example_args{more_arguments})
+
 Result:
 
 .. code-block::
@@ -67,11 +74,10 @@ Result:
 
     # Get resulting graph from dynamo trace
     try:
-        inputs = normalize_inputs(example_case.example_inputs)
         exported_program = export(
             model,
-            inputs.args,
-            inputs.kwargs,
+            example_case.example_args,
+            example_case.example_kwargs,
             dynamic_shapes=example_case.dynamic_shapes,
         )
         graph_output = str(exported_program)

--- a/test/export/test_db.py
+++ b/test/export/test_db.py
@@ -4,7 +4,7 @@ import copy
 import unittest
 
 import torch._dynamo as torchdynamo
-from torch._export.db.case import ExportCase, normalize_inputs, SupportLevel
+from torch._export.db.case import ExportCase, SupportLevel
 from torch._export.db.examples import (
     filter_examples_by_support_level,
     get_rewrite_cases,
@@ -31,26 +31,29 @@ class ExampleTests(TestCase):
     def test_exportdb_supported(self, name: str, case: ExportCase) -> None:
         model = case.model
 
-        inputs_export = normalize_inputs(case.example_inputs)
-        inputs_model = copy.deepcopy(inputs_export)
+        args_export = case.example_args
+        kwargs_export = case.example_kwargs
+        args_model = copy.deepcopy(args_export)
+        kwargs_model = copy.deepcopy(kwargs_export)
         exported_program = export(
             model,
-            inputs_export.args,
-            inputs_export.kwargs,
+            args_export,
+            kwargs_export,
             dynamic_shapes=case.dynamic_shapes,
         )
         exported_program.graph_module.print_readable()
 
         self.assertEqual(
-            exported_program.module()(*inputs_export.args, **inputs_export.kwargs),
-            model(*inputs_model.args, **inputs_model.kwargs),
+            exported_program.module()(*args_export, **kwargs_export),
+            model(*args_model, **kwargs_model),
         )
 
-        if case.extra_inputs is not None:
-            inputs = normalize_inputs(case.extra_inputs)
+        if case.extra_args is not None:
+            args = case.extra_args
+            args_model = copy.deepcopy(args)
             self.assertEqual(
-                exported_program.module()(*inputs.args, **inputs.kwargs),
-                model(*inputs.args, **inputs.kwargs),
+                exported_program.module()(*args),
+                model(*args_model),
             )
 
     @parametrize(
@@ -64,11 +67,10 @@ class ExampleTests(TestCase):
         with self.assertRaises(
             (torchdynamo.exc.Unsupported, AssertionError, RuntimeError)
         ):
-            inputs = normalize_inputs(case.example_inputs)
-            exported_model = export(
+            export(
                 model,
-                inputs.args,
-                inputs.kwargs,
+                case.example_args,
+                case.example_kwargs,
                 dynamic_shapes=case.dynamic_shapes,
             )
 
@@ -90,11 +92,10 @@ class ExampleTests(TestCase):
             self, name: str, rewrite_case: ExportCase
         ) -> None:
             # pyre-ignore
-            inputs = normalize_inputs(rewrite_case.example_inputs)
-            exported_model = export(
+            export(
                 rewrite_case.model,
-                inputs.args,
-                inputs.kwargs,
+                rewrite_case.example_args,
+                rewrite_case.example_kwargs,
                 dynamic_shapes=rewrite_case.dynamic_shapes,
             )
 

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -16,7 +16,7 @@ import torch
 import torch._dynamo as torchdynamo
 import torch.export._trace
 import torch.utils._pytree as pytree
-from torch._export.db.case import ExportCase, normalize_inputs, SupportLevel
+from torch._export.db.case import ExportCase, SupportLevel
 from torch._export.db.examples import all_examples
 from torch._export.serde.serialize import (
     canonicalize,
@@ -852,9 +852,8 @@ def forward(self, x):
     )
     def test_exportdb_supported(self, name: str, case: ExportCase) -> None:
         model = case.model
-        inputs = normalize_inputs(case.example_inputs)
         _check_meta = "map" not in name
-        self.check_graph(model, inputs.args, _check_meta=_check_meta)
+        self.check_graph(model, case.example_args, _check_meta=_check_meta)
 
     def test_constraints(self):
         class Module(torch.nn.Module):

--- a/torch/_export/db/examples/assume_constant_result.py
+++ b/torch/_export/db/examples/assume_constant_result.py
@@ -15,6 +15,6 @@ class AssumeConstantResult(torch.nn.Module):
     def forward(self, x, y):
         return x[: self.get_item(y)]
 
-example_inputs = (torch.randn(3, 2), torch.tensor(4))
+example_args = (torch.randn(3, 2), torch.tensor(4))
 tags = {"torch.escape-hatch"}
 model = AssumeConstantResult()

--- a/torch/_export/db/examples/autograd_function.py
+++ b/torch/_export/db/examples/autograd_function.py
@@ -19,5 +19,5 @@ class AutogradFunction(torch.nn.Module):
     def forward(self, x):
         return MyAutogradFunction.apply(x)
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 model = AutogradFunction()

--- a/torch/_export/db/examples/class_method.py
+++ b/torch/_export/db/examples/class_method.py
@@ -18,5 +18,5 @@ class ClassMethod(torch.nn.Module):
         x = self.linear(x)
         return self.method(x) * self.__class__.method(x) * type(self).method(x)
 
-example_inputs = (torch.randn(3, 4),)
+example_args = (torch.randn(3, 4),)
 model = ClassMethod()

--- a/torch/_export/db/examples/cond_branch_class_method.py
+++ b/torch/_export/db/examples/cond_branch_class_method.py
@@ -36,7 +36,7 @@ class CondBranchClassMethod(torch.nn.Module):
     def forward(self, x):
         return cond(x.shape[0] <= 2, self.subm.forward, self.bar, [x])
 
-example_inputs = (torch.randn(3),)
+example_args = (torch.randn(3),)
 tags = {
     "torch.cond",
     "torch.dynamic-shape",

--- a/torch/_export/db/examples/cond_branch_nested_function.py
+++ b/torch/_export/db/examples/cond_branch_nested_function.py
@@ -33,7 +33,7 @@ class CondBranchNestedFunction(torch.nn.Module):
 
         return cond(x.shape[0] < 10, true_fn, false_fn, [x])
 
-example_inputs = (torch.randn(3),)
+example_args = (torch.randn(3),)
 tags = {
     "torch.cond",
     "torch.dynamic-shape",

--- a/torch/_export/db/examples/cond_branch_nonlocal_variables.py
+++ b/torch/_export/db/examples/cond_branch_nonlocal_variables.py
@@ -51,7 +51,7 @@ class CondBranchNonlocalVariables(torch.nn.Module):
             [x, my_tensor_var, torch.tensor(my_primitive_var)],
         )
 
-example_inputs = (torch.randn(6),)
+example_args = (torch.randn(6),)
 tags = {
     "torch.cond",
     "torch.dynamic-shape",

--- a/torch/_export/db/examples/cond_closed_over_variable.py
+++ b/torch/_export/db/examples/cond_closed_over_variable.py
@@ -17,6 +17,6 @@ class CondClosedOverVariable(torch.nn.Module):
 
         return cond(pred, true_fn, false_fn, [x + 1])
 
-example_inputs = (torch.tensor(True), torch.randn(3, 2))
+example_args = (torch.tensor(True), torch.randn(3, 2))
 tags = {"torch.cond", "python.closure"}
 model = CondClosedOverVariable()

--- a/torch/_export/db/examples/cond_operands.py
+++ b/torch/_export/db/examples/cond_operands.py
@@ -26,7 +26,7 @@ class CondOperands(torch.nn.Module):
 
         return cond(x.shape[0] > 2, true_fn, false_fn, [x, y])
 
-example_inputs = (x, y)
+example_args = (x, y)
 tags = {
     "torch.cond",
     "torch.dynamic-shape",

--- a/torch/_export/db/examples/cond_predicate.py
+++ b/torch/_export/db/examples/cond_predicate.py
@@ -17,7 +17,7 @@ class CondPredicate(torch.nn.Module):
 
         return cond(pred, lambda x: x.cos(), lambda y: y.sin(), [x])
 
-example_inputs = (torch.randn(6, 4, 3),)
+example_args = (torch.randn(6, 4, 3),)
 tags = {
     "torch.cond",
     "torch.dynamic-shape",

--- a/torch/_export/db/examples/constrain_as_size_example.py
+++ b/torch/_export/db/examples/constrain_as_size_example.py
@@ -17,7 +17,7 @@ class ConstrainAsSizeExample(torch.nn.Module):
         return torch.zeros((a, 5))
 
 
-example_inputs = (torch.tensor(4),)
+example_args = (torch.tensor(4),)
 tags = {
     "torch.dynamic-value",
     "torch.escape-hatch",

--- a/torch/_export/db/examples/constrain_as_value_example.py
+++ b/torch/_export/db/examples/constrain_as_value_example.py
@@ -20,7 +20,7 @@ class ConstrainAsValueExample(torch.nn.Module):
         return y.cos()
 
 
-example_inputs = (torch.tensor(4), torch.randn(5, 5))
+example_args = (torch.tensor(4), torch.randn(5, 5))
 tags = {
     "torch.dynamic-value",
     "torch.escape-hatch",

--- a/torch/_export/db/examples/decorator.py
+++ b/torch/_export/db/examples/decorator.py
@@ -19,5 +19,5 @@ class Decorator(torch.nn.Module):
     def forward(self, x, y):
         return x + y
 
-example_inputs = (torch.randn(3, 2), torch.randn(3, 2))
+example_args = (torch.randn(3, 2), torch.randn(3, 2))
 model = Decorator()

--- a/torch/_export/db/examples/dictionary.py
+++ b/torch/_export/db/examples/dictionary.py
@@ -12,6 +12,6 @@ class Dictionary(torch.nn.Module):
         y = y * elements["x2"]
         return {"y": y}
 
-example_inputs = (torch.randn(3, 2), torch.tensor(4))
+example_args = (torch.randn(3, 2), torch.tensor(4))
 tags = {"python.data-structure"}
 model = Dictionary()

--- a/torch/_export/db/examples/dynamic_shape_assert.py
+++ b/torch/_export/db/examples/dynamic_shape_assert.py
@@ -13,6 +13,6 @@ class DynamicShapeAssert(torch.nn.Module):
         assert x.shape[0] > 1
         return x
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 tags = {"python.assert"}
 model = DynamicShapeAssert()

--- a/torch/_export/db/examples/dynamic_shape_constructor.py
+++ b/torch/_export/db/examples/dynamic_shape_constructor.py
@@ -10,6 +10,6 @@ class DynamicShapeConstructor(torch.nn.Module):
     def forward(self, x):
         return torch.zeros(x.shape[0] * 2)
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 tags = {"torch.dynamic-shape"}
 model = DynamicShapeConstructor()

--- a/torch/_export/db/examples/dynamic_shape_if_guard.py
+++ b/torch/_export/db/examples/dynamic_shape_if_guard.py
@@ -14,6 +14,6 @@ class DynamicShapeIfGuard(torch.nn.Module):
 
         return x.sin()
 
-example_inputs = (torch.randn(3, 2, 2),)
+example_args = (torch.randn(3, 2, 2),)
 tags = {"torch.dynamic-shape", "python.control-flow"}
 model = DynamicShapeIfGuard()

--- a/torch/_export/db/examples/dynamic_shape_map.py
+++ b/torch/_export/db/examples/dynamic_shape_map.py
@@ -14,6 +14,6 @@ class DynamicShapeMap(torch.nn.Module):
 
         return map(body, xs, y)
 
-example_inputs = (torch.randn(3, 2), torch.randn(2))
+example_args = (torch.randn(3, 2), torch.randn(2))
 tags = {"torch.dynamic-shape", "torch.map"}
 model = DynamicShapeMap()

--- a/torch/_export/db/examples/dynamic_shape_round.py
+++ b/torch/_export/db/examples/dynamic_shape_round.py
@@ -14,7 +14,7 @@ class DynamicShapeRound(torch.nn.Module):
 
 x = torch.randn(3, 2)
 dim0_x = Dim("dim0_x")
-example_inputs = (x,)
+example_args = (x,)
 tags = {"torch.dynamic-shape", "python.builtin"}
 support_level = SupportLevel.NOT_SUPPORTED_YET
 dynamic_shapes = {"x": {0: dim0_x}}

--- a/torch/_export/db/examples/dynamic_shape_slicing.py
+++ b/torch/_export/db/examples/dynamic_shape_slicing.py
@@ -10,6 +10,6 @@ class DynamicShapeSlicing(torch.nn.Module):
     def forward(self, x):
         return x[: x.shape[0] - 2, x.shape[1] - 1 :: 2]
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 tags = {"torch.dynamic-shape"}
 model = DynamicShapeSlicing()

--- a/torch/_export/db/examples/dynamic_shape_view.py
+++ b/torch/_export/db/examples/dynamic_shape_view.py
@@ -12,6 +12,6 @@ class DynamicShapeView(torch.nn.Module):
         x = x.view(*new_x_shape)
         return x.permute(0, 2, 1)
 
-example_inputs = (torch.randn(10, 10),)
+example_args = (torch.randn(10, 10),)
 tags = {"torch.dynamic-shape"}
 model = DynamicShapeView()

--- a/torch/_export/db/examples/fn_with_kwargs.py
+++ b/torch/_export/db/examples/fn_with_kwargs.py
@@ -1,8 +1,6 @@
 # mypy: allow-untyped-defs
 import torch
 
-from torch._export.db.case import ExportArgs
-
 class FnWithKwargs(torch.nn.Module):
     """
     Keyword arguments are not supported at the moment.
@@ -18,12 +16,15 @@ class FnWithKwargs(torch.nn.Module):
         out = out * mykwargs["input0"] * mykwargs["input1"]
         return out
 
-example_inputs = ExportArgs(
+example_args = (
     torch.randn(4),
     (torch.randn(4), torch.randn(4)),
-    *[torch.randn(4), torch.randn(4)],
-    mykw0=torch.randn(4),
-    input0=torch.randn(4), input1=torch.randn(4)
+    *[torch.randn(4), torch.randn(4)]
 )
+example_kwargs = {
+    "mykw0": torch.randn(4),
+    "input0": torch.randn(4),
+    "input1": torch.randn(4),
+}
 tags = {"python.data-structure"}
 model = FnWithKwargs()

--- a/torch/_export/db/examples/list_contains.py
+++ b/torch/_export/db/examples/list_contains.py
@@ -12,6 +12,6 @@ class ListContains(torch.nn.Module):
         assert "monkey" not in ["cow", "pig"]
         return x + x
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 tags = {"torch.dynamic-shape", "python.data-structure", "python.assert"}
 model = ListContains()

--- a/torch/_export/db/examples/list_unpack.py
+++ b/torch/_export/db/examples/list_unpack.py
@@ -17,6 +17,6 @@ class ListUnpack(torch.nn.Module):
         x, *y = args
         return x + y[0]
 
-example_inputs = ([torch.randn(3, 2), torch.tensor(4), torch.tensor(5)],)
+example_args = ([torch.randn(3, 2), torch.tensor(4), torch.tensor(5)],)
 tags = {"python.control-flow", "python.data-structure"}
 model = ListUnpack()

--- a/torch/_export/db/examples/model_attr_mutation.py
+++ b/torch/_export/db/examples/model_attr_mutation.py
@@ -21,7 +21,7 @@ class ModelAttrMutation(torch.nn.Module):
         return x.sum() + self.attr_list[0].sum()
 
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 tags = {"python.object-model"}
 support_level = SupportLevel.NOT_SUPPORTED_YET
 model = ModelAttrMutation()

--- a/torch/_export/db/examples/nested_function.py
+++ b/torch/_export/db/examples/nested_function.py
@@ -18,6 +18,6 @@ class NestedFunction(torch.nn.Module):
 
         return closure(x)
 
-example_inputs = (torch.randn(3, 2), torch.randn(2))
+example_args = (torch.randn(3, 2), torch.randn(2))
 tags = {"python.closure"}
 model = NestedFunction()

--- a/torch/_export/db/examples/null_context_manager.py
+++ b/torch/_export/db/examples/null_context_manager.py
@@ -16,6 +16,6 @@ class NullContextManager(torch.nn.Module):
         with ctx:
             return x.sin() + x.cos()
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 tags = {"python.context-manager"}
 model = NullContextManager()

--- a/torch/_export/db/examples/optional_input.py
+++ b/torch/_export/db/examples/optional_input.py
@@ -15,7 +15,7 @@ class OptionalInput(torch.nn.Module):
         return x
 
 
-example_inputs = (torch.randn(2, 3),)
+example_args = (torch.randn(2, 3),)
 tags = {"python.object-model"}
 support_level = SupportLevel.NOT_SUPPORTED_YET
 model = OptionalInput()

--- a/torch/_export/db/examples/pytree_flatten.py
+++ b/torch/_export/db/examples/pytree_flatten.py
@@ -12,5 +12,5 @@ class PytreeFlatten(torch.nn.Module):
         y, spec = pytree.tree_flatten(x)
         return y[0] + 1
 
-example_inputs = ({1: torch.randn(3, 2), 2: torch.randn(3, 2)},),
+example_args = ({1: torch.randn(3, 2), 2: torch.randn(3, 2)},),
 model = PytreeFlatten()

--- a/torch/_export/db/examples/scalar_output.py
+++ b/torch/_export/db/examples/scalar_output.py
@@ -17,7 +17,7 @@ class ScalarOutput(torch.nn.Module):
     def forward(self, x):
         return x.shape[1] + 1
 
-example_inputs = (x,)
+example_args = (x,)
 tags = {"torch.dynamic-shape"}
 dynamic_shapes = {"x": {1: dim1_x}}
 model = ScalarOutput()

--- a/torch/_export/db/examples/specialized_attribute.py
+++ b/torch/_export/db/examples/specialized_attribute.py
@@ -22,5 +22,5 @@ class SpecializedAttribute(torch.nn.Module):
         else:
             raise ValueError("bad")
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 model = SpecializedAttribute()

--- a/torch/_export/db/examples/static_for_loop.py
+++ b/torch/_export/db/examples/static_for_loop.py
@@ -12,6 +12,6 @@ class StaticForLoop(torch.nn.Module):
             ret.append(i + x)
         return ret
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 tags = {"python.control-flow"}
 model = StaticForLoop()

--- a/torch/_export/db/examples/static_if.py
+++ b/torch/_export/db/examples/static_if.py
@@ -13,6 +13,6 @@ class StaticIf(torch.nn.Module):
 
         return x
 
-example_inputs = (torch.randn(3, 2, 2),)
+example_args = (torch.randn(3, 2, 2),)
 tags = {"python.control-flow"}
 model = StaticIf()

--- a/torch/_export/db/examples/tensor_setattr.py
+++ b/torch/_export/db/examples/tensor_setattr.py
@@ -10,6 +10,6 @@ class TensorSetattr(torch.nn.Module):
         setattr(x, attr, torch.randn(3, 2))
         return x + 4
 
-example_inputs = (torch.randn(3, 2), "attr")
+example_args = (torch.randn(3, 2), "attr")
 tags = {"python.builtin"}
 model = TensorSetattr()

--- a/torch/_export/db/examples/torch_sym_min.py
+++ b/torch/_export/db/examples/torch_sym_min.py
@@ -13,7 +13,7 @@ class TorchSymMin(torch.nn.Module):
         return x.sum() + torch.sym_min(x.size(0), 100)
 
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 tags = {"torch.operator"}
 support_level = SupportLevel.NOT_SUPPORTED_YET
 model = TorchSymMin()

--- a/torch/_export/db/examples/type_reflection_method.py
+++ b/torch/_export/db/examples/type_reflection_method.py
@@ -17,6 +17,6 @@ class TypeReflectionMethod(torch.nn.Module):
         return type(a).func(x)
 
 
-example_inputs = (torch.randn(3, 4),)
+example_args = (torch.randn(3, 4),)
 tags = {"python.builtin"}
 model = TypeReflectionMethod()

--- a/torch/_export/db/examples/user_input_mutation.py
+++ b/torch/_export/db/examples/user_input_mutation.py
@@ -12,6 +12,6 @@ class UserInputMutation(torch.nn.Module):
         return x.cos()
 
 
-example_inputs = (torch.randn(3, 2),)
+example_args = (torch.randn(3, 2),)
 tags = {"torch.mutation"}
 model = UserInputMutation()


### PR DESCRIPTION
Summary: To give user a simpler example code, we are getting rid of ExportArgs in favor of example_args and example_kwargs.

Test Plan: CI

Differential Revision: D59288920
