### PR TITLE
[NCCL] Sync explicitly on a `CUDAEvent` for `torch.distributed.barrier`

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -332,6 +332,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // Tensors used for barrier op
     at::Tensor barrierTensor_;
 
+    // Event used to sync to allreduce
+    std::shared_ptr<at::cuda::CUDAEvent> barrierEvent_;
+
     // Clone of blockingWait_ from ProcessGroupNCCL.
     bool blockingWait_ = false;
 


### PR DESCRIPTION
Alternative to #129908 that uses `CUDAEvent` to sync rather than a stream sync.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang @d4l3k