### PR TITLE
[inductor][cpp] fix the vec convertion between float and int64 on AVX2

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256.h
@@ -149,16 +149,22 @@ inline convert_to_int_of_same_size<float>(const Vectorized<float> &src) {
   return _mm256_cvttps_epi32(src);
 }
 
-// Only works for inputs in the range: [-2^51, 2^51]
 // From: https://stackoverflow.com/a/41148578
 template<>
 Vectorized<double>
 inline convert_to_fp_of_same_size<double>(const Vectorized<int64_t> &src) {
-  auto x = _mm256_add_epi64(src, _mm256_castpd_si256(_mm256_set1_pd(0x0018000000000000)));
-  return _mm256_sub_pd(
-    _mm256_castsi256_pd(x),
-    _mm256_set1_pd(0x0018000000000000)
-  );
+  __m256i magic_i_lo   = _mm256_set1_epi64x(0x4330000000000000); /* 2^52 */
+  __m256i magic_i_hi32 = _mm256_set1_epi64x(0x4530000080000000); /* 2^84 + 2^63 */
+  __m256i magic_i_all  = _mm256_set1_epi64x(0x4530000080100000); /* 2^84 + 2^63 + 2^52 */
+  __m256d magic_d_all  = _mm256_castsi256_pd(magic_i_all);
+
+  __m256i v_lo         = _mm256_blend_epi32(magic_i_lo, src, 0b01010101); /* v_low = low32 + 2^52 */
+  __m256i v_hi         = _mm256_srli_epi64(src, 32);
+          v_hi         = _mm256_xor_si256(v_hi, magic_i_hi32); /* v_hi = high32*2^32 + 2^84 + 2^63 */
+  /* int64 = low32 + high32*2^32 = v_hi + v_lo - 2^52 - 2^63 - 2^84 */
+  __m256d v_hi_dbl     = _mm256_sub_pd(_mm256_castsi256_pd(v_hi), magic_d_all);
+  __m256d result       = _mm256_add_pd(v_hi_dbl, _mm256_castsi256_pd(v_lo));
+  return result;
 }
 
 template<>

--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -70,17 +70,24 @@ struct VecConvert<float, 1, int64_t, 2> {
 };
 
 template <>
-inline Vectorized<int32_t> convert_to_int_of_same_size<float>(
-    const Vectorized<float>& src);
-
-template <>
 struct VecConvert<int64_t, 2, float, 1> {
   static inline VectorizedN<int64_t, 2> apply(
       const VectorizedN<float, 1>& src) {
+    // Scalarization is the most reliable way of converting fp to int64 on AVX2.
+    // Check: https://stackoverflow.com/questions/41144668
+    float buffer[8];
+    src.store(buffer);
     at::vec::VectorizedN<int64_t, 2> result;
-    auto int32_vec = at::vec::convert_to_int_of_same_size(src[0]);
-    result[0] = _mm256_cvtepi32_epi64(_mm256_castsi256_si128(int32_vec));
-    result[1] = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(int32_vec, 1));
+    result[0] = Vectorized<int64_t>(
+      static_cast<int64_t>(buffer[3]),
+      static_cast<int64_t>(buffer[2]),
+      static_cast<int64_t>(buffer[1]),
+      static_cast<int64_t>(buffer[0]));
+    result[1] = Vectorized<int64_t>(
+      static_cast<int64_t>(buffer[7]),
+      static_cast<int64_t>(buffer[6]),
+      static_cast<int64_t>(buffer[5]),
+      static_cast<int64_t>(buffer[4]));
     return result;
   }
 };

--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -79,15 +79,15 @@ struct VecConvert<int64_t, 2, float, 1> {
     src.store(buffer);
     at::vec::VectorizedN<int64_t, 2> result;
     result[0] = Vectorized<int64_t>(
-      static_cast<int64_t>(buffer[3]),
-      static_cast<int64_t>(buffer[2]),
+      static_cast<int64_t>(buffer[0]),
       static_cast<int64_t>(buffer[1]),
-      static_cast<int64_t>(buffer[0]));
+      static_cast<int64_t>(buffer[2]),
+      static_cast<int64_t>(buffer[3]));
     result[1] = Vectorized<int64_t>(
-      static_cast<int64_t>(buffer[7]),
-      static_cast<int64_t>(buffer[6]),
+      static_cast<int64_t>(buffer[4]),
       static_cast<int64_t>(buffer[5]),
-      static_cast<int64_t>(buffer[4]));
+      static_cast<int64_t>(buffer[6]),
+      static_cast<int64_t>(buffer[7]));
     return result;
   }
 };

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -598,7 +598,7 @@ class cpp:
     # performance degradation.
     dynamic_threads = os.environ.get("TORCHINDUCTOR_CPP_DYNAMIC_THREADS", "0") == "1"
 
-    simdlen: Optional[int] = None
+    simdlen: Optional[int] = 256
     min_chunk_size = int(os.environ.get("TORCHINDUCTOR_CPP_MIN_CHUNK_SIZE", "4096"))
     cxx = (
         None,  # download gcc12 from conda-forge if conda is installed

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -598,7 +598,7 @@ class cpp:
     # performance degradation.
     dynamic_threads = os.environ.get("TORCHINDUCTOR_CPP_DYNAMIC_THREADS", "0") == "1"
 
-    simdlen: Optional[int] = 256
+    simdlen: Optional[int] = None
     min_chunk_size = int(os.environ.get("TORCHINDUCTOR_CPP_MIN_CHUNK_SIZE", "4096"))
     cxx = (
         None,  # download gcc12 from conda-forge if conda is installed


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130013

Fix https://github.com/pytorch/pytorch/issues/129863

There is no single instruction support on AVX2 to convert between fp and int64 and has to be emulated. The original fast implementation (see https://stackoverflow.com/questions/41144668) assumes the data range is within [-2^51, 2^51]. The issue reported in https://github.com/pytorch/pytorch/issues/129863 has the input data outside this range and failed the test. This PR supports the full range of the conversion.

cc @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang