### PR TITLE
[custom_ops] Mark older custom ops prototypes as deprecated

### DIFF
--- a/torch/_custom_op/impl.py
+++ b/torch/_custom_op/impl.py
@@ -5,6 +5,7 @@ import inspect
 import sys
 import typing
 import weakref
+import warnings
 
 from torchgen.model import FunctionSchema, OperatorName, SchemaKind, BaseType, ListType, BaseTy
 
@@ -18,10 +19,8 @@ import torch._library.infer_schema
 from torch._library.infer_schema import infer_schema
 
 """
-For a detailed guide on custom ops, please see
-https://docs.google.com/document/d/1aGWtgxV3HppuxQAdddyPrs74_aEntpkYt9MalnCKnhk
-
-This file includes pieces of the implementation of our custom operator API.
+torch._custom_op is deprecated. We shipped a production-ready version of it into torch.library.
+Please use those APIs instead.
 """
 
 __all__ = ["custom_op", "CustomOp", "get_ctx"]
@@ -43,76 +42,19 @@ RESERVED_NS = {
     "pytorch",
 }
 
+def warn_deprecated():
+    warnings.warn(
+        "torch._custom_op is deprecated and will be removed in PyTorch 2.6, please "
+        "use the equivalent torch.library API instead.", DeprecationWarning)
+
 
 def custom_op(
     qualname: str, manual_schema: typing.Optional[str] = None
 ) -> typing.Callable:
-    r"""Creates a new CustomOp object.
-
-    WARNING: if you're a user, please do not use this directly
-    (instead use the torch._custom_ops APIs).
-    Also please see the following for a detailed guide on custom ops.
-    https://docs.google.com/document/d/1aGWtgxV3HppuxQAdddyPrs74_aEntpkYt9MalnCKnhk
-
-    In PyTorch, defining an op (short for "operator") is a two step-process:
-    - we need to define (create) the op
-    - we need to implement behavior for how the operator interacts with
-      various PyTorch subsystems, like CPU/CUDA Tensors, Autograd, etc.
-
-    This entrypoint defines the CustomOp object (the first step);
-    you must then perform the second step by calling various methods on
-    the CustomOp object.
-
-    This API is used as a decorator (see examples).
-
-    Arguments:
-        qualname (str): Should be a string that looks like
-            "namespace::operator_name". Operators in PyTorch need a namespace to
-            avoid name collisions; a given operator may only be created once.
-            If you are writing a Python library, we recommend the namespace to
-            be the name of your top-level module. The operator_name must be
-            the same as the name of the function you pass to custom_op
-            (see examples).
-        manual_schema (Optional[str]): Each PyTorch operator needs a schema that
-            tells PyTorch the types of the inputs/outputs. If None (default),
-            we will infer the schema from the type annotations on the function
-            (see examples). Otherwise, if you don't want to use type annotations,
-            you may provide us the schema string.
-
-    Example::
-        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)
-        >>> import numpy as np
-        >>> from torch import Tensor
-        >>>
-        >>> # Step 1: define the CustomOp.
-        >>> # We need to provide the decorator a "prototype function"
-        >>> # (a function with Python ellipses as the body).
-        >>> @custom_op("my_library::numpy_sin")
-        >>> def numpy_sin(x: Tensor) -> Tensor:
-        >>>     ...
-        >>>
-        >>> # numpy_sin is now an instance of class CustomOp
-        >>> print(type(numpy_sin))
-        >>>
-        >>> # Step 2: Register an implementation for various PyTorch subsystems
-        >>>
-        >>> # Register an implementation for CPU tensors
-        >>> @numpy_sin.impl('cpu')
-        >>> def numpy_sin_impl_cpu(x):
-        >>>     return torch.from_numpy(np.sin(x.numpy()))
-        >>>
-        >>> # Register an implementation for CUDA tensors
-        >>> @numpy_sin.impl('cuda')
-        >>> def numpy_sin_impl_cuda(x):
-        >>>     return torch.from_numpy(np.sin(x.cpu().numpy())).to(x.device)
-        >>>
-        >>> x = torch.randn(3)
-        >>> numpy_sin(x)  # calls numpy_sin_impl_cpu
-        >>>
-        >>> x_cuda = x.cuda()
-        >>> numpy_sin(x)  # calls numpy_sin_impl_cuda
-
+    r"""
+    This API is deprecated, please use torch.library.custom_op instead
     """
+    warn_deprecated()
 
     def inner(func):
         if not inspect.isfunction(func):
@@ -170,17 +112,13 @@ global_registry: typing.Dict[str, "CustomOp"] = {}
 
 
 class CustomOp:
-    r"""Class for custom operators in PyTorch.
-
-    Use the CustomOp API to create user-defined custom operators that behave
-    just like regular PyTorch operators (e.g. torch.sin, torch.mm) when it
-    comes to various PyTorch subsystems (like torch.compile).
-
-    To construct a `CustomOp`, use `custom_op`.
+    r"""
+    This API is deprecated, please use torch.library.custom_op instead
     """
 
     def __init__(self, lib, cpp_ns, schema, operator_name, ophandle, *, _private_access=False):
         super().__init__()
+        warn_deprecated()
         if not _private_access:
             raise RuntimeError(
                 "The CustomOp constructor is private and we do not guarantee "
@@ -260,48 +198,8 @@ class CustomOp:
     def impl(
         self, device_types: typing.Union[str, typing.Iterable[str]], _stacklevel=2,
     ) -> typing.Callable:
-        r"""Register an implementation for a device type for this CustomOp object.
-
-        WARNING: if you're a user, please do not use this directly
-        (instead use the torch._custom_ops APIs).
-        Also please see the following for a detailed guide on custom ops.
-        https://docs.google.com/document/d/1aGWtgxV3HppuxQAdddyPrs74_aEntpkYt9MalnCKnhk
-
-        If the CustomOp is passed multiple Tensor inputs with different device
-        types, it will dispatch to the registered implementation for the highest
-        priority device type among those present.
-        The supported device types, in order of priority, are {'cuda', 'cpu'}.
-
-        This API is used as a decorator (see examples).
-
-        Arguments:
-            device_types (str or Iterable[str]): the device type(s) to register the function for.
-
-        Examples::
-            >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CUDA)
-            >>> import numpy as np
-            >>> from torch import Tensor
-            >>>
-            >>> @custom_op("my_library::numpy_cos")
-            >>> def numpy_cos(x: Tensor) -> Tensor:
-            >>>     ...
-            >>>
-            >>> # Register an implementation for CPU Tensors
-            >>> @numpy_cos.impl('cpu')
-            >>> def numpy_cos_impl_cpu(x):
-            >>>     return torch.from_numpy(np.cos(x.numpy()))
-            >>>
-            >>> # Register an implementation for CUDA Tensors
-            >>> @numpy_cos.impl('cuda')
-            >>> def numpy_cos_impl_cuda(x):
-            >>>     return torch.from_numpy(np.cos(x.cpu().numpy())).to(x.device)
-            >>>
-            >>> x = torch.randn(3)
-            >>> numpy_cos(x)  # calls numpy_cos_impl_cpu
-            >>>
-            >>> x_cuda = x.cuda()
-            >>> numpy_cos(x)  # calls numpy_cos_impl_cuda
-
+        r"""
+        This API is deprecated, please use torch.library.custom_op instead
         """
         if isinstance(device_types, str):
             device_types = [device_types]
@@ -339,75 +237,8 @@ class CustomOp:
         return inner
 
     def impl_abstract(self, _stacklevel=2) -> typing.Callable:
-        r"""Register an abstract implementation for this operator.
-
-        WARNING: please do not use this directly (and instead use the torch._custom_ops
-        APIs). Also please see the following for a detailed guide on custom ops.
-        https://docs.google.com/document/d/1aGWtgxV3HppuxQAdddyPrs74_aEntpkYt9MalnCKnhk
-
-        An "abstract implementation" specifies the behavior of this operator on
-        Tensors that carry no data. Given some input Tensors with certain properties
-        (sizes/strides/storage_offset/device), it specifies what the properties of
-        the output Tensors are.
-
-        The abstract implementation has the same signature as the operator.
-        It is run for both FakeTensors and meta tensors. To write an abstract
-        implementation, assume that all Tensor inputs to the operator are
-        regular CPU/CUDA/Meta tensors, but they do not have storage, and
-        you are trying to return regular CPU/CUDA/Meta tensor(s) as output.
-        The abstract implementation must consist of only PyTorch operations
-        (and may not directly access the storage or data of any input or
-        intermediate Tensors).
-
-        This API is used as a decorator (see examples).
-
-        Examples::
-            >>> import numpy as np
-            >>> from torch import Tensor
-            >>>
-            >>> # Example 1: an operator without data-dependent output shape
-            >>> @custom_op('my_library::custom_linear')
-            >>> def custom_linear(x: Tensor, weight: Tensor, bias: Tensor) -> Tensor:
-            >>>     ...
-            >>>
-            >>> @custom_linear.impl_abstract()
-            >>> def custom_linear_abstract(x, weight):
-            >>>     assert x.dim() == 2
-            >>>     assert weight.dim() == 2
-            >>>     assert bias.dim() == 1
-            >>>     assert x.shape[1] == weight.shape[1]
-            >>>     assert weight.shape[0] == bias.shape[0]
-            >>>     assert x.device == weight.device
-            >>>
-            >>>     return (x @ weight.t()) + bias
-            >>>
-            >>> # Example 2: an operator with data-dependent output shape
-            >>> @custom_op('my_library::custom_nonzero')
-            >>> def custom_nonzero(x: Tensor) -> Tensor:
-            >>>     ...
-            >>>
-            >>> @custom_nonzero.impl_abstract()
-            >>> def custom_nonzero_abstract(x):
-            >>>     # Number of nonzero-elements is data-dependent.
-            >>>     # Since we cannot peek at the data in an abstract impl,
-            >>>     # we use the ctx object to construct a new symint that
-            >>>     # represents the data-dependent size.
-            >>>     ctx = torch._custom_op.get_ctx()
-            >>>     nnz = ctx.create_unbacked_symint()
-            >>>     shape = [x.dim(), nnz]
-            >>>     result = x.new_empty(shape, dtype=torch.long)
-            >>>     return result
-            >>>
-            >>> @custom_nonzero.impl(['cpu', 'cuda'])
-            >>> def custom_nonzero_impl(x):
-            >>>     x_np = to_numpy(x)
-            >>>     res = np.stack(np.nonzero(x_np), axis=1)
-            >>>     # unbacked symbolic ints in PyTorch must be >= 2, so we
-            >>>     # constrain the range to at least 2
-            >>>     if res.shape[0] <= 1:
-            >>>         raise RuntimeError("not supported")
-            >>>     return torch.tensor(res, device=x.device)
-
+        r"""
+        This API is deprecated, please use torch.library.custom_op instead
         """
 
         def inner(f):
@@ -570,41 +401,8 @@ class CustomOp:
         return inner
 
     def impl_backward(self, output_differentiability=None, _stacklevel=2):
-        r"""Registers a backward formula.
-
-        WARNING: if you're a user, please do not use this directly
-        (instead use the torch._custom_ops APIs).
-        Also please see the following for a detailed guide on custom ops.
-        https://docs.google.com/document/d/1aGWtgxV3HppuxQAdddyPrs74_aEntpkYt9MalnCKnhk
-
-        In order for the CustomOp to work with autograd, you need to register
-        a backward formula. There are two pieces to this:
-        1. You must give us a function to specify what to save for backward.
-           Call this the "save for backward" function.
-        2. You must give us a function that computes gradients. Call this the
-           "backward" function.
-
-        Use `impl_save_for_backward` to define a "save for backward" function
-        that specifies what gets saved for backward. The function should accept
-        two arguments ``(inputs, output)`` and return the quantities to be saved
-        for backward.
-
-        During runtime, when you call the CustomOp, PyTorch will invoke the
-        "save for backward" function with the inputs and output of the CustomOp.
-
-        Use `impl_backward` to define the "backward" function. The backward
-        function must accept ``(ctx, saved, *grads)``:
-        - ``ctx`` is a context object where we may provide information
-        - ``saved`` is exactly what gets returned from the "save for backward"
-          function
-        - ``grads`` is one or more gradients. The number of gradients matches
-          the number of outputs of the CustomOp.
-
-        The backward function must return a dict that maps the name of
-        an input to the CustomOp to its corresponding gradient. All inputs that
-        were declared to be Tensors in the CustomOp definition must be accounted
-        for in the dict. The gradient may be a Tensor or None.
-
+        r"""
+        This API is deprecated, please use torch.library.custom_op instead
         """
         if output_differentiability is not None:
             def yell():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130032

I've had at least one person try to call APIs from here.