### PR TITLE
Skip test_profile_memory on windows

### DIFF
--- a/test/profiler/test_cpp_thread.py
+++ b/test/profiler/test_cpp_thread.py
@@ -6,7 +6,7 @@ import subprocess
 
 import torch
 import torch.utils.cpp_extension
-from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
+from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase, serialTest
 
 
 def remove_build_path():
@@ -191,6 +191,7 @@ class CppThreadTest(TestCase):
             }
         )
 
+    @serialTest()
     def test_profile_memory(self) -> None:
         self.start_profiler(True)
         cpp.start_threads(self.ThreadCount, IterationCount, True)

--- a/test/profiler/test_cpp_thread.py
+++ b/test/profiler/test_cpp_thread.py
@@ -172,6 +172,10 @@ class CppThreadTest(TestCase):
                         "not enough event recorded",
                     )
 
+    @skipIf(
+        IS_WINDOWS,
+        "Failing on windows cuda, see https://github.com/pytorch/pytorch/pull/130037 for slightly more context",
+    )
     def test_with_enable_profiler_in_child_thread(self) -> None:
         self.start_profiler(False)
         cpp.start_threads(self.ThreadCount, IterationCount, True)
@@ -182,6 +186,10 @@ class CppThreadTest(TestCase):
             }
         )
 
+    @skipIf(
+        IS_WINDOWS,
+        "Failing on windows cuda, see https://github.com/pytorch/pytorch/pull/130037 for slightly more context",
+    )
     def test_without_enable_profiler_in_child_thread(self) -> None:
         self.start_profiler(False)
         cpp.start_threads(self.ThreadCount, IterationCount, False)

--- a/test/profiler/test_cpp_thread.py
+++ b/test/profiler/test_cpp_thread.py
@@ -3,10 +3,11 @@
 import os
 import shutil
 import subprocess
+from unittest import skipIf
 
 import torch
 import torch.utils.cpp_extension
-from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase, serialTest
+from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 
 
 def remove_build_path():
@@ -191,7 +192,10 @@ class CppThreadTest(TestCase):
             }
         )
 
-    @serialTest()
+    @skipIf(
+        IS_WINDOWS,
+        "Failing on windows cuda, see https://github.com/pytorch/pytorch/pull/130037 for slightly more context",
+    )
     def test_profile_memory(self) -> None:
         self.start_profiler(True)
         cpp.start_threads(self.ThreadCount, IterationCount, True)


### PR DESCRIPTION
cc @LESSuseLESS @aaronenyeshi 
The test was introduced in https://github.com/pytorch/pytorch/pull/128743
It is failing on windows cuda https://hud.pytorch.org/hud/pytorch/pytorch/a9a744e442975cfbc6f4b26a532e5c1b3d9d5692/1?per_page=100&name_filter=win (it is skipped on cpu jobs)

After talking with the author and Aaron, I have been advised to skip it on windows, as windows support for kineto is not a high priority