### PR TITLE
MPS LSTM backward kernel workaround on MacOS 14.4+

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -31,6 +31,7 @@ enum class MacOSVersion : uint32_t {
   MACOS_VER_13_2_PLUS,
   MACOS_VER_13_3_PLUS,
   MACOS_VER_14_0_PLUS,
+  MACOS_VER_14_4_PLUS,
 };
 
 //-----------------------------------------------------------------

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -119,9 +119,10 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
 
   static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(conjugateWithTensor:name:)] == YES;
 
-  //TODO: Change all version checks to use this API
-  NSProcessInfo *processInfo = [[NSProcessInfo alloc] init];
-  static bool _macos_14_4_plus = [processInfo isOperatingSystemAtLeastVersion:{.majorVersion=14, .minorVersion=4, .patchVersion=0}];
+  // TODO: Change all version checks to use this API
+  NSProcessInfo* processInfo = [[NSProcessInfo alloc] init];
+  static bool _macos_14_4_plus =
+      [processInfo isOperatingSystemAtLeastVersion:{.majorVersion = 14, .minorVersion = 4, .patchVersion = 0}];
 
   switch (version) {
     case MacOSVersion::MACOS_VER_13_0_PLUS:

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -119,6 +119,10 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
 
   static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(conjugateWithTensor:name:)] == YES;
 
+  //TODO: Change all version checks to use this API
+  NSProcessInfo *processInfo = [[NSProcessInfo alloc] init];
+  static bool _macos_14_4_plus = [processInfo isOperatingSystemAtLeastVersion:{.majorVersion=14, .minorVersion=4, .patchVersion=0}];
+
   switch (version) {
     case MacOSVersion::MACOS_VER_13_0_PLUS:
       return _macos_13_0_plus;
@@ -130,6 +134,8 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
       return _macos_13_3_plus;
     case MacOSVersion::MACOS_VER_14_0_PLUS:
       return _macos_14_0_plus;
+    case MacOSVersion::MACOS_VER_14_4_PLUS:
+      return _macos_14_4_plus;
     default:
       return false;
   }

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -120,9 +120,10 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(conjugateWithTensor:name:)] == YES;
 
   // TODO: Change all version checks to use this API
-  NSProcessInfo* processInfo = [[NSProcessInfo alloc] init];
-  static bool _macos_14_4_plus =
-      [processInfo isOperatingSystemAtLeastVersion:{.majorVersion = 14, .minorVersion = 4, .patchVersion = 0}];
+  static bool _macos_14_4_plus = (){
+    NSProcessInfo* processInfo = [[NSProcessInfo alloc] init];
+    return [processInfo isOperatingSystemAtLeastVersion:{.majorVersion = 14, .minorVersion = 4, .patchVersion = 0}];
+     }();
 
   switch (version) {
     case MacOSVersion::MACOS_VER_13_0_PLUS:

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -120,10 +120,10 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(conjugateWithTensor:name:)] == YES;
 
   // TODO: Change all version checks to use this API
-  static bool _macos_14_4_plus = [](){
+  static bool _macos_14_4_plus = []() {
     NSProcessInfo* processInfo = [[NSProcessInfo alloc] init];
     return [processInfo isOperatingSystemAtLeastVersion:{.majorVersion = 14, .minorVersion = 4, .patchVersion = 0}];
-     }();
+  }();
 
   switch (version) {
     case MacOSVersion::MACOS_VER_13_0_PLUS:

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -120,7 +120,7 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(conjugateWithTensor:name:)] == YES;
 
   // TODO: Change all version checks to use this API
-  static bool _macos_14_4_plus = (){
+  static bool _macos_14_4_plus = [](){
     NSProcessInfo* processInfo = [[NSProcessInfo alloc] init];
     return [processInfo isOperatingSystemAtLeastVersion:{.majorVersion = 14, .minorVersion = 4, .patchVersion = 0}];
      }();

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -356,9 +356,7 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
                                                                                bool bidirectional,
                                                                                bool batch_first) {
   using namespace mps;
-  TORCH_CHECK(num_layers <= 2,
-              "MPS LSTM gradient kernel has an issue with the gradients for num_layers > 2. ",
-              "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` ");
+  bool ismacos_14_4_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_4_PLUS);
 
   const Tensor& grad_y_r = c10::value_or_else(grad_y_opt, [] { return Tensor(); });
   const Tensor& grad_hy_r = c10::value_or_else(grad_hy_opt, [] { return Tensor(); });
@@ -533,6 +531,10 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
                                                   start:i - num_layers
                                                  length:1
                                                    name:nil];
+          if is_macos_14_4_or_newer {
+            // Prevents shape optimization bug in kernel when num_layers > 2
+            iterationInputTensor_ = [mpsGraph identityWithTensor:iterationInputTensor_ name:nil];
+          }
           iterationInputTensor_ = [mpsGraph squeezeTensor:iterationInputTensor_ axis:0 name:nil];
         }
 

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -356,6 +356,10 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
                                                                                bool bidirectional,
                                                                                bool batch_first) {
   using namespace mps;
+  TORCH_CHECK(num_layers <= 2,
+              "MPS LSTM gradient kernel has an issue with the gradients for num_layers > 2. ",
+              "As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` ");
+
   const Tensor& grad_y_r = c10::value_or_else(grad_y_opt, [] { return Tensor(); });
   const Tensor& grad_hy_r = c10::value_or_else(grad_hy_opt, [] { return Tensor(); });
   const Tensor& grad_cy_r = c10::value_or_else(grad_cy_opt, [] { return Tensor(); });

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -531,7 +531,7 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
                                                   start:i - num_layers
                                                  length:1
                                                    name:nil];
-          if is_macos_14_4_or_newer {
+          if (is_macos_14_4_or_newer) {
             // Prevents shape optimization bug in kernel when num_layers > 2
             iterationInputTensor_ = [mpsGraph identityWithTensor:iterationInputTensor_ name:nil];
           }

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -356,7 +356,7 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
                                                                                bool bidirectional,
                                                                                bool batch_first) {
   using namespace mps;
-  bool ismacos_14_4_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_4_PLUS);
+  bool is_macos_14_4_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_4_PLUS);
 
   const Tensor& grad_y_r = c10::value_or_else(grad_y_opt, [] { return Tensor(); });
   const Tensor& grad_hy_r = c10::value_or_else(grad_hy_opt, [] { return Tensor(); });

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11531,8 +11531,6 @@ class TestRNNMPS(TestCaseMPS):
             for test_options in self.LSTM_TEST_CASES:
                 self._lstm_helper(num_layers=num_layers, dtype=dtype, device=device, **test_options)
 
-    # Broke on MacOS-14.4 (but works on 14.2), see https://github.com/pytorch/pytorch/issues/125803
-    @xfailIfMacOS14_4Plus
     def test_lstm_backward(self, device="mps", dtype=torch.float32):
         for num_layers in [1, 2, 5]:
             for test_options in self.LSTM_TEST_CASES:


### PR DESCRIPTION
The bug causing the correctness problem will be fixed in future OS release. Root cause of the problem is in a bug in an optimization to MPSGraph reshape operation in MacOS 14_4 that results in a correctness issue with the shapes the LSTM gradient operation has when num_layers > 2.

Solves silentness of issue #125803.