### PR TITLE
[Split Build][BE] remove extraneous .py, .a, and .so files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -876,7 +876,7 @@ else:
                             os.remove(os.path.join(root, file))
                         elif file.endswith('.py'):
                             os.remove(os.path.join(root, file))
-                # need an __init__.py file otherwise it would be treated as a directory
+                # need an __init__.py file otherwise we wouldn't have a package
                 open(os.path.join(self.bdist_dir, 'torch', '__init__.py'), 'w').close()
 
 

--- a/setup.py
+++ b/setup.py
@@ -872,14 +872,14 @@ else:
                 # Remove extraneneous files in the libtorch wheel
                 for root, dirs, files in os.walk(self.bdist_dir):
                     for file in files:
-                        if file.endswith(('.a', '.so')) and os.path.isfile(os.path.join(self.bdist_dir, file)):
+                        if file.endswith((".a", ".so")) and os.path.isfile(
+                            os.path.join(self.bdist_dir, file)
+                        ):
                             os.remove(os.path.join(root, file))
-                        elif file.endswith('.py'):
+                        elif file.endswith(".py"):
                             os.remove(os.path.join(root, file))
                 # need an __init__.py file otherwise we wouldn't have a package
-                open(os.path.join(self.bdist_dir, 'torch', '__init__.py'), 'w').close()
-
-
+                open(os.path.join(self.bdist_dir, "torch", "__init__.py"), "w").close()
 
 
 class install(setuptools.command.install.install):

--- a/setup.py
+++ b/setup.py
@@ -865,6 +865,22 @@ else:
             with concat_license_files(include_files=True):
                 super().run()
 
+        def write_wheelfile(self, *args, **kwargs):
+            super().write_wheelfile(*args, **kwargs)
+
+            if BUILD_LIBTORCH_WHL:
+                # Remove extraneneous files in the libtorch wheel
+                for root, dirs, files in os.walk(self.bdist_dir):
+                    for file in files:
+                        if file.endswith(('.a', '.so')) and os.path.isfile(os.path.join(self.bdist_dir, file)):
+                            os.remove(os.path.join(root, file))
+                        elif file.endswith('.py'):
+                            os.remove(os.path.join(root, file))
+                # need an __init__.py file otherwise it would be treated as a directory
+                open(os.path.join(self.bdist_dir, 'torch', '__init__.py'), 'w').close()
+
+
+
 
 class install(setuptools.command.install.install):
     def run(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130053

Removes extraneous .a, .so, and .py files from the split build. From here we can also clean up the builder script which produces the binary to do this. That pr is https://github.com/pytorch/builder/pull/1912

Verification:

The built wheel with BUILD_LIBTORCH_WHL=1 has the following files only (with .a, .so, and .py extensions)

```
sahanp@devgpu086 ~/p/dist (viable/strict)> pwd                                                                                                                                                                                                                            (pytorch-3.10) 
/home/sahanp/pytorch/dist
sahanp@devgpu086 ~/p/dist (viable/strict)> find . -type f \( -name "*.py" -o -name "*.a" -o -name "*.so" \)                                                                                                                                                               (pytorch-3.10) 
./torch/__init__.py
./torch/lib/libbackend_with_compiler.so
./torch/lib/libc10.so
./torch/lib/libjitbackend_test.so
./torch/lib/libtorch.so
./torch/lib/libtorch_cpu.so
./torch/lib/libtorch_global_deps.so
./torch/lib/libtorchbind_test.so
sahanp@devgpu086 ~/p/dist (viable/strict)>
```