### PR TITLE
[compiled autograd] c++ autograd function saved_data: lift tensors

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1574,9 +1574,8 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved_dynamic, m) {
                 loss.backward()
                 yield x.grad
 
-        # can bring this down to 2 if we support dynamic shapes
-        # instead of collecting the saved_data's tensor hash
-        self.check_output_and_recompiles(fn, 5)
+        # compiles for 10 (static) and 100 (dynamic)
+        self.check_output_and_recompiles(fn, 2)
 
     def test_autograd_cpp_node_data_dependent(self):
         cpp_source = """

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -259,6 +259,7 @@ class CompiledNodeArgs {
     }
   }
   void collect(const at::IValue& iv) {
+    // used by AutogradContext::saved_data from CppNode
     if (iv.isList()) {
       c10::List<at::IValue> list = iv.toList();
       collect_size(list.size());
@@ -273,6 +274,8 @@ class CompiledNodeArgs {
         collect(it->key());
         collect(it->value());
       }
+    } else if (iv.isTensor()) {
+      collect(iv.toTensor());
     } else {
       try {
         collect(static_cast<uint64_t>(at::IValue::hash(iv)));
@@ -519,9 +522,7 @@ class CompiledNodeArgs {
 };
 
 struct TraceState {
-  TraceState(
-      const std::vector<std::optional<c10::SymInt>>& ss,
-      size_t num_outputs)
+  TraceState(std::vector<std::optional<c10::SymInt>>&& ss, size_t num_outputs)
       : sym_sizes(ss), outputs(num_outputs) {}
 
   void debug_asserts() {
@@ -578,11 +579,19 @@ class SwapSavedVariables {
   }
 
   void before(at::IValue& t) {
-    stashed_ivalues.save(&t, at::IValue(t));
+    if (t.isTensor()) {
+      before(t.toTensor());
+    } else {
+      stashed_ivalues.save(&t, at::IValue(t));
+    }
   }
 
   void after(at::IValue& t) {
-    stashed_ivalues.restore(&t);
+    if (t.isTensor()) {
+      after(t.toTensor());
+    } else {
+      stashed_ivalues.restore(&t);
+    }
   }
 
   void before(Edge& t) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130057

avoid recompiles when custom c++ autograd function use ctx->saved_data to save tensors

iv.toTensor can return reference for `after(iv.toTensor())`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang