### PR TITLE
Updates to scaled_mm for rowwise scaling

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -858,49 +858,55 @@ ScalingType get_scaling_type(
       scale_a.scalar_type() == kFloat && scale_b.scalar_type() == kFloat,
       "Both scale_a and scale_b must be float (fp32) tensors.");
 
-
   // Check the singluar scale case for per-tensor scaling
   if (scale_a.numel() == 1 && scale_b.numel() == 1) {
     return ScalingType::TensorWise;
-  } else if (scale_a.dim() == 1 && scale_a.size(0) == dim_m) {
-// Check the per-row scaling case
+  }
+
+  // For non-TensorWise scaling, enforce 2D input tensors
+  TORCH_CHECK(
+      scale_a.dim() == 2 && scale_b.dim() == 2,
+      "For non-TensorWise scaling, scale tensors must be 2-dimensional, "
+      "but got scale_a.dim()=",
+      scale_a.dim(),
+      " and scale_b.dim()=",
+      scale_b.dim());
+
+  // Check for RowWise scaling
+  if (scale_a.size(0) == dim_m && scale_a.size(1) == 1 &&
+      scale_b.size(0) == 1 && scale_b.size(1) == dim_n) {
 #if !defined(USE_ROCM) && !defined(_MSC_VER) || \
     (defined(USE_ROCM) && ROCM_VERSION >= 60000)
     TORCH_CHECK(
-        scale_a.dim() == 1 && scale_b.dim() == 1,
-        "Both scale_a and scale_b must be 1-dimensional tensors");
-    TORCH_CHECK(
-        scale_b.size(0) == dim_n,
-        "For row-wise scaling, scale_b must have size ",
-        dim_n,
-        " but got ",
-        scale_b.size(0),
-        ".");
-    TORCH_CHECK(
         scale_a.is_contiguous() && scale_b.is_contiguous(),
-        "Both scale_a and scale_b must be contiguous.");
+        "Both scale_a and scale_b must be contiguous for RowWise scaling.");
     return ScalingType::RowWise;
 #else
     TORCH_CHECK(false, "Per-row scaling is not supported for this platform!");
     return ScalingType::Error;
-#endif // !defined(USE_ROCM) && !defined(_MSC_VER) || (defined(USE_ROCM) &&
-       // ROCM_VERSION >= 60000)
-  } else {
-    // Prettier Error Case messaging
-    TORCH_CHECK(
-        false,
-        "For row-wise scaling, scale_a must be size ",
-        dim_m,
-        " but got ",
-        scale_a.numel(),
-        " and scale_b must be size ",
-        dim_n,
-        " but got ",
-        scale_b.numel(),
-        ".");
-    // Unreachable
-    return ScalingType::RowWise;
+#endif
   }
+
+  // If we reach here, the input doesn't match any valid scaling type
+  TORCH_CHECK(
+      false,
+      "Invalid scaling configuration. For TensorWise scaling, both scales should be scalar. "
+      "For RowWise scaling, scale_a should be (",
+      dim_m,
+      ", 1) and scale_b should be (1, ",
+      dim_n,
+      "). "
+      "Got scale_a.size()=(",
+      scale_a.size(0),
+      ", ",
+      scale_a.size(1),
+      ") and ",
+      "scale_b.size()=(",
+      scale_b.size(0),
+      ", ",
+      scale_b.size(1),
+      ")");
+
   return ScalingType::Error;
 }
 


### PR DESCRIPTION
# Summary

This updates _scaled_mm's API to enforce that input scales are always 2 dimensional. This resolves ambiguity around scaling scheme