### PR TITLE
[export] add non-strict training IR

### DIFF
--- a/test/export/test_export_training_ir_to_run_decomp.py
+++ b/test/export/test_export_training_ir_to_run_decomp.py
@@ -10,23 +10,40 @@ from torch.export._trace import _export_for_training
 test_classes = {}
 
 
-def mocked_training_ir_to_run_decomp_export(*args, **kwargs):
+def mocked_training_ir_to_run_decomp_export_strict(*args, **kwargs):
     ep = _export_for_training(*args, **kwargs)
     return ep.run_decompositions(
         {}, _preserve_ops=testing._COMPOSITE_OPS_THAT_CAN_BE_PRESERVED_TESTING_ONLY
     )
 
 
-def make_dynamic_cls(cls):
-    cls_prefix = "TrainingIRToRunDecompExport"
-
-    test_class = testing.make_test_cls_with_mocked_export(
-        cls,
-        cls_prefix,
-        test_export.TRAINING_IR_DECOMP_SUFFIX,
-        mocked_training_ir_to_run_decomp_export,
-        xfail_prop="_expected_failure_training_ir_to_run_decomp",
+def mocked_training_ir_to_run_decomp_export_non_strict(*args, **kwargs):
+    if "strict" in kwargs:
+        ep = _export_for_training(*args, **kwargs)
+    else:
+        ep = _export_for_training(*args, **kwargs, strict=False)
+    return ep.run_decompositions(
+        {}, _preserve_ops=testing._COMPOSITE_OPS_THAT_CAN_BE_PRESERVED_TESTING_ONLY
     )
+
+
+def make_dynamic_cls(cls, strict):
+    if strict:
+        test_class = testing.make_test_cls_with_mocked_export(
+            cls,
+            "TrainingIRToRunDecompExport",
+            test_export.TRAINING_IR_DECOMP_STRICT_SUFFIX,
+            mocked_training_ir_to_run_decomp_export_strict,
+            xfail_prop="_expected_failure_training_ir_to_run_decomp",
+        )
+    else:
+        test_class = testing.make_test_cls_with_mocked_export(
+            cls,
+            "TrainingIRToRunDecompExportNonStrict",
+            test_export.TRAINING_IR_DECOMP_NON_STRICT_SUFFIX,
+            mocked_training_ir_to_run_decomp_export_non_strict,
+            xfail_prop="_expected_failure_training_ir_to_run_decomp_non_strict",
+        )
 
     test_classes[test_class.__name__] = test_class
     # REMOVING THIS LINE WILL STOP TESTS FROM RUNNING
@@ -40,7 +57,8 @@ tests = [
     test_export.TestExport,
 ]
 for test in tests:
-    make_dynamic_cls(test)
+    make_dynamic_cls(test, True)
+    make_dynamic_cls(test, False)
 del test
 
 if __name__ == "__main__":

--- a/test/export/testing.py
+++ b/test/export/testing.py
@@ -239,6 +239,12 @@ def expectedFailureTrainingIRToRunDecomp(fn):
     return fn
 
 
+# Controls tests generated in test/export/test_export_training_ir_to_run_decomp.py
+def expectedFailureTrainingIRToRunDecompNonStrict(fn):
+    fn._expected_failure_training_ir_to_run_decomp_non_strict = True
+    return fn
+
+
 # Controls tests generated in test/export/test_export_nonstrict.py
 def expectedFailureNonStrict(fn):
     fn._expected_failure_non_strict = True


### PR DESCRIPTION
Summary: Adds non-strict implementation of training IR export. Any expected non-strict training IR failures are also either existing strict training IR or non-strict failures (no new failures added). 4 strict training IR failures also resolved.

Refraining from unifying export/export_for_training, per @ydwu4's feedback :)

Test Plan: added test_export_training_ir_to_run_decomp_non_strict.py for non-strict training IR

Differential Revision: D59349454


