### PR TITLE
TunableOp more unit test follow-up

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -56,18 +56,19 @@ def blaslt_supported_device():
     return False
 
 def set_tunableop_defaults():
-    if torch.cuda.is_available():
-        # disables TunableOp and restore to default values
-        ordinal = torch.cuda.current_device()
-        filename = f"tunableop_results{ordinal}.csv"
-        torch.cuda.tunable.enable(False)
-        torch.cuda.tunable.tuning_enable(True)
-        torch.cuda.tunable.set_filename(filename)  # reset back to default filename for next unit test
-        torch.cuda.tunable.set_max_tuning_duration(30)
-        torch.cuda.tunable.set_max_tuning_iterations(100)
-    else:
+    if not torch.cuda.is_available():
         # TunableOp not supported on CPU at this time.
-        pass
+        return
+
+    # disable TunableOp and restore to default values
+    ordinal = torch.cuda.current_device()
+    filename = f"tunableop_results{ordinal}.csv"
+    torch.cuda.tunable.enable(False)
+    torch.cuda.tunable.tuning_enable(True)
+    torch.cuda.tunable.set_filename(filename)  # reset back to default filename for next unit test
+    torch.cuda.tunable.set_max_tuning_duration(30)
+    torch.cuda.tunable.set_max_tuning_iterations(100)
+
 
 class TestLinalg(TestCase):
     def setUp(self):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4712,7 +4712,7 @@ class TestLinalg(TestCase):
         assert( (total_num_results - ref_num_results) == 1)
 
         # Set tuning iterations to zero
-        import os
+        # Tune a single GEMM and verify that we get a new tuning result
         os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "0"
         assert(torch.cuda.tunable.get_max_tuning_iterations() > 0)
         os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "100" # reset to default

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4654,6 +4654,119 @@ class TestLinalg(TestCase):
             else:
                 os.environ[PYTORCH_TUNABLEOP_NUMERICAL_CHECK] = prev_val
 
+    @onlyCUDA
+    @skipCUDAIfNotRocm
+    @dtypes(torch.float)
+    def test_validator_tunableop_rocm(self, device, dtype):
+        # Test that the validator on ROCM has exactly 5 lines
+        # Format of the Validator is as follows:
+        # Validator,PT_VERSION,X.Y.Z.
+        # Validator,ROCBLAS_VERSION,X.Y,Z
+        # Validator,HIPBLASLT_VERSION,X,Y.Z
+        # Validator,ROCM_Version,X,Y.Z
+        # Validator,GCN_ARCH_NAME,<architecutre name>
+        validator_num_lines = 5
+        set_tunableop_defaults()
+        torch.cuda.tunable.enable()
+        # set these to single iterations to keep it short but still exercise the code
+        torch.cuda.tunable.set_max_tuning_iterations(1)
+
+        N = M = K = 4
+        A = torch.randn(N, K, device=device, dtype=dtype)
+        B = torch.randn(K, M, device=device, dtype=dtype)
+        C = torch.matmul(A, B)
+        assert len(torch.cuda.tunable.get_validators()) == validator_num_lines
+
+        # disables TunableOp
+        torch.cuda.tunable.enable(False)
+
+    @onlyCUDA
+    @dtypes(torch.half)
+    def test_minimum_tuning_iteration_tunableop(self, device, dtype):
+        # Make sure that there is at least one tuning iteration under various scenarios
+        set_tunableop_defaults()
+
+        torch.cuda.tunable.enable()
+        # set these to single iterations to keep it short but still exercise the code
+        torch.cuda.tunable.set_max_tuning_iterations(1)
+
+        # Set tuning duration to zero milliseconds
+        # Tune a single GEMM and verify that we get a new tuning result
+        import os
+        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS"] = "0"
+        assert(torch.cuda.tunable.get_max_tuning_iterations() > 0)
+        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS"] = "30" # reset to default
+
+        # Reference number of results
+        ref_num_results = len(torch.cuda.tunable.get_results())
+
+        N = M = K = 8
+        A = torch.randn(N, K, device=device, dtype=dtype)
+        B = torch.randn(K, M, device=device, dtype=dtype)
+        C = torch.matmul(A, B)
+
+        # This stores total number of cummulative results
+        total_num_results = len(torch.cuda.tunable.get_results())
+
+        # There must be a new tuning result
+        assert( (total_num_results - ref_num_results) == 1)
+
+        # Set tuning iterations to zero
+        import os
+        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "0"
+        assert(torch.cuda.tunable.get_max_tuning_iterations() > 0)
+        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "100" # reset to default
+
+        # Reference number of results
+        ref_num_results = total_num_results
+
+        N = M = K = 16
+        A = torch.randn(N, K, device=device, dtype=dtype)
+        B = torch.randn(K, M, device=device, dtype=dtype)
+        C = torch.matmul(A, B)
+
+        # This stores total number of cummulative results
+        total_num_results = len(torch.cuda.tunable.get_results())
+
+        # There must be a new tuning result
+        assert( (total_num_results - ref_num_results) == 1)
+
+        # disables TunableOp
+        torch.cuda.tunable.enable(False)
+
+    @onlyCUDA
+    @dtypes(torch.half)
+    def test_matmul_check_entries_tunableop(self, device, dtype):
+        # Tune a couple of matrix multiplies
+        # Verify we get the correct number of results
+        set_tunableop_defaults()
+        torch.cuda.tunable.enable()
+        # set these to single iterations to keep it short but still exercise the code
+        torch.cuda.tunable.set_max_tuning_iterations(1)
+
+        # Reference number of results
+        ref_num_results = len(torch.cuda.tunable.get_results())
+
+        # Execute matrix multiplies. We intentionally throw in M list the same index
+        # twice. The CSV file should only get unique GEMMs
+        count_matmul = 4
+        K = 64
+        for M in [32, 64, 32]:
+            for N in [32, 64]:
+                A = torch.randn(N, K, device=device, dtype=dtype)
+                B = torch.randn(K, M, device=device, dtype=dtype)
+                C = torch.matmul(A, B)
+
+        # This stores total number of cummulative results
+        total_num_results = len(torch.cuda.tunable.get_results())
+
+        # Take the difference to calculate the number of results from
+        # the this test and verify that it agrees with the number of
+        # GEMMs.
+        assert( (total_num_results - ref_num_results) == count_matmul)
+
+        # disables TunableOp
+        torch.cuda.tunable.enable(False)
 
     @dtypes(torch.float, torch.complex64)
     def test_matmul_out_kernel_errors_with_autograd(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -55,6 +55,20 @@ def blaslt_supported_device():
             return True
     return False
 
+def set_tunableop_defaults():
+    if torch.cuda.is_available():
+        # disables TunableOp and restore to default values
+        ordinal = torch.cuda.current_device()
+        filename = f"tunableop_results{ordinal}.csv"
+        torch.cuda.tunable.enable(False)
+        torch.cuda.tunable.tuning_enable(True)
+        torch.cuda.tunable.set_filename(filename)  # reset back to default filename for next unit test
+        torch.cuda.tunable.set_max_tuning_duration(30)
+        torch.cuda.tunable.set_max_tuning_iterations(100)
+    else:
+        # TunableOp not supported on CPU at this time.
+        pass
+
 class TestLinalg(TestCase):
     def setUp(self):
         super(self.__class__, self).setUp()

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4694,8 +4694,8 @@ class TestLinalg(TestCase):
         # Tune a single GEMM and verify that we get a new tuning result
         import os
         os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS"] = "0"
-        assert(torch.cuda.tunable.get_max_tuning_iterations() > 0)
-        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS"] = "30" # reset to default
+        assert (torch.cuda.tunable.get_max_tuning_iterations() > 0)
+        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_DURATION_MS"] = "30"  # reset to default
 
         # Reference number of results
         ref_num_results = len(torch.cuda.tunable.get_results())
@@ -4709,13 +4709,13 @@ class TestLinalg(TestCase):
         total_num_results = len(torch.cuda.tunable.get_results())
 
         # There must be a new tuning result
-        assert( (total_num_results - ref_num_results) == 1)
+        assert ((total_num_results - ref_num_results) == 1)
 
         # Set tuning iterations to zero
         # Tune a single GEMM and verify that we get a new tuning result
         os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "0"
-        assert(torch.cuda.tunable.get_max_tuning_iterations() > 0)
-        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "100" # reset to default
+        assert (torch.cuda.tunable.get_max_tuning_iterations() > 0)
+        os.environ["PYTORCH_TUNABLEOP_MAX_TUNING_ITERATIONS"] = "100"  # reset to default
 
         # Reference number of results
         ref_num_results = total_num_results
@@ -4729,7 +4729,7 @@ class TestLinalg(TestCase):
         total_num_results = len(torch.cuda.tunable.get_results())
 
         # There must be a new tuning result
-        assert( (total_num_results - ref_num_results) == 1)
+        assert ((total_num_results - ref_num_results) == 1)
 
         # disables TunableOp
         torch.cuda.tunable.enable(False)
@@ -4763,7 +4763,7 @@ class TestLinalg(TestCase):
         # Take the difference to calculate the number of results from
         # the this test and verify that it agrees with the number of
         # GEMMs.
-        assert( (total_num_results - ref_num_results) == count_matmul)
+        assert ((total_num_results - ref_num_results) == count_matmul)
 
         # disables TunableOp
         torch.cuda.tunable.enable(False)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4671,6 +4671,7 @@ class TestLinalg(TestCase):
         # Test in try-finally block to avoid leaking state
         # if test is interrupted.
         try:
+            set_tunableop_defaults()
             torch.cuda.tunable.enable()
             # set these to single iterations to keep it short but still exercise the code
             torch.cuda.tunable.set_max_tuning_iterations(1)
@@ -4681,8 +4682,8 @@ class TestLinalg(TestCase):
             C = torch.matmul(A, B)
             self.assertEqual(len(torch.cuda.tunable.get_validators()), validator_num_lines)
         finally:
-            # disable TunableOp and reset to defaults
-            set_tunableop_defaults()
+            # disable TunableOp
+            torch.cuda.tunable.enable(False)
 
     @onlyCUDA
     @dtypes(torch.half)
@@ -4692,6 +4693,7 @@ class TestLinalg(TestCase):
         # Test in try-finally block to avoid leaking state
         # if test is interrupted.
         try:
+            set_tunableop_defaults()
             torch.cuda.tunable.enable()
             # set these to single iterations to keep it short but still exercise the code
             torch.cuda.tunable.set_max_tuning_iterations(1)
@@ -4738,8 +4740,8 @@ class TestLinalg(TestCase):
             self.assertEqual((total_num_results - ref_num_results), 1)
 
         finally:
-            # disables TunableOp and reset to defaults
-            set_tunableop_defaults()
+            # disable TunableOp
+            torch.cuda.tunable.enable(False)
 
     @onlyCUDA
     @dtypes(torch.half)
@@ -4748,6 +4750,7 @@ class TestLinalg(TestCase):
         # Verify we get the correct number of results
 
         try:
+            set_tunableop_defaults()
             torch.cuda.tunable.enable()
             # set these to single iterations to keep it short but still exercise the code
             torch.cuda.tunable.set_max_tuning_iterations(1)
@@ -4774,8 +4777,8 @@ class TestLinalg(TestCase):
             self.assertEqual((total_num_results - ref_num_results), count_matmul)
 
         finally:
-            # disables TunableOp and reset to defaults
-            set_tunableop_defaults()
+            # disable TunableOp
+            torch.cuda.tunable.enable(False)
 
     @dtypes(torch.float, torch.complex64)
     def test_matmul_out_kernel_errors_with_autograd(self, device, dtype):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4685,6 +4685,14 @@ class TestLinalg(TestCase):
             # disable TunableOp
             torch.cuda.tunable.enable(False)
 
+            # clean up, remove any file that was generated
+            try:
+                import os
+                filename = torch.cuda.tunable.get_filename()
+                os.remove(filename)
+            except FileNotFoundError:
+                pass
+
     @onlyCUDA
     @dtypes(torch.half)
     def test_minimum_tuning_iteration_tunableop(self, device, dtype):
@@ -4743,6 +4751,14 @@ class TestLinalg(TestCase):
             # disable TunableOp
             torch.cuda.tunable.enable(False)
 
+            # clean up, remove any file that was generated
+            try:
+                import os
+                filename = torch.cuda.tunable.get_filename()
+                os.remove(filename)
+            except FileNotFoundError:
+                pass
+
     @onlyCUDA
     @dtypes(torch.half)
     def test_matmul_check_entries_tunableop(self, device, dtype):
@@ -4779,6 +4795,14 @@ class TestLinalg(TestCase):
         finally:
             # disable TunableOp
             torch.cuda.tunable.enable(False)
+
+            # clean up, remove any file that was generated
+            try:
+                import os
+                filename = torch.cuda.tunable.get_filename()
+                os.remove(filename)
+            except FileNotFoundError:
+                pass
 
     @dtypes(torch.float, torch.complex64)
     def test_matmul_out_kernel_errors_with_autograd(self, device, dtype):


### PR DESCRIPTION
More unit tests for preventing TunableOp regressions.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang