### PR TITLE
[ONNX] Add `artifacts_dir` to torch-onnx-patch in benchmark

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1547,7 +1547,12 @@ class OnnxModelFromTorchScript(OnnxModel):
         if self.use_experimental_patch:
             import torch_onnx
 
-            torch_onnx.patch_torch(error_report=True, profile=True)
+            torch_onnx.patch_torch(
+                error_report=True,
+                profile=True,
+                dump_exported_program=False,
+                artifacts_dir=os.path.dirname(output_path),
+            )
         else:
             # make sure the patch is not in effect
             try:


### PR DESCRIPTION
Add `artifacts_dir` to torch-onnx-patch to save error report for debugging.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang