### PR TITLE
Forward fix the missing torch.nn.Module.set_submodule from D59140215

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1447,7 +1447,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(net.get_submodule(target), l2)
         self.assertRaises(ValueError, net.set_submodule, "", l)
         self.assertRaises(AttributeError, net.set_submodule, "a.l", l)
-        self.assertRaises(AttributeError, net.set_submodule, "t.l.l2", l2)
 
     def test_module_to_argparse(self):
         net = nn.Sequential(nn.Linear(3, 3))

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -777,8 +777,10 @@ class Module:
 
             mod = getattr(mod, item)
 
-            if type(mod) is not torch.nn.Module:
+            # Use isinstance instead of type here to also handle subclass of nn.Module
+            if not isinstance(mod, torch.nn.Module):
                 raise AttributeError("`" + item + "` is not an nn.Module")
+
         setattr(mod, name, module)
 
     def get_parameter(self, target: str) -> "Parameter":


### PR DESCRIPTION
Summary: This is to forward fix D59140215 from a PyTorch open source contributor T194074371. On PyTorch side, we need to use isinstance instead of type when checking for nn.Module.  This is the same way get_submodule is currently implemented.

Test Plan: `buck2 test 'fbcode//mode/opt' fbcode//dper3/dper3/core/tests:module_test`

Differential Revision: D59254638
