### PR TITLE
Only run mixed_mm heuristic if shapes are static

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -291,6 +291,8 @@ class TestPatternMatcher(TestCase):
 
         # examples that should not be selected by heuristic
         mat1_dtype = torch.float16
+        dyn_tensor = torch.randn(4, 4096, dtype=mat1_dtype, device="cuda")
+        torch._dynamo.mark_dynamic(dyn_tensor, 0)
         args_list = [
             (
                 torch.randn(1, 4097, dtype=mat1_dtype, device="cuda"),
@@ -322,6 +324,10 @@ class TestPatternMatcher(TestCase):
             ),
             (
                 torch.randn(1, 4096, dtype=torch.float32, device="cuda"),
+                torch.randint(-128, 127, (4096, 4096), dtype=torch.int8, device="cuda"),
+            ),
+            (
+                dyn_tensor,
                 torch.randint(-128, 127, (4096, 4096), dtype=torch.int8, device="cuda"),
             ),
         ]

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -474,7 +474,7 @@ def tuned_mixed_mm(mat1, mat2, mat2_dtype):
 
     if not skip_triton:
         b_prologue_cast_type = f"tl.{mat2_dtype}".replace("torch.", "")
-        if inductor_config.mixed_mm_choice == "heuristic":
+        if static_shape and inductor_config.mixed_mm_choice == "heuristic":
             choices = []
             config = try_heuristic(m, n, k, choices, mat1, mat2, mat2_dtype, layout)
             if config is not None:


### PR DESCRIPTION
If we have dynamic shapes, the heuristic in mixed_mm will cause a crash, because it cannot compare m, k and n to integer values. This PR makes it so that the heuristic only runs if we have static shapes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang