### PR TITLE
[torchscript] variable misuse in `call_prepare_scriptable_func_impl`

### DIFF
--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -1039,7 +1039,7 @@ def call_prepare_scriptable_func_impl(obj, memo):
             new_obj_dict[name] = sub_module
 
     for k, v in new_obj_dict.items():
-        obj.__dict__[name] = v
+        obj.__dict__[k] = v
 
     return obj
 


### PR DESCRIPTION
It looks like the dictionary update logic in `call_prepare_scriptable_func_impl` is incorrect. The function is using the variable `name` instead of the correct dictionary key `k` when updating `obj.__dict__`. This is likely caused by a typo.