### PR TITLE
elastic/store: use wait instead of get for barrier

### DIFF
--- a/test/distributed/elastic/utils/util_test.py
+++ b/test/distributed/elastic/utils/util_test.py
@@ -46,6 +46,9 @@ class MockStore:
         self.ops.append(("add", key, val))
         return 3
 
+    def wait(self, keys: List[str]) -> None:
+        self.ops.append(("wait", keys))
+
 
 class StoreUtilTest(TestCase):
     def test_get_all_rank_0(self):
@@ -61,7 +64,7 @@ class StoreUtilTest(TestCase):
                 ("multi_get", ["test/store0", "test/store1", "test/store2"]),
                 ("add", "test/store/finished/num_members", 1),
                 ("set", "test/store/finished/last_member", "<val_ignored>"),
-                ("get", "test/store/finished/last_member"),
+                ("wait", ["test/store/finished/last_member"]),
             ],
         )
 
@@ -94,7 +97,7 @@ class StoreUtilTest(TestCase):
                 ("multi_get", ["test/store0", "test/store1", "test/store2"]),
                 ("add", "test/store/finished/num_members", 1),
                 ("set", "test/store/finished/last_member", "<val_ignored>"),
-                ("get", "test/store/finished/last_member"),
+                ("wait", ["test/store/finished/last_member"]),
                 ("set_timeout", datetime.timedelta(seconds=1234)),
             ],
         )
@@ -126,7 +129,7 @@ class StoreUtilTest(TestCase):
                 ("set_timeout", datetime.timedelta(seconds=300)),
                 ("add", "test/store/num_members", 1),
                 ("set", "test/store/last_member", "<val_ignored>"),
-                ("get", "test/store/last_member"),
+                ("wait", ["test/store/last_member"]),
                 ("set_timeout", datetime.timedelta(seconds=1234)),
             ],
         )

--- a/torch/distributed/elastic/utils/store.py
+++ b/torch/distributed/elastic/utils/store.py
@@ -65,7 +65,7 @@ def get_all(store, rank: int, prefix: str, world_size: int):
         # Rank0 runs the TCPStore daemon, as a result it needs to exit last.
         # Otherwise, the barrier may timeout if rank0 process finished the work
         # before other processes finished `get_all` method
-        store.get(barrier_key)
+        store.wait([barrier_key])
 
     return data_arr
 
@@ -128,4 +128,4 @@ def barrier(
         last_member_key = _barrier_nonblocking(
             store=store, world_size=world_size, key_prefix=key_prefix
         )
-        store.get(last_member_key)
+        store.wait([last_member_key])


### PR DESCRIPTION
Summary: We call `.get` in the elastic store barrier operation but we don't need the result. This switches it to use `.wait` instead which eliminates one network round trip as `get` internally does a wait first.

Test Plan:

CI + existing tests -- no behavior change

Differential Revision: D59396199


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang