### PR TITLE
c10d/Handlers: expose running handlers from Python

### DIFF
--- a/test/distributed/elastic/test_control_plane.py
+++ b/test/distributed/elastic/test_control_plane.py
@@ -7,6 +7,7 @@ import pickle
 import socket
 import tempfile
 from contextlib import contextmanager
+from typing import Dict
 
 from urllib3.connection import HTTPConnection
 from urllib3.connectionpool import HTTPConnectionPool
@@ -134,6 +135,53 @@ class WorkerServerTest(TestCase):
             resp = pool.request("POST", "/handler/dump_traceback")
             self.assertEqual(resp.status, 200)
             self.assertIn(b"in test_dump_traceback\n", resp.data)
+
+    def test_run_handler(self) -> None:
+        from torch._C._distributed_c10d import _get_handler, _Request, _Response
+
+        handler = _get_handler("ping")
+
+        class Request(_Request):
+            def __init__(self) -> None:
+                _Request.__init__(self)
+
+            def body(self) -> bytes:
+                return b"dummy"
+
+            def params(self) -> Dict[str, str]:
+                return {}
+
+        class Response(_Response):
+            def __init__(self) -> None:
+                _Response.__init__(self)
+
+            def set_content(self, content: str, content_type: str) -> None:
+                self.content = content
+                self.content_type = content_type
+
+            def set_status(self, status: int) -> None:
+                self.status = status
+
+        req = Request()
+        resp = Response()
+
+        handler(req, resp)
+
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.content, "pong")
+        self.assertEqual(resp.content_type, "text/plain")
+
+    def test_get_handler_nonexistant(self) -> None:
+        from torch._C._distributed_c10d import _get_handler
+
+        with self.assertRaisesRegex(ValueError, "Failed to find handler nonexistant"):
+            _get_handler("nonexistant")
+
+    def test_get_handler_names(self) -> None:
+        from torch._C._distributed_c10d import _get_handler_names
+
+        names = _get_handler_names()
+        self.assertIn("ping", names)
 
 
 if __name__ == "__main__":

--- a/torch/csrc/distributed/c10d/control_plane/Handlers.cpp
+++ b/torch/csrc/distributed/c10d/control_plane/Handlers.cpp
@@ -16,7 +16,7 @@ class HandlerRegistry {
     std::unique_lock<std::shared_mutex> lock(handlersMutex_);
 
     if (handlers_.find(name) != handlers_.end()) {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           fmt::format("Handler {} already registered", name));
     }
 
@@ -28,7 +28,8 @@ class HandlerRegistry {
 
     auto it = handlers_.find(name);
     if (it == handlers_.end()) {
-      throw std::runtime_error(fmt::format("Failed to find handler {}", name));
+      throw std::invalid_argument(
+          fmt::format("Failed to find handler {}", name));
     }
     return handlers_[name];
   }
@@ -55,6 +56,7 @@ HandlerRegistry& getHandlerRegistry() {
 
 RegisterHandler pingHandler{"ping", [](const Request&, Response& res) {
                               res.setContent("pong", "text/plain");
+                              res.setStatus(200);
                             }};
 
 } // namespace

--- a/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
+++ b/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
@@ -15,7 +15,7 @@ class TORCH_API Request {
  public:
   virtual ~Request() = default;
 
-  virtual const std::string& body() = 0;
+  virtual const std::string& body() const = 0;
 
   virtual const std::multimap<std::string, std::string>& params() const = 0;
 };

--- a/torch/csrc/distributed/c10d/control_plane/WorkerServer.cpp
+++ b/torch/csrc/distributed/c10d/control_plane/WorkerServer.cpp
@@ -19,7 +19,7 @@ class RequestImpl : public Request {
  public:
   RequestImpl(const httplib::Request& req) : req_(req) {}
 
-  const std::string& body() override {
+  const std::string& body() const override {
     return req_.body;
   }
 


### PR DESCRIPTION
This adds a `_run_handler` method that will invoke a specific handler.

Test plan:

```
python test/distributed/elastic/test_control_plane.py
```


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @fegin @XilunWu @wanchaol @fduwjj @wz337 @tianyu-l @wconstab @chauhang