### PR TITLE
Pin optree==0.11.0 on windows CI

### DIFF
--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -188,7 +188,7 @@ jobs:
         run: |
           pushd "${PYTORCH_FINAL_PACKAGE_DIR}"
           # shellcheck disable=SC2046,SC2102
-          python3 -mpip install $(echo *.whl)[opt-einsum,optree]
+          python3 -mpip install $(echo *.whl)[opt-einsum,optree==0.11.0]
           popd
 
           .ci/pytorch/win-test.sh

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -188,7 +188,7 @@ jobs:
         run: |
           pushd "${PYTORCH_FINAL_PACKAGE_DIR}"
           # shellcheck disable=SC2046,SC2102
-          python3 -mpip install $(echo *.whl)[opt-einsum,optree==0.11.0]
+          python3 -mpip install $(echo *.whl)[opt-einsum,optree]
           popd
 
           .ci/pytorch/win-test.sh

--- a/setup.py
+++ b/setup.py
@@ -1183,7 +1183,7 @@ def main():
     install_requires += extra_install_requires
 
     extras_require = {
-        "optree": ["optree>=0.11.0"],
+        "optree": ["optree==0.11.0"],
         "opt-einsum": ["opt-einsum>=3.3"],
     }
 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

doctests
test_testing

Failing run has 0.12.0 https://github.com/pytorch/pytorch/actions/runs/9804335516/job/27072891998
Succeeding run has 0.11.0 https://github.com/pytorch/pytorch/actions/runs/9798330845/job/27057359554

It is already pinned for mac and linux