### PR TITLE
[custom_op]Fix self in mutation_args

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -586,6 +586,22 @@ class MiscTests(torch._inductor.test_case.TestCase):
 
             f(x, out)
 
+    def test_auto_functionalize_self_as_mutate_arg(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            lib.define("foo(Tensor(a!) self) -> None")
+
+            def foo_impl(self: torch.Tensor) -> None:
+                self.sin_()
+
+            x = torch.randn(3)
+            lib.impl("foo", foo_impl, "CompositeExplicitAutograd")
+
+            @torch.compile(backend="inductor", fullgraph=True)
+            def f(x):
+                torch.ops.mylib.foo(x)
+
+            f(x)
+
     def test_user_defined_setattr1(self):
         @torch.compile(backend="eager", fullgraph=True)
         def fn(obj):

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -56,7 +57,7 @@ class AutoFunctionalized(HigherOrderOperator):
         super().__init__("auto_functionalized")
 
     def __call__(
-        self_,
+        self_,  # noqa: B902
         _mutable_op: torch._ops.OpOverload,
         **kwargs: Dict[str, Any],
     ) -> Tuple[Any, Tuple[Tensor, ...]]:
@@ -233,7 +234,8 @@ def do_auto_functionalize(
     unwrapped_kwargs = ctx.unwrap_tensors(normalized_kwargs)  # type: ignore[arg-type]
     if "self" in unwrapped_kwargs:
         warnings.warn(
-            "Using `self` as an argument in the definition of custom ops may lead to ambiguous parsing. Please consider using a different name for this argument to avoid potential issues."
+            "Using `self` as an argument in the definition of custom ops may lead to ambiguous parsing. "
+            "Please consider using a different name for this argument to avoid potential issues."
         )
     with ctx.redispatch_to_next():
         unwrapped_outs = auto_functionalized(

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -56,7 +56,7 @@ class AutoFunctionalized(HigherOrderOperator):
         super().__init__("auto_functionalized")
 
     def __call__(
-        self,
+        self_,
         _mutable_op: torch._ops.OpOverload,
         **kwargs: Dict[str, Any],
     ) -> Tuple[Any, Tuple[Tensor, ...]]:
@@ -231,6 +231,10 @@ def do_auto_functionalize(
             normalized_kwargs[arg.name] = arg.default_value
 
     unwrapped_kwargs = ctx.unwrap_tensors(normalized_kwargs)  # type: ignore[arg-type]
+    if "self" in unwrapped_kwargs:
+        warnings.warn(
+            "Using `self` as an argument in the definition of custom ops may lead to ambiguous parsing. Please consider using a different name for this argument to avoid potential issues."
+        )
     with ctx.redispatch_to_next():
         unwrapped_outs = auto_functionalized(
             op, **unwrapped_kwargs  # type: ignore[arg-type]

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -232,9 +232,9 @@ def do_auto_functionalize(
             normalized_kwargs[arg.name] = arg.default_value
 
     unwrapped_kwargs = ctx.unwrap_tensors(normalized_kwargs)  # type: ignore[arg-type]
-    if "self" in unwrapped_kwargs:
+    if "self" in unwrapped_kwargs or "self_" in unwrapped_kwargs:
         warnings.warn(
-            "Using `self` as an argument in the definition of custom ops may lead to ambiguous parsing. "
+            "Using `self` or `self_` as an argument in the definition of custom ops may lead to ambiguous parsing. "
             "Please consider using a different name for this argument to avoid potential issues."
         )
     with ctx.redispatch_to_next():

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 import inspect
 import typing
-import warnings
 from typing import List, Optional, Sequence, Union  # noqa: F401
 
 import torch  # noqa: F401
@@ -42,15 +41,6 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
     seen_args = set()
     saw_kwarg_only_arg = False
     for idx, (name, param) in enumerate(sig.parameters.items()):
-        if name == "self" and name in mutates_args:
-            new_name = "_torch_self"
-            mutates_args.remove(name)
-            mutates_args.add(new_name)
-            name = new_name
-            warnings.warn(
-                "`self` in mutates_args is not supported. It has been renamed to `_torch_self`.",
-                UserWarning,
-            )
         if not supported_param(param):
             error_fn("We do not support positional-only args, varargs, or varkwargs.")
 

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import inspect
 import typing
+import warnings
 from typing import List, Optional, Sequence, Union  # noqa: F401
 
 import torch  # noqa: F401
@@ -41,6 +42,15 @@ def infer_schema(prototype_function: typing.Callable, mutates_args=()) -> str:
     seen_args = set()
     saw_kwarg_only_arg = False
     for idx, (name, param) in enumerate(sig.parameters.items()):
+        if name == "self" and name in mutates_args:
+            new_name = "_torch_self"
+            mutates_args.remove(name)
+            mutates_args.add(new_name)
+            name = new_name
+            warnings.warn(
+                "`self` in mutates_args is not supported. It has been renamed to `_torch_self`.",
+                UserWarning,
+            )
         if not supported_param(param):
             error_fn("We do not support positional-only args, varargs, or varkwargs.")
 

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -289,7 +289,7 @@ class HigherOrderOperator(OperatorBase):
         self.non_fallthrough_keys = self.non_fallthrough_keys.remove(dispatch_key)
 
     # Use `self_` to avoid naming collide with custom ops arguments that are named "self".
-    def dispatch(self_, dispatch_key, *args, **kwargs):
+    def dispatch(self_, dispatch_key, *args, **kwargs):  # noqa: B902
         from torch.utils._python_dispatch import _get_current_dispatch_mode
 
         if dispatch_key in self_._dispatch_cache:
@@ -331,19 +331,19 @@ class HigherOrderOperator(OperatorBase):
                     curr_mode is not None
                 ), "Illegal invocation of dispatch on torch._C.DispatchKey.PreDispatch without a mode."
                 assert (
-                    type(curr_mode) in self.python_key_mode_table
+                    type(curr_mode) in self_.python_key_mode_table
                 ), f"Current active mode {curr_mode} not registered"
-                handler = self.python_key_mode_table[type(curr_mode)]
+                handler = self_.python_key_mode_table[type(curr_mode)]
                 with _pop_mode_temporarily(functionality_key) as mode:
                     return handler(mode, *args, **kwargs)
 
-        final_key = resolve_key(self, dispatch_key)
+        final_key = resolve_key(self_, dispatch_key)
 
         # This can current fail due to backend fallbacks.  You just have to
         # register them by hand for HigherOrderOperator.
-        if final_key not in self.py_kernels:
+        if final_key not in self_.py_kernels:
             raise NotImplementedError(
-                f"could not find kernel for HigherOrderOperator {self._name} "
+                f"could not find kernel for HigherOrderOperator {self_._name} "
                 f"at dispatch key {final_key} (resolved from {dispatch_key})"
             )
 
@@ -352,14 +352,14 @@ class HigherOrderOperator(OperatorBase):
         # Also we do same thing for normal ops:
         # See Note [Not Caching Per-Dispatch-Key Mode Handlers]
         if dispatch_key != torch._C.DispatchKey.PreDispatch:
-            self._dispatch_cache[dispatch_key] = self.py_kernels[final_key]
-        kernel = self.py_kernels[final_key]
+            self_._dispatch_cache[dispatch_key] = self_.py_kernels[final_key]
+        kernel = self_.py_kernels[final_key]
         # It's illegal to register DispatchKey to py_kernels, since there's no
         # C++ kernel to call into
         assert not isinstance(kernel, torch._C.DispatchKey)
         return kernel(*args, **kwargs)
 
-    def __call__(self_, *args, **kwargs):
+    def __call__(self_, *args, **kwargs):  # noqa: B902
         # Dynamo already traces the body of HigherOrderOp beforehand when it
         # so no need to trace into it.
         import torch._dynamo
@@ -370,7 +370,7 @@ class HigherOrderOperator(OperatorBase):
             flat_args = _to_flat_tuple(args, kwargs)
             if torch.overrides.has_torch_function(flat_args):
                 return torch.overrides.handle_torch_function(
-                    self, flat_args, *args, **kwargs
+                    self_, flat_args, *args, **kwargs
                 )
 
             dispatch_key_set = _compute_keyset(args, kwargs, self_.non_fallthrough_keys)

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -288,16 +288,17 @@ class HigherOrderOperator(OperatorBase):
     def fallthrough(self, dispatch_key):
         self.non_fallthrough_keys = self.non_fallthrough_keys.remove(dispatch_key)
 
-    def dispatch(self, dispatch_key, *args, **kwargs):
+    # Use `self_` to avoid naming collide with custom ops arguments that are named "self".
+    def dispatch(self_, dispatch_key, *args, **kwargs):
         from torch.utils._python_dispatch import _get_current_dispatch_mode
 
-        if dispatch_key in self._dispatch_cache:
-            kernel = self._dispatch_cache[dispatch_key]
+        if dispatch_key in self_._dispatch_cache:
+            kernel = self_._dispatch_cache[dispatch_key]
             assert not isinstance(kernel, torch._C.DispatchKey)
             return kernel(*args, **kwargs)
 
         if dispatch_key == torch._C.DispatchKey.FuncTorchDynamicLayerFrontMode:
-            return dispatch_functorch(self, args, kwargs)
+            return dispatch_functorch(self_, args, kwargs)
 
         if dispatch_key == torch._C.DispatchKey.Python:
             # The place to handle ProxyTorchDispatchMode, FakeTensorMode, etc
@@ -308,9 +309,9 @@ class HigherOrderOperator(OperatorBase):
                 curr_mode is not None
             ), "Illegal invocation of dispatch on torch._C.DispatchKey.Python without a mode."
             assert (
-                type(curr_mode) in self.python_key_mode_table
+                type(curr_mode) in self_.python_key_mode_table
             ), f"Current active mode {curr_mode} not registered"
-            handler = self.python_key_mode_table[type(curr_mode)]
+            handler = self_.python_key_mode_table[type(curr_mode)]
             with _pop_mode_temporarily() as mode:
                 return handler(mode, *args, **kwargs)
 
@@ -358,7 +359,7 @@ class HigherOrderOperator(OperatorBase):
         assert not isinstance(kernel, torch._C.DispatchKey)
         return kernel(*args, **kwargs)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self_, *args, **kwargs):
         # Dynamo already traces the body of HigherOrderOp beforehand when it
         # so no need to trace into it.
         import torch._dynamo
@@ -372,8 +373,8 @@ class HigherOrderOperator(OperatorBase):
                     self, flat_args, *args, **kwargs
                 )
 
-            dispatch_key_set = _compute_keyset(args, kwargs, self.non_fallthrough_keys)
-            return self.dispatch(
+            dispatch_key_set = _compute_keyset(args, kwargs, self_.non_fallthrough_keys)
+            return self_.dispatch(
                 dispatch_key_set.highestPriorityTypeId(), *args, **kwargs
             )
 


### PR DESCRIPTION
Fixes #124933

## Issue Summary
If users define `self` as mutate args, there is an error occurs `TypeError: AutoFunctionalized.__call__() got multiple values for argument 'self'`. For the following example, the schema for mutates_args is parsed as {"self": FakeTensor}.  https://github.com/pytorch/pytorch/blob/6df963a2c8077e80d8dd0f716b302aa72e8ea47e/torch/_higher_order_ops/auto_functionalize.py#L234
In the above line, it is unwrapped as `self=FakeTensor` and leads to wrong argument pass because `self` is the default keyword for functions of a class, such as https://github.com/pytorch/pytorch/compare/main...findhao/fix-self-custom-ops#diff-9453b6b52a54783beec3dd1c60248620f61c3a524d404a188af17bbdf6be3d9eR292 . 
```python
import torch

@torch.library.custom_op("mylib::foo", mutates_args={"self"})
def foo(self: torch.Tensor) -> None:
    self.sin_()

x = torch.randn(3)

@torch.compile(backend="inductor", fullgraph=True)
def f(x):
    foo(x)

f(x)
```
## Fix
This PR changes all related default argument `self` to `self_` following the existing way in https://github.com/pytorch/pytorch/blob/6fc771d19b1e0dc6be678bd447dd5c280fb56382/torch/_ops.py#L667 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang