### PR TITLE
Fix an example: Resolve broadcasting error in attn_bias and attn_mask…

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5615,7 +5615,7 @@ greater than 0.0 is specified. The optional scale argument can only be specified
     def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None) -> torch.Tensor:
         L, S = query.size(-2), key.size(-2)
         scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
-        attn_bias = torch.zeros(L, S, dtype=query.dtype)
+        attn_bias = torch.zeros(L, S, dtype=query.dtype).to(query.device)
         if is_causal:
             assert attn_mask is None
             temp_mask = torch.ones(L, S, dtype=torch.bool).tril(diagonal=0)
@@ -5626,7 +5626,7 @@ greater than 0.0 is specified. The optional scale argument can only be specified
             if attn_mask.dtype == torch.bool:
                 attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
             else:
-                attn_bias += attn_mask
+                attn_bias = attn_mask + attn_bias
         attn_weight = query @ key.transpose(-2, -1) * scale_factor
         attn_weight += attn_bias
         attn_weight = torch.softmax(attn_weight, dim=-1)


### PR DESCRIPTION
… addition, fix device assignment for newly created variables in method

Fix an example: Resolve broadcasting error in attn_bias and attn_mask addition, fix device assignment for newly created variables in method。
