### PR TITLE
Refactored multi-head attention implementation for efficiency and con…

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1387,9 +1387,9 @@ class MultiheadAttention(Module):
                 is_causal=is_causal,
             )
         if self.batch_first and is_batched:
-            return attn_output.transpose(1, 0), attn_output_weights
-        else:
             return attn_output, attn_output_weights
+        else:
+            return attn_output.transpose(1, 0), attn_output_weights
 
     def merge_masks(
         self,


### PR DESCRIPTION
…sistency in tensor operations.
Refactored multi-head attention implementation for efficiency and consistency in tensor operations.

After going through `torch.nn.functional.multi_head_attention_forward`, the shape of `attn_output` is `(bsz, len, embed_dim)`. This is then reshaped to `(tgt_len*bsz, embed_dim)` before being input to a linear layer, and the output is also `(tgt_len*bsz, embed_dim)`. However, when this vector is returned to `torch.nn.modules.activation.MultiheadAttention`, it is reshaped to `(len, bsz, embed_dim)` while `torch.nn.modules.activation.MultiheadAttention` reshaped it back to `(bsz, len, embed_dim)` for return.

Meanwhile, according to the official Tensor2Tensor code, the output of the multi-head attention is directly `(bsz, len, embed_dim)` in shape, which is then directly input to a linear layer, and the output remains `(bsz, len, embed_dim)`.

There are a couple of issues with the first implementation:

1. Reshaping the 3D vector to 2D before inputting to the linear layer is unnecessary and does not match the original implementation. See [tensor2tensor](https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/layers/common_attention.py#L4816).
2. Swapping the `bsz` and `len` dimensions, and then swapping them back, is also unnecessary.

Additionally, since the pytorch implementation involves swapping dimensions and merging the first two dimensions before inputting to the linear layer, this could impact the final results.


