### PR TITLE
Add support for global feedback in AutoHeuristic and enable it for mixed_mm

### DIFF
--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -4,11 +4,9 @@ import unittest
 
 import torch
 import torch._inductor.config as inductor_config
-from torch._inductor.autoheuristic.autoheuristic import (
-    AHContext,
-    AutoHeuristic,
-    LocalFeedback,
-)
+
+from torch._inductor.autoheuristic.autoheuristic import AutoHeuristic, LocalFeedback
+from torch._inductor.autoheuristic.autoheuristic_utils import AHContext
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import get_gpu_shared_memory
@@ -129,6 +127,22 @@ class AutoHeuristicTest(TestCase):
         # Make sure heuristic does not break anything
         # TODO (AlnisM): Find a way to check whether heuristic is used
         self.run_mm()
+
+    @inductor_config.patch(autoheuristic_collect="mixed_mm")
+    def test_global_feedback(self):
+        def fn(a, b):
+            return torch.mm(a, b.to(a.dtype))
+
+        a = torch.randn(8, 8, device="cuda")
+        b = torch.randint(-128, 127, (8, 8), dtype=torch.int8, device="cuda")
+        torch.compile(fn, mode="max-autotune-no-cudagraphs")(a, b)
+        path = self.get_path_to_autoheuristic_log("mixed_mm")
+        self.assertTrue(os.path.exists(path))
+        num_lines = self.count_lines_in_file(path)
+
+        # 1 line for metadata, 1 line for header
+        # 1 line for fallback + at least 1 config
+        self.assertTrue(num_lines > 4)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -4,7 +4,6 @@ import unittest
 
 import torch
 import torch._inductor.config as inductor_config
-
 from torch._inductor.autoheuristic.autoheuristic import AutoHeuristic, LocalFeedback
 from torch._inductor.autoheuristic.autoheuristic_utils import AHContext
 from torch._inductor.runtime.runtime_utils import cache_dir

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 
@@ -41,16 +41,7 @@ def get_metadata_str_from_log(log_path: str) -> str:
         return json_string
 
 
-class _Feedback:
-    """
-    This is a base class for Feedback objects. It takes a function that calculates the feedback for a given choice.
-    """
-
-    def __init__(self) -> None:
-        pass
-
-
-class LocalFeedback(_Feedback):
+class LocalFeedback:
     """
     To be able to collect data for a choice, a function providing feedback given a choice has to be provided.
     LocalFeedback can be used when AutoHeuristic should immediately run the function to collect feedback for each choice
@@ -63,23 +54,6 @@ class LocalFeedback(_Feedback):
 
     def __call__(self, choice: Choice) -> Feedback:
         return self.feedback_fn(choice)
-
-
-class GlobalFeedback(_Feedback):
-    """
-    In contrast to LocalFeedback, GlobalFeedback can be used when it is not possible to immediately collect feedback for
-    the provided choices. GlobalFeedback is required for example for kernel choice selection, where the feedback
-    will be provided later after autotuning has happened in select_algorithm.py.
-    """
-
-    def __init__(self, inputs: List[Any], choices: List[ChoiceCaller]) -> None:
-        """
-        Args:
-            inputs: List of inputs. This has to match the input_nodes that are passed to autotune_select_algorithm().
-        """
-        super().__init__()
-        self.inputs = inputs
-        self.choices = choices
 
 
 class InconsistentMetadata(Exception):
@@ -104,7 +78,7 @@ class AutoHeuristic:
         self,
         fallback: Callable[[], Choice],
         choices: List[Choice],
-        feedback: Union[LocalFeedback, GlobalFeedback],
+        feedback: Optional[LocalFeedback],
         context: AHContext,
         name: str,
         augment_context: Optional[List[AHOperation]] = None,
@@ -117,7 +91,7 @@ class AutoHeuristic:
             fallback: A callable that returns a Choice when the heuristic is unsure which choice to make, or
             AutoHeuristic is in data collection mode.
             choices: A list of possible choices the heuristic can make.
-            feedback: An instance of LocalFeedback or GlobalFeedback that provides feedback for a given choice.
+            feedback: An instance of LocalFeedback that provides feedback for a given choice.
             context: Context to store with each choice and feedback.
             name: A string that identifies the heuristic.
             augment_context: An optional list of AHOperation instances that augment the context.
@@ -151,10 +125,6 @@ class AutoHeuristic:
                 for choice in self.choices:
                     feedback_val = self.feedback(choice)
                     self.save_data(choice, feedback_val)
-            elif isinstance(self.feedback, GlobalFeedback):
-                self.register_global_feedback(
-                    self.feedback.inputs, self.feedback.choices
-                )
 
     def satisfies_precondition(self) -> bool:
         return self.precondition is None or self.precondition(
@@ -185,24 +155,6 @@ class AutoHeuristic:
 
     def get_collected_feedback(self, choice: Choice) -> Any:
         return self.collected_feedback.get(choice, None)
-
-    def register_global_feedback(
-        self, inputs: List[Any], choices: List[ChoiceCaller]
-    ) -> None:
-        from torch._inductor.select_algorithm import (
-            autoheuristic_registry,
-            create_inputs_key,
-            create_precompile_key,
-        )
-
-        inputs_key = create_inputs_key(inputs)
-        precompile_key = create_precompile_key(self.name, inputs_key, choices)
-
-        def store_global_feedback(ah_feedback: List[Tuple[str, float]]) -> None:
-            for choice, time in ah_feedback:
-                self.save_data(choice, time)
-
-        autoheuristic_registry[precompile_key] = store_global_feedback
 
     @staticmethod
     def get_device_identifier() -> str:
@@ -257,3 +209,69 @@ class AutoHeuristic:
 
         with open(log_path, "a") as f:
             f.write("\n".join(lines) + "\n")
+
+
+class AutoHeuristicSelectAlgorithm(AutoHeuristic):
+    """
+    AutoHeuristicSelectAlgorithm is a subclass of AutoHeuristic that allows one to collect data and learn a heuristic
+    when one wants to use AutoHeuristic for kernel choice selection.
+    """
+
+    def __init__(
+        self,
+        fallback: Callable[[], Optional[ChoiceCaller]],
+        choices: List[ChoiceCaller],
+        input_nodes: List[Any],
+        context: AHContext,
+        name: str,
+        augment_context: Optional[List[AHOperation]] = None,
+        precondition: Optional[Callable[[AHMetadata, AHContext], bool]] = None,
+    ) -> None:
+        self.input_nodes = input_nodes
+        self.choicestr2choice: Dict[str, ChoiceCaller] = {}
+        for choice in choices:
+            self.choicestr2choice[choice.autoheuristic_id()] = choice
+        choices_str = list(self.choicestr2choice.keys())
+
+        def fallback_str() -> str:
+            fallback_choice = fallback()
+            if fallback_choice is None:
+                # TODO: Find a nicer way to handle this
+                return "unsure"
+            return fallback_choice.autoheuristic_id()
+
+        super().__init__(
+            fallback_str,
+            choices_str,
+            None,
+            context,
+            name,
+            augment_context,
+            precondition,
+        )
+
+        self.register_global_feedback(input_nodes, choices)
+
+    def register_global_feedback(
+        self, input_nodes: List[Any], choices: List[ChoiceCaller]
+    ) -> None:
+        from torch._inductor.select_algorithm import (
+            autoheuristic_registry,
+            create_inputs_key,
+            create_precompile_key,
+        )
+
+        inputs_key = create_inputs_key(input_nodes)
+        precompile_key = create_precompile_key(self.name, inputs_key, choices)
+
+        def store_global_feedback(
+            ah_feedback: List[Tuple[ChoiceCaller, float]]
+        ) -> None:
+            for choice, time in ah_feedback:
+                self.save_data(choice.autoheuristic_id(), time)
+
+        autoheuristic_registry[precompile_key] = store_global_feedback
+
+    def get_choice_caller(self) -> Optional[ChoiceCaller]:
+        choice = self.get_choice()
+        return self.choicestr2choice.get(choice, None)

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -249,7 +249,8 @@ class AutoHeuristicSelectAlgorithm(AutoHeuristic):
             precondition,
         )
 
-        self.register_global_feedback(input_nodes, choices)
+        if self.satisfies_precondition():
+            self.register_global_feedback(input_nodes, choices)
 
     def register_global_feedback(
         self, input_nodes: List[Any], choices: List[ChoiceCaller]

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -121,7 +121,7 @@ class AutoHeuristic:
             self.log_path = torch._inductor.config.autoheuristic_log_path
 
         if torch._inductor.config.collect_autoheuristic(self.name):
-            if isinstance(self.feedback, LocalFeedback):
+            if self.feedback is not None:
                 for choice in self.choices:
                     feedback_val = self.feedback(choice)
                     self.save_data(choice, feedback_val)

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -49,7 +49,6 @@ class LocalFeedback:
     """
 
     def __init__(self, feedback_fn: Callable[[Choice], Feedback]) -> None:
-        super().__init__()
         self.feedback_fn = feedback_fn
 
     def __call__(self, choice: Choice) -> Feedback:

--- a/torch/_inductor/autoheuristic/autoheuristic_utils.py
+++ b/torch/_inductor/autoheuristic/autoheuristic_utils.py
@@ -266,3 +266,6 @@ def get_is_contig_ops() -> List[AHOperation]:
     )
 
     return [mat1_is_contig_op, mat2_is_contig_op]
+def context_add_strides(context: AHContext, name: str, stride: Tuple[int, ...]) -> None:
+    for i, s in enumerate(stride):
+        context.add_feature(f"{name}_stride_{i}", s)

--- a/torch/_inductor/autoheuristic/autoheuristic_utils.py
+++ b/torch/_inductor/autoheuristic/autoheuristic_utils.py
@@ -266,6 +266,8 @@ def get_is_contig_ops() -> List[AHOperation]:
     )
 
     return [mat1_is_contig_op, mat2_is_contig_op]
+
+
 def context_add_strides(context: AHContext, name: str, stride: Tuple[int, ...]) -> None:
     for i, s in enumerate(stride):
         context.add_feature(f"{name}_stride_{i}", s)

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -16,6 +16,7 @@ from torch._inductor.autoheuristic.autoheuristic import (
     LocalFeedback,
 )
 from torch._inductor.autoheuristic.autoheuristic_utils import (
+    context_add_strides,
     pad_mm_operations,
     pad_mm_precondition,
 )
@@ -583,12 +584,8 @@ def get_context(
     context.add_feature("k", mat1.shape[1])
     context.add_feature("n", mat2.shape[1])
 
-    mat1_strides = mat1.stride()
-    mat2_strides = mat2.stride()
-    context.add_feature("mat1_stride_0", mat1_strides[0])
-    context.add_feature("mat1_stride_1", mat1_strides[1])
-    context.add_feature("mat2_stride_0", mat2_strides[0])
-    context.add_feature("mat2_stride_1", mat2_strides[1])
+    context_add_strides(context, "mat1", mat1.stride())
+    context_add_strides(context, "mat2", mat2.stride())
 
     context.add_feature("m_padded_length", m_padded_length)
     context.add_feature("k_padded_length", k_padded_length)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3789,6 +3789,9 @@ class ChoiceCaller:
         """Information returned here is logged to the autotune log file when that is enabled."""
         return {}
 
+    def autoheuristic_id(self) -> str:
+        raise NotImplementedError
+
 
 class TritonTemplateCallerBase(ChoiceCaller):
     def get_make_kernel_render(self) -> Any:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3790,7 +3790,7 @@ class ChoiceCaller:
         return {}
 
     def autoheuristic_id(self) -> str:
-        raise "unsupported_choice"
+        return "unsupported_choice"
 
 
 class TritonTemplateCallerBase(ChoiceCaller):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3790,7 +3790,7 @@ class ChoiceCaller:
         return {}
 
     def autoheuristic_id(self) -> str:
-        raise NotImplementedError
+        raise "unsupported_choice"
 
 
 class TritonTemplateCallerBase(ChoiceCaller):

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -492,7 +492,7 @@ def mixed_mm_autoheuristic(mat1, mat2, m, n, k, choices, name, input_nodes):
     for choice in choices:
         choicestr2choice[choice.autoheuristic_id()] = choice
     choices_str = list(choicestr2choice.keys())
-    feedback = GlobalFeedback(inputs=input_nodes)
+    feedback = GlobalFeedback(inputs=input_nodes, choices=choices)
     context = get_context(m, k, n, mat1, mat2)
     autoheuristic = AutoHeuristic(
         fallback=fallback,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -906,6 +906,19 @@ class TritonTemplateCaller(ir.TritonTemplateCallerBase):
     def get_make_kernel_render(self):
         return self.make_kernel_render
 
+    def autoheuristic_id(self):
+        type_name = "triton"
+        info = self.info_dict()
+        # TODO(AlnisM): Does tile_shape always exist?
+        tile = info["tile_shape"]
+        tile_vals = eval(tile)  # type: ignore[arg-type]
+        BLOCK_M = tile_vals[0]
+        BLOCK_K = tile_vals[1]
+        BLOCK_N = tile_vals[2]
+        num_stages = info["num_stages"]
+        num_warps = info["num_warps"]
+        return f"type={type_name}_BLOCK-M={BLOCK_M}_BLOCK-K={BLOCK_K}_BLOCK-N={BLOCK_N}_numstages={num_stages}_numwarps={num_warps}"
+
 
 class ExternKernelCaller(ChoiceCaller):
     def __init__(
@@ -989,6 +1002,9 @@ class ExternKernelCaller(ChoiceCaller):
             "backend": "extern",
             "kernel_call_name": self.choice.call_name(),
         }
+
+    def autoheuristic_id(self):
+        return f"extern_{self.choice.name}"
 
 
 @functools.lru_cache(None)
@@ -1117,6 +1133,25 @@ def get_env_num_workers() -> Optional[int]:
     return None
 
 
+# keeps track of the situations where autotuning results should be transfered to AutoHeuristic
+autoheuristic_registry: Dict[str, Callable[[List[Tuple[str, float]]], None]] = {}
+
+
+def create_inputs_key(input_nodes):
+    return repr([AlgorithmSelectorCache.key_of(x) for x in input_nodes])
+
+
+def create_precompile_key(name: str, inputs_key: str) -> str:
+    return ":".join(
+                [
+                    name,
+                    inputs_key,
+                    torch.get_float32_matmul_precision(),
+                ]
+                + [choice.hash_key() for choice in choices]
+            )
+
+
 class AlgorithmSelectorCache(PersistentCache):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1176,7 +1211,7 @@ class AlgorithmSelectorCache(PersistentCache):
         def make_benchmark_fn():
             return self.make_benchmark_fn(choices, input_nodes, layout, input_gen_fns)
 
-        inputs_key = repr([self.key_of(x) for x in input_nodes])
+        inputs_key = create_inputs_key(input_nodes)
 
         def precompile(choices) -> Callable[[], None]:
             def no_op(*args, **kwargs):
@@ -1218,14 +1253,7 @@ class AlgorithmSelectorCache(PersistentCache):
             ):
                 return no_op
 
-            precompile_key = ":".join(
-                [
-                    name,
-                    inputs_key,
-                    torch.get_float32_matmul_precision(),
-                ]
-                + [choice.hash_key() for choice in choices]
-            )
+            precompile_key = create_precompile_key(name, inputs_key)
             if precompile_func := self.precompile_cache.get(precompile_key):
                 return precompile_func
 
@@ -1313,6 +1341,13 @@ class AlgorithmSelectorCache(PersistentCache):
                 self.log_results(
                     name, input_nodes, timings, autotune_elapse, precompile_elapse
                 )
+
+            precompile_key = create_precompile_key(name, inputs_key)
+            if precompile_key in autoheuristic_registry:
+                ah_feedback = []
+                for choice, timing in timings.items():
+                    ah_feedback.append((choice.autoheuristic_id(), timing))
+                autoheuristic_registry[precompile_key](ah_feedback)
 
             return timings
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1342,12 +1342,13 @@ class AlgorithmSelectorCache(PersistentCache):
                     name, input_nodes, timings, autotune_elapse, precompile_elapse
                 )
 
-            precompile_key = create_precompile_key(name, inputs_key)
-            if precompile_key in autoheuristic_registry:
-                ah_feedback = []
-                for choice, timing in timings.items():
-                    ah_feedback.append((choice.autoheuristic_id(), timing))
-                autoheuristic_registry[precompile_key](ah_feedback)
+            if config.collect_autoheuristic(name):
+                precompile_key = create_precompile_key(name, inputs_key)
+                if precompile_key in autoheuristic_registry:
+                    ah_feedback = []
+                    for choice, timing in timings.items():
+                        ah_feedback.append((choice.autoheuristic_id(), timing))
+                    autoheuristic_registry[precompile_key](ah_feedback)
 
             return timings
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1141,15 +1141,17 @@ def create_inputs_key(input_nodes):
     return repr([AlgorithmSelectorCache.key_of(x) for x in input_nodes])
 
 
-def create_precompile_key(name: str, inputs_key: str) -> str:
+def create_precompile_key(
+    name: str, inputs_key: str, choices: List[ChoiceCaller]
+) -> str:
     return ":".join(
-                [
-                    name,
-                    inputs_key,
-                    torch.get_float32_matmul_precision(),
-                ]
-                + [choice.hash_key() for choice in choices]
-            )
+        [
+            name,
+            inputs_key,
+            torch.get_float32_matmul_precision(),
+        ]
+        + [choice.hash_key() for choice in choices]
+    )
 
 
 class AlgorithmSelectorCache(PersistentCache):
@@ -1253,7 +1255,7 @@ class AlgorithmSelectorCache(PersistentCache):
             ):
                 return no_op
 
-            precompile_key = create_precompile_key(name, inputs_key)
+            precompile_key = create_precompile_key(name, inputs_key, choices)
             if precompile_func := self.precompile_cache.get(precompile_key):
                 return precompile_func
 
@@ -1343,7 +1345,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 )
 
             if config.collect_autoheuristic(name):
-                precompile_key = create_precompile_key(name, inputs_key)
+                precompile_key = create_precompile_key(name, inputs_key, choices)
                 if precompile_key in autoheuristic_registry:
                     ah_feedback = []
                     for choice, timing in timings.items():

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1134,7 +1134,9 @@ def get_env_num_workers() -> Optional[int]:
 
 
 # keeps track of the situations where autotuning results should be transfered to AutoHeuristic
-autoheuristic_registry: Dict[str, Callable[[List[Tuple[str, float]]], None]] = {}
+autoheuristic_registry: Dict[
+    str, Callable[[List[Tuple[ChoiceCaller, float]]], None]
+] = {}
 
 
 def create_inputs_key(input_nodes):
@@ -1349,7 +1351,7 @@ class AlgorithmSelectorCache(PersistentCache):
                 if precompile_key in autoheuristic_registry:
                     ah_feedback = []
                     for choice, timing in timings.items():
-                        ah_feedback.append((choice.autoheuristic_id(), timing))
+                        ah_feedback.append((choice, timing))
                     autoheuristic_registry[precompile_key](ah_feedback)
 
             return timings


### PR DESCRIPTION
This PR enables AutoHeuristic for kernel choice selection, where the feedback can not immediately be provided when AutoHeuristic is called, but only after autotuning has happened. The steps are the following:
- When the AutoHeuristic constructor is called, AutoHeuristic registers a function in select_algorithm.py.
- After autotuning in select_algorithm.py has happened, and there is an entry in `autoheuristic_registry`, select_algorithm provides the autotuning results to AutoHeuristic, which stores the results.

I enabled AutoHeuristic for mixed_mm to have an example to test it on. We probably want to add more context, and also add an augment_context function. I will add support for this in another PR.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang