### PR TITLE
Mark some test_decomp tests as slow on win

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18328,8 +18328,8 @@ op_db: List[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs__unsafe_masked_index,
            skips=(
-                DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu',
-                             dtypes=(torch.float64,), active_if=IS_WINDOWS),
+               DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu',
+                            dtypes=(torch.float64,), active_if=IS_WINDOWS),
            ),),
     OpInfo('_unsafe_masked_index_put_accumulate',
            dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16, torch.bool),
@@ -18346,8 +18346,8 @@ op_db: List[OpInfo] = [
            ),
            sample_inputs_func=sample_inputs__unsafe_masked_index_put_accumulate,
            skips=(
-                DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu',
-                             dtypes=(torch.float64,), active_if=IS_WINDOWS),
+               DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu',
+                            dtypes=(torch.float64,), active_if=IS_WINDOWS),
            ),),
     OpInfo('__getitem__',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16, torch.chalf),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18326,7 +18326,10 @@ op_db: List[OpInfo] = [
            supports_scripting=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
-           sample_inputs_func=sample_inputs__unsafe_masked_index),
+           sample_inputs_func=sample_inputs__unsafe_masked_index,
+           skips=(
+                DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu', dtypes=(torch.float64,), active_if=IS_WINDOWS),
+           ),),
     OpInfo('_unsafe_masked_index_put_accumulate',
            dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16, torch.bool),
            supports_out=False,
@@ -18340,7 +18343,10 @@ op_db: List[OpInfo] = [
                    'TestInductorOpInfo', 'test_comprehensive', device_type='cpu'
                ),
            ),
-           sample_inputs_func=sample_inputs__unsafe_masked_index_put_accumulate),
+           sample_inputs_func=sample_inputs__unsafe_masked_index_put_accumulate,
+           skips=(
+                DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu', dtypes=(torch.float64,), active_if=IS_WINDOWS),
+           ),),
     OpInfo('__getitem__',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16, torch.chalf),
            # Runs very slowly on slow gradcheck - alternatively reduce input sizes
@@ -20641,7 +20647,10 @@ op_db: List[OpInfo] = [
         supports_out=False,
         sample_inputs_func=sample_inputs_grid_sampler_2d,
         supports_gradgrad=False,
-        gradcheck_nondet_tol=1e-15),
+        gradcheck_nondet_tol=1e-15,
+        skips=(
+            DecorateInfo(slowTest, 'TestDecomp', 'test_comprehensive', dtypes=(torch.float32, torch.float64), active_if=IS_WINDOWS),
+        ),),
     OpInfo(
         "argwhere",
         ref=np.argwhere,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18328,7 +18328,8 @@ op_db: List[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs__unsafe_masked_index,
            skips=(
-                DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu', dtypes=(torch.float64,), active_if=IS_WINDOWS),
+                DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu',
+                             dtypes=(torch.float64,), active_if=IS_WINDOWS),
            ),),
     OpInfo('_unsafe_masked_index_put_accumulate',
            dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16, torch.bool),
@@ -18345,7 +18346,8 @@ op_db: List[OpInfo] = [
            ),
            sample_inputs_func=sample_inputs__unsafe_masked_index_put_accumulate,
            skips=(
-                DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu', dtypes=(torch.float64,), active_if=IS_WINDOWS),
+                DecorateInfo(slowTest, 'TestDecomp', 'test_quick_core_backward', device_type='cpu',
+                             dtypes=(torch.float64,), active_if=IS_WINDOWS),
            ),),
     OpInfo('__getitem__',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16, torch.chalf),
@@ -20649,7 +20651,8 @@ op_db: List[OpInfo] = [
         supports_gradgrad=False,
         gradcheck_nondet_tol=1e-15,
         skips=(
-            DecorateInfo(slowTest, 'TestDecomp', 'test_comprehensive', dtypes=(torch.float32, torch.float64), active_if=IS_WINDOWS),
+            DecorateInfo(slowTest, 'TestDecomp', 'test_comprehensive', dtypes=(torch.float32, torch.float64),
+                         active_if=IS_WINDOWS),
         ),),
     OpInfo(
         "argwhere",


### PR DESCRIPTION
Auto slow test detection is marking and then un marking these as slow, so permanently mark them as slow on windows.

These tests take >500s on windows.

This is part of the reason why test_decomp keeps failing on windows (ex https://hud.pytorch.org/pytorch/pytorch/commit/da66e50e6e5ea1cdc6d7ed3116bc2aa49ff6e5b3)

The other part is something to do with reruns + thresholds that I am still investigating