### PR TITLE
[inductor] Add TORCHINDUCTOR_ADDITIONAL_COMPILER_FLAGS

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1244,6 +1244,8 @@ def optimization_flags() -> str:
         base_flags += " -fno-unsafe-math-optimizations"
     if not config.cpp.enable_floating_point_contract_flag:
         base_flags += " -ffp-contract=off"
+    for additional_flag in config.cpp.additional_compiler_flags:
+        base_flags += " " + additional_flag
 
     if config.is_fbcode():
         # FIXME: passing `-fopenmp` adds libgomp.so to the generated shared library's dependencies.

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -655,6 +655,11 @@ class cpp:
         == "1"
     )
 
+    # Pass additional flags to the compiler, separated by ";"
+    additional_compiler_flags = os.environ.get(
+        "TORCHINDUCTOR_ADDITIONAL_COMPILER_FLAGS", ""
+    ).split(";")
+
 
 # config specific to codegen/triton.py
 class triton:


### PR DESCRIPTION
Summary: Add TORCHINDUCTOR_ADDITIONAL_COMPILER_FLAGS so that the additional compiler flags can be added to compile command.

Test Plan: - sandcastle

Differential Revision: D59285311


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang