### PR TITLE
[inductor][cpp] force inline codegen function

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3991,7 +3991,7 @@ class KernelGroup:
         arg_defs = ",\n".ljust(25).join(arg_defs)
         func_export_decl = self.get_export_declaration()
         code.writeline(
-            f'extern "C" {func_export_decl} void {kernel_decl_name}({arg_defs})'
+            f'extern "C" {func_export_decl} void C10_ALWAYS_INLINE {kernel_decl_name}({arg_defs})'
         )
 
         # 3. Function body


### PR DESCRIPTION
Summary: Force inline the codegen function because it cannot always be inlined automatically by clang.

Differential Revision: D59491911


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang