### PR TITLE
[dtensor] slice_backward to use op strategy

### DIFF
--- a/torch/distributed/_tensor/ops/experimental_ops.py
+++ b/torch/distributed/_tensor/ops/experimental_ops.py
@@ -1,43 +1,26 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # implement matrix related ops for distributed tensor
-from typing import List
 
 import torch
-from torch.distributed._tensor._op_schema import OpSchema, OutputSharding
-from torch.distributed._tensor.ops.utils import register_prop_rule
-from torch.distributed._tensor.placement_types import DTensorSpec, TensorMeta
+from torch.distributed._tensor._op_schema import (
+    OpSchema,
+    OpStrategy,
+    PlacementStrategy,
+    StrategyType,
+)
+from torch.distributed._tensor.device_mesh import DeviceMesh
+from torch.distributed._tensor.ops.utils import register_op_strategy
+from torch.distributed._tensor.placement_types import DTensorSpec, Replicate
 
 
 aten = torch.ops.aten
 
 
-try:
-    import numpy as np
-except ModuleNotFoundError:
-    np = None  # type: ignore[assignment]
-
-
-@register_prop_rule(aten.slice_backward.default)
-def slice_backward_rules(op_schema: OpSchema) -> OutputSharding:
-    grad_output_spec, input_sizes, dim, start, end, step = op_schema.args_schema
-    assert isinstance(grad_output_spec, DTensorSpec)
-    assert isinstance(input_sizes, List)
-    assert grad_output_spec.tensor_meta is not None
-    grad_input_stride = list(np.cumprod(input_sizes[::-1])[:-1][::-1])
-    grad_input_stride.append(1)
-    dim_map = grad_output_spec.dim_map
-    sums = grad_output_spec.sums
-
-    grad_input_tensor_meta = TensorMeta(
-        torch.Size(input_sizes),
-        tuple(grad_input_stride),
-        grad_output_spec.tensor_meta.dtype,
-    )
-    grad_input_spec = DTensorSpec.from_dim_map(
-        grad_output_spec.mesh,
-        dim_map,
-        sums,
-        tensor_meta=grad_input_tensor_meta,
-    )
-
-    return OutputSharding(grad_input_spec)
+@register_op_strategy(aten.slice_backward.default)
+def slice_backward_rules(mesh: DeviceMesh, op_schema: OpSchema) -> StrategyType:
+    """
+    slice_backward is a new_zeros + slice_scatter, we only allow replication
+    on the input/output for now since new_zeros would produce replication
+    """
+    replicate_spec = DTensorSpec(mesh, tuple([Replicate()] * mesh.ndim))
+    return OpStrategy([PlacementStrategy(replicate_spec)])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #130289
* #130288
* __->__ #130287
* #130286

as titled. slice_backward right now forward the sharding
unconditionally, which is wrong mathmatically. This PR switch it to op
strategy and only allow replication

cc @XilunWu @H-Huang @awgu @kwen2501 @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o