### PR TITLE
[CCA][Memory Snapshot] Stop duplicating annotations to all device_traces

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3044,9 +3044,9 @@ class NativeCachingAllocator : public CUDAAllocator {
   }
 
   void recordAnnotation(const std::shared_ptr<GatheredContext>& name) override {
-    for (auto& allocator : device_allocator) {
-      allocator->recordAnnotation(name);
-    }
+    c10::DeviceIndex device = 0;
+    C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
+    device_allocator[device]->recordAnnotation(name);
   }
 
   bool isHistoryEnabled() override {


### PR DESCRIPTION
Summary: This diff fixes a bug, where all record_annotations will save a TraceEntry to each of the device_traces. Instead, we should only save annotations to the current device_trace that is being called by the thread calling the native allocator's recordAnnotation.

Test Plan: CI and ran workloads on MVAI WPR FBR.

Reviewed By: zdevito

Differential Revision: D59477339

Pulled By: aaronenyeshi
