### PR TITLE
[DO NOT MERGE] [Testing CI] ROCm keyboard interrupt investigation

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -349,7 +349,7 @@ test_inductor_shard() {
     --verbose
 
   # Do not add --inductor for the following inductor unit tests, otherwise we will fail because of nested dynamo state
-  python test/run_test.py \
+  python test/run_test.py --full-trace \
     --include inductor/test_torchinductor inductor/test_torchinductor_opinfo inductor/test_aot_inductor \
     --shard "$1" "$NUM_TEST_SHARDS" \
     --verbose


### PR DESCRIPTION
ROCm inductor workflow is seeing KeyboardInterrupts in test_torchinductor_opinfo, attempting run the test_inductor shard with `--full-trace` to get a full story.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang