### PR TITLE
increase tensor size to force out of memory exception on the latest generations of GPUs

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -715,7 +715,9 @@ class TestProfiler(TestCase):
 
         def create_cuda_tensor_oom():
             device = torch.device("cuda:0")
-            return torch.empty(1024, 1024, 1024, 1024, dtype=torch.float32, device=device)
+            return torch.empty(
+                1024, 1024, 1024, 1024, dtype=torch.float32, device=device
+            )
 
         def check_trace(fname):
             prof.export_chrome_trace(fname)

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -715,7 +715,7 @@ class TestProfiler(TestCase):
 
         def create_cuda_tensor_oom():
             device = torch.device("cuda:0")
-            return torch.empty(1024, 1024, 1024, 20, dtype=torch.float32, device=device)
+            return torch.empty(1024, 1024, 1024, 1024, dtype=torch.float32, device=device)
 
         def check_trace(fname):
             prof.export_chrome_trace(fname)


### PR DESCRIPTION
This PR fixes profiler/test_profiler.py::.TestProfiler::test_oom_tracing
Test expects OOM by allocating huge tensor. But MI300X has enough memory to allocate such a tensor.
This PR increases tensor size with a large margin to force OutOfMemory exception on MI300X and future GPU generations

cc: @jithunnair-amd @pruthvistony @jeffdaily 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang