### PR TITLE
bump custom op input size

### DIFF
--- a/c10/util/Bitset.h
+++ b/c10/util/Bitset.h
@@ -27,7 +27,7 @@ struct bitset final {
 #endif
  public:
   static constexpr size_t NUM_BITS() {
-    return 8 * sizeof(bitset_type);
+    return 100 * sizeof(bitset_type);
   }
 
   constexpr bitset() noexcept = default;


### PR DESCRIPTION
Currently the upper bound of custom operator inputs is 64
```
8 * sizeof(bitset_type) => 8 * 8 = 64
```
Bump it to 800 (`100 * sizeof(bitset_type)` to accommodate the case when the custom has 516 inputs. 

