### PR TITLE
[torch][fx] Add normalize_args constructor argument to FxGraphDrawer

### DIFF
--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -9,6 +9,7 @@ import torch.fx
 from torch.fx._compatibility import compatibility
 from torch.fx.graph import _parse_stack_trace
 from torch.fx.node import _format_arg, _get_qualified_name
+from torch.fx.operator_schemas import normalize_function
 from torch.fx.passes.shape_prop import TensorMetadata
 
 
@@ -75,11 +76,13 @@ if HAS_PYDOT:
             skip_node_names_in_args: bool = True,
             parse_stack_trace: bool = False,
             dot_graph_shape: Optional[str] = None,
+            normalize_args: bool = False,
         ):
             self._name = name
             self.dot_graph_shape = (
                 dot_graph_shape if dot_graph_shape is not None else "record"
             )
+            self.normalize_args = normalize_args
             _WEIGHT_TEMPLATE["shape"] = self.dot_graph_shape
 
             self._dot_graphs = {
@@ -96,7 +99,6 @@ if HAS_PYDOT:
 
                 if not isinstance(leaf_node, torch.fx.GraphModule):
                     continue
-
 
                 self._dot_graphs[f"{name}_{node.target}"] = self._to_dot(
                     leaf_node,
@@ -247,10 +249,21 @@ if HAS_PYDOT:
                 label += extra + r"\n"
             else:
                 label += f"|target={self._typename(node.target)}" + r"\n"
-                if len(node.args) > 0:
-                    label += _get_str_for_args_kwargs(node.args)
-                if len(node.kwargs) > 0:
-                    label += _get_str_for_args_kwargs(node.kwargs)
+                if self.normalize_args:
+                    try:
+                        args, kwargs = normalize_function(
+                            node.target, node.args, node.kwargs, normalize_to_only_use_kwargs=True
+                        )
+                    except Exception:
+                        # Fallback to not normalizing if there's an exception.
+                        # Some functions need overloads specified to normalize.
+                        args, kwargs = node.args, node.kwargs
+                else:
+                    args, kwargs = node.args, node.kwargs
+                if len(args) > 0:
+                    label += _get_str_for_args_kwargs(args)
+                if len(kwargs) > 0:
+                    label += _get_str_for_args_kwargs(kwargs)
                 label += f"|num_users={len(node.users)}" + r"\n"
 
             tensor_meta = node.meta.get('tensor_meta')
@@ -424,6 +437,7 @@ else:
                 skip_node_names_in_args: bool = True,
                 parse_stack_trace: bool = False,
                 dot_graph_shape: Optional[str] = None,
+                normalize_args: bool = False,
             ):
                 raise RuntimeError('FXGraphDrawer requires the pydot package to be installed. Please install '
                                    'pydot through your favorite Python package manager.')


### PR DESCRIPTION
Summary:
When writing out Graphviz files for graphs, sometimes the arguments are all
in a row and it's unclear which is which. Like for `aten.conv2d`, someone might not
remember the stride, padding, dilation order.

Add an option `normalize_args` (defaults to False) to normalize all args into kwargs.
This should help the readability of a graph.

Differential Revision: D59529417
