### PR TITLE
torch.distributed: skip waitForWorkers in shared env

### DIFF
--- a/torch/csrc/distributed/c10d/PrefixStore.cpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.cpp
@@ -128,4 +128,8 @@ c10::intrusive_ptr<Store> PrefixStore::getUnderlyingNonPrefixStore() {
   return store;
 }
 
+const std::string& PrefixStore::prefix() const {
+  return prefix_;
+}
+
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/PrefixStore.hpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.hpp
@@ -55,6 +55,9 @@ class TORCH_API PrefixStore : public Store {
   // Recursively to fetch the store before layers of wrapping with PrefixStore.
   c10::intrusive_ptr<Store> getUnderlyingNonPrefixStore();
 
+  // Returns the prefix this store was initialized with.
+  const std::string& prefix() const;
+
  protected:
   std::string prefix_;
   c10::intrusive_ptr<Store> store_;

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1533,7 +1533,11 @@ Arguments:
       .def_property_readonly(
           "_underlying_non_prefix_store",
           &::c10d::PrefixStore::getUnderlyingNonPrefixStore,
-          R"(Recursively to get the store before layers of wrapping with PrefixStore.)");
+          R"(Recursively to get the store before layers of wrapping with PrefixStore.)")
+      .def_property_readonly(
+          "prefix",
+          &::c10d::PrefixStore::prefix,
+          "Gets the prefix string that is prepended to each key before being inserted into the store.");
 
   using namespace std::chrono_literals;
 

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -182,7 +182,16 @@ def _create_c10d_store(
 
     if _torchelastic_use_agent_store():
         attempt = os.environ["TORCHELASTIC_RESTART_COUNT"]
-        tcp_store = TCPStore(hostname, port, world_size, False, timeout)
+        tcp_store = TCPStore(
+            host_name=hostname,
+            port=port,
+            world_size=world_size,
+            is_master=False,
+            timeout=timeout,
+            # wait_for_workers is a noop when using a shared store with no
+            # master so we can disable it or performance reasons.
+            wait_for_workers=False,
+        )
         return PrefixStore(f"/worker/attempt_{attempt}", tcp_store)
     else:
         start_daemon = rank == 0


### PR DESCRIPTION
waitForWorkers doesn't do anything if none of the stores being initialized is the server. They merely increment a counter and immediately return without checking the value.

This just eliminates that call which should reduce some load on the TCPStore server.

Test plan:

Added test for rendezvous

```
python test/distributed/test_store.py -v -k shared
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @chauhang