### PR TITLE
Fix Apple crash when running PyTorch with Metal API validation turned on

### DIFF
--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -829,8 +829,8 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst) {
     [computeEncoder setComputePipelineState:gatherPSO];
     mtl_setBuffer(computeEncoder, src, 0);
     mtl_setBuffer(computeEncoder, dst.has_storage() ? dst : output, 1);
-    [computeEncoder setBytes:&src_sizes[0] length:sizeof(uint32_t) * kernel_size atIndex:2];
-    [computeEncoder setBytes:&src_strides[0] length:sizeof(uint32_t) * kernel_size atIndex:3];
+    [computeEncoder setBytes:&src_sizes[0] length:sizeof(uint32_t) * src_sizes.size() atIndex:2];
+    [computeEncoder setBytes:&src_strides[0] length:sizeof(uint32_t) * src_strides.size() atIndex:3];
     [computeEncoder setBytes:&numThreads length:sizeof(uint32_t) atIndex:4];
     mtl_dispatch1DJob(computeEncoder, gatherPSO, numThreads);
 
@@ -885,8 +885,8 @@ Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output) {
       [computeEncoder setComputePipelineState:scatterPSO];
       mtl_setBuffer(computeEncoder, src, 0);
       mtl_setBuffer(computeEncoder, output, 1);
-      [computeEncoder setBytes:&output_sizes[0] length:sizeof(uint32_t) * kernel_size atIndex:2];
-      [computeEncoder setBytes:&output_strides[0] length:sizeof(uint32_t) * kernel_size atIndex:3];
+      [computeEncoder setBytes:&output_sizes[0] length:sizeof(uint32_t) * output_sizes.size() atIndex:2];
+      [computeEncoder setBytes:&output_strides[0] length:sizeof(uint32_t) * output_strides.size() atIndex:3];
       [computeEncoder setBytes:&numThreads length:sizeof(uint32_t) atIndex:4];
       mtl_dispatch1DJob(computeEncoder, scatterPSO, numThreads);
 

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -829,8 +829,8 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst) {
     [computeEncoder setComputePipelineState:gatherPSO];
     mtl_setBuffer(computeEncoder, src, 0);
     mtl_setBuffer(computeEncoder, dst.has_storage() ? dst : output, 1);
-    [computeEncoder setBytes:&src_sizes[0] length:sizeof(uint32_t) * src_sizes.size() atIndex:2];
-    [computeEncoder setBytes:&src_strides[0] length:sizeof(uint32_t) * src_strides.size() atIndex:3];
+    mtl_setBytes(computeEncoder, src_sizes, 2);
+    mtl_setBytes(computeEncoder, src_strides, 3);
     [computeEncoder setBytes:&numThreads length:sizeof(uint32_t) atIndex:4];
     mtl_dispatch1DJob(computeEncoder, gatherPSO, numThreads);
 
@@ -885,8 +885,8 @@ Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output) {
       [computeEncoder setComputePipelineState:scatterPSO];
       mtl_setBuffer(computeEncoder, src, 0);
       mtl_setBuffer(computeEncoder, output, 1);
-      [computeEncoder setBytes:&output_sizes[0] length:sizeof(uint32_t) * output_sizes.size() atIndex:2];
-      [computeEncoder setBytes:&output_strides[0] length:sizeof(uint32_t) * output_strides.size() atIndex:3];
+      mtl_setBytes(computeEncoder, output_sizes, 2);
+      mtl_setBytes(computeEncoder, output_strides, 3);
       [computeEncoder setBytes:&numThreads length:sizeof(uint32_t) atIndex:4];
       mtl_dispatch1DJob(computeEncoder, scatterPSO, numThreads);
 


### PR DESCRIPTION
Fixes #130376 (at least, for my usage)

There may be other places in the code base where `-setBytes:length:` is called with a length of 0 besides this, but this is the case that has triggered for me. Please let me know if there are any specific tests I should run.