### PR TITLE
[decomps] Fix aten._to_copy decomp

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -2314,6 +2314,23 @@ class GraphModule(torch.nn.Module):
             """{'sin': ['sin']}""",
         )
 
+    def test_vmap_multiply_scalar(self):
+        @torch.compile(backend="inductor", fullgraph=True)
+        def g(x):
+            return torch.vmap(torch.mul, in_dims=(0, None))(x, 3.14)
+
+        x = torch.randn(3)
+        y = g(x)
+        self.assertEqual(y, x * 3.14)
+
+        @torch.compile(backend="inductor", fullgraph=True)
+        def f(x):
+            return torch.vmap(torch.mul, in_dims=(0, None))(x, 314)
+
+        x = torch.randn(3)
+        y = f(x)
+        self.assertEqual(y, x * 314)
+
     def test_vmap_source_fn_stack(self):
         backend = EagerAndRecordGraphs()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130381

`aten._to_copy` can receive a python number as input. This occurs in
torch.compile support for vmap (see #130188). Previously, this would
raise an assertion error. This PR changes it so that if we see a python
number, we call torch.scalar_tensor on it first (h/t @bdhirsh).

Fixes #130362

Fixes #130188

Test Plan:
- new tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames