### PR TITLE
Do not abort on SPARSE_STATUS_INVALID_VALUE

### DIFF
--- a/aten/src/ATen/mkl/Exceptions.h
+++ b/aten/src/ATen/mkl/Exceptions.h
@@ -55,3 +55,14 @@ static inline const char* _mklGetErrorString(sparse_status_t status) {
         at::mkl::sparse::_mklGetErrorString(__err), \
         " when calling `" #EXPR "`");               \
   } while (0)
+
+#define TORCH_MKLSPARSE_CHECK_SUCCESS_OR_INVALID(status, function_name) \
+  do {                                                   \
+    sparse_status_t __status = (status);                 \
+    TORCH_CHECK(                                         \
+        __status == SPARSE_STATUS_SUCCESS ||             \
+            __status == SPARSE_STATUS_INVALID_VALUE,     \
+        "MKL error: ",                                   \
+        at::mkl::sparse::_mklGetErrorString(__status),   \
+        " when calling `" function_name "`");            \
+  } while (0)

--- a/aten/src/ATen/mkl/SparseBlas.cpp
+++ b/aten/src/ATen/mkl/SparseBlas.cpp
@@ -278,48 +278,60 @@ void spmmd<c10::complex<double>>(MKL_SPARSE_SPMMD_ARGTYPES(c10::complex<double>)
 }
 
 template <>
-void trsv<float>(MKL_SPARSE_TRSV_ARGTYPES(float)) {
-  TORCH_MKLSPARSE_CHECK(mkl_sparse_s_trsv(operation, alpha, A, descr, x, y));
+sparse_status_t trsv<float>(MKL_SPARSE_TRSV_ARGTYPES(float)) {
+  sparse_status_t status = mkl_sparse_s_trsv(operation, alpha, A, descr, x, y);
+  TORCH_MKLSPARSE_CHECK_SUCCESS_OR_INVALID(status, "mkl_sparse_s_trsv");
+  return status;
 }
 template <>
-void trsv<double>(MKL_SPARSE_TRSV_ARGTYPES(double)) {
-  TORCH_MKLSPARSE_CHECK(mkl_sparse_d_trsv(operation, alpha, A, descr, x, y));
+sparse_status_t trsv<double>(MKL_SPARSE_TRSV_ARGTYPES(double)) {
+  sparse_status_t status = mkl_sparse_d_trsv(operation, alpha, A, descr, x, y);
+  TORCH_MKLSPARSE_CHECK_SUCCESS_OR_INVALID(status, "mkl_sparse_d_trsv");
+  return status;
 }
 template <>
-void trsv<c10::complex<float>>(MKL_SPARSE_TRSV_ARGTYPES(c10::complex<float>)) {
-  TORCH_MKLSPARSE_CHECK(mkl_sparse_c_trsv(
+sparse_status_t trsv<c10::complex<float>>(MKL_SPARSE_TRSV_ARGTYPES(c10::complex<float>)) {
+  sparse_status_t status = mkl_sparse_c_trsv(
       operation,
       to_mkl_complex<float, MKL_Complex8>(alpha),
       A,
       descr,
       reinterpret_cast<const MKL_Complex8*>(x),
-      reinterpret_cast<MKL_Complex8*>(y)));
+      reinterpret_cast<MKL_Complex8*>(y));
+  TORCH_MKLSPARSE_CHECK_SUCCESS_OR_INVALID(status, "mkl_sparse_c_trsv");
+  return status;
 }
 template <>
-void trsv<c10::complex<double>>(
+sparse_status_t trsv<c10::complex<double>>(
     MKL_SPARSE_TRSV_ARGTYPES(c10::complex<double>)) {
-  TORCH_MKLSPARSE_CHECK(mkl_sparse_z_trsv(
+  sparse_status_t status = mkl_sparse_z_trsv(
       operation,
       to_mkl_complex<double, MKL_Complex16>(alpha),
       A,
       descr,
       reinterpret_cast<const MKL_Complex16*>(x),
-      reinterpret_cast<MKL_Complex16*>(y)));
+      reinterpret_cast<MKL_Complex16*>(y));
+  TORCH_MKLSPARSE_CHECK_SUCCESS_OR_INVALID(status, "mkl_sparse_z_trsv");
+  return status;
 }
 
 template <>
-void trsm<float>(MKL_SPARSE_TRSM_ARGTYPES(float)) {
-  TORCH_MKLSPARSE_CHECK(mkl_sparse_s_trsm(
-      operation, alpha, A, descr, layout, x, columns, ldx, y, ldy));
+sparse_status_t trsm<float>(MKL_SPARSE_TRSM_ARGTYPES(float)) {
+  sparse_status_t status = mkl_sparse_s_trsm(
+      operation, alpha, A, descr, layout, x, columns, ldx, y, ldy);
+  TORCH_MKLSPARSE_CHECK_SUCCESS_OR_INVALID(status, "mkl_sparse_s_trsm");
+  return status;
 }
 template <>
-void trsm<double>(MKL_SPARSE_TRSM_ARGTYPES(double)) {
-  TORCH_MKLSPARSE_CHECK(mkl_sparse_d_trsm(
-      operation, alpha, A, descr, layout, x, columns, ldx, y, ldy));
+sparse_status_t trsm<double>(MKL_SPARSE_TRSM_ARGTYPES(double)) {
+  sparse_status_t status = mkl_sparse_d_trsm(
+      operation, alpha, A, descr, layout, x, columns, ldx, y, ldy);
+  TORCH_MKLSPARSE_CHECK_SUCCESS_OR_INVALID(status, "mkl_sparse_d_trsm");
+  return status;
 }
 template <>
-void trsm<c10::complex<float>>(MKL_SPARSE_TRSM_ARGTYPES(c10::complex<float>)) {
-  TORCH_MKLSPARSE_CHECK(mkl_sparse_c_trsm(
+sparse_status_t trsm<c10::complex<float>>(MKL_SPARSE_TRSM_ARGTYPES(c10::complex<float>)) {
+  sparse_status_t status = mkl_sparse_c_trsm(
       operation,
       to_mkl_complex<float, MKL_Complex8>(alpha),
       A,
@@ -329,12 +341,14 @@ void trsm<c10::complex<float>>(MKL_SPARSE_TRSM_ARGTYPES(c10::complex<float>)) {
       columns,
       ldx,
       reinterpret_cast<MKL_Complex8*>(y),
-      ldy));
+      ldy);
+  TORCH_MKLSPARSE_CHECK_SUCCESS_OR_INVALID(status, "mkl_sparse_c_trsm");
+  return status;
 }
 template <>
-void trsm<c10::complex<double>>(
+sparse_status_t trsm<c10::complex<double>>(
     MKL_SPARSE_TRSM_ARGTYPES(c10::complex<double>)) {
-  TORCH_MKLSPARSE_CHECK(mkl_sparse_z_trsm(
+  sparse_status_t status = mkl_sparse_z_trsm(
       operation,
       to_mkl_complex<double, MKL_Complex16>(alpha),
       A,
@@ -344,7 +358,9 @@ void trsm<c10::complex<double>>(
       columns,
       ldx,
       reinterpret_cast<MKL_Complex16*>(y),
-      ldy));
+      ldy);
+  TORCH_MKLSPARSE_CHECK_SUCCESS_OR_INVALID(status, "mkl_sparse_z_trsm");
+  return status;
 }
 
 } // namespace at::mkl::sparse

--- a/aten/src/ATen/mkl/SparseBlas.h
+++ b/aten/src/ATen/mkl/SparseBlas.h
@@ -184,7 +184,7 @@ void spmmd<c10::complex<double>>(
       const scalar_t *x, scalar_t *y
 
 template <typename scalar_t>
-inline void trsv(MKL_SPARSE_TRSV_ARGTYPES(scalar_t)) {
+inline sparse_status_t trsv(MKL_SPARSE_TRSV_ARGTYPES(scalar_t)) {
   TORCH_INTERNAL_ASSERT(
       false,
       "at::mkl::sparse::trsv: not implemented for ",
@@ -192,13 +192,13 @@ inline void trsv(MKL_SPARSE_TRSV_ARGTYPES(scalar_t)) {
 }
 
 template <>
-void trsv<float>(MKL_SPARSE_TRSV_ARGTYPES(float));
+sparse_status_t trsv<float>(MKL_SPARSE_TRSV_ARGTYPES(float));
 template <>
-void trsv<double>(MKL_SPARSE_TRSV_ARGTYPES(double));
+sparse_status_t trsv<double>(MKL_SPARSE_TRSV_ARGTYPES(double));
 template <>
-void trsv<c10::complex<float>>(MKL_SPARSE_TRSV_ARGTYPES(c10::complex<float>));
+sparse_status_t trsv<c10::complex<float>>(MKL_SPARSE_TRSV_ARGTYPES(c10::complex<float>));
 template <>
-void trsv<c10::complex<double>>(MKL_SPARSE_TRSV_ARGTYPES(c10::complex<double>));
+sparse_status_t trsv<c10::complex<double>>(MKL_SPARSE_TRSV_ARGTYPES(c10::complex<double>));
 
 #define MKL_SPARSE_TRSM_ARGTYPES(scalar_t)                                    \
   const sparse_operation_t operation, const scalar_t alpha,                   \
@@ -207,7 +207,7 @@ void trsv<c10::complex<double>>(MKL_SPARSE_TRSV_ARGTYPES(c10::complex<double>));
       const MKL_INT ldx, scalar_t *y, const MKL_INT ldy
 
 template <typename scalar_t>
-inline void trsm(MKL_SPARSE_TRSM_ARGTYPES(scalar_t)) {
+inline sparse_status_t trsm(MKL_SPARSE_TRSM_ARGTYPES(scalar_t)) {
   TORCH_INTERNAL_ASSERT(
       false,
       "at::mkl::sparse::trsm: not implemented for ",
@@ -215,12 +215,12 @@ inline void trsm(MKL_SPARSE_TRSM_ARGTYPES(scalar_t)) {
 }
 
 template <>
-void trsm<float>(MKL_SPARSE_TRSM_ARGTYPES(float));
+sparse_status_t trsm<float>(MKL_SPARSE_TRSM_ARGTYPES(float));
 template <>
-void trsm<double>(MKL_SPARSE_TRSM_ARGTYPES(double));
+sparse_status_t trsm<double>(MKL_SPARSE_TRSM_ARGTYPES(double));
 template <>
-void trsm<c10::complex<float>>(MKL_SPARSE_TRSM_ARGTYPES(c10::complex<float>));
+sparse_status_t trsm<c10::complex<float>>(MKL_SPARSE_TRSM_ARGTYPES(c10::complex<float>));
 template <>
-void trsm<c10::complex<double>>(MKL_SPARSE_TRSM_ARGTYPES(c10::complex<double>));
+sparse_status_t trsm<c10::complex<double>>(MKL_SPARSE_TRSM_ARGTYPES(c10::complex<double>));
 
 } // namespace at::mkl::sparse


### PR DESCRIPTION
Summary:
Newer versions of the MKL library return `SPARSE_STATUS_INVALID_VALUE` when badly formed non-triangular matrices are passed to the `mkl_sparse_?_trsv`/`mkl_sparse_?_mrsv` functions. This would start aborting (badly written) tests that worked with the old version which just filled the result tensor with `-NaN` instead of returning an error status.

This changes the code to fill the result tensor with `-NaN` on `SPARSE_STATUS_INVALID_VALUE` so we get the same behavior regardless of the MKL version in use.

Test Plan: `buck2 test 'fbcode//mode/opt' fbcode//caffe2/test:sparse -- --run-disabled`

Differential Revision: D59542023
