### PR TITLE
Mark nn_module params and buffers as static in dynamo

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2648,6 +2648,51 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         expected = mod(x)
         self.assertEqual(actual, expected)
 
+    @torch._dynamo.config.patch("inline_inbuilt_nn_modules", True)
+    def test_mark_static_previously_seen_tensor(self):
+        # This test verifies that dynamo will mark
+        # the buffers/params of a module as static
+        # even if this param was previously seen
+        # (ex. as a different input)
+        num_compiles = 0
+
+        def debug_compiler(gm, _):
+            nonlocal num_compiles
+            num_compiles += 1
+
+            print(list(gm.graph.nodes))
+            input_nodes = [
+                n for n in gm.graph.nodes if n.op == "placeholder" and n.name == "l_b_"
+            ]
+
+            self.assertGreater(len(input_nodes), 0)
+            for input_node in input_nodes:
+                self.assertEqual(
+                    input_node.meta["tensor_dict"]["_dynamo_static_input_type"],
+                    "unguarded",
+                )
+
+            return gm
+
+        class TestModule(torch.nn.Module):
+            def __init__(self, buf) -> None:
+                super().__init__()
+                self.register_buffer("buf", buf)
+
+            def forward(self, x):
+                return self.buf * x
+
+        @torch._dynamo.optimize(backend=debug_compiler)
+        def fn(x, b, mod):
+            z = b + 1
+            return z * mod(x)
+
+        buf = torch.ones(2, 2, device="cuda:0")
+        inp = torch.ones(2, device="cuda:0")
+        mod = TestModule(buf)
+        fn(inp, buf, mod)
+        self.assertEqual(num_compiles, 1)
+
     def test_no_guard_on_torch_nn_modules(self):
         # https://github.com/pytorch/pytorch/issues/110048
 

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2696,10 +2696,9 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
     @torch._inductor.config.patch("freezing", True)
     @torch.no_grad()
     def test_mark_static_with_freezing(self):
-        # This test verifies that dynamo will mark
-        # the buffers/params of a module as static
-        # even if this param was previously seen
-        # (ex. as a different input)
+        # This test verifies that dynamo will
+        # add buffers/params as attributes of the
+        # graph w/ guards if freezing is enabled
         num_compiles = 0
 
         def debug_compiler(gm, _):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2834,3 +2834,7 @@ def _disable_saved_tensors_hooks_during_tracing():
         yield
     finally:
         torch._C._autograd._saved_tensors_hooks_set_tracing(prior)
+
+
+def is_parameter_freezing():
+    return torch._inductor.config.freezing and not torch.is_grad_enabled()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1318,7 +1318,6 @@ class VariableBuilder:
             and isinstance(value, torch.nn.Parameter)
         ):
             self.mark_static_input(value, guard=False)
-            is_static_input = True
 
         if (
             source.guard_source().is_nn_module()
@@ -1889,7 +1888,6 @@ def wrap_fx_proxy_cls(
     proxy,
     example_value=None,
     subclass_type=None,
-    is_static_input=False,
     **options,
 ):
     from ..symbolic_convert import InstructionTranslatorBase

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1414,7 +1414,6 @@ class VariableBuilder:
             example_value=value,
             subclass_type=subclass_type,
             source=source,
-            is_static_input=is_static_input,
             **options,
         )
 
@@ -1813,14 +1812,13 @@ def _dataclasses_fields_lambda(obj):
 
 
 def wrap_fx_proxy(
-    tx, proxy, example_value=None, subclass_type=None, is_static_input=False, **options
+    tx, proxy, example_value=None, subclass_type=None, **options
 ) -> VariableTracker:
     kwargs = {
         "tx": tx,
         "proxy": proxy,
         "example_value": example_value,
         "subclass_type": subclass_type,
-        "is_static_input": is_static_input,
         **options,
     }
     if subclass_type is None:
@@ -1963,7 +1961,6 @@ def wrap_fx_proxy_cls(
         # tensor, the stored example value will update too!)
         example_value = _clone_input(example_value)
         set_example_value(proxy.node, example_value)
-        proxy.node.meta["is_static_input"] = is_static_input
         specialized_props = target_cls.specialize(example_value)
         # TODO: not sure about this fake mode test
         if (

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -777,6 +777,16 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
 
         super().__init__(value=value, **kwargs)
         self.is_state_mutated = False
+
+        if torch._dynamo.config.inline_inbuilt_nn_modules:
+            from ..decorators import mark_static_address
+
+            for p in value.parameters():
+                mark_static_address(p, guard=False)
+
+            for b in value.buffers():
+                mark_static_address(b, guard=False)
+
         # nn_module_stack_source is used to ensure BC for nn_module_stack.
         # Downstream users prefer mod.linear instead of mod._modules['linear']
         # as the module stack. When Dynamo inlines the __getattr__ method, we

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -777,7 +777,6 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
 
         super().__init__(value=value, **kwargs)
         self.is_state_mutated = False
-
         # nn_module_stack_source is used to ensure BC for nn_module_stack.
         # Downstream users prefer mod.linear instead of mod._modules['linear']
         # as the module stack. When Dynamo inlines the __getattr__ method, we

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -778,15 +778,6 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
         super().__init__(value=value, **kwargs)
         self.is_state_mutated = False
 
-        if torch._dynamo.config.inline_inbuilt_nn_modules:
-            from ..decorators import mark_static_address
-
-            for p in value.parameters():
-                mark_static_address(p, guard=False)
-
-            for b in value.buffers():
-                mark_static_address(b, guard=False)
-
         # nn_module_stack_source is used to ensure BC for nn_module_stack.
         # Downstream users prefer mod.linear instead of mod._modules['linear']
         # as the module stack. When Dynamo inlines the __getattr__ method, we


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #130402
* #130393
* #130503
* #130392
* __->__ #130391

This PR marks all buffers and parameters of an NNModule as static using the `mark_static_address` API. As a result, when tensors are passed to AOT, the `tensor_dict` metadata of placeholder nodes will contain the `static_address_type` key, indicating which graph argument positions are static for cudagraphs. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames