### PR TITLE
[TD] More synonyms, new heuristic for test_public_bindings

### DIFF
--- a/tools/testing/target_determination/heuristics/__init__.py
+++ b/tools/testing/target_determination/heuristics/__init__.py
@@ -23,6 +23,7 @@ from tools.testing.target_determination.heuristics.previously_failed_in_pr impor
     PreviouslyFailedInPR,
 )
 from tools.testing.target_determination.heuristics.profiling import Profiling
+from tools.testing.target_determination.heuristics.public_bindings import PublicBindings
 
 
 if TYPE_CHECKING:
@@ -43,4 +44,5 @@ HEURISTICS: list[HeuristicInterface] = [
     Profiling(),
     LLM(),
     Filepath(),
+    PublicBindings(),
 ]

--- a/tools/testing/target_determination/heuristics/filepath.py
+++ b/tools/testing/target_determination/heuristics/filepath.py
@@ -25,6 +25,7 @@ keyword_synonyms: dict[str, list[str]] = {
     "decomp": ["decomposition", "decompositions"],
     "numpy": ["torch_np", "numpy_tests"],
     "ops": ["opinfo"],
+    "hop": ["higher_order_op"]
 }
 
 not_keyword = [

--- a/tools/testing/target_determination/heuristics/filepath.py
+++ b/tools/testing/target_determination/heuristics/filepath.py
@@ -25,7 +25,8 @@ keyword_synonyms: dict[str, list[str]] = {
     "decomp": ["decomposition", "decompositions"],
     "numpy": ["torch_np", "numpy_tests"],
     "ops": ["opinfo"],
-    "hop": ["higher_order_op"]
+    "hop": ["higher_order_op"],
+    "aot": ["flex_attention", "autograd"],
 }
 
 not_keyword = [

--- a/tools/testing/target_determination/heuristics/hipri.py
+++ b/tools/testing/target_determination/heuristics/hipri.py
@@ -1,0 +1,34 @@
+
+from __future__ import annotations
+
+from collections import defaultdict
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Callable
+from warnings import warn
+
+from tools.testing.target_determination.heuristics.interface import (
+    HeuristicInterface,
+    TestPrioritizations,
+)
+
+from tools.testing.target_determination.heuristics.utils import (
+    normalize_ratings,
+    query_changed_files,
+)
+from tools.testing.test_run import TestRun
+
+class HiPri(HeuristicInterface):
+    # Literally just a heuristic for test_public_bindings.  Pretty much anything
+    # that changes the public API can affect this test
+    hi_pri = [
+        "test_public_bindings",
+    ]
+    def __init__(self, **kwargs: dict[str, Any]) -> None:
+        super().__init__(**kwargs)
+
+    def get_prediction_confidence(self, tests: list[str]) -> TestPrioritizations:
+        test_ratings = {TestRun(k): 1 for k in self.hi_pri if k in tests}
+        return TestPrioritizations(
+            tests, test_ratings
+        )

--- a/tools/testing/target_determination/heuristics/hipri.py
+++ b/tools/testing/target_determination/heuristics/hipri.py
@@ -19,7 +19,7 @@ class HiPri(HeuristicInterface):
         super().__init__(**kwargs)
 
     def get_prediction_confidence(self, tests: list[str]) -> TestPrioritizations:
-        test_ratings = {TestRun(k): 1 for k in self.hi_pri if k in tests}
+        test_ratings = {TestRun(k): 1.0 for k in self.hi_pri if k in tests}
         return TestPrioritizations(
             tests, test_ratings
         )

--- a/tools/testing/target_determination/heuristics/hipri.py
+++ b/tools/testing/target_determination/heuristics/hipri.py
@@ -1,5 +1,5 @@
-
 from __future__ import annotations
+
 from typing import Any
 
 from tools.testing.target_determination.heuristics.interface import (
@@ -9,17 +9,17 @@ from tools.testing.target_determination.heuristics.interface import (
 
 from tools.testing.test_run import TestRun
 
+
 class HiPri(HeuristicInterface):
     # Literally just a heuristic for test_public_bindings.  Pretty much anything
     # that changes the public API can affect this test
     hi_pri = [
         "test_public_bindings",
     ]
+
     def __init__(self, **kwargs: dict[str, Any]) -> None:
         super().__init__(**kwargs)
 
     def get_prediction_confidence(self, tests: list[str]) -> TestPrioritizations:
         test_ratings = {TestRun(k): 1.0 for k in self.hi_pri if k in tests}
-        return TestPrioritizations(
-            tests, test_ratings
-        )
+        return TestPrioritizations(tests, test_ratings)

--- a/tools/testing/target_determination/heuristics/hipri.py
+++ b/tools/testing/target_determination/heuristics/hipri.py
@@ -1,21 +1,11 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-from functools import lru_cache
-from pathlib import Path
-from typing import Any, Callable
-from warnings import warn
-
 from tools.testing.target_determination.heuristics.interface import (
     HeuristicInterface,
     TestPrioritizations,
 )
 
-from tools.testing.target_determination.heuristics.utils import (
-    normalize_ratings,
-    query_changed_files,
-)
 from tools.testing.test_run import TestRun
 
 class HiPri(HeuristicInterface):

--- a/tools/testing/target_determination/heuristics/hipri.py
+++ b/tools/testing/target_determination/heuristics/hipri.py
@@ -1,5 +1,6 @@
 
 from __future__ import annotations
+from typing import Any
 
 from tools.testing.target_determination.heuristics.interface import (
     HeuristicInterface,

--- a/tools/testing/target_determination/heuristics/public_bindings.py
+++ b/tools/testing/target_determination/heuristics/public_bindings.py
@@ -1,25 +1,35 @@
 from __future__ import annotations
 
+from logging import warn
 from typing import Any
 
 from tools.testing.target_determination.heuristics.interface import (
     HeuristicInterface,
     TestPrioritizations,
 )
+from tools.testing.target_determination.heuristics.utils import (
+    query_changed_files,
+)
 
 from tools.testing.test_run import TestRun
 
 
-class HiPri(HeuristicInterface):
+class PublicBindings(HeuristicInterface):
     # Literally just a heuristic for test_public_bindings.  Pretty much anything
     # that changes the public API can affect this test
-    hi_pri = [
-        "test_public_bindings",
-    ]
+    test_public_bindings = "test_public_bindings"
 
     def __init__(self, **kwargs: dict[str, Any]) -> None:
         super().__init__(**kwargs)
 
     def get_prediction_confidence(self, tests: list[str]) -> TestPrioritizations:
-        test_ratings = {TestRun(k): 1.0 for k in self.hi_pri if k in tests}
+        test_ratings = {}
+        try:
+            changed_files = query_changed_files()
+        except Exception as e:
+            warn(f"Can't query changed test files due to {e}")
+            changed_files = []
+
+        if any(file.startswith("torch/") for file in changed_files):
+            test_ratings[TestRun(self.test_public_bindings)] = 1.0
         return TestPrioritizations(tests, test_ratings)

--- a/tools/testing/target_determination/heuristics/public_bindings.py
+++ b/tools/testing/target_determination/heuristics/public_bindings.py
@@ -1,22 +1,20 @@
 from __future__ import annotations
 
-from logging import warn
 from typing import Any
+from warnings import warn
 
 from tools.testing.target_determination.heuristics.interface import (
     HeuristicInterface,
     TestPrioritizations,
 )
-from tools.testing.target_determination.heuristics.utils import (
-    query_changed_files,
-)
+from tools.testing.target_determination.heuristics.utils import query_changed_files
 
 from tools.testing.test_run import TestRun
 
 
 class PublicBindings(HeuristicInterface):
     # Literally just a heuristic for test_public_bindings.  Pretty much anything
-    # that changes the public API can affect this test
+    # that changes the public API can affect this testp
     test_public_bindings = "test_public_bindings"
 
     def __init__(self, **kwargs: dict[str, Any]) -> None:
@@ -30,6 +28,8 @@ class PublicBindings(HeuristicInterface):
             warn(f"Can't query changed test files due to {e}")
             changed_files = []
 
-        if any(file.startswith("torch/") for file in changed_files):
+        if any(
+            file.startswith("torch/") and file.endswith(".py") for file in changed_files
+        ):
             test_ratings[TestRun(self.test_public_bindings)] = 1.0
         return TestPrioritizations(tests, test_ratings)

--- a/tools/testing/target_determination/heuristics/public_bindings.py
+++ b/tools/testing/target_determination/heuristics/public_bindings.py
@@ -8,7 +8,6 @@ from tools.testing.target_determination.heuristics.interface import (
     TestPrioritizations,
 )
 from tools.testing.target_determination.heuristics.utils import query_changed_files
-
 from tools.testing.test_run import TestRun
 
 


### PR DESCRIPTION
test_public_bindings should be run on anything that changes the public API - need to figure out in the future what is part of the public api, currently I'm using anything in torch/

flex_attention should be run on anything involving autograd