### PR TITLE
[CUDA] Don't double-destroy CUDA graph when debug dump is used

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -270,6 +270,7 @@ void CUDAGraph::debug_dump(const std::string& debug_path) {
       TORCH_WARN("DEBUG: calling cudaGraphDebugDotPrint() with ", debug_path);
       C10_CUDA_CHECK_WARN(cudaGraphDebugDotPrint(graph_, debug_path.c_str(), cudaGraphDebugDotFlagsVerbose)); // most verbose output
       AT_CUDA_CHECK(cudaGraphDestroy(graph_));
+      has_graph_ = false;
     }
   } else {
     TORCH_WARN("CUDA Graphs debug not enabled, set with torch._C._cuda_enable_graphs_debug_mode");

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2274,21 +2274,21 @@ torch.cuda.synchronize()
     )
     def test_graph_debugdump(self):
         torch.cuda.empty_cache()
-        x=torch.randn(10240000, device="cuda")
-        y=torch.rand_like(x)
-        g=torch.cuda.CUDAGraph()
+        x = torch.randn(10240000, device="cuda")
+        y = torch.rand_like(x)
+        g = torch.cuda.CUDAGraph()
         g.enable_debug_mode()
         s0 = torch.cuda.Stream()
         s1 = torch.cuda.Stream()
         s0.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(s0):
-          g.capture_begin()
-          z = x+y
-          with torch.cuda.stream(s1):
-            s1.wait_stream(s0)
-            w = z+y
-          s0.wait_stream(s1)
-          g.capture_end()
+            g.capture_begin()
+            z = x + y
+            with torch.cuda.stream(s1):
+                s1.wait_stream(s0)
+                w = z + y
+            s0.wait_stream(s1)
+            g.capture_end()
         s0.synchronize()
         torch.cuda.synchronize()
         with tempfile.TemporaryDirectory() as tempdir:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2272,6 +2272,31 @@ torch.cuda.synchronize()
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    def test_graph_debugdump(self):
+        torch.cuda.empty_cache()
+        x=torch.randn(10240000, device="cuda")
+        y=torch.rand_like(x)
+        g=torch.cuda.CUDAGraph()
+        g.enable_debug_mode()
+        s0 = torch.cuda.Stream()
+        s1 = torch.cuda.Stream()
+        s0.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s0):
+          g.capture_begin()
+          z = x+y
+          with torch.cuda.stream(s1):
+            s1.wait_stream(s0)
+            w = z+y
+          s0.wait_stream(s1)
+          g.capture_end()
+        s0.synchronize()
+        torch.cuda.synchronize()
+        with tempfile.TemporaryDirectory() as tempdir:
+            g.debug_dump(os.path.join(tempdir, "out_multi_stream.dot"))
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_graph_error(self):
         # We need to run this test in a separate thread as the error we trigger
         # puts the cuda context in a bad state


### PR DESCRIPTION
Repro from @eellison 

Could have sworn we had another PR with this fix floating around somewhere but I couldn't find it...