### PR TITLE
[AMD] Pull rdc/amd-smi upstream 0701

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1113,7 +1113,7 @@ def _get_amdsmi_power_draw(device: Optional[Union[Device, int]] = None) -> int:
 
 def _get_amdsmi_clock_rate(device: Optional[Union[Device, int]] = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return amdsmi.amdsmi_get_clock_info(handle, amdsmi.AmdSmiClkType.GFX)["cur_clk"]
+    return amdsmi.amdsmi_get_clock_info(handle, amdsmi.AmdSmiClkType.GFX)["clk"]
 
 
 def memory_usage(device: Optional[Union[Device, int]] = None) -> int:


### PR DESCRIPTION
Summary:
import rdc and amd-smi from github so we can start integrating RDC for collecting profiling metrics

some manual works other than copy files from github:

1) manually add amd_hsmp.h to amdsmi/esmi_ib_library/include/asm/amd_hsmp.h
2) generate rocm_smi64Config.h using cmake outside of fbsource and copy it to amdsmi/rocm_smi/include/rocm_smi/rocm_smi64Config.h
3) add "fbsource//third-party/rocm/6.0/amdsmi:amd_smi" dependency to rdc/BUCK
4) add the __init__.py file back to "fbsource//third-party/rocm/6.0/amdsmi/__init__.py"

Test Plan:
```
buck run rgpu:rgpu -- getGpuInfo # with next diff in the stack
buck build scripts/alston64:rdc_test
```

Reviewed By: Rupan

Differential Revision: D59256270
