### PR TITLE
Fix usage of USE_ROCM when calling cudaFuncGetAttributes

### DIFF
--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -981,17 +981,17 @@ void launch_tinygemm_kernel(
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   cudaFuncAttributes funcAttr;
-  #if defined(USE_ROCM)
+#if defined(USE_ROCM)
   C10_CUDA_CHECK(cudaFuncGetAttributes(
       &funcAttr,
       (void *)func
   ));
-  #else
+#else
   C10_CUDA_CHECK(cudaFuncGetAttributes(
       &funcAttr,
       func
   ));
-  #endif
+#endif
 }
 
 // FIXME: parallelize better, smem staging etc?

--- a/aten/src/ATen/native/cuda/int4mm.cu
+++ b/aten/src/ATen/native/cuda/int4mm.cu
@@ -981,14 +981,17 @@ void launch_tinygemm_kernel(
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   cudaFuncAttributes funcAttr;
+  #if defined(USE_ROCM)
   C10_CUDA_CHECK(cudaFuncGetAttributes(
       &funcAttr,
-#if defined(USE_ROCM)
       (void *)func
-#else
-      func
-#endif
   ));
+  #else
+  C10_CUDA_CHECK(cudaFuncGetAttributes(
+      &funcAttr,
+      func
+  ));
+  #endif
 }
 
 // FIXME: parallelize better, smem staging etc?


### PR DESCRIPTION
This fixes MSVC build regression introduced by https://github.com/pytorch/pytorch/pull/129710 as VC++ fails to unroll nested defines in the specific order and fails with
```
C:\actions-runner\_work\pytorch\pytorch\builder\windows\pytorch\aten\src\ATen\native\cuda\int4mm.cu(984): error: "#" not expected here
    do { const cudaError_t __err = cudaFuncGetAttributes( &funcAttr, #if defined(USE_ROCM) (void *)func #else func #endif ); c10::cuda::c10_cuda_check_implementation( static_cast<int32_t>(__err), "C:\\actions-runner\\_work\\pytorch\\pytorch\\builder\\windows\\pytorch\\aten\\src\\ATen\\native\\cuda\\int4mm.cu", __func__, static_cast<uint32_t>(991), true); } while (0);
```

Fixes https://github.com/pytorch/pytorch/issues/130437

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang