### PR TITLE
[TD] Pin numpy to 1.26.0 in indexer

### DIFF
--- a/.github/scripts/td_llm_indexer.sh
+++ b/.github/scripts/td_llm_indexer.sh
@@ -7,6 +7,7 @@ cd llm-target-determinator
 pip install -q -r requirements.txt
 cd ../codellama
 pip install -e .
+pip install numpy==1.26.0
 
 # Run indexer
 cd ../llm-target-determinator

--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   index:
     runs-on: linux.g5.4xlarge.nvidia.gpu # 1 GPU A10G 24GB each
-    environment: target-determinator-env
     steps:
       - name: Clone PyTorch
         uses: actions/checkout@v3

--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+  push:
 
 permissions:
   id-token: write

--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
-  push:
 
 permissions:
   id-token: write
@@ -13,6 +12,7 @@ permissions:
 jobs:
   index:
     runs-on: linux.g5.4xlarge.nvidia.gpu # 1 GPU A10G 24GB each
+    environment: target-determinator-env
     steps:
       - name: Clone PyTorch
         uses: actions/checkout@v3


### PR DESCRIPTION
Temporarily pin 1.26.0 to get the workflow working while I go sort out which dependencies need to be updated

Succeeding run: https://github.com/pytorch/pytorch/actions/runs/9877733366/job/27280052419?pr=130442

Tested by adding my branch to the trust relationship for the policy and removing the environment 