### PR TITLE
flash_attn: limit compilation parallelism due to high memory requirements

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -175,9 +175,13 @@ file(GLOB mem_eff_attention_cuda_cu "native/transformers/cuda/mem_eff_attention/
 file(GLOB mem_eff_attention_cuda_kernels_cu "native/transformers/cuda/mem_eff_attention/kernels/*.cu")
 file(GLOB mem_eff_attention_cuda_cpp "native/transformers/cuda/mem_eff_attention/*.cpp")
 
+# flash_attn for cuda requires excessive memory, so restrict parallelism in ninja builds
+add_library(flash_attention_cuda OBJECT)
+set_property(GLOBAL PROPERTY JOB_POOLS flash_attention_pool=3)
+set_property(TARGET flash_attention_cuda PROPERTY JOB_POOL_COMPILE flash_attention_pool)
+
 if(USE_FLASH_ATTENTION)
-  list(APPEND native_transformers_cuda_cu ${flash_attention_cuda_cu})
-  list(APPEND native_transformers_cuda_cu ${flash_attention_cuda_kernels_cu})
+  target_sources(flash_attention_cuda PRIVATE ${flash_attention_cuda_cu} ${flash_attention_cuda_kernels_cu})
   list(APPEND native_transformers_cuda_cpp ${flash_attention_cuda_cpp})
   list(APPEND FLASH_ATTENTION_CUDA_SOURCES ${flash_attention_cuda_cu} ${flash_attention_cuda_kernels_cu})
   list(APPEND ATen_ATTENTION_KERNEL_SRCS ${flash_attention_cuda_kernels_cu})

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -927,6 +927,7 @@ elseif(USE_CUDA)
   set(CUDA_LINK_LIBRARIES_KEYWORD)
   torch_compile_options(torch_cuda)  # see cmake/public/utils.cmake
   target_compile_definitions(torch_cuda PRIVATE USE_CUDA)
+  target_link_libraries(torch_cuda PRIVATE flash_attention_cuda)
 
   if(USE_CUSPARSELT)
       target_link_libraries(torch_cuda PRIVATE torch::cusparselt)
@@ -1509,6 +1510,9 @@ if(USE_CUDA)
       torch_cuda PRIVATE ${Caffe2_GPU_INCLUDE})
   target_link_libraries(
       torch_cuda PRIVATE ${Caffe2_CUDA_DEPENDENCY_LIBS})
+
+  target_include_directories(
+      flash_attention_cuda PRIVATE ${Caffe2_GPU_INCLUDE})
 
   # These public dependencies must go after the previous dependencies, as the
   # order of the libraries in the linker call matters here when statically


### PR DESCRIPTION
For whatever reason, the `flash_attn` CUDA kernels require about 5.3GB to compile,
so better to limit parallelism, since it leads to frequent OOM errors when compiling
in parallel.

This is done with a ninja job pool. I've hard-coded the number of jobs to 3, since
16GB of memory sounds reasonably standard.

Overall compile time is identical for me: other cpp sources are being compiled
concurrently while at most 3 of these cuda kernels compile.

Fixes #124018
