### PR TITLE
DCP checkpoint_dist_client integration

### DIFF
--- a/torch/distributed/checkpoint/logger.py
+++ b/torch/distributed/checkpoint/logger.py
@@ -2,11 +2,12 @@
 import functools
 import time
 from typing import Any, Callable, Dict, List, TypeVar
+
 from typing_extensions import ParamSpec
+from uuid import uuid4
 
 import torch.distributed.c10d_logger as c10d_logger
 from torch.distributed.checkpoint.logging_handlers import DCP_LOGGER_NAME
-
 
 __all__: List[str] = []
 
@@ -35,6 +36,9 @@ def _msg_dict_from_dcp_method_args(*args, **kwargs) -> Dict[str, Any]:
     msg_dict["checkpoint_id"] = (
         str(checkpoint_id) if checkpoint_id is not None else checkpoint_id
     )
+
+    # Uniquely identify a _dcp_method_logger wrapped function call.
+    msg_dict["uuid"] = str(uuid4().int)
 
     if storage_writer:
         msg_dict["storage_writer"] = storage_writer.__class__.__name__
@@ -71,12 +75,13 @@ def _dcp_method_logger(
             msg_dict["event"] = "start"
             t0 = time.time_ns()
             msg_dict["time"] = t0
+            msg_dict["log_exceptions"] = log_exceptions
             _dcp_logger.debug(msg_dict)
 
             # exceptions
             try:
                 result = func(*args, **kwargs)
-            except Exception as error:
+            except BaseException as error:
                 if log_exceptions:
                     msg_dict["event"] = "exception"
                     msg_dict["error"] = f"{error}"


### PR DESCRIPTION
Summary:
Integrate scope tracking with `checkpoint/fb/logging_handlers.py`.

Add a map of uuid -> tracker context manager. when logging handler has following events:
* `start`: create scope_tracker object, call `__enter__`, add to map with uuid
* `end`: retrieve scope_tracker object by uuid, call `__exit__`.
* `exception`: retrieve scope_tracker object by uuid, call `__exit__` with current exception info.

Test Plan:
Test with bento notebook (attached).
with a runtime_error in finish_checkpoint method.

scuba records:
https://fburl.com/scuba/workflow_signpost/ddttgmv2

Differential Revision: D56654417


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @chauhang