### PR TITLE
[Memory Snapshot] Skip device traces that contain only user_defined annotations

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -770,6 +770,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
 
   for (const auto& traceInfo : snapshot.device_traces) {
     py::list trace;
+    bool trace_contains_only_user_defined = true;
     for (const auto& te : traceInfo) {
       py::dict trace_entry;
       if (te.context_) {
@@ -785,8 +786,18 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
       trace_entry[stream_s] = int64_t(te.stream_);
       trace_entry[time_us_s] = te.time_.t_;
       trace.append(trace_entry);
+      // Skip device_traces with only user_defined frames
+      if (te.action_ != TraceEntry::USER_DEFINED) {
+        trace_contains_only_user_defined = false;
+      }
     }
-    traces.append(trace);
+    // Skip device_traces with only user_defined frames
+    if (trace_contains_only_user_defined) {
+      py::list trace;
+      traces.append(trace);
+    } else {
+      traces.append(trace);
+    }
   }
 
   py::dict allocator_settings;

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -334,6 +334,7 @@ std::string _memory_snapshot_pickled() {
 
   for (const auto& traceInfo : snapshot.device_traces) {
     auto trace = new_list();
+    bool trace_contains_only_user_defined = true;
     for (const auto& te : traceInfo) {
       auto trace_entry = new_dict();
       trace_entry.insert(action_s, action_to_str(te.action_));
@@ -349,8 +350,17 @@ std::string _memory_snapshot_pickled() {
       }
       trace_entry.insert(time_us_s, te.time_.t_);
       trace.push_back(trace_entry);
+      // Skip device_traces with only user_defined frames
+      if (te.action_ != TraceEntry::USER_DEFINED) {
+        trace_contains_only_user_defined = false;
+      }
     }
-    traces.push_back(trace);
+    // Skip device_traces with only user_defined frames
+    if (trace_contains_only_user_defined) {
+      trace.push_back(new_list());
+    } else {
+      traces.push_back(trace);
+    }
   }
 
   auto allocator_settings = new_dict();


### PR DESCRIPTION
Summary:
Non-gpu related threads may call record_function, however their device is set to default. This results in user_defined annotations to be saved into device_traces[0]'s list, even though these threads don't allocate any GPU memory. This makes it hard for users to find the memory snapshot for the device that they are interested in.

For example, gloo:broadcast record_function will run on a separate thread, and the device is set to default 0. So then memory snapshots for ranks 1-7 will save user_defined annotations to device_traces[0].

Test Plan:
CI and ran locally on gloo workload.

# Before:
rank0:
```
user_defined: 440, other: 99560
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
```
rank2:
```
user_defined: 3070, other: 0
user_defined: 0, other: 0
user_defined: 423, other: 99577
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
```

# After:
rank0:
```
user_defined: 441, other: 99559
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
```
rank2:
```
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 423, other: 99577
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
user_defined: 0, other: 0
```

Differential Revision: D59497927

Pulled By: aaronenyeshi
