### PR TITLE
[dtensor][debug] adding functionality to comm_debug_mode

### DIFF
--- a/torch/distributed/_tensor/debug/comm_mode.py
+++ b/torch/distributed/_tensor/debug/comm_mode.py
@@ -56,7 +56,14 @@ c10d_collective_ops = {
     c10d_ops.reduce_scatter_tensor_coalesced_,
 }
 
-trivial_ops = {"aten.detach.default", "aten.t.default", "aten.view.default"}
+trivial_ops = {
+    "aten.detach.default",
+    "aten.t.default",
+    "aten.view.default",
+    "aten._to_copy.default",
+    "aten.as_strided.default",
+    "aten.transpose.int",
+}
 
 
 class CommModeModuleTracker(ModuleTracker):
@@ -447,11 +454,16 @@ class CommDebugMode(TorchDispatchMode):
         self.advanced_module_tracker.__exit__()
         super().__exit__(*args)
 
-    def log_comm_debug_tracing_table_to_file(self, noise_level):
+    def log_comm_debug_tracing_table_to_file(
+        self, file_name="comm_mode_log.txt", noise_level=3
+    ):
+        """
+        Alternative to console CommDebugMode output, writes to file specified by the user
+        """
         ansi_escape = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
         table = ansi_escape.sub("", self.generate_comm_debug_tracing_table(noise_level))
 
-        with open("output.txt", "w") as log_file:
+        with open(file_name, "w") as log_file:
             log_file.write(table)
 
     def print_paramater_info(self):

--- a/torch/distributed/_tensor/examples/comm_mode_features_example.py
+++ b/torch/distributed/_tensor/examples/comm_mode_features_example.py
@@ -155,7 +155,7 @@ class CommDebugModeExample:
     def example_MLP_module_tracing(self) -> None:
         """
         Example code to demonstrate CommModeDebug's module level tracing using a MLP model.
-        Prints a table of module level collective tracing information and logs table to output.txt
+        Prints a table of module level collective tracing information and logs table to comm_mode_log.txt
 
         Expected Output:
         Global
@@ -188,7 +188,7 @@ class CommDebugModeExample:
     def example_transformer_module_tracing(self) -> None:
         """
         Example code to demonstrate CommModeDebug's module level tracing using a distributed Transformer model.
-        Prints a table of module level collective tracing information and logs table to output.txt
+        Prints a table of module level collective tracing information and logs table to comm_mode_log.txt
 
         Expected output:
         Global
@@ -276,7 +276,7 @@ class CommDebugModeExample:
     def example_MLP_operation_tracing(self) -> None:
         """
         Example code to demonstrate CommModeDebug's module operation level tracing using a distributed MLP model.
-        Prints a table of module opoeration level collective tracing information and logs table to output.txt
+        Prints a table of module opoeration level collective tracing information and logs table to comm_mode_log.txt
 
         Expected output:
         Global
@@ -568,7 +568,7 @@ class CommDebugModeExample:
         """
         Example code to demonstrate CommModeDebug's module operation level tracing using a distributed transformer model.
         Prints a table of module opoeration level collective tracing information, excluding trivial operations and logs
-        table to output.txt
+        table to transformer_operation_log.txt
         """
 
         torch.manual_seed(0)
@@ -581,7 +581,9 @@ class CommDebugModeExample:
 
         # print the operation level collective tracing information
         print(comm_mode.generate_comm_debug_tracing_table(noise_level=2))
-        comm_mode.log_comm_debug_tracing_table_to_file(noise_level=2)
+        comm_mode.log_comm_debug_tracing_table_to_file(
+            noise_level=2, file_name="transformer_operation_log.txt"
+        )
 
     def example_MLP_json_dump(self) -> None:
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130466
* #130410

**Summary**
I have added the functionality for the user to choose what file they want to write CommDebugMode's log to with the default file being comm_mode_log.txt. In addition I added three more aten operations to trivial operations in order to make the output cleaner. 


**Test Plan**
1. torchrun --standalone --nnodes=1 --nproc-per-node=4 torch/distributed/_tensor/examples/comm_mode_features_example.py -e MLP_operation_tracing

2. torchrun --standalone --nnodes=1 --nproc-per-node=4 torch/distributed/_tensor/examples/comm_mode_features_example.py -e transformer_operation_tracing




cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @fegin @XilunWu @wanchaol @fduwjj @wz337 @wconstab @chauhang @d4l3k