### PR TITLE
[export] Add a knob to allow writes to to_copy tensors.

### DIFF
--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -475,9 +475,11 @@ class FunctionalTensorMode(TorchDispatchMode):
                     )
                     # We don't allow any mutation on result of dropout or _to_copy
                     if self.export:
-                        if func in (
-                            torch.ops.aten.dropout.default,
-                            torch.ops.aten._to_copy.default,
+                        from torch.export._trace import _ALLOW_WRITE_TO_COPY
+
+                        if func == torch.ops.aten.dropout.default or (
+                            func == torch.ops.aten._to_copy.default
+                            and not _ALLOW_WRITE_TO_COPY
                         ):
                             torch._freeze_functional_tensor(outs_unwrapped)  # type: ignore[attr-defined]
                     outs_wrapped = pytree.tree_map_only(

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -2026,4 +2026,23 @@ def _export(
         constants=export_artifact.aten.constants,
     )
 
+    if _ALLOW_WRITE_TO_COPY:
+        log.warning(
+            "_ALLOW_WRITE_TO_COPY is set to True, this may or may not cause soundness issue with torch.export."
+        )
+
     return exported_program
+
+
+_ALLOW_WRITE_TO_COPY: bool = False
+
+
+@contextmanager
+def _allow_write_to_copy():
+    global _ALLOW_WRITE_TO_COPY
+    assert not _ALLOW_WRITE_TO_COPY
+    _ALLOW_WRITE_TO_COPY = True
+    try:
+        yield
+    finally:
+        _ALLOW_WRITE_TO_COPY = False


### PR DESCRIPTION
Summary: Add a knob to override the behavior where we ban the mutations on _to_copy tensors.

Test Plan: CI

Differential Revision: D59536865
