### PR TITLE
[BE][EZ] Migrate to new dcp save and load APIs

### DIFF
--- a/test/distributed/checkpoint/e2e/test_pipeline.py
+++ b/test/distributed/checkpoint/e2e/test_pipeline.py
@@ -69,7 +69,7 @@ class TestPipeline(FSDPTest):
         # Save state_dict
         model_state_dict, optim_state_dict = get_state_dict(model, optimizers=optim)
         saved_state_dict = {"model": model_state_dict, "optim": optim_state_dict}
-        dcp.save_state_dict(
+        dcp.save(
             state_dict=saved_state_dict,
             storage_writer=dcp.FileSystemWriter(pipeline_dir),
         )
@@ -80,7 +80,7 @@ class TestPipeline(FSDPTest):
 
         # Load the checkpoint
         model_state_dict, optim_state_dict = get_state_dict(model, optimizers=optim)
-        dcp.load_state_dict(
+        dcp.load(
             {"model": model_state_dict, "optim": optim_state_dict},
             storage_reader=dcp.FileSystemReader(pipeline_dir),
         )

--- a/test/distributed/checkpoint/test_fsdp_optim_state.py
+++ b/test/distributed/checkpoint/test_fsdp_optim_state.py
@@ -2,7 +2,7 @@
 
 import torch
 
-import torch.distributed.checkpoint as DCP
+import torch.distributed.checkpoint as dcp
 import torch.nn as nn
 from torch.distributed._shard.sharded_tensor.api import ShardedTensor
 from torch.distributed.checkpoint.optimizer import load_sharded_optimizer_state_dict
@@ -60,7 +60,7 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
     @parametrize("pass_planner", [True, False])
     def test_load_sharded_optimizer_state_dict(self, pass_planner) -> None:
         CHECKPOINT_DIR = self.temp_dir
-        planner = DCP.DefaultLoadPlanner() if pass_planner else None
+        planner = dcp.DefaultLoadPlanner() if pass_planner else None
 
         model = self._create_model()
         model = FSDP(model)
@@ -80,9 +80,9 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
             "model": model.state_dict(),
             "optim": optim_osd,
         }
-        DCP.save_state_dict(
+        dcp.save(
             state_dict=state_dict,
-            storage_writer=DCP.FileSystemWriter(CHECKPOINT_DIR),
+            storage_writer=dcp.FileSystemWriter(CHECKPOINT_DIR),
         )
 
         # now load the model and ensure the values are the same
@@ -101,16 +101,16 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
             "model": model_2.state_dict(),
             # cannot load the optimizer together with the model
         }
-        DCP.load_state_dict(
+        dcp.load(
             state_dict=state_dict,
-            storage_reader=DCP.FileSystemReader(CHECKPOINT_DIR),
+            storage_reader=dcp.FileSystemReader(CHECKPOINT_DIR),
         )
         model_2.load_state_dict(state_dict["model"])
 
         optim_state = load_sharded_optimizer_state_dict(
             model_state_dict=state_dict["model"],
             optimizer_key="optim",
-            storage_reader=DCP.FileSystemReader(CHECKPOINT_DIR),
+            storage_reader=dcp.FileSystemReader(CHECKPOINT_DIR),
             planner=planner,
         )
         flattened_osd = FSDP.optim_state_dict_to_load(

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -15,7 +15,7 @@ from torch.distributed.checkpoint.utils import CheckpointException
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     with_comms,
@@ -65,40 +65,7 @@ class MyTestModule(torch.nn.Module):
         return self.net4(self.net3(self.net2(self.net1(x))))
 
 
-class TestFSSpecNoDist(TestCase):
-    def test_fsspec_no_dist(self) -> None:
-        with tempfile.TemporaryDirectory() as path:
-            state_dict_to_save = MyTestModule().state_dict()
-
-            dcp.save(
-                state_dict=state_dict_to_save,
-                storage_writer=FsspecWriter(path),
-                no_dist=True,
-            )
-
-            state_dict_to_load_to = MyTestModule().state_dict()
-
-            for p1, p2 in zip(
-                state_dict_to_save.items(),
-                state_dict_to_load_to.items(),
-            ):
-                self.assertNotEqual(p1, p2)
-
-            # Load from file without any resharding
-            dcp.load(
-                state_dict=state_dict_to_load_to,
-                storage_reader=FsspecReader(path),
-                no_dist=True,
-            )
-
-            for p1, p2 in zip(
-                state_dict_to_save.items(),
-                state_dict_to_load_to.items(),
-            ):
-                self.assertEqual(p1, p2)
-
-
-class TestFSSpecWithDist(ShardedTensorTestBase):
+class TestFSSpec(ShardedTensorTestBase):
     @property
     def world_size(self) -> int:
         return 2
@@ -107,7 +74,7 @@ class TestFSSpecWithDist(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     @with_temp_dir
-    def test_fsspec_with_dist(self):
+    def test_fsspec(self):
         CHECKPOINT_DIR = self.temp_dir
 
         model = FSDP(MyTestModule().cuda())

--- a/test/distributed/checkpoint/test_fsspec.py
+++ b/test/distributed/checkpoint/test_fsspec.py
@@ -70,7 +70,7 @@ class TestFSSpecNoDist(TestCase):
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
-            dcp.save_state_dict(
+            dcp.save(
                 state_dict=state_dict_to_save,
                 storage_writer=FsspecWriter(path),
                 no_dist=True,
@@ -85,7 +85,7 @@ class TestFSSpecNoDist(TestCase):
                 self.assertNotEqual(p1, p2)
 
             # Load from file without any resharding
-            dcp.load_state_dict(
+            dcp.load(
                 state_dict=state_dict_to_load_to,
                 storage_reader=FsspecReader(path),
                 no_dist=True,
@@ -121,7 +121,7 @@ class TestFSSpecWithDist(ShardedTensorTestBase):
                 "optim": FSDP.optim_state_dict(model, optim),
             }
 
-            dcp.save_state_dict(
+            dcp.save(
                 state_dict=state_dict,
                 storage_writer=FsspecWriter(CHECKPOINT_DIR),
                 planner=dcp.DefaultSavePlanner(),
@@ -143,7 +143,7 @@ class TestFSSpecWithDist(ShardedTensorTestBase):
                 "model": model_2.state_dict(),
             }
 
-            dcp.load_state_dict(
+            dcp.load(
                 state_dict=state_dict,
                 storage_reader=FsspecReader(CHECKPOINT_DIR),
                 planner=dcp.DefaultLoadPlanner(),

--- a/test/distributed/checkpoint/test_tp_checkpoint.py
+++ b/test/distributed/checkpoint/test_tp_checkpoint.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 
 import torch
-import torch.distributed.checkpoint as DCP
+import torch.distributed.checkpoint as dcp
 
 from torch.distributed._tensor import init_device_mesh
 
@@ -61,9 +61,9 @@ class TestTpCheckpoint(DTensorTestBase):
         optimizer = torch.optim.SGD(model.parameters(), lr=0.25)
         original_state_dict = deepcopy(model.state_dict())
 
-        DCP.save_state_dict(
+        dcp.save(
             state_dict=original_state_dict,
-            storage_writer=DCP.FileSystemWriter(CHECKPOINT_DIR),
+            storage_writer=dcp.FileSystemWriter(CHECKPOINT_DIR),
             planner=DefaultSavePlanner(),
         )
 
@@ -79,9 +79,9 @@ class TestTpCheckpoint(DTensorTestBase):
         for param1, param2 in zip(original_state_dict.values(), state_dict.values()):
             self.assertNotEqual(param1.to_local(), param2.to_local())
 
-        DCP.load_state_dict(
+        dcp.load(
             state_dict=state_dict,
-            storage_reader=DCP.FileSystemReader(CHECKPOINT_DIR),
+            storage_reader=dcp.FileSystemReader(CHECKPOINT_DIR),
             planner=DefaultLoadPlanner(),
         )
 
@@ -107,9 +107,9 @@ class TestTpCheckpoint(DTensorTestBase):
         model = parallelize_module(model, tp_mesh, parallelize_plan=parallelize_plan)
         original_state_dict = deepcopy(model.state_dict())
 
-        DCP.save_state_dict(
+        dcp.save(
             state_dict=original_state_dict,
-            storage_writer=DCP.FileSystemWriter(CHECKPOINT_DIR),
+            storage_writer=dcp.FileSystemWriter(CHECKPOINT_DIR),
         )
 
         model2 = parallelize_module(
@@ -117,9 +117,9 @@ class TestTpCheckpoint(DTensorTestBase):
         )
         state_dict_to_load = model2.state_dict()
 
-        DCP.load_state_dict(
+        dcp.load(
             state_dict=state_dict_to_load,
-            storage_reader=DCP.FileSystemReader(CHECKPOINT_DIR),
+            storage_reader=dcp.FileSystemReader(CHECKPOINT_DIR),
         )
         model2.load_state_dict(state_dict_to_load, assign=True)
         state_dict_after_load = model2.state_dict()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130475

When I play with DCP for distributed inference, I found that we are still using deprecated APIs for DCP even in unit test. So this PR is using the new API with unified small letters "dcp".


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @mrshenli @pritamdamania87 @zhaojuanmao @satgera @gqchen @aazzolini @osalpekar @jiayisuse @chauhang