### PR TITLE
Allow kwargs in _remove_effect_tokens_pass

### DIFF
--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -68,7 +68,7 @@ def _remove_effect_tokens_from_graph_helper(
             schema = _get_schema(func, node.args[2:])
 
         with ep.graph.inserting_before(node):
-            new_node = ep.graph.call_function(func, node.args[2:])
+            new_node = ep.graph.call_function(func, node.args[2:], node.kwargs)
         for k, v in node.meta.items():
             new_node.meta[k] = v
 

--- a/torch/testing/_internal/torchbind_impls.py
+++ b/torch/testing/_internal/torchbind_impls.py
@@ -69,7 +69,8 @@ def register_fake_operators():
     )(meta_takes_foo_tuple_return)
 
     torch.ops._TorchScriptTesting.takes_foo.default.py_impl(torch._C.DispatchKey.Meta)(
-        lambda cc, x: cc.add_tensor(x)
+        # make signature match original cpp implementation to support kwargs
+        lambda foo, x: foo.add_tensor(x)
     )
 
 


### PR DESCRIPTION
Summary: Previously, remove_effect_tokens pass didn't pass kwargs to the internal nodes. This PR fix it and add a test for it.

Test Plan: buck2 run caffe2/test:test_export -- -r test_remove_effect_token_kwargs

Reviewed By: angelayi

Differential Revision: D59603147
