### PR TITLE
[cuDNN][SDPA] Limit cuDNN SDPA head-dim to 128

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -345,10 +345,8 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
     }
     return false;
   }
-  auto head_dim_limit = 128;
+  constexpr auto head_dim_limit = 128;
   auto dprops = at::cuda::getCurrentDeviceProperties();
-  auto sm90orabove = dprops->major >= 9;
-  head_dim_limit = cudnn_version >= 90000 && sm90orabove ? 256 : head_dim_limit;
   if (d_qk > head_dim_limit || d_v > head_dim_limit) {
     if (debug) {
       TORCH_WARN("head_dim should be no more than ", head_dim_limit);

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -346,7 +346,6 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
     return false;
   }
   constexpr auto head_dim_limit = 128;
-  auto dprops = at::cuda::getCurrentDeviceProperties();
   if (d_qk > head_dim_limit || d_v > head_dim_limit) {
     if (debug) {
       TORCH_WARN("head_dim should be no more than ", head_dim_limit);


### PR DESCRIPTION
Limit cuDNN SDPA to head-dim 128 globally. Apparently the support for 256 is only for the forward on sm90+, which would be clunky to maintain as it would mean dispatching different for forward/backward.

CC @drisspg 

cc @csarofeen @ptrblck @xwang233