### PR TITLE
[Dynamo] Fix - `str` handler for UserDefinedObjectVariable

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3543,6 +3543,46 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(opt_fn_1(t), fn(t))
         self.assertEqual(counter.frame_count, 2)
 
+    def test_str_handler_for_user_defined_object(self):
+        """
+        Confirms handler behaviour for `str` is the same between eager and dynamo.
+        Compares a user defined object with custom `__str__` method and without.
+        """
+
+        class CustomStr:
+            def __str__(self):
+                return "ok"
+
+        def foo_custom_str(x):
+            a = CustomStr()
+            return x, str(a)
+
+        eager_custom_str = foo_custom_str(torch.ones(4))
+        dynamo_custom_str = torch.compile(foo_custom_str, fullgraph=True)(torch.ones(4))
+
+        self.assertEqual(eager_custom_str[1], dynamo_custom_str[1])
+        self.assertEqual(eager_custom_str[1], "ok")
+
+        class DefaultStr:
+            pass
+
+        def foo_default_str(x):
+            a = DefaultStr()
+            return x, str(a)
+
+        eager_default_str = foo_default_str(torch.ones(4))
+        dynamo_default_str = torch.compile(foo_default_str, fullgraph=True)(
+            torch.ones(4)
+        )
+
+        # Check that the tensor output from eager and dynamo modes are the same
+        self.assertEqual(eager_default_str[0], dynamo_default_str[0])
+
+        # Check that the class name (without memory address) is the same in both modes
+        eager_class_name = eager_default_str[1].split(" object at")[0]
+        dynamo_class_name = dynamo_default_str[1].split(" object at")[0]
+        self.assertEqual(eager_class_name, dynamo_class_name)
+
 
 instantiate_parametrized_tests(FunctionTests)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9605,10 +9605,9 @@ for shape in [(1,), ()]:
             def unpack(name):
                 return torch.load(name)
 
-            a = torch.ones(5, requires_grad=True)
-            y = a * a
-
             with torch.autograd.graph.saved_tensors_hooks(pack, unpack):
+                a = torch.ones(5, requires_grad=True)
+                y = a * a
                 self.assertEqual(a, y.grad_fn._saved_self)
 
                 y.sum().backward()

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9605,9 +9605,10 @@ for shape in [(1,), ()]:
             def unpack(name):
                 return torch.load(name)
 
+            a = torch.ones(5, requires_grad=True)
+            y = a * a
+
             with torch.autograd.graph.saved_tensors_hooks(pack, unpack):
-                a = torch.ones(5, requires_grad=True)
-                y = a * a
                 self.assertEqual(a, y.grad_fn._saved_self)
 
                 y.sum().backward()

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1064,7 +1064,7 @@ class BuiltinVariable(VariableTracker):
                     user_func_variable = variables.UserFunctionVariable(bound_method)
                 except AssertionError as e:
                     # Won't be able to do inline the str method, return to avoid graph break
-                    log.warning(f"Failed to create UserFunctionVariable: {e}")
+                    log.warning("Failed to create UserFunctionVariable: %s", e)
                     return
 
                 # Inline the user function

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1068,7 +1068,6 @@ class BuiltinVariable(VariableTracker):
                     return
 
                 # Inline the user function
-                user_func_variable = variables.UserFunctionVariable(bound_method)
                 return tx.inline_user_function_return(user_func_variable, [arg], {})
 
     def _call_min_max(self, tx: "InstructionTranslator", *args):


### PR DESCRIPTION
Fixes #130301 

Adjusted the call_str method to handle str conversion for UserDefinedObjectVariable.
Attempt in a clean branch for unrelated test errors.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames