### PR TITLE
Fix stack named "queue" in Util::ComputePostOrder

### DIFF
--- a/torch/csrc/lazy/core/ir_util.cpp
+++ b/torch/csrc/lazy/core/ir_util.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/lazy/core/ir_util.h>
 
+#include <stack>
+
 #include <c10/util/Logging.h>
 
 namespace torch::lazy {
@@ -8,17 +10,17 @@ std::vector<const Node*> Util::ComputePostOrder(
     const Node* node,
     EmissionMap* emap) {
   std::vector<const Node*> post_order;
-  std::vector<const Node*> queue;
-  queue.push_back(node);
-  while (!queue.empty()) {
-    node = queue.back();
+  std::stack<const Node*> node_stack;
+  node_stack.push(node);
+  while (!node_stack.empty()) {
+    node = node_stack.top();
     auto it = emap->find(node);
     if (it == emap->end()) {
       (*emap)[node] = kEmitting;
       for (auto& output : node->operands()) {
         auto oit = emap->find(output.node);
         if (oit == emap->end()) {
-          queue.push_back(output.node);
+          node_stack.push(output.node);
         } else {
           TORCH_CHECK(
               oit->second != kEmitting,
@@ -36,10 +38,10 @@ std::vector<const Node*> Util::ComputePostOrder(
       }
       (*emap)[node] = kEmitted;
       post_order.push_back(node);
-      queue.pop_back();
+      node_stack.pop();
     } else {
       TORCH_CHECK(it->second == kEmitted);
-      queue.pop_back();
+      node_stack.pop();
     }
   }
   return post_order;


### PR DESCRIPTION
This function computes a topological sort using a non-recursive implementation of DFS. Upon first reading, I thought it was using Kahn’s algorithm because it uses a variable called `queue`, but upon closer reading, I noticed this variable is actually used as a stack.

This pull request improves readability by renaming the stack and changing it from `std::vector` to `std::stack`.
Note: this also changes the backing store from an `std::vector` to an `std::deque`.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @mcarilli @ptrblck @leslie-fang-intel @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @rec @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn