### PR TITLE
[BE] Cleanup unused vars in MPS

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -41,9 +41,9 @@
 
 namespace at::native {
 namespace mps {
-typedef MPSGraphTensor* (^NormOpBlock)(mps::MPSBinaryCachedGraph*, MPSGraphTensor*, MPSGraphTensor*);
+typedef MPSGraphTensor* (^NormOpBlock)(MPSBinaryCachedGraph*, MPSGraphTensor*, MPSGraphTensor*);
 #define NormOpFn(graph, primary, secondary) \
-  MPSGraphTensor*(mps::MPSBinaryCachedGraph * graph, MPSGraphTensor * primary, MPSGraphTensor * secondary)
+  MPSGraphTensor*(MPSBinaryCachedGraph * graph, MPSGraphTensor * primary, MPSGraphTensor * secondary)
 
 enum StdVarType { STANDARD_VARIANCE, STANDARD_DEVIATION };
 
@@ -59,8 +59,6 @@ enum MPSReductionType {
   TRACE,
   NANSUM,
 };
-
-using namespace mps;
 
 static void set_apparent_shapes(NSMutableArray<NSNumber*>*& apparent_out_shape,
                                 NSMutableArray<NSNumber*>*& apparent_in_shape,
@@ -192,7 +190,7 @@ static void reduction_out_mps(const Tensor& input_t,
   NSMutableArray<NSNumber*>* output_shape = nil;
 
   set_axes_and_shapes(input_shape, opt_dim, axes, apparent_input_shape, apparent_output_shape, output_shape);
-  NSArray<NSNumber*>* wrappedAxes = mps::getTensorAxes(input_shape, opt_dim);
+  NSArray<NSNumber*>* wrappedAxes = getTensorAxes(input_shape, opt_dim);
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
     if (reduction_type == MPSReductionType::PROD) {
@@ -202,9 +200,9 @@ static void reduction_out_mps(const Tensor& input_t,
     }
     return;
   }
-  auto stream = at::mps::getCurrentMPSStream();
+  auto stream = getCurrentMPSStream();
   @autoreleasepool {
-    std::string dtype_str = dtype.has_value() ? mps::getMPSTypeString(dtype.value()) : "";
+    std::string dtype_str = dtype.has_value() ? getMPSTypeString(dtype.value()) : "";
     NSString* ns_key = [[wrappedAxes valueForKey:@"description"] componentsJoinedByString:@","];
     string key = func_name + ":" + string([ns_key UTF8String]) + ":" + getTensorsStringKey(input_t) + ":" +
         std::to_string(keepdim) + ":" + std::to_string(reduction_type) + ":" + getTensorsStringKey(output_t) + ":" +
@@ -213,8 +211,7 @@ static void reduction_out_mps(const Tensor& input_t,
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       auto inputScalarType = input_t.scalar_type();
 
-      MPSGraphTensor* inputTensor =
-          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input_t.scalar_type()), mpsShape);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input_t), mpsShape);
       MPSGraphTensor* castInputTensor = inputTensor;
       MPSDataType inputCastType = MPSDataTypeInvalid;
       if (dtype.has_value() &&
@@ -336,10 +333,10 @@ static void impl_func_norm_mps(const Tensor& input_tensor,
 
   set_apparent_shapes(apparent_output_shape, apparent_input_shape, num_reduce_dims, num_output_dims, input_shape, axes);
 
-  NSArray<NSNumber*>* wrappedAxes = mps::getTensorAxes(input_shape, dim);
+  NSArray<NSNumber*>* wrappedAxes = getTensorAxes(input_shape, dim);
   if (cdist) {
-    apparent_input_shape = [mps::getMPSShape(input_tensor.sizes()) mutableCopy];
-    apparent_output_shape = [mps::getMPSShape(output_t.sizes()) mutableCopy];
+    apparent_input_shape = [getMPSShape(input_tensor.sizes()) mutableCopy];
+    apparent_output_shape = [getMPSShape(output_t.sizes()) mutableCopy];
   }
 
   if (output_t.numel() == 0) {
@@ -354,7 +351,7 @@ static void impl_func_norm_mps(const Tensor& input_tensor,
     mps_input_dtype = MPSDataTypeFloat32;
   }
 
-  auto stream = at::mps::getCurrentMPSStream();
+  auto stream = getCurrentMPSStream();
   @autoreleasepool {
     NSString* ns_key = [[wrappedAxes valueForKey:@"description"] componentsJoinedByString:@","];
     string keepdim_info = (keepdim) ? "keepdim=1" : "keepdim=0";
@@ -412,7 +409,7 @@ static void impl_func_norm_mps(const Tensor& input_tensor,
       }
 
       if (cdist) {
-        outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:mps::getMPSShape(output_t) name:nil];
+        outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:getMPSShape(output_t) name:nil];
       }
 
       newCachedGraph->outputTensor_ =
@@ -566,7 +563,7 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
 
   double dof = std::max(0.0, correction_n - correction_value);
   double bessel_correction = correction_n / dof;
-  auto stream = at::mps::getCurrentMPSStream();
+  auto stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string op_key = (stdVarType == STANDARD_DEVIATION) ? "std_mps" : "var_mps";
@@ -623,7 +620,7 @@ static Tensor min_max_mps_impl(const Tensor& input_t, MPSReductionType reduction
   }
 
   @autoreleasepool {
-    string key = func_name + mps::getTensorsStringKey(input_t);
+    string key = func_name + getTensorsStringKey(input_t);
     CachedGraph* cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
 
@@ -697,7 +694,7 @@ static void min_max_out_mps(const Tensor& input_t,
     apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
   }
 
-  auto stream = at::mps::getCurrentMPSStream();
+  auto stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = func_name + getTensorsStringKey({input_t, indices_t}) + ":" + std::to_string(dim_);
@@ -856,7 +853,6 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
     apparent_in_shape = [getMPSShape(input_t.sizes()) mutableCopy];
   }
 
-  auto stream = at::mps::getCurrentMPSStream();
   @autoreleasepool {
     NSString* ns_key = [[apparent_in_shape valueForKey:@"description"] componentsJoinedByString:@","];
     string key =
@@ -903,13 +899,15 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
 
 } // namespace mps
 
+using namespace mps;
+
 TORCH_IMPL_FUNC(sum_out_mps)
 (const Tensor& input_t,
  OptionalIntArrayRef opt_dim,
  bool keepdim,
  std::optional<ScalarType> dtype,
  const Tensor& output_t) {
-  mps::reduction_out_mps(input_t, opt_dim, keepdim, dtype, output_t, mps::MPSReductionType::SUM, "sum_out_mps");
+  reduction_out_mps(input_t, opt_dim, keepdim, dtype, output_t, MPSReductionType::SUM, "sum_out_mps");
 }
 
 Tensor& nansum_out_mps(const Tensor& self,
@@ -924,7 +922,7 @@ Tensor& nansum_out_mps(const Tensor& self,
   ScalarType dtype = get_dtype_from_result(result, opt_dtype);
   const auto mask = make_dim_mask(dim, self.dim());
   resize_reduction_result(result, self, mask, keepdim, dtype);
-  mps::reduction_out_mps(self, dim, keepdim, dtype, result, mps::MPSReductionType::NANSUM, "nansum_out_mps");
+  reduction_out_mps(self, dim, keepdim, dtype, result, MPSReductionType::NANSUM, "nansum_out_mps");
   return result;
 }
 
@@ -943,13 +941,13 @@ Tensor trace_mps(const Tensor& self) {
   std::vector<int64_t> dims(self.dim());
   std::iota(dims.begin(), dims.end(), 0);
 
-  mps::reduction_out_mps(self,
-                         IntArrayRef(dims),
-                         false,
-                         std::nullopt,
-                         const_cast<Tensor&>(output_t),
-                         mps::MPSReductionType::TRACE,
-                         "trace_mps");
+  reduction_out_mps(self,
+                    IntArrayRef(dims),
+                    false,
+                    std::nullopt,
+                    const_cast<Tensor&>(output_t),
+                    MPSReductionType::TRACE,
+                    "trace_mps");
 
   return output_t;
 }
@@ -957,34 +955,33 @@ Tensor trace_mps(const Tensor& self) {
 TORCH_IMPL_FUNC(prod_out_mps)
 (const Tensor& input_t, int64_t dim, bool keepdim, std::optional<ScalarType> dtype, const Tensor& output_t) {
   int64_t dims[1] = {dim};
-  mps::reduction_out_mps(
-      input_t, IntArrayRef(dims, 1), keepdim, dtype, output_t, mps::MPSReductionType::PROD, "prod_out_mps");
+  reduction_out_mps(input_t, IntArrayRef(dims, 1), keepdim, dtype, output_t, MPSReductionType::PROD, "prod_out_mps");
 }
 
 TORCH_IMPL_FUNC(amax_out_mps)(const Tensor& input_t, IntArrayRef dim, bool keepdim, const Tensor& output_t) {
-  mps::reduction_out_mps(input_t, dim, keepdim, std::nullopt, output_t, mps::MPSReductionType::AMAX, "amax_out_mps");
+  reduction_out_mps(input_t, dim, keepdim, std::nullopt, output_t, MPSReductionType::AMAX, "amax_out_mps");
 }
 
 TORCH_IMPL_FUNC(amin_out_mps)(const Tensor& input_t, IntArrayRef dim, bool keepdim, const Tensor& output_t) {
-  mps::reduction_out_mps(input_t, dim, keepdim, std::nullopt, output_t, mps::MPSReductionType::AMIN, "amin_out_mps");
+  reduction_out_mps(input_t, dim, keepdim, std::nullopt, output_t, MPSReductionType::AMIN, "amin_out_mps");
 }
 
 TORCH_IMPL_FUNC(aminmax_out_mps)
 (const Tensor& input_t, std::optional<int64_t> dim_opt, bool keepdim, const Tensor& min_t, const Tensor& max_t) {
-  mps::reduction_out_mps(input_t,
-                         dim_opt.has_value() ? OptionalIntArrayRef({*dim_opt}) : std::nullopt,
-                         keepdim,
-                         std::nullopt,
-                         min_t,
-                         mps::MPSReductionType::AMIN,
-                         "aminmax_out_mps_min");
-  mps::reduction_out_mps(input_t,
-                         dim_opt.has_value() ? OptionalIntArrayRef({*dim_opt}) : std::nullopt,
-                         keepdim,
-                         std::nullopt,
-                         max_t,
-                         mps::MPSReductionType::AMAX,
-                         "aminmax_out_mps_max");
+  reduction_out_mps(input_t,
+                    dim_opt.has_value() ? OptionalIntArrayRef({*dim_opt}) : std::nullopt,
+                    keepdim,
+                    std::nullopt,
+                    min_t,
+                    MPSReductionType::AMIN,
+                    "aminmax_out_mps_min");
+  reduction_out_mps(input_t,
+                    dim_opt.has_value() ? OptionalIntArrayRef({*dim_opt}) : std::nullopt,
+                    keepdim,
+                    std::nullopt,
+                    max_t,
+                    MPSReductionType::AMAX,
+                    "aminmax_out_mps_max");
 }
 
 Tensor prod_mps(const Tensor& self, std::optional<ScalarType> opt_dtype) {
@@ -994,13 +991,8 @@ Tensor prod_mps(const Tensor& self, std::optional<ScalarType> opt_dtype) {
   Tensor output_t =
       at::empty({}, get_dtype_from_self(self, opt_dtype, true), std::nullopt, kMPS, std::nullopt, std::nullopt);
 
-  mps::reduction_out_mps(self,
-                         IntArrayRef(dims),
-                         false,
-                         opt_dtype,
-                         const_cast<Tensor&>(output_t),
-                         mps::MPSReductionType::PROD,
-                         "prod_mps");
+  reduction_out_mps(
+      self, IntArrayRef(dims), false, opt_dtype, const_cast<Tensor&>(output_t), MPSReductionType::PROD, "prod_mps");
 
   return output_t;
 }
@@ -1023,13 +1015,13 @@ Tensor count_nonzero_mps(const Tensor& self, IntArrayRef dims) {
 
   Tensor output_t =
       at::empty(IntArrayRef(output_shape), ScalarType::Long, std::nullopt, kMPS, std::nullopt, std::nullopt);
-  mps::reduction_out_mps(self,
-                         dims,
-                         false,
-                         self.scalar_type(),
-                         const_cast<Tensor&>(output_t),
-                         mps::MPSReductionType::COUNT_NONZERO,
-                         "count_nonzero_mps");
+  reduction_out_mps(self,
+                    dims,
+                    false,
+                    self.scalar_type(),
+                    const_cast<Tensor&>(output_t),
+                    MPSReductionType::COUNT_NONZERO,
+                    "count_nonzero_mps");
 
   return output_t;
 }
@@ -1040,12 +1032,12 @@ TORCH_IMPL_FUNC(mean_out_mps)
  bool keepdim,
  std::optional<ScalarType> dtype,
  const Tensor& output_t) {
-  mps::reduction_out_mps(input_t, opt_dim, keepdim, dtype, output_t, mps::MPSReductionType::MEAN, "mean_out_mps");
+  reduction_out_mps(input_t, opt_dim, keepdim, dtype, output_t, MPSReductionType::MEAN, "mean_out_mps");
 }
 
 TORCH_IMPL_FUNC(norm_out_mps)
 (const Tensor& self, const OptionalScalarRef opt_p, IntArrayRef dim, bool keepdim, const Tensor& result) {
-  mps::impl_func_norm_mps(self, self, opt_p, dim, keepdim, std::nullopt, result, /*cdist=*/false);
+  impl_func_norm_mps(self, self, opt_p, dim, keepdim, std::nullopt, result, /*cdist=*/false);
 }
 
 TORCH_IMPL_FUNC(norm_dtype_out_mps)
@@ -1055,7 +1047,7 @@ TORCH_IMPL_FUNC(norm_dtype_out_mps)
  bool keepdim,
  ScalarType dtype,
  const Tensor& result) {
-  mps::impl_func_norm_mps(self, self, opt_p, dim, keepdim, dtype, result, /*cdist=*/false);
+  impl_func_norm_mps(self, self, opt_p, dim, keepdim, dtype, result, /*cdist=*/false);
 }
 
 TORCH_IMPL_FUNC(linalg_vector_norm_out_mps)
@@ -1065,12 +1057,11 @@ TORCH_IMPL_FUNC(linalg_vector_norm_out_mps)
  bool keepdim,
  std::optional<ScalarType> opt_dtype,
  const Tensor& result) {
-  mps::impl_func_norm_mps(
+  impl_func_norm_mps(
       self, self, scalar_ord, opt_dim.value_or(IntArrayRef{}), keepdim, opt_dtype, result, /*cdist=*/false);
 }
 
 Tensor _cdist_forward_mps(const Tensor& x1, const Tensor& x2, const double p, std::optional<int64_t> compute_mode) {
-  using namespace mps;
   TORCH_CHECK(x1.dim() >= 2, "cdist only supports at least 2D tensors, X1 got: ", x1.dim(), "D");
   TORCH_CHECK(x2.dim() >= 2, "cdist only supports at least 2D tensors, X2 got: ", x2.dim(), "D");
   TORCH_CHECK(x1.size(-1) == x2.size(-1),
@@ -1178,19 +1169,18 @@ Tensor var_mps(const Tensor& input_t,
                at::OptionalIntArrayRef dim,
                const std::optional<Scalar>& correction,
                bool keepdim) {
-  return mps::std_var_common_impl_mps(input_t, dim, correction, keepdim, mps::STANDARD_VARIANCE);
+  return std_var_common_impl_mps(input_t, dim, correction, keepdim, STANDARD_VARIANCE);
 }
 
 Tensor std_mps(const Tensor& input_t,
                at::OptionalIntArrayRef dim,
                const std::optional<Scalar>& correction,
                bool keepdim) {
-  return mps::std_var_common_impl_mps(input_t, dim, correction, keepdim, mps::STANDARD_DEVIATION);
+  return std_var_common_impl_mps(input_t, dim, correction, keepdim, STANDARD_DEVIATION);
 }
 
 TORCH_IMPL_FUNC(any_out_mps)
 (const Tensor& input_t, int64_t dim, bool keepdim, const Tensor& output_t) {
-  using namespace mps;
   using CachedGraph = MPSUnaryCachedGraph;
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
@@ -1213,15 +1203,10 @@ TORCH_IMPL_FUNC(any_out_mps)
     apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
   }
 
-  auto stream = at::mps::getCurrentMPSStream();
-
   @autoreleasepool {
-    MPSShape* input_t_shape = getMPSShape(input_t);
-    string key = string("any_out_mps:") + getMPSShapeString(input_t_shape) + ":" + std::to_string(dim_) + ":" +
-        getMPSTypeString(input_t);
+    string key = string("any_out_mps:") + getTensorsStringKey(input_t) + ":" + std::to_string(dim_);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSDataType input_type = getMPSDataType(input_t);
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
 
       MPSGraphTensor* castInputTensor =
           castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
@@ -1242,7 +1227,6 @@ TORCH_IMPL_FUNC(any_out_mps)
 }
 
 TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t) {
-  using namespace mps;
   using CachedGraph = MPSUnaryCachedGraph;
   if (input_t.numel() == 0) {
     output_t.zero_();
@@ -1257,14 +1241,10 @@ TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, "any_all_out");
 
-  auto stream = at::mps::getCurrentMPSStream();
-
   @autoreleasepool {
-    MPSShape* input_t_shape = getMPSShape(input_t);
-    string key = string("any_all_out_mps:") + getMPSShapeString(input_t_shape) + ":" + getMPSTypeString(input_t);
+    string key = string("any_all_out_mps:") + getTensorsStringKey(input_t);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSDataType input_type = getMPSDataType(input_t);
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
       MPSGraphTensor* castInputTensor =
           castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
       MPSGraphTensor* castOutputTensor = [mpsGraph reductionOrWithTensor:castInputTensor axes:nil name:nil];
@@ -1286,7 +1266,6 @@ TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
 
 TORCH_IMPL_FUNC(all_out_mps)
 (const Tensor& input_t, int64_t dim, bool keepdim, const Tensor& output_t) {
-  using namespace mps;
   using CachedGraph = MPSUnaryCachedGraph;
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
@@ -1309,15 +1288,10 @@ TORCH_IMPL_FUNC(all_out_mps)
     apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
   }
 
-  auto stream = at::mps::getCurrentMPSStream();
-
   @autoreleasepool {
-    MPSShape* input_t_shape = getMPSShape(input_t);
-    string key = string("all_out_mps:") + getMPSShapeString(input_t_shape) + ":" + std::to_string(dim_) + ":" +
-        getMPSTypeString(input_t);
+    string key = string("all_out_mps:") + getTensorsStringKey(input_t) + ":" + std::to_string(dim_);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSDataType input_type = getMPSDataType(input_t);
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
       MPSGraphTensor* castInputTensor =
           castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
       MPSGraphTensor* castOutputTensor = [mpsGraph reductionAndWithTensor:castInputTensor axis:dim_ name:nil];
@@ -1337,7 +1311,6 @@ TORCH_IMPL_FUNC(all_out_mps)
 }
 
 TORCH_IMPL_FUNC(all_all_out_mps)(const Tensor& input_t, const Tensor& output_t) {
-  using namespace mps;
   using CachedGraph = MPSUnaryCachedGraph;
   if (output_t.numel() == 0 || input_t.numel() == 0) {
     // in line with cpu behaviour and numpy, an empty tensor should return true.
@@ -1349,14 +1322,10 @@ TORCH_IMPL_FUNC(all_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, "all_all_out");
 
-  auto stream = at::mps::getCurrentMPSStream();
-
   @autoreleasepool {
-    MPSShape* input_t_shape = getMPSShape(input_t);
-    string key = string("all_all_out_mps:") + getMPSShapeString(input_t_shape) + ":" + getMPSTypeString(input_t);
+    string key = string("all_all_out_mps:") + getTensorsStringKey(input_t);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSDataType input_type = getMPSDataType(input_t);
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
+      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
       MPSGraphTensor* castInputTensor =
           castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
       MPSGraphTensor* castOutputTensor = [mpsGraph reductionAndWithTensor:castInputTensor axes:nil name:nil];
@@ -1381,12 +1350,12 @@ TORCH_IMPL_FUNC(all_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
 
 // Max entire tensor into scalar result
 Tensor max_mps(const Tensor& input_t) {
-  return mps::min_max_mps_impl(input_t, mps::MPSReductionType::MAX, "max_mps");
+  return min_max_mps_impl(input_t, MPSReductionType::MAX, "max_mps");
 }
 
 // Min entire tensor into scalar result
 Tensor min_mps(const Tensor& input_t) {
-  return mps::min_max_mps_impl(input_t, mps::MPSReductionType::MIN, "min_mps");
+  return min_max_mps_impl(input_t, MPSReductionType::MIN, "min_mps");
 }
 
 // Max out with dim
@@ -1395,7 +1364,7 @@ TORCH_IMPL_FUNC(max_out_mps)
   int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
   native::zero_numel_check_dims(input_t, dim_, "max()");
 
-  mps::min_max_out_mps(input_t, dim, keepdim, output_t, indices_t, mps::MPSReductionType::MAX, "max_out_mps");
+  min_max_out_mps(input_t, dim, keepdim, output_t, indices_t, MPSReductionType::MAX, "max_out_mps");
 }
 
 // Min out with dim
@@ -1404,27 +1373,27 @@ TORCH_IMPL_FUNC(min_out_mps)
   int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
   native::zero_numel_check_dims(input_t, dim_, "min()");
 
-  mps::min_max_out_mps(input_t, dim, keepdim, output_t, indices_t, mps::MPSReductionType::MIN, "min_out_mps");
+  min_max_out_mps(input_t, dim, keepdim, output_t, indices_t, MPSReductionType::MIN, "min_out_mps");
 }
 
 TORCH_IMPL_FUNC(argmax_out_mps)
 (const Tensor& input_t, std::optional<int64_t> dim, bool keepdim, const Tensor& output_t) {
-  mps::argmax_argmin_out_mps(input_t, dim, keepdim, output_t, mps::MPSReductionType::MAX, "argmax_out_mps");
+  argmax_argmin_out_mps(input_t, dim, keepdim, output_t, MPSReductionType::MAX, "argmax_out_mps");
 }
 
 TORCH_IMPL_FUNC(argmin_out_mps)
 (const Tensor& input_t, std::optional<int64_t> dim, bool keepdim, const Tensor& output_t) {
-  mps::argmax_argmin_out_mps(input_t, dim, keepdim, output_t, mps::MPSReductionType::MIN, "argmin_out_mps");
+  argmax_argmin_out_mps(input_t, dim, keepdim, output_t, MPSReductionType::MIN, "argmin_out_mps");
 }
 
 // Max with dim
 static std::tuple<Tensor, Tensor> max_mps(const Tensor& input_t, int64_t dim, bool keepdim) {
-  return mps::min_max_mps_impl(input_t, dim, keepdim, mps::MPSReductionType::MAX, "max_mps");
+  return min_max_mps_impl(input_t, dim, keepdim, MPSReductionType::MAX, "max_mps");
 }
 
 // Min with dim
 static std::tuple<Tensor, Tensor> min_mps(const Tensor& input_t, int64_t dim, bool keepdim) {
-  return mps::min_max_mps_impl(input_t, dim, keepdim, mps::MPSReductionType::MIN, "min_mps");
+  return min_max_mps_impl(input_t, dim, keepdim, MPSReductionType::MIN, "min_mps");
 }
 
 // Median of entire tensor into scalar result
@@ -1434,8 +1403,6 @@ Tensor median_mps(const Tensor& input_t) {
                     "Falling back on CPU. This may have performance implications.");
     return at::median(input_t.to("cpu"));
   }
-
-  using namespace mps;
 
   bool macOS13_3_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_3_PLUS);
   MPS_CHECK_INT64_OP_SUPPORTED(input_t, macOS13_3_plus, "median");
@@ -1457,7 +1424,7 @@ Tensor median_mps(const Tensor& input_t) {
   }
 
   @autoreleasepool {
-    string key = "median_mps:" + mps::getMPSTypeString(input_t) + mps::getTensorsStringKey(input_t);
+    string key = "median_mps:" + getMPSTypeString(input_t) + getTensorsStringKey(input_t);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       auto inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
       MPSGraphTensor* castInputTensor =
@@ -1491,8 +1458,6 @@ static void median_out_mps(const Tensor& input_t,
                            const Tensor& output_t,
                            const Tensor& indices_t,
                            const std::string& func_name) {
-  using namespace mps;
-
   if (output_t.numel() == 0) {
     return;
   }
@@ -1528,7 +1493,7 @@ static void median_out_mps(const Tensor& input_t,
   }
   int dim_total_elements = input_shape[dim_];
 
-  auto stream = at::mps::getCurrentMPSStream();
+  auto stream = getCurrentMPSStream();
 
   @autoreleasepool {
     string key = func_name + ":" + std::to_string(dim_) + ":" + getTensorsStringKey(input_t) + ":" +
@@ -1668,7 +1633,7 @@ std::tuple<Tensor, Tensor> std_mean_mps(const Tensor& self,
   // TODO: Refactor it into a proper std_var_mean composite function
   auto std = std_mps(self, dim, correction, keepdim);
   auto mean = at::empty(std.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
-  mps::reduction_out_mps(self, dim, keepdim, std::nullopt, mean, mps::MPSReductionType::MEAN, "mean_out_mps");
+  reduction_out_mps(self, dim, keepdim, std::nullopt, mean, MPSReductionType::MEAN, "mean_out_mps");
   return {std, mean};
 }
 
@@ -1679,7 +1644,7 @@ std::tuple<Tensor, Tensor> var_mean_mps(const Tensor& self,
   // TODO: Refactor it into a proper std_var_mean composite function
   auto var = var_mps(self, dim, correction, keepdim);
   auto mean = at::empty(var.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
-  mps::reduction_out_mps(self, dim, keepdim, std::nullopt, mean, mps::MPSReductionType::MEAN, "mean_out_mps");
+  reduction_out_mps(self, dim, keepdim, std::nullopt, mean, MPSReductionType::MEAN, "mean_out_mps");
   return {var, mean};
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #130542
* __->__ #130541

And move `using namespace mps` outside of every function as there are no
need to repeat it
Use `getTensorsStringKey` instead of explicit
`getMPSShapeString(getMPSShape(t)) + getMPSDataTypeString(t)`