### PR TITLE
[MPS] Fix `torch.[all|any]` for 5+D tensors

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5349,15 +5349,21 @@ class TestMPS(TestCaseMPS):
         helper((7, 13))
         helper((2, 8, 4, 5))
 
-    @unittest.skip("Test is crashing")
     def test_reduction_ops_5D(self):
         def helper(fn, dim):
             x_cpu = fn(torch.zeros(1, 1, 1, 1, 1), dim=dim)
             x_mps = fn(torch.zeros(1, 1, 1, 1, 1, device="mps"), dim=dim)
             self.assertEqual(x_cpu, x_mps.to('cpu'))
-        for fn in [torch.any]:
+        for fn in [torch.any, torch.all]:
             for dim in range(0, 4):
                 helper(fn, dim)
+
+        # 6D tensor reductions
+        # Regression test for https://github.com/pytorch/pytorch/issues/95538
+        x = (torch.rand(2, 3, 4, 3, 4, 2, device="mps")-.5).relu()
+        self.assertEqual(x.all(), x.cpu().all())
+        for i in range(-5, 6):
+            self.assertEqual(x.all(dim=i), x.cpu().all(dim=i))
 
     def test_all(self):
         def helper(shape):
@@ -5423,9 +5429,11 @@ class TestMPS(TestCaseMPS):
         helper((1, 1, 3, 3))
         helper((7, 13))
         helper((2, 8, 4, 5))
+        # Empty tensor
         x_cpu = torch.tensor([], dtype=torch.bool)
         x_mps = x_cpu.to("mps")
-        assert x_cpu.all() == x_mps.all().cpu()
+        self.assertEqual(x_cpu.all(), x_mps.all().cpu())
+
 
     # Test forward min
     def test_min_el(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5360,7 +5360,7 @@ class TestMPS(TestCaseMPS):
 
         # 6D tensor reductions
         # Regression test for https://github.com/pytorch/pytorch/issues/95538
-        x = (torch.rand(2, 3, 4, 3, 4, 2, device="mps")-.5).relu()
+        x = (torch.rand(2, 3, 4, 3, 4, 2, device="mps") - .5).relu()
         self.assertEqual(x.all(), x.cpu().all())
         for i in range(-5, 6):
             self.assertEqual(x.all(dim=i), x.cpu().all(dim=i))
@@ -5433,7 +5433,6 @@ class TestMPS(TestCaseMPS):
         x_cpu = torch.tensor([], dtype=torch.bool)
         x_mps = x_cpu.to("mps")
         self.assertEqual(x_cpu.all(), x_mps.all().cpu())
-
 
     # Test forward min
     def test_min_el(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5351,9 +5351,10 @@ class TestMPS(TestCaseMPS):
 
     def test_reduction_ops_5D(self):
         def helper(fn, dim):
-            x_cpu = fn(torch.zeros(1, 1, 1, 1, 1), dim=dim)
-            x_mps = fn(torch.zeros(1, 1, 1, 1, 1, device="mps"), dim=dim)
-            self.assertEqual(x_cpu, x_mps.to('cpu'))
+            shape = (1, 1, 2, 1, 1)
+            x_cpu = fn(torch.zeros(shape), dim=dim)
+            x_mps = fn(torch.zeros(shape, device="mps"), dim=dim)
+            self.assertEqual(x_cpu, x_mps.cpu())
         for fn in [torch.any, torch.all]:
             for dim in range(0, 4):
                 helper(fn, dim)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130542
* #130541

Workaround bug in `reductionAndWithTensor:` that kills app with the
following assert if 5+D tensor as an input
```
Assertion failed: (0 <= mpsAxis && mpsAxis < 4 && "Runtime canonicalization must simplify reduction axes to minor 4 dimensions."), function encodeNDArrayOp, file GPUReductionOps.mm, line 76.
```
by reshaping the tensor to 2D/3D one before running the reduction.

Refactored common code into `all_any_common_impl_mps` as both `reductionOrWithTensor:` and `reductionAndWithTensor:` suffer from the same issue

Enabled `test_reduction_ops_5D` and  added regression test to it