### PR TITLE
Fix loss_parallel with BF16 logits

### DIFF
--- a/torch/distributed/tensor/parallel/loss.py
+++ b/torch/distributed/tensor/parallel/loss.py
@@ -367,7 +367,7 @@ def _nll_loss_and_log_softmax_backward(
     masked_safe_target = partial_placement._partition_value(safe_target, mesh, mesh_dim)
     # only update grad_input to -1 if not masked
     assert partial_placement.mask_buffer.data is not None
-    grad_update = partial_placement.mask_buffer.data.float() - 1.0
+    grad_update = partial_placement.mask_buffer.data.to(grad_input.dtype) - 1.0
     arange_1d = torch.arange(
         masked_safe_target.shape[0], device=masked_safe_target.device
     )


### PR DESCRIPTION
Fixes #130549

This PR uses the specific dtype for the `grad_input` buffer and fixes the error

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o