### PR TITLE
[FX][export] strict DCE pass, check schema for node impurity

### DIFF
--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -12,7 +12,7 @@ torch.fx.graph.Graph.call_function(self, the_function: Callable[..., Any], args:
 torch.fx.graph.Graph.call_method(self, method_name: str, args: Optional[Tuple[Argument, ...]] = None, kwargs: Optional[Dict[str, Argument]] = None, type_expr: Optional[Any] = None) -> torch.fx.node.Node
 torch.fx.graph.Graph.call_module(self, module_name: str, args: Optional[Tuple[Argument, ...]] = None, kwargs: Optional[Dict[str, Argument]] = None, type_expr: Optional[Any] = None) -> torch.fx.node.Node
 torch.fx.graph.Graph.create_node(self, op: str, target: 'Target', args: Optional[Tuple[Argument, ...]] = None, kwargs: Optional[Dict[str, Argument]] = None, name: Optional[str] = None, type_expr: Optional[Any] = None) -> torch.fx.node.Node
-torch.fx.graph.Graph.eliminate_dead_code(self)
+torch.fx.graph.Graph.eliminate_dead_code(self, is_impure_node: Optional[Callable[[torch.fx.node.Node], bool]] = None)
 torch.fx.graph.Graph.erase_node(self, to_erase: torch.fx.node.Node) -> None
 torch.fx.graph.Graph.get_attr(self, qualified_name: str, type_expr: Optional[Any] = None) -> torch.fx.node.Node
 torch.fx.graph.Graph.graph_copy(self, g: 'Graph', val_map: Dict[torch.fx.node.Node, torch.fx.node.Node], return_output_node = False) -> 'Optional[Argument]'

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2804,7 +2804,6 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         self.assertEqual(params[0].shape, [1, 10])  # weight
         self.assertEqual(params[1].shape, [1])  # bias
 
-    @testing.expectedFailureTrainingIRToRunDecomp  # T193700631
     def test_buffer_util(self):
         ep = export(
             torch.nn.BatchNorm2d(100, affine=False), (torch.ones(20, 100, 35, 45),)
@@ -3491,7 +3490,6 @@ def forward(self, x):
             _ = exported.module()(torch.randn(4, 4), torch.randn(4), "floor")
         self.assertTrue(torch.allclose(exported.module()(*inps), foo(*inps)))
 
-    @testing.expectedFailureTrainingIRToRunDecomp  # T193701923
     def test_to_module_with_mutated_buffer_multiple_update_sub_later(self):
         class Bar(torch.nn.Module):
             def __init__(self):
@@ -4604,7 +4602,6 @@ graph():
         optimized_model = torch.compile(exported_model)
         optimized_model(tensor_cpu, mask_cpu)
 
-    @testing.expectedFailureTrainingIRToRunDecomp  # T193701923
     def test_export_input_mutation_static_shape(self):
         class MutationModel(torch.nn.Module):
             def forward(self, x, y):

--- a/test/fx/test_dce_pass.py
+++ b/test/fx/test_dce_pass.py
@@ -64,7 +64,7 @@ class TestDCE(TestCase):
         # during DCE.
         orig_num_phs = self._get_num_placeholders(traced)
         if custom:
-            changed = traced.graph._eliminate_dead_code_custom(
+            changed = traced.graph.eliminate_dead_code(
                 is_impure_node=self._custom_is_impure_node
             )
         else:

--- a/test/fx/test_dce_pass.py
+++ b/test/fx/test_dce_pass.py
@@ -62,7 +62,10 @@ class TestDCE(TestCase):
             # Get the original number of placeholders to verify it doesn't change
             # during DCE.
             orig_num_phs = self._get_num_placeholders(traced)
-            changed = traced.graph.eliminate_dead_code(strict=strict)
+            if strict:
+                changed = traced.graph._eliminate_dead_code_strict()
+            else:
+                changed = traced.graph.eliminate_dead_code()
 
             self.assertTrue(changed if expect_dce_changes else not changed)
 

--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -114,7 +114,7 @@ def _remove_effect_tokens_from_graph_helper(
         assert inp_token.name in input_token_names
         ep.graph.erase_node(inp_token)
 
-    ep.graph.eliminate_dead_code(strict=True)
+    ep.graph._eliminate_dead_code_strict()
 
 
 def _remove_effect_tokens(ep: ExportedProgram) -> ExportedProgram:

--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -128,7 +128,7 @@ def _remove_effect_tokens_from_graph_helper(
         assert inp_token.name in input_token_names
         ep.graph.erase_node(inp_token)
 
-    ep.graph._eliminate_dead_code_custom(is_impure_node=_is_impure_node)
+    ep.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
 
 
 def _remove_effect_tokens(ep: ExportedProgram) -> ExportedProgram:

--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -114,7 +114,7 @@ def _remove_effect_tokens_from_graph_helper(
         assert inp_token.name in input_token_names
         ep.graph.erase_node(inp_token)
 
-    ep.graph.eliminate_dead_code()
+    ep.graph.eliminate_dead_code(strict=True)
 
 
 def _remove_effect_tokens(ep: ExportedProgram) -> ExportedProgram:

--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -15,6 +15,20 @@ from .graph_signature import (
 )
 
 
+def _is_impure_node(node: torch.fx.Node) -> bool:
+    """
+    Check the schema of node target to detect side-effectful nodes.
+    """
+    if node.is_impure():
+        return True
+
+    if node.op == "call_function":
+        schema = getattr(node.target, "_schema", None)
+        schema_mutable = schema is not None and schema.is_mutable
+        return schema_mutable
+    return False
+
+
 def _remove_effect_tokens_from_graph_helper(
     ep, num_tokens, input_token_names, output_token_names
 ):
@@ -114,7 +128,7 @@ def _remove_effect_tokens_from_graph_helper(
         assert inp_token.name in input_token_names
         ep.graph.erase_node(inp_token)
 
-    ep.graph._eliminate_dead_code_strict()
+    ep.graph._eliminate_dead_code_custom(is_impure_node=_is_impure_node)
 
 
 def _remove_effect_tokens(ep: ExportedProgram) -> ExportedProgram:

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -184,7 +184,7 @@ def _unlift(
     )
     gm.graph._codegen = _get_codegen(in_spec, out_spec, forward_arg_names)
     gm.graph.lint()
-    gm.graph.eliminate_dead_code()
+    gm.graph.eliminate_dead_code(strict=True)
     gm.recompile()
     return gm
 

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -8,7 +8,7 @@ import torch.utils._pytree as pytree
 from torch._export.utils import _check_input_constraints_for_graph
 from torch.export.unflatten import _assign_attr, _AttrKind
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
-from ._remove_effect_tokens_pass import _remove_effect_tokens
+from ._remove_effect_tokens_pass import _is_impure_node, _remove_effect_tokens
 
 from .exported_program import (
     ExportedProgram,
@@ -184,7 +184,7 @@ def _unlift(
     )
     gm.graph._codegen = _get_codegen(in_spec, out_spec, forward_arg_names)
     gm.graph.lint()
-    gm.graph._eliminate_dead_code_strict()
+    gm.graph._eliminate_dead_code_custom(is_impure_node=_is_impure_node)
     gm.recompile()
     return gm
 

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -184,7 +184,7 @@ def _unlift(
     )
     gm.graph._codegen = _get_codegen(in_spec, out_spec, forward_arg_names)
     gm.graph.lint()
-    gm.graph._eliminate_dead_code_custom(is_impure_node=_is_impure_node)
+    gm.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
     gm.recompile()
     return gm
 

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -184,7 +184,7 @@ def _unlift(
     )
     gm.graph._codegen = _get_codegen(in_spec, out_spec, forward_arg_names)
     gm.graph.lint()
-    gm.graph.eliminate_dead_code(strict=True)
+    gm.graph._eliminate_dead_code_strict()
     gm.recompile()
     return gm
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1574,7 +1574,7 @@ class Graph:
                             m_itr = new_m_itr
 
     @compatibility(is_backward_compatible=True)
-    def eliminate_dead_code(self):
+    def eliminate_dead_code(self, is_impure_node: Optional[Callable[[Node], bool]] = None):
         """
         Remove all dead code from the graph, based on each node's number of
         users, and whether the nodes have any side effects. The graph must be
@@ -1582,6 +1582,11 @@ class Graph:
 
         Returns:
           bool: Whether the graph was changed as a result of the pass.
+
+        Args:
+            is_impure_node (Optional[Callable[[Node], bool]]): A function that returns
+            whether a node is impure. If this is None, then the default behavior is to
+            use Node.is_impure.
 
         Example:
 
@@ -1608,46 +1613,24 @@ class Graph:
             side-effectful nodes (see Node.is_impure) but in general coverage
             is very bad, so you should assume that this method is not sound
             to call unless you know that your FX graph consists entirely
-            of functional operations.
+            of functional operations or that you supply your own custom
+            function for detecting side-effectful nodes.
         """
         # Lint the graph first to make sure its topologically sorted, otherwise
         # DCE below will not behave as expected.
         self.lint()
+
+        def has_side_effect(node):
+            if is_impure_node is not None:
+                return is_impure_node(node)
+            return node.is_impure()
 
         # Reverse iterate so that when we remove a node, any nodes used as an
         # input to that node have an updated user count that no longer reflects
         # the removed node.
         changed = False
         for node in reversed(self.nodes):
-            if not node.is_impure() and len(node.users) == 0:
-                self.erase_node(node)
-                changed = True
-
-        return changed
-
-    def _eliminate_dead_code_custom(self, is_impure_node: Callable[[Node], bool]):
-        """
-        Remove all dead code from the graph, based on each node's number of
-        users, and whether the nodes have any side effects. The graph must be
-        topologically sorted before calling.
-
-        Args:
-            is_impure_node (Callable[[Node], bool]): A function that returns whether
-            a node is impure.
-
-        Returns:
-          bool: Whether the graph was changed as a result of the pass.
-        """
-        # Lint the graph first to make sure its topologically sorted, otherwise
-        # DCE below will not behave as expected.
-        self.lint()
-
-        # Reverse iterate so that when we remove a node, any nodes used as an
-        # input to that node have an updated user count that no longer reflects
-        # the removed node.
-        changed = False
-        for node in reversed(self.nodes):
-            if not is_impure_node(node) and len(node.users) == 0:
+            if not has_side_effect(node) and len(node.users) == 0:
                 self.erase_node(node)
                 changed = True
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1580,13 +1580,13 @@ class Graph:
         users, and whether the nodes have any side effects. The graph must be
         topologically sorted before calling.
 
-        Returns:
-          bool: Whether the graph was changed as a result of the pass.
-
         Args:
             is_impure_node (Optional[Callable[[Node], bool]]): A function that returns
             whether a node is impure. If this is None, then the default behavior is to
             use Node.is_impure.
+
+        Returns:
+          bool: Whether the graph was changed as a result of the pass.
 
         Example:
 
@@ -1613,7 +1613,7 @@ class Graph:
             side-effectful nodes (see Node.is_impure) but in general coverage
             is very bad, so you should assume that this method is not sound
             to call unless you know that your FX graph consists entirely
-            of functional operations or that you supply your own custom
+            of functional operations or you supply your own custom
             function for detecting side-effectful nodes.
         """
         # Lint the graph first to make sure its topologically sorted, otherwise

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1574,7 +1574,7 @@ class Graph:
                             m_itr = new_m_itr
 
     @compatibility(is_backward_compatible=True)
-    def eliminate_dead_code(self):
+    def eliminate_dead_code(self, strict=False):
         """
         Remove all dead code from the graph, based on each node's number of
         users, and whether the nodes have any side effects. The graph must be
@@ -1609,6 +1609,9 @@ class Graph:
             is very bad, so you should assume that this method is not sound
             to call unless you know that your FX graph consists entirely
             of functional operations.
+
+            If strict = True, then this will also check the schema of node target
+            to detect side-effectful nodes.
         """
         # Lint the graph first to make sure its topologically sorted, otherwise
         # DCE below will not behave as expected.
@@ -1619,7 +1622,7 @@ class Graph:
         # the removed node.
         changed = False
         for node in reversed(self.nodes):
-            if not node.is_impure() and len(node.users) == 0:
+            if not node.is_impure(strict) and len(node.users) == 0:
                 self.erase_node(node)
                 changed = True
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -636,13 +636,10 @@ class Node(_NodeBase):
         return [n for n in to_process if n not in skipped]
 
     @compatibility(is_backward_compatible=False)
-    def is_impure(self, strict=False):
+    def is_impure(self):
         """
         Returns whether this op is impure, i.e. if its op is a placeholder or
         output, or if a call_function or call_module which is impure.
-
-        If strict is true, then this will also check the schema of a call_function
-        to determine if it has side effects.
 
         Returns:
 
@@ -653,12 +650,7 @@ class Node(_NodeBase):
 
         # Check if an impure function.
         if self.op == "call_function":
-            if not strict:
-                return self.target in _side_effectful_functions
-
-            schema = getattr(self.target, "_schema", None)
-            schema_mutable = schema is not None and schema.is_mutable
-            return schema_mutable or self.target in _side_effectful_functions
+            return self.target in _side_effectful_functions
 
         # Check if an impure module.
         if self.op == "call_module":

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -636,10 +636,13 @@ class Node(_NodeBase):
         return [n for n in to_process if n not in skipped]
 
     @compatibility(is_backward_compatible=False)
-    def is_impure(self):
+    def is_impure(self, strict=False):
         """
         Returns whether this op is impure, i.e. if its op is a placeholder or
         output, or if a call_function or call_module which is impure.
+
+        If strict is true, then this will also check the schema of a call_function
+        to determine if it has side effects.
 
         Returns:
 
@@ -650,7 +653,12 @@ class Node(_NodeBase):
 
         # Check if an impure function.
         if self.op == "call_function":
-            return self.target in _side_effectful_functions
+            if not strict:
+                return self.target in _side_effectful_functions
+
+            schema = getattr(self.target, "_schema", None)
+            schema_mutable = schema is not None and schema.is_mutable
+            return schema_mutable or self.target in _side_effectful_functions
 
         # Check if an impure module.
         if self.op == "call_module":


### PR DESCRIPTION
Fixes the failure in `test/export/test_export_training_ir_to_run_decomp.py ` caused by dead code elimination removing node with side effects.

For background, in export, we may want to export higher-level IRs that are not functional, so we need to check for side effects more carefully.

 A call_function node is impure if it has at least one mutable argument.


Fixed the tests below:

test_to_module_with_mutated_buffer_multiple_update_sub_later
test_export_input_mutation_static_shape
test_buffer_util

Another attempt modifying the original DCE pass is made in PR #130395, but it breaks some other tests, so here we add a flag and use it for export only.
