### PR TITLE
[dynamo] add meta fn for aten.kthvalue.default

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2314,6 +2314,21 @@ class GraphModule(torch.nn.Module):
         test(True, False)
         test(torch.ones(4, dtype=torch.float32), 1.1)
 
+    def test_kthvalue(self):
+        def fn(x, k, dim, keepdim):
+            return x.kthvalue(k, dim, keepdim)
+
+        def test(x, k, dim, keepdim):
+            self.assertEqual(opt_fn(x, k, dim, keepdim), fn(x, k, dim, keepdim))
+
+        opt_fn = torch.compile(fullgraph=True, dynamic=True)(fn)
+
+        test(torch.tensor(30), k=1, dim=0, keepdim=True)
+        test(torch.tensor(30), k=1, dim=-1, keepdim=False)
+        test(torch.randn(2, 3, 4), k=1, dim=0, keepdim=True)
+        test(torch.randn(2, 3, 4), k=2, dim=1, keepdim=False)
+        test(torch.randn(2, 3, 4), k=3, dim=2, keepdim=False)
+
     def test_index(self):
         def fn(x, t):
             v = operator.index(x)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2314,21 +2314,6 @@ class GraphModule(torch.nn.Module):
         test(True, False)
         test(torch.ones(4, dtype=torch.float32), 1.1)
 
-    def test_kthvalue(self):
-        def fn(x, k, dim, keepdim):
-            return x.kthvalue(k, dim, keepdim)
-
-        def test(x, k, dim, keepdim):
-            self.assertEqual(opt_fn(x, k, dim, keepdim), fn(x, k, dim, keepdim))
-
-        opt_fn = torch.compile(fullgraph=True, dynamic=True)(fn)
-
-        test(torch.tensor(30), k=1, dim=0, keepdim=True)
-        test(torch.tensor(30), k=1, dim=-1, keepdim=False)
-        test(torch.randn(2, 3, 4), k=1, dim=0, keepdim=True)
-        test(torch.randn(2, 3, 4), k=2, dim=1, keepdim=False)
-        test(torch.randn(2, 3, 4), k=3, dim=2, keepdim=False)
-
     def test_index(self):
         def fn(x, t):
             v = operator.index(x)

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -5917,7 +5917,6 @@ symbolic_aot_autograd_failures = {
     xfail(
         "index_fill", ""
     ),  # Cannot call sizes() on tensor with symbolic sizes/strides
-    xfail("kthvalue", ""),  # Cannot call sizes() on tensor with symbolic sizes/strides
     xfail(
         "linalg.lstsq", ""
     ),  # aten.linalg_lstsq.default - couldn't find symbolic meta function/decomposition

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -674,7 +674,6 @@ meta_function_expected_failures = {
     torch.functional.unique_consecutive : {f64, i32, i64, u8, i16, f16, bf16, b8, i8, f32, u16, u32, u64},
     torch.histogram : {f64, f32},
     torch.histogramdd : {f64, f32},
-    torch.kthvalue : {f64, i32, i64, u8, i16, f16, bf16, i8, f32},
     torch.nn.functional.ctc_loss : {f64, f32},
     torch.nn.functional.gaussian_nll_loss : {f16, f64, bf16, f32},
     torch.linalg.lstsq : {f64, f32, c128, c64},
@@ -748,7 +747,6 @@ meta_function_device_expected_failures['cuda'] = {
     torch.functional.unique: {f16},  # aten::_unique2, aten::unique_dim
     torch.functional.unique_consecutive: {f16},  # aten::unique_consecutive
     torch.geqrf: {f32, f64},  # aten::geqrf
-    torch.kthvalue: {f16},  # aten::kthvalue.values
 }
 
 meta_function_device_skips['cpu'] = {
@@ -846,7 +844,6 @@ meta_dispatch_expected_failures = {
     aten.equal.default : {c64, f16, i8, f64, c128, i64, bf16, f32, i32, b8, i16, u8},
     aten.histogram.bin_ct : {f32, f64},
     aten.histogram.bins_tensor : {f32, f64},
-    aten.kthvalue.default : {i8, f64, i64, f16, bf16, f32, i32, i16, u8},
     aten.unique_consecutive.default : {i8, f64, i64, f16, bf16, f32, i32, b8, i16, u8, u16, u32, u64},
     aten.unique_dim.default : {i8, f64, i64, f16, bf16, f32, i32, b8, i16, u8, u16, u32, u64},
     aten.upsample_nearest3d.vec : {bf16, f32, f64, u8},
@@ -895,7 +892,6 @@ meta_dispatch_device_expected_failures['cuda'] = {
     aten._use_cudnn_ctc_loss.Tensor: {f32, f64},  # aten::_use_cudnn_ctc_loss.Tensor
     aten.cudnn_grid_sampler.default: {f16, f32, f64},  # aten::cudnn_grid_sampler
     aten.geqrf.default: {f32, f64},  # aten::geqrf
-    aten.kthvalue.default: {f16},  # aten::kthvalue.values
     aten.linalg_eigvalsh.out: {f32, f64},  # aten::linalg_eigvalsh.out
     aten.log_sigmoid_forward.default: {bf16, f16, f64, f32},
     aten.log_sigmoid_forward.output : {bf16, f16, f64, f32},  # aten::log_sigmoid_forward.output

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1999,7 +1999,6 @@ symbolic_tensor_failures = {
     xfail('geqrf', ''),  # aten.geqrf.default - couldn't find symbolic meta function/decomposition
     xfail('histogram', ''),  # Could not run 'aten::histogram.bin_ct' with arguments from the 'Meta' backend. This c...
     xfail('histogramdd', ''),  # aten._histogramdd_bin_edges.default - couldn't find symbolic meta function/decomposition
-    xfail('kthvalue', ''),  # aten.kthvalue.default - couldn't find symbolic meta function/decomposition
     xfail('nanquantile', ''),  # Could not run 'aten::equal' with arguments from the 'Meta' backend.
     xfail('nn.functional.binary_cross_entropy', ''),  # aten.new_empty.default - couldn't find symbolic meta function/decom...
     xfail('nn.functional.cross_entropy', ''),  # aten.size.default - couldn't find symbolic meta function/decomposition

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5791,7 +5791,7 @@ def kthvalue_meta(self, k, dim=-1, keepdim=False):
     )
 
     shape = list(self.shape[:dim] + self.shape[dim + 1 :])
-    if keepdim:
+    if keepdim and self.dim() > 0:
         shape.insert(dim, 1)
     return self.new_empty(shape), self.new_empty(shape, dtype=torch.int64)
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5781,7 +5781,8 @@ def topk_meta(self, k, dim=-1, largest=True, sorted=True):
     return self.new_empty(topKSize), self.new_empty(topKSize, dtype=torch.int64)
 
 
-@register_meta(aten.kthvalue.default)
+@register_meta([aten.kthvalue.default, aten.kthvalue.values])
+@out_wrapper("values", "indices")
 def kthvalue_meta(self, k, dim=-1, keepdim=False):
     dim = maybe_wrap_dim(dim, self.dim(), wrap_scalar=True)
     dimSize = self.size(dim) if self.dim() > 0 else 1

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5772,10 +5772,6 @@ def scalar_tensor(s, dtype=None, layout=None, device=None, pin_memory=None):
 def topk_meta(self, k, dim=-1, largest=True, sorted=True):
     # From aten/src/ATen/native/Sorting.cpp
     dim = maybe_wrap_dim(dim, self.dim(), wrap_scalar=True)
-    torch._check(
-        k >= 0 and k <= (self.size(dim) if self.dim() > 0 else 1),
-        lambda: "selected index k out of range",
-    )
     sliceSize = 1 if self.dim() == 0 else self.size(dim)
     torch._check(k >= 0 and k <= sliceSize, lambda: "k not in range for dimension")
 
@@ -5783,6 +5779,21 @@ def topk_meta(self, k, dim=-1, largest=True, sorted=True):
     if len(topKSize) > 0:
         topKSize[dim] = k
     return self.new_empty(topKSize), self.new_empty(topKSize, dtype=torch.int64)
+
+
+@register_meta(aten.kthvalue.default)
+def kthvalue_meta(self, k, dim=-1, keepdim=False):
+    dim = maybe_wrap_dim(dim, self.dim(), wrap_scalar=True)
+    dimSize = self.size(dim) if self.dim() > 0 else 1
+    torch._check(
+        k >= 1 and k <= dimSize,
+        lambda: f"kthvalue(): selected number k out of range for dimension {dim}",
+    )
+
+    shape = list(self.shape[:dim] + self.shape[dim + 1 :])
+    if keepdim:
+        shape.insert(dim, 1)
+    return self.new_empty(shape), self.new_empty(shape, dtype=torch.int64)
 
 
 legacy_contiguous_memory_format = torch.contiguous_format


### PR DESCRIPTION
I saw
```
torch._dynamo.exc.Unsupported: unsupported operator: aten.kthvalue.default
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130562



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames