### PR TITLE
[Pipelining] add looped schedules to fsdp/ddp test

### DIFF
--- a/test/distributed/pipelining/test_composability.py
+++ b/test/distributed/pipelining/test_composability.py
@@ -20,7 +20,10 @@ from torch.distributed.pipelining import PipelineStage
 from torch.distributed.pipelining.schedules import (
     PipelineScheduleSingle,
     Schedule1F1B,
+    ScheduleFlexibleInterleaved1F1B,
     ScheduleGPipe,
+    ScheduleInterleaved1F1B,
+    ScheduleLoopedBFS,
 )
 from torch.nn.parallel import DistributedDataParallel as DDP
 
@@ -57,7 +60,16 @@ class ComposabilityTest(MultiProcContinousTest):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "Test requires 4+ GPUs")
     @parametrize("dp_type", ["DDP", "FSDP"])
-    @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
+    @parametrize(
+        "ScheduleClass",
+        [
+            ScheduleGPipe,
+            Schedule1F1B,
+            ScheduleInterleaved1F1B,
+            ScheduleLoopedBFS,
+            ScheduleFlexibleInterleaved1F1B,
+        ],
+    )
     def test_manual_with_data_parallel(self, dp_type, ScheduleClass):
         device_mesh = init_device_mesh(
             "cuda", mesh_shape=(2, 2), mesh_dim_names=("dp", "pp")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #130488
* #130378
* #129810
* __->__ #130563

It feels like an oversight that these were not tested, especially since
the test case already handles multi schedules specially but no
multi-schedules were being tested

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @d4l3k @c-p-i-o