### PR TITLE
Fix and improve reorder_compute_for_overlap

### DIFF
--- a/test/distributed/test_compute_comm_reordering.py
+++ b/test/distributed/test_compute_comm_reordering.py
@@ -200,7 +200,6 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             correct = func(inputs, **self.get_world_trs())
             self.assertTrue(same(out, correct))
 
-    @unittest.skipIf(True, "FIXME: broken test/feature.")
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
     @patch.object(torch._inductor.config, "allow_buffer_reuse", True)
@@ -234,26 +233,24 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             # 2. then, we schedule the ops (g) that ARE NOT required for second all_reduce and DO NOT depend on first all_reduce.
             # 3. then, we schedule the ops (f) that ARE required for second all_reduce and DO depend on first all_reduce.
             # and then, we schedule the second all_reduce. And then schedule all ops that depend on second all_reduce.
-            FileCheck().check("dist.all_reduce(").check("triton_poi_fused_relu").check(
-                "extern_kernels.mm("
-            ).check("extern_kernels.mm(").check("_wait_tensor(").check(
-                "triton_poi_fused_mul"
-            ).check(
-                "dist.all_reduce("
-            ).check(
-                "_wait_tensor("
-            ).check(
-                "triton_poi_fused_add"
-            ).check(
-                "extern_kernels.mm("
-            ).run(
-                code
+            (
+                FileCheck()
+                .check("torch.ops._c10d_functional.all_reduce_.default")
+                .check("triton_poi_fused_relu")
+                .check("extern_kernels.mm")
+                .check("extern_kernels.mm")
+                .check("torch.ops._c10d_functional.wait_tensor.default")
+                .check("triton_poi_fused_mul")
+                .check("torch.ops._c10d_functional.all_reduce_.default")
+                .check("torch.ops._c10d_functional.wait_tensor.default")
+                .check("triton_poi_fused_add")
+                .check("extern_kernels.mm")
+                .run(code)
             )
             out = compiled(inputs, **self.get_world_trs())
             correct = func(inputs, **self.get_world_trs())
             self.assertTrue(same(out, correct))
 
-    @unittest.skipIf(True, "FIXME: broken test/feature.")
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
     @patch.object(torch._inductor.config, "allow_buffer_reuse", True)
@@ -292,20 +289,19 @@ class TestComputeCommReorderingMultiProc(DynamoDistributedMultiProcTestCase):
             # 2. then, we schedule the ops (g) that ARE NOT required for second all_reduce and DO NOT depend on first all_reduce.
             # 3. then, we schedule the ops (f) that ARE required for second all_reduce and DO depend on first all_reduce.
             # and then, we schedule the second all_reduce. And then schedule all ops that depend on second all_reduce.
-            FileCheck().check("dist.all_reduce(").check("triton_poi_fused_relu").check(
-                "extern_kernels.mm("
-            ).check("extern_kernels.mm(").check("_wait_tensor(").check(
-                "triton_poi_fused_mul"
-            ).check(
-                "dist.all_reduce("
-            ).check(
-                "_wait_tensor("
-            ).check(
-                "triton_poi_fused_add"
-            ).check(
-                "extern_kernels.mm("
-            ).run(
-                code
+            (
+                FileCheck()
+                .check("torch.ops._c10d_functional.all_reduce_.default")
+                .check("triton_poi_fused_relu")
+                .check("extern_kernels.mm")
+                .check("extern_kernels.mm")
+                .check("torch.ops._c10d_functional.wait_tensor.default")
+                .check("triton_poi_fused_mul")
+                .check("torch.ops._c10d_functional.all_reduce_.default")
+                .check("torch.ops._c10d_functional.wait_tensor.default")
+                .check("triton_poi_fused_add")
+                .check("extern_kernels.mm")
+                .run(code)
             )
             out = compiled(inputs, **self.get_world_trs())
             correct = func(inputs, **self.get_world_trs())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130573
* #129980

Since the raise_comms and sink_waits passes are also scheduling-based, we can now implement reorder_compute_for_overlap as an optional step in the same pass. Merging them into the same pass greatly simplifies the logic and makes it easier to reason about the synergy between different passes.

- The unit tests are now fixed and re-enabled.
- Verified that the pass produces good schedulling w/ Llama3 70B in torchtitan (the scheduling was sub-optimal before this PR).

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang