### PR TITLE
[TEST][Inductor] Fix scaled_mm call

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -714,7 +714,7 @@ class AOTInductorTestsTemplate:
 
             def forward(self, x, weight, bias, scale_a, scale_b):
                 weight = weight.to(torch.float8_e4m3fn)
-                output, updated_amax = torch._scaled_mm(
+                output = torch._scaled_mm(
                     x,
                     weight,
                     bias=input_bias,

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -69,7 +69,7 @@ class TestFP8Types(TestCase):
             )
             a_inverse_scale = 1 / a_scale
             b_inverse_scale = 1 / b_scale
-            output, updated_amax = torch._scaled_mm(
+            output = torch._scaled_mm(
                 x,
                 weight,
                 bias=input_bias,


### PR DESCRIPTION
`_scaled_mm` no longer returns `amax` (see #128683)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang