### PR TITLE
[Inductor] Avoid nan in value_ranges

### DIFF
--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -383,7 +383,8 @@ class ValueRanges(Generic[_T]):
             fn(a, b)
             for a, b in itertools.product([x.lower, x.upper], [y.lower, y.upper])
         ]
-        return ValueRanges(min(products), max(products))
+        products_no_nan = [x for x in products if str(x) != "nan"]
+        return ValueRanges(min(products_no_nan), max(products_no_nan))
 
 
 class SymPyValueRangeAnalysis:


### PR DESCRIPTION
Fixes `TypeError: Invalid NaN comparison` raised by SymPy. The tests following test suffer from this error:
- test_interpolate_ceil_eq_cuda
- test_upsample_nearest2d_dynamic_shapes_cuda
- test_upsample_nearest1d_dynamic_shapes_cuda
- test_upsample_bilinear2d_a_dynamic_shapes_cuda
- test_upsample_nearest3d_dynamic_shapes_cuda
- test_upsample_bicubic2d_dynamic_shapes_cuda



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10