### PR TITLE
[ONNX] Fix torch_onnx patch accuracy bug in benchmark

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4005,7 +4005,7 @@ def run(runner, args, original_dir=None):
         )
         experiment = speedup_experiment_onnx
         output_filename = "torch_onnx_patch.csv"
-        current_onnx_compiler = "torch_onnx_patch"
+        current_onnx_compiler = "dynamo"
     elif args.dynamo_onnx:
         optimize_ctx = functools.partial(
             optimize_onnx_ctx,


### PR DESCRIPTION
The ONNX related compilers have another route of accuracy check, and this PR brings torch_onnx compiler to the right measurement.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames