### PR TITLE
[EZ] Make test_pytree_inputs actually run tests on CUDA

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1511,7 +1511,15 @@ class AOTInductorTestsTemplate:
 
                 return [add_, mul_]
 
-        self.check_model(M(), ({"x": torch.ones(5, device=self.device), "y": torch.ones(5, device=self.device)},))
+        self.check_model(
+            M(),
+            (
+                {
+                    "x": torch.ones(5, device=self.device),
+                    "y": torch.ones(5, device=self.device),
+                },
+            ),
+        )
 
     @requires_multigpu()
     def test_non_default_cuda_device(self):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1502,15 +1502,16 @@ class AOTInductorTestsTemplate:
                 super().__init__()
 
             def forward(self, x: Dict[str, torch.Tensor]):
-                add_ = torch.zeros(5)
-                mul_ = torch.ones(5)
+                device = next(iter(x.values())).device
+                add_ = torch.zeros(5, device=device)
+                mul_ = torch.ones(5, device=device)
                 for v in x.values():
                     add_ += v
                     mul_ *= v
 
                 return [add_, mul_]
 
-        self.check_model(M(), ({"x": torch.ones(5), "y": torch.ones(5)},))
+        self.check_model(M(), ({"x": torch.ones(5, device=self.device), "y": torch.ones(5, device=self.device)},))
 
     @requires_multigpu()
     def test_non_default_cuda_device(self):


### PR DESCRIPTION
Right now it's only running it on CPU even when `self.device` is set to CUDA


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang