### PR TITLE
Change BN to eval before QAT Convert phase

### DIFF
--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -2957,6 +2957,6 @@ def _generate_qdq_quantized_model(
             else prepare_pt2e(export_model, quantizer)
         )
         prepare_model(*inputs)
+        torch.ao.quantization.move_exported_model_to_eval(prepare_model)
         convert_model = convert_pt2e(prepare_model)
-        torch.ao.quantization.move_exported_model_to_eval(convert_model)
         return convert_model


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130598

**Summary**
In the QAT convert phase, we fold bn into conv and do DCE to this BN node. We should change `torch.ops.aten._native_batch_norm_legit.default` to `torch.ops.aten._native_batch_norm_legit_no_training.default`  for a safe DCE.

