### PR TITLE
add total wall time in calculate_time_spent

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -172,7 +172,6 @@ def calculate_time_spent():
         )
 
         for key, timing in timings.items():
-            total += timing
             if key not in total_by_key:
                 total_by_key[key] = timing
             else:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -164,15 +164,22 @@ def increment_op_count(cnt):
 # Calculate total time spent so far for each phase
 # For example, {'entire_frame_compile':8.574629999999999, 'backend_compile':5.26806}
 def calculate_time_spent():
-    total = 0.0
+    total_wall_time = 0.0
     total_by_key = {}
     for timings in frame_phase_timing.values():
+        total_wall_time += timings.get(
+            "entire_frame_compile", timings.get("inductor_compile", 0)
+        )
+
         for key, timing in timings.items():
             total += timing
             if key not in total_by_key:
                 total_by_key[key] = timing
             else:
                 total_by_key[key] += timing
+
+    if total_by_key:
+        total_by_key["total_wall_time"] = total_wall_time
 
     return total_by_key
 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

Actual wall time is fwd_entire_frame_time + bwd_inductor_compile.  `calculate_time_spent` is accessed internally for monitoring use https://fburl.com/code/iiurj5m6.  However, summing values up lose the info of fwd/bwd.  

This PR adds a new key of `total_wall_time` without affecting dynamo counters.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames