### PR TITLE
[inductor] Replace torch.allclose with torch.testing.assert_close in test_fx_fusion

### DIFF
--- a/test/inductor/test_fx_fusion.py
+++ b/test/inductor/test_fx_fusion.py
@@ -11,6 +11,7 @@ from torch._inductor.fx_passes.pre_grad import (
     transpose_linear,
     transpose_matmul,
 )
+from torch._dynamo.testing import same
 from torch._inductor.test_case import run_tests, TestCase
 from torch.fx.passes.shape_prop import ShapeProp
 
@@ -67,7 +68,7 @@ class TestFxFusion(TestCase):
         ]
         for f in [test_kwarg, test_arg, test_arg2, test_kwarg2, test_kwarg3]:
             traced = trace_func(f, inputs)
-            self.assertTrue(torch.allclose(f(*inputs), traced(*inputs)))
+            self.assertTrue(same(f(*inputs), traced(*inputs)))
             self.assertEqual(count_call_method(traced, "tanh"), 2)
 
     def test_linear_permute_fusion(self):
@@ -98,7 +99,7 @@ class TestFxFusion(TestCase):
             self.assertEqual(num_linear, 0)
             self.assertEqual(num_linear_transpose, 1)
 
-            self.assertTrue(torch.allclose(module(input), traced(input)))
+            self.assertTrue(same(module(input), traced(input)))
 
     def test_permute_linear_fusion(self):
         class TestModule(torch.nn.Module):
@@ -127,7 +128,7 @@ class TestFxFusion(TestCase):
             self.assertEqual(num_linear, 0)
             self.assertEqual(num_transpose_linear, 1)
 
-            self.assertTrue(torch.allclose(module(input), traced(input)))
+            self.assertTrue(same(module(input), traced(input)))
 
     def test_permute_bmm_fusion(self):
         class TestModule(torch.nn.Module):
@@ -151,7 +152,7 @@ class TestFxFusion(TestCase):
         self.assertEqual(num_bmm, 0)
         self.assertEqual(num_transpose_matmul, 1)
 
-        self.assertTrue(torch.allclose(module(input), traced(input)))
+        self.assertTrue(same(module(input), traced(input)))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_fx_fusion.py
+++ b/test/inductor/test_fx_fusion.py
@@ -11,7 +11,6 @@ from torch._inductor.fx_passes.pre_grad import (
     transpose_linear,
     transpose_matmul,
 )
-from torch._dynamo.testing import same
 from torch._inductor.test_case import run_tests, TestCase
 from torch.fx.passes.shape_prop import ShapeProp
 
@@ -68,7 +67,7 @@ class TestFxFusion(TestCase):
         ]
         for f in [test_kwarg, test_arg, test_arg2, test_kwarg2, test_kwarg3]:
             traced = trace_func(f, inputs)
-            self.assertTrue(same(f(*inputs), traced(*inputs)))
+            torch.testing.assert_close(f(*inputs), traced(*inputs))
             self.assertEqual(count_call_method(traced, "tanh"), 2)
 
     def test_linear_permute_fusion(self):
@@ -99,7 +98,7 @@ class TestFxFusion(TestCase):
             self.assertEqual(num_linear, 0)
             self.assertEqual(num_linear_transpose, 1)
 
-            self.assertTrue(same(module(input), traced(input)))
+            torch.testing.assert_close(module(input), traced(input))
 
     def test_permute_linear_fusion(self):
         class TestModule(torch.nn.Module):
@@ -128,7 +127,7 @@ class TestFxFusion(TestCase):
             self.assertEqual(num_linear, 0)
             self.assertEqual(num_transpose_linear, 1)
 
-            self.assertTrue(same(module(input), traced(input)))
+            torch.testing.assert_close(module(input), traced(input))
 
     def test_permute_bmm_fusion(self):
         class TestModule(torch.nn.Module):
@@ -152,7 +151,7 @@ class TestFxFusion(TestCase):
         self.assertEqual(num_bmm, 0)
         self.assertEqual(num_transpose_matmul, 1)
 
-        self.assertTrue(same(module(input), traced(input)))
+        torch.testing.assert_close(module(input), traced(input))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Preventative fix of a test failure with oneDNN v3.5 upgrade where order of float32 arithmetic may change in torch.admm ( bias term can be at the start or end of the arithmetic ) resulting in slightly different output due to float32 precision loss.

Replaced occurrences of torch.allclose with ~~torch._dynamo.testing.same~~  torch.testing.assert_close which is the recommended approach as per this issue https://github.com/pytorch/pytorch/issues/56544 ,the default tolerance is more relaxed than torch.allclose which satisfies the test with upcoming oneDNN change.

This should fix aarch64 ci failures in #129932 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @milpuz01 