### PR TITLE
Increase tolerance for tensorsolve tests

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -2393,6 +2393,12 @@ op_db: List[OpInfo] = [
                 device_type="cuda",
             ),
             DecorateInfo(
+                toleranceOverride({torch.float32: tol(atol=1e-3, rtol=1e-03)}),
+                "TestOperatorsCUDA",
+                "test_vjp",
+                device_type="cuda",
+            ),
+            DecorateInfo(
                 toleranceOverride({torch.float32: tol(atol=8e-04, rtol=7e-06)}),
                 "TestCommon",
                 "test_noncontiguous_samples",


### PR DESCRIPTION
Fix current failure in periodic trunk https://hud.pytorch.org/failure?name=periodic%20%2F%20linux-focal-cuda11.8-py3.10-gcc9-debug%20%2F%20test%20(default%2C%204%2C%205%2C%20linux.4xlarge.nvidia.gpu)&jobName=undefined&failureCaptures=%5B%22functorch%2Ftest_ops.py%3A%3ATestOperatorsCUDA%3A%3Atest_vjp_linalg_tensorsolve_cuda_float32%22%5D

Since it appeared with https://github.com/pytorch/pytorch/pull/128238 that only updates random seed for the test, I expect this is just bad luck of the draw. Thus increasing tolerance like we do for other tests.