### PR TITLE
Fix custom ops warning during export

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -696,6 +696,12 @@ class OpOverload(OperatorBase):
     def namespace(self):
         return self._schema.name.split("::")[0]
 
+    def _can_decompose(self):
+        dk = torch._C.DispatchKey.CompositeImplicitAutograd
+        return dk in self.py_kernels or torch._C._dispatch_has_kernel_for_dispatch_key(
+            self.name(), dk
+        )
+
     def decompose(self, *args, **kwargs):
         dk = torch._C.DispatchKey.CompositeImplicitAutograd
         if dk in self.py_kernels:

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -358,7 +358,7 @@ class FunctionalTensorMode(TorchDispatchMode):
 
             # If we are here, it means we are seeing functional composite op.
             # For pre-dispatch IR or export inference IR, we wont' decompose them
-            if self.export or self.pre_dispatch:
+            if (self.export or self.pre_dispatch) and func._can_decompose():
                 if func.namespace not in ["aten", "prim"]:
                     # TODO (tmanlaibaatar) check if the op is PT2 compliant
                     warnings.warn(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130623

Fixes https://github.com/pytorch/pytorch/issues/130588

The problem was we were warning on all custom ops, not just ones marked
as CompositeImplicitAutograd. This PR changes the warning to just warn
on CompositeImplicitAutograd ops.