### PR TITLE
Add testing regarding SparseAdam state_dicts

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1327,7 +1327,7 @@ class TestOptimRenewed(TestCase):
             optim.zero_grad()
             loss = (w.mv(i) + b).pow(2).sum()
             loss.backward()
-            if optim.__class__.__name__ == "SparseAdam":
+            if optim.only_supports_sparse_grads:
                 if w.grad is not None:
                     w.grad = w.grad.to_sparse()
                 if b.grad is not None:

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1327,7 +1327,7 @@ class TestOptimRenewed(TestCase):
             optim.zero_grad()
             loss = (w.mv(i) + b).pow(2).sum()
             loss.backward()
-            if optim.only_supports_sparse_grads:
+            if optim_info.only_supports_sparse_grads:
                 if w.grad is not None:
                     w.grad = w.grad.to_sparse()
                 if b.grad is not None:

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1327,6 +1327,11 @@ class TestOptimRenewed(TestCase):
             optim.zero_grad()
             loss = (w.mv(i) + b).pow(2).sum()
             loss.backward()
+            if optim.__class__.__name__ == "SparseAdam":
+                if w.grad is not None:
+                    w.grad = w.grad.to_sparse()
+                if b.grad is not None:
+                    b.grad = b.grad.to_sparse()
             return loss
 
         for optim_input in all_optim_inputs:
@@ -1399,6 +1404,11 @@ class TestOptimRenewed(TestCase):
                 optim.zero_grad()
                 loss = mod(i).sum()
                 loss.backward()
+                if optim.__class__.__name__ == "SparseAdam":
+                    if w.grad is not None:
+                        w.grad = w.grad.to_sparse()
+                    if b.grad is not None:
+                        b.grad = b.grad.to_sparse()
                 return loss
 
             for _ in range(3):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1404,11 +1404,6 @@ class TestOptimRenewed(TestCase):
                 optim.zero_grad()
                 loss = mod(i).sum()
                 loss.backward()
-                if optim.__class__.__name__ == "SparseAdam":
-                    if w.grad is not None:
-                        w.grad = w.grad.to_sparse()
-                    if b.grad is not None:
-                        b.grad = b.grad.to_sparse()
                 return loss
 
             for _ in range(3):

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1836,6 +1836,13 @@ optim_db: List[OptimizerInfo] = [
                 "test_tensor_lr",
             ),
             DecorateInfo(
+                unittest.skip(
+                    "SparseAdam does not support dense gradients, see #116507"
+                ),
+                "TestOptimRenewed",
+                "test_can_load_older_state_dict",
+            ),
+            DecorateInfo(
                 skipIfTorchDynamo("cannot call to_sparse on p.grad, see #117184"),
                 "TestOptimRenewed",
                 "test_load_nontensor_step",

--- a/torch/testing/_internal/common_optimizers.py
+++ b/torch/testing/_internal/common_optimizers.py
@@ -1826,13 +1826,6 @@ optim_db: List[OptimizerInfo] = [
                 "TestOptimRenewed",
             ),
             DecorateInfo(
-                unittest.skip(
-                    "SparseAdam does not support dense gradients, see #116507"
-                ),
-                "TestOptimRenewed",
-                "test_state_dict_deterministic",
-            ),
-            DecorateInfo(
                 skipIfTorchDynamo("cannot call to_sparse on p.grad, see #117184"),
                 "TestOptimRenewed",
                 "test_param_groups_lr",
@@ -1841,13 +1834,6 @@ optim_db: List[OptimizerInfo] = [
                 skipIfTorchDynamo("cannot call to_sparse on p.grad, see #117184"),
                 "TestOptimRenewed",
                 "test_tensor_lr",
-            ),
-            DecorateInfo(
-                unittest.skip(
-                    "SparseAdam does not support dense gradients, see #116507"
-                ),
-                "TestOptimRenewed",
-                "test_can_load_older_state_dict",
             ),
             DecorateInfo(
                 skipIfTorchDynamo("cannot call to_sparse on p.grad, see #117184"),


### PR DESCRIPTION
Summary:
- Updated SparseAdam to run test_state_dict_deterministic unit test.
- Made gradients sparse while keeping weights dense in the above test.

Test Plan:
- Ran test_optim.py locally.

Fixes #116507 
