### PR TITLE
[dynamo][cpp-guards] Use dict tags to skip guards on immutable dict getitems

### DIFF
--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2098,20 +2098,20 @@ class DictGuardManager : public GuardManager {
         KeyValueManager& key_value_manager = _key_value_managers[dict_pointer];
         std::unique_ptr<GuardManager>& key_manager = key_value_manager.first;
         // If dict tag matches and key is immutable, skip the key guard manager
-        bool skip_key_manager =
-            matches_dict_tag && _is_key_at_index_immutable[dict_pointer];
+        bool skip_key_manager = !key_manager ||
+            (matches_dict_tag && _is_key_at_index_immutable[dict_pointer]);
         if (!skip_key_manager) {
-          if (key_manager && !key_manager->check_nopybind(key)) {
+          if (key_manager->check_nopybind(key)) {
             return false;
           }
         }
         // If dict tag matches and value is immutable, skip the value guard
         // manager
         std::unique_ptr<GuardManager>& value_manager = key_value_manager.second;
-        bool skip_value_manager =
-            matches_dict_tag && _is_value_at_index_immutable[dict_pointer];
+        bool skip_value_manager = !value_manager ||
+            (matches_dict_tag && _is_value_at_index_immutable[dict_pointer]);
         if (!skip_value_manager) {
-          if (value_manager && !value_manager->check_nopybind(value)) {
+          if (!value_manager->check_nopybind(value)) {
             return false;
           }
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #128148
* #130420
* __->__ #130654


Reduces the guard overhead from 3.7k units to 2.1k units.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames