### PR TITLE
[pytorch][counters] WaitCounter cleanup

### DIFF
--- a/torch/csrc/monitor/instrumentation.cpp
+++ b/torch/csrc/monitor/instrumentation.cpp
@@ -20,11 +20,12 @@ WaitCounterHandle::WaitCounterHandle(std::string_view key)
   // implement
 }
 
-void WaitCounterHandle::start(std::chrono::steady_clock::time_point now) {
+WaitCounterHandle::WaitGuard WaitCounterHandle::start() {
   // implement
+  return WaitCounterHandle::WaitGuard(*this, 0);
 }
 
-void WaitCounterHandle::stop(std::chrono::steady_clock::time_point now) {
+void WaitCounterHandle::stop(intptr_t) {
   // implement
 }
 


### PR DESCRIPTION
Summary:
This diff does a minor cleanup of WaitCounters:
1. Fixes some singleton use to ensure one instance of WaitCounterImpl per counter per process
2. Updates API to enable measuring duration of individual wait operations

Test Plan: unit test

Differential Revision: D59709324
