### PR TITLE
[DeviceMesh] Add is_initialized() check with get_backend()

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -255,7 +255,7 @@ else:
                     self._get_or_create_default_group()
                     self._init_process_groups()
 
-                if get_backend() == "threaded":
+                if is_initialized() and get_backend() == "threaded":
                     self._thread_id = threading.get_ident()
 
                 # calculate the coordinates of the current global rank on the mesh


### PR DESCRIPTION
Summary: APF has a test mocking the backend without pg initialized. Therefore, we need to add the is_initialized() check to avoid test failure. Not sure if we want to add this specifically for the test, but temporarily adding it to unblock APF conveyor runs.

Test Plan:
```
[irisz@devgpu051.cln3 /data/users/irisz/fbsource/fbcode (73a3bdaa6)]$ buck2 test 'fbcode//mode/opt' fbcode//apf/distributed/tests:pipeline_parallel_test_cpu -- --exact 'apf/distributed/tests:pipeline_parallel_test_cpu - apf.distributed.tests.pipeline_parallel_test_cpu.PipelineParallelContextTestCPU: test_stage_pg_creation_with_different_backends'
File changed: fbcode//caffe2/torch/distributed/device_mesh.py
Buck UI: https://www.internalfb.com/buck2/c6eecde6-88b8-4921-a7a7-a79e18970c24
Test UI: https://www.internalfb.com/intern/testinfra/testrun/16607023667022384
Network: Up: 27KiB  Down: 17MiB  (reSessionID-c2fd6c92-3a55-4c9b-b4f8-88e10f52b642)
Jobs completed: 9. Time elapsed: 18.2s.
Cache hits: 0%. Commands: 2 (cached: 0, remote: 1, local: 1)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D59725608


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o