### PR TITLE
[PT2] Log compile ID in the signpost event

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -461,6 +461,7 @@ class ConvertFrameAssert:
             "dynamo",
             "_convert_frame_assert._compile",
             {
+                "compile_id": compile_id,
                 "co_name": code.co_name,
                 "co_filename": code.co_filename,
                 "co_firstlineno": code.co_firstlineno,


### PR DESCRIPTION
Summary:
We should log compile ID as well for easier comparison.

Currently going through some of this data, I think we should make few more changes as well.

Test Plan: Sandcastle

Differential Revision: D59725870


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames

@diff-train-skip-merge
(reverted internally)