### PR TITLE
[NJT] throw an exception if nested_tensor_from_jagged is fx-traced without being fx.wrapped

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -4454,6 +4454,20 @@ class TestNestedTensorSubclass(TestCase):
         ):
             torch.nested.nested_tensor_from_jagged(values, offsets=None, lengths=None)
 
+    @onlyCPU
+    def test_nested_tensor_from_jagged_fx_trace(self, device):
+        def fn(x, y):
+            return torch.nested.nested_tensor_from_jagged(x, y)
+
+        def user_unwrapped(x, y):
+            return fn(x, y)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "torch.nested.nested_tensor_from_jagged does not support tracing with fx.symbolic_trace",
+        ):
+            torch.fx.symbolic_trace(user_unwrapped)
+
     @dtypes(torch.float, torch.double, torch.half)
     @parametrize("dim", range(5))
     @parametrize(

--- a/torch/nested/__init__.py
+++ b/torch/nested/__init__.py
@@ -383,6 +383,13 @@ Example::
     >>> torch.equal(c, values[3:5, :])
     True
     """
+    from torch.fx._symbolic_trace import is_fx_tracing
+    if is_fx_tracing():
+        raise RuntimeError(
+            "torch.nested.nested_tensor_from_jagged does not support tracing with fx.symbolic_trace. "
+            "Use fx.wrap to wrap the function that calls nested_tensor_from_jagged."
+        )
+
     if offsets is None:
         if lengths is None:
             raise RuntimeError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130702

The NJT constructor can't be fx-traced safely due to the dummy nt used:

https://github.com/pytorch/pytorch/blob/774ca93fd2b99808761010528267ef14fa816bda/torch/nested/_internal/nested_tensor.py#L501-L508

The error doesn't appear immediately, but appears if you try to move a module with an fx-traced NJT constructor onto a different device, or try to serialize it. Let's throw an error if we try to fx-trace the NJT constructor so users know to wrap the call.

cc @ezyang @gchanan @cpuhrsch @jbschlosser @bhosmer @drisspg @soulitzer @YuqingJ