### PR TITLE
Always use high precision for SDPA math backend (#128922)

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -31,7 +31,6 @@ from torch.testing._internal.common_methods_invocations import (
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_utils import (
     is_iterable_of_tensors,
-    IS_MACOS,
     run_tests,
     skipIfCrossRef,
     skipIfTorchDynamo,
@@ -1159,7 +1158,7 @@ class DecompOneOffTests(TestCase):
         [
             xfail(
                 "nn.functional.scaled_dot_product_attention",
-                dtypes=[torch.half] + ([torch.bfloat16] if IS_MACOS else []),
+                dtypes=[torch.half],
             ),
         ],
     )

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2778,7 +2778,7 @@ class TestSDPACudaOnly(NNTestCase):
         # Fudge Factor when dropout is enabled
         dropout_fudge_factor = 1.5 if dropout_p == 0.0 else 2.0
 
-        query_fudge_factor = dropout_fudge_factor
+        query_fudge_factor = 6 * dropout_fudge_factor
         grad_q_ref_atol, grad_q_ref_rtol = get_tolerances(query_ref.grad, query_ref_lp.grad, query_fudge_factor)
 
         # TODO: Investigate why grad_k needs larger tolerances
@@ -2899,7 +2899,7 @@ class TestSDPACudaOnly(NNTestCase):
         # Fudge Factor when dropout is enabled
         dropout_fudge_factor = 1.0 if dropout_p == 0.0 else 1.75
         mask_fudge_factor = 1.0 if attn_mask is None else 1.5
-        query_fudge_factor = 2.0
+        query_fudge_factor = 6.0
 
         grad_q_ref_atol, grad_q_ref_rtol = get_tolerances(query_ref.grad, query_ref_lp.grad, query_fudge_factor)
 
@@ -3026,13 +3026,13 @@ class TestSDPACudaOnly(NNTestCase):
         output_ref_atol, output_ref_rtol = get_tolerances(out_ref, out_lp_ref, output_fudge_factor)
 
         # TODO: Investigate why grad_q needs larger tolerances
-        query_fudge_factor = 4
+        query_fudge_factor = 8
         grad_q_ref_atol, grad_q_ref_rtol = get_tolerances(query_ref.grad, query_ref_lp.grad, query_fudge_factor)
 
-        key_fudge_factor = 2
+        key_fudge_factor = 4
         grad_k_ref_atol, grad_k_ref_rtol = get_tolerances(key_ref.grad, key_ref_lp.grad, key_fudge_factor)
 
-        value_fudge_factor = 2
+        value_fudge_factor = 4
         grad_v_ref_atol, grad_v_ref_rtol = get_tolerances(value_ref.grad, value_ref_lp.grad, value_fudge_factor)
 
         self.assertEqual(out, out_ref.to(out.dtype), atol=output_ref_atol, rtol=output_ref_rtol)
@@ -3197,7 +3197,7 @@ class TestSDPACudaOnly(NNTestCase):
             # Fudge Factor when dropout is enabled
             dropout_fudge_factor = 1.0 if dropout_p == 0.0 else 1.5
 
-            query_fudge_factor = dropout_fudge_factor
+            query_fudge_factor = 6 * dropout_fudge_factor
             grad_q_ref_atol, grad_q_ref_rtol = get_tolerances(query_ref.grad, query_ref_lp.grad, query_fudge_factor)
 
             # TODO: Investigate why grad_k needs larger tolerances


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130704

Summary:

feikou observed the big numerical gaps when using math backend on AMD and NV GPUs. It's mainly because we are not using higher precision FP32 for the intermediate accumulated/materialized parts.

Since math backend is expected to be slower anyways, and we expect math backend to generate the correct reference result, I think it should be worth to upcast FP16/BF16 input to FP32, and do FP32/TF32 computations, and then downcast FP32 output back to FP16/BF16.

Reviewed By: feikou, xw285cornell

Differential Revision: D58710805