### PR TITLE
[MPS] Add support for MPS int4 (groupwise) and int8 (per channel) kernels starting with macOS 15.0

### DIFF
--- a/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+
+#if !defined(__MAC_15_0) && \
+    (!defined(MAC_OS_X_VERSION_15_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_15_0))
+
+#define MPSDataTypeInt4  ((MPSDataType) (MPSDataTypeSignedBit | 4))
+
+@interface MPSNDArrayIdentity : MPSNDArrayUnaryKernel
+-(MPSNDArray * __nullable) reshapeWithCommandBuffer: (__nullable id <MTLCommandBuffer>) cmdBuf
+                                        sourceArray: (MPSNDArray * __nonnull) sourceArray
+                                              shape: (MPSShape * __nonnull) shape
+                                   destinationArray: (MPSNDArray * __nullable) destinationArray;
+@end
+
+@interface MPSNDArrayDescriptor()
+@property (readwrite, nonatomic) BOOL preferPackedRows;
+@end
+
+@interface MPSNDArray()
+-(nonnull instancetype) initWithBuffer:(id<MTLBuffer> _Nonnull) buffer
+                                offset:(NSUInteger) offset
+                            descriptor:(MPSNDArrayDescriptor * _Nonnull) descriptor;
+-(MPSNDArray * __nullable) arrayViewWithShape:(MPSShape * _Nullable) shape
+                                      strides:(MPSShape * _Nonnull)  strides;
+@end
+
+@interface MPSNDArrayQuantizationDescriptor : NSObject <NSCopying>
+@end
+
+@interface MPSNDArrayQuantizedMatrixMultiplication : MPSNDArrayMatrixMultiplication
+- (nonnull instancetype) initWithDevice: (nonnull id<MTLDevice>) device
+             leftQuantizationDescriptor: (MPSNDArrayQuantizationDescriptor* _Nullable) leftQuantizationDescriptor
+            rightQuantizationDescriptor: (MPSNDArrayQuantizationDescriptor* _Nullable) rightQuantizationDescriptor;
+
+-(void) encodeToCommandEncoder: (id <MTLComputeCommandEncoder> _Nullable)encoder
+                 commandBuffer: (nonnull id <MTLCommandBuffer>) commandBuffer
+                  sourceArrays: (nonnull NSArray <MPSNDArray *> *) sourceArrays
+              destinationArray: (nonnull MPSNDArray *) destination;
+@end
+
+@interface MPSNDArrayAffineQuantizationDescriptor : MPSNDArrayQuantizationDescriptor
+- (nonnull instancetype) initWithDataType: (MPSDataType) quantizationDataType
+                             hasZeroPoint: (BOOL) hasZeroPoint
+                              hasMinValue: (BOOL) hasMinValue;
+@property (readwrite, nonatomic) bool implicitZeroPoint;
+@end
+
+#endif

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -313,6 +313,21 @@ inline T* LookUpOrCreateCachedGraph(const std::string& key, std::function<void(M
   });
 }
 
+template<typename T>
+inline T* LookUpOrCreateCachedMPSKernel(const std::string& key, std::function<T*()> instantiate) {
+  static std::unordered_map<int64_t, void*> _mps_cache;
+  auto keyHash = std::hash<std::string>{}(key);
+  auto it = _mps_cache.find(keyHash);
+  if (it != _mps_cache.end()) {
+    return (T*)it->second;
+  }
+
+  T* mpsKernel = instantiate();
+  TORCH_CHECK(mpsKernel != nil);
+  _mps_cache[keyHash] = (void*)mpsKernel;
+  return mpsKernel;
+}
+
 // Common math operations
 MPSGraphTensor* log1p(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor);
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4131,6 +4131,11 @@
     CPU: _int_mm_out_cpu
     CUDA: _int_mm_out_cuda
 
+- func: _convert_scales_and_zeros_mps(Tensor scales, Tensor zeros) -> Tensor
+  dispatch:
+    MPS: _convert_scales_and_zeros_mps
+  autogen: _convert_scales_and_zeros_mps.out
+
 - func: _convert_weight_to_int4pack(Tensor self, int innerKTiles) -> Tensor
   dispatch:
     CPU: _convert_weight_to_int4pack_cpu

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -56,6 +56,8 @@ aten::_convert_indices_from_coo_to_csr
 aten::_convert_indices_from_coo_to_csr.out
 aten::_convert_indices_from_csr_to_coo
 aten::_convert_indices_from_csr_to_coo.out
+aten::_convert_scales_and_zeros_mps
+aten::_convert_scales_and_zeros_mps.out
 aten::_convert_weight_to_int4pack
 aten::_convolution
 aten::_convolution.out

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9216,6 +9216,11 @@ class TestLinalgMPS(TestCaseMPS):
             )
             b_int32 = b_int32.to("mps")
             b_scales_and_zeros = b_scales_and_zeros.to("mps")
+
+            if product_version >= 15.0:
+                scales_and_zeros = b_scales_and_zeros.transpose(0, 1).contiguous()
+                b_scales_and_zeros = torch._convert_scales_and_zeros_mps(scales_and_zeros[:, :, 0], scales_and_zeros[:, :, 1])
+
             b_int4pack = torch._convert_weight_to_int4pack(
                 b_int32, inner_k_tiles
             )

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -1336,6 +1336,7 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
         "torch._conj",
         "torch._convert_indices_from_coo_to_csr",
         "torch._convert_indices_from_csr_to_coo",
+        "torch._convert_scales_and_zeros_mps",
         "torch._convert_weight_to_int4pack",
         "torch._convolution_mode",
         "torch._convolution",


### PR DESCRIPTION
Add support for MPS int4 (groupwise) and int8 (per channel) kernels starting with macOS 15.0

Summary of changes:
- `_convert_weight_to_int4pack_mps`: Add preferred way of MPS packing for the weights (starting with macOS 15.0)
- `_convert_scales_and_zeros_mps`: New function to pre-pack the scales and min values the way MPS expects
- Add support for calling directly into MPS quantized kernels + caching of the kernels

**Testing**:
- int8 and int4 tests are fully passing on macOS15

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec