### PR TITLE
[SDPA] Return false when PyTorch is not compiled with Flash attention

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -701,10 +701,14 @@ PyObject* THPModule_setSDPUseFlash(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 PyObject* THPModule_userEnabledFlashSDP(PyObject* _unused, PyObject* noargs) {
+#ifndef USE_FLASH_ATTENTION
+  Py_RETURN_FALSE;
+#else
   if (at::globalContext().userEnabledFlashSDP())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
+#endif
 }
 PyObject* THPModule_setSDPUseMemEfficient(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
@@ -718,10 +722,14 @@ PyObject* THPModule_setSDPUseMemEfficient(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 PyObject* userEnabledMemEfficientSDP(PyObject* _unused, PyObject* noargs) {
+#ifndef USE_MEM_EFF_ATTENTION
+  Py_RETURN_FALSE;
+#else
   if (at::globalContext().userEnabledMemEfficientSDP())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
+#endif
 }
 PyObject* THPModule_setSDPUseMath(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS


### PR DESCRIPTION
Summary:
When PyTorch is not compiled with Flash or mem efficient attention, `torch.backends.cuda.flash_sdp_enabled()` should return False, otherwise it's going confuse the caller, e.g.: https://github.com/facebookresearch/xformers/blob/2456ea3b8cc273fcc3be84e8a8d8871f5e4b04a9/xformers/ops/fmha/torch_attention_compat.py#L60

We could call `torch.backends.cuda.can_use_flash_attention(params)` API which should return the right value; however this maybe an overhead every time we call the attention API which maybe too much.

I think we can fail explicitly if users want to enable SDPA (although this may crash the code that was running). Or print some debug msg.

Test Plan:
```
(Pdb) torch.backends.cuda.flash_sdp_enabled()
False
(Pdb) torch.backends.cuda.mem_efficient_sdp_enabled()
False

```

Differential Revision: D59741848
