### PR TITLE
[CD] Fix xpu nightly wheel test failure

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -127,6 +127,9 @@ fi
 # Test the package
 /builder/check_binary.sh
 
+# Clean temp files
+cd /builder && git clean -ffdx
+
 # =================== The above code will be executed inside Docker container ===================
 EOL
 echo


### PR DESCRIPTION
The xpu nightly wheel test met permission issue on `linux.idc.xpu` runner. Because those runners onboarded with `jenkins` user but the binary test in docker container with `root` directly. The temp files can't be deleted, refer https://github.com/pytorch/pytorch/actions/runs/9935452320/job/27448053625#step:8:91. Link to #114850