### PR TITLE
[inductor] Remove "spawn" as an option for parallel compile method

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -429,7 +429,7 @@ optimize_scatter_upon_const_tensor = (
 
 
 # The multiprocessing start method to use for inductor workers in the codecache.
-# "subprocess", "fork", or "spawn"
+# Can be "subprocess" or "fork".
 def decide_worker_start_method():
     start_method = os.environ.get(
         "TORCHINDUCTOR_WORKER_START", "fork" if is_fbcode() else "subprocess"
@@ -437,7 +437,6 @@ def decide_worker_start_method():
     assert start_method in [
         "subprocess",
         "fork",
-        "spawn",
     ], f"Invalid start method: {start_method}"
     return start_method
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -434,10 +434,10 @@ def decide_worker_start_method():
     start_method = os.environ.get(
         "TORCHINDUCTOR_WORKER_START", "fork" if is_fbcode() else "subprocess"
     )
-    assert start_method in [
+    assert start_method in (
         "subprocess",
         "fork",
-    ], f"Invalid start method: {start_method}"
+    ), f"Invalid start method: {start_method}"
     return start_method
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130746

Summary: Looks like "spawn" is broken. Since we have "subprocess", I don't think we need it any more, so just remove as an option.

Test Plan: Verified that we get: `AssertionError: Invalid start method: spawn`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang