### PR TITLE
Cache min / max seq len for torch.nested.as_nested_tensor(t)

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -4499,9 +4499,8 @@ class TestNestedTensorSubclass(TestCase):
             dim=dim,
             batch_size=expected_batch_size,
             contiguous=True,
-            # TODO: compute min / max during construction for this case since it's easy
-            cached_min_seqlen=None,
-            cached_max_seqlen=None,
+            cached_min_seqlen=expected_seqlen,
+            cached_max_seqlen=expected_seqlen,
         )
 
         if torch.device(device) == t.device and dtype == t.dtype and contiguous:
@@ -4536,9 +4535,8 @@ class TestNestedTensorSubclass(TestCase):
             dim=dim,
             batch_size=expected_batch_size,
             contiguous=True,
-            # TODO: compute min / max during construction for this case since it's easy
-            cached_min_seqlen=None,
-            cached_max_seqlen=None,
+            cached_min_seqlen=expected_seqlen,
+            cached_max_seqlen=expected_seqlen,
         )
 
         # we don't support conversion between layouts this way atm

--- a/torch/nested/__init__.py
+++ b/torch/nested/__init__.py
@@ -119,7 +119,9 @@ def as_nested_tensor(
 
             from torch.nested._internal.nested_tensor import nested_view_from_values_offsets
 
-            return nested_view_from_values_offsets(values, offsets)
+            return nested_view_from_values_offsets(
+                values, offsets, min_seqlen=seq_len, max_seqlen=seq_len
+            )
         else:
             from torch.nested._internal.nested_tensor import jagged_from_list
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #130505
* __->__ #130766

For the `torch.nested.as_nested_tensor(t)` constructor, computing min / max seq len is trivial since the sequence lengths are all the same. Might as well cache them during construction.

Differential Revision: [D59821734](https://our.internmc.facebook.com/intern/diff/D59821734)