### PR TITLE
[caffe2] Adding null check for crash in Convolution function happening in AutoMOS inference

### DIFF
--- a/aten/src/ATen/detail/CUDAHooksInterface.cpp
+++ b/aten/src/ATen/detail/CUDAHooksInterface.cpp
@@ -24,8 +24,8 @@ namespace detail {
 // you're probably losing only a word (the vptr in the allocated object.)
 static CUDAHooksInterface* cuda_hooks = nullptr;
 
-const CUDAHooksInterface& getCUDAHooks() {
-  // NB: The once_flag here implies that if you try to call any CUDA
+const CUDAHooksInterface* getCUDAHooksPtr() {
+   // NB: The once_flag here implies that if you try to call any CUDA
   // functionality before libATen_cuda.so is loaded, CUDA is permanently
   // disabled for that copy of ATen.  In principle, we can relax this
   // restriction, but you might have to fix some code.  See getVariableHooks()
@@ -46,8 +46,13 @@ const CUDAHooksInterface& getCUDAHooks() {
     cuda_hooks = new CUDAHooksInterface();
   }
 #endif
-  return *cuda_hooks;
+  return cuda_hooks;
 }
+
+const CUDAHooksInterface& getCUDAHooks() {
+  return *(getCUDAHooksPtr());
+}
+
 } // namespace detail
 
 C10_DEFINE_REGISTRY(CUDAHooksRegistry, CUDAHooksInterface, CUDAHooksArgs)

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -207,5 +207,6 @@ TORCH_DECLARE_REGISTRY(CUDAHooksRegistry, CUDAHooksInterface, CUDAHooksArgs);
 
 namespace detail {
 TORCH_API const CUDAHooksInterface& getCUDAHooks();
+TORCH_API const CUDAHooksInterface* getCUDAHooksPtr();
 } // namespace detail
 } // namespace at

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -500,8 +500,14 @@ struct ConvParams {
     if (needs_64bit_indexing_no_split(input, weight)) {
       return false;
     }
+    bool compiledWithMiOpen = false;
+    // Checking the pointer before using it
+    auto cudaHooksPtr = detail::getCUDAHooksPtr();
+    if(cudaHooksPtr != nullptr) {
+      compiledWithMiOpen = cudaHooksPtr->compiledWithMIOpen();
+    }
     return ((input.scalar_type() == at::kFloat) || (input.scalar_type() == at::kHalf) || (input.scalar_type() == at::kBFloat16))
-           && detail::getCUDAHooks().compiledWithMIOpen()
+           && compiledWithMiOpen
            && input.is_cuda()
            && input.dim() <= MIOPEN_DIM_MAX
            && !(groups > 1 && is_dilated()) // MIOpen currently does not support dilation with groups of size > 1


### PR DESCRIPTION
Summary:
See post for more details: https://fb.workplace.com/groups/1405155842844877/permalink/8719141948112860/
Function getCUDAHooks() returns a reference to an object without checking if the object is null. In the AutoMOS QE, which runs a ML model in Messenger Android, we are getting native crashes because of this reason: https://www.internalfb.com/code/fbsource/[b7f8e18320f9d5d8347c3428c67301f20c3c81d2]/xplat/caffe2/aten/src/ATen/native/Convolution.cpp?lines=504, crash https://fburl.com/logview/xi4w7jk4
In this diff, adding an auxiliary function, getCudaHooksPtr() that returns the pointer to the object.
Then, in Convolution.cpp, adding a null check before using it.

Following guidance from ezyang who answered in the post

Test Plan: Sandcastle

Differential Revision: D59771131




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10