### PR TITLE
TCPStoreLibUvBackend: log port on error

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -275,12 +275,26 @@ class TCPStoreTest(TestCase, StoreTestBase):
             addr, world_size, wait_for_workers=False, use_libuv=self._use_libuv
         )
 
-    def test_address_already_in_use(self):
-        err_msg_reg = "^The server socket has failed to listen on any local "
-        with self.assertRaisesRegex(RuntimeError, err_msg_reg):
-            addr = DEFAULT_HOSTNAME
-            port = common.find_free_port()
+    def test_invalid_port(self):
+        addr = DEFAULT_HOSTNAME
+        port = 1
 
+        err_msg_reg = f"^(The server socket has failed to listen on any local|The server socket has failed to bind).*{port}"
+        with self.assertRaisesRegex(RuntimeError, err_msg_reg):
+            # Use noqa to silence flake8.
+            # Need to store in an unused variable here to ensure the first
+            # object is not destroyed before the second object is created.
+            store1 = dist.TCPStore(
+                addr, port, 1, True, use_libuv=self._use_libuv
+            )  # noqa: F841
+            self.assertEqual(store1.libuvBackend, self._use_libuv)
+
+    def test_address_already_in_use(self):
+        addr = DEFAULT_HOSTNAME
+        port = common.find_free_port()
+
+        err_msg_reg = f"^The server socket has failed to listen on any local .*{port}"
+        with self.assertRaisesRegex(RuntimeError, err_msg_reg):
             # Use noqa to silence flake8.
             # Need to store in an unused variable here to ensure the first
             # object is not destroyed before the second object is created.

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -236,7 +236,9 @@ class UvTcpServer : public UvTcpSocket {
       TORCH_CHECK(
           uv_res == 0,
           "UV Store addr parsing failure. ",
-          "useIpv6: ",
+          "port: ",
+          port,
+          ", useIpv6: ",
           useIpv6,
           ", code: ",
           uv_res,
@@ -250,7 +252,9 @@ class UvTcpServer : public UvTcpSocket {
       TORCH_CHECK(
           uv_res == 0,
           "The server socket has failed to bind. ",
-          "useIpv6: ",
+          "port: ",
+          port,
+          ", useIpv6: ",
           useIpv6,
           ", code: ",
           uv_res,
@@ -264,7 +268,9 @@ class UvTcpServer : public UvTcpSocket {
       TORCH_CHECK(
           uv_res == 0,
           "The server socket has failed to listen on any local network address. ",
-          "useIpv6: ",
+          "port: ",
+          port,
+          ", useIpv6: ",
           useIpv6,
           ", code: ",
           uv_res,


### PR DESCRIPTION
Adds better error messages when a socket fails to bind in libuv.

New format:
```
The server socket has failed to bind. port: 1, useIpv6: 0, code: -13, name: EACCES, message: permission denied
```

Old format:

```
The server socket has failed to listen on any local network address. useIpv6: 0, code: -98, name: EADDRINUSE, message: address already in use
```

Test plan:

Added test in `test_store.py`

```
python test/distributed/test_store.py
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o