### PR TITLE
Define 'zero-preserving unary functions' in docs

### DIFF
--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -1341,10 +1341,10 @@ see:
 
     sparse.as_sparse_gradcheck
 
-Unary functions
----------------
+Zero-preserving unary functions
+-------------------------------
 
-We aim to support all zero-preserving unary functions.
+We aim to support all 'zero-preserving unary functions': functions of one argument that map zero to zero.
 
 If you find that we are missing a zero-preserving unary function
 that you need, please feel encouraged to open an issue for a feature request.


### PR DESCRIPTION
Make explicit the definition of 'zero-preserving unary functions' in the sparse tensors documentation.



cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal