### PR TITLE
Pin `sympy < 1.13.0a0`

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -83,7 +83,7 @@ if [[ "$PACKAGE_TYPE" == conda ]]; then
       "numpy\${NUMPY_PIN}" \
       mkl>=2018 \
       ninja \
-      sympy \
+      'sympy>=1.11.0,<1.13.0a0' \
       typing-extensions \
       ${PROTOBUF_PACKAGE}
     if [[ "$DESIRED_CUDA" == 'cpu' ]]; then

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -17,11 +17,10 @@ pytest-xdist==3.3.1
 pytest-rerunfailures==10.3
 pytest-flakefinder==1.1.0
 scipy==1.10.1
-sympy==1.11.1
+sympy==1.12.1
 unittest-xml-reporting<=3.2.0,>=2.0.0
 xdoctest==1.1.0
 filelock==3.6.0
-sympy==1.11.1
 pytest-cpp==2.3.0
 rockset==1.0.3
 z3-solver==4.12.2.0

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -139,7 +139,7 @@ init_command = [
     'numpy==1.26.0 ; python_version >= "3.9"',
     'expecttest==0.1.6',
     'mypy==1.10.0',
-    'sympy==1.11.1',
+    'sympy==1.12.1',
     'types-requests==2.27.25',
     'types-PyYAML==6.0.7',
     'types-tabulate==0.8.8',

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests
 setuptools
 types-dataclasses
 typing-extensions>=4.8.0
-sympy
+sympy>=1.11.0,<1.13.0a0
 filelock
 networkx
 jinja2

--- a/setup.py
+++ b/setup.py
@@ -1138,7 +1138,7 @@ def main():
     install_requires = [
         "filelock",
         "typing-extensions>=4.8.0",
-        "sympy",
+        "sympy>=1.11.0,<1.13.0a0",
         "networkx",
         "jinja2",
         "fsspec",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #130140
* #130141
* #130144
* #130139
* __->__ #130836

`sympy` 1.13.0 introduces some breaking changes which break our tests. More specifically:

- Ref [Backwards compatibility breaks and deprecations](https://github.com/sympy/sympy/wiki/release-notes-for-1.13.0#backwards-compatibility-breaks-and-deprecations)

> BREAKING CHANGE: Float and Integer/Rational no longer compare equal with a == b. From now on Float(2.0) != Integer(2). Previously expressions involving Float would compare unequal e.g. x*2.0 != x*2 but an individual Float would compare equal to an Integer. In SymPy 1.7 a Float will always compare unequal to an Integer even if they have the same "value". Use sympy.numbers.int_valued(number) to test if a number is a concrete number with no decimal part. ([#25614](https://github.com/sympy/sympy/pull/25614) by [@smichr](https://github.com/smichr))

With `sympy` 1.12.1:

```python
In [1]: from torch.utils._sympy.functions import FloorDiv

In [2]: FloorDiv(1.0, 1.0)
Out[2]: (1.0//1.0)
```

```console
$ PYTORCH_TEST_WITH_DYNAMO=1 python test/test_sympy_utils.py
.........................................................................................s....................................................................
----------------------------------------------------------------------
Ran 158 tests in 15.362s

OK (skipped=1)
```

With `sympy` 1.13.0:

```python
In [1]: from torch.utils._sympy.functions import FloorDiv

In [2]: FloorDiv(1.0, 1.0)
RecursionError: maximum recursion depth exceeded
```

```console
$ PYTORCH_TEST_WITH_DYNAMO=1 python test/test_sympy_utils.py
.........................................................................................s....EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE....................................................F..........
======================================================================
...

======================================================================
ERROR: test_binary_ref_fn_floordiv_dtype_float (__main__.TestValueRanges.test_binary_ref_fn_floordiv_dtype_float) (a=9223372036854775807., b=9223372036854775807.)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/PanXuehai/Projects/pytorch/test/test_sympy_utils.py", line 229, in test_binary_ref
    r = getattr(ValueRangeAnalysis, fn)(a, b)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/PanXuehai/Projects/pytorch/torch/utils/_sympy/value_ranges.py", line 564, in floordiv
    r = FloorDiv(x, y)
...
RecursionError: maximum recursion depth exceeded

======================================================================
FAIL: test_unary_ref_fn_square_dtype_float (__main__.TestValueRanges.test_unary_ref_fn_square_dtype_float) (v=0)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/PanXuehai/Projects/pytorch/test/test_sympy_utils.py", line 210, in test_unary_ref
    self.assertEqual(ref_r, r.lower)
  File "/Users/PanXuehai/Projects/pytorch/torch/testing/_internal/common_utils.py", line 3721, in assertEqual
    raise error_metas.pop()[0].to_error(
AssertionError: Object comparison failed: 0.0 != 0

----------------------------------------------------------------------
Ran 158 tests in 35.650s

FAILED (failures=1, errors=289, skipped=1)
```

See also:

- #130729