### PR TITLE
[inductor] Add num_matches_for_scatter_upon_const_tensor to list of cached metrics

### DIFF
--- a/torch/_inductor/metrics.py
+++ b/torch/_inductor/metrics.py
@@ -90,6 +90,7 @@ class CachedMetricsDeltas:
     ir_nodes_pre_fusion: int
     cpp_to_dtype_count: int
     num_bytes_accessed: int
+    num_matches_for_scatter_upon_const_tensor: int
 
 
 def get_metric_fields():


### PR DESCRIPTION
Summary: test/inductor:scatter_optimization is using this counter and fails with remote caching enabled

Test Plan: `buck2 test -j 18 'fbcode//mode/opt' fbcode//caffe2/test/inductor:scatter_optimization -- --exact 'caffe2/test/inductor:scatter_optimization - test_cross_entropy_loss (caffe2.test.inductor.test_scatter_optimization.TestScatterOpt)' --run-disabled --stress-runs 10`

Differential Revision: D59817406


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang