### PR TITLE
[export] Fully support extension op in serialization/deserialization.

### DIFF
--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -136,8 +136,7 @@ class Verifier(metaclass=_VerifierMeta):
         ]
 
     def allowed_op_types(self) -> Tuple[Type[Any], ...]:
-        from torch._export.serde.serialize import allowed_registered_op_types  # Avoid circular import.
-        return (OpOverload, HigherOrderOperator, *allowed_registered_op_types())
+        return (OpOverload, HigherOrderOperator)
 
     def allowed_getattr_types(self) -> Tuple[Type[Any], ...]:
         return (torch.fx.GraphModule,)

--- a/torch/distributed/_tensor/experimental/tp_transform.py
+++ b/torch/distributed/_tensor/experimental/tp_transform.py
@@ -65,7 +65,7 @@ def tensor_parallel_transformation(
         assert res is not None
         gm = res.graph_module
 
-    return exported_program._update(gm, sig, state_dict)
+    return exported_program._update(gm, sig, state_dict=state_dict)
 
 
 class TensorParallelTransformPass(PassBase):

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -1112,23 +1112,26 @@ class ExportedProgram:
 
     @final
     def _validate(self):
+        assert (
+            len(self.verifiers) > 0
+        ), "ExportedProgram must have at least one verifier."
         for v in self.verifiers:
             v().check(self)
 
     # TODO(zhxchen17) Formalize this.
     def _update(
-        self, graph_module, graph_signature, state_dict=None
+        self, graph_module, graph_signature, *, state_dict=None, verifiers=None
     ) -> "ExportedProgram":
         return ExportedProgram(
             root=graph_module,
             graph=graph_module.graph,
             graph_signature=graph_signature,
-            state_dict=state_dict or self.state_dict,
+            state_dict=state_dict if state_dict is not None else self.state_dict,
             range_constraints=copy.deepcopy(self.range_constraints),
             module_call_graph=copy.deepcopy(self._module_call_graph),
             example_inputs=self.example_inputs,
-            verifier=self.verifier,
-            tensor_constants=self.tensor_constants,
+            verifiers=verifiers if verifiers is not None else self.verifiers,
+            constants=self.constants,
         )
 
 


### PR DESCRIPTION
Summary: Finishing up the mechanism to "register" certain types of operators to a registry so that the serializer can handle them correctly. This is expected to be firstly used by executorch.

Test Plan: buck run mode/opt caffe2/test:test_export -- -r test_export_with_extension_op_serialization

Differential Revision: D59825148


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o