### PR TITLE
[inductor] skip fx remote cache for 2 tests in test_metrics.py

### DIFF
--- a/test/inductor/test_metrics.py
+++ b/test/inductor/test_metrics.py
@@ -77,6 +77,7 @@ class TestMetrics(TestCase):
             "INNER", metrics._parse_reduction_hint(kernel_category, example_kernel)
         )
 
+    @config.patch("fx_graph_remote_cache", False)
     def test_atomic_add(self):
         @torch.compile
         def f(lhs, index, rhs):
@@ -95,6 +96,7 @@ class TestMetrics(TestCase):
         self.assertEqual(metrics._count_pattern(kernel_code, "tl.atomic_add"), 1)
 
     @largeTensorTest(25e7 * 2 * 4, device=GPU_TYPE)
+    @config.patch("fx_graph_remote_cache", False)
     @config.patch("benchmark_kernel", True)
     def test_kernel_args_num_gb(self):
         @torch.compile


### PR DESCRIPTION
Summary: `collect_defined_kernels()` is essentially patching deep inside to see if a specific codegen is happening. We could also patch somewhere in the cache path to make sure it's called, but I'm not sure that's really testing anything interesting. I suggest it's better to just disable the remote cache here.

Test Plan: `buck2 test -j 18 'fbcode//mode/opt' fbcode//caffe2/test/inductor:metrics -- --exact 'caffe2/test/inductor:metrics - test_kernel_args_num_gb (caffe2.test.inductor.test_metrics.TestMetrics)' --run-disabled --stress-runs 10`

Differential Revision: D59825899


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang