### PR TITLE
[torch.mtia] Noop set_rng_state and get_rng_state APIs

### DIFF
--- a/docs/source/mtia.rst
+++ b/docs/source/mtia.rst
@@ -23,6 +23,8 @@ The MTIA backend is implemented out of the tree, only interfaces are be defined 
     stream
     synchronize
     device
+    set_rng_state
+    get_rng_state
     DeferredMtiaCallError
 
 Streams and events

--- a/torch/mtia/__init__.py
+++ b/torch/mtia/__init__.py
@@ -4,6 +4,7 @@ This package enables an interface for accessing MTIA backend in python
 """
 
 import threading
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -261,6 +262,39 @@ def stream(stream: Optional["torch.mtia.Stream"]) -> StreamContext:
     return StreamContext(stream)
 
 
+def get_rng_state(device: Union[int, str, torch.device] = "mtia") -> Tensor:
+    r"""Returns the random number generator state as a ByteTensor.
+
+    Args:
+        device (torch.device or int, optional): The device to return the RNG state of.
+            Default: ``'mtia'`` (i.e., ``torch.device('mtia')``, the current mtia device).
+    """
+    warnings.warn(
+        "get_rng_state is not implemented in torch.mtia",
+        UserWarning,
+        stacklevel=2,
+    )
+    return torch.zeros([1], dtype=torch.uint8, device=device)
+
+
+def set_rng_state(
+    new_state: Tensor, device: Union[int, str, torch.device] = "mtia"
+) -> None:
+    r"""Sets the random number generator state.
+
+    Args:
+        new_state (torch.ByteTensor): The desired state
+        device (torch.device or int, optional): The device to set the RNG state.
+            Default: ``'mtia'`` (i.e., ``torch.device('mtia')``, the current mtia device).
+    """
+    warnings.warn(
+        "set_rng_state is not implemented in torch.mtia",
+        UserWarning,
+        stacklevel=2,
+    )
+    pass
+
+
 __all__ = [
     "init",
     "is_available",
@@ -274,4 +308,6 @@ __all__ = [
     "set_stream",
     "stream",
     "device",
+    "set_rng_state",
+    "get_rng_state",
 ]


### PR DESCRIPTION
Summary: As title

Test Plan: CI tests

Reviewed By: joebos

Differential Revision: D59036602
