### PR TITLE
Move handle-creation logic into cudacaching allocator.

### DIFF
--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -242,6 +242,11 @@ using OutOfMemoryObserver = std::function<void(
 
 using AllocatorTraceTracker = std::function<void(const TraceEntry&)>;
 
+struct ShareableHandle {
+  ptrdiff_t offset;
+  std::string handle;
+};
+
 class CUDAAllocator : public Allocator {
  public:
   virtual void* raw_alloc(size_t nbytes) = 0;
@@ -277,6 +282,7 @@ class CUDAAllocator : public Allocator {
         " does not yet support checkPoolLiveAllocations. "
         "If you need it, please file an issue describing your use case.");
   }
+  virtual ShareableHandle shareIpcHandle(void* ptr) = 0;
   virtual std::shared_ptr<void> getIpcDevPtr(std::string handle) = 0;
   virtual bool isHistoryEnabled() {
     TORCH_CHECK(
@@ -460,6 +466,10 @@ inline void releasePool(c10::DeviceIndex device, MempoolId_t mempool_id) {
 // Not part of CUDA_ALLOCATOR_BACKEND_INTERFACE
 inline std::shared_ptr<void> getIpcDevPtr(std::string handle) {
   return get()->getIpcDevPtr(std::move(handle));
+}
+
+inline ShareableHandle shareIpcHandle(void* ptr) {
+  return get()->shareIpcHandle(ptr);
 }
 
 inline std::string name() {

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -609,6 +609,13 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
     }
   }
 
+  ShareableHandle shareIpcHandle(void* handle) override {
+    TORCH_CHECK(
+        false,
+        "cudaMallocAsync does not yet support shareIpcHandle. "
+        "If you need it, please file an issue describing your use case.");
+  }
+
   std::shared_ptr<void> getIpcDevPtr(std::string handle) override {
     TORCH_CHECK(
         false,

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -314,17 +314,11 @@ static PyObject* THPStorage_shareCuda(PyObject* self, PyObject* noargs) {
   Py_INCREF(Py_None);
   if (storage.data()) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    size_t base_size;
-    void* base_ptr = c10::cuda::CUDACachingAllocator::getBaseAllocation(
-        storage.mutable_data(), &base_size);
-    ptrdiff_t offset_bytes = (char*)storage.data() - (char*)base_ptr;
-
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    cudaIpcMemHandle_t handle;
-    C10_CUDA_CHECK(cudaIpcGetMemHandle(&handle, base_ptr));
-
-    _handle = PyBytes_FromStringAndSize((char*)&handle, CUDA_IPC_HANDLE_SIZE);
-    _offset_bytes = PyLong_FromSsize_t((Py_ssize_t)offset_bytes);
+    auto shandle =
+        c10::cuda::CUDACachingAllocator::shareIpcHandle(storage.mutable_data());
+    _handle = PyBytes_FromStringAndSize(
+        shandle.handle.c_str(), (Py_ssize_t)shandle.handle.size());
+    _offset_bytes = PyLong_FromSsize_t((Py_ssize_t)shandle.offset);
 
     // Put Storage Data behind new ref counting context
     // See Note [CUDA IPC Refcounting implementation explained]

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -221,6 +221,14 @@ c10::cuda::CUDACachingAllocator::SnapshotInfo CUDAPluggableAllocator::
       "If you need it, please file an issue describing your use case.");
 }
 
+c10::cuda::CUDACachingAllocator::ShareableHandle CUDAPluggableAllocator::
+    shareIpcHandle(void* ptr) {
+  TORCH_CHECK(
+      false,
+      "CUDAPluggableAllocator does not yet support shareIPcHandle. "
+      "If you need it, please file an issue describing your use case.");
+}
+
 std::shared_ptr<void> CUDAPluggableAllocator::getIpcDevPtr(std::string handle) {
   TORCH_CHECK(
       false,

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -101,6 +101,8 @@ struct CUDAPluggableAllocator
   void releasePool(c10::DeviceIndex device, c10::cuda::MempoolId_t mempool_id)
       override;
   std::shared_ptr<void> getIpcDevPtr(std::string handle) override;
+  c10::cuda::CUDACachingAllocator::ShareableHandle shareIpcHandle(
+      void*) override;
   void recordHistory(
       bool enabled,
       c10::cuda::CUDACachingAllocator::CreateContextFn context_recorder,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #130959
* #130890
* #130889
* __->__ #130888

A later PR will then make the handle abstract and able to use
either cudaMalloc or expandable segments.