### PR TITLE
[TEST] Fix _scaled_mm tests

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1154,6 +1154,8 @@ class TestMeta(TestCase):
     @suppress_warnings
     @ops(itertools.chain(op_db, foreach_op_db))
     def test_meta_outplace(self, device, dtype, op):
+        if "_scaled_mm" in op.name:
+           raise unittest.SkipTest("_scaled_mm dose not support meta device")
         skip_op_names = (
             "fft.ihfft",
             "fft.ihfft2",
@@ -1217,6 +1219,8 @@ class TestMeta(TestCase):
                 expected = func(*args, **kwargs)
 
     def _run_dispatch_meta_test(self, device, dtype, op, symbolic_meta, inplace, all_stride_variants=False):
+        if "_scaled_mm" in op.name:
+           raise unittest.SkipTest("_scaled_mm dose not support meta device")
         if inplace:
             func = op.get_inplace()
             if not func:

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1155,7 +1155,7 @@ class TestMeta(TestCase):
     @ops(itertools.chain(op_db, foreach_op_db))
     def test_meta_outplace(self, device, dtype, op):
         if "_scaled_mm" in op.name:
-           raise unittest.SkipTest("_scaled_mm dose not support meta device")
+            raise unittest.SkipTest("_scaled_mm dose not support meta device")
         skip_op_names = (
             "fft.ihfft",
             "fft.ihfft2",
@@ -1220,7 +1220,7 @@ class TestMeta(TestCase):
 
     def _run_dispatch_meta_test(self, device, dtype, op, symbolic_meta, inplace, all_stride_variants=False):
         if "_scaled_mm" in op.name:
-           raise unittest.SkipTest("_scaled_mm dose not support meta device")
+            raise unittest.SkipTest("_scaled_mm dose not support meta device")
         if inplace:
             func = op.get_inplace()
             if not func:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8662,20 +8662,27 @@ def error_inputs_triplet_margin_loss(op_info, device, **kwargs):
 def sample_inputs_scaled_mm(op_info, device, dtype, requires_grad, **kwargs):
     make_mat_e4m3 = partial(make_tensor, device=device, dtype=torch.float8_e4m3fn, requires_grad=requires_grad)
     make_mat_e5m2 = partial(make_tensor, device=device, dtype=torch.float8_e5m2, requires_grad=requires_grad)
+    make_scale = partial(make_tensor, device=device, dtype=torch.float, requires_grad=False)
     M, N, K = 15, 32, 16
     samples = []
     # two e4m3
     mat1 = make_mat_e4m3((M, K))
     mat2 = make_mat_e4m3((K, N)).t().contiguous().t()
-    samples.append(SampleInput(mat1, mat2))
+    scale1 = make_scale((1))
+    scale2 = make_scale((1))
+    samples.append(SampleInput(mat1, mat2, scale1, scale2))
     # mat1 e4m3 mat2 e5m2
     mat1 = make_mat_e4m3((M, K))
     mat2 = make_mat_e5m2((K, N)).t().contiguous().t()
-    samples.append(SampleInput(mat1, mat2))
+    scale1 = make_scale((1))
+    scale2 = make_scale((1))
+    samples.append(SampleInput(mat1, mat2, scale1, scale2))
     # mat1 e5m2 mat2 e4m3
     mat1 = make_mat_e5m2((M, K))
     mat2 = make_mat_e4m3((K, N)).t().contiguous().t()
-    samples.append(SampleInput(mat1, mat2))
+    scale1 = make_scale((1))
+    scale2 = make_scale((1))
+    samples.append(SampleInput(mat1, mat2, scale1, scale2))
 
     yield from samples
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8668,20 +8668,20 @@ def sample_inputs_scaled_mm(op_info, device, dtype, requires_grad, **kwargs):
     # two e4m3
     mat1 = make_mat_e4m3((M, K))
     mat2 = make_mat_e4m3((K, N)).t().contiguous().t()
-    scale1 = make_scale((1))
-    scale2 = make_scale((1))
+    scale1 = make_scale((1,))
+    scale2 = make_scale((1,))
     samples.append(SampleInput(mat1, mat2, scale1, scale2))
     # mat1 e4m3 mat2 e5m2
     mat1 = make_mat_e4m3((M, K))
     mat2 = make_mat_e5m2((K, N)).t().contiguous().t()
-    scale1 = make_scale((1))
-    scale2 = make_scale((1))
+    scale1 = make_scale((1,))
+    scale2 = make_scale((1,))
     samples.append(SampleInput(mat1, mat2, scale1, scale2))
     # mat1 e5m2 mat2 e4m3
     mat1 = make_mat_e5m2((M, K))
     mat2 = make_mat_e4m3((K, N)).t().contiguous().t()
-    scale1 = make_scale((1))
-    scale2 = make_scale((1))
+    scale1 = make_scale((1,))
+    scale2 = make_scale((1,))
     samples.append(SampleInput(mat1, mat2, scale1, scale2))
 
     yield from samples


### PR DESCRIPTION
This PR resolves several sets of `_scaled_mm` test failures:
- `scale_a` and `scale_b` are now required arguments, so the function `sample_inputs_scaled_mm` must supply them
- `_scaled_mm` does not support `"meta"` device, so it should be skipped in `test_meta.py`

cc @drisspg  @xwang233 