### PR TITLE
Refactor serialization IO infrastructure and support HDFS/HTTP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ ninja
 packaging
 optree>=0.13.0
 cmake
+pyarrow

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -23,6 +23,11 @@ from pathlib import Path
 
 import torch
 from torch._subclasses.fake_tensor import FakeTensorMode, FakeTensorConverter
+from torch.io import (
+    open_file_like,
+    open_zipfile_reader,
+    open_zipfile_writer
+)
 from torch._utils import _rebuild_tensor
 from torch._utils_internal import get_file_path_2
 from torch.serialization import (
@@ -161,14 +166,14 @@ class SerializationMixin:
         }
 
         def test(name_or_buffer):
-            with torch.serialization._open_zipfile_writer(name_or_buffer) as zip_file:
+            with open_zipfile_writer(name_or_buffer) as zip_file:
                 for key in data:
                     zip_file.write_record(key, data[key], len(data[key]))
 
             if hasattr(name_or_buffer, 'seek'):
                 name_or_buffer.seek(0)
 
-            with torch.serialization._open_zipfile_reader(name_or_buffer) as zip_file:
+            with open_zipfile_reader(name_or_buffer) as zip_file:
                 for key in data:
                     actual = zip_file.get_record(key)
                     expected = data[key]
@@ -1247,7 +1252,7 @@ class TestSerialization(TestCase, SerializationMixin):
         torch.save(lstm.state_dict(), databuffer)
         databuffer.seek(0)
 
-        with torch.serialization._open_zipfile_reader(databuffer) as zip_file:
+        with open_zipfile_reader(databuffer) as zip_file:
             byteordername = 'byteorder'
             self.assertTrue(zip_file.has_record(byteordername))
             byteorderdata = zip_file.get_record(byteordername)
@@ -4217,8 +4222,8 @@ class TestSerialization(TestCase, SerializationMixin):
             if not filename:
                 f.seek(0)
             # extract 'data.pkl' for use in our fake checkpoint
-            with torch.serialization._open_file_like(f, 'rb') as opened_file:
-                with torch.serialization._open_zipfile_reader(opened_file) as zip_file:
+            with open_file_like(f, 'rb') as opened_file:
+                with open_zipfile_reader(opened_file) as zip_file:
                     data_file = io.BytesIO(zip_file.get_record('data.pkl'))
                     data_0_offset = zip_file.get_record_offset('data/0')
                     data_1_offset = zip_file.get_record_offset('data/1')
@@ -4230,7 +4235,7 @@ class TestSerialization(TestCase, SerializationMixin):
                 opened_f.seek(data_1_offset)
                 opened_f.write(b'0' * bias_nbytes)
 
-            with torch.serialization._open_zipfile_writer(g) as zip_file:
+            with open_zipfile_writer(g) as zip_file:
                 data_value = data_file.getvalue()
                 zip_file.write_record('data.pkl', data_value, len(data_value))
                 zip_file.write_record('byteorder', sys.byteorder, len(sys.byteorder))

--- a/torch/io/__init__.py
+++ b/torch/io/__init__.py
@@ -1,0 +1,67 @@
+import io
+import os
+from typing import Union, Type
+from typing_extensions import TypeIs
+
+from .file import *
+from .opener import Opener
+
+__all__ = [
+    "is_path",
+    "is_protocol",
+    "open_file_like",
+    "open_zipfile_writer",
+    "open_zipfile_reader",
+    "check_seekable"
+]
+
+supported_protocol = {}
+
+
+def is_path(file_like) -> TypeIs[Union[str, os.PathLike]]:
+    if not isinstance(file_like, (str, os.PathLike)):
+        return False
+
+    return not is_protocol(file_like)
+
+
+def is_protocol(file_like) -> bool:
+    if not isinstance(file_like, str):
+        return False
+
+    return '://' in file_like
+
+
+def _open_protocol(url: str, mode) -> Opener:
+    url_list = url.split('://')
+    if len(url_list) != 2 or url_list[0] not in supported_protocol:
+        raise RuntimeError("unsupported protocol: %s" % url)
+
+    return supported_protocol[url_list[0]](url, mode)
+
+
+def open_file_like(file_like, mode):
+    if is_path(file_like):
+        return OpenFile(file_like, mode)
+    elif is_protocol(file_like):
+        return _open_protocol(file_like, mode)
+    else:
+        if "w" in mode:
+            return OpenBufferWriter(file_like)
+        elif "r" in mode:
+            return OpenBufferReader(file_like)
+        else:
+            raise RuntimeError(f"Expected 'r' or 'w' in mode but got {mode}")
+
+
+def open_zipfile_writer(file_like):
+    container: Type[Opener]
+    if is_path(file_like):
+        container = OpenZipfileWriterFile
+    else:
+        container = OpenZipfileWriterBufferOrProtocol
+    return container(file_like)
+
+
+def open_zipfile_reader(file_like) -> Type[Opener]:
+    return OpenZipfileReader(file_like)

--- a/torch/io/__init__.py
+++ b/torch/io/__init__.py
@@ -4,6 +4,7 @@ from typing import Union, Type
 from typing_extensions import TypeIs
 
 from .file import *
+from .hdfs import HDFSOpener
 from .opener import Opener
 
 __all__ = [
@@ -15,7 +16,7 @@ __all__ = [
     "check_seekable"
 ]
 
-supported_protocol = {}
+supported_protocol = {"hdfs": HDFSOpener}
 
 
 def is_path(file_like) -> TypeIs[Union[str, os.PathLike]]:

--- a/torch/io/__init__.py
+++ b/torch/io/__init__.py
@@ -5,6 +5,7 @@ from typing_extensions import TypeIs
 
 from .file import *
 from .hdfs import HDFSOpener
+from .http import HTTPOpener
 from .opener import Opener
 
 __all__ = [
@@ -16,7 +17,7 @@ __all__ = [
     "check_seekable"
 ]
 
-supported_protocol = {"hdfs": HDFSOpener}
+supported_protocol = {"hdfs": HDFSOpener, "http": HTTPOpener}
 
 
 def is_path(file_like) -> TypeIs[Union[str, os.PathLike]]:

--- a/torch/io/base_io.py
+++ b/torch/io/base_io.py
@@ -1,0 +1,19 @@
+class BaseIO():
+    def __init__(self):
+        pass
+
+    def _readline(self, read):
+        # line terminator is always b'\n' for binary files
+        line = bytearray()
+        while True:
+            char = read(1)
+            if char == b'\n':
+                line += b'\n'
+                break
+
+            if char == b'':
+                break
+
+            line += char
+
+        return line

--- a/torch/io/file/__init__.py
+++ b/torch/io/file/__init__.py
@@ -1,0 +1,114 @@
+import io
+
+import torch
+from ..opener import Opener
+
+__all__ = [
+    "OpenFile",
+    "OpenBufferReader",
+    "OpenBufferWriter",
+    "OpenZipfileReader",
+    "OpenZipfileWriterFile",
+    "OpenZipfileWriterBufferOrProtocol",
+    "check_seekable"
+]
+
+
+class OpenFile(Opener):
+    """
+    Opener for local disk file
+    """
+    def __init__(self, name, mode):
+        super().__init__(open(name, mode))
+
+    def __exit__(self, *args):
+        self.file_like.close()
+
+
+class OpenBufferReader(Opener):
+    """
+    Opener for buffer reader
+    """
+    def __init__(self, buffer):
+        super().__init__(buffer)
+        check_seekable(buffer)
+
+
+class OpenBufferWriter(Opener):
+    """
+    Opener for buffer writer
+    """
+    def __exit__(self, *args):
+        self.file_like.flush()
+
+
+class OpenZipfileReader(Opener):
+    """
+    Opener for zipfile reader, file_like can be either path or buffer or
+    an opened url-like object
+    """
+    def __init__(self, file_like) -> None:
+        super().__init__(torch._C.PyTorchFileReader(file_like))
+
+
+class OpenZipfileWriterFile(Opener):
+    """
+    Opener for local disk zipfile writer
+    """
+    def __init__(self, name) -> None:
+        self.file_stream = None
+        self.name = str(name)
+        try:
+            self.name.encode("ascii")
+        except UnicodeEncodeError:
+            # PyTorchFileWriter only supports ascii filename.
+            # For filenames with non-ascii characters, we rely on Python
+            # for writing out the file.
+            self.file_stream = io.FileIO(self.name, mode="w")
+            super().__init__(torch._C.PyTorchFileWriter(self.file_stream))
+        else:
+            super().__init__(torch._C.PyTorchFileWriter(self.name))
+
+    def __exit__(self, *args) -> None:
+        self.file_like.write_end_of_file()
+        if self.file_stream is not None:
+            self.file_stream.close()
+
+
+class OpenZipfileWriterBufferOrProtocol(Opener):
+    """
+    Opener for buffer or opened url-like object zipfile writer
+    """
+    def __init__(self, buffer_or_protocol) -> None:
+        if not callable(getattr(buffer_or_protocol, "write", None)):
+            msg = f"Buffer/Protocol of {str(type(buffer_or_protocol)).strip('<>')} has no callable attribute 'write'"
+            if not hasattr(buffer_or_protocol, "write"):
+                raise AttributeError(msg)
+            raise TypeError(msg)
+        self.buffer_or_protocol = buffer_or_protocol
+        super().__init__(torch._C.PyTorchFileWriter(buffer_or_protocol))
+
+    def __exit__(self, *args) -> None:
+        self.file_like.write_end_of_file()
+        self.buffer_or_protocol.flush()
+
+
+def check_seekable(f) -> bool:
+    def raise_err_msg(patterns, e):
+        for p in patterns:
+            if p in str(e):
+                msg = (
+                    str(e)
+                    + ". You can only torch.load from a file that is seekable."
+                    + " Please pre-load the data into a buffer like io.BytesIO and"
+                    + " try to load from it instead."
+                )
+                raise type(e)(msg)
+        raise e
+
+    try:
+        f.seek(f.tell())
+        return True
+    except (io.UnsupportedOperation, AttributeError) as e:
+        raise_err_msg(["seek", "tell"], e)
+    return False

--- a/torch/io/hdfs/__init__.py
+++ b/torch/io/hdfs/__init__.py
@@ -1,0 +1,14 @@
+from ..opener import Opener
+from .hdfs import HDFSIO
+
+
+class HDFSOpener(Opener):
+    """
+    Opener for HDFS storage
+    """
+    def __init__(self, url, mode):
+        file_like = HDFSIO(url, mode)
+        super().__init__(file_like)
+
+    def __exit__(self, *args):
+        self.file_like.close()

--- a/torch/io/hdfs/hdfs.py
+++ b/torch/io/hdfs/hdfs.py
@@ -1,8 +1,10 @@
 from urllib import parse
 from pyarrow import fs
 
+from ..base_io import BaseIO
 
-class HDFSIO():
+
+class HDFSIO(BaseIO):
     def __init__(self, url: str, mode) -> None:
         parse_result = parse.urlparse(url, scheme='hdfs')
         self.path = parse_result.path
@@ -30,25 +32,9 @@ class HDFSIO():
 
     def readline(self, size: int | None = -1, /) -> bytes:
         if size < 0:
-            line = self._readline()
+            line = self._readline(self.read)
         else:
             line = self.read(size)
-
-        return line
-
-    def _readline(self):
-        # line terminator is always b'\n' for binary files
-        line = bytearray()
-        while True:
-            char = self.read(1)
-            if char == b'\n':
-                line += b'\n'
-                break
-
-            if char == b'':
-                break
-
-            line += char
 
         return line
 

--- a/torch/io/hdfs/hdfs.py
+++ b/torch/io/hdfs/hdfs.py
@@ -1,0 +1,66 @@
+from urllib import parse
+from pyarrow import fs
+
+
+class HDFSIO():
+    def __init__(self, url: str, mode) -> None:
+        parse_result = parse.urlparse(url, scheme='hdfs')
+        self.path = parse_result.path
+        # no path in hdfs uri
+        self.uri = parse_result._replace(path='').geturl()
+        self.hdfs = fs.HadoopFileSystem.from_uri(self.uri)
+
+        self.reader = None
+        self.writer = None
+        if "w" in mode:
+            self.writer = self.hdfs.open_output_stream(self.path)
+        elif "r" in mode:
+            self.reader = self.hdfs.open_input_file(self.path)
+        else:
+            raise RuntimeError(f"Expected 'r' or 'w' in mode but got {mode}")
+
+    def seek(self, offset: int, whence=0) -> int:
+        return self.reader.seek(offset, whence)
+
+    def tell(self) -> int:
+        return self.reader.tell()
+
+    def read(self, size: int = -1, /) -> bytes | None:
+        return self.reader.read(size)
+
+    def readline(self, size: int | None = -1, /) -> bytes:
+        if size < 0:
+            line = self._readline()
+        else:
+            line = self.read(size)
+
+        return line
+
+    def _readline(self):
+        # line terminator is always b'\n' for binary files
+        line = bytearray()
+        while True:
+            char = self.read(1)
+            if char == b'\n':
+                line += b'\n'
+                break
+
+            if char == b'':
+                break
+
+            line += char
+
+        return line
+
+    def write(self, b, /) -> int | None:
+        return self.writer.write(b)
+
+    def flush(self) -> None:
+        return self.writer.flush()
+
+    def close(self) -> None:
+        if self.reader is not None:
+            self.reader.close()
+
+        if self.writer is not None:
+            self.writer.close()

--- a/torch/io/http/__init__.py
+++ b/torch/io/http/__init__.py
@@ -1,0 +1,19 @@
+from ..opener import Opener
+from .http import HTTPIO
+
+
+class HTTPOpener(Opener):
+    """
+    Opener for HTTP
+
+    HTTP only support load
+    """
+    def __init__(self, url, mode):
+        if 'w' in mode:
+            raise ValueError('http only support load')
+
+        file_like = HTTPIO(url)
+        super().__init__(file_like)
+
+    def __exit__(self, *args):
+        self.file_like.close()

--- a/torch/io/http/http.py
+++ b/torch/io/http/http.py
@@ -1,0 +1,30 @@
+from fsspec.implementations.http import HTTPFileSystem
+
+from ..base_io import BaseIO
+
+class HTTPIO(BaseIO):
+    def __init__(self, url) -> None:
+        self.cur = 0
+        self.url = url
+        fs = HTTPFileSystem()
+        self.f = fs.open(url, 'rb')
+
+    def seek(self, offset: int, whence=0) -> int:
+        return self.f.seek(offset, whence)
+
+    def tell(self) -> int:
+        return self.f.tell()
+
+    def read(self, size: int = -1, /) -> bytes | None:
+        return self.f.read(size)
+
+    def readline(self, size: int | None = -1, /) -> bytes:
+        if size < 0:
+            line = self._readline(self.read)
+        else:
+            line = self.read(size)
+
+        return line
+
+    def close(self):
+        self.f.close()

--- a/torch/io/opener.py
+++ b/torch/io/opener.py
@@ -1,0 +1,19 @@
+class Opener:
+    """
+    Opener encapsulates file-like object and supports context manager.
+
+    file-like is an object that implements basic io operations, such as
+    an opened local file, a read/write buffer, or user-defined object that
+    supports specific storage protocol.
+
+    For reader, file-like must implement seek, tell, read and readline.
+    For writer, file-like must implement write and flush.
+    """
+    def __init__(self, file_like):
+        self.file_like = file_like
+
+    def __enter__(self):
+        return self.file_like
+
+    def __exit__(self, *args):
+        pass

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1205,6 +1205,8 @@ def load(
         >>> torch.load("module.pt", encoding="ascii", weights_only=False)
         # Load a module from HDFS
         >>> torch.load('hdfs://ip:port/tensor.pt', weights_only=True)
+        # Load a module from HTTP
+        >>> torch.load('http://ip:port/tensor.pt', weights_only=True)
     """
     torch._C._log_api_usage_once("torch.load")
     UNSAFE_MESSAGE = (

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -809,6 +809,9 @@ def save(
         >>> # Save to io.BytesIO buffer
         >>> buffer = io.BytesIO()
         >>> torch.save(x, buffer)
+
+        >>> # Save to HDFS
+        >>> torch.save(x, 'hdfs://ip:port/tensor.pt')
     """
     torch._C._log_api_usage_once("torch.save")
     _check_dill_version(pickle_module)
@@ -1200,6 +1203,8 @@ def load(
         # Load a module with 'ascii' encoding for unpickling
         # Loading from a module setting weights_only=False, warning this can be unsafe
         >>> torch.load("module.pt", encoding="ascii", weights_only=False)
+        # Load a module from HDFS
+        >>> torch.load('hdfs://ip:port/tensor.pt', weights_only=True)
     """
     torch._C._log_api_usage_once("torch.load")
     UNSAFE_MESSAGE = (

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -25,7 +25,6 @@ from typing import (
     List,
     Optional,
     Tuple,
-    Type,
     Union,
 )
 from typing_extensions import TypeAlias, TypeIs
@@ -36,6 +35,7 @@ from torch._sources import get_source_lines_and_file
 from torch._utils import _import_dotted_name
 from torch.storage import _get_dtype_from_pickle_storage_type
 from torch.types import Storage
+from torch.io import *
 
 
 __all__ = [
@@ -705,104 +705,6 @@ def storage_to_tensor_type(storage):
     return getattr(module, storage_type.__name__.replace("Storage", "Tensor"))
 
 
-def _is_path(name_or_buffer) -> TypeIs[Union[str, os.PathLike]]:
-    return isinstance(name_or_buffer, (str, os.PathLike))
-
-
-class _opener:
-    def __init__(self, file_like):
-        self.file_like = file_like
-
-    def __enter__(self):
-        return self.file_like
-
-    def __exit__(self, *args):
-        pass
-
-
-class _open_file(_opener):
-    def __init__(self, name, mode):
-        super().__init__(open(name, mode))
-
-    def __exit__(self, *args):
-        self.file_like.close()
-
-
-class _open_buffer_reader(_opener):
-    def __init__(self, buffer):
-        super().__init__(buffer)
-        _check_seekable(buffer)
-
-
-class _open_buffer_writer(_opener):
-    def __exit__(self, *args):
-        self.file_like.flush()
-
-
-def _open_file_like(name_or_buffer, mode):
-    if _is_path(name_or_buffer):
-        return _open_file(name_or_buffer, mode)
-    else:
-        if "w" in mode:
-            return _open_buffer_writer(name_or_buffer)
-        elif "r" in mode:
-            return _open_buffer_reader(name_or_buffer)
-        else:
-            raise RuntimeError(f"Expected 'r' or 'w' in mode but got {mode}")
-
-
-class _open_zipfile_reader(_opener):
-    def __init__(self, name_or_buffer) -> None:
-        super().__init__(torch._C.PyTorchFileReader(name_or_buffer))
-
-
-class _open_zipfile_writer_file(_opener):
-    def __init__(self, name) -> None:
-        self.file_stream = None
-        self.name = str(name)
-        try:
-            self.name.encode("ascii")
-        except UnicodeEncodeError:
-            # PyTorchFileWriter only supports ascii filename.
-            # For filenames with non-ascii characters, we rely on Python
-            # for writing out the file.
-            self.file_stream = io.FileIO(self.name, mode="w")
-            super().__init__(
-                torch._C.PyTorchFileWriter(self.file_stream, _compute_crc32)
-            )
-        else:
-            super().__init__(torch._C.PyTorchFileWriter(self.name, _compute_crc32))
-
-    def __exit__(self, *args) -> None:
-        self.file_like.write_end_of_file()
-        if self.file_stream is not None:
-            self.file_stream.close()
-
-
-class _open_zipfile_writer_buffer(_opener):
-    def __init__(self, buffer) -> None:
-        if not callable(getattr(buffer, "write", None)):
-            msg = f"Buffer of {str(type(buffer)).strip('<>')} has no callable attribute 'write'"
-            if not hasattr(buffer, "write"):
-                raise AttributeError(msg)
-            raise TypeError(msg)
-        self.buffer = buffer
-        super().__init__(torch._C.PyTorchFileWriter(buffer, _compute_crc32))
-
-    def __exit__(self, *args) -> None:
-        self.file_like.write_end_of_file()
-        self.buffer.flush()
-
-
-def _open_zipfile_writer(name_or_buffer):
-    container: Type[_opener]
-    if _is_path(name_or_buffer):
-        container = _open_zipfile_writer_file
-    else:
-        container = _open_zipfile_writer_buffer
-    return container(name_or_buffer)
-
-
 def _is_compressed_file(f) -> bool:
     compress_modules = ["gzip"]
     try:
@@ -825,27 +727,6 @@ def _should_read_directly(f):
         return False
     except AttributeError:
         return False
-
-
-def _check_seekable(f) -> bool:
-    def raise_err_msg(patterns, e):
-        for p in patterns:
-            if p in str(e):
-                msg = (
-                    str(e)
-                    + ". You can only torch.load from a file that is seekable."
-                    + " Please pre-load the data into a buffer like io.BytesIO and"
-                    + " try to load from it instead."
-                )
-                raise type(e)(msg)
-        raise e
-
-    try:
-        f.seek(f.tell())
-        return True
-    except (io.UnsupportedOperation, AttributeError) as e:
-        raise_err_msg(["seek", "tell"], e)
-    return False
 
 
 def _check_dill_version(pickle_module) -> None:
@@ -873,7 +754,7 @@ def _check_dill_version(pickle_module) -> None:
 
 
 def _check_save_filelike(f):
-    if not _is_path(f) and not hasattr(f, "write"):
+    if not is_path(f) and not is_protocol(f) and not hasattr(f, "write"):
         raise AttributeError(
             "expected 'f' to be string, path, or a file-like object with "
             "a 'write' attribute"
@@ -902,7 +783,8 @@ def save(
     Args:
         obj: saved object
         f: a file-like object (has to implement write and flush) or a string or
-           os.PathLike object containing a file name
+           os.PathLike object containing a file name or
+           a url-like path like `scheme://netloc/path?key1=value1&key2=value2`
         pickle_module: module used for pickling metadata and objects
         pickle_protocol: can be specified to override the default protocol
 
@@ -932,23 +814,18 @@ def save(
     _check_dill_version(pickle_module)
     _check_save_filelike(f)
 
-    if _use_new_zipfile_serialization:
-        with _open_zipfile_writer(f) as opened_zipfile:
-            _save(
-                obj,
-                opened_zipfile,
-                pickle_module,
-                pickle_protocol,
-                _disable_byteorder_record,
-            )
-            return
-    else:
-        global _serialization_tls
-        if _serialization_tls.skip_data:
-            raise RuntimeError(
-                "Cannot use skip_data=True with _use_new_zipfile_serialization=False"
-            )
-        with _open_file_like(f, "wb") as opened_file:
+    with open_file_like(f, "wb") as opened_file:
+        if _use_new_zipfile_serialization:
+            with open_zipfile_writer(opened_file) as opened_zipfile:
+                _save(
+                    obj,
+                    opened_zipfile,
+                    pickle_module,
+                    pickle_protocol,
+                    _disable_byteorder_record,
+                )
+                return
+        else:
             _legacy_save(obj, opened_file, pickle_module, pickle_protocol)
 
 
@@ -1258,7 +1135,8 @@ def load(
 
     Args:
         f: a file-like object (has to implement :meth:`read`, :meth:`readline`, :meth:`tell`, and :meth:`seek`),
-            or a string or os.PathLike object containing a file name
+            or a string or os.PathLike object containing a file name,
+            or a url-like path like `scheme://netloc/path?key1=value1&key2=value2`
         map_location: a function, :class:`torch.device`, string or a dict specifying how to remap storage
             locations
         pickle_module: module used for unpickling metadata and objects (has to
@@ -1421,14 +1299,14 @@ def load(
     if "encoding" not in pickle_load_args.keys():
         pickle_load_args["encoding"] = "utf-8"
 
-    with _open_file_like(f, "rb") as opened_file:
+    with open_file_like(f, "rb") as opened_file:
         if _is_zipfile(opened_file):
             # The zipfile reader is going to advance the current file position.
             # If we want to actually tail call to torch.jit.load, we need to
             # reset back to the original position.
             orig_position = opened_file.tell()
             overall_storage = None
-            with _open_zipfile_reader(opened_file) as opened_zipfile:
+            with open_zipfile_reader(opened_file) as opened_zipfile:
                 if _is_torchscript_zip(opened_zipfile):
                     warnings.warn(
                         "'torch.load' received a zip file that looks like a TorchScript archive"
@@ -1439,7 +1317,7 @@ def load(
                     opened_file.seek(orig_position)
                     return torch.jit.load(opened_file, map_location=map_location)
                 if mmap:
-                    if not _is_path(f):
+                    if not is_path(f):
                         raise ValueError(
                             "f must be a file path in order to use the mmap argument"
                         )
@@ -1706,7 +1584,7 @@ def _legacy_load(f, map_location, pickle_module, **pickle_load_args):
         else:
             raise RuntimeError(f"Unknown saved id type: {saved_id[0]}")
 
-    _check_seekable(f)
+    check_seekable(f)
     f_should_read_directly = _should_read_directly(f)
 
     if f_should_read_directly and f.tell() == 0:


### PR DESCRIPTION
This is an implementation for #132024.

## Background
Currently, serialization.py does not support IO abstraction. As a result, torch.save and torch.load only support local disk file.
But in most cases, we hope to save the models remotely, e.g. cloud storage or remote server. There are 2 ways to use remote storage at this time:
### download to local
Easy to understand and handle. Every time we hope to save the model, call torch.save, and upload it manually. Similar thing happens when loading a model file from cloud, we have to download the model file to local disk and then call torch.load.
### fuse
FUSE is a userspace filesystem framework. It makes it possible for developer to build a filesystem in user space instead of kernel. [sshfs](https://github.com/libfuse/sshfs) is an example. network filesystem client to connect to SSH servers.

```
                                                                                                +-----------+
USER                                                            +------------------------------>|HDFS cluser|
                                                                |                               +-----------+
        +-------+                                         +-----------+
        |pytorch|                                         |fuse daemon|                         +-----------+
        +-------+                                         +-----------+------------------------>|    S3     |
            |                                                   |                               +-----------+
            | torch.save()                                      | handle fuse write
            |                                                   |
-------------------------------------------------------------------------------------
KERNEL      |                                                   |
            | sys.write()                                       |
	    |                                                   |
	    |                     +--------+                    |
	    +-------------------->|fuse dev|--------------------+
				  +--------+
```

## New IO abstraction
I am going to introduce an IO abstraction for pytorch serialization, also implement 3 new IO drivers:
* file: Compatible with current syntax. Users could save/load models locally. 
* hdfs: Support save/load to HDFS.
* http: Support load from HTTP server (HTTPS on its way).

User can also implement other storage protocols easily,by inheriting base class and implement its own IO methods.

By doing this, we have some advantages:
* Rather than upload/download to local disk file manually, this new framework makes it diskless and convenient.
* Compared to fuse-based filesystem, pytorch read/write data directly. The shorter path reduce cpu and memory of fuse. Besides, we can also avoid pytorch IO stuck in D state (uninterruptable in Linux Kernel) when the network is down.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal