### PR TITLE
Fix non-torchscriptable `torch.nn.MultiheadAttention` with `bias=False`

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1242,8 +1242,9 @@ class MultiheadAttention(Module):
             # enforce that the dtypes all match or test cases where
             # they don't!
             why_not_fast_path = "non-self attention was used (query, key, and value are not the same Tensor)"
-        elif self.in_proj_bias is not None and query.dtype != self.in_proj_bias.dtype:
-            why_not_fast_path = f"dtypes of query ({query.dtype}) and self.in_proj_bias ({self.in_proj_bias.dtype}) don't match"
+        elif self.in_proj_bias is not None:
+            if query.dtype != self.in_proj_bias.dtype:
+                why_not_fast_path = f"dtypes of query ({query.dtype}) and self.in_proj_bias ({self.in_proj_bias.dtype}) do not match"
         elif self.in_proj_weight is None:
             why_not_fast_path = "in_proj_weight was None"
         elif query.dtype != self.in_proj_weight.dtype:


### PR DESCRIPTION
To reproduce the bug, it is sufficient to run
```
import torch


attention = torch.nn.MultiheadAttention(
    embed_dim=512,
    num_heads=8,
    bias=False,
)
torch.jit.script(attention)
```

The small fix in this PR solves the issue