### PR TITLE
Fixes for the extension backend tests

### DIFF
--- a/test/inductor/extension_backends/cpp/extension_codegen_backend.py
+++ b/test/inductor/extension_backends/cpp/extension_codegen_backend.py
@@ -4,13 +4,13 @@ from torch._inductor.virtualized import V
 
 
 class ExtensionWrapperCodegen(wrapper.WrapperCodeGen):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ExtensionCppWrapperCodegen(cpp_wrapper_cpu.CppWrapperCpu):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ExtensionScheduling(BaseScheduling):

--- a/test/inductor/extension_backends/triton/device_interface.py
+++ b/test/inductor/extension_backends/triton/device_interface.py
@@ -121,3 +121,7 @@ class DeviceInterface(device_interface.DeviceInterface):
     @staticmethod
     def get_compute_capability(device) -> int:
         return 0
+
+    @staticmethod
+    def triton_supported() -> bool:
+        return True

--- a/test/inductor/extension_backends/triton/extension_codegen_backend.py
+++ b/test/inductor/extension_backends/triton/extension_codegen_backend.py
@@ -4,8 +4,8 @@ from torch._inductor.scheduler import BaseScheduling
 
 
 class ExtensionWrapperCodegen(wrapper.WrapperCodeGen):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ExtensionScheduling(BaseScheduling):


### PR DESCRIPTION
There were some miscellaneous issues I found:

* The WrapperCodeGen subclass constructors don't accept any arguments, which doesn't mesh with how Inductor can try to construct them.
* A DeviceInterface subclass for Triton doesn't implement `triton_supported() == True`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang