### PR TITLE
[inductor] Avoid fallback case for custom scan op lowering

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1909,6 +1909,8 @@ class CommonTemplate:
         actual = associative_scan(argmax_combine, (a, idx), 0)
         self.assertEqual(expect, actual)
 
+    @skipCUDAIf(TEST_WITH_ROCM, "associative_scan is not supported on ROCm")
+    @skip_if_halide  # scan ops
     def test_custom_scan_would_split(self):
         if self.device != "cuda":
             raise unittest.SkipTest("associative_scan only supported on GPU")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1909,6 +1909,46 @@ class CommonTemplate:
         actual = associative_scan(argmax_combine, (a, idx), 0)
         self.assertEqual(expect, actual)
 
+    def test_custom_scan_would_split(self):
+        def combine_linear_recurrence(left, right):
+            xl, fl = left
+            xr, fr = right
+            x = xl * fr + xr
+            f = fl * fr
+            return x, f
+
+        def eager_scan(x, g):
+            x, g = x.to(torch.float64), g.to(torch.float64)
+            x_out = torch.empty_like(x)
+            g_out = torch.empty_like(g)
+            x_out[:, 0] = x[:, 0]
+            g_out[:, 0] = g[:, 0]
+            for i in range(1, x.shape[1]):
+                x_out[:, i], g_out[:, i] = combine_linear_recurrence(
+                    (x_out[:, i - 1], g_out[:, i - 1]),
+                    (x[:, i], g[:, i]),
+                )
+            return x_out.float(), g_out.float()
+
+        @torch.compile
+        def compiled_scan(x, f):
+            from torch._higher_order_ops.associative_scan import associative_scan
+            x, f = associative_scan(combine_linear_recurrence, (x, f), dim=1)
+            return x, f
+
+        x = torch.randn(1, 129, 2, device=self.device)
+        f = torch.randn(1, 129, 2, device=self.device)
+        expect = eager_scan(x, f)
+        actual = compiled_scan(x, f)
+        print(expect[0][0,:,0])
+        print(actual[0][0,:,0])
+        print(expect[0][0,:,0] - actual[0][0,:,0])
+        print(x[0, :, 0])
+        print(f[0, :, 0])
+        self.assertEqual(expect[0], actual[0])
+        self.assertEqual(expect[1], actual[1])
+        self.assertEqual(expect, actual)
+
     def test_embedding_bag_byte_unpack(self):
         if self.device != "cpu":
             raise unittest.SkipTest(f"No {GPU_TYPE} implementation (it returns empty)")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1910,6 +1910,9 @@ class CommonTemplate:
         self.assertEqual(expect, actual)
 
     def test_custom_scan_would_split(self):
+        if self.device != "cuda":
+            raise unittest.SkipTest("associative_scan only supported on GPU")
+
         def combine_linear_recurrence(left, right):
             xl, fl = left
             xr, fr = right
@@ -1933,6 +1936,7 @@ class CommonTemplate:
         @torch.compile
         def compiled_scan(x, f):
             from torch._higher_order_ops.associative_scan import associative_scan
+
             x, f = associative_scan(combine_linear_recurrence, (x, f), dim=1)
             return x, f
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1940,13 +1940,6 @@ class CommonTemplate:
         f = torch.randn(1, 129, 2, device=self.device)
         expect = eager_scan(x, f)
         actual = compiled_scan(x, f)
-        print(expect[0][0,:,0])
-        print(actual[0][0,:,0])
-        print(expect[0][0,:,0] - actual[0][0,:,0])
-        print(x[0, :, 0])
-        print(f[0, :, 0])
-        self.assertEqual(expect[0], actual[0])
-        self.assertEqual(expect[1], actual[1])
         self.assertEqual(expect, actual)
 
     def test_embedding_bag_byte_unpack(self):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1672,9 +1672,8 @@ class Scan(Loops):
         combine_fn: Callable[[Tuple[Any, ...], Tuple[Any, ...]], Tuple[Any, ...]],
         reduction_hint: ReductionHint = ReductionHint.DEFAULT,
         *,
-        # Whether we should fallback if split criteria is met but the backend
-        # feature is not available
-        require_split_scan: bool = True,
+        # Whether we have the option to fallback to aten
+        can_fallback_to_aten: bool = True,
         **kwargs,
     ) -> List[Optional[TensorBox]]:
         pointwise_ranges = [*size[:axis], *size[axis + 1 :]]
@@ -1719,7 +1718,7 @@ class Scan(Loops):
         if num_splits > 1:
             supports_split = torch.version.hip is None and len(dtypes) == 1
             if not supports_split:
-                if require_split_scan:
+                if can_fallback_to_aten:
                     # Fallback to ATen
                     return [None] * len(dtypes)
                 else:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1715,7 +1715,7 @@ class Scan(Loops):
             combine_fn=combine_fn,
             scan_numel=scan_numel,
         )
-        scan_type: Union[Literal[Scan], Literal[SplitScan]] = Scan
+        scan_type = Scan
         if num_splits > 1:
             supports_split = torch.version.hip is None and len(dtypes) == 1
             if not supports_split:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1672,10 +1672,10 @@ class Scan(Loops):
         combine_fn: Callable[[Tuple[Any, ...], Tuple[Any, ...]], Tuple[Any, ...]],
         reduction_hint: ReductionHint = ReductionHint.DEFAULT,
         *,
-        require_split_scan: bool = True,
-        **kwargs,
         # Whether we should fallback if split criteria is met but the backend
         # feature is not available
+        require_split_scan: bool = True,
+        **kwargs,
     ) -> List[Optional[TensorBox]]:
         pointwise_ranges = [*size[:axis], *size[axis + 1 :]]
         scan_ranges = [size[axis]]

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6265,8 +6265,7 @@ def associative_scan(combine_fn: ir.Subgraph, input, dim: int):
     kwargs["inner_fns"] = tuple(x.make_loader() for x in input)
     result = ir.Scan.create(
         combine_fn=wrapped_combine_fn,
-        # If split scan is not supported, just use a non-split scan
-        require_split_scan=False,
+        can_fallback_to_aten=False,
         **kwargs,
     )
     if result[0] is None:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6264,10 +6264,10 @@ def associative_scan(combine_fn: ir.Subgraph, input, dim: int):
     kwargs["dtypes"] = tuple(x.get_dtype() for x in input)
     kwargs["inner_fns"] = tuple(x.make_loader() for x in input)
     result = ir.Scan.create(
-        **kwargs,
         combine_fn=wrapped_combine_fn,
         # If split scan is not supported, just use a non-split scan
         require_split_scan=False,
+        **kwargs,
     )
     if result[0] is None:
         raise RuntimeError("Unable to generate code for associative_scan op")

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6263,7 +6263,12 @@ def associative_scan(combine_fn: ir.Subgraph, input, dim: int):
     kwargs = _make_scan_inner(input[0], axis=dim, dtype=None)
     kwargs["dtypes"] = tuple(x.get_dtype() for x in input)
     kwargs["inner_fns"] = tuple(x.make_loader() for x in input)
-    result = ir.Scan.create(**kwargs, combine_fn=wrapped_combine_fn)
+    result = ir.Scan.create(
+        **kwargs,
+        combine_fn=wrapped_combine_fn,
+        # If split scan is not supported, just use a non-split scan
+        require_split_scan=False,
+    )
     if result[0] is None:
         raise RuntimeError("Unable to generate code for associative_scan op")
     return result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130936

We currently can't generate split scans when there are multiple scan
values, so we normally fall back to ATen. However, for the higher order
scan op, we can't fallback so it makes sense to just generate the slower
kernel anyway. This avoids having special shapes where we fail to
codegen.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang