### PR TITLE
Revert "[PT-D] Relaxed `contract` to allow `Sequence[nn.Module]` (#127773)"

### DIFF
--- a/test/distributed/_composable/test_contract.py
+++ b/test/distributed/_composable/test_contract.py
@@ -1,7 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 from copy import deepcopy
-from typing import List, Tuple
+from typing import Tuple
 
 import torch
 import torch.nn as nn
@@ -87,7 +87,7 @@ class TestContract(TestCase):
 
         with self.assertRaisesRegex(
             RuntimeError,
-            "wrap_module should not change the module structure",
+            "Check parameters, Composable distributed API implementations cannot modify FQNs",
         ):
             wrap_module(model.seq1)
 
@@ -137,41 +137,6 @@ class TestContract(TestCase):
 
         with self.assertRaisesRegex(AssertionError, "api1 has already been applied"):
             model = api1(model)
-
-    @skipIfTorchDynamo("Dynamo does not support the state key")
-    def test_multi_module_api(self):
-        @contract()
-        def multi_module_api(modules: List[nn.Module]) -> nn.Module:
-            return modules
-
-        model = nn.Sequential(*[nn.Linear(3, 3) for _ in range(5)])
-        multi_module_api([model[0], model[1]])
-        multi_module_api([model[2], model[3]])
-        multi_module_api([model[4]])
-        # Check that modules have the same state and registry iff they shared
-        # the same API call
-        states = [multi_module_api.state(module) for module in model]
-        self.assertEqual(states[0], states[1])
-        self.assertEqual(states[2], states[3])
-        self.assertNotEqual(states[0], states[2])
-        self.assertNotEqual(states[0], states[4])
-        self.assertNotEqual(states[2], states[4])
-        registries = [_get_registry(module) for module in model]
-        self.assertEqual(registries[0], registries[1])
-        self.assertEqual(registries[2], registries[3])
-        self.assertNotEqual(registries[0], registries[2])
-        self.assertNotEqual(registries[0], registries[4])
-        self.assertNotEqual(registries[2], registries[4])
-        # Check that applying an API to a module multiple times errors
-        model = nn.Sequential(*[nn.Linear(3, 3) for _ in range(5)])
-        multi_module_api([model[0], model[1]])
-        with self.assertRaisesRegex(
-            AssertionError,
-            "Each distinct composable distributed API can only be applied to "
-            r"a module once. multi_module_api has already been applied to the "
-            "following module:",
-        ):
-            multi_module_api([model[0], model[2]])
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_composable/contract.py
+++ b/torch/distributed/_composable/contract.py
@@ -2,12 +2,10 @@
 import uuid
 from collections import OrderedDict
 from functools import wraps
-from typing import Callable, Dict, List, Optional, Sequence, Type, Union
+from typing import Callable, Dict, List, Optional, Type
 
-import torch
 import torch.nn as nn
 from torch.distributed._composable_state import _State
-from torch.distributed.utils import _get_root_modules
 
 
 def generate_state_key(string="__composable_api_state_key"):
@@ -67,79 +65,63 @@ def contract(state_cls: Type[_State] = _State):
     @wraps(state_cls)
     def inner(func):
         @wraps(func)
-        def wrapper(
-            module: Union[nn.Module, Sequence[nn.Module]], *args, **kwargs
-        ) -> Optional[nn.Module]:
-            inp_module = module
-            if isinstance(module, nn.Module):
-                modules = [module]
-            else:
-                # Special case: only FSDP permits a sequence of modules, in
-                # which case we only want to insert the state object on the
-                # root modules (i.e. those without a parent) with respect to
-                # the passed-in modules.
-                modules = _get_root_modules(list(module))
-            state = state_cls()  # shared across all modules
-            registry_item = RegistryItem()  # shared across all modules
-            module_to_orig_named_params: Dict[nn.Module, Dict[str, nn.Parameter]] = {}
-            module_to_orig_named_buffers: Dict[nn.Module, Dict[str, torch.Tensor]] = {}
-            module_to_orig_named_modules: Dict[nn.Module, Dict[str, nn.Module]] = {}
-            for module in modules:
-                default_all_state: Dict[Callable, _State] = OrderedDict()
-                default_registry: Dict[str, RegistryItem] = OrderedDict()
-                all_state: Dict[Callable, _State] = module.__dict__.setdefault(  # type: ignore[call-overload]
-                    STATE_KEY, default_all_state
-                )
-                assert isinstance(
-                    all_state, dict
-                ), "Distributed composable API states corrupted"
-                registry: Dict[str, RegistryItem] = module.__dict__.setdefault(  # type: ignore[call-overload]
-                    REGISTRY_KEY, default_registry
-                )
-                assert isinstance(
-                    registry, dict
-                ), "Distributed composable API registry corrupted"
-                # Make sure that func has not been applied to the module yet
-                assert func not in all_state and func.__name__ not in registry, (
-                    "Each distinct composable distributed API can only be applied to a "
-                    f"module once. {func.__name__} has already been applied to the "
-                    f"following module:\n{module}"
-                )
-                all_state.setdefault(func, state)
-                registry.setdefault(func.__name__, registry_item)
+        def wrapper(module: nn.Module, *args, **kwargs) -> Optional[nn.Module]:
+            # get existing global states
+            default_all_state: Dict[Callable, _State] = OrderedDict()
+            all_state: Dict[Callable, _State] = module.__dict__.setdefault(  # type: ignore[call-overload]
+                STATE_KEY, default_all_state
+            )
+            assert isinstance(
+                all_state, dict
+            ), "Distributed composable API states corrupted"
 
-                module_to_orig_named_params[module] = OrderedDict(
-                    module.named_parameters()
-                )
-                module_to_orig_named_buffers[module] = OrderedDict(
-                    module.named_buffers(remove_duplicate=False)
-                )
-                module_to_orig_named_modules[module] = OrderedDict(
-                    module.named_modules(remove_duplicate=False)
-                )
+            # get global registry
+            default_registry: Dict[str, RegistryItem] = OrderedDict()
+            registry: Dict[str, RegistryItem] = module.__dict__.setdefault(  # type: ignore[call-overload]
+                REGISTRY_KEY, default_registry
+            )
 
-            # `func` should return the same type as the input module/modules
-            updated = func(inp_module, *args, **kwargs)
+            assert isinstance(
+                registry, dict
+            ), "Distributed composable API registry corrupted"
+
+            # make sure the API func has not been applied to the input module yet.
+            assert func not in all_state and func.__name__ not in registry, (
+                "Each distinct composable distributed API can only be applied to a "
+                f"module once. {func.__name__} has already been applied to the "
+                f"following module.\n{module}"
+            )
+
+            # install states specific to the wrapped ``func``
+            all_state.setdefault(func, state_cls())
+            # register ``func`` in the global registry by name
+            registry.setdefault(func.__name__, RegistryItem())
+
+            orig_named_params = OrderedDict(module.named_parameters())
+            orig_named_buffers = OrderedDict(
+                module.named_buffers(remove_duplicate=False)
+            )
+            orig_named_modules = OrderedDict(
+                module.named_modules(remove_duplicate=False)
+            )
+
+            updated = func(module, *args, **kwargs)
+
             if updated is None:
-                updated = inp_module
-            if isinstance(updated, nn.Module):
-                updated_modules = [updated]
-            else:
-                updated_modules = _get_root_modules(list(inp_module))
+                updated = module
 
-            module_to_new_named_params: Dict[nn.Module, Dict[str, nn.Parameter]] = {}
-            module_to_new_named_buffers: Dict[nn.Module, Dict[str, torch.Tensor]] = {}
-            module_to_new_named_modules: Dict[nn.Module, Dict[str, nn.Module]] = {}
-            for module in updated_modules:
-                module_to_new_named_params[module] = OrderedDict(
-                    module.named_parameters()
-                )
-                module_to_new_named_buffers[module] = OrderedDict(
-                    module.named_buffers(remove_duplicate=False)
-                )
-                module_to_new_named_modules[module] = OrderedDict(
-                    module.named_modules(remove_duplicate=False)
-                )
+            new_named_params = OrderedDict(updated.named_parameters())
+            new_named_buffers = OrderedDict(
+                updated.named_buffers(remove_duplicate=False)
+            )
+            new_named_modules = OrderedDict(
+                updated.named_modules(remove_duplicate=False)
+            )
+
+            assert isinstance(updated, nn.Module), (
+                "Output of composable distributed APIs must be either None or "
+                f"nn.Module, but got {type(updated)}"
+            )
 
             def check_fqn(orig_fqns: List[str], new_fqns: List[str], check_key: str):
                 if orig_fqns == new_fqns:
@@ -165,30 +147,21 @@ def contract(state_cls: Type[_State] = _State):
                         f"New FQNs: {new_only}"
                     )
 
-            if set(module_to_new_named_modules.keys()) != set(
-                module_to_orig_named_modules.keys()
-            ):
-                raise RuntimeError(
-                    f"{func.__name__} should not change the module structure.\n"
-                    f"Before: {[str(type(m)) for m in module_to_orig_named_modules]}\n"
-                    f"After: {[str(type(m)) for m in module_to_new_named_modules]}"
-                )
-            for module in module_to_new_named_modules:
-                check_fqn(
-                    list(module_to_orig_named_params[module].keys()),
-                    list(module_to_new_named_params[module].keys()),
-                    "Check parameters, ",
-                )
-                check_fqn(
-                    list(module_to_orig_named_buffers[module].keys()),
-                    list(module_to_new_named_buffers[module].keys()),
-                    "Check buffers, ",
-                )
-                check_fqn(
-                    list(module_to_orig_named_modules[module].keys()),
-                    list(module_to_new_named_modules[module].keys()),
-                    "Check modules, ",
-                )
+            check_fqn(
+                list(orig_named_params.keys()),
+                list(new_named_params.keys()),
+                "Check parameters, ",
+            )
+            check_fqn(
+                list(orig_named_buffers.keys()),
+                list(new_named_buffers.keys()),
+                "Check buffer, ",
+            )
+            check_fqn(
+                list(orig_named_modules.keys()),
+                list(new_named_modules.keys()),
+                "Check modules, ",
+            )
 
             # TODO: a stricter verification should also reject changing module
             # types and monkey-patching forward() method implementations.

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -10,7 +10,6 @@ from typing import (
     Optional,
     OrderedDict,
     overload,
-    Set,
     Tuple,
     TypeVar,
 )
@@ -356,28 +355,3 @@ def _replace_by_prefix(
 
 def _data_ptr_allocated(tensor: torch.Tensor) -> bool:
     return tensor.untyped_storage().data_ptr() > 0
-
-
-def _get_root_modules(modules: List[nn.Module]) -> List[nn.Module]:
-    """
-    Returns the modules in ``modules`` that are root modules (i.e.
-    parent-less) with respect to the set ``modules``. In other words, these
-    are the modules in ``modules`` that are the not child of any other
-    module in ``modules``.
-    """
-    root_modules: List[nn.Module] = []
-    module_to_modules: Dict[nn.Module, Set[nn.Module]] = {
-        module: set(module.modules()) for module in modules
-    }
-    for candidate_module in modules:
-        is_root_module = True
-        for module, _modules in module_to_modules.items():
-            is_child_module = (
-                candidate_module is not module and candidate_module in _modules
-            )
-            if is_child_module:
-                is_root_module = False
-                break
-        if is_root_module:
-            root_modules.append(candidate_module)
-    return root_modules


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This reverts commit b27695791e9cc4eedb1b713b1be20398bfeb911b.

Reverted https://github.com/pytorch/pytorch/pull/127773 on behalf of https://github.com/atalman due to failing internally ([comment](https://github.com/pytorch/pytorch/pull/127773#issuecomment-2232004006))

cc @XilunWu @H-Huang @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o