### PR TITLE
[Reland][FSDP2] Allowed `List[nn.Module]` as arg

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -104,7 +104,7 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
         )
         fsdp_param_group = FSDPParamGroup(
             list(module.parameters()),
-            module,
+            (module,),
             mesh_info,
             post_forward_mesh_info,
             self.device,
@@ -176,7 +176,7 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
             orig_params, reshard_after_forward
         )
         fsdp_params = fsdp_param_group.fsdp_params
-        module = fsdp_param_group.module
+        module = fsdp_param_group.modules[0]
 
         # Sanity check that the parameter sharding is as expected
         for orig_param, param in zip(orig_params, module.parameters()):
@@ -771,6 +771,144 @@ class TestFullyShardPrefetch(FSDPTest):
             ]
             self.assertEqual(events, expected_backward_events)
             events.clear()
+
+    @skip_if_lt_x_gpu(2)
+    def test_fully_shard_multi_module_backward_prefetch(self):
+        n_layers = 5
+        model_args = ModelArgs(n_layers=n_layers, checkpoint_activations=True)
+        model = Transformer(model_args)
+        for i in range(n_layers):
+            if i == 0:
+                fully_shard(model.layers[i])
+            elif i % 2 == 1:
+                fully_shard([model.layers[i], model.layers[i + 1]])
+        fully_shard([model.tok_embeddings, model.pos_embeddings])
+        fully_shard([model.norm, model.output], reshard_after_forward=False)
+        fully_shard(model)
+        optim = torch.optim.AdamW(model.parameters(), lr=1e-2)
+
+        events: List[EventType] = []
+        unshard_with_record = self._get_unshard_with_record(
+            FSDPParamGroup.unshard, events
+        )
+        post_backward_with_record = self._get_post_backward_with_record(
+            FSDPParamGroup.post_backward, events
+        )
+        inp = torch.randint(
+            0, model_args.vocab_size, (2, model_args.max_seq_len), device="cuda"
+        )
+        with patch_unshard(unshard_with_record), patch_post_backward(
+            post_backward_with_record
+        ):
+            for iter_idx in range(3):
+                loss = model(inp)
+                expected_events = [
+                    (
+                        "unshard",
+                        "tok_embeddings, pos_embeddings",
+                        TrainingState.FORWARD,
+                    ),
+                    ("unshard", "layers.0", TrainingState.FORWARD),
+                    ("unshard", "layers.1, layers.2", TrainingState.FORWARD),
+                    ("unshard", "layers.3, layers.4", TrainingState.FORWARD),
+                    ("unshard", "norm, output", TrainingState.FORWARD),
+                ]
+                self.assertEqual(events, expected_events)
+                events.clear()
+                loss.sum().backward()
+                expected_events = [
+                    # (norm, output) does not reshard after forward, so there is
+                    # no unshard to begin backward
+                    ("unshard", "layers.3, layers.4", TrainingState.PRE_BACKWARD),
+                    ("post_backward", "norm, output", TrainingState.POST_BACKWARD),
+                    ("unshard", "layers.1, layers.2", TrainingState.PRE_BACKWARD),
+                    (
+                        "post_backward",
+                        "layers.3, layers.4",
+                        TrainingState.POST_BACKWARD,
+                    ),
+                    ("unshard", "layers.0", TrainingState.PRE_BACKWARD),
+                    (
+                        "post_backward",
+                        "layers.1, layers.2",
+                        TrainingState.POST_BACKWARD,
+                    ),
+                    (
+                        "unshard",
+                        "tok_embeddings, pos_embeddings",
+                        TrainingState.PRE_BACKWARD,
+                    ),
+                    ("post_backward", "layers.0", TrainingState.POST_BACKWARD),
+                    (
+                        "post_backward",
+                        "tok_embeddings, pos_embeddings",
+                        TrainingState.POST_BACKWARD,
+                    ),
+                ]
+                events.clear()
+                optim.step()
+                optim.zero_grad()
+
+    @skip_if_lt_x_gpu(2)
+    def test_fully_shard_multi_module_unused_module(self):
+        class ModuleWithUnusedLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.unused_lin = nn.Linear(1, 1)
+                self.lin = nn.Linear(16, 16)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return nn.functional.relu(self.lin(x))
+
+        model = nn.Sequential(
+            ModuleWithUnusedLinear(), ModuleWithUnusedLinear(), nn.Linear(16, 16)
+        )
+        fully_shard([model[0].unused_lin, model[0].lin], reshard_after_forward=True)
+        fully_shard([model[1].unused_lin, model[1].lin], reshard_after_forward=True)
+        fully_shard(model)
+        optim = torch.optim.AdamW(model.parameters(), lr=1e-2)
+
+        events: List[EventType] = []
+        unshard_with_record = self._get_unshard_with_record(
+            FSDPParamGroup.unshard, events
+        )
+        post_backward_with_record = self._get_post_backward_with_record(
+            FSDPParamGroup.post_backward, events
+        )
+        inp = torch.randn((2, 16), device="cuda")
+        with patch_unshard(unshard_with_record), patch_post_backward(
+            post_backward_with_record
+        ):
+            for iter_idx in range(3):
+                loss = model(inp)
+                expected_events = [
+                    ("unshard", "", TrainingState.FORWARD),
+                    ("unshard", "0.unused_lin, 0.lin", TrainingState.FORWARD),
+                    ("unshard", "1.unused_lin, 1.lin", TrainingState.FORWARD),
+                ]
+                self.assertEqual(events, expected_events)
+                events.clear()
+                loss.sum().backward()
+                expected_events = [
+                    # Since both `model[0]` and `model[1]` have unused modules
+                    # that never ran forward, they do not reshard after forward
+                    # despite setting it to `True`. Check that there are no
+                    # unshards in backward.
+                    (
+                        "post_backward",
+                        "1.unused_lin, 1.lin",
+                        TrainingState.POST_BACKWARD,
+                    ),
+                    (
+                        "post_backward",
+                        "0.unused_lin, 0.lin",
+                        TrainingState.POST_BACKWARD,
+                    ),
+                    ("post_backward", "", TrainingState.POST_BACKWARD),
+                ]
+                events.clear()
+                optim.step()
+                optim.zero_grad()
 
     def _init_transformer(
         self,

--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -84,7 +84,7 @@ class TestFullyShardCompile(FSDPTest):
         # Construct a dummy FSDPParamGroup, since we just want to test the `use_training_state` ctx manager.
         param_group = FSDPParamGroup(
             [],  # params: List[nn.Parameter],
-            torch.nn.Linear(1, 1),  # module: nn.Module,
+            (torch.nn.Linear(1, 1),),  # module: Tuple[nn.Module, ...],
             None,  # mesh_info: FSDPMeshInfo,
             None,  # post_forward_mesh_info: Optional[FSDPMeshInfo],
             None,  # device: torch.device,

--- a/test/distributed/_composable/fsdp/test_fully_shard_init.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_init.py
@@ -150,7 +150,7 @@ class TestFullyShardManagedModulesAndStates(FSDPTestMultiThread):
     def test_managed_modules_single(self):
         model = MLP(8)
         # Assume calling `fully_shard` on `model`
-        managed_modules = _get_managed_modules(model)
+        managed_modules = _get_managed_modules((model,))
         expected_managed_modules = list(model.modules())
         self._check_managed_modules(managed_modules, expected_managed_modules)
 
@@ -159,7 +159,7 @@ class TestFullyShardManagedModulesAndStates(FSDPTestMultiThread):
         model = nn.Sequential(*[MLP(8) for _ in range(2)])
         fully_shard(model[0])
         # Assume calling `fully_shard` on `model`
-        managed_modules = _get_managed_modules(model)
+        managed_modules = _get_managed_modules((model,))
         expected_managed_modules = list(model[1].modules()) + [model]
         self._check_managed_modules(managed_modules, expected_managed_modules)
 
@@ -169,7 +169,7 @@ class TestFullyShardManagedModulesAndStates(FSDPTestMultiThread):
         replicate(model[0])
         fully_shard(model[2])
         # Assume calling `fully_shard` on `model`
-        managed_modules = _get_managed_modules(model)
+        managed_modules = _get_managed_modules((model,))
         expected_managed_modules = list(model[1].modules()) + [model]
         self._check_managed_modules(managed_modules, expected_managed_modules)
 
@@ -178,10 +178,25 @@ class TestFullyShardManagedModulesAndStates(FSDPTestMultiThread):
         mlp = MLP(8)
         model = nn.Sequential(mlp, mlp)  # duplicate MLP
         # Assume calling `fully_shard` on `model`
-        managed_modules = _get_managed_modules(model)
+        managed_modules = _get_managed_modules((model,))
         # Check that the duplicate module is only counted once
         expected_managed_modules = list(mlp.modules()) + [model]
         self._check_managed_modules(managed_modules, expected_managed_modules)
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_managed_modules_list_of_mlps(self):
+        model = nn.Sequential(*[MLP(8) for _ in range(5)])
+        # Assume calling `fully_shard` on `[model[0], model[1], model[2]]`
+        managed_modules = _get_managed_modules((model[0], model[1], model[2]))
+        expected_managed_modules = (
+            list(model[0].modules())
+            + list(model[1].modules())
+            + list(model[2].modules())
+        )
+        self._check_managed_modules(managed_modules, expected_managed_modules)
+        # Assume calling `fully_shard` on `[model[1], model[3]]`
+        managed_modules = _get_managed_modules((model[1], model[3]))
+        expected_managed_modules = list(model[1].modules()) + list(model[3].modules())
 
     def _check_managed_modules(
         self,
@@ -199,7 +214,7 @@ class TestFullyShardManagedModulesAndStates(FSDPTestMultiThread):
         model[2].in_proj.weight = model[1].in_proj.weight
         model[1].buffer = model[2].buffer
         # Assume calling `fully_shard` on `model`
-        managed_modules = _get_managed_modules(model)
+        managed_modules = _get_managed_modules((model,))
         params, buffers = _get_managed_states(managed_modules)
         expected_params = list(model.parameters())  # de-dups shared
         expected_buffers = list(model.buffers())  # de-dups shared
@@ -210,10 +225,28 @@ class TestFullyShardManagedModulesAndStates(FSDPTestMultiThread):
         model = nn.Sequential(*[MLP(8, with_buffer=True) for _ in range(2)])
         fully_shard(model[0])
         # Assume calling `fully_shard` on `model`
-        managed_modules = _get_managed_modules(model)
+        managed_modules = _get_managed_modules((model,))
         params, buffers = _get_managed_states(managed_modules)
         expected_params = list(model[1].parameters())
         expected_buffers = list(model[1].buffers())
+        self._check_managed_states(params, buffers, expected_params, expected_buffers)
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_managed_states_list_of_mlps(self):
+        model = nn.Sequential(*[MLP(8, with_buffer=True) for _ in range(5)])
+        # Assume calling `fully_shard` on `[model[0], model[1], model[2]]`
+        managed_modules = _get_managed_modules((model[0], model[1], model[2]))
+        params, buffers = _get_managed_states(managed_modules)
+        expected_params = (
+            list(model[0].parameters())
+            + list(model[1].parameters())
+            + list(model[2].parameters())
+        )
+        expected_buffers = (
+            list(model[0].buffers())
+            + list(model[1].buffers())
+            + list(model[2].buffers())
+        )
         self._check_managed_states(params, buffers, expected_params, expected_buffers)
 
     def _check_managed_states(
@@ -238,7 +271,7 @@ class TestFullyShardParamModuleInfos(FSDPTestMultiThread):
     def test_get_param_module_infos_shared_params(self):
         model = nn.Sequential(*[MLP(8) for _ in range(2)])
         model[0].in_proj.weight = model[1].in_proj.weight
-        managed_modules = _get_managed_modules(model)
+        managed_modules = _get_managed_modules((model,))
         params, _ = _get_managed_states(managed_modules)
         param_module_infos = _get_param_module_infos(params, model)
         self.assertEqual(len(param_module_infos), len(params))
@@ -282,6 +315,26 @@ class TestFullyShardParamModuleInfos(FSDPTestMultiThread):
             ParamModuleInfo(mlp.out_proj, "weight", [], []),
             ParamModuleInfo(mlp.out_proj, "bias", [], []),
         ]
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_get_param_module_infos_list_of_mlps(self):
+        model = nn.Sequential(*[MLP(8) for _ in range(2)])
+        managed_modules = _get_managed_modules((model[0], model[1]))
+        params, _ = _get_managed_states(managed_modules)
+        param_module_infos = _get_param_module_infos(params, model)
+        self.assertEqual(len(param_module_infos), len(params))
+        expected_param_module_infos = [
+            ParamModuleInfo(model[0].in_proj, "weight", [], []),
+            ParamModuleInfo(model[0].in_proj, "bias", [], []),
+            ParamModuleInfo(model[0].out_proj, "weight", [], []),
+            ParamModuleInfo(model[0].out_proj, "bias", [], []),
+            ParamModuleInfo(model[1].in_proj, "weight", [], []),
+            ParamModuleInfo(model[1].in_proj, "bias", [], []),
+            ParamModuleInfo(model[1].out_proj, "weight", [], []),
+            ParamModuleInfo(model[1].out_proj, "bias", [], []),
+        ]
+        self.assertEqual(len(param_module_infos), len(expected_param_module_infos))
+        self.assertEqual(param_module_infos, expected_param_module_infos)
 
 
 class TestFullyShardShardedParameterTensor(FSDPTestMultiThread):
@@ -465,6 +518,15 @@ class TestFullyShardLazyInit(FSDPTestMultiThread):
             "FSDP state has already been lazily initialized for 0.in_proj\n"
             "FSDP requires running forward through the root module first"
         )
+        with self.assertRaisesRegex(RuntimeError, regex):
+            root_state._lazy_init()
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_fully_shard_multi_module_root(self):
+        model = nn.Sequential(MLP(8), MLP(8))
+        fully_shard([model[0], model[1]])
+        root_state = fully_shard.state(model[0])
+        regex = "FSDP requires a single root module but got "
         with self.assertRaisesRegex(RuntimeError, regex):
             root_state._lazy_init()
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -24,7 +24,6 @@ from torch.distributed._tensor.debug.comm_mode import CommDebugMode
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     _CHECKPOINT_PREFIX,
     apply_activation_checkpointing,
-    CheckpointWrapper,
 )
 from torch.distributed.checkpoint.state_dict import (
     get_model_state_dict,
@@ -590,14 +589,18 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
         """
         self.run_subtests(
             {
-                "reshard_after_forward": [True, False, 2],
+                "reshard_after_forward": [True, False],
                 "checkpoint_impl": ["composable", "utils", "wrapper"],
+                "module_grouping": ["block", "mem_eff", "mem_eff_weight_tied"],
             },
             self._test_train_parity_with_activation_checkpointing,
         )
 
     def _test_train_parity_with_activation_checkpointing(
-        self, reshard_after_forward: Union[bool, int], checkpoint_impl: str
+        self,
+        reshard_after_forward: Union[bool, int],
+        checkpoint_impl: str,
+        module_grouping: str,
     ):
         assert checkpoint_impl in ("composable", "utils", "wrapper")
         testing_compile = fully_shard != torch.distributed._composable.fsdp.fully_shard
@@ -613,33 +616,46 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                 max_seq_len=64,
                 dropout_p=0,
                 checkpoint_activations=(checkpoint_impl == "utils"),
+                # For the mem-efficient module grouping, we separate the
+                # embeddings from the output projection, which does not support
+                # weight tying
+                weight_tying=module_grouping != "mem_eff",
             )
             model = Transformer(model_args)
         ref_model = replicate(copy.deepcopy(model), device_ids=[self.rank])
-        foreach = True
-        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=foreach)
-        fully_shard_fn = functools.partial(
-            fully_shard,
-            reshard_after_forward=reshard_after_forward,
-        )
+        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
+
+        # Apply activation checkpointing
+        prefixes_to_ignore = ()
         if checkpoint_impl == "wrapper":
             prefixes_to_ignore = (_CHECKPOINT_PREFIX,)
             apply_activation_checkpointing(
                 model, check_fn=lambda m: isinstance(m, TransformerBlock)
             )
-            for module in model.modules():
-                # Apply to `CheckpointWrapper`, which wraps `TransformerBlock`
-                if isinstance(module, CheckpointWrapper):
-                    fully_shard_fn(module)
-        else:
-            prefixes_to_ignore = ()
+        elif checkpoint_impl == "composable":
             for module in model.modules():
                 if isinstance(module, TransformerBlock):
-                    if checkpoint_impl == "composable":
-                        checkpoint(module)
-                    fully_shard_fn(module)
-        fully_shard_fn(model)
-        optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=foreach)
+                    checkpoint(module)
+
+        # Apply FSDP
+        fsdp_kwargs = {"reshard_after_forward": reshard_after_forward}
+        if module_grouping == "mem_eff":
+            assert model_args.n_layers == 3
+            fully_shard(model.layers[0], **fsdp_kwargs)
+            fully_shard([model.layers[1], model.layers[2]], **fsdp_kwargs)
+            fully_shard([model.tok_embeddings, model.pos_embeddings], **fsdp_kwargs)
+            fully_shard([model.norm, model.output], **fsdp_kwargs)
+        elif module_grouping == "mem_eff_weight_tied":
+            fully_shard([model.tok_embeddings, model.output], **fsdp_kwargs)
+            for layer in model.layers:
+                fully_shard(layer, **fsdp_kwargs)
+        elif module_grouping == "block":
+            for layer in model.layers:
+                fully_shard(layer, **fsdp_kwargs)
+        else:
+            raise NotImplementedError(f"Unknown module grouping: {module_grouping}")
+        fully_shard(model, **fsdp_kwargs)
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
 
         torch.manual_seed(42 + self.rank)
         # Reuse the same input across iterations to avoid loss explosion from

--- a/torch/distributed/_composable/fsdp/_fsdp_state.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_state.py
@@ -1,12 +1,25 @@
 # mypy: allow-untyped-defs
 import functools
 import logging
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TYPE_CHECKING,
+)
 
 import torch
 import torch._dynamo.compiled_autograd as ca
 import torch.nn as nn
+from torch._logging import warning_once
 from torch.autograd import Variable
+from torch.autograd.graph import _MultiHandle
 from torch.distributed._composable_state import (
     _get_module_state,
     _insert_module_state,
@@ -67,21 +80,36 @@ class FSDPState(_State):
         self._training_state: TrainingState = TrainingState.IDLE
         self._states_to_forward_prefetch: List[FSDPState] = []
         self._states_to_backward_prefetch: List[FSDPState] = []
+        self._modules_to_run_forward: Set[nn.Module] = set()
 
     # Define a separate init since `__init__` is called in the contract
     def init(
-        self, module: nn.Module, device: torch.device, mp_policy: MixedPrecisionPolicy
+        self,
+        modules: Tuple[nn.Module, ...],
+        device: torch.device,
+        mp_policy: MixedPrecisionPolicy,
     ) -> None:
-        _insert_module_state(module, self)
-        self._module = module
+        for module in modules:
+            _insert_module_state(module, self)
+        self._modules = modules
         self._device = device
         self._mp_policy = mp_policy
-        self._pre_forward_hook_handle = module.register_forward_pre_hook(
-            self._pre_forward, prepend=True, with_kwargs=True
-        )
-        self._post_forward_hook_handle = module.register_forward_hook(
-            self._post_forward, prepend=False
-        )
+        if len(modules) == 1:
+            self._pre_forward_hook_handle = modules[0].register_forward_pre_hook(
+                self._pre_forward, prepend=True, with_kwargs=True
+            )
+            self._post_forward_hook_handle = modules[0].register_forward_hook(
+                self._post_forward, prepend=False
+            )
+        else:
+            hook_handle = _register_group_forward_hooks(
+                modules,
+                self._pre_forward,
+                self._post_forward,
+                self._modules_to_run_forward,
+            )
+            self._pre_forward_hook_handle = hook_handle
+            self._post_forward_hook_handle = hook_handle
 
     def _root_pre_forward(
         self, module: nn.Module, args: Tuple[Any, ...], kwargs: Dict[str, Any]
@@ -120,12 +148,17 @@ class FSDPState(_State):
         if self._is_root is not None:
             return  # no-op: already initialized
         self._is_root = True
-        root_module = self._module
+        if len(self._modules) > 1:
+            raise RuntimeError(
+                f"FSDP requires a single root module but got {self._modules}"
+            )
+        root_module = self._modules[0]
+        visited_states: Set[FSDPState] = set()
         for module_name, module in root_module.named_modules():
             if (state := _get_module_fsdp_state(module)) is None:
                 continue
             if module is not root_module:
-                if state._is_root is not None:
+                if state not in visited_states and state._is_root is not None:
                     raise RuntimeError(
                         "FSDP state has already been lazily initialized for "
                         f"{module_name}\nFSDP requires running forward through "
@@ -133,6 +166,7 @@ class FSDPState(_State):
                     )
                 state._is_root = False
             self._state_ctx.all_states.append(state)
+            visited_states.add(state)
         if self._fsdp_param_group:
             # For the root, do not reshard after forward since for training,
             # the parameters would be freed and all-gathered immediately
@@ -156,20 +190,27 @@ class FSDPState(_State):
     def _init_fqns(self) -> None:
         """Sets module and parameter FQN attributes for debugging."""
         assert self._is_root
-        root_module = self._module
+        root_module = self._modules[0]
         param_to_fsdp_param: Dict[nn.Parameter, FSDPParam] = {}
         module_to_fsdp_param_group: Dict[nn.Module, FSDPParamGroup] = {}
         for state in self._state_ctx.all_states:
             if fsdp_param_group := state._fsdp_param_group:
                 for fsdp_param in fsdp_param_group.fsdp_params:
                     param_to_fsdp_param[fsdp_param.sharded_param] = fsdp_param
-                module_to_fsdp_param_group[fsdp_param_group.module] = fsdp_param_group
+                for module in fsdp_param_group.modules:
+                    module_to_fsdp_param_group[module] = fsdp_param_group
         for param_name, param in root_module.named_parameters():
             if param in param_to_fsdp_param:
                 param_to_fsdp_param[param]._param_fqn = param_name
         for module_name, module in root_module.named_modules():
             if module in module_to_fsdp_param_group:
-                module_to_fsdp_param_group[module]._module_fqn = module_name
+                module_fqn = module_to_fsdp_param_group[module]._module_fqn
+                if module_fqn is None:
+                    module_to_fsdp_param_group[module]._module_fqn = module_name
+                else:
+                    assert isinstance(module_fqn, str), f"{module_fqn}"
+                    module_fqn += f", {module_name}"
+                    module_to_fsdp_param_group[module]._module_fqn = module_fqn
 
     @disable_if_config_true
     def _pre_forward(
@@ -253,6 +294,18 @@ class FSDPState(_State):
             self._state_ctx.post_backward_final_callback_queued = False
 
     def _finalize_backward(self) -> None:
+        if self._modules_to_run_forward:
+            msg = (
+                f"{len(self._modules_to_run_forward)} of the {len(self._modules)} "
+                f"modules passed to fully_shard did not run forward before backward, "
+                "which is error-prone since FSDP post-forward/pre-backward logic "
+                "will not run for these modules. We recommend passing only modules "
+                "that run forward together. Modules that did not run forward: "
+                f"{list(self._modules_to_run_forward)}"
+            )
+            warning_once(logger, msg, stacklevel=2)
+            # Clear since we want the next forward to run
+            self._modules_to_run_forward.clear()
         if self._fsdp_param_group:
             self._fsdp_param_group.finalize_backward()
 
@@ -282,3 +335,46 @@ def _get_module_fsdp_state(module: nn.Module) -> Optional[FSDPState]:
     if isinstance(state, FSDPState):
         return state
     return None
+
+
+def _register_group_forward_hooks(
+    modules: Sequence[nn.Module],
+    pre_hook: Callable,
+    post_hook: Callable,
+    modules_to_run: Set[nn.Module],
+):
+    """
+    Registers group forward pre and post-hooks. The pre-hook runs upon the
+    first module pre-forward, and the post-hook runs upon the last. If at least
+    one module does not run forward, then the post-hook does not run.
+    """
+    modules_set = set(modules)
+
+    @functools.wraps(pre_hook)
+    def wrapped_pre_hook(*args: Any, **kwargs: Any):
+        if len(modules_to_run) == 0:  # first to run
+            modules_to_run.update(modules_set)
+            return pre_hook(*args, **kwargs)
+
+    def get_wrapped_post_hook(module: nn.Module):
+        @functools.wraps(post_hook)
+        def wrapped_post_hook(*args: Any, **kwargs: Any):
+            modules_to_run.discard(module)
+            if len(modules_to_run) == 0:
+                return post_hook(*args, **kwargs)
+
+        return wrapped_post_hook
+
+    pre_handles = [
+        module.register_forward_pre_hook(
+            wrapped_pre_hook, prepend=True, with_kwargs=True
+        )
+        for module in modules
+    ]
+    post_handles = [
+        module.register_forward_hook(
+            get_wrapped_post_hook(module), prepend=False, always_call=True
+        )
+        for module in modules
+    ]
+    return _MultiHandle(tuple(pre_handles + post_handles))

--- a/torch/distributed/_composable/fsdp/fully_shard.py
+++ b/torch/distributed/_composable/fsdp/fully_shard.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 from torch.distributed._composable import contract
 from torch.distributed._tensor import DeviceMesh
+from torch.distributed.utils import _get_root_modules
 
 from ._fsdp_api import MixedPrecisionPolicy, OffloadPolicy
 from ._fsdp_common import FSDPMeshInfo, HSDPMeshInfo
@@ -25,7 +26,7 @@ from ._fsdp_state import _get_module_fsdp_state, FSDPState
 # `fully_shard.state(module)`. The state object and module are 1:1.
 @contract(state_cls=FSDPState)  # type: ignore[operator]
 def fully_shard(
-    module: nn.Module,
+    module: Union[nn.Module, List[nn.Module]],
     *,
     mesh: Optional[DeviceMesh] = None,
     reshard_after_forward: Union[bool, int] = True,
@@ -60,6 +61,8 @@ def fully_shard(
     gather parameters and later free parameters/reduce gradients.
 
     Args:
+        module (Union[nn.Module, List[nn.Module]): The module or modules to
+            shard with FSDP and group together for communication.
         mesh (Optional[DeviceMesh]): This data parallel mesh defines the
             sharding and device. If 1D, then parameters are fully sharded
             across the 1D mesh (FSDP). If 2D, then parameters are sharded
@@ -111,16 +114,20 @@ def fully_shard(
         reshard_after_forward, mesh_info
     )
 
-    state = fully_shard.state(module)
-    state.init(module, device, mp_policy)
+    arg_module = module
+    modules = (
+        (module,) if isinstance(module, nn.Module) else tuple(_get_root_modules(module))
+    )
+    state = fully_shard.state(modules[0])
+    state.init(modules, device, mp_policy)
 
-    managed_modules = _get_managed_modules(module)
+    managed_modules = _get_managed_modules(modules)
     params, buffers = _get_managed_states(managed_modules)
     _move_states_to_device(params, buffers, device)
     if params:
         state._fsdp_param_group = FSDPParamGroup(
             params,
-            module,
+            modules,
             mesh_info,
             post_forward_mesh_info,
             device,
@@ -134,11 +141,12 @@ def fully_shard(
         managed_module._fsdp_use_orig_params = True  # type: ignore[assignment]
 
     # Place FSDP leftmost for highest priority in the method resolution order
-    cls = module.__class__
-    dct = {"__deepcopy__": unimplemented_deepcopy}
-    new_cls = type(f"FSDP{cls.__name__}", (FSDPModule, cls), dct)
-    module.__class__ = new_cls
-    return module
+    for module in modules:
+        cls = module.__class__
+        dct = {"__deepcopy__": unimplemented_deepcopy}
+        new_cls = type(f"FSDP{cls.__name__}", (FSDPModule, cls), dct)
+        module.__class__ = new_cls
+    return arg_module
 
 
 def unimplemented_deepcopy(*args: Any, **kwargs: Any) -> NoReturn:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130949
* #130947

This PR allows `fully_shard`'s first argument to be `List[nn.Module]` instead of strictly `nn.Module`. This allows more flexible grouping of modules/parameters for communication, which can lead to memory savings and/or more efficient communication.

**Approach**
At a high level, we can think of a model as a tree of modules. Previously, we could only select specific module nodes in this tree as representing one FSDP parameter group. With this PR, we can select a group of module nodes, effectively becoming a single super node.

To implement the runtime schedule, we define new forward hooks that run based on the following semantics:
- If a module is the first to run the pre-hook, actually run the given pre-hook. Otherwise, the pre-hook is no-op.
- If a module is the last to run the post-hook, actually run the given post-hook. Otherwise, the post-hook is a no-op.
- First and last are determined by scoreboarding against a set of the modules.
- This set must get cleared at the end of backward in the case that >=1 module in the list is never used, in which case we still want the forward hooks to run in the next forward after this backward.

Beyond these new forward hooks, everything else is some simple generalization from `Module` to `List[Module]` or `Tuple[Module, ...]`.

**Examples**
This PR enables wrapping Llama models more efficiently by grouping the final norm and output linear together: https://github.com/pytorch/torchtitan/pull/382.

If at least one of the modules in the list does not run forward before backward, then there will be a warning message like:
```
1 of the 2 modules passed to fully_shard did not run forward before backward, which is error-prone since FSDP post-forward/pre-backward logic will not run for these modules. We recommend passing only modules that run forward together. Modules that did not run forward: [FSDPLinear(in_features=1, out_features=1, bias=True)]
```

---

**Changes for reland:** none since breakage was from PR below

cc @XilunWu @H-Huang @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o