### PR TITLE
[Fix]: ScriptObject lifting issue

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1014,6 +1014,7 @@ class TestConverter(TestCase):
 
         ep_list = self._check_equal_ts_ep_converter(M(), (torch.tensor(1),))
         for ep in ep_list:
+            print(ep.constants)
             self.assertEqual(len(ep.constants), 1)
 
     def test_aten_tensor_prim_dtype(self):

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -637,8 +637,10 @@ class TS2FXGraphConverter:
             return (
                 fqn in self.name_to_buffer
                 or fqn in self.name_to_param
-                or (fqn in self.name_to_constant
-                and isinstance(self.name_to_constant[fqn], torch.ScriptObject))
+                or (
+                    fqn in self.name_to_constant
+                    and isinstance(self.name_to_constant[fqn], torch.ScriptObject)
+                )
             )
 
         if self.is_top_level_graph():
@@ -1332,6 +1334,8 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionally
         ep._constants = {**name_to_tensor_constants, **name_to_constant}
         for k in name_to_tensor_constants:
             ep.state_dict.pop(k, None)
+        for k in name_to_constant:
+            ep.state_dict.pop(k, None)
         for spec in ep.graph_signature.input_specs:
             # Mark as constant tensors for erroneously traced buffers.
             if (
@@ -1346,7 +1350,7 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionally
     def lift_get_attr(self):
         # This function lifts multiple data types.
 
-        #     1. Tensor constants attributes (e.g., self.data = torch.tensor([2,3])) 
+        #     1. Tensor constants attributes (e.g., self.data = torch.tensor([2,3]))
         #     to buffers. Currently, when there are tensor constants, export
         #     would error and ask users to register tensor constants as buffers.
         #     Since it is hard to manually do so for TorchScript models
@@ -1355,7 +1359,7 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionally
 
         #     2. ScriptObbject to constant. It will then be converted to getattr in
         #     in the fx graph.
-        # 
+        #
         # This function should happen in TS2EPConverter instead of
         # TS2FXGraphConverter since it gets attributes from self.ts_model
         # which is not accessable in TS2FXGraphConverter. It is similar to where

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -13,6 +13,7 @@ from torch import _C
 from torch.export.exported_program import ExportedProgram
 from torch.export.graph_signature import (
     ConstantArgument,
+    CustomObjArgument,
     InputKind,
     InputSpec,
     OutputKind,
@@ -161,7 +162,7 @@ def ir_name_to_func_name(name: str) -> str:
     return "convert_" + "_".join(name_list)
 
 
-def get_node_for_param_and_buffer(fx_graph, name, is_top_level_graph):
+def get_node_as_placeholder_or_get_attr(fx_graph, name, is_top_level_graph):
     if is_top_level_graph:
         return fx_graph.get_attr(name)
     return fx_graph.placeholder(name)
@@ -366,6 +367,7 @@ class TS2FXGraphConverter:
         name_to_buffer: Dict[str, torch.Tensor],
         blocks_to_lifted_attrs: Dict[torch._C.Block, Set[str]],
         name_to_non_tensor_attribute: Dict[str, Any],
+        name_to_constant: Dict[str, Any],
     ):
         self.ts_graph = ts_graph
         self.name_to_param = name_to_param
@@ -378,7 +380,7 @@ class TS2FXGraphConverter:
         self.name_to_node: Dict[
             str, Union[torch.fx.Node, List[torch.fx.Node], Dict[Any, torch.fx.Node]]
         ] = {}
-        self.constant_map: Dict[str, Any] = {}
+        self.name_to_constant: Dict[str, Any] = name_to_constant
 
         # Mapping from torchscript node output name to attribute fully qualified name
         self.name_to_attribute_fqn: Dict[str, str] = {}
@@ -440,8 +442,10 @@ class TS2FXGraphConverter:
         if value_name in self.name_to_node:
             input_node = self.name_to_node[value_name]
             return input_node
-        elif value_name in self.constant_map:
-            return self.constant_map[value_name]
+        elif value_name in self.name_to_constant:
+            if isinstance(self.name_to_constant[value_name], torch.ScriptObject):
+                return self.fx_graph.get_attr(value_name)
+            return self.name_to_constant[value_name]
         else:
             raise ValueError(f"Input {value_name} not found")
 
@@ -461,6 +465,7 @@ class TS2FXGraphConverter:
                 **self.name_to_buffer,
                 **self.name_to_tensor_constants,
                 **self.name_to_non_tensor_attribute,
+                **self.name_to_constant,
             },
             self.fx_graph,
         )
@@ -484,7 +489,7 @@ class TS2FXGraphConverter:
                         target=name,
                     )
                 )
-                fx_node = get_node_for_param_and_buffer(
+                fx_node = get_node_as_placeholder_or_get_attr(
                     self.fx_graph, name, self.is_top_level_graph()
                 )
             elif name in self.name_to_buffer:
@@ -497,9 +502,27 @@ class TS2FXGraphConverter:
                         persistent=True,
                     )
                 )
-                fx_node = get_node_for_param_and_buffer(
+                fx_node = get_node_as_placeholder_or_get_attr(
                     self.fx_graph, name, self.is_top_level_graph()
                 )
+            elif name in self.name_to_constant:
+                normalized_name = normalize_name(name)
+                self.input_specs.append(
+                    InputSpec(
+                        InputKind.CUSTOM_OBJ,
+                        arg=CustomObjArgument(
+                            name=normalized_name, class_fqn=normalized_name
+                        ),
+                        target=name,
+                        persistent=False,
+                    )
+                )
+                fx_node = get_node_as_placeholder_or_get_attr(
+                    self.fx_graph, name, self.is_top_level_graph()
+                )
+            elif isinstance(graph_input.type(), torch.ClassType):
+                # Directly skip inputs that are ScriptObject but not used in the graph.
+                continue
             else:
                 normalized_name = normalize_name(name, prefix="input")
                 self.input_specs.append(
@@ -585,14 +608,22 @@ class TS2FXGraphConverter:
         else:
             value = None
 
-        self.constant_map[name] = value
+        self.name_to_constant[name] = value
+
+    def convert_prim_CallMethod(self, node: torch._C.Node):
+        inp_list = [self.get_fx_value(inp) for inp in node.inputs()]  # noqa: C416
+        fx_node = self.fx_graph.call_method(
+            node.s("name"),
+            tuple(inp_list),
+        )
+        self.name_to_node[node.output().debugName()] = fx_node
 
     def convert_prim_device(self, node: torch._C.Node):
         input_type = node.input().type()
         if input_type.isSubtypeOf(torch._C.TensorType.get()):
             device = input_type.device()  # type: ignore[attr-defined]
             output_name = node.output().debugName()
-            self.constant_map[output_name] = device
+            self.name_to_constant[output_name] = device
         else:
             raise ValueError(f"Unsupported JitType ({input_type}) when get device")
 
@@ -602,9 +633,16 @@ class TS2FXGraphConverter:
         output_name = node.output().debugName()
         self.name_to_attribute_fqn[output_name] = attr_fqn
 
-        attr_value = node.output()
+        def _should_be_get_attr(fqn):
+            return (
+                fqn in self.name_to_buffer
+                or fqn in self.name_to_param
+                or (fqn in self.name_to_constant
+                and isinstance(self.name_to_constant[fqn], torch.ScriptObject))
+            )
+
         if self.is_top_level_graph():
-            if attr_value.type().annotation_str == "Tensor":
+            if _should_be_get_attr(attr_fqn):
                 # We insert a get_attr node due to two reasons.
                 # First, ts graph does not lift tensor constants as input nodes. So
                 # tensor constants may be ignored by in convert_graph_inputs().
@@ -622,7 +660,7 @@ class TS2FXGraphConverter:
         else:
             # Special support for if blocks which do not allow SetAttr TorchScript
             # node and get_attr FX Graph Node.
-            if attr_value.type().annotation_str == "Tensor":
+            if _should_be_get_attr(attr_fqn):
                 self.name_to_node[output_name] = self.name_to_node[attr_fqn]
 
     def convert_prim_SetAttr(self, node: torch._C.Node):
@@ -909,9 +947,8 @@ class TS2FXGraphConverter:
         subgraph_nodes = []
         for block in node.blocks():
             subgraph_converter = TS2FXGraphConverter(
-                block, {}, {}, self.blocks_to_lifted_attrs, {}
+                block, {}, {}, self.blocks_to_lifted_attrs, {}, self.name_to_constant
             )
-            subgraph_converter.constant_map = self.constant_map
             subgraph_converter.name_to_attribute_fqn = self.name_to_attribute_fqn
 
             for block_arg in arguments:
@@ -1008,7 +1045,7 @@ class TS2FXGraphConverter:
         # breaks, continues, and returns.
         # So we add a dummy constant to the graph.
         output_name = node.output().debugName()
-        self.constant_map[output_name] = torch.Tensor()
+        self.name_to_constant[output_name] = torch.Tensor()
 
     def _convert_standard_operators(self, node: torch._C.Node):
         target = kind_to_standard_operators[node.kind()]
@@ -1058,13 +1095,13 @@ class TS2FXGraphConverter:
                         target=output_name,
                     )
                 )
-            elif output_name in self.constant_map:
-                args.append(self.constant_map[output_name])
+            elif output_name in self.name_to_constant:
+                args.append(self.name_to_constant[output_name])
                 self.output_specs.append(
                     OutputSpec(
                         OutputKind.USER_OUTPUT,
                         arg=ConstantArgument(
-                            name=output_name, value=self.constant_map[output_name]
+                            name=output_name, value=self.name_to_constant[output_name]
                         ),
                         target=output_name,
                     )
@@ -1114,6 +1151,7 @@ class ExplainTS2FXGraphConverter(TS2FXGraphConverter):
         name_to_buffer: Dict[str, torch.Tensor],
         blocks_to_lifted_attrs: Dict[torch._C.Block, Set[str]],
         name_to_non_tensor_attribute: Dict[str, Any],
+        name_to_constant: Dict[str, Any],
     ):
         super().__init__(
             ts_graph,
@@ -1121,6 +1159,7 @@ class ExplainTS2FXGraphConverter(TS2FXGraphConverter):
             name_to_buffer,
             blocks_to_lifted_attrs,
             name_to_non_tensor_attribute,
+            name_to_constant,
         )
 
         # Data to keep track of unsupported nodes.
@@ -1197,8 +1236,9 @@ class TS2EPConverter:
                     self.name_to_buffer[k] = tensor
 
         self.name_to_non_tensor_attributes: Dict[str, Any] = {}
+        self.name_to_constant: Dict[str, Any] = {}
 
-        self.lift_tensor_constants_to_buffer()
+        self.lift_get_attr()
 
     def convert(self) -> ExportedProgram:
         log.info(
@@ -1222,12 +1262,15 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionally
             self.name_to_buffer,
             blocks_to_lifted_attrs,
             self.name_to_non_tensor_attributes,
+            self.name_to_constant,
         )
         gm = graph_converter.convert()
         log.info("GraphModule: %s", gm.print_readable(print_output=False))
 
         ep = self.retrace_as_exported_program(
-            gm, graph_converter.name_to_tensor_constants
+            gm,
+            graph_converter.name_to_tensor_constants,
+            graph_converter.name_to_constant,
         )
         log.info("%s", ep)
 
@@ -1254,6 +1297,7 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionally
             self.name_to_buffer,
             blocks_to_lifted_attrs,
             self.name_to_non_tensor_attributes,
+            self.name_to_constant,
         )
         graph_converter.explain()
         if len(graph_converter.unsupported_node_list) > 0:
@@ -1268,7 +1312,10 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionally
         return explain_str
 
     def retrace_as_exported_program(
-        self, gm: torch.fx.GraphModule, tensor_constants: Dict[str, torch.Tensor]
+        self,
+        gm: torch.fx.GraphModule,
+        name_to_tensor_constants: Dict[str, torch.Tensor],
+        name_to_constant: Dict[str, Any],
     ):
         # TODO: adjust input orders to match GraphSignature convention
         ep = torch.export._trace._export(
@@ -1282,24 +1329,33 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionally
         # Because during conversion, we set tensor constants as GetAttr,
         # retracing cannot recognize them as tensor constants but instead
         # treat them as buffers. We need to set them again here.
-        ep._constants = {**ep._constants, **tensor_constants}
-        for k in tensor_constants:
+        ep._constants = {**name_to_tensor_constants, **name_to_constant}
+        for k in name_to_tensor_constants:
             ep.state_dict.pop(k, None)
         for spec in ep.graph_signature.input_specs:
             # Mark as constant tensors for erroneously traced buffers.
-            if spec.kind == InputKind.BUFFER and spec.target in tensor_constants:
+            if (
+                spec.kind == InputKind.BUFFER
+                and spec.target in name_to_tensor_constants
+            ):
                 spec.kind = InputKind.CONSTANT_TENSOR
         ep.verifier().check(ep)
 
         return ep
 
-    def lift_tensor_constants_to_buffer(self):
-        # This function lifts tensor constants attributes (e.g., self.data = torch.tensor([2,3]))
-        # to buffers. Currently, when there are tensor constants, export
-        # would error and ask users to register tensor constants as buffers.
-        # Since it is hard to manually do so for TorchScript models
-        # (e.g., source code is missing), this function automatically
-        # lifts tensor constants to be buffers.
+    def lift_get_attr(self):
+        # This function lifts multiple data types.
+
+        #     1. Tensor constants attributes (e.g., self.data = torch.tensor([2,3])) 
+        #     to buffers. Currently, when there are tensor constants, export
+        #     would error and ask users to register tensor constants as buffers.
+        #     Since it is hard to manually do so for TorchScript models
+        #     (e.g., source code is missing), this function automatically
+        #     lifts tensor constants to be buffers.
+
+        #     2. ScriptObbject to constant. It will then be converted to getattr in
+        #     in the fx graph.
+        # 
         # This function should happen in TS2EPConverter instead of
         # TS2FXGraphConverter since it gets attributes from self.ts_model
         # which is not accessable in TS2FXGraphConverter. It is similar to where
@@ -1335,6 +1391,9 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionally
                         if attr_fqn not in self.name_to_buffer:
                             # Lift tensor constants to be a buffer
                             self.name_to_buffer[attr_fqn] = value
+                    elif isinstance(value, torch.ScriptObject):
+                        if attr_fqn not in self.name_to_constant:
+                            self.name_to_constant[attr_fqn] = value
                     else:
                         self.name_to_non_tensor_attributes[attr_fqn] = value
 

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -513,6 +513,9 @@ class TS2FXGraphConverter:
                     self.fx_graph, name, self.is_top_level_graph()
                 )
             elif name in self.name_to_constant:
+                assert isinstance(
+                    self.name_to_constant[name], torch.ScriptObject
+                ), "Input conversion only handles ScriptObject"
                 normalized_name = normalize_name(name)
                 self.input_specs.append(
                     InputSpec(

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -1333,10 +1333,10 @@ DEBUG: (TORCH_LOGS="+export" <cmd>), additionally
         # Because during conversion, we set tensor constants as GetAttr,
         # retracing cannot recognize them as tensor constants but instead
         # treat them as buffers. We need to set them again here.
-        ep._constants = {
+        ep._constants.update({
             k: v for k, v in name_to_constant.items()
             if isinstance(v, (torch.Tensor, torch.ScriptObject))
-        }
+        })
         for k in name_to_constant:
             ep.state_dict.pop(k, None)
 


### PR DESCRIPTION
#### Issue
ScriptObject was treated as normal attribute by the converter previously. This PR lifts it to be a constant and convert it directly to a GetAttr fx node. ScriptObject would also trigger `CallMethod` and this PR adds that support as well.

#### Test Plan
Add test case for ScriptObject.
`pytest test/export/test_converter.py -s -k test_convert_script_object`