### PR TITLE
[BE] Remove references to outdated `macos-m1-13` labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -41,7 +41,6 @@ self-hosted-runner:
     - macos-m2-14
     # Org wise AWS `mac2.metal` runners (2020 Mac mini hardware powered by Apple silicon M1 processors)
     - macos-m1-stable
-    - macos-m1-13
     - macos-m1-14
     # GitHub-hosted MacOS runners
     - macos-latest-xlarge

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -27,7 +27,7 @@ jobs:
       # than our AWS macos-m1-14 runners
       test-matrix: |
         { include: [
-          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
+          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-stable" },
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m2-14" },
         ]}
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -160,8 +160,7 @@ jobs:
       python-version: 3.9.12
       test-matrix: |
         { include: [
-          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
-          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-14" },
+          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-stable" },
         ]}
 
   macos-py3-arm64-test:


### PR DESCRIPTION
We have just a few runners with `macos-m1-13` (too few to actually be reliable) and those are becoming problematic. The work to support them does not seems to pay-out, so the goal is to remove any reference to this particular label so we can retire this fleet.