### PR TITLE
Unwrap Identity in prepare indexing

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -29,7 +29,7 @@ import sympy
 import torch
 import torch._logging
 
-from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Identity
+from torch.utils._sympy.functions import FloorDiv, Identity, ModularIndexing
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 from ..._dynamo.utils import counters
 from .. import config, ir, scheduler
@@ -693,13 +693,15 @@ class SIMDKernel(Kernel):
                 ):
                     replacements = {a: V.graph.sizevars.lookup_precomputed_size(a)}
                     index = sympy_subs(index, replacements)
-        
+
         simp_index = self.simplify_indexing(index)
 
         # Now that we are done simplifying we can unwrap Identity so that downstream handling
         # for its contained expression will work. previously, tl.full wrapping of sympy.Integer
         # would not occur
-        simp_index = simp_index if not isinstance(simp_index, Identity) else simp_index.args[0]
+        simp_index = (
+            simp_index if not isinstance(simp_index, Identity) else simp_index.args[0]
+        )
 
         return self.codegen_indexing(simp_index)
 

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -29,7 +29,7 @@ import sympy
 import torch
 import torch._logging
 
-from torch.utils._sympy.functions import FloorDiv, ModularIndexing
+from torch.utils._sympy.functions import FloorDiv, ModularIndexing, Identity
 from torch.utils._sympy.symbol import free_symbol_is_type, symbol_is_type, SymT
 from ..._dynamo.utils import counters
 from .. import config, ir, scheduler
@@ -693,8 +693,15 @@ class SIMDKernel(Kernel):
                 ):
                     replacements = {a: V.graph.sizevars.lookup_precomputed_size(a)}
                     index = sympy_subs(index, replacements)
+        
+        simp_index = self.simplify_indexing(index)
 
-        return self.codegen_indexing(self.simplify_indexing(index))
+        # Now that we are done simplifying we can unwrap Identity so that downstream handling
+        # for its contained expression will work. previously, tl.full wrapping of sympy.Integer
+        # would not occur
+        simp_index = simp_index if not isinstance(simp_index, Identity) else simp_index.args[0]
+
+        return self.codegen_indexing(simp_index)
 
     def active_range_trees(self, reorder=False):
         trees = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #130967

We wrap indexing calculation in the concat kernel in `Identity` so that we do not expand int32 intermediates to int64. This was causing an issue where the index simplified to an integer and would not hit an intended [path](https://github.com/pytorch/pytorch/blob/752c81789829cfce94f9664db97cc45aaae8ce32/torch/_inductor/codegen/triton.py#L1554) which would do wrapping with tl.full. 

I couldn't generate a minimal repro to add as test but I have a repro you can check here: P1483831261 There is already a test that we dont expand the int32 intermediates to int64.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang

Differential Revision: [D59871850](https://our.internmc.facebook.com/intern/diff/D59871850)