### PR TITLE
[CUDAGraph] Add operator.mul to skip list for find_input_mutations

### DIFF
--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -1,7 +1,6 @@
 # mypy: ignore-errors
 
 import functools
-import operator
 from collections import defaultdict
 from typing import Dict, List, Optional
 
@@ -42,13 +41,9 @@ def find_input_mutations(g):
                 inputs[StorageWeakRef(meta_fk(n.meta)._typed_storage())].add(input_idx)
             input_idx += 1
         elif n.op == "call_function":
-            if n.target in [
-                operator.getitem,
-                operator.ge,
-                operator.le,  # runtime asserts
-                operator.mul,  # support symints from dynamic shapes
-            ]:
+            if not hasattr(n.target, "_schema"):
                 continue
+
             schema = n.target._schema
             for i, arg in enumerate(schema.arguments):
                 if i < len(n.args):

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -46,6 +46,7 @@ def find_input_mutations(g):
                 operator.getitem,
                 operator.ge,
                 operator.le,  # runtime asserts
+                operator.mul, # support symints from dynamic shapes
             ]:
                 continue
             schema = n.target._schema

--- a/torch/_dynamo/backends/cudagraphs.py
+++ b/torch/_dynamo/backends/cudagraphs.py
@@ -46,7 +46,7 @@ def find_input_mutations(g):
                 operator.getitem,
                 operator.ge,
                 operator.le,  # runtime asserts
-                operator.mul, # support symints from dynamic shapes
+                operator.mul,  # support symints from dynamic shapes
             ]:
                 continue
             schema = n.target._schema


### PR DESCRIPTION
The #130912 error happens since `operator.mul` does not have `_schema`.

So why do we have `operator.mul` and why is it not dispatched to `torch.ops.aten.mul`? This op comes from %mul_3.

    %mul_3 : [num_users=50] = call_function[target=operator.mul](args = (%arg689_1, 4096), kwargs = {})

`%arg689_1` is a placeholder with `meta[‘val’] = s0`. It comes form dynamic shapes and represents the batch size since it’s also used in many other nodes such as:

    %view_1 : [num_users=1] = call_function[target=torch.ops.aten.view.default](args = (%mm, [%arg689_1, 4096, 320]), kwargs = {})
and

    %native_group_norm_2 : [num_users=1] = call_function[target=torch.ops.aten.native_group_norm.default](args = (%div_1, %arg16_1, %arg17_1, %arg689_1, 320, 4096, 32, 1e-06), kwargs = {})

To fix the issue, we can add `operator.mul` to skip list.

Fixes #130912


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames