### PR TITLE
[debug][dtensor] fixed updating current module

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -5,6 +5,7 @@ import copy
 import functools
 import itertools
 import unittest
+from collections import defaultdict
 from typing import Iterable, List, Tuple, Type, Union
 
 import torch
@@ -817,18 +818,25 @@ class TestFullyShardGradientAccumulation(FSDPTest):
 
         torch.manual_seed(42 + self.rank + 1)
         for iter_idx in range(5):
-            with CommDebugMode() as comm_mode:
-                for microbatch_idx in range(num_microbatches):
-                    is_last_microbatch = microbatch_idx == num_microbatches - 1
-                    set_backward_flags(model, is_last_microbatch)
-                    inp = torch.randn(batch_size, lin_dim, device="cuda")
-                    losses: List[torch.Tensor] = []
-                    for _model in (ref_model, model):
+            comm_count_list = []
+
+            for microbatch_idx in range(num_microbatches):
+                is_last_microbatch = microbatch_idx == num_microbatches - 1
+                set_backward_flags(model, is_last_microbatch)
+                inp = torch.randn(batch_size, lin_dim, device="cuda")
+                losses: List[torch.Tensor] = []
+                for _model in (ref_model, model):
+                    with CommDebugMode() as comm_mode:
                         losses.append(_model(inp).sum())
                         losses[-1].backward()
-                    self.assertEqual(losses[0], losses[1])
+                    comm_count_list.append(comm_mode.get_comm_counts())
+                self.assertEqual(losses[0], losses[1])
 
-            comm_counts = comm_mode.get_comm_counts()
+            comm_counts = defaultdict(int)
+            for comm_count_dict in comm_count_list:
+                for collective, count in comm_count_dict.items():
+                    comm_counts[collective] += count
+
             all_gather_count = comm_counts[c10d_ops._allgather_base_]
             reduce_scatter_count = comm_counts[c10d_ops._reduce_scatter_base_]
             all_reduce_count = comm_counts[c10d_ops.allreduce_]

--- a/test/distributed/_tensor/debug/test_comm_mode_features.py
+++ b/test/distributed/_tensor/debug/test_comm_mode_features.py
@@ -247,7 +247,10 @@ class TestCommModeFeatures(DTensorTestBase):
             self.assertEqual(
                 len(comm_mode.advanced_module_tracker.module_helper_dict), 1
             )
-            self.assertEqual(comm_mode.comm_module_counts, {})
+            self.assertEqual(
+                comm_mode.comm_module_counts,
+                {"Global": {"forward": {}, "backward": {}}},
+            )
             output_tp = model(inp)
 
         model_args = ModelArgs(dropout_p=0.0)

--- a/torch/distributed/_tensor/examples/comm_mode_features_example.py
+++ b/torch/distributed/_tensor/examples/comm_mode_features_example.py
@@ -282,10 +282,18 @@ class CommDebugModeExample:
         Global
           FORWARD PASS
             *c10d_functional.all_reduce: 1
+            **aten.view.default
+            **aten.sum.default
+            **aten.ones_like.default
+          BACKWARD PASS
+            **aten.expand.default
             MLPModule
             *module type: class 'torch.testing._internal.distributed._tensor.common_dtensor.MLPModule'
               FORWARD PASS
                 *c10d_functional.all_reduce: 1
+                **aten.view.default
+                **aten.view.default
+                **aten.view.default
                 MLPModule.net1
                 *module type: class 'torch.nn.modules.linear.Linear'
                 *Parameter List
@@ -352,11 +360,68 @@ class CommDebugModeExample:
                       device mesh: DeviceMesh([0, 1, 2, 3])
                     **aten.addmm.default
                     **aten.view.default
+                  BACKWARD PASS
+                    **aten.t.default
+                      shape: [torch.Size([8, 16])]
+                      sharding: [(Shard(dim=1),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.t.default
+                    **aten.mm.default
+                      shape: [torch.Size([16, 8]), torch.Size([8, 10])]
+                      sharding: [(Shard(dim=0),), (Replicate(),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.mm.default
+                    **aten.t.default
+                      shape: [torch.Size([16, 10])]
+                      sharding: [(Shard(dim=0),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.t.default
+                    **aten.sum.dim_IntList
+                      shape: [torch.Size([8, 16])]
+                      sharding: [(Shard(dim=1),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.sum.dim_IntList
+                    **aten.view.default
+                      shape: [torch.Size([1, 16])]
+                      sharding: [(Shard(dim=1),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.view.default
+                    **aten.detach.default
+                      shape: [torch.Size([16])]
+                      sharding: [(Shard(dim=0),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.detach.default
+                    **aten.detach.default
+                      shape: [torch.Size([16])]
+                      sharding: [(Shard(dim=0),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.detach.default
+                    **aten.detach.default
+                    **aten.t.default
+                      shape: [torch.Size([10, 16])]
+                      sharding: [(Shard(dim=1),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.t.default
+                    **aten.detach.default
+                      shape: [torch.Size([16, 10])]
+                      sharding: [(Shard(dim=0),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.detach.default
+                    **aten.detach.default
+                      shape: [torch.Size([16, 10])]
+                      sharding: [(Shard(dim=0),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.detach.default
+                    **aten.detach.default
                 MLPModule.relu
                 *module type: class 'torch.nn.modules.activation.ReLU'
                   FORWARD PASS
+                    **aten.view.default
                     **aten.relu.default
                     **aten.detach.default
+                  BACKWARD PASS
+                    **aten.detach.default
+                    **aten.threshold_backward.default
                 MLPModule.net2
                 *module type: class 'torch.nn.modules.linear.Linear'
                 *Parameter List
@@ -413,6 +478,11 @@ class CommDebugModeExample:
                     **aten.detach.default
                     **aten.detach.default
                     **aten.view.default
+                    **aten.view.default
+                      shape: [torch.Size([8, 16])]
+                      sharding: [(Shard(dim=1),)]
+                      device mesh: DeviceMesh([0, 1, 2, 3])
+                    **aten.view.default
                     **aten.t.default
                       shape: [torch.Size([10, 16])]
                       sharding: [(Shard(dim=1),)]
@@ -426,10 +496,7 @@ class CommDebugModeExample:
                     **aten.addmm.default
                     **_c10d_functional.all_reduce.default
                     **aten.view.default
-                    **aten.sum.default
-                    **aten.ones_like.default
                   BACKWARD PASS
-                    **aten.expand.default
                     **aten.t.default
                       shape: [torch.Size([16, 10])]
                       sharding: [(Shard(dim=0),)]
@@ -489,60 +556,6 @@ class CommDebugModeExample:
                     **aten.detach.default
                       shape: [torch.Size([10, 16])]
                       sharding: [(Shard(dim=1),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.detach.default
-                    **aten.detach.default
-                    **aten.detach.default
-                    **aten.threshold_backward.default
-                    **aten.t.default
-                      shape: [torch.Size([8, 16])]
-                      sharding: [(Shard(dim=1),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.t.default
-                    **aten.mm.default
-                      shape: [torch.Size([16, 8]), torch.Size([8, 10])]
-                      sharding: [(Shard(dim=0),), (Replicate(),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.mm.default
-                    **aten.t.default
-                      shape: [torch.Size([16, 10])]
-                      sharding: [(Shard(dim=0),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.t.default
-                    **aten.sum.dim_IntList
-                      shape: [torch.Size([8, 16])]
-                      sharding: [(Shard(dim=1),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.sum.dim_IntList
-                    **aten.view.default
-                      shape: [torch.Size([1, 16])]
-                      sharding: [(Shard(dim=1),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.view.default
-                    **aten.detach.default
-                      shape: [torch.Size([16])]
-                      sharding: [(Shard(dim=0),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.detach.default
-                    **aten.detach.default
-                      shape: [torch.Size([16])]
-                      sharding: [(Shard(dim=0),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.detach.default
-                    **aten.detach.default
-                    **aten.t.default
-                      shape: [torch.Size([10, 16])]
-                      sharding: [(Shard(dim=1),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.t.default
-                    **aten.detach.default
-                      shape: [torch.Size([16, 10])]
-                      sharding: [(Shard(dim=0),)]
-                      device mesh: DeviceMesh([0, 1, 2, 3])
-                    **aten.detach.default
-                    **aten.detach.default
-                      shape: [torch.Size([16, 10])]
-                      sharding: [(Shard(dim=0),)]
                       device mesh: DeviceMesh([0, 1, 2, 3])
                     **aten.detach.default
                     **aten.detach.default


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #130518
* #130996
* __->__ #130995

**Summary**
Fixed issue with updating the current module when transitioning between child module to parent module and in the backward pass. The first issue is caused because the prehook is not called again when we go back to the parent module and that the hook being used was a register_module_forward_hook, which runs before the register_module_hook used in redistribute, causing the collective call to be assigned to the incorrect module. In order to do this, I updated the current module to be the parent module in a register_forward_hook in the module tracker. The second issue was caused by the parent set in the module tracker I inherit from being incorrect. I fixed this issue by saving the parents of each module and using them in collective counter instead of the incorrect set. I have updated the example in module_operation_tracing to reflect the correct output. In addition, I changed the test cases that used the incompatible old CommDebugMode. 

**Test Case**
1. torchrun --standalone --nnodes=1 --nproc-per-node=4 torch/distributed/_tensor/examples/comm_mode_features_example.py -e MLP_operation_tracing

2. pytest test/distributed/_tensor/debug/test_comm_mode_features.py -s -k test_transformer_module_tracing

3. python test/distributed/_composable/fsdp/test_fully_shard_training.py -k TestFullyShardGradientAccumulation.test_gradient_accumulation

4. python test/distributed/_tensor/test_math_ops.py -k DistMathOpsTest.test_layer_norm_bwd  




cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o