### PR TITLE
[Distributed][PP export] update tracing to handle autocast inclusion

### DIFF
--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -13,6 +13,7 @@ import torch
 import torch.fx as fx
 from torch.distributed import ProcessGroup
 from torch.export import ExportedProgram
+from torch.export._trace import _export
 from torch.export.unflatten import (
     _assign_attr,
     _AttrKind,
@@ -1004,11 +1005,14 @@ class Pipe(torch.nn.Module):
     ) -> ExportedProgram:
         logger.info("Tracing model ...")
         try:
-            ep = torch.export.export(
-                mod,
-                example_args,
-                example_kwargs,
-            )
+            with torch.no_grad():
+                ep = _export(
+                        mod,
+                        example_args,
+                        example_kwargs,
+                        strict=True,
+                        pre_dispatch=False,
+                    )
         except Exception as e:
             raise RuntimeError(
                 "It seems that we cannot capture your model as a full graph. "

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -1012,7 +1012,7 @@ class Pipe(torch.nn.Module):
                     example_kwargs,
                     strict=True,
                     pre_dispatch=False,
-                    )
+                )
         except Exception as e:
             raise RuntimeError(
                 "It seems that we cannot capture your model as a full graph. "

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -1007,12 +1007,12 @@ class Pipe(torch.nn.Module):
         try:
             with torch.no_grad():
                 ep = _export(
-                        mod,
-                        example_args,
-                        example_kwargs,
-                        strict=True,
-                        pre_dispatch=False,
-                        )
+                    mod,
+                    example_args,
+                    example_kwargs,
+                    strict=True,
+                    pre_dispatch=False,
+                    )
         except Exception as e:
             raise RuntimeError(
                 "It seems that we cannot capture your model as a full graph. "

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -1012,7 +1012,7 @@ class Pipe(torch.nn.Module):
                         example_kwargs,
                         strict=True,
                         pre_dispatch=False,
-                    )
+                        )
         except Exception as e:
             raise RuntimeError(
                 "It seems that we cannot capture your model as a full graph. "


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/128394

This updates PP export tracing to use no_grad() context along with avoid predispatch.  
This enables tracing for HF llama models that currently fail due to not handling the use of autocast in the Rope embeddings.




cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o