### PR TITLE
Add recursive metadata guard test

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1378,6 +1378,15 @@ s1 > 3""",
         _check_recompiles(self, lambda x: x * x, (x,), (x2,), False)
         _check_recompiles(self, lambda x: x * x, (x,), (x3,), True)
 
+    def test_tensor_subclass_ctx_recursive_guards(self):
+        x0 = torch.ones(2, 2)
+        x1 = CtxSubclassTensor(x0.clone(), 2)
+        x2 = CtxSubclassTensor(x0.clone(), 3)
+        tt0 = TwoTensor(x0.clone(), x1)
+        tt1 = TwoTensor(x0.clone(), x2)
+
+        _check_recompiles(self, lambda x: x * x, (tt0,), (tt1,), True)
+
     def test_tensor_subclass_ctx_custom_guards_override(self):
         class CtxSubclassTensorCustomGuardFn(CtxSubclassTensor):
             @classmethod

--- a/torch/testing/_internal/two_tensor.py
+++ b/torch/testing/_internal/two_tensor.py
@@ -61,7 +61,6 @@ class TwoTensor(torch.Tensor):
 
         out_a = func(*args_a, **kwargs_a)
         out_b = func(*args_b, **kwargs_b)
-        assert type(out_a) == type(out_b)
         out_a_flat, spec = pytree.tree_flatten(out_a)
         out_b_flat = pytree.tree_leaves(out_b)
         # for aten ops that return non-tensors, just assume that


### PR DESCRIPTION
Ensures that nested tensors subclasses are guarded properly. It turns out this case is already handled [here](https://github.com/pytorch/pytorch/blob/d77af49380de8215ee6e60bc0e3aa32c9092b1a7/torch/_dynamo/variables/builder.py#L1496) which will recursively wrap inner tensors adding metadata guards for them. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames