### PR TITLE
[Inductor UT] Generalize device-bias code in case TestFxGraphCache.test_inductor_counters.

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -26,7 +26,10 @@ from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import clear_inductor_caches, fresh_inductor_cache
 from torch.testing._internal.common_cuda import SM80OrLater
-from torch.testing._internal.common_device_type import largeTensorTest
+from torch.testing._internal.common_device_type import (
+    expectedFailureXPU,
+    largeTensorTest,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -99,6 +102,8 @@ class MyModelConv2d(torch.nn.Module):
 
 @instantiate_parametrized_tests
 class TestFxGraphCache(TestCase):
+    device_type = GPU_TYPE
+
     def setUp(self):
         super().setUp()
         counters.clear()
@@ -437,6 +442,7 @@ class TestFxGraphCache(TestCase):
         self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
         self.assertEqual(metrics.generated_kernel_count, 2)
 
+    @expectedFailureXPU
     @requires_gpu()
     @requires_triton()
     @config.patch({"max_autotune": True})
@@ -450,8 +456,8 @@ class TestFxGraphCache(TestCase):
         def fn(a, b):
             return torch.mm(a, b)
 
-        a = torch.rand(8, 32, device="cuda")
-        b = torch.rand(32, 8, device="cuda")
+        a = torch.rand(8, 32, device=GPU_TYPE)
+        b = torch.rand(32, 8, device=GPU_TYPE)
 
         compiled_fn = torch.compile(fn)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131006

[Inductor UT] Generalize device-bias code in case `TestFxGraphCache.test_inductor_counters`.
Fix #131005

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang