### PR TITLE
[easy][pytorch][counters] Move WaitCounter in c10/util

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -691,7 +691,6 @@ libtorch_cuda_distributed_extra_sources = [
     "torch/csrc/distributed/c10d/Utils.cu",
     "torch/csrc/distributed/rpc/tensorpipe_cuda.cpp",
     "torch/csrc/distributed/c10d/quantization/quantization_gpu.cu",
-    "torch/csrc/monitor/instrumentation.cpp",
 ]
 
 libtorch_cuda_distributed_sources = libtorch_cuda_distributed_base_sources + libtorch_cuda_distributed_extra_sources

--- a/c10/util/WaitCounter.cpp
+++ b/c10/util/WaitCounter.cpp
@@ -1,4 +1,4 @@
-#include <torch/csrc/monitor/instrumentation.h>
+#include <c10/util/WaitCounter.h>
 
 #include <c10/util/Synchronized.h>
 
@@ -8,15 +8,15 @@
 #include <unordered_map>
 #include <vector>
 
-namespace torch::monitor {
+namespace c10::monitor {
 
 namespace detail {
 namespace {
 using WaitCounterBackendFactories =
     std::vector<std::shared_ptr<WaitCounterBackendFactoryIf>>;
 
-c10::Synchronized<WaitCounterBackendFactories>& waitCounterBackendFactories() {
-  static auto instance = new c10::Synchronized<WaitCounterBackendFactories>();
+Synchronized<WaitCounterBackendFactories>& waitCounterBackendFactories() {
+  static auto instance = new Synchronized<WaitCounterBackendFactories>();
   return *instance;
 }
 } // namespace
@@ -24,7 +24,7 @@ c10::Synchronized<WaitCounterBackendFactories>& waitCounterBackendFactories() {
 class WaitCounterImpl {
  public:
   static WaitCounterImpl& getInstance(std::string_view key) {
-    static auto& implMapSynchronized = *new c10::Synchronized<
+    static auto& implMapSynchronized = *new Synchronized<
         std::unordered_map<std::string, std::unique_ptr<WaitCounterImpl>>>();
 
     return *implMapSynchronized.withLock([&](auto& implMap) {
@@ -43,9 +43,9 @@ class WaitCounterImpl {
     });
   }
 
-  c10::SmallVector<intptr_t> start() noexcept {
+  SmallVector<intptr_t> start() noexcept {
     auto now = std::chrono::steady_clock::now();
-    c10::SmallVector<intptr_t> ctxs;
+    SmallVector<intptr_t> ctxs;
     ctxs.reserve(backends_.size());
     for (const auto& backend : backends_) {
       ctxs.push_back(backend->start(now));
@@ -53,7 +53,7 @@ class WaitCounterImpl {
     return ctxs;
   }
 
-  void stop(c10::SmallVector<intptr_t>&& ctxs) noexcept {
+  void stop(SmallVector<intptr_t>&& ctxs) noexcept {
     auto now = std::chrono::steady_clock::now();
     assert(ctxs.size() == backends_.size());
     for (size_t i = 0; i < ctxs.size(); ++i) {
@@ -72,7 +72,7 @@ class WaitCounterImpl {
     }
   }
 
-  c10::SmallVector<std::unique_ptr<WaitCounterBackendIf>> backends_;
+  SmallVector<std::unique_ptr<WaitCounterBackendIf>> backends_;
 };
 
 void registerWaitCounterBackend(
@@ -89,7 +89,7 @@ WaitCounterHandle::WaitGuard WaitCounterHandle::start() {
   return WaitCounterHandle::WaitGuard(*this, impl_.start());
 }
 
-void WaitCounterHandle::stop(c10::SmallVector<intptr_t>&& ctxs) {
+void WaitCounterHandle::stop(SmallVector<intptr_t>&& ctxs) {
   return impl_.stop(std::move(ctxs));
 }
-} // namespace torch::monitor
+} // namespace c10::monitor

--- a/c10/util/WaitCounter.h
+++ b/c10/util/WaitCounter.h
@@ -9,7 +9,7 @@
 #include <c10/util/ScopeExit.h>
 #include <c10/util/SmallVector.h>
 
-namespace torch::monitor {
+namespace c10::monitor {
 namespace detail {
 class WaitCounterImpl;
 
@@ -34,11 +34,12 @@ class WaitCounterBackendFactoryIf {
       std::string_view key) noexcept = 0;
 };
 
-void registerWaitCounterBackend(std::unique_ptr<WaitCounterBackendFactoryIf>);
+C10_API void registerWaitCounterBackend(
+    std::unique_ptr<WaitCounterBackendFactoryIf>);
 } // namespace detail
 
 // A handle to a wait counter.
-class WaitCounterHandle {
+class C10_API WaitCounterHandle {
  public:
   explicit WaitCounterHandle(std::string_view key);
 
@@ -55,13 +56,13 @@ class WaitCounterHandle {
     }
 
    private:
-    WaitGuard(WaitCounterHandle& handle, c10::SmallVector<intptr_t>&& ctxs)
+    WaitGuard(WaitCounterHandle& handle, SmallVector<intptr_t>&& ctxs)
         : handle_{&handle}, ctxs_{std::move(ctxs)} {}
 
     friend class WaitCounterHandle;
 
     WaitCounterHandle* handle_;
-    c10::SmallVector<intptr_t> ctxs_;
+    SmallVector<intptr_t> ctxs_;
   };
 
   // Starts a waiter
@@ -70,15 +71,15 @@ class WaitCounterHandle {
  private:
   // Stops the waiter. Each start() call should be matched by exactly one stop()
   // call.
-  void stop(c10::SmallVector<intptr_t>&& ctxs);
+  void stop(SmallVector<intptr_t>&& ctxs);
 
   detail::WaitCounterImpl& impl_;
 };
-} // namespace torch::monitor
+} // namespace c10::monitor
 
 #define STATIC_WAIT_COUNTER(_key)                           \
-  []() -> torch::monitor::WaitCounterHandle& {              \
-    static torch::monitor::WaitCounterHandle handle(#_key); \
+  []() -> ::c10::monitor::WaitCounterHandle& {              \
+    static ::c10::monitor::WaitCounterHandle handle(#_key); \
     return handle;                                          \
   }()
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -19,6 +19,7 @@
 #include <c10/util/CallOnce.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
+#include <c10/util/WaitCounter.h>
 #include <c10/util/irange.h>
 #include <c10/util/thread_name.h>
 #include <torch/csrc/cuda/nccl.h>
@@ -29,7 +30,6 @@
 #include <torch/csrc/distributed/c10d/TraceUtils.h>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/csrc/distributed/c10d/logger.hpp>
-#include <torch/csrc/monitor/instrumentation.h>
 #include <torch/torch.h>
 #include <optional>
 


### PR DESCRIPTION
Summary: Since WaitCounter frontend itself has minimal depdendencies it's fine to be moved into c10. Specific backends can be registered/linked separately.

Test Plan: unit test

Reviewed By: jamesperng, asiab4, c-p-i-o

Differential Revision: D59842868


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o