### PR TITLE
 [inductor] Replace self_cuda_time_total function calls with self_dev…

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -150,7 +150,7 @@ def do_bench_using_profiling(fn: Callable[[], Any], warmup=25, rep=100) -> float
         torch.cuda.synchronize()
 
     log.debug("raw events")
-    log.debug(p.key_averages().table(sort_by="self_cuda_time_total", row_limit=-1))
+    log.debug(p.key_averages().table(sort_by="self_device_time_total", row_limit=-1))
 
     filtered_events = EventList(
         [

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -155,7 +155,9 @@ class ProfileEvent:
     count: float
 
 
-def parse_profile_event_list(benchmark_name, event_list, wall_time_ms, nruns, device_name):
+def parse_profile_event_list(
+    benchmark_name, event_list, wall_time_ms, nruns, device_name
+):
     def get_self_device_time(ev):
         """
         ev.self_device_time_total is in microsecond. Convert to millisecond.
@@ -209,7 +211,13 @@ def parse_profile_event_list(benchmark_name, event_list, wall_time_ms, nruns, de
         )
         print(
             tabulate(
-                rows, headers=["Kernel", f"Self {device_name.upper()} TIME (ms)", "Count", "Percent"]
+                rows,
+                headers=[
+                    "Kernel",
+                    f"Self {device_name.upper()} TIME (ms)",
+                    "Count",
+                    "Percent",
+                ],
             )
         )
         return total_time
@@ -235,7 +243,9 @@ def parse_profile_event_list(benchmark_name, event_list, wall_time_ms, nruns, de
                 total_device_ms += _time
 
         device_busy_percent = f"{total_device_ms / wall_time_ms * 100:.2f}%"
-        print(f"\nPercent of time when {device_name.upper()} is busy: {device_busy_percent}")
+        print(
+            f"\nPercent of time when {device_name.upper()} is busy: {device_busy_percent}"
+        )
         print(f"Total wall time {wall_time_ms:.3f} ms")
 
         # output such a line so we can gather such line from all compiled modules from all

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -149,18 +149,18 @@ def benchmark_all_kernels(benchmark_name, benchmark_all_configs):
 class ProfileEvent:
     category: str
     key: str
-    self_cuda_time_ms: float
+    self_device_time_ms: float
     # the benchmark is run multiple times and we average the count across all the
     # runs. It should be an integer but define a float just in case.
     count: float
 
 
 def parse_profile_event_list(benchmark_name, event_list, wall_time_ms, nruns):
-    def get_self_cuda_time(ev):
+    def get_self_device_time(ev):
         """
-        ev.self_cuda_time_total is in microsecond. Convert to millisecond.
+        ev.self_device_time_total is in microsecond. Convert to millisecond.
         """
-        return ev.self_cuda_time_total / 1000 / nruns
+        return ev.self_device_time_total / 1000 / nruns
 
     all_events = defaultdict(list)
 
@@ -168,7 +168,7 @@ def parse_profile_event_list(benchmark_name, event_list, wall_time_ms, nruns):
         profile_ev = ProfileEvent(
             category=category,
             key=ev.key,
-            self_cuda_time_ms=get_self_cuda_time(ev),
+            self_device_time_ms=get_self_device_time(ev),
             count=ev.count / nruns,  # average across all runs
         )
         all_events[category].append(profile_ev)
@@ -195,21 +195,21 @@ def parse_profile_event_list(benchmark_name, event_list, wall_time_ms, nruns):
     def report_category(category, profile_events):
         from tabulate import tabulate
 
-        profile_events.sort(key=lambda ev: ev.self_cuda_time_ms, reverse=True)
+        profile_events.sort(key=lambda ev: ev.self_device_time_ms, reverse=True)
 
         rows = []
         total_time = 0.0
         print(f"\n  == {category} category kernels == ")
         for ev in profile_events:
-            total_time += ev.self_cuda_time_ms
-            percent = f"{ev.self_cuda_time_ms / wall_time_ms * 100:.2f}%"
-            rows.append([ev.key[:120], ev.self_cuda_time_ms, ev.count, percent])
+            total_time += ev.self_device_time_ms
+            percent = f"{ev.self_device_time_ms / wall_time_ms * 100:.2f}%"
+            rows.append([ev.key[:120], ev.self_device_time_ms, ev.count, percent])
         rows.append(
             ["Total", total_time, "", f"{total_time / wall_time_ms * 100:.2f}%"]
         )
         print(
             tabulate(
-                rows, headers=["Kernel", "Self CUDA TIME (ms)", "Count", "Percent"]
+                rows, headers=["Kernel", "Self Device TIME (ms)", "Count", "Percent"]
             )
         )
         return total_time
@@ -227,14 +227,14 @@ def parse_profile_event_list(benchmark_name, event_list, wall_time_ms, nruns):
         ), f"{list(all_events.keys())}"
 
         per_category_wall_time = {}
-        total_cuda_ms = 0.0
+        total_device_ms = 0.0
         for category in category_list:
             if category in all_events:
                 _time = report_category(category, all_events[category])
                 per_category_wall_time[category] = _time
-                total_cuda_ms += _time
+                total_device_ms += _time
 
-        gpu_busy_percent = f"{total_cuda_ms / wall_time_ms * 100:.2f}%"
+        gpu_busy_percent = f"{total_device_ms / wall_time_ms * 100:.2f}%"
         print(f"\nPercent of time when GPU is busy: {gpu_busy_percent}")
         print(f"Total wall time {wall_time_ms:.3f} ms")
 
@@ -300,7 +300,7 @@ def compiled_module_main(benchmark_name, benchmark_compiled_module_fn):
         print(f"Profiling result for a compiled module of benchmark {benchmark_name}:")
         print(f"Chrome trace for the profile is written to {path}")
         event_list = p.key_averages(group_by_input_shape=True)
-        print(event_list.table(sort_by="self_cuda_time_total", row_limit=10))
+        print(event_list.table(sort_by="self_device_time_total", row_limit=10))
         parse_profile_event_list(
             benchmark_name, event_list, wall_time_ms, times * repeat
         )


### PR DESCRIPTION
…ice_time_total for wrapper_bench

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang