### PR TITLE
[inductor] Fix split-scan interaction with multi-kernel

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -409,6 +409,19 @@ class TestKernelBenchmark(TestCase):
         # 20000 * 5000 * 4 = 200MB for a
         self.check_bandwidth(compiled_module, "0.200")
 
+    def test_split_scan(self):
+
+        @torch.compile
+        def f(a):
+            return a.cumsum(-1)
+
+        a = torch.rand(10000, 5000, device=GPU_TYPE)
+        f(a.reshape(-1))
+        compiled_module = self.get_compiled_module()
+        # 10000 * 5000 * 4 = 200 MB for a
+        # Double that for output as well
+        self.check_bandwidth(compiled_module, "0.400")
+
     @config.patch("triton.unique_kernel_names", True)
     @config.patch(benchmark_kernel=False)
     @config.patch(compile_threads=1)

--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -410,7 +410,6 @@ class TestKernelBenchmark(TestCase):
         self.check_bandwidth(compiled_module, "0.200")
 
     def test_split_scan(self):
-
         @torch.compile
         def f(a):
             return a.cumsum(-1)

--- a/test/inductor/test_multi_kernel.py
+++ b/test/inductor/test_multi_kernel.py
@@ -13,12 +13,12 @@ from torch._inductor.codegen.multi_kernel import MultiKernelCall
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import run_and_get_code
 from torch.nn import functional as F
+from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
 from torch.testing._internal.inductor_utils import HAS_CUDA
-from torch.testing import make_tensor
 
 
 class TransformerSnippet(nn.Module):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2384,8 +2384,9 @@ class TritonKernel(SIMDKernel):
                     result.writeline(f"{var_name} = {symval_hint}")
                 elif isinstance(arg_sig, WorkspaceArg):
                     device = V.graph.scheduler.get_current_device_or_throw()
+                    nbytes = V.graph.sizevars.size_hint(arg_sig.nbytes)
                     result.writeline(
-                        f"{var_name} = torch.zeros({V.graph.sizevars.size_hint(arg_sig.nbytes)}, device='{device}', dtype=torch.uint8)"
+                        f"{var_name} = torch.zeros({nbytes}, device='{device}', dtype=torch.uint8)"
                     )
                 else:
                     raise KeyError(

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -62,6 +62,7 @@ from .common import (
     PythonPrinter,
     SizeArg,
     TensorArg,
+    WorkspaceArg,
 )
 from .simd import (
     constant_repr,
@@ -2381,6 +2382,11 @@ class TritonKernel(SIMDKernel):
                     if "seed_offset" in arg_sig.name:
                         symval_hint = 0
                     result.writeline(f"{var_name} = {symval_hint}")
+                elif isinstance(arg_sig, WorkspaceArg):
+                    device = V.graph.scheduler.get_current_device_or_throw()
+                    result.writeline(
+                        f"{var_name} = torch.zeros({V.graph.sizevars.size_hint(arg_sig.nbytes)}, device='{device}', dtype=torch.uint8)"
+                    )
                 else:
                     raise KeyError(
                         f"Don't find the buffer or const tensor for {arg_name}"

--- a/torch/_inductor/codegen/triton_split_scan.py
+++ b/torch/_inductor/codegen/triton_split_scan.py
@@ -48,6 +48,9 @@ class TritonSplitScanKernel(TritonKernel):
         )
         self.no_x_dim = True
 
+    def should_use_persistent_reduction(self) -> bool:
+        return False
+
     def initialize_range_tree(self, pid_cache):
         prefixes = "yxr"
         assert len(self.numels) <= len(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #130988
* #127725
* #127724
* __->__ #131044

This fixes a couple errors that come up when multi-kernel is used with
split-scan.
1. The split-scan was being marked as a persistent kernel, which allowed
   a multi-kernel to be created but this isn't supported. Fix is to
   never mark split-scan as persistent.
2. Benchmark codegen was not handling WorkspaceArg, and would raise a
   KeyError during codegen.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang