### PR TITLE
[export] add runtime asserts on replacement expressions

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2196,7 +2196,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         dim0_x = None
         dim1_x = 2 * torch.export.Dim("_dim1_x", max=4000)
         dynamic_shapes = {"x": (dim0_x, dim1_x)}
-        em = torch.export.export(m, (a,), dynamic_shapes=dynamic_shapes)
+        em = export(m, (a,), dynamic_shapes=dynamic_shapes)
         x = torch.randn(3, 5)
         with self.assertRaisesRegex(
             RuntimeError,
@@ -6115,12 +6115,6 @@ def forward(self, x, y):
             "y": [Dim(f"dy{i}", min=2) for i in range(2)],
             "z": [Dim(f"dz{i}", min=4) for i in range(1)],
         }
-        ep = torch.export._trace._export(
-            FreeReshape(),
-            inputs,
-            dynamic_shapes=dynamic_shapes,
-            allow_complex_guards_as_runtime_asserts=True,
-        )
         ep = export(FreeReshape(), inputs, dynamic_shapes=dynamic_shapes)
         out1 = ep.module()(torch.randn(48, 1), torch.randn(4, 12), torch.randn(48))
         self.assertEqual(out1.shape, torch.ones(48).shape)
@@ -6131,6 +6125,11 @@ def forward(self, x, y):
             r"Runtime assertion failed for expression Eq\(s0\*s1, s2\*s3\) on node 'eq.*'",
         ):  # fail only at runtime
             ep.module()(torch.randn(5, 8), torch.randn(4, 5), torch.randn(30))  # fail
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Runtime assertion failed for expression Eq\(s0\*s1, s4\) on node 'eq.*'",
+        ):
+            ep.module()(torch.randn(4, 6), torch.randn(8, 3), torch.randn(22))
 
         # case 3: 3d reshape (previously failing with different issue)
         class Reshape3d(torch.nn.Module):
@@ -6145,12 +6144,7 @@ def forward(self, x, y):
             "x": (Dim("dx0", min=2), Dim("dx1", min=2), Dim("dx2", min=2)),
             "y": (Dim("dy", min=8),),
         }
-        ep = torch.export._trace._export(
-            Reshape3d(),
-            inputs,
-            dynamic_shapes=dynamic_shapes,
-            allow_complex_guards_as_runtime_asserts=True,
-        )
+        ep = export(Reshape3d(), inputs, dynamic_shapes=dynamic_shapes)
         out1 = ep.module()(torch.randn(9, 7, 2), torch.randn(126))
         self.assertEqual(out1.shape, torch.ones(126).shape)
         with self.assertRaisesRegex(
@@ -6183,12 +6177,7 @@ def forward(self, x, y):
             r"Suggested fixes:(.*\n)*"
             r".*dz = dy(.*\n)*",
         ) as msg:
-            export(
-                Foo(),
-                inputs,
-                dynamic_shapes=dynamic_shapes,
-                strict=False,
-            )
+            export(Foo(), inputs, dynamic_shapes=dynamic_shapes)
 
     # TODO requires_grad doesn't seem to work with serialization.
     @testing.expectedFailureSerDer
@@ -6400,20 +6389,6 @@ def forward(self, x, y):
         self.assertEqual(len(sym_size_nodes), 2)
         self.assertTrue(
             all(node.args[0].op == "placeholder" for node in sym_size_nodes)
-        )
-        # dynamo will DCE the repeat node, AOTAutograd will leave it
-        # training IR will also DCE due to retracing
-        repeat_nodes = [
-            node
-            for node in ep.graph.nodes
-            if node.target == torch.ops.aten.repeat.default
-        ]
-        self.assertEqual(
-            len(repeat_nodes),
-            1
-            if is_non_strict_test(self._testMethodName)
-            and not is_training_ir_test(self._testMethodName)
-            else 0,
         )
 
     def test_checks_to_constrain_range(self):

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -103,7 +103,7 @@ class ExportDynamoConfig:
     # This isn't really necessary, and isn't much more efficient since the runtime asserts pass does CSE,
     # but if we want to reason more about what guards/runtime asserts to emit,
     # this makes it a bit cleaner to do from the export side. Also no real point in running this twice.
-    do_not_emit_runtime_asserts = True
+    do_not_emit_runtime_asserts: bool = True
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Currently, Hybrid SymInts can lead to symbols being replaced with nonlinear expressions of other symbols. For example, the following reshape + add emits a guard `s0*s1 == s2`, which replaces `s2` with `s0*s1`:
```
def forward(self, x, y):
    # x: [s0, s1]; y: [s2]
    return x.flatten() + y
```
The exported program then looks like this, with `s0*s1` containing its own ValueRange:
```
ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, w: "f32[s0, s1]", x: "f32[s0*s1]"):
            view: "f32[s0*s1]" = torch.ops.aten.view.default(w, [-1]);  w = None
            add: "f32[s0*s1]" = torch.ops.aten.add.Tensor(view, x);  view = x = None
            return (add,)

Range constraints: {s0: VR[0, int_oo], s1: VR[0, int_oo], s0*s1: VR[0, int_oo]}
```

During analysis, the runtime assert `Eq(s0*s1, s2)` is added, which results in this `_set_replacement()` call. However, during the runtime asserts pass, `s2` no longer exists in the program as an input symbol, and so the runtime assert never gets reified. This means that nothing exists in the program to assert this equality, and an error is raised during the op instead.

This PR proposes to look up ShapeEnv replacements, and makes sure to reify the replaced symbol with a `sym_size` or `sym_stride` call, and computes the replacement expression from other input shapes, to assert equality.