### PR TITLE
Use inductor TestCase for test_replicate_with_compiler.py

### DIFF
--- a/test/distributed/_composable/test_replicate_with_compiler.py
+++ b/test/distributed/_composable/test_replicate_with_compiler.py
@@ -13,6 +13,7 @@ from torch import _inductor as inductor, nn
 from torch._C import FileCheck
 from torch._dynamo import compiled_autograd
 from torch._dynamo.utils import counters
+from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_triton_code
 from torch.distributed._composable.replicate import replicate
 from torch.distributed.algorithms.ddp_comm_hooks import (
@@ -69,7 +70,15 @@ def compiler_fn(no_inductor=False):
     return _compiler_fn
 
 
-class ReplicateTest(MultiProcessTestCase):
+class MultiProcessInductorTestCase(MultiProcessTestCase, InductorTestCase):
+    """
+    A version of MultiProcessTestCase that derives from the Inductor TestCase
+    to handle isolation of the inductor cache dir.
+    """
+    pass
+
+
+class ReplicateTest(MultiProcessInductorTestCase):
     @property
     def world_size(self) -> int:
         return min(2, torch.cuda.device_count())
@@ -350,7 +359,7 @@ class ReplicateTest(MultiProcessTestCase):
         fc.run(code)
 
 
-class DDP_TP_Test(MultiProcessTestCase):
+class DDP_TP_Test(MultiProcessInductorTestCase):
     @property
     def world_size(self) -> int:
         return min(4, torch.cuda.device_count())

--- a/test/distributed/_composable/test_replicate_with_compiler.py
+++ b/test/distributed/_composable/test_replicate_with_compiler.py
@@ -75,6 +75,7 @@ class MultiProcessInductorTestCase(MultiProcessTestCase, InductorTestCase):
     A version of MultiProcessTestCase that derives from the Inductor TestCase
     to handle isolation of the inductor cache dir.
     """
+
     pass
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131053

Summary: `test/distributed/_composable/test_replicate_with_compiler.py` torch.compiles. This change introduces a version of MultiProcessTestCase that derives from the inductor TestCase class to make sure we always get a clean cache dir.

Test Plan: `python test/distributed/_composable/test_replicate_with_compiler.py`

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o

Differential Revision: [D59925519](https://our.internmc.facebook.com/intern/diff/D59925519)