### PR TITLE
[aoti] Remove mutable tensor assertion

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5669,10 +5669,6 @@ class FallbackKernel(ExternKernelAlloc):
     def set_cpp_kernel(self, kernel):
         from .codegen.wrapper import get_cpp_op_schema
 
-        assert (
-            not kernel._schema.is_mutable
-        ), f"mutable {kernel.__name__} is not supported with cpp_wrapper"
-
         # These checks are here because ops that return aliasing tensors will
         # return type Tensor& instead of Tensor, but codegen will always write
         # type Tensor on the LHS.


### PR DESCRIPTION
Differential Revision: D59943838

Trying to remove the assertion. If the CI passes, it should be good to land.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang