### PR TITLE
[export] Allow non-CIA ops to be preserved

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -18,6 +18,7 @@ import torch._dynamo as torchdynamo
 import torch.nn.functional as F
 from functorch.experimental.control_flow import cond, map
 from torch import Tensor
+from torch._decomp import get_decompositions
 from torch._dynamo.test_case import TestCase
 from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
 from torch._export.utils import (
@@ -1187,15 +1188,6 @@ def forward(self, p_linear_weight, p_linear_bias, x):
                 Foo(),
                 (torch.randn(3, 3),),
             ).run_decompositions({}, _preserve_ops=(torch.ops.aten.chunk.default,))
-
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "aten.add.Tensor is not CompositeImplicitAutograd op, so we will preserve it as",
-        ):
-            _ = torch.export.export(
-                Foo(),
-                (torch.randn(3, 3),),
-            ).run_decompositions({}, _preserve_ops=(torch.ops.aten.add.Tensor,))
 
         with self.assertRaisesRegex(
             RuntimeError, "aten.sym_size.default is a metadata query function"
@@ -6702,7 +6694,25 @@ class TestExportCustomClass(TorchTestCase):
 
         ep = torch.export.export(M(), (torch.ones(3),), strict=False)
 
-    def test_preserve_bilinear(self):
+    def test_preserve_non_cia_op(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.elu(x)
+
+        ep = export(M(), (torch.randn(2, 3, 4, 5),))
+        FileCheck().check_count("torch.ops.aten.elu.default", 1, exactly=True).run(
+            ep.graph_module.code
+        )
+
+        ep = ep.run_decompositions(
+            decomp_table=get_decompositions([torch.ops.aten.elu.default]),
+            _preserve_ops=[torch.ops.aten.elu.default],
+        )
+        FileCheck().check_count("torch.ops.aten.elu.default", 1, exactly=True).run(
+            ep.graph_module.code
+        )
+
+    def test_preserve_cia_op(self):
         class StaticResizeBilinear2dModule(torch.nn.Module):
             def forward(self, x):
                 a = torch.nn.functional.interpolate(
@@ -6719,9 +6729,12 @@ class TestExportCustomClass(TorchTestCase):
             "torch.ops.aten.upsample_bilinear2d.vec", 1, exactly=True
         ).run(ep.graph_module.code)
 
+        decomp_table = get_decompositions([torch.ops.aten.upsample_bilinear2d.vec])
         ep = ep.run_decompositions(
-            decomp_table=None, _preserve_ops=[torch.ops.aten.upsample_bilinear2d.vec]
+            decomp_table=decomp_table,
+            _preserve_ops=[torch.ops.aten.upsample_bilinear2d.vec],
         )
+        assert torch.ops.aten.upsample_bilinear2d.vec in decomp_table
         FileCheck().check_count(
             "torch.ops.aten.upsample_bilinear2d.vec", 1, exactly=True
         ).run(ep.graph_module.code)

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -206,14 +206,6 @@ def _override_composite_implicit_decomp(ops_to_preserve, decomp_table):
                     f"{op_overload} is a TorchScript op, we can't preserve it as is"
                 )
 
-            if not torch._C._dispatch_has_kernel_for_dispatch_key(
-                op_overload.name(), torch._C.DispatchKey.CompositeImplicitAutograd
-            ):
-                raise RuntimeError(
-                    f"{op_overload} is not CompositeImplicitAutograd op, so we will preserve "
-                    "it as long as there is no python decomposition"
-                )
-
             return True
 
         # If we didn't error, it means we can go ahead
@@ -221,6 +213,7 @@ def _override_composite_implicit_decomp(ops_to_preserve, decomp_table):
 
         saved_tables[op_overload] = op_overload.py_kernels.copy()
         patched_ops.add(op_overload)
+
         for override_dispatch_key in _AUTOGRAD_ALIAS_BACKEND_KEYS_TO_OVERRIDE:
             if override_dispatch_key not in op_overload.py_kernels:
                 # TODO (tmanlaibaatar)https://github.com/pytorch/pytorch/issues/129430
@@ -242,10 +235,6 @@ def _override_composite_implicit_decomp(ops_to_preserve, decomp_table):
             )
 
         if op_overload in decomp_table:
-            warnings.warn(
-                f"Deleting decomposition registered for operator `{op_overload}`, "
-                "which was sepecified in the `preserve_ops` list."
-            )
             removed_decomps[op_overload] = decomp_table[op_overload]
             del decomp_table[op_overload]
 


### PR DESCRIPTION
I feel like the semantics of `run_decompositions(preserve_ops,...)` should be that we should always preserve whatever operator is put into `preserve_ops`, even if it's not CIA?