### PR TITLE
propagate XLA's metadata after functional sync

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -671,7 +671,7 @@ void propagate_xla_data_direct(const ITensorListRef tensor,
   auto tensor_it = tensor.begin();
   auto other_it = other.begin();
   for (C10_UNUSED const auto i : c10::irange(tensor.size())) {
-    propagate_xla_data(*tensor_it++, *other_it++);
+    propagate_xla_data_direct(*tensor_it++, *other_it++);
   }
 }
 

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -660,6 +660,21 @@ void propagate_xla_data(const ITensorListRef functional_tensor, ITensorListRef o
   }
 }
 
+void propagate_xla_data_direct(const Tensor& tensor, const Tensor& other) {
+  if (tensor.key_set().has(c10::DispatchKey::XLA)) {
+    at::_propagate_xla_data(tensor, other);
+  }
+ }
+
+void propagate_xla_data_direct(const ITensorListRef tensor,
+                               ITensorListRef other) {
+  auto tensor_it = tensor.begin();
+  auto other_it = other.begin();
+  for (C10_UNUSED const auto i : c10::irange(tensor.size())) {
+    propagate_xla_data(*tensor_it++, *other_it++);
+  }
+}
+
 void commit_update(const Tensor& functional_tensor) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(isFunctionalTensor(functional_tensor));
   unsafeGetFunctionalWrapper(functional_tensor)->commit_update();

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -343,6 +343,13 @@ TORCH_API void propagate_xla_data(
     const ITensorListRef functional_tensor,
     ITensorListRef other);
 
+TORCH_API void propagate_xla_data_direct(
+    const Tensor& tensor,
+    const Tensor& other);
+TORCH_API void propagate_xla_data_direct(
+    const ITensorListRef tensor,
+    ITensorListRef other);
+
 Tensor create_functional_tensor_with_view_meta(
     const Tensor& view_to_wrap,
     const Tensor& base,

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -590,10 +590,12 @@ def wrap_propagate_mutations_and_return(
     ):
         updates.append(
             f"""\
-  at::functionalization::impl::propagate_xla_data({outer_arg}, {inner_ret});
+  auto {outer_arg}_inner = at::functionalization::impl::from_functional_tensor({outer_arg});
   at::functionalization::impl::replace_({outer_arg}, {inner_ret});
   at::functionalization::impl::commit_update({outer_arg});
-  at::functionalization::impl::sync({outer_arg});"""
+  at::functionalization::impl::sync({outer_arg});
+  auto {outer_arg}_inner_updated = at::functionalization::impl::from_functional_tensor({outer_arg});
+  at::functionalization::impl::propagate_xla_data_direct({outer_arg}_inner, {outer_arg}_inner_updated);"""
         )
 
     # Finally, we return:


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/7174
