### PR TITLE
[ROCm] Enable cudagraph expandable segments UTs in inductory/dynamo

### DIFF
--- a/test/dynamo/test_cudagraphs_expandable_segments.py
+++ b/test/dynamo/test_cudagraphs_expandable_segments.py
@@ -8,7 +8,7 @@ import sys
 import torch
 
 from torch.testing._internal.common_cuda import IS_JETSON, IS_WINDOWS
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_ROCM
+from torch.testing._internal.common_utils import run_tests
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
@@ -24,11 +24,7 @@ from tools.stats.import_test_stats import get_disabled_tests
 sys.path.remove(str(REPO_ROOT))
 
 if __name__ == "__main__":
-    if (
-        torch.cuda.is_available()
-        and not IS_JETSON
-        and not IS_WINDOWS
-    ):
+    if torch.cuda.is_available() and not IS_JETSON and not IS_WINDOWS:
         get_disabled_tests(".")
 
         torch.cuda.memory._set_allocator_settings("expandable_segments:True")

--- a/test/dynamo/test_cudagraphs_expandable_segments.py
+++ b/test/dynamo/test_cudagraphs_expandable_segments.py
@@ -28,7 +28,6 @@ if __name__ == "__main__":
         torch.cuda.is_available()
         and not IS_JETSON
         and not IS_WINDOWS
-        and not TEST_WITH_ROCM
     ):
         get_disabled_tests(".")
 

--- a/test/inductor/test_cudagraph_trees_expandable_segments.py
+++ b/test/inductor/test_cudagraph_trees_expandable_segments.py
@@ -7,11 +7,7 @@ import sys
 
 import torch
 from torch.testing._internal.common_cuda import IS_JETSON, IS_WINDOWS
-from torch.testing._internal.common_utils import (
-    run_tests,
-    TEST_WITH_ASAN,
-    TEST_WITH_ROCM,
-)
+from torch.testing._internal.common_utils import run_tests, TEST_WITH_ASAN
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
 

--- a/test/inductor/test_cudagraph_trees_expandable_segments.py
+++ b/test/inductor/test_cudagraph_trees_expandable_segments.py
@@ -37,7 +37,6 @@ if __name__ == "__main__":
         and not IS_WINDOWS
         and HAS_CUDA
         and not TEST_WITH_ASAN
-        and not TEST_WITH_ROCM
     ):
         get_disabled_tests(".")
 


### PR DESCRIPTION
Test runtimes extracted from CI logs are as follows.

"linux-focal-rocm6.1-py3.8": 
"dynamo/test_cudagraphs_expandable_segments": 3.3185000000000002, 
"inductor/test_cudagraph_trees_expandable_segments": 153.233,   


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang