### PR TITLE
[inductor] Enable dynamo for Windows and disable unsupported UT.

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -24,7 +24,8 @@ from torch.testing._internal.common_quantization import (
     skipIfNoX86,
 )
 from torch.testing._internal.common_quantized import override_quantized_engine
-from torch.testing._internal.common_utils import skipIfTorchDynamo
+
+from torch.testing._internal.common_utils import skipIfTorchDynamo, skipIfWindows
 
 
 class NodePosType(Enum):
@@ -592,6 +593,7 @@ class X86InductorQuantTestCase(QuantizationTestCase):
 
 @skipIfNoInductorSupport
 class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
+    @skipIfWindows
     @skipIfNoX86
     def test_conv2d(self):
         """
@@ -624,6 +626,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                 node_list,
             )
 
+    @skipIfWindows
     @skipIfNoX86
     def test_conv2d_unary(self):
         """
@@ -693,6 +696,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     node_list,
                 )
 
+    @skipIfWindows
     @skipIfNoX86
     def test_conv2d_binary(self):
         """
@@ -743,6 +747,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                     node_list,
                 )
 
+    @skipIfWindows
     @skipIfNoX86
     def test_conv2d_binary2(self):
         """
@@ -939,6 +944,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
             torch.ops.aten.max_pool2d.default,
         )
 
+    @skipIfWindows
     @skipIfNoX86
     def test_adaptive_avg_pool2d_recipe(self):
         r"""
@@ -967,6 +973,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
             torch.ops.aten.flatten.using_ints,
         )
 
+    @skipIfWindows
     @skipIfNoX86
     def test_cat_recipe(self):
         r"""
@@ -1033,6 +1040,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
         self.assertTrue(cat_out_obs is input_obs_of_maxpool)
         self.assertTrue(input_obs_of_maxpool is output_obs_of_maxpool)
 
+    @skipIfWindows
     @skipIfNoX86
     def test_cat_recipe_same_inputs(self):
         r"""
@@ -1081,6 +1089,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
         self.assertTrue(cat_act_obs0 is cat_act_obs1)
         self.assertTrue(cat_act_obs0 is cat_out_obs)
 
+    @skipIfWindows
     @skipIfNoX86
     def test_cat_recipe_single_input(self):
         r"""
@@ -1126,6 +1135,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
         self.assertTrue(isinstance(cat_out_obs, ObserverBase))
         self.assertTrue(cat_act_obs0 is cat_out_obs)
 
+    @skipIfWindows
     @skipIfNoX86
     def test_avg_pool2d_recipe(self):
         r"""
@@ -2547,6 +2557,7 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                 node_list,
             )
 
+    @skipIfWindows
     @skipIfNoX86
     def test_attention_block(self):
         """

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -13,6 +13,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TestCase,
+    skipIfWindows,
 )
 from torch.utils._sympy.functions import FloorDiv
 from torch.utils._sympy.solve import INEQUALITY_TYPES, mirror_rel_op, try_solve
@@ -24,7 +25,6 @@ from torch.utils._sympy.numbers import int_oo, IntInfinity, NegativeIntInfinity
 from sympy.core.relational import is_ge, is_le, is_gt, is_lt
 import functools
 import torch.fx as fx
-
 
 
 UNARY_OPS = [
@@ -192,6 +192,7 @@ class TestNumbers(TestCase):
         self.assertIs(min(-int_oo, -sympy.oo), -sympy.oo)
 
 
+@skipIfWindows
 class TestValueRanges(TestCase):
     @parametrize("fn", UNARY_OPS)
     @parametrize("dtype", ("int", "float"))
@@ -212,6 +213,7 @@ class TestValueRanges(TestCase):
     def test_pow_half(self):
         ValueRangeAnalysis.pow(ValueRanges.unknown(), ValueRanges.wrap(0.5))
 
+    @skipIfWindows
     @parametrize("fn", BINARY_OPS)
     @parametrize("dtype", ("int", "float"))
     def test_binary_ref(self, fn, dtype):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -670,9 +670,6 @@ def is_dynamo_supported():
 def check_if_inductor_supported():
     check_if_dynamo_supported()
 
-    if sys.platform == "win32":
-        raise RuntimeError("Windows not yet supported for inductor")
-
 
 def is_inductor_supported():
     try:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1614,6 +1614,9 @@ class AotCodeCompiler:
         serialized_extern_kernel_nodes: Optional[str],
         cuda: bool,
     ) -> str:
+        if sys.platform == "win32":
+            raise RuntimeError("AotCodeCompiler not yet supported for inductor")
+
         _set_gpu_runtime_env()  # cpp_extension consults the env
 
         picked_vec_isa = pick_vec_isa()

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -355,6 +355,12 @@ def _get_warning_all_cflag(warning_all: bool = True) -> List[str]:
 
 def _get_cpp_std_cflag(std_num: str = "c++17") -> List[str]:
     if _IS_WINDOWS:
+        """
+        On Windows, only c++20 can support `std::enable_if_t`.
+        Ref: https://learn.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements-2019?view=msvc-170#checking-for-abstract-class-types # noqa: B950
+        TODO: discuss upgrade pytorch to c++20.
+        """
+        std_num = "c++20"
         return [f"std:{std_num}"]
     else:
         return [f"std={std_num}"]

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1735,6 +1735,20 @@ def skipIfNotMiopenSuggestNHWC(fn):
             fn(*args, **kwargs)
     return wrapper
 
+def skipIfWindows(func=None, *, msg="test doesn't currently work on the Windows stack"):
+    def dec_fn(fn):
+        reason = f"skipIfWindows: {msg}"
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            if IS_WINDOWS:  # noqa: F821
+                raise unittest.SkipTest(reason)
+            else:
+                return fn(*args, **kwargs)
+        return wrapper
+    if func:
+        return dec_fn(func)
+    return dec_fn
 
 # Reverts the linalg backend back to default to make sure potential failures in one
 # test do not affect other tests


### PR DESCRIPTION
Changes:
1. Enable Windows in `check_if_inductor_supported`.
2. Disable Windows in `AotCodeCompiler`.
3. Force Windows inductor to c++20 to support `std::enable_if_t`.
4. Disable unsupported UTs.

TODO: 
1. Discuss upgrade pytorch `torch_cpu` module to c++20.
2. Re-enable unsupported UTs.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht @iremyux @Blackhex @cristianPanaite @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang