### PR TITLE
[c10d] add bfloat16 support for NAN check

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -236,6 +236,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
             self.test_nan_assert_float16.__wrapped__,
             self.test_nan_assert_float32.__wrapped__,
             self.test_nan_assert_float64.__wrapped__,
+            self.test_nan_assert_bfloat16.__wrapped__,
         ]
 
         # TORCH_NCCL_BLOCKING_WAIT overrides TORCH_NCCL_ASYNC_ERROR_HANDLING hence tests
@@ -346,7 +347,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         not (TEST_MULTIGPU and CUDA_12_AND_ABOVE),
         "NCCL test requires 2+ GPUs and Device side assert could cause unexpected errors in lower versions of CUDA",
     )
-    @parametrize("type", [torch.float16, torch.float32, torch.float64])
+    @parametrize("type", [torch.float16, torch.float32, torch.float64, torch.bfloat16])
     @skip_if_rocm
     def test_nan_assert(self, type):
         os.environ["TORCH_NCCL_NAN_CHECK"] = "1"

--- a/torch/csrc/distributed/c10d/Utils.cu
+++ b/torch/csrc/distributed/c10d/Utils.cu
@@ -34,7 +34,12 @@ void checkForNan(const at::Tensor& tensor) {
       maxNumBlocks,
       (tensor.numel() + numThreadsPerBlock - 1) / numThreadsPerBlock);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(tensor.scalar_type(), "checkForNaN", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+    at::ScalarType::Half,
+    at::ScalarType::BFloat16,
+    tensor.scalar_type(),
+    "checkForNaN",
+    [&] {
     checkForNaN<scalar_t><<<numBlocks, numThreadsPerBlock>>>(
         tensor.data_ptr<scalar_t>(), tensor.numel());
     C10_CUDA_KERNEL_LAUNCH_CHECK();

--- a/torch/csrc/distributed/c10d/Utils.cu
+++ b/torch/csrc/distributed/c10d/Utils.cu
@@ -35,16 +35,15 @@ void checkForNan(const at::Tensor& tensor) {
       (tensor.numel() + numThreadsPerBlock - 1) / numThreadsPerBlock);
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
-    at::ScalarType::Half,
-    at::ScalarType::BFloat16,
-    tensor.scalar_type(),
-    "checkForNaN",
-    [&] {
-    checkForNaN<scalar_t><<<numBlocks, numThreadsPerBlock>>>(
-        tensor.data_ptr<scalar_t>(), tensor.numel());
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-  });
-
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      tensor.scalar_type(),
+      "checkForNaN",
+      [&] {
+        checkForNaN<scalar_t><<<numBlocks, numThreadsPerBlock>>>(
+            tensor.data_ptr<scalar_t>(), tensor.numel());
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
 }
 
 } // namespace c10d


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131131

Summary:
Need another dispacher macro to support more data types
Test Plan:
(sqzhang_1) [sqzhang@devgpu009.cln1 ~/pytorch (86fcae11)]$ python
test/distributed/test_c10d_nccl.py -k test_nan_assert_bfloat16
/home/sqzhang/pytorch/torch/csrc/distributed/c10d/Utils.cu:18:
checkForNaN: block: [0,0,0], thread: [85,0,0] Assertion
`!isnan(data[i])` failed.
/home/sqzhang/pytorch/torch/csrc/distributed/c10d/Utils.cu:18:
checkForNaN: block: [0,0,0], thread: [18,0,0] Assertion
`!isnan(data[i])` failed.
NCCL version 2.21.5+cuda12.0

devgpu009:1193787:1193787 [0] init.cc:1773 NCCL WARN Cuda failure
'device-side assert triggered'
.
----------------------------------------------------------------------
Ran 1 test in 9.416s

OK
Reviewers:

Subscribers:

Tasks:

Tags:

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o