### PR TITLE
[NestedTensor] Integrate the mean operator along the jagged dimension into NestedTensor

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -228,6 +228,11 @@ def layout_name(layout):
     return layout.__repr__().split(".")[-1]
 
 
+def get_op_name(layout):
+    # e.g. "<OpOverload(op='aten.sum', overload='dim_IntList')>" -> "sum"
+    return layout.__name__.split(".")[0]
+
+
 # Helper function for test_dummy_mha_with_nt
 @torch.fx.wrap
 def convert_dense_to_nested_tensor(values):
@@ -4010,40 +4015,61 @@ class TestNestedTensorSubclass(TestCase):
         self.assertEqual(res_dense, res_nt.values())
 
     @dtypes(torch.float32)
+    @parametrize(
+        "func",
+        [torch.ops.aten.sum.dim_IntList, torch.ops.aten.mean.dim],
+        name_fn=get_op_name,
+    )
     @parametrize("keepdim", [False, True])
     @parametrize("requires_grad", [False, True])
     @parametrize("components_require_grad", [False, True])
-    def test_sum_dim(
-        self, device, dtype, keepdim, requires_grad, components_require_grad
+    def test_jagged_op_dim(
+        self, device, dtype, keepdim, requires_grad, components_require_grad, func
     ):
+        """
+        Operator passes when reducing on valid reduction dimensions
+        """
+        if get_op_name(func) == "mean" and not keepdim:
+            return
+
+        op_name = get_op_name(func)
+
         ts = self._get_list_for_jagged_tensor(
             ((2, 3, 4), 3, 4), device=device, requires_grad=True
         )  # (B, j0, 3, 4)
 
         # verify correctness of shapes (assuming that ragged_idx == 1)
-        reduce_dims = (
-            ((0, 1), (3, 4), (1, 1, 3, 4), (0,)),  # batch, ragged
-            ((2, 3), (3, None), (3, None, 1, 1), (1, 2)),  # non-batch, non-batch
-            ((0, 1, 3), (3,), (1, 1, 3, 1), (0, 2)),  # batch, ragged, non-batch
-            ((0, 1, 2), (4,), (1, 1, 1, 4), (0, 1)),  # batch, ragged, non-batch
-            (
-                (0, 1, 2, 3),
-                (),
-                (1, 1, 1, 1),
-                (0, 1, 2),
-            ),  # batch, ragged, non-batch, non-batch
-            ((2,), (3, None, 4), (3, None, 1, 4), (1,)),  # non-batch
-        )  # (dims, expected shape, expected keepdim shape, reduce_dim_expected), where j0 is represented as None
+        if op_name == "sum":
+            reduce_dims = (
+                ((0, 1), (3, 4), (1, 1, 3, 4), (0,)),  # batch, ragged
+                ((2, 3), (3, None), (3, None, 1, 1), (1, 2)),  # non-batch, non-batch
+                ((0, 1, 3), (3,), (1, 1, 3, 1), (0, 2)),  # batch, ragged, non-batch
+                ((0, 1, 2), (4,), (1, 1, 1, 4), (0, 1)),  # batch, ragged, non-batch
+                (
+                    (0, 1, 2, 3),
+                    (),
+                    (1, 1, 1, 1),
+                    (0, 1, 2),
+                ),  # batch, ragged, non-batch, non-batch
+                ((2,), (3, None, 4), (3, None, 1, 4), (1,)),  # non-batch
+            )  # (dims, expected shape, expected keepdim shape, reduce_dim_expected), where j0 is represented as None
+        elif op_name == "mean":
+            reduce_dims = (
+                ((2,), (3, None, 4), (3, None, 1, 4), (1,)),
+                ((3,), (3, None, 3), (3, None, 3, 1), (2,)),
+            )
+
         for rd, ref_shape_no_keepdim, ref_shape_keepdim, _ in reduce_dims:
             nt = torch.nested.as_nested_tensor(ts, layout=torch.jagged)
-            out = torch.sum(nt, dim=rd, keepdim=keepdim)
+            out = func(nt, dim=rd, keepdim=keepdim)
             ref_shape = ref_shape_keepdim if keepdim else ref_shape_no_keepdim
-            self.assertEqual(len(out.shape), len(ref_shape))
-            for o, r in zip(out.shape, ref_shape):
-                if r is not None:
-                    self.assertEqual(o, r)
-                else:
-                    self.assertTrue(isinstance(o, torch.SymInt))
+            if not torch.compiler.is_compiling:  # if not using torch dynamo
+                self.assertEqual(len(out.shape), len(ref_shape))
+                for o, r in zip(out.shape, ref_shape):
+                    if r is not None:
+                        self.assertEqual(o, r)
+                    else:
+                        self.assertTrue(isinstance(o, torch.SymInt))
 
         # verify correctness of values
         tensor_lists = self._get_example_tensor_lists(
@@ -4064,15 +4090,14 @@ class TestNestedTensorSubclass(TestCase):
             reduce_dim, _, _, reduce_dim_expected = reduce_dim_tuple
 
             if nt.dim() > reduce_dim[-1]:
+                out_actual = func(nt, dim=reduce_dim, keepdim=keepdim)
                 if nt._ragged_idx in reduce_dim:  # raggedness reduced away
-                    out_actual = torch.sum(nt, dim=reduce_dim, keepdim=keepdim)
-                    out_expected = torch.sum(
+                    out_expected = func(
                         nt.values(), dim=reduce_dim_expected, keepdim=keepdim
                     )
                     self.assertTrue(torch.allclose(out_actual, out_expected))
                 else:  # raggedness preserved
-                    out_actual = torch.sum(nt, dim=reduce_dim, keepdim=keepdim)
-                    out_expected = torch.sum(nt.values(), dim=reduce_dim_expected)
+                    out_expected = func(nt.values(), dim=reduce_dim_expected)
                     self.assertTrue(
                         torch.allclose(
                             out_actual.values().view(-1), out_expected.view(-1)
@@ -4080,20 +4105,25 @@ class TestNestedTensorSubclass(TestCase):
                     )
 
     @dtypes(torch.float32)
+    @parametrize(
+        "func",
+        [torch.ops.aten.sum.dim_IntList, torch.ops.aten.mean.dim],
+        name_fn=get_op_name,
+    )
     @parametrize("keepdim", [False, True])
     @parametrize("requires_grad", [False, True])
     @parametrize("components_require_grad", [False, True])
-    def test_sum_dim_reduce_ragged_dim_1(
-        self,
-        device,
-        dtype,
-        keepdim,
-        requires_grad,
-        components_require_grad,
+    def test_jagged_op_dim_reduce_ragged_idx_1(
+        self, device, dtype, keepdim, requires_grad, components_require_grad, func
     ):
         """
-        Sum on NestedTensor passes when trying to reduce across ragged dimension, where ragged_idx == 1
+        Operator on NestedTensor passes when trying to reduce across ragged dimension, where ragged_idx == 1
         """
+        if get_op_name(func) == "mean" and not keepdim:
+            return
+
+        op_name = get_op_name(func)
+
         tensor_lists = self._get_example_tensor_lists(
             include_list_of_lists=False, include_requires_grad=components_require_grad
         )
@@ -4108,17 +4138,14 @@ class TestNestedTensorSubclass(TestCase):
                 requires_grad=requires_grad,
             )
 
-            out_actual = torch.sum(nt, dim=reduce_dim, keepdim=keepdim)
+            out_actual = func(nt, dim=reduce_dim, keepdim=keepdim)
             out_expected = torch.cat(
-                [
-                    torch.sum(t, dim=(reduce_dim[0] - 1)).unsqueeze(0)
-                    for t in nt.unbind()
-                ]
+                [func(t, dim=(reduce_dim[0] - 1)).unsqueeze(0) for t in nt.unbind()]
             )
 
             self.assertFalse(
                 out_actual.is_nested,
-                "sum(): the result of reducing a nested tensor along the ragged dimension is a dense tensor",
+                f"{op_name}(): the result of reducing a nested tensor along the ragged dimension is a dense tensor",
             )  # output is a dense tensor
             self.assertTrue(torch.allclose(out_actual, out_expected))
 
@@ -4236,26 +4263,35 @@ class TestNestedTensorSubclass(TestCase):
                 out = torch.sum(nt, dim=reduce_dim, keepdim=keepdim)
 
     @dtypes(torch.float32)
+    @parametrize(
+        "func",
+        [torch.ops.aten.sum.dim_IntList, torch.ops.aten.mean.dim],
+        name_fn=get_op_name,
+    )
     @parametrize("keepdim", [False, True])
     @parametrize("requires_grad", [False, True])
     @parametrize("components_require_grad", [False, True])
-    def test_sum_dim_ragged_dim_not_1(
+    def test_jagged_op_dim_ragged_dim_not_1(
         self,
         device,
         dtype,
         keepdim,
         requires_grad,
         components_require_grad,
+        func,
     ):
         """
-        Sum on NestedTensor fails when trying to reduce a nested tensor with ragged_idx != 1
+        Operator on NestedTensor fails when trying to reduce a nested tensor with ragged_idx != 1
         """
+        if get_op_name(func) == "mean" and not keepdim:
+            return
+
         tensor_lists = self._get_example_tensor_lists(
             include_list_of_lists=False, include_requires_grad=components_require_grad
         )
         reduce_dims = (
             (1,),
-            (2, 3),
+            (2,),
         )
 
         for tensor_list, reduce_dim in itertools.product(tensor_lists, reduce_dims):
@@ -4276,24 +4312,33 @@ class TestNestedTensorSubclass(TestCase):
                     RuntimeError,
                     "not supported when ragged_idx != 1 for NestedTensor",
                 ):
-                    out = torch.sum(nt_transposed, dim=reduce_dim, keepdim=keepdim)
+                    out = func(nt_transposed, dim=reduce_dim, keepdim=keepdim)
 
     @dtypes(torch.float32)
+    @parametrize(
+        "func",
+        [torch.ops.aten.sum.dim_IntList, torch.ops.aten.mean.dim],
+        name_fn=get_op_name,
+    )
     @parametrize("keepdim", [False, True])
     @parametrize("requires_grad", [False, True])
     @parametrize("components_require_grad", [False, True])
-    def test_sum_dim_with_lengths(
+    def test_jagged_op_dim_with_lengths(
         self,
         device,
         dtype,
         keepdim,
         requires_grad,
         components_require_grad,
+        func,
     ):
         """
-        Sum on NestedTensor fails when trying to reduce a nested tensor with lengths,
-        i.e. a nested tensor with holes, when reducing on the ragged dimension
+        Operator on NestedTensor fails when trying to reduce a nested tensor with lengths,
+        i.e. a nested tensor with holes, if reducing on the ragged dimension
         """
+        if get_op_name(func) == "mean" and not keepdim:
+            return
+
         reduce_dims = (
             (1,),
             (2,),
@@ -4325,9 +4370,92 @@ class TestNestedTensorSubclass(TestCase):
                         "not supported where lengths is not None "
                         + "if reducing across the ragged dimension for NestedTensor",
                     ):
-                        out = torch.sum(nt_with_holes, dim=reduce_dim, keepdim=keepdim)
+                        out = func(nt_with_holes, dim=reduce_dim, keepdim=keepdim)
                 else:
-                    out = torch.sum(nt_with_holes, dim=reduce_dim, keepdim=keepdim)
+                    out = func(nt_with_holes, dim=reduce_dim, keepdim=keepdim)
+
+    @dtypes(torch.float32)
+    @parametrize("keepdim", [True])
+    @parametrize("requires_grad", [False, True])
+    @parametrize("components_require_grad", [False, True])
+    def test_mean_dim_reduce_multiple_dims(
+        self,
+        device,
+        dtype,
+        keepdim,
+        requires_grad,
+        components_require_grad,
+    ):
+        """
+        Mean on NestedTensor fails when trying to reduce across multiple dimensions
+        """
+        tensor_lists = self._get_example_tensor_lists(
+            include_list_of_lists=False, include_requires_grad=components_require_grad
+        )
+        reduce_dims = (
+            (0, 1),
+            (2, 3),
+            (2, 3, 4),
+        )
+
+        for tensor_list, reduce_dim in itertools.product(tensor_lists, reduce_dims):
+            nt = torch.nested.nested_tensor(
+                tensor_list,
+                device=device,
+                dtype=dtype,
+                layout=torch.jagged,
+                requires_grad=requires_grad,
+            )
+
+            if nt.dim() > reduce_dim[-1]:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "not supported across multiple dimensions for NestedTensor",
+                ):
+                    out = torch.mean(nt, dim=reduce_dim, keepdim=keepdim)
+
+    @dtypes(torch.float32)
+    @parametrize("keepdim", [False, True])
+    @parametrize("requires_grad", [False, True])
+    @parametrize("components_require_grad", [False, True])
+    def test_mean_dim_keepdim_False(
+        self,
+        device,
+        dtype,
+        keepdim,
+        requires_grad,
+        components_require_grad,
+    ):
+        """
+        Mean on NestedTensor fails when keepdim=False
+        """
+        tensor_lists = self._get_example_tensor_lists(
+            include_list_of_lists=False, include_requires_grad=components_require_grad
+        )
+        reduce_dims = (
+            (1,),
+            (2,),
+            (3,),
+        )
+
+        for tensor_list, reduce_dim in itertools.product(tensor_lists, reduce_dims):
+            nt = torch.nested.nested_tensor(
+                tensor_list,
+                device=device,
+                dtype=dtype,
+                layout=torch.jagged,
+                requires_grad=requires_grad,
+            )
+
+            if nt.dim() > reduce_dim[-1]:
+                if not keepdim:
+                    with self.assertRaisesRegex(
+                        RuntimeError,
+                        "not supported when keepdim=False for NestedTensor",
+                    ):
+                        out = torch.mean(nt, dim=reduce_dim, keepdim=keepdim)
+                else:
+                    out = torch.mean(nt, dim=reduce_dim, keepdim=keepdim)
 
     @dtypes(torch.float, torch.double, torch.half)
     @parametrize("requires_grad", [False, True])

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -37,6 +37,11 @@ def _wrap_jagged_dim(
 
 
 def _wrap_jagged_dims(ndim, dims, op_name, ragged_idx=1):
+    """
+    For NestedTensor operators that support multiple dimensions,
+    wraps dimensions to non-negative values,
+    and returns metadata related to reduction dimension(s).
+    """
     from torch._prims_common import canonicalize_dims
 
     wrapped_dims = [
@@ -1097,18 +1102,65 @@ def convolution_default(func, *args, **kwargs):
 
 
 @register_jagged_func(
-    torch.ops.aten.mean.dim, "self: jt, dim: any?, keepdim: any, dtype: any?"
+    torch.ops.aten.mean.dim, "self: jt_all, dim: any?, keepdim: any?, dtype: any?"
 )
 def mean_dim(func, *args, **kwargs):
+    """
+    Performs a mean along the provided tensor dimension.
+    Returns a dense tensor if the ragged dimension is reduced away, else returns a nested tensor.
+    """
     _, new_kwargs = normalize_function(
         func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
     )
 
-    inp = new_kwargs.pop("input")
-    # NB: mean expects dim as a single item list of ints for some reason
-    new_kwargs["dim"] = [_wrap_jagged_dim(inp.dim(), new_kwargs["dim"][0], "mean")]
+    if len(new_kwargs["dim"]) > 1:
+        raise RuntimeError(
+            "mean(): not supported across multiple dimensions for NestedTensor"
+        )
 
-    return NestedTensor(func(inp._values, **new_kwargs), **extract_kwargs(inp))
+    if not new_kwargs["keepdim"]:
+        raise RuntimeError("mean(): not supported when keepdim=False for NestedTensor")
+
+    inp = new_kwargs.pop("input")
+
+    (
+        new_kwargs["dim"],
+        reduce_on_batch,
+        reduce_on_ragged,
+        reduce_on_non_batch,  # noqa: UFMT
+    ) = _wrap_jagged_dims(
+        inp.dim(),
+        new_kwargs["dim"],
+        "mean",
+        inp._ragged_idx,
+    )
+
+    if inp._ragged_idx != 1:
+        raise RuntimeError(
+            "mean(): not supported when ragged_idx != 1 for NestedTensor"
+        )
+
+    if reduce_on_ragged and inp._lengths is not None:
+        raise RuntimeError(
+            "mean(): not supported where lengths is not None "
+            + "if reducing across the ragged dimension for NestedTensor"
+        )
+
+    if reduce_on_ragged:  # raggedness reduced away
+        torch_sum = torch.sum(inp, dim=inp._ragged_idx, keepdim=new_kwargs["keepdim"])
+
+        # for every non-batch dimension past the ragged dimension,
+        #   unsqueeze lengths into the same shape as the PyTorch sum,
+        #   as the extra dimensions must all be divided by the same length
+        lengths = inp._offsets.diff()
+        for _ in range(inp.dim() - inp._ragged_idx - 1):
+            lengths = lengths.unsqueeze(-1)
+
+        return torch_sum / lengths.broadcast_to(torch_sum.shape)
+
+    return NestedTensor(
+        func(inp._values, **new_kwargs), **extract_kwargs(inp)
+    )  # raggedness preserved
 
 
 @register_jagged_func(torch.ops.aten.stack.default, "tensors: any, dim: any")


### PR DESCRIPTION
Summary:
Modify the existing `mean` operator in PyTorch, invoked by `torch.mean`, to allow for reductions along the jagged dimension of a nested tensor. The function originally had a basic implementation for reducing along 1 non-ragged dimension. This diff enables PyTorch users to invoke `torch.mean` on a nested tensor when reducing along the ragged dimension, e.g. `*` in a `(B, *, M)` nested tensor.

Parametrize unit tests from `sum` to verify the accuracy of the ragged reduction implementation for `torch.mean`. Add unit tests and parametrize `sum` unit tests to verify error handling for unsupported features in `NestedTensor` `torch.mean`.

Test Plan:
Verify that the new unit test passes via the following command:
```
buck2 run mode/{opt,inplace} //caffe2/test:nested -- --regex test_mean
```

```
buck2 run mode/{opt,inplace} //caffe2/test:nested -- --regex test_jagged_op
```

Differential Revision: D59654668
