### PR TITLE
[ROCm] Temporarily move inductor workflow to periodic

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -284,6 +284,7 @@ test_python_shard() {
     # timeout issues on the CI. Disabled in the test shard so we can continue to test in a periodic
     # inductor workflow
     time python test/run_test.py -x inductor/test_torchinductor_opinfo --exclude-jit-executor --exclude-distributed-tests $INCLUDE_CLAUSE --shard "$1" "$NUM_TEST_SHARDS" --verbose $PYTHON_TEST_EXTRA_OPTION
+  fi
   assert_git_not_dirty
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -275,11 +275,15 @@ test_python_shard() {
 
   # Bare --include flag is not supported and quoting for lint ends up with flag not being interpreted correctly
   # shellcheck disable=SC2086
-
-  # modify LD_LIBRARY_PATH to ensure it has the conda env.
-  # This set of tests has been shown to be buggy without it for the split-build
-  time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests $INCLUDE_CLAUSE --shard "$1" "$NUM_TEST_SHARDS" --verbose $PYTHON_TEST_EXTRA_OPTION
-
+  if [[ "$BUILD_ENVIRONMENT" != *rocm* ]]; then
+    # modify LD_LIBRARY_PATH to ensure it has the conda env.
+    # This set of tests has been shown to be buggy without it for the split-build
+    time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests $INCLUDE_CLAUSE --shard "$1" "$NUM_TEST_SHARDS" --verbose $PYTHON_TEST_EXTRA_OPTION
+  else
+    # Temporarily disable test_torchinductor_opinfo tests on ROCm due to ongoing KeyboardInterrupt
+    # timeout issues on the CI. Disabled in the test shard so we can continue to test in a periodic
+    # inductor workflow
+    time python test/run_test.py -x inductor/test_torchinductor_opinfo --exclude-jit-executor --exclude-distributed-tests $INCLUDE_CLAUSE --shard "$1" "$NUM_TEST_SHARDS" --verbose $PYTHON_TEST_EXTRA_OPTION
   assert_git_not_dirty
 }
 

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -16,30 +16,6 @@ concurrency:
 permissions: read-all
 
 jobs:
-  linux-focal-rocm6_1-py3_8-inductor-build:
-    name: rocm6.1-py3.8-inductor
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-focal-rocm6.1-py3.8
-      docker-image-name: pytorch-linux-focal-rocm-n-py3
-      test-matrix: |
-        { include: [
-          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.2" },
-          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.2" },
-        ]}
-
-  linux-focal-rocm6_1-py3_8-inductor-test:
-    permissions:
-      id-token: write
-      contents: read
-    name: rocm6.1-py3.8-inductor
-    uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-focal-rocm6_1-py3_8-inductor-build
-    with:
-      build-environment: linux-focal-rocm6.1-py3.8
-      docker-image: ${{ needs.linux-focal-rocm6_1-py3_8-inductor-build.outputs.docker-image }}
-      test-matrix:  ${{ needs.linux-focal-rocm6_1-py3_8-inductor-build.outputs.test-matrix }}
-
   linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
     name: cuda12.1-py3.10-gcc9-sm86
     uses: ./.github/workflows/_linux-build.yml

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -344,3 +344,28 @@ jobs:
       build-environment: linux-focal-cuda11.8-py3.9-gcc9-experimental-split-build
       docker-image: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build.outputs.test-matrix }}
+
+  linux-focal-rocm6_1-py3_8-inductor-build:
+    name: rocm6.1-py3.8-inductor
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-focal-rocm6.1-py3.8
+      docker-image-name: pytorch-linux-focal-rocm-n-py3
+      test-matrix: |
+        { include: [
+          { config: "inductor", shard: 1, num_shards: 2, runner: "linux.rocm.gpu.2" },
+          { config: "inductor", shard: 2, num_shards: 2, runner: "linux.rocm.gpu.2" },
+        ]}
+
+  linux-focal-rocm6_1-py3_8-inductor-test:
+    permissions:
+      id-token: write
+      contents: read
+    name: rocm6.1-py3.8-inductor
+    uses: ./.github/workflows/_rocm-test.yml
+    needs: linux-focal-rocm6_1-py3_8-inductor-build
+    with:
+      build-environment: linux-focal-rocm6.1-py3.8
+      docker-image: ${{ needs.linux-focal-rocm6_1-py3_8-inductor-build.outputs.docker-image }}
+      test-matrix:  ${{ needs.linux-focal-rocm6_1-py3_8-inductor-build.outputs.test-matrix }}
+


### PR DESCRIPTION
Large queues on ROCm, for now moving inductor to periodic workflow while we investigate a flakey KeyboardInterrupt issue occuring in "test_torchinductor_opinfo" UT suite. 

Also disabling this UT suite running on ROCm in the default test python shard.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang