### PR TITLE
Remove use of `softmax` in example of `torch.nn.functional.cross_entropy`

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3457,7 +3457,7 @@ def cross_entropy(
         >>>
         >>> # Example of target with class probabilities
         >>> input = torch.randn(3, 5, requires_grad=True)
-        >>> target = torch.randn(3, 5).softmax(dim=1)
+        >>> target = torch.randn(3, 5)
         >>> loss = F.cross_entropy(input, target)
         >>> loss.backward()
     """


### PR DESCRIPTION
The cross-entropy (as implemented in `torch.nn.functional.cross_entropy`) takes as input un-normalized logits, and this is specified in the docstring.

However, the examples at the bottom of the docstring still apply a softmax before calling the function, which effectively leads to two softmax being applied in a row, thus yielding terrible results.

I suggest we update the last example to prevent anyone from thinking that they have to apply softmax before cross-entropy.
