### PR TITLE
[lint] Remove unnecessary BUCKRESTRICTEDSYNTAX suppressions

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -53,7 +53,6 @@ load(
 )
 
 def read_bool(section, field, default, required = True):
-    # @lint-ignore BUCKRESTRICTEDSYNTAX
     val = read_config(section, field)
     if val != None:
         if val in ["true", "True", "1"]:
@@ -147,7 +146,6 @@ def get_glsl_paths():
 def spv_shader_library():
     pass
 
-# @lint-ignore BUCKRESTRICTEDSYNTAX
 IS_OSS = read_config("pt", "is_oss", "0") == "1"  # True for OSS BUCK build, and False for internal BUCK build
 
 NOT_OSS = not IS_OSS
@@ -847,7 +845,6 @@ def define_buck_targets(
     # @lint-ignore BUCKLINT
     fb_native.filegroup(
         name = "metal_build_srcs",
-        # @lint-ignore BUCKRESTRICTEDSYNTAX
         srcs = glob(METAL_SOURCE_LIST),
         visibility = [
             "PUBLIC",
@@ -858,7 +855,6 @@ def define_buck_targets(
     fb_native.filegroup(
         name = "templated_selective_build_srcs",
         # NB: no glob here, there are generated targets in this list!
-        # @lint-ignore BUCKRESTRICTEDSYNTAX
         srcs = glob(TEMPLATE_SOURCE_LIST) + aten_ufunc_generated_all_cpu_sources(":gen_aten[{}]"),
         visibility = [
             "PUBLIC",
@@ -1044,7 +1040,6 @@ def define_buck_targets(
         srcs = [
             "aten/src/ATen/native/native_functions.yaml",
             "aten/src/ATen/native/tags.yaml",
-            # @lint-ignore BUCKRESTRICTEDSYNTAX
         ] + glob(["aten/src/ATen/templates/*"]),
         visibility = [
             "PUBLIC",

--- a/pt_ops.bzl
+++ b/pt_ops.bzl
@@ -3,7 +3,6 @@ load("//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
 load("//tools/build_defs:fb_xplat_genrule.bzl", "fb_xplat_genrule")
 load("//tools/build_defs:type_defs.bzl", "is_list", "is_string")
 
-# @lint-ignore BUCKRESTRICTEDSYNTAX
 IS_OSS = read_config("pt", "is_oss", "0") == "1"  # True for OSS BUCK build, and False for internal BUCK build
 
 USED_PT_BACKENDS = [

--- a/third_party/kineto.buck.bzl
+++ b/third_party/kineto.buck.bzl
@@ -94,7 +94,6 @@ def define_kineto():
             "kineto/libkineto/include",
             "kineto/libkineto/src",
         ],
-        # @lint-ignore BUCKRESTRICTEDSYNTAX
         raw_headers = glob([
             "kineto/libkineto/include/*.h",
             "kineto/libkineto/src/*.h",
@@ -138,7 +137,6 @@ def define_kineto():
             "kineto/libkineto/include",
             "kineto/libkineto/src",
         ],
-        # @lint-ignore BUCKRESTRICTEDSYNTAX
         raw_headers = glob([
             "kineto/libkineto/include/*.h",
             "kineto/libkineto/src/*.h",

--- a/tools/BUCK.bzl
+++ b/tools/BUCK.bzl
@@ -26,7 +26,6 @@ def define_tools_targets(
 
     python_library(
         name = "jit",
-        # @lint-ignore BUCKRESTRICTEDSYNTAX
         srcs = glob([
             "jit/*.py",
             "jit/templates/*",
@@ -110,10 +109,7 @@ def define_tools_targets(
 
     python_library(
         name = "autograd",
-        # @lint-ignore BUCKRESTRICTEDSYNTAX
-        srcs = glob(
-            ["autograd/*.py"],
-        ),
+        srcs = glob(["autograd/*.py"]),
         base_module = "tools",
         resources = [
             "autograd/deprecated.yaml",

--- a/tools/build_defs/android/build_mode_defs.bzl
+++ b/tools/build_defs/android/build_mode_defs.bzl
@@ -1,4 +1,3 @@
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
 def is_production_build():
     if read_config("pt", "is_oss", "0") == "0":
         fail("This file is for open source pytorch build. Do not use it in fbsource!")

--- a/tools/build_defs/apple/build_mode_defs.bzl
+++ b/tools/build_defs/apple/build_mode_defs.bzl
@@ -1,4 +1,3 @@
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
 def is_production_build():
     if read_config("pt", "is_oss", "0") == "0":
         fail("This file is for open source pytorch build. Do not use it in fbsource!")

--- a/tools/build_defs/default_platform_defs.bzl
+++ b/tools/build_defs/default_platform_defs.bzl
@@ -1,5 +1,4 @@
 # Only used for PyTorch open source BUCK build
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
 
 def compose_platform_setting_list(settings):
     """Settings object:

--- a/tools/build_defs/fb_native_wrapper.bzl
+++ b/tools/build_defs/fb_native_wrapper.bzl
@@ -1,5 +1,5 @@
 # Only used for PyTorch open source BUCK build
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
+
 def _genrule(default_outs = ["."], **kwargs):
     if read_config("pt", "is_oss", "0") == "0":
         fail("This file is for open source pytorch build. Do not use it in fbsource!")

--- a/tools/build_defs/fb_xplat_cxx_library.bzl
+++ b/tools/build_defs/fb_xplat_cxx_library.bzl
@@ -1,10 +1,6 @@
 # Only used for PyTorch open source BUCK build
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
 
-load(
-    ":buck_helpers.bzl",
-    "filter_attributes",
-)
+load(":buck_helpers.bzl", "filter_attributes")
 
 def fb_xplat_cxx_library(
         name,

--- a/tools/build_defs/fb_xplat_cxx_test.bzl
+++ b/tools/build_defs/fb_xplat_cxx_test.bzl
@@ -1,5 +1,5 @@
 # Only used for PyTorch open source BUCK build
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
+
 load(":buck_helpers.bzl", "filter_attributes")
 
 def fb_xplat_cxx_test(

--- a/tools/build_defs/fb_xplat_genrule.bzl
+++ b/tools/build_defs/fb_xplat_genrule.bzl
@@ -1,5 +1,4 @@
 # Only used for PyTorch open source BUCK build
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
 
 def fb_xplat_genrule(default_outs = ["."], apple_sdks = None, **kwargs):
     if read_config("pt", "is_oss", "0") == "0":

--- a/tools/build_defs/fbsource_utils.bzl
+++ b/tools/build_defs/fbsource_utils.bzl
@@ -1,5 +1,4 @@
 # Only used for PyTorch open source BUCK build
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
 
 def is_arvr_mode():
     if read_config("pt", "is_oss", "0") == "0":

--- a/tools/build_defs/select.bzl
+++ b/tools/build_defs/select.bzl
@@ -1,5 +1,4 @@
 # Only used for PyTorch open source BUCK build
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
 
 def select(conditions):
     if read_config("pt", "is_oss", "0") == "0":

--- a/tools/build_defs/windows/windows_flag_map.bzl
+++ b/tools/build_defs/windows/windows_flag_map.bzl
@@ -1,5 +1,4 @@
 # Only used for PyTorch open source BUCK build
-# @lint-ignore-every BUCKRESTRICTEDSYNTAX
 
 def windows_convert_gcc_clang_flags(flags = []):
     if read_config("pt", "is_oss", "0") == "0":


### PR DESCRIPTION
Summary:
These suppressions overwhelmingly were for rules that no longer exist or
have been improved - a few suppressions appear to be just overzealous.

Test Plan: arc lint --take BUCKRESTRICTEDSYNTAX --lintall --no-filter-ruleset-filter

Reviewed By: JakobDegen

Differential Revision: D59935630
