### PR TITLE
Add support for using LF Canary runners

### DIFF
--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -12,6 +12,7 @@ from github.Issue import Issue
 
 WORKFLOW_LABEL_META = ""  # use meta runners
 WORKFLOW_LABEL_LF = "lf."  # use runners from the linux foundation
+WORKFLOW_LABEL_LF_CANARY = "lf.c."  # use canary runners from the linux foundation
 
 GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
 GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
@@ -202,6 +203,10 @@ def main() -> None:
                 f"Failed to get issue. Falling back to meta runners. Exception: {e}"
             )
             label_type = WORKFLOW_LABEL_META
+
+    # For Canary builds use canary runners
+    if args.github_repo == "pytorch/pytorch-canary" and label_type == WORKFLOW_LABEL_LF:
+        label_type = WORKFLOW_LABEL_LF_CANARY
 
     set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, label_type)
 

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -71,6 +71,7 @@ jobs:
 
           WORKFLOW_LABEL_META = ""  # use meta runners
           WORKFLOW_LABEL_LF = "lf."  # use runners from the linux foundation
+          WORKFLOW_LABEL_LF_CANARY = "lf.c."  # use canary runners from the linux foundation
 
           GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
           GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
@@ -262,8 +263,11 @@ jobs:
                       )
                       label_type = WORKFLOW_LABEL_META
 
-              set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, label_type)
+              # For Canary builds use canary runners
+              if args.github_repo == "pytorch/pytorch-canary" and label_type == WORKFLOW_LABEL_LF:
+                  label_type = WORKFLOW_LABEL_LF_CANARY
 
+              set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, label_type)
 
           if __name__ == "__main__":
               main()


### PR DESCRIPTION
The script is updated such that if a canary build is detected and the label_type is LF runner it will run on an LF Canary runner.

Closes pytorch/ci-infra#245.
