### PR TITLE
Allow device specific imports for inductor wrapper

### DIFF
--- a/test/inductor/extension_backends/cpp/extension_codegen_backend.py
+++ b/test/inductor/extension_backends/cpp/extension_codegen_backend.py
@@ -4,13 +4,13 @@ from torch._inductor.virtualized import V
 
 
 class ExtensionWrapperCodegen(wrapper.WrapperCodeGen):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ExtensionCppWrapperCodegen(cpp_wrapper_cpu.CppWrapperCpu):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ExtensionScheduling(BaseScheduling):

--- a/test/inductor/extension_backends/cpp/extension_device_import.cpp
+++ b/test/inductor/extension_backends/cpp/extension_device_import.cpp
@@ -1,0 +1,68 @@
+#include <torch/extension.h>
+#include <c10/core/CPUAllocator.h>
+#include <ATen/ops/eq_ops.h>
+#include <ATen/ops/fill_ops.h>
+#include <ATen/ops/view_ops.h>
+#include <ATen/ops/zero_ops.h>
+#include <ATen/ops/_local_scalar_dense_ops.h>
+
+constexpr c10::DispatchKeySet dense_cpu = c10::DispatchKeySet(
+    c10::BackendComponent::CPUBit).add(c10::DispatchKey::Dense);
+
+at::Tensor custom_as_strided(const at::Tensor& self, at::IntArrayRef size,
+                             at::IntArrayRef stride, at::optional<int64_t> storage_offset_) {
+    return at::native::as_strided_tensorimpl(self, size, stride, storage_offset_);
+}
+
+at::Tensor custom_empty_memory_format(at::IntArrayRef size,
+                                           std::optional<at::ScalarType> dtype,
+                                           std::optional<at::Layout> layout,
+                                           std::optional<at::Device> device,
+                                           std::optional<bool> pin_memory,
+                                           std::optional<at::MemoryFormat> memory_format) {
+    return at::detail::empty_generic(size,
+                                     c10::GetDefaultCPUAllocator(),
+                                     c10::DispatchKeySet(c10::DispatchKey::PrivateUse1),
+                                     c10::dtype_or_default(dtype),
+                                     memory_format);
+}
+
+
+at::Tensor &custom_eq_Tensor_out(c10::DispatchKeySet ks, const at::Tensor & self,
+                                 const at::Tensor & other, at::Tensor &out) {
+    return at::_ops::eq_Tensor_out::redispatch(dense_cpu, self, other, out);
+}
+
+at::Tensor &custom_fill_(at::Tensor& self, const at::Scalar& value) {
+    return at::_ops::fill__Scalar::redispatch(dense_cpu, self, value);
+}
+
+at::Tensor custom_view(c10::DispatchKeySet ks, const at::Tensor & self, c10::SymIntArrayRef size) {
+    return at::_ops::view::redispatch(dense_cpu, self, size);
+}
+
+at::Tensor &custom_zero_(at::Tensor &self){
+    return at::_ops::zero_::redispatch(dense_cpu, self);
+}
+
+at::Scalar custom__local_scalar_dense_(const at::Tensor& self) {
+    return at::_ops::_local_scalar_dense::redispatch(dense_cpu, self);
+}
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
+    m.impl("as_strided", custom_as_strided);
+    m.impl("empty.memory_format", &custom_empty_memory_format);
+    m.impl("eq.Tensor_out", &custom_eq_Tensor_out);
+    m.impl("fill_.Scalar", &custom_fill_);
+    m.impl("view", &custom_view);
+    m.impl("zero_", &custom_zero_);
+    m.impl("_local_scalar_dense", &custom__local_scalar_dense_);
+}
+
+c10::Device get_custom_device() {
+  return c10::Device(c10::DeviceType::PrivateUse1, 0);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("get_custom_device", &get_custom_device, "get custom device object");
+}

--- a/test/inductor/extension_backends/cpp/extension_device_import_wrapper.cpp
+++ b/test/inductor/extension_backends/cpp/extension_device_import_wrapper.cpp
@@ -1,0 +1,18 @@
+#include <c10/core/CPUAllocator.h>
+#include <torch/extension.h>
+
+at::Tensor custom_empty_strided(c10::IntArrayRef size, c10::IntArrayRef stride,
+                                std::optional<at::ScalarType> dtype_opt,
+                                std::optional<at::Layout> layout_opt,
+                                std::optional<at::Device> device_opt,
+                                std::optional<bool> pin_memory_opt) {
+  constexpr c10::DispatchKeySet private_use_ks(c10::DispatchKey::PrivateUse1);
+  auto dtype = c10::dtype_or_default(dtype_opt);
+  return at::detail::empty_strided_generic(size, stride, c10::GetDefaultCPUAllocator(), private_use_ks, dtype);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+      m.def("_empty_strided_extension_device_import",
+            &custom_empty_strided,
+             "mimic _empty_strided_cpu for test");
+}

--- a/test/inductor/extension_backends/cpp/extension_device_import_wrapper.py
+++ b/test/inductor/extension_backends/cpp/extension_device_import_wrapper.py
@@ -1,0 +1,25 @@
+import os
+
+import torch.utils.cpp_extension
+
+module = torch.utils.cpp_extension.load(
+    name="extension_device_import_wrapper",
+    sources=[
+        str(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "extension_device_import_wrapper.cpp",
+            )
+        ),
+    ],
+    extra_cflags=["-g"],
+    verbose=True,
+)
+
+
+def empty_strided_extension_device_import(
+    size, stride, dtype_opt=None, layout_opt=None, device_opt=None, pin_memory_opt=None
+):
+    return module._empty_strided_extension_device_import(
+        size, stride, dtype_opt, layout_opt, device_opt, pin_memory_opt
+    )

--- a/test/inductor/extension_backends/triton/extension_codegen_backend.py
+++ b/test/inductor/extension_backends/triton/extension_codegen_backend.py
@@ -4,8 +4,8 @@ from torch._inductor.scheduler import BaseScheduling
 
 
 class ExtensionWrapperCodegen(wrapper.WrapperCodeGen):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ExtensionScheduling(BaseScheduling):

--- a/test/inductor/test_extension_backend_wrapper.py
+++ b/test/inductor/test_extension_backend_wrapper.py
@@ -1,0 +1,157 @@
+# Owner(s): ["module: inductor"]
+import os
+import shutil
+import sys
+import unittest
+
+import torch
+import torch._dynamo
+import torch.utils.cpp_extension
+
+try:
+    from extension_backends.cpp.extension_codegen_backend import (
+        ExtensionScheduling,
+        ExtensionWrapperCodegen,
+    )
+except ImportError:
+    from .extension_backends.cpp.extension_codegen_backend import (
+        ExtensionScheduling,
+        ExtensionWrapperCodegen,
+    )
+
+from torch._inductor.codegen.common import register_backend_for_device
+from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS
+
+try:
+    try:
+        from . import test_torchinductor
+    except ImportError:
+        import test_torchinductor
+except unittest.SkipTest:
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise
+
+
+TestCase = test_torchinductor.TestCase
+
+
+def remove_build_path():
+    if sys.platform == "win32":
+        return
+    default_build_root = torch.utils.cpp_extension.get_default_build_root()
+    if os.path.exists(default_build_root):
+        shutil.rmtree(default_build_root, ignore_errors=True)
+
+
+@unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
+class ExtensionBackendDeviceImportTests(TestCase):
+    """ Tests the custom_empty_strided_device and device_imports parameters of
+        WrapperCodeGen """
+    module = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Build Extension
+        remove_build_path()
+        source_file_path = os.path.dirname(os.path.abspath(__file__))
+        source_file = os.path.join(
+            source_file_path, "extension_backends/cpp/extension_device_import.cpp"
+        )
+        cls.module = torch.utils.cpp_extension.load(
+            name="extension_device_import",
+            sources=[
+                str(source_file),
+            ],
+            extra_cflags=["-g"],
+            verbose=True,
+        )
+        torch.utils.rename_privateuse1_backend("extension_device_import")
+        torch._register_device_module("extension_device_import", cls.module)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._stack.close()
+        super().tearDownClass()
+
+        remove_build_path()
+
+    def setUp(self):
+        torch._dynamo.reset()
+        super().setUp()
+
+        # cpp extensions use relative paths. Those paths are relative to
+        # this file, so we'll change the working directory temporarily
+        self.old_working_dir = os.getcwd()
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+        assert self.module is not None
+
+    def tearDown(self):
+        super().tearDown()
+        torch._dynamo.reset()
+
+        # return the working directory (see setUp)
+        os.chdir(self.old_working_dir)
+
+    def compile_test_fn(cls):
+        device = cls.module.get_custom_device()
+        return torch.empty(2, 16, device=device)
+
+    def test_without_import(self):
+        """Register a new cpu backend to mimic an out-of-tree import which
+        does so. Do not add an import."""
+
+        class CustomEmptyWrapperCodeGen(ExtensionWrapperCodegen):
+            def __init__(self) -> None:
+                pytorch_test_dir = os.path.dirname(os.path.realpath(__file__))
+                super().__init__(custom_empty_strided_device="extension_device_import")
+
+        register_backend_for_device(
+            "extension_device_import", ExtensionScheduling, CustomEmptyWrapperCodeGen
+        )
+
+        compiled_fn = torch.compile(self.compile_test_fn)
+        # Check that this fails due to missing import
+        with self.assertRaises(NameError):
+            compiled_fn()
+
+    def test_with_import(self):
+        """Register a new cpu backend to mimic an out-of-tree import which
+        does so. Add an import for empty_strided for the extension to test
+        importing"""
+
+        class ImportingWrapperCodeGen(ExtensionWrapperCodegen):
+            def __init__(self) -> None:
+
+                pytorch_test_dir = os.path.dirname(os.path.realpath(__file__))
+                device_imports = [
+                    "import sys",
+                    'sys.path.append("' + pytorch_test_dir + '")',
+                    "from extension_backends.cpp import extension_device_import_wrapper",
+                    "empty_strided_extension_device_import = "
+                    + "extension_device_import_wrapper."
+                    + "empty_strided_extension_device_import",
+                ]
+
+                super().__init__(
+                    device_imports=device_imports,
+                    custom_empty_strided_device="extension_device_import",
+                )
+
+        register_backend_for_device(
+            "extension_device_import", ExtensionScheduling, ImportingWrapperCodeGen
+        )
+
+        compiled_fn = torch.compile(self.compile_test_fn)
+        compiled_fn()
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+    from torch.testing._internal.inductor_utils import HAS_CPU
+
+    # cpp_extension doesn't work in fbcode right now
+    if HAS_CPU and not IS_MACOS and not IS_FBCODE:
+        run_tests(needs="filelock")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -455,8 +455,14 @@ class WrapperCodeGen(CodeGen):
     Generate outer wrapper in Python that calls the kernels.
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        custom_empty_strided_device=None,
+        device_imports: list[str] | None = None,
+    ):
         super().__init__()
+
         self._names_iter: Iterator[int] = count()
         self.header = IndentedBuffer()
         self.prefix = IndentedBuffer()
@@ -489,12 +495,20 @@ class WrapperCodeGen(CodeGen):
         self.stack_allocated_buffers: Dict[BufferName, ir.Buffer] = {}
         self.computed_sizes: Set[sympy.Symbol] = set()
 
+        # Allow a custom device (other than cpu/cuda) to use its own
+        # empty_strided method.
+        self.custom_empty_strided_device: str = custom_empty_strided_device
+
+        # Extra device specific imports which will added to the header of the
+        # wrapper.
+        self.device_imports: list[str] | None = device_imports
+
         # this is used for tracking which GraphLowering instance---parent graph
         # or (nested) subgraph---is currently codegened; the primary use case is
         # including the graph instance into a cache key to avoid cross-graph
         # caching during lowering of nested subgraphs
-        self.codegened_graph_stack = []
-        self.computed_sizes_stack = []
+        self.codegened_graph_stack: List[GraphLowering] = []
+        self.computed_sizes_stack: List[Set[sympy.Symbol]] = []
 
         self.write_header()
         self.write_prefix()
@@ -534,6 +548,13 @@ class WrapperCodeGen(CodeGen):
         aot_config_comment = ""
         if context is not None and context.aot_graph_name is not None:
             aot_config_comment = f"# AOT ID: {context.aot_graph_name}"
+
+        import_str = ""
+        if self.device_imports is not None:
+            import_str = "\n".join(
+                f"                {line}" for line in self.device_imports
+            )
+
         self.header.splice(
             f"""
                 {aot_config_comment}
@@ -546,9 +567,9 @@ class WrapperCodeGen(CodeGen):
                 from math import inf, nan
                 from torch._inductor.hooks import run_intermediate_hooks
                 from torch._inductor.utils import maybe_profile
-                from torch._inductor.codegen.memory_planning import _align as align
-
+{import_str}
                 from torch import device, empty_strided
+                from torch._inductor.codegen.memory_planning import _align as align
                 from {async_compile.__name__} import AsyncCompile
                 from torch._inductor.select_algorithm import extern_kernels
                 from torch._inductor.codegen.multi_kernel import MultiKernelCall
@@ -562,7 +583,6 @@ class WrapperCodeGen(CodeGen):
                 reinterpret_tensor = torch._C._dynamo.guards._reinterpret_tensor
                 alloc_from_pool = torch.ops.inductor._alloc_from_pool
                 async_compile = AsyncCompile()
-
             """
         )
 
@@ -1721,7 +1741,7 @@ class WrapperCodeGen(CodeGen):
         return self.make_allocation(buffer.get_name(), device, dtype, shape, stride)
 
     def make_allocation(self, name, device, dtype, shape, stride):
-        if device.type in ("cpu", "cuda"):
+        if device.type in ("cpu", "cuda", self.custom_empty_strided_device):
             # optimized path for faster allocations, saving ~2us versus the stuff below
             return (
                 f"{name} = empty_strided_{device.type}("


### PR DESCRIPTION
- Allow a backend registered to inject extra imports into the inductor wrapper by supplying arguments to the WrapperCodegen class.
- Allow a backend introduce a device specific empty_strided function to match the behaviour of _empty_strided_cpu and empty_strided_cuda.
- Add a test for both new functionality.
- Make misc changes to satisfy lintrunner.
- Move _align import in wrapper to prevent circular imports in some circumstances.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang