### PR TITLE
[functorch] saved tensor hooks error should only apply to grad, vjp transforms.

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -2839,12 +2839,9 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         child_1 = torch._C._functorch._add_batch_dim(child, 0, 1);  child = None
-
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_x_,), (child_1,))
 
@@ -2858,7 +2855,7 @@ class GraphModule(torch.nn.Module):
 
         _wrap_for_grad = torch._C._functorch._wrap_for_grad(l_x_, 2);  l_x_ = None
 
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_primals = torch._C._functorch._wrap_for_grad(child_2, 3);  child_2 = None
@@ -2874,7 +2871,7 @@ class GraphModule(torch.nn.Module):
         results = torch._C._functorch._unwrap_for_grad(o, 3)
 
         _grad_decrement_nesting = torch._C._functorch._grad_decrement_nesting()
-        _saved_tensors_hooks_disable_3 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
 
         tensor_1 = torch.tensor((12,))
         cumsum_1 = tensor_1.cumsum(dim = 0);  tensor_1 = None
@@ -2891,7 +2888,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions_1 = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable_4 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting_1 = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         _add_batch_dim_1 = torch._C._functorch._add_batch_dim(basis, 0, 3);  basis = None
@@ -2904,7 +2900,6 @@ class GraphModule(torch.nn.Module):
         chunked_result = torch._C._functorch._remove_batch_dim(batched_outputs, 3, 12, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_disable_5 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         split = chunked_result.split((12,), dim = 0);  chunked_result = None
         split_1 = split[0];  split = None
@@ -2922,12 +2917,10 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_disable_6 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         results_1: "f32[12, 4, 3, 4, 3]" = torch._C._functorch._remove_batch_dim(tangents_out_unflatten, 1, 12, 0);  tangents_out_unflatten = None
 
         _vmap_decrement_nesting_1 = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
 
         movedim: "f32[4, 3, 4, 3, 12]" = results_1.movedim(0, -1);  results_1 = None
         split_2 = movedim.split((12,), dim = -1);  movedim = None
@@ -2978,12 +2971,9 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         child_1 = torch._C._functorch._add_batch_dim(child, 0, 1);  child = None
-
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_y_,), (child_1,))
 
@@ -2998,7 +2988,7 @@ class GraphModule(torch.nn.Module):
         child_2 = torch._C._functorch._wrap_for_grad(l_x_, 2);  l_x_ = None
         _wrap_for_grad_1 = torch._C._functorch._wrap_for_grad(l_y_, 2);  l_y_ = None
 
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         _wrap_for_grad_2 = torch._C._functorch._wrap_for_grad(child_2, 3);  child_2 = None
@@ -3015,7 +3005,7 @@ class GraphModule(torch.nn.Module):
         results = torch._C._functorch._unwrap_for_grad(o, 3)
 
         _grad_decrement_nesting = torch._C._functorch._grad_decrement_nesting()
-        _saved_tensors_hooks_disable_3 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
 
         tensor_1 = torch.tensor((12,))
         cumsum_1 = tensor_1.cumsum(dim = 0);  tensor_1 = None
@@ -3032,7 +3022,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions_1 = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable_4 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting_1 = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         _add_batch_dim_1 = torch._C._functorch._add_batch_dim(basis, 0, 3);  basis = None
@@ -3045,7 +3034,6 @@ class GraphModule(torch.nn.Module):
         child_6 = torch._C._functorch._remove_batch_dim(child_5, 3, 12, 0);  child_5 = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_disable_5 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         split = child_6.split((12,), dim = 0);  child_6 = None
         split_1 = split[0];  split = None
@@ -3064,12 +3052,10 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_disable_6 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         child_10: "f32[12, 4, 3, 3, 4]" = torch._C._functorch._remove_batch_dim(child_9, 1, 12, 0);  child_9 = None
 
         _vmap_decrement_nesting_1 = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
 
         movedim: "f32[4, 3, 3, 4, 12]" = child_10.movedim(0, -1);  child_10 = None
         split_2 = movedim.split((12,), dim = -1);  movedim = None
@@ -3129,7 +3115,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[4, 3]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_primals = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3162,7 +3148,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(basis, 0, 1);  basis = None
@@ -3175,7 +3160,6 @@ class GraphModule(torch.nn.Module):
         chunked_result: "f32[12, 4, 3]" = torch._C._functorch._remove_batch_dim(batched_outputs, 1, 12, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable_1 = torch._C._autograd._saved_tensors_hooks_enable()
 
         split = chunked_result.split((12,), dim = 0);  chunked_result = None
         split_1: "f32[12, 4, 3]" = split[0];  split = None
@@ -3210,7 +3194,7 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_y_ = L_y_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         _wrap_for_grad = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3244,7 +3228,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(basis, 0, 1);  basis = None
@@ -3257,7 +3240,6 @@ class GraphModule(torch.nn.Module):
         chunked_result: "f32[12, 3, 4]" = torch._C._functorch._remove_batch_dim(batched_outputs, 1, 12, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable_1 = torch._C._autograd._saved_tensors_hooks_enable()
 
         split = chunked_result.split((12,), dim = 0);  chunked_result = None
         split_1: "f32[12, 3, 4]" = split[0];  split = None
@@ -3292,7 +3274,7 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_y_ = L_y_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         aux = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3328,7 +3310,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(basis, 0, 1);  basis = None
@@ -3341,7 +3322,6 @@ class GraphModule(torch.nn.Module):
         chunked_result: "f32[12, 3, 4]" = torch._C._functorch._remove_batch_dim(batched_outputs, 1, 12, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable_1 = torch._C._autograd._saved_tensors_hooks_enable()
 
         split = chunked_result.split((12,), dim = 0);  chunked_result = None
         split_1: "f32[12, 3, 4]" = split[0];  split = None
@@ -3403,7 +3383,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[5]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         child = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3451,7 +3431,7 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_v_ = L_v_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         child = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3505,7 +3485,7 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_v_ = L_v_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         child = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3561,7 +3541,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[5]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         child = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3634,7 +3614,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[3, 3, 3]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_args = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3701,7 +3681,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[3, 3, 3]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_args = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3758,7 +3738,7 @@ class GraphModule(torch.nn.Module):
 
         y: "f32[3]" = torch.randn(3)
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_args = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3815,7 +3795,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[3, 3, 3]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_args = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3869,7 +3849,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[3, 3, 3]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_args = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3926,7 +3906,7 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_y_ = L_y_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_args = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -3995,7 +3975,7 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_y_ = L_y_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         child = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -4041,7 +4021,7 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_y_ = L_y_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         child = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -4103,7 +4083,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_args = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -4113,7 +4093,7 @@ class GraphModule(torch.nn.Module):
         _set_tensor_requires_grad = torch._functorch.eager_transforms._set_tensor_requires_grad(diff_args)
 
         set_inplace_requires_grad_allowed_1 = torch._C._functorch.set_inplace_requires_grad_allowed(False)
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting_1 = torch._C._functorch._grad_increment_nesting()
 
         diff_args_1 = torch._C._functorch._wrap_for_grad(diff_args, 2)
@@ -4135,7 +4115,7 @@ class GraphModule(torch.nn.Module):
         output_1 = torch._C._functorch._unwrap_for_grad(output, 2);  output = None
 
         _grad_decrement_nesting = torch._C._functorch._grad_decrement_nesting()
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _autograd_grad_1 = torch._functorch.eager_transforms._autograd_grad((grad_input_1,), [diff_args], create_graph = True);  diff_args = None
         grad_input_2 = _autograd_grad_1[0];  _autograd_grad_1 = None
@@ -4228,7 +4208,7 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[3, 3, 3]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
+        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.")
         _grad_increment_nesting = torch._C._functorch._grad_increment_nesting()
 
         diff_args = torch._C._functorch._wrap_for_grad(l_x_, 1);  l_x_ = None
@@ -4332,12 +4312,9 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         child_1 = torch._C._functorch._add_batch_dim(child, 0, 1);  child = None
-
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_x_,), (child_1,))
 
@@ -4364,12 +4341,10 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         results: "f32[12, 4, 3]" = torch._C._functorch._remove_batch_dim(tangents_out_unflatten, 1, 12, 0);  tangents_out_unflatten = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
 
         movedim: "f32[4, 3, 12]" = results.movedim(0, -1);  results = None
         split = movedim.split((12,), dim = -1);  movedim = None
@@ -4420,12 +4395,9 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         child_1 = torch._C._functorch._add_batch_dim(child, 0, 1);  child = None
-
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_y_,), (child_1,))
 
@@ -4453,12 +4425,10 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         results: "f32[12, 3, 4]" = torch._C._functorch._remove_batch_dim(tangents_out_unflatten, 1, 12, 0);  tangents_out_unflatten = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
 
         movedim: "f32[3, 4, 12]" = results.movedim(0, -1);  results = None
         split = movedim.split((12,), dim = -1);  movedim = None
@@ -4509,12 +4479,9 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(12, 'error')
 
         child_1 = torch._C._functorch._add_batch_dim(child, 0, 1);  child = None
-
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_y_,), (child_1,))
 
@@ -4544,13 +4511,11 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         results: "f32[12, 3, 4]" = torch._C._functorch._remove_batch_dim(tangents_out_unflatten, 1, 12, 0);  tangents_out_unflatten = None
         aux_2: "f32[12, 4, 3]" = torch._C._functorch._remove_batch_dim(aux_1, 1, 12, 0);  aux_1 = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
 
         aux_3: "f32[4, 3]" = aux_2[0];  aux_2 = None
 
@@ -4603,12 +4568,9 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(12, 'same')
 
         child_1 = torch._C._functorch._add_batch_dim(child, 0, 1);  child = None
-
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_x_,), (child_1,))
 
@@ -4643,13 +4605,11 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         child_8: "f32[12, 3, 4]" = torch._C._functorch._remove_batch_dim(child_6, 1, 12, 0);  child_6 = None
         child_9: "f32[12, 4, 3]" = torch._C._functorch._remove_batch_dim(child_7, 1, 12, 0);  child_7 = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
 
         movedim: "f32[3, 4, 12]" = child_8.movedim(0, -1);  child_8 = None
         split = movedim.split((12,), dim = -1);  movedim = None
@@ -4718,8 +4678,6 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_v_ = L_v_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
-
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_x_,), (l_v_,))
 
         _jvp_increment_nesting = torch._C._functorch._jvp_increment_nesting()
@@ -4744,7 +4702,6 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (primals_out_unflatten, tangents_out_unflatten)
 """,
         )
@@ -4775,8 +4732,6 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_v_ = L_v_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
-
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_x_,), (l_v_,))
 
         _jvp_increment_nesting = torch._C._functorch._jvp_increment_nesting()
@@ -4803,7 +4758,6 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (primals_out_unflatten, tangents_out_unflatten, aux_1)
 """,
         )
@@ -4835,8 +4789,6 @@ class GraphModule(torch.nn.Module):
         l_x_ = L_x_
         l_y_ = L_y_
         l_v_ = L_v_
-
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_x_, l_y_), (l_v_, l_v_))
 
@@ -4870,7 +4822,6 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (primals_out_unflatten, tangents_out_unflatten, aux_1)
 """,
         )
@@ -4903,7 +4854,6 @@ class GraphModule(torch.nn.Module):
         l_v_ = L_v_
 
         _set_fwd_grad_enabled = torch._C._set_fwd_grad_enabled(False)
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_x_,), (l_v_,))
 
@@ -4929,7 +4879,6 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_2 = torch._C._set_fwd_grad_enabled(False)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         _set_fwd_grad_enabled_3 = torch._C._set_fwd_grad_enabled(True)
         return (primals_out_unflatten, tangents_out_unflatten)
 """,
@@ -4976,7 +4925,6 @@ class GraphModule(torch.nn.Module):
         _set_fwd_grad_enabled = torch._C._set_fwd_grad_enabled(False)
         _set_fwd_grad_enabled_1 = torch._C._set_fwd_grad_enabled(True)
         _set_fwd_grad_enabled_2 = torch._C._set_fwd_grad_enabled(False)
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_x_,), (l_v_,))
 
@@ -5002,7 +4950,6 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_4 = torch._C._set_fwd_grad_enabled(False)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         _set_fwd_grad_enabled_5 = torch._C._set_fwd_grad_enabled(True)
         _set_fwd_grad_enabled_6 = torch._C._set_fwd_grad_enabled(False)
         _set_fwd_grad_enabled_7 = torch._C._set_fwd_grad_enabled(True)
@@ -5052,8 +4999,6 @@ class GraphModule(torch.nn.Module):
     def forward(self, L_x_: "f32[3, 3, 3]"):
         l_x_ = L_x_
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
-
         _jvp_treespec_compare = torch._functorch.eager_transforms._jvp_treespec_compare((l_x_,), (l_x_,))
 
         _jvp_increment_nesting = torch._C._functorch._jvp_increment_nesting()
@@ -5063,8 +5008,6 @@ class GraphModule(torch.nn.Module):
         _maybe_load_decompositions = torch.autograd.forward_ad._maybe_load_decompositions()
 
         child = torch._make_dual(l_x_, l_x_, level = 0);  l_x_ = None
-
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _jvp_treespec_compare_1 = torch._functorch.eager_transforms._jvp_treespec_compare((child,), (child,))
 
@@ -5087,7 +5030,6 @@ class GraphModule(torch.nn.Module):
 
         _set_fwd_grad_enabled_2 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _unpack_dual_1 = torch._unpack_dual(primals_out_unflatten, level = 0);  primals_out_unflatten = None
         primal_1 = _unpack_dual_1[0]
@@ -5105,7 +5047,6 @@ class GraphModule(torch.nn.Module):
         _exit_dual_level = torch._C._exit_dual_level(0)
         _set_fwd_grad_enabled_3 = torch._C._set_fwd_grad_enabled(True)
         _jvp_decrement_nesting_1 = torch._C._functorch._jvp_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_unwrap_for_grad_2, _unwrap_for_grad_3, _unwrap_for_grad_4, _unwrap_for_grad_5)
 """,
         )
@@ -5409,7 +5350,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(3, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(l_x_, 0, 1);  l_x_ = None
@@ -5421,7 +5361,6 @@ class GraphModule(torch.nn.Module):
         _remove_batch_dim: "f32[3, 3]" = torch._C._functorch._remove_batch_dim(batched_outputs, 1, 3, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim,)
 """,
         )
@@ -5449,7 +5388,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(3, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(l_x_, 0, 1);  l_x_ = None
@@ -5462,7 +5400,6 @@ class GraphModule(torch.nn.Module):
         _remove_batch_dim: "f32[3, 3]" = torch._C._functorch._remove_batch_dim(batched_outputs, 1, 3, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim,)
 """,
         )
@@ -5491,7 +5428,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(3, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(l_x_, 0, 1);  l_x_ = None
@@ -5504,7 +5440,6 @@ class GraphModule(torch.nn.Module):
         _remove_batch_dim: "f32[3, 3, 3]" = torch._C._functorch._remove_batch_dim(batched_outputs, 1, 3, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim,)
 """,
         )
@@ -5534,7 +5469,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(3, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(l_x_, 0, 1);  l_x_ = None
@@ -5548,7 +5482,6 @@ class GraphModule(torch.nn.Module):
         _remove_batch_dim: "f32[3, 3]" = torch._C._functorch._remove_batch_dim(batched_outputs, 1, 3, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim,)
 """,
         )
@@ -5580,7 +5513,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(3, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(l_x_, 0, 1);  l_x_ = None
@@ -5594,7 +5526,6 @@ class GraphModule(torch.nn.Module):
         _remove_batch_dim: "f32[3, 3]" = torch._C._functorch._remove_batch_dim(batched_outputs, 1, 3, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim,)
 """,
         )
@@ -5622,7 +5553,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(3, 'error')
 
         child = torch._C._functorch._add_batch_dim(l_x_, 0, 1);  l_x_ = None
@@ -5630,7 +5560,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions_1 = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting_1 = torch._C._functorch._vmap_increment_nesting(3, 'error')
 
         _add_batch_dim_2 = torch._C._functorch._add_batch_dim(child, 1, 2);  child = None
@@ -5641,12 +5570,10 @@ class GraphModule(torch.nn.Module):
         batched_outputs_1 = torch._C._functorch._remove_batch_dim(batched_outputs, 2, 3, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _remove_batch_dim_1: "f32[3, 3, 3]" = torch._C._functorch._remove_batch_dim(batched_outputs_1, 1, 3, 0);  batched_outputs_1 = None
 
         _vmap_decrement_nesting_1 = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim_1,)
 """,
         )
@@ -5675,14 +5602,12 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(5, 'error')
 
         child = torch._C._functorch._add_batch_dim(l_y_, 0, 1);  l_y_ = None
 
         lazy_load_decompositions_1 = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable_1 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting_1 = torch._C._functorch._vmap_increment_nesting(3, 'error')
 
         _add_batch_dim_1 = torch._C._functorch._add_batch_dim(child, 0, 2);  child = None
@@ -5692,12 +5617,10 @@ class GraphModule(torch.nn.Module):
         batched_outputs_1 = torch._C._functorch._remove_batch_dim(batched_outputs, 2, 3, 0);  batched_outputs = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_disable_2 = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
 
         _remove_batch_dim_1: "f32[5, 3, 2, 3]" = torch._C._functorch._remove_batch_dim(batched_outputs_1, 1, 5, 0);  batched_outputs_1 = None
 
         _vmap_decrement_nesting_1 = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim_1,)
 """,
         )
@@ -5724,7 +5647,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(2, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(l_x_, 0, 1);  l_x_ = None
@@ -5736,7 +5658,6 @@ class GraphModule(torch.nn.Module):
         _remove_batch_dim_1: "f32[2, 4]" = torch._C._functorch._remove_batch_dim(child_1, 1, 2, 0);  child_1 = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim, _remove_batch_dim_1)
 """,
         )
@@ -5763,7 +5684,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(2, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(l_x_, 0, 1);  l_x_ = None
@@ -5775,7 +5695,6 @@ class GraphModule(torch.nn.Module):
         _remove_batch_dim_1: "f32[2, 4]" = torch._C._functorch._remove_batch_dim(child_1, 1, 2, 0);  child_1 = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim, _remove_batch_dim_1)
 """,
         )
@@ -5803,7 +5722,6 @@ class GraphModule(torch.nn.Module):
 
         lazy_load_decompositions = torch._functorch.vmap.lazy_load_decompositions()
 
-        _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func transforms don't yet support saved tensor hooks. Please open an issue with your use case.")
         _vmap_increment_nesting = torch._C._functorch._vmap_increment_nesting(2, 'error')
 
         _add_batch_dim = torch._C._functorch._add_batch_dim(l_x_, 0, 1);  l_x_ = None
@@ -5815,7 +5733,6 @@ class GraphModule(torch.nn.Module):
         _remove_batch_dim_1: "f32[2, 4]" = torch._C._functorch._remove_batch_dim(child_1, 1, 2, 0);  child_1 = None
 
         _vmap_decrement_nesting = torch._C._functorch._vmap_decrement_nesting()
-        _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable()
         return (_remove_batch_dim, _remove_batch_dim_1)
 """,
         )
@@ -5947,7 +5864,7 @@ class GraphModule(torch.nn.Module):
         actual = opt(x, 0), opt(x, 1), opt(x, 2)
         self.assertEqual(expected, actual)
         self.assertEqual(cnt.frame_count, 3)
-        self.assertEqual(cnt.op_count, 27)
+        self.assertEqual(cnt.op_count, 21)
 
     def test_vmap_multiple_invocation_out_dims(self):
         counters.clear()
@@ -5963,7 +5880,7 @@ class GraphModule(torch.nn.Module):
         actual = opt(x, 0), opt(x, 1), opt(x, 2)
         self.assertEqual(expected, actual)
         self.assertEqual(cnt.frame_count, 3)
-        self.assertEqual(cnt.op_count, 27)
+        self.assertEqual(cnt.op_count, 21)
 
     def test_vmap_new_tensor_in_body(self):
         def fn(x):

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3529,13 +3529,10 @@ class TestComposability(TestCase):
     @parametrize(
         "transform",
         [
-            "vmap",
             "grad",
             "jacrev",
-            "jacfwd",
             "grad_and_value",
             "hessian",
-            "functionalize",
         ],
     )
     def test_transforms_dont_support_saved_tensor_hooks(self, device, transform):
@@ -3575,7 +3572,7 @@ class TestComposability(TestCase):
         with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
             vjp(g, x)
 
-    def test_jvp_doesnt_support_saved_tensor_hooks(self, device):
+    def test_jvp_supports_saved_tensor_hooks(self, device):
         def f(x):
             return torch.sin(x).sum()
 
@@ -3586,12 +3583,12 @@ class TestComposability(TestCase):
         x = torch.randn(3, device=device)
         t = torch.randn(3, device=device)
 
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            with torch.autograd.graph.save_on_cpu():
-                jvp(f, (x,), (t,))
+        # smoke tests
+        with torch.autograd.graph.save_on_cpu():
+            jvp(f, (x,), (t,))
 
-        with self.assertRaisesRegex(RuntimeError, "saved tensor hooks"):
-            jvp(g, (x,), (t,))
+        # smoke tests
+        jvp(g, (x,), (t,))
 
     def test_can_use_functionalize_when_key_is_excluded(self, device):
         def f(x):

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -213,6 +213,29 @@ class TestVmapAPI(TestCase):
         output = vmap(lambda x: vmap(lambda y: x)(y))(x)
         self.assertEqual(output, x.view(3, 1).expand(3, 5))
 
+    def test_checkpoint(self):
+        A = torch.randn((3, 8, 8), dtype=torch.float64, requires_grad=True)
+
+        def get_grad(checkpoint):
+            A.grad = None
+
+            def get_loss(A):
+                ortho_A, _ = torch.func.vmap(torch.linalg.qr)(A)
+                return torch.sum(ortho_A)
+
+            if checkpoint:
+                loss = torch.utils.checkpoint.checkpoint(
+                    get_loss, A, use_reentrant=False
+                )
+            else:
+                loss = get_loss(A)
+            loss.backward()
+            return A.grad
+
+        expected = get_grad(checkpoint=False)
+        result = get_grad(checkpoint=True)
+        self.assertEqual(result, expected)
+
     def test_unsupported_op_err_msg(self):
         # Unsupported view op
         tensor = torch.randn(2, 3)

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -1086,7 +1086,6 @@ def jvp(
     )
 
 
-@doesnt_support_saved_tensors_hooks
 def _jvp_with_argnums(
     func: Callable,
     primals: Any,
@@ -1675,7 +1674,6 @@ def functionalize(func: Callable, *, remove: str = "mutations") -> Callable:
             " replaced with their non-aliasing counterparts, {view}_copy.\n"
         )
 
-    @doesnt_support_saved_tensors_hooks
     @wraps(func)
     def wrapped(*args, **kwargs):
         try:

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -38,7 +38,7 @@ out_dims_t = Union[int, Tuple[int, ...]]
 
 def doesnt_support_saved_tensors_hooks(f):
     message = (
-        "torch.func transforms don't yet support saved tensor hooks. "
+        "torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. "
         "Please open an issue with your use case."
     )
 
@@ -469,7 +469,6 @@ def vmap_increment_nesting(batch_size, randomness):
         _vmap_decrement_nesting()
 
 
-@doesnt_support_saved_tensors_hooks
 def _flat_vmap(
     func, batch_size, flat_in_dims, flat_args, args_spec, out_dims, randomness, **kwargs
 ):
@@ -501,7 +500,6 @@ def _flat_vmap(
 # - vmap couples the tensor-wrapping code with error checking
 # - vmap's tensor unwrapping code is in C++; we would need to rewrite part of it
 #   in python because it overlaps with unwrap_batched
-@doesnt_support_saved_tensors_hooks
 def restore_vmap(func, in_dims, batch_size, randomness):
     def inner(*args, **kwargs):
         with vmap_increment_nesting(batch_size, randomness) as vmap_level:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131191

There's no reason to ban them for vmap or jvp, because without the
{grad, vjp} transforms those just act above PyTorch autograd, which will
end up saving regular Tensors.

Test Plan:
- some tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames