### PR TITLE
[MTIA][Type][FP8][4/N] Add float8_e4m3fn datatype support for glow backend and kernels_db

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -977,6 +977,7 @@ ANY_DTYPE_ORDER = (
     torch.complex128,
     torch.float16,
     torch.bfloat16,
+    torch.float8_e4m3fn,
     torch.long,
     torch.int32,
     torch.int16,


### PR DESCRIPTION
Summary: Add fp8 support for kernel development to the fx, backend and kernels_db.

Test Plan: CIs

Differential Revision: D58367846
