### PR TITLE
[BE] Improve CUDA UpSample error message

### DIFF
--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -292,9 +292,9 @@ static void upsample_bilinear2d_out_cuda_template(
       using accscalar_t = at::acc_type<scalar_t, true>;
 
       TORCH_CHECK(input.numel() < std::numeric_limits<int>::max(),
-        "upsample_bilinear2d_nhwc only supports input tensors with less than INT_MAX elements");
+        "upsample_bilinear2d_nhwc only supports input tensors with less than INT_MAX elements, but got ", input.sizes());
       TORCH_CHECK(output.numel() < std::numeric_limits<int>::max(),
-        "upsample_bilinear2d_nhwc only supports output tensors with less than INT_MAX elements");
+        "upsample_bilinear2d_nhwc only supports output tensors with less than INT_MAX elements, but got ", output.sizes());
 
       const int channels = input.size(1);
       const int height1 = input.size(2);

--- a/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
@@ -174,8 +174,10 @@ static void upsample_nearest1d_backward_out_cuda_template(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
   dim3 gdim{ceil_div(n, bdim.x)};
   // safe check for int32 indexing; implicitly restrict launch config for kernel
-  TORCH_CHECK(grad_input.numel() <= std::numeric_limits<int32_t>::max());
-  TORCH_CHECK(grad_output.numel() <= std::numeric_limits<int32_t>::max());
+  TORCH_CHECK(grad_input.numel() <= std::numeric_limits<int32_t>::max(),
+    "upsample_nearest1d_backward only supports input tensors with less than INT_MAX elements, but got ", grad_input.sizes());
+  TORCH_CHECK(grad_output.numel() <= std::numeric_limits<int32_t>::max(),
+        "upsample_nearest1d_backward only supports output tensors with less than INT_MAX elements, but got ", grad_output.sizes());
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Byte, grad_output.scalar_type(), "upsample_nearest1d_backward_out_frame", [&] {

--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -240,9 +240,9 @@ static void upsample_nearest2d_out_cuda_template(
     at::Tensor input = input_.contiguous(at::MemoryFormat::ChannelsLast);
 
     TORCH_CHECK(input.numel() < std::numeric_limits<int64_t>::max(),
-      "upsample_nearest_nhwc only supports input tensors with less than 2^63 - 1 elements");
+      "upsample_nearest_nhwc only supports input tensors with less than 2^63 - 1 elements, but got ", input.sizes());
     TORCH_CHECK(output.numel() < std::numeric_limits<int64_t>::max(),
-      "upsample_nearest_nhwc only supports output tensors with less than 2^63 - 1 elements");
+      "upsample_nearest_nhwc only supports output tensors with less than 2^63 - 1 elements, but got ", output.sizes());
 
     const int64_t num_kernels = output.numel();
     const int64_t num_threads = std::min(at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
@@ -370,9 +370,9 @@ static void upsample_nearest2d_backward_out_cuda_template(
     Tensor grad_output = grad_output_.contiguous(at::MemoryFormat::ChannelsLast);
 
     TORCH_CHECK(grad_input.numel() < std::numeric_limits<int>::max(),
-      "upsample_nearest_nhwc only supports grad_input tensors with less than INT_MAX elements");
+      "upsample_nearest_nhwc only supports grad_input tensors with less than INT_MAX elements, but got ", grad_input.sizes());
     TORCH_CHECK(grad_output.numel() < std::numeric_limits<int>::max(),
-      "upsample_nearest_nhwc only supports grad_output tensors with less than INT_MAX elements");
+      "upsample_nearest_nhwc only supports grad_output tensors with less than INT_MAX elements, but got ", grad_output.sizes());
 
     const int num_kernels = grad_input.numel();
     const int num_threads = std::min(at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
@@ -409,8 +409,8 @@ static void upsample_nearest2d_backward_out_cuda_template(
         at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
     dim3 gdim{ceil_div(n, bdim.x)};
     // safe check for int64 indexing; implicitly restrict launch config for kernel
-    TORCH_CHECK(grad_input.numel() <= std::numeric_limits<int64_t>::max(), "upsample2d grad_input.numel() <= std::numeric_limits<int64_t>::max()");
-    TORCH_CHECK(grad_output.numel() <= std::numeric_limits<int64_t>::max(), "upsample2d grad_output.numel() <= std::numeric_limits<int64_t>::max()");
+    TORCH_CHECK(grad_input.numel() <= std::numeric_limits<int64_t>::max(), "upsample2d grad_input.numel() <= std::numeric_limits<int64_t>::max(), but got ", grad_input.sizes());
+    TORCH_CHECK(grad_output.numel() <= std::numeric_limits<int64_t>::max(), "upsample2d grad_output.numel() <= std::numeric_limits<int64_t>::max(), but got ", grad_output.sizes());
 
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
     AT_DISPATCH_FLOATING_TYPES_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Byte, grad_output.scalar_type(), "upsample_nearest2d_backward_out_frame", [&] {

--- a/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
@@ -183,7 +183,6 @@ static void upsample_nearest3d_out_cuda_template(
   // safe check for int32 indexing; implicitly restrict launch config for kernel
   TORCH_CHECK(output.numel() <= std::numeric_limits<int32_t>::max(),
         "upsample_nearest3d only supports output tensors with less than INT_MAX elements, but got ", output.sizes());
-   );
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Byte,input.scalar_type(), "upsample_nearest3d_out_frame", [&] {

--- a/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
@@ -181,7 +181,9 @@ static void upsample_nearest3d_out_cuda_template(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
   dim3 gdim{ceil_div(n, bdim.x)};
   // safe check for int32 indexing; implicitly restrict launch config for kernel
-  TORCH_CHECK(output.numel() <= std::numeric_limits<int32_t>::max());
+  TORCH_CHECK(output.numel() <= std::numeric_limits<int32_t>::max(),
+        "upsample_nearest3d only supports output tensors with less than INT_MAX elements, but got ", output.sizes());
+   );
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Byte,input.scalar_type(), "upsample_nearest3d_out_frame", [&] {
@@ -254,8 +256,10 @@ static void upsample_nearest3d_backward_out_cuda_template(
       at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, MAX_THREADS)};
   dim3 gdim{ceil_div(n, bdim.x)};
   // safe check for int32 indexing; implicitly restrict launch config for kernel
-  TORCH_CHECK(grad_input.numel() <= std::numeric_limits<int32_t>::max());
-  TORCH_CHECK(grad_output.numel() <= std::numeric_limits<int32_t>::max());
+  TORCH_CHECK(grad_input.numel() <= std::numeric_limits<int32_t>::max(),
+    "upsample_nearest3d_backward only supports input tensors with less than INT_MAX elements, but got ", grad_input.sizes());
+  TORCH_CHECK(grad_output.numel() <= std::numeric_limits<int32_t>::max(),
+    "upsample_nearest3d_backward only supports output tensors with less than INT_MAX elements, but got ", grad_output.sizes());
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND3(ScalarType::Half, ScalarType::BFloat16, ScalarType::Byte, grad_output.scalar_type(), "upsample_nearest3d_backward_out_frame", [&] {


### PR DESCRIPTION
`Expected grad_output.numel() <= std::numeric_limits<int32_t>::max() to be true` is not very helpful, it's better to mention method name as well as actual tensor size

This error was reported in https://github.com/pytorch/pytorch/issues/131185
