### PR TITLE
[dynamo] Add a JK kill switch for disabling compile

### DIFF
--- a/test/dynamo/test_frame_init.py
+++ b/test/dynamo/test_frame_init.py
@@ -4,6 +4,8 @@ import torch
 import torch._dynamo.test_case
 from torch._guards import CompileId
 
+set_eval_frame = torch._C._dynamo.eval_frame.set_eval_frame  # noqa: F401
+
 
 def target_with_varkwargs(arg1, /, positional_only_arg, *, keyword_only_arg, **kwargs):
     local = 1
@@ -110,7 +112,7 @@ class FrameInitTests(torch._dynamo.test_case.TestCase):
             expected_kwargs_output = target_with_varkwargs(
                 1, 2, keyword_only_arg=1, name2=2, name3=3
             )
-            original = torch._dynamo.eval_frame.set_eval_frame(callback1)
+            original = set_eval_frame(callback1)
             real_varargs_output = target_with_varargs(
                 1, 2, 3, 4, name1=1, name2=2, name3=3
             )
@@ -119,7 +121,7 @@ class FrameInitTests(torch._dynamo.test_case.TestCase):
             )
             self.assertEqual(real_varargs_output, expected_varargs_output)
             self.assertEqual(real_kwargs_output, expected_kwargs_output)
-            torch._dynamo.eval_frame.set_eval_frame(original)
+            set_eval_frame(original)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: The JK disables dynamo by passing None to set_eval_frame.

Test Plan:
Ran buck test mode/opt caffe2/test/dynamo:test_dynamo

Buck UI: https://www.internalfb.com/buck2/1fec33b4-c95a-4bdf-b47b-7c0b8ab9e24a
Test UI: https://www.internalfb.com/intern/testinfra/testrun/2814750010105363
Network: Up: 0B  Down: 0B
Jobs completed: 9596. Time elapsed: 28:54.5s.
Tests finished: Pass 4796. Fail 0. Fatal 0. Skip 17. Build failure 0

Also manually write a small local test with torch.compile and toggles the code to see if PT2 can be disabled. Validated with running the test and observing the log.

PT2 enabled: P1486847242. Can see dynamo log about graph breaks.
PT2 disabled: P1486847727. No dynamo log. The newly added warning printed.

Reviewed By: ezyang

Differential Revision: D59968925




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames