### PR TITLE
[distributed] test_store: remove flaky bind test

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -277,20 +277,6 @@ class TCPStoreTest(TestCase, StoreTestBase):
             addr, world_size, wait_for_workers=False, use_libuv=self._use_libuv
         )
 
-    def test_invalid_port(self):
-        addr = DEFAULT_HOSTNAME
-        port = 1
-
-        err_msg_reg = f"^(The server socket has failed to listen on any local|The server socket has failed to bind).*{port}"
-        with self.assertRaisesRegex(RuntimeError, err_msg_reg):
-            # Use noqa to silence flake8.
-            # Need to store in an unused variable here to ensure the first
-            # object is not destroyed before the second object is created.
-            store1 = dist.TCPStore(
-                addr, port, 1, True, use_libuv=self._use_libuv
-            )  # noqa: F841
-            self.assertEqual(store1.libuvBackend, self._use_libuv)
-
     def test_address_already_in_use(self):
         addr = DEFAULT_HOSTNAME
         port = common.find_free_port()


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/131084

There's no good way to fix this since some tests environments can bind the protected range. Removing test since the value is relatively low since it's just testing error messages.

Test plan:

```
python test/distributed/test_store.py -v -k address
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o