### PR TITLE
[PTD][c10d] Include PG status into flight recorder

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -3562,13 +3562,21 @@ class NCCLTraceTestBase(MultiProcessTestCase):
 class NCCLTraceTest(NCCLTraceTestBase):
     def _verify_trace(self, t, include_collectives, timing_enabled, is_json):
         ver = t["version"]
-        self.assertEqual(ver, "2.2")
+        self.assertEqual(ver, "2.3")
         pg_config = t["pg_config"]
         self.assertEqual(len(pg_config), 1)
         default_pg_info = pg_config["0"]
         self.assertIn("name", default_pg_info)
         self.assertIn("desc", default_pg_info)
         self.assertIn("ranks", default_pg_info)
+        pg_status = t["pg_status"]
+        self.assertEqual(len(pg_status), 1)
+        self.assertEqual(str(pg_status["0"]["last_enqueued_collective"]), "2")
+        self.assertEqual(str(pg_status["0"]["last_completed_collective"]), "2")
+        self.assertEqual(
+            str(pg_status["0"]["last_started_collective"]),
+            "2" if timing_enabled else "-1",
+        )
         global_ranks = pg_config["0"]["ranks"]
         self.assertEqual(len(json.loads(global_ranks)), self.world_size)
         if include_collectives:

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -185,8 +185,9 @@ DEFINE_CONSTANT(version_key, "version");
 // (minor when adding fields, major when changing existing fields)
 // Also update both JSON and Pickle dumps to make use of the newly defined
 // field(s).
-DEFINE_CONSTANT(version_val, "2.2");
+DEFINE_CONSTANT(version_val, "2.3");
 DEFINE_CONSTANT(pg_config_key, "pg_config");
+DEFINE_CONSTANT(pg_status_key, "pg_status");
 DEFINE_CONSTANT(record_id_key, "record_id");
 DEFINE_CONSTANT(pg_id_key, "pg_id");
 DEFINE_CONSTANT(pg_name_key, "process_group");
@@ -644,6 +645,7 @@ struct NCCLTraceBuffer {
   size_t max_entries_ = 0;
   size_t next_ = 0;
   size_t id_ = 0;
+  std::map<size_t, std::shared_ptr<ProcessGroupStatus>> all_pg_status_ = {};
   std::map<std::tuple<std::string, std::string>, std::vector<uint64_t>>
       pg_name_to_ranks_ = {};
 
@@ -659,9 +661,14 @@ struct NCCLTraceBuffer {
       Event* start,
       Event* end,
       std::chrono::milliseconds timeout_ms,
+      std::shared_ptr<ProcessGroupStatus> pg_status,
       bool isP2P) {
     if (!enabled_) {
       return std::nullopt;
+    }
+    if (all_pg_status_.find(pg_id) == all_pg_status_.end()) {
+      // Current pg_status is not in FR.
+      all_pg_status_[pg_id] = pg_status;
     }
     auto traceback =
         torch::CapturedTraceback::gather(true, true, capture_cpp_stack_);
@@ -1014,6 +1021,35 @@ struct NCCLTraceBuffer {
     return result;
   }
 
+  // dump pg_status
+  const c10::Dict<c10::IValue, c10::IValue> getPgStatus() {
+    auto all_pg_status = new_dict();
+    for (const auto& [pg_id, status] : all_pg_status_) {
+      auto pg_status = new_dict();
+      pg_status.insert("last_enqueued_collective", status->lastEnqueuedSeq);
+      pg_status.insert("last_started_collective", status->lastStartedSeq);
+      pg_status.insert("last_completed_collective", status->lastCompletedSeq);
+      all_pg_status.insert(std::to_string(pg_id), pg_status);
+    }
+    return all_pg_status;
+  }
+
+  const std::map<std::string, std::map<std::string, std::string>>
+  getPgStatusJson() {
+    std::map<std::string, std::map<std::string, std::string>> result;
+    for (const auto& [pg_id, status] : all_pg_status_) {
+      auto pg_status = std::map<std::string, std::string>();
+      pg_status["last_enqueued_collective"] =
+          std::to_string(status->lastEnqueuedSeq);
+      pg_status["last_started_collective"] =
+          std::to_string(status->lastStartedSeq);
+      pg_status["last_completed_collective"] =
+          std::to_string(status->lastCompletedSeq);
+      result[std::to_string(pg_id)] = pg_status;
+    }
+    return result;
+  }
+
   std::string dump_json(
       const std::optional<std::unordered_map<
           std::string,
@@ -1023,6 +1059,7 @@ struct NCCLTraceBuffer {
     json result;
     result[version_key_str] = version_val_str;
     result[pg_config_key_str] = getPgConfigJson();
+    result[pg_status_key_str] = getPgStatusJson();
 
     // collective trace
     if (includeCollectives) {
@@ -1051,6 +1088,7 @@ struct NCCLTraceBuffer {
     // common values
     result.insert(version_key, version_val);
     result.insert(pg_config_key, getPgConfig());
+    result.insert(pg_status_key, getPgStatus());
 
     // collective trace
     if (includeCollectives) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1293,9 +1293,9 @@ void ProcessGroupNCCL::heartbeatMonitor() {
             "Received a dump signal from this local rank and will ",
             "start to dump the debug info. ",
             "Last enqueued NCCL work: ",
-            pgStatus_.lastEnqueuedSeq,
+            pgStatus_->lastEnqueuedSeq,
             ", last completed NCCL work: ",
-            pgStatus_.lastCompletedSeq,
+            pgStatus_->lastCompletedSeq,
             ".");
         exitMsg = c10::str(
             "ProcessGroupNCCL's watchdog detected an exception from the local rank. ",
@@ -1355,9 +1355,9 @@ void ProcessGroupNCCL::heartbeatMonitor() {
               timeOutRank,
               ", and will start to dump the debug info. ",
               "Last enqueued NCCL work: ",
-              pgStatus_.lastEnqueuedSeq,
+              pgStatus_->lastEnqueuedSeq,
               ", last completed NCCL work: ",
-              pgStatus_.lastCompletedSeq,
+              pgStatus_->lastCompletedSeq,
               ".");
           exitMsg = c10::str(
               "ProcessGroupNCCL's watchdog detected a dump signal from rank ",
@@ -1627,9 +1627,9 @@ void ProcessGroupNCCL::watchdogHandler() {
         logPrefix(),
         "NCCL Work update periodically: ",
         "last enqueued NCCL work: ",
-        pgStatus_.lastEnqueuedSeq,
+        pgStatus_->lastEnqueuedSeq,
         ", last completed NCCL work: ",
-        pgStatus_.lastCompletedSeq,
+        pgStatus_->lastCompletedSeq,
         ".");
 #endif
     auto logger = ::c10d::C10dLogger::getLogger();
@@ -1642,19 +1642,21 @@ void ProcessGroupNCCL::watchdogHandler() {
       data.integers["pg_id"] = uid_;
       data.integers["rank"] = rank_;
       data.integers["global_rank"] = globalRank();
-      data.integers["last_enqueued_work"] = pgStatus_.lastEnqueuedSeq;
-      data.integers["last_started_work"] = pgStatus_.lastStartedSeq;
-      data.integers["last_completed_work"] = pgStatus_.lastCompletedSeq;
-      data.integers["last_enqueued_numel_in"] = pgStatus_.lastEnqueuedNumelIn;
-      data.integers["last_enqueued_numel_out"] = pgStatus_.lastEnqueuedNumelOut;
-      data.integers["last_completed_numel_in"] = pgStatus_.lastCompletedNumelIn;
+      data.integers["last_enqueued_work"] = pgStatus_->lastEnqueuedSeq;
+      data.integers["last_started_work"] = pgStatus_->lastStartedSeq;
+      data.integers["last_completed_work"] = pgStatus_->lastCompletedSeq;
+      data.integers["last_enqueued_numel_in"] = pgStatus_->lastEnqueuedNumelIn;
+      data.integers["last_enqueued_numel_out"] =
+          pgStatus_->lastEnqueuedNumelOut;
+      data.integers["last_completed_numel_in"] =
+          pgStatus_->lastCompletedNumelIn;
       data.integers["last_completed_numel_out"] =
-          pgStatus_.lastCompletedNumelOut;
+          pgStatus_->lastCompletedNumelOut;
       // logging strings
-      data.strings["last_enqueued_work_name"] = pgStatus_.lastEnqueuedWorkName;
-      data.strings["last_started_work_name"] = pgStatus_.lastStartedWorkName;
+      data.strings["last_enqueued_work_name"] = pgStatus_->lastEnqueuedWorkName;
+      data.strings["last_started_work_name"] = pgStatus_->lastStartedWorkName;
       data.strings["last_completed_work_name"] =
-          pgStatus_.lastCompletedWorkName;
+          pgStatus_->lastCompletedWorkName;
       data.strings["pg_name"] = pg_name_;
       data.strings["pg_desc"] = pg_desc_;
       logger->log(data);
@@ -1681,9 +1683,9 @@ void ProcessGroupNCCL::watchdogHandler() {
             "Exception (either an error or timeout) detected by watchdog at work: ",
             work.seq_,
             ", last enqueued NCCL work: ",
-            pgStatus_.lastEnqueuedSeq,
+            pgStatus_->lastEnqueuedSeq,
             ", last completed NCCL work: ",
-            pgStatus_.lastCompletedSeq,
+            pgStatus_->lastCompletedSeq,
             ".");
         // try to dump flight records if exception happens.
         // Flight recorder behavior should be independent of desync Debug
@@ -1728,9 +1730,9 @@ void ProcessGroupNCCL::watchdogHandler() {
               "Timeout at NCCL work: ",
               work.seq_,
               ", last enqueued NCCL work: ",
-              pgStatus_.lastEnqueuedSeq,
+              pgStatus_->lastEnqueuedSeq,
               ", last completed NCCL work: ",
-              pgStatus_.lastCompletedSeq,
+              pgStatus_->lastCompletedSeq,
               ".");
           if (desyncDebug_) {
             try {
@@ -1767,18 +1769,18 @@ void ProcessGroupNCCL::watchdogHandler() {
       // a work could be started but not completed, so we should not update
       // lastStartedSeq and lastStartedOpName if the work state is checked
       // multiple times after the start
-      if (pgStatus_.lastStartedSeq < static_cast<int64_t>(work.seq_) &&
+      if (pgStatus_->lastStartedSeq < static_cast<int64_t>(work.seq_) &&
           work.isStarted()) {
-        pgStatus_.lastStartedSeq = work.seq_;
-        pgStatus_.lastStartedWorkName = opTypeToString(work.opType_);
+        pgStatus_->lastStartedSeq = work.seq_;
+        pgStatus_->lastStartedWorkName = opTypeToString(work.opType_);
       }
 
       // Clean up completed work
       if (work.isCompleted()) {
-        pgStatus_.lastCompletedSeq = work.seq_;
-        pgStatus_.lastCompletedWorkName = opTypeToString(work.opType_);
-        pgStatus_.lastCompletedNumelIn = work.numelIn_;
-        pgStatus_.lastCompletedNumelOut = work.numelOut_;
+        pgStatus_->lastCompletedSeq = work.seq_;
+        pgStatus_->lastCompletedWorkName = opTypeToString(work.opType_);
+        pgStatus_->lastCompletedNumelIn = work.numelIn_;
+        pgStatus_->lastCompletedNumelOut = work.numelOut_;
         NCCLTraceBuffer::get()->retire_id(work.trace_id_, true);
         if (onCompletionHook_) {
           // Move Work object to completedWorkList_ to be consumed by the hook
@@ -2376,6 +2378,7 @@ c10::intrusive_ptr<ProcessGroupNCCL::WorkNCCL> ProcessGroupNCCL::initWork(
         r->ncclStartEvent_.get(),
         r->ncclEndEvent_.get(),
         options_->timeout,
+        pgStatus_,
         isP2P);
   }
   return r;
@@ -2416,10 +2419,10 @@ void ProcessGroupNCCL::workEnqueue(
     // get deadlock. Here we enqueue work without outputs_.
     workMetaList_.emplace_back(*work);
     // update the PG status related to the last enqueued work
-    pgStatus_.lastEnqueuedSeq = work->seq_;
-    pgStatus_.lastEnqueuedWorkName = opTypeToString(work->opType_);
-    pgStatus_.lastEnqueuedNumelIn = work->numelIn_;
-    pgStatus_.lastEnqueuedNumelOut = work->numelOut_;
+    pgStatus_->lastEnqueuedSeq = work->seq_;
+    pgStatus_->lastEnqueuedWorkName = opTypeToString(work->opType_);
+    pgStatus_->lastEnqueuedNumelIn = work->numelIn_;
+    pgStatus_->lastEnqueuedNumelOut = work->numelOut_;
     lastWorkListUpdateTime_ = std::chrono::steady_clock::now();
   }
 }
@@ -2987,6 +2990,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
         nullptr,
         nullptr,
         options_->timeout,
+        pgStatus_,
         /*isP2P=*/true);
     // TODO(whc) if we want to make the per-p2p-op flightrecorder entries get
     // their timings/states updated by proxy when the Work obj representing the
@@ -3021,6 +3025,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
         work->ncclStartEvent_.get(),
         work->ncclEndEvent_.get(),
         options_->timeout,
+        pgStatus_,
         /*isP2P=*/true);
   }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -437,34 +437,6 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     std::string group_name;
   };
 
-  // A struct to hold the latest status of the process group.
-  struct ProcessGroupStatus {
-    // the sequential number of the last collective enqueued into workMetaList_
-    // This is useful for indentifying a rank that has not join a collective
-    // initialized to be -1 to indicate no collective has been enqueued
-    int64_t lastEnqueuedSeq{-1};
-    // the sequential number of the last collective started as the kernel
-    int64_t lastStartedSeq{-1};
-    // the sequential number of the last colletive completed marked by
-    // the watchdog thread
-    // initialized to be -1 to indicate no collective has been completed
-    int64_t lastCompletedSeq{-1};
-
-    // the name of the last collective enqueued into workMetaList_
-    std::string lastEnqueuedWorkName;
-    // the name of the last collective started as the kernel
-    std::string lastStartedWorkName;
-    // the name of the last collective completed
-    std::string lastCompletedWorkName;
-
-    // the sizes of the last work enqueued
-    size_t lastEnqueuedNumelIn;
-    size_t lastEnqueuedNumelOut;
-    // the sizes of the last work completed
-    size_t lastCompletedNumelIn;
-    size_t lastCompletedNumelOut;
-  };
-
   // If you wish to create multiple process groups, each with a potentially
   // different rank and size, you can do so by passing a new store instance
   // to each one. If you have only a single store object, you can
@@ -1111,7 +1083,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Number of devices on this node.
   int localDeviceCount_{0};
 
-  ProcessGroupStatus pgStatus_;
+  std::shared_ptr<ProcessGroupStatus> pgStatus_ =
+      std::make_shared<ProcessGroupStatus>();
 };
 
 // Dumps the NCCL comm traces and additional information about the Process

--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -19,6 +19,34 @@
 
 namespace c10d {
 
+// A struct to hold the latest status of the process group.
+struct ProcessGroupStatus {
+  // the sequential number of the last collective enqueued into workMetaList_
+  // This is useful for indentifying a rank that has not join a collective
+  // initialized to be -1 to indicate no collective has been enqueued
+  int64_t lastEnqueuedSeq{-1};
+  // the sequential number of the last collective started as the kernel
+  int64_t lastStartedSeq{-1};
+  // the sequential number of the last colletive completed marked by
+  // the watchdog thread
+  // initialized to be -1 to indicate no collective has been completed
+  int64_t lastCompletedSeq{-1};
+
+  // the name of the last collective enqueued into workMetaList_
+  std::string lastEnqueuedWorkName;
+  // the name of the last collective started as the kernel
+  std::string lastStartedWorkName;
+  // the name of the last collective completed
+  std::string lastCompletedWorkName;
+
+  // the sizes of the last work enqueued
+  size_t lastEnqueuedNumelIn;
+  size_t lastEnqueuedNumelOut;
+  // the sizes of the last work completed
+  size_t lastCompletedNumelIn;
+  size_t lastCompletedNumelOut;
+};
+
 inline std::string getTraceStartKey(const std::string& pgName, int rank) {
   return pgName + "_" + std::to_string(rank) + "_trace_start";
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131268

We are considering consolidating data source for logging and flight recorder so that we don't build multiple paths for debugging information. Before we do any merging, we want to first ensure that the PG status is also included in flight recorder. Also, we can leverage this information to validate our FR dump as well. Because the dump is not synced so we might potentially see some variants in the dump.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o