### PR TITLE
Fix IMAs in Flash-Attention splitkv kernel

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
@@ -479,12 +479,16 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
     std::tie(softmax_lse_accum, out_accum) = set_params_splitkv(params, batch_size, num_heads,
                         head_size, seqlen_k, seqlen_q,
                         head_size_rounded, p_dropout, /*num_splits*/0, dprops, opts);
-    params.softmax_lseaccum_ptr = softmax_lse_accum.data_ptr();
-    params.oaccum_ptr = out_accum.data_ptr();
+    if (softmax_lse_accum.defined()){
+       params.softmax_lseaccum_ptr = softmax_lse_accum.data_ptr();
+    }
+    if (out_accum.defined()){
+       params.oaccum_ptr = out_accum.data_ptr();
+    }
 
-    std::cout<<"softmax_lseaccum_ptr =" << softmax_lse_accum.data_ptr() << std::endl;
-    std::cout<<"oaccum_ptr =" << out_accum.data_ptr() << std::endl;
-    std::cout <<"softmax_lse_ptr = "<< params.softmax_lse_ptr << std::endl;
+    // std::cout<<"softmax_lseaccum_ptr =" << softmax_lse_accum.data_ptr() << std::endl;
+    // std::cout<<"oaccum_ptr =" << out_accum.data_ptr() << std::endl;
+    // std::cout <<"softmax_lse_ptr = "<< params.softmax_lse_ptr << std::endl;
 
     // Keep references to these tensors to extend their lifetime
     // params.softmax_lse_accum = softmax_lse_accum;
@@ -544,7 +548,7 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
         q_padded = q_padded.transpose(1, 2).reshape({batch_size, 1, num_heads_k * seqlen_q, head_size_og});
         softmax_lse = softmax_lse.reshape({batch_size, num_heads_k * seqlen_q, 1});
     }
-    
+
     softmax_lse = softmax_lse.slice(2, 0, seqlen_q);
     return {out, q_padded, k_padded, v_padded, softmax_lse, seed_t, offset_t, p};
 }

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
@@ -446,7 +446,8 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
 
     auto opts = q.options();
 
-    auto softmax_lse = at::empty({batch_size, num_heads, seqlen_q_rounded }, opts.dtype(at::kFloat));
+    auto softmax_lse = at::empty({batch_size, num_heads, seqlen_q }, opts.dtype(at::kFloat));
+
     at::Tensor p;
     // Only return softmax if there's dropout to reduce compilation time
     if (return_softmax) {
@@ -530,7 +531,6 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
         q_padded = q_padded.transpose(1, 2).reshape({batch_size, 1, num_heads_k * seqlen_q, head_size_og});
         softmax_lse = softmax_lse.reshape({batch_size, num_heads_k * seqlen_q, 1});
     }
-    softmax_lse = softmax_lse.slice(2, 0, seqlen_q);
     return {out, q_padded, k_padded, v_padded, softmax_lse, seed_t, offset_t, p};
 }
 

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
@@ -692,9 +692,11 @@ mha_varlen_fwd(const at::Tensor &q,  // total_q x num_heads x head_size, total_q
                      window_size_left,
                      window_size_right,
                      seqlenq_ngroups_swapped);
+    // Keep references to these tensors to extend their lifetime
+    at::Tensor softmax_lse_accum, out_accum;
     if (seqlenq_ngroups_swapped) {
         // Only apply split-k for decoding
-        set_params_splitkv(params, batch_size, num_heads,
+        std::tie(softmax_lse_accum, out_accum) = set_params_splitkv(params, batch_size, num_heads,
                            head_size, max_seqlen_k, max_seqlen_q,
                            head_size_rounded, p_dropout, /*num_splits*/0, dprops, opts);
     }
@@ -1447,7 +1449,9 @@ mha_fwd_kvcache(at::Tensor &q,                 // batch_size x seqlen_q x num_he
         params.cache_batch_idx = reinterpret_cast<int *>(cache_batch_idx.data_ptr());
     }
 
-    set_params_splitkv(params, batch_size, num_heads,
+    // Keep references to these tensors to extend their lifetime
+    at::Tensor softmax_lse_accum, out_accum;
+    std::tie(softmax_lse_accum, out_accum) = set_params_splitkv(params, batch_size, num_heads,
                        head_size, seqlen_k, seqlen_q,
                        head_size_rounded, /*dropout*/0.f, num_splits, dprops, opts);
 

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_api.cpp
@@ -447,7 +447,7 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
 
     auto opts = q.options();
 
-    auto softmax_lse = at::empty({batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));
+    auto softmax_lse = at::empty({batch_size, num_heads, seqlen_q_rounded }, opts.dtype(at::kFloat));
     at::Tensor p;
     // Only return softmax if there's dropout to reduce compilation time
     if (return_softmax) {
@@ -544,7 +544,8 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
         q_padded = q_padded.transpose(1, 2).reshape({batch_size, 1, num_heads_k * seqlen_q, head_size_og});
         softmax_lse = softmax_lse.reshape({batch_size, num_heads_k * seqlen_q, 1});
     }
-    cudaDeviceSynchronize();
+    
+    softmax_lse = softmax_lse.slice(2, 0, seqlen_q);
     return {out, q_padded, k_padded, v_padded, softmax_lse, seed_t, offset_t, p};
 }
 

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/flash_fwd_kernel.h
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/flash_fwd_kernel.h
@@ -1077,6 +1077,12 @@ inline __device__ void compute_attn_splitkv(const Params &params) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+template <typename T>
+constexpr T ceil_div(T numerator, T denominator) {
+    return (numerator + denominator - 1) / denominator;
+}
+
+
 template<typename Kernel_traits, int kBlockM, int Log_max_splits, bool Is_even_K, typename Params>
 inline __device__ void combine_attn_seqk_parallel(const Params &params) {
     using Element = typename Kernel_traits::Element;
@@ -1104,8 +1110,7 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
                                    make_stride(params.b * params.h * params.seqlen_q, _1{}));
     Tensor gLSE = make_tensor(make_gmem_ptr(reinterpret_cast<ElementAccum *>(params.softmax_lse_ptr) + row_offset_lse),
                               Shape<Int<kBlockM>>{}, Stride<_1>{});
-    constexpr int kNLsePerThread = (kMaxSplits * kBlockM + kNThreads - 1) / kNThreads;
-
+    constexpr int kNLsePerThread = ceil_div(kMaxSplits * kBlockM, kNThreads);
     // Read the LSE values from gmem and store them in shared memory, then tranpose them.
     constexpr int kRowsPerLoadLSE = kNThreads / kBlockM;
     #pragma unroll
@@ -1150,8 +1155,16 @@ inline __device__ void combine_attn_seqk_parallel(const Params &params) {
     // For the case where all local lse == -INFINITY, we want to set lse_logsum to INFINITY. Otherwise
     // lse_logsum is log(0.0) = -INFINITY and we get NaN when we do lse_accum(l) - lse_logsum.
     ElementAccum lse_logsum = (lse_sum == 0.f || lse_sum != lse_sum) ? INFINITY : logf(lse_sum) + lse_max;
-    // if (bidx == 0 && tidx < 32) { printf("tidx = %d, lse = %f, lse_max = %f, lse_logsum = %f\n", tidx, lse_accum(0), lse_max, lse_logsum); }
-    if (tidx % kRowsPerLoadTranspose == 0 && tidx / kRowsPerLoadTranspose < kBlockM) { gLSE(tidx / kRowsPerLoadTranspose) = lse_logsum; }
+    // Calculate the actual number of valid rows for this block
+    // This tid contains the final reduction of different K splits.
+    const bool group_leader = tidx % kRowsPerLoadTranspose == 0;
+    const int total_rows = params.b * params.h * params.seqlen_q;
+    const int rows_per_block = kBlockM;
+    const int global_row = bidx * rows_per_block + (tidx / kRowsPerLoadTranspose);
+    const bool valid_row = global_row < total_rows;
+    if (group_leader && valid_row) {
+      gLSE(tidx / kRowsPerLoadTranspose) = lse_logsum;
+    }
     // Store the scales exp(lse - lse_logsum) in shared memory.
     #pragma unroll
     for (int l = 0; l < kNLsePerThread; ++l) {

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -705,6 +705,9 @@ def meta__scaled_dot_product_flash(fake_mode, func, *args, **kwargs):
     def convert_tensor(t, device):
         return FakeTensor(fake_mode, t, device)
 
+    def round_multiple(x: int, m: int) -> int:
+        return ((x + m - 1) // m) * m
+
     batch_size = query.size(0)
     num_heads = query.size(1)
     max_seqlen_batch_q = query.size(2)
@@ -714,9 +717,10 @@ def meta__scaled_dot_product_flash(fake_mode, func, *args, **kwargs):
     query_t = query.transpose(1, 2)
     # empty_like already returns a fake tensor so we don't need to convert it
     attention = torch.empty_like(query_t).transpose(1, 2)
+    max_seq_len_batch_q_rounded = round_multiple(max_seqlen_batch_q, 128)
     logsumexp = convert_tensor(
         torch.empty(
-            (batch_size, num_heads, max_seqlen_batch_q),
+            (batch_size, num_heads, max_seq_len_batch_q_rounded),
             dtype=torch.float,
             device="meta",
         ),
@@ -749,6 +753,7 @@ def meta__scaled_dot_product_flash(fake_mode, func, *args, **kwargs):
     # are going to use cudagraphs or not, so we return meta tensors here
     # it's possible we'll need to have some special handling in inductor for sdpa
 
+    logsumexp = logsumexp[..., :max_seqlen_batch_q]
     return (
         attention,
         logsumexp,


### PR DESCRIPTION
# Summary

While debugging CI failures for flash_attention tests I stumbled across 2 IMAs for the split-kv variant of flash attention.
1. Illegal global memory writes during the writing of softmax_lse_accum. This was pinpointed to the temporary liftime of these out_accum and softmax_lse_accum. These were likely getting their refcount dropped **before** the kernel launch that used, them allowing them to potentially get used for other allocations.
2. After debugging this there was illegal writes of the combine kernel. I was able to pinpoint this to the writing to the reduce LSE. From my understanding it was making assumption that kBlocKM evenly divided the global number of rows and wasn't masking out these writes.


### History
My line of thinking for this: 

We create the temporary split accum + LSE stats tensors to store the data for each split. We then launch a follow up kernel to do the reduction.

Under ordinary non roofline memory usage the cuda memory caching allocator will keep these allocations alive even though the tensors were created within a temporary scope and no longer have any live references.

On CI we often run near max memory usage. We change/add tests and suddenly we get close to oom threshold. The memory allocator will reap these segments and we get write after free errors.

After that  fix I did get further past the splitkv_flash kernel and then got the following error:

``` Shell
❯ TORCH_DISABLE_ADDR2LINE=1 PYTORCH_NO_CUDA_MEMORY_CACHING=1  compute-sanitizer --show-backtrace=device --tool memcheck --log-file ima.txt python ima.py

softmax_lseaccum_ptr =0x7f5ebb208a00
oaccum_ptr =0x7f5ebb208c00
softmax_lse_ptr = 0x7f5ebb208800
❯ 
❯ head ima.txt -n 10
========= COMPUTE-SANITIZER
========= Invalid __global__ write of size 4 bytes
=========     at void pytorch_flash::flash_fwd_splitkv_combine_kernel<pytorch_flash::Flash_fwd_kernel_traits<(int)32, (int)64, (int)256, (int)4, (bool)0, (bool)0, cutlass::bfloat16_t, pytorch_flash::Flash_kernel_traits<(int)32, (int)64, (int)256, (int)4, cutlass::bfloat16_t>>, (int)16, (int)1, (bool)1>(pytorch_flash::Flash_fwd_params)+0x630
=========     by thread (2,0,0) in block (0,0,0)
=========     Address 0x7f5ebb208804 is out of bounds
=========     and is 1 bytes after the nearest allocation at 0x7f5ebb208800 of size 4 bytes
```

Okay I looked at the address and it looks like we are writing consective bytes past the softmax_lse_ptr in from the combine func: I tried padding out the softmax_lse to q_padded and no more illegal memory errors on my repro:
```
========= COMPUTE-SANITIZER
========= ERROR SUMMARY: 0 errors
```

Fixes https://github.com/pytorch/pytorch/issues/131240
Fixes https://github.com/pytorch/pytorch/issues/131227
Fixes https://github.com/pytorch/pytorch/issues/131221


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131277

