### PR TITLE
multiprocessing.spawn: allow a grace period when shutdown

### DIFF
--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -133,7 +133,8 @@ class ProcessContext:
         Args:
             timeout (float): Wait this long (in seconds) before giving up on waiting.
             grace_period (float): When any processes fail, wait this long (in seconds)
-                for others to shutdown gracefully before killing them.
+                for others to shutdown gracefully before terminating them. If they
+                still don't exit, wait another grace period before killing them.
         """
         # Ensure this function can be called even when we're done.
         if len(self.sentinels) == 0:

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -110,19 +110,28 @@ class ProcessContext:
     def pids(self):
         return [int(process.pid) for process in self.processes]
 
-    def join(self, timeout=None):
+    def _join_procs_with_timeout(self, timeout: float):
+        """Attempt to join all processes with a shared timeout."""
+        end = time.monotonic() + timeout
+        for process in self.processes:
+            time_to_wait = max(0, end - time.monotonic())
+            process.join(time_to_wait)
+
+    def join(self, timeout: float | None = None, grace_period: float | None = None):
         r"""Join one or more processes within spawn context.
 
         Attempt to join one or more processes in this spawn context.
         If one of them exited with a non-zero exit status, this function
-        kills the remaining processes and raises an exception with the cause
-        of the first process exiting.
+        kills the remaining processes (optionally with a grace period)
+        and raises an exception with the cause of the first process exiting.
 
         Returns ``True`` if all processes have been joined successfully,
         ``False`` if there are more processes that need to be joined.
 
         Args:
-            timeout (float): Wait this long before giving up on waiting.
+            timeout: Wait this long before giving up on waiting.
+            grace_period: When some processes fail, wait this long for others
+                to shutdown gracefully before killing them.
         """
         # Ensure this function can be called even when we're done.
         if len(self.sentinels) == 0:
@@ -148,21 +157,23 @@ class ProcessContext:
             # Return whether or not all processes have been joined.
             return len(self.sentinels) == 0
 
-        # Assume failure. Terminate processes that are still alive.
-        # Try SIGTERM then SIGKILL if the process isn't going down.
-        # The reason is related to python signal handling is limited
-        # to main thread and if that is in c/c++ land and stuck it won't
-        # to handle it. We have seen processes getting stuck not handling
-        # SIGTERM for the above reason.
-        timeout: int = 30
+        # First, allow a grace period for processes to shutdown themselves.
+        if grace_period is not None:
+            self._join_procs_with_timeout(grace_period)
+        # Then, terminate processes that are still alive. Try SIGTERM first.
         for process in self.processes:
             if process.is_alive():
                 log.warning("Terminating process %s via signal SIGTERM", process.pid)
                 process.terminate()
-        end = time.monotonic() + timeout
-        for process in self.processes:
-            time_to_wait = max(0, end - time.monotonic())
-            process.join(time_to_wait)
+
+        # Try SIGKILL if the process isn't going down after another grace_period.
+        # The reason is related to python signal handling is limited
+        # to main thread and if that is in c/c++ land and stuck it won't
+        # to handle it. We have seen processes getting stuck not handling
+        # SIGTERM for the above reason.
+        self._join_procs_with_timeout(
+            30 if grace_period is None else grace_period
+        )
         for process in self.processes:
             if process.is_alive():
                 log.warning(


### PR DESCRIPTION
When one process fails, others are immediately killed. This prevents other processes to do necessary cleanups, or dump debug information (in particular, the NCCL flight recorder).

This PR adds a grace period. Default behavior is unchanged.