### PR TITLE
Add `nvjitlink` to the list of loadable global deps

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -307,8 +307,9 @@ def _load_global_deps() -> None:
             "cuda_cupti": "libcupti.so.*[0-9]",
             "cufft": "libcufft.so.*[0-9]",
             "curand": "libcurand.so.*[0-9]",
-            "cusolver": "libcusolver.so.*[0-9]",
+            "nvjitlink": "libnvJitLink.so.*[0-9]",
             "cusparse": "libcusparse.so.*[0-9]",
+            "cusolver": "libcusolver.so.*[0-9]",
             "nccl": "libnccl.so.*[0-9]",
             "nvtx": "libnvToolsExt.so.*[0-9]",
         }


### PR DESCRIPTION
To fix the cusparse dependency resolution in CUDA-12.x, that has nvJitLink dependency:
```
$ ldd -r /usr/local/cuda-11.8/lib64/libcusparse.so.11.7.5.86 
	linux-vdso.so.1 (0x00007ffea6f51000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fb13306f000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fb133065000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fb13305f000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fb132f10000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fb132eeb000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fb132cf7000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fb143db7000)
$ ldd -r /usr/local/cuda-12.1/lib64/libcusparse.so.12.1.0.106 
	linux-vdso.so.1 (0x00007ffc41909000)
	libnvJitLink.so.12 => /usr/local/cuda-12.1/lib64/libnvJitLink.so.12 (0x00007f3916b38000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f3916aea000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f3916ae0000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f3916ada000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f391698b000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f3916964000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f3916772000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f3929a8c000)
```
Fixes #131284 