### PR TITLE
[aoti] use reshape instead of view for flattening tensors for the nan checker

### DIFF
--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -51,15 +51,13 @@ inline AtenTensorHandle new_tensor_handle(at::Tensor&& tensor) {
 inline void assert_inf_and_nan(
     const std::string& tensor_name,
     at::Tensor& check_tensor) {
-  auto flattened = check_tensor.reshape({-1});
-
-  for (int64_t i = 0; i < flattened.numel(); i++) {
-    auto value = flattened[i].item<float>();
-    if (std::isinf(value)) {
-      throw std::runtime_error("At least one INF in " + tensor_name);
-    } else if (std::isnan(value)) {
-      throw std::runtime_error("At least one NaN in " + tensor_name);
-    }
+  auto isnan_tensor = check_tensor.isnan();
+  if (isnan_tensor.any().item<bool>()) {
+    throw std::runtime_error("At least one NaN in " + tensor_name);
+  }
+  auto isinf_tensor = check_tensor.isinf();
+  if (isinf_tensor.any().item<bool>()) {
+    throw std::runtime_error("At least one INF in " + tensor_name);
   }
 }
 

--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -51,7 +51,7 @@ inline AtenTensorHandle new_tensor_handle(at::Tensor&& tensor) {
 inline void assert_inf_and_nan(
     const std::string& tensor_name,
     at::Tensor& check_tensor) {
-  auto flattened = check_tensor.view({-1});
+  auto flattened = check_tensor.reshape({-1});
 
   for (int64_t i = 0; i < flattened.numel(); i++) {
     auto value = flattened[i].item<float>();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131302

For some non-contiguous tensors, tensor.view would trigger the following
runtime error:

"RuntimeError: view size is not compatible with input tensor’s size and stride
(at least one dimension spans across two contiguous subspaces).
Use .reshape(…) instead"

So, let's use reshape instead.