### PR TITLE
[inductor pattern][cpu] add a new int8 woq mm pattern

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -2610,7 +2610,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
         class M(torch.nn.Module):
             def forward(self, x, weight, scales):
                 return (
-                    torch.matmul(x, weight.permute([1, 0]).to(dtype=x.dtype)) * scales
+                    torch.ops.aten.mm.default(x, weight.permute([1, 0]).to(dtype=x.dtype)) * scales
                 )
 
         mod = M().eval()

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -2619,7 +2619,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
         s_shape = 12
         x = torch.randn(x_shape, dtype=torch.bfloat16)
         w = torch.randint(-128, 127, w_shape, dtype=torch.int8)
-        s = torch.randn(s_shape, dtype=torch.float32)
+        s = torch.randn(s_shape, dtype=torch.bfloat16)
 
         def matcher_check_fn():
             self.assertEqual(counters["inductor"]["woq_matcher_count"], 1)

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -2610,7 +2610,10 @@ class TestPatternMatcher(TestPatternMatcherBase):
         class M(torch.nn.Module):
             def forward(self, x, weight, scales):
                 return (
-                    torch.ops.aten.mm.default(x, weight.permute([1, 0]).to(dtype=x.dtype)) * scales
+                    torch.ops.aten.mm.default(
+                        x, weight.permute([1, 0]).to(dtype=x.dtype)
+                    )
+                    * scales
                 )
 
         mod = M().eval()

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -55,7 +55,10 @@ def is_const_source(
     return (
         node.op == "get_attr"
         or (
-            node.target == torch.ops.aten.permute.default
+            # convert -> permute
+            next(iter(node.users.keys())).target
+            == torch.ops.prims.convert_element_type.default
+            and node.target == torch.ops.aten.permute.default
             and node.args[0].op == "get_attr"  # type: ignore[union-attr]
         )
         or (

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -55,11 +55,12 @@ def is_const_source(
     return (
         node.op == "get_attr"
         or (
-            # convert -> permute
-            next(iter(node.users.keys())).target
-            == torch.ops.prims.convert_element_type.default
-            and node.target == torch.ops.aten.permute.default
+            # const_arg -> convert -> permute
+            node.target == torch.ops.aten.permute.default
             and node.args[0].op == "get_attr"  # type: ignore[union-attr]
+            and node.users.keys()
+            and next(iter(node.users.keys())).target
+            == torch.ops.prims.convert_element_type.default
         )
         or (
             node.op == "placeholder"

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -55,7 +55,7 @@ def is_const_source(
     return (
         node.op == "get_attr"
         or (
-            # const_arg -> convert -> permute
+            # const_arg -> permute -> convert
             node.target == torch.ops.aten.permute.default
             and node.args[0].op == "get_attr"  # type: ignore[union-attr]
             and node.users.keys()

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1594,7 +1594,6 @@ def _register_quantization_lowerings():
 
 
 def _register_woq_lowerings():
-    print("enter _register_woq_lowerings")
     _register_woq_mm_int8_pattern1()
     _register_woq_mm_int8_pattern2()
     _register_woq_mm_int8_pattern3()

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1471,7 +1471,8 @@ def _register_woq_lowering(pattern, computation_woq, computation_reshape=None):
         scales = kwargs["scales"]
         counters["inductor"]["woq_matcher_count"] += 1
         counters["inductor"]["woq_matcher_nodes"] += len(match.nodes)
-        if scales.dtype == torch.float32:
+        scales_dtype = scales.dtype
+        if scales_dtype == torch.float32:
             scales = L[prims.convert_element_type.default](scales, torch.bfloat16)
         if computation_reshape:
             out_features = weight.get_size()[0]
@@ -1485,7 +1486,7 @@ def _register_woq_lowering(pattern, computation_woq, computation_reshape=None):
             func = L[computation_reshape](func2, out_shape)
         else:
             func = L[computation_woq](x, weight, scales)
-        if scales.dtype == torch.float32:
+        if scales_dtype == torch.float32:
             func = L[prims.convert_element_type.default](func, torch.float32)
         return func
 


### PR DESCRIPTION
Add int8 woq mm pattern for llama, which successfully hits all the 675 woq linears.

### Implementation
Differences with previous patterns:
- scale is fp32 instead of bf16.
- no reshape for x and output.

### Performance
Performance data on llama, with 1 numa node, freezing mode:
- Before pattern match:
---------- Summary: ----------
inference-latency: 4.810 sec.
first-token-latency: 0.280 sec.
rest-token-latency: 0.146 sec.
P90-rest-token-latency: 0.148 sec.

- After pattern match:
---------- Summary: ----------
inference-latency: 2.537 sec.
first-token-latency: 0.964 sec.
rest-token-latency: 0.051 sec.
P90-rest-token-latency: 0.052 sec.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov