### PR TITLE
[FSDP2] Removed state dict error for HSDP

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -324,6 +324,7 @@ test_inductor_distributed() {
   python test/run_test.py -i distributed/_composable/fsdp/test_fully_shard_training.py -k test_train_parity_hsdp --verbose
   python test/run_test.py -i distributed/_composable/fsdp/test_fully_shard_training.py -k test_train_parity_2d_transformer_checkpoint_resume --verbose
   python test/run_test.py -i distributed/_composable/fsdp/test_fully_shard_training.py -k test_gradient_accumulation --verbose
+  python test/run_test.py -i distributed/_composable/fsdp/test_fully_shard_state_dict.py -k test_dp_state_dict_save_load --verbose
   python test/run_test.py -i distributed/_composable/fsdp/test_fully_shard_frozen.py --verbose
   python test/run_test.py -i distributed/_composable/fsdp/test_fully_shard_mixed_precision.py -k test_compute_dtype --verbose
   python test/run_test.py -i distributed/_composable/fsdp/test_fully_shard_mixed_precision.py -k test_reduce_dtype --verbose

--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -32,13 +32,21 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
         return min(4, torch.cuda.device_count())
 
     @skip_if_lt_x_gpu(2)
-    def test_1d_state_dict_save_load(self):
+    def test_dp_state_dict_save_load(self):
+        fsdp_mesh = init_device_mesh("cuda", (self.world_size,))
         self.run_subtests(
-            {"mlp_dim": [2, 3, 4, 5]},
-            self._test_1d_state_dict_save_load,
+            {"mlp_dim": [2, 3, 4, 5], "mesh": [fsdp_mesh]},
+            self._test_dp_state_dict_save_load,
+        )
+        if self.world_size % 2 != 0:
+            return
+        hsdp_mesh = init_device_mesh("cuda", (self.world_size // 2, 2))
+        self.run_subtests(
+            {"mlp_dim": [2, 3, 4, 5], "mesh": [hsdp_mesh]},
+            self._test_dp_state_dict_save_load,
         )
 
-    def _test_1d_state_dict_save_load(self, mlp_dim: int):
+    def _test_dp_state_dict_save_load(self, mlp_dim: int, mesh: DeviceMesh):
         torch.manual_seed(42)
         base_model = nn.Sequential(
             MLP(mlp_dim),
@@ -48,15 +56,15 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
         # Check basic `reshard_after_forward=True`
         model1 = copy.deepcopy(base_model)
         for module in model1:
-            fully_shard(module)
-        fully_shard(model1)
+            fully_shard(module, mesh=mesh)
+        fully_shard(model1, mesh=mesh)
         self._test_state_dict_save_load(model1)
 
         # Check `reshard_after_forward=False` before and after a forward
         model2 = copy.deepcopy(base_model)
         for module in model2:
-            fully_shard(module, reshard_after_forward=False)
-        fully_shard(model2, reshard_after_forward=False)
+            fully_shard(module, mesh=mesh, reshard_after_forward=False)
+        fully_shard(model2, mesh=mesh, reshard_after_forward=False)
         self._test_state_dict_save_load(model2)
         ref_sharded_sd = model2.state_dict()
         inp = torch.randn((2, mlp_dim), device="cuda")
@@ -68,7 +76,7 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
             self.assertEqual(value, sharded_sd[key])
 
     @skip_if_lt_x_gpu(2)
-    def test_1d_state_dict_cpu_offload(self):
+    def test_dp_state_dict_cpu_offload(self):
         mlp_dim = 4
         offload_policy = CPUOffloadPolicy(pin_memory=True)
         torch.manual_seed(42)
@@ -106,17 +114,17 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
     # Temporarily disable 2D state dict test, while strided sharding is being devleoped.
     # TODO: re-enable this test once 2d state_dict is ready.
     @skip_if_lt_x_gpu(2)
-    def _temp_disable_test_2d_state_dict_save_load(self):
+    def _temp_disable_test_dp_tp_state_dict_save_load(self):
         dp_size = 2
         global_mesh = init_device_mesh(
             "cuda", (dp_size, self.world_size // dp_size), mesh_dim_names=("dp", "tp")
         )
         self.run_subtests(
             {"mlp_dim": [2, 3, 4, 5]},
-            functools.partial(self._test_2d_state_dict_save_load, global_mesh),
+            functools.partial(self._test_dp_tp_state_dict_save_load, global_mesh),
         )
 
-    def _test_2d_state_dict_save_load(self, global_mesh: DeviceMesh, mlp_dim: int):
+    def _test_dp_tp_state_dict_save_load(self, global_mesh: DeviceMesh, mlp_dim: int):
         dp_mesh, tp_mesh = global_mesh["dp"], global_mesh["tp"]
         torch.manual_seed(42)
         model = nn.Sequential(*[MLP(mlp_dim) for _ in range(3)])

--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -270,20 +270,17 @@ class FSDPParam:
             name_dims_error = "FSDP requires named DeviceMesh dims for ND parallelism"
             assert dp_mesh.mesh_dim_names is not None, name_dims_error
             assert tp_mesh.mesh_dim_names is not None, name_dims_error
-
             submesh_names = dp_mesh.mesh_dim_names + tp_mesh.mesh_dim_names
             self._spmd_mesh = dp_global_mesh[submesh_names]
             if len(self._tp_spec.placements) != 1:
                 raise NotImplementedError(
                     f"FSDP only supports 1D TP, not {self._tp_spec.placements}"
                 )
-
             # TODO: Hard code FSDP + TP; need to support HSDP + TP
             self._spmd_placements: Tuple[Placement, ...] = (
                 Shard(0),
                 self._tp_spec.placements[0],
             )
-
             self._sharding_spec = DTensorSpec(
                 self._spmd_mesh,
                 self._spmd_placements,

--- a/torch/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -175,7 +175,7 @@ class FSDPParamGroup:
         modules_with_2d_params: Set[nn.Module] = set()
         for fsdp_param in self.fsdp_params:
             module = fsdp_param._module_info.module
-            if len(fsdp_param._spmd_placements) > 1:
+            if len(fsdp_param._spmd_placements) > 1 and hasattr(fsdp_param, "_tp_spec"):
                 modules_with_2d_params.add(module)
         for module in modules_with_2d_params:
             module.register_state_dict_pre_hook(_raise_not_implemented_if_2d)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131320

Fixes https://github.com/pytorch/torchtitan/issues/441#issuecomment-2241288906.

This PR avoids raising the 2D state dict error for HSDP, which does not depend on strided sharding.

cc @XilunWu @H-Huang @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o