### PR TITLE
[export] Filter errors by exception type, add case name

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -89,12 +89,13 @@ class BackendCompilerFailed(TorchDynamoException):
 
 
 class Unsupported(TorchDynamoException):
-    def __init__(self, msg):
+    def __init__(self, msg, *, case_name=None):
         super().__init__(msg)
         self.real_stack = torch._guards.TracingContext.extract_stack()
         self.msg = msg
         self.category: Optional[str] = None
         self.add_to_stats()
+        self.case_name: Optional[str] = case_name
 
     def remove_from_stats(self):
         assert self.category is not None
@@ -217,11 +218,13 @@ def unimplemented_with_warning(e: Exception, code, msg: str) -> NoReturn:
 _NOTHING = object()
 
 
-def unimplemented(msg: str, *, from_exc: Any = _NOTHING) -> NoReturn:
+def unimplemented(
+    msg: str, *, from_exc: Any = _NOTHING, case_name: Optional[str] = None
+) -> NoReturn:
     assert msg != os.environ.get("BREAK", False)
     if from_exc is not _NOTHING:
-        raise Unsupported(msg) from from_exc
-    raise Unsupported(msg)
+        raise Unsupported(msg, case_name=case_name) from from_exc
+    raise Unsupported(msg, case_name=case_name)
 
 
 def warning(msg: str) -> None:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2151,7 +2151,8 @@ def wrap_fx_proxy_cls(
     else:
         unimplemented(
             "torch.* op returned non-Tensor "
-            + f"{typestr(example_value)} {proxy.node.op} {proxy.node.target}"
+            + f"{typestr(example_value)} {proxy.node.op} {proxy.node.target}",
+            case_name="unsupported_operator",
         )
 
 

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -982,6 +982,20 @@ _EXPORT_FLAGS: Optional[Set[str]] = None
 _EXPORT_MODULE_HIERARCHY: Optional[Dict[str, str]] = None
 
 
+_ALLOW_LIST = {
+    torch._dynamo.exc.Unsupported,
+    torch._dynamo.exc.UserError,
+    torch._dynamo.exc.TorchRuntimeError,
+}
+
+
+def _get_class_if_classified_error(e):
+    case_name = getattr(e, "case_name", None)
+    if type(e) in _ALLOW_LIST and case_name is not None:
+        return case_name
+    return None
+
+
 def _log_export_wrapper(fn):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
@@ -999,12 +1013,23 @@ def _log_export_wrapper(fn):
         except Exception as e:
             t = type(e)
             error_type = t.__module__ + "." + t.__qualname__
-            log_export_usage(
-                event="export.error",
-                type=error_type,
-                message=str(e),
-                flags=_EXPORT_FLAGS,
-            )
+            case_name = _get_class_if_classified_error(e)
+            if case_name is not None:
+                # TODO (shangdiy): detect whether case_name is really registered in exportdb after we set up exportdb registration.
+                log.error("See %s in exportdb for unsupported case.", case_name)
+                log_export_usage(
+                    event="export.error.classified",
+                    type=error_type,
+                    message=str(e),
+                    flags=_EXPORT_FLAGS,
+                )
+            else:
+                log_export_usage(
+                    event="export.error.unclassified",
+                    type=error_type,
+                    message=str(e),
+                    flags=_EXPORT_FLAGS,
+                )
             raise e
         finally:
             _EXPORT_FLAGS = None


### PR DESCRIPTION
Summary:
-  Log export errors to Scuba and mark them with "classified" and "unclassified"
- Classify errors by exception type (ALLOW_LIST) and a `case_name` attribute
- Add `case_name` for some exceptions.

Test Plan:
Running the code below logs a classified error to `torch_export_usage` table in Scuba.

```
import torch

from torch._export.db.case import SupportLevel

class TorchSymMin(torch.nn.Module):
    """
    torch.sym_min operator is not supported in export.
    """

    def forward(self, x):
        return x.sum() + torch.sym_min(x.size(0), 100)

example_args = (torch.randn(3, 2),)
tags = {"torch.operator"}
support_level = SupportLevel.NOT_SUPPORTED_YET
model = TorchSymMin()

torch.export.export(model, example_args)
``

Differential Revision: D59981459


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames