### PR TITLE
[PT2] Minor fix in signpost

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -488,7 +488,7 @@ class ConvertFrameAssert:
             {
                 "co_name": code.co_name,
                 "frame_id": frame_id,
-                "compile_id": compile_id,
+                "compile_id": str(compile_id),
                 "co_filename": code.co_filename,
                 "co_firstlineno": code.co_firstlineno,
                 "cache_size": cache_size.num_cache_entries_with_same_id_matched_objs,


### PR DESCRIPTION
Summary: compile_id is a named Tuple. We want to log signposts.

Test Plan:
Run e2e job.
Confirm this shows up correctly.
{F1767320364}

Differential Revision: D60045020


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames