### PR TITLE
Add path used by pip's build isolation procedure to DLL search

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -154,7 +154,7 @@ if sys.platform == "win32":
         pfiles_path = os.getenv("ProgramFiles", r"C:\Program Files")
         py_dll_path = os.path.join(sys.exec_prefix, "Library", "bin")
         th_dll_path = os.path.join(os.path.dirname(__file__), "lib")
-        usebase_path = os.path.join(
+        userbase_path = os.path.join(
             sysconfig.get_config_var("userbase"), "Library", "bin"
         )
 
@@ -167,9 +167,16 @@ if sys.platform == "win32":
         else:
             base_py_dll_path = ""
 
+        # when using pip install on a project that depends on PyTorch, pip installs
+        # torch & mkl in a custom path that's included in sys.path but does not match
+        # any of the other DLLs path above, so we need to manually add it here.
+        mkl_dll_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "Library", "bin"
+        )
+
         dll_paths = [
             p
-            for p in (th_dll_path, py_dll_path, base_py_dll_path, usebase_path)
+            for p in (th_dll_path, py_dll_path, base_py_dll_path, userbase_path, mkl_dll_path)
             if os.path.exists(p)
         ]
 


### PR DESCRIPTION
Without this, trying to `import torch` in a downstream `setup.py` file would result in

```
The specified module could not be found. Error loading "C:\...\pip-build-env-himl3xh3\normal\Lib\site-packages\torch\lib\shm.dll" or one of its dependencies."
```

This seems to be because pip does not use a full virtualenv for build isolation, instead creating directories and manually adding them to `sys.path`. The same issue does not seem to apply when using `python -m build`.

---

To reproduce, you can create a directory with two files:

```toml
# pyproject.toml
[project]
name = "windows-torch-mkl-pip"
version = "0.0.0"

[build-system]
requires = [
    "setuptools",
    "torch"
]
```


```py
# setup.py
from setuptools import setup

import torch


setup()
```

Then, trying to build a wheel with `pip install .` will give some output similar to:

```
Installing collected packages: tbb, mpmath, intel-openmp, typing-extensions, sympy, numpy, networkx, mkl, MarkupSafe, fsspec, filelock, jinja2, torch
      Creating C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-himl3xh3\normal\Scripts
    Successfully installed MarkupSafe-2.1.5 filelock-3.14.0 fsspec-2024.6.0 intel-openmp-2021.4.0 jinja2-3.1.4 mkl-2021.4.0 mpmath-1.3.0 networkx-3.3 numpy-1.26.4 sympy-1.12.1 tbb-2021.12.0 torch-2.3.1+cpu typing-extensions-4.12.2
    Created temporary directory: C:\Users\runneradmin\AppData\Local\Temp\pip-modern-metadata-ascqww5w
    Preparing metadata (pyproject.toml): started
    Running command Preparing metadata (pyproject.toml)
    Traceback (most recent call last):
      File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-7yztij8w\cp312-win_amd64\build\venv\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
        main()
      File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-7yztij8w\cp312-win_amd64\build\venv\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-7yztij8w\cp312-win_amd64\build\venv\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 149, in prepare_metadata_for_build_wheel
        return hook(metadata_directory, config_settings)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-himl3xh3\overlay\Lib\site-packages\setuptools\build_meta.py", line 366, in prepare_metadata_for_build_wheel
        self.run_setup()
      File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-himl3xh3\overlay\Lib\site-packages\setuptools\build_meta.py", line 311, in run_setup
        exec(code, locals())
      File "<string>", line 295, in <module>
      File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-himl3xh3\normal\Lib\site-packages\torch\__init__.py", line 143, in <module>
        raise err
    OSError: [WinError 126] The specified module could not be found. Error loading "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-himl3xh3\normal\Lib\site-packages\torch\lib\shm.dll" or one of its dependencies.
    error: subprocess-exited-with-error
    
    Preparing metadata (pyproject.toml) did not run successfully.
    exit code: 1
    
    See above for output.
```

Torch is properly installed in `C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-himl3xh3\normal\Lib\site-packages\torch\` and all the mkl libraries are in `C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-himl3xh3\normal\Library\bin`, but this directory is not covered by existing DLL paths.

---

This is similar to #125109, and the fix is similar to #125684. Ping @atalman and @malfet since you fixed & reviewed the previous similar fix.

cc @malfet @seemethere @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht @iremyux @Blackhex @cristianPanaite