### PR TITLE
Revert D59561509: Multisect successfully blamed "D59561509: [FX][export] DCE pass, check schema for node impurity (#130395)" for one test failure

### DIFF
--- a/test/fx/test_dce_pass.py
+++ b/test/fx/test_dce_pass.py
@@ -12,9 +12,11 @@ class TestDCE(TestCase):
     def _custom_is_impure_node(self, node: torch.fx.Node) -> bool:
         if node.is_impure():
             return True
-        # a custom function that defines add operators as impure.
-        if node.target == torch.ops.aten.add:
-            return True
+
+        if node.op == "call_function":
+            schema = getattr(node.target, "_schema", None)
+            schema_mutable = schema is not None and schema.is_mutable
+            return schema_mutable
         return False
 
     def _has_nodes_without_users(self, m: torch.fx.GraphModule, custom: bool = False):
@@ -203,7 +205,7 @@ class TestDCE(TestCase):
                 return a * 2
 
         # %add_ node should not be removed because it has side effects.
-        self._run_dce_and_test(TestModule(), expect_dce_changes=False)
+        self._run_dce_and_test(TestModule(), expect_dce_changes=False, custom=True)
 
     def test_impure_kwargs(self):
         """
@@ -214,20 +216,6 @@ class TestDCE(TestCase):
             def forward(self, a: torch.Tensor) -> torch.Tensor:
                 b = a + 1
                 torch._ops.ops.aten.add.out(b, b, out=a, alpha=2)
-                return a
-
-        # %add_out node should not be removed because it has side effects.
-        self._run_dce_and_test(TestModule(), expect_dce_changes=False)
-
-    def test_impure_custom(self):
-        """
-        Test that DCE doesn't remove nodes marked as impure by a custom function.
-        """
-
-        class TestModule(torch.nn.Module):
-            def forward(self, a: torch.Tensor) -> torch.Tensor:
-                b = a + 1
-                c = torch._ops.ops.aten.add(b, b)
                 return a
 
         # %add_out node should not be removed because it has side effects.

--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -15,6 +15,20 @@ from .graph_signature import (
 )
 
 
+def _is_impure_node(node: torch.fx.Node) -> bool:
+    """
+    Check the schema of node target to detect side-effectful nodes.
+    """
+    if node.is_impure():
+        return True
+
+    if node.op == "call_function":
+        schema = getattr(node.target, "_schema", None)
+        schema_mutable = schema is not None and schema.is_mutable
+        return schema_mutable
+    return False
+
+
 def _remove_effect_tokens_from_graph_helper(
     ep, num_tokens, input_token_names, output_token_names
 ):
@@ -114,7 +128,7 @@ def _remove_effect_tokens_from_graph_helper(
         assert inp_token.name in input_token_names
         ep.graph.erase_node(inp_token)
 
-    ep.graph.eliminate_dead_code()
+    ep.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
 
 
 def _remove_effect_tokens(ep: ExportedProgram) -> ExportedProgram:

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -48,6 +48,7 @@ from torch._guards import detect_fake_mode
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._utils_internal import log_export_usage
+from torch.export._remove_effect_tokens_pass import _is_impure_node
 from torch.export.dynamic_shapes import _combine_args
 from torch.export.exported_program import OutputKind
 from torch.fx._utils import first_call_function_nn_module_stack
@@ -1368,7 +1369,7 @@ def _export_to_aten_ir_make_fx(
                 record_module_stack=True,
                 pre_dispatch=True,
             )(*flat_args)
-            gm.graph.eliminate_dead_code()
+            gm.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
 
         return gm, None
 

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -8,7 +8,8 @@ import torch.utils._pytree as pytree
 from torch._export.utils import _check_input_constraints_for_graph
 from torch.export.unflatten import _assign_attr, _AttrKind
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
-from ._remove_effect_tokens_pass import _remove_effect_tokens
+
+from ._remove_effect_tokens_pass import _is_impure_node, _remove_effect_tokens
 
 from .exported_program import (
     ExportedProgram,
@@ -184,7 +185,7 @@ def _unlift(
     )
     gm.graph._codegen = _get_codegen(in_spec, out_spec, forward_arg_names)
     gm.graph.lint()
-    gm.graph.eliminate_dead_code()
+    gm.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
     gm.recompile()
     return gm
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -47,6 +47,9 @@ _side_effectful_functions: Set[Callable] = {
     torch._assert_async,
     _ops.aten._assert_async.msg,
     _ops.aten._assert_scalar.default,
+    _ops.aten.copy_.default,
+    _ops.aten.set_.source_Tensor,
+    _ops.aten.index_put_.default,
     _ops.aten.sym_constrain_range.default,
     _ops.aten.sym_constrain_range_for_size.default,
     _ops.profiler._record_function_enter,
@@ -645,11 +648,9 @@ class Node(_NodeBase):
         if self.op in {"placeholder", "output"}:
             return True
 
-        # Check if an impure function based on schema.
+        # Check if an impure function.
         if self.op == "call_function":
-            schema = getattr(self.target, "_schema", None)
-            schema_mutable = schema is not None and schema.is_mutable
-            return schema_mutable or self.target in _side_effectful_functions
+            return self.target in _side_effectful_functions
 
         # Check if an impure module.
         if self.op == "call_module":


### PR DESCRIPTION
Summary:
This diff reverts D59561509
D59561509: [FX][export] DCE pass, check schema for node impurity (#130395) by yushangdi causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_mtia_cmf_m5_shrunk_test#test_flow_with_verification](https://www.internalfb.com/intern/test/844425041436985/)

Here's the Multisect link:
https://www.internalfb.com/multisect/6533402
Here are the tasks that are relevant to this breakage:
T191383430: 10+ tests unhealthy for ads_mtia_inference

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Test Plan: NA

Differential Revision: D60029318
