### PR TITLE
[tp] improve SequenceParallel and its documentation

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -435,9 +435,6 @@ class TensorParallelStyleTest(DTensorTestBase):
             self.assertEqual(sp_rmsnorm.weight.grad.placements, (_Partial(),))
             # communication happens in both fwd/bwd to redistribute input
             self.assertEqual(comm_mode.get_total_counts(), 2)
-            self.assertEqual(
-                comm_mode.get_comm_counts()[torch.ops._dtensor.shard_dim_alltoall], 2
-            )
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -420,6 +420,25 @@ class TensorParallelStyleTest(DTensorTestBase):
             self.assertEqual(sharded_out.placements, (Shard(1),))
             self.assertEqual(comm_mode.get_total_counts(), 0)
 
+        # test sharded on non-sequence dim input
+        sharded_batch_input = distribute_tensor(global_input, mesh, [Shard(0)])
+        rmsnorm = RMSNormPython(embedding_dim).to(self.device_type)
+        sp_rmsnorm = parallelize_module(deepcopy(rmsnorm), mesh, SequenceParallel())
+
+        with comm_mode:
+            sharded_out = sp_rmsnorm(sharded_batch_input)
+            grad_out = torch.ones_like(sharded_out)
+            sharded_out.backward(grad_out)
+            self.assertIsInstance(sharded_out, DTensor)
+            # output still sharded on sequence dimension
+            self.assertEqual(sharded_out.placements, (Shard(1),))
+            self.assertEqual(sp_rmsnorm.weight.grad.placements, (_Partial(),))
+            # communication happens in both fwd/bwd to redistribute input
+            self.assertEqual(comm_mode.get_total_counts(), 2)
+            self.assertEqual(
+                comm_mode.get_comm_counts()[torch.ops._dtensor.shard_dim_alltoall], 2
+            )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -287,10 +287,10 @@ class SequenceParallel(ParallelStyle):
     This style implements the operation that is described in the paper
     `Reducing Activation Recomputation in Large Transformer Models <https://arxiv.org/abs/2205.05198>`__
 
-    If the input passed in to this ``nn.Module`` is a :class:`torch.Tensor`, it assumes the input already sharded on the
-    sequence dimension and convert the input to a :class:`DTensor` sharded on the sequence dimension. If input passed in
-    to this ``nn.Module`` is already a :class:`DTensor` but not sharded on the sequence dimension, it would redistribute
-    the input to be sharded on the sequence dimension.
+    If the input passed in to this ``nn.Module`` is a :class:`torch.Tensor`, it assumes that the input is already sharded
+    on the sequence dimension and converts the input to a :class:`DTensor` sharded on the sequence dimension. If the input
+    passed in to this ``nn.Module`` is already a :class:`DTensor` but is not sharded on the sequence dimension, it would
+    redistribute the input to be sharded on the sequence dimension.
 
     The output of the ``nn.Module`` will be sharded on the sequence dimension.
 

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -287,10 +287,10 @@ class SequenceParallel(ParallelStyle):
     This style implements the operation that is described in the paper
     `Reducing Activation Recomputation in Large Transformer Models <https://arxiv.org/abs/2205.05198>`__
 
-    If input passed in to this ``nn.Module`` is a :class:`torch.Tensor`, it assumes the input already sharded on the
-    sequence dimension and convert the input to a :class:`DTensor` sharded on the sequence dimension. If input passed
-    in to this ``nn.Module`` is already a :class:`DTensor` but not sharded on the sequence dimension, it would redistribute
-    the input to sharded on the sequence dimension.
+    If the input passed in to this ``nn.Module`` is a :class:`torch.Tensor`, it assumes the input already sharded on the
+    sequence dimension and convert the input to a :class:`DTensor` sharded on the sequence dimension. If input passed in
+    to this ``nn.Module`` is already a :class:`DTensor` but not sharded on the sequence dimension, it would redistribute
+    the input to be sharded on the sequence dimension.
 
     Keyword Args:
         sequence_dim (int, optional):

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -292,6 +292,8 @@ class SequenceParallel(ParallelStyle):
     to this ``nn.Module`` is already a :class:`DTensor` but not sharded on the sequence dimension, it would redistribute
     the input to be sharded on the sequence dimension.
 
+    The output of the ``nn.Module`` will be sharded on the sequence dimension.
+
     Keyword Args:
         sequence_dim (int, optional):
             The sequence dimension of the input tensor for the ``nn.Module``, this is used to annotate the input tensor to

--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -287,7 +287,10 @@ class SequenceParallel(ParallelStyle):
     This style implements the operation that is described in the paper
     `Reducing Activation Recomputation in Large Transformer Models <https://arxiv.org/abs/2205.05198>`__
 
-    Both the input and output of the ``nn.Module`` will be sharded on the sequence dimension.
+    If input passed in to this ``nn.Module`` is a :class:`torch.Tensor`, it assumes the input already sharded on the
+    sequence dimension and convert the input to a :class:`DTensor` sharded on the sequence dimension. If input passed
+    in to this ``nn.Module`` is already a :class:`DTensor` but not sharded on the sequence dimension, it would redistribute
+    the input to sharded on the sequence dimension.
 
     Keyword Args:
         sequence_dim (int, optional):
@@ -320,7 +323,7 @@ class SequenceParallel(ParallelStyle):
 
     def __init__(self, *, sequence_dim: int = 1, use_local_output: bool = False):
         super().__init__()
-        self.sequence_dim = sequence_dim
+        self.sequence_sharding = (Shard(sequence_dim),)
         self.use_local_output = use_local_output
 
     def _replicate_module_fn(
@@ -335,13 +338,19 @@ class SequenceParallel(ParallelStyle):
             module.register_parameter(p_name, replicated_param)
 
     @staticmethod
-    def _prepare_input_fn(sequence_dim, mod, inputs, device_mesh):
+    def _prepare_input_fn(sequence_sharding, mod, inputs, device_mesh):
         input_tensor = inputs[0]
         if isinstance(input_tensor, DTensor):
-            return inputs
+            # if the passed in input DTensor is not sharded on the sequence dim, we need to redistribute it
+            if input_tensor.placements != sequence_sharding:
+                input_tensor = input_tensor.redistribute(
+                    placements=sequence_sharding, async_op=True
+                )
+            return input_tensor
         elif isinstance(input_tensor, torch.Tensor):
+            # assume the input passed in already sharded on the sequence dim and create the DTensor
             return DTensor.from_local(
-                input_tensor, device_mesh, [Shard(sequence_dim)], run_check=False
+                input_tensor, device_mesh, sequence_sharding, run_check=False
             )
         else:
             raise ValueError(
@@ -357,7 +366,7 @@ class SequenceParallel(ParallelStyle):
             module,
             device_mesh,
             self._replicate_module_fn,
-            partial(self._prepare_input_fn, self.sequence_dim),
+            partial(self._prepare_input_fn, self.sequence_sharding),
             partial(self._prepare_output_fn, self.use_local_output),
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131346

SequenceParallel style assumes the input torch.Tensor ALREADY sharded on
the sequence dimension if not passing in DTensor. Since it causes some
user confusion on the documentation, this PR:

1. for the case where input passed in is already a DTensor, we check the
   input placements and redistribute if it's not sharded on the sequence
dimension
2. update the doc to make it more explicit about the case when user
   passed in a torch.Tensor and DTensor

This would fix https://github.com/pytorch/pytorch/issues/129355

cc @XilunWu @H-Huang @awgu @kwen2501 @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o