### PR TITLE
[aoti] forward fix of D60006838, add back test_multiple_output_alias (#131331)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3144,6 +3144,8 @@ CPU_TEST_FAILURES = {
     "test_reuse_kernel_dynamic": fail_minimal_arrayref_interface(is_skip=True),
     # the test segfaults
     "test_repeat_output": fail_stack_allocation(is_skip=True),
+    # TODO: failed internally
+    "test_multiple_output_alias": fail_with_and_without_stack_allocation(is_skip=True),
     # segfault
     "test_buffer_mutation_1": fail_stack_allocation(is_skip=True),
     # segfault


### PR DESCRIPTION
Summary:

Forward fix of D60006838.

The unit test test_multiple_output_alias passed in OSS CI, but failing internally. So adding it back to skip list.

Test Plan: ci

Differential Revision: D60044926


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang