### PR TITLE
[BE] remove unnecessary _dispatch_sqrt by using ** 0.5

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -9,7 +9,6 @@ from .optimizer import (
     _default_to_fused_or_foreach,
     _differentiable_doc,
     _disable_dynamo_if_unsupported,
-    _dispatch_sqrt,
     _foreach_doc,
     _fused_doc,
     _get_capturable_supported_devices,
@@ -421,7 +420,7 @@ def _single_tensor_adam(
 
             step_size = lr / bias_correction1
 
-            bias_correction2_sqrt = _dispatch_sqrt(bias_correction2)
+            bias_correction2_sqrt = bias_correction2**0.5
 
             if amsgrad:
                 # Maintains the maximum of all 2nd moment running avg. till now
@@ -592,7 +591,7 @@ def _multi_tensor_adam(
 
             step_size = _stack_if_compiling([(lr / bc) * -1 for bc in bias_correction1])
 
-            bias_correction2_sqrt = [_dispatch_sqrt(bc) for bc in bias_correction2]  # type: ignore[arg-type]
+            bias_correction2_sqrt = [bc**0.5 for bc in bias_correction2]  # type: ignore[arg-type]
 
             if amsgrad:
                 # Maintains the maximum of all 2nd moment running avg. till now

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -9,7 +9,6 @@ from .optimizer import (
     _default_to_fused_or_foreach,
     _differentiable_doc,
     _disable_dynamo_if_unsupported,
-    _dispatch_sqrt,
     _foreach_doc,
     _fused_doc,
     _get_capturable_supported_devices,
@@ -422,7 +421,7 @@ def _single_tensor_adamw(
 
             step_size = lr / bias_correction1
 
-            bias_correction2_sqrt = _dispatch_sqrt(bias_correction2)
+            bias_correction2_sqrt = bias_correction2**0.5
 
             if amsgrad:
                 # Maintains the maximum of all 2nd moment running avg. till now
@@ -589,7 +588,7 @@ def _multi_tensor_adamw(
             step_size = _stack_if_compiling([(lr / bc) * -1 for bc in bias_correction1])
 
             bias_correction2_sqrt = [
-                _dispatch_sqrt(bc) for bc in bias_correction2  # type: ignore[arg-type]
+                bc**0.5 for bc in bias_correction2  # type: ignore[arg-type]
             ]
 
             if amsgrad:

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -9,7 +9,6 @@ from .optimizer import (
     _default_to_fused_or_foreach,
     _differentiable_doc,
     _disable_dynamo_if_unsupported,
-    _dispatch_sqrt,
     _foreach_doc,
     _get_capturable_supported_devices,
     _get_scalar_dtype,
@@ -486,8 +485,7 @@ def _multi_tensor_nadam(
             torch._foreach_sqrt_(bias_correction_sqrt)
         else:
             bias_correction_sqrt = [
-                _dispatch_sqrt(1 - beta2 ** _get_value(step))
-                for step in grouped_state_steps
+                (1 - beta2 ** _get_value(step)) ** 0.5 for step in grouped_state_steps
             ]
             mus = [
                 beta1 * (1.0 - 0.5 * (0.96 ** (_get_value(step) * momentum_decay)))

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 """Base optimizer."""
 import functools
-import math
 import warnings
 from collections import defaultdict, OrderedDict
 from copy import deepcopy
@@ -110,15 +109,6 @@ def _stack_if_compiling(x):
         return torch.stack(x)
     else:
         return x
-
-
-def _dispatch_sqrt(
-    x: float,
-):  # float annotation is needed because of torchscript type inference
-    if not torch.jit.is_scripting() and isinstance(x, torch.Tensor):
-        return x.sqrt()
-    else:
-        return math.sqrt(x)
 
 
 def _disable_dynamo_if_unsupported(single_tensor_fn=None):

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -10,7 +10,6 @@ from .optimizer import (
     _default_to_fused_or_foreach,
     _differentiable_doc,
     _disable_dynamo_if_unsupported,
-    _dispatch_sqrt,
     _foreach_doc,
     _get_capturable_supported_devices,
     _get_scalar_dtype,
@@ -502,12 +501,13 @@ def _multi_tensor_radam(
             del bias_correction1
         else:
             rect = [
-                _dispatch_sqrt(
+                (
                     (rho_t - 4)  # type: ignore[arg-type]
                     * (rho_t - 2)
                     * rho_inf
                     / ((rho_inf - 4) * (rho_inf - 2) * rho_t)
                 )
+                ** 0.5
                 if rho_t > 5
                 else 0
                 for rho_t in rho_t_list
@@ -521,7 +521,7 @@ def _multi_tensor_radam(
                 (lr * rect / bc) * -1 for rect, bc in zip(unrectified, bias_correction1)
             ]
             bias_correction2 = [
-                _dispatch_sqrt(1 - beta2 ** _get_value(step)) * (lr * rect / bc) * -1
+                ((1 - beta2 ** _get_value(step)) ** 0.5) * (lr * rect / bc) * -1
                 for step, rect, bc in zip(grouped_state_steps, rect, bias_correction1)
             ]
 


### PR DESCRIPTION
Based on the discussion here where ** 0.5 is not slower than math.sqrt. https://github.com/pytorch/pytorch/pull/129905#discussion_r1675605075

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131358

