### PR TITLE
AutoHeuristic: A100 Heuristic for mixed_mm

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -277,12 +277,12 @@ class TestPatternMatcher(TestCase):
 
     @unittest.skipIf(not SM80OrLater, "need sm_80")
     @unittest.skipIf(not IS_A100, "heuristic only run on Linux A100")
-    @inductor_config.patch(mixed_mm_choice="heuristic")
+    @inductor_config.patch(mixed_mm_choice="heuristic", autoheuristic_use="")
     def test_mixed_mm_heuristic_no(self):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))
 
-        # examples that should not be selected by heuristic
+        # examples that should not be selected by handwritten heuristic
         mat1_dtype = torch.float16
         dyn_tensor = torch.randn(4, 4096, dtype=mat1_dtype, device="cuda")
         torch._dynamo.mark_dynamic(dyn_tensor, 0)
@@ -336,7 +336,7 @@ class TestPatternMatcher(TestCase):
             return torch.mm(a, b.to(a.dtype))
 
         mat1_dtype = torch.float16
-        # examples that should be selected by heuristic
+        # examples that should be selected by handwritten heuristic
         args_list = [
             (
                 torch.randn(1, 4096, dtype=mat1_dtype, device="cuda"),

--- a/torch/_inductor/autoheuristic/artifacts/_MixedMMA100.py
+++ b/torch/_inductor/autoheuristic/artifacts/_MixedMMA100.py
@@ -1,0 +1,240 @@
+# flake8: noqa: B950
+from typing import List, Optional, Tuple
+
+from torch._inductor.autoheuristic.autoheuristic_utils import (
+    AHContext,
+    AHMetadata,
+    Choice,
+)
+from torch._inductor.autoheuristic.learnedheuristic_interface import (
+    LearnedHeuristicDecision,
+)
+
+
+class MixedMMA100(LearnedHeuristicDecision):
+    def __init__(self) -> None:
+        self.choices: List[Choice] = []
+        self.fill_choices()
+
+    def check_precondition(
+        self,
+        metadata: AHMetadata,
+        context: AHContext,
+    ) -> bool:
+        return (
+            metadata.name == self.get_name()
+            and metadata.shared_memory == 166912
+            and str(metadata.device_capa) == "(8, 0)"
+        )
+
+    def get_confidence_threshold(self) -> float:
+        return 0.0
+
+    def get_choice(self, idx: int) -> Optional[str]:
+        if idx < len(self.choices):
+            return self.choices[idx]
+        return None
+
+    def fill_choices(self) -> None:
+        self.choices.append("extern_fallback_mixed_mm")
+        self.choices.append(
+            "type=triton_BLOCK-M=128_BLOCK-K=32_BLOCK-N=128_numstages=3_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=128_BLOCK-K=64_BLOCK-N=128_numstages=3_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=16_BLOCK-K=128_BLOCK-N=128_numstages=4_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=16_BLOCK-K=128_BLOCK-N=32_numstages=2_numwarps=2"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=16_BLOCK-K=128_BLOCK-N=32_numstages=5_numwarps=2"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=16_BLOCK-K=128_BLOCK-N=64_numstages=5_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=16_BLOCK-K=256_BLOCK-N=128_numstages=3_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=16_BLOCK-K=256_BLOCK-N=128_numstages=5_numwarps=8"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=16_BLOCK-K=64_BLOCK-N=128_numstages=5_numwarps=8"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=16_BLOCK-K=64_BLOCK-N=64_numstages=3_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=32_BLOCK-K=128_BLOCK-N=128_numstages=4_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=32_BLOCK-K=128_BLOCK-N=32_numstages=2_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=32_BLOCK-K=128_BLOCK-N=32_numstages=5_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=64_BLOCK-K=128_BLOCK-N=128_numstages=4_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=64_BLOCK-K=128_BLOCK-N=32_numstages=5_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=64_BLOCK-K=128_BLOCK-N=64_numstages=5_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=64_BLOCK-K=32_BLOCK-N=128_numstages=3_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=64_BLOCK-K=32_BLOCK-N=128_numstages=4_numwarps=8"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=64_BLOCK-K=32_BLOCK-N=64_numstages=3_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=64_BLOCK-K=64_BLOCK-N=128_numstages=3_numwarps=4"
+        )
+        self.choices.append(
+            "type=triton_BLOCK-M=64_BLOCK-K=64_BLOCK-N=128_numstages=5_numwarps=8"
+        )
+
+    def get_name(self) -> str:
+        return "mixed_mm"
+
+    def get_best_choices(self, context: AHContext) -> Optional[List[Tuple[float, int]]]:
+        if str(context.get_value("1LEQmLEQ16")) != "True":
+            if context.get_value("m") <= 32.5:
+                if context.get_value("n") <= 6976.0:
+                    if context.get_value("n") <= 3520.0:
+                        if context.get_value("m*n") <= 37632.0:
+                            return None
+                        else:
+                            return [(1.000, 13)]
+                    else:
+                        if context.get_value("m*k") <= 452352.0:
+                            return [(0.590, 13), (0.256, 8), (0.103, 7), (0.051, 11)]
+                        else:
+                            return [(0.778, 8), (0.222, 13)]
+                else:
+                    if context.get_value("k*n") <= 102776832.0:
+                        if context.get_value("n") <= 14656.0:
+                            return [(1.000, 11)]
+                        else:
+                            return [(0.889, 11), (0.111, 13)]
+                    else:
+                        return [(1.000, 11)]
+            else:
+                if context.get_value("m*n") <= 446464.0:
+                    if context.get_value("m*n") <= 223424.0:
+                        if context.get_value("mat1_stride_0") <= 3968.0:
+                            return None
+                        else:
+                            return None
+                    else:
+                        if context.get_value("m*n") <= 346112.0:
+                            return [(0.960, 16), (0.040, 7)]
+                        else:
+                            return [(0.750, 16), (0.136, 14), (0.114, 7)]
+                else:
+                    if str(context.get_value("33LEQmLEQ64")) != "True":
+                        if context.get_value("n") <= 6976.0:
+                            return [(1.000, 14)]
+                        else:
+                            return [
+                                (0.753, 2),
+                                (0.222, 1),
+                                (0.015, 7),
+                                (0.007, 16),
+                                (0.004, 12),
+                            ]
+                    else:
+                        if context.get_value("n") <= 13888.0:
+                            return [(0.710, 14), (0.275, 21), (0.014, 12)]
+                        else:
+                            return [
+                                (0.374, 19),
+                                (0.339, 20),
+                                (0.106, 21),
+                                (0.101, 16),
+                                (0.066, 17),
+                                (0.009, 14),
+                                (0.004, 18),
+                            ]
+        else:
+            if context.get_value("n") <= 3520.0:
+                if context.get_value("arith_intensity") <= 3.994754433631897:
+                    if str(context.get_value("mat2_dtype")) != "torch.uint8":
+                        if context.get_value("m*k") <= 18944.0:
+                            return [(0.577, 5), (0.423, 6)]
+                        else:
+                            return [(0.988, 5), (0.012, 6)]
+                    else:
+                        if context.get_value("arith_intensity") <= 2.9899919033050537:
+                            return None
+                        else:
+                            return None
+                else:
+                    if context.get_value("arith_intensity") <= 7.956453561782837:
+                        if context.get_value("k*n") <= 9244032.0:
+                            return [(0.822, 5), (0.178, 6)]
+                        else:
+                            return [(0.977, 5), (0.023, 0)]
+                    else:
+                        if context.get_value("m*k") <= 978944.0:
+                            return [(1.000, 5)]
+                        else:
+                            return [(0.971, 5), (0.029, 0)]
+            else:
+                if context.get_value("n") <= 13632.0:
+                    if context.get_value("n") <= 6976.0:
+                        return [(1.000, 6)]
+                    else:
+                        if context.get_value("k") <= 3968.0:
+                            return [
+                                (0.617, 3),
+                                (0.111, 5),
+                                (0.099, 7),
+                                (0.086, 9),
+                                (0.062, 6),
+                                (0.025, 8),
+                            ]
+                        else:
+                            return [
+                                (0.779, 8),
+                                (0.119, 5),
+                                (0.053, 7),
+                                (0.035, 6),
+                                (0.013, 3),
+                            ]
+                else:
+                    if context.get_value("k*n") <= 39518208.0:
+                        return [
+                            (0.385, 4),
+                            (0.327, 3),
+                            (0.192, 6),
+                            (0.038, 7),
+                            (0.038, 10),
+                            (0.019, 5),
+                        ]
+                    else:
+                        if context.get_value("n") <= 20800.0:
+                            return [
+                                (0.821, 6),
+                                (0.121, 7),
+                                (0.029, 4),
+                                (0.014, 5),
+                                (0.007, 3),
+                                (0.007, 8),
+                            ]
+                        else:
+                            return [
+                                (0.530, 7),
+                                (0.386, 6),
+                                (0.046, 8),
+                                (0.021, 3),
+                                (0.015, 4),
+                                (0.002, 5),
+                            ]

--- a/torch/_inductor/autoheuristic/artifacts/_PadMMA100.py
+++ b/torch/_inductor/autoheuristic/artifacts/_PadMMA100.py
@@ -6,10 +6,12 @@ from torch._inductor.autoheuristic.autoheuristic_utils import (
     Choice,
     CHOICE_COL,
 )
-from torch._inductor.autoheuristic.learnedheuristic_interface import LearnedHeuristic
+from torch._inductor.autoheuristic.learnedheuristic_interface import (
+    LearnedHeuristicRegression,
+)
 
 
-class PadMMA100(LearnedHeuristic):
+class PadMMA100(LearnedHeuristicRegression):
     def __init__(self) -> None:
         pass
 
@@ -28,7 +30,7 @@ class PadMMA100(LearnedHeuristic):
         context.context_dict[CHOICE_COL] = choice
         return self.predict(context)
 
-    def get_speedup_threshold(self) -> float:
+    def get_confidence_threshold(self) -> float:
         return 1.7025303314066
 
     def get_name(self) -> str:

--- a/torch/_inductor/autoheuristic/autoheuristic_utils.py
+++ b/torch/_inductor/autoheuristic/autoheuristic_utils.py
@@ -110,6 +110,12 @@ class AHMetadata:
         }
 
 
+def get_metadata_str_from_log(log_path: str) -> str:
+    with open(log_path, newline="") as file:
+        json_string = file.readline().strip()
+        return json_string
+
+
 def check_minsize(context: AHContext, minsize: int) -> bool:
     return (
         context.get_value("m") >= minsize
@@ -128,10 +134,33 @@ def pad_mm_precondition(metadata: AHMetadata, context: AHContext) -> bool:
     return True
 
 
-def pad_mm_operations() -> List[AHOperation]:
+def get_mixedmm_precondition(metadata: AHMetadata, context: AHContext) -> bool:
+    m = context.get_value("m")
+    k = context.get_value("k")
+    n = context.get_value("n")
+    if m > 128 or k < 1024 or n < 1024:
+        return False
+    mat1_iscontig = context.get_value("mat1_iscontig")
+    mat2_iscontig = context.get_value("mat2_iscontig")
+    return mat1_iscontig and not mat2_iscontig
+
+
+def get_mult_dims_ops() -> List[AHOperation]:
     m_times_k_op = AHOperation("m*k", lambda data: data["m"] * data["k"])
     m_times_n_op = AHOperation("m*n", lambda data: data["m"] * data["n"])
     k_times_n_op = AHOperation("k*n", lambda data: data["k"] * data["n"])
+    return [m_times_k_op, m_times_n_op, k_times_n_op]
+
+
+def get_arith_intensity(data: Any) -> float:
+    m = data["m"]
+    k = data["k"]
+    n = data["n"]
+    return m * k * n / (m * k + k * n + m * n)
+
+
+def pad_mm_operations() -> List[AHOperation]:
+    mult_dims_ops = get_mult_dims_ops()
     k_div_m_times_n_op = AHOperation(
         "k/(m*n)", lambda data: data["k"] / (data["m"] * data["n"])
     )
@@ -147,21 +176,12 @@ def pad_mm_operations() -> List[AHOperation]:
         "bfloat_perf_hit", bfloat_perf_hit, is_categorical=True
     )
 
-    def get_arith_intensity(data: Any) -> float:
-        m = data["m"]
-        k = data["k"]
-        n = data["n"]
-        return m * k * n / (m * k + k * n + m * n)
-
     arith_intensity_op = AHOperation("arith_intensity", get_arith_intensity)
     dims_need_padding_ops = get_dims_need_padding_ops()
     dims_multiple_ops = get_dims_multiple_ops()
     is_contig_ops = get_is_contig_ops()
 
-    ah_operations = [
-        m_times_k_op,
-        m_times_n_op,
-        k_times_n_op,
+    ah_operations = mult_dims_ops + [
         k_div_m_times_n_op,
         bfloat_perf_hit_op,
         arith_intensity_op,
@@ -170,6 +190,37 @@ def pad_mm_operations() -> List[AHOperation]:
     ah_operations.extend(dims_multiple_ops)
     ah_operations.extend(is_contig_ops)
     return ah_operations
+
+
+def between_op(data: Any, dim: str, lower: int, upper: int) -> bool:
+    return data[dim] >= lower and data[dim] <= upper
+
+
+def between_ops() -> List[AHOperation]:
+    dims = ["m", "k", "n"]
+    limits = [(1, 16), (17, 32), (33, 64), (65, 128), (129, 256)]
+    ah_operations = []
+    for dim in dims:
+        for lower, upper in limits:
+            between_op_fn = functools.partial(
+                between_op, dim=dim, lower=lower, upper=upper
+            )
+            # using 'LEQ' instead of '<=' because '<=' cannot be exported to dot
+            between_op_name = f"{lower}LEQ{dim}LEQ{upper}"
+            ah_operations.append(
+                AHOperation(between_op_name, between_op_fn, is_categorical=True)
+            )
+    return ah_operations
+
+
+def pow2_op(data: Any, dim: str, exponent: int) -> bool:
+    return data[dim] == 2**exponent
+
+
+def mixed_mm_operations() -> List[AHOperation]:
+    mult_dims_ops = get_mult_dims_ops()
+    arith_intensity_op = AHOperation("arith_intensity", get_arith_intensity)
+    return mult_dims_ops + [arith_intensity_op] + between_ops()
 
 
 def is_multiple(data: Any, dim: str, mult: int) -> bool:

--- a/torch/_inductor/autoheuristic/learnedheuristic_interface.py
+++ b/torch/_inductor/autoheuristic/learnedheuristic_interface.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from torch._inductor.autoheuristic.autoheuristic_utils import (
     AHContext,
@@ -25,6 +25,25 @@ class LearnedHeuristic:
     def get_decision(
         self, context: AHContext, choices: List[Choice]
     ) -> Optional[Choice]:
+        return None
+
+    def get_confidence_threshold(self) -> float:
+        return 1.0
+
+    def get_name(self) -> str:
+        return ""
+
+
+class LearnedHeuristicRegression(LearnedHeuristic):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def get_feedback(self, context: AHContext, choice: Choice) -> float:
+        return 1.0
+
+    def get_decision(
+        self, context: AHContext, choices: List[Choice]
+    ) -> Optional[Choice]:
         choice2feedback = {}
         for choice in choices:
             predicted_feedback = self.get_feedback(context, choice)
@@ -32,16 +51,29 @@ class LearnedHeuristic:
         sorted_choices_feedback = sorted(choice2feedback.items(), key=lambda t: t[1])
         highest_feedback = sorted_choices_feedback[-1][1]
         second_highest_feedback = sorted_choices_feedback[-2][1]
-        if highest_feedback / second_highest_feedback > self.get_speedup_threshold():
+        if highest_feedback / second_highest_feedback > self.get_confidence_threshold():
             return sorted_choices_feedback[-1][0]
         # We are not sure which choice is the best one
         return None
 
-    def get_feedback(self, context: AHContext, choice: Choice) -> float:
-        return 1.0
 
-    def get_speedup_threshold(self) -> float:
-        return 1.0
+class LearnedHeuristicDecision(LearnedHeuristic):
+    def __init__(self) -> None:
+        super().__init__()
 
-    def get_name(self) -> str:
-        return ""
+    def get_choice(self, idx: int) -> Optional[str]:
+        return None
+
+    def get_decision(
+        self, context: AHContext, choices: List[Choice]
+    ) -> Optional[Choice]:
+        best_choices = self.get_best_choices(context)
+        if not best_choices:
+            return None
+        (best_choice_proba, best_choice_idx) = best_choices[0]
+        if best_choice_proba <= self.get_confidence_threshold():
+            return None
+        return self.get_choice(best_choice_idx)
+
+    def get_best_choices(self, context: AHContext) -> Optional[List[Tuple[float, int]]]:
+        return []

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -328,7 +328,7 @@ coordinate_descent_search_radius = int(
 # Specify a list of comma separated optimizations to collect data for
 autoheuristic_collect = os.environ.get("TORCHINDUCTOR_AUTOHEURISTIC_COLLECT", "")
 # Specify a list of comma separated optimizations to use learned heuristics for
-autoheuristic_use = os.environ.get("TORCHINDUCTOR_AUTOHEURISTIC_USE", "")
+autoheuristic_use = os.environ.get("TORCHINDUCTOR_AUTOHEURISTIC_USE", "mixed_mm")
 
 
 def run_autoheuristic(name):

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -8,6 +8,8 @@ from torch._inductor.autoheuristic.autoheuristic import AutoHeuristicSelectAlgor
 from torch._inductor.autoheuristic.autoheuristic_utils import (
     AHContext,
     context_add_strides,
+    get_mixedmm_precondition,
+    mixed_mm_operations,
 )
 from torch._inductor.codegen.cpp_gemm_template import CppPackedGemmTemplate
 from torch._inductor.virtualized import V
@@ -495,6 +497,8 @@ def mixed_mm_autoheuristic(mat1, mat2, m, n, k, choices, name, input_nodes):
         input_nodes=input_nodes,
         context=context,
         name=name,
+        augment_context=mixed_mm_operations(),
+        precondition=get_mixedmm_precondition,
     )
     return autoheuristic.get_choice_caller()
 
@@ -571,7 +575,11 @@ def tuned_mixed_mm(mat1, mat2, mat2_dtype):
     input_nodes = [mat1, mat2]
     if torch._inductor.config.run_autoheuristic(name):
         choice = mixed_mm_autoheuristic(mat1, mat2, m, n, k, choices, name, input_nodes)
-        if choice is not None:
+        if (
+            not skip_triton
+            and inductor_config.mixed_mm_choice == "heuristic"
+            and choice is not None
+        ):
             choices.insert(0, choice)
     return autotune_select_algorithm(name, choices, input_nodes, layout)
 

--- a/torchgen/autoheuristic/mixed_mm/gen_mixedmm_heuristic_a100.sh
+++ b/torchgen/autoheuristic/mixed_mm/gen_mixedmm_heuristic_a100.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+data="mixedmm_a100_data.txt"
+
+python train_decision_mixedmm.py ${data} --heuristic-name MixedMMA100

--- a/torchgen/autoheuristic/mixed_mm/get_mixedmm_dataset.sh
+++ b/torchgen/autoheuristic/mixed_mm/get_mixedmm_dataset.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+a100_data='https://github.com/AlnisM/autoheuristic-datasets/raw/main/mixedmm_a100_data.zip'
+wget ${a100_data}
+unzip mixedmm_a100_data.zip
+rm mixedmm_a100_data.zip

--- a/torchgen/autoheuristic/mixed_mm/train_decision_mixedmm.py
+++ b/torchgen/autoheuristic/mixed_mm/train_decision_mixedmm.py
@@ -1,0 +1,56 @@
+# mypy: ignore-errors
+import os
+import sys
+
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from train_decision import AHTrainDecisionTree
+
+from torch._inductor.autoheuristic.autoheuristic_utils import mixed_mm_operations
+
+
+class AHTrainDecisionTreeMixedMM(AHTrainDecisionTree):
+    def __init__(self):
+        super().__init__()
+
+    def add_new_features(self, results):
+        ops = mixed_mm_operations()
+        added_categorical_features = []
+        for op in ops:
+            results[op.name] = results.apply(op.func, axis=1)
+            if op.is_categorical:
+                added_categorical_features.append(op.name)
+        return (results, added_categorical_features)
+
+    def get_default_config(self, row):
+        return "extern_fallback_mixed_mm"
+
+    def get_allowed_wrong_prediction_pct(self):
+        # it is okay to have wrong predictions
+        # we introduce uncertainty by marking leaves as unsafe instead
+        return 1.0
+
+    def get_test_and_val_size(self):
+        return (0.01, 0.19)
+
+    def is_unsafe_leaf(self, row, predicted_config, choice2time):
+        if predicted_config not in choice2time:
+            # heuristic always returns "unsure" in such a case
+            return False
+        predicted_time = choice2time[predicted_config]
+        fallback_time = choice2time[self.get_default_config(row)]
+        # we mark leaves as unsafe if there is a chance our choice will be 5% slower than fallback
+        # we are okay with making the wrong choice, as long as our choice is better than fallback because
+        # fallback is the default when max_autotune is false
+        return 1.05 * fallback_time < predicted_time
+
+    def get_grid_search_values(self):
+        # A lot of different hyperparameters perform very similar on mixed_mm
+        # it is kind of hard to automatically pick one so I just manually picked one with a small max_depth
+        return {"max_depth": [5], "min_samples_leaf": [0.01], "criterion": ["entropy"]}
+
+
+if __name__ == "__main__":
+    train = AHTrainDecisionTreeMixedMM()
+    train.generate_heuristic()

--- a/torchgen/autoheuristic/pad_mm/gen_pad_mm_a100.sh
+++ b/torchgen/autoheuristic/pad_mm/gen_pad_mm_a100.sh
@@ -2,4 +2,4 @@
 
 data="pad_mm_a100_data.txt"
 
-python train_pad_mm.py ${data} --heuristic-name PadMMA100
+python train_regression_pad_mm.py ${data} --heuristic-name PadMMA100

--- a/torchgen/autoheuristic/pad_mm/gen_pad_mm_h100.sh
+++ b/torchgen/autoheuristic/pad_mm/gen_pad_mm_h100.sh
@@ -2,4 +2,4 @@
 
 data="pad_mm_h100_data.txt"
 
-python train_pad_mm.py ${data} --heuristic-name PadMMH100
+python train_regression_pad_mm.py ${data} --heuristic-name PadMMH100

--- a/torchgen/autoheuristic/pad_mm/train_decision_pad_mm.py
+++ b/torchgen/autoheuristic/pad_mm/train_decision_pad_mm.py
@@ -5,12 +5,12 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from train import AHTrain
+from train_decision import AHTrainDecisionTree
 
-from torch._inductor.fx_passes.pad_mm import pad_mm_operations
+from torch._inductor.autoheuristic.autoheuristic_utils import pad_mm_operations
 
 
-class AHTrainPadMM(AHTrain):
+class AHTrainDecisionTreePadMM(AHTrainDecisionTree):
     def __init__(self):
         super().__init__()
 
@@ -23,5 +23,5 @@ class AHTrainPadMM(AHTrain):
 
 
 if __name__ == "__main__":
-    train = AHTrainPadMM()
+    train = AHTrainDecisionTreePadMM()
     train.generate_heuristic()

--- a/torchgen/autoheuristic/pad_mm/train_regression_pad_mm.py
+++ b/torchgen/autoheuristic/pad_mm/train_regression_pad_mm.py
@@ -1,0 +1,27 @@
+# mypy: ignore-errors
+import os
+import sys
+
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from train_regression import AHTrainRegressionTree
+
+from torch._inductor.fx_passes.pad_mm import pad_mm_operations
+
+
+class AHTrainPadMM(AHTrainRegressionTree):
+    def __init__(self):
+        super().__init__()
+
+    def add_new_features(self, results):
+        ops = pad_mm_operations()
+        for op in ops:
+            results[op.name] = results.apply(op.func, axis=1)
+        added_categorical_features = [op.name for op in ops if op.is_categorical]
+        return (results, added_categorical_features)
+
+
+if __name__ == "__main__":
+    train = AHTrainPadMM()
+    train.generate_heuristic()

--- a/torchgen/autoheuristic/train.py
+++ b/torchgen/autoheuristic/train.py
@@ -1,17 +1,16 @@
 # mypy: ignore-errors
 
 import argparse
+import json
 import sys
 import warnings
 
-import numpy as np
 import pandas as pd  # type: ignore[import-untyped]
-from scipy.stats import gmean  # type: ignore[import-untyped]
-from sklearn.model_selection import train_test_split  # type: ignore[import-untyped]
-from sklearn.tree import DecisionTreeRegressor  # type: ignore[import-untyped]
 
-from torch._inductor.autoheuristic.autoheuristic import deserialize_data
-from torch._inductor.autoheuristic.autoheuristic_utils import CHOICE_COL, FEEDBACK_COL
+from torch._inductor.autoheuristic.autoheuristic_utils import (
+    CHOICE_COL,
+    get_metadata_str_from_log,
+)
 
 
 # TODO (AlnisM): Fix these warnings
@@ -27,10 +26,7 @@ warnings.filterwarnings(
 
 class AHTrain:
     """
-    This class is responsible for generating a heuristic by using data collected with AutoHeuristic. It will learn a
-    regression tree that predicts a score that represents how well a specific choice will perform given an input.
-    A higher score means a better choice. The heuristic will be generated in a file named <heuristic_name>.py in the
-    torch/_inductor/autoheuristic/artifacts/ directory.
+    Base class for AutoHeuristic training.
     """
 
     def __init__(self):
@@ -63,136 +59,53 @@ class AHTrain:
             metavar=("TYPE", "PATH"),
             help="Specify name of datasets and file paths to be evaluated.",
         )
+        self.parser.add_argument(
+            "--save-dot",
+            action="store_true",
+            help="Export heuristic to graphviz dot.",
+        )
 
     def parse_args(self):
         return self.parser.parse_args()
 
-    def generate_heuristic(self):
-        self.args = self.parse_args()
-        self.main(
-            self.args.dataset, self.args.data, self.args.nrows, self.args.heuristic_name
-        )
-
-    def main(self, log_path, other_datasets, nrows, heuristic_name):
-        (df, choices, cat_feature2cats, dummy_col_2_col_val, metadata) = self.get_df(
-            log_path, nrows=nrows, apply_filters=True
-        )
-        df_train, df_val, df_test, feature_columns = self.custom_train_test_split(df)
-        datasets = {"train": df_train, "val": df_val, "test": df_test}
-        self.add_real_datasets(datasets, other_datasets, cat_feature2cats)
-
-        # We will do a grid search over the values
-        max_depths = [5, 10, 13, 15, 17, 20, 23, None]
-        min_samples_leafs = [1, 2, 5, 10]
-        choice_columns = [f"{CHOICE_COL}_{choice}" for choice in choices]
-        (results_df, best_model, threshold) = self.train_and_evaluate_models(
-            datasets, feature_columns, choice_columns, max_depths, min_samples_leafs
-        )
-
-        # prints results for all models and datasets
-        print(results_df.to_string())
-
-        # prints results grouped by dataset
-        for set_name in results_df["dataset"].unique():
-            dataset_results = results_df[results_df["dataset"] == set_name]
-            dataset_results = dataset_results.sort_values(by="correct")
-            print(dataset_results.to_string() + "\n")
-
-        feature_names = feature_columns + choice_columns
-        self.dt_to_python(
-            best_model,
-            metadata,
-            feature_names,
-            dummy_col_2_col_val,
-            heuristic_name,
-            threshold,
-        )
-
-    def filter_df(self, df):
-        return df
-
-    def get_df(self, log_path, cat_feature2cats=None, nrows=None, apply_filters=False):
-        (df, metadata) = deserialize_data(log_path)
+    def parse_log(self, log_path, nrows=None):
+        (df, metadata) = self.deserialize_data(log_path)
         numerical_features = metadata["numerical_features"]
         categorical_features = metadata["categorical_features"]
         choices = df[CHOICE_COL].unique().tolist()
         features = numerical_features + categorical_features
         if nrows is not None:
             df = df.head(nrows)
-
         df = self.filter_df(df)
+        return (df, metadata, features, categorical_features, choices)
 
-        feature_columns = features
+    def generate_heuristic(self):
+        self.args = self.parse_args()
+        self.main(
+            self.args.dataset,
+            self.args.data,
+            self.args.nrows,
+            self.args.heuristic_name,
+            self.args.save_dot,
+        )
 
-        def process_data(
-            df,
-            feature_columns,
-            apply_filters,
-            min_count_measurements=3,
-            max_relative_std=5,
-        ):
-            # Calculate statistics for each input and choice combination
-            def calculate_stats(group):
-                count = len(group)
-                mean = group[FEEDBACK_COL].mean()
-                std = group[FEEDBACK_COL].std()
-                relative_std = (std / mean) * 100 if mean != 0 else np.inf
-                median = group[FEEDBACK_COL].median()
-                return pd.Series(
-                    {
-                        "count": count,
-                        "median_execution_time": median,
-                        "relative_std": relative_std,
-                    }
+    def filter_df(self, df):
+        return df
+
+    def add_new_features(self, results):
+        return (results, [])
+
+    def add_real_datasets(self, datasets, other_datasets, cat_feature2cats):
+        if other_datasets:
+            for name, path in other_datasets:
+                (df_other, choices, _, _, _) = self.get_df(
+                    path, cat_feature2cats=cat_feature2cats, apply_filters=False
                 )
+                datasets[name] = df_other
 
-            stats = (
-                df.groupby(feature_columns + [CHOICE_COL])
-                .apply(calculate_stats)
-                .reset_index()
-            )
-
-            if apply_filters:
-                # Remove unstables measurements
-                valid_stats = stats[
-                    (stats["count"] >= min_count_measurements)
-                    & (stats["relative_std"] <= max_relative_std)
-                ]
-                # Keep only inputs with at least two valid choices
-                valid_inputs = valid_stats.groupby(feature_columns).filter(
-                    lambda x: len(x) >= 2
-                )
-            else:
-                valid_inputs = stats
-
-            # Compute the winner and ratios for each input
-            def get_winner_and_speedups(group):
-                mean_time = group["median_execution_time"].mean()
-                winner = group.loc[group["median_execution_time"].idxmin(), CHOICE_COL]
-                min_time = group["median_execution_time"].min()
-                max_time = group["median_execution_time"].max()
-
-                group["winner"] = winner
-                group["speedup"] = max_time / min_time
-                group["target"] = mean_time / group["median_execution_time"]
-
-                return group[
-                    feature_columns + [CHOICE_COL, "winner", "speedup", "target"]
-                ]
-
-            results = (
-                valid_inputs.groupby(feature_columns)
-                .apply(get_winner_and_speedups)
-                .reset_index(drop=True)
-            )
-
-            return results
-
-        results = process_data(df, feature_columns, apply_filters)
-        (results, added_categorical_features) = self.add_new_features(results)
-        categorical_features += added_categorical_features
-        categorical_features += [CHOICE_COL]
-
+    def handle_categorical_features(
+        self, cat_feature2cats, categorical_features, results
+    ):
         # Doing this here because if we create another df for testing purposes
         # and that other df does not contain all categories for a categorical feature,
         # pd.dummies will not create columns for the missing categories
@@ -213,225 +126,28 @@ class AHTrain:
             unique_vals = results[col].unique()
             for val in unique_vals:
                 dummy_col_2_col_val[f"{col}_{val}"] = (col, val)
-
         # one-hot encode categorical features
         results = pd.get_dummies(results, columns=categorical_features)
-        return (results, choices, cat_feature2cats, dummy_col_2_col_val, metadata)
+        return (results, cat_feature2cats, dummy_col_2_col_val)
 
-    def custom_train_test_split(
-        self, df, test_size=0.2, val_size=0.25, random_state=42
-    ):
-        # We want to make sure that rows with the same input but different choice are kept in the same set
-        exclude_columns = ["speedup", "winner", "target"]
-        feature_columns = [
-            col
-            for col in df.columns
-            if col not in exclude_columns and not col.startswith(CHOICE_COL + "_")
-        ]
-        df["input_id"] = df.groupby(feature_columns).ngroup()
-
-        # Get unique input IDs
-        unique_inputs = df["input_id"].unique()
-
-        # Split unique inputs into train+val and test
-        train_val_inputs, test_inputs = train_test_split(
-            unique_inputs, test_size=test_size, random_state=random_state
-        )
-
-        # Split train+val inputs into train and val
-        train_inputs, val_inputs = train_test_split(
-            train_val_inputs, test_size=val_size, random_state=random_state
-        )
-
-        # Create masks for each set
-        train_mask = df["input_id"].isin(train_inputs)
-        val_mask = df["input_id"].isin(val_inputs)
-        test_mask = df["input_id"].isin(test_inputs)
-
-        # Split the dataframe
-        df_train = df[train_mask]
-        df_val = df[val_mask]
-        df_test = df[test_mask]
-
-        # Remove the temporary input_id column
-        df_train = df_train.drop("input_id", axis=1)
-        df_val = df_val.drop("input_id", axis=1)
-        df_test = df_test.drop("input_id", axis=1)
-
-        return df_train, df_val, df_test, feature_columns
-
-    def train_and_evaluate_models(
-        self,
-        datasets,
-        feature_columns,
-        choice_columns,
-        max_depths,
-        min_samples_leafs,
-        threshold=0.99,
-    ):
-        results = []
-        df_train = datasets["train"]
-        df_val = datasets["val"]
-
-        best_model = None
-        best_model_threshold = 0
-        max_correct_predictions = -1
-        for max_depth in max_depths:
-            for min_samples_leaf in min_samples_leafs:
-                print(
-                    f"Evaluating max_depth={max_depth}, min_samples_leaf={min_samples_leaf}"
-                )
-                model = DecisionTreeRegressor(
-                    random_state=42,
-                    max_depth=max_depth,
-                    min_samples_leaf=min_samples_leaf,
-                )
-                model.fit(
-                    df_train[feature_columns + choice_columns], df_train["target"]
-                )
-
-                # we first compute a safe threshold: this threshold ensures that on the validation set,
-                # if the heuristic returns a choice, the choice will be correct, although a high threshold
-                # can lead to a lot of 'unsure' choices
-                eval_result = self.evaluate_model(
-                    model, df_val, feature_columns, choice_columns, threshold
-                )
-                safe_threshold = eval_result["wrong_max_ratio"]
-                for dataset_name, dataset in datasets.items():
-                    eval_result = self.evaluate_model(
-                        model, dataset, feature_columns, choice_columns, safe_threshold
-                    )
-                    print(eval_result)
-                    if dataset_name == "val":
-                        eval_correct = eval_result["correct"]
-                        if eval_correct > max_correct_predictions:
-                            best_model = model
-                            best_model_threshold = safe_threshold
-                            max_correct_predictions = eval_correct
-                    results.append(
-                        {
-                            "max_depth": max_depth,
-                            "min_samples_leaf": min_samples_leaf,
-                            "dataset": dataset_name,
-                            "correct": eval_result["correct"],
-                            "wrong": eval_result["wrong"],
-                            "unsure": eval_result["unsure"],
-                            "total": eval_result["total"],
-                            "max_wrong_speedup": eval_result["max_wrong_speedup"],
-                            "gman_wrong_speedup": eval_result["gman_wrong_speedup"],
-                            "threshold": safe_threshold,
-                        }
-                    )
-
-        return (pd.DataFrame(results), best_model, best_model_threshold)
-
-    def evaluate_model(self, model, df, feature_columns, choice_columns, threshold):
-        def predict_winner(group):
-            predictions = model.predict(group[feature_columns + choice_columns])
-
-            # Find the index of the maximum prediction (best choice)
-            best_choice_index = np.argmax(predictions)
-
-            # Get the corresponding choice
-            predicted_choice = (
-                group[choice_columns].iloc[best_choice_index].idxmax().split("_")[-1]
-            )
-
-            # Calculate the ratio between the best and second-best prediction
-            sorted_predictions = np.sort(predictions)[::-1]
-            top_pred_ratio = (
-                sorted_predictions[0] / sorted_predictions[1]
-                if len(sorted_predictions) > 1
-                else np.inf
-            )
-
-            # If the best choice is not "significantly" better than the second best choice,
-            # the learned heuristic will return "unsure"
-            if top_pred_ratio <= threshold:
-                predicted_winner = "unsure"
-            else:
-                predicted_winner = predicted_choice
-
-            actual_winner = group["winner"].iloc[0]
-            is_correct = (
-                predicted_winner == actual_winner
-                if predicted_winner != "unsure"
-                else "unsure"
-            )
-
-            return pd.Series(
-                {
-                    "predicted_winner": predicted_winner,
-                    "ratio": top_pred_ratio,
-                    "actual_winner": actual_winner,
-                    "is_correct": is_correct,
-                    "speedup": group["speedup"].iloc[
-                        0
-                    ],  # Speedup is the same for all rows in the group
-                }
-            )
-
-        results = df.groupby(feature_columns).apply(predict_winner).reset_index()
-        correct = (results["is_correct"].eq(True)).sum()
-        unsure = (results["is_correct"] == "unsure").sum()
-        wrong_results = results[results["is_correct"].eq(False)]
-        wrong = len(wrong_results)
-
-        # Calculate max and geometric mean of speedup for wrong predictions
-        # Used for debugging purposes
-        wrong_speedups = wrong_results["speedup"]
-        max_wrong_speedup = wrong_speedups.max() if not wrong_speedups.empty else np.nan
-        geo_mean_wrong_speedup = (
-            gmean(wrong_speedups) if not wrong_speedups.empty else np.nan
-        )
-        wrong_max_ratio = wrong_results["ratio"].max()
-
-        total = correct + wrong + unsure
-        return {
-            "correct": correct,
-            "wrong": wrong,
-            "unsure": unsure,
-            "total": total,
-            "max_wrong_speedup": max_wrong_speedup,
-            "gman_wrong_speedup": geo_mean_wrong_speedup,
-            "wrong_max_ratio": wrong_max_ratio,
-        }
-
-    def add_new_features(self, results):
-        return (results, [])
-
-    def codegen_boilerplate(
-        self, heuristic_name, opt_name, threshold, shared_memory, device_capa
-    ):
-        boiler_plate = f"""# flake8: noqa: B950
-
-from torch._inductor.autoheuristic.autoheuristic_utils import AHContext, AHMetadata, Choice, CHOICE_COL
-from torch._inductor.autoheuristic.learnedheuristic_interface import (
-    LearnedHeuristic,
-)
-
-class {heuristic_name}(LearnedHeuristic):
-
-    def __init__(self) -> None:
-        pass
-
-    def check_precondition(self, metadata: AHMetadata, context: AHContext,) -> bool:
+    def gen_precondition(self, opt_name, shared_memory, device_capa):
+        return f"""    def check_precondition(self, metadata: AHMetadata, context: AHContext,) -> bool:
         return (
             metadata.name == self.get_name()
             and metadata.shared_memory == {shared_memory}
             and str(metadata.device_capa) == "{device_capa}"
-        )
+        )"""
 
-    def get_feedback(self, context: AHContext, choice: Choice) -> float:
-        context.context_dict[CHOICE_COL] = choice
-        return self.predict(context)
+    def handle_leaf(self, tree_, node, indent, unsafe_leaves):
+        pass
 
-    def get_speedup_threshold(self) -> float:
-        return {threshold}
+    def codegen_boilerplate(
+        self, heuristic_name, opt_name, threshold, shared_memory, device_capa, dt
+    ):
+        pass
 
-    def get_name(self) -> str:
-        return '{opt_name}'"""
-        return boiler_plate
+    def gen_predict_fn_def(self):
+        pass
 
     def dt_to_python(
         self,
@@ -441,6 +157,7 @@ class {heuristic_name}(LearnedHeuristic):
         dummy_col_2_col_val,
         heuristic_name,
         threshold,
+        unsafe_leaves=None,
     ):
         tree_ = dt.tree_
         feature_name = [
@@ -458,9 +175,10 @@ class {heuristic_name}(LearnedHeuristic):
                 threshold,
                 metadata["shared_memory"],
                 device_capa_str,
+                dt,
             )
         )
-        fn_def = "\n    def predict(self, context: AHContext) -> float:"
+        fn_def = f"\n    {self.gen_predict_fn_def()}"
         lines.append(fn_def)
 
         def dt_to_python(node, depth):
@@ -484,25 +202,26 @@ class {heuristic_name}(LearnedHeuristic):
                 lines.append(f"{indent}else:")
                 dt_to_python(tree_.children_right[node], depth + 1)
             else:
-                value = tree_.value[node][0][0]
-                lines.append(f"{indent}return {str(value)}")
+                lines.append(self.handle_leaf(tree_, node, indent, unsafe_leaves))
 
         dt_to_python(0, 1)
 
         output_file = (
-            f"../../torch/_inductor/autoheuristic/artifacts/_{heuristic_name}.py"
+            f"../../../torch/_inductor/autoheuristic/artifacts/_{heuristic_name}.py"
         )
         path = f"{output_file}"
         with open(path, "w") as f:
             f.write("\n".join(lines) + "\n")
 
-    def add_real_datasets(self, datasets, other_datasets, cat_feature2cats):
-        if other_datasets:
-            for name, path in other_datasets:
-                (df_other, choices, _, _, _) = self.get_df(
-                    path, cat_feature2cats=cat_feature2cats, apply_filters=False
-                )
-                datasets[name] = df_other
+    def deserialize_data(self, log_path):
+        json_string = get_metadata_str_from_log(log_path)
+        metadata = self.deserialize_metadata(json_string)
+
+        df = pd.read_csv(log_path, skiprows=1, on_bad_lines="skip")
+        return (df, metadata)
+
+    def deserialize_metadata(self, json_string):
+        return json.loads(json_string)
 
 
 if __name__ == "__main__":

--- a/torchgen/autoheuristic/train_decision.py
+++ b/torchgen/autoheuristic/train_decision.py
@@ -1,0 +1,604 @@
+# mypy: ignore-errors
+
+import itertools
+import json
+import math
+import warnings
+
+
+warnings.filterwarnings(
+    "ignore",
+    message="The behavior of DataFrame concatenation with empty or all-NA entries is deprecated",
+)
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+from scipy.stats import gmean
+from sklearn.model_selection import train_test_split
+from sklearn.tree import DecisionTreeClassifier
+from train import AHTrain
+
+
+class AHTrainDecisionTree(AHTrain):
+    def __init__(self):
+        super().__init__()
+
+    def get_time(self, row, choice):
+        choices_feedback = json.loads(row["choice2time"])
+        return choices_feedback.get(choice, None)
+
+    def top_k_classes(self, model, probas, k, avail_choices):
+        # Get classes and their corresponding probabilities
+        classes = model.classes_
+        class_proba_pairs = list(zip(classes, probas))
+
+        # Sort by probability (descending) and filter out zero probabilities
+        sorted_classes = [
+            c
+            for c, p in sorted(zip(classes, probas), key=lambda x: x[1], reverse=True)
+            if p > 0 and c in avail_choices
+        ]
+
+        # Return top k choices
+        return sorted_classes[:k]
+
+    def is_unsafe_leaf(self, row, predicted_config, choice2time):
+        return False
+
+    def get_unsafe_leaves(self, model, df, feature_columns):
+        X = df[feature_columns]
+        y = df["winner"]
+        leaf_ids = model.apply(X)
+        unique_leaves = np.unique(leaf_ids)
+
+        unsafe_leaves = []
+        for leaf in unique_leaves:
+            leaf_mask = leaf_ids == leaf
+            leaf_X = X[leaf_mask]
+
+            predicted_config = model.predict(leaf_X.iloc[[0]])[0]
+
+            for idx, row in leaf_X.iterrows():
+                choice2time = json.loads(df.loc[idx, "choice2time"])
+                if self.is_unsafe_leaf(row, predicted_config, choice2time):
+                    unsafe_leaves.append(leaf)
+                    break
+        return unsafe_leaves
+
+    def get_allowed_wrong_prediction_pct(self):
+        return 0.01
+
+    def get_grid_search_values(self):
+        return {
+            "max_depth": [5, 6, 7],
+            "min_samples_leaf": [1, 5, 10, 0.01, 0.05, 0.02],
+            "criterion": ["gini", "entropy"],
+        }
+
+    def predict(self, model, df, feature_columns):
+        predictions = model.predict(df[feature_columns])
+        proba = model.predict_proba(df[feature_columns])
+        leaf_ids = model.apply(df[feature_columns])
+        return predictions, proba, leaf_ids
+
+    def train_and_evaluate_models(
+        self, datasets, max_depths, min_samples_leafs, criterion_list, feature_columns
+    ):
+        results = []
+        best_model = None
+        best_model_safe_proba = 0
+        best_model_num_correct = 0
+        best_model_num_wrong = 0
+        best_model_unsafe_leaves = []
+        for max_depth, min_samples_leaf, criterion in itertools.product(
+            max_depths, min_samples_leafs, criterion_list
+        ):
+            print(
+                f"max_depth={max_depth} min_samples_leaf={min_samples_leaf} criterion={criterion}"
+            )
+            model = DecisionTreeClassifier(
+                max_depth=max_depth,
+                min_samples_leaf=min_samples_leaf,
+                criterion=criterion,
+                random_state=42,
+            )
+            df_train = datasets["train"]
+            df_val = datasets["val"]
+            model.fit(df_train[feature_columns], df_train["winner"])
+            unsafe_leaves = self.get_unsafe_leaves(model, df_train, feature_columns)
+            predictions, proba, leaf_ids = self.predict(model, df_val, feature_columns)
+
+            wrong_pct = self.get_allowed_wrong_prediction_pct()
+            safe_proba = self.get_results(
+                model,
+                predictions,
+                df_val,
+                probas=proba,
+                return_safe_proba=True,
+                wrong_pct=wrong_pct,
+                unsafe_leaves=unsafe_leaves,
+                leaf_ids=leaf_ids,
+            )
+            print(f"safe_proba={safe_proba}")
+
+            def eval(name, df):
+                predictions, proba, leaf_ids = self.predict(model, df, feature_columns)
+                eval_result = self.get_results(
+                    model,
+                    predictions,
+                    df,
+                    probas=proba,
+                    threshold=safe_proba,
+                    unsafe_leaves=unsafe_leaves,
+                    leaf_ids=leaf_ids,
+                )
+                if name == "val":
+                    nonlocal best_model_num_correct
+                    nonlocal best_model_num_wrong
+                    nonlocal best_model_safe_proba
+                    nonlocal best_model
+                    nonlocal best_model_unsafe_leaves
+                    num_correct = eval_result["correct"]
+                    num_wrong = eval_result["wrong"]
+                    num_total = eval_result["total"]
+                    if num_wrong <= num_total * wrong_pct:
+                        if num_correct > best_model_num_correct:
+                            print(
+                                f"new best model with {num_correct} correct and {num_wrong} wrong"
+                            )
+                            best_model = model
+                            best_model_num_correct = num_correct
+                            best_model_num_wrong = num_wrong
+                            best_model_safe_proba = safe_proba
+                            best_model_unsafe_leaves = unsafe_leaves
+
+                results.append(
+                    (
+                        name,
+                        criterion,
+                        max_depth,
+                        min_samples_leaf,
+                        eval_result["correct"],
+                        eval_result["wrong"],
+                        eval_result["unsure"],
+                        eval_result["total"],
+                        eval_result["wrong_max_speedup"],
+                        eval_result["wrong_gmean_speedup"],
+                        eval_result["top_k_correct"],
+                        eval_result["wrong_max_speedup_k"],
+                        eval_result["wrong_gmean_speedup_k"],
+                        eval_result["top_k_unsure"],
+                        eval_result["max_speedup_default"],
+                        eval_result["gmean_speedup_default"],
+                        eval_result["max_slowdown_default"],
+                        eval_result["non_default_predictions"],
+                        eval_result["default_better"],
+                    )
+                )
+
+            for dataset_name, dataset in datasets.items():
+                eval(dataset_name, dataset)
+
+        return (
+            pd.DataFrame(
+                results,
+                columns=[
+                    "set",
+                    "crit",
+                    "max_depth",
+                    "min_samples_leaf",
+                    "correct",
+                    "wrong",
+                    "unsure",
+                    "total",
+                    "wrong_max_spdup",
+                    "wrong_gman_spdup",
+                    "top_k_correct",
+                    "wrong_max_spdup_k",
+                    "wrong_gman_spdup_k",
+                    "top_k_unsure",
+                    "max_spdup_default",
+                    "gman_spdup_default",
+                    "max_slowdown_default",
+                    "non_default_preds",
+                    "default_better",
+                ],
+            ),
+            best_model,
+            best_model_safe_proba,
+            best_model_unsafe_leaves,
+        )
+
+    def get_test_and_val_size(self):
+        return (0.15, 0.15)
+
+    def prepare_datasets(self, df, other_datasets, cat_feature2cats):
+        test_size, val_size = self.get_test_and_val_size()
+        # Split into train+val and test
+        df_train_val, df_test = train_test_split(
+            df, test_size=test_size, random_state=42
+        )
+
+        # Split train+val inputs into train and val
+        train_val_size = 1 - test_size
+        df_train, df_val = train_test_split(
+            df_train_val, test_size=val_size / train_val_size, random_state=42
+        )
+        datasets = {"train": df_train, "val": df_val, "test": df_test}
+        self.add_real_datasets(datasets, other_datasets, cat_feature2cats)
+        return datasets
+
+    def export_to_dot(self, best_model, df, feature_columns):
+        from sklearn import tree
+
+        tree.export_graphviz(
+            best_model,
+            out_file="best_model.dot",
+            feature_names=df[feature_columns].columns,
+            class_names=[str(c) for c in best_model.classes_],
+            filled=True,
+            rounded=True,
+            special_characters=True,
+        )
+
+    def get_feature_columns(self, df):
+        exclude_columns = [
+            "speedup",
+            "winner",
+            "target",
+            "avail_choices",
+            "choice2time",
+            "index",
+        ]
+        feature_columns = [col for col in df.columns if col not in exclude_columns]
+        return feature_columns
+
+    def main(self, log_path, other_datasets, nrows, heuristic_name, save_dot=False):
+        # TODO: Enable apply_filters
+        (df, choices, cat_feature2cats, dummy_col_2_col_val, metadata) = self.get_df(
+            log_path, nrows=nrows, apply_filters=False
+        )
+        print(df["winner"].value_counts())
+        datasets = self.prepare_datasets(df, other_datasets, cat_feature2cats)
+        feature_columns = self.get_feature_columns(df)
+        grid_search_values = self.get_grid_search_values()
+        max_depths = grid_search_values["max_depth"]
+        min_samples_leafs = grid_search_values["min_samples_leaf"]
+        criterion_list = grid_search_values["criterion"]
+        (
+            results_df,
+            best_model,
+            best_model_safe_proba,
+            unsafe_leaves,
+        ) = self.train_and_evaluate_models(
+            datasets, max_depths, min_samples_leafs, criterion_list, feature_columns
+        )
+
+        # prints results for all models and datasets
+        print(results_df.to_string())
+
+        # prints results grouped by dataset
+        for set_name in results_df["set"].unique():
+            dataset_results = results_df[results_df["set"] == set_name]
+            dataset_results = dataset_results.sort_values(by="correct")
+            print(dataset_results.to_string() + "\n")
+
+        if best_model is not None:
+            if save_dot:
+                self.export_to_dot(best_model, df, feature_columns)
+            self.dt_to_python(
+                best_model,
+                metadata,
+                feature_columns,
+                dummy_col_2_col_val,
+                heuristic_name,
+                best_model_safe_proba,
+                unsafe_leaves,
+            )
+        else:
+            print(
+                "All learned models have too many wrong predictions, so no heuristic was generated"
+            )
+
+    def get_df(self, log_path, cat_feature2cats=None, nrows=None, apply_filters=False):
+        (df, metadata, features, categorical_features, choices) = self.parse_log(
+            log_path, nrows
+        )
+
+        def calculate_stats(group):
+            count = len(group)
+            mean = group["feedback"].mean()
+            std = group["feedback"].std()
+            relative_std = (std / mean) * 100 if mean != 0 else np.inf
+            median = group["feedback"].median()
+            return pd.Series(
+                {
+                    "count": count,
+                    "relative_std": relative_std,
+                    "median_execution_time": median,
+                }
+            )
+
+        feature_columns = features
+        stats = (
+            df.groupby(feature_columns + ["choice"], as_index=False)
+            .apply(calculate_stats, include_groups=False)
+            .reset_index()
+        )
+
+        # TODO: We have to be careful with removing certain choices, because if we e.g. remove the winner, the
+        # heuristic will end up learning wrong things. But, execution times with high variance are also bad
+        if apply_filters:
+            # Filter out inputs with less than 3 measurements or high relative std
+            valid_stats = stats[(stats["count"] >= 3) & (stats["relative_std"] <= 5)]
+            # Group by input features and count how many valid choices we have for each input
+            valid_inputs = valid_stats.groupby(feature_columns).filter(
+                lambda x: len(x) >= 2
+            )
+        else:
+            valid_inputs = stats
+
+        # Compute the winner and speedup for each valid input
+        def get_winner_and_speedup(group):
+            assert len(group) >= 2, "Need at least 2 choices"
+
+            sorted_group = group.sort_values("median_execution_time")
+            winner = sorted_group.iloc[0]["choice"]
+            winning_time = sorted_group.iloc[0]["median_execution_time"]
+            second_best_time = sorted_group.iloc[1]["median_execution_time"]
+            speedup = second_best_time / winning_time
+            unique_choices = group["choice"].unique()
+
+            choice2time = {}
+            for row in group.itertuples():
+                choice2time[row.choice] = row.median_execution_time
+
+            assert len(unique_choices) == len(
+                group
+            ), f"len(unique_choices) != len(group): {len(unique_choices)} != {len(group)}"
+
+            return pd.Series(
+                {
+                    "winner": winner,
+                    "speedup": speedup,
+                    "avail_choices": unique_choices,
+                    "choice2time": json.dumps(choice2time),
+                }
+            )
+
+        results = (
+            valid_inputs.groupby(feature_columns, as_index=False)
+            .filter(lambda x: len(x) >= 2)
+            .groupby(feature_columns, as_index=False)
+            .apply(get_winner_and_speedup, include_groups=False)
+            .reset_index()
+        )
+
+        (results, added_categorical_features) = self.add_new_features(results)
+        categorical_features += added_categorical_features
+
+        (
+            results,
+            cat_feature2cats,
+            dummy_col_2_col_val,
+        ) = self.handle_categorical_features(
+            cat_feature2cats, categorical_features, results
+        )
+        return (results, choices, cat_feature2cats, dummy_col_2_col_val, metadata)
+
+    def get_results(
+        self,
+        model,
+        predictions,
+        df,
+        probas,
+        return_safe_proba=False,
+        wrong_pct=0.01,
+        threshold=0.0,
+        k=3,
+        unsafe_leaves=None,
+        leaf_ids=None,
+    ):
+        def compute_speedup_over_default(default_config, pred, df, i, predicted_time):
+            nonlocal num_non_default_predictions
+            nonlocal speedups_over_default
+            nonlocal num_default_better
+            if default_config is not None:
+                if pred != default_config:
+                    num_non_default_predictions += 1
+                default_time = self.get_time(df.iloc[i], default_config)
+                # TODO: We should keep track of how often this happens
+                if default_time is not None and not math.isinf(default_time):
+                    speedup_over_default = default_time / predicted_time
+                    if speedup_over_default < 1:
+                        num_default_better += 1
+                    speedups_over_default.append(speedup_over_default)
+
+        y_true = df["winner"]
+        num_correct = 0
+        num_wrong = 0
+        num_unsure = 0
+        wrong_probas = []
+        i = 0
+        speedups_wrong = []
+        num_correct_top_k = 0
+        wrong_speedups_top_k = []
+        top_k_unsure = 0
+        speedups_over_default = []
+        num_non_default_predictions = 0
+        num_default_better = 0
+        for pred, true, prob, leaf_id in zip(predictions, y_true, probas, leaf_ids):
+            avail_choices = df["avail_choices"].iloc[i]
+            top_k_choices = self.top_k_classes(
+                model, probas[i], k=k, avail_choices=avail_choices
+            )
+            predicted_time = self.get_time(df.iloc[i], pred)
+            assert true in avail_choices, f"{true} not in {avail_choices}"
+
+            default_config = self.get_default_config(df.iloc[i])
+
+            max_prob = max(prob)
+            if (
+                leaf_id in unsafe_leaves
+                or pred not in avail_choices
+                or (max_prob != 1.0 and max(prob) <= threshold)
+            ):
+                num_unsure += 1
+                speedups_over_default.append(1.0)
+            elif pred == true:
+                compute_speedup_over_default(
+                    default_config, pred, df, i, predicted_time
+                )
+                num_correct += 1
+            else:
+                compute_speedup_over_default(
+                    default_config, pred, df, i, predicted_time
+                )
+                num_wrong += 1
+                wrong_probas.append(max_prob)
+                best_time = self.get_time(df.iloc[i], true)
+                wrong_speedup = predicted_time / best_time
+                speedups_wrong.append(wrong_speedup)
+
+            if true in top_k_choices:
+                num_correct_top_k += 1
+            else:
+                times = []
+                for choice in top_k_choices:
+                    time = self.get_time(df.iloc[i], choice)
+                    if time is not None:
+                        times.append(time)
+                best_time = self.get_time(df.iloc[i], true)
+                min_time = min(times) if times else None
+                if min_time is not None:
+                    speedup = min_time / best_time
+                    wrong_speedups_top_k.append(speedup)
+                else:
+                    top_k_unsure += 1
+            i += 1
+
+        if return_safe_proba:
+            wrong_probas.sort()
+            total = len(predictions)
+            num_wrong = len(wrong_probas)
+            allowed_wrong = int(total * wrong_pct)
+            if allowed_wrong >= num_wrong:
+                return 0.0
+            too_many_wrong = num_wrong - allowed_wrong
+            idx = min(too_many_wrong, len(wrong_probas) - 1)
+            return wrong_probas[idx]
+
+        total = len(predictions)
+        max_speedup = max(speedups_wrong) if speedups_wrong else 0
+        gmean_speedup = gmean(speedups_wrong) if speedups_wrong else 0
+        max_speedup_top_k = max(wrong_speedups_top_k) if wrong_speedups_top_k else 0
+        gmean_speedup_top_k = gmean(wrong_speedups_top_k) if wrong_speedups_top_k else 0
+
+        max_speedup_over_default = (
+            max(speedups_over_default) if speedups_over_default else 0
+        )
+        gmean_speedup_over_default = (
+            gmean(speedups_over_default) if speedups_over_default else 0
+        )
+        max_slowdown_over_defalt = (
+            min(speedups_over_default) if speedups_over_default else 0
+        )
+        return {
+            "correct": num_correct,
+            "wrong": num_wrong,
+            "unsure": num_unsure,
+            "total": total,
+            "wrong_max_speedup": max_speedup,
+            "wrong_gmean_speedup": gmean_speedup,
+            "top_k_correct": num_correct_top_k,
+            "wrong_max_speedup_k": max_speedup_top_k,
+            "wrong_gmean_speedup_k": gmean_speedup_top_k,
+            "top_k_unsure": top_k_unsure,
+            "max_speedup_default": max_speedup_over_default,
+            "gmean_speedup_default": gmean_speedup_over_default,
+            "max_slowdown_default": max_slowdown_over_defalt,
+            "non_default_predictions": num_non_default_predictions,
+            "default_better": num_default_better,
+        }
+
+    def gen_classes(self, classes, num_spaces):
+        indent = " " * num_spaces
+        return "\n".join([f"{indent}self.choices.append('{c}')" for c in classes])
+
+    def best_probas_and_indices(self, class_probas):
+        # we generate a list of tuples (proba, idx) sorted by proba in descending order
+        # idx is the index of a choice
+        # we only generate a tuple if proba > 0
+        probas_indices_sorted = sorted(
+            [(proba, index) for index, proba in enumerate(class_probas) if proba > 0],
+            key=lambda x: x[0],
+            reverse=True,
+        )
+        probas_indices_sorted_str = ", ".join(
+            f"({value:.3f}, {index})" for value, index in probas_indices_sorted
+        )
+        return f"[{probas_indices_sorted_str}]"
+
+    def get_default_config(self, row):
+        return None
+
+    def handle_leaf(self, tree_, node, indent, unsafe_leaves):
+        if node in unsafe_leaves:
+            return f"{indent}return None"
+        leaf_num_samples = tree_.n_node_samples[node]
+        class_probas = tree_.value[node][0]
+        return f"{indent}return {self.best_probas_and_indices(class_probas)}"
+
+    def gen_predict_fn_def(self):
+        return "def get_best_choices(self, context: AHContext) -> Optional[List[Tuple[float, int]]]:"
+
+    def codegen_boilerplate(
+        self, heuristic_name, opt_name, threshold, shared_memory, device_capa, dt
+    ):
+        boiler_plate = f"""# flake8: noqa: B950
+from typing import Any, List, Optional, Tuple
+
+from torch._inductor.autoheuristic.autoheuristic_utils import (
+    AHContext,
+    AHMetadata,
+    Choice,
+)
+from torch._inductor.autoheuristic.learnedheuristic_interface import (
+    LearnedHeuristicDecision,
+)
+
+class {heuristic_name}(LearnedHeuristicDecision):
+
+    def __init__(self) -> None:
+        self.choices: List[Choice] = []
+        self.fill_choices()
+
+{self.gen_precondition(opt_name, shared_memory, device_capa)}
+
+    def get_confidence_threshold(self) -> float:
+        return {threshold}
+
+    def get_choice(self, idx: int) -> Optional[str]:
+        if idx < len(self.choices):
+            return self.choices[idx]
+        return None
+
+    def fill_choices(self) -> None:
+{self.gen_classes(dt.classes_, num_spaces=8)}
+
+    def get_name(self) -> str:
+        return '{opt_name}'"""
+        return boiler_plate
+
+    def add_real_datasets(self, datasets, other_datasets, cat_feature2cats):
+        if other_datasets:
+            for name, path in other_datasets:
+                (df_other, choices, _, _, _) = self.get_df(
+                    path, cat_feature2cats=cat_feature2cats, apply_filters=False
+                )
+                datasets[name] = df_other
+
+
+if __name__ == "__main__":
+    train = AHTrainDecisionTree()
+    train.generate_heuristic()

--- a/torchgen/autoheuristic/train_regression.py
+++ b/torchgen/autoheuristic/train_regression.py
@@ -1,0 +1,372 @@
+# mypy: ignore-errors
+
+import warnings
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+from scipy.stats import gmean  # type: ignore[import-untyped]
+from sklearn.model_selection import train_test_split  # type: ignore[import-untyped]
+from sklearn.tree import DecisionTreeRegressor  # type: ignore[import-untyped]
+from train import AHTrain
+
+from torch._inductor.autoheuristic.autoheuristic_utils import CHOICE_COL, FEEDBACK_COL
+
+
+# TODO (AlnisM): Fix these warnings
+warnings.filterwarnings(
+    "ignore",
+    message="The behavior of DataFrame concatenation with empty or all-NA entries is deprecated",
+)
+warnings.filterwarnings(
+    "ignore",
+    message="DataFrameGroupBy.apply operated on the grouping columns.",
+)
+
+
+class AHTrainRegressionTree(AHTrain):
+    """
+    This class is responsible for generating a heuristic by using data collected with AutoHeuristic. It will learn a
+    regression tree that predicts a score that represents how well a specific choice will perform given an input.
+    A higher score means a better choice. The heuristic will be generated in a file named <heuristic_name>.py in the
+    torch/_inductor/autoheuristic/artifacts/ directory.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def main(self, log_path, other_datasets, nrows, heuristic_name):
+        (df, choices, cat_feature2cats, dummy_col_2_col_val, metadata) = self.get_df(
+            log_path, nrows=nrows, apply_filters=True
+        )
+        df_train, df_val, df_test, feature_columns = self.custom_train_test_split(df)
+        datasets = {"train": df_train, "val": df_val, "test": df_test}
+        self.add_real_datasets(datasets, other_datasets, cat_feature2cats)
+
+        # We will do a grid search over the values
+        max_depths = [5, 10, 13, 15, 17, 20, 23, None]
+        min_samples_leafs = [1, 2, 5, 10]
+        choice_columns = [f"{CHOICE_COL}_{choice}" for choice in choices]
+        (results_df, best_model, threshold) = self.train_and_evaluate_models(
+            datasets, feature_columns, choice_columns, max_depths, min_samples_leafs
+        )
+
+        # prints results for all models and datasets
+        print(results_df.to_string())
+
+        # prints results grouped by dataset
+        for set_name in results_df["dataset"].unique():
+            dataset_results = results_df[results_df["dataset"] == set_name]
+            dataset_results = dataset_results.sort_values(by="correct")
+            print(dataset_results.to_string() + "\n")
+
+        feature_names = feature_columns + choice_columns
+        self.dt_to_python(
+            best_model,
+            metadata,
+            feature_names,
+            dummy_col_2_col_val,
+            heuristic_name,
+            threshold,
+        )
+
+    def get_df(self, log_path, cat_feature2cats=None, nrows=None, apply_filters=False):
+        (df, metadata, feature_columns, categorical_features, choices) = self.parse_log(
+            log_path, nrows
+        )
+
+        def process_data(
+            df,
+            feature_columns,
+            apply_filters,
+            min_count_measurements=3,
+            max_relative_std=5,
+        ):
+            # Calculate statistics for each input and choice combination
+            def calculate_stats(group):
+                count = len(group)
+                mean = group[FEEDBACK_COL].mean()
+                std = group[FEEDBACK_COL].std()
+                relative_std = (std / mean) * 100 if mean != 0 else np.inf
+                median = group[FEEDBACK_COL].median()
+                return pd.Series(
+                    {
+                        "count": count,
+                        "median_execution_time": median,
+                        "relative_std": relative_std,
+                    }
+                )
+
+            stats = (
+                df.groupby(feature_columns + [CHOICE_COL])
+                .apply(calculate_stats)
+                .reset_index()
+            )
+
+            if apply_filters:
+                # Remove unstables measurements
+                valid_stats = stats[
+                    (stats["count"] >= min_count_measurements)
+                    & (stats["relative_std"] <= max_relative_std)
+                ]
+                # Keep only inputs with at least two valid choices
+                valid_inputs = valid_stats.groupby(feature_columns).filter(
+                    lambda x: len(x) >= 2
+                )
+            else:
+                valid_inputs = stats
+
+            # Compute the winner and ratios for each input
+            def get_winner_and_speedups(group):
+                mean_time = group["median_execution_time"].mean()
+                winner = group.loc[group["median_execution_time"].idxmin(), CHOICE_COL]
+                min_time = group["median_execution_time"].min()
+                max_time = group["median_execution_time"].max()
+
+                group["winner"] = winner
+                group["speedup"] = max_time / min_time
+                group["target"] = mean_time / group["median_execution_time"]
+
+                return group[
+                    feature_columns + [CHOICE_COL, "winner", "speedup", "target"]
+                ]
+
+            results = (
+                valid_inputs.groupby(feature_columns)
+                .apply(get_winner_and_speedups)
+                .reset_index(drop=True)
+            )
+
+            return results
+
+        results = process_data(df, feature_columns, apply_filters)
+        (results, added_categorical_features) = self.add_new_features(results)
+        categorical_features += added_categorical_features
+        categorical_features += [CHOICE_COL]
+
+        (
+            results,
+            cat_feature2cats,
+            dummy_col_2_col_val,
+        ) = self.handle_categorical_features(
+            cat_feature2cats, categorical_features, results
+        )
+        return (results, choices, cat_feature2cats, dummy_col_2_col_val, metadata)
+
+    def custom_train_test_split(
+        self, df, test_size=0.2, val_size=0.25, random_state=42
+    ):
+        # We want to make sure that rows with the same input but different choice are kept in the same set
+        exclude_columns = ["speedup", "winner", "target"]
+        feature_columns = [
+            col
+            for col in df.columns
+            if col not in exclude_columns and not col.startswith(CHOICE_COL + "_")
+        ]
+        df["input_id"] = df.groupby(feature_columns).ngroup()
+
+        # Get unique input IDs
+        unique_inputs = df["input_id"].unique()
+
+        # Split unique inputs into train+val and test
+        train_val_inputs, test_inputs = train_test_split(
+            unique_inputs, test_size=test_size, random_state=random_state
+        )
+
+        # Split train+val inputs into train and val
+        train_inputs, val_inputs = train_test_split(
+            train_val_inputs, test_size=val_size, random_state=random_state
+        )
+
+        # Create masks for each set
+        train_mask = df["input_id"].isin(train_inputs)
+        val_mask = df["input_id"].isin(val_inputs)
+        test_mask = df["input_id"].isin(test_inputs)
+
+        # Split the dataframe
+        df_train = df[train_mask]
+        df_val = df[val_mask]
+        df_test = df[test_mask]
+
+        # Remove the temporary input_id column
+        df_train = df_train.drop("input_id", axis=1)
+        df_val = df_val.drop("input_id", axis=1)
+        df_test = df_test.drop("input_id", axis=1)
+
+        return df_train, df_val, df_test, feature_columns
+
+    def train_and_evaluate_models(
+        self,
+        datasets,
+        feature_columns,
+        choice_columns,
+        max_depths,
+        min_samples_leafs,
+        threshold=0.99,
+    ):
+        results = []
+        df_train = datasets["train"]
+        df_val = datasets["val"]
+
+        best_model = None
+        best_model_threshold = 0
+        max_correct_predictions = -1
+        for max_depth in max_depths:
+            for min_samples_leaf in min_samples_leafs:
+                print(
+                    f"Evaluating max_depth={max_depth}, min_samples_leaf={min_samples_leaf}"
+                )
+                model = DecisionTreeRegressor(
+                    random_state=42,
+                    max_depth=max_depth,
+                    min_samples_leaf=min_samples_leaf,
+                )
+                model.fit(
+                    df_train[feature_columns + choice_columns], df_train["target"]
+                )
+
+                # we first compute a safe threshold: this threshold ensures that on the validation set,
+                # if the heuristic returns a choice, the choice will be correct, although a high threshold
+                # can lead to a lot of 'unsure' choices
+                eval_result = self.evaluate_model(
+                    model, df_val, feature_columns, choice_columns, threshold
+                )
+                safe_threshold = eval_result["wrong_max_ratio"]
+                for dataset_name, dataset in datasets.items():
+                    eval_result = self.evaluate_model(
+                        model, dataset, feature_columns, choice_columns, safe_threshold
+                    )
+                    print(eval_result)
+                    if dataset_name == "val":
+                        eval_correct = eval_result["correct"]
+                        if eval_correct > max_correct_predictions:
+                            best_model = model
+                            best_model_threshold = safe_threshold
+                            max_correct_predictions = eval_correct
+                    results.append(
+                        {
+                            "max_depth": max_depth,
+                            "min_samples_leaf": min_samples_leaf,
+                            "dataset": dataset_name,
+                            "correct": eval_result["correct"],
+                            "wrong": eval_result["wrong"],
+                            "unsure": eval_result["unsure"],
+                            "total": eval_result["total"],
+                            "max_wrong_speedup": eval_result["max_wrong_speedup"],
+                            "gman_wrong_speedup": eval_result["gman_wrong_speedup"],
+                            "threshold": safe_threshold,
+                        }
+                    )
+
+        return (pd.DataFrame(results), best_model, best_model_threshold)
+
+    def evaluate_model(self, model, df, feature_columns, choice_columns, threshold):
+        def predict_winner(group):
+            predictions = model.predict(group[feature_columns + choice_columns])
+
+            # Find the index of the maximum prediction (best choice)
+            best_choice_index = np.argmax(predictions)
+
+            # Get the corresponding choice
+            predicted_choice = (
+                group[choice_columns].iloc[best_choice_index].idxmax().split("_")[-1]
+            )
+
+            # Calculate the ratio between the best and second-best prediction
+            sorted_predictions = np.sort(predictions)[::-1]
+            top_pred_ratio = (
+                sorted_predictions[0] / sorted_predictions[1]
+                if len(sorted_predictions) > 1
+                else np.inf
+            )
+
+            # If the best choice is not "significantly" better than the second best choice,
+            # the learned heuristic will return "unsure"
+            if top_pred_ratio <= threshold:
+                predicted_winner = "unsure"
+            else:
+                predicted_winner = predicted_choice
+
+            actual_winner = group["winner"].iloc[0]
+            is_correct = (
+                predicted_winner == actual_winner
+                if predicted_winner != "unsure"
+                else "unsure"
+            )
+
+            return pd.Series(
+                {
+                    "predicted_winner": predicted_winner,
+                    "ratio": top_pred_ratio,
+                    "actual_winner": actual_winner,
+                    "is_correct": is_correct,
+                    "speedup": group["speedup"].iloc[
+                        0
+                    ],  # Speedup is the same for all rows in the group
+                }
+            )
+
+        results = df.groupby(feature_columns).apply(predict_winner).reset_index()
+        correct = (results["is_correct"].eq(True)).sum()
+        unsure = (results["is_correct"] == "unsure").sum()
+        wrong_results = results[results["is_correct"].eq(False)]
+        wrong = len(wrong_results)
+
+        # Calculate max and geometric mean of speedup for wrong predictions
+        # Used for debugging purposes
+        wrong_speedups = wrong_results["speedup"]
+        max_wrong_speedup = wrong_speedups.max() if not wrong_speedups.empty else np.nan
+        geo_mean_wrong_speedup = (
+            gmean(wrong_speedups) if not wrong_speedups.empty else np.nan
+        )
+        wrong_max_ratio = wrong_results["ratio"].max()
+
+        total = correct + wrong + unsure
+        return {
+            "correct": correct,
+            "wrong": wrong,
+            "unsure": unsure,
+            "total": total,
+            "max_wrong_speedup": max_wrong_speedup,
+            "gman_wrong_speedup": geo_mean_wrong_speedup,
+            "wrong_max_ratio": wrong_max_ratio,
+        }
+
+    def handle_leaf(self, tree_, node, indent, unsafe_leaves):
+        value = tree_.value[node][0][0]
+        return f"{indent}return {str(value)}"
+
+    def gen_predict_fn_def(self):
+        return "def predict(self, context: AHContext) -> float:"
+
+    def codegen_boilerplate(
+        self, heuristic_name, opt_name, threshold, shared_memory, device_capa, dt
+    ):
+        boiler_plate = f"""# flake8: noqa: B950
+
+from torch._inductor.autoheuristic.autoheuristic_utils import AHContext, AHMetadata, Choice, CHOICE_COL
+from torch._inductor.autoheuristic.learnedheuristic_interface import (
+    LearnedHeuristicRegression,
+)
+
+class {heuristic_name}(LearnedHeuristicRegression):
+
+    def __init__(self) -> None:
+        pass
+
+{self.gen_precondition(opt_name, shared_memory, device_capa)}
+
+    def get_feedback(self, context: AHContext, choice: Choice) -> float:
+        context.context_dict[CHOICE_COL] = choice
+        return self.predict(context)
+
+    def get_confidence_threshold(self) -> float:
+        return {threshold}
+
+    def get_name(self) -> str:
+        return '{opt_name}'"""
+        return boiler_plate
+
+
+if __name__ == "__main__":
+    train = AHTrain()
+    train.generate_heuristic()


### PR DESCRIPTION
This PR introduces changes to AutoHeuristic that allow one to learn a heuristic as a decision tree. I used this to learn a heuristic for mixed_mm on A100 that consistenly performs better than the default choice (https://github.com/pytorch/pytorch/blob/main/torch/_inductor/kernel/mm.py#L402).

This is how the results look like:
Explanation of columns:
**wrong_max_spdup**: In the worst case, how much better would the best choice have been
**wrong_gman_spdup**: For inputs where the heuristic is wrong, how much better is the best choice on average (geomean)
**max_spdup_default**: Highest speedup achieved by the learned heuristic over the default choice
**gman_spdup_default**: Geomean speedup achived by the learned heuristic over the default choice
**max_slowdown_default**: If the default choice is better than the choice predicted by the learned heuristic, how much is it better in the worst case
**non_default_preds**: Number of times the learned heuristic predicted a choice that is not the default choice
**default_better**: Number of times the default choice is better than the choice made by the heuristic
```
  set     crit  max_depth  min_samples_leaf  correct  wrong  unsure  total  wrong_max_spdup  wrong_gman_spdup    max_spdup_default  gman_spdup_default  max_slowdown_default  non_default_preds  default_better
train  entropy          5              0.01     2376    740     323   3439         1.855386          1.063236            11.352318            3.438279              1.022164               3116               2
 test  entropy          5              0.01      563    183      71    817         1.622222          1.060897            10.084181            3.507741              1.017039                746               2
```

While the number of wrong predictions is high, on average the best choice is only around 6% better. What is important is that the choice predicted by the learned heuristic performs better than the default choice.

I evaluated my heuristic on gpt-fast `meta-llama/Llama-2-7b-chat-hf` with int8 weight quantization. To get the `tuned_mixed_mm` to trigger, I had to replace `F.linear()` in https://github.com/pytorch-labs/gpt-fast/blob/main/quantize.py#L355 with `torch.matmul(input, self.weight.t().to(dtype=input.dtype))` because the mixed_mm pattern does not match if there is a transpose between a cast and the matmul.
|batch size|prompt length| fallback    |  heuristic  | speedup |
|----------|-------------|------------:|------------:|--------:|
|     1    |      6      | 75.31 tok/s | 148.83 tok/s|  1.97   |
|     1    |     11      | 75.99 tok/s | 148.15 tok/s|  1.94   |
|     4    |      6      | 25.87 tok/s | 118.00 tok/s|  4.56   |
|     4    |     11      | 25.89 tok/s |  92.84 tok/s|  3.58   |
|     8    |      6      | 25.24 tok/s | 101.68 tok/s|  4.02   |
|     8    |     11      | 25.22 tok/s |  87.42 tok/s|  3.46   |



Currently, the heuristic only applies to the following inputs:
- m <= 128, k >= 1024, n >= 1024 (For these sizes, one of the triton kernels wins in most cases, but the heuristic still has to be careful to not choose a config that performs worse than the fallback)
- k % 256 == 0 (If k is not a multiple of the block size, some choices perform extremely bad. In one case one config, that usually performs very well, was 130x slower.)
- mat1 not transposed
- mat2 transposed (In some cases, it was hard for the learned heuristic to detect some cases where it made a big difference whether the tensors were transposed or not.)

I think we might be able to lift some of these restrictions if we collect more data, add new features, and improve the way the decision tree is learned. But for now, I want to ship this heuristic because it performs well on this restricted set of inputs.

The results for a heuristic that I learned for H100 look similar. I will add an H100 heuristic in another PR.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #131396
* #131395
* #131394
* __->__ #131393
* #131392
* #131391

