### PR TITLE
Print ExportedProgram without color by default

### DIFF
--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -952,7 +952,7 @@ class ExportedProgram:
 
     def __str__(self) -> str:
         graph_module = self.graph_module.print_readable(
-            print_output=False, colored=True
+            print_output=False, colored=False
         ).replace("\n", "\n    ")
         string = (
             "ExportedProgram:\n"


### PR DESCRIPTION
Summary:
Without plugin, colored ExportedProgram is not really readable.

![image](https://github.com/user-attachments/assets/319920a9-bb4b-4ad2-bcac-0c4f76973b11)

Test Plan: CI

Differential Revision: D60074481
