### PR TITLE
[BE][Inductor] fix do_bench test

### DIFF
--- a/test/inductor/test_inductor_utils.py
+++ b/test/inductor/test_inductor_utils.py
@@ -21,7 +21,7 @@ class TestBench(TestCase):
         cls._bench_fn = functools.partial(torch.nn.functional.linear, x, w)
 
     def test_do_bench(self):
-        res = do_bench(self._bench_fn)
+        res = do_bench(self._bench_fn, (), {})
         log.warning("do_bench result: %s", res)
         self.assertGreater(res, 0)
 

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -26,8 +26,9 @@ def run_tests(needs=()):
     if isinstance(needs, str):
         needs = (needs,)
     for need in needs:
-        if need == "cuda" and not torch.cuda.is_available():
-            return
+        if need == "cuda":
+            if not torch.cuda.is_available():
+                return
         else:
             try:
                 importlib.import_module(need)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131402

The test fail internally [T195592444](https://www.internalfb.com/intern/tasks/?t=195592444) (This is meta internal link). But we don't see the failure in OSS.

It turns out that there are 2 issues:
1. `run_test('cuda')` is improperly handled since it tries to import a module named 'cuda' if cuda is available. Since the import fails, all tests in the file are skipped. This hides the failure in OSS. The failure is exposed in internal tests since the main block which runs `run_test('cuda')` is skipped sometimes.
2. fix the real issue that incompatible inputs are provided to `do_bench`.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang