### PR TITLE
[ts-migration][1/N]: Add prim::Loop for constant number of iterations and condition

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1328,9 +1328,16 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(M1(), inp, ["script"])
 
     def test_ts2ep_with_loop(self):
-        def func1(x: List[torch.Tensor]):
+        def func1(x, x_list: List[torch.Tensor]):
+            a, b, c = x, x, x
             for i in range(5):
-                x.append(x[i] + x[i + 1])
+                a = a + a + i
+                b = b + b - i
+                x_list.append(x_list[i] + x_list[i + 1])
+            for i in range(5):
+                b = b + b - i
+                c = c + c * i
+                x_list.append(x_list[i] + x_list[i + 1] - x_list[i + 2])
             return x
 
         def func2(x):
@@ -1343,7 +1350,7 @@ class TestConverter(TestCase):
                 x += x.sin()
             return x
 
-        inp = ([torch.ones([2, 2]), torch.ones([2, 2]) * 2],)
+        inp = (torch.tensor(1), [torch.ones([2, 2]), torch.ones([2, 2]) * 2],)
         # Trace unrolls the loop.
         self._check_equal_ts_ep_converter(func1, inp, ["script"])
 

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1350,7 +1350,10 @@ class TestConverter(TestCase):
                 x += x.sin()
             return x
 
-        inp = (torch.tensor(1), [torch.ones([2, 2]), torch.ones([2, 2]) * 2],)
+        inp = (
+            torch.tensor(1),
+            [torch.ones([2, 2]), torch.ones([2, 2]) * 2],
+        )
         # Trace unrolls the loop.
         self._check_equal_ts_ep_converter(func1, inp, ["script"])
 

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -102,10 +102,7 @@ class TestConverter(TestCase):
                 raise RuntimeError(f"Unrecognized mode for torch.jit: {opt}")
 
             converter = TS2EPConverter(ts_model, inp)
-            print(opt, converter.ts_graph)
-
             ep = converter.convert()
-            print(ep)
             ep_list.append(ep)
 
             for _ in range(num_iterations):
@@ -1014,7 +1011,6 @@ class TestConverter(TestCase):
 
         ep_list = self._check_equal_ts_ep_converter(M(), (torch.tensor(1),))
         for ep in ep_list:
-            print(ep.constants)
             self.assertEqual(len(ep.constants), 1)
 
     def test_aten_tensor_prim_dtype(self):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1327,6 +1327,36 @@ class TestConverter(TestCase):
         inp = (torch.randn(2, 3),)
         self._check_equal_ts_ep_converter(M1(), inp, ["script"])
 
+    def test_ts2ep_with_loop(self):
+        def func1(x):
+            a, b = x, x
+            for i in range(0, 4, 2):
+                a = a + a + i
+                b = b * b + i
+            return a, b
+
+        def func2(x):
+            for i in range(x.size(0)):
+                x = x * x * i
+            return x
+
+        def func3(x):
+            while x.sum() < 10:
+                x += x.sin()
+            return x
+
+        inp = (torch.ones([2, 2]) * 2,)
+        # Trace unrolls the loop.
+        self._check_equal_ts_ep_converter(func1, inp, ["script"])
+
+        # TODO: (2/N)
+        # Trace unrolls the loop.
+        # self._check_equal_ts_ep_converter(func2, inp, ["script"])
+
+        # TODO: (3/N)
+        # Trace unrolls the loop.
+        # self._check_equal_ts_ep_converter(func3, inp, ["script"])
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1328,13 +1328,10 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(M1(), inp, ["script"])
 
     def test_ts2ep_with_loop(self):
-        def func1(x, y):
-            y = y / 1
-            a, b = x, x
-            for i in range(0, 4, 2):
-                a = a + a + i + y
-                b = b * b + i - y
-            return a, b
+        def func1(x: List[torch.Tensor]):
+            for i in range(5):
+                x.append(x[i] + x[i + 1])
+            return x
 
         def func2(x):
             for i in range(x.size(0)):
@@ -1346,7 +1343,7 @@ class TestConverter(TestCase):
                 x += x.sin()
             return x
 
-        inp = (torch.ones([2, 2]), torch.ones([2, 2]) * 2,)
+        inp = ([torch.ones([2, 2]), torch.ones([2, 2]) * 2],)
         # Trace unrolls the loop.
         self._check_equal_ts_ep_converter(func1, inp, ["script"])
 

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1328,11 +1328,12 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(M1(), inp, ["script"])
 
     def test_ts2ep_with_loop(self):
-        def func1(x):
+        def func1(x, y):
+            y = y / 1
             a, b = x, x
             for i in range(0, 4, 2):
-                a = a + a + i
-                b = b * b + i
+                a = a + a + i + y
+                b = b * b + i - y
             return a, b
 
         def func2(x):
@@ -1345,7 +1346,7 @@ class TestConverter(TestCase):
                 x += x.sin()
             return x
 
-        inp = (torch.ones([2, 2]) * 2,)
+        inp = (torch.ones([2, 2]), torch.ones([2, 2]) * 2,)
         # Trace unrolls the loop.
         self._check_equal_ts_ep_converter(func1, inp, ["script"])
 

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1328,10 +1328,13 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(M1(), inp, ["script"])
 
     def test_ts2ep_with_loop(self):
-        def func1(x: List[torch.Tensor]):
-            for i in range(4):
-                x.append(x[i] + x[i + 1])
-            return x
+        def func1(x, y):
+            y = y / 1
+            a, b = x, x
+            for i in range(0, 4, 2):
+                a = a + a + i + y
+                b = b * b + i - y
+            return a, b
 
         def func2(x):
             for i in range(x.size(0)):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1328,13 +1328,10 @@ class TestConverter(TestCase):
         self._check_equal_ts_ep_converter(M1(), inp, ["script"])
 
     def test_ts2ep_with_loop(self):
-        def func1(x, y):
-            y = y / 1
-            a, b = x, x
-            for i in range(0, 4, 2):
-                a = a + a + i + y
-                b = b * b + i - y
-            return a, b
+        def func1(x: List[torch.Tensor]):
+            for i in range(4):
+                x.append(x[i] + x[i + 1])
+            return x
 
         def func2(x):
             for i in range(x.size(0)):

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1330,15 +1330,16 @@ class TestConverter(TestCase):
     def test_ts2ep_with_loop(self):
         def func1(x, x_list: List[torch.Tensor]):
             a, b, c = x, x, x
-            for i in range(5):
-                a = a + a + i
-                b = b + b - i
-                x_list.append(x_list[i] + x_list[i + 1])
-            for i in range(5):
-                b = b + b - i
-                c = c + c * i
-                x_list.append(x_list[i] + x_list[i + 1] - x_list[i + 2])
-            return x
+            for i in range(1, 5, 2):
+                for k in range(5):
+                    a = a + a + k
+                    b = b + b - k
+                    x_list.append(x_list[k] + x_list[k + 1])
+                for k in range(5):
+                    b = b + b - k
+                    c = c + c * k
+                    x_list.append(x_list[k] + x_list[k + 1] - x_list[k + 2])
+            return x, x_list
 
         def func2(x):
             for i in range(x.size(0)):

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -1028,7 +1028,7 @@ class TS2FXGraphConverter:
             loop_local_args = args[2 : 2 + len(loop_local_arguments)]
             global_args = args[2 + len(loop_local_arguments) :]
             return node_func(
-                *global_args, torch.tensor(iter_idx), *loop_local_args, **kwargs
+                *global_args, iter_idx, *loop_local_args, **kwargs
             )
 
         fx_block_args = [
@@ -1062,7 +1062,8 @@ class TS2FXGraphConverter:
                         i + node.outputsSize() + 1,
                     ),  # + 1 because the 0th element is the condition.
                 )
-                fx_block_args[i + node.outputsSize()] = self.name_to_node[name]
+                global_argument_index = global_arguments.index(name)
+                fx_block_args[i + node.outputsSize() + global_argument_index] = self.name_to_node[name]
 
     def _check_set_attr_in_if_block(self, if_node: torch._C.Node):
         for block in if_node.blocks():


### PR DESCRIPTION
#### Description
This PR adds prim::Loop support for the simplest case where the number of iteration is constant and the loop termination condition is also a constant.

[PR by stages](https://docs.google.com/document/d/1q6OprW3HBHbYPwEyE_DikBn-uzmhnN284Cmen_CnlhI/edit?usp=sharing)

#### Test Plan
Add reprod example.
* `pytest test/export/test_converter.py -s -k test_ts2ep_with_loop`