### PR TITLE
refactor post-trace fakification in strict

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -108,7 +108,7 @@ def capture_pre_autograd_graph(
         An nn.Module containing the traced method.
 
     """
-    from torch.export._trace import _convert_input_to_fake, DEFAULT_EXPORT_DYNAMO_CONFIG, _ignore_backend_decomps
+    from torch.export._trace import _extract_fake_inputs, DEFAULT_EXPORT_DYNAMO_CONFIG, _ignore_backend_decomps
     from torch._utils_internal import export_api_rollout_check
     from torch._export.non_strict_utils import make_constraints
     from torch._subclasses.functional_tensor import FunctionalTensor
@@ -154,7 +154,7 @@ def capture_pre_autograd_graph(
                 **kwargs,
             )[0]
 
-            _, _, _, fake_mode = _convert_input_to_fake(m, args, kwargs)
+            _, _, fake_mode = _extract_fake_inputs(m, args, kwargs)
 
             m.meta["inline_constraints"] = {
                 k: v

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -18,7 +18,7 @@ from torch._export.passes.add_runtime_assertions_for_constraints_pass import Inp
 from torch._export.passes.lift_constants_pass import ConstantAttrMap
 from torch._guards import Source
 from torch._library.fake_class_registry import FakeScriptObject
-from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.export import Constraint
 from torch.export.dynamic_shapes import _tree_map
 from torch.export.graph_signature import CustomObjArgument
@@ -94,22 +94,6 @@ def fakify(
     fake = mode.from_tensor(t, source=source, symbolic_context=symbolic_context)
     mode.shape_env.tracked_fakes.append(TrackedFake(fake, source, symbolic_context))  # type: ignore[union-attr]
     return fake
-
-
-def make_fake_params_buffers(
-    fake_mode: FakeTensorMode,
-    params_buffers: Dict[str, torch.Tensor],
-) -> Dict[str, Union[torch.Tensor, torch.nn.Parameter]]:
-    faked_params_buffers = {}
-    memo: Dict[int, FakeTensor] = {}
-    for key, value in params_buffers.items():
-        if id(value) in memo:
-            fake_tensor = memo[id(value)]
-        else:
-            fake_tensor = fake_mode.from_tensor(value, static_shapes=True)
-            memo[id(value)] = fake_tensor
-        faked_params_buffers[key] = fake_tensor
-    return faked_params_buffers  # type: ignore[return-value]
 
 
 def make_fake_inputs(

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -21,7 +21,6 @@ from torch._export.non_strict_utils import (
     _gather_constant_attrs,
     make_constraints,
     make_fake_inputs,
-    make_fake_params_buffers,
     produce_guards_and_solve_constraints,
 )
 from torch._export.passes._node_metadata_hook import (
@@ -182,8 +181,13 @@ def _rewrite_node(gm):
                     gm.graph.erase_node(node)
 
 
-def _convert_input_to_fake(gm, args, kwargs):
-    params_buffers = _get_params_buffers(gm)
+def _extract_fake_inputs(gm, args, kwargs):
+    """
+    Given a graph module, extract fakified input tensors from the metadata of
+    its placeholders, and map them to the structure of given args and kwargs.
+    Also return the fake mode used to fakify those inputs.
+    """
+
     fake_inps: List[torch.Tensor] = []
     fake_vals: List[torch.Tensor] = []
     for node in gm.graph.nodes:
@@ -191,7 +195,7 @@ def _convert_input_to_fake(gm, args, kwargs):
             fake_val = node.meta["val"]
             if fake_val is not None and isinstance(fake_val, torch.Tensor):
                 fake_inps.append(fake_val)
-        elif len(fake_inps) == 0 and "example_value" in node.meta:
+        elif "example_value" in node.meta:
             fake_val = node.meta["example_value"]
             if fake_val is not None and isinstance(fake_val, torch.Tensor):
                 fake_vals.append(fake_val)
@@ -201,26 +205,18 @@ def _convert_input_to_fake(gm, args, kwargs):
     else:
         fake_mode = FakeTensorMode(shape_env=ShapeEnv(), export=True)
 
-    if len(args) == 0 and len(kwargs) == 0:
-        return (), {}, params_buffers, fake_mode
-
     count = 0
 
-    def convert_to_fake(x):
+    def lookup_fake(x):
         nonlocal count
         val = fake_inps[count]
         count += 1
         return val
 
-    fake_args = pytree.tree_map_only(torch.Tensor, convert_to_fake, args)
-    # TODO properly use the cached fake tensor
-    fake_kwargs = pytree.tree_map_only(torch.Tensor, fake_mode.from_tensor, kwargs)
-    fake_params_buffers = pytree.tree_map_only(
-        torch.Tensor,
-        functools.partial(fake_mode.from_tensor, static_shapes=True),
-        params_buffers,
-    )
-    return fake_args, fake_kwargs, fake_params_buffers, fake_mode
+    fake_args = pytree.tree_map_only(torch.Tensor, lookup_fake, args)
+    fake_kwargs = pytree.tree_map_only(torch.Tensor, lookup_fake, kwargs)
+
+    return fake_args, fake_kwargs, fake_mode
 
 
 def _replace_param_buffer_names(param_buffer_table, sig):
@@ -790,14 +786,25 @@ def _export_to_aten_ir(
     )
 
 
-def _get_params_buffers(mod: torch.nn.Module) -> Dict[str, torch.Tensor]:
-    params_buffers: Dict[str, torch.Tensor] = {}
-    for name, param in mod.named_parameters(remove_duplicate=False):
-        params_buffers[name] = param
+def _fakify_params_buffers(
+    fake_mode: FakeTensorMode,
+    mod: torch.nn.Module,
+) -> Dict[str, Union[torch.Tensor, torch.nn.Parameter]]:
+    params_buffers = {
+        **dict(mod.named_parameters(remove_duplicate=False)),
+        **dict(mod.named_buffers(remove_duplicate=False)),
+    }
 
-    for name, buffer in mod.named_buffers(remove_duplicate=False):
-        params_buffers[name] = buffer
-    return params_buffers
+    faked_params_buffers = {}
+    memo: Dict[int, FakeTensor] = {}
+    for key, value in params_buffers.items():
+        if id(value) in memo:
+            fake_tensor = memo[id(value)]
+        else:
+            fake_tensor = fake_mode.from_tensor(value, static_shapes=True)
+            memo[id(value)] = fake_tensor
+        faked_params_buffers[key] = fake_tensor
+    return faked_params_buffers  # type: ignore[return-value]
 
 
 def _get_forward_arg_names(
@@ -1164,9 +1171,10 @@ def _strict_export_lower_to_aten_ir(
     (
         fake_args,
         fake_kwargs,
-        fake_params_buffers,
         dynamo_fake_mode,
-    ) = _convert_input_to_fake(gm_torch_level, args, kwargs)
+    ) = _extract_fake_inputs(gm_torch_level, args, kwargs)
+
+    fake_params_buffers = _fakify_params_buffers(dynamo_fake_mode, gm_torch_level)
 
     # First, we want to pass through the graph to try populating
     # val field for getattr if there is anything missing.
@@ -1333,14 +1341,9 @@ def _export_to_aten_ir_make_fx(
     def _make_fx_helper(mod, args, kwargs, **flags):
         kwargs = kwargs or {}
 
-        named_parameters = dict(mod.named_parameters(remove_duplicate=False))
-        param_len = len(named_parameters)
-        named_buffers = dict(mod.named_buffers(remove_duplicate=False))
-        buffer_len = len(named_buffers)
-
         params_and_buffers = {
-            **dict(named_parameters),
-            **dict(named_buffers),
+            **dict(mod.named_parameters(remove_duplicate=False)),
+            **dict(mod.named_buffers(remove_duplicate=False)),
         }
         params_and_buffers_flat, params_spec = pytree.tree_flatten(params_and_buffers)
         params_and_buffers_flat = tuple(params_and_buffers_flat)
@@ -1388,10 +1391,7 @@ def _export_to_aten_ir_make_fx(
         named_buffers = dict(mod.named_buffers(remove_duplicate=False))
         buffer_len = len(named_buffers)
 
-        params_and_buffers = {
-            **dict(named_parameters),
-            **dict(named_buffers),
-        }
+        params_and_buffers = {**named_parameters, **named_buffers}
         params_and_buffers_flat, params_spec = pytree.tree_flatten(params_and_buffers)
         params_and_buffers_flat = tuple(params_and_buffers_flat)
         params_len = len(params_and_buffers)
@@ -1643,7 +1643,7 @@ def _non_strict_export(
         allow_complex_guards_as_runtime_asserts=allow_complex_guards_as_runtime_asserts,  # for shape env initialization
     )
 
-    fake_params_buffers = make_fake_params_buffers(fake_mode, _get_params_buffers(mod))
+    fake_params_buffers = _fakify_params_buffers(fake_mode, mod)
 
     def _produce_guards_callback(gm):
         return produce_guards_and_solve_constraints(

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -328,14 +328,13 @@ def _decompose_and_get_gm_with_new_signature_constants(
     _preserve_ops: Tuple[torch._ops.OpOverload],
     joint_loss_index: Optional[int],
 ):
-    from torch._export.non_strict_utils import make_fake_params_buffers
     from torch._export.passes.lift_constants_pass import ConstantAttrMap
     from torch._functorch.aot_autograd import aot_export_module
     from torch._guards import detect_fake_mode
 
     from torch.export._trace import (
         _export_to_aten_ir,
-        _get_params_buffers,
+        _fakify_params_buffers,
         _ignore_backend_decomps,
         _verify_nn_module_stack,
         _verify_placeholder_names,
@@ -394,9 +393,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
             constant_attrs.add(value, name)
 
         # get params & buffers after excluding constants
-        fake_params_buffers = make_fake_params_buffers(
-            fake_mode, _get_params_buffers(mod)
-        )
+        fake_params_buffers = _fakify_params_buffers(fake_mode, mod)
         aten_export_artifact = _export_to_aten_ir(
             mod,
             # this requires empty kwargs, but not in pytree.flattened format


### PR DESCRIPTION
Summary:
Previously it was unclear what `_convert_input_to_fake` actually does (used in strict), and in particular how it is different from `make_fake_inputs` (used in non-strict).

This PR splits that function to work purely on user inputs, then renames it to `extract_fake_inputs` and adds a comment clarifying what it does—namely, it extracts fake inputs from a given graph module instead of "converting inputs to fake inputs" (as suggested by the current name) or "making fake inputs" (as happens in non-strict, where no tracing has taken place yet).

The remainder of that function used to also fakify params and buffers. It turns out that this part is identical to what happens in non-strict, hence we also pull `make_fake_inputs` out from `non_strict_utils` into `_trace`, merge it with another util, and make both modes call it.

Test Plan: existing tests

Differential Revision: D60084442
