### PR TITLE
Check module spec of triton at first

### DIFF
--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -1,14 +1,21 @@
 # mypy: allow-untyped-defs
 import functools
 import hashlib
+import importlib
 
 
 @functools.lru_cache(None)
 def has_triton_package() -> bool:
     try:
-        from triton.compiler.compiler import triton_key
-
-        return triton_key is not None
+        import triton
+        if triton.language.dtype is not None:
+            try:
+                from triton.compiler.compiler import triton_key
+                return triton_key is not None
+            except ImportError:
+                return False
+    except AttributeError:
+        return False
     except ImportError:
         return False
 


### PR DESCRIPTION
Fixes #130723
Some models like [BERT](https://github.com/NVIDIA/DeepLearningExamples/tree/master/PyTorch/LanguageModeling/BERT/triton) have their own triton folder.
Try to avoid import error because has_triton_package will be called during torch._dynamo init.
