### PR TITLE
[aoti] Fix float16 and bfloat16 for generated GPU code

### DIFF
--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -186,6 +186,7 @@ if RUN_CUDA:
         BaseTest("test_sum_dtype"),  # float64
         BaseTest("test_sum_int"),  # bool, int64, int8, uint8
         BaseTest("test_transpose"),  # multiple outputs, buffer clear
+        BaseTest("test_unspec_input"),
         BaseTest(
             "test_foreach_cpp_wrapper",
             tests=test_foreach.ForeachTests(),

--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -186,7 +186,7 @@ if RUN_CUDA:
         BaseTest("test_sum_dtype"),  # float64
         BaseTest("test_sum_int"),  # bool, int64, int8, uint8
         BaseTest("test_transpose"),  # multiple outputs, buffer clear
-        BaseTest("test_unspec_input"),
+        BaseTest("test_unspec_inputs"),
         BaseTest(
             "test_foreach_cpp_wrapper",
             tests=test_foreach.ForeachTests(),

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -20,7 +20,7 @@ from .common import CSEVariable, ExprPrinter, Kernel, KernelArgs
 DTYPE_TO_CPP = {
     torch.float32: "float",
     torch.float64: "double",
-    torch.float16: "half",
+    torch.float16: "c10::Half",
     torch.int64: "int64_t",
     torch.int32: "int32_t",
     torch.int16: "int16_t",

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -20,7 +20,7 @@ from .common import CSEVariable, ExprPrinter, Kernel, KernelArgs
 DTYPE_TO_CPP = {
     torch.float32: "float",
     torch.float64: "double",
-    torch.float16: "c10::Half",
+    torch.float16: "half",
     torch.int64: "int64_t",
     torch.int32: "int32_t",
     torch.int16: "int16_t",

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -934,9 +934,7 @@ class CppWrapperCpu(WrapperCodeGen):
             writer.writeline(
                 f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_{dtype_str}({tensor}, &{scalar_tmp}));"
             )
-            writer.writeline(
-                f"float {scalar} = float({scalar_tmp});"
-            )
+            writer.writeline(f"float {scalar} = float({scalar_tmp});")
         else:
             writer.writeline(f"{DTYPE_TO_CPP[dtype]} {scalar};")
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -923,14 +923,29 @@ class CppWrapperCpu(WrapperCodeGen):
         ), "codegen_tensor_item is only used for the ABI-compatible mode"
         dtype_str = str(dtype).split(".")[-1]
         writer = indented_buffer or self
-        writer.writeline(f"{DTYPE_TO_CPP[dtype]} {scalar};")
 
-        # need convert_arrayref_tensor_to_tensor for ArrayRefTensors
-        tensor = f"convert_arrayref_tensor_to_tensor({tensor})"
+        if dtype == torch.float16 or dtype == torch.bfloat16:
+            scalar_tmp = f"{scalar}_tmp"
+            writer.writeline(f"{DTYPE_TO_CPP[dtype]} {scalar_tmp};")
 
-        writer.writeline(
-            f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_{dtype_str}({tensor}, &{scalar}));"
-        )
+            # need convert_arrayref_tensor_to_tensor for ArrayRefTensors
+            tensor = f"convert_arrayref_tensor_to_tensor({tensor})"
+
+            writer.writeline(
+                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_{dtype_str}({tensor}, &{scalar_tmp}));"
+            )
+            writer.writeline(
+                f"float {scalar} = float({scalar_tmp});"
+            )
+        else:
+            writer.writeline(f"{DTYPE_TO_CPP[dtype]} {scalar};")
+
+            # need convert_arrayref_tensor_to_tensor for ArrayRefTensors
+            tensor = f"convert_arrayref_tensor_to_tensor({tensor})"
+
+            writer.writeline(
+                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_{dtype_str}({tensor}, &{scalar}));"
+            )
 
     @cache_on_self
     def get_output_refs(self):

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -43,6 +43,8 @@ class CppWrapperCuda(CppWrapperCpu):
         super().write_header()
 
         self.header.splice("#include <filesystem>")
+        self.header.splice("typedef at::Half half;")
+        self.header.splice("typedef at::BFloat16 bfloat16;")
         if config.abi_compatible:
             self.header.splice(
                 "#include <torch/csrc/inductor/aoti_runtime/utils_cuda.h>"

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -43,7 +43,9 @@ class CppWrapperCuda(CppWrapperCpu):
         super().write_header()
 
         self.header.splice("#include <filesystem>")
-        self.header.splice("#include <cuda_fp16.h>")
+        # Half.h is a header-only implementation so it's ok to include this c10 header directly.
+        # This is checked in test/cpp/aoti_abi_check.
+        self.header.splice("#include <c10/util/Half.h>")
         if config.abi_compatible:
             self.header.splice(
                 "#include <torch/csrc/inductor/aoti_runtime/utils_cuda.h>"

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -43,6 +43,7 @@ class CppWrapperCuda(CppWrapperCpu):
         super().write_header()
 
         self.header.splice("#include <filesystem>")
+        self.header.splice("#include <cuda_fp16.h>")
         if config.abi_compatible:
             self.header.splice(
                 "#include <torch/csrc/inductor/aoti_runtime/utils_cuda.h>"

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -43,9 +43,6 @@ class CppWrapperCuda(CppWrapperCpu):
         super().write_header()
 
         self.header.splice("#include <filesystem>")
-        # Half.h is a header-only implementation so it's ok to include this c10 header directly.
-        # This is checked in test/cpp/aoti_abi_check.
-        self.header.splice("#include <c10/util/Half.h>")
         if config.abi_compatible:
             self.header.splice(
                 "#include <torch/csrc/inductor/aoti_runtime/utils_cuda.h>"

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -156,7 +156,18 @@ class CppWrapperCuda(CppWrapperCpu):
                             var_name,
                         )
                     else:
-                        self.writeline(f"{ctype} {var_name} = {arg}.item<{ctype}>();")
+                        from torch import bfloat16, float16
+
+                        if arg_type in (float16, bfloat16):
+                            var_name_tmp = f"{var_name}_tmp"
+                            self.writeline(
+                                f"{ctype} {var_name_tmp} = {arg}.item<{ctype}>();"
+                            )
+                            self.writeline(f"float {var_name} = float({var_name_tmp});")
+                        else:
+                            self.writeline(
+                                f"{ctype} {var_name} = {arg}.item<{ctype}>();"
+                            )
                 else:
                     if config.abi_compatible:
                         self.writeline(

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -55,6 +55,10 @@
 #include <cuda_fp16.h>
 #endif
 
+#ifdef USE_ROCM
+#include <hip/hip_fp16.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -120,9 +124,9 @@ AOTI_TORCH_EXPORT int32_t aoti_torch_layout_strided();
 AOTI_TORCH_EXPORT int32_t aoti_torch_layout__mkldnn();
 
 // Functions for converting a single-element tensor to a scalar value
-#ifdef USE_CUDA
+#if defined(USE_CUDA) || defined(USE_ROCM)  
 AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_item_float16(AtenTensorHandle tensor, half* ret_value);
+aoti_torch_item_float16(AtenTensorHandle tensor, __half* ret_value);
 #endif
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_float32(AtenTensorHandle tensor, float* ret_value);

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -51,6 +51,10 @@
 #endif // _WIN32
 #endif // __GNUC__
 
+#ifdef USE_CUDA
+#include <cuda_fp16.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -116,6 +120,10 @@ AOTI_TORCH_EXPORT int32_t aoti_torch_layout_strided();
 AOTI_TORCH_EXPORT int32_t aoti_torch_layout__mkldnn();
 
 // Functions for converting a single-element tensor to a scalar value
+#ifdef USE_CUDA
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_item_float16(AtenTensorHandle tensor, half* ret_value);
+#endif
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_float32(AtenTensorHandle tensor, float* ret_value);
 AOTI_TORCH_EXPORT AOTITorchError

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -51,8 +51,8 @@
 #endif // _WIN32
 #endif // __GNUC__
 
-#include <c10/util/Half.h>
 #include <c10/util/BFloat16.h>
+#include <c10/util/Half.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -143,6 +143,8 @@ AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_int64(AtenTensorHandle tensor, int64_t* ret_value);
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_bool(AtenTensorHandle tensor, bool* ret_value);
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_item_bfloat16(AtenTensorHandle tensor, c10::BFloat16* ret_value);
 
 // Functions for wrapping a scalar value to a single-element tensor
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_scalar_to_tensor_float32(

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -52,6 +52,7 @@
 #endif // __GNUC__
 
 #include <c10/util/Half.h>
+#include <c10/util/BFloat16.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -51,13 +51,7 @@
 #endif // _WIN32
 #endif // __GNUC__
 
-#ifdef USE_CUDA
-#include <cuda_fp16.h>
-#endif
-
-#ifdef USE_ROCM
-#include <hip/hip_fp16.h>
-#endif
+#include <c10/util/Half.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -124,10 +118,8 @@ AOTI_TORCH_EXPORT int32_t aoti_torch_layout_strided();
 AOTI_TORCH_EXPORT int32_t aoti_torch_layout__mkldnn();
 
 // Functions for converting a single-element tensor to a scalar value
-#if defined(USE_CUDA) || defined(USE_ROCM)  
 AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_item_float16(AtenTensorHandle tensor, __half* ret_value);
-#endif
+aoti_torch_item_float16(AtenTensorHandle tensor, c10::Half* ret_value);
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_float32(AtenTensorHandle tensor, float* ret_value);
 AOTI_TORCH_EXPORT AOTITorchError

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -43,13 +43,6 @@
 
 #endif
 
-// #ifdef USE_CUDA
-#include <cuda_fp16.h>
-// #endif
-
-// #ifdef USE_ROCM
-// #include <hip/hip_fp16.h>
-// #endif
 
 using namespace torch::aot_inductor;
 
@@ -117,17 +110,7 @@ int32_t aoti_torch_layout__mkldnn() {
     });                                                        \
   }
 
-// #if defined(USE_CUDA) || defined(USE_ROCM)  
-// AOTI_TORCH_ITEM_IMPL(float16, at::Half)
-AOTITorchError aoti_torch_item_float16(                      
-    AtenTensorHandle tensor, __half* ret_value) {             
-  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({               
-    at::Tensor* t = tensor_handle_to_tensor_pointer(tensor); 
-    *ret_value = static_cast<__half>(t->item().to<at::Half>());                      
-  });                                                        
-}
-// #endif
-
+AOTI_TORCH_ITEM_IMPL(float16, c10::Half)
 AOTI_TORCH_ITEM_IMPL(float32, float)
 AOTI_TORCH_ITEM_IMPL(float64, double)
 AOTI_TORCH_ITEM_IMPL(uint8, uint8_t)

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -109,6 +109,9 @@ int32_t aoti_torch_layout__mkldnn() {
     });                                                        \
   }
 
+#ifdef USE_CUDA
+AOTI_TORCH_ITEM_IMPL(float16, half)
+#endif
 AOTI_TORCH_ITEM_IMPL(float32, float)
 AOTI_TORCH_ITEM_IMPL(float64, double)
 AOTI_TORCH_ITEM_IMPL(uint8, uint8_t)

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -43,6 +43,14 @@
 
 #endif
 
+// #ifdef USE_CUDA
+#include <cuda_fp16.h>
+// #endif
+
+// #ifdef USE_ROCM
+// #include <hip/hip_fp16.h>
+// #endif
+
 using namespace torch::aot_inductor;
 
 namespace {
@@ -109,9 +117,17 @@ int32_t aoti_torch_layout__mkldnn() {
     });                                                        \
   }
 
-#ifdef USE_CUDA
-AOTI_TORCH_ITEM_IMPL(float16, half)
-#endif
+// #if defined(USE_CUDA) || defined(USE_ROCM)  
+// AOTI_TORCH_ITEM_IMPL(float16, at::Half)
+AOTITorchError aoti_torch_item_float16(                      
+    AtenTensorHandle tensor, __half* ret_value) {             
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({               
+    at::Tensor* t = tensor_handle_to_tensor_pointer(tensor); 
+    *ret_value = static_cast<__half>(t->item().to<at::Half>());                      
+  });                                                        
+}
+// #endif
+
 AOTI_TORCH_ITEM_IMPL(float32, float)
 AOTI_TORCH_ITEM_IMPL(float64, double)
 AOTI_TORCH_ITEM_IMPL(uint8, uint8_t)

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -43,7 +43,6 @@
 
 #endif
 
-
 using namespace torch::aot_inductor;
 
 namespace {
@@ -122,6 +121,7 @@ AOTI_TORCH_ITEM_IMPL(int16, int16_t)
 AOTI_TORCH_ITEM_IMPL(int32, int32_t)
 AOTI_TORCH_ITEM_IMPL(int64, int64_t)
 AOTI_TORCH_ITEM_IMPL(bool, bool)
+AOTI_TORCH_ITEM_IMPL(bfloat16, c10::BFloat16)
 #undef AOTI_TORCH_ITEM_IMPL
 
 #define AOTI_TORCH_SCALAR_TO_TENSOR_IMPL(dtype, ctype, ttype)                  \


### PR DESCRIPTION
Fixes #131333

Summary:
- Add header to define `float16` and `bfloat16` as `at::Half` and `at::BFloat16`.
- change `float16` and `bfloat16` to `float` before passing to kernel.


code generated before:
```cpp
.....
    half var_1;
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_float16(convert_arrayref_tensor_to_tensor(arg1_1), &var_1));
....
```

code generated now:
```cpp
typedef at::Half half;
typedef at::BFloat16 bfloat16;
.....
    half var_1_tmp;
    AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_float16(convert_arrayref_tensor_to_tensor(arg1_1), &var_1_tmp));
    float var_1 = float(var_1_tmp);
....
```


Test plan: `TORCHINDUCTOR_ABI_COMPATIBLE=1 TORCHINDUCTOR_CPP_WRAPPER=1 python test/inductor/test_torchinductor.py -k GPUTests.test_unspec_inputs_cuda` 
Work in progress.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang