### PR TITLE
[export] prettify runtime shape-related asserts

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1907,7 +1907,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         em.module()(torch.randn(4, 3))
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(Mod\(s0\*s1, s0 \- 1\), 0\)",
+            r"Runtime assertion failed for expression Eq\(Mod\(x.size\(0\)\*x.size\(1\), x.size\(0\) \- 1\), 0\)",
         ):
             em.module()(torch.randn(4, 5))
 
@@ -5726,11 +5726,15 @@ def forward(self, x, y):
     sin = torch.ops.aten.sin.default(y)
     sum_1 = torch.ops.aten.sum.dim_IntList(sin, []);  sin = None
     _local_scalar_dense = torch.ops.aten._local_scalar_dense.default(x);  x = None
-    sym_constrain_range_for_size_default = torch.ops.aten.sym_constrain_range_for_size.default(_local_scalar_dense)
-    ge_1 = _local_scalar_dense >= 3
-    _assert_scalar_default = torch.ops.aten._assert_scalar.default(ge_1, "Runtime assertion failed for expression u3 >= 3 on node 'ge_1'");  ge_1 = None
-    le_1 = _local_scalar_dense <= 5;  _local_scalar_dense = None
-    _assert_scalar_default_1 = torch.ops.aten._assert_scalar.default(le_1, "Runtime assertion failed for expression u3 <= 5 on node 'le_1'");  le_1 = None
+    sym_constrain_range_for_size = torch.ops.aten.sym_constrain_range_for_size.default(_local_scalar_dense)
+    ge = _local_scalar_dense >= 3
+    _assert_scalar = torch.ops.aten._assert_scalar.default(ge, "Runtime assertion failed for expression u1 >= 3 on node 'ge'");  ge = None
+    le = _local_scalar_dense <= 5
+    _assert_scalar_1 = torch.ops.aten._assert_scalar.default(le, "Runtime assertion failed for expression u1 <= 5 on node 'le'");  le = None
+    gt = _local_scalar_dense > 2
+    _assert_scalar_2 = torch.ops.aten._assert_scalar.default(gt, "Runtime assertion failed for expression 2 < u1 on node 'gt'");  gt = None
+    lt = _local_scalar_dense < 6;  _local_scalar_dense = None
+    _assert_scalar_3 = torch.ops.aten._assert_scalar.default(lt, "Runtime assertion failed for expression u1 < 6 on node 'lt'");  lt = None
     full = torch.ops.aten.full.default([4, 4], 1, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
     add = torch.ops.aten.add.Tensor(y, sum_1);  y = sum_1 = None
     sum_2 = torch.ops.aten.sum.dim_IntList(full, []);  full = None
@@ -5791,7 +5795,7 @@ def forward(self, x, y):
         self.assertEqual(out2.shape, torch.ones(11, 4, 3).shape)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(Mod\(s0\*s1, 4\*s0 \- 4\), 0\) on node 'eq.*'",
+            r"Runtime assertion failed for expression Eq\(Mod\(x.size\(0\)\*x.size\(1\), 4\*x.size\(0\) \- 4\), 0\) on node 'eq.*'",
         ):
             ep.module()(torch.randn(8, 8))  # fail
 
@@ -5823,7 +5827,7 @@ def forward(self, x, y):
         self.assertEqual(out2.shape, torch.ones(40).shape)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(s0\*s1, s2\*s3\) on node 'eq.*'",
+            r"Runtime assertion failed for expression Eq\(x.size\(0\)\*x.size\(1\), y.size\(0\)\*y.size\(1\)\) on node 'eq.*'",
         ):  # fail only at runtime
             ep.module()(torch.randn(5, 8), torch.randn(4, 5), torch.randn(30))  # fail
 
@@ -5850,7 +5854,7 @@ def forward(self, x, y):
         self.assertEqual(out1.shape, torch.ones(126).shape)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(s0\*s1\*s2, s3\) on node 'eq.*'",
+            r"Runtime assertion failed for expression Eq\(x.size\(0\)\*x.size\(1\)\*x.size\(2\), y.size\(0\)\) on node 'eq.*'",
         ):  # fail only at runtime
             ep.module()(torch.randn(4, 3, 2), torch.randn(10))  # fail
 
@@ -5933,12 +5937,12 @@ def forward(self, x, y):
         )
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Ne\(s0, 20\)",
+            r"Runtime assertion failed for expression Ne\(x.size\(0\), 20\)",
         ):
             ep.module()(torch.randn(20, 20, 16))
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Ne\(Mod\(s0, 20\), 0\)",
+            r"Runtime assertion failed for expression Ne\(Mod\(x.size\(0\), 20\), 0\)",
         ):
             ep.module()(torch.randn(400, 20, 16))
         ep.module()(torch.randn(42, 20, 16))
@@ -5969,17 +5973,17 @@ def forward(self, x, y):
         self.assertEqual(out1.shape, torch.ones(27).shape)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Ne\(s0, s1\)",
+            r"Runtime assertion failed for expression Ne\(x.size\(0\), y.size\(0\)\)",
         ):  # fail only at runtime
             ep.module()(torch.randn(4), torch.randn(4))  # fail
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Ne\(s0, s1\**3\)",
+            r"Runtime assertion failed for expression Ne\(x.size\(0\), y.size\(0\)\**3\)",
         ):
             ep.module()(torch.randn(64), torch.randn(4))  # fail
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(s0\**2, 3\*s1\)",
+            r"Runtime assertion failed for expression Eq\(x.size\(0\)\**2, 3\*y.size\(0\)\)",
         ):
             ep.module()(torch.randn(10), torch.randn(9))  # fail
 
@@ -6225,7 +6229,7 @@ def forward(self, x, y):
         ep.module()(torch.ones(8), torch.ones(5))
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression \(s0//2\) \<\= s1",
+            r"Runtime assertion failed for expression \(x.size\(0\)//2\) \<\= y.size\(0\)",
         ):
             ep.module()(torch.ones(10), torch.ones(4))
 

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -34,7 +34,11 @@ from torch._export.passes.lift_constants_pass import (
     lift_constants_pass,
     rewrite_script_object_meta,
 )
-from torch._export.utils import placeholder_naming_pass, placeholder_prefixes
+from torch._export.utils import (
+    placeholder_naming_pass,
+    placeholder_prefixes,
+    runtime_asserts_naming_pass,
+)
 from torch._export.verifier import SpecViolationError
 from torch._export.wrappers import _wrap_submodules
 from torch._functorch._aot_autograd.traced_function_transforms import (
@@ -1761,6 +1765,9 @@ def _export_for_training(
     fake_mode = export_artifact.fake_mode
     module_call_specs = export_artifact.module_call_specs
 
+    # Prettify runtime asserts with sources
+    runtime_asserts_naming_pass(gm, fake_mode.shape_env, forward_arg_names, strict)
+
     # Add forward args metadata.
     gm.meta["forward_arg_names"] = forward_arg_names
 
@@ -1930,6 +1937,9 @@ def _export(
     out_spec = export_artifact.out_spec
     fake_mode = export_artifact.fake_mode
     module_call_specs = export_artifact.module_call_specs
+
+    # Prettify runtime asserts with sources
+    runtime_asserts_naming_pass(gm, fake_mode.shape_env, forward_arg_names, strict)
 
     # Add forward args metadata.
     gm.meta["forward_arg_names"] = forward_arg_names

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -489,30 +489,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
     # propagate names to higher order op subgraphs
     _name_hoo_subgraph_placeholders(gm)
 
-    # Run this pass before creating input/output specs, since size-related CSE/DCE might affect output signature.
-    # Overwrite output specs afterwards.
-    from torch._export.passes._node_metadata_hook import (
-        _node_metadata_hook,
-        _set_node_metadata_hook,
-    )
     from torch._functorch._aot_autograd.input_output_analysis import _graph_output_names
-
-    if not torch._dynamo.config.do_not_emit_runtime_asserts:
-        stack_trace = (
-            'File "torch/fx/passes/runtime_assert.py", line 24, '
-            "in insert_deferred_runtime_asserts"
-        )
-        shape_env = _get_shape_env(gm)
-        if shape_env is not None:
-            with _set_node_metadata_hook(
-                gm, functools.partial(_node_metadata_hook, stack_trace=stack_trace)
-            ):
-                insert_deferred_runtime_asserts(
-                    gm,
-                    shape_env,
-                    f"exported program: {first_call_function_nn_module_stack(gm.graph)}",
-                    export=True,
-                )
 
     # update output specs
     gm.recompile()


### PR DESCRIPTION
Prettifies runtime asserts for export by adding input shape labels instead of SymInts, e.g. x.size(0) instead of s0. Does this based on the source name and original module input arguments. Runtime asserts now look like:
```
Runtime assertion failed on expression Eq(x.size(0)*x.size(1), y.size(0)) on node ...
```