### PR TITLE
[operator_benchmark] Remove TARGETS from broken benchmarks

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -1,8 +1,6 @@
 import json
 import time
 
-import benchmark_cpp_extension  # noqa: F401
-
 import torch
 
 


### PR DESCRIPTION
Summary:
Remove operator_benchmark caffe2 build due to the removal of caffe2: https://github.com/pytorch/pytorch/commit/2fd75667b4f92dcf95486ba50d658fb53536cded

Plus, we are deleting the TARGETS file from broken benchmarks that we do not intend to maintain.

Test Plan: Sandcastle CI

Differential Revision: D60086216
