### PR TITLE
Remove MacOS M2 14 runner from MacMPS job

### DIFF
--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -28,7 +28,7 @@ jobs:
       test-matrix: |
         { include: [
           { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-13" },
-          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m2-14" },
+          { config: "mps", shard: 1, num_shards: 1, runner: "macos-m1-14" },
         ]}
 
   macos-py3-arm64-mps-test:


### PR DESCRIPTION
As it's been dead for 2+ weeks and causing queuing issues

<img width="760" alt="image" src="https://github.com/user-attachments/assets/4e806cae-3a67-4acb-b84f-1a9131d2a859">