### PR TITLE
Simplify THPEvent_get_device

### DIFF
--- a/torch/csrc/Event.cpp
+++ b/torch/csrc/Event.cpp
@@ -87,11 +87,7 @@ static void THPEvent_dealloc(THPEvent* self) {
 
 static PyObject* THPEvent_get_device(THPEvent* self, void* unused) {
   HANDLE_TH_ERRORS
-  std::optional<at::Device> device = self->event.device();
-  if (!device) {
-    Py_RETURN_NONE;
-  }
-  return THPDevice_New(device.value());
+  return THPDevice_New(self->event.device());
   END_HANDLE_TH_ERRORS
 }
 


### PR DESCRIPTION
Because self->event.device() always returns Device.
