### PR TITLE
[pytree] Only import optree if it's used

### DIFF
--- a/torch/utils/_cxx_pytree.py
+++ b/torch/utils/_cxx_pytree.py
@@ -32,8 +32,9 @@ from typing_extensions import deprecated
 import optree
 from optree import PyTreeSpec  # direct import for type annotations
 
-from torch.utils._pytree import KeyEntry
+import torch.utils._pytree as _pytree
 
+from torch.utils._pytree import KeyEntry
 
 __all__ = [
     "PyTree",
@@ -999,3 +1000,8 @@ def keystr(kp: KeyPath) -> str:
 def key_get(obj: Any, kp: KeyPath) -> Any:
     """Given an object and a key path, return the value at the key path."""
     raise NotImplementedError("KeyPaths are not yet supported in cxx_pytree.")
+
+
+_pytree._cxx_pytree_imported = True
+for args, kwargs in _pytree._cxx_pytree_pending_imports:
+    _private_register_pytree_node(*args, **kwargs)

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -160,6 +160,13 @@ class _SerializeNodeDef(NamedTuple):
 SUPPORTED_SERIALIZED_TYPES: Dict[Type[Any], _SerializeNodeDef] = {}
 SERIALIZED_TYPE_TO_PYTHON_TYPE: Dict[str, Type[Any]] = {}
 
+# NB: we try really hard to not import _cxx_pytree (which depends on optree)
+# as much as possible. This is for isolation: a user who is not using C++ pytree
+# shouldn't pay for it, and it helps makes things like cpython upgrades easier.
+_cxx_pytree_exists = importlib.util.find_spec("optree")  # type: ignore[attr-defined]
+_cxx_pytree_imported = False
+_cxx_pytree_pending_imports: List[Any] = []
+
 
 def register_pytree_node(
     cls: Type[Any],
@@ -209,11 +216,12 @@ def register_pytree_node(
         flatten_with_keys_fn=flatten_with_keys_fn,
     )
 
-    try:
+    if not _cxx_pytree_exists:
+        return
+
+    if _cxx_pytree_imported:
         from . import _cxx_pytree as cxx
-    except ImportError:
-        pass
-    else:
+
         cxx._private_register_pytree_node(
             cls,
             flatten_fn,
@@ -222,6 +230,14 @@ def register_pytree_node(
             to_dumpable_context=to_dumpable_context,
             from_dumpable_context=from_dumpable_context,
         )
+    else:
+        args = (cls, flatten_fn, unflatten_fn)
+        kwargs = {
+            "serialized_type_name": serialized_type_name,
+            "to_dumpable_context": to_dumpable_context,
+            "from_dumpable_context": from_dumpable_context,
+        }
+        _cxx_pytree_pending_imports.append((args, kwargs))
 
 
 def _register_namedtuple(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131478

torch.utils._pytree imports optree if it's available. Instead, we change
it to if it gets used. The motivation for this is better isolation.

Test Plan:
- new tests