### PR TITLE
WIP, Switching MPS to use `SharedMemory`, adapt MPS<->CPU to COW. 

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -33,7 +33,6 @@ enum UsageFlags : uint32_t {
   PRIVATE = 0,
   SMALL   = (1 << 0), // small heaps have sizes of kSmallHeap, and large ones kLargeHeap
   SHARED  = (1 << 1), // shared pools allocated on devices with unified memory; otherwise, private between host/device
-  MANAGED = (1 << 2), // managed storage mode
   HAZARD  = (1 << 3), // enables Automatic Hazard Tracking for the resources allocated on the pool
   SCALAR  = (1 << 4), // used to import CPU scalar values to GPU and use them in MPS Stream
 };
@@ -119,13 +118,11 @@ struct HeapBlock {
     // TODO: check the caching performance of write-combined mode
     MTLResourceOptions options = MTLResourceCPUCacheModeDefaultCache;
 
-    if (usage & UsageFlags::MANAGED)
-      options |= MTLResourceStorageModeManaged;
-    else if (usage & UsageFlags::SHARED)
+    if (usage & UsageFlags::SHARED) {
       options |= MTLResourceStorageModeShared;
-    else
+    } else {
       options |= MTLResourceStorageModePrivate;
-
+    }
     options |= (usage & UsageFlags::HAZARD) ? MTLResourceHazardTrackingModeTracked : MTLResourceHazardTrackingModeUntracked;
 
     return options;
@@ -212,7 +209,6 @@ typedef bool (*HeapComparison)(const HeapBlock*, const HeapBlock*);
 
 struct BufferPool {
   enum class Kind {
-    PRIVATE_SMALL,
     PRIVATE_LARGE,
     SHARED_SMALL,
     SHARED_LARGE,

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -57,6 +57,6 @@ C10_DECLARE_REGISTRY(MPSAllocatorCallbacksRegistry, IMpsAllocatorCallback);
 #define REGISTER_MPS_ALLOCATOR_CALLBACK(name, ...) \
   C10_REGISTER_CLASS(MPSAllocatorCallbacksRegistry, name, __VA_ARGS__);
 
-IMPSAllocator* getIMPSAllocator(bool sharedAllocator = false);
+IMPSAllocator* getIMPSAllocator(bool sharedAllocator = true);
 
 } // namespace at::mps

--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -78,6 +78,6 @@ class TORCH_API MPSDevice {
 
 TORCH_API bool is_available();
 TORCH_API bool is_macos_13_or_newer(MacOSVersion version = MacOSVersion::MACOS_VER_13_0_PLUS);
-TORCH_API at::Allocator* GetMPSAllocator(bool useSharedAllocator = false);
+TORCH_API at::Allocator* GetMPSAllocator(bool useSharedAllocator = true);
 
 } // namespace at::mps

--- a/aten/src/ATen/native/AutogradComposite.cpp
+++ b/aten/src/ATen/native/AutogradComposite.cpp
@@ -131,25 +131,25 @@ static Tensor _lazy_clone_impl(Tensor const& self,
   // } else if (device.value().is_cpu()) {
   //   std::cout << "Device is CPU" << std::endl;
   // }
-  if (c10::impl::cow::get_future_lazy_clone()) {  // TODO(Frank): This is assuming future.
+  if (c10::impl::cow::get_future_lazy_clone()) {
+    // TODO(Frank): Unclear if this is the right approach.
     if (device == std::nullopt) {
       device = c10::Device("cpu");
     }
-    // TODO(Frank): Set MPS if guard?
     at::Allocator* allocator = nullptr;
-    if (device.value().is_cpu()) {
-      allocator = c10::GetDefaultCPUAllocator();
-    } else if (device.value().is_mps()) {
-      allocator = at::mps::GetMPSAllocator();
-    } else {
-      std::cout << "AutograComposite" << std::endl;
-      assert(false);
-    }
-    if (storage->allocator() == at::mps::GetMPSAllocator()) {
-      std::cout << "Changing from MPS Allocator to CPU Allocator" << std::endl;
-    } else {
-      std::cout << "Changing from CPU Allocator to MPS Allocator" << std::endl;
-    }
+    // if (device.value().is_cpu()) {
+    //   allocator = c10::GetDefaultCPUAllocator();
+    // } else if (device.value().is_mps()) {
+    //   allocator = at::mps::GetMPSAllocator();
+    // } else {
+    //   std::cout << "AutograComposite" << std::endl;
+    //   assert(false);
+    // }
+    // if (storage->allocator() == at::mps::GetMPSAllocator()) {
+    //   std::cout << "Changing from MPS Allocator to CPU Allocator" << std::endl;
+    // } else {
+    //   std::cout << "Changing from CPU Allocator to MPS Allocator" << std::endl;
+    // }
 
     allocator = c10::GetAllocator(device.value().type());
     if (allocator == nullptr) {

--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -3,6 +3,8 @@
 
 #include <c10/core/DeviceType.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Backtrace.h>
+#include <iostream>
 
 #if !defined(__s390x__) && !defined(__powerpc__)
 #include <cpuinfo.h>
@@ -208,6 +210,7 @@ void* DispatchStubImpl::get_call_ptr(
     auto error = std::get<ErrorType>(result);
     switch (error) {
       case ErrorType::MissingDeviceKernel:
+        std::cout << c10::get_backtrace() << std::endl;
         TORCH_INTERNAL_ASSERT(
             false, "DispatchStub: missing kernel for ", device_type);
         return nullptr;

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -431,6 +431,7 @@ bool to_will_cow(
   auto is_shared_memory = ((self.device().is_cpu() && device->is_mps()) ||
   (self.device().is_mps() && (device == std::nullopt || device->is_cpu())));
 
+  // Debug message.
   std::cout << "ToWillCOW" << std::endl;
   if (self.device().is_mps()) {
     std::cout << "\tCurrent Device is MPS" << std::endl;
@@ -446,9 +447,9 @@ bool to_will_cow(
   }
   std::cout << "IsSharedMemory:" << is_shared_memory << std::endl;
 
-
   return is_null_or_equal_to(dtype, self.dtype().toScalarType()) &&
     is_null_or_equal_to(layout, self.layout()) &&
+    is_shared_memory &&
     !copy &&
     (memory_format == MemoryFormat::Preserve ||
      self.suggest_memory_format() == memory_format);
@@ -474,13 +475,16 @@ static inline Tensor to_impl(
   // create a copy-on-write context
   if (c10::impl::cow::get_future_lazy_clone() && to_will_cow_result) {
 
+    // Debug
     std::cout << "IsFutureLazyClone: " << c10::impl::cow::get_future_lazy_clone() << std::endl;
     std::cout << "self, is_cow_data_ptr: " << c10::impl::cow::is_cow_data_ptr(
       self.storage().data_ptr()
     ) << std::endl;
 
+    // Only line matters
     auto lazy_clone = self._lazy_clone(device);
 
+    // Debug
     std::cout << "self._lazy_clone(), is_cow_data_ptr: " << c10::impl::cow::is_cow_data_ptr(
       lazy_clone.storage().data_ptr()
     ) << std::endl;

--- a/aten/src/ATen/native/TensorConversions.h
+++ b/aten/src/ATen/native/TensorConversions.h
@@ -17,6 +17,14 @@ bool to_will_alias(
     bool copy,
     std::optional<c10::MemoryFormat> optional_memory_format);
 
+bool to_will_cow(
+    const Tensor& self,
+    std::optional<ScalarType> dtype,
+    std::optional<Layout> layout,
+    std::optional<Device> device,
+    bool copy,
+    std::optional<c10::MemoryFormat> optional_memory_format);
+
 Tensor to_meta(const Tensor& tensor);
 std::optional<Tensor> to_meta(const std::optional<Tensor>& tensor);
 std::vector<Tensor> to_meta(at::ITensorListRef t_list);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -31,6 +31,7 @@
 #include <c10/util/SmallVector.h>
 #include <c10/util/accumulate.h>
 #include <c10/util/irange.h>
+#include <c10/util/Backtrace.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -1174,6 +1175,9 @@ static Tensor make_qtensor(const Tensor& self, IntArrayRef size, IntArrayRef str
 }
 
 Tensor as_strided_tensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef stride, std::optional<int64_t> storage_offset_) {
+
+  std::cout << c10::get_backtrace() << std::endl;
+
   TORCH_INTERNAL_ASSERT(!self.is_mps(), "as_strided_tensorimpl does not work with MPS; call self.as_strided(...) instead");
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
   auto result = at::detail::make_tensor<TensorImpl>(

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1247,10 +1247,10 @@
 # the input to COW tensors.
 #
 # From Python, this function should only be called for testing COW behavior.
-- func: _lazy_clone(Tensor(a) self) -> Tensor(a)
+- func: _lazy_clone(Tensor(a) self, *, Device? device=None) -> Tensor(a)
   variants: function, method
 
-- func: _lazy_clone_future(Tensor self) -> Tensor
+- func: _lazy_clone_future(Tensor self, *, Device? device=None) -> Tensor
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: _lazy_clone_future
@@ -1260,7 +1260,7 @@
   dispatch:
     CompositeExplicitAutograd: _lazy_clone_alias
 
-- func: _lazy_clone_copy(Tensor self) -> Tensor
+- func: _lazy_clone_copy(Tensor self, *, Device? device=None) -> Tensor
   variants: function
   tags: view_copy
   dispatch:

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -355,6 +355,10 @@ class TORCH_API Tensor: public TensorBase {
     return to(options().device(c10::DeviceType::Metal), /*non_blocking*/ false, /*copy*/ false);
   }
 
+  Tensor mps() const {
+    return to(options().device(c10::DeviceType::MPS), /*non_blocking*/ false, /*copy*/ false);
+  }
+
   Tensor meta() const {
     return to(options().device(c10::DeviceType::Meta), /*non_blocking*/ false, /*copy*/ false);
   }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1244,6 +1244,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   Device device() const {
+    std::cout << "InquiryDevice" << std::endl;
     if (C10_UNLIKELY(device_policy_)) {
       return device_custom();
     }
@@ -2343,6 +2344,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         err_msg_tensor_metadata_change_not_allowed);
     storage_ = std::move(storage);
     device_opt_ = storage_.device();
+    std::cout << "Storage's Device " << device_opt_.value() << std::endl;
   }
 
   void set_storage_and_dtype(


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

Currently simple tests don't pass 
```
import torch
torch.set_future_lazy_clone(True)

cpu = torch.zeros((1, 2, 3), device=torch.device('cpu'))
mps = cpu.to("mps")

print(mps)
```
will result 
```
Traceback (most recent call last):
  File "/Users/chenfan_sun/workspace/pytorch/test_cow.py", line 67, in <module>
    main()
  File "/Users/chenfan_sun/workspace/pytorch/test_cow.py", line 63, in main
    verify_new_behavior()
  File "/Users/chenfan_sun/workspace/pytorch/test_cow.py", line 26, in verify_new_behavior
    print(mps)
  File "/Users/chenfan_sun/workspace/pytorch/torch/_tensor.py", line 464, in __repr__
    return torch._tensor_str._str(self, tensor_contents=tensor_contents)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chenfan_sun/workspace/pytorch/torch/_tensor_str.py", line 705, in _str
    return _str_intern(self, tensor_contents=tensor_contents)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chenfan_sun/workspace/pytorch/torch/_tensor_str.py", line 625, in _str_intern
    tensor_str = _tensor_str(self, indent)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chenfan_sun/workspace/pytorch/torch/_tensor_str.py", line 357, in _tensor_str
    formatter = _Formatter(get_summarized_data(self) if summarize else self)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chenfan_sun/workspace/pytorch/torch/_tensor_str.py", line 137, in __init__
    tensor_view = tensor.reshape(-1)
                  ^^^^^^^^^^^^^^^^^^
RuntimeError: allocator_ INTERNAL ASSERT FAILED at "/Users/chenfan_sun/workspace/pytorch/c10/core/StorageImpl.h":76, please report a bug to PyTorch. For resizable storage, allocator must be provided
```