### PR TITLE
Add an extra shard for distributed periodic jobs

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -277,8 +277,9 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
-          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
+          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
         ]}
 
   linux-focal-rocm6_1-py3_8-test:


### PR DESCRIPTION
Fixes issue of timeouts being observed in ROCm periodic workflow for distributed runs
