### PR TITLE
Fix reference counting for saved variable hook TLS

### DIFF
--- a/aten/src/ATen/SavedTensorHooks.h
+++ b/aten/src/ATen/SavedTensorHooks.h
@@ -2,6 +2,7 @@
 
 #include <c10/macros/Export.h>
 #include <c10/util/python_stub.h>
+#include <c10/core/impl/SavedVariableHookTLS.h>
 #include <optional>
 #include <stack>
 #include <string>
@@ -9,34 +10,14 @@
 #include <utility>
 
 namespace at {
-
-namespace impl {
-
-struct TORCH_API SavedTensorDefaultHooksTLS {
-  // PyObject is defined in c10/util/python_stub.h
-  std::stack<std::pair<PyObject*, PyObject*>> stack;
-
-  // See NOTE: [Disabling SavedTensorDefaultHooks] for context
-  // NOTE: [disabled_error_message invariant]
-  // disabled_error_message is nullopt IFF Saved Tensor hooks is enabled
-  // We did this for efficiency (so we didn't have to keep a separate bool
-  // around)
-  std::optional<std::string> disabled_error_message;
-
-  // See NOTE: [Deferring tensor pack/unpack hooks until runtime]
-  bool is_tracing = false;
-};
-
-} // namespace impl
-
 struct TORCH_API SavedTensorDefaultHooks {
   static void push_hooks(PyObject* pack_hook, PyObject* unpack_hook);
   static std::pair<PyObject*, PyObject*> pop_hooks();
   static std::pair<PyObject*, PyObject*> get_hooks();
   static void lazy_initialize();
 
-  static const impl::SavedTensorDefaultHooksTLS& get_tls_state();
-  static void set_tls_state(const impl::SavedTensorDefaultHooksTLS& tls);
+  static const c10::impl::SavedTensorDefaultHooksTLS& get_tls_state();
+  static void set_tls_state(const c10::impl::SavedTensorDefaultHooksTLS& tls);
 
   // NOTE: [Disabling SavedTensorDefaultHooks]
   // A developer of a PyTorch feature may choose to disable SavedTensorDefault

--- a/aten/src/ATen/ThreadLocalState.cpp
+++ b/aten/src/ATen/ThreadLocalState.cpp
@@ -7,6 +7,9 @@
 #include <ATen/record_function.h>
 #include <ATen/SavedTensorHooks.h>
 #include <ATen/FunctionalTensorWrapper.h>
+#include <c10/core/impl/SavedVariableHookTLS.h>
+#include <c10/core/impl/GPUTrace.h>
+
 
 namespace at {
 
@@ -41,7 +44,11 @@ void ThreadLocalState::setThreadLocalState(
 
   at::set_record_function_tls_(state.rf_tls_);
 
-  at::SavedTensorDefaultHooks::set_tls_state(state.saved_tensors_default_hooks_state_);
+  const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
+  if (C10_UNLIKELY(interp)) {
+    (*interp)->set_default_saved_variable_hooks_tls(state.saved_tensors_default_hooks_state_);
+  }
+  // at::SavedTensorDefaultHooks::set_tls_state(state.saved_tensors_default_hooks_state_);
 
   c10::impl::PythonDispatcherTLS::set_state(state.python_dispatcher_state_);
 

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -12,6 +12,8 @@
 #include <ATen/record_function.h>
 #include <c10/core/impl/PythonDispatcherTLS.h>
 #include <c10/core/impl/TorchDispatchModeTLS.h>
+#include <c10/core/impl/SavedVariableHookTLS.h>
+
 
 namespace at {
 
@@ -71,7 +73,7 @@ class TORCH_API ThreadLocalState {
   at::impl::PythonTorchFunctionTLS python_torch_function_state_;
 
   // TLS for saved tensors default hooks
-  at::impl::SavedTensorDefaultHooksTLS saved_tensors_default_hooks_state_;
+  c10::impl::SavedTensorDefaultHooksTLS saved_tensors_default_hooks_state_;
 
   bool functionalization_reapply_views_state_;
 

--- a/c10/core/impl/PyInterpreter.cpp
+++ b/c10/core/impl/PyInterpreter.cpp
@@ -126,6 +126,10 @@ struct NoopPyInterpreterVTable final : public PyInterpreterVTable {
   void reset_backward_hooks(const TensorImpl* self) const override {
     PANIC(reset_backward_hooks);
   };
+
+  void set_default_saved_variable_hooks_tls(const SavedTensorDefaultHooksTLS& tls) const override {
+    PANIC(reset_backward_hooks);
+  };
 };
 
 // Construct this in Global scope instead of within `disarm`

--- a/c10/core/impl/PyInterpreter.h
+++ b/c10/core/impl/PyInterpreter.h
@@ -9,8 +9,10 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/python_stub.h>
+#include <c10/core/impl/SavedVariableHookTLS.h>
 #include <string>
 #include <vector>
+#include <stack>
 
 // Forward declarations
 
@@ -212,6 +214,9 @@ struct C10_API PyInterpreterVTable {
       uintptr_t event) const = 0;
 
   virtual void reset_backward_hooks(const TensorImpl* self) const = 0;
+
+  virtual void set_default_saved_variable_hooks_tls(const SavedTensorDefaultHooksTLS& tls) const = 0;
+
 };
 
 struct C10_API PyInterpreter {

--- a/c10/core/impl/SavedVariableHookTLS.cpp
+++ b/c10/core/impl/SavedVariableHookTLS.cpp
@@ -1,0 +1,1 @@
+#include <c10/core/impl/SavedVariableHookTLS.h>

--- a/c10/core/impl/SavedVariableHookTLS.h
+++ b/c10/core/impl/SavedVariableHookTLS.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <c10/macros/Export.h>
+#include <c10/util/python_stub.h>
+
+#include <vector>
+#include <optional>
+
+
+namespace c10::impl {
+
+struct C10_API SavedTensorDefaultHooksTLS {
+  // PyObject is defined in c10/util/python_stub.h
+  std::vector<std::pair<PyObject*, PyObject*>> stack;
+
+  // See NOTE: [Disabling SavedTensorDefaultHooks] for context
+  // NOTE: [disabled_error_message invariant]
+  // disabled_error_message is nullopt IFF Saved Tensor hooks is enabled
+  // We did this for efficiency (so we didn't have to keep a separate bool
+  // around)
+  std::optional<std::string> disabled_error_message;
+
+  // See NOTE: [Deferring tensor pack/unpack hooks until runtime]
+  bool is_tracing = false;
+};
+
+} // namespace c10::impl

--- a/c10/core/impl/SavedVariableHookTLS.h
+++ b/c10/core/impl/SavedVariableHookTLS.h
@@ -5,6 +5,7 @@
 
 #include <vector>
 #include <optional>
+#include <string>
 
 
 namespace c10::impl {

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -293,6 +293,7 @@ class saved_tensors_hooks:
     ) -> None:
         self.pack_hook = pack_hook
         self.unpack_hook = unpack_hook
+        torch._C._activate_gpu_trace()
 
     def __enter__(self) -> None:
         torch._C._autograd._push_saved_tensors_default_hooks(

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -4,7 +4,10 @@
 #include <torch/csrc/THP.h>
 #include <torch/csrc/autograd/generated/VariableType.h>
 #include <torch/csrc/utils/python_arg_parser.h>
+#include <c10/core/impl/SavedVariableHookTLS.h>
 #include <torch/csrc/utils/python_dispatch.h>
+#include <torch/csrc/autograd/python_saved_variable_hooks.h>
+
 
 #include <string>
 
@@ -140,6 +143,9 @@ struct ConcretePyInterpreterVTable final
   }
 
   void reset_backward_hooks(const c10::TensorImpl* self) const override;
+
+  void set_default_saved_variable_hooks_tls(const c10::impl::SavedTensorDefaultHooksTLS& tls) const override;
+
 
   static ConcretePyInterpreterVTable* instance() {
     static ConcretePyInterpreterVTable s;
@@ -954,6 +960,10 @@ void ConcretePyInterpreterVTable::reset_backward_hooks(
       py::reinterpret_steal<py::object>(THPVariable_Wrap(std::move(self_t)));
   PyObject_SetAttrString(self_p.ptr(), "_backward_hooks", Py_None);
   END_HANDLE_TH_ERRORS_PYBIND
+}
+
+void ConcretePyInterpreterVTable::set_default_saved_variable_hooks_tls(const c10::impl::SavedTensorDefaultHooksTLS& tls) const {
+  torch::autograd::PyDefaultSavedVariableHooks::set_tls_state(tls);
 }
 
 PyInterpreterHolder self_interpreter;

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -4,6 +4,7 @@
 
 #include <torch/csrc/autograd/engine.h>
 #include <torch/csrc/autograd/function.h>
+#include <ATen/SavedTensorHooks.h>
 
 bool THPEngine_initModule(PyObject* module);
 

--- a/torch/csrc/autograd/python_saved_variable_hooks.h
+++ b/torch/csrc/autograd/python_saved_variable_hooks.h
@@ -14,6 +14,7 @@ namespace torch::autograd {
 
 struct PySavedVariableHooks : public SavedVariableHooks {
   PySavedVariableHooks(py::function& pack_hook, py::function& unpack_hook);
+  PySavedVariableHooks(const PySavedVariableHooks& other);
   void call_pack_hook(const at::Tensor& tensor) override;
   at::Tensor call_unpack_hook() override;
   ~PySavedVariableHooks() override;
@@ -28,6 +29,7 @@ struct PyDefaultSavedVariableHooks {
   static void push_hooks(py::function& pack_hook, py::function& unpack_hook);
   static void pop_hooks();
   static std::unique_ptr<SavedVariableHooks> get_hooks();
+  static void set_tls_state(const c10::impl::SavedTensorDefaultHooksTLS& tls);
 };
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -51,6 +51,8 @@ class TORCH_API SavedVariable {
     return (bool)hooks_;
   }
 
+  static std::unique_ptr<SavedVariableHooks> get_default_hooks();
+
  private:
   // This field contains either:
   // 1. the variable to save
@@ -112,7 +114,6 @@ class TORCH_API SavedVariable {
   bool requires_grad_ = false;
 
   void save_metadata(const Variable& data);
-  static std::unique_ptr<SavedVariableHooks> get_default_hooks();
   void set_hooks_and_pack_data(
       std::unique_ptr<SavedVariableHooks>&& hooks,
       const Variable& data);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131550

The problem: 
- Today the static methods on PyDefaultSavedVariableHooks are expected to properly manage the reference count of PyObject stored on the TLS stack of hooks, e.g. when pushed/popped. More generally, someone needs to properly manage the reference count of PyObjects on the TLS stack whenever the stack is updated. **The issue is that today we do not update reference counts when calling `set_tls_state`.**
-  As a result of this, a segfault can happen if the user manually pops from the saved variable hooks stack during backward. A leak can happen if the user manually pushes to the stack without cleaning up.

Option 1 (this PR):
- Whenever TLS state is set, INCREF all PyObjects in the new state's stack and DECREF all PyObjects in the old state's stack.
- Optionally: still explicitly error when the user tries to call the private APIs to manually push/pop in a weird way during backward because it is likely not what the user wants.

Option 2 (alternative):
- Do not care about properly reference counting because it is hard, but produce explicit error in cases we know it can segfault/leak, i.e., update the ThreadLocalState guard API such that it checks TLS state before after, and see if it is the same. If differ, we error.

Discussion:
- Option 1 is quite annoying to do because we need a way to access Python things in aten. The current approach is to use the existing PyInterpreter infra for this. 
- Option 2 does not solve the fundamental issue. If ThreadLocalState is used without the guard API, then we could still have a problem.

Some things left to do:
- GPUTrace has some preexisting logic to get/set PyInterpreter. It would be nice to be able to just make this a general utility. If you care about multipy there may be issues however, because whichever API relying this is the first to be invoked would decide which interpreter will be set globally. 
