### PR TITLE
Revert mm pad Changes Made in D59946410

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -422,28 +422,6 @@ class PadMMTest(TestCase):
             repr(local_cache)
         )
 
-    @fresh_inductor_cache()
-    @inductor_config.patch(max_pointwise_cat_inputs=2)
-    def test_exclude_cat_padding(self):
-        @torch.compile()
-        def mm(inps, b):
-            return torch.cat(inps) @ b
-
-        inp = torch.rand([2046, 2046], device="cuda")
-        inp2 = torch.rand([2046, 2046], device="cuda")
-
-        inps = inp.chunk(3)
-        mm(inps, inp2)
-        FileCheck().check_count("exclude_pad:False", 2, exactly=True).run(
-            repr(get_pad_cache().get_local_cache())
-        )
-
-        inps = inp.chunk(2)
-        mm(inps, inp2)
-        FileCheck().check_count("exclude_pad:False", 3, exactly=True).run(
-            repr(get_pad_cache().get_local_cache())
-        )
-
 
 if __name__ == "__main__":
     if HAS_CUDA:

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -318,30 +318,6 @@ def should_exclude_padding_time(match, arg_name):
     if not fetch_fake_tensors(match, (arg_name,))[0].is_contiguous():
         return False
 
-    # TODO - see issue https://githpub.com/pytorch/pytorch/issues/128889
-    # We would only able to completely plan these out if we were only doing
-    # first dimension padding. non-first we would still need a copy
-    # because these outputs are fixed dense.
-    cannot_plan_output = [
-        aten.mm.default,
-        aten.convolution.default,
-        aten.convolution_backward.default,
-        aten.bmm.default,
-        aten.addmm.default,
-        aten._scaled_dot_product_flash_attention.default,
-        aten._scaled_dot_product_efficient_attention.default,
-    ]
-
-    if node_def.target in cannot_plan_output:
-        return False
-
-    if (
-        node_def.target == aten.cat.default
-        and len(node_def.all_input_nodes)
-        > torch._inductor.config.max_pointwise_cat_inputs
-    ):
-        return False
-
     # optimistically assume we should be able to memory plan away
     # all non inputs
     return node_def.op != "placeholder"
@@ -451,7 +427,6 @@ def should_pad_bench(
         mat2_pad = mat2
 
         is_bmm = op is torch.ops.aten.bmm
-
         mat1_pre_padded = should_exclude_padding_time(match, "mat1")
         fns = []
         if mat1_pre_padded and (m_padded_length or k_padded_length):
@@ -689,35 +664,24 @@ def should_pad_mm(match: Match) -> bool:
 
 
 def pad_mat1(mat1, *, m_padded_length, k_padded_length, is_bmm=False):
-    if m_padded_length == 0 and k_padded_length == 0:
-        return mat1
-    elif k_padded_length != 0 and m_padded_length != 0:
+    if k_padded_length != 0 or m_padded_length != 0:
         # dim order is reversed for constant_pad_nd, for every dim we specify right and left padding
         pad_arg = [0, k_padded_length, 0, m_padded_length]
         if is_bmm:
             pad_arg.extend((0, 0))
         return aten.constant_pad_nd(mat1, pad_arg)
-    elif m_padded_length != 0:
-        return pad_dim(mat1, m_padded_length, 0 if not is_bmm else 1)
-    else:
-        assert k_padded_length != 0
-        return pad_dim(mat1, k_padded_length, 1 if not is_bmm else 2)
+    return mat1
 
 
 def pad_mat2(mat2, *, k_padded_length, n_padded_length, is_bmm=False):
-    if k_padded_length == 0 and n_padded_length == 0:
-        return mat2
-    elif k_padded_length != 0 and n_padded_length != 0:
+    if k_padded_length != 0 or n_padded_length != 0:
         # dim order is reversed for constant_pad_nd, for every dim we specify right and left padding
         pad_arg = [0, n_padded_length, 0, k_padded_length]
         if is_bmm:
             pad_arg.extend((0, 0))
         return aten.constant_pad_nd(mat2, pad_arg)
-    elif k_padded_length != 0:
-        return pad_dim(mat2, k_padded_length, 0 if not is_bmm else 1)
     else:
-        assert n_padded_length != 0
-        return pad_dim(mat2, n_padded_length, 1 if not is_bmm else 2)
+        return mat2
 
 
 def pad_mm(


### PR DESCRIPTION
Summary: The changes in D59946410 to pad_mm.py regressed some Ads models' merge net perf by 10%.

Test Plan:
The perf can be compared by running
```
CUDA_VISIBLE_DEVICES=7 TORCH_COMPILE_DEBUG=0 buck2 run mode/opt-split-dwarf mode/inplace -c fbcode.enable_gpu_sections=true -c fbcode.platform=platform010  -c fbcode.nvcc_arch=a100 caffe2/torch/fb/model_transform/experimental/benchmark:mts_gpu_benchmark -- --model-path manifold://ads_storage_fblearner/tree/user/facebook/fblearner/predictor/550712715/1950/gpu_lowering/input.predictor.disagg.gpu.merge --lower-backend=AOT_INDUCTOR
```
with and without the change.

Differential Revision: D60139016


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang