### PR TITLE
Add explicit GQA support. TODO: debug cuda memory error

### DIFF
--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -104,9 +104,7 @@ def generate_inputs(
         torch.rand, kv_shape, device=device, dtype=dtype, requires_grad=requires_grad
     )
     query = (
-        make_q()
-        .view(batch_size, num_h_groups * q_sequence_length, kv_heads, head_dim)
-        .transpose(1, 2)
+        make_q().view(batch_size, q_sequence_length, q_heads, head_dim).transpose(1, 2)
     )
     key = (
         make_kv()
@@ -139,7 +137,8 @@ def run_single_experiment(
     )
 
     def eager_sdpa(query, key, value, _):
-        return F.scaled_dot_product_attention(query, key, value)
+        flattened_query = query.reshape(batch_size, kv_heads, -1, head_dim)
+        return F.scaled_dot_product_attention(flattened_query, key, value)
 
     if max_autotune:
         compiled_sdpa = torch.compile(
@@ -161,7 +160,12 @@ def run_single_experiment(
         eager_sdpa, query, key, value, score_mod
     )
     forward_compiled_time = benchmark_torch_function_in_microseconds(
-        compiled_sdpa, query, key, value, score_mod, block_mask
+        compiled_sdpa,
+        query.reshape(batch_size, kv_heads, -1, head_dim),
+        key,
+        value,
+        score_mod, 
+        block_mask,
     )
 
     if config.calculate_bwd_time:
@@ -171,8 +175,13 @@ def run_single_experiment(
             out_eager.backward, dOut, retain_graph=True
         )
 
-        out_compile = compiled_sdpa(query, key, value, score_mod)
-        dOut = torch.randn_like(out_eager)
+        out_compile = compiled_sdpa(
+            query.reshape(batch_size, kv_heads, -1, head_dim),
+            key,
+            value,
+            score_mod,
+        )
+        dOut = torch.randn_like(out_compile)
         backward_compile_time = benchmark_torch_function_in_microseconds(
             out_compile.backward, dOut, retain_graph=True
         )

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -50,13 +50,23 @@ def rmse(ref, res):
     return torch.sqrt(torch.mean(torch.square(ref - res)))
 
 
-def create_attention(score_mod, block_mask):
-    return functools.partial(flex_attention, score_mod=score_mod, block_mask=block_mask)
+def create_attention(score_mod, block_mask, enable_gqa=False):
+    return functools.partial(
+        flex_attention,
+        score_mod=score_mod,
+        block_mask=block_mask,
+        enable_gqa=enable_gqa,
+    )
 
 
 def create_block_mask_test(score_mod, query, key):
     block_mask = create_block_mask(
-        score_mod, 1, 1, query.shape[-2], key.shape[-2], query.device
+        score_mod,
+        None,
+        None,
+        query.shape[-2],
+        key.shape[-2],
+        query.device,
     )
     return block_mask
 
@@ -272,7 +282,9 @@ class TestFlexAttention(InductorTestCase):
         q_ref, k_ref, v_ref = query_key_value_clones(q, k, v)
         q_gold, k_gold, v_gold = query_key_value_clones(q, k, v, torch.float64)
         block_mask = None
-        sdpa_partial = create_attention(score_mod, block_mask)
+        sdpa_partial = create_attention(
+            score_mod, block_mask, enable_gqa=(not Q_H == KV_H)
+        )
         compiled_sdpa = torch.compile(sdpa_partial)
         golden_out = sdpa_partial(q_gold, k_gold, v_gold)
         ref_out = sdpa_partial(q_ref, k_ref, v_ref)
@@ -537,6 +549,23 @@ class TestFlexAttention(InductorTestCase):
             B,
             H,
             S // 2,  # Seqlen of Q is different from seqlen of K/V
+            D,
+            B,
+            H,
+            S,
+            D,
+        )
+
+    @supported_platform
+    @common_utils.parametrize("dtype", test_dtypes_fast)
+    @common_utils.parametrize("score_mod", test_score_mods)
+    def test_GQA(self, dtype: torch.dtype, score_mod: Callable):
+        self.run_test(
+            score_mod,
+            dtype,
+            B,
+            H * 4,  # Hq = 4*Hkv.
+            S // 8,
             D,
             B,
             H,
@@ -1451,7 +1480,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         def causal_mask(b, h, q, kv):
             return q >= kv
 
-        block_mask = create_block_mask(causal_mask, 1, 1, 2048, 2048)
+        block_mask = create_block_mask(causal_mask,1, 1, 2048, 2048)
 
         def replace_non_printable(s):
             def replace(c):

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -128,12 +128,19 @@ def _math_attention_inner(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     working_precision = torch.float64 if query.dtype == torch.float64 else torch.float32
 
+    
+
     scores = (query @ key.transpose(-2, -1)).to(dtype=working_precision)
 
     b = torch.arange(0, scores.size(0), device=scores.device)
-    h = torch.arange(0, scores.size(1), device=scores.device)
-    m = torch.arange(0, scores.size(2), device=scores.device)
-    n = torch.arange(0, scores.size(3), device=scores.device)
+    hkv = torch.arange(0, scores.size(1), device=scores.device)
+    g = torch.arange(0, scores.size(2), device=scores.device)
+    h = hkv[:, None] * scores.size(2) + g[None, :]
+    m = torch.arange(0, scores.size(-2), device=scores.device)
+    n = torch.arange(0, scores.size(-1), device=scores.device)
+
+
+    
 
     captured_buffers_in_dim = (None,) * len(score_mod_other_buffers)
     from torch.nn.attention.flex_attention import _vmap_for_bhqkv
@@ -181,6 +188,12 @@ def math_attention(
         score_mod: The score_mod function
         other_buffers: Other buffers that are passed to the score_mod function
     """
+    query = query.view(
+        query.size(0), key.size(1), -1, query.size(-2), query.size(-1)
+    )  # [B, Hq, Mq, D] -> [B, Hkv, G, Mq, D], G=Hq//Hkv
+    key = torch.unsqueeze(key, 2)  # [B, Hkv, Mkv, D] -> [B, Hkv, 1, Mkv, D]
+    value = torch.unsqueeze(value, 2)  # [B, Hkv, Mkv, D] -> [B, Hkv, 1, Mkv, D]
+
     _, post_mod_scores = _math_attention_inner(
         query,
         key,
@@ -198,7 +211,12 @@ def math_attention(
 
     post_mod_scores = post_mod_scores.softmax(dim=-1)
 
-    return post_mod_scores.to(query.dtype) @ value, logsumexp
+    output = scores.to(query.dtype) @ value
+
+    output = torch.flatten(output, 1, 2)
+    logsumexp = torch.flatten(logsumexp, 1, 2)
+
+    return output, logsumexp
 
 
 @flex_attention.py_impl(DispatchKey.CompositeExplicitAutograd)
@@ -663,6 +681,16 @@ def sdpa_dense_backward(
     score_mod_other_buffers: Tuple = (),
     mask_mod_other_buffers: Tuple = (),
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    # [B, Hq, Mq, D] -> [B, Hkv, G, Mq, D], G=Hq//Hkv
+    q_gqa_shape = (query.size(0), key.size(1), -1, query.size(-2), query.size(-1))
+    query = query.view(q_gqa_shape)
+    out = out.view(q_gqa_shape)
+    grad_out = grad_out.view(q_gqa_shape)
+    logsumexp = logsumexp.view(q_gqa_shape[:-1])
+
+    key = torch.unsqueeze(key, 2)  # [B, Hkv, Mkv, D] -> [B, Hkv, 1, Mkv, D]
+    value = torch.unsqueeze(value, 2)  # [B, Hkv, Mkv, D] -> [B, Hkv, 1, Mkv, D]
+
     scores, post_mod_scores = _math_attention_inner(
         query,
         key,
@@ -684,9 +712,11 @@ def sdpa_dense_backward(
     grad_score_mod = softmax_scores * (grad_softmax_scores - sum_scores)
 
     b = torch.arange(0, scores.size(0), device=scores.device)
-    h = torch.arange(0, scores.size(1), device=scores.device)
-    m = torch.arange(0, scores.size(2), device=scores.device)
-    n = torch.arange(0, scores.size(3), device=scores.device)
+    hkv = torch.arange(0, scores.size(1), device=scores.device)
+    g = torch.arange(0, scores.size(2), device=scores.device)
+    h = hkv[:, None] * scores.size(2) + g[None, :]
+    m = torch.arange(0, scores.size(-2), device=scores.device)
+    n = torch.arange(0, scores.size(-1), device=scores.device)
 
     mask_graph = block_mask[-1]
     # Gradient of the inline score_mod function, with respect to the scores
@@ -720,6 +750,12 @@ def sdpa_dense_backward(
 
     grad_query = grad_scores @ key
     grad_key = grad_scores.transpose(-2, -1) @ query
+
+    # Flatten GQA dimensions. [Hkv, G] -> [Hq]
+    grad_query = torch.flatten(grad_query, 1, 2)
+    grad_key = torch.sum(grad_key, 2, keepdim=False)
+    grad_value = torch.sum(grad_value, 2, keepdim=False)
+
     return grad_query.contiguous(), grad_key.contiguous(), grad_value.contiguous()
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131558
* #131404

Attempt to add GQA to mask generation

Fix backward

Fix submodule

Reduce GQA unit test mem usage

Remove special empty mask pass in flex_attention kernel

Generate GQA block mask from input

move mask group braodcast to kernel

Fix Group dim reduction

Flex DQ

Fix backward DK DV

Revert changes in flex_attention

default is_gqa in test

Fix tests

Fix lint

rename API is_gqa->enable_gqa

Update score_mod to support GQA inputs

Fix benchmark Lint

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang