### PR TITLE
[BE] Remove some mypy allow-untyped-decorators that are no longer needed

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import collections
 import contextlib

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from __future__ import annotations
 

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 from __future__ import annotations
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # mypy: disallow-untyped-defs
 from __future__ import annotations
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #131590
* #131589
* #131588
* #131587
* #131586
* #131585
* #131584
* #131583
* #131582
* #131581
* #131580
* #131579
* #131578
* #131577
* #131576
* #131575
* #131574
* #131573
* #131572
* #131571
* #131570
* #131569
* #131568
* #131567
* #131566
* #131565
* __->__ #131564

See #131429

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang