### PR TITLE
[dtensor][debug] adding new noise level which allows users to only print operations with dtensors

### DIFF
--- a/torch/distributed/_tensor/examples/comm_mode_features_example.py
+++ b/torch/distributed/_tensor/examples/comm_mode_features_example.py
@@ -184,8 +184,8 @@ class CommDebugModeExample:
             output_tp.sum().backward()
 
         # print the module level collective tracing information
-        print(comm_mode.generate_comm_debug_tracing_table(noise_level=1))
-        comm_mode.log_comm_debug_tracing_table_to_file(noise_level=1)
+        print(comm_mode.generate_comm_debug_tracing_table(noise_level=0))
+        comm_mode.log_comm_debug_tracing_table_to_file(noise_level=0)
 
     def example_transformer_module_tracing(self) -> None:
         """
@@ -272,8 +272,8 @@ class CommDebugModeExample:
             output = model(inp)
 
         # print the module level collective tracing information
-        print(comm_mode.generate_comm_debug_tracing_table(noise_level=1))
-        comm_mode.log_comm_debug_tracing_table_to_file(noise_level=1)
+        print(comm_mode.generate_comm_debug_tracing_table(noise_level=0))
+        comm_mode.log_comm_debug_tracing_table_to_file(noise_level=0)
 
     def example_MLP_operation_tracing(self) -> None:
         """
@@ -597,7 +597,7 @@ class CommDebugModeExample:
         # print the operation level collective tracing information
         print(comm_mode.generate_comm_debug_tracing_table(noise_level=2))
         comm_mode.log_comm_debug_tracing_table_to_file(
-            noise_level=2, file_name="transformer_operation_log.txt"
+            noise_level=1, file_name="transformer_operation_log.txt"
         )
 
     def example_MLP_json_dump(self) -> None:
@@ -630,7 +630,8 @@ class CommDebugModeExample:
         with comm_mode:
             output = model(inp)
 
-        comm_mode.generate_json_dump(file_name="transformer_log.json", noise_level=2)
+        comm_mode.generate_json_dump(file_name="transformer_log.json", noise_level=1)
+        comm_mode.generate_json_dump(file_name="transformer_log_2.json", noise_level=2)
 
     def example_activation_checkpointing(self) -> None:
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131592

**Summary**
I have added a new noise level between the existing levels of 1 and 2, such that the noise level controls are now:
          0. prints module-level collective counts
          1. prints dTensor operations not included in trivial operations (new noise level)
          2. prints operations not included in trivial operations
          3. prints all operations
          
This gives the user more flexibility in controlling what information they want to use. The noise levels are used both for creating the console/file log and the json dump. In the example file, I have changed the module_tracing examples to noise level 0 and have changed my transformer examples to show off the new noise level. 

**Test Plan**
1. torchrun --standalone --nnodes=1 --nproc-per-node=4 torch/distributed/_tensor/examples/comm_mode_features_example.py -e transformer_json_dump

2. torchrun --standalone --nnodes=1 --nproc-per-node=4 torch/distributed/_tensor/examples/comm_mode_features_example.py -e transformer_operation_tracing

3. torchrun --standalone --nnodes=1 --nproc-per-node=4 torch/distributed/_tensor/examples/comm_mode_features_example.py -e MLP_module_tracing

4. torchrun --standalone --nnodes=1 --nproc-per-node=4 torch/distributed/_tensor/examples/comm_mode_features_example.py -e transformer_module_tracing


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o