### PR TITLE
[aoti] Fix constant inputs passed to aoti

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1361,13 +1361,12 @@ class AOTInductorTestsTemplate:
         self.check_model(Model(self.device), example_inputs)
 
     def test_non_tensor_input(self):
-        def fn(a, b, alpha=1.0):
-            return torch.add(a, b, alpha=alpha)
+        class Model(torch.nn.Module):
+            def forward(self, a, b, alpha=1.0):
+                return torch.add(a, b, alpha=alpha)
 
         a = torch.randn(10, device=self.device)
         b = torch.randn(10, device=self.device)
-        with self.assertRaises(RuntimeError):
-            torch._export.aot_compile(fn, args=(a, b), kwargs={"alpha": 2.0})
 
         for simdlen in [0, None]:
             with torch._inductor.config.patch({"cpp.simdlen": simdlen}):
@@ -1375,13 +1374,12 @@ class AOTInductorTestsTemplate:
                     torch.ops.aten.add,
                     args=(a, b),
                     kwargs={"alpha": 2.0},
-                    same_signature=False,
                 )
                 kernel_runner = AOTIRunnerUtil.load_runner(self.device, so_path)
                 res = kernel_runner.run([a, b])
                 self.assertTrue(isinstance(res, list))
                 self.assertTrue(len(res) == 1)
-                self.assertEqual(fn(a, b, alpha=2.0), res[0])
+                self.assertEqual(Model()(a, b, alpha=2.0), res[0])
 
     def test_buffer_mutation_2(self):
         class Model(torch.nn.Module):
@@ -2955,6 +2953,26 @@ class AOTInductorTestsTemplate:
         example_inputs = (torch.randn(16, 16, 16, device=self.device),)
         self.check_model(Model(), example_inputs)
 
+    def test_bool_input(self):
+        # Specialize on whichever branch the example input for b is
+        class Model(torch.nn.Module):
+            def forward(self, x, b):
+                if b:
+                    return x * x
+                else:
+                    return x + x
+
+        example_inputs = (torch.randn(3, 3, device=self.device), True)
+        self.check_model(Model(), example_inputs)
+
+    def test_int_list_input(self):
+        class Model(torch.nn.Module):
+            def forward(self, x, i):
+                return x * i[0] * i[1]
+
+        example_inputs = (torch.randn(3, 3, device=self.device), [3, 4])
+        self.check_model(Model(), example_inputs)
+
     def test_nested_tensor_from_jagged(self):
         class Model(nn.Module):
             def __init__(self):
@@ -3150,6 +3168,10 @@ CPU_TEST_FAILURES = {
     "test_buffer_mutation_1": fail_stack_allocation(is_skip=True),
     # segfault
     "test_buffer_mutation_2": fail_stack_allocation(is_skip=True),
+    # segfault
+    "test_bool_input": fail_stack_allocation(is_skip=True),
+    # segfault
+    "test_int_list_input": fail_stack_allocation(is_skip=True),
     # segfault
     # 'AOTInductorTestABICompatibleCpuWithStackAllocation' object has no attribute 'code_check_count'
     "test_buffer_mutation_3": fail_stack_allocation(is_skip=True),

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -78,6 +78,7 @@ class AOTIRunnerUtil:
                 in_spec = pytree.treespec_loads(call_spec[0])
                 out_spec = pytree.treespec_loads(call_spec[1])
                 flat_inputs = fx_pytree.tree_flatten_spec((args, kwargs), in_spec)
+                flat_inputs = [x for x in flat_inputs if isinstance(x, torch.Tensor)]
                 flat_outputs = runner.run(flat_inputs)
                 return pytree.tree_unflatten(flat_outputs, out_spec)
 

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -302,6 +302,7 @@ def aot_load(so_path: str, device: str) -> Callable:
         in_spec = pytree.treespec_loads(call_spec[0])
         out_spec = pytree.treespec_loads(call_spec[1])
         flat_inputs = pytree.tree_flatten((args, reorder_kwargs(kwargs, in_spec)))[0]
+        flat_inputs = [x for x in flat_inputs if isinstance(x, torch.Tensor)]
         flat_outputs = runner.run(flat_inputs)  # type: ignore[attr-defined]
         return pytree.tree_unflatten(flat_outputs, out_spec)
 

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -84,9 +84,12 @@ def aot_compile(
     flat_args_with_path, received_spec = pytree.tree_flatten_with_path(
         (args, kwargs or {})
     )
-    flat_example_inputs = tuple(
-        x[1] for x in flat_args_with_path if isinstance(x[1], torch.Tensor)
-    )
+
+    # Replace non-tensor (constant) inputs with Nones, since these are not being
+    # used anyways by the graph
+    flat_example_inputs = [
+        x[1] if isinstance(x[1], torch.Tensor) else None for x in flat_args_with_path
+    ]
 
     if in_spec is not None and received_spec != in_spec:
         raise ValueError(  # noqa: B904
@@ -111,7 +114,7 @@ def aot_compile(
 
     return compile_fx_aot(
         gm,
-        list(flat_example_inputs),
+        flat_example_inputs,  # type: ignore[arg-type]
         config_patches=options,
     )
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -912,6 +912,8 @@ class GraphLowering(torch.fx.Interpreter):
             expr = sympy.sympify(example)
             self.graph_inputs[target] = expr
             return expr
+        elif example is None:
+            return None
         if isinstance(example, BackwardState):
             # Ignored arg, must be unused
             # Alternately we could filter this out in AotAutograd
@@ -1616,7 +1618,9 @@ class GraphLowering(torch.fx.Interpreter):
                 def materialize(
                     x: Union[torch.SymInt, torch.SymFloat, torch.Tensor]
                 ) -> Union[int, float, torch.Tensor]:
-                    if isinstance(x, (torch.SymInt, torch.SymFloat)):
+                    if x is None:
+                        return None
+                    elif isinstance(x, (torch.SymInt, torch.SymFloat)):
                         # Need concrete value to run dynamic shapes and tune the result
                         return x.node.hint
                     elif isinstance(x, FakeTensor):


### PR DESCRIPTION
In cases where the program takes in a constant, export will specialize on the constant and embed the constant into the graph, with the graph containing a placeholder node with no users. However, inductor errors further down as typically in torch.compile, these constants don't show up as inputs. Since these constants are already embedded in the graph, we will just ignore these inputs while compiling with AOTI, and filter out the non-tensor inputs during the runtime.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang