### PR TITLE
Improve namespace for `c10::MemoryFormat::Contiguous` in `torchgen/api/cpp.py`

### DIFF
--- a/torchgen/api/cpp.py
+++ b/torchgen/api/cpp.py
@@ -318,7 +318,7 @@ JIT_TO_CPP_DEFAULT = {
     "None": "::std::nullopt",  # UGH this one is type directed
     "Mean": "at::Reduction::Mean",
     "[]": "{}",
-    "contiguous_format": "MemoryFormat::Contiguous",
+    "contiguous_format": "c10::MemoryFormat::Contiguous",
     "long": "at::kLong",
 }
 

--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -287,7 +287,7 @@ class PythonArgument:
                     "::std::nullopt": "None",
                     "std::nullopt": "None",
                     "{}": "None",
-                    "MemoryFormat::Contiguous": "contiguous_format",
+                    "c10::MemoryFormat::Contiguous": "contiguous_format",
                     "QScheme::PER_TENSOR_AFFINE": "per_tensor_affine",
                 }.get(self.default, self.default)
             return f"{name}: {type_str} = {default}"


### PR DESCRIPTION
Top-level namespaces are more convenient for out-of-tree device extensions.

For example, now we have a patch for it in `torch_npu`:

https://github.com/Ascend/pytorch/blob/98c50ced165964732f0316dcb6cdd68b2452f49d/codegen/gen_backend_stubs.py#L772-L778

```python
JIT_TO_CPP_DEFAULT["contiguous_format"] = "c10::MemoryFormat::Contiguous"
```