### PR TITLE
[CI][dashboard] Rename cpu-x86 to cpu_x86

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -431,8 +431,8 @@ test_perf_for_dashboard() {
 
   local device=cuda
   local taskset=""
-  if [[ "${TEST_CONFIG}" == *cpu-x86* ]]; then
-    device=cpu-x86
+  if [[ "${TEST_CONFIG}" == *cpu_x86* ]]; then
+    device=cpu_x86
     test_inductor_set_cpu_affinity
     end_core=$(( $(test_inductor_get_core_number)-1 ))
     taskset="taskset -c 0-$end_core"

--- a/.github/workflows/inductor-perf-test-nightly-x86.yml
+++ b/.github/workflows/inductor-perf-test-nightly-x86.yml
@@ -39,7 +39,7 @@ on:
         description: The list of configs used the benchmark
         required: false
         type: string
-        default: inductor_huggingface_perf_cpu-x86,inductor_timm_perf_cpu-x86,inductor_torchbench_perf_cpu-x86
+        default: inductor_huggingface_perf_cpu_x86,inductor_timm_perf_cpu_x86,inductor_torchbench_perf_cpu_x86
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
@@ -56,18 +56,18 @@ jobs:
       docker-image-name: pytorch-linux-jammy-py3.8-gcc11-inductor-benchmarks
       test-matrix: |
         { include: [
-          { config: "inductor_huggingface_perf_cpu-x86", shard: 1, num_shards: 3, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_huggingface_perf_cpu-x86", shard: 2, num_shards: 3, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_huggingface_perf_cpu-x86", shard: 3, num_shards: 3, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_timm_perf_cpu-x86", shard: 1, num_shards: 5, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_timm_perf_cpu-x86", shard: 2, num_shards: 5, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_timm_perf_cpu-x86", shard: 3, num_shards: 5, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_timm_perf_cpu-x86", shard: 4, num_shards: 5, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_timm_perf_cpu-x86", shard: 5, num_shards: 5, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_torchbench_perf_cpu-x86", shard: 1, num_shards: 4, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_torchbench_perf_cpu-x86", shard: 2, num_shards: 4, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_torchbench_perf_cpu-x86", shard: 3, num_shards: 4, runner: "linux.24xl.spr-metal" },
-          { config: "inductor_torchbench_perf_cpu-x86", shard: 4, num_shards: 4, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_huggingface_perf_cpu_x86", shard: 1, num_shards: 3, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_huggingface_perf_cpu_x86", shard: 2, num_shards: 3, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_huggingface_perf_cpu_x86", shard: 3, num_shards: 3, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf_cpu_x86", shard: 1, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf_cpu_x86", shard: 2, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf_cpu_x86", shard: 3, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf_cpu_x86", shard: 4, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_timm_perf_cpu_x86", shard: 5, num_shards: 5, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_torchbench_perf_cpu_x86", shard: 1, num_shards: 4, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_torchbench_perf_cpu_x86", shard: 2, num_shards: 4, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_torchbench_perf_cpu_x86", shard: 3, num_shards: 4, runner: "linux.24xl.spr-metal" },
+          { config: "inductor_torchbench_perf_cpu_x86", shard: 4, num_shards: 4, runner: "linux.24xl.spr-metal" },
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
     secrets:

--- a/tools/stats/upload_dynamo_perf_stats.py
+++ b/tools/stats/upload_dynamo_perf_stats.py
@@ -22,7 +22,7 @@ ARTIFACTS = [
     "test-reports",
 ]
 ARTIFACT_REGEX = re.compile(
-    r"test-reports-test-(?P<name>[\w\-]+)-\d+-\d+-(?P<runner>[\w\.]+)_(?P<job>\d+).zip"
+    r"test-reports-test-(?P<name>[\w\-]+)-\d+-\d+-(?P<runner>[\w\.-]+)_(?P<job>\d+).zip"
 )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131658

Summary: '-' is used as a special separator by upload_dynamo_perf_stats.py, so switch to '_' instead.