### PR TITLE
[Distributed] [10/N] Fix clang-tidy warnings in torch/csrc/distributed/c10d/control_plane

### DIFF
--- a/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
+++ b/torch/csrc/distributed/c10d/control_plane/Handlers.hpp
@@ -3,11 +3,11 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <utility>
 
 #include <c10/macros/Export.h>
 
-namespace c10d {
-namespace control_plane {
+namespace c10d::control_plane {
 
 // Request represents a request to the handler. This conceptually maps to an
 // HTTP request but could be called via other transports.
@@ -56,7 +56,7 @@ TORCH_API std::vector<std::string> getHandlerNames();
 class TORCH_API RegisterHandler {
  public:
   RegisterHandler(const std::string& name, HandlerFunc f) {
-    registerHandler(name, f);
+    registerHandler(name, std::move(f));
   }
 
   // disable move, copy
@@ -66,5 +66,4 @@ class TORCH_API RegisterHandler {
   RegisterHandler& operator=(RegisterHandler&&) = delete;
 };
 
-} // namespace control_plane
-} // namespace c10d
+} // namespace c10d::control_plane

--- a/torch/csrc/distributed/c10d/control_plane/WorkerServer.cpp
+++ b/torch/csrc/distributed/c10d/control_plane/WorkerServer.cpp
@@ -1,8 +1,5 @@
 #include <filesystem>
-#include <mutex>
-#include <shared_mutex>
 #include <sstream>
-#include <tuple>
 #include <unordered_map>
 
 #include <ATen/core/interned_strings.h>
@@ -11,8 +8,7 @@
 #include <torch/csrc/distributed/c10d/control_plane/WorkerServer.hpp>
 #include <torch/csrc/distributed/c10d/logging.h>
 
-namespace c10d {
-namespace control_plane {
+namespace c10d::control_plane {
 
 namespace {
 class RequestImpl : public Request {
@@ -189,5 +185,4 @@ WorkerServer::~WorkerServer() {
   }
 }
 
-} // namespace control_plane
-} // namespace c10d
+} // namespace c10d::control_plane

--- a/torch/csrc/distributed/c10d/control_plane/WorkerServer.hpp
+++ b/torch/csrc/distributed/c10d/control_plane/WorkerServer.hpp
@@ -2,20 +2,18 @@
 
 #include <string>
 #include <thread>
-#include <unordered_map>
 
 #include <httplib.h>
 
 #include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/distributed/c10d/control_plane/Handlers.hpp>
 
-namespace c10d {
-namespace control_plane {
+namespace c10d::control_plane {
 
 class TORCH_API WorkerServer : public c10::intrusive_ptr_target {
  public:
   WorkerServer(const std::string& hostOrFile, int port = -1);
-  ~WorkerServer();
+  ~WorkerServer() override;
 
   void shutdown();
 
@@ -24,5 +22,4 @@ class TORCH_API WorkerServer : public c10::intrusive_ptr_target {
   std::thread serverThread_;
 };
 
-} // namespace control_plane
-} // namespace c10d
+} // namespace c10d::control_plane


### PR DESCRIPTION
Follows #130109

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o