### PR TITLE
[2/2] PT2 Inductor ComboKernels - automatic horizontal fusing

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1,0 +1,260 @@
+# Owner(s): ["module: inductor"]
+
+import sys
+import unittest
+
+import torch
+import torch._inductor
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    TestCase,
+)
+from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
+from torch.testing._internal.triton_utils import requires_cuda
+
+
+aten = torch.ops.aten
+
+try:
+    try:
+        from .test_torchinductor import check_model, check_model_cuda
+    except ImportError:
+        from test_torchinductor import check_model, check_model_cuda
+except (unittest.SkipTest, ImportError) as e:
+    sys.stderr.write(f"{type(e)}: {e}\n")
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise
+
+
+@instantiate_parametrized_tests
+class ComboKernelTests(TestCase):
+    check_model_cuda = check_model_cuda
+    check_model_cpu = check_model
+    check_kernel_count = True
+
+    def setUp(self):
+        super().setUp()
+        torch._inductor.metrics.reset()
+        torch._inductor.config.combo_kernels = True
+        torch._inductor.config.benchmark_combo_kernel = False
+
+    def tearDown(self):
+        super().tearDown()
+        torch._inductor.metrics.reset()
+
+    @requires_cuda
+    def test_activation_functions(self):
+        def test_activations(a, b, c):
+            a1 = torch.nn.functional.relu(a)
+            b1 = torch.nn.functional.sigmoid(b)
+            c1 = torch.nn.functional.tanh(c)
+            return a1, b1, c1
+
+        inps = [
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(20, 20, device="cuda"),
+            torch.rand(10, 10, device="cuda"),
+        ]
+
+        out_eager = test_activations(*inps)
+        out_compiled = torch.compile(test_activations)(*inps)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+    @requires_cuda
+    def test_reduce_functions(self):
+        def test_reduce(a, b, c, d):
+            a1 = torch.sum(a, dim=0)
+            b1 = torch.max(b, dim=0)
+            c1 = torch.min(c, dim=0)
+            d1 = torch.nn.functional.tanh(d)
+
+            return a1, b1, c1, d1
+
+        inps = [
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(20, 20, device="cuda"),
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(30, 8, device="cuda"),
+        ]
+
+        out_eager = test_reduce(*inps)
+        out_compiled = torch.compile(test_reduce)(*inps)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertTrue(torch._inductor.metrics.generated_kernel_count <= 2)
+
+    @requires_cuda
+    def test_mutated_args(self):
+        def test_mutated(a, b, c, d):
+            a.add_(1)
+            b.sigmoid_()
+            c = torch.add(c, 5)
+            d.tanh_()
+
+            return a, b, c, d
+
+        inps = [
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(20, 20, device="cuda"),
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(30, 8, device="cuda"),
+        ]
+
+        out_eager = test_mutated(*inps)
+        out_compiled = torch.compile(test_mutated)(*inps)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+    @requires_cuda
+    def test_reduce_split(self):
+        def fn(a, b):
+            a1 = torch.linalg.vector_norm(a)
+            b1 = torch.sum(b, dim=0)
+            return a1, b1
+
+        inps = [
+            torch.rand(2048, 512, device="cuda"),
+            torch.rand(20, 20, device="cuda"),
+        ]
+        out_eager = fn(*inps)
+        out_compiled = torch.compile(fn)(*inps)
+
+        self.assertEqual(out_eager, out_compiled)
+
+    @requires_cuda
+    def test_2d_blocking_partitioning(self):
+        def fn(a0, a1, a2, b0, b1, b2):
+            c0 = torch.add(a0, b0)
+            c1 = torch.add(a1, b1)
+            c2 = torch.add(a2, b2)
+            return c0, c1, c2
+
+        self.check_model_cuda(
+            fn,
+            (
+                torch.rand(30, 20, device="cuda"),
+                torch.rand(40, 30, device="cuda"),
+                torch.rand(36, 40, device="cuda"),
+                torch.rand(30, 20, device="cuda"),
+                torch.rand(30, 40, device="cuda").t(),
+                torch.rand(40, 36, device="cuda").t(),
+            ),
+        )
+
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 2)
+
+
+@instantiate_parametrized_tests
+class ComboKernelBenchmarkTests(TestCase):
+    check_model_cuda = check_model_cuda
+    check_model_cpu = check_model
+    check_kernel_count = True
+
+    def setUp(self):
+        super().setUp()
+        torch._inductor.metrics.reset()
+        torch._inductor.config.combo_kernels = True
+        torch._inductor.config.benchmark_combo_kernel = True
+
+    def tearDown(self):
+        super().tearDown()
+        torch._inductor.metrics.reset()
+
+    @requires_cuda
+    def test_activation_benchmark(self):
+        def test_activations(a, b, c):
+            a1 = torch.nn.functional.relu(a)
+            b1 = torch.nn.functional.sigmoid(b)
+            c1 = torch.nn.functional.tanh(c)
+            return a1, b1, c1
+
+        inps = [
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(20, 20, device="cuda"),
+            torch.rand(10, 10, device="cuda"),
+        ]
+
+        out_eager = test_activations(*inps)
+        out_compiled = torch.compile(test_activations)(*inps)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 5)
+
+    @requires_cuda
+    def test_reduce_benchmark(self):
+        def test_reduce(a, b, c, d):
+            a1 = torch.sum(a, dim=0)
+            b1 = torch.max(b, dim=0)
+            c1 = torch.min(c, dim=0)
+            d1 = torch.nn.functional.tanh(d)
+
+            return a1, b1, c1, d1
+
+        inps = [
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(20, 20, device="cuda"),
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(30, 8, device="cuda"),
+        ]
+
+        out_eager = test_reduce(*inps)
+        out_compiled = torch.compile(test_reduce)(*inps)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertTrue(4 < torch._inductor.metrics.generated_kernel_count <= 10)
+
+    @requires_cuda
+    def test_mutated_benchmark(self):
+        def test_mutated(a, b, c, d):
+            a.add_(1)
+            b.sigmoid_()
+            c = torch.add(c, 5)
+            d.tanh_()
+
+            return a, b, c, d
+
+        inps = [
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(20, 20, device="cuda"),
+            torch.rand(10, 10, device="cuda"),
+            torch.rand(30, 8, device="cuda"),
+        ]
+
+        out_eager = test_mutated(*inps)
+        out_compiled = torch.compile(test_mutated)(*inps)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 6)
+
+    @requires_cuda
+    def test_2d_blocking_benchmark(self):
+        def fn(a0, a1, a2, b0, b1, b2):
+            c0 = torch.add(a0, b0)
+            c1 = torch.add(a1, b1)
+            c2 = torch.add(a2, b2)
+            return c0, c1, c2
+
+        self.check_model_cuda(
+            fn,
+            (
+                torch.rand(30, 20, device="cuda"),
+                torch.rand(40, 30, device="cuda"),
+                torch.rand(36, 40, device="cuda"),
+                torch.rand(30, 20, device="cuda"),
+                torch.rand(30, 40, device="cuda").t(),
+                torch.rand(40, 36, device="cuda").t(),
+            ),
+        )
+
+        self.assertTrue(7 <= torch._inductor.metrics.generated_kernel_count <= 8)
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    if HAS_CPU or HAS_CUDA:
+        run_tests(needs="filelock")

--- a/torch/_inductor/codegen/cuda_combined_scheduling.py
+++ b/torch/_inductor/codegen/cuda_combined_scheduling.py
@@ -95,3 +95,6 @@ class CUDACombinedScheduling(BaseScheduling):
         return self._triton_scheduling.generate_kernel_code_from_nodes(
             nodes, benchmark_kernel
         )
+
+    def benchmark_combo_kernel(self, node_list):
+        return self._triton_scheduling.benchmark_combo_kernel(node_list)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3094,3 +3094,91 @@ class TritonScheduling(SIMDScheduling):
             )
             store_cache()
             return ms, mod.__file__
+
+    def benchmark_combo_kernel(self, node_list):
+        def cache_file_path():
+            assert mod.__file__ is not None
+            return os.path.splitext(mod.__file__)[0] + ".kernel_perf"
+
+        def load_cache():
+            path = cache_file_path()
+            if os.path.exists(path):
+                with open(path) as fd:
+                    return tuple(float(e) for e in fd.read().split())
+            return (None, None)
+
+        def store_cache():
+            path = cache_file_path()
+            with open(path, "w") as fd:
+                fd.write(str(ms) + " " + str(ms_clone))
+
+        total_ms, file_list = 0, []
+        total_clone_ms = 0
+        removed_buffers_orig = V.graph.removed_buffers
+        V.graph.removed_buffers = OrderedSet(removed_buffers_orig)
+        inplaced_to_remove_orig = V.graph.inplaced_to_remove
+        V.graph.inplaced_to_remove = OrderedSet(inplaced_to_remove_orig)
+        enable_autotune = config.combo_kernels_autotune > 0
+        mixed_sizes = config.combo_kernel_allow_mixed_sizes > 0
+        kernel_code_list = self.generate_combo_kernel_code(
+            subkernel_nodes=node_list,
+            custom_part_algorithm=True,
+            enable_autotune=enable_autotune,
+            mixed_sizes=mixed_sizes,
+            only_gen_src_code=True,
+        )
+
+        for src_code, _, node_group in kernel_code_list:
+            fused_node_lists = [node.get_nodes() for node in node_group]
+            names = [n.get_name() for nodes in fused_node_lists for n in nodes]
+
+            src_code = src_code.replace(str(Placeholder.KERNEL_NAME), "triton_")
+            mod = PyCodeCache.load(src_code)
+
+            log.debug(
+                "kernel src code for %s written to: %s",
+                names,
+                mod.__file__,
+            )
+            ms, ms_clone = load_cache()
+            if ms is not None:
+                total_ms += ms
+                total_clone_ms += ms_clone
+                file_list.append(mod.__file__)
+                continue
+
+            args = mod.get_args()
+            call = mod.call
+            wrapped_jit_function = mod.triton_
+
+            # call once to trigger the compilation
+            call(wrapped_jit_function.clone_args(*args)[0])
+
+            launchers = wrapped_jit_function.launchers
+            assert len(launchers) == 1
+            if launchers[0].n_spills > 0:
+                # skip benchmarking the kernel if there are register spills
+                ms = ms_clone = float("inf")
+            else:
+                # We have to clone the inplace updated arguments to avoid earlier calls
+                # generating out of range indices for later calls.
+                ms = benchmarker.benchmark_gpu(
+                    lambda: call(wrapped_jit_function.clone_args(*args)[0])
+                )
+                ms_clone = benchmarker.benchmark_gpu(
+                    lambda: wrapped_jit_function.clone_args(*args)[0]
+                )
+
+            log.debug(
+                "The fused kernel for %s took %.3f ms to run, %.3f ms to clone inputs",
+                {n.get_name() for n in node_group},
+                ms,
+                ms_clone,
+            )
+            store_cache()
+            total_ms += ms
+            total_clone_ms += ms_clone
+            file_list.append(mod.__file__)
+        V.graph.removed_buffers = removed_buffers_orig
+        V.graph.inplaced_to_remove = inplaced_to_remove_orig
+        return total_ms, total_clone_ms, file_list

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -1,18 +1,19 @@
-# mypy: allow-untyped-defs
 import itertools
 import logging
 import textwrap
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, cast, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Type, Union
 
 from sympy import Integer
 
+from torch.utils._ordered_set import OrderedSet
+
 from .. import config, metrics
-from ..runtime.hints import DeviceProperties
+from ..runtime.hints import DeviceProperties, ReductionHint
 from ..runtime.runtime_utils import next_power_of_2
 from ..runtime.triton_heuristics import grid_combo_kernels
-from ..scheduler import BaseSchedulerNode, FusedSchedulerNode
+from ..scheduler import BaseSchedulerNode
 from ..utils import Placeholder
 from ..virtualized import V
 from .common import DeferredLine, IndentedBuffer, Kernel, PythonPrinter, SizeArg
@@ -32,7 +33,7 @@ def _default_custom_combo_kernel_horizontal_partition(
     triton_scheduling: SIMDScheduling,
     kernel_map: Dict[BaseSchedulerNode, TritonKernel],
     node_info_map: Dict[BaseSchedulerNode, Tuple[Any, Any, Any, Any]],
-):
+) -> List[List[BaseSchedulerNode]]:
     """Horizontally partition the given list of nodes into a list of list of nodes where each sublist
     represents a partion. Nodes in different partitions are implemented in different combo kernels.
     Nodes in the same partition are likely to be implemented
@@ -102,12 +103,28 @@ def _default_custom_combo_kernel_horizontal_partition(
     return nodes_per_ndim
 
 
-_custom_combo_kernel_horizontal_partition_algorithm = (
-    _default_custom_combo_kernel_horizontal_partition
-)
+_custom_combo_kernel_horizontal_partition_algorithm: Callable[
+    [
+        List[BaseSchedulerNode],
+        SIMDScheduling,
+        Dict[BaseSchedulerNode, TritonKernel],
+        Dict[BaseSchedulerNode, Tuple[Any, Any, Any, Any]],
+    ],
+    List[List[BaseSchedulerNode]],
+] = _default_custom_combo_kernel_horizontal_partition
 
 
-def set_custom_combo_kernel_horizontal_partition(algorithm):
+def set_custom_combo_kernel_horizontal_partition(
+    algorithm: Callable[
+        [
+            List[BaseSchedulerNode],
+            SIMDScheduling,
+            Dict[BaseSchedulerNode, TritonKernel],
+            Dict[BaseSchedulerNode, Tuple[Any, Any, Any, Any]],
+        ],
+        List[List[BaseSchedulerNode]],
+    ]
+) -> None:
     """Sets the algorithm used to partition nodes into horizontal partitions. Nodes in different partitions
     are implemented in different combo kernels. Nodes in the same partition are likely to be implemented
     in the same combo kernel, but subject to subsequent restricts like CUDA limits for number of args.
@@ -122,11 +139,11 @@ def set_custom_combo_kernel_horizontal_partition(algorithm):
 
 @dataclass
 class PartitionState:
-    partitions: List[List[FusedSchedulerNode]]
-    cur_partition: List[FusedSchedulerNode]
+    partitions: List[List[BaseSchedulerNode]]
+    cur_partition: List[BaseSchedulerNode]
     cur_count: int
 
-    def finalize(self):
+    def finalize(self) -> None:
         if self.cur_partition:
             self.partitions.append(self.cur_partition)
 
@@ -135,7 +152,11 @@ class ComboKernel(Kernel):
     MAX_NUM_ARGS = 250  # number where I would no longer get triton errors
 
     @staticmethod
-    def _update_partition(partition_state, node_rw_count, node_info):
+    def _update_partition(
+        partition_state: PartitionState,
+        node_rw_count: int,
+        node_info: BaseSchedulerNode,
+    ) -> None:
         if partition_state.cur_count + node_rw_count > ComboKernel.MAX_NUM_ARGS:
             partition_state.partitions.append(partition_state.cur_partition)
             partition_state.cur_partition = [node_info]
@@ -150,7 +171,7 @@ class ComboKernel(Kernel):
         triton_scheduling: SIMDScheduling,
         node_info_map: Dict[BaseSchedulerNode, Tuple[Any, Any, Any, Any]],
         custom_algorithm: bool,
-    ):
+    ) -> List[List[BaseSchedulerNode]]:
         """Generates a list of lists of node info tuples which consist of (fused_nodes, tiling, numel, rnumel)
         for each subkernel node where each sublist is guaranteed to not exceed CUDA limits for number of args
         (read/writes) and to have the same 2D or 1D blocking strategy."""
@@ -206,7 +227,7 @@ class ComboKernel(Kernel):
         kernel_map: Dict[BaseSchedulerNode, TritonKernel],
         node_info_map: Dict[BaseSchedulerNode, Tuple[Any, Any, Any, Any]],
         custom_algorithm: bool = False,
-    ):
+    ) -> List[List[BaseSchedulerNode]]:
         """Generates a list of lists of node info tuples which consist of (fused_nodes, tiling, numel, rnum)
         for each subkernel node where each sublist forms a ComboKernel. It horizontally partitions nodes into
         sublists in the following way:
@@ -246,7 +267,9 @@ class ComboKernel(Kernel):
         """
 
         @classmethod
-        def codegen_pid_range(cls, kernel, num, code):
+        def codegen_pid_range(
+            cls, kernel: "ComboKernel", num: int, code: IndentedBuffer
+        ) -> None:
             if num == 0:
                 cls._calculate_xblocks(kernel, code)
                 code.splice(f"if pid < num_xblocks_{num}:")
@@ -258,7 +281,9 @@ class ComboKernel(Kernel):
                     code.splice(f"pid_offset = pid - num_xblocks_{num-1}")
 
         @classmethod
-        def _calculate_xblocks(cls, kernel, code):
+        def _calculate_xblocks(
+            cls, kernel: "ComboKernel", code: IndentedBuffer
+        ) -> None:
             x_numels_list = kernel.x_numels_list
             for i in range(len(x_numels_list)):
                 xnumels = (
@@ -277,14 +302,20 @@ class ComboKernel(Kernel):
                     code.splice(f"num_xblocks_{i} = num_xblocks_{i-1} + {xblock_str}")
 
         @classmethod
-        def grid(cls, sub_kernel_numels, x_blocks_list):
+        def grid(
+            cls, sub_kernel_numels: List[List[int]], x_blocks_list: List[int]
+        ) -> Tuple[Any, ...]:
             xnumel = x_blocks_list
             ynumel = [e[-2] if len(e) > 1 else None for e in sub_kernel_numels]
             znumel = [e[-3] if len(e) > 2 else None for e in sub_kernel_numels]
 
             # TODO: improve 1d/2d mixed cases
-            ynumel = None if any(e is None for e in ynumel) else max(ynumel)
-            znumel = None if any(e is None for e in znumel) else max(znumel)
+            ynumel = (
+                None if any(e is None for e in ynumel) else max(cast(List[int], ynumel))
+            )
+            znumel = (
+                None if any(e is None for e in znumel) else max(cast(List[int], znumel))
+            )
 
             numels = (
                 (xnumel,)
@@ -307,7 +338,9 @@ class ComboKernel(Kernel):
         """
 
         @classmethod
-        def codegen_pid_range(cls, kernel, num, code):
+        def codegen_pid_range(
+            cls, kernel: "ComboKernel", num: int, code: IndentedBuffer
+        ) -> None:
             num_kernels = len(kernel.sub_kernels)
             if num == 0:
                 cond = "if"
@@ -318,15 +351,23 @@ class ComboKernel(Kernel):
                 code.splice(f"pid_offset = pid // {num_kernels}")
 
         @classmethod
-        def grid(cls, sub_kernel_numels, x_blocks_list):
+        def grid(
+            cls, sub_kernel_numels: List[List[int]], x_blocks_list: List[int]
+        ) -> Tuple[Any, ...]:
             xnumel = [e[-1] if len(e) > 0 else None for e in sub_kernel_numels]
             ynumel = [e[-2] if len(e) > 1 else None for e in sub_kernel_numels]
             znumel = [e[-3] if len(e) > 2 else None for e in sub_kernel_numels]
 
             # TODO: support 1d/2d mixed cases
-            xnumel = None if any(e is None for e in xnumel) else max(xnumel)
-            ynumel = None if any(e is None for e in ynumel) else max(ynumel)
-            znumel = None if any(e is None for e in znumel) else max(znumel)
+            xnumel = (
+                None if any(e is None for e in xnumel) else max(cast(List[int], xnumel))
+            )
+            ynumel = (
+                None if any(e is None for e in ynumel) else max(cast(List[int], ynumel))
+            )
+            znumel = (
+                None if any(e is None for e in znumel) else max(cast(List[int], znumel))
+            )
 
             numels = (
                 (xnumel,)
@@ -337,13 +378,15 @@ class ComboKernel(Kernel):
             )
             return numels
 
-    def __init__(self, enable_autotune=False, mixed_sizes=False):
+    def __init__(
+        self, enable_autotune: bool = False, mixed_sizes: bool = False
+    ) -> None:
         super().__init__()
-        self.sub_kernels = []
+        self.sub_kernels: List[TritonKernel] = []
         self.iter_vars_count = itertools.count()
-        self.grids = []
-        self.min_x_blocks_list = []
-        self.x_numels_list = []
+        self.grids: List[List[int]] = []
+        self.min_x_blocks_list: List[int] = []
+        self.x_numels_list: List[int] = []
         self.enable_autotune = enable_autotune
         self.mixed_sizes = mixed_sizes
         self.dispatch_class: Optional[
@@ -352,14 +395,14 @@ class ComboKernel(Kernel):
                 Type[ComboKernel.RoundRobinDispatch],
             ]
         ] = None
-        self.block_args = []
+        self.block_args: List[str] = []
         # there following are used when autotuning is disabled
         self.block_size_1d = 1024  # Try tuning this value
         self.block_size_2d = 32
         self.num_warps = 8
         self.block_size_reduce = 256
 
-    def create_sub_kernel(self, triton_kernel):
+    def create_sub_kernel(self, triton_kernel: TritonKernel) -> TritonKernel:
         sub_kernel = triton_kernel
         metrics.generated_kernel_count -= 1
         sub_kernel.args = self.args
@@ -370,8 +413,12 @@ class ComboKernel(Kernel):
 
     @staticmethod
     def create_triton_kernel(
-        *groups, index_dtype, mutations, reduction_hint, optimize_mask
-    ):
+        *groups: Any,
+        index_dtype: str,
+        mutations: OrderedSet[str],
+        reduction_hint: ReductionHint,
+        optimize_mask: bool,
+    ) -> TritonKernel:
         return TritonKernel(
             *groups,
             index_dtype=index_dtype,
@@ -381,7 +428,9 @@ class ComboKernel(Kernel):
             optimize_mask=optimize_mask,
         )
 
-    def codegen_static_numels_sub_kernel(self, code, sub_kernel, num):
+    def codegen_static_numels_sub_kernel(
+        self, code: IndentedBuffer, sub_kernel: TritonKernel, num: int
+    ) -> List[str]:
         """
         We get a small speedup from hard coding numels if they are static.
 
@@ -422,7 +471,7 @@ class ComboKernel(Kernel):
         self.grids.append(grid)
         return uniquify_block_sizes
 
-    def min_x_blocks_sub_kernel(self, sub_kernel, num):
+    def min_x_blocks_sub_kernel(self, sub_kernel: TritonKernel, num: int) -> None:
         """
         Kernels with no_x_dim being true has no tunable XBLOCK. They have a fixed number of X blocks.
         Grid calculation needs to make sure that they are assigned with enough number of blocks.
@@ -440,7 +489,7 @@ class ComboKernel(Kernel):
         self.min_x_blocks_list.append(min_x_blocks)
         self.x_numels_list.append(x_numels)
 
-    def select_heuristics(self, sub_kernel) -> Tuple[str, List[int]]:
+    def select_heuristics(self, sub_kernel: TritonKernel) -> Tuple[str, List[int]]:
         size_hints = [
             next_power_of_2(V.graph.sizevars.size_hint(numel))
             for numel in sub_kernel.numels
@@ -455,7 +504,9 @@ class ComboKernel(Kernel):
             heuristics = "pointwise"
         return heuristics, size_hints
 
-    def select_combo_heuristics(self, heuristics_list, size_hints_list):
+    def select_combo_heuristics(
+        self, heuristics_list: List[str], size_hints_list: List[List[int]]
+    ) -> Tuple[str, List[int], TritonKernel]:
         if not self.enable_autotune:
             return "foreach", size_hints_list[0], self.sub_kernels[0]
         if "reduction" in heuristics_list:
@@ -508,7 +559,7 @@ class ComboKernel(Kernel):
                     mutated_args.add(sub_kernel.args.output_buffers[mutation])
         return sorted(mutated_args)
 
-    def select_dispatch_strategy(self):
+    def select_dispatch_strategy(self) -> None:
         if self.dispatch_class is not None:
             return
         if not self.mixed_sizes:
@@ -526,8 +577,12 @@ class ComboKernel(Kernel):
             self.dispatch_class = ComboKernel.SequentialDispatch
 
     def jit_line(
-        self, heuristics, size_hints, selected_kernel, pointwise_with_reduce=False
-    ):
+        self,
+        heuristics: str,
+        size_hints: List[int],
+        selected_kernel: TritonKernel,
+        pointwise_with_reduce: bool = False,
+    ) -> str:
         can_use_32bit = all(k.index_dtype == "tl.int32" for k in self.sub_kernels)
         size_dtype = "tl.int32" if can_use_32bit else "tl.int64"
         _, _, signature, _ = self.args.python_argdefs()
@@ -589,7 +644,7 @@ class ComboKernel(Kernel):
 
         return heuristics_line
 
-    def codegen_blocks(self, code):
+    def codegen_blocks(self, code: IndentedBuffer) -> None:
         for block in self.block_args:
             assert block in [
                 "XBLOCK",
@@ -604,7 +659,7 @@ class ComboKernel(Kernel):
         if "RBLOCK" in self.block_args:
             code.splice(f"RBLOCK: tl.constexpr = {self.block_size_reduce}")
 
-    def add_blockd_to_args(self, argdefs):
+    def add_blockd_to_args(self, argdefs: List[str]) -> List[str]:
         block_args = {}
         block_names = {}
         for num, sub_kernel in enumerate(self.sub_kernels):
@@ -616,16 +671,14 @@ class ComboKernel(Kernel):
                     continue
                 if tree.prefix == "x" and sub_kernel.no_x_dim:
                     continue
-                # argdefs.append(f"{tree.prefix.upper()}BLOCK_{num} : tl.constexpr")
                 block_args[f"{tree.prefix.upper()}BLOCK : tl.constexpr"] = tree.prefix
                 block_names[f"{tree.prefix.upper()}BLOCK"] = tree.prefix
         if self.enable_autotune:
-            for arg in block_args:
-                argdefs.append(arg)
+            argdefs.extend(block_args)
         self.block_args = list(block_names.keys())
         return argdefs
 
-    def codegen_kernel(self, name=None):
+    def codegen_kernel(self, name: Optional[str] = None) -> str:
         # TODO: is it correct to use the first sub kernel's heuristics?
         heuristics_list, size_hints_list = [], []
         for subkernel in self.sub_kernels:
@@ -687,7 +740,9 @@ class ComboKernel(Kernel):
 
         return code.getvalue()
 
-    def codegen_kernel_benchmark(self, num_gb, grid=None):
+    def codegen_kernel_benchmark(
+        self, num_gb: float, grid: Optional[List[Any]] = None
+    ) -> IndentedBuffer:
         result = IndentedBuffer()
         argdefs, call_args, signature, _ = self.args.python_argdefs()
 
@@ -727,8 +782,8 @@ class ComboKernel(Kernel):
         result.writelines(["\n", "\n", "def call(args):"])
         if grid is None:
             assert self.dispatch_class is not None
-            grid = self.dispatch_class.grid(self.grids, self.x_numels_list)
-            grid_str = ", ".join(pexpr(item) for item in grid)
+            grid_tuple = self.dispatch_class.grid(self.grids, self.x_numels_list)
+            grid_str = ", ".join(pexpr(item) for item in grid_tuple)
             grid_extra_kwargs = (
                 f"num_kernels={len(self.sub_kernels)}, "
                 f"min_blocks={max(self.min_x_blocks_list) * len(self.sub_kernels)}, "
@@ -782,7 +837,7 @@ class ComboKernel(Kernel):
 
         return result
 
-    def imports_for_benchmark_kernel(self):
+    def imports_for_benchmark_kernel(self) -> str:
         return textwrap.dedent(
             """
             from torch._dynamo.testing import rand_strided
@@ -822,12 +877,8 @@ class ComboKernel(Kernel):
                 modified.writeline(line)
         return modified
 
-    def call_kernel(self, code, name: str):
+    def call_kernel(self, code: IndentedBuffer, name: str) -> None:
         _, call_args, _, arg_types = self.args.python_argdefs()
-        # dynamo wraps unspec variable as 0d CPU tensor, need convert to scalar
-        # for i in range(len(call_args)):
-        #     if V.graph.is_unspec_arg(call_args[i]):
-        #         call_args[i] = call_args[i] + ".item()"
 
         wrapper = V.graph.wrapper_code
         assert self.dispatch_class is not None
@@ -850,7 +901,7 @@ class ComboKernel(Kernel):
         # autotuning is enabled
         grid = wrapper.generate_default_grid(
             name,
-            grid,
+            list(grid),
             grid_callable=grid_combo_kernels,
             num_kernels=num_kernels,
             min_blocks=min_blocks,
@@ -872,7 +923,13 @@ class ComboKernel(Kernel):
             ),
         )
 
-    def grid_no_autotune(self, grid, num_kernels, min_blocks, is_sequential):
+    def grid_no_autotune(
+        self,
+        grid: Tuple[Any],
+        num_kernels: int,
+        min_blocks: int,
+        is_sequential: bool,
+    ) -> List[int]:
         if "YBLOCK" in self.block_args:
             meta = {"XBLOCK": self.block_size_2d, "YBLOCK": self.block_size_2d}
         else:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -453,6 +453,9 @@ assert_indirect_indexing = True
 # compute CSE bounds on variables that do not appear in the FX graph
 compute_all_bounds = False
 
+# enable the combo kernel that combines data-independent kernels (additional
+# to foreach kernels) into a single one (Experimental)
+combo_kernels = False
 # benchmark combo kernels and only allow ones with perf gains
 benchmark_combo_kernel = False
 # combo_kernel autotuning options: 0 - disable, 1 - enable except for foreach,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -14,6 +14,7 @@ import textwrap
 import typing
 from typing import (
     Any,
+    Callable,
     Counter,
     DefaultDict,
     Dict,
@@ -1366,6 +1367,76 @@ class ForeachKernelSchedulerNode(FusedSchedulerNode):
         self.origins: OrderedSet[torch.fx.Node] = OrderedSet()
         self.enable_autotune = enable_autotune
 
+    @classmethod
+    def combinable_nodes(
+        cls, nodes: List[BaseSchedulerNode]
+    ) -> List[BaseSchedulerNode]:
+        extern = [x for x in nodes if isinstance(x, ExternKernelSchedulerNode)]
+        if extern:
+            log.debug(
+                "ComboKernels: %d external nodes are filtered %s",
+                len(extern),
+                [node.node.get_origins() for node in extern if node.node is not None],
+            )
+        filtered_nodes = [
+            x
+            for x in nodes
+            if not isinstance(x, (NopKernelSchedulerNode, ExternKernelSchedulerNode))
+        ]
+        foreach_nodes = [
+            x for x in filtered_nodes if isinstance(x, ForeachKernelSchedulerNode)
+        ]
+        if foreach_nodes:
+            log.debug("ComboKernels: %d foreach nodes are filtered", len(foreach_nodes))
+        filtered_nodes = [
+            x for x in filtered_nodes if not isinstance(x, ForeachKernelSchedulerNode)
+        ]
+        template_nodes = [x for x in filtered_nodes if x.is_template()]
+        if template_nodes:
+            log.debug(
+                "ComboKernels: %d template nodes are filtered", {len(template_nodes)}
+            )
+        filtered_nodes = [x for x in filtered_nodes if x not in template_nodes]
+        return filtered_nodes
+
+    @staticmethod
+    def _default_group_nodes_for_combo_kernels(
+        scheduler: Scheduler,
+    ) -> List[List[BaseSchedulerNode]]:
+        """
+        Returns a list of lists of nodes that are to be grouped together.
+        """
+        sorted_nodes = scheduler._topological_sort_nodes()
+        grouped_nodes = []
+        max_num_nodes = 8
+        for nodes in sorted_nodes:
+            grouped_nodes.extend(
+                [
+                    nodes[i : i + max_num_nodes]
+                    for i in range(0, len(nodes), max_num_nodes)
+                ]
+            )
+
+        return grouped_nodes
+
+    group_algorithm_for_combo_kernels: Callable[
+        [Scheduler], List[List[BaseSchedulerNode]]
+    ] = _default_group_nodes_for_combo_kernels
+
+    @staticmethod
+    def set_group_algorithm_for_combo_kernels(
+        custom_group_algorithm: Callable[[Scheduler], List[List[BaseSchedulerNode]]]
+    ) -> None:
+        ForeachKernelSchedulerNode.group_algorithm_for_combo_kernels = (
+            custom_group_algorithm
+        )
+
+    @staticmethod
+    def group_nodes_for_combo_kernels(
+        scheduler: Scheduler,
+    ) -> List[List[BaseSchedulerNode]]:
+        return ForeachKernelSchedulerNode.group_algorithm_for_combo_kernels(scheduler)
+
     def mark_run(self) -> None:
         raise NotImplementedError
 
@@ -1377,7 +1448,7 @@ class ForeachKernelSchedulerNode(FusedSchedulerNode):
         return True
 
     def get_subkernel_nodes(self) -> List[BaseSchedulerNode]:
-        """Returns a list of nodes which comprise the foreach kernel, operating on corresponding elements of our input lists.
+        """Returns a list of nodes which comprise the combo kernel.
         These nodes may be vertically fused."""
         return list(self.snodes)
 
@@ -1624,6 +1695,8 @@ class Scheduler:
         self.finalize_multi_template_buffers()
         if config.reorder_for_compute_comm_overlap:
             self.nodes = comms.reorder_compute_and_comm_for_overlap(self.nodes)
+        if config.combo_kernels:
+            self.create_combo_kernel_nodes(num_ck_nodes=None)
         self.process_grouped_nodes()
         self.compute_last_usage()
         V.debug.ir_post_fusion(self.nodes)
@@ -1984,6 +2057,52 @@ class Scheduler:
             visit(node)
         return result
 
+    def _get_unmet_dep_nodes(self, snode: BaseSchedulerNode) -> List[BaseSchedulerNode]:
+        unmet_deps = set()
+        if isinstance(
+            snode,
+            (
+                SchedulerNode,
+                ExternKernelSchedulerNode,
+                NopKernelSchedulerNode,
+                FusedSchedulerNode,
+            ),
+        ):
+            for dep in snode.unmet_dependencies:
+                unmet_deps.add(dep.name)
+        else:
+            raise RuntimeError(
+                f"get_unmet_dep_nodes is not implemented for {type(snode)}."
+            )
+        unmet_dep_ops = (self.name_to_buf[dep].defining_op for dep in unmet_deps)
+        return list({self.name_to_fused_node[n.get_name()] for n in unmet_dep_ops})
+
+    def _topological_sort_nodes(self) -> List[List[BaseSchedulerNode]]:
+        """
+        Sort nodes by their topological order, return a list of node lists.
+        """
+        order = []
+        nodes = dict.fromkeys(self.nodes, 0)
+        children: Dict[Any, Any] = {}
+        for node in self.nodes:
+            deps = self._get_unmet_dep_nodes(node)
+            nodes[node] = len(deps)
+            for dep in deps:
+                c = children.get(dep, [])
+                c.append(node)
+                children[dep] = c
+
+        zero_deg_nodes = [n for n, v in nodes.items() if v == 0]
+        while zero_deg_nodes:
+            order.append(zero_deg_nodes)
+            for n in zero_deg_nodes:
+                for user in children.get(n, []):
+                    nodes[user] -= 1
+                nodes.pop(n)
+            zero_deg_nodes = [n for n, v in nodes.items() if v == 0]
+        assert not nodes, "Topological sort failed!"
+        return order
+
     def compute_ancestors(self) -> None:
         """
         Populate each node.ancestors
@@ -2117,6 +2236,15 @@ class Scheduler:
                 new_scheduler_node.max_order = node.max_order
                 new_scheduler_node.last_usage = node.last_usage
 
+    def _any_atomic_add(self, node_list: Sequence[BaseSchedulerNode]) -> bool:
+        return any(
+            hasattr(n.node, "data")
+            and n.node is not None
+            and hasattr(n.node.data, "scatter_mode")
+            and n.node.data.scatter_mode == "atomic_add"
+            for n in node_list
+        )
+
     def speedup_by_fusion(
         self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
     ) -> bool:
@@ -2153,13 +2281,7 @@ class Scheduler:
         # We can not accurately benchmark kernel using atomic_add
         # due to how we generate random integer inputs.
         # Skip benchmarking them by allowing fusion.
-        if any(
-            hasattr(n.node, "data")
-            and n.node is not None
-            and hasattr(n.node.data, "scatter_mode")
-            and n.node.data.scatter_mode == "atomic_add"
-            for n in node_list_fused
-        ):
+        if self._any_atomic_add(node_list_fused):
             return True
 
         from triton.compiler.errors import CompilationError
@@ -2309,6 +2431,54 @@ class Scheduler:
         nodes = self.topological_sort_schedule(nodes)
         self.prune_redundant_deps(nodes)
         return nodes
+
+    def create_combo_kernel_nodes(self, num_ck_nodes: Optional[int] = None) -> None:
+        """
+        Groups parallel nodes
+        """
+        fused_nodes = set(self.nodes)
+        count = 0
+        num_nodes_orig = len(self.nodes)
+        log.debug("ComboKernels: Generating with num_ck_nodes = %d...", num_ck_nodes)
+        for num, node_list in enumerate(
+            ForeachKernelSchedulerNode.group_nodes_for_combo_kernels(self)
+        ):
+            node_list = ForeachKernelSchedulerNode.combinable_nodes(node_list)
+            if len(node_list) < 2:
+                continue
+            if num_ck_nodes is not None and count > num_ck_nodes:
+                break
+            if not self.speedup_by_combo_kernel(node_list):
+                log.debug("ComboKernels: Not speeding up %d-th group", num)
+                continue
+            count += 1
+            enable_autotune = config.combo_kernels_autotune > 0
+            group_snode = ForeachKernelSchedulerNode(
+                node_list[0].scheduler,
+                node_list,
+                use_custom_partition_algo=True,
+                enable_autotune=enable_autotune,
+            )
+            log.info(
+                "ComboKernels: Combining %d nodes for %d-th group",
+                len(node_list),
+                num,
+            )
+            for node in node_list:
+                fused_nodes.remove(node)
+            fused_nodes.add(group_snode)
+            self.name_to_fused_node.update(
+                {n.get_name(): group_snode for n in group_snode.get_nodes()}
+            )
+        self.nodes = sorted(fused_nodes, key=lambda x: x.min_order)
+        self.nodes = self.topological_sort_schedule(self.nodes)
+        log.info(
+            "Generated ComboKernel nodes: %d ComboKernels, totally %d -> %d nodels",
+            count,
+            num_nodes_orig,
+            len(self.nodes),
+        )
+        self.prune_redundant_deps(self.nodes)
 
     def prune_redundant_deps(self, nodes: List[BaseSchedulerNode]) -> None:
         for node in nodes:
@@ -3057,6 +3227,94 @@ class Scheduler:
 
         self.flush()
 
+    def benchmark_combo_kernel(
+        self, node_list: Sequence[BaseSchedulerNode]
+    ) -> Tuple[float, float, str]:
+        """
+        Benchmark fused list of nodes and return the execution time
+        in milliseconds on randomly generated inputs.
+        """
+        device = node_list[0].get_device()
+        V.graph.scheduler = self
+        self.current_device = device
+        backend = self.get_backend(device)
+        return backend.benchmark_combo_kernel(node_list)
+
+    def speedup_by_combo_kernel(self, nodes: List[BaseSchedulerNode]) -> bool:
+        """
+        If config.benchmark_fusion is False, always return True.
+        Otherwise, return True if fusion can brings speedup.
+        """
+        if not config.benchmark_combo_kernel:
+            return True
+
+        subkernel_nodes = nodes
+        device = subkernel_nodes[0].get_device()
+
+        # don't support benchmark fusion for CPU right now.
+        if device.type == "cpu":
+            return True
+
+        from triton.compiler.errors import CompilationError
+
+        ms1, path1_list = 0.0, []
+        for i, snode in enumerate(subkernel_nodes):
+            node_list = snode.get_nodes()
+            # We can not accurately benchmark kernel using atomic_add
+            # due to how we generate random integer inputs.
+            if self._any_atomic_add(node_list):
+                fusion_log.debug(
+                    "ComboKernel: benchmarking may not accurate due to atomic_add"
+                )
+
+            try:
+                ms, path = self.benchmark_fused_nodes(node_list)
+                if math.isinf(ms):
+                    fusion_log.debug(
+                        "ComboKernel benchmark: register spilling of %d-th subkernel",
+                        i,
+                    )
+                    return False
+            except CompilationError as e:
+                # workaround triton issue: https://github.com/openai/triton/issues/2151
+                if "Loop-carried variable" in str(e):
+                    fusion_log.debug(
+                        "ComboKernel benchmark: return True because of loop-carried variable"
+                    )
+                    return True  # allow fusion
+                else:
+                    raise
+            ms1 += ms
+            path1_list.append(path)
+
+        try:
+            ms2, ms2_clone, path2_list = self.benchmark_combo_kernel(subkernel_nodes)
+        except CompilationError as e:
+            # workaround triton issue: https://github.com/openai/triton/issues/2151
+            if "Loop-carried variable" in str(e):
+                fusion_log.debug(
+                    "ComboKernel benchmark: return True because of loop-carried variable"
+                )
+                return True  # allow fusion
+            else:
+                raise
+
+        # small kernels are very likely to have speedup but hard to benchmark. So we skip benchmarking.
+        small_kernel = ms2_clone / ms2 > 0.6 and ms2 - ms2_clone < 0.2
+        if fusion_log.isEnabledFor(logging.DEBUG):
+            if ms1 > ms2 or small_kernel:
+                fusion_log.debug(
+                    "can fuse (benchmark): fusing causes %sx speedup",
+                    green_text(f"{ms1 / ms2:.3f}"),
+                )
+            else:
+                fusion_log.debug(
+                    "cannot fuse (benchmark): fusing causes %sx slowdown",
+                    red_text(f"{ms1 / ms2:.3f}"),
+                )
+
+        return ms2 < ms1 or small_kernel
+
     def get_buffer_layout(self, buf_name: str) -> ir.Layout:
         buf = self.name_to_buf[buf_name]
         assert buf.node is not None
@@ -3159,6 +3417,15 @@ class BaseScheduling:
         The smaller is with higher priority.
         """
         return 0
+
+    def benchmark_combo_kernel(
+        self, node_list: Sequence[BaseSchedulerNode]
+    ) -> Tuple[float, float, str]:
+        """
+        Benchmark the list of nodes to combine and return the execution time
+        and memory copy time in milliseconds on randomly generated inputs.
+        """
+        raise NotImplementedError
 
 
 def debug_triton_code(node: Union[SchedulerNode, FusedSchedulerNode]) -> List[str]:


### PR DESCRIPTION
Summary:
A ComboKernel combines independent Inductor Triton kernels into a single one.
This is part 2 pull request which 1) adds automatic horizontal fusion in the end of the inductor operator fusion process, 2) adds type annotation for trition_combo_kernel.py

ComboKernel is used in two cases: 1) for existing foreach kernels, combo kernels are used as the backend kernel. the front-end kernel generation logic remains the same. 2) Added an extra optimization phase to the end of the scheduler to generate extra combo kernels if combo_kernels is True in config.py

This is part 2 pull request which deals with the 2nd case above:

- The combo kernel generation in the added optimization phase is done in two steps: 1) in the front end inside the scheduler, it topologically sort the schedule nodes to find all the nodes with no data dependency and create a frond end schedule node for them. We currently limit the maximal number of sub-nodes for each combo kernel to 8 (but we still need to find what is the optimal number). 2) then, these sub-nodes are combined in the codegen phase to generate the combo kernel code for them based on a few rules. For example, 1d and 2d kernels are separated into different combo kernels, as mixing them is not supported yet. Note these algorithms we provide are very basic, and the users can register their customized combo kernel generation algorithms for both steps.

- Performance wise, combining small kernels is about always to see performance gain. however, combining very large kernels may not see any perf gain, sometimes even regression possibly due to improper block sizes. Thus, a benchmark function is implemented to avoid such perf regression, and it is recommended to turn it on by setting benchmark_combo_kernels to True whenever combo_kernels is True.

Please refer to part 1 pull request https://github.com/pytorch/pytorch/pull/124969 for more details.

Test Plan: buck2 test mode/dev-nosan caffe2/test/inductor:combo_kernels

Differential Revision: D60067757


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang