### PR TITLE
Register buffer in static input test

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -2142,7 +2142,9 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             class Foo(torch.nn.Module):
                 def __init__(self) -> None:
                     super().__init__()
-                    self.static_tensor = torch.zeros((2, 2), device="cuda")
+                    self.register_buffer(
+                        "static_tensor", torch.zeros((2, 2), device="cuda")
+                    )
                     self.goo = Goo()
 
                 def forward(self, x) -> torch.Tensor:
@@ -2160,11 +2162,20 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             foo.static_tensor = torch.ones((2, 2), device="cuda")
             foo.goo.linear.bias = torch.nn.Parameter(torch.ones((2,), device="cuda"))
 
-            # Run with specific function id to avoid dynamo recompiling
-            self.get_manager().run(
-                [foo.goo.linear.weight, foo.goo.linear.bias, foo.static_tensor, inp],
-                FunctionID(0),
-            )
+            if torch._dynamo.config.inline_inbuilt_nn_modules:
+                for _ in range(3):
+                    foo(inp)
+            else:
+                # Run with specific function id to avoid dynamo recompiling
+                self.get_manager().run(
+                    [
+                        foo.goo.linear.weight,
+                        foo.goo.linear.bias,
+                        foo.static_tensor,
+                        inp,
+                    ],
+                    FunctionID(0),
+                )
 
             self.assertEqual(self.get_manager().new_graph_id().id, 2)
 


### PR DESCRIPTION
Previously, without nn module inlining, dynamo would lift all tensor attributes on an nn module to be constant on the graph. With nn module inlining these need to be buffers explicitly. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang