### PR TITLE
[inductor] Fix flaky tests in test_memory_planning.py

### DIFF
--- a/test/inductor/test_memory_planning.py
+++ b/test/inductor/test_memory_planning.py
@@ -65,7 +65,7 @@ class TestMemoryPlanning(TestCase):
     def test_cpp_wrapper(self):
         f, args = self._generate(device="cuda")
         compiled = torch.compile(f, dynamic=True)
-        with config.patch("cpp_wrapper", True):
+        with config.patch({"cpp_wrapper": True, "abi_compatible": False}):
             result, code = run_and_get_cpp_code(compiled, *args)
 
         FileCheck().check(


### PR DESCRIPTION
Summary: Internally, the ABI-compatible mode is [enabled by default](https://github.com/pytorch/pytorch/blob/eb54ca7abe3820d7d0512ab13dea681a6989c780/torch/_inductor/config.py#L53). As a result, when the `abi_compatible: False` flag is not specified explitictly in the tests assuming non-ABI-compatible C++ codegen, those are failing internally. Here we fix one such test in `test_memory_planning.py`.

Test Plan: Tested internally.

Differential Revision: D60197327


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang