### PR TITLE
[ROCm] performance optimization for index select 

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1342,7 +1342,7 @@ uint64_t getDefaultMaxThreadsPerBlock() {
 #else
   hipDeviceProp_t* prop = at::cuda::getCurrentDeviceProperties();
   // MI300x optimization
-  if (std::string(prop->gcnArchName).find("gfx942") != std::string::npos) {
+  if (std::string(prop->gcnArchName).find("gfx94") != std::string::npos) {
     return 1024;
   }
   // bigger default

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1334,7 +1334,7 @@ tensorInfoLegacyIfScalar(cuda::detail::TensorInfo<T, IndexType> ti) {
   return ti;
 }
 
-uint64_t getDefaultMaxThreadsPerBlock() {
+constexpr uint64_t getDefaultMaxThreadsPerBlock() {
 #ifndef USE_ROCM
   return 128;
 #else

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1338,13 +1338,8 @@ uint64_t getDefaultMaxThreadsPerBlock() {
 #ifndef USE_ROCM
   return 128;
 #else
-  hipDeviceProp_t* prop = at::cuda::getCurrentDeviceProperties();
-  // MI300x optimization
-  if (std::string(prop->gcnArchName).find("gfx94") != std::string::npos) {
-    return 1024;
-  }
   // bigger default
-  return 256;
+  return 512;
 #endif
 }
 

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1334,8 +1334,6 @@ tensorInfoLegacyIfScalar(cuda::detail::TensorInfo<T, IndexType> ti) {
   return ti;
 }
 
-}
-
 uint64_t getDefaultMaxThreadsPerBlock() {
 #ifndef USE_ROCM
   return 128;
@@ -1349,6 +1347,9 @@ uint64_t getDefaultMaxThreadsPerBlock() {
   return 256;
 #endif
 }
+
+}
+
 
 template <typename scalar_t>
 void index_select_out_cuda_impl(


### PR DESCRIPTION
As observed during working on this fix (https://github.com/pytorch/pytorch/pull/130994), 128 threads per block seems quite low. This PR is to increase the default to improve the performance, and also slightly refactoring the code to replace the hard-coded 128 for better maintenance.

By increasing the default max threads per block from 128 to 256, I saw for `aten::index_select`,  its "CUDA total" time drop from 44.820ms to 33.608ms by profiling below embedding script: 
```
input = torch.randint(low=0, high=16032, size=[131072], device="cuda")
w = torch.randn([16032, 16384], device="cuda")

with profiler.profile(record_shapes=True) as prof:
    x = torch.nn.functional.embedding(input, w)

```
I tested with the default from 128 to 256, 512, 1024 on several different types of devices, and observed "CUDA total" time dropping even more and more latency improvement as the number increases. Below is one example of latency improvement ratio:
128 | 1x
256 | 1.33x
512 | 1.44x
1024 | 1.49x

Using 512 as the new default max for non-mi300x to be conservative, which is 1.44x faster than using 128 with the above profiling script.

Using 1024 for mi300x is 1.61x faster than using 128 with the same profiling script, and using 512 is 1.57x faster.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo