### PR TITLE
[inductor] Improve sort kernel perf

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2311,12 +2311,12 @@ class TritonKernel(SIMDKernel):
             return tuple(result_vars)
 
         assert self.range_trees[-1].prefix == "r"
-        rmask = "None" if self._has_constant_mask(self.range_trees[-1]) else "rmask"
+        rnumel = "None" if self._has_constant_mask(self.range_trees[-1]) else "rnumel"
 
         if len(values) == 2:
             line = (
                 f"triton_helpers.sort_with_index({broadcasted_values[0]}, {broadcasted_values[1]},"
-                f" {rmask}, {dim}, stable={stable}, descending={descending})"
+                f" {rnumel}, {dim}, stable={stable}, descending={descending})"
             )
             result_vars = cse_multiple(line, len(values), masks)
         else:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1956,7 +1956,7 @@ class Sort(Loops):
 
         # Heuristic, smallest rblock where triton usually outperforms aten.sort
         # It also isn't bandwidth bound so fusion is unlikely to help.
-        max_rblock = 256
+        max_rblock = 512
         is_persistent_kernel = (
             config.triton.persistent_reductions
             and sizevars.is_expr_static_and_true(sympy.Le(sort_numel, max_rblock))

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -5671,8 +5671,11 @@ def sort_stable(x, *, stable=None, dim=-1, descending=False):
         return clone(x), _full(0, device, torch.int64, shape)
 
     dim_size = shape[dim] if len(shape) else 1
+    if not V.graph.sizevars.statically_known_lt(dim_size, torch.iinfo(torch.int16).max):
+        return sort_fallback(x, stable=stable, dim=dim, descending=descending)
+
     indices = iota(
-        dim_size, start=0, step=1, dtype=torch.int64, device=device, requires_grad=False
+        dim_size, start=0, step=1, dtype=torch.int16, device=device, requires_grad=False
     )
     view_shape = [1] * len(shape)
     if len(shape):
@@ -5692,7 +5695,8 @@ def sort_stable(x, *, stable=None, dim=-1, descending=False):
     if values is None:
         return sort_fallback(x, stable=stable, dim=dim, descending=descending)
 
-    return values, indices
+    assert indices is not None
+    return values, to_dtype(indices, torch.int64)
 
 
 @register_lowering(aten.sort.default, type_promotion_kind=None)

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -488,7 +488,7 @@ def _bitonic_merge_with_index(
 def sort_with_index(
     x,  # value
     idxs,  # index
-    rnumel, # number of elements
+    rnumel,  # number of elements
     dim: tl.constexpr = None,
     stable: tl.constexpr = tl.constexpr(False),
     descending: tl.constexpr = tl.constexpr(False),

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -386,7 +386,7 @@ def frexp(x):
 def _compare_and_swap_with_index(
     x,
     idxs,
-    valid_mask,
+    rnumel,
     flip,
     i: tl.constexpr,
     n_dims: tl.constexpr,
@@ -422,19 +422,12 @@ def _compare_and_swap_with_index(
     right_idx = tl.reshape(right_idx, x.shape)
 
     # valid
-    if valid_mask is None:
+    if rnumel is None:
         left_valid_mask = tl.full(x.shape, True, tl.int1)
         right_valid_mask = tl.full(x.shape, True, tl.int1)
     else:
-        y_valid_mask = tl.reshape(valid_mask, shape)
-        left_valid_mask = tl.broadcast_to(
-            tl.sum(y_valid_mask * left_mask.to(tl.int8), 1)[:, None, :], shape
-        ).to(tl.int1)
-        right_valid_mask = tl.broadcast_to(
-            tl.sum(y_valid_mask * right_mask.to(tl.int8), 1)[:, None, :], shape
-        ).to(tl.int1)
-        left_valid_mask = tl.reshape(left_valid_mask, x.shape)
-        right_valid_mask = tl.reshape(right_valid_mask, x.shape)
+        left_valid_mask = left_idx < rnumel
+        right_valid_mask = right_idx < rnumel
 
     # actual compare-and-swap
     ix = x.to(idtype, bitcast=True)
@@ -454,21 +447,15 @@ def _compare_and_swap_with_index(
     cond = cond ^ flip
     ret = ix ^ tl.where(cond, ileft ^ iright, tl.zeros_like(ix))
     new_idxs = idxs ^ tl.where(cond, left_idx ^ right_idx, tl.zeros_like(idxs))
-    if valid_mask is None:
-        new_valid_mask = tl.full(x.shape, True, tl.int1)
-    else:
-        new_valid_mask = valid_mask ^ tl.where(
-            cond, left_valid_mask ^ right_valid_mask, tl.zeros_like(valid_mask)
-        )
 
-    return ret.to(x.dtype, bitcast=True), new_idxs, new_valid_mask
+    return ret.to(x.dtype, bitcast=True), new_idxs
 
 
 @triton.jit
 def _bitonic_merge_with_index(
     x,
     idxs,
-    mask,
+    rnumel,
     stage: tl.constexpr,
     alternating: tl.constexpr,
     n_dims: tl.constexpr,
@@ -490,28 +477,23 @@ def _bitonic_merge_with_index(
     else:
         flip = False
     # perform `stage` rounds of `compare-and-swap`
-    next_mask = mask
     for i in tl.static_range(stage):
-        x, idxs, next_mask = _compare_and_swap_with_index(
-            x, idxs, mask, flip, i + (n_dims - stage), n_dims, stable, descending
+        x, idxs = _compare_and_swap_with_index(
+            x, idxs, rnumel, flip, i + (n_dims - stage), n_dims, stable, descending
         )
-        if mask is not None:
-            mask = next_mask
-    return x, idxs, next_mask
+    return x, idxs
 
 
 @triton.jit
 def sort_with_index(
     x,  # value
     idxs,  # index
-    mask,  # mask if current value is valid (invalid values sort to the end)
+    rnumel, # number of elements
     dim: tl.constexpr = None,
     stable: tl.constexpr = tl.constexpr(False),
     descending: tl.constexpr = tl.constexpr(False),
 ):
     x, idxs = tl.broadcast(x, idxs)
-    if mask is not None:
-        x, mask = tl.broadcast(x, mask)
     # handle default dimension or check that it is the most minor dim
     _dim: tl.constexpr = len(x.shape) - 1 if dim is None else dim
     tl.static_assert(
@@ -521,16 +503,14 @@ def sort_with_index(
     n_dims: tl.constexpr = _log2(x.shape[_dim])
 
     for i in tl.static_range(1, n_dims + 1):
-        x, idxs, next_mask = _bitonic_merge_with_index(
+        x, idxs = _bitonic_merge_with_index(
             x,
             idxs,
-            mask,
+            rnumel,
             i,
             alternating=i < n_dims,
             n_dims=n_dims,
             stable=stable,
             descending=descending,
         )
-        if mask is not None:
-            mask = next_mask
     return x, idxs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131719

Closes #129507

This makes two changes to the sort kernel:
1. Use int16 for the indices since we only operate on small dims anyway
2. Instead of passing an explicit mask, we pass the rnumel and imply the
   mask from that which saves an additional reduction in the sort
   kernel's inner loop.

In my benchmarks, this gives enough of a perf improvement to bump up the
max rblock to 512.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang