### PR TITLE
TCPStore: add async init

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -28,8 +28,14 @@
 #endif
 
 #include <torch/csrc/distributed/c10d/socket.h>
+namespace {
+// Control whether or not we use async TCPStore connection init.
+static const std::vector<std::string> TORCH_TCPSTORE_ASYNC = {
+    "TORCH_TCPSTORE_ASYNC"};
+} // namespace
 
 namespace c10d {
+
 namespace detail {
 
 class timing_guard {
@@ -356,6 +362,27 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
     addr_.port = opts.port;
   }
 
+  const bool connectAsync = getCvarBool(TORCH_TCPSTORE_ASYNC, true);
+  if (!opts.waitWorkers && connectAsync) {
+    C10D_INFO(
+        "Connecting to store on {}:{} asynchronously since waitWorkers=false, "
+        "set {}=0 to disable",
+        addr_.host,
+        addr_.port,
+        TORCH_TCPSTORE_ASYNC[0]);
+
+    connectFuture_ =
+        std::async(std::launch::async, [this, opts] { connect(opts); });
+  } else {
+    connect(opts);
+  }
+
+  if (opts.waitWorkers) {
+    waitForWorkers();
+  }
+}
+
+void TCPStore::connect(const TCPStoreOptions& opts) {
   // Try connecting several times -- if the server listen backlog is full it may
   // fail on the first send in validate.
   auto deadline = std::chrono::steady_clock::now() + opts.timeout;
@@ -403,9 +430,23 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
       retry += 1;
     }
   } while (true);
+}
 
-  if (opts.waitWorkers) {
-    waitForWorkers();
+void TCPStore::waitConnected() {
+  // TODO: this is a good spot to check if connection is down and reconnect if
+  // necessary.
+  const std::lock_guard<std::mutex> lock(connectLock_);
+  if (connectFuture_.valid()) {
+    try {
+      C10D_DEBUG("waiting for connection");
+      connectFuture_.get();
+    } catch (...) {
+      // ensure future calls have the same exception
+      std::promise<void> promise;
+      promise.set_exception(std::current_exception());
+      connectFuture_ = promise.get_future();
+      throw;
+    }
   }
 }
 
@@ -482,8 +523,11 @@ void TCPStore::_splitSet(
 }
 
 void TCPStore::set(const std::string& key, const std::vector<uint8_t>& data) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["set"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   detail::SendBuffer buffer(*client_, detail::QueryType::SET);
   buffer.appendString(keyPrefix_ + key);
   buffer.appendBytes(data);
@@ -494,8 +538,11 @@ std::vector<uint8_t> TCPStore::compareSet(
     const std::string& key,
     const std::vector<uint8_t>& expectedValue,
     const std::vector<uint8_t>& desiredValue) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["compareSet"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   detail::SendBuffer buffer(*client_, detail::QueryType::COMPARE_SET);
   buffer.appendString(keyPrefix_ + key);
   buffer.appendBytes(expectedValue);
@@ -506,8 +553,11 @@ std::vector<uint8_t> TCPStore::compareSet(
 }
 
 std::vector<uint8_t> TCPStore::get(const std::string& key) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["get"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   return doGet(keyPrefix_ + key);
 }
 
@@ -521,14 +571,20 @@ std::vector<uint8_t> TCPStore::doGet(const std::string& key) {
 }
 
 int64_t TCPStore::add(const std::string& key, int64_t value) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["add"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   return incrementValueBy(keyPrefix_ + key, value);
 }
 
 bool TCPStore::deleteKey(const std::string& key) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["deleteKey"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   detail::SendBuffer buffer(*client_, detail::QueryType::DELETE_KEY);
   buffer.appendString(keyPrefix_ + key);
   buffer.flush();
@@ -547,7 +603,10 @@ int64_t TCPStore::incrementValueBy(const std::string& key, int64_t delta) {
 }
 
 int64_t TCPStore::getNumKeys() {
+  waitConnected();
+
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   detail::SendBuffer buffer(*client_, detail::QueryType::GETNUMKEYS);
   buffer.flush();
 
@@ -555,8 +614,11 @@ int64_t TCPStore::getNumKeys() {
 }
 
 bool TCPStore::check(const std::vector<std::string>& keys) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["check"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   detail::SendBuffer buffer(*client_, detail::QueryType::CHECK);
   buffer.appendValue(keys.size());
 
@@ -582,8 +644,11 @@ void TCPStore::wait(const std::vector<std::string>& keys) {
 void TCPStore::wait(
     const std::vector<std::string>& keys,
     const std::chrono::milliseconds& timeout) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["wait"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   std::vector<std::string> prefixedKeys{};
   prefixedKeys.reserve(keys.size());
   for (const std::string& key : keys) {
@@ -638,8 +703,11 @@ void TCPStore::doWait(
 void TCPStore::append(
     const std::string& key,
     const std::vector<uint8_t>& data) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["append"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   detail::SendBuffer buffer(*client_, detail::QueryType::APPEND);
   buffer.appendString(keyPrefix_ + key);
   buffer.appendBytes(data);
@@ -648,8 +716,11 @@ void TCPStore::append(
 
 std::vector<std::vector<uint8_t>> TCPStore::multiGet(
     const std::vector<std::string>& keys) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["multiGet"]);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
+
   std::vector<std::string> prefixedKeys;
   prefixedKeys.reserve(keys.size());
   for (const std::string& key : keys) {
@@ -675,6 +746,8 @@ std::vector<std::vector<uint8_t>> TCPStore::multiGet(
 void TCPStore::multiSet(
     const std::vector<std::string>& keys,
     const std::vector<std::vector<uint8_t>>& values) {
+  waitConnected();
+
   detail::timing_guard tguard(clientCounters_["multiSet"]);
   TORCH_CHECK(
       keys.size() == values.size(),

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <future>
 #include <memory>
 
 #include <torch/csrc/distributed/c10d/Store.hpp>
@@ -143,6 +144,8 @@ class TORCH_API TCPStore : public Store {
  private:
   int64_t incrementValueBy(const std::string& key, int64_t delta);
 
+  void connect(const TCPStoreOptions& opts);
+  void waitConnected();
   void ping();
   void validate();
 
@@ -152,6 +155,7 @@ class TORCH_API TCPStore : public Store {
       c10::ArrayRef<std::string> keys,
       std::chrono::milliseconds timeout);
 
+ private:
   detail::SocketAddress addr_;
   std::shared_ptr<detail::TCPServer> server_;
   std::unique_ptr<detail::TCPClient> client_;
@@ -162,6 +166,9 @@ class TORCH_API TCPStore : public Store {
   std::mutex activeOpLock_;
   std::unordered_map<std::string, detail::Counter> clientCounters_;
   bool usingLibUv_ = true;
+
+  std::mutex connectLock_;
+  std::future<void> connectFuture_;
 };
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1481,7 +1481,7 @@ Arguments:
     world_size (int, optional): The total number of store users (number of clients + 1 for the server). Default is None (None indicates a non-fixed number of store users).
     is_master (bool, optional): True when initializing the server store and False for client stores. Default is False.
     timeout (timedelta, optional): Timeout used by the store during initialization and for methods such as :meth:`~torch.distributed.store.get` and :meth:`~torch.distributed.store.wait`. Default is timedelta(seconds=300)
-    wait_for_workers (bool, optional): Whether to wait for all the workers to connect with the server store. This is only applicable when world_size is a fixed value. Default is True.
+    wait_for_workers (bool, optional): Whether the server node will wait for all the workers to connect with the server store. This is only applicable when world_size is a fixed value. Additionally when False, client connections will be established asynchronously and any error will be reported on first store operation. Default is True.
     multi_tenant (bool, optional): If True, all ``TCPStore`` instances in the current process with the same host/port will use the same underlying ``TCPServer``. Default is False.
     master_listen_fd (int, optional): If specified, the underlying ``TCPServer`` will listen on this file descriptor, which must be a socket already bound to ``port``. Useful to avoid port assignment races in some scenarios. Default is None (meaning the server creates a new socket and attempts to bind it to ``port``).
     use_libuv (bool, optional): If True, use libuv for ``TCPServer`` backend. Default is True.

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -370,7 +370,12 @@ def create_tcp_store(
         )
     else:
         return c10d.TCPStore(
-            addr, port, world_size, is_master, wait_for_workers=wait_for_workers, use_libuv=use_libuv
+            addr,
+            port,
+            world_size,
+            is_master,
+            wait_for_workers=wait_for_workers,
+            use_libuv=use_libuv,
         )
 
 


### PR DESCRIPTION
This makes TCPStore connection init async when `wait_for_workers=False` is set . This allows for overlapping other initialization with the TCPStore connection establishment.

This should be safe in all cases since the only functional behavior change is that the connection error will occur on the first use of the store rather than during initialization. The default is `wait_for_workers=True` so this shouldn't change the behavior for the majority of use cases.

If this causes an issue you can set `TORCH_TCPSTORE_ASYNC=0` to disable. 

Test plan:

```
python test/distributed/test_store.py
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o