### PR TITLE
[inductor] Fix flaky tests in test_debug_trace.py

### DIFF
--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -4,11 +4,13 @@ import os
 import re
 import shutil
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
 import torch
 from torch._inductor import config, test_operators
+from torch._inductor.utils import fresh_inductor_cache
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -36,10 +38,20 @@ class TestDebugTrace(test_torchinductor.TestCase):
             a = test_operators.realize(a + 1) + 2
             return torch.matmul(a, b)
 
-        with self.assertLogs(
-            logging.getLogger("torch._inductor.debug"), level=logging.WARNING
-        ) as cm:
-            fn(torch.randn(16, 16), torch.randn(16, 16))
+        # TODO(aakhundov): make this work with fresh_inductor_cache
+        # instead of force_disable_caches. currently, with the latter
+        # enabled, we get `inductor [('fxgraph_cache_hit', 1)]` in
+        # the counters: so the cache is actually hit and the test fails.
+        with config.patch(
+            {
+                "trace.debug_dir": tempfile.mkdtemp(),
+                "force_disable_caches": True,
+            }
+        ):
+            with self.assertLogs(
+                logging.getLogger("torch._inductor.debug"), level=logging.WARNING
+            ) as cm:
+                fn(torch.randn(16, 16), torch.randn(16, 16))
 
         self.assertEqual(len(cm.output), 1)
         m = re.match(r"WARNING.* debug trace: (.*)", cm.output[0])
@@ -213,9 +225,6 @@ op2.node.kernel = extern_kernels.mm""",
                 return self.relu(self.l(x))
 
         # no failure
-
-        from torch._inductor.utils import fresh_inductor_cache
-
         with self.assertLogs(
             logging.getLogger("torch._inductor.debug"), level=logging.WARNING
         ), fresh_inductor_cache():


### PR DESCRIPTION
Summary:
When run internally in multiple parallel processes, the `test_debug_trace` hits the cache and skips writing all the expected outputs. Here we force-disable inductor cache to circumvent the problem. Ideally, we should switch to using a cleaner `fresh_inductor_cache` decorator approach, but it doesn't work at the moment.

Additionally, the debug trace dir is now generated by `tempfile.mkdtemp` to avoid a (rather unlikely) race condition.

Test Plan: Tested internally.

Differential Revision: D60207586


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang