### PR TITLE
Generalization of distributed UT content to enable non cuda device execution

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -40,6 +40,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_TSAN,
     TestCase,
     run_tests,
+    TEST_HPU,
 )
 from torch.testing._internal.distributed.multi_threaded_pg import (
     _install_threaded_pg,
@@ -98,6 +99,8 @@ class DistTestCases:
     backend_feature["ddp"] = {"nccl", "gloo", "ucc"}
     backend_feature["subgroup"] = {"nccl", "gloo", "ucc"}
     backend_feature["plugin"] = set()
+    if TEST_HPU:
+        backend_feature["hpu"] = {"hccl"}
 
 
 def skip_if_no_gpu(func):
@@ -110,6 +113,8 @@ def skip_if_no_gpu(func):
             sys.exit(TEST_SKIPS["no_cuda"].exit_code)
         world_size = int(os.environ["WORLD_SIZE"])
         if torch.cuda.device_count() < world_size:
+            sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
+        if TEST_HPU and torch.hpu.device_count < world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
 
         return func(*args, **kwargs)
@@ -181,6 +186,8 @@ def skip_if_lt_x_gpu(x):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if torch.cuda.is_available() and torch.cuda.device_count() >= x:
+                return func(*args, **kwargs)
+            if TEST_HPU and torch.hpu.device_count() >= x:
                 return func(*args, **kwargs)
             sys.exit(TEST_SKIPS[f"multi-gpu-{x}"].exit_code)
 
@@ -464,6 +471,9 @@ def init_multigpu_helper(world_size: int, backend: str):
     divided to subsets, each process only uses a subset.
     """
     nGPUs = torch.cuda.device_count()
+    if TEST_HPU:
+        nGPUs = torch.hpu.device_count()
+
     visible_devices = range(nGPUs)
 
     # If rank is less than or equal to number of available GPU's
@@ -855,6 +865,66 @@ class MultiProcessTestCase(TestCase):
     def is_master(self) -> bool:
         return self.rank == 0
 
+# Utility base class for DDP based Multi Process Test cases
+# This abstracts the PG creation and deletion, the backends are selected based
+# on device type. The tests functions can be instantiated per device type using
+# common_device_type.instantiate_device_type_tests
+# other backends can add entry in backend() function
+class DistributedTestBase(MultiProcessTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self):
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    def backend(self, device) -> str:
+        if "cuda" in device:
+            return "nccl"
+        elif "hpu" in device :   # intel gaudi
+            return "hccl"
+        else :
+            return "gloo"
+
+    def device_handle(self, device) :
+        device_name = device.split(":")[0]
+        if hasattr(torch, device_name):
+            return getattr(torch, device_name, None)
+        else:
+            raise RuntimeError(
+                f"Device {device} library not found"
+            )
+
+    def create_pg(self, device):
+        num_visible_devices = self.device_handle(device).device_count()
+        store = torch.distributed.FileStore(self.file_name, num_visible_devices)
+        torch.distributed.init_process_group(
+            backend=self.backend(device),
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store
+        )
+        if "nccl" in self.backend(device):
+            torch.cuda.set_device(self.rank)
+        return torch.distributed.distributed_c10d._get_default_group()
+
+    def rank_to_device(self, device):
+        num_visible_devices = self.device_handle(device).device_count()
+        visible_device = range(num_visible_devices)
+        num_devices_per_process = 1
+        rank_to_device = {
+            i : list(visible_device[i * num_devices_per_process : (i + 1) * num_devices_per_process])
+            for i in range(num_visible_devices)
+        }
+        return rank_to_device
+
+    def destroy_pg(self) -> None:
+        torch.distributed.barrier()
+        torch.distributed.destroy_process_group()
 
 def run_subtests(
     cls_inst,


### PR DESCRIPTION
## Motivation

The distributed UT content is primarily targeted for cuda devices , however other devices like the intel Gaudi  do support much of the functionality validated.
Since the code has explicit cuda api calls , it becomes hard to adapt these for non cuda devices.

Here we introduce a new class derived from MultiProcessTestCase, which helps abstracts out the process group creation /deletion and other functionality for a given device.

The tests can be instantiated per device using existing utilities such as instantiate_device_type_tests , which will pass the device as argument and accordingly create the PG with the right backend 

The new  generalized content can be added by deriving from this base class.
Also includes other misc changes for gaudi support

Note that this is a follow-up of functionality introduced with PR : https://github.com/pytorch/pytorch/pull/126970

## Example Use :  Here is a snippet from existing content (distributed/tests/test_c10d_nccl.py)  to illustrate the use 
```
from torch.testing._internal.common_device_type import instantiate_device_type_tests
class ProcessGroupNCCLTest(DistributedTestBase):
 
    def test_empty_tensors(self,device):
        #store = c10d.FileStore(self.file_name, self.world_size)
        pg = self.create_pg(device)
        local_device_idx = self.rank_to_device(device)[self.rank][0]
 
        xs = [torch.FloatTensor([]).to(device)]
        pg.broadcast(xs).wait()
        self.assertEqual(0, xs[0].numel())
 
        pg.allreduce(xs).wait()
        self.assertEqual(0, xs[0].numel())
 
        pg.reduce(xs).wait()
        self.assertEqual(0, xs[0].numel())
 
        ys = [[torch.FloatTensor([]).to(device) for _ in range(self.world_size)]]
        pg.allgather(ys, xs).wait()
        for y in ys[0]:
            self.assertEqual(0, y.numel())
 
        ys = [torch.FloatTensor([]).to(device)]
        xs = [[torch.FloatTensor([]).to(device) for _ in range(self.world_size)]]
        pg.reduce_scatter(ys, xs).wait()
        self.assertEqual(0, ys[0].numel())
 
 
devices = ["cuda"]
if TEST_HPU:
    devices.append("hpu")
instantiate_device_type_tests(ProcessGroupNCCLTest,globals(),only_for=devices)

```




cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames