### PR TITLE
[aotd] Align partitioner graph output type to tuple

### DIFF
--- a/test/distributed/_tensor/test_dtensor_compile.py
+++ b/test/distributed/_tensor/test_dtensor_compile.py
@@ -530,7 +530,7 @@ def forward(self, primals_1):
     wait_tensor = torch.ops._c10d_functional.wait_tensor.default(primals_1)
     sin = torch.ops.aten.sin.default(wait_tensor)
     sin_1 = torch.ops.aten.sin.default(sin);  sin = None
-    return [sin_1, primals_1, wait_tensor]""",
+    return (sin_1, primals_1, wait_tensor)""",
         )
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -573,7 +573,7 @@ def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     mul = torch.ops.aten.mul.Tensor(clone, 2);  clone = None
     mul_1 = torch.ops.aten.mul.Tensor(mul, 3)
-    return [mul, mul_1]""",
+    return (mul, mul_1)""",
         )
 
     def test_input_mutation_set__input_mutation(self):
@@ -643,7 +643,7 @@ def forward(self, primals_1, primals_2):
     add = torch.ops.aten.add.Tensor(mul, mul)
     set_ = torch.ops.aten.set_.source_Tensor(primals_1, mul);  primals_1 = None
     copy_ = torch.ops.aten.copy_.default(primals_2, mul);  primals_2 = mul = None
-    return [add]""",
+    return (add,)""",
         )
 
     # This is a (hopefully) extremely rare case that is difficult to handle,
@@ -722,7 +722,7 @@ def forward(self, primals_1):
     alias = torch.ops.aten.alias.default(primals_1);  primals_1 = None
     view = torch.ops.aten.view.default(arange, [3, 3]);  arange = None
     add = torch.ops.aten.add.Tensor(alias, view);  alias = view = None
-    return [add]""",
+    return (add,)""",
         )
 
     @unittest.skipIf(IS_WINDOWS, "TODO: need to fix the test case")
@@ -774,7 +774,7 @@ def forward(self, primals_1):
     mul_2 = torch.ops.aten.mul.Tensor(primals_1, primals_1)
     add = torch.ops.aten.add.Tensor(mul, mul_1);  mul = mul_1 = None
     add_1 = torch.ops.aten.add.Tensor(add, mul_2);  add = mul_2 = None
-    return [add_1, primals_1]""",
+    return (add_1, primals_1)""",
         )
         self.assertEqual(torch.compile(f, backend="inductor")(*inp), f(*inp))
 
@@ -1020,7 +1020,7 @@ def forward(self, primals_1):
 def forward(self, primals_1, primals_2, primals_3):
     t = torch.ops.aten.t.default(primals_1);  primals_1 = None
     addmm = torch.ops.aten.addmm.default(primals_2, primals_3, t);  primals_2 = None
-    return [addmm, primals_3, t]""",
+    return (addmm, primals_3, t)""",
         )
 
         with torch.inference_mode():
@@ -1071,7 +1071,7 @@ def forward(self, arg0_1, arg1_1, arg2_1):
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     mul = torch.ops.aten.mul.Tensor(clone, 2);  clone = None
-    return [mul, mul]""",
+    return (mul, mul)""",
         )
 
     def test_input_mutation_multiple(self):
@@ -1100,7 +1100,7 @@ def forward(self, primals_1, primals_2, primals_3):
     mul_1 = torch.ops.aten.mul.Tensor(clone_1, 2);  clone_1 = None
     add = torch.ops.aten.add.Tensor(mul, primals_2);  primals_2 = None
     add_1 = torch.ops.aten.add.Tensor(add, mul_1);  add = None
-    return [mul, mul_1, add_1]""",
+    return (mul, mul_1, add_1)""",
         )
 
     def test_input_mutation_return(self):
@@ -1171,7 +1171,7 @@ def forward(self, primals_1):
     copy = torch.ops.aten.copy.default(primals_1, ones);  ones = None
     add = torch.ops.aten.add.Tensor(copy, 1)
     copy_ = torch.ops.aten.copy_.default(primals_1, copy);  primals_1 = copy = None
-    return [add]""",
+    return (add,)""",
         )
 
     def test_input_mutation_storage_resize_down(self):
@@ -1204,7 +1204,7 @@ def forward(self, primals_1):
 def forward(self, primals_1):
     sin = torch.ops.aten.sin.default(primals_1)
     resize_storage_bytes_ = torch.ops.inductor.resize_storage_bytes_.default(primals_1, 0)
-    return [sin, primals_1]""",
+    return (sin, primals_1)""",
         )
 
     #     def test_input_mutation_storage_resize_up_down(self):
@@ -1305,7 +1305,7 @@ def forward(self, primals_1, primals_2):
     sin = torch.ops.aten.sin.default(cat)
     resize_storage_bytes_ = torch.ops.inductor.resize_storage_bytes_.default(cat, 0)
     set_ = torch.ops.aten.set_.source_Tensor(primals_1, cat);  primals_1 = None
-    return [sin, cat]""",
+    return (sin, cat)""",
         )
 
     def test_input_mutation_storage_resize_before_set_(self):
@@ -1401,7 +1401,7 @@ def forward(self, primals_1):
     view_1 = torch.ops.aten.view.default(mul, [4]);  mul = None
     add = torch.ops.aten.add.Tensor(view_1, 1)
     copy_ = torch.ops.aten.copy_.default(primals_1, view_1);  primals_1 = view_1 = None
-    return [add]""",
+    return (add,)""",
         )
 
     def test_input_mutation_requires_grad_no_grad(self):
@@ -1423,7 +1423,7 @@ def forward(self, primals_1):
     mul = torch.ops.aten.mul.Tensor(primals_1, 2)
     add = torch.ops.aten.add.Tensor(mul, 3)
     copy_ = torch.ops.aten.copy_.default(primals_1, mul);  primals_1 = mul = None
-    return [add]""",
+    return (add,)""",
         )
 
     def test_input_mutation_requires_grad_no_grad_inference_graph(self):
@@ -1549,7 +1549,7 @@ def forward(self, arg0_1):
             """\
 def forward(self, primals_1):
     view = torch.ops.aten.view.default(primals_1, [-1]);  primals_1 = None
-    return [view]""",
+    return (view,)""",
         )
 
     def test_input_output_view_mutate_multiple(self):
@@ -1581,7 +1581,7 @@ def forward(self, primals_1, primals_2, primals_3):
     mul_1 = torch.ops.aten.mul.Tensor(clone_1, 3);  clone_1 = None
     view = torch.ops.aten.view.default(primals_2, [2, 2]);  primals_2 = None
     view_2 = torch.ops.aten.view.default(mul_1, [2, 2])
-    return [mul, mul_1, view, view_2]""",
+    return (mul, mul_1, view, view_2)""",
         )
 
     def test_input_output_view_metadata_mutate_multiple(self):
@@ -1615,7 +1615,7 @@ def forward(self, primals_1, primals_2, primals_3):
     view_1 = torch.ops.aten.view.default(primals_1, [2, 2]);  primals_1 = None
     view_3 = torch.ops.aten.view.default(t, [2, 2])
     view_4 = torch.ops.aten.view.default(mul, [2, 2])
-    return [mul, t, view_1, view_4, view_3]""",
+    return (mul, t, view_1, view_4, view_3)""",
         )
 
     def test_input_mutation_and_output_view(self):
@@ -1637,7 +1637,7 @@ def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
     view_1 = torch.ops.aten.view.default(add, [-1])
-    return [add, view_1]""",
+    return (add, view_1)""",
         )
 
     def test_input_mutation_output_view_multiple(self):
@@ -1671,7 +1671,7 @@ def forward(self, primals_1, primals_2, primals_3, primals_4):
     add_1 = torch.ops.aten.add.Tensor(primals_4, 1);  primals_4 = None
     diagonal = torch.ops.aten.diagonal.default(transpose)
     add_2 = torch.ops.aten.add.Tensor(primals_1, add);  primals_1 = None
-    return [transpose, add, add_1, diagonal, add_2]""",
+    return (transpose, add, add_1, diagonal, add_2)""",
         )
 
     def test_output_aliases_intermediate_single(self):
@@ -1691,7 +1691,7 @@ def forward(self, primals_1, primals_2, primals_3, primals_4):
 def forward(self, primals_1):
     mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
     view = torch.ops.aten.view.default(mul, [-1]);  mul = None
-    return [view]""",
+    return (view,)""",
         )
 
     def test_output_aliases_input_multi_output_view_should_raise_autograd_error(self):
@@ -1926,7 +1926,7 @@ def forward(self, primals_1, primals_2):
     mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
     view = torch.ops.aten.view.default(mul, [-1]);  mul = None
     add = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
-    return [view, add]""",
+    return (view, add)""",
         )
 
     def test_output_aliases_intermediate_returned_multiple_times(self):
@@ -1957,7 +1957,7 @@ def forward(self, primals_1):
     mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
     view = torch.ops.aten.view.default(mul, [-1])
     view_1 = torch.ops.aten.view.default(mul, [-1])
-    return [view, view_1, mul]""",
+    return (view, view_1, mul)""",
         )
 
     def test_output_aliases_intermediate_and_returned(self):
@@ -1977,7 +1977,7 @@ def forward(self, primals_1):
 def forward(self, primals_1):
     mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
     view = torch.ops.aten.view.default(mul, [-1])
-    return [view, mul]""",
+    return (view, mul)""",
         )
 
     def test_output_aliases_intermediate_and_returned_flipped(self):
@@ -1997,7 +1997,7 @@ def forward(self, primals_1):
 def forward(self, primals_1):
     mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
     view = torch.ops.aten.view.default(mul, [-1])
-    return [mul, view]""",
+    return (mul, view)""",
         )
 
     def test_output_aliases_intermediate_and_returned_different_grad(self):
@@ -2021,7 +2021,7 @@ def forward(self, primals_1):
     detach = torch.ops.aten.detach.default(select);  select = None
     detach_1 = torch.ops.aten.detach.default(detach);  detach = None
     detach_2 = torch.ops.aten.detach.default(detach_1);  detach_1 = None
-    return [view, mul, detach_2]""",
+    return (view, mul, detach_2)""",
         )
 
     def test_output_aliases_intermediate_inplace_view(self):
@@ -2057,7 +2057,7 @@ def forward(self, primals_1):
     mul = torch.ops.aten.mul.Tensor(primals_1, 3)
     t = torch.ops.aten.t.default(mul);  mul = None
     add = torch.ops.aten.add.Tensor(primals_1, 1);  primals_1 = None
-    return [t, add]""",
+    return (t, add)""",
         )
 
     def test_output_aliases_intermediate_inplace_view_and_view(self):
@@ -2094,7 +2094,7 @@ def forward(self, primals_1):
     view = torch.ops.aten.view.default(mul, [-1])
     transpose = torch.ops.aten.transpose.int(mul_1, 1, 0);  mul_1 = None
     transpose_1 = torch.ops.aten.transpose.int(mul, 1, 0)
-    return [view, transpose, transpose_1, mul]""",
+    return (view, transpose, transpose_1, mul)""",
         )
 
     def test_output_all_alias_types(self):
@@ -2130,7 +2130,7 @@ def forward(self, primals_1):
     squeeze = torch.ops.aten.squeeze.default(mul)
     transpose_1 = torch.ops.aten.transpose.int(mul, 1, 0)
     unsqueeze = torch.ops.aten.unsqueeze.default(transpose, 0)
-    return [transpose, squeeze, transpose_1, unsqueeze, mul]""",
+    return (transpose, squeeze, transpose_1, unsqueeze, mul)""",
         )
 
     @parametrize("req_grad", [False, True])
@@ -2180,7 +2180,7 @@ def forward(self, primals_1):
     t_4 = torch.ops.aten.t.default(t_2)
     t_6 = torch.ops.aten.t.default(t_2);  t_2 = None
     view_1 = torch.ops.aten.view.default(t_6, [3, 3]);  t_6 = None
-    return [t_4, view_1]""",
+    return (t_4, view_1)""",
         )
 
     def test_view_and_inplace_view(self):
@@ -2204,7 +2204,7 @@ def forward(self, primals_1, primals_2):
     t = torch.ops.aten.t.default(view);  view = None
     view_1 = torch.ops.aten.view.default(primals_2, [3, 3]);  primals_2 = None
     view_2 = torch.ops.aten.view.default(t, [3, 3])
-    return [t, view_1, view_2]""",
+    return (t, view_1, view_2)""",
         )
 
     def test_view_detach(self):
@@ -2236,7 +2236,7 @@ def forward(self, primals_1, primals_2):
 def forward(self, primals_1, primals_2):
     mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
     mul_1 = torch.ops.aten.mul.Tensor(primals_2, 4);  primals_2 = None
-    return [mul, mul_1]""",
+    return (mul, mul_1)""",
         )
 
     # This is a torture test:
@@ -2756,7 +2756,7 @@ def forward(self, primals_1):
     as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
     as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
     add_1 = torch.ops.aten.add.Tensor(as_strided_2, as_strided_5);  as_strided_2 = as_strided_5 = None
-    return [as_strided_scatter, add_1]""",
+    return (as_strided_scatter, add_1)""",
         )  # noqa: B950
 
     def test_input_mutation_aliases_other_input2(self):
@@ -2789,7 +2789,7 @@ def forward(self, primals_1):
     as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
     as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [2, 2], [2, 1], 0)
     add_1 = torch.ops.aten.add.Tensor(as_strided_2, as_strided_5);  as_strided_2 = as_strided_5 = None
-    return [as_strided_scatter, add_1]""",
+    return (as_strided_scatter, add_1)""",
         )  # noqa: B950
 
     def test_input_mutation_aliases_and_output_alias(self):
@@ -2820,7 +2820,7 @@ def forward(self, primals_1):
     as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [4], [1], 0);  clone = add = None
     as_strided_8 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
     view_1 = torch.ops.aten.view.default(as_strided_8, [4]);  as_strided_8 = None
-    return [as_strided_scatter, view_1]""",
+    return (as_strided_scatter, view_1)""",
         )  # noqa: B950
 
     def test_input_aliased_with_mutation_output_alias(self):
@@ -2857,7 +2857,7 @@ def forward(self, primals_1, primals_2):
     add = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
     as_strided_7 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
     view_1 = torch.ops.aten.view.default(as_strided_7, [-1]);  as_strided_7 = None
-    return [as_strided_scatter, add, view_1]""",
+    return (as_strided_scatter, add, view_1)""",
         )  # noqa: B950
 
     def test_input_metadata_mutation_aliases(self):
@@ -2886,7 +2886,7 @@ def forward(self, primals_1, primals_2):
 def forward(self, primals_1, primals_2):
     t = torch.ops.aten.t.default(primals_1);  primals_1 = None
     add = torch.ops.aten.add.Tensor(t, primals_2);  t = primals_2 = None
-    return [add]""",
+    return (add,)""",
         )
 
     def test_input_mutation_aliases_and_none_require_gradients(self):
@@ -2929,7 +2929,7 @@ def forward(self, primals_1, primals_2):
     as_strided_3 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
     add = torch.ops.aten.add.Tensor(as_strided_3, 1);  as_strided_3 = None
     add_1 = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
-    return [as_strided_scatter, add, add_1]""",
+    return (as_strided_scatter, add, add_1)""",
         )  # noqa: B950
 
     @skipIfDynamoInput("Fails with dynamo")
@@ -2988,7 +2988,7 @@ def forward(self, primals_1, primals_2, primals_3):
     add_2 = torch.ops.aten.add.Tensor(add_1, unsqueeze_1);  add_1 = None
     as_strided_14 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
     view_2 = torch.ops.aten.view.default(as_strided_14, [-1]);  as_strided_14 = None
-    return [as_strided_scatter, add_2, view_2, unsqueeze_1]""",
+    return (as_strided_scatter, add_2, view_2, unsqueeze_1)""",
         )  # noqa: B950
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
@@ -3062,7 +3062,7 @@ def forward(self, primals_1, primals_2):
     view_1 = torch.ops.aten.view.default(add, [-1])
     t_1 = torch.ops.aten.t.default(t)
     unsqueeze = torch.ops.aten.unsqueeze.default(view_1, 0)
-    return [as_strided_scatter, t, view_1, t_1, unsqueeze, add]""",
+    return (as_strided_scatter, t, view_1, t_1, unsqueeze, add)""",
         )  # noqa: B950
 
     def test_dynamic_shape_output_not_in_bw_graph(self):
@@ -3090,7 +3090,7 @@ def forward(self, primals_1, primals_2):
             bw_graph_cell[0].code.strip(),
             """\
 def forward(self, tangents_1):
-    return [tangents_1]""",
+    return (tangents_1,)""",
         )
 
     def test_no_grad_input_output(self):
@@ -3610,7 +3610,7 @@ def forward(self, primals_1, primals_2, primals_3, primals_4):
     sum_2 = torch.ops.aten.sum.default(add)
     add_1 = torch.ops.aten.add.Tensor(sum_1, sum_2);  sum_1 = sum_2 = None
     copy_ = torch.ops.aten.copy_.default(primals_3, add);  primals_3 = add = None
-    return [add_1, primals_1, primals_2, primals_4, mul]""",
+    return (add_1, primals_1, primals_2, primals_4, mul)""",
         )
 
         self.assertEqual(out_ref, out_test)
@@ -3665,7 +3665,7 @@ def forward(self, primals_1, primals_2, primals_3):
     sum_2 = torch.ops.aten.sum.default(add)
     add_1 = torch.ops.aten.add.Tensor(sum_1, sum_2);  sum_1 = sum_2 = None
     copy_ = torch.ops.aten.copy_.default(primals_2, add);  primals_2 = add = None
-    return [add_1, primals_1, primals_3]""",
+    return (add_1, primals_1, primals_3)""",
         )
         self.assertEqual(out_ref, out_test)
 
@@ -3723,7 +3723,7 @@ def forward(self, primals_1, primals_2, primals_3, primals_4, primals_5, primals
     copy_ = torch.ops.aten.copy_.default(primals_3, getitem_3);  primals_3 = None
     copy__1 = torch.ops.aten.copy_.default(primals_4, getitem_4);  primals_4 = None
     copy__2 = torch.ops.aten.copy_.default(primals_5, add);  primals_5 = add = None
-    return [getitem, primals_1, primals_6, getitem_1, getitem_2, getitem_3, getitem_4]""",  # noqa: B950
+    return (getitem, primals_1, primals_6, getitem_1, getitem_2, getitem_3, getitem_4)""",  # noqa: B950
         )
 
         self.assertEqual(out_ref, out_test)
@@ -3743,7 +3743,7 @@ def forward(self, primals_1, primals_6, getitem_1, getitem_2, getitem_3, getitem
     getitem_5 = native_batch_norm_backward[0]
     getitem_6 = native_batch_norm_backward[1]
     getitem_7 = native_batch_norm_backward[2];  native_batch_norm_backward = None
-    return [getitem_6, getitem_7, None, None, None, getitem_5]""",  # noqa: B950
+    return (getitem_6, getitem_7, None, None, None, getitem_5)""",  # noqa: B950
         )
 
         self.assertEqual(inp_ref.grad, inp_test.grad)
@@ -3784,7 +3784,7 @@ def forward(self, primals_1, primals_6, getitem_1, getitem_2, getitem_3, getitem
 def forward(self, primals_1, primals_2):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     add = torch.ops.aten.add.Tensor(clone, primals_2);  clone = primals_2 = None
-    return [add, add]""",
+    return (add, add)""",
         )  # noqa: B950
 
         self.assertEqual(out_ref, out_test)
@@ -3796,7 +3796,7 @@ def forward(self, primals_1, primals_2):
             bw_graph_cell[0].code.strip(),
             """\
 def forward(self, tangents_1):
-    return [None, tangents_1]""",
+    return (None, tangents_1)""",
         )  # noqa: B950
 
     def test_real_weights_in_symbolic_mode(self):
@@ -3883,10 +3883,10 @@ def forward(self, tangents_1):
         # Wraps the outputs that are views of the FX graph 'g' with NoViewReplayTensor,
         # since they are the only ones that will get reconstructed.
         def wrapper(g, *args, **kwargs):
-            outs = g(*args, **kwargs)
+            outs = list(g(*args, **kwargs))
             for i in output_view_indices:
                 outs[i] = NoViewReplayTensor(outs[i])
-            return outs
+            return tuple(outs)
 
         return lambda f: aot_function(f, fw_compiler=lambda g, _: partial(wrapper, g))
 
@@ -5397,7 +5397,7 @@ def forward(self, primals_1, primals_2, primals_3):
     div = torch.ops.aten.div.Tensor(primals_3, 2);  primals_3 = None
     add = torch.ops.aten.add.Tensor(mul, div);  mul = None
     add_1 = torch.ops.aten.add.Tensor(mul_1, div);  mul_1 = div = None
-    return [add, add_1]""",
+    return (add, add_1)""",
         )
 
         # Important pieces of the graph:
@@ -5415,7 +5415,7 @@ def forward(self, tangents_1, tangents_2):
     div_2 = torch.ops.aten.div.Tensor(tangents_2, 2)
     mul_2 = torch.ops.aten.mul.Tensor(tangents_1, 6);  tangents_1 = None
     mul_3 = torch.ops.aten.mul.Tensor(tangents_2, 6);  tangents_2 = None
-    return [mul_2, mul_3, div_1, div_2]""",
+    return (mul_2, mul_3, div_1, div_2)""",
         )
 
     def test_aot_dispatch_inference(self):

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1590,7 +1590,7 @@ class GraphModule(torch.nn.Module):
         getitem_4: "f64[2, 2, 128, 4]" = flex_attention_backward[0]
         getitem_5: "f64[2, 2, 128, 4]" = flex_attention_backward[1]
         getitem_6: "f64[2, 2, 128, 4]" = flex_attention_backward[2];  flex_attention_backward = None
-        return [getitem_4, getitem_5, getitem_6]
+        return (getitem_4, getitem_5, getitem_6)
 
     class <lambda>(torch.nn.Module):
         def forward(self, arg0_1: "f64[]", arg1_1: "i32[]", arg2_1: "i32[]", arg3_1: "i32[]", arg4_1: "i32[]"):

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -204,7 +204,7 @@ def _extract_graph_with_inputs_outputs(
             output_values.append(env[x])
         else:
             output_values.append(x)
-    new_graph.output(output_values)
+    new_graph.output(tuple(output_values))
 
     new_graph.eliminate_dead_code()
     new_graph.lint()
@@ -727,7 +727,7 @@ def functionalize_rng_ops(
     sym_node_start_idx = len(fw_outputs) - num_sym_nodes
     outputs = (
         fw_outputs[:sym_node_start_idx]
-        + fw_rng_state_outputs
+        + tuple(fw_rng_state_outputs)
         + fw_outputs[sym_node_start_idx:]
     )
     fw_module.graph.output(outputs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131759

Brian debugged the difference of the output type for inference and train graph.
Partitioner sometimes return list output type.

After this PR it will always return tuple.

Potentially there can be some new graphs inside tests that will be landed between this PR ci jobs finish and landing. 
This could be easily fixed with fast-forward fix on:
```
EXPECTTEST_ACCEPT=1 python test/test.py
```

Adding ciflows/periodic to minimize this probability



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang