### PR TITLE
[Reland] Fix vulkan builds with missing overrides errors 

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Allocator.h
+++ b/aten/src/ATen/native/vulkan/api/Allocator.h
@@ -41,10 +41,13 @@
 */
 #endif /* VULKAN_DEBUG */
 
+// Note: Do not try to use C10 convenience macors here, as this header is
+// included from ExecuTorch that does not want to have dependency on C10
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 #pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Winconsistent-missing-destructor-override"
 #endif /* __clang__ */
 
 #include <include/vk_mem_alloc.h>

--- a/aten/src/ATen/native/vulkan/api/Allocator.h
+++ b/aten/src/ATen/native/vulkan/api/Allocator.h
@@ -5,8 +5,8 @@
 // Always include this file (Allocator.h) instead.
 //
 
-#include <c10/macros/Macros.h>
 #include <ATen/native/vulkan/api/vk_api.h>
+#include <c10/macros/Macros.h>
 
 #ifdef USE_VULKAN_API
 

--- a/aten/src/ATen/native/vulkan/api/Allocator.h
+++ b/aten/src/ATen/native/vulkan/api/Allocator.h
@@ -5,6 +5,7 @@
 // Always include this file (Allocator.h) instead.
 //
 
+#include <c10/macros/Macros.h>
 #include <ATen/native/vulkan/api/vk_api.h>
 
 #ifdef USE_VULKAN_API
@@ -41,16 +42,13 @@
 */
 #endif /* VULKAN_DEBUG */
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnullability-completeness"
-#pragma clang diagnostic ignored "-Wunused-variable"
-#endif /* __clang__ */
-
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wnullability-completeness")
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-variable")
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED(
+    "-Winconsistent-missing-destructor-override")
 #include <include/vk_mem_alloc.h>
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif /* __clang__ */
+C10_DIAGNOSTIC_POP()
+C10_DIAGNOSTIC_POP()
+C10_DIAGNOSTIC_POP()
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/api/Allocator.h
+++ b/aten/src/ATen/native/vulkan/api/Allocator.h
@@ -5,7 +5,6 @@
 // Always include this file (Allocator.h) instead.
 //
 
-#include <c10/macros/Macros.h>
 #include <ATen/native/vulkan/api/vk_api.h>
 
 #ifdef USE_VULKAN_API
@@ -42,13 +41,16 @@
 */
 #endif /* VULKAN_DEBUG */
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wnullability-completeness")
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-variable")
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED(
-    "-Winconsistent-missing-destructor-override")
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#endif /* __clang__ */
+
 #include <include/vk_mem_alloc.h>
-C10_DIAGNOSTIC_POP()
-C10_DIAGNOSTIC_POP()
-C10_DIAGNOSTIC_POP()
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif /* __clang__ */
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/api/Allocator.h
+++ b/aten/src/ATen/native/vulkan/api/Allocator.h
@@ -5,8 +5,8 @@
 // Always include this file (Allocator.h) instead.
 //
 
-#include <ATen/native/vulkan/api/vk_api.h>
 #include <c10/macros/Macros.h>
+#include <ATen/native/vulkan/api/vk_api.h>
 
 #ifdef USE_VULKAN_API
 


### PR DESCRIPTION
Followup after https://github.com/pytorch/pytorch/pull/131524

Add note explaining why C10 macros should not be used in that header