### PR TITLE
torch.optim: explicitly export attributes

### DIFF
--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -24,6 +24,27 @@ from torch.optim.sgd import SGD
 from torch.optim.sparse_adam import SparseAdam
 
 
+__all__ = [
+    'lr_scheduler',
+    'swa_utils',
+    'Adafactor',
+    'Adadelta',
+    'Adagrad',
+    'Adam',
+    'Adamax',
+    'AdamW',
+    'ASGD',
+    'LBFGS',
+    'NAdam',
+    'Optimizer',
+    'RAdam',
+    'RMSprop',
+    'Rprop',
+    'SGD',
+    'SparseAdam',
+]
+
+
 del adadelta  # type: ignore[name-defined] # noqa: F821
 del adagrad  # type: ignore[name-defined] # noqa: F821
 del adam  # type: ignore[name-defined] # noqa: F821


### PR DESCRIPTION
Starting with PyTorch 2.4, I now see the following mypy warning in all of my code:
```
error: Module "torch.optim" does not explicitly export attribute "SGD"  [attr-defined]
error: Module "torch.optim" does not explicitly export attribute "Adam"  [attr-defined]
```
Defining `__all__` should silence this. Only question is why it started in 2.4 and not in 2.3, which was also missing `__all__`...