### PR TITLE
[Fix]: prim::If with multiple outputs and input return directly

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -410,7 +410,6 @@ class TestConverter(TestCase):
                 M()(torch.tensor(False), torch.tensor(4)),
             )
 
-    @unittest.skip("Wrong fx subgraph for cond, need to fix")
     def test_convert_if_multiple_out(self):
         class M(torch.nn.Module):
             def true_fn(self, y, z):


### PR DESCRIPTION
#### Issue
Test is not working for prim::Loop with multiple outputs. Additionally fix issue where input is directly returned, which is not supported by HigherOrderOp.

#### Test Plan
`pytest test/export/test_converter.py -s -k test_convert_if_multiple_out`