### PR TITLE
[export] fix set_grad x tensor constant.

### DIFF
--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -185,8 +185,6 @@ def _sequential_split_and_maybe_inline_subgraphs(
     new_gm.recompile()
     return new_gm, new_signature
 
-    return gm, graph_signature
-
 
 def replace_set_grad_with_hop_pass(gm: torch.fx.GraphModule, graph_signature):
     new_gm, new_signature = _sequential_split_and_maybe_inline_subgraphs(

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -759,11 +759,19 @@ def _export_to_aten_ir(
         input_specs=input_specs, output_specs=output_specs
     )
 
+    constants = rewrite_script_object_meta(gm)
+    constants.update(lift_constants_pass(gm, export_graph_signature, constant_attrs))
+
     if pre_dispatch:
         from torch._export.passes.replace_set_grad_with_hop_pass import (
             replace_set_grad_with_hop_pass,
         )
 
+        # Note: replace_set_grad_with_hop_pass need to be after lift_constant_pass because
+        # a getattr of a constant tensor doesn't have meta["val"] until after lift_constant_pass.
+        # If replace_set_grad_with_hop_pass is before lift_constant_pass,
+        # and the constant_tensor is passed as input of the set grad hop, the placeholder's
+        # meta["val"] will be None and fails our verifier for placeholder.
         gm, export_graph_signature = replace_set_grad_with_hop_pass(
             gm, export_graph_signature
         )
@@ -776,9 +784,6 @@ def _export_to_aten_ir(
             if node.op in ["placeholder", "output"]:
                 node.meta.pop("nn_module_stack", None)
                 node.meta.pop("stack_trace", None)
-
-    constants = rewrite_script_object_meta(gm)
-    constants.update(lift_constants_pass(gm, export_graph_signature, constant_attrs))
 
     # Prettify names for placeholder nodes.
     placeholder_naming_pass(


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/pytorch/issues/130379.

The original error is verifier finds that the placeholder nodes' meta[''val"] are missing in subgraph of WrapSetGradEnabled hop.

In this PR, we fixed it by re-ordering the replace_set_grad_with_hop_pass with lift_constant_tensor pass because only after lift_constant_pass, all the constant attrs start to have meta["val"].

Test Plan: buck2 test test:test_export -- -r "test_setgrad_lifted_tensor"

Differential Revision: D60244935
