### PR TITLE
[AOTI] Fix ABI-compatible mode link issue for CPU

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -702,6 +702,14 @@ test_inductor_torchbench_cpu_smoketest_perf(){
     cat "$output_name"
     # The threshold value needs to be actively maintained to make this check useful.
     python benchmarks/dynamo/check_perf_csv.py -f "$output_name" -t "$speedup_target"
+
+    # Add a few ABI-compatible accuracy tests for CPU. These can be removed once we turn on ABI-compatible as default.
+    TORCHINDUCTOR_ABI_COMPATIBLE=1 python benchmarks/dynamo/timm.py --device cpu --accuracy \
+      --bfloat16 --inference --export-aot-inductor --disable-cudagraphs --only adv_inception_v3 \
+      --output "$TEST_REPORTS_DIR/aot_inductor_smoke_test.csv"
+    python benchmarks/dynamo/check_accuracy.py \
+      --actual "$TEST_REPORTS_DIR/aot_inductor_smoke_test.csv" \
+      --expected "benchmarks/dynamo/ci_expected_accuracy/aot_inductor_timm_inference.csv"
   done
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -704,7 +704,7 @@ test_inductor_torchbench_cpu_smoketest_perf(){
     python benchmarks/dynamo/check_perf_csv.py -f "$output_name" -t "$speedup_target"
 
     # Add a few ABI-compatible accuracy tests for CPU. These can be removed once we turn on ABI-compatible as default.
-    TORCHINDUCTOR_ABI_COMPATIBLE=1 python benchmarks/dynamo/timm.py --device cpu --accuracy \
+    TORCHINDUCTOR_ABI_COMPATIBLE=1 python benchmarks/dynamo/timm_models.py --device cpu --accuracy \
       --bfloat16 --inference --export-aot-inductor --disable-cudagraphs --only adv_inception_v3 \
       --output "$TEST_REPORTS_DIR/aot_inductor_smoke_test.csv"
     python benchmarks/dynamo/check_accuracy.py \

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -702,15 +702,15 @@ test_inductor_torchbench_cpu_smoketest_perf(){
     cat "$output_name"
     # The threshold value needs to be actively maintained to make this check useful.
     python benchmarks/dynamo/check_perf_csv.py -f "$output_name" -t "$speedup_target"
-
-    # Add a few ABI-compatible accuracy tests for CPU. These can be removed once we turn on ABI-compatible as default.
-    TORCHINDUCTOR_ABI_COMPATIBLE=1 python benchmarks/dynamo/timm_models.py --device cpu --accuracy \
-      --bfloat16 --inference --export-aot-inductor --disable-cudagraphs --only adv_inception_v3 \
-      --output "$TEST_REPORTS_DIR/aot_inductor_smoke_test.csv"
-    python benchmarks/dynamo/check_accuracy.py \
-      --actual "$TEST_REPORTS_DIR/aot_inductor_smoke_test.csv" \
-      --expected "benchmarks/dynamo/ci_expected_accuracy/aot_inductor_timm_inference.csv"
   done
+
+  # Add a few ABI-compatible accuracy tests for CPU. These can be removed once we turn on ABI-compatible as default.
+  TORCHINDUCTOR_ABI_COMPATIBLE=1 python benchmarks/dynamo/timm_models.py --device cpu --accuracy \
+    --bfloat16 --inference --export-aot-inductor --disable-cudagraphs --only adv_inception_v3 \
+    --output "$TEST_REPORTS_DIR/aot_inductor_smoke_test.csv"
+  python benchmarks/dynamo/check_accuracy.py \
+    --actual "$TEST_REPORTS_DIR/aot_inductor_smoke_test.csv" \
+    --expected "benchmarks/dynamo/ci_expected_accuracy/aot_inductor_timm_inference.csv"
 }
 
 test_torchbench_gcp_smoketest(){

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1464,6 +1464,7 @@ def get_include_and_linking_paths(
         # like aoti_torch_grad_mode_set_enabled
         if aot_mode and sys.platform == "linux" and not config.is_fbcode():
             libs += ["torch", "torch_cpu"]
+            lpaths += [cpp_extension.TORCH_LIB_PATH]
 
     # Unconditionally import c10 for non-abi-compatible mode to use TORCH_CHECK - See PyTorch #108690
     if not config.abi_compatible:

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -128,6 +128,7 @@ cdll.LoadLibrary("__lib_path__")
                         "-c",
                         VecISA._avx_py_load.replace("__lib_path__", output_path),
                     ],
+                    cwd=output_dir,
                     stderr=subprocess.DEVNULL,
                     env={**os.environ, "PYTHONPATH": ":".join(sys.path)},
                 )

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -128,7 +128,6 @@ cdll.LoadLibrary("__lib_path__")
                         "-c",
                         VecISA._avx_py_load.replace("__lib_path__", output_path),
                     ],
-                    cwd=output_dir,
                     stderr=subprocess.DEVNULL,
                     env={**os.environ, "PYTHONPATH": ":".join(sys.path)},
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #131812
* #131798
* __->__ #131791

Summary: Found this "cannot find -ltorch: No such file or directory" issue when collecting AOTI CPU perf for the dashboard. Debugging on the CI machine revealed two problems: 1) no valid VEC_ISA was picked; 2) when 1 happens, libtorch path is not specified in the linker path.

This PR fixes the second problem. A later PR will fix the first problem, but somehow finding the right VEC_ISA causes a performance regression, which needs more investigation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang