### PR TITLE
Add get_optin_feature() to allow opt-in to amz2023

### DIFF
--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -1,5 +1,29 @@
 # flake8: noqa: G004
 
+"""
+This runner determinator is used to determine which set of runners to run a
+GitHub job on. It uses the first comment of a GitHub issue (by default
+https://github.com/pytorch/test-infra/issues/5132) as a user list to determine
+which users will get their jobs to run on experimental runners. This user list
+is also a comma separated list of additional features or experiments which the
+user could be opted in to.
+
+The user list has the following rules:
+
+- Users are GitHub usernames with the @ prefix
+- If the first line is a "*" then all users will use the new runners
+- If the first line is a "!" then all users will use the old runners
+- Each user is also a comma-separated list of features/experiments to enable
+- A "#" prefix indicates the user is opted out of the new runners but is opting
+  into features/experiments.
+
+Example user list:
+
+    @User1
+    @User2,amz2023
+    #@UserOptOutOfNewRunner,amz2023
+"""
+
 import logging
 import os
 from argparse import ArgumentParser
@@ -14,7 +38,11 @@ WORKFLOW_LABEL_META = ""  # use meta runners
 WORKFLOW_LABEL_LF = "lf."  # use runners from the linux foundation
 WORKFLOW_LABEL_LF_CANARY = "lf.c."  # use canary runners from the linux foundation
 
+RUNNER_AMI_LEGACY = ""
+RUNNER_AMI_AMZ2023 = "amz2023"
+
 GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
+GH_OUTPUT_KEY_AMI = "runner-ami"
 GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
 
 
@@ -150,7 +178,8 @@ def get_workflow_type(issue: Issue, workflow_requestors: Iterable[str]) -> str:
             return WORKFLOW_LABEL_LF
         else:
             all_opted_in_users = {
-                usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split()
+                usr_raw.strip("\n\t@ ").split(",")[0]
+                for usr_raw in first_comment.split()
             }
             opted_in_requestors = {
                 usr for usr in workflow_requestors if usr in all_opted_in_users
@@ -173,12 +202,46 @@ def get_workflow_type(issue: Issue, workflow_requestors: Iterable[str]) -> str:
         return WORKFLOW_LABEL_META
 
 
+def get_optin_feature(
+    issue: Issue, workflow_requestors: Iterable[str], feature: str, fallback: str
+) -> str:
+    try:
+        first_comment = issue.get_comments()[0].body.strip("\n\t ")
+        userlist = {u.lstrip("#").strip("\n\t@ ") for u in first_comment.split()}
+        all_opted_in_users = set()
+        for user in userlist:
+            for i in user.split(","):
+                if i == feature:
+                    all_opted_in_users.add(user.split(",")[0])
+        opted_in_requestors = {
+            usr for usr in workflow_requestors if usr in all_opted_in_users
+        }
+
+        if opted_in_requestors:
+            log.info(
+                f"Feature {feature} is enabled for {', '.join(opted_in_requestors)}. Using feature {feature}."
+            )
+            return feature
+        else:
+            log.info(
+                f"Feature {feature} is disabled for {', '.join(workflow_requestors)}. Using fallback \"{fallback}\"."
+            )
+            return fallback
+
+    except Exception as e:
+        log.error(
+            f'Failed to determine if user has opted-in to feature {feature}. Using fallback "{fallback}". Exception: {e}'
+        )
+        return fallback
+
+
 def main() -> None:
     args = parse_args()
 
     if args.github_ref_type == "branch" and is_exception_branch(args.github_branch):
         log.info(f"Exception branch: '{args.github_branch}', using meta runners")
         label_type = WORKFLOW_LABEL_META
+        runner_ami = RUNNER_AMI_LEGACY
     else:
         try:
             gh = get_gh_client(args.github_token)
@@ -198,17 +261,28 @@ def main() -> None:
                     username,
                 ),
             )
+            runner_ami = get_optin_feature(
+                issue=issue,
+                workflow_requestors=(
+                    args.github_issue_owner,
+                    username,
+                ),
+                feature=RUNNER_AMI_AMZ2023,
+                fallback=RUNNER_AMI_LEGACY,
+            )
         except Exception as e:
             log.error(
                 f"Failed to get issue. Falling back to meta runners. Exception: {e}"
             )
             label_type = WORKFLOW_LABEL_META
+            runner_ami = RUNNER_AMI_LEGACY
 
     # For Canary builds use canary runners
     if args.github_repo == "pytorch/pytorch-canary" and label_type == WORKFLOW_LABEL_LF:
         label_type = WORKFLOW_LABEL_LF_CANARY
 
     set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, label_type)
+    set_github_output(GH_OUTPUT_KEY_AMI, runner_ami)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -59,6 +59,30 @@ jobs:
           cat <<EOF > runner_determinator.py
           # flake8: noqa: G004
 
+          """
+          This runner determinator is used to determine which set of runners to run a
+          GitHub job on. It uses the first comment of a GitHub issue (by default
+          https://github.com/pytorch/test-infra/issues/5132) as a user list to determine
+          which users will get their jobs to run on experimental runners. This user list
+          is also a comma separated list of additional features or experiments which the
+          user could be opted in to.
+
+          The user list has the following rules:
+
+          - Users are GitHub usernames with the @ prefix
+          - If the first line is a "*" then all users will use the new runners
+          - If the first line is a "!" then all users will use the old runners
+          - Each user is also a comma-separated list of features/experiments to enable
+          - A "#" prefix indicates the user is opted out of the new runners but is opting
+            into features/experiments.
+
+          Example user list:
+
+              @User1
+              @User2,amz2023
+              #@UserOptOutOfNewRunner,amz2023
+          """
+
           import logging
           import os
           from argparse import ArgumentParser
@@ -73,7 +97,11 @@ jobs:
           WORKFLOW_LABEL_LF = "lf."  # use runners from the linux foundation
           WORKFLOW_LABEL_LF_CANARY = "lf.c."  # use canary runners from the linux foundation
 
+          RUNNER_AMI_LEGACY = ""
+          RUNNER_AMI_AMZ2023 = "amz2023"
+
           GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT", "")
+          GH_OUTPUT_KEY_AMI = "runner-ami"
           GH_OUTPUT_KEY_LABEL_TYPE = "label-type"
 
 
@@ -209,7 +237,8 @@ jobs:
                       return WORKFLOW_LABEL_LF
                   else:
                       all_opted_in_users = {
-                          usr_raw.strip("\n\t@ ") for usr_raw in first_comment.split()
+                          usr_raw.strip("\n\t@ ").split(",")[0]
+                          for usr_raw in first_comment.split()
                       }
                       opted_in_requestors = {
                           usr for usr in workflow_requestors if usr in all_opted_in_users
@@ -232,12 +261,46 @@ jobs:
                   return WORKFLOW_LABEL_META
 
 
+          def get_optin_feature(
+              issue: Issue, workflow_requestors: Iterable[str], feature: str, fallback: str
+          ) -> str:
+              try:
+                  first_comment = issue.get_comments()[0].body.strip("\n\t ")
+                  userlist = {u.lstrip("#").strip("\n\t@ ") for u in first_comment.split()}
+                  all_opted_in_users = set()
+                  for user in userlist:
+                      for i in user.split(","):
+                          if i == feature:
+                              all_opted_in_users.add(user.split(",")[0])
+                  opted_in_requestors = {
+                      usr for usr in workflow_requestors if usr in all_opted_in_users
+                  }
+
+                  if opted_in_requestors:
+                      log.info(
+                          f"Feature {feature} is enabled for {', '.join(opted_in_requestors)}. Using feature {feature}."
+                      )
+                      return feature
+                  else:
+                      log.info(
+                          f"Feature {feature} is disabled for {', '.join(workflow_requestors)}. Using fallback \"{fallback}\"."
+                      )
+                      return fallback
+
+              except Exception as e:
+                  log.error(
+                      f'Failed to determine if user has opted-in to feature {feature}. Using fallback "{fallback}". Exception: {e}'
+                  )
+                  return fallback
+
+
           def main() -> None:
               args = parse_args()
 
               if args.github_ref_type == "branch" and is_exception_branch(args.github_branch):
                   log.info(f"Exception branch: '{args.github_branch}', using meta runners")
                   label_type = WORKFLOW_LABEL_META
+                  runner_ami = RUNNER_AMI_LEGACY
               else:
                   try:
                       gh = get_gh_client(args.github_token)
@@ -257,17 +320,29 @@ jobs:
                               username,
                           ),
                       )
+                      runner_ami = get_optin_feature(
+                          issue=issue,
+                          workflow_requestors=(
+                              args.github_issue_owner,
+                              username,
+                          ),
+                          feature=RUNNER_AMI_AMZ2023,
+                          fallback=RUNNER_AMI_LEGACY,
+                      )
                   except Exception as e:
                       log.error(
                           f"Failed to get issue. Falling back to meta runners. Exception: {e}"
                       )
                       label_type = WORKFLOW_LABEL_META
+                      runner_ami = RUNNER_AMI_LEGACY
 
               # For Canary builds use canary runners
               if args.github_repo == "pytorch/pytorch-canary" and label_type == WORKFLOW_LABEL_LF:
                   label_type = WORKFLOW_LABEL_LF_CANARY
 
               set_github_output(GH_OUTPUT_KEY_LABEL_TYPE, label_type)
+              set_github_output(GH_OUTPUT_KEY_AMI, runner_ami)
+
 
           if __name__ == "__main__":
               main()


### PR DESCRIPTION
This extends the runner determinator to be able to opt-in to keywords
to provide additional options when determining which systems to run
jobs on. This enables us to support opt-in users to Amazon Linux 2023.

This change creates a generic get_optin_feature() which hopefully will
be useful to handle additional future features that we might want to
experiment with.
    
This change has kept backwards compatability with the existing issue
userlist format and adds support for the comma-separated list of users
in a backwards compatible way.
    
The user list has the following rules:
    
- Users are GitHub usernames with the @ prefix
- If the first line is a "*" then all users will use the new runners
- If the first line is a "!" then all users will use the old runners
- Each user is also a comma-separated list of features/experiments to enable
- A "#" prefix indicates the user is opted out of the new runners but is opting
  into features/experiments.
    
Example user list:
    
```
@User1
@User2,amz2023
#@UserOptOutOfNewRunner,amz2023
```

This closes pytorch/ci-infra#249.
