### PR TITLE
fit(...) method of nn.Module class

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2947,13 +2947,13 @@ class Module:
         if name in optimizer_dict:
             return optimizer_dict[name](self.parameters(), **kwargs)
         else:
-            raise ValueError(f"Optimizer '{name}' is not supported.")
+            raise ValueError(f"Optimizer '{name}' is not supported")
 
     def _get_loss_by_name(self, name, **kwargs):
         if name in loss_dict:
             return loss_dict[name](**kwargs)
         else:
-            raise ValueError(f"Unknown loss function: {name}")
+            raise ValueError(f"Loss '{name}' is not supported")
 
     def fit(self,
             train_loader: DataLoader,

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -24,9 +24,12 @@ from typing_extensions import Self
 import torch
 from torch import device, dtype, Tensor
 from torch._prims_common import DeviceLikeType
+from torch import optim
 from torch.nn.parameter import Parameter
+from torch.optim import Optimizer
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from torch.utils.hooks import BackwardHook, RemovableHandle
+from torch.utils.data import DataLoader
 
 
 __all__ = [
@@ -46,6 +49,20 @@ _grad_t = Union[Tuple[Tensor, ...], Tensor]
 # of `T` to annotate `self`. Many methods of `Module` return `self` and we want those return values to be
 # the type of the subclass, not the looser type of `Module`.
 T = TypeVar("T", bound="Module")
+OptimizerFactory = Callable[[int, Any], Optimizer]
+
+
+# Define a dictionary that maps short names to optimizer classes
+optimizer_dict = {
+    'sgd': optim.SGD,
+    'adam': optim.Adam,
+    'adadelta': optim.Adadelta,
+    'adagrad': optim.Adagrad,
+    'adamw': optim.AdamW,
+    'adamax': optim.Adamax,
+    'rmsprop': optim.RMSprop,
+    'lbfgs': optim.LBFGS
+}
 
 
 class _IncompatibleKeys(
@@ -2906,3 +2923,58 @@ class Module:
         See :func:`torch.compile` for details on the arguments for this function.
         """
         self._compiled_call_impl = torch.compile(self._call_impl, *args, **kwargs)
+    
+    def train_step(self, batch_idx, batch):
+        """
+        Abstract method to be implemented by the subclass
+        
+        This method is used inside of self.fit(...)
+        """
+        raise NotImplementedError
+
+    def _get_optimizer_by_name(self, name, **kwargs) -> Optimizer:
+        if name in optimizer_dict:
+            return optimizer_dict[name](self.parameters(), **kwargs)
+        else:
+            raise ValueError(f"Optimizer '{name}' is not supported.")
+
+    def fit(self,
+            train_loader: DataLoader,
+            optimizer: Union[str, OptimizerFactory] = 'adam',
+            max_epochs: int = 10,
+            log_interval: int = 100):
+        if isinstance(optimizer, str):
+            def default_optimizer_factory(batch_idx: int, batch) -> Optimizer:
+                return self._get_optimizer_by_name(optimizer, **self.optimizer_kwargs)
+
+            optimizer_factory = default_optimizer_factory
+        else:
+            optimizer_factory = optimizer
+
+        training = self.training
+
+        self.train()
+
+        with torch.enable_grad():
+            # Training loop
+            for epoch in range(max_epochs):  # loop over the dataset multiple times
+                running_loss = 0.0
+                for i, data in enumerate(train_loader, 0):
+                    inputs, _ = data
+
+                    optimizer = optimizer_factory(i, inputs)
+
+                    optimizer.zero_grad()
+
+                    loss = self.train_step(i, inputs)
+                    loss.backward()
+
+                    optimizer.step()
+
+                    running_loss += loss.item()
+                    if i % log_interval == log_interval-1:  # print every 100 mini-batches
+                        print(f"Epoch: {epoch + 1}, Data Idx: {i + 1}, Loss: {running_loss / 100:.3f}")
+                        running_loss = 0.0
+
+        if not training:
+            self.eval()

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2972,8 +2972,8 @@ class Module:
                     optimizer.step()
 
                     running_loss += loss.item()
-                    if i % log_interval == log_interval-1:  # print every 100 mini-batches
-                        print(f"Epoch: {epoch + 1}, Data Idx: {i + 1}, Loss: {running_loss / 100:.3f}")
+                    if i % log_interval == log_interval-1:  # print every `log_interval` mini-batches
+                        print(f"Epoch: {epoch + 1}, Data Idx: {i + 1}, Loss: {running_loss / log_interval:.3f}")
                         running_loss = 0.0
 
         if not training:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2944,8 +2944,10 @@ class Module:
             max_epochs: int = 10,
             log_interval: int = 100):
         if isinstance(optimizer, str):
+            optimizer_ = self._get_optimizer_by_name(optimizer, **self.optimizer_kwargs)
+            
             def default_optimizer_factory(batch_idx: int, batch) -> Optimizer:
-                return self._get_optimizer_by_name(optimizer, **self.optimizer_kwargs)
+                return optimizer_
 
             optimizer_factory = default_optimizer_factory
         else:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -49,7 +49,6 @@ _grad_t = Union[Tuple[Tensor, ...], Tensor]
 # of `T` to annotate `self`. Many methods of `Module` return `self` and we want those return values to be
 # the type of the subclass, not the looser type of `Module`.
 T = TypeVar("T", bound="Module")
-OptimizerFactory = Callable[[int, Any], Optimizer]
 
 
 # Define a dictionary that maps short names to optimizer classes
@@ -2959,7 +2958,7 @@ class Module:
             train_loader: DataLoader,
             loss: str,
             loss_args: Optional[Dict[str, Any]] = None,
-            optimizer: Union[str, OptimizerFactory] = 'adam',
+            optimizer: Union[str, Optimizer] = 'adam',
             optimizer_args: Optional[Dict[str, Any]] = None,
             max_epochs: int = 10,
             log_interval: int = 100):
@@ -2970,14 +2969,7 @@ class Module:
         if optimizer_args is None:
             optimizer_args = {}
         if isinstance(optimizer, str):
-            optimizer_ = self._get_optimizer_by_name(optimizer, **optimizer_args)
-            
-            def default_optimizer_factory(batch_idx: int, batch) -> Optimizer:
-                return optimizer_
-
-            optimizer_factory = default_optimizer_factory
-        else:
-            optimizer_factory = optimizer
+            optimizer = self._get_optimizer_by_name(optimizer, **optimizer_args)
 
         training = self.training
 
@@ -2989,8 +2981,6 @@ class Module:
                 running_loss = 0.0
                 for i, data in enumerate(train_loader, 0):
                     inputs, labels = data
-
-                    optimizer = optimizer_factory(i, inputs)
 
                     optimizer.zero_grad()
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -63,6 +63,7 @@ optimizer_dict = {
     'lbfgs': optim.LBFGS
 }
 
+# Define a dictionary that maps short names to loss classes
 loss_dict = {
     'mse': nn.MSELoss,
     'l1': nn.L1Loss,

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -51,18 +51,6 @@ _grad_t = Union[Tuple[Tensor, ...], Tensor]
 T = TypeVar("T", bound="Module")
 
 
-# Define a dictionary that maps short names to optimizer classes
-optimizer_dict = {
-    'sgd': optim.SGD,
-    'adam': optim.Adam,
-    'adadelta': optim.Adadelta,
-    'adagrad': optim.Adagrad,
-    'adamw': optim.AdamW,
-    'adamax': optim.Adamax,
-    'rmsprop': optim.RMSprop,
-    'lbfgs': optim.LBFGS
-}
-
 # Define a dictionary that maps short names to loss classes
 loss_dict = {
     'mse': nn.MSELoss,
@@ -81,6 +69,18 @@ loss_dict = {
     'multi_margin': nn.MultiMarginLoss,
     'triplet_margin': nn.TripletMarginLoss,
     'ctc': nn.CTCLoss
+}
+
+# Define a dictionary that maps short names to optimizer classes
+optimizer_dict = {
+    'sgd': optim.SGD,
+    'adam': optim.Adam,
+    'adadelta': optim.Adadelta,
+    'adagrad': optim.Adagrad,
+    'adamw': optim.AdamW,
+    'adamax': optim.Adamax,
+    'rmsprop': optim.RMSprop,
+    'lbfgs': optim.LBFGS
 }
 
 
@@ -2943,17 +2943,17 @@ class Module:
         """
         self._compiled_call_impl = torch.compile(self._call_impl, *args, **kwargs)
     
-    def _get_optimizer_by_name(self, name, **kwargs) -> Optimizer:
-        if name in optimizer_dict:
-            return optimizer_dict[name](self.parameters(), **kwargs)
-        else:
-            raise ValueError(f"Optimizer '{name}' is not supported")
-
     def _get_loss_by_name(self, name, **kwargs):
         if name in loss_dict:
             return loss_dict[name](**kwargs)
         else:
             raise ValueError(f"Loss '{name}' is not supported")
+    
+    def _get_optimizer_by_name(self, name, **kwargs) -> Optimizer:
+        if name in optimizer_dict:
+            return optimizer_dict[name](self.parameters(), **kwargs)
+        else:
+            raise ValueError(f"Optimizer '{name}' is not supported")
 
     def fit(self,
             train_loader: DataLoader,


### PR DESCRIPTION
## Description

Usually pytorch has too many boilerplate code for training model.
This PR brings `fit` method that allow to reduce a repeated boilerplate code

Instead of writing each time for new model:
```python
criterion = ...
optimizer = ...
for epoch in range(max_epochs):  # loop over the dataset multiple times
    running_loss = 0.0
    for i, data in enumerate(train_loader, 0):
        inputs, labels = data
    
        optimizer.zero_grad()
    
        logits = model.forward(inputs)
        loss = criterion(logits, labels)
        loss.backward()
    
        optimizer.step()
```
this method allows to write it in following way:
```python
model.fit(train_loader, loss="cross_entropy", optimizer="adam", max_epochs=max_epochs)
```

This function do not require user to use only `fit` method, user still could write code in old style.

For custom model, user could override method `fit`, to add custom training behavior. This would have also one additional benefit, model would encapsulate not only layers, but also training algorithm, which usually not separable from model