### PR TITLE
TCPStore: add better logging on wait timeout

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -88,7 +88,7 @@ class AbstractTimeoutTest:
             )
             default_store = c10d._get_default_store()
             tik = time.time()
-            with self.assertRaisesRegex(RuntimeError, "Timeout"):
+            with self.assertRaisesRegex(RuntimeError, "(?i)timeout"):
                 default_store.get("nonexistent key")
             tok = time.time()
             dist.destroy_process_group()

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -710,28 +710,34 @@ class RendezvousTCPTest(TestCase):
     @retry_on_connect_failures(connect_errors=(CONNECT_TIMEOUT, ADDRESS_IN_USE))
     def test_tcp_store_timeout_set(self):
         url = self.create_tcp_url()
-        test_store_timeout = timedelta(seconds=10)
-        gen0 = dist.rendezvous(url + "&rank=0", timeout=test_store_timeout)
+        test_store_timeout = timedelta(seconds=0.1)
+        gen0 = dist.rendezvous(url + "&rank=0", timeout=timedelta(seconds=10))
         store0, rank0, size0 = next(gen0)
-        # this should time out in 10s. If the timeout passed into rendezvous was
+        store0.set_timeout(test_store_timeout)
+        # this should time out in 0.1s. If the timeout passed into rendezvous was
         # not respected, it will take much longer to timeout.
         start = time.time()
-        with self.assertRaisesRegex(RuntimeError, "Timeout"):
+        with self.assertRaisesRegex(
+            DistStoreError, "wait timeout after 100ms, keys: /nonexistant key"
+        ):
             store0.get("nonexistant key")
 
         end = time.time()
         time_diff = end - start
-        self.assertGreater(test_store_timeout.seconds * 10, time_diff)
+        self.assertGreater(10, time_diff)
 
     def test_tcp_store_timeout_doest_break_client(self):
         url = self.create_tcp_url()
-        test_store_timeout = timedelta(seconds=10)
-        gen0 = dist.rendezvous(url + "&rank=0", timeout=test_store_timeout)
+        test_store_timeout = timedelta(seconds=0.1)
+        gen0 = dist.rendezvous(url + "&rank=0", timeout=timedelta(seconds=10))
         store0, rank0, size0 = next(gen0)
+        store0.set_timeout(test_store_timeout)
         # this should time out in 10s. If the timeout passed into rendezvous was
         # not respected, it will take much longer to timeout.
         start = time.time()
-        with self.assertRaisesRegex(RuntimeError, "Timeout"):
+        with self.assertRaisesRegex(
+            DistStoreError, "wait timeout after 100ms, keys: /the_key"
+        ):
             store0.get("the_key")
 
         store0.set("the_key", "x")
@@ -740,7 +746,7 @@ class RendezvousTCPTest(TestCase):
 
         end = time.time()
         time_diff = end - start
-        self.assertGreater(test_store_timeout.seconds * 10, time_diff)
+        self.assertGreater(10, time_diff)
 
     def test_tcp_store_url_with_libuv(self):
         url = self.create_tcp_url()

--- a/torch/csrc/distributed/c10d/socket.h
+++ b/torch/csrc/distributed/c10d/socket.h
@@ -31,13 +31,13 @@ class SocketOptions {
     return prefer_ipv6_;
   }
 
-  SocketOptions& connect_timeout(std::chrono::seconds value) noexcept {
+  SocketOptions& connect_timeout(std::chrono::milliseconds value) noexcept {
     connect_timeout_ = value;
 
     return *this;
   }
 
-  std::chrono::seconds connect_timeout() const noexcept {
+  std::chrono::milliseconds connect_timeout() const noexcept {
     return connect_timeout_;
   }
 
@@ -54,7 +54,7 @@ class SocketOptions {
 
  private:
   bool prefer_ipv6_ = true;
-  std::chrono::seconds connect_timeout_{30};
+  std::chrono::milliseconds connect_timeout_{std::chrono::seconds{30}};
   std::shared_ptr<Backoff> connect_backoff_{
       std::make_shared<FixedBackoff>(std::chrono::milliseconds(1000))};
 };


### PR DESCRIPTION
This makes TCPStore `wait` timeout print actually useful info instead of a generic `Socket Timeout` message on timeout.

Bonus:

* fix weirdness where `connect_timeout` only supported seconds unlike the reset of our timeouts (thus minimum timeout was 1s)
* Fixed tests that used a 10s timeout (test_store now only takes 20s instead of 40s)

Ex:

```
DistStoreError: wait timeout after 100ms, keys: /the_key
```

Test plan:

```
python test/distributed/test_store.py
python test/distributed/test_c10d_gloo.py -v -k timeout
```


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o