### PR TITLE
Specialize sym node when used as device kwarg

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6617,6 +6617,16 @@ utils_device.CURRENT_DEVICE == None""".split(
             # This guard was created
             self.assertTrue(guard.name != "nested_fn.__closure__[0].cell_contents")
 
+    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
+    def test_symnode_as_device_kwarg(self):
+        def f(rank):
+            return torch.ones(10, device=rank.size(0))
+
+        x = torch.randn(2)
+        out = f(torch.randn(2))
+        opt_out = torch.compile(dynamic=True, fullgraph=True)(f)(x)
+        self.assertEqual(out, opt_out)
+
     def test_call_parent_non_class_methods_from_child(self):
         class A:
             a = 4

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6620,7 +6620,8 @@ utils_device.CURRENT_DEVICE == None""".split(
     @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
     def test_symnode_as_device_kwarg(self):
         def f(rank):
-            return torch.ones(10, device=rank.size(0))
+            # -2 to make device id 0 for easier testing on CI
+            return torch.ones(10, device=rank.size(0) - 2)
 
         x = torch.randn(2)
         out = f(torch.randn(2))

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6618,7 +6618,7 @@ utils_device.CURRENT_DEVICE == None""".split(
             self.assertTrue(guard.name != "nested_fn.__closure__[0].cell_contents")
 
     @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
-    def test_symnode_as_device_kwarg(self):
+    def test_symint_as_device_kwarg(self):
         def f(rank):
             # -2 to make device id 0 for easier testing on CI
             return torch.ones(10, device=rank.size(0) - 2)
@@ -6629,7 +6629,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         self.assertEqual(out, opt_out)
 
     @unittest.skipIf(not TEST_MULTIGPU, "need multiple GPU")
-    def test_symnode_as_device_kwarg_multi_gpu(self):
+    def test_symint_as_device_kwarg_multi_gpu(self):
         def fn(rank):
             # -2 to make device id smaller for easier testing on CI
             return torch.ones(10, device=rank.size(0) - 2)
@@ -6656,7 +6656,7 @@ utils_device.CURRENT_DEVICE == None""".split(
         )
 
     @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
-    def test_symnode_as_device_kwarg_non_strict_export(self):
+    def test_symint_as_device_kwarg_non_strict_export(self):
         class Mod(torch.nn.Module):
             def forward(self, x):
                 # -2 to make device id 0 for easier testing on CI

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6625,7 +6625,7 @@ utils_device.CURRENT_DEVICE == None""".split(
 
         x = torch.randn(2)
         out = f(torch.randn(2))
-        opt_out = torch.compile(dynamic=True, fullgraph=True)(f)(x)
+        opt_out = torch.compile(backend="eager", dynamic=True, fullgraph=True)(f)(x)
         self.assertEqual(out, opt_out)
 
     @unittest.skipIf(not TEST_MULTIGPU, "need multiple GPU")

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6628,6 +6628,50 @@ utils_device.CURRENT_DEVICE == None""".split(
         opt_out = torch.compile(dynamic=True, fullgraph=True)(f)(x)
         self.assertEqual(out, opt_out)
 
+    @unittest.skipIf(not TEST_MULTIGPU, "need multiple GPU")
+    def test_symnode_as_device_kwarg_multi_gpu(self):
+        def fn(rank):
+            # -2 to make device id smaller for easier testing on CI
+            return torch.ones(10, device=rank.size(0) - 2)
+
+        x = torch.randn(2)
+        out = fn(torch.randn(2))
+
+        guard_failure = None
+
+        def guard_failures(failure):
+            nonlocal guard_failure
+            guard_failure = failure
+
+        opt_fn = torch._dynamo.optimize(
+            "eager", guard_fail_fn=guard_failures, dynamic=True
+        )(fn)
+        self.assertEqual(out, opt_fn(x))
+
+        x = torch.randn(3)
+        self.assertEqual(fn(x), opt_fn(x))
+        self.assertTrue(guard_failure is not None)
+        self.assertIn(
+            """tensor 'L['rank']' size mismatch at index 0""", guard_failure[0]
+        )
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
+    def test_symnode_as_device_kwarg_non_strict_export(self):
+        class Mod(torch.nn.Module):
+            def forward(self, x):
+                # -2 to make device id 0 for easier testing on CI
+                return torch.ones(10, device=x.size(0) - 2)
+
+        x = torch.randn(2)
+        m = Mod()
+        d1 = torch.export.Dim("d1", max=2048)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.UserError, "Constraints violated \(d1\)"
+        ):
+            ep = torch.export.export(
+                m, (x,), dynamic_shapes={"x": {0: d1}}, strict=False
+            )
+
     def test_call_parent_non_class_methods_from_child(self):
         class A:
             a = 4

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -810,22 +810,12 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                 # changed. If it has, graph break.
                 fake_out_shape = kwargs["out"].proxy.node.meta["example_value"].shape
 
-            proxy_args, proxy_kwargs = proxy_args_kwargs(args, kwargs)
-
-            if "device" in kwargs and isinstance(
-                kwargs["device"], variables.SymNodeVariable
-            ):
-                # when SymNodeVariables are used as device kwargs, we evaluate_expr() to
-                # specialize and guard on the sym expression.
-                proxy_kwargs["device"] = kwargs["device"].evaluate_expr()
-
             tensor_variable = wrap_fx_proxy(
                 tx=tx,
                 proxy=tx.output.create_proxy(
                     "call_function",
                     fn_,
-                    proxy_args,
-                    proxy_kwargs,
+                    *proxy_args_kwargs(args, kwargs),
                 ),
             )
 

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1528,16 +1528,17 @@ bool FunctionSignature::parse(
       }
       return false;
     } else if (param.check(obj, overloaded_args, i, &failed_idx)) {
-      if (param.type_ == ParameterType::DEVICE &&
-          torch::is_symint(py::handle(obj))) {
-        // Cast to c10::SymInt first to guard_int with stack trace
-        // then cast it back to python.
-        auto guarded_int = py::cast<c10::SymInt>(py::handle(obj))
-                               .guard_int(__FILE__, __LINE__);
-        dst[i++] = py::cast(guarded_int).ptr();
-      } else {
-        dst[i++] = obj;
-      }
+      dst[i++] = obj;
+      // if (param.type_ == ParameterType::DEVICE &&
+      // torch::is_symint(py::handle(obj))) {
+      //     // Cast to c10::SymInt first guard_int with stack trace
+      //     // then cast it back to python for further processing.
+      //     auto guarded_int =
+      //     py::cast<c10::SymInt>(py::handle(obj)).guard_int(__FILE__,
+      //     __LINE__); dst[i++] = py::cast(guarded_int).ptr();
+      // } else {
+      //   dst[i++] = obj;
+      // }
       // XXX: the Variable check is necessary because sizes become tensors when
       // tracer is enabled. This behavior easily leads to ambiguities, and we
       // should avoid having complex signatures that make use of it...

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1529,16 +1529,6 @@ bool FunctionSignature::parse(
       return false;
     } else if (param.check(obj, overloaded_args, i, &failed_idx)) {
       dst[i++] = obj;
-      // if (param.type_ == ParameterType::DEVICE &&
-      // torch::is_symint(py::handle(obj))) {
-      //     // Cast to c10::SymInt first guard_int with stack trace
-      //     // then cast it back to python for further processing.
-      //     auto guarded_int =
-      //     py::cast<c10::SymInt>(py::handle(obj)).guard_int(__FILE__,
-      //     __LINE__); dst[i++] = py::cast(guarded_int).ptr();
-      // } else {
-      //   dst[i++] = obj;
-      // }
       // XXX: the Variable check is necessary because sizes become tensors when
       // tracer is enabled. This behavior easily leads to ambiguities, and we
       // should avoid having complex signatures that make use of it...


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131811

Fixes https://github.com/pytorch/pytorch/issues/131189.

We specialize the symint in python_arg_parser when used as kwarg device.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames