### PR TITLE
[MPS] Add native implementation for shift ops

### DIFF
--- a/aten/src/ATen/mps/MPSFallback.mm
+++ b/aten/src/ATen/mps/MPSFallback.mm
@@ -85,8 +85,6 @@ TORCH_LIBRARY_IMPL(aten, MPS, m) {
   // These ops are not supported via MPS backend currently, and we fallback to run on CPU.
   // For the rest of unsupported ops the user needs to pass 'PYTORCH_ENABLE_MPS_FALLBACK=1'
   // to fallback on CPU, otherwise we will error out.
-  m.impl("bitwise_left_shift.Tensor_out", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
-  m.impl("bitwise_right_shift.Tensor_out", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("embedding_renorm_", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("linalg_svd", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("linalg_svd.U", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -1,6 +1,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/ExpandUtils.h>
 #include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/BinaryOps.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/ops/bitwise_and_native.h>
@@ -79,6 +80,50 @@ kernel void bitwise_xor_scalar(constant uint& length [[buffer(0)]],
     return;
   }}
   out[offset] = a[offset] ^ b;
+}}
+
+kernel void bitwise_lshift_tensor(constant uint& length [[buffer(0)]],
+                         device {0}  *out [[buffer(1)]],
+                         device {1}  *a [[buffer(2)]],
+                         device {2}  *b [[buffer(3)]],
+                         uint offset [[thread_position_in_grid]]) {{
+  if (offset >= length) {{
+    return;
+  }}
+  out[offset] = a[offset] << b [offset];
+}}
+
+kernel void bitwise_lshift_scalar(constant uint& length [[buffer(0)]],
+                         device {0}  *out [[buffer(1)]],
+                         device {1}  *a [[buffer(2)]],
+                         constant {2}  &b [[buffer(3)]],
+                         uint offset [[thread_position_in_grid]]) {{
+  if (offset >= length) {{
+    return;
+  }}
+  out[offset] = a[offset] << b;
+}}
+
+kernel void bitwise_rshift_tensor(constant uint& length [[buffer(0)]],
+                         device {0}  *out [[buffer(1)]],
+                         device {1}  *a [[buffer(2)]],
+                         device {2}  *b [[buffer(3)]],
+                         uint offset [[thread_position_in_grid]]) {{
+  if (offset >= length) {{
+    return;
+  }}
+  out[offset] = a[offset] >> b [offset];
+}}
+
+kernel void bitwise_rshift_scalar(constant uint& length [[buffer(0)]],
+                         device {0}  *out [[buffer(1)]],
+                         device {1}  *a [[buffer(2)]],
+                         constant {2}  &b [[buffer(3)]],
+                         uint offset [[thread_position_in_grid]]) {{
+  if (offset >= length) {{
+    return;
+  }}
+  out[offset] = a[offset] >> b;
 }}
 
 kernel void bitwise_not(constant uint& length [[buffer(0)]],
@@ -280,6 +325,16 @@ static void _bitwise_not_out_mps(const Tensor& self, const Tensor& output_) {
 }
 
 } // namespace mps
+namespace {
+void lshift_kernel_mps(TensorIteratorBase& iter) {
+  mps::_bitwise_op_out_mps(iter.input(0), iter.input(1), iter.output(0), "lshift");
+}
+
+void rshift_kernel_mps(TensorIteratorBase& iter) {
+  mps::_bitwise_op_out_mps(iter.input(0), iter.input(1), iter.output(0), "rshift");
+}
+
+} // namespace
 
 TORCH_IMPL_FUNC(bitwise_and_out_mps)(const Tensor& self, const Tensor& other, const Tensor& output) {
   mps::_bitwise_op_out_mps(self, other, output, "and");
@@ -296,4 +351,8 @@ TORCH_IMPL_FUNC(bitwise_xor_out_mps)(const Tensor& self, const Tensor& other, co
 TORCH_IMPL_FUNC(bitwise_not_out_mps)(const Tensor& self, const Tensor& output) {
   mps::_bitwise_not_out_mps(self, output);
 }
+
+REGISTER_MPS_DISPATCH(lshift_stub, &lshift_kernel_mps);
+REGISTER_MPS_DISPATCH(rshift_stub, &rshift_kernel_mps);
+
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -255,6 +255,10 @@ static void _bitwise_op_out_mps(const Tensor& self,
       output.fill_(c10::Scalar(self.item<int64_t>() | other.item<int64_t>()));
     } else if (op_name == "xor") {
       output.fill_(c10::Scalar(self.item<int64_t>() ^ other.item<int64_t>()));
+    } else if (op_name == "lshift") {
+      output.fill_(c10::Scalar(self.item<int64_t>() << other.item<int64_t>()));
+    } else if (op_name == "rshift") {
+      output.fill_(c10::Scalar(self.item<int64_t>() >> other.item<int64_t>()));
     } else {
       TORCH_CHECK(false, "Unknown operation to be performed over scalars ", op_name);
     }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8457,21 +8457,21 @@
   device_check: NoCheck   # TensorIterator
   variants: method, function
   dispatch:
-    CPU, CUDA: __lshift__
+    CPU, CUDA, MPS: __lshift__
   tags: pointwise
 
 - func: __lshift__.Tensor(Tensor self, Tensor other) -> Tensor
   device_check: NoCheck   # TensorIterator
   variants: method, function
   dispatch:
-    CPU, CUDA: __lshift__
+    CPU, CUDA, MPS: __lshift__
   tags: pointwise
 
 - func: __ilshift__.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   variants: method
   dispatch:
-    CPU, CUDA: __ilshift__
+    CPU, CUDA, MPS: __ilshift__
   autogen: __lshift__.Scalar_out
   tags: pointwise
 
@@ -8479,7 +8479,7 @@
   device_check: NoCheck   # TensorIterator
   variants: method
   dispatch:
-    CPU, CUDA: __ilshift__
+    CPU, CUDA, MPS: __ilshift__
   autogen: __lshift__.Tensor_out
   tags: pointwise
 
@@ -8500,7 +8500,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: bitwise_left_shift_out
+    CPU, CUDA, MPS: bitwise_left_shift_out
   tags: pointwise
 
 - func: bitwise_left_shift.Tensor_Scalar(Tensor self, Scalar other) -> Tensor
@@ -8536,7 +8536,7 @@
   device_check: NoCheck   # TensorIterator
   variants: method, function
   dispatch:
-    CPU, CUDA: __rshift__
+    CPU, CUDA, MPS: __rshift__
   tags: pointwise
 
 - func: __rshift__.Tensor(Tensor self, Tensor other) -> Tensor
@@ -8550,14 +8550,14 @@
   device_check: NoCheck   # TensorIterator
   variants: method
   dispatch:
-    CPU, CUDA: __irshift__
+    CPU, CUDA, MPS: __irshift__
   autogen: __rshift__.Scalar_out
 
 - func: __irshift__.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   variants: method
   dispatch:
-    CPU, CUDA: __irshift__
+    CPU, CUDA, MPS: __irshift__
   autogen: __rshift__.Tensor_out
 
 - func: bitwise_right_shift.Tensor(Tensor self, Tensor other) -> Tensor
@@ -8577,7 +8577,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA: bitwise_right_shift_out
+    CPU, CUDA, MPS: bitwise_right_shift_out
   tags: pointwise
 
 - func: bitwise_right_shift.Tensor_Scalar(Tensor self, Scalar other) -> Tensor


### PR DESCRIPTION
Similar to how AND/OR/XOR ops are implemented

TODO: Consider using MPS method calls rather than metal kernels
