### PR TITLE
[c10d] Fix split_group usage when there is a single rank

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -4439,9 +4439,9 @@ def split_group(
             my_group = split_group
             group_rank = split_group.index(parent_group_rank)
             break
-    # if my rank does not belong to any sub group or my rank is the only member in the subgroup,
+    # if my rank does not belong to any sub group,
     # no_color split should be called
-    if my_group is None or group_rank == -1 or len(my_group) == 1:
+    if my_group is None or group_rank == -1:
         parent_backend.perform_nocolor_split(device_id)
         return None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131824

Summary:
This is a request from xlformer team to allow single rank PG/comms
Test Plan:
UT

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o