### PR TITLE
Fix cpp template kernel in ABI compatible mode

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -101,11 +101,6 @@ if config.abi_compatible:
         "test_qlinear_dequant_promotion_cpu",
         "test_qlinear_gelu_cpu",
         "test_qlinear_relu_cpu",
-        *[
-            func
-            for func in dir(test_cpu_select_algorithm.TestSelectAlgorithmCPU())
-            if func.startswith("test_linear_with_pointwise")
-        ],
     ]
     for test_name in xfail_list:
         test_failures_cpp_wrapper[test_name] = test_torchinductor.TestFailure(

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -237,7 +237,10 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
         if (
             (
-                (dtype == torch.bfloat16 and torch.ops.mkldnn._is_mkldnn_bf16_supported())
+                (
+                    dtype == torch.bfloat16
+                    and torch.ops.mkldnn._is_mkldnn_bf16_supported()
+                )
                 or (
                     dtype == torch.float16
                     and torch.ops.mkldnn._is_mkldnn_fp16_supported()
@@ -245,7 +248,17 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
             )
             and epilogue != "mul"
             and epilogue != "div"
-            or ((dtype == torch.half or (dtype == torch.bfloat16 and not torch.ops.mkldnn._is_mkldnn_bf16_supported()) and epilogue == "add" and not bias)
+            or (
+                (
+                    dtype == torch.half
+                    or (
+                        dtype == torch.bfloat16
+                        and not torch.ops.mkldnn._is_mkldnn_bf16_supported()
+                    )
+                )
+                and epilogue == "add"
+                and not bias
+            )
         ):
             # Several scenarios where epilogue fusion is not counted in:
             # 1. For bfloat16, the epilogue fusion is part of the template,

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -237,7 +237,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
         if (
             (
-                dtype == torch.bfloat16
+                (dtype == torch.bfloat16 and torch.ops.mkldnn._is_mkldnn_bf16_supported())
                 or (
                     dtype == torch.float16
                     and torch.ops.mkldnn._is_mkldnn_fp16_supported()
@@ -245,7 +245,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
             )
             and epilogue != "mul"
             and epilogue != "div"
-            or (dtype == torch.half and epilogue == "add" and not bias)
+            or ((dtype == torch.half or (dtype == torch.bfloat16 and not torch.ops.mkldnn._is_mkldnn_bf16_supported()) and epilogue == "add" and not bias)
         ):
             # Several scenarios where epilogue fusion is not counted in:
             # 1. For bfloat16, the epilogue fusion is part of the template,

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2037,7 +2037,7 @@ class CppKernel(Kernel):
 
     @property
     def assert_function(self) -> str:
-        if V.graph.aot_mode:
+        if V.graph.aot_mode or config.abi_compatible:
             # TODO: Using AOTI_TORCH_CHECK is causing performance drop for some models
             # compared with JIT Inductor which uses TORCH_CHECK
             return "AOTI_TORCH_CHECK"

--- a/torch/_inductor/codegen/cpp_micro_gemm.py
+++ b/torch/_inductor/codegen/cpp_micro_gemm.py
@@ -332,7 +332,7 @@ class CppMicroGemmFP32Vec(CppMicroGemm):
                     break;
                 {%- endfor %}
                 default:
-                    {{kernel.assert_function}}(false, "Unsupported block_m: ", block_m);
+                    {{kernel.assert_function}}(false, "Unsupported block_m");
                 }
             }
         }

--- a/torch/_inductor/codegen/cpp_template.py
+++ b/torch/_inductor/codegen/cpp_template.py
@@ -114,6 +114,15 @@ class CppTemplate(KernelTemplate):
                 #include "c10/util/Unroll.h"
             """
         )
+        # The below header is needed for kernel.assert_function in abi compatible mode
+        if config.abi_compatible:
+            if config.c_shim_version == "1":
+                res.splice("#include <torch/csrc/inductor/aoti_torch/c/shim.h>")
+            else:
+                device = "cpu"
+                res.splice(
+                    f"#include <torch/csrc/inductor/aoti_torch/generated/c_shim_{device}.h>"
+                )
         enable_kernel_profile = (
             config.cpp.enable_kernel_profile and sys.platform == "linux"
         )

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -788,6 +788,9 @@ class GraphLowering(torch.fx.Interpreter):
         assert name in self.allocated_constant_name and name in self.constants, (
             "Can not find the original value for " + name
         )
+        if self.allocated_constant_name[name] is None:
+            print("debug gm:")
+            print(V.graph.orig_gm.print_readable())
         orig_name = get_cloned_parameter_buffer_name(self.allocated_constant_name[name])
         return (
             self.module.meta[orig_name]

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -837,6 +837,8 @@ class GraphLowering(torch.fx.Interpreter):
         return name
 
     def add_tensor_constant(self, data, name=None):
+        if name is None:
+            print("debug data: ", data)
         new_name = self.allocate_non_dup_const_name(name, data)
         return TensorBox.create(
             ir.ConstantBuffer(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131841
* #129557

Fix for abi compatible:
undefined symbol: _ZN3c106detail14torchCheckFailEPKcS2_jRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
https://github.com/pytorch/pytorch/blob/ff026f3d0a68a4533b193498adc5b5c7b045b73c/torch/_inductor/codegen/cpp.py#L2033-L2039

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang