### PR TITLE
Override setCurrentDevice methods for specific accelerators

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -444,6 +444,10 @@ DeviceIndex CUDAHooks::getCurrentDevice() const {
   return at::cuda::detail::current_device();
 }
 
+void CUDAHooks::setCurrentDevice(DeviceIndex device) const {
+  c10::cuda::set_device(device);
+}
+
 #ifdef USE_ROCM
 bool CUDAHooks::isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const {
   hipDeviceProp_t* prop = at::cuda::getDeviceProperties(device_index);
@@ -461,14 +465,6 @@ bool CUDAHooks::isGPUArch(DeviceIndex device_index, const std::vector<std::strin
 void CUDAHooks::deviceSynchronize(DeviceIndex device_index) const {
   at::DeviceGuard device_guard(at::Device(at::DeviceType::CUDA, device_index));
   c10::cuda::device_synchronize();
-}
-
-void CUDAHooks::setCurrentDevice(DeviceIndex device) const {
-  c10::cuda::set_device(device);
-}
-
-DeviceIndex CUDAHooks::getCurrentDevice() const {
-  return c10::cuda::current_device();
 }
 
 // Sigh, the registry doesn't support namespaces :(

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -463,6 +463,14 @@ void CUDAHooks::deviceSynchronize(DeviceIndex device_index) const {
   c10::cuda::device_synchronize();
 }
 
+void CUDAHooks::setCurrentDevice(DeviceIndex device) const {
+  c10::cuda::set_device(device);
+}
+
+DeviceIndex CUDAHooks::getCurrentDevice() const {
+  return c10::cuda::current_device();
+}
+
 // Sigh, the registry doesn't support namespaces :(
 using at::CUDAHooksRegistry;
 using at::RegistererCUDAHooksRegistry;

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -57,6 +57,8 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   bool isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const override;
 #endif
   void deviceSynchronize(DeviceIndex device_index) const override;
+  void setCurrentDevice(DeviceIndex device) const override;
+  DeviceIndex getCurrentDevice() const override;
 };
 
 } // at::cuda::detail

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -52,13 +52,12 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   int getNumGPUs() const override;
   DeviceIndex deviceCount() const override;
   DeviceIndex getCurrentDevice() const override;
+  void setCurrentDevice(DeviceIndex device) const override;
 
 #ifdef USE_ROCM
   bool isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const override;
 #endif
   void deviceSynchronize(DeviceIndex device_index) const override;
-  void setCurrentDevice(DeviceIndex device) const override;
-  DeviceIndex getCurrentDevice() const override;
 };
 
 } // at::cuda::detail

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -196,6 +196,15 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
   virtual void deviceSynchronize(DeviceIndex /*device_index*/) const {
     TORCH_CHECK(false, "Cannot synchronize CUDA device without ATen_cuda library. ", CUDA_HELP);
   }
+
+  virtual void setCurrentDevice(DeviceIndex device) const override {
+    TORCH_CHECK(false, "Cannot set current device without ATen_cuda library. ", CUDA_HELP);
+  }
+
+  virtual DeviceIndex getCurrentDevice() const override {
+    TORCH_CHECK(false, "Cannot get current device without ATen_cuda library. ", CUDA_HELP);
+    return -1;
+  }
 };
 
 // NB: dummy argument to suppress "ISO C++11 requires at least one argument

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -187,6 +187,19 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
     return 0;
   }
 
+  DeviceIndex deviceCount() const override {
+    return 0;
+  }
+
+  void setCurrentDevice(DeviceIndex device) const override {
+    TORCH_CHECK(false, "Cannot set current device without ATen_cuda library. ", CUDA_HELP);
+  }
+
+  DeviceIndex getCurrentDevice() const override {
+    TORCH_CHECK(false, "Cannot get current device without ATen_cuda library. ", CUDA_HELP);
+    return -1;
+  }
+
 #ifdef USE_ROCM
   virtual bool isGPUArch(DeviceIndex /*device_index*/, const std::vector<std::string>& /*archs*/) const {
     TORCH_CHECK(false, "Cannot check GPU arch without ATen_cuda library. ", CUDA_HELP);
@@ -195,15 +208,6 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
 
   virtual void deviceSynchronize(DeviceIndex /*device_index*/) const {
     TORCH_CHECK(false, "Cannot synchronize CUDA device without ATen_cuda library. ", CUDA_HELP);
-  }
-
-  virtual void setCurrentDevice(DeviceIndex device) const override {
-    TORCH_CHECK(false, "Cannot set current device without ATen_cuda library. ", CUDA_HELP);
-  }
-
-  virtual DeviceIndex getCurrentDevice() const override {
-    TORCH_CHECK(false, "Cannot get current device without ATen_cuda library. ", CUDA_HELP);
-    return -1;
   }
 };
 

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -42,6 +42,19 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
         "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `hasPrimaryContext`.");
   }
 
+  virtual void setCurrentDevice(DeviceIndex device) const override {
+    TORCH_CHECK(
+        false,
+        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `setCurrentDevice`.");
+  }
+
+  virtual DeviceIndex getCurrentDevice() const override {
+    TORCH_CHECK(
+        false,
+        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `getCurrentDevice`.");
+    return -1;
+  }
+
   void init() const override {}
   virtual void resizePrivateUse1Bytes(
       const c10::Storage& storage,

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -26,6 +26,23 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
         "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `getDeviceFromPtr`.");
   }
 
+  DeviceIndex deviceCount() const override {
+    return 0;
+  }
+
+  void setCurrentDevice(DeviceIndex device) const override {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false,
+        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `setCurrentDevice`.");
+  }
+
+  DeviceIndex getCurrentDevice() const override {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false,
+        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `getCurrentDevice`.");
+    return -1;
+  }
+
   bool isPinnedPtr(const void* data) const override {
     return false;
   }
@@ -40,19 +57,6 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
     TORCH_CHECK_NOT_IMPLEMENTED(
         false,
         "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `hasPrimaryContext`.");
-  }
-
-  virtual void setCurrentDevice(DeviceIndex device) const override {
-    TORCH_CHECK(
-        false,
-        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `setCurrentDevice`.");
-  }
-
-  virtual DeviceIndex getCurrentDevice() const override {
-    TORCH_CHECK(
-        false,
-        "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `getCurrentDevice`.");
-    return -1;
   }
 
   void init() const override {}

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -70,11 +70,15 @@ struct TORCH_API XPUHooksInterface : AcceleratorHooksInterface{
     TORCH_CHECK(false, "Cannot query primary context without ATen_xpu library.");
   }
 
-  virtual void setCurrentDevice(DeviceIndex device) const override {
+  DeviceIndex deviceCount() const override {
+    return 0;
+  }
+
+  void setCurrentDevice(DeviceIndex device) const override {
     TORCH_CHECK(false, "Cannot set current device without ATen_xpu library.");
   }
 
-  virtual DeviceIndex getCurrentDevice() const override {
+  DeviceIndex getCurrentDevice() const override {
     TORCH_CHECK(false, "Cannot get current device without ATen_xpu library.");
     return -1;
   }

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -69,6 +69,15 @@ struct TORCH_API XPUHooksInterface : AcceleratorHooksInterface{
   bool hasPrimaryContext(DeviceIndex device_index) const override {
     TORCH_CHECK(false, "Cannot query primary context without ATen_xpu library.");
   }
+
+  virtual void setCurrentDevice(DeviceIndex device) const override {
+    TORCH_CHECK(false, "Cannot set current device without ATen_xpu library.");
+  }
+
+  virtual DeviceIndex getCurrentDevice() const override {
+    TORCH_CHECK(false, "Cannot get current device without ATen_xpu library.");
+    return -1;
+  }
 };
 
 struct TORCH_API XPUHooksArgs {};

--- a/aten/src/ATen/xpu/detail/XPUHooks.cpp
+++ b/aten/src/ATen/xpu/detail/XPUHooks.cpp
@@ -94,13 +94,12 @@ DeviceIndex XPUHooks::deviceCount() const {
   return at::xpu::device_count();
 }
 
-DeviceIndex XPUHooks::getCurrentDevice() const {
-  return at::xpu::current_device();
-
 void XPUHooks::setCurrentDevice(DeviceIndex device) const {
   at::xpu::set_device(device);
 }
 
+DeviceIndex XPUHooks::getCurrentDevice() const {
+  return at::xpu::current_device();
 }
 
 REGISTER_XPU_HOOKS(XPUHooks);

--- a/aten/src/ATen/xpu/detail/XPUHooks.cpp
+++ b/aten/src/ATen/xpu/detail/XPUHooks.cpp
@@ -96,6 +96,11 @@ DeviceIndex XPUHooks::deviceCount() const {
 
 DeviceIndex XPUHooks::getCurrentDevice() const {
   return at::xpu::current_device();
+
+void XPUHooks::setCurrentDevice(DeviceIndex device) const {
+  at::xpu::set_device(device);
+}
+
 }
 
 REGISTER_XPU_HOOKS(XPUHooks);

--- a/aten/src/ATen/xpu/detail/XPUHooks.h
+++ b/aten/src/ATen/xpu/detail/XPUHooks.h
@@ -23,6 +23,7 @@ struct XPUHooks : public at::XPUHooksInterface {
   bool hasPrimaryContext(DeviceIndex device_index) const override;
   DeviceIndex deviceCount() const override;
   DeviceIndex getCurrentDevice() const override;
+  void setCurrentDevice(DeviceIndex device) const override;
 };
 
 } // namespace at::xpu::detail

--- a/aten/src/ATen/xpu/detail/XPUHooks.h
+++ b/aten/src/ATen/xpu/detail/XPUHooks.h
@@ -22,8 +22,8 @@ struct XPUHooks : public at::XPUHooksInterface {
   bool isPinnedPtr(const void* data) const override;
   bool hasPrimaryContext(DeviceIndex device_index) const override;
   DeviceIndex deviceCount() const override;
-  DeviceIndex getCurrentDevice() const override;
   void setCurrentDevice(DeviceIndex device) const override;
+  DeviceIndex getCurrentDevice() const override;
 };
 
 } // namespace at::xpu::detail

--- a/test/test_cuda_multigpu.py
+++ b/test/test_cuda_multigpu.py
@@ -499,6 +499,29 @@ class TestCudaMultiGPU(TestCase):
         self.assertEqual(x.cuda().get_device(), 0)
 
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    def test_cuda_set_device_by_accelerator_hooks(self):
+        x = torch.randn(5, 5)
+        with torch.cuda.device(1):
+            self.assertEqual(x.cuda().get_device(), 1)
+            torch._C._accelerator_hooks_set_current_device(0)
+            self.assertEqual(x.cuda().get_device(), 0)
+            with torch.cuda.device(1):
+                self.assertEqual(x.cuda().get_device(), 1)
+            self.assertEqual(x.cuda().get_device(), 0)
+            torch._C._accelerator_hooks_set_current_device(1)
+        self.assertEqual(x.cuda().get_device(), 0)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    def test_cuda_get_device_by_accelerator_hooks(self):
+        self.assertEqual(torch._C._accelerator_hooks_get_current_device(), 0)
+        with torch.cuda.device(1):
+            self.assertEqual(torch._C._accelerator_hooks_get_current_device(), 1)
+            torch._C._accelerator_hooks_set_current_device(0)
+            self.assertEqual(torch._C._accelerator_hooks_get_current_device(), 0)
+            torch._C._accelerator_hooks_set_current_device(1)
+        self.assertEqual(torch._C._accelerator_hooks_get_current_device(), 0)
+
+    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     def test_current_stream(self):
         d0 = torch.device("cuda:0")
         d1 = torch.device("cuda:1")

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -75,6 +75,13 @@ class TestXpu(TestCase):
         torch.xpu.set_device(current_device)
         self.assertEqual(current_device, torch.xpu.current_device())
 
+    def test_device_behavior_by_accelerator_hooks(self):
+        current_device = torch._C._accelerator_hooks_get_current_device()
+        torch._C._accelerator_hooks_set_current_device(current_device)
+        self.assertEqual(
+            current_device, torch._C._accelerator_hooks_get_current_device()
+        )
+
     @unittest.skipIf(not TEST_MULTIXPU, "only one GPU detected")
     def test_multi_device_behavior(self):
         current_device = torch.xpu.current_device()
@@ -87,6 +94,27 @@ class TestXpu(TestCase):
         with torch.xpu._DeviceGuard(target_device):
             self.assertEqual(target_device, torch.xpu.current_device())
         self.assertEqual(current_device, torch.xpu.current_device())
+
+    @unittest.skipIf(not TEST_MULTIXPU, "only one GPU detected")
+    def test_multi_device_behavior_by_accelerator_hooks(self):
+        current_device = torch._C._accelerator_hooks_get_current_device()
+        target_device = (current_device + 1) % torch.xpu.device_count()
+
+        with torch.xpu.device(target_device):
+            self.assertEqual(
+                target_device, torch._C._accelerator_hooks_get_current_device()
+            )
+        self.assertEqual(
+            current_device, torch._C._accelerator_hooks_get_current_device()
+        )
+
+        with torch.xpu._DeviceGuard(target_device):
+            self.assertEqual(
+                target_device, torch._C._accelerator_hooks_get_current_device()
+            )
+        self.assertEqual(
+            current_device, torch._C._accelerator_hooks_get_current_device()
+        )
 
     def test_get_device_properties(self):
         current_device = torch.xpu.current_device()

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -84,6 +84,7 @@
 #include <torch/csrc/onnx/init.h>
 #include <torch/csrc/profiler/python/init.h>
 #include <torch/csrc/tensor/python_tensor.h>
+#include <torch/csrc/utils/device_lazy_init.h>
 #include <torch/csrc/utils/disable_torch_function.h>
 #include <torch/csrc/utils/init.h>
 #include <torch/csrc/utils/pycfunction_helpers.h>
@@ -2131,6 +2132,7 @@ Call this whenever a new thread is created in order to propagate values from
       [](c10::DeviceIndex device_index) {
         auto device_type = at::getAccelerator();
         if (device_type.has_value()) {
+          torch::utils::device_lazy_init(device_type.value());
           at::globalContext()
               .getAcceleratorHooksInterface(device_type)
               .setCurrentDevice(device_index);
@@ -2140,6 +2142,7 @@ Call this whenever a new thread is created in order to propagate values from
   py_module.def("_accelerator_hooks_get_current_device", []() {
     auto device_type = at::getAccelerator();
     if (device_type.has_value()) {
+      torch::utils::device_lazy_init(device_type.value());
       return at::globalContext()
           .getAcceleratorHooksInterface(device_type)
           .getCurrentDevice();
@@ -2151,6 +2154,7 @@ Call this whenever a new thread is created in order to propagate values from
       "_accelerator_hooks_exchange_device", [](c10::DeviceIndex device_index) {
         auto device_type = at::getAccelerator();
         if (device_type.has_value()) {
+          torch::utils::device_lazy_init(device_type.value());
           return at::globalContext()
               .getAcceleratorHooksInterface(device_type)
               .exchangeDevice(device_index);
@@ -2163,6 +2167,7 @@ Call this whenever a new thread is created in order to propagate values from
       [](c10::DeviceIndex device_index) {
         auto device_type = at::getAccelerator();
         if (device_type.has_value()) {
+          torch::utils::device_lazy_init(device_type.value());
           return at::globalContext()
               .getAcceleratorHooksInterface(device_type)
               .maybeExchangeDevice(device_index);


### PR DESCRIPTION
This PR overrides [setCurrentDevice](https://github.com/pytorch/pytorch/blob/f69bf005f7b3be70b9a38ba663e6bc825dfe7ffd/aten/src/ATen/detail/AcceleratorHooksInterface.h#L34) methods of AcceleratorHooksInterface for specific accelerator subclass(CUDA, XPU, PrivateUse1). So that support python methods [`torch._C._accelerator_hooks_set_current_device`](https://github.com/pytorch/pytorch/blob/f69bf005f7b3be70b9a38ba663e6bc825dfe7ffd/torch/csrc/Module.cpp#L2129).

cc: @albanD @guangyey 
