### PR TITLE
[CI] Fix an arm64 benchmarking docker build issue

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -14,6 +14,7 @@ self-hosted-runner:
     - linux.12xlarge.ephemeral
     - linux.24xlarge
     - linux.arm64.2xlarge
+    - linux.arm64.m7g.4xlarge
     - linux.4xlarge.nvidia.gpu
     - linux.8xlarge.nvidia.gpu
     - linux.16xlarge.nvidia.gpu

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -66,7 +66,7 @@ jobs:
           - docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc11
             runner: linux.arm64.2xlarge
           - docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc11-inductor-benchmarks
-            runner: linux.arm64.2xlarge
+            runner: linux.arm64.m7g.4xlarge
     runs-on: [self-hosted, "${{ matrix.runner }}"]
     env:
       DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${{ matrix.docker-image-name }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131855

Summary: Use linux.arm64.m7g.4xlarge to build pytorch-linux-jammy-aarch64-py3.10-gcc11-inductor-benchmarks docker image, fixing "The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64/v4) and no specific platform was requested".