### PR TITLE
remove unused code for XPU

### DIFF
--- a/torch/csrc/xpu/Stream.cpp
+++ b/torch/csrc/xpu/Stream.cpp
@@ -67,12 +67,6 @@ static void THXPStream_dealloc(THXPStream* self) {
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
-static PyObject* THXPStream_get_device(THXPStream* self, void* unused) {
-  HANDLE_TH_ERRORS
-  return THPDevice_New(self->xpu_stream.device());
-  END_HANDLE_TH_ERRORS
-}
-
 static PyObject* THXPStream_get_sycl_queue(THXPStream* self, void* unused) {
   HANDLE_TH_ERRORS
   return PyLong_FromVoidPtr(&self->xpu_stream.queue());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131856

# Motivation
This PR aims to remove unused code in PyTorch for XPU, following https://github.com/pytorch/pytorch/pull/128179
Otherwise, CI will block without this PR.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10