### PR TITLE
Update pin memory related APIs to not pass 'device' argument

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -326,25 +326,25 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         # Check if the pin_memory is functioning properly on custom device
         cpu_tensor = torch.empty(3)
         self.assertFalse(cpu_tensor.is_openreg)
-        self.assertFalse(cpu_tensor.is_pinned("openreg"))
+        self.assertFalse(cpu_tensor.is_pinned())
 
-        cpu_tensor_pin = cpu_tensor.pin_memory("openreg")
-        self.assertTrue(cpu_tensor_pin.is_pinned("openreg"))
+        cpu_tensor_pin = cpu_tensor.pin_memory()
+        self.assertTrue(cpu_tensor_pin.is_pinned())
 
         # Test storage pin_memory and is_pin
         cpu_storage = cpu_tensor.storage()
-        self.assertFalse(cpu_storage.is_pinned("openreg"))
+        self.assertFalse(cpu_storage.is_pinned())
 
-        cpu_storage_pinned = cpu_storage.pin_memory("openreg")
-        self.assertTrue(cpu_storage_pinned.is_pinned("openreg"))
+        cpu_storage_pinned = cpu_storage.pin_memory()
+        self.assertTrue(cpu_storage_pinned.is_pinned())
 
         # Test untyped storage pin_memory and is_pin
         cpu_tensor = torch.randn([3, 2, 1, 4])
         cpu_untyped_storage = cpu_tensor.untyped_storage()
-        self.assertFalse(cpu_untyped_storage.is_pinned("openreg"))
+        self.assertFalse(cpu_untyped_storage.is_pinned())
 
-        cpu_untyped_storage_pinned = cpu_untyped_storage.pin_memory("openreg")
-        self.assertTrue(cpu_untyped_storage_pinned.is_pinned("openreg"))
+        cpu_untyped_storage_pinned = cpu_untyped_storage.pin_memory()
+        self.assertTrue(cpu_untyped_storage_pinned.is_pinned())
 
     @unittest.skip(
         "Temporarily disable due to the tiny differences between clang++ and g++ in defining static variable in inline function"

--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -333,18 +333,18 @@ class TestCppExtensionOpenRgistration(common.TestCase):
 
         # Test storage pin_memory and is_pin
         cpu_storage = cpu_tensor.storage()
-        self.assertFalse(cpu_storage.is_pinned())
+        self.assertFalse(cpu_storage.is_pinned("openreg"))
 
-        cpu_storage_pinned = cpu_storage.pin_memory()
-        self.assertTrue(cpu_storage_pinned.is_pinned())
+        cpu_storage_pinned = cpu_storage.pin_memory("openreg")
+        self.assertTrue(cpu_storage_pinned.is_pinned("openreg"))
 
         # Test untyped storage pin_memory and is_pin
         cpu_tensor = torch.randn([3, 2, 1, 4])
         cpu_untyped_storage = cpu_tensor.untyped_storage()
-        self.assertFalse(cpu_untyped_storage.is_pinned())
+        self.assertFalse(cpu_untyped_storage.is_pinned("openreg"))
 
-        cpu_untyped_storage_pinned = cpu_untyped_storage.pin_memory()
-        self.assertTrue(cpu_untyped_storage_pinned.is_pinned())
+        cpu_untyped_storage_pinned = cpu_untyped_storage.pin_memory("openreg")
+        self.assertTrue(cpu_untyped_storage_pinned.is_pinned("openreg"))
 
     @unittest.skip(
         "Temporarily disable due to the tiny differences between clang++ and g++ in defining static variable in inline function"

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3092,17 +3092,15 @@ class TestDictDataLoader(TestCase):
             self.dataset, batch_size=2, pin_memory=True, pin_memory_device="cuda"
         )
         for sample in loader:
-            self.assertTrue(sample["a_tensor"].is_pinned(device="cuda"))
-            self.assertTrue(sample["another_dict"]["a_number"].is_pinned(device="cuda"))
+            self.assertTrue(sample["a_tensor"].is_pinned())
+            self.assertTrue(sample["another_dict"]["a_number"].is_pinned())
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_pin_memory_with_only_device(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory_device="cuda")
         for sample in loader:
-            self.assertFalse(sample["a_tensor"].is_pinned(device="cuda"))
-            self.assertFalse(
-                sample["another_dict"]["a_number"].is_pinned(device="cuda")
-            )
+            self.assertFalse(sample["a_tensor"].is_pinned())
+            self.assertFalse(sample["another_dict"]["a_number"].is_pinned())
 
 
 class DummyDataset(torch.utils.data.Dataset):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3226,7 +3226,7 @@ if __name__ == '__main__':
         RandomDataset(64, (28, 28)),
         batch_size=16,
         num_workers=2,
-        pin_memory=True if not torch.backends.mps.is_available() else False,
+        pin_memory=True,
         persistent_workers=True,
         multiprocessing_context="fork",
     )

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3226,7 +3226,7 @@ if __name__ == '__main__':
         RandomDataset(64, (28, 28)),
         batch_size=16,
         num_workers=2,
-        pin_memory=True,
+        pin_memory=True if not torch.backends.mps.is_available() else False,
         persistent_workers=True,
         multiprocessing_context="fork",
     )

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -5262,7 +5262,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
         nt_contiguous, nt_noncontiguous = random_nt_noncontiguous_pair((2, 3, 6, 7))
         for nt in [nt_contiguous, nt_noncontiguous]:
             self.assertFalse(nt.is_pinned())
-            pinned = nt.pin_memory(device)
+            pinned = nt.pin_memory()
             self.assertTrue(pinned.is_pinned())
             self.assertEqual(nt, pinned)
             self.assertNotEqual(nt.data_ptr(), pinned.data_ptr())

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2749,6 +2749,7 @@ add_docstr_all(
     "is_pinned",
     r"""
 Returns true if this tensor resides in pinned memory.
+By default, the device wrt pinned memory will be selected automatically.
 """,
 )
 
@@ -6465,6 +6466,7 @@ add_docstr_all(
 pin_memory() -> Tensor
 
 Copies the tensor to pinned memory, if it's not already pinned.
+By default, the device will be selected automatically to pin memory on.
 """,
 )
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2749,7 +2749,7 @@ add_docstr_all(
     "is_pinned",
     r"""
 Returns true if this tensor resides in pinned memory.
-By default, the device wrt pinned memory will be selected automatically.
+By default, the device pinned memory on will be the current :ref:`accelerator<accelerators>`.
 """,
 )
 
@@ -6466,7 +6466,7 @@ add_docstr_all(
 pin_memory() -> Tensor
 
 Copies the tensor to pinned memory, if it's not already pinned.
-By default, the device will be selected automatically to pin memory on.
+By default, the device pinned memory on will be the current :ref:`accelerator<accelerators>`.
 """,
 )
 

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -1229,14 +1229,12 @@ class FlatParamHandle:
         flat_param._local_shard = flat_param.data
         if self._offload_params:
             # Pin the memory for faster H2D transfer
-            flat_param._local_shard = flat_param._local_shard.pin_memory(
-                device=self.device
-            )
+            flat_param._local_shard = flat_param._local_shard.pin_memory()
             # Pre-allocate the sharded gradient on CPU to enable non-blocking
             # D2H transfer during the backward pass
             flat_param._cpu_grad = torch.zeros_like(
                 flat_param._local_shard, device=cpu_device
-            ).pin_memory(device=self.device)
+            ).pin_memory()
         if self._uses_param_mixed_precision:
             # For parameter mixed precision, we maintain a low precision
             # sharded tensor on the compute device to be all-gathered (for

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -389,7 +389,7 @@ def _pre_forward(
         if handle and handle._offload_params and handle.flat_param._cpu_grad is None:
             handle.flat_param._cpu_grad = torch.zeros_like(
                 handle.flat_param._local_shard, device=torch.device("cpu")
-            ).pin_memory(device=state.compute_device)
+            ).pin_memory()
 
         should_cast_forward_inputs = (
             state._handle and not state._handle._force_full_precision

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -355,26 +355,39 @@ class _StorageBase:
         """Casts this storage to float8_e4m3fnuz type"""
         return self._to(torch.float8_e4m3fnuz)
 
-    def is_pinned(self, device: Union[str, torch.device] = "cuda"):
+    def is_pinned(self, device: Union[None, str, torch.device] = None):
         r"""Determine whether the CPU storage is already pinned on device.
 
         Args:
-            device (str or torch.device): The device to pin memory on. Default: ``'cuda'``.
+            device (None, str or torch.device): The device to pin memory on. Default: ``None``.
+                This argument is deprecated, since the device is autoselected to pin memory on.
 
         Returns:
             A boolean variable.
         """
+        if device is not None:
+            warnings.warn(
+                "'device' argument is deprecated, please do not pass it.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            return (
+                torch.tensor([], dtype=torch.uint8, device=self.device)
+                .set_(cast(Storage, self))
+                .is_pinned(device)
+            )
         return (
             torch.tensor([], dtype=torch.uint8, device=self.device)
             .set_(cast(Storage, self))
-            .is_pinned(device)
+            .is_pinned()
         )
 
-    def pin_memory(self, device: Union[str, torch.device] = "cuda"):
+    def pin_memory(self, device: Union[None, str, torch.device] = None):
         r"""Copy the CPU storage to pinned memory, if it's not already pinned.
 
         Args:
-            device (str or torch.device): The device to pin memory on. Default: ``'cuda'``.
+            device (None, str or torch.device): The device to pin memory on. Default: ``None``.
+                This argument is deprecated, since the device is autoselected to pin memory on.
 
         Returns:
             A pinned CPU storage.
@@ -382,11 +395,23 @@ class _StorageBase:
         if self.device.type != "cpu":
             raise TypeError(f"cannot pin '{self.type()}' only CPU memory can be pinned")
 
-        pinned_tensor = (
-            torch.tensor([], dtype=torch.uint8, device=self.device)
-            .set_(cast(Storage, self))
-            .pin_memory(device)
-        )
+        if device is not None:
+            warnings.warn(
+                "'device' argument is deprecated, please do not pass it.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            pinned_tensor = (
+                torch.tensor([], dtype=torch.uint8, device=self.device)
+                .set_(cast(Storage, self))
+                .pin_memory(device)
+            )
+        else:
+            pinned_tensor = (
+                torch.tensor([], dtype=torch.uint8, device=self.device)
+                .set_(cast(Storage, self))
+                .pin_memory()
+            )
         return pinned_tensor.untyped_storage()
 
     def share_memory_(self):
@@ -1154,31 +1179,47 @@ class TypedStorage:
         _warn_typed_storage_removal()
         return self._new_wrapped_storage(self._untyped_storage.cpu())
 
-    def is_pinned(self, device: Union[str, torch.device] = "cuda"):
+    def is_pinned(self, device: Union[None, str, torch.device] = None):
         r"""Determine whether the CPU TypedStorage is already pinned on device.
 
         Args:
-            device (str or torch.device): The device to pin memory on. Default: ``'cuda'``
+            device (None, str or torch.device): The device to pin memory on. Default: ``None``
+                This argument is deprecated, since the device is autoselected to pin memory on.
 
         Returns:
             A boolean variable.
         """
         _warn_typed_storage_removal()
-        return self._untyped_storage.is_pinned(device)
+        if device is not None:
+            warnings.warn(
+                "'device' argument is deprecated, please do not pass it.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            return self._untyped_storage.is_pinned(device)
+        return self._untyped_storage.is_pinned()
 
-    def pin_memory(self, device: Union[str, torch.device] = "cuda"):
+    def pin_memory(self, device: Union[None, str, torch.device] = None):
         r"""Copy the CPU TypedStorage to pinned memory, if it's not already pinned.
 
         Args:
-            device (str or torch.device): The device to pin memory on. Default: ``'cuda'``.
+            device (None, str or torch.device): The device to pin memory on. Default: ``None``.
+                This argument is deprecated, since the device is autoselected to pin memory on.
 
         Returns:
             A pinned CPU storage.
         """
         _warn_typed_storage_removal()
-        return self._new_wrapped_storage(
-            self._untyped_storage.pin_memory(device=device)
-        )
+        if device is not None:
+            warnings.warn(
+                "'device' argument is deprecated, please do not pass it.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            return self._new_wrapped_storage(
+                self._untyped_storage.pin_memory(device=device)
+            )
+        return self._new_wrapped_storage(self._untyped_storage.pin_memory())
 
     def share_memory_(self):
         """See :meth:`torch.UntypedStorage.share_memory_`"""

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -355,39 +355,28 @@ class _StorageBase:
         """Casts this storage to float8_e4m3fnuz type"""
         return self._to(torch.float8_e4m3fnuz)
 
-    def is_pinned(self, device: Union[None, str, torch.device] = None):
+    def is_pinned(self, device: Union[str, torch.device] = "cuda"):
         r"""Determine whether the CPU storage is already pinned on device.
 
         Args:
-            device (None, str or torch.device): The device to pin memory on. Default: ``None``.
-                This argument is deprecated, since the device is autoselected to pin memory on.
+            device (str or torch.device): The device to pin memory on (default: ``'cuda'``).
+                This argument is discouraged and subject to deprecated.
 
         Returns:
             A boolean variable.
         """
-        if device is not None:
-            warnings.warn(
-                "'device' argument is deprecated, please do not pass it.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            return (
-                torch.tensor([], dtype=torch.uint8, device=self.device)
-                .set_(cast(Storage, self))
-                .is_pinned(device)
-            )
         return (
             torch.tensor([], dtype=torch.uint8, device=self.device)
             .set_(cast(Storage, self))
-            .is_pinned()
+            .is_pinned(device)
         )
 
-    def pin_memory(self, device: Union[None, str, torch.device] = None):
+    def pin_memory(self, device: Union[str, torch.device] = "cuda"):
         r"""Copy the CPU storage to pinned memory, if it's not already pinned.
 
         Args:
-            device (None, str or torch.device): The device to pin memory on. Default: ``None``.
-                This argument is deprecated, since the device is autoselected to pin memory on.
+            device (str or torch.device): The device to pin memory on (default: ``'cuda'``).
+                This argument is discouraged and subject to deprecated.
 
         Returns:
             A pinned CPU storage.
@@ -395,23 +384,11 @@ class _StorageBase:
         if self.device.type != "cpu":
             raise TypeError(f"cannot pin '{self.type()}' only CPU memory can be pinned")
 
-        if device is not None:
-            warnings.warn(
-                "'device' argument is deprecated, please do not pass it.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            pinned_tensor = (
-                torch.tensor([], dtype=torch.uint8, device=self.device)
-                .set_(cast(Storage, self))
-                .pin_memory(device)
-            )
-        else:
-            pinned_tensor = (
-                torch.tensor([], dtype=torch.uint8, device=self.device)
-                .set_(cast(Storage, self))
-                .pin_memory()
-            )
+        pinned_tensor = (
+            torch.tensor([], dtype=torch.uint8, device=self.device)
+            .set_(cast(Storage, self))
+            .pin_memory(device)
+        )
         return pinned_tensor.untyped_storage()
 
     def share_memory_(self):
@@ -1179,47 +1156,33 @@ class TypedStorage:
         _warn_typed_storage_removal()
         return self._new_wrapped_storage(self._untyped_storage.cpu())
 
-    def is_pinned(self, device: Union[None, str, torch.device] = None):
+    def is_pinned(self, device: Union[str, torch.device] = "cuda"):
         r"""Determine whether the CPU TypedStorage is already pinned on device.
 
         Args:
-            device (None, str or torch.device): The device to pin memory on. Default: ``None``
-                This argument is deprecated, since the device is autoselected to pin memory on.
+            device (str or torch.device): The device to pin memory on (default: ``'cuda'``).
+                This argument is discouraged and subject to deprecated.
 
         Returns:
             A boolean variable.
         """
         _warn_typed_storage_removal()
-        if device is not None:
-            warnings.warn(
-                "'device' argument is deprecated, please do not pass it.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            return self._untyped_storage.is_pinned(device)
-        return self._untyped_storage.is_pinned()
+        return self._untyped_storage.is_pinned(device)
 
-    def pin_memory(self, device: Union[None, str, torch.device] = None):
+    def pin_memory(self, device: Union[str, torch.device] = "cuda"):
         r"""Copy the CPU TypedStorage to pinned memory, if it's not already pinned.
 
         Args:
-            device (None, str or torch.device): The device to pin memory on. Default: ``None``.
-                This argument is deprecated, since the device is autoselected to pin memory on.
+            device (str or torch.device): The device to pin memory on (default: ``'cuda'``).
+                This argument is discouraged and subject to deprecated.
 
         Returns:
             A pinned CPU storage.
         """
         _warn_typed_storage_removal()
-        if device is not None:
-            warnings.warn(
-                "'device' argument is deprecated, please do not pass it.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            return self._new_wrapped_storage(
-                self._untyped_storage.pin_memory(device=device)
-            )
-        return self._new_wrapped_storage(self._untyped_storage.pin_memory())
+        return self._new_wrapped_storage(
+            self._untyped_storage.pin_memory(device=device)
+        )
 
     def share_memory_(self):
         """See :meth:`torch.UntypedStorage.share_memory_`"""

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -30,7 +30,7 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
         custom_device_mod = getattr(torch, torch._C._get_privateuse1_backend_name())
         custom_device_mod.set_device(device_id)
     elif device is None:
-        torch._C._accelerator_hooks_set_current_device(device_id)
+        torch.accelerator.set_device_idx(device_id)
 
     def do_one_step():
         try:

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -15,20 +15,14 @@ from torch._utils import ExceptionWrapper
 from . import MP_STATUS_CHECK_INTERVAL
 
 
-def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
+def _pin_memory_loop(in_queue, out_queue, device_id, done_event):
     # This setting is thread local, and prevents the copy in pin_memory from
     # consuming all CPU cores.
     torch.set_num_threads(1)
 
     torch.multiprocessing._set_thread_name("pt_data_pin")
 
-    if device == "cuda":
-        torch.cuda.set_device(device_id)
-    elif device == "xpu":
-        torch.xpu.set_device(device_id)  # type: ignore[attr-defined]
-    elif device == torch._C._get_privateuse1_backend_name():
-        custom_device_mod = getattr(torch, torch._C._get_privateuse1_backend_name())
-        custom_device_mod.set_device(device_id)
+    torch._C._accelerator_hooks_set_current_device(device_id)
 
     def do_one_step():
         try:
@@ -38,7 +32,7 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
         idx, data = r
         if not done_event.is_set() and not isinstance(data, ExceptionWrapper):
             try:
-                data = pin_memory(data, device)
+                data = pin_memory(data)
             except Exception:
                 data = ExceptionWrapper(
                     where=f"in pin memory thread for device {device_id}"
@@ -59,9 +53,9 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
         do_one_step()
 
 
-def pin_memory(data, device=None):
+def pin_memory(data):
     if isinstance(data, torch.Tensor):
-        return data.pin_memory(device)
+        return data.pin_memory()
     elif isinstance(data, (str, bytes)):
         return data
     elif isinstance(data, collections.abc.Mapping):
@@ -71,22 +65,18 @@ def pin_memory(data, device=None):
                 # use `type(data)(...)` to create the new sequence.
                 # Create a clone and update it if the sequence type is mutable.
                 clone = copy.copy(data)
-                clone.update(
-                    {k: pin_memory(sample, device) for k, sample in data.items()}
-                )
+                clone.update({k: pin_memory(sample) for k, sample in data.items()})
                 return clone
             else:
-                return type(data)({k: pin_memory(sample, device) for k, sample in data.items()})  # type: ignore[call-arg]
+                return type(data)({k: pin_memory(sample) for k, sample in data.items()})  # type: ignore[call-arg]
         except TypeError:
             # The mapping type may not support `copy()` / `update(mapping)`
             # or `__init__(iterable)`.
-            return {k: pin_memory(sample, device) for k, sample in data.items()}
+            return {k: pin_memory(sample) for k, sample in data.items()}
     elif isinstance(data, tuple) and hasattr(data, "_fields"):  # namedtuple
-        return type(data)(*(pin_memory(sample, device) for sample in data))
+        return type(data)(*(pin_memory(sample) for sample in data))
     elif isinstance(data, tuple):
-        return [
-            pin_memory(sample, device) for sample in data
-        ]  # Backwards compatibility.
+        return [pin_memory(sample) for sample in data]  # Backwards compatibility.
     elif isinstance(data, collections.abc.Sequence):
         try:
             if isinstance(data, collections.abc.MutableSequence):
@@ -95,13 +85,13 @@ def pin_memory(data, device=None):
                 # Create a clone and update it if the sequence type is mutable.
                 clone = copy.copy(data)  # type: ignore[arg-type]
                 for i, item in enumerate(data):
-                    clone[i] = pin_memory(item, device)
+                    clone[i] = pin_memory(item)
                 return clone
-            return type(data)([pin_memory(sample, device) for sample in data])  # type: ignore[call-arg]
+            return type(data)([pin_memory(sample) for sample in data])  # type: ignore[call-arg]
         except TypeError:
             # The sequence type may not support `copy()` / `__setitem__(index, item)`
             # or `__init__(iterable)` (e.g., `range`).
-            return [pin_memory(sample, device) for sample in data]
+            return [pin_memory(sample) for sample in data]
     elif hasattr(data, "pin_memory"):
         return data.pin_memory()
     else:

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -30,7 +30,7 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
         custom_device_mod = getattr(torch, torch._C._get_privateuse1_backend_name())
         custom_device_mod.set_device(device_id)
     elif device is None:
-        torch.accelerator.set_device_idx(device_id)
+        torch.accelerator.set_device_index(device_id)
 
     def do_one_step():
         try:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -1172,7 +1172,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                 )
                 current_device = custom_device_mod.current_device()
             elif self._pin_memory_device is None:
-                current_device = torch.accelerator.current_device_idx()
+                current_device = torch.accelerator.current_device_index()
             pin_memory_thread = threading.Thread(
                 target=_utils.pin_memory._pin_memory_loop,
                 args=(

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -183,8 +183,9 @@ class DataLoader(Generic[_T_co]):
         persistent_workers (bool, optional): If ``True``, the data loader will not shut down
             the worker processes after a dataset has been consumed once. This allows to
             maintain the workers `Dataset` instances alive. (default: ``False``)
-        pin_memory_device (str, optional): the device to :attr:`pin_memory` to if ``pin_memory`` is
-            ``True``.
+        pin_memory_device (str, optional): the device to :attr:`pin_memory` on if ``pin_memory`` is
+            ``True``. This argument is deprecated and will be ignored, since the device to
+            ``pin_memory`` on is selected automatically now.
         in_order (bool, optional): If ``False``, the data loader will not enforce that batches
             are returned in a first-in, first-out order. Only applies when ``num_workers > 0``. (default: ``True``)
 
@@ -279,11 +280,18 @@ class DataLoader(Generic[_T_co]):
         if persistent_workers and num_workers == 0:
             raise ValueError("persistent_workers option needs num_workers > 0")
 
+        if len(pin_memory_device) != 0:
+            warnings.warn(
+                "'pin_memory_device' argument is deprecated and "
+                "this arg will be ignored. Please do not pass it.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
         self.dataset = dataset
         self.num_workers = num_workers
         self.prefetch_factor = prefetch_factor
         self.pin_memory = pin_memory
-        self.pin_memory_device = pin_memory_device
         self.timeout = timeout
         self.worker_init_fn = worker_init_fn
         self.multiprocessing_context = multiprocessing_context
@@ -651,22 +659,14 @@ class _BaseDataLoaderIter:
         ws, rank = _get_distributed_settings()
         self._world_size = ws
         self._rank = rank
-        # for other backends, pin_memory_device need to set. if not set
-        # default behaviour is CUDA device. if pin_memory_device is selected
-        # and pin_memory is not set, the default behaviour false.
-        if len(loader.pin_memory_device) == 0:
-            self._pin_memory = loader.pin_memory and torch.cuda.is_available()
-            self._pin_memory_device = None
-        else:
-            if not loader.pin_memory:
-                warn_msg = (
-                    "pin memory device is set and pin_memory flag is not used then device pinned memory won't be used"
-                    "please set pin_memory to true, if you need to use the device pin memory"
-                )
-                warnings.warn(warn_msg)
-
-            self._pin_memory = loader.pin_memory
-            self._pin_memory_device = loader.pin_memory_device
+        self._pin_memory = loader.pin_memory
+        if loader.pin_memory and torch._C._get_accelerator() == torch.device("cpu"):
+            warn_msg = (
+                "'pin_memory' argument is set as true but no accelerator is found, "
+                "then device pinned memory won't be used."
+            )
+            warnings.warn(warn_msg)
+            self._pin_memory = False
         self._timeout = loader.timeout
         self._collate_fn = loader.collate_fn
         self._sampler_iter = iter(self._index_sampler)
@@ -763,7 +763,7 @@ class _SingleProcessDataLoaderIter(_BaseDataLoaderIter):
         index = self._next_index()  # may raise StopIteration
         data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
         if self._pin_memory:
-            data = _utils.pin_memory.pin_memory(data, self._pin_memory_device)
+            data = _utils.pin_memory.pin_memory(data)
         return data
 
 
@@ -1152,15 +1152,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
 
             # Queue is not type-annotated
             self._data_queue = queue.Queue()  # type: ignore[var-annotated]
-            if self._pin_memory_device == "xpu":
-                current_device = torch.xpu.current_device()  # type: ignore[attr-defined]
-            elif self._pin_memory_device == torch._C._get_privateuse1_backend_name():
-                custom_device_mod = getattr(
-                    torch, torch._C._get_privateuse1_backend_name()
-                )
-                current_device = custom_device_mod.current_device()
-            else:
-                current_device = torch.cuda.current_device()  # choose cuda for default
+            current_device = torch._C._accelerator_hooks_get_current_device()
             pin_memory_thread = threading.Thread(
                 target=_utils.pin_memory._pin_memory_loop,
                 args=(
@@ -1168,7 +1160,6 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                     self._data_queue,
                     current_device,
                     self._pin_memory_thread_done_event,
-                    self._pin_memory_device,
                 ),
             )
             pin_memory_thread.daemon = True


### PR DESCRIPTION
Based on https://github.com/pytorch/pytorch/pull/126376, this PR tries to update all PT callers (e.g., `Tensor.is_pinned()`, `Tensor.pin_memory()`) to not pass `device` argument. 
As for `storage/untyped_storage.is_pinned()/pin_memory()`, we keep the `device` argument but passing `device` is discouraged. And if not given, the default `device` is still 'cuda' for BC.
Additionally, based on device-agnostic pin_memory, `pin_memory_device` argument of `torch.utils.data.DataLoader` is discouraged  now. For BC, explictly passing this argument is still effective. If not given, the default `device` will be the current accelerator.

Fixes #124908 
Relates https://github.com/pytorch/pytorch/pull/126376

cc: @albanD 


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o