### PR TITLE
[aoti] Rename OSS DynamicArg and OpKernel

### DIFF
--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -16,7 +16,7 @@ void OSSProxyExecutor::prefill_stack_with_static_arguments(
     int index,
     at::TypePtr schema_arg_type,
     const nlohmann::json& serialized_arg,
-    OpKernel& op_kernel) {
+    OSSOpKernel& op_kernel) {
   auto& stack = op_kernel.stack_;
   auto& dynamic_args = op_kernel.dynamic_args_;
 
@@ -42,7 +42,7 @@ void OSSProxyExecutor::prefill_stack_with_static_arguments(
 void OSSProxyExecutor::get_input_info_from_serialized(
     const std::vector<c10::Argument>& schema_args,
     const nlohmann::json& serialized_node,
-    OpKernel& op_kernel) {
+    OSSOpKernel& op_kernel) {
   int index = 0;
   for (const auto& named_argument : serialized_node["inputs"]) {
     const auto& arg = named_argument["arg"];
@@ -59,8 +59,8 @@ void OSSProxyExecutor::get_input_info_from_serialized(
 void OSSProxyExecutor::get_output_info_from_serialized(
     const std::vector<c10::Argument>& schema_returns,
     const nlohmann::json& serialized_node,
-    OpKernel& op_kernel) {
-  std::vector<DynamicArg>& outputs = op_kernel.outputs_;
+    OSSOpKernel& op_kernel) {
+  std::vector<OSSDynamicArg>& outputs = op_kernel.outputs_;
 
   TORCH_CHECK(
       schema_returns.size() == serialized_node["outputs"].size(),
@@ -165,7 +165,7 @@ OSSProxyExecutor::OSSProxyExecutor(const std::string& json_path, bool is_cpu) {
     const auto& schema_args = schema.arguments();
     const auto& schema_returns = schema.returns();
 
-    OpKernel op_kernel(target, op_handle);
+    OSSOpKernel op_kernel(target, op_handle);
     get_input_info_from_serialized(schema_args, serialized_node, op_kernel);
     get_output_info_from_serialized(schema_returns, serialized_node, op_kernel);
 
@@ -182,7 +182,7 @@ void OSSProxyExecutor::call_function(
   TORCH_CHECK(
       extern_node_index < static_cast<int>(op_kernels_.size()),
       "Invalid extern node index");
-  OpKernel& op_kernel = op_kernels_[extern_node_index];
+  OSSOpKernel& op_kernel = op_kernels_[extern_node_index];
 
   std::vector<c10::IValue> stack = op_kernel.stack_;
   auto& dynamic_args = op_kernel.dynamic_args_;

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
@@ -29,8 +29,8 @@ inline bool isTensorType(DynamicArgType arg_type) {
       arg_type == DynamicArgType::ListOptionalTensorType;
 }
 
-struct DynamicArg {
-  DynamicArg(
+struct OSSDynamicArg {
+  OSSDynamicArg(
       int arg_index,
       DynamicArgType arg_type,
       int length,
@@ -45,14 +45,14 @@ struct DynamicArg {
   nlohmann::json serialized_arg_val;
 };
 
-struct OpKernel {
-  OpKernel(const std::string& target, const c10::OperatorHandle& op_handle)
+struct OSSOpKernel {
+  OSSOpKernel(const std::string& target, const c10::OperatorHandle& op_handle)
       : target_(target), op_handle_(op_handle) {}
 
   std::string target_;
   c10::OperatorHandle op_handle_;
-  std::vector<DynamicArg> dynamic_args_;
-  std::vector<DynamicArg> outputs_;
+  std::vector<OSSDynamicArg> dynamic_args_;
+  std::vector<OSSDynamicArg> outputs_;
   std::vector<c10::IValue> stack_;
 
   int num_output_tensors() const {
@@ -82,19 +82,19 @@ class OSSProxyExecutor : public ProxyExecutor {
       int index,
       at::TypePtr schema_arg_type,
       const nlohmann::json& thrift_arg,
-      OpKernel& op_kernel);
+      OSSOpKernel& op_kernel);
 
   void get_input_info_from_serialized(
       const std::vector<c10::Argument>& schema_args,
       const nlohmann::json& serialized_node,
-      OpKernel& op_kernel);
+      OSSOpKernel& op_kernel);
 
   void get_output_info_from_serialized(
       const std::vector<c10::Argument>& schema_returns,
       const nlohmann::json& serialized_node,
-      OpKernel& op_kernel);
+      OSSOpKernel& op_kernel);
 
-  std::vector<OpKernel> op_kernels_;
+  std::vector<OSSOpKernel> op_kernels_;
   std::unique_ptr<c10::Device> device_;
 };
 


### PR DESCRIPTION
Summary: Fixing P1495466240 which I think is due to the fact that internal also has an "OpKernel" in the same namespace, using thrift instead of json.

Test Plan: https://www.internalfb.com/intern/testinfra/testrun/4785074844896831

Differential Revision: D60273354
