### PR TITLE
[PT2][Optimus] Optimize cat node inputs pattern

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -1127,14 +1127,90 @@ class TestSplitCatFxPasses(TestCase):
             )
             return torch.cat((output, cat), dim=0)
 
+        @torch._inductor.config.patch(
+            pre_grad_fusion_options={
+                "optimize_cat_inputs_pass": {},
+            },
+            post_grad_fusion_options={},
+        )
+        def optimize_cat_inputs(x):
+            x_c = x.clone()
+            x_c_2 = x.clone()
+            l1_out = torch.split(x, [50, 50, 50, 50, 50, 50, 50, 50, 50, 50], dim=0)
+            l2_out = torch.split(x_c, [50, 50, 50, 50, 50, 50, 50, 50, 50, 50], dim=0)
+            l3_out = torch.split(x_c_2, [100, 100, 100, 100, 100], dim=0)
+            item0 = l1_out[0]
+            item1 = l1_out[1]
+            item2 = l1_out[2]
+            item3 = l1_out[3]
+            item4 = l1_out[4]
+            item5 = l1_out[5]
+            item6 = l1_out[6]
+            item7 = l1_out[7]
+            item8 = l1_out[8]
+            item9 = l1_out[9]
+            item0_c = l2_out[0]
+            item1_c = l2_out[1]
+            item2_c = l2_out[2]
+            item3_c = l2_out[3]
+            item4_c = l2_out[4]
+            item5_c = l2_out[5]
+            item6_c = l2_out[6]
+            item7_c = l2_out[7]
+            item8_c = l2_out[8]
+            item9_c = l2_out[9]
+            item0_c_2 = l3_out[0]
+            item1_c_2 = l3_out[1]
+            item2_c_2 = l3_out[2]
+            item3_c_2 = l3_out[3]
+            item4_c_2 = l3_out[4]
+            other = item0.clone()
+            return torch.cat(
+                [
+                    other,
+                    item0,
+                    item1,
+                    item2,
+                    item3,
+                    item4,
+                    item5,
+                    item6,
+                    item7,
+                    item8,
+                    item9,
+                    item4_c,
+                    item5_c,
+                    item6_c,
+                    item7_c,
+                    item8_c,
+                    item9_c,
+                    item0_c,
+                    item1_c,
+                    item2_c,
+                    item3_c,
+                    item0_c_2,
+                    item1_c_2,
+                    item2_c_2,
+                    item3_c_2,
+                    item4_c_2,
+                ],
+                dim=0,
+            )
+
         args = [
             torch.randn(500, 500),
         ]
-        for fn, expected_getitem_cat_merged, expected_cat_removed in [
-            (split_cat_split, 2, 0),
-            (split_cat_split_kwarg, 2, 0),
-            (remove_cat_node_with_all_getitmes, 0, 2),
-            (mutate_cat_node_with_some_getitmes, 0, 1),
+        for (
+            fn,
+            expected_getitem_cat_merged,
+            expected_cat_removed,
+            expected_cat_optimized,
+        ) in [
+            (split_cat_split, 2, 0, 0),
+            (split_cat_split_kwarg, 2, 0, 0),
+            (remove_cat_node_with_all_getitmes, 0, 2, 0),
+            (mutate_cat_node_with_some_getitmes, 0, 1, 0),
+            (optimize_cat_inputs, 0, 0, 1),
         ]:
             expected = fn(*args)
             actual = torch.compile(fn)(*args)
@@ -1147,6 +1223,10 @@ class TestSplitCatFxPasses(TestCase):
             self.assertEqual(
                 counters["inductor"]["mutate_cat_pass"],
                 expected_cat_removed,
+            )
+            self.assertEqual(
+                counters["inductor"]["optimize_cat_inputs_pass"],
+                expected_cat_optimized,
             )
             counters.clear()
 


### PR DESCRIPTION
Test Plan:
# unit test
```
buck2 test 'fbcode//mode/dev-nosan' fbcode//caffe2/test/inductor:split_cat_fx_passes
```

# benchmark

```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "ig_ctr" --flow_id 584880697
```

Counter({'pattern_matcher_nodes': 1589, 'pattern_matcher_count': 1497, 'extern_calls': 393, 'normalization_pass': 342, 'merge_splits_pass': 19, 'fxgraph_cache_miss': 12, 'scmerge_cat_added': 4, 'scmerge_cat_removed': 4, 'scmerge_split_removed': 3, 'unbind_stack_pass': 3, 'batch_tanh': 2, 'scmerge_split_sections_removed': 2, 'scmerge_split_added': 2, 'merge_stack_tahn_unbind_pass': 1, 'optimize_cat_inputs_pass': 1})

P1496150856

Differential Revision: D60274533


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang