### PR TITLE
[cpu] add more VecConvert for 8bits

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -159,24 +159,6 @@ struct VecConvert<int16_t, 1, uint8_t, 1> {
   }
 };
 
-template <>
-struct VecConvert<float, 1, uint8_t, 1> {
-  static inline VectorizedN<float, 1> apply(
-      const VectorizedN<uint8_t, 1>& src) {
-    return VecConvert<float, 1, int32_t, 1>::apply(
-        VecConvert<int32_t, 1, uint8_t, 1>::apply(src));
-  }
-};
-
-template <>
-struct VecConvert<int8_t, 1, float, 1> {
-  static inline VectorizedN<int8_t, 1> apply(
-      const VectorizedN<float, 1>& src) {
-    return VecConvert<int8_t, 1, int32_t, 1>::apply(
-        VecConvert<int32_t, 1, float, 1>::apply(src));
-  }
-};
-
 template <typename dst_t, typename src_t>
 struct VecConvert<
     dst_t,

--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -169,24 +169,6 @@ struct VecConvert<float, 1, uint8_t, 1> {
 };
 
 template <>
-struct VecConvert<int8_t, 1, int32_t, 1> {
-  static inline VectorizedN<int8_t, 1> apply(
-      const VectorizedN<int32_t, 1>& src) {
-    auto src128 = _mm256_cvtepi32_epi8(src[0]);
-    return Vectorized<int8_t>(_mm256_castsi128_si256(src128));
-  }
-};
-
-template <>
-struct VecConvert<int8_t, 1, int16_t, 1> {
-  static inline VectorizedN<int8_t, 1> apply(
-      const VectorizedN<int16_t, 1>& src) {
-    auto src128 = _mm256_cvtepi16_epi8(src[0]);
-    return Vectorized<int8_t>(_mm256_castsi128_si256(src128));
-  }
-};
-
-template <>
 struct VecConvert<int8_t, 1, float, 1> {
   static inline VectorizedN<int8_t, 1> apply(
       const VectorizedN<float, 1>& src) {

--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -133,6 +133,68 @@ struct VecConvert<int32_t, 1, uint8_t, 1> {
   }
 };
 
+
+template <>
+struct VecConvert<int32_t, 1, float, 1> {
+  static inline VectorizedN<int32_t, 1> apply(
+      const VectorizedN<float, 1>& src) {
+    return  Vectorized<int32_t>(_mm256_cvttps_epi32(src[0]));
+  }
+};
+
+template <>
+struct VecConvert<float, 1, int32_t, 1> {
+  static inline VectorizedN<float, 1> apply(
+      const VectorizedN<int32_t, 1>& src) {
+    return  Vectorized<float>(_mm256_cvtepi32_ps(src[0]));
+  }
+};
+
+template <>
+struct VecConvert<int16_t, 1, uint8_t, 1> {
+  static inline VectorizedN<int16_t, 1> apply(
+      const VectorizedN<uint8_t, 1>& src) {
+    auto src128 = _mm256_castsi256_si128(src[0]);
+    return Vectorized<int16_t>(_mm256_cvtepu8_epi16(src128));
+  }
+};
+
+template <>
+struct VecConvert<float, 1, uint8_t, 1> {
+  static inline VectorizedN<float, 1> apply(
+      const VectorizedN<uint8_t, 1>& src) {
+    return VecConvert<float, 1, int32_t, 1>::apply(
+        VecConvert<int32_t, 1, uint8_t, 1>::apply(src));
+  }
+};
+
+template <>
+struct VecConvert<int8_t, 1, int32_t, 1> {
+  static inline VectorizedN<int8_t, 1> apply(
+      const VectorizedN<int32_t, 1>& src) {
+    auto src128 = _mm256_cvtepi32_epi8(src[0]);
+    return Vectorized<int8_t>(_mm256_castsi128_si256(src128));
+  }
+};
+
+template <>
+struct VecConvert<int8_t, 1, int16_t, 1> {
+  static inline VectorizedN<int8_t, 1> apply(
+      const VectorizedN<int16_t, 1>& src) {
+    auto src128 = _mm256_cvtepi16_epi8(src[0]);
+    return Vectorized<int8_t>(_mm256_castsi128_si256(src128));
+  }
+};
+
+template <>
+struct VecConvert<int8_t, 1, float, 1> {
+  static inline VectorizedN<int8_t, 1> apply(
+      const VectorizedN<float, 1>& src) {
+    return VecConvert<int8_t, 1, int32_t, 1>::apply(
+        VecConvert<int32_t, 1, float, 1>::apply(src));
+  }
+};
+
 template <typename dst_t, typename src_t>
 struct VecConvert<
     dst_t,

--- a/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
@@ -143,15 +143,6 @@ struct VecConvert<int16_t, 1, uint8_t, 1> {
 };
 
 template <>
-struct VecConvert<float, 1, uint8_t, 1> {
-  static inline VectorizedN<float, 1> apply(
-      const VectorizedN<uint8_t, 1>& src) {
-    return VecConvert<float, 1, int32_t, 1>::apply(
-        VecConvert<int32_t, 1, uint8_t, 1>::apply(src));
-  }
-};
-
-template <>
 struct VecConvert<int8_t, 1, int32_t, 1> {
   static inline VectorizedN<int8_t, 1> apply(
       const VectorizedN<int32_t, 1>& src) {
@@ -166,15 +157,6 @@ struct VecConvert<int8_t, 1, int16_t, 1> {
       const VectorizedN<int16_t, 1>& src) {
     auto src256 = _mm512_cvtepi16_epi8(src[0]);
     return Vectorized<int8_t>(_mm512_castsi256_si512(src256));
-  }
-};
-
-template <>
-struct VecConvert<int8_t, 1, float, 1> {
-  static inline VectorizedN<int8_t, 1> apply(
-      const VectorizedN<float, 1>& src) {
-    return VecConvert<int8_t, 1, int32_t, 1>::apply(
-        VecConvert<int32_t, 1, float, 1>::apply(src));
   }
 };
 

--- a/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_convert.h
@@ -117,6 +117,67 @@ struct VecConvert<int32_t, 1, uint8_t, 1> {
   }
 };
 
+template <>
+struct VecConvert<int32_t, 1, float, 1> {
+  static inline VectorizedN<int32_t, 1> apply(
+      const VectorizedN<float, 1>& src) {
+    return  Vectorized<int32_t>(_mm512_cvttps_epi32(src[0]));
+  }
+};
+
+template <>
+struct VecConvert<float, 1, int32_t, 1> {
+  static inline VectorizedN<float, 1> apply(
+      const VectorizedN<int32_t, 1>& src) {
+    return  Vectorized<float>(_mm512_cvtepi32_ps(src[0]));
+  }
+};
+
+template <>
+struct VecConvert<int16_t, 1, uint8_t, 1> {
+  static inline VectorizedN<int16_t, 1> apply(
+      const VectorizedN<uint8_t, 1>& src) {
+    auto src256 = _mm512_castsi512_si256(src[0]);
+    return Vectorized<int16_t>(_mm512_cvtepu8_epi16(src256));
+  }
+};
+
+template <>
+struct VecConvert<float, 1, uint8_t, 1> {
+  static inline VectorizedN<float, 1> apply(
+      const VectorizedN<uint8_t, 1>& src) {
+    return VecConvert<float, 1, int32_t, 1>::apply(
+        VecConvert<int32_t, 1, uint8_t, 1>::apply(src));
+  }
+};
+
+template <>
+struct VecConvert<int8_t, 1, int32_t, 1> {
+  static inline VectorizedN<int8_t, 1> apply(
+      const VectorizedN<int32_t, 1>& src) {
+    auto src128 = _mm512_cvtepi32_epi8(src[0]);
+    return Vectorized<int8_t>(_mm512_castsi128_si512(src128));
+  }
+};
+
+template <>
+struct VecConvert<int8_t, 1, int16_t, 1> {
+  static inline VectorizedN<int8_t, 1> apply(
+      const VectorizedN<int16_t, 1>& src) {
+    auto src256 = _mm512_cvtepi16_epi8(src[0]);
+    return Vectorized<int8_t>(_mm512_castsi256_si512(src256));
+  }
+};
+
+template <>
+struct VecConvert<int8_t, 1, float, 1> {
+  static inline VectorizedN<int8_t, 1> apply(
+      const VectorizedN<float, 1>& src) {
+    return VecConvert<int8_t, 1, int32_t, 1>::apply(
+        VecConvert<int32_t, 1, float, 1>::apply(src));
+  }
+};
+
 template <typename dst_t, typename src_t>
 struct VecConvert<
     dst_t,


### PR DESCRIPTION
Adds more intrinsic specializations for 8bits conversions, in order to speed up bit8 SDPA in the future.
- u8 -> i16
- i32 -> f32
- f32 -> i32
- i32 -> i8 (only add vec512 cause lack of avx512vl for vec256)
- i16 -> i8 (only add vec512 cause lack of avx512vl for vec256)


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10