### PR TITLE
Change signature of CompilerFn for register_backend decorator

### DIFF
--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -2,7 +2,7 @@
 
 import functools
 import sys
-from typing import Callable, Dict, List, Optional, Protocol, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Protocol, Sequence, Tuple, Union
 
 import torch
 from torch import fx
@@ -13,7 +13,7 @@ class CompiledFn(Protocol):
         ...
 
 
-CompilerFn = Callable[[fx.GraphModule, List[torch.Tensor]], CompiledFn]
+CompilerFn = Callable[[fx.GraphModule, List[torch.Tensor], Optional[Union[str, dict]]], CompiledFn]
 
 _BACKENDS: Dict[str, CompilerFn] = {}
 


### PR DESCRIPTION
## Description
Add `...` to show that CompilerFn for custom backend could take additional options

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec @jansel @Xia-Weiwen @aakhundov

Re: Recreated closed PR https://github.com/pytorch/pytorch/pull/110006