### PR TITLE
docs(multinomial): Add reference to `Multinomial` class

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7838,7 +7838,7 @@ multinomial(input, num_samples, replacement=False, *, generator=None, out=None) 
 
 Returns a tensor where each row contains :attr:`num_samples` indices sampled
 from the multinomial (a stricter definition would be multivariate,
-refer to torch.distributions.multinomial.Multinomial for more details)
+refer to :class:`torch.distributions.multinomial.Multinomial` for more details)
 probability distribution located in the corresponding row
 of tensor :attr:`input`.
 


### PR DESCRIPTION
This PR just adds the reference to the class
`torch.distributions.multinomial.Multinomial` in `torch.multinomial`.
