### PR TITLE
[export] Convert autocast to HOO

### DIFF
--- a/torch/_export/passes/replace_autocast_with_hop_pass.py
+++ b/torch/_export/passes/replace_autocast_with_hop_pass.py
@@ -1,0 +1,202 @@
+# mypy: allow-untyped-defs
+import contextlib
+import copy
+
+from typing import List
+
+import torch
+from torch._higher_order_ops.wrap import wrap_with_autocast
+
+from ..utils import node_inline_, nodes_filter, nodes_first, nodes_map, sequential_split
+
+from .replace_with_hop_pass_util import _replace_with_hop_helper
+
+
+def _is_autocast_node(node: torch.fx.Node):
+    return (
+        node
+        and node.op == "call_function"
+        and node.target
+        in [
+            torch.amp.autocast_mode._enter_autocast,
+            torch.amp.autocast_mode._exit_autocast,
+        ]
+    )
+
+
+def _is_enter_autocast_node(node: torch.fx.Node):
+    return (
+        node
+        and node.op == "call_function"
+        and node.target == torch.amp.autocast_mode._enter_autocast
+    )
+
+
+def _is_exit_autocast_node(node: torch.fx.Node):
+    return (
+        node
+        and node.op == "call_function"
+        and node.target == torch.amp.autocast_mode._exit_autocast
+    )
+
+
+def _is_autocast_sub_mod(node: torch.fx.Node):
+    """
+    Check if the first non-placeholder node is `torch.amp.autocast_mode._enter_autocast`.
+    """
+    if node.op == "call_module":
+        assert isinstance(node.target, str)
+        subgm = getattr(node.graph.owning_module, node.target)
+        first_non_ph = nodes_first(
+            subgm.graph.nodes, lambda node: node.op != "placeholder"
+        )
+        if (
+            first_non_ph
+            and first_non_ph.op == "call_function"
+            and first_non_ph.target == torch.amp.autocast_mode._enter_autocast
+        ):
+            # TODO: check if current auto-cast type is the same as the args of
+            # _enter_autocast. If so, return False, i.e. do not create a submodule.
+            return True
+    return False
+
+
+def _check_valid_autocast_block(enter_autocast_node, exit_autocast_node):
+    assert _is_enter_autocast_node(enter_autocast_node)
+    assert _is_exit_autocast_node(exit_autocast_node)
+    assert exit_autocast_node.args[0] == enter_autocast_node
+
+
+def _replace_with_hop(node: torch.fx.Node):
+    assert node.op == "call_module"
+    graph: torch.fx.Graph = node.graph
+    gm: torch.fx.GraphModule = graph.owning_module
+    assert isinstance(node.target, str)
+    sub_gm = getattr(gm, node.target)
+    sub_graph = sub_gm.graph
+    autocast_nodes = nodes_filter(sub_graph.nodes, _is_autocast_node)
+    if len(autocast_nodes) > 0:
+        assert len(autocast_nodes) > 1  # need at least an enter node and an exist node
+        enter_autocast_node = autocast_nodes[0]
+        exit_autocast_node = autocast_nodes[-1]
+        _check_valid_autocast_block(enter_autocast_node, exit_autocast_node)
+
+        _replace_with_hop_helper(
+            node, enter_autocast_node, _is_autocast_node, wrap_with_autocast
+        )
+        sub_graph.erase_node(exit_autocast_node)
+        sub_graph.erase_node(enter_autocast_node)
+
+
+def _split_autocast(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    """
+    split_autocast creates a new graph module that splits the input graph module into multiple submodules
+    based on the `_enter_autocast` and `_exit_autocast` nodes. It doesn't mutate the input graph module.
+
+    Nodes between the **outer-most** `_enter_autocast` and `_exit_autocast(_enter_autocast)` are splitted
+    into a submodule. Nested autocast regions are not splitted.
+    `_enter_autocast` and `_exit_autocast(_enter_autocast)` nodes are in the submodule as well.
+    """
+    enter_autocast_node_stack: List[torch.fx.Node] = []
+    first_node_after_outer_most_exit: bool = False
+
+    def node_call_back(node: torch.fx.Node):
+        nonlocal enter_autocast_node_stack, first_node_after_outer_most_exit
+        if first_node_after_outer_most_exit or (
+            len(enter_autocast_node_stack) == 0 and _is_enter_autocast_node(node)
+        ):
+            assert len(enter_autocast_node_stack) == 0
+            first_node_after_outer_most_exit = False
+            if _is_enter_autocast_node(node):
+                enter_autocast_node_stack.append(node)
+            return True
+        if _is_exit_autocast_node(node):
+            assert len(enter_autocast_node_stack) > 0
+            last_enter_autocast_node = enter_autocast_node_stack.pop()
+            assert node.args[0] == last_enter_autocast_node
+            if len(enter_autocast_node_stack) == 0:
+                # next node should be in the next submodule since
+                # autocast block ends
+                first_node_after_outer_most_exit = True
+        return False
+
+    return sequential_split(gm, node_call_back)
+
+
+def _sequential_split_and_maybe_inline_subgraphs(
+    gm: torch.fx.GraphModule, graph_signature
+):
+    """
+    Helper function for replace_autocast_with_hop_pass().
+    Split the graph module into multiple subgraphs based on the autocast nodes.
+    For each subgraph, decides whether to construct a HOO subgraph, or inline the calls
+    back into the parent graph module.
+    Nodes between `_enter_autocast` and `_exit_autocast(_enter_autocast)` are considered
+    as a subgraph.
+    """
+    need_replacing = any(_is_autocast_node(node) for node in gm.graph.nodes)
+    if not need_replacing:
+        return gm, graph_signature
+
+    # split_autocast returns a new graph module that could have different output
+    # args names. We need to fix the graph signature.
+    new_gm = _split_autocast(gm)
+
+    # TODO (shangdiy): can merge the block below with replace_set_grad_with_hop_pass.
+    replace_ctx = contextlib.nullcontext()
+    new_signature = None
+    if graph_signature is not None:
+        new_signature = copy.deepcopy(graph_signature)
+        new_gm_out_node = next(reversed(new_gm.graph.find_nodes(op="output")))
+        assert new_gm_out_node.op == "output" and len(new_gm_out_node.args[0]) == len(
+            new_signature.output_specs
+        )
+        for arg_node, out_spec in zip(
+            new_gm_out_node.args[0], new_signature.output_specs
+        ):
+            if arg_node is None:
+                assert out_spec.arg.value is None
+            elif out_spec.arg.name != arg_node.name:
+                out_spec.arg.name = arg_node.name
+
+        replace_ctx = new_gm._set_replace_hook(new_signature.get_replace_hook())  # type: ignore[assignment]
+
+    with replace_ctx:
+
+        def _maybe_inline_or_replace_with_hop(node: torch.fx.Node):
+            if _is_autocast_sub_mod(node):
+                _replace_with_hop(node)
+            else:
+                assert node.op == "call_module"
+                assert isinstance(node.target, str)
+                node_inline_(node)
+
+        nodes_map(
+            list(new_gm.graph.nodes),
+            lambda node: (
+                _maybe_inline_or_replace_with_hop(node)
+                if node.op == "call_module"
+                else node
+            ),
+        )
+    new_gm.recompile()
+    return new_gm, new_signature
+
+
+# TODO (shangdiy): can merge the block below with replace_set_grad_with_hop_pass.
+def replace_autocast_with_hop_pass(gm: torch.fx.GraphModule, graph_signature):
+    new_gm, new_signature = _sequential_split_and_maybe_inline_subgraphs(
+        gm, graph_signature
+    )
+    # recursively call
+    for node in new_gm.graph.nodes:
+        if node.op == "get_attr":
+            subgm = getattr(new_gm, node.target)
+            if not isinstance(subgm, torch.fx.GraphModule):
+                continue
+            new_subgm, _ = replace_autocast_with_hop_pass(subgm, None)
+            setattr(new_gm, node.target, new_subgm)
+
+    new_gm.recompile()
+    new_gm.graph.lint()
+    return new_gm, new_signature

--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -5,14 +5,9 @@ import copy
 import torch
 from torch._higher_order_ops.wrap import wrap_with_set_grad_enabled
 
-from ..utils import (
-    node_inline_,
-    node_replace_,
-    nodes_filter,
-    nodes_first,
-    nodes_map,
-    sequential_split,
-)
+from ..utils import node_inline_, nodes_filter, nodes_first, nodes_map, sequential_split
+
+from .replace_with_hop_pass_util import _replace_with_hop_helper
 
 
 def _is_set_grad_enabled_node(node: torch.fx.Node):
@@ -54,66 +49,9 @@ def _replace_with_hop(node: torch.fx.Node):
     if len(set_grad_nodes) > 0:
         assert len(set_grad_nodes) == 1
         set_grad_node = set_grad_nodes[0]
-        enable_grad_val = set_grad_node.args[0]
-        with graph.inserting_before(node):
-            get_attr_node = graph.get_attr(node.target)
-            get_attr_node.meta["nn_module_stack"] = copy.copy(
-                set_grad_node.meta.get("nn_module_stack", {})
-            )
-            output_node = next(iter(reversed(sub_gm.graph.nodes)), None)
-            # Split_module pass intentially doesn't add output node
-            # if the graph doesn't return anything.
-            # TODO (tmanlaibaatar) Figure out if this is right behaviour
-            # for split_module
-            if isinstance(output_node, torch.fx.Node) and output_node.op != "output":
-                output_node = None
-            if output_node is not None:
-                assert len(output_node.args) == 1
-                output_args = output_node.args[0]
-                if isinstance(output_args, (tuple, list)):
-                    call_func_node = graph.call_function(
-                        wrap_with_set_grad_enabled,
-                        (enable_grad_val, get_attr_node, *node.args),
-                        {},
-                    )
-                    # Create the metadata
-                    call_func_node.meta["val"] = tuple(
-                        arg.meta["val"] for arg in output_args
-                    )
-                    call_func_node.meta["nn_module_stack"] = copy.copy(
-                        set_grad_node.meta.get("nn_module_stack", {})
-                    )
-                    call_func_node.meta["torch_fn"] = (
-                        f"{wrap_with_set_grad_enabled.__name__}",
-                        f"{wrap_with_set_grad_enabled.__class__.__name__}.{wrap_with_set_grad_enabled.__name__}",
-                    )
-                    node_replace_(node, call_func_node, delete_old=True)
-
-                    # Rename the name of getitem nodes to the actual name of its contents
-                    # for passing verifier and better readability, also propagate metadata
-                    for get_item_node in call_func_node.users.keys():
-                        idx: int = get_item_node.args[1]
-                        output_node = output_args[idx]
-                        get_item_node._rename(output_node.name)
-                        get_item_node.meta = output_node.meta
-                        pass
-
-                elif isinstance(output_args, torch.fx.Node):
-                    call_func_node = graph.create_node(
-                        "call_function",
-                        wrap_with_set_grad_enabled,
-                        (enable_grad_val, get_attr_node, *node.args),
-                        {},
-                        output_args.name,
-                    )
-                    call_func_node.meta = output_args.meta
-                    node_replace_(node, call_func_node, delete_old=True)
-                else:
-                    raise NotImplementedError(
-                        f"repalce_set_grad_with_hop_pass doesnt' support output type {type(output_args)}"
-                    )
-            else:
-                node.graph.erase_node(node)
+        _replace_with_hop_helper(
+            node, set_grad_node, _is_set_grad_enabled_node, wrap_with_set_grad_enabled
+        )
         sub_graph.erase_node(set_grad_node)
 
 

--- a/torch/_export/passes/replace_with_hop_pass_util.py
+++ b/torch/_export/passes/replace_with_hop_pass_util.py
@@ -1,0 +1,85 @@
+# mypy: allow-untyped-defs
+
+import copy
+
+from typing import Callable
+
+import torch
+
+from torch._ops import HigherOrderOperator
+
+from ..utils import node_replace_
+
+
+def _replace_with_hop_helper(
+    node: torch.fx.Node,
+    enter_block_node: torch.fx.Node,
+    node_filter: Callable,
+    wrap_hoo: HigherOrderOperator,
+):
+    graph: torch.fx.Graph = node.graph
+    gm: torch.fx.GraphModule = graph.owning_module
+    assert isinstance(node.target, str)
+    sub_gm = getattr(gm, node.target)
+
+    with graph.inserting_before(node):
+        get_attr_node = graph.get_attr(node.target)
+        get_attr_node.meta["nn_module_stack"] = copy.copy(
+            enter_block_node.meta.get("nn_module_stack", {})
+        )
+        output_node = next(iter(reversed(sub_gm.graph.nodes)), None)
+        # Split_module pass intentially doesn't add output node
+        # if the graph doesn't return anything.
+        # TODO (tmanlaibaatar) Figure out if this is right behaviour
+        # for split_module
+        if isinstance(output_node, torch.fx.Node) and output_node.op != "output":
+            output_node = None
+        if output_node is not None:
+            assert len(output_node.args) == 1
+            output_args = output_node.args[0]
+            enter_block_node_args = enter_block_node.args
+            if isinstance(output_args, (tuple, list)):
+                call_func_node = graph.call_function(
+                    wrap_hoo,
+                    (*enter_block_node_args, get_attr_node, *node.args),
+                    {},
+                )
+                # Create the metadata
+                call_func_node.meta["val"] = tuple(
+                    arg.meta["val"] for arg in output_args
+                )
+                call_func_node.meta["nn_module_stack"] = copy.copy(
+                    enter_block_node.meta.get("nn_module_stack", {})
+                )
+                call_func_node.meta["torch_fn"] = (
+                    f"{wrap_hoo.__name__}",
+                    f"{wrap_hoo.__class__.__name__}.{wrap_hoo.__name__}",
+                )
+                node_replace_(node, call_func_node, delete_old=True)
+
+                # Rename the name of getitem nodes to the actual name of its contents
+                # for passing verifier and better readability, also propagate metadata
+                for get_item_node in call_func_node.users.keys():
+                    idx: int = get_item_node.args[1]
+                    output_node = output_args[idx]
+                    get_item_node._rename(output_node.name)
+                    get_item_node.meta = output_node.meta
+                    pass
+
+            elif isinstance(output_args, torch.fx.Node):
+                call_func_node = graph.create_node(
+                    "call_function",
+                    wrap_hoo,
+                    (*enter_block_node_args, get_attr_node, *node.args),
+                    {},
+                    output_args.name,
+                )
+                call_func_node.meta = output_args.meta
+                node_replace_(node, call_func_node, delete_old=True)
+            else:
+                raise NotImplementedError(
+                    f"repalce_set_grad_with_hop_pass doesnt' support output type {type(output_args)}"
+                )
+        else:
+            # TODO (shangdiy): remove this line, since the export graph can be non-functional
+            node.graph.erase_node(node)

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -3,11 +3,13 @@ import inspect
 import itertools
 import logging
 
+from typing import Optional
+
 from torch._logging import warning_once
 
 from torch._ops import HigherOrderOperator
+from torch.types import _dtype
 from torch.utils.checkpoint import checkpoint, CheckpointPolicy
-
 
 log = logging.getLogger(__name__)
 
@@ -55,6 +57,36 @@ class WrapWithSetGradEnabled(HigherOrderOperator):
 
 
 wrap_with_set_grad_enabled = WrapWithSetGradEnabled()
+
+
+class WrapWithAutocast(HigherOrderOperator):
+    def __init__(self):
+        super().__init__("wrap_with_autocast")
+
+    def __call__(
+        self,
+        device_type: str,
+        dtype: Optional[_dtype],
+        enabled: bool,
+        cache_enabled: Optional[bool],
+        wrapped_func,
+        *args,
+        **kwargs,
+    ):
+        # Dynamo already traces the body of HigherOrderOp beforehand when it
+        # so no need to trace into it.
+        import torch._dynamo  # noqa: F401
+        from torch._dynamo import disable
+
+        @disable
+        def wrapper():
+            with torch.autocast(device_type, dtype, enabled, cache_enabled):
+                return wrapped_func(*args, **kwargs)
+
+        return wrapper()
+
+
+wrap_with_autocast = WrapWithAutocast()
 
 
 class WrapActivationCheckpoint(HigherOrderOperator):

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -765,6 +765,9 @@ def _export_to_aten_ir(
     constants.update(lift_constants_pass(gm, export_graph_signature, constant_attrs))
 
     if pre_dispatch:
+        from torch._export.passes.replace_autocast_with_hop_pass import (
+            replace_autocast_with_hop_pass,
+        )
         from torch._export.passes.replace_set_grad_with_hop_pass import (
             replace_set_grad_with_hop_pass,
         )
@@ -775,6 +778,10 @@ def _export_to_aten_ir(
         # and the constant_tensor is passed as input of the set grad hop, the placeholder's
         # meta["val"] will be None and fails our verifier for placeholder.
         gm, export_graph_signature = replace_set_grad_with_hop_pass(
+            gm, export_graph_signature
+        )
+
+        gm, export_graph_signature = replace_autocast_with_hop_pass(
             gm, export_graph_signature
         )
 


### PR DESCRIPTION
Summary:
Suggested in https://github.com/pytorch/pytorch/issues/128394.

If there's an autocast context manager, the predispatch (strict) graph can look something like:

```
class <lambda>(torch.nn.Module):
    def forward(self, x: "f32[1]"):
        ...
        _enter_autocast = torch.amp.autocast_mode._enter_autocast('cuda', torch.bfloat16, True, None)
        mm: "f32[8, 8]" = torch.ops.aten.mm.default(rand, rand_1);  rand = rand_1 = None
        _exit_autocast = torch.amp.autocast_mode._exit_autocast(_enter_autocast);  _enter_autocast = None
        return (mm_1,)
```

But the operator `torch.amp.autocast_mode._enter_autocast` is not a valid ATen op. We remove these nodes by turning autocast into a higher order operator and make a submodule for the blocks between `_enter_autocast` and `_exit_autocast`.

Some potential followup improvement:
1) Merge some of the duplicated logic with `replace_set_grad_with_hop_pass.py`
2) Check the current autocast status (any enabled? dtype?) and not create a submodule if the autocast args matches current autocast status.

Test Plan:
CI

```
parsh --build-flags fbcode//mode/dev-nosan  fbcode//caffe2/test:test_export
run_tests("test_predispatch_autocast")
```

Reviewed By: angelayi

Differential Revision: D60206382
