### PR TITLE
[inductor] set autotune_at_compile_time=True for FBCode

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -1364,12 +1364,7 @@ def compile_fx(
                 "cpp_wrapper": False,
                 # For triton.autotune_at_compile_time, disable by default for
                 # FBCode, but enabled by default for OSS.
-                "triton.autotune_at_compile_time": config.triton.autotune_at_compile_time
-                if config.is_fbcode()
-                else os.environ.get(
-                    "TORCHINDUCTOR_TRITON_AUTOTUNE_AT_COMPILE_TIME", "1"
-                )
-                == "1",
+                "triton.autotune_at_compile_time": config.triton.autotune_at_compile_time,
                 "triton.autotune_cublasLt": False,
                 "triton.cudagraphs": False,
                 "triton.store_cubin": True,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -770,7 +770,7 @@ class triton:
     autotune_cublasLt = True
 
     # Tune the generated Triton kernels at compile time instead of first time they run
-    autotune_at_compile_time = False
+    autotune_at_compile_time = True
 
     # should we stop a fusion to allow better tiling?
     tiling_prevents_pointwise_fusion = True


### PR DESCRIPTION
Summary: For AOTI, this will start autotuning Triton kernels in a standalone file instead of running the JIT-compiled model.

Test Plan:
CI

we should have ample test coverage now, and I also manually tested in T196529074

Differential Revision: D60299373


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang