### PR TITLE
[inline_inbuilt_nn_modules][inductor-cpu] Skip test_quantized_linear_amx

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -556,6 +556,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
                 0,
             )
 
+    @torch._dynamo.config.patch(inline_inbuilt_nn_modules=False)
     @inductor_config.patch({"freezing": True})
     @patches
     @torch.no_grad


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #131275
* #131948
* __->__ #131928
* #131744

The issue is tracked here - https://github.com/pytorch/pytorch/issues/131929


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang