### PR TITLE
Fix to support unary pointwise ops when an NJT is not the first arg

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -6477,10 +6477,6 @@ FORWARD_FAILURES = {
     "masked.sum",
     "masked.var",
     # === BEGIN BUG SECTION ===
-    # NJT arg is second for these signatures; need to support this
-    *(f"polygamma.polygamma_n_{n}" for n in range(5)),
-    "special.polygamma.special_polygamma_n_0",
-    "ldexp",
     # Returns a tuple of Tensors so it doesn't work with NJT's unary pointwise logic
     "frexp",
     # Need to adjust sample input func to pass the right thing
@@ -6504,26 +6500,10 @@ FORWARD_FAILURES = {
 
 BACKWARD_FAILURES = {
     *FORWARD_FAILURES,
-    # TODO: sort these
-    "__rpow__",
-    "atanh",
+    # TODO: categorize these
     "cdouble",
     "cfloat",
     "chalf",
-    "clamp_max",
-    "clamp_min",
-    "copysign",
-    "digamma",
-    "float_power",
-    "max.binary",
-    "maximum",
-    "min.binary",
-    "minimum",
-    "pow",
-    "sgn",
-    "sinc",
-    "special.i1",
-    "special.i1e",
 }
 
 COMPILE_BACKWARD_FAILURES = {

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -205,7 +205,18 @@ def lookup_jagged(func, *args, **kwargs) -> Optional[Callable]:
         # Assume there aren't additional tensors that aren't the "unary/binary" args
         num_tensor_args = sum(isinstance(x, torch.Tensor) for x in args)
         if num_tensor_args == 1:
-            check_schema("self: jt_all, ...", func, *args, **kwargs)
+            # Build up the check schema string. The first tensor arg is assumed to be
+            # an NJT and other args are sent through as-is.
+            schema_parts = []
+            for arg in func._schema.arguments:
+                if isinstance(arg.type, torch.TensorType):
+                    schema_parts.append(f"{arg.name}: jt_all")
+                    break
+                else:
+                    schema_parts.append(f"{arg.name}: any")
+            schema_parts.append("...")
+            check_schema_str = ", ".join(schema_parts)
+            check_schema(check_schema_str, func, *args, **kwargs)
             return functools.partial(jagged_unary_pointwise, func)
         elif num_tensor_args == 2:
             check_schema("lhs: any, rhs: any, ...", func, *args, **kwargs)
@@ -224,8 +235,11 @@ def extract_kwargs(arg):
 
 
 def jagged_unary_pointwise(func, *args, **kwargs):
+    # assume if we get here that there is a single NJT input in the args
+    njt = next(arg for arg in args if isinstance(arg, NestedTensor))
     return NestedTensor(
-        func(args[0]._values, *args[1:], **kwargs), **extract_kwargs(args[0])
+        func(*(arg._values if arg is njt else arg for arg in args), **kwargs),
+        **extract_kwargs(njt),
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #131945
* __->__ #131937
* #131704
* #131898

**Background:** NJT utilizes a `jagged_unary_pointwise()` fallback that historically has assumed blindly that the first arg is an NJT. This assumption breaks certain ops; for example `pow(scalar, Tensor)` has an NJT as the second arg.

This PR expands `jagged_unary_pointwise()` and the associated schema validation logic to handle an NJT in args other than the first position.