### PR TITLE
[inline_inbuilt_nn_modules][inductor-cpu] More skips for dynamic shapes when inlining enabled

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -52,6 +52,8 @@ def patches(fn):
 
     for patcher in [
         dynamo_config.patch(verbose=True),
+        # Fails due to https://github.com/pytorch/pytorch/issues/131929
+        dynamo_config.patch(inline_inbuilt_nn_modules=False)
         inductor_config.patch(
             debug=True,
             max_autotune=True,
@@ -399,7 +401,6 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
         self.assertEqual(counters["inductor"]["cpp_epilogue_fusion_counter"], 1)
 
-    @torch._dynamo.config.patch(inline_inbuilt_nn_modules=False)
     @inductor_config.patch({"freezing": True})
     @patches
     @torch.no_grad
@@ -466,7 +467,6 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
             self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 2)
             self.assertEqual(counters["inductor"]["cpp_epilogue_fusion_counter"], 0)
 
-    @torch._dynamo.config.patch(inline_inbuilt_nn_modules=False)
     @inductor_config.patch({"freezing": True})
     @patches
     @torch.no_grad
@@ -558,7 +558,6 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
                 0,
             )
 
-    @torch._dynamo.config.patch(inline_inbuilt_nn_modules=False)
     @inductor_config.patch({"freezing": True})
     @patches
     @torch.no_grad

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -53,7 +53,7 @@ def patches(fn):
     for patcher in [
         dynamo_config.patch(verbose=True),
         # Fails due to https://github.com/pytorch/pytorch/issues/131929
-        dynamo_config.patch(inline_inbuilt_nn_modules=False)
+        dynamo_config.patch(inline_inbuilt_nn_modules=False),
         inductor_config.patch(
             debug=True,
             max_autotune=True,

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -399,6 +399,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
         self.assertEqual(counters["inductor"]["cpp_epilogue_fusion_counter"], 1)
 
+    @torch._dynamo.config.patch(inline_inbuilt_nn_modules=False)
     @inductor_config.patch({"freezing": True})
     @patches
     @torch.no_grad
@@ -465,6 +466,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
             self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 2)
             self.assertEqual(counters["inductor"]["cpp_epilogue_fusion_counter"], 0)
 
+    @torch._dynamo.config.patch(inline_inbuilt_nn_modules=False)
     @inductor_config.patch({"freezing": True})
     @patches
     @torch.no_grad


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #131275
* __->__ #131948
* #131928
* #131744

The issue is tracked here - https://github.com/pytorch/pytorch/issues/131929

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang