### PR TITLE
Build PT aarch64 on arm runner

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly-aarch64.yml
+++ b/.github/workflows/inductor-perf-test-nightly-aarch64.yml
@@ -52,6 +52,7 @@ jobs:
     name: linux-jammy-aarch64-py3.10-inductor
     uses: ./.github/workflows/_linux-build.yml
     with:
+      runner: linux.arm64.m7g.4xlarge
       build-environment: linux-jammy-aarch64-py3.10
       docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc11-inductor-benchmarks
       test-matrix: |

--- a/test/dynamo/test_model_output.py
+++ b/test/dynamo/test_model_output.py
@@ -239,10 +239,12 @@ class TestModelOutput(torch._dynamo.test_case.TestCase):
 
     @maybe_skip
     def test_HF_bert_model_output(self):
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
         class BertPooler(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.dense = torch.nn.Linear(768, 768).to("cuda")
+                self.dense = torch.nn.Linear(768, 768).to(device)
                 self.activation = torch.nn.Tanh()
 
             def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -300,7 +302,7 @@ class TestModelOutput(torch._dynamo.test_case.TestCase):
                 result["pooler_output"] = pooled_output
                 return result
 
-        sequence_output = torch.rand(1, 12, 768).to("cuda")
+        sequence_output = torch.rand(1, 12, 768).to(device)
         model = BertModel()
         orig_result = model(sequence_output)
         compiled_model = torch.compile(model, backend="eager")


### PR DESCRIPTION
Another fix is needed to address https://github.com/pytorch/pytorch/actions/runs/10118374576/job/27985575620.  The build needs to be done on arm runner to stay compatible with the Docker image.

### Testing

https://github.com/pytorch/pytorch/actions/runs/10118589329/job/27985670691

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames