### PR TITLE
[Inductor][CPP] Fix symbolic size issue of gemm template

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -399,6 +399,7 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
         self.assertEqual(counters["inductor"]["cpp_epilogue_fusion_counter"], 1)
 
+    @torch._dynamo.config.patch(inline_inbuilt_nn_modules=True)
     @inductor_config.patch({"freezing": True})
     @patches
     @torch.no_grad

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -239,6 +239,8 @@ class CppPackedGemmTemplate(CppTemplate):
         self.register_blocking = register_blocking
         m, n = layout.size
         _, k = input_nodes[0].get_size()
+        if has_free_symbols((k,)):
+            k = V.graph.sizevars.shape_env.size_hint(k)
         self.m, self.n, self.k = m, n, k
         self.padded_n = get_padded_n(n, self.register_blocking.block_n)
         self.is_dynamic_M = has_free_symbols((m,))

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -12,7 +12,7 @@ from torch._inductor.virtualized import V
 
 from .. import config as inductor_config
 from ..runtime.runtime_utils import next_power_of_2
-from ..utils import ceildiv as cdiv
+from ..utils import has_free_symbols, ceildiv as cdiv
 
 
 log = logging.getLogger(__name__)
@@ -279,6 +279,9 @@ def mm_args(mat1, mat2, *others, layout=None, out_dtype=None, use_4x2_dim=False)
     if use_4x2_dim:
         k2 = k2 * 2
     k = V.graph.sizevars.guard_equals(k1, k2)
+    if has_free_symbols((k,)) and any(_k.is_number for _k in [k1, k2]):
+        k = V.graph.sizevars.shape_env.size_hint(k)
+
     if layout is None:
         from torch._inductor.ir import FixedLayout
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -12,7 +12,7 @@ from torch._inductor.virtualized import V
 
 from .. import config as inductor_config
 from ..runtime.runtime_utils import next_power_of_2
-from ..utils import has_free_symbols, ceildiv as cdiv
+from ..utils import ceildiv as cdiv, has_free_symbols
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #131968

**Summary**
Fix https://github.com/pytorch/pytorch/issues/131929, after turning on `inline_inbuilt_nn_modules`, in the dynamic shape testing, the size of activation has changed from `[s0, 128]` to `[s0, s1]` and fails the check that https://github.com/pytorch/pytorch/blob/8b04edcac1f00a8c292a2de18dabd1138f7c3c99/torch/_inductor/utils.py#L1172

In this PR, when we found one of size K in activation or weight is constant, we will use this constant number instead of another symbolic value.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang