### PR TITLE
[inductor] optimize cflags for Windows.

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -366,14 +366,26 @@ def _get_cpp_std_cflag(std_num: str = "c++17") -> List[str]:
         return [f"std={std_num}"]
 
 
-def _get_linux_cpp_cflags(cpp_compiler: str) -> List[str]:
-    if not _IS_WINDOWS:
+def _get_os_related_cpp_cflags(cpp_compiler: str) -> List[str]:
+    if _IS_WINDOWS:
+        cflags = [
+            "wd4819",
+            "wd4251",
+            "wd4244",
+            "wd4267",
+            "wd4275",
+            "wd4018",
+            "wd4190",
+            "wd4624",
+            "wd4067",
+            "wd4068",
+            "EHsc",
+        ]
+    else:
         cflags = ["Wno-unused-variable", "Wno-unknown-pragmas"]
         if _is_clang(cpp_compiler):
             cflags.append("Werror=ignored-optimization-argument")
-        return cflags
-    else:
-        return []
+    return cflags
 
 
 def _get_optimization_cflags() -> List[str]:
@@ -439,7 +451,7 @@ def get_cpp_options(
         + _get_optimization_cflags()
         + _get_warning_all_cflag(warning_all)
         + _get_cpp_std_cflag()
-        + _get_linux_cpp_cflags(cpp_compiler)
+        + _get_os_related_cpp_cflags(cpp_compiler)
     )
 
     passthough_args.append(" ".join(extra_flags))


### PR DESCRIPTION
changes:
1. optimize cflags for Windows. Ref: https://github.com/pytorch/pytorch/blob/v2.4.0/torch/utils/cpp_extension.py#L215



cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht @iremyux @Blackhex @cristianPanaite @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang