### PR TITLE
Don't check for autograd state when lowering to inference IR

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1403,8 +1403,6 @@ def forward(self, p_conv_weight, p_conv_bias, p_conv1d_weight, p_conv1d_bias, b_
         )
 
     @testing.expectedFailureRetraceability  # Unexpected type in sourceless builder torch._higher_order_ops.wrap.WrapWithSetGradEnabled
-    @testing.expectedFailureTrainingIRToRunDecomp  # Encountered autograd state manager op
-    @testing.expectedFailureTrainingIRToRunDecompNonStrict
     def test_set_grad_empty(self):
         class M(torch.nn.Module):
             def forward(self, x):

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -404,6 +404,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
             {},
             fake_params_buffers,
             constant_attrs,
+            _check_autograd_state=False,
         )
 
         gm = aten_export_artifact.gm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132033
* #131999
* #131995
* __->__ #131988

When lowering to inference IR, we shouldn't error on autograd state changes because we will have preserved the autograd state change at the training level. I think the more correct way of implementing it would be to wrap autograd ops in HOP before decomposing, but that seems low ROI.

Differential Revision: [D60346235](https://our.internmc.facebook.com/intern/diff/D60346235/)