### PR TITLE
[inductor] Fix flaky tests in test_aot_inductor.py

### DIFF
--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -1,5 +1,9 @@
 # Owner(s): ["module: inductor"]
 
+import os
+import shutil
+import tempfile
+
 import torch
 import torch._export
 import torch._inductor
@@ -19,9 +23,8 @@ class WrapperModule(torch.nn.Module):
 
 
 class AOTIRunnerUtil:
-    @classmethod
+    @staticmethod
     def compile(
-        cls,
         model,
         example_inputs,
         options=None,
@@ -61,14 +64,21 @@ class AOTIRunnerUtil:
 
         return so_path
 
-    @classmethod
-    def load_runner(cls, device, so_path):
+    @staticmethod
+    def load_runner(device, so_path):
         if IS_FBCODE:
             from .fb import test_aot_inductor_model_runner_pybind
 
-            return test_aot_inductor_model_runner_pybind.Runner(
-                so_path, device == "cpu"
-            )
+            with tempfile.TemporaryDirectory() as temp_dir:
+                # copy *.so file to a unique path just before loading
+                # to avoid stale dlopen handles when an updated *.so
+                # from the same path is loaded repetitively in a test
+                temp_so_path = os.path.join(temp_dir, "model.so")
+                shutil.copy(so_path, temp_so_path)
+
+                return test_aot_inductor_model_runner_pybind.Runner(
+                    temp_so_path, device == "cpu"
+                )
         else:
             return (
                 torch._C._aoti.AOTIModelContainerRunnerCpu(so_path, 1)
@@ -76,8 +86,8 @@ class AOTIRunnerUtil:
                 else torch._C._aoti.AOTIModelContainerRunnerCuda(so_path, 1, device)
             )
 
-    @classmethod
-    def load(cls, device, so_path):
+    @staticmethod
+    def load(device, so_path):
         # TODO: unify fbcode and oss behavior to only use torch._export.aot_load
         if IS_FBCODE:
             runner = AOTIRunnerUtil.load_runner(device, so_path)
@@ -95,9 +105,8 @@ class AOTIRunnerUtil:
         else:
             return torch._export.aot_load(so_path, device)
 
-    @classmethod
+    @staticmethod
     def run(
-        cls,
         device,
         model,
         example_inputs,
@@ -115,9 +124,8 @@ class AOTIRunnerUtil:
         optimized = AOTIRunnerUtil.load(device, so_path)
         return optimized(*example_inputs)
 
-    @classmethod
+    @staticmethod
     def run_multiple(
-        cls,
         device,
         model,
         list_example_inputs,


### PR DESCRIPTION
Summary:
The `test_model_modified_weights` in `test_aot_inductor.py` has been failing internally for a while. The behavior leading to the test failure was that, after updating the eager model's weights and recompiling the (CPU) model with AOTI, the output of the model was identical to the one before the weights were updated.

The root cause is here in Python:

https://github.com/pytorch/pytorch/blob/8927fc209f4ce73fd642fd1e9cc4264a07921c8f/test/inductor/test_aot_inductor_utils.py#L69-L71

which, in turn, instantiates the `Runner` object in C++ relying on `dlopen` for loading the *.so. The problem is that repeated `dlopen` call does not reload the library from the same path, unless `dlclose` is called in-between the two `dlopen` calls. There is `dlclose` in the `Runner`'s destructor, but it's not called, likely due to the way the loaded `runner` gets closed over in Python:

https://github.com/pytorch/pytorch/blob/8927fc209f4ce73fd642fd1e9cc4264a07921c8f/test/inductor/test_aot_inductor_utils.py#L83-L94

Here we add copying the *.so file to a unique temporary path right before loading it into a `runner` to avoid the `dlopen` staleness described above. This fixes the `test_model_modified_weights` and, hopefully, will help avoiding similar errors in the future tests.

Test Plan: Tested internally.

Differential Revision: D60348165


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang