### PR TITLE
Fix error handling in _triton.py

### DIFF
--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -11,6 +11,8 @@ def has_triton_package() -> bool:
         return triton_key is not None
     except ImportError:
         return False
+    except RuntimeError:
+        return False
 
 
 @functools.lru_cache(None)


### PR DESCRIPTION
On Windows, _triton.py creates a confusing error ("RuntimeError: Should never be _installed")_ as triton is not supported in Windows. This is not caught in the current Pytorch exception handling. This pull request adds a new exception handling for the runtime error.