### PR TITLE
[Inductor][CPP] Fix Local Buffer issue with inplace result line

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -2703,6 +2703,31 @@ class CPUReproTests(TestCase):
                 2,
             )
 
+    def test_local_buffer_with_line_reuse(self):
+        # Test Global buffer which is inplace buffer and replaced by local buffer
+        def fn(x, y):
+            z = torch.matmul(x, y)
+            a_max = torch.amax(x, -1, keepdim=True)
+            # Previous is a inplace buffer and now is a local buffer
+            exp = torch.exp((z - a_max) / z)
+            sum = torch.sum(exp, -1, keepdim=True)
+            return exp - sum
+
+        inputs = [torch.rand(4, 32), torch.rand(32, 32)]
+
+        with config.patch({"cpp.simdlen": None}):
+            torch._dynamo.reset()
+            metrics.reset()
+            self.common(fn, inputs)
+            self.assertEqual(
+                len(metrics.cpp_outer_loop_fused_inner_counts),
+                1,
+            )
+            self.assertEqual(
+                metrics.cpp_outer_loop_fused_inner_counts[0].local_buffer_number,
+                1,
+            )
+
     def test_argmin(self):
         def fn(x):
             return torch.argmin(x, -1)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -428,6 +428,7 @@ class BaseSchedulerNode:
                         )
                         and buffer_reuse_key(input_buf.node)
                         == buffer_reuse_key(buf.node)
+                        and buf.get_name() not in V.graph.removed_buffers
                     ):
                         # if there isn't a triton kernel, then we don't need to call triton-specific things.
                         # but TODO this might be a convenient place to signal to the Collective kernels to inplace

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -389,6 +389,7 @@ class BaseSchedulerNode:
                 not buf_node.should_allocate()
                 or buf_node.get_inputs_that_alias_output()
                 or buf_node.get_mutation_names()
+                or buf.get_name() in V.graph.removed_buffers
             ):
                 continue
 
@@ -428,7 +429,6 @@ class BaseSchedulerNode:
                         )
                         and buffer_reuse_key(input_buf.node)
                         == buffer_reuse_key(buf.node)
-                        and buf.get_name() not in V.graph.removed_buffers
                     ):
                         # if there isn't a triton kernel, then we don't need to call triton-specific things.
                         # but TODO this might be a convenient place to signal to the Collective kernels to inplace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132018

**Summary**
If a `global buffer` has been replaced by `local buffer`, we will add this `global buffer` into `removed_buffers` to avoid unnecessary allocation. However, a special case is when this `global buffer` can reuse previous buffer. We didn't handle this case previously which cause functional failure in https://github.com/pytorch/pytorch/blob/f151f25c0b80d5c78197af38fc7e72b951f1addf/torch/_inductor/codegen/wrapper.py#L440

In this PR, we resolve this issue by avoid adding this global buffer into `V.kernel.inplace_update_buffers` when this buffer has been marked as `removed`.

**Test Plan**
```
python test/inductor/test_cpu_repro.py -k test_local_buffer_with_line_reuse
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang