### PR TITLE
[cpu-test] enable test_cpu_repro in fbcode

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -38,6 +38,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn import functional as F
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
+    IS_FBCODE,
     IS_MACOS,
     parametrize,
     skipIfRocm,
@@ -1583,6 +1584,7 @@ class CPUReproTests(TestCase):
             metrics.reset()
             self.common(fn, (value,))
 
+    @unittest.skipIf(IS_FBCODE, "Not yet runnable in fbcode")
     @unittest.skipIf(
         platform.machine() != "x86_64" or not cpu_vec_isa.valid_vec_isa_list(),
         "Does not support vectorization or not x86_64 machine",
@@ -1958,6 +1960,7 @@ class CPUReproTests(TestCase):
             with config.patch({"cpp.dynamic_threads": True}), set_num_threads(1):
                 _internal_check(fn, inps, "aten.scatter_reduce_")
 
+    @unittest.skipIf(IS_FBCODE, "Not yet runnable in fbcode")
     @requires_vectorization
     @patch("torch.cuda.is_available", lambda: False)
     def test_new_vec_op_cpu_only(self):
@@ -2748,6 +2751,7 @@ class CPUReproTests(TestCase):
     # supported, the vectorization will not work and skip this test case. For ARM or
     # other platforms support, we just need to add the ISA info to the supported_vector_isa
     # and include proper aten vectorization head file.
+    @unittest.skipIf(IS_FBCODE, "Not yet runnable in fbcode")
     @requires_vectorization
     @patch("torch.cuda.is_available", lambda: False)
     def test_vec_kernel_cpu_only(self):
@@ -2816,6 +2820,7 @@ class CPUReproTests(TestCase):
             self.common(fn, (x1, x2))
             check_metrics_vec_kernel_count(1)
 
+    @unittest.skipIf(IS_FBCODE, "Not yet runnable in fbcode")
     @unittest.skipIf(
         sys.platform != "linux", "cpp kernel profile only support linux now"
     )


### PR DESCRIPTION
Summary: This diff enables test_cpu_repro in fbcode

Test Plan: ci

Differential Revision: D60364517


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang