### PR TITLE
[cpp-wrapper] create null pointer for zero-size array

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2484,12 +2484,18 @@ if (py_{buf_name}.get() == NULL) {{
             ), f"{val} does not match with arg type {type_}"
             element_type = type_.getElementType()
             if config.abi_compatible:
-                assert len(val) > 0, "Empty array is not supported in C"
                 var_name = f"var_array_{next(self.var_array_id)}"
-                result = f"{{{', '.join(self.val_to_arg_str(x, element_type) for x in val)}}}"
-                self.writeline(
-                    f"const {self.c_type_for_prim_type(element_type)} {var_name}[] = {result};"
-                )
+                if len(val) == 0:
+                    # Zero-size array is not supported in the C or C++ standard, so
+                    # we declare a null pointer for it.
+                    self.writeline(
+                        f"const {self.c_type_for_prim_type(element_type)}* {var_name} = nullptr;"
+                    )
+                else:
+                    result = f"{{{', '.join(self.val_to_arg_str(x, element_type) for x in val)}}}"
+                    self.writeline(
+                        f"const {self.c_type_for_prim_type(element_type)} {var_name}[] = {result};"
+                    )
                 # Need to pass the array length because we can't use std::vector
                 return f"{var_name}, {len(val)}"
             else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132023

zero-size array is not supported in the C or C++ standard,
so we create a null pointer for it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang