### PR TITLE
 Add Weighted Loss Functions to PyTorch : WMSE, WMAE, and Weighted Huber Loss

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2580,24 +2580,24 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     def test_weighted_mse_loss(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])
-        weights = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        loss = F.mse_loss(inputs, targets, weights=weights, reduction='mean')
+        weight = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        loss = F.mse_loss(inputs, targets, weight=weight, reduction='mean')
         expected_loss = torch.tensor(0.25)
         self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
 
     def test_weighted_l1_loss_with_weights(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])
-        weights = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        loss = F.l1_loss(inputs, targets, weights=weights, reduction='mean')
+        weight = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        loss = F.l1_loss(inputs, targets, weight=weight, reduction='mean')
         expected_loss = torch.tensor(0.5)
         self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
 
     def test_weighted_huber_loss(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])
-        weights = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        loss = F.huber_loss(input=inputs, target=targets, weights=weights, reduction='mean', delta=1.0)
+        weight = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        loss = F.huber_loss(input=inputs, target=targets, weight=weight, reduction='mean', delta=1.0)
         expected_loss = torch.tensor(0.25)
         print(torch.isclose(loss, expected_loss, atol=1e-6), f"Expected {expected_loss}, but got {loss}")
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9156,8 +9156,7 @@ class TestNNDeviceType(NNTestCase):
             v(lambda: F.hinge_embedding_loss(input, input, reduction=reduction))
             v(lambda: F.poisson_nll_loss(input, input, reduction=reduction))
             v(lambda: F.gaussian_nll_loss(input, input, var, reduction=reduction))
-            v(lambda: F.binary_cross_entropy(torch.sigmoid(input), input.gt(
-                0).to(torch.get_default_dtype()), reduction=reduction))
+            v(lambda: F.binary_cross_entropy(torch.sigmoid(input), input.gt(0).to(torch.get_default_dtype()), reduction=reduction))
             v(lambda: F.binary_cross_entropy_with_logits(input, input, reduction=reduction))
 
             zeros = torch.zeros_like(input).to(torch.int64)
@@ -9418,8 +9417,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
 
         # test forward when input's height is not same as width
-        in_t = torch.ones(1, 2, 2, 1, device=device, dtype=torch.double).contiguous(
-            memory_format=memory_format).requires_grad_()
+        in_t = torch.ones(1, 2, 2, 1, device=device, dtype=torch.double).contiguous(memory_format=memory_format).requires_grad_()
         out_t = F.interpolate(in_t, size=(4, 2), mode=mode)
         self.assertEqual(torch.ones(1, 2, 4, 2, device=device, dtype=torch.double), out_t)
         self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
@@ -9521,8 +9519,7 @@ class TestNNDeviceType(NNTestCase):
         check_forward_ad = torch.device(device).type != 'xla'
 
         m = nn.Upsample(size=4, mode=mode)
-        in_t = torch.ones(1, 2, 2, 2, 2, device=device, dtype=torch.double).contiguous(
-            memory_format=memory_format).requires_grad_()
+        in_t = torch.ones(1, 2, 2, 2, 2, device=device, dtype=torch.double).contiguous(memory_format=memory_format).requires_grad_()
         in_uint8_t = torch.ones(
             1, 2, 2, 2, 2, dtype=torch.uint8, device=device
         ).contiguous(memory_format=memory_format)
@@ -9767,8 +9764,7 @@ class TestNNDeviceType(NNTestCase):
         #   to be clipped in uint8 path, but not in float path. This isn't
         #   an issue with bilinear kernel.
         input_range = (30, 220) if mode == "bicubic" else (0, 256)
-        input_ui8 = torch.randint(*input_range, size=(batch_size, num_channels,
-                                  400, 400), dtype=torch.uint8, device=device)
+        input_ui8 = torch.randint(*input_range, size=(batch_size, num_channels, 400, 400), dtype=torch.uint8, device=device)
         input_ui8 = input_ui8.contiguous(memory_format=memory_format)
 
         if non_contig == "sliced":
@@ -10225,8 +10221,7 @@ class TestNNDeviceType(NNTestCase):
     def test_softmax_results(self, device, dtype):
         # Non-even sizes and non-zero shifts test fallback paths in vectorized kernel
         # Note: dim1 > 1024 is needed to exercise the vectorized (non-persistent) path, (16, 30576) is BERT-esque
-        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23),
-                 (32, 1536), (31, 2048), (33, 2049), (16, 30576)]
+        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23), (32, 1536), (31, 2048), (33, 2049), (16, 30576)]
         shifts = [(0, 0), (1, 0), (0, 1), (1, 1)]
         for fn in [F.softmax, F.log_softmax]:
             for size in sizes:
@@ -10293,6 +10288,7 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(x.grad[0], x.grad[-1])
 
         run_test(1024 * 256 + 1, 8192)  # https://github.com/pytorch/pytorch/issues/84144
+
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.float, torch.half)
@@ -10746,8 +10742,7 @@ class TestNNDeviceType(NNTestCase):
             log_probs_ref = log_probs.detach().clone().requires_grad_()
 
             with torch.backends.cudnn.flags(enabled=True):
-                res = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths,
-                                                   target_lengths, zero_infinity=zero_infinity)
+                res = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, zero_infinity=zero_infinity)
                 res.backward()
 
             expected = ctcloss_reference(log_probs, targets.cuda(), input_lengths, target_lengths).float()
@@ -10998,6 +10993,7 @@ class TestNNDeviceType(NNTestCase):
         inputs = (torch.randn(4, 16, 16, device=device, dtype=torch.double) - 0.5) * 10
         inputs.requires_grad = True
         self.assertTrue(gradcheck(F.hardswish, (inputs,)))
+
 
     def _test_batchnorm_eval(self, ndim, device, dtype, module_dtype=None):
         module_dtype = module_dtype or dtype
@@ -11272,16 +11268,14 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size,
-                                      num_labels, device='cuda', dtype=torch.float), 2)
+        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
         log_probs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
         target_lengths = batch_size * [target_length]
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(
-                log_probs, targets, input_lengths, target_lengths, reduction='none')
+            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
         loss_cudnn = torch.nn.functional.ctc_loss(log_probs, targets.to('cpu', torch.int32),
                                                   input_lengths, target_lengths, reduction='none')
@@ -11299,8 +11293,7 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size,
-                                      num_labels, device='cuda', dtype=torch.float), 2)
+        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
         log_probs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
@@ -11308,8 +11301,7 @@ class TestNNDeviceType(NNTestCase):
         target_lengths = torch.tensor(batch_size * [target_length], dtype=torch.long, device='cuda')
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(
-                log_probs, targets, input_lengths, target_lengths, reduction='none')
+            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
         loss_cudnn = torch.nn.functional.ctc_loss(log_probs,
                                                   targets.to('cuda', torch.int32),
@@ -11498,8 +11490,7 @@ class TestNNDeviceType(NNTestCase):
         for dim in [0, 1, 2, 3]:
             _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=1e-2)
             # test softmax with large input value which casues exp() to overflow
-            _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device,
-                               inp_dims=(16, 33, 15, 16), prec=0.05, scale_factor=1000.0)
+            _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=0.05, scale_factor=1000.0)
 
     def test_nll_loss_mismatched_batch(self, device):
         x = torch.randn((10, 3), requires_grad=True, device=device)
@@ -11629,8 +11620,7 @@ class TestNNDeviceType(NNTestCase):
             weight = torch.zeros([num_channels], device=device)
             self.assertEqual(F.nll_loss(input, target, weight, reduction="sum").item(), 0.)
             self.assertEqual(F.nll_loss(input, target, weight, reduction="mean").item(), float("nan"))
-            self.assertEqual(F.nll_loss(input, target, weight, reduction="none"),
-                             torch.zeros(target.shape, device=device))
+            self.assertEqual(F.nll_loss(input, target, weight, reduction="none"), torch.zeros(target.shape, device=device))
 
         helper([2, 3])
         helper([2, 3, 5, 7])
@@ -11645,8 +11635,7 @@ class TestNNDeviceType(NNTestCase):
             target = torch.zeros(target_size, dtype=torch.long, device=device)
             self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="sum").item(), 0)
             self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="mean").item(), float("nan"))
-            self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="none"),
-                             torch.zeros(target.shape, device=device))
+            self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="none"), torch.zeros(target.shape, device=device))
 
         helper([2, 3])
         helper([2, 3, 5, 7])
@@ -11712,6 +11701,8 @@ if __name__ == '__main__':
     run_tests()
         """)
         self.assertIn('CUDA error: device-side assert triggered', stderr)
+
+
 
     def test_cross_entropy_loss_prob_target_all_reductions(self, device):
         # Test with k-dimensional loss.
@@ -11877,6 +11868,7 @@ if __name__ == '__main__':
 
                 self.assertEqual(output_with_smoothing, output_with_manual_smoothing)
 
+
     def test_cross_entropy_label_smoothing_weight_ignore_indices(self, device):
         reductions = ['none', 'sum', 'mean']
         label_smoothings = [0.05, 0.15]
@@ -11997,6 +11989,7 @@ if __name__ == '__main__':
             if device == 'cpu':
                 test_dtype(func, x, torch.bfloat16)
 
+
     def test_logsigmoid_out(self, device):
         # this isn't actually documented, but was broken previously:
         # https://github.com/pytorch/pytorch/issues/36499
@@ -12105,12 +12098,10 @@ if __name__ == '__main__':
         for grad_only_one_elem, prefix_finite_grad_param, scalars, norms_nonfinite, norms_finite in test_cases:
             for error_if_nonfinite in [False, True]:
                 for norm_type, scalar in product(norms_nonfinite, scalars):
-                    run_test_case(norm_type, error_if_nonfinite, scalar,
-                                  grad_only_one_elem, prefix_finite_grad_param, True)
+                    run_test_case(norm_type, error_if_nonfinite, scalar, grad_only_one_elem, prefix_finite_grad_param, True)
 
                 for norm_type, scalar in product(norms_finite, scalars):
-                    run_test_case(norm_type, error_if_nonfinite, scalar,
-                                  grad_only_one_elem, prefix_finite_grad_param, False)
+                    run_test_case(norm_type, error_if_nonfinite, scalar, grad_only_one_elem, prefix_finite_grad_param, False)
 
     @onlyCUDA
     @deviceCountAtLeast(2)
@@ -12561,10 +12552,10 @@ if __name__ == '__main__':
             ref_output = perm_fn(torch.tensor([[[2.429026, 0.020793, -0.601741, -0.085642],
                                                 [2.428811, 0.021445, -0.601912, -0.084252]],
                                                [[2.425009, 0.019155, -0.604566, -0.085899],
-                                                [2.415408, 0.02249, -0.611415, -0.073]],
+                                                [2.415408, 0.02249 , -0.611415, -0.073]],
                                                [[2.434199, 0.021682, -0.598039, -0.087699],
                                                 [2.42598, 0.019941, -0.603896, -0.085091]],
-                                               [[2.436457, 0.022736, -0.59643, -0.08736],
+                                               [[2.436457, 0.022736, -0.59643 , -0.08736],
                                                 [2.434021, 0.022093, -0.598179, -0.08679]],
                                                [[2.416531, 0.017498, -0.610513, -0.083181],
                                                 [2.4242, 0.024653, -0.605266, -0.074959]]], device=device, dtype=dtype))
@@ -12619,6 +12610,7 @@ if __name__ == '__main__':
                 else:
                     torch.testing.assert_close(result, ref_output)
 
+
         for batch_first in (True, False):
             for training in (True, False):
                 if training:
@@ -12660,6 +12652,7 @@ if __name__ == '__main__':
         # Provide both masks
         with torch.no_grad():
             model(src, src_mask=src_mask, src_key_padding_mask=src_key_padding_mask)
+
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.half, torch.float)
@@ -12754,8 +12747,7 @@ if __name__ == '__main__':
         l = nn.Linear(10, 10).to(device)
         clip_value = 2.5
 
-        grad_w, grad_b = torch.arange(-50., 50, device=device).view(10,
-                                                                    10).div_(5), torch.ones(10, device=device).mul_(2)
+        grad_w, grad_b = torch.arange(-50., 50, device=device).view(10, 10).div_(5), torch.ones(10, device=device).mul_(2)
         for grad_list in [[grad_w, grad_b], [grad_w, None]]:
             for p, g in zip(l.parameters(), grad_list):
                 p._grad = g.clone().view_as(p.data) if g is not None else g
@@ -13005,7 +12997,6 @@ class TestFusionUtils(TestCase):
             self.assertEqual(weight.requires_grad, w_rg)
             self.assertEqual(bias.requires_grad, b_rg)
 
-
 class TestUtils(TestCase):
     def test_consume_prefix_in_state_dict_if_present(self):
         class Block(nn.Module):
@@ -13048,7 +13039,6 @@ class TestUtils(TestCase):
         # Check they are the same preserving order
         self.assertEqual(list(state_dict.keys()), list(ddp_state_dict.keys()))
         self.assertEqual(list(state_dict._metadata.keys()), list(ddp_state_dict._metadata.keys()))
-
 
 instantiate_device_type_tests(TestNNDeviceType, globals())
 instantiate_parametrized_tests(TestNN)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13056,7 +13056,7 @@ class TestUtils(TestCase):
         self.assertEqual(list(state_dict._metadata.keys()), list(ddp_state_dict._metadata.keys()))
 
 
-instantiate_device_type_tests(TestNNDeviceType, globals())
+instantiate_device_type_tests(TestNNDeviceType, globals(), allow_mps=True)
 instantiate_parametrized_tests(TestNN)
 
 if __name__ == '__main__':

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1782,6 +1782,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         check_weight_norm(torch.nn.LSTM(32, 32), 'weight_ih_l0', 4)
         check_weight_norm(torch.nn.LSTM(32, 32, proj_size=16), 'weight_hr_l0', 5)
 
+
     def test_weight_norm(self):
         for dtype in [torch.float, torch.bfloat16]:
             input = torch.randn(3, 4, dtype=dtype)
@@ -2691,8 +2692,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         batch_size = 4
         target_length = 1200
 
-        log_probs = torch.randn(input_length, batch_size, vocab_size,
-                                dtype=torch.double).log_softmax(2).requires_grad_()
+        log_probs = torch.randn(input_length, batch_size, vocab_size, dtype=torch.double).log_softmax(2).requires_grad_()
         targets = torch.randint(low=1, high=vocab_size - 1, size=(batch_size, target_length), dtype=torch.long)
         input_lengths = batch_size * [input_length]
         target_lengths = batch_size * [target_length]
@@ -2827,6 +2827,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         lstm = nn.LSTMCell(10, 20)
         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
         self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
+
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_pack_sequence_batch_sizes_throw(self):
@@ -3540,6 +3541,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             output_cpu = rnn(input.cpu(), hx)
             self.assertEqual(output_cuda, output_cpu)
 
+
     def test_transformer_args_check(self):
         model_name = 'Transformer'
         d_model = 128
@@ -3611,6 +3613,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                       src_is_causal=src_is_causal,
                       tgt_is_causal=tgt_is_causal,
                       memory_is_causal=memory_is_causal)
+
 
         correct_encoder_input_shape = (seq_len, bsz, d_model)
         correct_decoder_input_shape = (tgt_len, bsz, d_model)
@@ -3695,6 +3698,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             model = getattr(nn, model_name)(d_model, nhead, num_encoder_layers, num_decoder_layers,
                                             dim_feedforward, dropout, wrong_activation)
+
 
     def test_transformer_layer_args_check(self):
         model_names = ['TransformerEncoderLayer', 'TransformerDecoderLayer']
@@ -4414,6 +4418,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             grad_output_clone = grad_output.clone()
             output.backward(grad_output)
             self.assertEqual(grad_output, grad_output_clone)
+
 
     def test_pixel_shuffle_unshuffle(self):
         def _test_pixel_shuffle_unshuffle_helper(num_input_dims, valid_channels_dim=True,
@@ -5433,6 +5438,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         out = F.cosine_similarity(a, b)
         self.assertEqual(out, torch.ones(2, dtype=torch.float))
 
+
     def test_grid_sample_error_checking(self):
         input = torch.empty(1, 1, 2, 2)
         grid = torch.empty(1, 1, 1, 2)
@@ -5603,6 +5609,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
                     gradients = torch.randn_like(out_cpu)
                     out_cpu.backward(gradients)
+
 
                     # Compare against unvectorized CPU fallback
 
@@ -6438,8 +6445,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     def test_upsampling_bfloat16(self, dtype=torch.bfloat16):
         def helper(size, scale_factor, mode, device, memory_format=torch.contiguous_format):
-            input = torch.randn(size, device=device, dtype=dtype).to(
-                memory_format=memory_format).detach().requires_grad_(True)
+            input = torch.randn(size, device=device, dtype=dtype).to(memory_format=memory_format).detach().requires_grad_(True)
             inputf = input.to(torch.float32).to(memory_format=torch.contiguous_format).detach().requires_grad_(True)
             m = nn.Upsample(scale_factor=scale_factor, mode=mode)
 
@@ -6568,6 +6574,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                         continue
                     for is_channels_last in (True, False):
                         helper(size, dtype, mode, device, is_channels_last)
+
 
     @set_default_dtype(torch.double)
     def test_interpolate(self):
@@ -7030,10 +7037,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertEqual(mean_ref, mean1)
             self.assertEqual(mean_ref, mean2)
 
-        _batch_norm_stats(torch.randn(1, 96, 112, 112, dtype=torch.float,
-                          device='cuda'), torch.channels_last, (0, 2, 3))
-        _batch_norm_stats(torch.randn(1, 96, 112, 112, 112, dtype=torch.float,
-                          device='cuda'), torch.channels_last_3d, (0, 2, 3, 4))
+        _batch_norm_stats(torch.randn(1, 96, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last, (0, 2, 3))
+        _batch_norm_stats(torch.randn(1, 96, 112, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last_3d, (0, 2, 3, 4))
 
     def test_flatten(self):
         tensor_input = torch.randn(2, 1, 2, 3)
@@ -7151,6 +7156,10 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             res = arg_class(*arg_4)
 
+    def test_pickle_module_no_weights_only_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            pickle.loads(pickle.dumps(torch.nn.Linear(10, 10)))
+        self.assertEqual(len(w), 0)
 
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)
@@ -7308,7 +7317,6 @@ def add_test(test, decorator=None):
             add(cuda_test_name + '_tf32', with_tf32_on)
         else:
             add(cuda_test_name, with_tf32_off)
-
 
 for test_params in module_tests + new_module_tests:
     # TODO: CUDA is not implemented yet
@@ -7470,12 +7478,10 @@ add_test(NewModuleTest(
     check_gradgrad=False,
     default_dtype=torch.double,))
 
-
 class _AdaptiveLogSoftmaxWithLoss(nn.AdaptiveLogSoftmaxWithLoss):
     def __call__(self, input):
         t = torch.tensor([0, 1, 4, 8]).to(input.device)
         return nn.AdaptiveLogSoftmaxWithLoss.__call__(self, input, t).output
-
 
 add_test(NewModuleTest(
     constructor=lambda: _AdaptiveLogSoftmaxWithLoss(16, 10, [2, 6]),
@@ -8238,6 +8244,7 @@ class TestNNDeviceType(NNTestCase):
 
             self.assertEqual(scipy_ary, gridsample_ary.reshape_as(scipy_ary))
 
+
     @onlyCUDA
     @dtypes(torch.float, torch.half)
     def test_batchnorm_large_batch(self, device, dtype):
@@ -8633,17 +8640,17 @@ class TestNNDeviceType(NNTestCase):
 
             # forward
             out = model(x)
-            self.assertEqual(out[:, :, pl: -pr], x)
+            self.assertEqual(out[:, :, pl : -pr], x)
 
             left_padding = out[:, :, : pl]
             self.assertEqual(left_padding, x[:, :, :1].expand_as(left_padding))
-            right_padding = out[:, :, -pr:]
+            right_padding = out[:, :, -pr :]
             self.assertEqual(right_padding, x[:, :, -1:].expand_as(right_padding))
 
             # backward
             g = torch.randn_like(out)
             out.backward(g)
-            self.assertEqual(x.grad[:, :, 1: -1], g[:, :, pl + 1: -pr - 1])
+            self.assertEqual(x.grad[:, :, 1 : -1], g[:, :, pl + 1 : -pr - 1])
 
             self.assertEqual(x.grad[:, :, 0], g[:, :, : pl + 1].sum(-1))
             self.assertEqual(x.grad[:, :, -1], g[:, :, -pr - 1:].sum(-1))
@@ -8658,15 +8665,15 @@ class TestNNDeviceType(NNTestCase):
 
             # forward center, edge
             out = model(x)
-            self.assertEqual(out[:, :, pt: -pb, pl: -pr], x)
+            self.assertEqual(out[:, :, pt : -pb, pl : -pr], x)
 
-            left_padding = out[:, :, pt: -pb, : pl]
+            left_padding = out[:, :, pt : -pb, : pl]
             self.assertEqual(left_padding, x[:, :, :, :1].expand_as(left_padding))
-            right_padding = out[:, :, pt: -pb, -pr:]
+            right_padding = out[:, :, pt : -pb, -pr :]
             self.assertEqual(right_padding, x[:, :, :, -1:].expand_as(right_padding))
-            top_padding = out[:, :, : pt, pl: -pr]
+            top_padding = out[:, :, : pt, pl : -pr]
             self.assertEqual(top_padding, x[:, :, :1, :].expand_as(top_padding))
-            bottom_padding = out[:, :, -pb:, pl: -pr]
+            bottom_padding = out[:, :, -pb : , pl : -pr]
             self.assertEqual(bottom_padding, x[:, :, -1:, :].expand_as(bottom_padding))
 
             # forward corner
@@ -8682,18 +8689,18 @@ class TestNNDeviceType(NNTestCase):
             # backward center, edge
             g = torch.randn_like(out)
             out.backward(g)
-            self.assertEqual(x.grad[:, :, 1:-1, 1:-1], g[:, :, pt + 1: -pb - 1, pl + 1: -pr - 1])
+            self.assertEqual(x.grad[:, :, 1:-1, 1:-1], g[:, :, pt + 1 : -pb - 1, pl + 1 : -pr - 1])
 
-            self.assertEqual(x.grad[:, :, 1:-1, 0], g[:, :, pt + 1: -pb - 1, : pl + 1].sum(-1))
-            self.assertEqual(x.grad[:, :, 1:-1, -1], g[:, :, pt + 1: -pb - 1, -pr - 1:].sum(-1))
-            self.assertEqual(x.grad[:, :, 0, 1:-1], g[:, :, : pt + 1, pl + 1: -pr - 1].sum(-2))
-            self.assertEqual(x.grad[:, :, -1, 1:-1], g[:, :, -pb - 1:, pl + 1: -pr - 1].sum(-2))
+            self.assertEqual(x.grad[:, :, 1:-1, 0], g[:, :, pt + 1 : -pb - 1, : pl + 1].sum(-1))
+            self.assertEqual(x.grad[:, :, 1:-1, -1], g[:, :, pt + 1 : -pb - 1, -pr - 1 :].sum(-1))
+            self.assertEqual(x.grad[:, :, 0, 1:-1], g[:, :, : pt + 1, pl + 1 : -pr - 1].sum(-2))
+            self.assertEqual(x.grad[:, :, -1, 1:-1], g[:, :, -pb - 1 :, pl + 1 : -pr - 1].sum(-2))
 
             # backward corner
             self.assertEqual(x.grad[:, :, 0, 0], g[:, :, : pt + 1, : pl + 1].sum((-2, -1)))
-            self.assertEqual(x.grad[:, :, 0, -1], g[:, :, : pt + 1, -pr - 1:].sum((-2, -1)))
-            self.assertEqual(x.grad[:, :, -1, 0], g[:, :, -pb - 1:, : pl + 1].sum((-2, -1)))
-            self.assertEqual(x.grad[:, :, -1, -1], g[:, :, -pb - 1:, -pr - 1:].sum((-2, -1)))
+            self.assertEqual(x.grad[:, :, 0, -1], g[:, :, : pt + 1, -pr - 1 :].sum((-2, -1)))
+            self.assertEqual(x.grad[:, :, -1, 0], g[:, :, -pb - 1 :, : pl + 1].sum((-2, -1)))
+            self.assertEqual(x.grad[:, :, -1, -1], g[:, :, -pb - 1 :, -pr - 1 :].sum((-2, -1)))
 
     @largeTensorTest("6GB")
     def test_ReplicationPad3d_large(self, device):
@@ -8706,13 +8713,12 @@ class TestNNDeviceType(NNTestCase):
 
             # forward center
             out = model(x)
-            self.assertEqual(out[:, :, pf: -pbk, pt: -pbt, pl: -pr], x)
+            self.assertEqual(out[:, :, pf : -pbk, pt : -pbt, pl : -pr], x)
 
             # backward center
             g = torch.randn_like(out)
             out.backward(g)
-            self.assertEqual(x.grad[:, :, 1:-1, 1:-1, 1:-1], g[:, :, pf +
-                             1: -pbk - 1, pt + 1: -pbt - 1, pl + 1: -pr - 1])
+            self.assertEqual(x.grad[:, :, 1:-1, 1:-1, 1:-1], g[:, :, pf + 1 : -pbk - 1, pt + 1 : -pbt - 1, pl + 1 : -pr - 1])
 
     @onlyNativeDeviceTypes
     def test_Bilinear_empty(self, device):
@@ -8752,8 +8758,7 @@ class TestNNDeviceType(NNTestCase):
                                 nt = torch.nested.nested_tensor([], device=device)
                                 _test_module_empty_input(self, encoder_layer, nt, check_size=False, inference=True)
 
-                            nt = torch.nested.nested_tensor(
-                                [torch.rand(0, 512, device=device, dtype=torch.double)], device=device)
+                            nt = torch.nested.nested_tensor([torch.rand(0, 512, device=device, dtype=torch.double)], device=device)
                             _test_module_empty_input(self, encoder_layer, nt, check_size=False, inference=True)
                 else:
                     _test_module_empty_input(self, encoder_layer, input, check_size=False)
@@ -8764,8 +8769,7 @@ class TestNNDeviceType(NNTestCase):
         for batch_first, input_shape in [(True, (0, 10, 512)),
                                          (False, (10, 0, 512))]:
             input = torch.rand(*input_shape, device=device, dtype=torch.double)
-            encoder_layer = nn.TransformerEncoderLayer(
-                d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
+            encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
             transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6).to(device)
             _test_module_empty_input(self, transformer_encoder, input, check_size=False)
 
@@ -8776,8 +8780,7 @@ class TestNNDeviceType(NNTestCase):
                                                      (False, (10, 0, 512), (20, 0, 512))]:
             memory = torch.rand(*memory_shape, device=device, dtype=torch.double)
             tgt = torch.rand(*tgt_shape, requires_grad=True, device=device, dtype=torch.double)
-            decoder_layer = nn.TransformerDecoderLayer(
-                d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
+            decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
             self._test_module_empty_inputs(decoder_layer, [tgt, memory])
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
@@ -8787,8 +8790,7 @@ class TestNNDeviceType(NNTestCase):
                                                      (False, (10, 0, 512), (20, 0, 512))]:
             memory = torch.rand(*memory_shape, device=device, dtype=torch.double)
             tgt = torch.rand(*tgt_shape, requires_grad=True, device=device, dtype=torch.double)
-            decoder_layer = nn.TransformerDecoderLayer(
-                d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
+            decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
             transformer_decoder = nn.TransformerDecoder(decoder_layer, num_layers=6).to(device)
             self._test_module_empty_inputs(transformer_decoder, [tgt, memory])
 
@@ -9162,8 +9164,7 @@ class TestNNDeviceType(NNTestCase):
             v(lambda: F.hinge_embedding_loss(input, input, reduction=reduction))
             v(lambda: F.poisson_nll_loss(input, input, reduction=reduction))
             v(lambda: F.gaussian_nll_loss(input, input, var, reduction=reduction))
-            v(lambda: F.binary_cross_entropy(torch.sigmoid(input), input.gt(
-                0).to(torch.get_default_dtype()), reduction=reduction))
+            v(lambda: F.binary_cross_entropy(torch.sigmoid(input), input.gt(0).to(torch.get_default_dtype()), reduction=reduction))
             v(lambda: F.binary_cross_entropy_with_logits(input, input, reduction=reduction))
 
             zeros = torch.zeros_like(input).to(torch.int64)
@@ -9424,8 +9425,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
 
         # test forward when input's height is not same as width
-        in_t = torch.ones(1, 2, 2, 1, device=device, dtype=torch.double).contiguous(
-            memory_format=memory_format).requires_grad_()
+        in_t = torch.ones(1, 2, 2, 1, device=device, dtype=torch.double).contiguous(memory_format=memory_format).requires_grad_()
         out_t = F.interpolate(in_t, size=(4, 2), mode=mode)
         self.assertEqual(torch.ones(1, 2, 4, 2, device=device, dtype=torch.double), out_t)
         self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
@@ -9527,8 +9527,7 @@ class TestNNDeviceType(NNTestCase):
         check_forward_ad = torch.device(device).type != 'xla'
 
         m = nn.Upsample(size=4, mode=mode)
-        in_t = torch.ones(1, 2, 2, 2, 2, device=device, dtype=torch.double).contiguous(
-            memory_format=memory_format).requires_grad_()
+        in_t = torch.ones(1, 2, 2, 2, 2, device=device, dtype=torch.double).contiguous(memory_format=memory_format).requires_grad_()
         in_uint8_t = torch.ones(
             1, 2, 2, 2, 2, dtype=torch.uint8, device=device
         ).contiguous(memory_format=memory_format)
@@ -9773,8 +9772,7 @@ class TestNNDeviceType(NNTestCase):
         #   to be clipped in uint8 path, but not in float path. This isn't
         #   an issue with bilinear kernel.
         input_range = (30, 220) if mode == "bicubic" else (0, 256)
-        input_ui8 = torch.randint(*input_range, size=(batch_size, num_channels,
-                                  400, 400), dtype=torch.uint8, device=device)
+        input_ui8 = torch.randint(*input_range, size=(batch_size, num_channels, 400, 400), dtype=torch.uint8, device=device)
         input_ui8 = input_ui8.contiguous(memory_format=memory_format)
 
         if non_contig == "sliced":
@@ -10231,8 +10229,7 @@ class TestNNDeviceType(NNTestCase):
     def test_softmax_results(self, device, dtype):
         # Non-even sizes and non-zero shifts test fallback paths in vectorized kernel
         # Note: dim1 > 1024 is needed to exercise the vectorized (non-persistent) path, (16, 30576) is BERT-esque
-        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23),
-                 (32, 1536), (31, 2048), (33, 2049), (16, 30576)]
+        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23), (32, 1536), (31, 2048), (33, 2049), (16, 30576)]
         shifts = [(0, 0), (1, 0), (0, 1), (1, 1)]
         for fn in [F.softmax, F.log_softmax]:
             for size in sizes:
@@ -10299,6 +10296,7 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(x.grad[0], x.grad[-1])
 
         run_test(1024 * 256 + 1, 8192)  # https://github.com/pytorch/pytorch/issues/84144
+
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.float, torch.half)
@@ -10752,8 +10750,7 @@ class TestNNDeviceType(NNTestCase):
             log_probs_ref = log_probs.detach().clone().requires_grad_()
 
             with torch.backends.cudnn.flags(enabled=True):
-                res = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths,
-                                                   target_lengths, zero_infinity=zero_infinity)
+                res = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, zero_infinity=zero_infinity)
                 res.backward()
 
             expected = ctcloss_reference(log_probs, targets.cuda(), input_lengths, target_lengths).float()
@@ -11004,6 +11001,7 @@ class TestNNDeviceType(NNTestCase):
         inputs = (torch.randn(4, 16, 16, device=device, dtype=torch.double) - 0.5) * 10
         inputs.requires_grad = True
         self.assertTrue(gradcheck(F.hardswish, (inputs,)))
+
 
     def _test_batchnorm_eval(self, ndim, device, dtype, module_dtype=None):
         module_dtype = module_dtype or dtype
@@ -11278,16 +11276,14 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size,
-                                      num_labels, device='cuda', dtype=torch.float), 2)
+        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
         log_probs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
         target_lengths = batch_size * [target_length]
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(
-                log_probs, targets, input_lengths, target_lengths, reduction='none')
+            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
         loss_cudnn = torch.nn.functional.ctc_loss(log_probs, targets.to('cpu', torch.int32),
                                                   input_lengths, target_lengths, reduction='none')
@@ -11305,8 +11301,7 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size,
-                                      num_labels, device='cuda', dtype=torch.float), 2)
+        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
         log_probs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
@@ -11314,8 +11309,7 @@ class TestNNDeviceType(NNTestCase):
         target_lengths = torch.tensor(batch_size * [target_length], dtype=torch.long, device='cuda')
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(
-                log_probs, targets, input_lengths, target_lengths, reduction='none')
+            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
         loss_cudnn = torch.nn.functional.ctc_loss(log_probs,
                                                   targets.to('cuda', torch.int32),
@@ -11504,8 +11498,7 @@ class TestNNDeviceType(NNTestCase):
         for dim in [0, 1, 2, 3]:
             _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=1e-2)
             # test softmax with large input value which casues exp() to overflow
-            _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device,
-                               inp_dims=(16, 33, 15, 16), prec=0.05, scale_factor=1000.0)
+            _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=0.05, scale_factor=1000.0)
 
     def test_nll_loss_mismatched_batch(self, device):
         x = torch.randn((10, 3), requires_grad=True, device=device)
@@ -11635,8 +11628,7 @@ class TestNNDeviceType(NNTestCase):
             weight = torch.zeros([num_channels], device=device)
             self.assertEqual(F.nll_loss(input, target, weight, reduction="sum").item(), 0.)
             self.assertEqual(F.nll_loss(input, target, weight, reduction="mean").item(), float("nan"))
-            self.assertEqual(F.nll_loss(input, target, weight, reduction="none"),
-                             torch.zeros(target.shape, device=device))
+            self.assertEqual(F.nll_loss(input, target, weight, reduction="none"), torch.zeros(target.shape, device=device))
 
         helper([2, 3])
         helper([2, 3, 5, 7])
@@ -11651,8 +11643,7 @@ class TestNNDeviceType(NNTestCase):
             target = torch.zeros(target_size, dtype=torch.long, device=device)
             self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="sum").item(), 0)
             self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="mean").item(), float("nan"))
-            self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="none"),
-                             torch.zeros(target.shape, device=device))
+            self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="none"), torch.zeros(target.shape, device=device))
 
         helper([2, 3])
         helper([2, 3, 5, 7])
@@ -11718,6 +11709,8 @@ if __name__ == '__main__':
     run_tests()
         """)
         self.assertIn('CUDA error: device-side assert triggered', stderr)
+
+
 
     def test_cross_entropy_loss_prob_target_all_reductions(self, device):
         # Test with k-dimensional loss.
@@ -11883,6 +11876,7 @@ if __name__ == '__main__':
 
                 self.assertEqual(output_with_smoothing, output_with_manual_smoothing)
 
+
     def test_cross_entropy_label_smoothing_weight_ignore_indices(self, device):
         reductions = ['none', 'sum', 'mean']
         label_smoothings = [0.05, 0.15]
@@ -12003,6 +11997,7 @@ if __name__ == '__main__':
             if device == 'cpu':
                 test_dtype(func, x, torch.bfloat16)
 
+
     def test_logsigmoid_out(self, device):
         # this isn't actually documented, but was broken previously:
         # https://github.com/pytorch/pytorch/issues/36499
@@ -12111,12 +12106,10 @@ if __name__ == '__main__':
         for grad_only_one_elem, prefix_finite_grad_param, scalars, norms_nonfinite, norms_finite in test_cases:
             for error_if_nonfinite in [False, True]:
                 for norm_type, scalar in product(norms_nonfinite, scalars):
-                    run_test_case(norm_type, error_if_nonfinite, scalar,
-                                  grad_only_one_elem, prefix_finite_grad_param, True)
+                    run_test_case(norm_type, error_if_nonfinite, scalar, grad_only_one_elem, prefix_finite_grad_param, True)
 
                 for norm_type, scalar in product(norms_finite, scalars):
-                    run_test_case(norm_type, error_if_nonfinite, scalar,
-                                  grad_only_one_elem, prefix_finite_grad_param, False)
+                    run_test_case(norm_type, error_if_nonfinite, scalar, grad_only_one_elem, prefix_finite_grad_param, False)
 
     @onlyCUDA
     @deviceCountAtLeast(2)
@@ -12567,10 +12560,10 @@ if __name__ == '__main__':
             ref_output = perm_fn(torch.tensor([[[2.429026, 0.020793, -0.601741, -0.085642],
                                                 [2.428811, 0.021445, -0.601912, -0.084252]],
                                                [[2.425009, 0.019155, -0.604566, -0.085899],
-                                                [2.415408, 0.02249, -0.611415, -0.073]],
+                                                [2.415408, 0.02249 , -0.611415, -0.073]],
                                                [[2.434199, 0.021682, -0.598039, -0.087699],
                                                 [2.42598, 0.019941, -0.603896, -0.085091]],
-                                               [[2.436457, 0.022736, -0.59643, -0.08736],
+                                               [[2.436457, 0.022736, -0.59643 , -0.08736],
                                                 [2.434021, 0.022093, -0.598179, -0.08679]],
                                                [[2.416531, 0.017498, -0.610513, -0.083181],
                                                 [2.4242, 0.024653, -0.605266, -0.074959]]], device=device, dtype=dtype))
@@ -12625,6 +12618,7 @@ if __name__ == '__main__':
                 else:
                     torch.testing.assert_close(result, ref_output)
 
+
         for batch_first in (True, False):
             for training in (True, False):
                 if training:
@@ -12666,6 +12660,7 @@ if __name__ == '__main__':
         # Provide both masks
         with torch.no_grad():
             model(src, src_mask=src_mask, src_key_padding_mask=src_key_padding_mask)
+
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.half, torch.float)
@@ -12760,8 +12755,7 @@ if __name__ == '__main__':
         l = nn.Linear(10, 10).to(device)
         clip_value = 2.5
 
-        grad_w, grad_b = torch.arange(-50., 50, device=device).view(10,
-                                                                    10).div_(5), torch.ones(10, device=device).mul_(2)
+        grad_w, grad_b = torch.arange(-50., 50, device=device).view(10, 10).div_(5), torch.ones(10, device=device).mul_(2)
         for grad_list in [[grad_w, grad_b], [grad_w, None]]:
             for p, g in zip(l.parameters(), grad_list):
                 p._grad = g.clone().view_as(p.data) if g is not None else g
@@ -13010,7 +13004,6 @@ class TestFusionUtils(TestCase):
                                        bn.running_mean, bn.running_var, bn.eps, bn.weight, bn.bias)
             self.assertEqual(weight.requires_grad, w_rg)
             self.assertEqual(bias.requires_grad, b_rg)
-
 
 class TestUtils(TestCase):
     def test_consume_prefix_in_state_dict_if_present(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1782,6 +1782,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         check_weight_norm(torch.nn.LSTM(32, 32), 'weight_ih_l0', 4)
         check_weight_norm(torch.nn.LSTM(32, 32, proj_size=16), 'weight_hr_l0', 5)
 
+
     def test_weight_norm(self):
         for dtype in [torch.float, torch.bfloat16]:
             input = torch.randn(3, 4, dtype=dtype)
@@ -2691,8 +2692,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         batch_size = 4
         target_length = 1200
 
-        log_probs = torch.randn(input_length, batch_size, vocab_size,
-                                dtype=torch.double).log_softmax(2).requires_grad_()
+        log_probs = torch.randn(input_length, batch_size, vocab_size, dtype=torch.double).log_softmax(2).requires_grad_()
         targets = torch.randint(low=1, high=vocab_size - 1, size=(batch_size, target_length), dtype=torch.long)
         input_lengths = batch_size * [input_length]
         target_lengths = batch_size * [target_length]
@@ -2827,6 +2827,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         lstm = nn.LSTMCell(10, 20)
         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
         self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
+
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_pack_sequence_batch_sizes_throw(self):
@@ -3540,6 +3541,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             output_cpu = rnn(input.cpu(), hx)
             self.assertEqual(output_cuda, output_cpu)
 
+
     def test_transformer_args_check(self):
         model_name = 'Transformer'
         d_model = 128
@@ -3611,6 +3613,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                       src_is_causal=src_is_causal,
                       tgt_is_causal=tgt_is_causal,
                       memory_is_causal=memory_is_causal)
+
 
         correct_encoder_input_shape = (seq_len, bsz, d_model)
         correct_decoder_input_shape = (tgt_len, bsz, d_model)
@@ -3695,6 +3698,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             model = getattr(nn, model_name)(d_model, nhead, num_encoder_layers, num_decoder_layers,
                                             dim_feedforward, dropout, wrong_activation)
+
 
     def test_transformer_layer_args_check(self):
         model_names = ['TransformerEncoderLayer', 'TransformerDecoderLayer']
@@ -4414,6 +4418,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             grad_output_clone = grad_output.clone()
             output.backward(grad_output)
             self.assertEqual(grad_output, grad_output_clone)
+
 
     def test_pixel_shuffle_unshuffle(self):
         def _test_pixel_shuffle_unshuffle_helper(num_input_dims, valid_channels_dim=True,
@@ -5433,6 +5438,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         out = F.cosine_similarity(a, b)
         self.assertEqual(out, torch.ones(2, dtype=torch.float))
 
+
     def test_grid_sample_error_checking(self):
         input = torch.empty(1, 1, 2, 2)
         grid = torch.empty(1, 1, 1, 2)
@@ -5603,6 +5609,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
                     gradients = torch.randn_like(out_cpu)
                     out_cpu.backward(gradients)
+
 
                     # Compare against unvectorized CPU fallback
 
@@ -6438,8 +6445,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     def test_upsampling_bfloat16(self, dtype=torch.bfloat16):
         def helper(size, scale_factor, mode, device, memory_format=torch.contiguous_format):
-            input = torch.randn(size, device=device, dtype=dtype).to(
-                memory_format=memory_format).detach().requires_grad_(True)
+            input = torch.randn(size, device=device, dtype=dtype).to(memory_format=memory_format).detach().requires_grad_(True)
             inputf = input.to(torch.float32).to(memory_format=torch.contiguous_format).detach().requires_grad_(True)
             m = nn.Upsample(scale_factor=scale_factor, mode=mode)
 
@@ -6568,6 +6574,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                         continue
                     for is_channels_last in (True, False):
                         helper(size, dtype, mode, device, is_channels_last)
+
 
     @set_default_dtype(torch.double)
     def test_interpolate(self):
@@ -7030,10 +7037,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertEqual(mean_ref, mean1)
             self.assertEqual(mean_ref, mean2)
 
-        _batch_norm_stats(torch.randn(1, 96, 112, 112, dtype=torch.float,
-                          device='cuda'), torch.channels_last, (0, 2, 3))
-        _batch_norm_stats(torch.randn(1, 96, 112, 112, 112, dtype=torch.float,
-                          device='cuda'), torch.channels_last_3d, (0, 2, 3, 4))
+        _batch_norm_stats(torch.randn(1, 96, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last, (0, 2, 3))
+        _batch_norm_stats(torch.randn(1, 96, 112, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last_3d, (0, 2, 3, 4))
 
     def test_flatten(self):
         tensor_input = torch.randn(2, 1, 2, 3)
@@ -7150,7 +7155,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
         with self.assertRaises(RuntimeError):
             res = arg_class(*arg_4)
-
 
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)
@@ -7308,7 +7312,6 @@ def add_test(test, decorator=None):
             add(cuda_test_name + '_tf32', with_tf32_on)
         else:
             add(cuda_test_name, with_tf32_off)
-
 
 for test_params in module_tests + new_module_tests:
     # TODO: CUDA is not implemented yet
@@ -7470,12 +7473,10 @@ add_test(NewModuleTest(
     check_gradgrad=False,
     default_dtype=torch.double,))
 
-
 class _AdaptiveLogSoftmaxWithLoss(nn.AdaptiveLogSoftmaxWithLoss):
     def __call__(self, input):
         t = torch.tensor([0, 1, 4, 8]).to(input.device)
         return nn.AdaptiveLogSoftmaxWithLoss.__call__(self, input, t).output
-
 
 add_test(NewModuleTest(
     constructor=lambda: _AdaptiveLogSoftmaxWithLoss(16, 10, [2, 6]),
@@ -8238,6 +8239,7 @@ class TestNNDeviceType(NNTestCase):
 
             self.assertEqual(scipy_ary, gridsample_ary.reshape_as(scipy_ary))
 
+
     @onlyCUDA
     @dtypes(torch.float, torch.half)
     def test_batchnorm_large_batch(self, device, dtype):
@@ -8633,17 +8635,17 @@ class TestNNDeviceType(NNTestCase):
 
             # forward
             out = model(x)
-            self.assertEqual(out[:, :, pl: -pr], x)
+            self.assertEqual(out[:, :, pl : -pr], x)
 
             left_padding = out[:, :, : pl]
             self.assertEqual(left_padding, x[:, :, :1].expand_as(left_padding))
-            right_padding = out[:, :, -pr:]
+            right_padding = out[:, :, -pr :]
             self.assertEqual(right_padding, x[:, :, -1:].expand_as(right_padding))
 
             # backward
             g = torch.randn_like(out)
             out.backward(g)
-            self.assertEqual(x.grad[:, :, 1: -1], g[:, :, pl + 1: -pr - 1])
+            self.assertEqual(x.grad[:, :, 1 : -1], g[:, :, pl + 1 : -pr - 1])
 
             self.assertEqual(x.grad[:, :, 0], g[:, :, : pl + 1].sum(-1))
             self.assertEqual(x.grad[:, :, -1], g[:, :, -pr - 1:].sum(-1))
@@ -8658,15 +8660,15 @@ class TestNNDeviceType(NNTestCase):
 
             # forward center, edge
             out = model(x)
-            self.assertEqual(out[:, :, pt: -pb, pl: -pr], x)
+            self.assertEqual(out[:, :, pt : -pb, pl : -pr], x)
 
-            left_padding = out[:, :, pt: -pb, : pl]
+            left_padding = out[:, :, pt : -pb, : pl]
             self.assertEqual(left_padding, x[:, :, :, :1].expand_as(left_padding))
-            right_padding = out[:, :, pt: -pb, -pr:]
+            right_padding = out[:, :, pt : -pb, -pr :]
             self.assertEqual(right_padding, x[:, :, :, -1:].expand_as(right_padding))
-            top_padding = out[:, :, : pt, pl: -pr]
+            top_padding = out[:, :, : pt, pl : -pr]
             self.assertEqual(top_padding, x[:, :, :1, :].expand_as(top_padding))
-            bottom_padding = out[:, :, -pb:, pl: -pr]
+            bottom_padding = out[:, :, -pb : , pl : -pr]
             self.assertEqual(bottom_padding, x[:, :, -1:, :].expand_as(bottom_padding))
 
             # forward corner
@@ -8682,18 +8684,18 @@ class TestNNDeviceType(NNTestCase):
             # backward center, edge
             g = torch.randn_like(out)
             out.backward(g)
-            self.assertEqual(x.grad[:, :, 1:-1, 1:-1], g[:, :, pt + 1: -pb - 1, pl + 1: -pr - 1])
+            self.assertEqual(x.grad[:, :, 1:-1, 1:-1], g[:, :, pt + 1 : -pb - 1, pl + 1 : -pr - 1])
 
-            self.assertEqual(x.grad[:, :, 1:-1, 0], g[:, :, pt + 1: -pb - 1, : pl + 1].sum(-1))
-            self.assertEqual(x.grad[:, :, 1:-1, -1], g[:, :, pt + 1: -pb - 1, -pr - 1:].sum(-1))
-            self.assertEqual(x.grad[:, :, 0, 1:-1], g[:, :, : pt + 1, pl + 1: -pr - 1].sum(-2))
-            self.assertEqual(x.grad[:, :, -1, 1:-1], g[:, :, -pb - 1:, pl + 1: -pr - 1].sum(-2))
+            self.assertEqual(x.grad[:, :, 1:-1, 0], g[:, :, pt + 1 : -pb - 1, : pl + 1].sum(-1))
+            self.assertEqual(x.grad[:, :, 1:-1, -1], g[:, :, pt + 1 : -pb - 1, -pr - 1 :].sum(-1))
+            self.assertEqual(x.grad[:, :, 0, 1:-1], g[:, :, : pt + 1, pl + 1 : -pr - 1].sum(-2))
+            self.assertEqual(x.grad[:, :, -1, 1:-1], g[:, :, -pb - 1 :, pl + 1 : -pr - 1].sum(-2))
 
             # backward corner
             self.assertEqual(x.grad[:, :, 0, 0], g[:, :, : pt + 1, : pl + 1].sum((-2, -1)))
-            self.assertEqual(x.grad[:, :, 0, -1], g[:, :, : pt + 1, -pr - 1:].sum((-2, -1)))
-            self.assertEqual(x.grad[:, :, -1, 0], g[:, :, -pb - 1:, : pl + 1].sum((-2, -1)))
-            self.assertEqual(x.grad[:, :, -1, -1], g[:, :, -pb - 1:, -pr - 1:].sum((-2, -1)))
+            self.assertEqual(x.grad[:, :, 0, -1], g[:, :, : pt + 1, -pr - 1 :].sum((-2, -1)))
+            self.assertEqual(x.grad[:, :, -1, 0], g[:, :, -pb - 1 :, : pl + 1].sum((-2, -1)))
+            self.assertEqual(x.grad[:, :, -1, -1], g[:, :, -pb - 1 :, -pr - 1 :].sum((-2, -1)))
 
     @largeTensorTest("6GB")
     def test_ReplicationPad3d_large(self, device):
@@ -8706,13 +8708,12 @@ class TestNNDeviceType(NNTestCase):
 
             # forward center
             out = model(x)
-            self.assertEqual(out[:, :, pf: -pbk, pt: -pbt, pl: -pr], x)
+            self.assertEqual(out[:, :, pf : -pbk, pt : -pbt, pl : -pr], x)
 
             # backward center
             g = torch.randn_like(out)
             out.backward(g)
-            self.assertEqual(x.grad[:, :, 1:-1, 1:-1, 1:-1], g[:, :, pf +
-                             1: -pbk - 1, pt + 1: -pbt - 1, pl + 1: -pr - 1])
+            self.assertEqual(x.grad[:, :, 1:-1, 1:-1, 1:-1], g[:, :, pf + 1 : -pbk - 1, pt + 1 : -pbt - 1, pl + 1 : -pr - 1])
 
     @onlyNativeDeviceTypes
     def test_Bilinear_empty(self, device):
@@ -8752,8 +8753,7 @@ class TestNNDeviceType(NNTestCase):
                                 nt = torch.nested.nested_tensor([], device=device)
                                 _test_module_empty_input(self, encoder_layer, nt, check_size=False, inference=True)
 
-                            nt = torch.nested.nested_tensor(
-                                [torch.rand(0, 512, device=device, dtype=torch.double)], device=device)
+                            nt = torch.nested.nested_tensor([torch.rand(0, 512, device=device, dtype=torch.double)], device=device)
                             _test_module_empty_input(self, encoder_layer, nt, check_size=False, inference=True)
                 else:
                     _test_module_empty_input(self, encoder_layer, input, check_size=False)
@@ -8764,8 +8764,7 @@ class TestNNDeviceType(NNTestCase):
         for batch_first, input_shape in [(True, (0, 10, 512)),
                                          (False, (10, 0, 512))]:
             input = torch.rand(*input_shape, device=device, dtype=torch.double)
-            encoder_layer = nn.TransformerEncoderLayer(
-                d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
+            encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
             transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6).to(device)
             _test_module_empty_input(self, transformer_encoder, input, check_size=False)
 
@@ -8776,8 +8775,7 @@ class TestNNDeviceType(NNTestCase):
                                                      (False, (10, 0, 512), (20, 0, 512))]:
             memory = torch.rand(*memory_shape, device=device, dtype=torch.double)
             tgt = torch.rand(*tgt_shape, requires_grad=True, device=device, dtype=torch.double)
-            decoder_layer = nn.TransformerDecoderLayer(
-                d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
+            decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
             self._test_module_empty_inputs(decoder_layer, [tgt, memory])
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
@@ -8787,8 +8785,7 @@ class TestNNDeviceType(NNTestCase):
                                                      (False, (10, 0, 512), (20, 0, 512))]:
             memory = torch.rand(*memory_shape, device=device, dtype=torch.double)
             tgt = torch.rand(*tgt_shape, requires_grad=True, device=device, dtype=torch.double)
-            decoder_layer = nn.TransformerDecoderLayer(
-                d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
+            decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
             transformer_decoder = nn.TransformerDecoder(decoder_layer, num_layers=6).to(device)
             self._test_module_empty_inputs(transformer_decoder, [tgt, memory])
 
@@ -9162,8 +9159,7 @@ class TestNNDeviceType(NNTestCase):
             v(lambda: F.hinge_embedding_loss(input, input, reduction=reduction))
             v(lambda: F.poisson_nll_loss(input, input, reduction=reduction))
             v(lambda: F.gaussian_nll_loss(input, input, var, reduction=reduction))
-            v(lambda: F.binary_cross_entropy(torch.sigmoid(input), input.gt(
-                0).to(torch.get_default_dtype()), reduction=reduction))
+            v(lambda: F.binary_cross_entropy(torch.sigmoid(input), input.gt(0).to(torch.get_default_dtype()), reduction=reduction))
             v(lambda: F.binary_cross_entropy_with_logits(input, input, reduction=reduction))
 
             zeros = torch.zeros_like(input).to(torch.int64)
@@ -9424,8 +9420,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
 
         # test forward when input's height is not same as width
-        in_t = torch.ones(1, 2, 2, 1, device=device, dtype=torch.double).contiguous(
-            memory_format=memory_format).requires_grad_()
+        in_t = torch.ones(1, 2, 2, 1, device=device, dtype=torch.double).contiguous(memory_format=memory_format).requires_grad_()
         out_t = F.interpolate(in_t, size=(4, 2), mode=mode)
         self.assertEqual(torch.ones(1, 2, 4, 2, device=device, dtype=torch.double), out_t)
         self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
@@ -9527,8 +9522,7 @@ class TestNNDeviceType(NNTestCase):
         check_forward_ad = torch.device(device).type != 'xla'
 
         m = nn.Upsample(size=4, mode=mode)
-        in_t = torch.ones(1, 2, 2, 2, 2, device=device, dtype=torch.double).contiguous(
-            memory_format=memory_format).requires_grad_()
+        in_t = torch.ones(1, 2, 2, 2, 2, device=device, dtype=torch.double).contiguous(memory_format=memory_format).requires_grad_()
         in_uint8_t = torch.ones(
             1, 2, 2, 2, 2, dtype=torch.uint8, device=device
         ).contiguous(memory_format=memory_format)
@@ -9773,8 +9767,7 @@ class TestNNDeviceType(NNTestCase):
         #   to be clipped in uint8 path, but not in float path. This isn't
         #   an issue with bilinear kernel.
         input_range = (30, 220) if mode == "bicubic" else (0, 256)
-        input_ui8 = torch.randint(*input_range, size=(batch_size, num_channels,
-                                  400, 400), dtype=torch.uint8, device=device)
+        input_ui8 = torch.randint(*input_range, size=(batch_size, num_channels, 400, 400), dtype=torch.uint8, device=device)
         input_ui8 = input_ui8.contiguous(memory_format=memory_format)
 
         if non_contig == "sliced":
@@ -10231,8 +10224,7 @@ class TestNNDeviceType(NNTestCase):
     def test_softmax_results(self, device, dtype):
         # Non-even sizes and non-zero shifts test fallback paths in vectorized kernel
         # Note: dim1 > 1024 is needed to exercise the vectorized (non-persistent) path, (16, 30576) is BERT-esque
-        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23),
-                 (32, 1536), (31, 2048), (33, 2049), (16, 30576)]
+        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23), (32, 1536), (31, 2048), (33, 2049), (16, 30576)]
         shifts = [(0, 0), (1, 0), (0, 1), (1, 1)]
         for fn in [F.softmax, F.log_softmax]:
             for size in sizes:
@@ -10299,6 +10291,7 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(x.grad[0], x.grad[-1])
 
         run_test(1024 * 256 + 1, 8192)  # https://github.com/pytorch/pytorch/issues/84144
+
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.float, torch.half)
@@ -10752,8 +10745,7 @@ class TestNNDeviceType(NNTestCase):
             log_probs_ref = log_probs.detach().clone().requires_grad_()
 
             with torch.backends.cudnn.flags(enabled=True):
-                res = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths,
-                                                   target_lengths, zero_infinity=zero_infinity)
+                res = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, zero_infinity=zero_infinity)
                 res.backward()
 
             expected = ctcloss_reference(log_probs, targets.cuda(), input_lengths, target_lengths).float()
@@ -11004,6 +10996,7 @@ class TestNNDeviceType(NNTestCase):
         inputs = (torch.randn(4, 16, 16, device=device, dtype=torch.double) - 0.5) * 10
         inputs.requires_grad = True
         self.assertTrue(gradcheck(F.hardswish, (inputs,)))
+
 
     def _test_batchnorm_eval(self, ndim, device, dtype, module_dtype=None):
         module_dtype = module_dtype or dtype
@@ -11278,16 +11271,14 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size,
-                                      num_labels, device='cuda', dtype=torch.float), 2)
+        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
         log_probs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
         target_lengths = batch_size * [target_length]
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(
-                log_probs, targets, input_lengths, target_lengths, reduction='none')
+            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
         loss_cudnn = torch.nn.functional.ctc_loss(log_probs, targets.to('cpu', torch.int32),
                                                   input_lengths, target_lengths, reduction='none')
@@ -11305,8 +11296,7 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size,
-                                      num_labels, device='cuda', dtype=torch.float), 2)
+        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
         log_probs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
@@ -11314,8 +11304,7 @@ class TestNNDeviceType(NNTestCase):
         target_lengths = torch.tensor(batch_size * [target_length], dtype=torch.long, device='cuda')
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(
-                log_probs, targets, input_lengths, target_lengths, reduction='none')
+            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
         loss_cudnn = torch.nn.functional.ctc_loss(log_probs,
                                                   targets.to('cuda', torch.int32),
@@ -11504,8 +11493,7 @@ class TestNNDeviceType(NNTestCase):
         for dim in [0, 1, 2, 3]:
             _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=1e-2)
             # test softmax with large input value which casues exp() to overflow
-            _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device,
-                               inp_dims=(16, 33, 15, 16), prec=0.05, scale_factor=1000.0)
+            _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=0.05, scale_factor=1000.0)
 
     def test_nll_loss_mismatched_batch(self, device):
         x = torch.randn((10, 3), requires_grad=True, device=device)
@@ -11635,8 +11623,7 @@ class TestNNDeviceType(NNTestCase):
             weight = torch.zeros([num_channels], device=device)
             self.assertEqual(F.nll_loss(input, target, weight, reduction="sum").item(), 0.)
             self.assertEqual(F.nll_loss(input, target, weight, reduction="mean").item(), float("nan"))
-            self.assertEqual(F.nll_loss(input, target, weight, reduction="none"),
-                             torch.zeros(target.shape, device=device))
+            self.assertEqual(F.nll_loss(input, target, weight, reduction="none"), torch.zeros(target.shape, device=device))
 
         helper([2, 3])
         helper([2, 3, 5, 7])
@@ -11651,8 +11638,7 @@ class TestNNDeviceType(NNTestCase):
             target = torch.zeros(target_size, dtype=torch.long, device=device)
             self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="sum").item(), 0)
             self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="mean").item(), float("nan"))
-            self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="none"),
-                             torch.zeros(target.shape, device=device))
+            self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="none"), torch.zeros(target.shape, device=device))
 
         helper([2, 3])
         helper([2, 3, 5, 7])
@@ -11718,6 +11704,8 @@ if __name__ == '__main__':
     run_tests()
         """)
         self.assertIn('CUDA error: device-side assert triggered', stderr)
+
+
 
     def test_cross_entropy_loss_prob_target_all_reductions(self, device):
         # Test with k-dimensional loss.
@@ -11883,6 +11871,7 @@ if __name__ == '__main__':
 
                 self.assertEqual(output_with_smoothing, output_with_manual_smoothing)
 
+
     def test_cross_entropy_label_smoothing_weight_ignore_indices(self, device):
         reductions = ['none', 'sum', 'mean']
         label_smoothings = [0.05, 0.15]
@@ -12003,6 +11992,7 @@ if __name__ == '__main__':
             if device == 'cpu':
                 test_dtype(func, x, torch.bfloat16)
 
+
     def test_logsigmoid_out(self, device):
         # this isn't actually documented, but was broken previously:
         # https://github.com/pytorch/pytorch/issues/36499
@@ -12111,12 +12101,10 @@ if __name__ == '__main__':
         for grad_only_one_elem, prefix_finite_grad_param, scalars, norms_nonfinite, norms_finite in test_cases:
             for error_if_nonfinite in [False, True]:
                 for norm_type, scalar in product(norms_nonfinite, scalars):
-                    run_test_case(norm_type, error_if_nonfinite, scalar,
-                                  grad_only_one_elem, prefix_finite_grad_param, True)
+                    run_test_case(norm_type, error_if_nonfinite, scalar, grad_only_one_elem, prefix_finite_grad_param, True)
 
                 for norm_type, scalar in product(norms_finite, scalars):
-                    run_test_case(norm_type, error_if_nonfinite, scalar,
-                                  grad_only_one_elem, prefix_finite_grad_param, False)
+                    run_test_case(norm_type, error_if_nonfinite, scalar, grad_only_one_elem, prefix_finite_grad_param, False)
 
     @onlyCUDA
     @deviceCountAtLeast(2)
@@ -12567,10 +12555,10 @@ if __name__ == '__main__':
             ref_output = perm_fn(torch.tensor([[[2.429026, 0.020793, -0.601741, -0.085642],
                                                 [2.428811, 0.021445, -0.601912, -0.084252]],
                                                [[2.425009, 0.019155, -0.604566, -0.085899],
-                                                [2.415408, 0.02249, -0.611415, -0.073]],
+                                                [2.415408, 0.02249 , -0.611415, -0.073]],
                                                [[2.434199, 0.021682, -0.598039, -0.087699],
                                                 [2.42598, 0.019941, -0.603896, -0.085091]],
-                                               [[2.436457, 0.022736, -0.59643, -0.08736],
+                                               [[2.436457, 0.022736, -0.59643 , -0.08736],
                                                 [2.434021, 0.022093, -0.598179, -0.08679]],
                                                [[2.416531, 0.017498, -0.610513, -0.083181],
                                                 [2.4242, 0.024653, -0.605266, -0.074959]]], device=device, dtype=dtype))
@@ -12625,6 +12613,7 @@ if __name__ == '__main__':
                 else:
                     torch.testing.assert_close(result, ref_output)
 
+
         for batch_first in (True, False):
             for training in (True, False):
                 if training:
@@ -12666,6 +12655,7 @@ if __name__ == '__main__':
         # Provide both masks
         with torch.no_grad():
             model(src, src_mask=src_mask, src_key_padding_mask=src_key_padding_mask)
+
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.half, torch.float)
@@ -12760,8 +12750,7 @@ if __name__ == '__main__':
         l = nn.Linear(10, 10).to(device)
         clip_value = 2.5
 
-        grad_w, grad_b = torch.arange(-50., 50, device=device).view(10,
-                                                                    10).div_(5), torch.ones(10, device=device).mul_(2)
+        grad_w, grad_b = torch.arange(-50., 50, device=device).view(10, 10).div_(5), torch.ones(10, device=device).mul_(2)
         for grad_list in [[grad_w, grad_b], [grad_w, None]]:
             for p, g in zip(l.parameters(), grad_list):
                 p._grad = g.clone().view_as(p.data) if g is not None else g
@@ -13011,7 +13000,6 @@ class TestFusionUtils(TestCase):
             self.assertEqual(weight.requires_grad, w_rg)
             self.assertEqual(bias.requires_grad, b_rg)
 
-
 class TestUtils(TestCase):
     def test_consume_prefix_in_state_dict_if_present(self):
         class Block(nn.Module):
@@ -13054,7 +13042,6 @@ class TestUtils(TestCase):
         # Check they are the same preserving order
         self.assertEqual(list(state_dict.keys()), list(ddp_state_dict.keys()))
         self.assertEqual(list(state_dict._metadata.keys()), list(ddp_state_dict._metadata.keys()))
-
 
 instantiate_device_type_tests(TestNNDeviceType, globals())
 instantiate_parametrized_tests(TestNN)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2589,7 +2589,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])
         weights = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        loss = F.wmae_loss(inputs, targets, weights=weights, reduction='mean')
+        loss = F.mae_loss(inputs, targets, weights=weights, reduction='mean')
         expected_loss = torch.tensor(1.25)
         self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2577,19 +2577,19 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertEqual(len(w), 1)
             self.assertIn('Please ensure they have the same size.', str(w[0]))
 
-    def test_wmse_loss(self):
+    def test_weighted_mse_loss(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])
         weights = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        loss = F.wmse_loss(inputs, targets, weights, reduction='mean')
+        loss = F.mse_loss(inputs, targets, weights=weights, reduction='mean')
         expected_loss = torch.tensor(0.25)
         self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
 
-    def test_wmae_loss(self):
+    def test_weighted_mae_loss(self):
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])
         weights = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        loss = F.wmae_loss(inputs, targets, weights, reduction='mean')
+        loss = F.wmae_loss(inputs, targets, weights=weights, reduction='mean')
         expected_loss = torch.tensor(1.25)
         self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
 
@@ -2597,7 +2597,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
         targets = torch.tensor([1.5, 2.5, 3.5, 4.5])
         weights = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        loss = F.weighted_huber_loss(input=inputs, target=targets, weights=weights, reduction='mean', delta=1.0)
+        loss = F.huber_loss(input=inputs, target=targets, weights=weights, reduction='mean', delta=1.0)
         expected_loss = torch.tensor(0.25)
         print(torch.isclose(loss, expected_loss, atol=1e-6), f"Expected {expected_loss}, but got {loss}")
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1782,7 +1782,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         check_weight_norm(torch.nn.LSTM(32, 32), 'weight_ih_l0', 4)
         check_weight_norm(torch.nn.LSTM(32, 32, proj_size=16), 'weight_hr_l0', 5)
 
-
     def test_weight_norm(self):
         for dtype in [torch.float, torch.bfloat16]:
             input = torch.randn(3, 4, dtype=dtype)
@@ -2593,6 +2592,14 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         expected_loss = torch.tensor(1.25)
         self.assertTrue(torch.isclose(loss, expected_loss), f"Expected {expected_loss}, but got {loss}")
 
+    def test_weighted_huber_loss(self):
+        inputs = torch.tensor([1.0, 2.0, 3.0, 4.0], requires_grad=True)
+        targets = torch.tensor([1.5, 2.5, 3.5, 4.5])
+        weights = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        loss = F.weighted_huber_loss(input=inputs, target=targets, weights=weights, reduction='mean', delta=1.0)
+        expected_loss = torch.tensor(0.25)
+        print(torch.isclose(loss, expected_loss, atol=1e-6), f"Expected {expected_loss}, but got {loss}")
+
     def test_gaussian_nll_loss_broadcasting(self):
         input = torch.tensor([[0.5, 1.5, 2.5], [2., 4., 6.]])
         target_full = torch.tensor([[1., 2., 3.], [1., 2., 3.]])
@@ -2684,7 +2691,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         batch_size = 4
         target_length = 1200
 
-        log_probs = torch.randn(input_length, batch_size, vocab_size, dtype=torch.double).log_softmax(2).requires_grad_()
+        log_probs = torch.randn(input_length, batch_size, vocab_size,
+                                dtype=torch.double).log_softmax(2).requires_grad_()
         targets = torch.randint(low=1, high=vocab_size - 1, size=(batch_size, target_length), dtype=torch.long)
         input_lengths = batch_size * [input_length]
         target_lengths = batch_size * [target_length]
@@ -2819,7 +2827,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         lstm = nn.LSTMCell(10, 20)
         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
         self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
-
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_pack_sequence_batch_sizes_throw(self):
@@ -3533,7 +3540,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             output_cpu = rnn(input.cpu(), hx)
             self.assertEqual(output_cuda, output_cpu)
 
-
     def test_transformer_args_check(self):
         model_name = 'Transformer'
         d_model = 128
@@ -3605,7 +3611,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                       src_is_causal=src_is_causal,
                       tgt_is_causal=tgt_is_causal,
                       memory_is_causal=memory_is_causal)
-
 
         correct_encoder_input_shape = (seq_len, bsz, d_model)
         correct_decoder_input_shape = (tgt_len, bsz, d_model)
@@ -3690,7 +3695,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             model = getattr(nn, model_name)(d_model, nhead, num_encoder_layers, num_decoder_layers,
                                             dim_feedforward, dropout, wrong_activation)
-
 
     def test_transformer_layer_args_check(self):
         model_names = ['TransformerEncoderLayer', 'TransformerDecoderLayer']
@@ -4410,7 +4414,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             grad_output_clone = grad_output.clone()
             output.backward(grad_output)
             self.assertEqual(grad_output, grad_output_clone)
-
 
     def test_pixel_shuffle_unshuffle(self):
         def _test_pixel_shuffle_unshuffle_helper(num_input_dims, valid_channels_dim=True,
@@ -5430,7 +5433,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         out = F.cosine_similarity(a, b)
         self.assertEqual(out, torch.ones(2, dtype=torch.float))
 
-
     def test_grid_sample_error_checking(self):
         input = torch.empty(1, 1, 2, 2)
         grid = torch.empty(1, 1, 1, 2)
@@ -5601,7 +5603,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
                     gradients = torch.randn_like(out_cpu)
                     out_cpu.backward(gradients)
-
 
                     # Compare against unvectorized CPU fallback
 
@@ -6437,7 +6438,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     def test_upsampling_bfloat16(self, dtype=torch.bfloat16):
         def helper(size, scale_factor, mode, device, memory_format=torch.contiguous_format):
-            input = torch.randn(size, device=device, dtype=dtype).to(memory_format=memory_format).detach().requires_grad_(True)
+            input = torch.randn(size, device=device, dtype=dtype).to(
+                memory_format=memory_format).detach().requires_grad_(True)
             inputf = input.to(torch.float32).to(memory_format=torch.contiguous_format).detach().requires_grad_(True)
             m = nn.Upsample(scale_factor=scale_factor, mode=mode)
 
@@ -6566,7 +6568,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                         continue
                     for is_channels_last in (True, False):
                         helper(size, dtype, mode, device, is_channels_last)
-
 
     @set_default_dtype(torch.double)
     def test_interpolate(self):
@@ -7029,8 +7030,10 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertEqual(mean_ref, mean1)
             self.assertEqual(mean_ref, mean2)
 
-        _batch_norm_stats(torch.randn(1, 96, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last, (0, 2, 3))
-        _batch_norm_stats(torch.randn(1, 96, 112, 112, 112, dtype=torch.float, device='cuda'), torch.channels_last_3d, (0, 2, 3, 4))
+        _batch_norm_stats(torch.randn(1, 96, 112, 112, dtype=torch.float,
+                          device='cuda'), torch.channels_last, (0, 2, 3))
+        _batch_norm_stats(torch.randn(1, 96, 112, 112, 112, dtype=torch.float,
+                          device='cuda'), torch.channels_last_3d, (0, 2, 3, 4))
 
     def test_flatten(self):
         tensor_input = torch.randn(2, 1, 2, 3)
@@ -7148,10 +7151,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             res = arg_class(*arg_4)
 
-    def test_pickle_module_no_weights_only_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            pickle.loads(pickle.dumps(torch.nn.Linear(10, 10)))
-        self.assertEqual(len(w), 0)
 
 class TestFusionEval(TestCase):
     @set_default_dtype(torch.double)
@@ -7309,6 +7308,7 @@ def add_test(test, decorator=None):
             add(cuda_test_name + '_tf32', with_tf32_on)
         else:
             add(cuda_test_name, with_tf32_off)
+
 
 for test_params in module_tests + new_module_tests:
     # TODO: CUDA is not implemented yet
@@ -7470,10 +7470,12 @@ add_test(NewModuleTest(
     check_gradgrad=False,
     default_dtype=torch.double,))
 
+
 class _AdaptiveLogSoftmaxWithLoss(nn.AdaptiveLogSoftmaxWithLoss):
     def __call__(self, input):
         t = torch.tensor([0, 1, 4, 8]).to(input.device)
         return nn.AdaptiveLogSoftmaxWithLoss.__call__(self, input, t).output
+
 
 add_test(NewModuleTest(
     constructor=lambda: _AdaptiveLogSoftmaxWithLoss(16, 10, [2, 6]),
@@ -8236,7 +8238,6 @@ class TestNNDeviceType(NNTestCase):
 
             self.assertEqual(scipy_ary, gridsample_ary.reshape_as(scipy_ary))
 
-
     @onlyCUDA
     @dtypes(torch.float, torch.half)
     def test_batchnorm_large_batch(self, device, dtype):
@@ -8632,17 +8633,17 @@ class TestNNDeviceType(NNTestCase):
 
             # forward
             out = model(x)
-            self.assertEqual(out[:, :, pl : -pr], x)
+            self.assertEqual(out[:, :, pl: -pr], x)
 
             left_padding = out[:, :, : pl]
             self.assertEqual(left_padding, x[:, :, :1].expand_as(left_padding))
-            right_padding = out[:, :, -pr :]
+            right_padding = out[:, :, -pr:]
             self.assertEqual(right_padding, x[:, :, -1:].expand_as(right_padding))
 
             # backward
             g = torch.randn_like(out)
             out.backward(g)
-            self.assertEqual(x.grad[:, :, 1 : -1], g[:, :, pl + 1 : -pr - 1])
+            self.assertEqual(x.grad[:, :, 1: -1], g[:, :, pl + 1: -pr - 1])
 
             self.assertEqual(x.grad[:, :, 0], g[:, :, : pl + 1].sum(-1))
             self.assertEqual(x.grad[:, :, -1], g[:, :, -pr - 1:].sum(-1))
@@ -8657,15 +8658,15 @@ class TestNNDeviceType(NNTestCase):
 
             # forward center, edge
             out = model(x)
-            self.assertEqual(out[:, :, pt : -pb, pl : -pr], x)
+            self.assertEqual(out[:, :, pt: -pb, pl: -pr], x)
 
-            left_padding = out[:, :, pt : -pb, : pl]
+            left_padding = out[:, :, pt: -pb, : pl]
             self.assertEqual(left_padding, x[:, :, :, :1].expand_as(left_padding))
-            right_padding = out[:, :, pt : -pb, -pr :]
+            right_padding = out[:, :, pt: -pb, -pr:]
             self.assertEqual(right_padding, x[:, :, :, -1:].expand_as(right_padding))
-            top_padding = out[:, :, : pt, pl : -pr]
+            top_padding = out[:, :, : pt, pl: -pr]
             self.assertEqual(top_padding, x[:, :, :1, :].expand_as(top_padding))
-            bottom_padding = out[:, :, -pb : , pl : -pr]
+            bottom_padding = out[:, :, -pb:, pl: -pr]
             self.assertEqual(bottom_padding, x[:, :, -1:, :].expand_as(bottom_padding))
 
             # forward corner
@@ -8681,18 +8682,18 @@ class TestNNDeviceType(NNTestCase):
             # backward center, edge
             g = torch.randn_like(out)
             out.backward(g)
-            self.assertEqual(x.grad[:, :, 1:-1, 1:-1], g[:, :, pt + 1 : -pb - 1, pl + 1 : -pr - 1])
+            self.assertEqual(x.grad[:, :, 1:-1, 1:-1], g[:, :, pt + 1: -pb - 1, pl + 1: -pr - 1])
 
-            self.assertEqual(x.grad[:, :, 1:-1, 0], g[:, :, pt + 1 : -pb - 1, : pl + 1].sum(-1))
-            self.assertEqual(x.grad[:, :, 1:-1, -1], g[:, :, pt + 1 : -pb - 1, -pr - 1 :].sum(-1))
-            self.assertEqual(x.grad[:, :, 0, 1:-1], g[:, :, : pt + 1, pl + 1 : -pr - 1].sum(-2))
-            self.assertEqual(x.grad[:, :, -1, 1:-1], g[:, :, -pb - 1 :, pl + 1 : -pr - 1].sum(-2))
+            self.assertEqual(x.grad[:, :, 1:-1, 0], g[:, :, pt + 1: -pb - 1, : pl + 1].sum(-1))
+            self.assertEqual(x.grad[:, :, 1:-1, -1], g[:, :, pt + 1: -pb - 1, -pr - 1:].sum(-1))
+            self.assertEqual(x.grad[:, :, 0, 1:-1], g[:, :, : pt + 1, pl + 1: -pr - 1].sum(-2))
+            self.assertEqual(x.grad[:, :, -1, 1:-1], g[:, :, -pb - 1:, pl + 1: -pr - 1].sum(-2))
 
             # backward corner
             self.assertEqual(x.grad[:, :, 0, 0], g[:, :, : pt + 1, : pl + 1].sum((-2, -1)))
-            self.assertEqual(x.grad[:, :, 0, -1], g[:, :, : pt + 1, -pr - 1 :].sum((-2, -1)))
-            self.assertEqual(x.grad[:, :, -1, 0], g[:, :, -pb - 1 :, : pl + 1].sum((-2, -1)))
-            self.assertEqual(x.grad[:, :, -1, -1], g[:, :, -pb - 1 :, -pr - 1 :].sum((-2, -1)))
+            self.assertEqual(x.grad[:, :, 0, -1], g[:, :, : pt + 1, -pr - 1:].sum((-2, -1)))
+            self.assertEqual(x.grad[:, :, -1, 0], g[:, :, -pb - 1:, : pl + 1].sum((-2, -1)))
+            self.assertEqual(x.grad[:, :, -1, -1], g[:, :, -pb - 1:, -pr - 1:].sum((-2, -1)))
 
     @largeTensorTest("6GB")
     def test_ReplicationPad3d_large(self, device):
@@ -8705,12 +8706,13 @@ class TestNNDeviceType(NNTestCase):
 
             # forward center
             out = model(x)
-            self.assertEqual(out[:, :, pf : -pbk, pt : -pbt, pl : -pr], x)
+            self.assertEqual(out[:, :, pf: -pbk, pt: -pbt, pl: -pr], x)
 
             # backward center
             g = torch.randn_like(out)
             out.backward(g)
-            self.assertEqual(x.grad[:, :, 1:-1, 1:-1, 1:-1], g[:, :, pf + 1 : -pbk - 1, pt + 1 : -pbt - 1, pl + 1 : -pr - 1])
+            self.assertEqual(x.grad[:, :, 1:-1, 1:-1, 1:-1], g[:, :, pf +
+                             1: -pbk - 1, pt + 1: -pbt - 1, pl + 1: -pr - 1])
 
     @onlyNativeDeviceTypes
     def test_Bilinear_empty(self, device):
@@ -8750,7 +8752,8 @@ class TestNNDeviceType(NNTestCase):
                                 nt = torch.nested.nested_tensor([], device=device)
                                 _test_module_empty_input(self, encoder_layer, nt, check_size=False, inference=True)
 
-                            nt = torch.nested.nested_tensor([torch.rand(0, 512, device=device, dtype=torch.double)], device=device)
+                            nt = torch.nested.nested_tensor(
+                                [torch.rand(0, 512, device=device, dtype=torch.double)], device=device)
                             _test_module_empty_input(self, encoder_layer, nt, check_size=False, inference=True)
                 else:
                     _test_module_empty_input(self, encoder_layer, input, check_size=False)
@@ -8761,7 +8764,8 @@ class TestNNDeviceType(NNTestCase):
         for batch_first, input_shape in [(True, (0, 10, 512)),
                                          (False, (10, 0, 512))]:
             input = torch.rand(*input_shape, device=device, dtype=torch.double)
-            encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
+            encoder_layer = nn.TransformerEncoderLayer(
+                d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
             transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6).to(device)
             _test_module_empty_input(self, transformer_encoder, input, check_size=False)
 
@@ -8772,7 +8776,8 @@ class TestNNDeviceType(NNTestCase):
                                                      (False, (10, 0, 512), (20, 0, 512))]:
             memory = torch.rand(*memory_shape, device=device, dtype=torch.double)
             tgt = torch.rand(*tgt_shape, requires_grad=True, device=device, dtype=torch.double)
-            decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
+            decoder_layer = nn.TransformerDecoderLayer(
+                d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
             self._test_module_empty_inputs(decoder_layer, [tgt, memory])
 
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
@@ -8782,7 +8787,8 @@ class TestNNDeviceType(NNTestCase):
                                                      (False, (10, 0, 512), (20, 0, 512))]:
             memory = torch.rand(*memory_shape, device=device, dtype=torch.double)
             tgt = torch.rand(*tgt_shape, requires_grad=True, device=device, dtype=torch.double)
-            decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
+            decoder_layer = nn.TransformerDecoderLayer(
+                d_model=512, nhead=8, batch_first=batch_first, dtype=torch.double).to(device)
             transformer_decoder = nn.TransformerDecoder(decoder_layer, num_layers=6).to(device)
             self._test_module_empty_inputs(transformer_decoder, [tgt, memory])
 
@@ -9156,7 +9162,8 @@ class TestNNDeviceType(NNTestCase):
             v(lambda: F.hinge_embedding_loss(input, input, reduction=reduction))
             v(lambda: F.poisson_nll_loss(input, input, reduction=reduction))
             v(lambda: F.gaussian_nll_loss(input, input, var, reduction=reduction))
-            v(lambda: F.binary_cross_entropy(torch.sigmoid(input), input.gt(0).to(torch.get_default_dtype()), reduction=reduction))
+            v(lambda: F.binary_cross_entropy(torch.sigmoid(input), input.gt(
+                0).to(torch.get_default_dtype()), reduction=reduction))
             v(lambda: F.binary_cross_entropy_with_logits(input, input, reduction=reduction))
 
             zeros = torch.zeros_like(input).to(torch.int64)
@@ -9417,7 +9424,8 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
 
         # test forward when input's height is not same as width
-        in_t = torch.ones(1, 2, 2, 1, device=device, dtype=torch.double).contiguous(memory_format=memory_format).requires_grad_()
+        in_t = torch.ones(1, 2, 2, 1, device=device, dtype=torch.double).contiguous(
+            memory_format=memory_format).requires_grad_()
         out_t = F.interpolate(in_t, size=(4, 2), mode=mode)
         self.assertEqual(torch.ones(1, 2, 4, 2, device=device, dtype=torch.double), out_t)
         self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
@@ -9519,7 +9527,8 @@ class TestNNDeviceType(NNTestCase):
         check_forward_ad = torch.device(device).type != 'xla'
 
         m = nn.Upsample(size=4, mode=mode)
-        in_t = torch.ones(1, 2, 2, 2, 2, device=device, dtype=torch.double).contiguous(memory_format=memory_format).requires_grad_()
+        in_t = torch.ones(1, 2, 2, 2, 2, device=device, dtype=torch.double).contiguous(
+            memory_format=memory_format).requires_grad_()
         in_uint8_t = torch.ones(
             1, 2, 2, 2, 2, dtype=torch.uint8, device=device
         ).contiguous(memory_format=memory_format)
@@ -9764,7 +9773,8 @@ class TestNNDeviceType(NNTestCase):
         #   to be clipped in uint8 path, but not in float path. This isn't
         #   an issue with bilinear kernel.
         input_range = (30, 220) if mode == "bicubic" else (0, 256)
-        input_ui8 = torch.randint(*input_range, size=(batch_size, num_channels, 400, 400), dtype=torch.uint8, device=device)
+        input_ui8 = torch.randint(*input_range, size=(batch_size, num_channels,
+                                  400, 400), dtype=torch.uint8, device=device)
         input_ui8 = input_ui8.contiguous(memory_format=memory_format)
 
         if non_contig == "sliced":
@@ -10221,7 +10231,8 @@ class TestNNDeviceType(NNTestCase):
     def test_softmax_results(self, device, dtype):
         # Non-even sizes and non-zero shifts test fallback paths in vectorized kernel
         # Note: dim1 > 1024 is needed to exercise the vectorized (non-persistent) path, (16, 30576) is BERT-esque
-        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23), (32, 1536), (31, 2048), (33, 2049), (16, 30576)]
+        sizes = [(0, 10), (32, 20), (10, 0), (31, 20), (32, 21), (31, 23),
+                 (32, 1536), (31, 2048), (33, 2049), (16, 30576)]
         shifts = [(0, 0), (1, 0), (0, 1), (1, 1)]
         for fn in [F.softmax, F.log_softmax]:
             for size in sizes:
@@ -10288,7 +10299,6 @@ class TestNNDeviceType(NNTestCase):
             self.assertEqual(x.grad[0], x.grad[-1])
 
         run_test(1024 * 256 + 1, 8192)  # https://github.com/pytorch/pytorch/issues/84144
-
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.float, torch.half)
@@ -10742,7 +10752,8 @@ class TestNNDeviceType(NNTestCase):
             log_probs_ref = log_probs.detach().clone().requires_grad_()
 
             with torch.backends.cudnn.flags(enabled=True):
-                res = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, zero_infinity=zero_infinity)
+                res = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths,
+                                                   target_lengths, zero_infinity=zero_infinity)
                 res.backward()
 
             expected = ctcloss_reference(log_probs, targets.cuda(), input_lengths, target_lengths).float()
@@ -10993,7 +11004,6 @@ class TestNNDeviceType(NNTestCase):
         inputs = (torch.randn(4, 16, 16, device=device, dtype=torch.double) - 0.5) * 10
         inputs.requires_grad = True
         self.assertTrue(gradcheck(F.hardswish, (inputs,)))
-
 
     def _test_batchnorm_eval(self, ndim, device, dtype, module_dtype=None):
         module_dtype = module_dtype or dtype
@@ -11268,14 +11278,16 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
+        log_probs = torch.log_softmax(torch.randn(input_length, batch_size,
+                                      num_labels, device='cuda', dtype=torch.float), 2)
         log_probs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
         target_lengths = batch_size * [target_length]
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
+            loss_native = torch.nn.functional.ctc_loss(
+                log_probs, targets, input_lengths, target_lengths, reduction='none')
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
         loss_cudnn = torch.nn.functional.ctc_loss(log_probs, targets.to('cpu', torch.int32),
                                                   input_lengths, target_lengths, reduction='none')
@@ -11293,7 +11305,8 @@ class TestNNDeviceType(NNTestCase):
         target_length = 15
         targets = torch.randint(1, num_labels, (batch_size * target_length,),
                                 device='cuda', dtype=torch.long)
-        log_probs = torch.log_softmax(torch.randn(input_length, batch_size, num_labels, device='cuda', dtype=torch.float), 2)
+        log_probs = torch.log_softmax(torch.randn(input_length, batch_size,
+                                      num_labels, device='cuda', dtype=torch.float), 2)
         log_probs.requires_grad_()
 
         input_lengths = batch_size * [input_length]
@@ -11301,7 +11314,8 @@ class TestNNDeviceType(NNTestCase):
         target_lengths = torch.tensor(batch_size * [target_length], dtype=torch.long, device='cuda')
         grad_out = torch.randn(batch_size, device='cuda', dtype=torch.float)
         with torch.backends.cudnn.flags(enabled=False):
-            loss_native = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
+            loss_native = torch.nn.functional.ctc_loss(
+                log_probs, targets, input_lengths, target_lengths, reduction='none')
             grad_native, = torch.autograd.grad(loss_native, log_probs, grad_out)
         loss_cudnn = torch.nn.functional.ctc_loss(log_probs,
                                                   targets.to('cuda', torch.int32),
@@ -11490,7 +11504,8 @@ class TestNNDeviceType(NNTestCase):
         for dim in [0, 1, 2, 3]:
             _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=1e-2)
             # test softmax with large input value which casues exp() to overflow
-            _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device, inp_dims=(16, 33, 15, 16), prec=0.05, scale_factor=1000.0)
+            _test_bfloat16_ops(self, torch.nn.Softmax(dim=dim), device,
+                               inp_dims=(16, 33, 15, 16), prec=0.05, scale_factor=1000.0)
 
     def test_nll_loss_mismatched_batch(self, device):
         x = torch.randn((10, 3), requires_grad=True, device=device)
@@ -11620,7 +11635,8 @@ class TestNNDeviceType(NNTestCase):
             weight = torch.zeros([num_channels], device=device)
             self.assertEqual(F.nll_loss(input, target, weight, reduction="sum").item(), 0.)
             self.assertEqual(F.nll_loss(input, target, weight, reduction="mean").item(), float("nan"))
-            self.assertEqual(F.nll_loss(input, target, weight, reduction="none"), torch.zeros(target.shape, device=device))
+            self.assertEqual(F.nll_loss(input, target, weight, reduction="none"),
+                             torch.zeros(target.shape, device=device))
 
         helper([2, 3])
         helper([2, 3, 5, 7])
@@ -11635,7 +11651,8 @@ class TestNNDeviceType(NNTestCase):
             target = torch.zeros(target_size, dtype=torch.long, device=device)
             self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="sum").item(), 0)
             self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="mean").item(), float("nan"))
-            self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="none"), torch.zeros(target.shape, device=device))
+            self.assertEqual(F.nll_loss(input, target, ignore_index=0, reduction="none"),
+                             torch.zeros(target.shape, device=device))
 
         helper([2, 3])
         helper([2, 3, 5, 7])
@@ -11701,8 +11718,6 @@ if __name__ == '__main__':
     run_tests()
         """)
         self.assertIn('CUDA error: device-side assert triggered', stderr)
-
-
 
     def test_cross_entropy_loss_prob_target_all_reductions(self, device):
         # Test with k-dimensional loss.
@@ -11868,7 +11883,6 @@ if __name__ == '__main__':
 
                 self.assertEqual(output_with_smoothing, output_with_manual_smoothing)
 
-
     def test_cross_entropy_label_smoothing_weight_ignore_indices(self, device):
         reductions = ['none', 'sum', 'mean']
         label_smoothings = [0.05, 0.15]
@@ -11989,7 +12003,6 @@ if __name__ == '__main__':
             if device == 'cpu':
                 test_dtype(func, x, torch.bfloat16)
 
-
     def test_logsigmoid_out(self, device):
         # this isn't actually documented, but was broken previously:
         # https://github.com/pytorch/pytorch/issues/36499
@@ -12098,10 +12111,12 @@ if __name__ == '__main__':
         for grad_only_one_elem, prefix_finite_grad_param, scalars, norms_nonfinite, norms_finite in test_cases:
             for error_if_nonfinite in [False, True]:
                 for norm_type, scalar in product(norms_nonfinite, scalars):
-                    run_test_case(norm_type, error_if_nonfinite, scalar, grad_only_one_elem, prefix_finite_grad_param, True)
+                    run_test_case(norm_type, error_if_nonfinite, scalar,
+                                  grad_only_one_elem, prefix_finite_grad_param, True)
 
                 for norm_type, scalar in product(norms_finite, scalars):
-                    run_test_case(norm_type, error_if_nonfinite, scalar, grad_only_one_elem, prefix_finite_grad_param, False)
+                    run_test_case(norm_type, error_if_nonfinite, scalar,
+                                  grad_only_one_elem, prefix_finite_grad_param, False)
 
     @onlyCUDA
     @deviceCountAtLeast(2)
@@ -12552,10 +12567,10 @@ if __name__ == '__main__':
             ref_output = perm_fn(torch.tensor([[[2.429026, 0.020793, -0.601741, -0.085642],
                                                 [2.428811, 0.021445, -0.601912, -0.084252]],
                                                [[2.425009, 0.019155, -0.604566, -0.085899],
-                                                [2.415408, 0.02249 , -0.611415, -0.073]],
+                                                [2.415408, 0.02249, -0.611415, -0.073]],
                                                [[2.434199, 0.021682, -0.598039, -0.087699],
                                                 [2.42598, 0.019941, -0.603896, -0.085091]],
-                                               [[2.436457, 0.022736, -0.59643 , -0.08736],
+                                               [[2.436457, 0.022736, -0.59643, -0.08736],
                                                 [2.434021, 0.022093, -0.598179, -0.08679]],
                                                [[2.416531, 0.017498, -0.610513, -0.083181],
                                                 [2.4242, 0.024653, -0.605266, -0.074959]]], device=device, dtype=dtype))
@@ -12610,7 +12625,6 @@ if __name__ == '__main__':
                 else:
                     torch.testing.assert_close(result, ref_output)
 
-
         for batch_first in (True, False):
             for training in (True, False):
                 if training:
@@ -12652,7 +12666,6 @@ if __name__ == '__main__':
         # Provide both masks
         with torch.no_grad():
             model(src, src_mask=src_mask, src_key_padding_mask=src_key_padding_mask)
-
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.half, torch.float)
@@ -12747,7 +12760,8 @@ if __name__ == '__main__':
         l = nn.Linear(10, 10).to(device)
         clip_value = 2.5
 
-        grad_w, grad_b = torch.arange(-50., 50, device=device).view(10, 10).div_(5), torch.ones(10, device=device).mul_(2)
+        grad_w, grad_b = torch.arange(-50., 50, device=device).view(10,
+                                                                    10).div_(5), torch.ones(10, device=device).mul_(2)
         for grad_list in [[grad_w, grad_b], [grad_w, None]]:
             for p, g in zip(l.parameters(), grad_list):
                 p._grad = g.clone().view_as(p.data) if g is not None else g
@@ -12997,6 +13011,7 @@ class TestFusionUtils(TestCase):
             self.assertEqual(weight.requires_grad, w_rg)
             self.assertEqual(bias.requires_grad, b_rg)
 
+
 class TestUtils(TestCase):
     def test_consume_prefix_in_state_dict_if_present(self):
         class Block(nn.Module):
@@ -13039,6 +13054,7 @@ class TestUtils(TestCase):
         # Check they are the same preserving order
         self.assertEqual(list(state_dict.keys()), list(ddp_state_dict.keys()))
         self.assertEqual(list(state_dict._metadata.keys()), list(ddp_state_dict._metadata.keys()))
+
 
 instantiate_device_type_tests(TestNNDeviceType, globals())
 instantiate_parametrized_tests(TestNN)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3718,7 +3718,7 @@ def huber_loss(
     Returns:
         Tensor: Huber loss (optionally weighted).
     """
-    if has_torch_function_variadic(input, target):
+    if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(
             huber_loss,
             (input, target, weight),
@@ -3782,7 +3782,7 @@ def l1_loss(
 
     See :class:`~torch.nn.L1Loss` for details.
     """
-    if has_torch_function_variadic(input, target):
+    if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(
             l1_loss,
             (input, target, weight),
@@ -3854,7 +3854,7 @@ def mse_loss(
     Returns:
         Tensor: Mean Squared Error loss (optionally weighted).
     """
-    if has_torch_function_variadic(input, target):
+    if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(
             mse_loss,
             (input, target, weight),

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3774,7 +3774,7 @@ def l1_loss(
     size_average: Optional[bool] = None,
     reduce: Optional[bool] = None,
     reduction: str = "mean",
-    **kwargs,
+    weight: Optional[Tensor] = None,
 ) -> Tensor:  # noqa: D400,D402
     r"""l1_loss(input, target, size_average=None, reduce=None, reduction='mean') -> Tensor
 
@@ -3782,14 +3782,13 @@ def l1_loss(
 
     See :class:`~torch.nn.L1Loss` for details.
     """
-    weight = kwargs.get('weight', None)
-
+   
     args = (input, target, weight) if weight is not None else (input, target)
 
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
             l1_loss,
-            (input, target),
+            args,
             input,
             target,
             size_average=size_average,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3720,7 +3720,8 @@ def huber_loss(
     """
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
-            huber_loss(input, target, weights),
+            huber_loss,
+            (input, target, weights),
             input,
             target,
             reduction=reduction,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3782,13 +3782,10 @@ def l1_loss(
 
     See :class:`~torch.nn.L1Loss` for details.
     """
-
-    args = (input, target, weight) if weight is not None else (input, target)
-
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
             l1_loss,
-            args,
+            (input, target, weight),
             input,
             target,
             size_average=size_average,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3782,7 +3782,7 @@ def l1_loss(
 
     See :class:`~torch.nn.L1Loss` for details.
     """
-   
+
     args = (input, target, weight) if weight is not None else (input, target)
 
     if has_torch_function_variadic(input, target):
@@ -3885,7 +3885,7 @@ def mse_loss(
         if weight.size() != input.size():
             raise ValueError("Weights and input must have the same size.")
 
-        # Perform weighted MSE loss manually      
+        # Perform weighted MSE loss manually
         squared_errors = torch.pow(expanded_input - expanded_target, 2)
         weighted_squared_errors = squared_errors * weight
 
@@ -3899,7 +3899,7 @@ def mse_loss(
             raise ValueError(
                 f"Invalid reduction mode: {reduction}. Expected one of 'none', 'mean', 'sum'."
             )
-    else:    
+    else:
         return torch._C._nn.mse_loss(
             expanded_input, expanded_target, _Reduction.get_enum(reduction)
         )

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3767,6 +3767,7 @@ def huber_loss(
                 f"Invalid reduction mode: {reduction}. Expected one of 'none', 'mean', 'sum'."
             )
 
+
 def l1_loss(
     input: Tensor,
     target: Tensor,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3693,9 +3693,9 @@ def huber_loss(
     target: Tensor,
     reduction: str = "mean",
     delta: float = 1.0,
-    weights: Optional[Tensor] = None,
+    weight: Optional[Tensor] = None,
 ) -> Tensor:
-    r"""huber_loss(input, target, reduction='mean', delta=1.0, weights=None) -> Tensor
+    r"""huber_loss(input, target, reduction='mean', delta=1.0, weight=None) -> Tensor
 
     Computes the Huber loss, with optional weighting.
 
@@ -3713,7 +3713,7 @@ def huber_loss(
                                    'sum': the output will be summed. 'none': no reduction will be applied.
                                    Default: 'mean'.
         delta (float, optional): The threshold at which to change between delta-scaled L1 and L2 loss. Default: 1.0.
-        weights (Tensor, optional): Weights for each sample. Default: None.
+        weight (Tensor, optional): Weights for each sample. Default: None.
 
     Returns:
         Tensor: Huber loss (optionally weighted).
@@ -3721,12 +3721,12 @@ def huber_loss(
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
             huber_loss,
-            (input, target, weights),
+            (input, target, weight),
             input,
             target,
             reduction=reduction,
             delta=delta,
-            weights=weights,
+            weight=weight,
         )
 
     if not (target.size() == input.size()):
@@ -3739,13 +3739,13 @@ def huber_loss(
 
     expanded_input, expanded_target = torch.broadcast_tensors(input, target)
 
-    if weights is None:
+    if weight is None:
         # Use the optimized C++ backend for standard Huber loss
         return torch._C._nn.huber_loss(
             expanded_input, expanded_target, _Reduction.get_enum(reduction), delta
         )
     else:
-        if weights.size() != input.size():
+        if weight.size() != input.size():
             raise ValueError("Weights and input must have the same size.")
 
         # Calculate the unweighted loss first
@@ -3753,15 +3753,15 @@ def huber_loss(
             expanded_input, expanded_target, _Reduction.get_enum("none"), delta
         )
 
-        # Apply weights to the unweighted loss
-        weighted_loss = unweighted_loss * weights
+        # Apply weight to the unweighted loss
+        weighted_loss = unweighted_loss * weight
 
         if reduction == "none":
             return weighted_loss
         elif reduction == "sum":
             return torch.sum(weighted_loss)
         elif reduction == "mean":
-            return torch.sum(weighted_loss) / torch.sum(weights)
+            return torch.sum(weighted_loss) / torch.sum(weight)
         else:
             raise ValueError(
                 f"Invalid reduction mode: {reduction}. Expected one of 'none', 'mean', 'sum'."
@@ -3774,9 +3774,9 @@ def l1_loss(
     size_average: Optional[bool] = None,
     reduce: Optional[bool] = None,
     reduction: str = "mean",
-    weights: Optional[Tensor] = None,
+    weight: Optional[Tensor] = None,
 ) -> Tensor:  # noqa: D400,D402
-    r"""l1_loss(input, target, size_average=None, reduce=None, reduction='mean', weights=None) -> Tensor
+    r"""l1_loss(input, target, size_average=None, reduce=None, reduction='mean', weight=None) -> Tensor
 
     Function that calculates the mean element-wise absolute value difference, with optional weighting.
 
@@ -3785,13 +3785,13 @@ def l1_loss(
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
             l1_loss,
-            (input, target, weights),
+            (input, target, weight),
             input,
             target,
             size_average=size_average,
             reduce=reduce,
             reduction=reduction,
-            weights=weights,
+            weight=weight,
         )
     if not (target.size() == input.size()):
         warnings.warn(
@@ -3805,19 +3805,19 @@ def l1_loss(
 
     expanded_input, expanded_target = torch.broadcast_tensors(input, target)
 
-    if weights is not None:
-        if weights.size() != input.size():
+    if weight is not None:
+        if weight.size() != input.size():
             raise ValueError("Weights and input must have the same size.")
 
         absolute_errors = torch.abs(expanded_input - expanded_target)
-        weighted_absolute_errors = absolute_errors * weights
+        weighted_absolute_errors = absolute_errors * weight
 
         if reduction == "none":
             return weighted_absolute_errors
         elif reduction == "sum":
             return torch.sum(weighted_absolute_errors)
         elif reduction == "mean":
-            return torch.sum(weighted_absolute_errors) / torch.sum(weights)
+            return torch.sum(weighted_absolute_errors) / torch.sum(weight)
         else:
             raise ValueError(
                 f"Invalid reduction mode: {reduction}. Expected one of 'none', 'mean', 'sum'."
@@ -3834,9 +3834,9 @@ def mse_loss(
     size_average: Optional[bool] = None,
     reduce: Optional[bool] = None,
     reduction: str = "mean",
-    weights: Optional[Tensor] = None,
+    weight: Optional[Tensor] = None,
 ) -> Tensor:
-    r"""mse_loss(input, target, size_average=None, reduce=None, reduction='mean', weights=None) -> Tensor
+    r"""mse_loss(input, target, size_average=None, reduce=None, reduction='mean', weight=None) -> Tensor
 
     Measures the element-wise mean squared error, with optional weighting.
 
@@ -3849,7 +3849,7 @@ def mse_loss(
                                    'none' | 'mean' | 'sum'. 'mean': the mean of the output is taken.
                                    'sum': the output will be summed. 'none': no reduction will be applied.
                                    Default: 'mean'.
-        weights (Tensor, optional): Weights for each sample. Default: None.
+        weight (Tensor, optional): Weights for each sample. Default: None.
 
     Returns:
         Tensor: Mean Squared Error loss (optionally weighted).
@@ -3857,13 +3857,13 @@ def mse_loss(
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
             mse_loss,
-            (input, target, weights),
+            (input, target, weight),
             input,
             target,
             size_average=size_average,
             reduce=reduce,
             reduction=reduction,
-            weights=weights,
+            weight=weight,
         )
 
     if not (target.size() == input.size()):
@@ -3877,21 +3877,21 @@ def mse_loss(
     if size_average is not None or reduce is not None:
         reduction = _Reduction.legacy_get_string(size_average, reduce)
 
-    if weights is not None:
-        if weights.size() != input.size():
+    if weight is not None:
+        if weight.size() != input.size():
             raise ValueError("Weights and input must have the same size.")
 
         # Perform weighted MSE loss manually
         expanded_input, expanded_target = torch.broadcast_tensors(input, target)
         squared_errors = torch.pow(expanded_input - expanded_target, 2)
-        weighted_squared_errors = squared_errors * weights
+        weighted_squared_errors = squared_errors * weight
 
         if reduction == "none":
             return weighted_squared_errors
         elif reduction == "sum":
             return torch.sum(weighted_squared_errors)
         elif reduction == "mean":
-            return torch.sum(weighted_squared_errors) / torch.sum(weights)
+            return torch.sum(weighted_squared_errors) / torch.sum(weight)
         else:
             raise ValueError(
                 f"Invalid reduction mode: {reduction}. Expected one of 'none', 'mean', 'sum'."

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3761,7 +3761,7 @@ def huber_loss(
         elif reduction == "sum":
             return torch.sum(weighted_loss)
         elif reduction == "mean":
-            return torch.sum(weighted_loss) / torch.sum(weight)
+            return weighted_loss.mean()
         else:
             raise ValueError(
                 f"Invalid reduction mode: {reduction}. Expected one of 'none', 'mean', 'sum'."

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -901,7 +901,8 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
             lambda input, size=None, scale_factor=None, mode="nearest", align_corners=None, recompute_scale_factor=None, antialias=False: -1  # noqa: B950
         ),
         torch.nn.functional.kl_div: lambda input, target, size_average=None, reduce=None, reduction="mean", log_target=False: -1,  # noqa: B950
-        torch.nn.functional.l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean": -1,
+        torch.nn.functional.l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", weight=None: -1,
+        torch.nn.functional.mse_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", weight=None: -1,
         torch.nn.functional.layer_norm: lambda input, normalized_shape, weight=None, bias=None, eps=1e-05: -1,
         torch.nn.functional.leaky_relu: lambda input, negative_slope=0.01, inplace=False: -1,
         torch.nn.functional.linear: lambda input, weight, bias=None: -1,
@@ -968,7 +969,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.nn.functional.mish: lambda input, inplace=False: -1,
         torch.nn.functional.scaled_dot_product_attention: lambda query, key, value, attn_mask=None, dropout_p=0.0: -1,
         torch.nn.functional.smooth_l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", beta=1.0: -1,  # noqa: B950
-        torch.nn.functional.huber_loss: lambda input, target, reduction="mean", delta=1.0: -1,
+        torch.nn.functional.huber_loss: lambda input, target, reduction="mean", delta=1.0, weight=None: -1,
         torch.nn.functional.soft_margin_loss: lambda input, target, size_average=None, reduce=None, reduction="mean": -1,  # noqa: B950
         torch.nn.functional.softmax: lambda input, dim=None, _stacklevel=3, dtype=None: -1,
         torch.nn.functional.softmin: lambda input, dim=None, _stacklevel=3, dtype=None: -1,

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -901,7 +901,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
             lambda input, size=None, scale_factor=None, mode="nearest", align_corners=None, recompute_scale_factor=None, antialias=False: -1  # noqa: B950
         ),
         torch.nn.functional.kl_div: lambda input, target, size_average=None, reduce=None, reduction="mean", log_target=False: -1,  # noqa: B950
-        torch.nn.functional.l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean": -1,
+        torch.nn.functional.l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", weight=None: -1,
         torch.nn.functional.layer_norm: lambda input, normalized_shape, weight=None, bias=None, eps=1e-05: -1,
         torch.nn.functional.leaky_relu: lambda input, negative_slope=0.01, inplace=False: -1,
         torch.nn.functional.linear: lambda input, weight, bias=None: -1,

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -902,7 +902,6 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         ),
         torch.nn.functional.kl_div: lambda input, target, size_average=None, reduce=None, reduction="mean", log_target=False: -1,  # noqa: B950
         torch.nn.functional.l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", weight=None: -1,
-        torch.nn.functional.mse_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", weight=None: -1,
         torch.nn.functional.layer_norm: lambda input, normalized_shape, weight=None, bias=None, eps=1e-05: -1,
         torch.nn.functional.leaky_relu: lambda input, negative_slope=0.01, inplace=False: -1,
         torch.nn.functional.linear: lambda input, weight, bias=None: -1,
@@ -936,7 +935,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.nn.functional.max_unpool1d: lambda input, indices, kernel_size, stride=None, padding=0, output_size=None: -1,  # noqa: B950
         torch.nn.functional.max_unpool2d: lambda input, indices, kernel_size, stride=None, padding=0, output_size=None: -1,  # noqa: B950
         torch.nn.functional.max_unpool3d: lambda input, indices, kernel_size, stride=None, padding=0, output_size=None: -1,  # noqa: B950
-        torch.nn.functional.mse_loss: lambda input, target, size_average=None, reduce=None, reduction="mean": -1,
+        torch.nn.functional.mse_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", weight=None: -1,
         torch.nn.functional.multi_head_attention_forward: (
             lambda query, key, value, embed_dim_to_check, num_heads, in_proj_weight, in_proj_bias, bias_k, bias_v, add_zero_attn, dropout_p, out_proj_weight, out_proj_bias, training=True, key_padding_mask=None, need_weights=True, attn_mask=None, use_separate_proj_weight=False, q_proj_weight=None, k_proj_weight=None, v_proj_weight=None, static_k=None, static_v=None, average_attn_weights=None, is_causal=False: -1  # noqa: B950
         ),

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -901,7 +901,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
             lambda input, size=None, scale_factor=None, mode="nearest", align_corners=None, recompute_scale_factor=None, antialias=False: -1  # noqa: B950
         ),
         torch.nn.functional.kl_div: lambda input, target, size_average=None, reduce=None, reduction="mean", log_target=False: -1,  # noqa: B950
-        torch.nn.functional.l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", weight=None: -1,
+        torch.nn.functional.l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean": -1,
         torch.nn.functional.layer_norm: lambda input, normalized_shape, weight=None, bias=None, eps=1e-05: -1,
         torch.nn.functional.leaky_relu: lambda input, negative_slope=0.01, inplace=False: -1,
         torch.nn.functional.linear: lambda input, weight, bias=None: -1,


### PR DESCRIPTION
#### Summary
This pull request introduces new weighted loss functions to the PyTorch library: `weighted_huber_loss`, `wmse_loss`, and `wmae_loss`. These functions allow for precise control over the influence of each sample during training, important for imbalanced data or when certain samples are more significant than others.

#### Changes
- **`weighted_huber_loss`**: Huber loss modified to incorporate weights, providing a balance between L1 and L2 loss based on the `delta` parameter.
- **`wmse_loss`** (Weighted Mean Squared Error): Applies weights to the standard MSE loss, useful for emphasizing certain samples in regression tasks.
- **`wmae_loss`** (Weighted Mean Absolute Error): Adjusts MAE loss calculation by including weights, ideal for datasets with outliers.

#### Code Details
- **Input Validation**: Ensures `input`, `target`, and `weights` tensors match in size to prevent broadcasting errors.
- **Reduction Options**: Supports `none`, `mean`, and `sum` reductions to suit various computational needs.
- **Backward Compatibility**: Maintains support for deprecated arguments `size_average` and `reduce`, while encouraging use of the `reduction` argument.

#### Usage Example
```python
import torch
input = torch.tensor([0.5, 2.5, 2.0], dtype=torch.float32)
target = torch.tensor([0.0, 2.0, 1.5], dtype=torch.float32)
weights = torch.tensor([1.0, 0.5, 1.5], dtype=torch.float32)

loss = weighted_huber_loss(input, target, weights, delta=1.0)
print(loss)
```
---

Feedback on these implementations is welcome; please let me know if further modifications are required.

Resolves #132465




cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki