### PR TITLE
Fix fake_tensor w/ non-view tensor

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1585,30 +1585,6 @@ class FakeTensorMode(TorchDispatchMode):
             storage = view_arg.untyped_storage()
             with in_kernel_invocation_manager(self), maybe_suppress():
                 empty.set_(storage, storage_offset, shape, stride)
-        else:
-            if isinstance(storage_offset, SymInt):
-                # Do it this way so we don't import symbolic_shapes (which imports
-                # expensive sympy) unless we have to.
-                from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
-
-                zero_offset = guard_size_oblivious(storage_offset == 0)
-            else:
-                zero_offset = storage_offset == 0
-            if not zero_offset:
-                storage = empty.untyped_storage()
-                with in_kernel_invocation_manager(self), maybe_suppress():
-                    empty.set_(storage, storage_offset, shape, stride)
-
-        if isinstance(storage_bytes, SymInt):
-            # Do it this way so we don't import symbolic_shapes (which imports
-            # expensive sympy) unless we have to.
-            from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
-
-            zero_bytes = guard_size_oblivious(storage_bytes == 0)
-        else:
-            zero_bytes = storage_bytes == 0
-        if zero_bytes:
-            empty.untyped_storage().resize_(0)
 
         return FakeTensor(self, empty, metadata.device)
 


### PR DESCRIPTION
Summary: This code was overly complex and is confusing some guards - basically if a result cached tensor isn't a view there's no reason to be messing with its storage.

Test Plan: unit tests pass

Differential Revision: D60387821
