### PR TITLE
[DTensor] Added `aten._foreach_div.Scalar` to supported foreach ops

### DIFF
--- a/torch/distributed/_tensor/ops/pointwise_ops.py
+++ b/torch/distributed/_tensor/ops/pointwise_ops.py
@@ -545,6 +545,7 @@ for_each_ops = [
     aten._foreach_clamp_max_.Scalar,
     aten._foreach_clamp_min_.Scalar,
     aten._foreach_div_.List,
+    aten._foreach_div.Scalar,
     aten._foreach_div_.ScalarList,
     aten._foreach_lerp_.Scalar,
     aten._foreach_maximum_.List,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132056

Fixes https://github.com/pytorch/pytorch/issues/132017

cc @XilunWu @H-Huang @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o