### PR TITLE
Fix stdout / stderr typing in SubprocessHandler

### DIFF
--- a/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
+++ b/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
@@ -36,8 +36,8 @@ class SubprocessHandler:
         entrypoint: str,
         args: Tuple,
         env: Dict[str, str],
-        stdout: str,
-        stderr: str,
+        stdout: Optional[str],
+        stderr: Optional[str],
         local_rank_id: int,
     ):
         self._stdout = open(stdout, "w") if stdout else None


### PR DESCRIPTION
Summary: Fix stdout / stderr typing in SubprocessHandler. Stdout and Stderr should be `Optional[str]` instead of `str`.

Test Plan: CI

Differential Revision: D60319648


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o