### PR TITLE
Add clone_* variants for wrapper functions for better cProfile

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -26,7 +26,7 @@ import typing
 import warnings
 import weakref
 from contextlib import contextmanager
-from functools import lru_cache, wraps
+from functools import lru_cache
 from types import MethodWrapperType
 from typing import (
     Any,
@@ -51,6 +51,8 @@ from typing import (
     ValuesView,
 )
 from typing_extensions import Literal, ParamSpec, TypeGuard
+
+from torch.utils._contextlib import clone_contextmanager, clone_wraps
 
 from ..utils.hooks import RemovableHandle
 
@@ -257,7 +259,7 @@ def dynamo_timed(
     fwd_only: bool = True,
 ):
     def dynamo_timed_inner(func: Callable[_P, T]) -> Callable[_P, T]:
-        @wraps(func)
+        @clone_wraps(func)  # type: ignore[misc]
         def time_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> T:
             key = func.__qualname__
             if key not in compilation_time_metrics:
@@ -972,7 +974,7 @@ def skip_frame_if_in_functorch_mode(val: torch.Tensor):
         ) from e
 
 
-@contextmanager
+@clone_contextmanager
 def preserve_rng_state():
     disable_functorch = torch._C._DisableFuncTorch
     disable_current_modes = torch.utils._python_dispatch._disable_current_modes

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 from torch.utils import _pytree as pytree
+from torch.utils._contextlib import clone_contextmanager
 from torch.utils._traceback import CapturedTraceback
 from torch.utils.weak import WeakTensorKeyDictionary
 
@@ -687,7 +688,7 @@ class TracingContext:
     # Call this when you want to call into some code that isn't necessarily
     # associated with the current frame state
     @staticmethod
-    @contextlib.contextmanager
+    @clone_contextmanager
     def clear_frame():
         tc = TracingContext.get()
         with unittest.mock.patch.object(

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -55,6 +55,7 @@ from torch._ops import OpOverload
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymExprPrinter
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
+from torch.utils._contextlib import clone_wraps
 
 from .._dynamo.backends.common import aot_autograd
 from ..fx._lazy_graph_module import _use_lazy_graph_module  # type: ignore[attr-defined]
@@ -427,7 +428,7 @@ def get_patched_config_dict(config_patches=None) -> Dict[str, Any]:
 
 
 def with_fresh_cache_if_config(fn):
-    @functools.wraps(fn)
+    @clone_wraps(fn)
     def wrapper(*args, **kwargs):
         if config.force_disable_caches:
             # Don't delete the cache dir because it has to survive beyond the

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -22,6 +22,7 @@ from torch._dynamo.utils import get_debug_dir
 from torch.fx.graph_module import GraphModule
 from torch.fx.passes.shape_prop import _extract_tensor_metadata, TensorMetadata
 from torch.fx.passes.tools_common import legalize_graph
+from torch.utils._contextlib import clone_wraps
 from torch.utils._pytree import tree_map
 
 from . import config, ir  # noqa: F811, this is needed
@@ -297,7 +298,7 @@ class DebugContext:
 
     @staticmethod
     def wrap(fn):
-        @functools.wraps(fn)
+        @clone_wraps(fn)
         def inner(*args, **kwargs):
             with DebugContext():
                 return fn(*args, **kwargs)

--- a/torch/fx/_lazy_graph_module.py
+++ b/torch/fx/_lazy_graph_module.py
@@ -9,6 +9,7 @@ from torch.fx.graph_module import (
     reduce_package_graph_module,
 )
 from torch.package import PackageExporter, sys_importer
+from torch.utils._contextlib import clone_contextmanager
 from ._compatibility import compatibility
 
 _use_lazy_graph_module_flag = False
@@ -35,7 +36,7 @@ def _force_skip_lazy_graph_module():
 
 
 @compatibility(is_backward_compatible=False)
-@contextmanager
+@clone_contextmanager
 def _use_lazy_graph_module(should_use: bool):
     try:
         global _use_lazy_graph_module_flag

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -17,6 +17,8 @@ from torch._C import (
     DispatchKey,
 )
 
+from torch.utils._contextlib import clone_contextmanager
+
 
 # TODO: Limitations and things about enable_torch_dispatch_mode we should fix before exposing it:
 # - We need a better user-facing api for _DisableTorchDispatch that
@@ -199,7 +201,7 @@ def _pop_mode_temporarily(k: Optional[DispatchKey] = None):
         _push_mode(old)
 
 
-@contextlib.contextmanager
+@clone_contextmanager
 def _disable_current_modes():
     from torch._ops import (
         _len_torch_dispatch_stack_pre_dispatch,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132073

cProfile only records parent function call pointers: it always groups functions together if they have the same code object. In the case of wrapper functions/context managers, this means that often profile results will be uselessly agglomerated into a single cost center, e.g., as seen here (look for the "inner" box):

<img width="821" alt="image" src="https://github.com/user-attachments/assets/4d24bda9-9e6b-4e95-b9d9-ea33ea73f192">

This PR uses code cloning to force every wrapper function to get its own unique code object.  This results in a much cleaner cProfile trace:

<img width="396" alt="image" src="https://github.com/user-attachments/assets/652756fd-e139-4424-b573-cd2894fb8e0d">

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang