### PR TITLE
Made `register_multi_grad_hook` return type `RemovableHandle`

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -434,7 +434,7 @@ def register_multi_grad_hook(
     ],
     *,
     mode: Literal["all", "any"] = "all",
-) -> _MultiHandle:
+) -> RemovableHandle:
     r"""Register a multi-grad backward hook.
 
     There are two supported modes: ``"all"`` and ``"any"``.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132074

`_MultiHandle` is private. Let us return `RemovableHandle`, which is public.