### PR TITLE
Fix pyi annotation for `ProcessGroupGloo.Options` 

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -524,7 +524,12 @@ def _round_robin_process_groups(
 
 class ProcessGroupGloo(Backend):
     class Device: ...
-    class Options: ...
+
+    class Options(ProcessGroup.Options):
+        devices: list[ProcessGroupGloo.Device]
+        threads: int
+
+        def __init__(self): ...
 
     def __init__(
         self,


### PR DESCRIPTION
This PR fixes the pyi annotation for `ProcessGroupGloo.Options` based on the definition in the `torch/csrc/distributed/c10d/init.cpp` file. 

Fixes #132054 
