### PR TITLE
Optimize aten.cat calls of a repeated element

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -2325,7 +2325,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             def forward(self, x, y):
                 x = self.conv(self.relu(x))
                 y = self.linear(y)
-                y = torch.cat((y, y), 1)
+                y = torch.cat((y, y + 1), 1)
                 y = torch.ops.aten.permute.default(y, [0, 2, 1]).reshape(1, 32, 28, 28)
                 return x + y
 

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -7,9 +7,9 @@ import unittest
 from collections import defaultdict
 from functools import partial
 
+import torch._inductor.decomposition
 import torch.autograd
 from torch import Tensor
-import torch._inductor.decomposition
 from torch._decomp import core_aten_decompositions, decomposition_table
 from torch._dispatch.python import enable_python_dispatcher
 from torch._ops import DispatchKey

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -350,6 +350,15 @@ def cat(
     elif 1 < len(filtered_tensors) < len(tensors):
         # on the first call, when we remove empty tensors, we redispatch recursively
         return aten.cat.default(filtered_tensors, dim)
+
+    # optimization, avoid concat for single, repeated input
+    if all(t is filtered_tensors[0] for t in filtered_tensors):
+        inp = filtered_tensors[0]
+        dim = dim + len(inp) if dim < 0 else dim
+        shape = list(inp.shape)
+        shape.insert(dim, len(filtered_tensors))
+        return inp.unsqueeze(dim).expand(*shape).flatten(dim, dim + 1).clone()
+
     # when no 'filtering' has occurred, we raise to prevent infinite recursion (no more decomposition needed)
     return NotImplemented
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -352,7 +352,7 @@ def cat(
         return aten.cat.default(filtered_tensors, dim)
 
     # optimization, avoid concat for single, repeated input
-    if len(filtered_tensors) >= 1 and all(
+    if len(filtered_tensors) > 1 and all(
         t is filtered_tensors[0] for t in filtered_tensors
     ):
         inp = filtered_tensors[0]

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -352,7 +352,9 @@ def cat(
         return aten.cat.default(filtered_tensors, dim)
 
     # optimization, avoid concat for single, repeated input
-    if all(t is filtered_tensors[0] for t in filtered_tensors):
+    if len(filtered_tensors) >= 1 and all(
+        t is filtered_tensors[0] for t in filtered_tensors
+    ):
         inp = filtered_tensors[0]
         shape = list(inp.shape)
         dim = dim + len(inp.shape) if dim < 0 else dim

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -354,8 +354,8 @@ def cat(
     # optimization, avoid concat for single, repeated input
     if all(t is filtered_tensors[0] for t in filtered_tensors):
         inp = filtered_tensors[0]
-        dim = dim + len(inp) if dim < 0 else dim
         shape = list(inp.shape)
+        dim = dim + len(inp.shape) if dim < 0 else dim
         shape.insert(dim, len(filtered_tensors))
         return inp.unsqueeze(dim).expand(*shape).flatten(dim, dim + 1).clone()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132081

This was a particular problem for a model I saw which would have a large number of repeats, making compilation slow.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang