### PR TITLE
[FSDP2] Relaxed overlap timing check to avoid flakiness

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -139,7 +139,11 @@ class TestFullyShardOverlap(FSDPTest):
             num_iters * (3 * compute_sleep_ms + buffer_ms) + comm_sleep_ms
         )
         self.assertLessEqual(test_time, expected_test_time)
-        self.assertGreater(baseline_time, expected_test_time)
+        # Since `get_cycles_per_ms` uses lru cache, there may be some variance
+        # between the initially determined cycles vs. the current cycles per
+        # ms, so we relax the baseline check to just that it is greater than
+        # the test time rather than the expected test time
+        self.assertGreater(baseline_time, test_time)
 
     def _time_fn(self, fn: Callable):
         start_event = torch.cuda.Event(enable_timing=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132116

Trying to fix https://github.com/pytorch/pytorch/issues/131081

See https://github.com/pytorch/pytorch/issues/131081#issuecomment-2239443504 for detailed context. This PR is relaxing one assertion against the _baseline_ to try to fix the flakiness.

cc @XilunWu @H-Huang @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o