### PR TITLE
[inductor] fix scalar miss constuctor for long type.

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -69,6 +69,12 @@ class C10_API Scalar {
       "int64_t is the same as long long on MacOS");
   Scalar(long vv) : Scalar(vv, true) {}
 #endif
+#if defined(_MSC_VER)
+  static_assert(
+      std::is_same_v<long long, int64_t>,
+      "int64_t is the same as long long on Windows");
+  Scalar(long vv) : Scalar(vv, true) {}
+#endif
 #if defined(__linux__) && !defined(__ANDROID__)
   static_assert(
       std::is_same_v<long, int64_t>,


### PR DESCRIPTION
Fix `long` to `c10::scalar` convert issue.

![image](https://github.com/user-attachments/assets/fc44a170-e293-4688-a185-d189484f6638)


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht @iremyux @Blackhex @cristianPanaite @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10