### PR TITLE
[FSDP] Add hpu device to _get_remote_device_str

### DIFF
--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
+
+from torch._utils import _get_device_module
 from torch.distributed import distributed_c10d
 from torch.distributed._shard.sharded_tensor import (
     Shard,
@@ -20,6 +22,8 @@ from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard as D
 def _get_remote_device_str(rank, device_type, num_devices_per_node):
     if device_type.lower() == "cpu":
         return f"rank:{rank}/{device_type}"
+    elif device_type.lower() == "hpu":
+        return f"rank:{rank}/{device_type}:{_get_device_module(device_type).current_device()}"
     else:
         return f"rank:{rank}/{device_type}:{rank % num_devices_per_node}"
 


### PR DESCRIPTION
In _creating chunk_sharded_tensor, _get_remote_device_str is used. by default it uses the node cound to determine the device:instance. for hpu, need to use current device to get the deivce_instance.

Fixes #ISSUE_NUMBER


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o