### PR TITLE
[BE][TP] Check module has bias before access

### DIFF
--- a/torch/distributed/tensor/parallel/style.py
+++ b/torch/distributed/tensor/parallel/style.py
@@ -227,7 +227,7 @@ class RowwiseParallel(ParallelStyle):
             "weight",
             nn.Parameter(distribute_tensor(module.weight, device_mesh, [Shard(1)])),
         )
-        if module.bias is not None:
+        if hasattr(module, "bias") and module.bias is not None:
             module.register_parameter(
                 "bias",
                 nn.Parameter(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132137

Some linear modules, such as the ones reconstructed by `torch.export.unflatten()`, may not have the `bias` attribute, if the original linear module has `bias=None`.

cc @XilunWu @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o