### PR TITLE
[capture_triton] fix special kwargs path

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -928,6 +928,9 @@ class DynamoTritonHOPifier(TritonHOPifier):
             maybe_callable, (NestedUserFunctionVariable, UserFunctionVariable)
         )
 
+    def get_value(self, val):
+        return val.value
+
     def check_grid(self, grid):
         from .lists import BaseListVariable
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132143

I didn't test this path when creating the orchestrator. This PR fixes
that path to work in the capture_triton path. The problem is that we are
handling a value that is an int (in the capture_triton path) and a
ConstantVariable (in the Dynamo triton path) so we abstract that out in
the orchestrator.

Test Plan:
- new tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang