### PR TITLE
[PT2][Optimus] Add unbind cat to view pass

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -54,6 +54,7 @@ pre_grad_pass_names = [
     "split_cat_pass",
     "unbind_stack_pass",
     "optimize_cat_inputs_pass",
+    "unbind_cat_to_view_pass",
 ]
 
 post_grad_pass_names = [
@@ -1814,3 +1815,95 @@ def optimize_cat_inputs(match: Match, *args, **kwargs):
             # remove the cat node
             graph.erase_node(cat_node)
             counters["inductor"]["optimize_cat_inputs_pass"] += 1
+
+
+# ############pattern to be optimized is#########
+
+#               unbind(dim=0)  -> user=multiple
+#       /           \         ...       /         \
+# getitem    getitem        getitem     getitem   -> user=multiple
+#            \                    /            \
+#                cat(user=mul, dim=1)             other_op
+#                      |
+
+# ################after transformation#############
+
+#                 input_of_unbind
+#                           |    \
+#                         slice
+#                           |
+#                          view
+#                           |
+
+
+@register_graph_pattern(
+    CallFunction(
+        torch.cat,
+        getitem_unbind,
+        dim=Ignored(),
+        _users=MULTIPLE,
+    ),
+    pass_dict=construct_pattern_matcher_pass("unbind_cat_to_view_pass"),
+)
+def unbind_cat_to_view(match: Match, unbind_input: torch.fx.Node, dim: int):
+    unbind_node = next(node for node in match.nodes if node.target == torch.unbind)
+    unbind_dim = get_arg_value(unbind_node, 1, "dim")
+    graph = match.graph
+    # get the cat_node and check its inputs and meta data
+    next_users = find_next_users(unbind_node)
+    for cat_node in next_users:
+        if cat_node.target != torch.cat or not is_node_meta_valid(cat_node):
+            continue
+        # check it has same parent and all of inputs are getitem
+        if not has_same_parent_node(cat_node):
+            continue
+        # check the indices of getitem are consecutive
+        getitem_indices = []
+        for getitem in cat_node.args[0]:  # type: ignore[union-attr]
+            getitem_indices.append(getitem.args[1])  # type: ignore[union-attr]
+        if not is_sorted_and_consecutive(getitem_indices):
+            continue
+        # get the view shape
+        cat_dim = get_arg_value(cat_node, 1, "dim")
+        cat_shape = cat_node.meta["example_value"].shape
+        # get the slice start and end, the tuple of slice(a, b, c) use
+        # a represents the start of the slice, b represents the end of the slice,
+        # c represents the step size of the slice
+        slice_list = []
+        for i in range(len(cat_shape) + 1):
+            if i != unbind_dim:
+                slice_list.append(slice(None, None, None))
+            else:
+                slice_list.append(
+                    slice(getitem_indices[0], getitem_indices[-1] + 1, None)
+                )
+        # construct the permute node args, which has the same shape as the slice node
+        # then it has the same dim as the unbind_input, i.e., shape of cat + 1
+        permute_list = list(range(len(cat_shape) + 1))
+        permute_list[unbind_dim], permute_list[cat_dim] = (
+            permute_list[cat_dim],
+            permute_list[unbind_dim],
+        )
+        with graph.inserting_after(cat_node):
+            slice_node = graph.call_function(
+                operator.getitem,
+                args=(unbind_input, tuple(slice_list)),
+            )
+            permute_node = graph.call_function(
+                torch.permute,
+                args=(slice_node, permute_list),
+            )
+            reshape_node = graph.call_function(
+                torch.reshape,
+                args=(permute_node, cat_shape),
+            )
+            cat_node.replace_all_uses_with(reshape_node)
+            reshape_node.meta.update(cat_node.meta)
+        # remove inputs of cat_node if they have no users
+        cat_inputs = cat_node.args[0]  # type: ignore[union-attr]
+        graph.erase_node(cat_node)
+        # remove inputs of cat_node is they have no users
+        for cat_input in cat_inputs:  # type: ignore[union-attr]
+            if len(cat_input.users.keys()) == 0:  # type: ignore[union-attr]
+                graph.erase_node(cat_input)
+        counters["inductor"]["unbind_cat_to_view_pass"] += 1


### PR DESCRIPTION
Summary: We observed new graph transformation opportunity in IG_CTR, which can further remove the cat node.

Test Plan:
# unit test

```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 test //caffe2/test/inductor:split_cat_fx_passes
```

Buck UI: https://www.internalfb.com/buck2/5061a3fe-b788-4031-b3af-66d48564a2df
Test UI: https://www.internalfb.com/intern/testinfra/testrun/9007199298289131
Network: Up: 2.5GiB  Down: 5.7GiB  (reSessionID-a49b1234-c02c-4a2d-a9ad-9f5b23557522)
Jobs completed: 294061. Time elapsed: 13:47.8s.
Cache hits: 68%. Commands: 106996 (cached: 72904, remote: 33875, local: 217)
Tests finished: Pass 10. Fail 0. Fatal 0. Skip 1. Build failure 0

# benchmark

```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "ig_ctr" --flow_id 584880697
```

Counter({'pattern_matcher_nodes': 1649, 'pattern_matcher_count': 1538, 'normalization_pass': 343, 'extern_calls': 160, 'normalization_aten_pass': 39, 'merge_splits_pass': 19, 'fxgraph_cache_miss': 9, 'scmerge_cat_added': 4, 'scmerge_cat_removed': 4, 'scmerge_split_removed': 3, 'unbind_stack_pass': 3, 'batch_tanh': 2, 'scmerge_split_sections_removed': 2, 'scmerge_split_added': 2, 'merge_stack_tahn_unbind_pass': 1, 'optimize_cat_inputs_pass': 1, 'unbind_cat_to_view_pass': 1})

before vs after graph diffing: https://www.internalfb.com/intern/diffing/?paste_number=1497865201

Differential Revision: D60325668


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang