### PR TITLE
Remove string length limit in ET

### DIFF
--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -63,7 +63,6 @@ inline std::string vectorToString(const std::vector<T>& v) {
 std::string json_str_escape(const std::string& str);
 
 constexpr size_t kMaxNumElements = 4096;
-constexpr size_t kMaxStrLength = 8192;
 
 inline std::string getScalarValue(const c10::IValue& val) {
   if (val.isDouble()) {
@@ -79,13 +78,6 @@ inline std::string getScalarValue(const c10::IValue& val) {
     return val.toBool() ? "true" : "false";
   } else if (val.isString()) {
     const std::string& str_val = val.toStringRef();
-    if (str_val.size() > kMaxStrLength) {
-      LOG(WARNING) << "string size=" << str_val.size()
-                   << " exceeded kMaxStrLength=" << kMaxStrLength;
-      return fmt::format(
-          "\"{}\"", json_str_escape(str_val.substr(0, kMaxStrLength)));
-    }
-
     return fmt::format("\"{}\"", json_str_escape(str_val));
   } else if (val.isDevice()) {
     return fmt::format("\"{}\"", val.toDevice().str());


### PR DESCRIPTION
Summary: ET sets the length limit of string input varaibele to 8192 characters. However, the node process_group::init has more than 8192 characters for a Ads 128 rank job. This DIFF is to temporaily remove this limit, so ET can capture the complete information of the process group.

Test Plan: buck2 test mode/opt caffe2/test:test_profiler_cuda -- profiler.test_execution_trace.TestExecutionTrace

Reviewed By: sanrise

Differential Revision: D60341306
