### PR TITLE
[export] change deepcopy to copy in _replace_set_grad_with_hop pass..

### DIFF
--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -151,7 +151,10 @@ def _sequential_split_and_maybe_inline_subgraphs(
     replace_ctx = contextlib.nullcontext()
     new_signature = None
     if graph_signature is not None:
-        new_signature = copy.deepcopy(graph_signature)
+        # Cannot deep copy a real ScriptObject, which is referenced
+        # in the FakeScriptObject. Copy should be good enough to guard
+        # against accidental mutation to original graph_signature.
+        new_signature = copy.copy(graph_signature)
         new_gm_out_node = next(reversed(new_gm.graph.find_nodes(op="output")))
         assert new_gm_out_node.op == "output" and len(new_gm_out_node.args[0]) == len(
             new_signature.output_specs


### PR DESCRIPTION
Summary:
Fixes T197371132.

Previously, we call copy.deepcopy to avoid mutating the original signature. However, this causes errors when the signature reference a FakeScriptObject, which then references a real torch.ScriptObject due to "The tensor has a non-zero number of elements, but its data is not allocated yet."

We therefore just change it to a shallow copy. This should be good enough for guarding the signature.

Test Plan: buck2 run 'fbcode//mode/opt' torchrec/distributed/tests:test_pt2 -- --filter-text "test_sharded_quant_ebc_non_strict_export"

Differential Revision: D60476839
