### PR TITLE
Add optional exact_ordering parameter to the DataLoader

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1404,6 +1404,24 @@ except RuntimeError as e:
         finally:
             p.terminate()
 
+    def test_inexact_ordering(self):
+        class FastSlowDataset(Dataset):
+            def __init__(self, size):
+                self.size = size
+
+            def __getitem__(self, idx):
+                if idx % 2 == 0:
+                    time.sleep(0.1)
+                return idx % 2 == 0
+
+            def __len__(self):
+                return self.size
+
+        dataset = FastSlowDataset(10)
+        dataloader = self._get_data_loader(dataset, batch_size=1, prefetch_factor=10, num_workers=2)
+        fetched = list(dataloader)
+        self.assertListEqual(fetched, ([False] * 5 + [True] * 5))
+
     # Tests if the child process forked by the DataLoader segfaults due to having more than 3 threads
     # in the parent process after at least one set_num_threads invocation in the parent process.
     # After forking, set_num_threads(1) in the child process entails handling some inherited data-structures


### PR DESCRIPTION
Today `torch.utils.data.DataLoader` preserves the exact ordering of batches returned from workers when run in a multiprocess configuration. This is normally ideal for ML applications, however, for some use-cases (like using a dataloader to stream over a dataset for inference), we don't really care about the order of data.

By giving up this guarantee, we can improve dataloading performance/throughput by avoiding getting stuck on slow batches or items (e.g. if the items are `[slow, fast, fast, ...]` then the current dataloader will block waiting on the `slow` item even if a number of the `fast` items are ready to be returned).

This change introduces the `exact_ordering` parameter which can be optionally passed to the dataloader instance which when set to False will remove this guarantee.

cc @andrewkho 