### PR TITLE
[AOTI] Fix a typo in ExternKernel.codegen_const_args

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4677,7 +4677,7 @@ class ExternKernel(InputsKernel):
             for i, x in enumerate(self.constant_args):
                 idx = len(self.inputs) + i
                 type_ = (
-                    self.arg_properties[i].get("type")
+                    self.arg_properties[idx].get("type")
                     if self.arg_properties and idx < len(self.arg_properties)
                     else None
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132191



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang

Differential Revision: [D60513923](https://our.internmc.facebook.com/intern/diff/D60513923)