### PR TITLE
[TESTING] dynamo output_graph code - always generate verbose graph

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -1322,7 +1322,7 @@ class OutputGraph:
             "dynamo_flat_name_to_original_fqn"
         ] = self.dynamo_flat_name_to_original_fqn.copy()
 
-        graph_code_log.debug(
+        graph_code_log.warning(
             "%s",
             lazy_format_graph_code(
                 name, gm, include_stride=True, include_device=True, colored=True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132195
* #132192

see if this triggers any additional failures from trying to print tensor info on tensors that don't support this.

The dynamo-generated graph seems most likely to contain weird types of tensors. This PR forces the lazy string containing the graph to generate a string, which should test the verbose graph generation over a large set of scenarios.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames