### PR TITLE
Address clang-tidy nits in BFloat16

### DIFF
--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -76,8 +76,8 @@ inline C10_HOST_DEVICE uint16_t round_to_nearest_even(float src) {
   } else {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     union {
-      uint32_t U32;
-      float F32;
+      uint32_t U32; // NOLINT(facebook-hte-BadMemberName)
+      float F32; // NOLINT(facebook-hte-BadMemberName)
     };
 
     F32 = src;
@@ -104,7 +104,7 @@ struct alignas(2) BFloat16 {
 
   constexpr C10_HOST_DEVICE BFloat16(unsigned short bits, from_bits_t)
       : x(bits) {}
-  inline C10_HOST_DEVICE BFloat16(float value);
+  /* implicit */ inline C10_HOST_DEVICE BFloat16(float value);
   inline C10_HOST_DEVICE operator float() const;
 
 #if defined(__CUDACC__)


### PR DESCRIPTION
Summary: In https://github.com/pytorch/pytorch/pull/131359 I forgot to amend with clang-tidy fixes before merging. This addresses that.

Test Plan: CI
