### PR TITLE
Workaround to SDPA bug in MacOS15

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -32,6 +32,7 @@ enum class MacOSVersion : uint32_t {
   MACOS_VER_13_3_PLUS,
   MACOS_VER_14_0_PLUS,
   MACOS_VER_14_4_PLUS,
+  MACOS_VER_15_0_PLUS,
 };
 
 //-----------------------------------------------------------------

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -118,6 +118,7 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   static bool _macos_13_3_plus = is_os_version_at_least(13, 3);
   static bool _macos_14_0_plus = is_os_version_at_least(14, 0);
   static bool _macos_14_4_plus = is_os_version_at_least(14, 0);
+  static bool _macos_15_0_plus = is_os_version_at_least(15, 0);
 
   switch (version) {
     case MacOSVersion::MACOS_VER_13_0_PLUS:
@@ -132,6 +133,8 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
       return _macos_14_0_plus;
     case MacOSVersion::MACOS_VER_14_4_PLUS:
       return _macos_14_4_plus;
+    case MacOSVersion::MACOS_VER_15_0_PLUS:
+      return _macos_15_0_plus;
     default:
       return false;
   }

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -68,10 +68,13 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
 
       auto maskedMM = [mpsGraph matrixMultiplicationWithPrimaryTensor:qTensor secondaryTensor:kT name:nil];
 
-      // TODO: In MacOS15 beta, there is a MPSGraph issue when the SDPA sequence gets remapped to use
-      // an improved kernel for the computation, causing NaNs in the result. This identity prevents the remapping.
-      // Move behind availability check once a fix lands.
-      maskedMM = [mpsGraph identityWithTensor:maskedMM name:nil];
+      bool macOS15_0_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
+      if (macOS15_0_plus) {
+        // TODO: In MacOS15 beta, there is a MPSGraph issue when the SDPA sequence gets remapped to use
+        // an improved kernel for the computation, causing NaNs in the result. This identity prevents the remapping.
+        // Limit the availability check once a fix lands.
+        maskedMM = [mpsGraph identityWithTensor:maskedMM name:nil];
+      }
 
       // upcasting to float32 if needed to improve precision when multiplying by the scale factor
       if ([maskedMM dataType] != MPSDataTypeFloat32) {

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -69,7 +69,7 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
       auto maskedMM = [mpsGraph matrixMultiplicationWithPrimaryTensor:qTensor secondaryTensor:kT name:nil];
 
       bool macOS15_0_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
-      if (macOS15_0_plus) {
+      if (macOS15_0_plus && [maskedMM dataType] == MPSDataTypeFloat32) {
         // TODO: In MacOS15 beta, there is a MPSGraph issue when the SDPA sequence gets remapped to use
         // an improved kernel for the computation, causing NaNs in the result. This identity prevents the remapping.
         // Limit the availability check once a fix lands.

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -68,6 +68,11 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
 
       auto maskedMM = [mpsGraph matrixMultiplicationWithPrimaryTensor:qTensor secondaryTensor:kT name:nil];
 
+      // TODO: In MacOS15 beta, there is a MPSGraph issue when the SDPA sequence gets remapped to use
+      // an improved kernel for the computation, causing NaNs in the result. This identity prevents the remapping.
+      // Move behind availability check once a fix lands.
+      maskedMM = [mpsGraph identityWithTensor:maskedMM name:nil];
+
       // upcasting to float32 if needed to improve precision when multiplying by the scale factor
       if ([maskedMM dataType] != MPSDataTypeFloat32) {
         maskedMM = [mpsGraph castTensor:maskedMM toType:MPSDataTypeFloat32 name:nil];


### PR DESCRIPTION
Currently MacOS15 automatically recognizes the SDPA pattern and remaps it to a more performant kernel. Unfortunately there seems to be a bug in the this remapping leading the op to produce NaNs. This issue has been forwarded to the MPSGraph team to have a look at.

At the moment this only affects the FP32 case since the upcasting op for FP16 is currently also disabling the remapping. Something to look into once the issue with the kernel is fixed.

This PR fixes the issue blocking us from adding a MacOS15 CI runner to the fleet: PR #132190 