### PR TITLE
[torch][take2] Implement BFloat16 __hip_bfloat16 overloads

### DIFF
--- a/c10/util/BFloat16-inl.h
+++ b/c10/util/BFloat16-inl.h
@@ -49,15 +49,15 @@ inline C10_HOST_DEVICE BFloat16::operator float() const {
 #endif
 }
 
-#if defined(__CUDACC__)
-#if !defined(USE_ROCM)
+#if defined(__CUDACC__) && !defined(USE_ROCM)
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __nv_bfloat16& value) {
   x = *reinterpret_cast<const unsigned short*>(&value);
 }
 inline C10_HOST_DEVICE BFloat16::operator __nv_bfloat16() const {
   return *reinterpret_cast<const __nv_bfloat16*>(&x);
 }
-#else // defined(USE_ROCM)
+#endif
+#if defined(__HIPCC__) && defined(USE_ROCM)
 // 6.2.0 introduced __hip_bfloat16_raw
 #if defined(__BF16_HOST_DEVICE__)
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __hip_bfloat16& value) {
@@ -66,16 +66,15 @@ inline C10_HOST_DEVICE BFloat16::BFloat16(const __hip_bfloat16& value) {
 inline C10_HOST_DEVICE BFloat16::operator __hip_bfloat16() const {
   return __hip_bfloat16(__hip_bfloat16_raw{x});
 }
-#else // __BF16_HOST_DEVICE__
+#else // !defined(__BF16_HOST_DEVICE__)
 inline C10_HOST_DEVICE BFloat16::BFloat16(const __hip_bfloat16& value) {
   x = value.data;
 }
 inline C10_HOST_DEVICE BFloat16::operator __hip_bfloat16() const {
   return __hip_bfloat16{x};
 }
-#endif // !__BF16_HOST_DEVICE__
-#endif // defined(USE_ROCM)
-#endif // defined(__CUDACC__)
+#endif // !defined(__BF16_HOST_DEVICE__)
+#endif // defined(__HIPCC__) && defined(USE_ROCM)
 
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
 inline C10_HOST_DEVICE BFloat16::BFloat16(

--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -10,13 +10,12 @@
 #include <iosfwd>
 #include <ostream>
 
-#if defined(__CUDACC__)
-#if !defined(USE_ROCM)
+#if defined(__CUDACC__) && !defined(USE_ROCM)
 #include <cuda_bf16.h>
-#else // defined(USE_ROCM)
-#include <hip_bf16.h>
-#endif // defined(USE_ROCM)
-#endif // defined(__CUDACC__)
+#endif
+#if defined(__HIPCC__) && defined(USE_ROCM)
+#include <hip/hip_bf16.h>
+#endif
 
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
 #if defined(CL_SYCL_LANGUAGE_VERSION)
@@ -107,15 +106,14 @@ struct alignas(2) BFloat16 {
   /* implicit */ inline C10_HOST_DEVICE BFloat16(float value);
   inline C10_HOST_DEVICE operator float() const;
 
-#if defined(__CUDACC__)
-#if !defined(USE_ROCM)
+#if defined(__CUDACC__) && !defined(USE_ROCM)
   inline C10_HOST_DEVICE BFloat16(const __nv_bfloat16& value);
   explicit inline C10_HOST_DEVICE operator __nv_bfloat16() const;
-#else // defined(USE_ROCM)
+#endif
+#if defined(__HIPCC__) && defined(USE_ROCM)
   inline C10_HOST_DEVICE BFloat16(const __hip_bfloat16& value);
   explicit inline C10_HOST_DEVICE operator __hip_bfloat16() const;
-#endif // defined(USE_ROCM)
-#endif // defined(__CUDACC__)
+#endif
 
 #if defined(SYCL_EXT_ONEAPI_BFLOAT16_MATH_FUNCTIONS)
   inline C10_HOST_DEVICE BFloat16(const sycl::ext::oneapi::bfloat16& value);


### PR DESCRIPTION
Summary:
In D60024830 I attempted to define these overloads, but gated the implementation on the wrong macros. Namely I used `__CUDACC__` instead of `__HIPCC__` (facepalm).

It might be worth merging this with the nvidia case via typedefs (e.g. `typedef __hip_bfloat16 __gpu_bfloat16` and `typedef __nv_bfloat16 __gpu_bfloat16`), but that seems like an entirely new paradigm for torch, so I'll punt that change to the future so we can focus on supporting `BFloat16(__hip_bfloat16)` here

Test Plan: CI

Differential Revision: D60362079
