### PR TITLE
Optimize sort kernel for contiguous tensors

### DIFF
--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -141,6 +141,32 @@ static void parallel_sort1d_kernel(
 }
 #endif
 
+template <typename scalar_t, typename value_accessor_t, typename indices_accessor_t>
+static inline void sort_kernel_impl(const value_accessor_t& value_accessor,
+				    const indices_accessor_t& indices_accessor,
+				    int64_t dim_size, bool descending, bool stable) {
+  auto composite_accessor = CompositeRandomAccessorCPU<
+    value_accessor_t, indices_accessor_t
+  >(value_accessor, indices_accessor);
+  if (descending) {
+    if (stable) {
+      std::stable_sort(composite_accessor, composite_accessor + dim_size,
+        KeyValueCompDesc<scalar_t>());
+    } else {
+      std::sort(composite_accessor, composite_accessor + dim_size,
+	KeyValueCompDesc<scalar_t>());
+    }
+  } else {
+    if (stable) {
+      std::stable_sort(composite_accessor, composite_accessor + dim_size,
+        KeyValueCompAsc<scalar_t>());
+    } else {
+      std::sort(composite_accessor, composite_accessor + dim_size,
+        KeyValueCompAsc<scalar_t>());
+    }
+  }
+}
+
 static void sort_kernel(
     const TensorBase& self,
     const TensorBase& values,
@@ -169,33 +195,30 @@ static void sort_kernel(
       int64_t dim_size
     ) {
       using scalar_t = typename std::remove_pointer<decltype(values)>::type;
-      auto values_accessor = StridedRandomAccessor<scalar_t>(
-        values, values_dim_stride);
-      auto indices_accessor = StridedRandomAccessor<int64_t>(
-        indices, indices_dim_stride);
-      auto composite_accessor = CompositeRandomAccessorCPU<
-        decltype(values_accessor), decltype(indices_accessor)
-      >(values_accessor, indices_accessor);
-
-      if (descending) {
-        if (stable) {
-          std::stable_sort(composite_accessor, composite_accessor + dim_size,
-            KeyValueCompDesc<scalar_t>());
-        }
-        else {
-          std::sort(composite_accessor, composite_accessor + dim_size,
-            KeyValueCompDesc<scalar_t>());
-        }
-      }
-      else {
-        if (stable) {
-          std::stable_sort(composite_accessor, composite_accessor + dim_size,
-            KeyValueCompAsc<scalar_t>());
-        }
-        else {
-          std::sort(composite_accessor, composite_accessor + dim_size,
-            KeyValueCompAsc<scalar_t>());
-        }
+      if (values_dim_stride == 1 && indices_dim_stride == 1) {
+        sort_kernel_impl<
+          scalar_t, decltype(values), decltype(indices)
+        >(values, indices, dim_size, descending, stable);
+      } else if (values_dim_stride == 1 && indices_dim_stride != 1) {
+        auto indices_accessor = StridedRandomAccessor<int64_t>(
+          indices, indices_dim_stride);
+        sort_kernel_impl<
+          scalar_t, decltype(values), decltype(indices_accessor)
+        >(values, indices_accessor, dim_size, descending, stable);
+      } else if (values_dim_stride != 1 && indices_dim_stride == 1) {
+        auto values_accessor = StridedRandomAccessor<scalar_t>(
+          values, values_dim_stride);
+        sort_kernel_impl<
+          scalar_t, decltype(values_accessor), decltype(indices)
+        >(values_accessor, indices, dim_size, descending, stable);
+      } else {
+        auto values_accessor = StridedRandomAccessor<scalar_t>(
+          values, values_dim_stride);
+        auto indices_accessor = StridedRandomAccessor<int64_t>(
+          indices, indices_dim_stride);
+        sort_kernel_impl<
+          scalar_t, decltype(values_accessor), decltype(indices_accessor)
+        >(values_accessor, indices_accessor, dim_size, descending, stable);
       }
     }
   );

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -143,8 +143,8 @@ static void parallel_sort1d_kernel(
 
 template <typename scalar_t, typename value_accessor_t, typename indices_accessor_t>
 static inline void sort_kernel_impl(const value_accessor_t& value_accessor,
-				    const indices_accessor_t& indices_accessor,
-				    int64_t dim_size, bool descending, bool stable) {
+            const indices_accessor_t& indices_accessor,
+            int64_t dim_size, bool descending, bool stable) {
   auto composite_accessor = CompositeRandomAccessorCPU<
     value_accessor_t, indices_accessor_t
   >(value_accessor, indices_accessor);
@@ -154,7 +154,7 @@ static inline void sort_kernel_impl(const value_accessor_t& value_accessor,
         KeyValueCompDesc<scalar_t>());
     } else {
       std::sort(composite_accessor, composite_accessor + dim_size,
-	KeyValueCompDesc<scalar_t>());
+        KeyValueCompDesc<scalar_t>());
     }
   } else {
     if (stable) {


### PR DESCRIPTION
Introduces enhancement for SortingKernel.cpp for cases where both the values and indices tensors have a stride 1, indicating contiguous memory layouts. 

The changes include:
1. A new function `sort_kernel_impl`, encapsulating the core sorting logic for distinct types of tensor accessors.
2. Modifications to the `sort_kernel` function to utilize `sort_kernel_impl`. It now checks for tensor strides and optimally handles contiguous and non-contiguous tensor scenarios.
3. The optimization aims to improve cache locality and efficiency in memory access for contiguous tensor sorts.
4. Enhanced Code Readability and Structure: The restructuring of the sorting process improves clarity and maintenance by clearly defining how different stride scenarios are handled, making the code more transparent and easier to understand.

Tests have been conducted across various tensor sizes and shapes to ensure stability and reliability of the change.

The result of running the `test/test_sort_and_select.py` test suite is consistent between the main branch, and this modified branch.

cc: @ezyang @mingfeima @nikitaved @malfet @ysiraichi @peterbell10 @ngimel 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10