### PR TITLE
[PT2][Optimus] Add missing example value for introduced nodes

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -16,7 +16,6 @@ def patch(f):
             "normalization_pass": {},
             "remove_split_with_size_one_pass": {},
             "merge_getitem_cat_pass": {},
-            "merge_stack_tahn_unbind_pass": {},
             "merge_splits_pass": {},
             "mutate_cat_pass": {},
             "split_cat_pass": {},
@@ -1267,41 +1266,6 @@ class TestSplitCatFxPasses(TestCase):
                 counters["inductor"]["unbind_cat_to_view_pass"],
                 exptected_unbind_to_cat_view,
             )
-            counters.clear()
-
-    @patch
-    def test_stack_tahn_unbind_merge(self):
-        def stack_tahn_unbind(x):
-            l1_out = torch.split(x, [20, 20, 20, 10, 10, 20, 20], 1)
-            item0 = l1_out[0]
-            item1 = l1_out[1]
-            item2 = l1_out[2]
-            item3 = l1_out[3]
-            item4 = l1_out[4]
-            item5 = l1_out[5]
-            item6 = l1_out[6]
-            stack = torch.stack(tensors=(item0, item1, item2), dim=0)
-            cat_1 = torch.cat((item3, item4), 1)
-            cat_2 = torch.cat((item5, item6), 1)
-            tanh = torch.tanh(stack)
-            unbind = torch.unbind(tanh, 0)
-            return torch.cat((unbind[0], unbind[1], torch.cat((cat_1, cat_2), 1)), 1)
-
-        args = [
-            torch.randn(50, 120),
-        ]
-        for fn, expected_stack_tahn_unbind_merged in [
-            (stack_tahn_unbind, 1),
-        ]:
-            expected = fn(*args)
-            actual = torch.compile(fn)(*args)
-
-            torch.testing.assert_close(actual, expected)
-            self.assertEqual(
-                counters["inductor"]["merge_stack_tahn_unbind_pass"],
-                expected_stack_tahn_unbind_merged,
-            )
-            self.assertIn("merge_getitem_cat_pass_pre_grad", optimus_scuba_log)
             counters.clear()
 
     def test_numpy_compat_normalization(self):

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -921,9 +921,15 @@ class BatchPointwiseOpsPreGradFusion(BatchPointwiseOpsFusionFactory):
                     self.op,
                     args=(stack_inputs,),
                 )
+            if is_node_meta_valid(batch_op):
+                batch_op.meta["example_value"] = self.op(batch_op.meta["example_value"])
             unbind_op = graph.call_function(
                 torch.unbind, args=(batch_op,), kwargs={"dim": 0}
             )
+            if is_node_meta_valid(unbind_op):
+                unbind_op.meta["example_value"] = torch.unbind(
+                    unbind_op.meta["example_value"], dim=0
+                )
             for i, node in enumerate(batch_nodes):
                 with graph.inserting_after(unbind_op):
                     getitem = graph.call_function(operator.getitem, args=(unbind_op, i))

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -511,6 +511,12 @@ def merge_splits(
             args=(first_split_input, new_split_sections),
             kwargs={"dim": first_split_dim},
         )
+        if is_node_meta_valid(first_split_input):
+            new_split.meta["example_value"] = torch.split(
+                first_split_input.meta["example_value"],
+                new_split_sections,
+                dim=first_split_dim,
+            )
         first_split_num_to_user = {
             user.args[1]: user for user in first_split.users.keys()  # type: ignore[union-attr]
         }
@@ -809,13 +815,20 @@ class SplitCatSimplifier:
                     ),
                     kwargs={"dim": split_dim},
                 )
-                new_split.meta.update(split_node.meta)
+                if is_node_meta_valid(split_input):  # type: ignore[arg-type, union-attr]
+                    new_split.meta["example_value"] = torch.split(
+                        split_input.meta["example_value"], [r[1] - r[0] for r in split_ranges], dim=split_dim  # type: ignore[union-attr]
+                    )
                 counters["inductor"]["scmerge_split_added"] += 1
+            split_items = []
             with graph.inserting_after(new_split):
-                split_items = [
-                    graph.call_function(operator.getitem, args=(new_split, i))
-                    for i in range(len(split_ranges))
-                ]
+                for i in range(len(split_ranges)):
+                    getitem = graph.call_function(operator.getitem, args=(new_split, i))
+                    if is_node_meta_valid(new_split):
+                        getitem.meta["example_value"] = new_split.meta["example_value"][
+                            i
+                        ]
+                        split_items.append(getitem)
         # Now assign the right getitem to the right input
         cumulative_sizes = [0] + torch.cumsum(torch.tensor(split_sections), 0).tolist()
         new_user_inputs_list = []
@@ -867,14 +880,17 @@ class SplitCatSimplifier:
 
             # Handle cat/stack user nodes
             cat_dim = get_arg_value(user_node, 1, "dim")
-            user_inputs_new_transformed = []
+            user_inputs_new_transformed, user_inputs_new_transformed_meta = [], []
             # For `unsqueeze` transform, we will combine consecutive inputs with the same unsqueeze params, and stack them
-            to_stack = []
+            to_stack, to_stack_meta = [], []
             stack_dim = None
             with graph.inserting_before(user_node):
                 for user_input_new, transform_param in zip(
                     user_inputs_new, transform_params
                 ):
+                    if not is_node_meta_valid(user_input_new):
+                        log.debug("example value absent for node: %s", user_input_new)
+                        return
                     # Apply transforms
                     (
                         unflatten_params,
@@ -886,38 +902,57 @@ class SplitCatSimplifier:
                         stack_dim is None or stack_dim == unsqueeze_params[0]
                     ):
                         to_stack.append(user_input_new)
+                        to_stack_meta.append(user_input_new.meta["example_value"])
                         stack_dim = unsqueeze_params[0]
                         continue
                     elif to_stack:
                         stacked_input = graph.call_function(
                             torch.stack, args=(to_stack,), kwargs={"dim": stack_dim}
                         )
-                        to_stack = []
+                        stacked_input.meta["example_value"] = torch.stack(to_stack_meta, dim=stack_dim)  # type: ignore[arg-type, union-attr]
+                        to_stack, to_stack_meta = [], []
                         stack_dim = None
                         user_inputs_new_transformed.append(stacked_input)
+                        user_inputs_new_transformed_meta.append(
+                            stacked_input.meta["example_value"]
+                        )
                         if unsqueeze_params:
                             to_stack.append(user_input_new)
                             stack_dim = unsqueeze_params[0]
+                            to_stack_meta.append(user_input_new.meta["example_value"])
                             continue
 
                     if unflatten_params:
+                        user_input_new_meta = user_input_new.meta["example_value"]
                         user_input_new = graph.call_function(
                             torch.unflatten, args=(user_input_new, *unflatten_params)
                         )
+                        user_input_new.meta["example_value"] = torch.unflatten(user_input_new_meta, *unflatten_params)  # type: ignore[arg-type, possibly-undefined, union-attr]
                     if movedim_params:
+                        user_input_new_meta = user_input_new.meta["example_value"]
                         user_input_new = graph.call_function(
                             torch.movedim, args=(user_input_new, *movedim_params)
                         )
+                        user_input_new.meta["example_value"] = torch.movedim(user_input_new_meta, *movedim_params)  # type: ignore[arg-type, possibly-undefined, union-attr]
                     if flatten_params:
+                        user_input_new_meta = user_input_new.meta["example_value"]
                         user_input_new = graph.call_function(
                             torch.flatten, args=(user_input_new, *flatten_params)
                         )
+                        user_input_new.meta["example_value"] = torch.flatten(user_input_new_meta, *flatten_params)  # type: ignore[arg-type, possibly-undefined, union-attr]
                     user_inputs_new_transformed.append(user_input_new)
+                    user_inputs_new_transformed_meta.append(
+                        user_input_new.meta["example_value"]
+                    )
                 if to_stack:
                     stacked_input = graph.call_function(
                         torch.stack, args=(to_stack,), kwargs={"dim": stack_dim}
                     )
+                    stacked_input.meta["example_value"] = torch.stack(to_stack_meta, dim=stack_dim)  # type: ignore[arg-type, union-attr]
                     user_inputs_new_transformed.append(stacked_input)
+                    user_inputs_new_transformed_meta.append(
+                        stacked_input.meta["example_value"]
+                    )
 
             with graph.inserting_after(user_node):
                 if len(user_inputs_new_transformed) > 1:
@@ -926,7 +961,9 @@ class SplitCatSimplifier:
                         args=(user_inputs_new_transformed,),
                         kwargs={"dim": cat_dim},
                     )
-                    new_cat_node.meta.update(user_node.meta)
+                    new_cat_node.meta["example_value"] = torch.cat(
+                        user_inputs_new_transformed_meta, dim=cat_dim
+                    )
                     counters["inductor"]["scmerge_cat_added"] += 1
                 else:
                     new_cat_node = user_inputs_new_transformed[-1]
@@ -937,9 +974,11 @@ class SplitCatSimplifier:
                 and split_node.target == torch.split
             ):
                 with graph.inserting_after(new_cat_node):
+                    new_cat_node_meta = new_cat_node.meta["example_value"]
                     new_cat_node = graph.call_function(
                         torch.flatten, args=(new_cat_node, cat_dim, cat_dim + 1)
                     )
+                    new_cat_node.meta["example_value"] = torch.flatten(new_cat_node_meta, cat_dim, cat_dim + 1)  # type: ignore[possibly-undefined, union-attr]
             user_node.replace_all_uses_with(new_cat_node)
             new_cats.append(new_cat_node)
 
@@ -958,7 +997,8 @@ class SplitCatSimplifier:
             counters["inductor"]["scmerge_cat_removed"] += 1
             to_remove.append(next_user)
         for node in reversed(to_remove):
-            graph.erase_node(node)
+            if len(node.users.keys()) == 0:
+                graph.erase_node(node)
 
 
 class UnbindCatRemover(SplitCatSimplifier):
@@ -975,9 +1015,20 @@ class UnbindCatRemover(SplitCatSimplifier):
         graph: torch.fx.Graph,
         unbind_node: torch.fx.Node,
     ):
-        num_unbind = (  # type: ignore[operator]
-            max(getitem_node.args[1] for getitem_node in unbind_node.users.keys()) + 1  # type: ignore[operator, union-attr, type-var]
-        )
+        if not is_node_meta_valid(unbind_node):
+            return
+        # we need to check if the getitem indices from unbind are consecutive and all go to the same cat node
+        # before we do the unbind remove, otherwise it will hit the error when we unbind part of them
+        getitem_indices = []
+        for getitem_node in unbind_node.users.keys():
+            getitem_indices.append(getitem_node.args[1])
+        if not is_sorted_and_consecutive(getitem_indices) or len(  # type: ignore[arg-type]
+            getitem_indices
+        ) != len(
+            unbind_node.meta["example_value"]
+        ):
+            return
+        num_unbind = len(getitem_indices)
         split_sections = [1 for _ in range(num_unbind)]  # type: ignore[operator, arg-type]
 
         super().simplify(graph, unbind_node, split_sections)
@@ -1119,6 +1170,10 @@ def merge_split_squeeze(
         unbind = graph.call_function(
             torch.unbind, args=(split_input,), kwargs={"dim": dim}
         )
+        if is_node_meta_valid(split_input):
+            unbind.meta["example_value"] = torch.unbind(
+                split_input.meta["example_value"], dim=dim
+            )
         for item_index, getitem_node in sorted(
             [
                 (getitem_node.args[1], getitem_node)
@@ -1465,158 +1520,6 @@ def mutate_cat_node(match: Match, split_sections: List[int], dim: int):
                 counters["inductor"]["mutate_cat_pass"] += 1
 
 
-# noqa: W605
-# ############The pattern to be optimized is#########
-#                            split_node (dim=1)
-#       /   ...    \             ...       /         \
-# getitem      getitem                 getitem     getitem -> user=1
-#    \           /
-#        stack (dim=0)  -> user=1, getitems to be consecutive
-#          |
-#         tahn  -> user=1
-#          |
-#         unbind (dim=0)
-#           |
-
-# ################After transformation#############
-#                  split_node (dim=1)
-#             /      ...       /         \
-#    getitem       getitem     getitem -> user=1
-#       |
-#     tahn
-#       |
-#     split
-#       |
-
-
-@register_graph_pattern(
-    CallFunction(
-        torch.tanh,
-        CallFunction(
-            torch.stack,
-            getitem_split,
-            dim=Ignored(),
-        ),
-    ),
-    pass_dict=construct_pattern_matcher_pass("merge_stack_tahn_unbind_pass"),
-)
-@register_graph_pattern(
-    CallFunction(
-        torch.tanh,
-        CallFunction(
-            torch.stack,
-            tensors=getitem_split,
-            dim=Ignored(),
-        ),
-    ),
-    pass_dict=construct_pattern_matcher_pass("merge_stack_tahn_unbind_pass"),
-)
-@register_graph_pattern(
-    CallFunction(
-        torch.tanh,
-        CallFunction(
-            torch.stack,
-            getitem_split,
-            Ignored(),
-        ),
-    ),
-    pass_dict=construct_pattern_matcher_pass("merge_stack_tahn_unbind_pass"),
-)
-def merge_stack_tahn_unbind(match: Match, split_sections: List[int], dim: int):
-    if not isinstance(split_sections, (list, tuple)):  # Unnormalized split
-        return
-    graph = match.graph
-    split_node = next(node for node in match.nodes if node.target == torch.split)
-    split_input, split_size, split_dim = _get_split_args_default(split_node)
-    # Find the next users (i.e. users after the getitem)
-    next_users = find_next_users(split_node)
-    # 'immutable_list' object does not support mutation. Create a new copy of it
-    split_sections = list(split_sections)
-    for user in next_users:
-        # stack user only has one user
-        if user.target == torch.stack:
-            stack_dim = get_arg_value(user, 1, "dim") or 0
-            unbind_user = find_next_users(user)[0]
-            if unbind_user.target != torch.unbind:
-                continue
-            unbind_dim = get_arg_value(unbind_user, 1, "dim") or 0
-            # stack and unbind should have the same dim
-            # check the all getitems in the user from the same node
-            # check all the getitems only has single user
-            if (
-                stack_dim != unbind_dim
-                or not has_same_parent_node(user)
-                or not all(len(arg.users) == 1 for arg in user.args[0])  # type: ignore[union-attr]
-            ):
-                continue
-            # find the index of getitems to be stacked
-            indices = []
-            split_sections_for_unbind = []
-            for arg in user.args[0]:  # type: ignore[union-attr]
-                indices.append(arg.args[1])  # type: ignore[union-attr]
-                split_sections_for_unbind.append(split_sections[arg.args[1]])  # type: ignore[union-attr]
-            # the gettitems to be merged must be consecutive, otherwise
-            # returned sliced tensor could be wrong
-            if not is_sorted_and_consecutive(indices):
-                continue
-            # update the arg of stack user, only keep the first getitem
-            user.update_arg(0, user.args[0][0])  # type: ignore[index]
-            # calculate the fused tensor sizes in the indices
-            fused_tensor_size = 0
-            for i in range(len(split_node.args[1])):  # type: ignore[arg-type]
-                if i in indices:
-                    fused_tensor_size += split_node.args[1][i]  # type: ignore[operator, index, assignment]
-            # update the split sections
-            split_sections[indices[0]] = calculate_fused_tensor_size(
-                split_node, indices
-            )
-            # padding others with zeros to keep the same dict size
-            for i in indices[1:]:
-                split_sections[i] = 0
-            # remove all unused indexes in the split_node
-            new_split_sections, index_mapping = remove_zeros(split_sections)
-            with graph.inserting_after(split_node):
-                new_split_node = graph.call_function(
-                    torch.split,
-                    args=(split_input, split_sections),
-                    kwargs={"dim": split_dim},
-                )
-                replace_unbind_with_split = graph.call_function(
-                    torch.split,
-                    args=(unbind_user.args[0], split_sections_for_unbind),
-                    kwargs={"dim": split_dim},
-                )
-                unbind_user.replace_all_uses_with(replace_unbind_with_split)
-                replace_unbind_with_split.meta.update(unbind_user.meta)
-                # remove getitem and split, stack
-                split_node.replace_all_uses_with(new_split_node)
-                new_split_node.meta.update(split_node.meta)
-                # remove all unused getitem nodes
-                to_remove = [unbind_user]
-                # dictionary keys changed during iteration
-                new_split_getitem_nodes = list(new_split_node.users.keys())
-                for getitem_node in new_split_getitem_nodes:
-                    if getitem_node.args[1] in indices[1:]:
-                        to_remove.append(getitem_node)
-                    # update meta data of getitem
-                    elif getitem_node.args[1] == indices[0]:
-                        user.replace_all_uses_with(getitem_node)
-                        getitem_node.meta.update(user.meta)
-                    else:
-                        # update getitem index for new split node
-                        getitem_node.update_arg(1, index_mapping[getitem_node.args[1]])
-                graph.erase_node(split_node)
-                graph.erase_node(user)
-                for getitem_node in to_remove:
-                    graph.erase_node(getitem_node)
-                # update the split sections of new split node
-                new_split_node.update_arg(1, new_split_sections)
-                split_node = new_split_node
-                split_sections = new_split_sections
-
-                counters["inductor"]["merge_stack_tahn_unbind_pass"] += 1
-
-
 @register_graph_pattern(
     CallFunctionVarArgs(torch.ops.aten.cat.default, users=MULTIPLE),
     pass_dict=construct_pattern_matcher_pass("normalization_aten_pass"),
@@ -1633,12 +1536,12 @@ def normalize_cat_default_aten(match: Match, *args, **kwargs):
         else:
             cat_dim = 0
     if tensors is None or cat_dim is None:
-        log.info("couldn't find cat args")
+        log.debug("couldn't find cat args")
         return
     assert isinstance(tensors, (list, tuple))
     for tensor in itertools.chain([cat_node], tensors):
         if "val" not in tensor.meta:
-            log.warning("val absent for node: %s", tensor)
+            log.debug("val absent for node: %s", tensor)
             return
 
     ndim = cat_node.meta["val"].dim()


### PR DESCRIPTION
Summary:
We observed that many introduced nodes during split cat and batch fusion pattern optimization did not have example value meta data, which will cause problems in our follow up pattern optimizations, thus we add all missing values.

We also fix bugs in some meta update and corner case bug for the old pattern, which caused problems in the follow up pattern optimization.

We delete merge_stack_tahn_unbind_pass pattern, which was designed for cmf model, and it could be replaced by the more advanced pattern we added, thus we remove it for easy maintenance.

Test Plan:
# unit test
```
buck2 test //caffe2/test/inductor:split_cat_fx_passes
```

Test UI: https://www.internalfb.com/intern/testinfra/testrun/15481123762720165
Network: Up: 230KiB  Down: 702KiB  (reSessionID-756346bf-6da3-4fa0-8d03-1b4fd61e0a7a)
Jobs completed: 30. Time elapsed: 7:23.9s.
Cache hits: 20%. Commands: 5 (cached: 1, remote: 0, local: 4)
Tests finished: Pass 9. Fail 0. Fatal 0. Skip 1. Build failure 0

```
buck2 test @mode/opt pytorch/diff_train_tests/ads/optimus:local_pt2_runner
```

Network: Up: 1.3GiB  Down: 84MiB  (reSessionID-ff135cdd-e42c-4ab5-8217-907ada465f01)
Jobs completed: 61. Time elapsed: 21:56.5s.
Cache hits: 0%. Commands: 39 (cached: 0, remote: 0, local: 39)
Tests finished: Pass 8. Fail 0. Fatal 0. Skip 0. Build failure 0


# benchmark

```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 run @mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "ig_ctr" --flow_id 584880697
```

Counter({'pattern_matcher_nodes': 752, 'pattern_matcher_count': 732, 'normalization_pass': 328, 'normalization_aten_pass': 12, 'scmerge_cat_removed': 5, 'scmerge_cat_added': 4, 'scmerge_split_removed': 3, 'unbind_stack_pass': 3, 'batch_tanh': 2, 'scmerge_split_sections_removed': 2, 'scmerge_split_added': 2, 'optimize_cat_inputs_pass': 1, 'unbind_cat_to_view_pass': 1, 'fxgraph_cache_miss': 1})


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang