### PR TITLE
[DeviceMesh] Add supports for non-continuous slicing

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -526,6 +526,29 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         tp_mesh = mesh["tp"]
         self.assertEqual(_world.group_count, ref_pg_count)
 
+    @with_comms
+    def test_get_item_3d_noncontinuous_slicing(self):
+        mesh_shape = (2, 2, 2)
+        mesh_dim_names = ("dp", "pp", "cp")
+        mesh_3d = init_device_mesh(
+            self.device_type, mesh_shape, mesh_dim_names=mesh_dim_names
+        )
+
+        # Slice order simply decides which mesh_dim sits on which mesh_dim.
+        # For dp_cp_mesh, cp mesh is the innermost dimension.
+        dp_cp_mesh = mesh_3d["dp", "cp"]
+        cp_mesh = mesh_3d["cp"]
+        dp_local_rank = dp_cp_mesh.get_local_rank("dp")
+        # Check on the current dp_local_rank, whether the cp mesh tensor is the same.
+        self.assertEqual(dp_cp_mesh.mesh[dp_local_rank], cp_mesh.mesh)
+
+        # For dp_cp_mesh, dp mesh is the innermost dimension.
+        cp_dp_mesh = mesh_3d["cp", "dp"]
+        dp_mesh = mesh_3d["dp"]
+        cp_local_rank = cp_dp_mesh.get_local_rank("cp")
+        # Check on the current cp_local_rank, whether the dp mesh tensor is the same.
+        self.assertEqual(cp_dp_mesh.mesh[cp_local_rank], dp_mesh.mesh)
+
 
 class TestMeshEnv(DTensorTestBase):
     @with_comms

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -537,15 +537,27 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         # Slice order simply decides which mesh_dim sits on which mesh_dim.
         # For dp_cp_mesh, cp mesh is the innermost dimension.
         dp_cp_mesh = mesh_3d["dp", "cp"]
-        cp_mesh = mesh_3d["cp"]
+        expected_mesh_tensor = (
+            torch.tensor([[0, 1], [4, 5]], dtype=torch.int)
+            if self.rank in (0, 1, 4, 5)
+            else torch.tensor([[2, 3], [6, 7]], dtype=torch.int)
+        )
         dp_local_rank = dp_cp_mesh.get_local_rank("dp")
+        self.assertEqual(dp_cp_mesh.mesh, expected_mesh_tensor)
+        cp_mesh = mesh_3d["cp"]
         # Check on the current dp_local_rank, whether the cp mesh tensor is the same.
         self.assertEqual(dp_cp_mesh.mesh[dp_local_rank], cp_mesh.mesh)
 
         # For dp_cp_mesh, dp mesh is the innermost dimension.
         cp_dp_mesh = mesh_3d["cp", "dp"]
-        dp_mesh = mesh_3d["dp"]
+        expected_mesh_tensor = (
+            torch.tensor([[0, 4], [1, 5]], dtype=torch.int)
+            if self.rank in (0, 1, 4, 5)
+            else torch.tensor([[2, 6], [3, 7]], dtype=torch.int)
+        )
         cp_local_rank = cp_dp_mesh.get_local_rank("cp")
+        self.assertEqual(cp_dp_mesh.mesh, expected_mesh_tensor)
+        dp_mesh = mesh_3d["dp"]
         # Check on the current cp_local_rank, whether the dp mesh tensor is the same.
         self.assertEqual(cp_dp_mesh.mesh[cp_local_rank], dp_mesh.mesh)
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -444,28 +444,15 @@ else:
                 (mesh_dim_names,) if isinstance(mesh_dim_names, str) else mesh_dim_names
             )
 
-            error_msg = (
-                f"Invalid mesh_dim_name {mesh_dim_names} specified. "
-                f"Valid mesh_dim_names should be a contiguous subsequence of {self.mesh_dim_names}."
-            )
-
             if mesh_dim_names == self.mesh_dim_names:
                 return self
             elif len(mesh_dim_names) > len(self.mesh_dim_names) or not all(
                 mesh_dim_name in self.mesh_dim_names for mesh_dim_name in mesh_dim_names
             ):
-                raise KeyError(error_msg)
-            # Check if the user-provided slicing is a valid contiguous subsequence of the mesh_dim_names
-            # of the current DeviceMesh.
-            else:
-                outermost_dim_name = mesh_dim_names[0]
-                outermost_dim_idx = self.mesh_dim_names.index(outermost_dim_name)
-                for i, j in zip(
-                    mesh_dim_names,
-                    self.mesh_dim_names[outermost_dim_idx : len(mesh_dim_names)],
-                ):
-                    if i != j:
-                        raise KeyError(error_msg)
+                raise KeyError(
+                    f"Invalid mesh_dim_name {mesh_dim_names} specified. "
+                    f"Valid mesh_dim_names should be a contiguous subsequence of {self.mesh_dim_names}."
+                )
 
             submesh = _mesh_resources.create_child_mesh(self, mesh_dim_names)
             return submesh

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -451,7 +451,8 @@ else:
             ):
                 raise KeyError(
                     f"Invalid mesh_dim_name {mesh_dim_names} specified. "
-                    f"Valid mesh_dim_names should be a contiguous subsequence of {self.mesh_dim_names}."
+                    "Valid mesh_dim_names should be a subsequence of valid"
+                    f"mesh_dim_names from {self.mesh_dim_names}."
                 )
 
             submesh = _mesh_resources.create_child_mesh(self, mesh_dim_names)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132632
* #132339
* #132311
* __->__ #132310

Removes constraint of continuous slicing to allow non-continuous slicing and adds a unit test for 3D non-continuous slicing. 


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l @chauhang