### PR TITLE
[CUDA] `is_bf16_supported()` should not crash if there are no GPUs

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10672,6 +10672,10 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         t7.d = "dog"
         self._checked_swap(t6, t7)
 
+    @unittest.skipIf(torch.cuda.is_available(), "Test specific for CPU")
+    def test_bf16_supported_on_cpu(self):
+        self.assertFalse(torch.cuda.is_bf16_supported())
+
 
 # The following block extends TestTorch with negative dim wrapping tests
 # FIXME: replace these with OpInfo sample inputs or systemic OpInfo tests

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -135,6 +135,10 @@ def is_bf16_supported(including_emulation: bool = True):
     if torch.version.hip:
         return True
 
+    # If CUDA is not available, than it does not support bf16 either
+    if not is_available():
+        return False
+
     device = torch.cuda.current_device()
 
     # Check for CUDA version and device compute capability.


### PR DESCRIPTION
`False` is the good answer on a system that does not have any CUDA GPUs. 
- Added regression test to TestTorch.

Fixes https://github.com/pytorch/pytorch/issues/132303
