### PR TITLE
[export][pre-dispatch] add test case for user-defined triton kernels

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -289,7 +289,7 @@ def snapshot_fake(val: Tensor) -> Optional[Tensor]:
 _ExtractValType = Optional[Union[
     PySymType, _AnyScriptObjectType, BackwardState,
     List["_ExtractValType"], Tuple["_ExtractValType", ...], Tensor,
-    int, float, bool]]
+    int, float, bool, dict]]
 
 def extract_val(val: _ExtractValType) -> _ExtractValType:
     if is_fake(val):
@@ -317,6 +317,8 @@ def extract_val(val: _ExtractValType) -> _ExtractValType:
             return None
     elif isinstance(val, (int, float, bool)):
         return val
+    elif isinstance(val, dict):
+        return {k: extract_val(v) for k, v in val.items()}
     elif val is None:
         return None
 
@@ -437,9 +439,8 @@ def track_tensor_tree(
             # which does not participate in const-prop)
             assert constant is None
 
-            # if isinstance(proxy, fx.Proxy):
-            #    # BUG? This is guaranteed to be a no-op
-            #    set_meta(proxy, e)
+            if isinstance(proxy, fx.Proxy):
+               set_meta(proxy, e)
 
             for key, val in e.items():
                 wrap_with_proxy(val, proxy[key], None)  # type: ignore[index]

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -440,7 +440,7 @@ def track_tensor_tree(
             assert constant is None
 
             if isinstance(proxy, fx.Proxy):
-               set_meta(proxy, e)
+                set_meta(proxy, e)
 
             for key, val in e.items():
                 wrap_with_proxy(val, proxy[key], None)  # type: ignore[index]


### PR DESCRIPTION
### Issue
When calling `torch.export._trace._export(..., pre_dispatch=True)` on a model with user-defined Triton kernels, we find ourselves here.

https://github.com/pytorch/pytorch/blob/4e966e8a1c2723374fd7d94ba84ed46c3241d94a/torch/_export/verifier.py#L61-L64

I realized the `node.meta['val']` was not set for our Triton kernel FX node. Instead, we generated a getitem FX node via `proxy[key]` and set `node.meta['val']` on that guy.

https://github.com/pytorch/pytorch/blob/4e966e8a1c2723374fd7d94ba84ed46c3241d94a/torch/fx/experimental/proxy_tensor.py#L440-L445


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132317

