### PR TITLE
[AOTI][tooling][1/n] Add intermediate value debug printer

### DIFF
--- a/torch/_inductor/codegen/cuda/cuda_cpp_scheduling.py
+++ b/torch/_inductor/codegen/cuda/cuda_cpp_scheduling.py
@@ -10,6 +10,7 @@ from ...scheduler import BaseSchedulerNode, BaseScheduling, Scheduler, Scheduler
 from ...utils import get_fused_kernel_name, get_kernel_metadata, sympy_product
 from ...virtualized import V
 from ..common import IndentedBuffer
+from ..debug_utils import DebugPrinterManager
 
 
 log = logging.getLogger(__name__)
@@ -100,6 +101,15 @@ class CUDACPPScheduling(BaseScheduling):
         with V.set_kernel_handler(kernel):
             node_schedule = [template_node]
             kernel_name = self.define_kernel(src_code, node_schedule)
-        kernel.call_kernel(kernel_name, ctb)
+
+        # debug printing values of intermediate tensors
+        # Note: MultiKernel debug printing is not supported for now
+        enable_debug_printer = config.aot_inductor.debug_intermediate_value_printer
+        _, call_args, _, arg_types = kernel.args.python_argdefs()
+        with DebugPrinterManager(
+            enable_debug_printer, call_args, kernel_name, kernel, arg_types
+        ):
+            kernel.call_kernel(kernel_name, ctb)
+
         V.graph.removed_buffers |= kernel.removed_buffers
         self.scheduler.free_buffers()

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -1,0 +1,91 @@
+# mypy: allow-untyped-defs
+from __future__ import annotations
+
+import os
+from typing import List, Optional
+
+from .. import config
+from ..virtualized import V
+from .common import TensorArg
+
+
+class DebugPrinterManager:
+    def __init__(
+        self,
+        enable_debug_printer: bool,
+        args_to_print: List[str],
+        kernel_name: str,
+        kernel=None,
+        arg_types: Optional[List[type]] = None,
+    ):
+        self.wrapper = V.graph.wrapper_code
+        self.enable_debug_printer = enable_debug_printer
+        self.args_to_print = args_to_print
+        self.kernel_name = kernel_name
+        self.arg_types: Optional[List[type]] = None
+        self.kernel = kernel
+
+    def __enter__(self):
+        if self.enable_debug_printer:
+            V.graph.all_codegen_kernel_names.add(self.kernel_name)
+            self.codegen_intermediate_tensor_value_printer(
+                self.args_to_print,
+                self.kernel_name,
+                before_launch=True,
+                arg_types=self.arg_types,
+            )
+
+    def __exit__(self, args_to_print, kernel_name, arg_types):
+        if self.enable_debug_printer:
+            self.codegen_intermediate_tensor_value_printer(
+                self.args_to_print,
+                self.kernel_name,
+                before_launch=False,
+                arg_types=self.arg_types,
+            )
+
+    def get_debug_filtered_kernel_names(self) -> List[str]:
+        return [
+            x.strip()
+            for x in os.environ.get(
+                "AOT_INDUCTOR_FILTERED_KERNELS_TO_PRINT",
+                ",".join(V.graph.all_codegen_kernel_names),
+            )
+            .lower()
+            .split(",")
+        ]
+
+    def codegen_intermediate_tensor_value_printer(
+        self,
+        args_to_print,
+        kernel_name,
+        before_launch=True,
+        arg_types: Optional[List[type]] = None,
+    ) -> None:
+        # when invoking this codegen_intermediate_tensor_value_printer function,
+        # we already assured that the AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER env var is set to 1,
+        # so we can directly use get method for filtered kernel info here
+        filtered_kernel_names_to_print = []
+        if V.graph.cpp_wrapper:
+            filtered_kernel_names_to_print = self.get_debug_filtered_kernel_names()
+
+        for i, arg in enumerate(args_to_print):
+            if arg_types is not None and not isinstance(arg_types[i], TensorArg):
+                continue
+            if (
+                len(filtered_kernel_names_to_print) > 0
+                and kernel_name not in filtered_kernel_names_to_print
+            ):
+                continue
+            launch_prefix = "before_launch" if before_launch else "after_launch"
+            if V.graph.cpp_wrapper:
+                if config.abi_compatible:
+                    self.wrapper.writeline(
+                        f'aoti_torch_print_tensor_handle({arg}, "{launch_prefix} - {kernel_name} - {arg}");'
+                    )
+                else:
+                    # TODO: add non-abi compatible mode debug printing info
+                    pass
+            else:
+                line = f"print('{launch_prefix} {kernel_name} - {arg}', {arg})"
+                self.wrapper.writeline(line)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2804,7 +2804,7 @@ class TritonKernel(SIMDKernel):
 
     def codegen_nan_check(self):
         wrapper = V.graph.wrapper_code
-        _, call_args, arg_types, _ = self.args.python_argdefs()
+        _, call_args, _, arg_types = self.args.python_argdefs()
         for arg, arg_type in zip(call_args, arg_types):
             if isinstance(arg_type, TensorArg):
                 if V.graph.cpp_wrapper:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -884,6 +884,15 @@ class aot_inductor:
         os.environ.get("AOT_INDUCTOR_DEBUG_DUMP_CONSTS_BIN", "0") == "1"
     )
 
+    # enable debug mode for aot inductor and it will print out more information including the intermediate tensor values, etc
+    # for debugging purpose
+    debug_intermediate_value_printer = (
+        os.environ.get("AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER", "0") == "1"
+    )
+
+    # filtered nodes to be printed for debug values. If not set, it will dump all debug tensor value info by default
+    filtered_kernel_names = os.environ.get("AOT_INDUCTOR_FILTERED_KERNELS_TO_PRINT", "")
+
     # Serialized tree spec for flattening inputs
     serialized_in_spec = ""
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -446,6 +446,9 @@ class GraphLowering(torch.fx.Interpreter):
         self.aligned_inputs: OrderedSet[str] = OrderedSet()
         self.no_fuse_buffer_names: OrderedSet[str] = OrderedSet()
 
+        # Below field is related to printing debug intermediate tensor values info for debugging
+        self.all_codegen_kernel_names: OrderedSet[str] = OrderedSet()
+
     def has_feature(
         self, device: Union[torch._inductor.ir.IRNode, device], feature: BackendFeature
     ) -> bool:
@@ -1719,6 +1722,12 @@ class GraphLowering(torch.fx.Interpreter):
 
         self.wrapper_code.push_codegened_graph(self)
         self.scheduler.codegen()
+
+        log.debug(
+            "Finished codegen for all nodes. The list of kernel names available: %s",
+            V.graph.all_codegen_kernel_names,
+        )
+
         result = self.wrapper_code.generate(self.is_inference)
         self.wrapper_code.pop_codegened_graph()
         return result

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -918,11 +918,38 @@ AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
     AtenTensorHandle self,
     const char* msg) {
   at::Tensor* t = tensor_handle_to_tensor_pointer(self);
+
+  auto device = t->device();
+  auto min = t->min().item<float>();
+  auto max = t->max().item<float>();
+
+  // Display message
   std::cout << "[";
   if (msg) {
-    std::cout << msg;
+    std::cout << "  " << msg;
   }
-  std::cout << "]:" << *t << "\n";
+  std::cout << "  "
+            << "]:" << std::endl;
+
+  // Print exact tensor values for small size tensors
+  const int threshold = 10;
+  if (t->numel() <= threshold) {
+    std::cout << *t << "\n";
+  }
+
+  // Print summary stats of the tensor
+  std::cout << "Min value: " << min << std::endl;
+  std::cout << "Max value: " << max << std::endl;
+  std::cout << "Device: " << device << std::endl;
+  std::cout << "Size: " << t->sizes() << std::endl;
+  std::cout << "Stride: " << t->strides() << std::endl;
+  std::cout << "Dtype: " << t->dtype() << std::endl;
+  std::cout << "Layout: " << t->layout() << std::endl;
+  std::cout << "Number of elements: " << t->numel() << std::endl;
+  std::cout << "Is contiguous: " << t->is_contiguous() << std::endl;
+  std::cout << "Requires grad: " << t->requires_grad() << std::endl;
+
+  std::cout << std::endl;
 }
 
 // ProxyExecutor


### PR DESCRIPTION
Summary:
**Context:**

Currently we have a helper to print out AtenTensor in [shim_common.cpp](https://github.com/pytorch/pytorch/blob/v2.4.0-rc4/torch/csrc/inductor/aoti_torch/shim_common.cpp#L866)

The way we were using this function was a “manual” process. We inject this function into the generated output.cpp file, and recompile and reload the file. This diff automates the printing value process.

**Changes:**

1. Added a simple initial debug printer helper to print out tensor values

2. Added a filter option to selectively dump tensor values.

**Usage:**

Sample cmd :

```
AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER=1 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1  TORCHINDUCTOR_ABI_COMPATIBLE=1 TORCH_COMPILE_DEBUG=1 TORCH_LOGS="+inductor, +schedule, output_code"  python test/inductor/test_aot_inductor.py -k test_addmm_abi_compatible_cuda
```

Sample outputs :
```
[  before_launch - triton_poi_fused_0 - buf0  ]:
 0.6331
 1.6358
-0.3459
 1.0196
-0.4122
 1.4279
[ CUDAFloatType{6} ]
Min value: -0.412198
Max value: 1.63582
Device: cuda:0
Size: [6]
Stride: [1]
Dtype: float
Layout: Strided
Number of elements: 6
Is contiguous: 1
Requires grad: 0

[  after_launch - triton_poi_fused_0 - buf0  ]:
 0.6331
 1.6358
-0.3459
 1.0196
-0.4122
 1.4279
[ CUDAFloatType{6} ]
Min value: -0.412198
Max value: 1.63582
Device: cuda:0
Size: [6]
Stride: [1]
Dtype: float
Layout: Strided
Number of elements: 6
Is contiguous: 1
Requires grad: 0

[ before_launch - aoti_torch_cuda_addmm_out - buf1  ]:
Min value: -2.25655
Max value: 2.32996
Device: cuda:0
Size: [16, 6]
Stride: [6, 1]
Dtype: float
Layout: Strided
Number of elements: 96
Is contiguous: 1
Requires grad: 0

[  before_launch - aoti_torch_cuda_addmm_out - buf0  ]:
 0.6331
 1.6358
-0.3459
 1.0196
-0.4122
 1.4279
[ CUDAFloatType{6} ]
Min value: -0.412198
Max value: 1.63582
Device: cuda:0
Size: [6]
Stride: [1]
Dtype: float
Layout: Strided
Number of elements: 6
Is contiguous: 1
Requires grad: 0

[  after_launch - aoti_torch_cuda_addmm_out - buf1  ]:
Min value: -12.0839
Max value: 11.6878
Device: cuda:0
Size: [16, 6]
Stride: [6, 1]
Dtype: float
Layout: Strided
Number of elements: 96
Is contiguous: 1
Requires grad: 0

[  after_launch - aoti_torch_cuda_addmm_out - buf0  ]:
 0.6331
 1.6358
-0.3459
 1.0196
-0.4122
 1.4279
[ CUDAFloatType{6} ]
Min value: -0.412198
Max value: 1.63582
Device: cuda:0
Size: [6]
Stride: [1]
Dtype: float
Layout: Strided
Number of elements: 6
Is contiguous: 1
Requires grad: 0

stats [('calls_captured', 1), ('unique_graphs', 1)]
inductor [('pattern_matcher_count', 2), ('pattern_matcher_nodes', 2), ('extern_calls', 2)]
.
----------------------------------------------------------------------
Ran 1 test in 10.867s

OK

```

The user is able to filter kernel names to print out values by specifying env var `AOT_INDUCTOR_FILTERED_KERNELS_TO_PRINT` and see choices of kernel names in a log message like below:
```
torch/_inductor/graph.py:1642] Finished codegen for all nodes. The list of kernel names available: ['triton_poi_fused_0', 'aoti_torch_cuda_addmm_out']

```

In the follow-up diff, will add `torch.save()` to dump/save the intermediate tensors into individual `.pt` files that can be further  `torch.load()`.

Test Plan:
Run Unit Tests in OSS: (similar cmd as mentioned above in the usage part)

 `AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER=1 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1  TORCHINDUCTOR_ABI_COMPATIBLE=1 TORCH_COMPILE_DEBUG=1 TORCH_LOGS="+inductor, output_code"  python test/inductor/test_aot_inductor.py -k test_addmm_abi_compatible_cuda`

Differential Revision: D60538496


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang