### PR TITLE
[inductor] fix UndefinedTensorImpl singleton can't export on Windows.

### DIFF
--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -38,6 +38,9 @@ const char* UndefinedTensorImpl::tensorimpl_type_name() const {
   return "UndefinedTensorImpl";
 }
 
-UndefinedTensorImpl UndefinedTensorImpl::_singleton;
+UndefinedTensorImpl& UndefinedTensorImpl::getInstance() {
+  static UndefinedTensorImpl instance;
+  return instance;
+}
 
 } // namespace c10

--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -38,9 +38,13 @@ const char* UndefinedTensorImpl::tensorimpl_type_name() const {
   return "UndefinedTensorImpl";
 }
 
+#ifdef _WIN32
 UndefinedTensorImpl& UndefinedTensorImpl::getInstance() {
   static UndefinedTensorImpl instance;
   return instance;
 }
+#else
+UndefinedTensorImpl UndefinedTensorImpl::_singleton;
+#endif
 
 } // namespace c10

--- a/c10/core/UndefinedTensorImpl.h
+++ b/c10/core/UndefinedTensorImpl.h
@@ -18,11 +18,14 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
   // function for device as well).
 #ifdef _WIN32
   static inline TensorImpl* singleton() {
-#else
-  static constexpr inline TensorImpl* singleton() {
-#endif
     return &getInstance();
   }
+#else
+  static constexpr inline TensorImpl* singleton() {
+    return &_singleton;
+  }
+#endif
+
 #ifdef DEBUG
   bool has_storage() const override;
 #endif
@@ -35,7 +38,11 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
 
  private:
   UndefinedTensorImpl();
+#ifdef _WIN32
   static UndefinedTensorImpl& getInstance();
+#else
+  static UndefinedTensorImpl _singleton;
+#endif
   const char* tensorimpl_type_name() const override;
 };
 

--- a/c10/core/UndefinedTensorImpl.h
+++ b/c10/core/UndefinedTensorImpl.h
@@ -21,7 +21,7 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
 #else
   static constexpr inline TensorImpl* singleton() {
 #endif
-    return &_singleton;
+    return &getInstance();
   }
 #ifdef DEBUG
   bool has_storage() const override;
@@ -35,7 +35,7 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
 
  private:
   UndefinedTensorImpl();
-  static UndefinedTensorImpl _singleton;
+  static UndefinedTensorImpl& getInstance();
   const char* tensorimpl_type_name() const override;
 };
 


### PR DESCRIPTION
This PR fix the `UndefinedTensorImpl::_singleton` can't export on Windows issue.
Snapshot:
<img width="1346" alt="image" src="https://github.com/user-attachments/assets/b34256ac-a0ae-473b-89e6-10d755eaad24">

The reason is MSVC can't export class static data to external linkage, ref: https://learn.microsoft.com/en-us/cpp/cpp/using-dllimport-and-dllexport-in-cpp-classes?view=msvc-170#_pluslang_using_dllimport_and_dllexport_in_c2b2bselectivememberimportexport 

I use another singleton implenmentation to avoid the issue, for Windows.

Since this PR, cpp_wrapper on Windows would start to work.
<img width="1916" alt="image" src="https://github.com/user-attachments/assets/c1d7d7e7-64ca-4c6d-9fb7-e3b91e675b58">

Next step, I will enable the cpp_wrapper UTs.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang