### PR TITLE
[DeviceMesh] Remove parent mesh concept from _MeshEnv and replace by root mesh

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -584,13 +584,6 @@ class TestMeshEnv(DTensorTestBase):
         self.assertEqual(_mesh_resources.get_root_mesh(cp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(tp_mesh), mesh_3d)
 
-        # Slice the 1D mesh from the 2D submesh.
-        dp_mesh = dp_cp_mesh["dp"]
-        cp_mesh = dp_cp_mesh["cp"]
-        # Check the root mesh is still the original 3D mesh.
-        self.assertEqual(_mesh_resources.get_root_mesh(dp_mesh), mesh_3d)
-        self.assertEqual(_mesh_resources.get_root_mesh(cp_mesh), mesh_3d)
-
     @with_comms
     def test_get_parent_mesh_dim_exist(self):
         mesh_shape = (2, self.world_size // 2)

--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -257,8 +257,8 @@ class FSDPParam:
             ):
                 raise NotImplementedError("Using TP with HSDP is not supported")
             dp_mesh, tp_mesh = (self.mesh_info.mesh, self._tp_spec.mesh)
-            dp_global_mesh = _mesh_resources.get_parent_mesh(dp_mesh)
-            tp_global_mesh = _mesh_resources.get_parent_mesh(tp_mesh)
+            dp_global_mesh = _mesh_resources.get_root_mesh(dp_mesh)
+            tp_global_mesh = _mesh_resources.get_root_mesh(tp_mesh)
             if dp_global_mesh != tp_global_mesh or (
                 dp_global_mesh is None or tp_global_mesh is None
             ):

--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -215,7 +215,10 @@ def replicate(
     if device_mesh is not None:
         from torch.distributed.device_mesh import _mesh_resources
 
-        if _mesh_resources.get_parent_mesh(device_mesh) is not None:
+        root_mesh = _mesh_resources.get_parent_mesh(device_mesh)
+        # if a root mesh is not the same as device_mesh,
+        # meaning the device_mesh is sliced out from the root mesh.
+        if root_mesh != device_mesh:
             # TODO: This is a temporary work around to enable DDP + TP.
             # We should do the logic in DDP so that the 2D implementation is
             # sound and the state_dict works out of the box.

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -72,7 +72,7 @@ else:
                 raise RuntimeError("No device mesh is currently active!")
             return self.mesh_stack[-1]
 
-        def create_child_mesh(
+        def create_sub_mesh(
             self, device_mesh: "DeviceMesh", submesh_dim_names: Tuple[str, ...]
         ) -> "DeviceMesh":
             # submesh_dims are the mesh dimension of the submesh in the device mesh.
@@ -475,7 +475,7 @@ else:
                     f"mesh_dim_names from {self.mesh_dim_names}."
                 )
 
-            submesh = _mesh_resources.create_child_mesh(self, mesh_dim_names)
+            submesh = _mesh_resources.create_sub_mesh(self, mesh_dim_names)
             return submesh
 
         def get_group(self, mesh_dim: Optional[Union[int, str]] = None) -> ProcessGroup:
@@ -651,6 +651,7 @@ else:
             dimensions of the mesh. If this rank is not part of the mesh, return None.
             """
             return self._coordinate_on_dim if self._coordinate_on_dim else None
+                    
 
     def init_device_mesh(
         device_type: str,

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -124,14 +124,14 @@ else:
             """
             Returns the index of the mesh dim in the root mesh.
             The device_mesh passed in needs to be sliced out from the root mesh
-            or children of the root mesh.
+            or submesh of the root mesh.
             """
             root_mesh = self.get_root_mesh(device_mesh)
             child_mesh_dim_names = device_mesh.mesh_dim_names
             if root_mesh and child_mesh_dim_names:
                 assert (
                     len(child_mesh_dim_names) == 1
-                ), "The child mesh can only be a 1D mesh."
+                ), "The submesh can only be a 1D mesh."
                 child_mesh_dim_name = child_mesh_dim_names[0]
                 return self.get_mesh_dim_by_name(root_mesh, child_mesh_dim_name)
             return None
@@ -422,11 +422,7 @@ else:
 
             Args:
                 mesh_dim_names (Union[str, Tuple[str]]): the name or the tuple of names of the
-<<<<<<< HEAD
                 mesh dimension of the DeviceMesh to create the submesh for.
-=======
-                mesh dimension of the DeviceMesh to create the child DeviceMesh for.
->>>>>>> 1231a3acd59 (remove parent mesh concept from _MeshEnv)
             Returns:
                 A :class:`DeviceMesh` object
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -651,7 +651,6 @@ else:
             dimensions of the mesh. If this rank is not part of the mesh, return None.
             """
             return self._coordinate_on_dim if self._coordinate_on_dim else None
-                    
 
     def init_device_mesh(
         device_type: str,

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -75,6 +75,9 @@ else:
         def create_sub_mesh(
             self, device_mesh: "DeviceMesh", submesh_dim_names: Tuple[str, ...]
         ) -> "DeviceMesh":
+            if device_mesh != self.get_root_mesh(device_mesh):
+                raise RuntimeError("Cannot create a submesh from a submesh.")
+
             # submesh_dims are the mesh dimension of the submesh in the device mesh.
             submesh_dims = [
                 not_none(device_mesh.mesh_dim_names).index(mesh_dim_name)
@@ -109,7 +112,7 @@ else:
             res_submesh._dim_group_infos = [  # type: ignore[possibly-undefined]
                 device_mesh._dim_group_infos[mesh_dim] for mesh_dim in submesh_dims
             ]
-            self.child_to_root_mapping[res_submesh] = self.get_root_mesh(device_mesh)
+            self.child_to_root_mapping[res_submesh] = device_mesh
 
             return res_submesh
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -113,7 +113,7 @@ else:
 
             return res_submesh
 
-        def get_root_mesh(self, device_mesh: "DeviceMesh") -> Optional["DeviceMesh"]:
+        def get_root_mesh(self, device_mesh: "DeviceMesh") -> "DeviceMesh":
             # If a mesh could not be found in the child_to_root_mapping, it is a root mesh itself.
             # A root mesh is not created through slicing.
             # We considers the root mesh of a root mesh is itself.

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -62,7 +62,7 @@ else:
     class _MeshEnv(threading.local):
         def __init__(self) -> None:
             self.mesh_stack: List[DeviceMesh] = []
-            self.child_to_parent_mapping: Dict[DeviceMesh, DeviceMesh] = {}
+            self.child_to_root_mapping: Dict[DeviceMesh, DeviceMesh] = {}
             self.mesh_dim_group_options: Dict[
                 int, Tuple[str, Optional[ProcessGroup.Options]]
             ] = {}
@@ -73,32 +73,32 @@ else:
             return self.mesh_stack[-1]
 
         def create_child_mesh(
-            self, parent_mesh: "DeviceMesh", submesh_dim_names: Tuple[str, ...]
+            self, device_mesh: "DeviceMesh", submesh_dim_names: Tuple[str, ...]
         ) -> "DeviceMesh":
-            # submesh_dims are the mesh dimension of the submesh in the parent mesh.
+            # submesh_dims are the mesh dimension of the submesh in the device mesh.
             submesh_dims = [
-                not_none(parent_mesh.mesh_dim_names).index(mesh_dim_name)
+                not_none(device_mesh.mesh_dim_names).index(mesh_dim_name)
                 for mesh_dim_name in submesh_dim_names
             ]
             submesh_dim_sizes = [
-                parent_mesh.mesh.size(mesh_dim) for mesh_dim in submesh_dims
+                device_mesh.mesh.size(mesh_dim) for mesh_dim in submesh_dims
             ]
 
-            mesh_dims_remained = list(range(parent_mesh.mesh.ndim))
+            mesh_dims_remained = list(range(device_mesh.mesh.ndim))
             for submesh_dim in submesh_dims:
                 mesh_dims_remained.remove(submesh_dim)
 
             # pg_ranks_by_dim is the size of [number of local ranks of the outermost submesh dimension, *sub_mesh_dims]
             # This means on each local rank of the outermost slice mesh dim, we have a tensor of submesh size with
             # the pg ranks of the submesh. From this, we can extract the submesh mesh tensor contains the current rank.
-            pg_ranks_by_dim = parent_mesh.mesh.permute(
+            pg_ranks_by_dim = device_mesh.mesh.permute(
                 *mesh_dims_remained, *submesh_dims
             ).reshape(-1, *submesh_dim_sizes)
 
-            cur_rank = parent_mesh.get_rank()
+            cur_rank = device_mesh.get_rank()
             for mesh_nd in pg_ranks_by_dim:
                 submesh = DeviceMesh(
-                    parent_mesh.device_type,
+                    device_mesh.device_type,
                     mesh_nd,
                     mesh_dim_names=submesh_dim_names,
                     _init_backend=False,
@@ -107,28 +107,33 @@ else:
                     res_submesh = submesh
 
             res_submesh._dim_group_infos = [  # type: ignore[possibly-undefined]
-                parent_mesh._dim_group_infos[mesh_dim] for mesh_dim in submesh_dims
+                device_mesh._dim_group_infos[mesh_dim] for mesh_dim in submesh_dims
             ]
-            self.child_to_parent_mapping[res_submesh] = parent_mesh
+            self.child_to_root_mapping[res_submesh] = self.get_root_mesh(device_mesh)
 
             return res_submesh
 
-        def get_parent_mesh(self, device_mesh: "DeviceMesh") -> Optional["DeviceMesh"]:
-            return self.child_to_parent_mapping.get(device_mesh, None)
+        def get_root_mesh(self, device_mesh: "DeviceMesh") -> Optional["DeviceMesh"]:
+            # If a mesh could not be found in the child_to_root_mapping, it is a root mesh itself.
+            # A root mesh is not created through slicing.
+            # We considers the root mesh of a root mesh is itself.
+            root_mesh = self.child_to_root_mapping.get(device_mesh, None)
+            return device_mesh if not root_mesh else root_mesh
 
-        def get_parent_mesh_dim(self, device_mesh: "DeviceMesh") -> Optional[int]:
+        def get_root_mesh_dim(self, device_mesh: "DeviceMesh") -> Optional[int]:
             """
-            Return the index of the mesh dim in the parent mesh.
-            The device_mesh passed in needs to be sliced out from a parent mesh.
+            Returns the index of the mesh dim in the root mesh.
+            The device_mesh passed in needs to be sliced out from the root mesh
+            or children of the root mesh.
             """
-            parent_mesh = self.get_parent_mesh(device_mesh)
+            root_mesh = self.get_root_mesh(device_mesh)
             child_mesh_dim_names = device_mesh.mesh_dim_names
-            if parent_mesh and child_mesh_dim_names:
+            if root_mesh and child_mesh_dim_names:
                 assert (
                     len(child_mesh_dim_names) == 1
                 ), "The child mesh can only be a 1D mesh."
                 child_mesh_dim_name = child_mesh_dim_names[0]
-                return self.get_mesh_dim_by_name(parent_mesh, child_mesh_dim_name)
+                return self.get_mesh_dim_by_name(root_mesh, child_mesh_dim_name)
             return None
 
         @staticmethod
@@ -418,7 +423,7 @@ else:
 
             Args:
                 mesh_dim_names (Union[str, Tuple[str]]): the name or the tuple of names of the
-                mesh dimension of the parent DeviceMesh to create the child DeviceMesh for.
+                mesh dimension of the DeviceMesh to create the child DeviceMesh for.
             Returns:
                 A :class:`DeviceMesh` object
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -521,7 +521,10 @@ def _init_prefetching_state(
 def _init_extension(state: _FSDPState, device_mesh: DeviceMesh = None) -> _FSDPState:
     # TODO: we need to add additional check once we support FSDP + PiPPy.
     # This check is currently sufficient, since we only support FSDP + TP.
-    if device_mesh and _mesh_resources.get_parent_mesh(state._device_mesh) is not None:
+    root_mesh = _mesh_resources.get_parent_mesh(device_mesh)
+    # if a root mesh is not the same as device_mesh,
+    # meaning the device_mesh is sliced out from the root mesh.
+    if device_mesh and root_mesh != state._device_mesh:
         state._fsdp_extension = DTensorExtensions(state._device_handle)
     else:
         # We need to explicilty set _fsdp_extension to None.

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -521,7 +521,7 @@ def _init_prefetching_state(
 def _init_extension(state: _FSDPState, device_mesh: DeviceMesh = None) -> _FSDPState:
     # TODO: we need to add additional check once we support FSDP + PiPPy.
     # This check is currently sufficient, since we only support FSDP + TP.
-    root_mesh = _mesh_resources.get_parent_mesh(device_mesh)
+    root_mesh = _mesh_resources.get_root_mesh(device_mesh)
     # if a root mesh is not the same as device_mesh,
     # meaning the device_mesh is sliced out from the root mesh.
     if device_mesh and root_mesh != state._device_mesh:

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -117,12 +117,14 @@ def _create_chunk_dtensor(
 
 def _all_gather_dtensor(
     tensor: DTensor,
-    parent_mesh: Optional[DeviceMesh],
+    root_mesh: Optional[DeviceMesh],
 ) -> torch.Tensor:
     """
     All gather a DTensor in its sharded dimension and return the local tensor.
     """
-    assert parent_mesh is None
+    assert (
+        root_mesh == tensor.device_mesh
+    ), "The device mesh of a tensor should be a root mesh."
 
     placements = list(copy.deepcopy(tensor.placements))
     # FSDP placements: [Shard(0)] -> [Replicate()]

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -297,7 +297,7 @@ def _full_pre_state_dict_hook(
     ``nn.Module``.
     """
     if getattr(fsdp_state, "_device_mesh", False):
-        parent_mesh = _mesh_resources.get_parent_mesh(fsdp_state._device_mesh)
+        root_mesh = _mesh_resources.root_mesh(fsdp_state._device_mesh)
 
     _common_pre_state_dict_hook(module, fsdp_state)
     _common_unshard_pre_state_dict_hook(
@@ -665,9 +665,9 @@ def _sharded_pre_load_state_dict_hook(
             if param.device != fsdp_state._device_mesh.device_type:
                 param = param.to(fsdp_state._device_mesh.device_type)
 
-            parent_mesh = _mesh_resources.get_parent_mesh(fsdp_state._device_mesh)
+            root_mesh = _mesh_resources.get_root_mesh(fsdp_state._device_mesh)
             local_tensor = _ext_all_gather_dtensor(
-                param, parent_mesh, fsdp_state._fsdp_extension
+                param, root_mesh, fsdp_state._fsdp_extension
             )
 
             if fqn_to_param_ext.get(fqn) is not None:

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -297,7 +297,7 @@ def _full_pre_state_dict_hook(
     ``nn.Module``.
     """
     if getattr(fsdp_state, "_device_mesh", False):
-        root_mesh = _mesh_resources.root_mesh(fsdp_state._device_mesh)
+        root_mesh = _mesh_resources.get_root_mesh(fsdp_state._device_mesh)
 
     _common_pre_state_dict_hook(module, fsdp_state)
     _common_unshard_pre_state_dict_hook(

--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -56,7 +56,9 @@ def _validate_tp_mesh_dim(
         )
 
     root_mesh = _mesh_resources.get_root_mesh(device_mesh)
-    if root_mesh:
+    # if a root mesh is not the same as device_mesh,
+    # meaning the device_mesh is sliced out from the root mesh.
+    if root_mesh and root_mesh != device_mesh:
         tp_mesh_dim_in_root = _mesh_resources.get_root_mesh_dim(device_mesh)
         if tp_mesh_dim_in_root != root_mesh.ndim - 1:
             raise RuntimeError(

--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -55,11 +55,11 @@ def _validate_tp_mesh_dim(
             'If you have a 2-D or N-D device_mesh, consider passing in device_mesh["tp"]'
         )
 
-    parent_mesh = _mesh_resources.get_parent_mesh(device_mesh)
-    if parent_mesh:
-        tp_mesh_dim_in_parent = _mesh_resources.get_parent_mesh_dim(device_mesh)
-        if tp_mesh_dim_in_parent != parent_mesh.ndim - 1:
+    root_mesh = _mesh_resources.get_root_mesh(device_mesh)
+    if root_mesh:
+        tp_mesh_dim_in_root = _mesh_resources.get_root_mesh_dim(device_mesh)
+        if tp_mesh_dim_in_root != root_mesh.ndim - 1:
             raise RuntimeError(
-                f"Found TP device_mesh on the {tp_mesh_dim_in_parent} dimension of its parent mesh.",
+                f"Found TP device_mesh on the {tp_mesh_dim_in_root} dimension of its parent mesh.",
                 "Currently we only support intranode TP and TP needs to be the innermost dimension on its parent mesh.",
             )

--- a/torch/distributed/tensor/parallel/fsdp.py
+++ b/torch/distributed/tensor/parallel/fsdp.py
@@ -227,12 +227,12 @@ def _chunk_dtensor(
 
     The local rank will gets its corresponding chunk as the local tensor to create a DTensor.
     """
-    parent_mesh = _mesh_resources.get_parent_mesh(device_mesh)
-    if parent_mesh is None:
+    root_mesh = _mesh_resources.get_root_mesh(device_mesh)
+    if root_mesh is None:
         raise RuntimeError("No parent device_mesh is found for FSDP device_mesh.")
-    if parent_mesh.ndim < 2:
+    if root_mesh.ndim < 2:
         raise RuntimeError(
-            f"Found parent device_mesh of ndim={parent_mesh.ndim},",
+            f"Found parent device_mesh of ndim={root_mesh.ndim},",
             "but meshes must be at least 2D.",
         )
 
@@ -246,14 +246,14 @@ def _chunk_dtensor(
         # For tensors, it is replicated across tp dimension and sharded across FSDP dimension.
         # TP is the inner dimension and FSDP is the outer dimension.
         # Therefore, shard placements for tensor is (Shard(0), Replicate()).
-        replicate_placements = [Replicate() for _ in range(parent_mesh.ndim)]
-        shard_placements = [Replicate() for _ in range(parent_mesh.ndim)]
+        replicate_placements = [Replicate() for _ in range(root_mesh.ndim)]
+        shard_placements = [Replicate() for _ in range(root_mesh.ndim)]
         shard_placements[0] = DShard(0)  # type: ignore[call-overload]
 
         return DTensor.from_local(
-            tensor, parent_mesh, replicate_placements, run_check=False
+            tensor, root_mesh, replicate_placements, run_check=False
         ).redistribute(
-            device_mesh=parent_mesh,
+            device_mesh=root_mesh,
             placements=shard_placements,
         )
 
@@ -268,16 +268,16 @@ def _chunk_dtensor(
         # Therefore, shard placements for tensor is (Shard(0), tp_placement).
         # For higher dimensional meshes, it is replicated across other dimensions. For example, with
         # HSDP the shard placements for tensor is (Replicate, Shard(0), tp_placement).
-        replicate_placements = [Replicate() for _ in range(parent_mesh.ndim)]
+        replicate_placements = [Replicate() for _ in range(root_mesh.ndim)]
         replicate_placements[-1] = tp_placement  # type: ignore[call-overload]
-        shard_placements = [Replicate() for i in range(parent_mesh.ndim)]  # type: ignore[misc]
+        shard_placements = [Replicate() for i in range(root_mesh.ndim)]  # type: ignore[misc]
         shard_placements[-2] = DShard(0)  # type: ignore[call-overload]
         shard_placements[-1] = tp_placement  # type: ignore[call-overload]
 
         return DTensor.from_local(
-            tensor, parent_mesh, replicate_placements, run_check=False
+            tensor, root_mesh, replicate_placements, run_check=False
         ).redistribute(
-            device_mesh=parent_mesh,
+            device_mesh=root_mesh,
             placements=shard_placements,
         )
 

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -672,7 +672,10 @@ class DistributedDataParallel(Module, Joinable):
             self.process_group = device_mesh.get_group(mesh_dim=0)
             from torch.distributed.device_mesh import _mesh_resources
 
-            if _mesh_resources.get_parent_mesh(device_mesh) is not None:
+            root_mesh = _mesh_resources.get_root_mesh(device_mesh)
+            # if a root mesh is not the same as device_mesh,
+            # meaning the device_mesh is sliced out from the root mesh.
+            if root_mesh != device_mesh:
                 # TODO: This is a temporary work around to enable DDP + TP.
                 # We should do the logic in DDP so that the 2D implementation is
                 # sound and the state_dict works out of the box.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132779
* #132632
* __->__ #132339

Previously, when we slice out a submesh from a mesh, we assign the mesh as the parent mesh of the submesh. In this case, when we have a 3D mesh topology, the parent mesh of a 1D mesh sliced out from the 3D mesh is different from the parent mesh of the same 1D mesh sliced out from the 2D submesh of the 3D mesh. For example:
```
mesh_3d = init_device_mesh("cuda", (2,2,2), ("dim0", "dim1", "dim2"))
mesh_dim0 = mesh_3d["dim0"]

mesh_2d = mesh_2d["dim0", "dim1"]
mesh_dim0_2 =  mesh_2d["dim0_2"]

# This would evaluate to be True
print(_mesh_resources.get_parent_mesh(mesh_dim0) != _mesh_resources.get_parent_mesh(mesh_dim0))
```

We can always reconstruct the mesh needed from the mesh dim names, as long as two dims come from the same root. For simplicity, we do not see the necessity of building a tree structure to represent child-parent relationship. Therefore, we are replacing the parent mesh concept with a root mesh concept in `_MeshEnv` so we would have:

```
mesh_3d = init_device_mesh("cuda", (2,2,2), ("dim0", "dim1", "dim2"))
mesh_dim0 = mesh_3d["dim0"]

mesh_2d = mesh_2d["dim0", "dim1"]
mesh_dim0_2 =  mesh_2d["dim0_2"]

# This would evaluate to be True
print(_mesh_resources.get_root_mesh(mesh_dim0) == _mesh_resources.get_root_mesh(mesh_dim0))
```
With this change, we will have two types of meshes in an environment. 
1. `device_mesh != _mesh_resources.get_root_mesh(device_mesh)` means that the device_mesh is created by slicing.
2. `device_mesh == _mesh_resources.get_root_mesh(device_mesh)` means that the device_mesh is a root mesh not created through slicing.



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l @chauhang