### PR TITLE
Only make wait_tensor as a side_effect op

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -963,66 +963,7 @@ if not torch._running_with_deploy():
 
     # mark these ops has side effect so that they won't be removed by DCE
     torch.fx.node.has_side_effect(torch.ops._c10d_functional.wait_tensor.default)
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional.all_gather_into_tensor_out.default
-    )
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional.all_gather_into_tensor.default
-    )
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional.all_gather_into_tensor_coalesced.default
-    )
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_reduce.default)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_reduce_.default)
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional.all_reduce_coalesced.default
-    )
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional.all_reduce_coalesced_.default
-    )
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_to_all_single.default)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.broadcast.default)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.broadcast_.default)
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional.reduce_scatter_tensor.default
-    )
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional.reduce_scatter_tensor_coalesced.default
-    )
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional_autograd.all_to_all_single.default
-    )
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional_autograd.reduce_scatter_tensor.default
-    )
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional_autograd.all_gather_into_tensor.default
-    )
-    # also the no-overload version
     torch.fx.node.has_side_effect(torch.ops._c10d_functional.wait_tensor)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_gather_into_tensor_out)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_gather_into_tensor)
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional.all_gather_into_tensor_coalesced
-    )
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_reduce)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_reduce_)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_reduce_coalesced)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_reduce_coalesced_)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.all_to_all_single)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.broadcast)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.broadcast_)
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional.reduce_scatter_tensor)
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional.reduce_scatter_tensor_coalesced
-    )
-    torch.fx.node.has_side_effect(torch.ops._c10d_functional_autograd.all_to_all_single)
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional_autograd.reduce_scatter_tensor
-    )
-    torch.fx.node.has_side_effect(
-        torch.ops._c10d_functional_autograd.all_gather_into_tensor
-    )
 
     # Register legacy ops for backward compatibility
     # TODO(yifu): remove these in functional collective beta release


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Summary:
https://github.com/pytorch/pytorch/pull/131023 add all the collective ops to the side effect list. But we should only make wait_tensor as a side_effect op because all collective ops should have a corresponding wait_tensor.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o