### PR TITLE
[CP] Extend CP to support load-blancing shards

### DIFF
--- a/test/distributed/_tensor/test_attention.py
+++ b/test/distributed/_tensor/test_attention.py
@@ -13,6 +13,7 @@ from torch.distributed._tensor.experimental.attention import (
     _is_causal_behavior,
     AttentionContextParallel,
     context_parallel_buffers,
+    context_parallel_unshard,
     enable_context_parallel,
 )
 from torch.distributed.tensor.parallel import parallelize_module
@@ -24,6 +25,7 @@ from torch.testing._internal.common_cuda import (
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    decorateIf,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -58,11 +60,19 @@ class RingAttentionTest(DTensorTestBase):
         "Does not support flash nor efficient attention",
     )
     @with_comms
+    @decorateIf(
+        unittest.skip, lambda params: params["load_balance"] and not params["is_causal"]
+    )
     @parametrize("is_causal", [True, False])
     @parametrize("compiled", [True, False])
     @parametrize("backend", backends)
+    @parametrize("load_balance", [True, False])
     def test_ring_attention_sdpa(
-        self, is_causal: bool, compiled: bool, backend: SDPBackend
+        self,
+        is_causal: bool,
+        compiled: bool,
+        backend: SDPBackend,
+        load_balance: bool,
     ) -> None:
         device_mesh = DeviceMesh(self.device_type, torch.arange(0, self.world_size))
         dtype = torch.bfloat16
@@ -74,6 +84,10 @@ class RingAttentionTest(DTensorTestBase):
         torch.manual_seed(10)
         dtype = (
             torch.bfloat16 if backend == SDPBackend.FLASH_ATTENTION else torch.float32
+        )
+
+        torch.distributed._tensor.experimental.attention._enable_load_balance = (
+            load_balance
         )
 
         if is_causal and compiled:
@@ -109,11 +123,6 @@ class RingAttentionTest(DTensorTestBase):
             out = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal)
             out.sum().backward()
 
-        with context_parallel_buffers(
-            device_mesh, (out, q.grad, k.grad, v.grad), (2, 2, 2, 2)
-        ) as local_buffers:
-            local_out, local_dq, local_dk, local_dv = local_buffers
-
         enable_context_parallel(2, [], device_mesh)
         with context_parallel_buffers(device_mesh, (q, k, v), (2, 2, 2)) as cp_buffers:
             cp_q, cp_k, cp_v = cp_buffers
@@ -144,21 +153,26 @@ class RingAttentionTest(DTensorTestBase):
 
             # Due to numerical error, we need to choose different atol for different
             # attention kernels
+            cp_out, cp_dq, cp_dk, cp_dv = context_parallel_unshard(
+                device_mesh,
+                [cp_out, cp_q.grad, cp_k.grad, cp_v.grad],
+                [2, 2, 2, 2],
+            )
             atol = (
                 1e-08
                 if backend == SDPBackend.EFFICIENT_ATTENTION
                 else 2e-3 * self.world_size
             )
-            self.assertTrue(torch.allclose(local_out, cp_out, atol=atol))
+            self.assertTrue(torch.allclose(out, cp_out, atol=atol))
 
             atol = (
                 2e-06
                 if backend == SDPBackend.EFFICIENT_ATTENTION
                 else 2e-2 * self.world_size
             )
-            self.assertTrue(torch.allclose(local_dq, cp_q.grad, atol=atol))
-            self.assertTrue(torch.allclose(local_dk, cp_k.grad, atol=atol))
-            self.assertTrue(torch.allclose(local_dv, cp_v.grad, atol=atol))
+            self.assertTrue(torch.allclose(q.grad, cp_dq, atol=atol))
+            self.assertTrue(torch.allclose(k.grad, cp_dk, atol=atol))
+            self.assertTrue(torch.allclose(v.grad, cp_dv, atol=atol))
 
     def test_is_causal_behavior(self) -> None:
         self.assertEqual(

--- a/torch/distributed/_tensor/experimental/attention.py
+++ b/torch/distributed/_tensor/experimental/attention.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import types
 import weakref
+from abc import ABC, abstractmethod
 from enum import Enum
 from typing import (
     Any,
@@ -35,6 +36,7 @@ from torch.distributed.tensor.parallel.style import ParallelStyle
 aten = torch.ops.aten
 logger = logging.getLogger(__name__)
 _convert_to_f32 = True
+_enable_load_balance = False
 
 
 class _CausalBehavior(Enum):
@@ -57,7 +59,7 @@ def _is_causal_behavior(
         return _CausalBehavior.IS_CAUSAL
 
     source_rank = (rank - i) % world_size
-    if source_rank < rank:
+    if source_rank < rank or _enable_load_balance:
         return _CausalBehavior.NOT_IS_CAUSAL
     else:
         return _CausalBehavior.SKIP
@@ -73,30 +75,57 @@ def _maybe_wait(tensor: torch.Tensor) -> torch.Tensor:
     return tensor
 
 
+def _partial_update(
+    original: torch.Tensor,
+    new: torch.Tensor,
+    dim: int,
+    n_chunks: int,
+    idx: int,
+    add: bool,
+) -> torch.Tensor:
+    chunks = list(original.chunk(n_chunks, dim=dim))
+    if add:
+        chunks[idx] += new
+    else:
+        chunks[idx] = new
+    return torch.cat(chunks, dim=dim)
+
+
 class _SDPAMerger:
     """A class to help to merge the local SDPA result."""
 
-    def __init__(self, convert_to_f32: bool):
+    def __init__(self, convert_to_f32: bool, seq_dim: int):
+        self._seq_dim = seq_dim
         self._out: Optional[torch.Tensor] = None
         self._lse: Optional[torch.Tensor] = None
         self._convert_to_f32 = convert_to_f32
         self._out_dtype = torch.float32
         self._lse_dtype = torch.float32
 
-    def _merge_one(self, block_out: torch.Tensor, block_lse: torch.Tensor) -> None:
+    def _merge_one(
+        self, block_out: torch.Tensor, block_lse: torch.Tensor, partial: bool
+    ) -> None:
         block_lse = block_lse.unsqueeze(dim=-1)
         if self._lse is None:
             self._lse = block_lse
             self._out = block_out
         else:
-            new_lse = self._lse + torch.log(1 + torch.exp(block_lse - self._lse))
-            self._out = (
-                torch.exp(self._lse - new_lse) * self._out
+            lse = self._lse.chunk(2, dim=self._seq_dim)[1] if partial else self._lse
+            out = self._out.chunk(2, dim=self._seq_dim)[1] if partial else self._out
+
+            new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))
+            out = (
+                torch.exp(lse - new_lse) * out
                 + torch.exp(block_lse - new_lse) * block_out
             )
-            self._lse = new_lse
+            if partial:
+                self._lse = _partial_update(self._lse, new_lse, 2, 2, 1, add=False)
+                self._out = _partial_update(self._out, out, 2, 2, 1, add=False)
+            else:
+                self._lse = new_lse
+                self._out = out
 
-    def step(self, out: torch.Tensor, lse: torch.Tensor) -> None:
+    def step(self, out: torch.Tensor, lse: torch.Tensor, partial: bool) -> None:
         self._out_dtype = out.dtype
         self._lse_dtype = lse.dtype
 
@@ -104,7 +133,7 @@ class _SDPAMerger:
             out = out.to(torch.float32)
             lse = lse.to(torch.float32)
 
-        self._merge_one(out, lse)
+        self._merge_one(out, lse, partial)
 
     def results(self) -> Tuple[torch.Tensor, torch.Tensor]:
         assert self._out is not None
@@ -184,6 +213,7 @@ class AttentionOp(Protocol):
 def _ring_rotate(
     block: torch.Tensor, pg: dist.ProcessGroup, send_to_next: bool
 ) -> torch.Tensor:
+    block = block.contiguous()
     size = dist.get_world_size(pg)
     dsts = (
         list(range(1, size)) + [0]
@@ -242,7 +272,7 @@ def _templated_ring_attention(
     key = key.contiguous()
     value = value.contiguous()
 
-    sdpa_merger = _SDPAMerger(_convert_to_f32)
+    sdpa_merger = _SDPAMerger(_convert_to_f32, seq_dim=2)
 
     rest: List[Any]
     out: torch.Tensor
@@ -263,16 +293,29 @@ def _templated_ring_attention(
             rank=rank, world_size=size, i=i, is_causal=is_causal
         )
 
-        if is_causal_behavior != _CausalBehavior.SKIP:
-            out, logsumexp, *rest = op(
-                query,
-                key,
-                value,
-                is_causal=is_causal_behavior.value,
-                **kwargs,
-            )
+        if is_causal_behavior == _CausalBehavior.SKIP:
+            continue
 
-            sdpa_merger.step(out, logsumexp)
+        if i == 0 or (not _enable_load_balance or not is_causal):
+            q, k, v, partial = (query, key, value, False)
+        elif i <= rank:
+            q, k, v, partial = (
+                query,
+                key.chunk(2, dim=2)[0],
+                value.chunk(2, dim=2)[0],
+                False,
+            )
+        else:
+            q, k, v, partial = query.chunk(2, dim=2)[1], key, value, True
+
+        out, logsumexp, *rest = op(
+            q,
+            k,
+            v,
+            is_causal=is_causal_behavior.value,
+            **kwargs,
+        )
+        sdpa_merger.step(out, logsumexp, partial)
 
     return *sdpa_merger.results(), *rest
 
@@ -383,13 +426,34 @@ def _templated_ring_attention_backward(
         )
 
         if is_causal_behavior != _CausalBehavior.SKIP:
-            kwargs[grad_out_name] = grad_out
+            if i == 0 or (not _enable_load_balance or not is_causal):
+                q, k, v, out_, dout, lse = (query, key, value, out, grad_out, logsumexp)
+            elif i <= rank:
+                q, k, v, out_, dout, lse = (
+                    query,
+                    key.chunk(2, dim=2)[0],
+                    value.chunk(2, dim=2)[0],
+                    out,
+                    grad_out,
+                    logsumexp,
+                )
+            else:
+                q, k, v, out_, dout, lse = (
+                    query.chunk(2, dim=2)[1],
+                    key,
+                    value,
+                    out.chunk(2, dim=2)[1],
+                    grad_out.chunk(2, dim=2)[1],
+                    logsumexp.chunk(2, dim=2)[1].contiguous(),
+                )
+
+            kwargs[grad_out_name] = dout
             grad_query_, grad_key_, grad_value_, *rest = op(
-                query=query,
-                key=key,
-                value=value,
-                out=out,
-                logsumexp=logsumexp,
+                query=q,
+                key=k,
+                value=v,
+                out=out_,
+                logsumexp=lse,
                 is_causal=is_causal_behavior.value,
                 **kwargs,
             )
@@ -415,15 +479,20 @@ def _templated_ring_attention_backward(
             grad_key = grad_key_
             grad_value = grad_value_
         else:
-            grad_key = buffer[pointer : pointer + grad_key_.numel()].reshape(
-                grad_key_.shape
+            grad_key = buffer[pointer : pointer + grad_key.numel()].reshape(
+                grad_key.shape
             )
-            pointer += grad_key_.numel()
-            grad_value = buffer[pointer : pointer + grad_value_.numel()].reshape(
-                grad_value_.shape
+            pointer += grad_key.numel()
+            grad_value = buffer[pointer : pointer + grad_value.numel()].reshape(
+                grad_value.shape
             )
-            grad_key += grad_key_
-            grad_value += grad_value_
+
+            if i <= rank and _enable_load_balance:
+                grad_key = _partial_update(grad_key, grad_key_, 2, 2, 0, add=True)
+                grad_value = _partial_update(grad_value, grad_value_, 2, 2, 0, add=True)
+            else:
+                grad_key += grad_key_
+                grad_value += grad_value_
 
         # Send the key, value, grad key, and grad value to the next rank.
         if i >= size - 2:
@@ -439,7 +508,11 @@ def _templated_ring_attention_backward(
             )
 
         next_grad_kv = _ring_rotate(next_grad_kv, pg, send_to_next=True)
-        grad_query += grad_query_
+
+        if i <= rank or not _enable_load_balance:
+            grad_query += grad_query_
+        else:
+            grad_query = _partial_update(grad_query, grad_query_, 2, 2, 1, add=True)
 
     assert grad_query is not None
     assert grad_key is not None
@@ -449,8 +522,8 @@ def _templated_ring_attention_backward(
     assert grad_value_ is not None
     grad_query = grad_query.to(query.dtype)
     next_grad_kv = _maybe_wait(next_grad_kv)
-    grad_key = next_grad_kv[: grad_key_.numel()].reshape(grad_key.shape)
-    grad_value = next_grad_kv[grad_value_.numel() :].reshape(grad_value.shape)
+    grad_key = next_grad_kv[: grad_key.numel()].reshape(grad_key.shape)
+    grad_value = next_grad_kv[grad_value.numel() :].reshape(grad_value.shape)
     return (
         grad_query,
         grad_key,
@@ -823,10 +896,60 @@ def enable_context_parallel(
     )
 
 
-def _get_sequence_shard(
-    buffer: torch.Tensor, mesh: DeviceMesh, seq_dim: int
-) -> torch.Tensor:
-    return buffer.chunk(mesh.size(), dim=seq_dim)[mesh.get_local_rank()]
+class _LoadBalancer(ABC):
+    @classmethod
+    @abstractmethod
+    def shard(cls, buffer: torch.Tensor, mesh: DeviceMesh, seq_dim: int):
+        ...
+
+    @classmethod
+    @abstractmethod
+    def unshard(cls, buffer: torch.Tensor, mesh: DeviceMesh, seq_dim: int):
+        ...
+
+
+class EvenSharder(_LoadBalancer):
+    @classmethod
+    def shard(cls, buffer: torch.Tensor, mesh: DeviceMesh, seq_dim: int):
+        assert buffer.size()[seq_dim] % mesh.size() == 0
+        return buffer.chunk(mesh.size(), dim=seq_dim)[mesh.get_local_rank()]
+
+    @classmethod
+    def unshard(cls, buffer: torch.Tensor, mesh: DeviceMesh, seq_dim: int):
+        buffer = buffer.contiguous()
+        all_buffers = [torch.empty_like(buffer) for _ in range(mesh.size())]
+        ft_c.all_gather_inplace(all_buffers, buffer, mesh)
+        return torch.cat(all_buffers, dim=seq_dim)
+
+
+class ZigzagLoadBalancer(_LoadBalancer):
+    @classmethod
+    def shard(cls, buffer: torch.Tensor, mesh: DeviceMesh, seq_dim: int):
+        cp_world_size = mesh.size()
+        cp_rank = mesh.get_rank()
+        assert buffer.size()[seq_dim] % (cp_world_size * 2) == 0
+        chunks = buffer.chunk(cp_world_size * 2, dim=seq_dim)
+        return torch.cat(
+            (chunks[cp_rank], chunks[cp_world_size * 2 - cp_rank - 1]),
+            dim=seq_dim,
+        )
+
+    @classmethod
+    def unshard(cls, buffer: torch.Tensor, mesh: DeviceMesh, seq_dim: int):
+        buffer = buffer.contiguous()
+        cp_world_size = mesh.size()
+        cp_rank = mesh.get_rank()
+
+        all_buffers = [torch.empty_like(buffer) for _ in range(cp_world_size)]
+        ft_c.all_gather_inplace(all_buffers, buffer, mesh)
+        sliced_buffers = [sb for b in all_buffers for sb in b.chunk(2, dim=seq_dim)]
+        ordered_buffers = list(sliced_buffers)
+        for i, b in enumerate(sliced_buffers):
+            if i % 2 == 0:
+                ordered_buffers[i // 2] = b
+            else:
+                ordered_buffers[cp_world_size * 2 - (i // 2) - 1] = b
+        return torch.cat(ordered_buffers, dim=seq_dim)
 
 
 @contextlib.contextmanager
@@ -857,11 +980,12 @@ def context_parallel_buffers(
             "number of as `buffers`."
         )
 
+    sharder = ZigzagLoadBalancer if _enable_load_balance else EvenSharder
     assert mesh is not None
     new_buffers = []
     for buffer, seq_dim, restore_func in zip(buffers, seq_dims, restore_funcs_tuple):
         original_buffers.append(buffer if restore_func else None)
-        new_buffers.append(_get_sequence_shard(buffer, mesh, seq_dim))
+        new_buffers.append(sharder.shard(buffer, mesh, seq_dim))
 
     yield new_buffers
 
@@ -869,3 +993,13 @@ def context_parallel_buffers(
         if original_buffer is not None:
             assert restore_func is not None
             restore_func(original_buffer)
+
+
+@torch.no_grad()
+def context_parallel_unshard(
+    mesh: DeviceMesh,
+    buffers: List[torch.Tensor],
+    seq_dims: List[int],
+) -> List[torch.Tensor]:
+    sharder = ZigzagLoadBalancer if _enable_load_balance else EvenSharder
+    return [sharder.unshard(b, mesh, dim) for b, dim in zip(buffers, seq_dims)]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #131352
* __->__ #132342
* #131351
* #132341

This PR extends the current ring attention to support load-balancing shards -- the context is divided into 2 * world_size shards and each rank gets rank_th and (world_size * 2 - rank_th - 1) shards.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o