### PR TITLE
[export] Apply CIA override only if implemented

### DIFF
--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -223,10 +223,10 @@ def _override_composite_implicit_decomp(ops_to_preserve, decomp_table):
         if torch._C.DispatchKey.CompositeImplicitAutograd in op_overload.py_kernels:
             del op_overload.py_kernels[torch._C.DispatchKey.CompositeImplicitAutograd]
 
-        def _(*args, **kwargs):
-            return NotImplemented
+            def _(*args, **kwargs):
+                return NotImplemented
 
-        op_overload.py_impl(torch._C.DispatchKey.CompositeImplicitAutograd)(_)
+            op_overload.py_impl(torch._C.DispatchKey.CompositeImplicitAutograd)(_)
 
         # For fake tensor prop, we do want to register meta kernel directly
         if torch._C.DispatchKey.Meta not in op_overload.py_kernels:


### PR DESCRIPTION
Differential Revision: D60553559

Without this change, after marking sdpa as "preserved op", sdpa will return `FakeTensor(..., size=(1, 12, 197, 64), stride=(12608, 64, 1))` which fails in the following view operation with `ValueError: Cannot view a tensor with shape torch.Size([197, 1, 12, 64]) and strides (64, 151296, 12608, 1) as a tensor with shape (197, 768)!` (https://www.internalfb.com/phabricator/paste/view/P1517731253).

With this change, sdpa will return `FakeTensor(..., size=(1, 12, 197, 64), stride=(151296, 64, 768, 1))` which works.

I'm not sure why the issue is happening or why the change works 😅 if maybe @tugsbayasgalan or @bdhirsh could take a look, that would be great!