### PR TITLE
[pytorch][counters] Pybind for WaitCounter

### DIFF
--- a/c10/util/WaitCounter.h
+++ b/c10/util/WaitCounter.h
@@ -45,6 +45,13 @@ class C10_API WaitCounterHandle {
 
   class WaitGuard {
    public:
+    WaitGuard(WaitGuard&& other) noexcept
+        : handle_{std::exchange(other.handle_, {})},
+          ctxs_{std::move(other.ctxs_)} {}
+    WaitGuard(const WaitGuard&) = delete;
+    WaitGuard& operator=(const WaitGuard&) = delete;
+    WaitGuard& operator=(WaitGuard&&) = delete;
+
     ~WaitGuard() {
       stop();
     }

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -1,22 +1,21 @@
 # Owner(s): ["oncall: r2p"]
 
-from torch.testing._internal.common_utils import (
-    TestCase, run_tests, skipIfTorchDynamo,
-)
-
-from datetime import timedelta, datetime
 import tempfile
 import time
+
+from datetime import datetime, timedelta
 
 from torch.monitor import (
     Aggregation,
     Event,
     log_event,
     register_event_handler,
-    unregister_event_handler,
     Stat,
     TensorboardEventHandler,
+    unregister_event_handler,
+    _WaitCounter,
 )
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
 
 class TestMonitor(TestCase):
     def test_interval_stat(self) -> None:
@@ -97,6 +96,13 @@ class TestMonitor(TestCase):
         unregister_event_handler(handle)
         log_event(e)
         self.assertEqual(len(events), 2)
+
+    def test_wait_counter(self) -> None:
+        wait_counter = _WaitCounter(
+            "test_wait_counter",
+        )
+        with wait_counter.guard() as wcg:
+            pass
 
 
 @skipIfTorchDynamo("Really weird error")

--- a/torch/monitor/__init__.py
+++ b/torch/monitor/__init__.py
@@ -1,6 +1,7 @@
 from torch._C._monitor import *  # noqa: F403
-
 from typing import TYPE_CHECKING
+
+from torch._C._monitor import _WaitCounter  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
     from torch.utils.tensorboard import SummaryWriter


### PR DESCRIPTION
Summary:
Basic pybind integration for WaitCounter providing a guard API.
Also fixes broken copy/move constructor in WaitGuard (it wasn't really used with the macro-based C++ API).

Test Plan: unit test

Differential Revision: D60557660
