### PR TITLE
Revert "[aoti] Fix float16 and bfloat16 for generated GPU code (#131437)"

### DIFF
--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -186,7 +186,6 @@ if RUN_CUDA:
         BaseTest("test_sum_dtype"),  # float64
         BaseTest("test_sum_int"),  # bool, int64, int8, uint8
         BaseTest("test_transpose"),  # multiple outputs, buffer clear
-        BaseTest("test_unspec_inputs"),
         BaseTest(
             "test_foreach_cpp_wrapper",
             tests=test_foreach.ForeachTests(),

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -923,27 +923,14 @@ class CppWrapperCpu(WrapperCodeGen):
         ), "codegen_tensor_item is only used for the ABI-compatible mode"
         dtype_str = str(dtype).split(".")[-1]
         writer = indented_buffer or self
+        writer.writeline(f"{DTYPE_TO_CPP[dtype]} {scalar};")
 
-        if dtype == torch.float16 or dtype == torch.bfloat16:
-            scalar_tmp = f"{scalar}_tmp"
-            writer.writeline(f"{DTYPE_TO_CPP[dtype]} {scalar_tmp};")
+        # need convert_arrayref_tensor_to_tensor for ArrayRefTensors
+        tensor = f"convert_arrayref_tensor_to_tensor({tensor})"
 
-            # need convert_arrayref_tensor_to_tensor for ArrayRefTensors
-            tensor = f"convert_arrayref_tensor_to_tensor({tensor})"
-
-            writer.writeline(
-                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_{dtype_str}({tensor}, &{scalar_tmp}));"
-            )
-            writer.writeline(f"float {scalar} = float({scalar_tmp});")
-        else:
-            writer.writeline(f"{DTYPE_TO_CPP[dtype]} {scalar};")
-
-            # need convert_arrayref_tensor_to_tensor for ArrayRefTensors
-            tensor = f"convert_arrayref_tensor_to_tensor({tensor})"
-
-            writer.writeline(
-                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_{dtype_str}({tensor}, &{scalar}));"
-            )
+        writer.writeline(
+            f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_item_{dtype_str}({tensor}, &{scalar}));"
+        )
 
     @cache_on_self
     def get_output_refs(self):

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -43,8 +43,6 @@ class CppWrapperCuda(CppWrapperCpu):
         super().write_header()
 
         self.header.splice("#include <filesystem>")
-        self.header.splice("typedef at::Half half;")
-        self.header.splice("typedef at::BFloat16 bfloat16;")
         if config.abi_compatible:
             self.header.splice(
                 "#include <torch/csrc/inductor/aoti_runtime/utils_cuda.h>"
@@ -156,18 +154,7 @@ class CppWrapperCuda(CppWrapperCpu):
                             var_name,
                         )
                     else:
-                        from torch import bfloat16, float16
-
-                        if arg_type in (float16, bfloat16):
-                            var_name_tmp = f"{var_name}_tmp"
-                            self.writeline(
-                                f"{ctype} {var_name_tmp} = {arg}.item<{ctype}>();"
-                            )
-                            self.writeline(f"float {var_name} = float({var_name_tmp});")
-                        else:
-                            self.writeline(
-                                f"{ctype} {var_name} = {arg}.item<{ctype}>();"
-                            )
+                        self.writeline(f"{ctype} {var_name} = {arg}.item<{ctype}>();")
                 else:
                     if config.abi_compatible:
                         self.writeline(

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -51,9 +51,6 @@
 #endif // _WIN32
 #endif // __GNUC__
 
-#include <c10/util/BFloat16.h>
-#include <c10/util/Half.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -120,8 +117,6 @@ AOTI_TORCH_EXPORT int32_t aoti_torch_layout__mkldnn();
 
 // Functions for converting a single-element tensor to a scalar value
 AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_item_float16(AtenTensorHandle tensor, c10::Half* ret_value);
-AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_float32(AtenTensorHandle tensor, float* ret_value);
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_float64(AtenTensorHandle tensor, double* ret_value);
@@ -143,8 +138,6 @@ AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_int64(AtenTensorHandle tensor, int64_t* ret_value);
 AOTI_TORCH_EXPORT AOTITorchError
 aoti_torch_item_bool(AtenTensorHandle tensor, bool* ret_value);
-AOTI_TORCH_EXPORT AOTITorchError
-aoti_torch_item_bfloat16(AtenTensorHandle tensor, c10::BFloat16* ret_value);
 
 // Functions for wrapping a scalar value to a single-element tensor
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_scalar_to_tensor_float32(

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -109,7 +109,6 @@ int32_t aoti_torch_layout__mkldnn() {
     });                                                        \
   }
 
-AOTI_TORCH_ITEM_IMPL(float16, c10::Half)
 AOTI_TORCH_ITEM_IMPL(float32, float)
 AOTI_TORCH_ITEM_IMPL(float64, double)
 AOTI_TORCH_ITEM_IMPL(uint8, uint8_t)
@@ -121,7 +120,6 @@ AOTI_TORCH_ITEM_IMPL(int16, int16_t)
 AOTI_TORCH_ITEM_IMPL(int32, int32_t)
 AOTI_TORCH_ITEM_IMPL(int64, int64_t)
 AOTI_TORCH_ITEM_IMPL(bool, bool)
-AOTI_TORCH_ITEM_IMPL(bfloat16, c10::BFloat16)
 #undef AOTI_TORCH_ITEM_IMPL
 
 #define AOTI_TORCH_SCALAR_TO_TENSOR_IMPL(dtype, ctype, ttype)                  \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132365

This reverts commit 02b922900b6366b34a35cf35ac1001d3c7ca2e50.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang