### PR TITLE
add src map to data-dependent errors

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1926,11 +1926,12 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         M = M_v0
         with self.assertRaisesRegex(
             error_type,
-            "User code(.*\n)+"
+            "The following call raised this error(.*\n)+"
             f".*{re.escape('return r.view(items[0], items[2])')}(.*\n)+"
-            "Suggested fixes.*:\n"
+            "To fix the error, insert one of the following checks before this call.*:\n"
             f".*{re.escape('torch._check(items[2] == (-1))')}.*\n"
-            f".*{re.escape('torch._check(items[2] != (-1))')}",
+            f".*{re.escape('torch._check(items[2] != (-1))')}(.*\n)+"
+            f".*{re.escape('(These suggested fixes were derived by replacing `u2` with items[2] in Eq(u2, -1) and its negation.)')}",
         ):
             export(N(), (t,), strict=strict)
 
@@ -1946,11 +1947,12 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         M = M_v1
         with self.assertRaisesRegex(
             error_type,
-            "User code(.*\n)+"
+            "The following call raised this error(.*\n)+"
             f".*{re.escape('return r.view(items[0], items[2])')}(.*\n)+"
-            "Suggested fixes.*:\n"
+            "To fix the error, insert one of the following checks before this call.*:\n"
             f".*{re.escape('torch._check(items[2] >= 0)')}.*\n"
-            f".*{re.escape('torch._check(items[2] < 0)')}",
+            f".*{re.escape('torch._check(items[2] < 0)')}(.*\n)+"
+            f".*{re.escape('(These suggested fixes were derived by replacing `u2` with items[2] in u2 >= 0 and its negation.)')}",
         ):
             export(N(), (t,), strict=strict)
 
@@ -1968,11 +1970,12 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         M = M_v2
         with self.assertRaisesRegex(
             error_type,
-            "User code(.*\n)+"
+            "The following call raised this error(.*\n)+"
             f".*{re.escape('return r.view(items[0], items[2])')}(.*\n)+"
-            "Suggested fixes.*:\n"
-            f".*{re.escape('torch._check(items[2] == r.shape[1])')}.*\n"
-            f".*{re.escape('torch._check(items[2] != r.shape[1])')}",
+            "To fix the error, insert one of the following checks before this call.*:\n"
+            f".*{re.escape('torch._check(items[2] == items[1])')}.*\n"
+            f".*{re.escape('torch._check(items[2] != items[1])')}(.*\n)+"
+            f".*{re.escape('(These suggested fixes were derived by replacing `u1` with items[1] or r.shape[1], `u2` with items[2] in Eq(u2, u1) and its negation.)')}",
         ):
             export(N(), (t,), strict=strict)
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5575,7 +5575,7 @@ def _blame_user_code(e, frame):
     )
     msg = e.args[0]
     msg += (
-        '\n\nUser code:\n' +
+        '\n\nThe following call raised this error:\n' +
         ''.join(traceback.StackSummary.from_list([frame_summary]).format())
     )
     e.args = (msg,)
@@ -5593,7 +5593,7 @@ class _PythonPrinter(sympy.printing.str.StrPrinter):
         self.src_map = src_map
 
     def _print_Symbol(self, sym):
-        return self.src_map[sym.name]
+        return self.src_map[sym.name][0]
 
     def _print_Relational(self, expr):
         lhs = self.parenthesize(expr.lhs, sympy.printing.precedence.precedence(expr))
@@ -5611,7 +5611,7 @@ def _suggest_torch_checks(e, src_map):
         return
     printer = _PythonPrinter(src_map)
     msg = e.args[0]
-    msg += "\nSuggested fixes (please choose one of the following):"
+    msg += "\nTo fix the error, insert one of the following checks before this call:"
     # suggested fixes to resolve `cond`` are to tell the compiler to assume
     # either `cond` or its negation (the user will need to select which)
     suggested_fixes = [
@@ -5620,6 +5620,11 @@ def _suggest_torch_checks(e, src_map):
     ]
     for i, fix in enumerate(suggested_fixes):
         msg += f"\n  {i+1}. {fix}"
+    src_mapped = ', '.join(
+        f"`{s}` with {' or '.join(src_map[s])}"
+        for s in sorted(s.name for s in cond.free_symbols)
+    )
+    msg += f"\n\n(These suggested fixes were derived by replacing {src_mapped} in {cond} and its negation.)"
     e.args = (msg,)
 
 
@@ -5638,17 +5643,17 @@ def _suggest_fixes_for_data_dependent_error_non_strict(e):
             _blame_user_code(e, frame)
 
             # map symbol names reachable via frame locals to their source-level names
-            src_map = {}
+            src_map = defaultdict(list)
             for var, val in frame.f_locals.items():
                 # figure out how to access any symbol inside `val` through `var`
                 for path, leaf in pytree.tree_leaves_with_path(val):
                     name = var + pytree.keystr(path)
                     if isinstance(leaf, torch.SymInt):
-                        src_map[str(leaf.node.expr)] = name
+                        src_map[str(leaf.node.expr)].append(name)
                     elif isinstance(leaf, torch.Tensor):
                         for i, dim in enumerate(leaf.shape):
                             if isinstance(dim, torch.SymInt):
-                                src_map[str(dim.node.expr)] = f"{name}.shape[{i}]"
+                                src_map[str(dim.node.expr)].append(f"{name}.shape[{i}]")
 
             # add suggested torch.check()s based on `src_map` to the error message
             # replacing unbacked symints in the unresolved condition in the error


### PR DESCRIPTION
Summary: Currently suggested fixes pick a map from symbols to user variables. However it is possible that many user variables  point to the same symbol, and some may be preferred over others. Thus we dump this info as well.

Test Plan: updated test

Sample error with new format:
```
Could not guard on data-dependent expression u2 >= 0 (unhinted: u2 >= 0).  (Size-like symbols: none)

<snip>

The following call raised this error:
  File "test/export/test_export.py", line 1950, in forward
    return r.view(items[0], items[2])

To fix the error, insert one of the following checks before this call:
  1. torch._check(items[2] >= 0)
  2. torch._check(items[2] < 0)

(These suggested fixes were derived by replacing `u2` with items[2] in u2 >= 0 and its negation.)
```

Differential Revision: D60574478
