### PR TITLE
[CUDA12] use MaybeSetDevice in cuda device guard setDevice

### DIFF
--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -49,10 +49,17 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     }
     return Device(DeviceType::CUDA, device);
   }
+#if CUDA_VERSION >= 12000
+  void setDevice(Device d) const override {
+    TORCH_INTERNAL_ASSERT(d.is_cuda());
+    C10_CUDA_CHECK(c10::cuda::MaybeSetDevice(d.index()));
+  }
+#else
   void setDevice(Device d) const override {
     TORCH_INTERNAL_ASSERT(d.is_cuda());
     C10_CUDA_CHECK(c10::cuda::SetDevice(d.index()));
   }
+#endif
   void uncheckedSetDevice(Device d) const noexcept override {
     C10_CUDA_CHECK_WARN(c10::cuda::MaybeSetDevice(d.index()));
   }


### PR DESCRIPTION
This PR leverages the `MaybeSetDevice` function (https://github.com/pytorch/pytorch/pull/94864) in cuda device guard `setDevice` function to address the issue of unnecessary context memory allocation on cuda:0 when using other devices, such as XLA:GPU. This PR resolves the issue described in https://github.com/pytorch/xla/pull/6208#issuecomment-2008740614. 

Before this PR, when testing [pytorch/xla](https://github.com/pytorch/xla/tree/v2.3.0) with the following command:
```
PJRT_DEVICE=CUDA torchrun --nnodes 1 --nproc_per_node 4 xla/test/test_train_mp_imagenet.py  --fake_data --pjrt_distributed --batch_size=32 --num_epochs=1
```
the GPU memory usage for each process was as follows:
```
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A    106448      C   /usr/bin/python                           62336MiB |
|    0   N/A  N/A    106449      C   /usr/bin/python                             414MiB |
|    0   N/A  N/A    106450      C   /usr/bin/python                             414MiB |
|    0   N/A  N/A    106451      C   /usr/bin/python                             414MiB |
|    1   N/A  N/A    106449      C   /usr/bin/python                           62480MiB |
|    2   N/A  N/A    106450      C   /usr/bin/python                           62480MiB |
|    3   N/A  N/A    106451      C   /usr/bin/python                           62336MiB |
+---------------------------------------------------------------------------------------+
```
There are unnecessary memory allocation on GPU#0.

After this PR, the CUDA Device Guard's `setDevice` will no longer call `cudaSetDevice` if a primary context does not exist on cuda:0. As a result, the GPU memory usage is now:
```
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A     66928      C   /usr/bin/python                           62336MiB |
|    1   N/A  N/A     66929      C   /usr/bin/python                           62480MiB |
|    2   N/A  N/A     66930      C   /usr/bin/python                           62480MiB |
|    3   N/A  N/A     66931      C   /usr/bin/python                           62336MiB |
+---------------------------------------------------------------------------------------+
```

Test Environment: CUDA12 + pytorch main branch + pytorch/xla v2.3.0.

cc @Aidyn-A , @vanbasten23 , @ezyang 