### PR TITLE
[MPS] Add regression test for memory leak in `nn.MaxPool2d`

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1263,8 +1263,39 @@ class TestMemoryLeak(TestCaseMPS):
         step(a)
         torch.mps.empty_cache()
         driver_after = torch.mps.driver_allocated_memory()
-        self.assertEqual(driver_before, driver_after, f"Detected {driver_after-driver_before} bytes leak of GPU memory")
+        self.assertEqual(driver_before, driver_after, f"Detected {driver_after - driver_before} bytes leak of GPU memory")
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/125217
+    # TODO(hvaara): When this is fixed in macOS:
+    #   * This test will start failing consistently.
+    #   * Update `0` in the predicate below to the macOS version that fixes the issue.
+    #   * Remove this TODO.
+    #   * Worry about flakes.
+    @xfailIf(product_version > 0)
+    def test_maxpool2d_no_leak(self):
+        N, C, H, W = 64, 32, 256, 256
+        iters = 5
+
+        model = torch.nn.Sequential(
+            nn.Conv2d(32, 32, 3),
+            nn.MaxPool2d((2, 2)),
+        ).to('mps')
+        input = torch.rand(N, C, H, W, device='mps')
+
+        # Warm up
+        model(input)
+        torch.mps.empty_cache()
+
+        # Begin test
+        driver_before = torch.mps.driver_allocated_memory()
+        model(input)
+        for _ in range(iters):
+            output = model(input)
+            loss = output.sum()
+            loss.backward()
+        torch.mps.empty_cache()
+        driver_after = torch.mps.driver_allocated_memory()
+        self.assertEqual(driver_before, driver_after, f"Detected {driver_after - driver_before} bytes leak of GPU memory")
 
 class TestPixelShuffle(TestCaseMPS):
     def test_pixel_shuffle_unshuffle(self):
@@ -7876,7 +7907,7 @@ class TestMPS(TestCaseMPS):
 
     def test_mps_allocator_stats(self):
         max_memory = torch.mps.recommended_max_memory()
-        print(f"Recommended Max Memory : {max_memory/ 1024 ** 3} GB")
+        print(f"Recommended Max Memory : {max_memory / 1024 ** 3} GB")
         self.assertGreater(max_memory, 0)
 
     # to verify this test, run XCode Instruments "Metal System Trace" or "Logging" tool,


### PR DESCRIPTION
This pull request introduces a regression test for the issue described in
- #125217

The test is designed to identify a GPU memory leak in the `nn.MaxPool2d` module in MPS. About 1.63 GiB is leaked in this test when the issue is present.

#### Summary of Changes:

1. **New Test Function:**
  Added `test_maxpool2d_no_leak` to verify that no GPU memory is leaked when performing a sequence of operations with `nn.MaxPool2d`.
2. **Temporary Workaround with @xfailIf:**
Used the `@xfailIf(product_version > 0)` decorator to mark the test as expected to fail for product versions greater than `0`.
This will help identify when the issue is resolved in macOS version 15 or later (estimate by upstream), as the test will start failing consistently, indicating that the memory leak has been fixed. Once the issue is resolved in macOS, the predicate needs to be updated. For example, use `@xfailIf(product_version < 15.1)` if the issue is fixed in macOS version `15.1`.