### PR TITLE
Fix DEBUG=1 asserts for mvlgamma backward with NJT

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -6994,13 +6994,6 @@ BACKWARD_FAILURES = {
     "special.i1e",
 }
 
-COMPILE_BACKWARD_FAILURES = {
-    *BACKWARD_FAILURES,
-    # mvlgamma_backward calls arange() passing self.options() and layout=torch.jagged
-    # is not supported for the arange() decomp. Backward function should be fixed
-    *(f"mvlgamma.mvlgamma_p_{p}" for p in [1, 3, 5]),
-}
-
 
 def withXFails(failure_list):
     return decorateIf(
@@ -7080,7 +7073,7 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
 
             self.assertEqual(out_compile, out_ref)
 
-    @withXFails(COMPILE_BACKWARD_FAILURES)
+    @withXFails(BACKWARD_FAILURES)
     @ops(
         [op for op in njt_op_db if op.supports_njt and op.supports_autograd],
         allowed_dtypes=(torch.float32,),

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -568,8 +568,12 @@ Tensor angle_backward(const Tensor& grad, const Tensor& self) {
 }
 
 Tensor mvlgamma_backward(const Tensor& grad, const Tensor& self, int64_t p) {
-  Tensor args =
-      at::arange(-static_cast<double>(p) / 2. + 0.5, 0.5, 0.5, self.options());
+  Tensor args = at::arange(
+      -static_cast<double>(p) / 2. + 0.5,
+      0.5,
+      0.5,
+      // use strided here regardless of self's layout; useful for e.g. NJT
+      self.options().layout(c10::kStrided));
   args = args.add(self.unsqueeze(-1));
   return grad * args.digamma_().sum(-1);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132422

mvlgamma backward trips DEBUG=1 asserts when trying to construct an empty tensor with `layout=torch.jagged`. This happens due to passing `self.options()` to `arange()` in `mvlgamma_backward()`. Fix in this PR unconditionally constructs `arange()` with the strided layout.