### PR TITLE
[inductor] tensor_is_align fallbacking False if unbacked expr not comptime evaled

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1336,17 +1336,6 @@ def triton_(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK : tl.constexpr):
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
             torch.testing.assert_allclose(foo(inp), foo_c(inp))
-    
-
-    def test_non_compiletime_known_aligned(self):
-        def fn(inp):
-            return inp[inp.size(0):] * 2
-
-        inp = torch.rand(1, 16, dtype=torch.uint8, device="cuda")
-        torch._dynamo.mark_unbacked(inp, 0)
-
-        fn_c = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=True)(inp)
-        torch.testing.assert_allclose(fn(inp), fn_c(inp))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1336,6 +1336,17 @@ def triton_(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK : tl.constexpr):
                 torch._dynamo.mark_dynamic(inp, 0)
             foo_c = torch.compile(foo)
             torch.testing.assert_allclose(foo(inp), foo_c(inp))
+    
+
+    def test_non_compiletime_known_aligned(self):
+        def fn(inp):
+            return inp[inp.size(0):] * 2
+
+        inp = torch.rand(1, 16, dtype=torch.uint8, device="cuda")
+        torch._dynamo.mark_unbacked(inp, 0)
+
+        fn_c = torch.compile(fn, backend="inductor", fullgraph=True, dynamic=True)(inp)
+        torch.testing.assert_allclose(fn(inp), fn_c(inp))
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1812,11 +1812,12 @@ def tensor_is_aligned(tensor: torch.Tensor):
     # but symbolic storage_offsets are. For consistency, we suppress guard creation
     # upon performing this check: that ensures that we don't add recompiles when we
     # add this logic.
-    from torch.fx.experimental.symbolic_shapes import statically_known_true
-
-    return statically_known_true(
-        (tensor.storage_offset() * get_dtype_size(tensor.dtype)) % GPU_ALIGN_BYTES == 0
-    )
+    
+    # from torch.fx.experimental.symbolic_shapes import statically_known_true
+    # return statically_known_true(
+    #     (tensor.storage_offset() * get_dtype_size(tensor.dtype)) % GPU_ALIGN_BYTES == 0
+    # )
+    return (tensor.storage_offset() * get_dtype_size(tensor.dtype)) % GPU_ALIGN_BYTES == 0
 
 
 def should_assume_input_aligned(example_input: torch.Tensor):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1812,12 +1812,11 @@ def tensor_is_aligned(tensor: torch.Tensor):
     # but symbolic storage_offsets are. For consistency, we suppress guard creation
     # upon performing this check: that ensures that we don't add recompiles when we
     # add this logic.
-    
-    # from torch.fx.experimental.symbolic_shapes import statically_known_true
-    # return statically_known_true(
-    #     (tensor.storage_offset() * get_dtype_size(tensor.dtype)) % GPU_ALIGN_BYTES == 0
-    # )
-    return (tensor.storage_offset() * get_dtype_size(tensor.dtype)) % GPU_ALIGN_BYTES == 0
+    from torch.fx.experimental.symbolic_shapes import statically_known_true
+
+    return statically_known_true(
+        (tensor.storage_offset() * get_dtype_size(tensor.dtype)) % GPU_ALIGN_BYTES == 0
+    )
 
 
 def should_assume_input_aligned(example_input: torch.Tensor):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1812,15 +1812,11 @@ def tensor_is_aligned(tensor: torch.Tensor):
     # but symbolic storage_offsets are. For consistency, we suppress guard creation
     # upon performing this check: that ensures that we don't add recompiles when we
     # add this logic.
-    from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+    from torch.fx.experimental.symbolic_shapes import statically_known_true
 
-    try:
-        return guard_size_oblivious(
-            (tensor.storage_offset() * get_dtype_size(tensor.dtype)) % GPU_ALIGN_BYTES
-            == 0
-        )
-    except torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode:
-        return False
+    return statically_known_true(
+        (tensor.storage_offset() * get_dtype_size(tensor.dtype)) % GPU_ALIGN_BYTES == 0
+    )
 
 
 def should_assume_input_aligned(example_input: torch.Tensor):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133002
* __->__ #132423

Currently if storage_offset is unbacked symbol and is_align can not be computed compiletime - it hard fails.

Doing the best we can: adding guard_size_oblivious and fallback on False if can not be evaluated compiletime


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang