### PR TITLE
[Testing only] See what fails when we no longer use numpy to serialize tensors without storage

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -269,9 +269,9 @@ class Tensor(torch._C.TensorBase):
             # support BFloat16. The rebuild tensor from numpy takes in the original self.dtype,
             # this would reconstruct the BFloat16 tensor from numpy.
             numpy_tensor = (
-                self.cpu().numpy()
+                self.cpu()
                 if self.dtype != torch.bfloat16
-                else self.cpu().to(torch.float32).numpy()
+                else self.cpu().to(torch.float32)
             )
             return (
                 torch._utils._rebuild_device_tensor_from_numpy,

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -336,7 +336,7 @@ def _rebuild_nested_tensor(buffer, sizes, strides, storage_offsets):
 
 def _rebuild_device_tensor_from_numpy(data, dtype, device, requires_grad):
     device = _get_restore_location(device)
-    tensor = torch.from_numpy(data).to(dtype=dtype, device=device)
+    tensor = data.to(dtype=dtype, device=device)
     tensor.requires_grad = requires_grad
     return tensor
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132438

