### PR TITLE
[aoti] Add additional custom op input type support

### DIFF
--- a/test/inductor/custom_ops.cpp
+++ b/test/inductor/custom_ops.cpp
@@ -26,9 +26,9 @@ Tensor fn_with_all_inputs_impl(
     at::ArrayRef<at::Scalar> scalars,
     const std::string& string,
     const std::vector<std::string>& strings,
-    const c10::ScalarType& dtype,
-    const MemoryFormat& memory_format,
-    const Layout& layout,
+    // const c10::ScalarType& dtype,
+    // const MemoryFormat& memory_format,
+    // const Layout& layout,
     const Device& device,
     // optional
     const std::optional<Tensor>& o_tensor,
@@ -45,9 +45,9 @@ Tensor fn_with_all_inputs_impl(
     const std::optional<at::ArrayRef<at::Scalar>>& o_scalars,
     const std::optional<std::string>& o_string,
     const std::optional<std::vector<std::string>>& o_strings,
-    const std::optional<c10::ScalarType>& o_dtype,
-    const std::optional<MemoryFormat>& o_memory_format,
-    const std::optional<Layout>& o_layout,
+    // const std::optional<c10::ScalarType>& o_dtype,
+    // const std::optional<MemoryFormat>& o_memory_format,
+    // const std::optional<Layout>& o_layout,
     const std::optional<Device>& o_device) {
   std::cout << "tensor shape: " << tensor.sizes() << std::endl;
 
@@ -79,9 +79,9 @@ Tensor fn_with_all_inputs_impl(
   std::cout << "scalars " << c10::IValue(scalars) << std::endl;
   std::cout << "string " << c10::IValue(string) << std::endl;
   std::cout << "strings " << c10::IValue(strings) << std::endl;
-  std::cout << "dtype " << c10::IValue(dtype) << std::endl;
-  std::cout << "memory_format " << c10::IValue(memory_format) << std::endl;
-  std::cout << "layout " << c10::IValue(layout) << std::endl;
+  // std::cout << "dtype " << c10::IValue(dtype) << std::endl;
+  // std::cout << "memory_format " << c10::IValue(memory_format) << std::endl;
+  // std::cout << "layout " << c10::IValue(layout) << std::endl;
   std::cout << "device " << c10::IValue(device) << std::endl;
 
   std::cout << "o_tensor "
@@ -135,17 +135,17 @@ Tensor fn_with_all_inputs_impl(
   std::cout << "o_strings "
             << (o_strings.has_value() ? c10::IValue(o_strings.value()) : "None")
             << std::endl;
-  std::cout << "o_dtype "
-            << (o_dtype.has_value() ? c10::IValue(o_dtype.value()) : "None")
-            << std::endl;
-  std::cout << "o_memory_format "
-            << (o_memory_format.has_value()
-                    ? c10::IValue(o_memory_format.value())
-                    : "None")
-            << std::endl;
-  std::cout << "o_layout "
-            << (o_layout.has_value() ? c10::IValue(o_layout.value()) : "None")
-            << std::endl;
+  // std::cout << "o_dtype "
+  //           << (o_dtype.has_value() ? c10::IValue(o_dtype.value()) : "None")
+  //           << std::endl;
+  // std::cout << "o_memory_format "
+  //           << (o_memory_format.has_value()
+  //                   ? c10::IValue(o_memory_format.value())
+  //                   : "None")
+  //           << std::endl;
+  // std::cout << "o_layout "
+  //           << (o_layout.has_value() ? c10::IValue(o_layout.value()) : "None")
+  //           << std::endl;
   std::cout << "o_device "
             << (o_device.has_value() ? c10::IValue(o_device.value()) : "None")
             << std::endl;
@@ -236,9 +236,9 @@ Tensor fn_with_all_inputs_meta(
     at::ArrayRef<at::Scalar> scalars,
     const std::string& string,
     const std::vector<std::string>& strings,
-    const c10::ScalarType& dtype,
-    const MemoryFormat& memory_format,
-    const Layout& layout,
+    // const c10::ScalarType& dtype,
+    // const MemoryFormat& memory_format,
+    // const Layout& layout,
     const Device& device,
     // optional
     const std::optional<Tensor>& o_tensor,
@@ -255,9 +255,9 @@ Tensor fn_with_all_inputs_meta(
     const std::optional<at::ArrayRef<at::Scalar>>& o_scalars,
     const std::optional<std::string>& o_string,
     const std::optional<std::vector<std::string>>& o_strings,
-    const std::optional<c10::ScalarType>& o_dtype,
-    const std::optional<MemoryFormat>& o_memory_format,
-    const std::optional<Layout>& o_layout,
+    // const std::optional<c10::ScalarType>& o_dtype,
+    // const std::optional<MemoryFormat>& o_memory_format,
+    // const std::optional<Layout>& o_layout,
     const std::optional<Device>& o_device) {
   return tensor;
 }
@@ -313,9 +313,9 @@ TORCH_LIBRARY(aoti_custom_ops, m) {
       "float f64, float[] f64s, "
       "Scalar scalar, Scalar[] scalars, "
       "str string, str[] strings, "
-      "ScalarType dtype, "
-      "MemoryFormat memory_format, "
-      "Layout layout, "
+      // "ScalarType dtype, "
+      // "MemoryFormat memory_format, "
+      // "Layout layout, "
       "Device device, "
       "*, "
       "Tensor? o_tensor, Tensor[]? o_tensors, "
@@ -325,9 +325,9 @@ TORCH_LIBRARY(aoti_custom_ops, m) {
       "float? o_f64, float[]? o_f64s, "
       "Scalar? o_scalar, Scalar[]? o_scalars, "
       "str? o_string, str[]? o_strings, "
-      "ScalarType? o_dtype, "
-      "MemoryFormat? o_memory_format, "
-      "Layout? o_layout, "
+      // "ScalarType? o_dtype, "
+      // "MemoryFormat? o_memory_format, "
+      // "Layout? o_layout, "
       "Device? o_device) -> Tensor");
 
   m.def("fn_with_default_input(Tensor t, int i=3) -> Tensor");

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -2521,6 +2521,137 @@ class AOTInductorTestsTemplate:
         )
         self.check_model(m, args)
 
+    def test_custom_op_all_inputs(self) -> None:
+        class MyModel(torch.nn.Module):
+            # pyre-fixme[3]: Return type must be annotated.
+            def __init__(self):
+                super().__init__()
+
+            # pyre-fixme[3]: Return type must be annotated.
+            # pyre-fixme[2]: Parameter must be annotated.
+            def forward(self, x, y):
+                with torch.no_grad():
+                    x_dim0 = x.shape[0]
+                    x_dim1 = x.shape[1]
+                    y_dim0 = y.shape[0]
+                    y_dim1 = y.shape[1]
+                    symint_0 = x_dim0 + x_dim1
+                    symint_1 = y_dim0 * y_dim1
+
+                    z = torch.concat((x, x))
+
+                    _2547 = torch.ops.aoti_custom_ops.fn_with_all_inputs(
+                        tensor=x,
+                        tensors=[x, y],
+                        optional_tensors=[None, z],
+                        b8=False,
+                        b8s=[True, False],
+                        i64=42,
+                        i64s=[16, 17],
+                        symint=symint_0,
+                        symints=[symint_0, symint_1],
+                        f64=3.14,
+                        f64s=[2.2, 3.3],
+                        scalar=1.23,
+                        scalars=[45, 67],
+                        string="hello",
+                        strings=["ab", "cde"],
+                        # dtype=torch.float16,
+                        # memory_format=torch.contiguous_format,
+                        # layout=torch.strided,
+                        device=torch.device("cpu"),
+                        # optional
+                        o_tensor=None,
+                        o_tensors=[x, y],
+                        o_b8=False,
+                        o_b8s=[True, False],
+                        o_i64=None,
+                        o_i64s=[16, 17],
+                        o_symint=symint_1,
+                        o_symints=[symint_1, symint_0],
+                        o_f64=3.14,
+                        o_f64s=None,
+                        o_scalar=None,
+                        o_scalars=[89, 910],
+                        o_string="hello",
+                        o_strings=["ab", "cde"],
+                        # o_dtype=None,
+                        # o_memory_format=torch.contiguous_format,
+                        # o_layout=torch.strided,
+                        o_device=None,
+                    )
+
+                return _2547
+
+        m = MyModel().to(device=self.device)
+        x = torch.zeros(4, 8, device=self.device)
+        y = torch.ones(3, 9, device=self.device)
+        args = (x, y)
+        m(*args)
+
+        self.check_model(m, args)
+
+    def test_custom_op_with_multiple_outputs(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                out = x + y
+                # tuple of Tensor output
+                out3, out4 = torch.ops.aoti_custom_ops.fn_with_tuple_output(out, 1)
+                # TensorList output
+                out5, out6 = torch.ops.aoti_custom_ops.fn_with_list_output(
+                    [out3, out4], 1
+                )
+                # tuple of Tensor and TensorList
+                out7, [out8, out9] = torch.ops.aoti_custom_ops.fn_with_mix_outputs(
+                    out5, [out6, out4]
+                )
+                return out3, out4, out5, out6, out7, out8, out9
+
+        m = Model().to(device=self.device)
+        args = (
+            torch.randn(4, 4, device=self.device),
+            torch.randn(4, 4, device=self.device),
+        )
+        m(*args)
+
+        self.check_model(m, args)
+
+    def test_custom_op_with_reinterpret_view_inputs(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                out = x.permute([1, 0])
+                return torch.ops.aoti_custom_ops.fn_with_default_input(out, 1)
+
+        m = Model().to(device=self.device)
+        args = (torch.randn(2, 3, device=self.device),)
+
+        self.check_model(m, args)
+
+    def test_custom_op_with_concat_inputs(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                out = torch.concat([x, y], dim=0)
+                return torch.ops.aoti_custom_ops.fn_with_default_input(out, 1)
+
+        m = Model().to(device=self.device)
+        args = (
+            torch.randn(2, 3, device=self.device),
+            torch.randn(2, 3, device=self.device),
+        )
+
+        self.check_model(m, args)
+
+    def test_custom_op_missing_arg_with_default_value(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                # missing second arg
+                return torch.ops.aoti_custom_ops.fn_with_default_input(x)
+
+        m = Model().to(device=self.device)
+        args = (torch.randn(2, 3, device=self.device),)
+
+        self.check_model(m, args)
+
     def test_triton_kernel_extern_kernel_arg(self):
         if self.device != "cuda":
             raise unittest.SkipTest("requires CUDA")
@@ -3368,9 +3499,18 @@ CPU_TEST_FAILURES = {
     "test_while_loop_with_outer_buffers": fail_stack_allocation(is_skip=True),
     # TODO: use of undeclared identifier 'float8_e4m3fn' and 'half'
     "test_fp8": fail_minimal_arrayref_interface(is_skip=True),
-    "test_custom_op_add": fail_stack_allocation(is_skip=True)
-    if IS_FBCODE
-    else fail_minimal_arrayref_interface(is_skip=True),
+    "test_custom_op_add": fail_minimal_arrayref_interface(is_skip=True),
+    "test_custom_op_all_inputs": fail_minimal_arrayref_interface(is_skip=True),
+    "test_custom_op_with_multiple_outputs": fail_minimal_arrayref_interface(
+        is_skip=True
+    ),
+    "test_custom_op_with_reinterpret_view_inputs": fail_minimal_arrayref_interface(
+        is_skip=True
+    ),
+    "test_custom_op_with_concat_inputs": fail_minimal_arrayref_interface(is_skip=True),
+    "test_custom_op_missing_arg_with_default_value": fail_minimal_arrayref_interface(
+        is_skip=True
+    ),
 }
 
 # test_failures, xfail by default, set is_skip=True to skip
@@ -3390,6 +3530,15 @@ CUDA_TEST_FAILURES = {
     "test_fp8": fail_cuda(is_skip=True),
     # non-abi compatible mode debug printer is not supported yet
     "test_aoti_debug_printer_codegen": fail_non_abi_compatible_cuda(is_skip=True),
+    "test_custom_op_all_inputs": fail_non_abi_compatible_cuda(is_skip=True),
+    "test_custom_op_missing_arg_with_default_value": fail_non_abi_compatible_cuda(
+        is_skip=True
+    ),
+    "test_custom_op_with_concat_inputs": fail_non_abi_compatible_cuda(is_skip=True),
+    "test_custom_op_with_reinterpret_view_inputs": fail_non_abi_compatible_cuda(
+        is_skip=True
+    ),
+    "test_custom_op_with_multiple_outputs": fail_non_abi_compatible_cuda(is_skip=True),
 }
 
 
@@ -3543,6 +3692,21 @@ copy_tests(
         ),
         "test_custom_op_add": TestFailure(("non_abi_compatible_cpu",), is_skip=True),
         "test_aoti_debug_printer_codegen": TestFailure(
+            ("non_abi_compatible_cpu",), is_skip=True
+        ),
+        "test_custom_op_all_inputs": TestFailure(
+            ("non_abi_compatible_cpu",), is_skip=True
+        ),
+        "test_custom_op_missing_arg_with_default_value": TestFailure(
+            ("non_abi_compatible_cpu",), is_skip=True
+        ),
+        "test_custom_op_with_concat_inputs": TestFailure(
+            ("non_abi_compatible_cpu",), is_skip=True
+        ),
+        "test_custom_op_with_multiple_outputs": TestFailure(
+            ("non_abi_compatible_cpu",), is_skip=True
+        ),
+        "test_custom_op_with_reinterpret_view_inputs": TestFailure(
             ("non_abi_compatible_cpu",), is_skip=True
         ),
     },

--- a/test/inductor/test_aot_inductor_utils.py
+++ b/test/inductor/test_aot_inductor_utils.py
@@ -76,6 +76,12 @@ class AOTIRunnerUtil:
                 temp_so_path = os.path.join(temp_dir, "model.so")
                 shutil.copy(so_path, temp_so_path)
 
+                # We also need to copy over the serialized extern_kernel_nodes for custom ops
+                extern_kernel_nodes_path = f"{so_path[:-3]}.json"
+                if os.path.isfile(extern_kernel_nodes_path):
+                    temp_extern_kernel_nodes_path = os.path.join(temp_dir, "model.json")
+                    shutil.copy(extern_kernel_nodes_path, temp_extern_kernel_nodes_path)
+
                 return test_aot_inductor_model_runner_pybind.Runner(
                     temp_so_path, device == "cpu"
                 )

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -28,8 +28,194 @@ void OSSProxyExecutor::prefill_stack_with_static_arguments(
     case c10::TypeKind::TensorType: {
       TORCH_CHECK(serialized_arg_type == "as_tensor");
       stack.emplace_back();
-      dynamic_args.emplace_back(
-          index, DynamicArgType::TensorType, 1, std::move(serialized_arg_val));
+      dynamic_args.emplace_back(index, DynamicArgType::TensorType, 1);
+      break;
+    }
+    case c10::TypeKind::IntType: {
+      TORCH_CHECK(serialized_arg_type == "as_int");
+      stack.emplace_back(c10::IValue());
+      dynamic_args.emplace_back(index, DynamicArgType::IntType, 1);
+      break;
+    }
+    case c10::TypeKind::SymIntType: {
+      TORCH_CHECK(
+          serialized_arg_type == "as_int" ||
+          serialized_arg_type == "as_sym_int");
+      stack.emplace_back(c10::IValue());
+      dynamic_args.emplace_back(index, DynamicArgType::IntType, 1);
+      break;
+    }
+    case c10::TypeKind::FloatType: {
+      TORCH_CHECK(serialized_arg_type == "as_float");
+      stack.emplace_back(serialized_arg_val.get<double>());
+      break;
+    }
+    case c10::TypeKind::BoolType: {
+      TORCH_CHECK(serialized_arg_type == "as_bool");
+      stack.emplace_back(serialized_arg_val.get<bool>());
+      break;
+    }
+    case c10::TypeKind::NumberType: {
+      if (serialized_arg_type == "as_int") {
+        // Only int Scalar is treated as dynamic arg for now
+        stack.emplace_back();
+        dynamic_args.emplace_back(index, DynamicArgType::IntType, 1);
+      } else if (serialized_arg_type == "as_float") {
+        stack.emplace_back(serialized_arg_val.get<double>());
+      } else if (serialized_arg_type == "as_bool") {
+        stack.emplace_back(serialized_arg_val.get<bool>());
+      } else {
+        TORCH_CHECK(
+            false,
+            "Invalid serialized argument type found for Scalar input: ",
+            serialized_arg_type);
+      }
+      break;
+    }
+    case c10::TypeKind::StringType: {
+      TORCH_CHECK(serialized_arg_type == "as_string");
+      stack.emplace_back(serialized_arg_val.get<std::string>());
+      break;
+    }
+    case c10::TypeKind::DeviceObjType: {
+      TORCH_CHECK(serialized_arg_type == "as_device");
+
+      std::string device_string = serialized_arg_val["type"].get<std::string>();
+      if (serialized_arg_val["index"].is_number()) {
+        device_string += ":" + serialized_arg_val["index"].get<std::string>();
+      }
+
+      c10::Device device(device_string);
+
+      if (device != *device_) {
+        VLOG(1) << "ProxyExecutor is using " << *device_ << " for "
+                << op_kernel.target_ << " argument #" << index
+                << ", which is different from the one serialized in thrift: "
+                << device << ". Please ensure this is intentional.";
+      }
+
+      stack.emplace_back(*device_);
+      break;
+    }
+    case c10::TypeKind::ListType: {
+      if (schema_arg_type->isSubtypeOf(at::ListType::ofTensors())) {
+        TORCH_CHECK(serialized_arg_type == "as_tensors");
+        stack.emplace_back();
+        dynamic_args.emplace_back(
+            index, DynamicArgType::ListTensorType, serialized_arg_val.size());
+      } else if (schema_arg_type->isSubtypeOf(at::ListType::ofInts())) {
+        TORCH_CHECK(serialized_arg_type == "as_ints");
+        dynamic_args.emplace_back(
+            index, DynamicArgType::ListIntType, serialized_arg_val.size());
+        stack.emplace_back(c10::IValue());
+      } else if (schema_arg_type->isSubtypeOf(at::ListType::ofSymInts())) {
+        TORCH_CHECK(
+            serialized_arg_type == "as_ints" ||
+            serialized_arg_type == "as_sym_ints");
+        dynamic_args.emplace_back(
+            index, DynamicArgType::ListIntType, serialized_arg_val.size());
+        stack.emplace_back(c10::IValue());
+      } else if (schema_arg_type->isSubtypeOf(at::ListType::ofFloats())) {
+        TORCH_CHECK(serialized_arg_type == "as_floats");
+        std::vector<double> ret;
+        for (const auto& arg : serialized_arg_val) {
+          ret.push_back(arg.get<double>());
+        }
+        stack.emplace_back(ret);
+      } else if (schema_arg_type->isSubtypeOf(at::ListType::ofBools())) {
+        TORCH_CHECK(serialized_arg_type == "as_bools");
+        std::vector<bool> ret;
+        for (const auto& arg : serialized_arg_val) {
+          ret.push_back(arg.get<bool>());
+        }
+        stack.emplace_back(ret);
+      } else if (schema_arg_type->isSubtypeOf(at::ListType::ofNumbers())) {
+        if (serialized_arg_type == "as_ints") {
+          dynamic_args.emplace_back(
+              index, DynamicArgType::ListIntType, serialized_arg_val.size());
+          stack.emplace_back(c10::IValue());
+        } else if (serialized_arg_type == "as_floats") {
+          std::vector<double> ret;
+          for (const auto& arg : serialized_arg_val) {
+            ret.push_back(arg);
+          }
+          stack.emplace_back(ret);
+        } else if (serialized_arg_type == "as_bools") {
+          std::vector<bool> ret;
+          for (const auto& arg : serialized_arg_val) {
+            ret.push_back(arg);
+          }
+          stack.emplace_back(ret);
+        } else {
+          TORCH_CHECK(
+              false,
+              "Invalid serialized argument type found for List[Scalar] ",
+              serialized_arg_type);
+        }
+      } else if (schema_arg_type->isSubtypeOf(
+                     at::ListType::ofOptionalTensors())) {
+        if (serialized_arg_type == "as_optional_tensors") {
+          std::vector<std::string> list_item_types;
+          for (const auto& arg : serialized_arg_val) {
+            list_item_types.push_back(arg.begin().key());
+          }
+          stack.emplace_back();
+          dynamic_args.emplace_back(
+              index,
+              DynamicArgType::ListOptionalTensorType,
+              serialized_arg_val.size(),
+              list_item_types);
+        } else if (serialized_arg_type == "as_tensors") {
+          stack.emplace_back();
+          dynamic_args.emplace_back(
+              index, DynamicArgType::ListTensorType, serialized_arg_val.size());
+        } else {
+          TORCH_CHECK(
+              false,
+              "Invalid serialized type found for argument of type `Tensor?[]`",
+              serialized_arg_type);
+        }
+      } else if (schema_arg_type->isSubtypeOf(at::ListType::ofStrings())) {
+        TORCH_CHECK(serialized_arg_type == "as_strings");
+        std::vector<std::string> ret;
+        for (const auto& arg : serialized_arg_val) {
+          ret.push_back(arg.get<std::string>());
+        }
+        stack.emplace_back(ret);
+      } else {
+        TORCH_CHECK(false, "NYI: Unsupported list type ", serialized_arg_type);
+      }
+      break;
+    }
+    case c10::TypeKind::OptionalType: {
+      auto inner_type =
+          schema_arg_type->castRaw<at::OptionalType>()->getElementType();
+
+      if (serialized_arg_type == "as_none") {
+        stack.emplace_back(c10::nullopt);
+        if (inner_type->kind() == c10::TypeKind::TensorType) {
+          // Tensor is None
+          dynamic_args.emplace_back(index, DynamicArgType::TensorType, 0);
+        } else if (
+            inner_type->kind() == c10::TypeKind::IntType ||
+            inner_type->kind() == c10::TypeKind::SymIntType) {
+          // Int or SymInt is None
+          dynamic_args.emplace_back(index, DynamicArgType::IntType, 0);
+        } else if (
+            inner_type->kind() == c10::TypeKind::ListType &&
+            schema_arg_type->isSubtypeOf(at::ListType::ofTensors())) {
+          // List[Tensor] is None
+          dynamic_args.emplace_back(index, DynamicArgType::ListTensorType, 0);
+        } else if (
+            inner_type->kind() == c10::TypeKind::ListType &&
+            schema_arg_type->isSubtypeOf(at::ListType::ofSymInts())) {
+          // List[SymInt] is None
+          dynamic_args.emplace_back(index, DynamicArgType::ListIntType, 0);
+        }
+      } else {
+        prefill_stack_with_static_arguments(
+            index, inner_type, serialized_arg, op_kernel);
+      }
       break;
     }
     // TODO: handle the other input types
@@ -82,11 +268,7 @@ void OSSProxyExecutor::get_output_info_from_serialized(
             serialized_node["target"],
             " got serialized_output_type of ",
             serialized_output_type);
-        outputs.emplace_back(
-            output_index,
-            DynamicArgType::TensorType,
-            1,
-            serialized_output_type);
+        outputs.emplace_back(output_index, DynamicArgType::TensorType, 1);
         break;
       }
       case c10::TypeKind::ListType: {
@@ -99,8 +281,7 @@ void OSSProxyExecutor::get_output_info_from_serialized(
           outputs.emplace_back(
               output_index,
               DynamicArgType::ListTensorType,
-              serialized_output_val.size(),
-              serialized_output_type);
+              serialized_output_val.size());
         } else {
           TORCH_CHECK(
               false,
@@ -205,7 +386,48 @@ void OSSProxyExecutor::call_function(
         stack[arg_index] = *tensor;
         break;
       }
-      // TODO: handle other dynamic arg types
+      case DynamicArgType::IntType: {
+        int64_t val = flatten_int_args[int_id++];
+        stack[arg_index] = val;
+        break;
+      }
+      case DynamicArgType::ListTensorType: {
+        std::vector<at::Tensor> tensor_list;
+        for (int j = 0; j < length; j++) {
+          at::Tensor* tensor =
+              tensor_handle_to_tensor_pointer(flatten_tensor_args[tensor_id++]);
+          tensor_list.push_back(*tensor);
+        }
+        stack[arg_index] = tensor_list;
+        break;
+      }
+      case DynamicArgType::ListOptionalTensorType: {
+        std::vector<std::optional<at::Tensor>> optional_tensor_list;
+        auto& list_item_types = dynamic_arg.list_item_types;
+        TORCH_CHECK(
+            list_item_types.has_value(),
+            "Could not find list of item types for optional tensor list input");
+
+        for (std::string item_type : list_item_types.value()) {
+          if (item_type == "as_tensor") {
+            at::Tensor* tensor = tensor_handle_to_tensor_pointer(
+                flatten_tensor_args[tensor_id++]);
+            optional_tensor_list.emplace_back(*tensor);
+          } else if (item_type == "as_none") {
+            optional_tensor_list.emplace_back(c10::nullopt);
+          }
+        }
+        stack[arg_index] = optional_tensor_list;
+        break;
+      }
+      case DynamicArgType::ListIntType: {
+        std::vector<int64_t> vals;
+        for (int j = 0; j < length; j++) {
+          vals.push_back(flatten_int_args[int_id++]);
+        }
+        stack[arg_index] = vals;
+        break;
+      }
       default:
         TORCH_CHECK(false, "Unsupported dynamic arg type: ", dynamic_arg_type);
     }
@@ -242,7 +464,15 @@ void OSSProxyExecutor::call_function(
       at::Tensor* tensor =
           tensor_handle_to_tensor_pointer(flatten_tensor_args[tensor_id++]);
       *tensor = stack[index++].toTensor();
-      // TODO: handle tensor list returns
+    } else if (
+        schema_return.type()->kind() == c10::TypeKind::ListType &&
+        schema_return.type()->isSubtypeOf(at::ListType::ofTensors())) {
+      auto tensors = stack[index++].toTensorList();
+      for (size_t i = 0; i < tensors.size(); ++i) {
+        at::Tensor* tensor =
+            tensor_handle_to_tensor_pointer(flatten_tensor_args[tensor_id++]);
+        *tensor = tensors[i];
+      }
     } else {
       TORCH_CHECK(
           false,

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
@@ -35,15 +35,16 @@ struct OSSDynamicArg {
       int arg_index,
       DynamicArgType arg_type,
       int length,
-      nlohmann::json serialized_arg_val)
+      std::optional<std::vector<std::string>> list_item_types = std::nullopt)
       : arg_index(arg_index),
         arg_type(arg_type),
         length(length),
-        serialized_arg_val(std::move(serialized_arg_val)) {}
+        list_item_types(std::move(list_item_types)) {}
   int arg_index;
   DynamicArgType arg_type;
   int length;
-  nlohmann::json serialized_arg_val;
+  std::optional<std::vector<std::string>>
+      list_item_types; // only used for parsing list of optional tensors
 };
 
 struct OSSOpKernel {
@@ -82,7 +83,7 @@ class OSSProxyExecutor : public ProxyExecutor {
   void prefill_stack_with_static_arguments(
       int index,
       at::TypePtr schema_arg_type,
-      const nlohmann::json& thrift_arg,
+      const nlohmann::json& serialized_arg,
       OSSOpKernel& op_kernel);
 
   void get_input_info_from_serialized(


### PR DESCRIPTION
Summary:
Added support for more custom op input types, now only missing dtype,
layout, memory format as input type, since we need to add some more testing for
mapping the types to their integer values
([previous
comment](https://github.com/pytorch/pytorch/pull/126215#discussion_r1617428066)).

This PR also replaces the `DynamicArg` struct's `serialized_arg_val` with
`list_item_types`, which stores an optional list of strings, where each string
represents the type of the value within this list. This is only used for
parsing lists of optional tensors, where we need to know if a specific value in
the list should be a tensor, or a None. Replacing with a list of strings is
also better than storing the actual json format because then we don't need to
parse the json string during the runtime, and can just loop over a preprocessed
list of strings.

Test Plan: `buck2 run @//mode/dev-nosan //caffe2/test/inductor:test_aot_inductor -- -r "test_custom_"`

Reviewed By: desertfire

Differential Revision: D60295995


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang