### PR TITLE
[easy] more debug in partitioner assert

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -478,10 +478,12 @@ def _size_of(node: fx.Node) -> int:
         elif isinstance(val, torch.Tensor):
             return _tensor_nbytes(hint_int(val.numel(), fallback=4096), val.dtype)
 
-        raise RuntimeError(f"Unknown metadata type {type(val)}")
+        raise RuntimeError(f"Unknown metadata type {type(val)} on node {node}")
     if node.op == "get_attr":
         return 0
-    raise RuntimeError("We should always have `val` metadata on the nodes")
+    raise RuntimeError(
+        f"Node {node} didn't have `val` metadata; we should always have `val` metadata on the nodes."
+    )
 
 
 # Used for some investigative purposes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132456

Print the name of the node that didn't have good meta['val']. An internal model is failing with this assert, we need this info to debug further.