### PR TITLE
[dynamo] Bugfix for recently added str handler

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -35,6 +35,7 @@ from ..utils import (
     extract_fake_example_value,
     get_fake_value,
     guard_if_dyn,
+    is_wrapper_or_member_descriptor,
     istype,
     numpy_operator_wrapper,
     proxy_args_kwargs,
@@ -1055,10 +1056,11 @@ class BuiltinVariable(VariableTracker):
                 except AttributeError:
                     # Graph break
                     return
+            elif is_wrapper_or_member_descriptor(str_method):
+                unimplemented(f"{type(arg.value)} has a C/C++ based str method")
             else:
                 # Overrides for custom str method
                 # Pass method as function to call tx.inline_user_function_return
-
                 bound_method = str_method.__func__
 
                 try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132461
* #132425

There is probably more work to improve support. But this is hot fix to not fail on `.__func__`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames