### PR TITLE
minor change to resolve compilation issue on windows

### DIFF
--- a/c10/xpu/XPUStream.h
+++ b/c10/xpu/XPUStream.h
@@ -183,7 +183,7 @@ namespace std {
 template <>
 struct hash<c10::xpu::XPUStream> {
   size_t operator()(c10::xpu::XPUStream s) const noexcept {
-    return std::hash<c10::Stream>{}(s.unwrap());
+    return ::std::hash<c10::Stream>{}(s.unwrap());
   }
 };
 } // namespace std


### PR DESCRIPTION
When compiling on windows, torch throws an error stating that the namespace std is now found.
The following code change allows the right namespace to be found. 