### PR TITLE
Link libc10 to pthreads

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -125,6 +125,10 @@ if(NOT BUILD_LIBTORCHLESS)
     add_dependencies(c10 mimalloc-static)
   endif()
 
+  if(LINUX)
+    target_link_libraries(c10 PRIVATE Threads::Threads)
+  endif()
+
   if(ANDROID)
     target_link_libraries(c10 PRIVATE log)
   endif()


### PR DESCRIPTION
It gets linked as transitive dependency of `libmkl` on x86_64,  but it's must be specified explicitly on s390x

Linking issue only appears when using gcc-13 with gold linker.
