### PR TITLE
Change owners of test/test_transformers.py to module: multi-headed-attention

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: nn"]
+# Owner(s): ["module: multi-headed-attention"]
 
 import contextlib
 from functools import partial


### PR DESCRIPTION
So flaky tests get tagged with `module: multi-headed-attention` instead of `module: nn`

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132519

