### PR TITLE
Drop GIL around cudart APIs

### DIFF
--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -71,6 +71,7 @@ void initCudartBindings(PyObject* module) {
       "cuda"
       "HostRegister",
       [](uintptr_t ptr, size_t size, unsigned int flags) -> cudaError_t {
+        py::gil_scoped_release no_gil;
         return C10_CUDA_ERROR_HANDLED(
             cudaHostRegister((void*)ptr, size, flags));
       });
@@ -78,18 +79,21 @@ void initCudartBindings(PyObject* module) {
       "cuda"
       "HostUnregister",
       [](uintptr_t ptr) -> cudaError_t {
+        py::gil_scoped_release no_gil;
         return C10_CUDA_ERROR_HANDLED(cudaHostUnregister((void*)ptr));
       });
   cudart.def(
       "cuda"
       "StreamCreate",
       [](uintptr_t ptr) -> cudaError_t {
+        py::gil_scoped_release no_gil;
         return C10_CUDA_ERROR_HANDLED(cudaStreamCreate((cudaStream_t*)ptr));
       });
   cudart.def(
       "cuda"
       "StreamDestroy",
       [](uintptr_t ptr) -> cudaError_t {
+        py::gil_scoped_release no_gil;
         return C10_CUDA_ERROR_HANDLED(cudaStreamDestroy((cudaStream_t)ptr));
       });
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION < 12000
@@ -98,7 +102,8 @@ void initCudartBindings(PyObject* module) {
   cudart.def(
       "cuda"
       "ProfilerInitialize",
-      cudaProfilerInitialize);
+      cudaProfilerInitialize,
+      py::call_guard<py::gil_scoped_release>());
 #endif
   cudart.def(
       "cuda"
@@ -107,6 +112,7 @@ void initCudartBindings(PyObject* module) {
         c10::cuda::CUDAGuard guard(device);
         size_t device_free = 0;
         size_t device_total = 0;
+        py::gil_scoped_release no_gil;
         C10_CUDA_CHECK(cudaMemGetInfo(&device_free, &device_total));
         return {device_free, device_total};
       });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132520

Noticed a hang where the stuck thread blocked on cudaHostUnregister
call, probably due to an internal cuda deadlock caused by something
else, but was holding the GIL at the time and blocked other python
threads.

As far as I can tell cudart APIs all do not require the GIL held nor are
they marked as thread unsafe.