### PR TITLE
[not for land] debug subgraphs around torch.nn.Linear layers

### DIFF
--- a/test/vasiliy_debug_test_analyze.py
+++ b/test/vasiliy_debug_test_analyze.py
@@ -1,0 +1,24 @@
+# not for land
+# test harness for vasiliy-debug
+
+import os
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torch._dynamo.vasiliy_debug_extract_subgraphs import debug_linears_for_float8
+from torch._dynamo.vasiliy_debug_analyze_subgraphs import analyze_subgraphs
+
+
+def test_debug():
+    # test, for debugging
+    target_folder = '/home/vasiliy/local/tmp/20240802_dynamo_test'
+    # note: this test currently requires data to already be in target_folder
+    analyze_subgraphs(target_folder, extracted_bsz=4, target_bsz=32)
+
+def test_interformer():
+    # real interformer subgraphs
+    target_folder = '/home/vasiliy/local/tmp/20240802_interformer_subgraphs'
+    analyze_subgraphs(target_folder, extracted_bsz=8, target_bsz=1280)
+    # analyze_subgraphs(target_folder, extracted_bsz=8, target_bsz=640)

--- a/test/vasiliy_debug_test_extract.py
+++ b/test/vasiliy_debug_test_extract.py
@@ -1,0 +1,288 @@
+# not for land
+# test harness for vasiliy-debug
+
+import os
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torch._dynamo.vasiliy_debug_extract_subgraphs import debug_linears_for_float8
+from torch._dynamo.vasiliy_debug_analyze_subgraphs import analyze_subgraphs
+
+target_folder = '/home/vasiliy/local/tmp/20240802_dynamo_test'
+
+def _test_impl(
+    m: torch.nn.Module, 
+    args, 
+    num_subgraphs=1, 
+    validate_subgraph_logs=True, 
+    validate_skip_logs=False,
+    linear_mod_filter_fn=None,
+):
+    # disable nn module inlining, our subgraph extraction logic depends on this
+    torch._dynamo.config.inline_inbuilt_nn_modules = False
+
+    # add a custom pass to inspect the pre-dispatch subgraphs and
+    # extract linear microbenchmark info from them
+    # context: https://github.com/pytorch/pytorch/pull/113823
+    torch._inductor.config.pre_grad_custom_pass = \
+        lambda g: debug_linears_for_float8(g, target_folder, linear_mod_filter_fn)
+
+    # run the extraction
+    m = torch.compile(m)
+    out = m(*args)
+
+    if validate_skip_logs:
+        assert os.path.isfile(os.path.join(target_folder, 'skip_logs.txt'))
+
+    if not validate_subgraph_logs:
+        return
+
+    # verify debug logs and summary got saved
+    assert os.path.isfile(os.path.join(target_folder, 'debug_logs.txt'))
+    assert os.path.isfile(os.path.join(target_folder, 'summary.csv'))
+
+    # verify all expected subgraphs got saved
+    for subgraph_idx in range(num_subgraphs):
+        subgraph_filename = os.path.join(target_folder, f'subgraph_with_inputs_{subgraph_idx}.pt')
+        assert os.path.isfile(subgraph_filename)
+
+        # open subgraph and verify runnable
+        gm, inputs = torch.load(subgraph_filename, weights_only=False)
+        output = gm(*inputs)
+        output = torch.cat([*output], dim=0)
+        output.sum().backward()
+
+
+def test_prev_mod():
+    x = torch.randn(4, 4, device='cuda')
+    m = nn.Sequential(nn.ReLU(), nn.Linear(4, 4)).cuda()
+    _test_impl(m, (x,))
+
+def test_prev_fun_mul():
+
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x, y):
+            z = x * y
+            z = self.fc(z)
+            return z
+
+    x = torch.randn(4, 4, device='cuda')
+    y = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x, y))
+
+def test_prev_fun_addcmul():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x, y, z):
+            a = torch.addcmul(x, y, z)
+            a = self.fc(a)
+            return a
+
+    x = torch.randn(4, 4, device='cuda')
+    y = torch.randn(4, 4, device='cuda')
+    z = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x, y, z))
+
+def test_prev_fun_addcmul_shared_input():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x, y):
+            a = torch.addcmul(x, y, y)
+            a = self.fc(a)
+            return a
+
+    x = torch.randn(4, 4, device='cuda')
+    y = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x, y))
+
+def test_prev_fun_layernorm():
+    
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.ln = nn.LayerNorm(4)
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x):
+            x = F.layer_norm(x, self.ln.normalized_shape, self.ln.weight, self.ln.bias, self.ln.eps)
+            x = self.fc(x)
+            return x
+
+    x = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x,))
+    
+def test_next_fun_add_scalar():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.relu = nn.ReLU()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x):
+            # Note: relu is here because linear as first op is not supported yet
+            x = self.relu(x)
+            x = self.fc(x)
+            x = x + 1
+            return x
+
+    x = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x,))
+
+def test_next_fun_add_tensor():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.relu = nn.ReLU()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x, y):
+            # Note: relu is here because linear as first op is not supported yet
+            x = self.relu(x)
+            x = self.fc(x)
+            x = x + y
+            return x
+
+    x = torch.randn(4, 4, device='cuda')
+    y = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x, y))
+
+def test_next_mod_sigmoid():
+    x = torch.randn(4, 4, device='cuda')
+    m = nn.Sequential(nn.ReLU(), nn.Linear(4, 4), nn.Sigmoid()).cuda()
+    _test_impl(m, (x,))
+
+def test_next_fun_layernorm():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.relu = nn.ReLU()
+            self.ln = nn.LayerNorm(4)
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x):
+            x = self.relu(x)
+            x = self.fc(x)
+            x = F.layer_norm(x, self.ln.normalized_shape, self.ln.weight, self.ln.bias, self.ln.eps)
+            return x
+
+    x = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x,))
+
+def test_next_fun_addcmul():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.relu = nn.ReLU()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x, y, z):
+            x = self.relu(x)
+            x = self.fc(x)
+            x = torch.addcmul(x, y, z)
+            return x
+
+    x = torch.randn(4, 4, device='cuda')
+    y = torch.randn(4, 4, device='cuda')
+    z = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x, y, z))
+
+def test_next_fun_addcmul_shared_input():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.relu = nn.ReLU()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x, y):
+            x = self.relu(x)
+            x = self.fc(x)
+            x = torch.addcmul(x, y, y)
+            return x
+
+    x = torch.randn(4, 4, device='cuda')
+    y = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x, y))
+
+def test_next_fun_cat():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.relu = nn.ReLU()
+            self.fc = nn.Linear(4, 4)
+
+        def forward(self, x, y):
+            x = self.relu(x)
+            x = self.fc(x)
+            x = torch.cat([x, y], dim=0)
+            return x
+
+    x = torch.randn(4, 4, device='cuda')
+    y = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x, y))
+
+def test_dual_linear():
+    x = torch.randn(4, 4, device='cuda')
+    m = nn.Sequential(nn.ReLU(), nn.Linear(4, 4), nn.Linear(4, 8), nn.Sigmoid()).cuda()
+    _test_impl(m, (x,))
+
+def test_addcmul_dual_linear():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = nn.Linear(4, 4)
+            self.fc2 = nn.Linear(4, 4)
+
+        def forward(self, x, y):
+            addcmul = torch.addcmul(x, x, y)
+            fc1 = self.fc1(addcmul)
+            fc2 = self.fc2(fc1)
+            x = torch.addcmul(addcmul, x, fc2)
+            return x
+
+    x = torch.randn(4, 4, device='cuda')
+    y = torch.randn(4, 4, device='cuda')
+    m = M().cuda()
+    _test_impl(m, (x, y))
+
+
+def test_multiple_subgraphs():
+    x = torch.randn(4, 4, device='cuda')
+    m = nn.Sequential(nn.ReLU(), nn.Linear(4, 4), nn.ReLU(), nn.Linear(4, 8), nn.Sigmoid()).cuda()
+    _test_impl(m, (x,), num_subgraphs=2)
+
+def test_placeholder_linear():
+    x = torch.randn(4, 4, device='cuda')
+    m = nn.Sequential(nn.Linear(4, 4), nn.ReLU()).cuda()
+    _test_impl(m, (x,), validate_subgraph_logs=False)
+    
+def test_skip_linear():
+    x = torch.randn(4, 4, device='cuda')
+    m = nn.Sequential(nn.ReLU(), nn.Linear(4, 4), nn.Sigmoid()).cuda()
+    linear_mod_filter_fn = lambda mod: mod.in_features > 16
+    _test_impl(
+        m, (x,), linear_mod_filter_fn=linear_mod_filter_fn, 
+        validate_subgraph_logs=False,
+        validate_skip_logs=True,
+    )

--- a/torch/_dynamo/vasiliy_debug_analyze_subgraphs.py
+++ b/torch/_dynamo/vasiliy_debug_analyze_subgraphs.py
@@ -1,0 +1,384 @@
+# not for land
+
+import collections
+import copy
+import csv
+import gc
+import os
+import time
+from typing import Callable, Tuple
+
+import pandas as pd
+
+import torch
+import torch.utils.benchmark as benchmark
+
+from torchao.float8 import (
+    convert_to_float8_training,
+    ScalingType,
+    Float8LinearConfig,
+    CastConfig,
+    sync_float8_amax_and_scale_history,
+)
+
+from .vasiliy_debug_extract_subgraphs import summary_headers
+from .vasiliy_debug_analyze_subgraphs_utils import (
+    profiler_output_to_filtered_time_by_kernel_name,
+    prof_to_gemm_vs_non_gemm_time,
+    benchmark_torch_function_in_microseconds,
+    profile_to_file,
+    reset_memory,
+    get_cuda_mem_allocated_gb,
+)
+
+# don't truncate long fields
+# pd.set_option('display.max_colwidth', None)
+# pd.set_option('display.max_columns', None)  
+
+bytes_in_gb = 1024 * 1024 * 1024
+
+
+def fwd_and_bwd(m, args):
+    outs = m(*args)
+    # TODO: maybe remove this cat if it contributes meaningfully to microbenchmarks
+    if isinstance(outs, tuple):
+        outs = torch.cat([*outs], dim=0)
+    outs.sum().backward()
+    torch.cuda.synchronize()
+
+# TODO reuse input and weight to save memory
+@torch.inference_mode
+def bench_fwd_bwd_gemms(M, K, N):
+    # fwd: in (M, K) @ w_t (K, N) -> out (M, N)
+    # bwd 1: grad_out (M, N) @ w (N, K) -> grad_in (M, K)
+    # bwd 2: grad_out_t (N, M) @ in (M, K) -> grad_w (N, K)
+
+    input = torch.randn(M, K, dtype=torch.bfloat16, device='cuda')
+    weight = torch.randn(N, K, dtype=torch.bfloat16, device='cuda')
+    grad_out = torch.randn(M, N, dtype=torch.bfloat16, device='cuda')
+
+    input_fp8 = input.to(torch.float8_e4m3fn)
+    weight_fp8 = weight.to(torch.float8_e4m3fn)
+    grad_out_fp8 = grad_out.to(torch.float8_e5m2)
+
+    scale_a = torch.tensor([1.0], device='cuda')
+    scale_b = torch.tensor([1.0], device='cuda')
+    
+    fwd_time_bf16 = benchmark_torch_function_in_microseconds(
+        torch.mm,
+        input, weight.t()
+    )
+
+    fwd_time_fp8 = benchmark_torch_function_in_microseconds(
+        torch._scaled_mm,
+        input_fp8, weight_fp8.t(),
+        scale_a, scale_b, out_dtype=torch.bfloat16, use_fast_accum=True,
+    )
+
+    grad_in_time_bf16 = benchmark_torch_function_in_microseconds(
+        torch.mm,
+        grad_out, weight,
+    )
+
+    grad_in_time_fp8 = benchmark_torch_function_in_microseconds(
+        torch._scaled_mm,
+        grad_out_fp8, weight_fp8.t().contiguous().t(),
+        scale_a, scale_b, out_dtype=torch.bfloat16, use_fast_accum=False,
+    )
+
+    grad_w_time_bf16 = benchmark_torch_function_in_microseconds(
+        torch.mm,
+        grad_out.t(), input,
+    )
+
+    grad_w_time_fp8 = benchmark_torch_function_in_microseconds(
+        torch._scaled_mm,
+        grad_out_fp8.t().contiguous(), input_fp8.t().contiguous().t(),
+        scale_a, scale_b, out_dtype=torch.bfloat16, use_fast_accum=False,
+    )
+
+    total_bf16 = fwd_time_bf16 + grad_in_time_bf16 + grad_w_time_bf16
+    total_fp8 = fwd_time_fp8 + grad_in_time_fp8 + grad_w_time_fp8
+    del input, weight, grad_out, input_fp8, weight_fp8, grad_out_fp8
+    return total_bf16, total_fp8
+
+
+def get_mkn(inputs: Tuple[torch.Tensor], m: torch.nn.Module):
+    # hack: assume that the first input with rank 2 is the linear input
+    # TODO fix it! 
+    first_linear_input = None
+    for input in inputs:
+        if len(input.size()) == 2:
+            first_linear_input = input
+            break
+    assert first_linear_input is not None, 'unsupported'
+    M1, K1 = first_linear_input.shape
+    # We know m.0 is the first linear because of how we constructed this 
+    # subgraph in the extraction code.
+    linear_mod = getattr(m, '0')
+    K1_extracted, N1 = linear_mod.in_features, linear_mod.out_features
+    assert K1 == K1_extracted, 'unexpected K'
+    mkn1 = M1, K1, N1
+
+    mkn2 = None
+    # hacky, but use the knowledge of how we constructed the sugraph
+    # to check for presence of dual linear
+    dual_linear_mod = getattr(m, 'dual_linear', None)
+    if dual_linear_mod is not None:
+        # assume output of linear1 feeds into linear2, we know this is ture
+        # from how we extracted the subgraphs
+        # linear1: (M1, K1) @ (K1, N1) -> (M1, N1)
+        # linear2: (M1, N1) @ (K2, N2) -> (M1, N2)
+        #               K2 == N1
+        assert N1 == dual_linear_mod.in_features, 'unexpected K'
+        mkn2 = M1, dual_linear_mod.in_features, dual_linear_mod.out_features
+
+    return mkn1, mkn2
+
+def bench_single_or_dual_gemms(inputs, m):
+    mkn1, mkn2 = get_mkn(inputs, m)
+    M1, K1, N1 = mkn1
+    gemm_time_bf16, gemm_time_fp8 = bench_fwd_bwd_gemms(M1, K1, N1)
+    if mkn2 is not None:
+        M2, K2, N2 = mkn2
+        gemm_time_bf16_2, gemm_time_fp8_2 = bench_fwd_bwd_gemms(M2, K2, N2)
+        gemm_time_bf16 += gemm_time_bf16_2
+        gemm_time_fp8 += gemm_time_fp8_2
+    gemm_time_speedup = gemm_time_bf16 / gemm_time_fp8
+    return gemm_time_bf16, gemm_time_fp8, gemm_time_speedup
+
+
+# adjust each input's bsz to target_bsz
+# enable grad
+def resize_input_and_enable_grad(t, extracted_bsz, target_bsz):
+    if len(t.shape) > 1:
+        old_first_dim, old_rest = t.size()[0], t.size()[1:]
+        new_first_dim = old_first_dim // extracted_bsz * target_bsz
+        new_shape = (new_first_dim, *old_rest)
+        t = torch.randn(*new_shape, dtype=t.dtype, device=t.device, requires_grad=True)
+    else:
+        # assume that rank 1 tensors do not depend on batch size
+        t.requires_grad_(True)
+        pass
+    return t
+
+def inputs_zero_grad(inputs):
+    # need to manually delete grad from inputs, otherwise it would survive
+    # and eventually OOM for large problem sizes
+    for inp in inputs:
+        del inp.grad
+
+def profile_performance(
+    func,
+    model,
+    inputs,
+    target_folder,
+    name_suffix,
+):
+    # save torch.compile logs to a file specific to this benchmark run
+    # TODO: can we hack torch.compile to print to file only and not stdout?
+    # or maybe just use tlparse?
+    logs_out = os.path.join(target_folder, f'torch_logs_{name_suffix}.txt')
+    torch._logging.set_logs(output_code=True)
+    torch._logging._init_logs(log_file_name=logs_out)
+
+    num_leaf_tensors = len(inputs) + len(list(model.parameters()))
+    time_compile_us = benchmark_torch_function_in_microseconds(fwd_and_bwd, model, inputs)
+    profile_file = os.path.join(target_folder, f'profile_{name_suffix}.json')
+    prof = profile_to_file(profile_file, fwd_and_bwd, model, inputs)
+    trace_gemm_time_us, trace_non_gemm_time_us = prof_to_gemm_vs_non_gemm_time(
+        prof, num_iter=3, num_leaf_tensors=num_leaf_tensors) 
+    trace_total_time_us = trace_gemm_time_us + trace_non_gemm_time_us
+
+    # undo custom log settings
+    torch._logging.set_logs(output_code=False)
+    torch._logging._init_logs(log_file_name=None)
+
+    return time_compile_us, trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us
+
+
+def analyze_subgraphs(
+    target_folder: str,
+    extracted_bsz: int,
+    target_bsz: int,
+) -> None:
+    """
+    Assumes folder structure:
+
+        target_folder/
+          debug_logs.txt
+          summary.csv
+          subgraph_with_inputs_0.pt
+          ...
+          subgraph_with_inputs_(n-1).pt
+
+    Writes new files as a part of the analysis:
+        
+        target_folder/
+          profile_0_eager.json 
+          profile_0_compile.json 
+          profile_0_float8_compile.json 
+          profile_0_float8_d_compile.json 
+          torch_logs_0_compile.txt
+          torch_logs_0_float8_compile.txt
+          torch_logs_0_float8_d_compile.txt
+          ...
+          analysis.csv 
+
+    Does the following:
+    * load each subgraph and example inputs in bf16
+    * increase batch size of inputs to target_batch_size
+    * benchmark the following data for each subgraph:
+    * gemm time (3 gemms across fwd and bwd) in bf16 vs float8
+    * for each in compile, float8_compile, float8_delayed_compile
+      * benchmark e2e time of fwd + bwd (includes benchmarking overhead)
+      * benchmark gpu kernel time of fwd + bwd, separated by gemm vs non-gemm (excludes benchmarking overhead)
+      * record peak GPU memory usage
+      * save a profiling trace to profile_{...}.json
+      * record TORCH_LOGS="output_code" to torch_logs_{...}.txt
+    * finally, outputs `analysis.csv` with a summary of all the above data
+    """
+    summary_filename = os.path.join(target_folder, 'summary.csv')
+
+    summary_rows = []
+    with open(summary_filename, 'r') as f:
+        reader = csv.reader(f)
+        for row in reader:
+            summary_rows.append(row)
+
+    # add names of metrics we are about to collect to headers
+    # TODO: adding new metrics is brittle because we need to hand track the
+    # indices, there is a definitely a better way to do this
+    # Note: not loading directly in a dataframe here because we are going to
+    # modify rows inplace and that seemed annoying with dataframes, but there
+    # is probably a solution. If someone figures that out, doing `df` throughout
+    # this file is cleaner.
+    summary_rows[0].extend([
+        'inp_shapes',
+        'gemm_time_bf16', 'gemm_time_fp8', 'gemm_time_speedup', 
+        'time_eager_us', 
+        'time_compile_us', 
+        'c_trace_gemm_time_us', 'c_trace_non_gemm_time_us', 'c_trace_total_time_us',
+        'mem_compile_gb',
+        'time_f8_compile_us',
+        'f8_c_trace_gemm_time_us', 'f8_c_trace_non_gemm_time_us', 'f8_c_trace_total_time_us',
+        'mem_f8_c_gb',
+        'time_f8_d_compile_us',
+        'f8_c_d_trace_gemm_time_us', 'f8_c_d_trace_non_gemm_time_us', 'f8_c_d_trace_total_time_us',
+        'mem_f8_c_d_gb',
+    ])
+
+    # [1:] to skip header row
+    for row_idx, row in enumerate(summary_rows[1:]):
+        # if row_idx > 1:
+        #     continue
+        subgraph_idx = row[1]
+        subgraph_fname = f'subgraph_with_inputs_{subgraph_idx}.pt'
+        print(f'benchmarking {subgraph_fname}')
+        subgraph_fname = os.path.join(target_folder, subgraph_fname)
+        m, inputs = torch.load(subgraph_fname, weights_only=False)
+
+        inputs = [resize_input_and_enable_grad(t, extracted_bsz, target_bsz) for t in inputs]
+        input_shapes_str = ', '.join(str(tuple(inp.shape)) for inp in inputs)
+        row.append(input_shapes_str)
+
+        # estimate memory used by inputs, params, grads
+        input_gb = 0
+        for inp in inputs:
+            input_gb += (inp.numel() * inp.element_size()) / bytes_in_gb
+        model_gb = sum(p.numel() * p.element_size() / bytes_in_gb for p in m.parameters())
+        grad_gb = input_gb + model_gb
+        total_gb = input_gb + model_gb + grad_gb
+        # print(f'param mem estimate (GB): input {input_gb} model {model_gb} grad {grad_gb} total {total_gb}')
+
+        # benchmark gemm time in bf16 vs fp8
+        bench_gemms = True
+        if bench_gemms:
+            gemm_time_bf16, gemm_time_fp8, gemm_time_speedup = \
+                bench_single_or_dual_gemms(inputs, m)
+            row.extend([gemm_time_bf16, gemm_time_fp8, gemm_time_speedup])
+        else:
+            row.extend([0., 0., 0.])
+
+        time_eager_us = benchmark_torch_function_in_microseconds(fwd_and_bwd, m, inputs)
+        profile_file_eager = os.path.join(target_folder, f'profile_{subgraph_idx}_eager.json')
+        prof = profile_to_file(profile_file_eager, fwd_and_bwd, m, inputs)
+        row.extend([time_eager_us])
+        inputs_zero_grad(inputs)
+
+        bench_compile = True
+        if bench_compile:
+            reset_memory()
+
+            m_c = torch.compile(m)
+            time_compile_us, trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us = \
+                profile_performance(fwd_and_bwd, m_c, inputs, target_folder, f'{subgraph_idx}_compile')
+            mem_usage_gb = get_cuda_mem_allocated_gb()
+            print('b16 trace times', trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us)
+            print('b16 mem', mem_usage_gb)
+            
+            row.extend([time_compile_us, trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us, mem_usage_gb])
+            inputs_zero_grad(inputs)
+            del m_c
+        else:
+            row.extend([0., 0., 0., 0., 0.])
+
+        # TODO: figure out why setting this to True influences the fusions in fp8 delayed scaling
+        bench_fp8 = True
+        if bench_fp8:
+            reset_memory()
+            f8_config = Float8LinearConfig()
+            m_f8 = convert_to_float8_training(copy.deepcopy(m), config=f8_config)
+            m_f8_c = torch.compile(m_f8)
+            time_compile_us, trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us = \
+                profile_performance(fwd_and_bwd, m_f8_c, inputs, target_folder, f'{subgraph_idx}_f8_compile')
+            mem_usage_gb = get_cuda_mem_allocated_gb()
+            print('fp8 trace times', trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us)
+            print('fp8 mem', mem_usage_gb)
+            row.extend([time_compile_us, trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us, mem_usage_gb])
+            inputs_zero_grad(inputs)
+            del m_f8, m_f8_c
+        else:
+            row.extend([0., 0., 0., 0., 0.])
+
+        bench_fp8_delayed = True
+        if bench_fp8_delayed:
+            reset_memory()
+            # upper bound on perf - all-delayed
+            # TODO(future): add weight-only delayed
+            f8_config = Float8LinearConfig(
+                enable_amax_init=False,
+                enable_pre_and_post_forward=False,
+                cast_config_input=CastConfig(scaling_type=ScalingType.DELAYED),
+                cast_config_weight=CastConfig(scaling_type=ScalingType.DELAYED),
+                cast_config_grad_output=CastConfig(scaling_type=ScalingType.DELAYED),
+            )
+            m_f8_d = convert_to_float8_training(m, config=f8_config)
+            m_f8_c_d = torch.compile(m_f8_d)
+            time_compile_us, trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us = \
+                profile_performance(fwd_and_bwd, m_f8_c_d, inputs, target_folder, f'{subgraph_idx}_f8_d_compile')
+            mem_usage_gb = get_cuda_mem_allocated_gb()
+            print('fp8_d trace times', trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us)
+            print('fp8_d mem', mem_usage_gb)
+            row.extend([time_compile_us, trace_gemm_time_us, trace_non_gemm_time_us, trace_total_time_us, mem_usage_gb])
+            inputs_zero_grad(inputs)
+            del m_f8_d, m_f8_c_d
+        else:
+            row.extend([0., 0., 0., 0., 0.])
+
+        del m, inputs
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    # convert to pandas df for easy printing and aggregate manipulations
+    summary_df = pd.DataFrame(summary_rows[1:], columns=summary_rows[0])
+
+    # calculate total subgraph time and each row's contribution to it
+    total_time_us = summary_df['time_compile_us'].sum()
+    summary_df['time_compile_pct'] = summary_df['time_compile_us'] / total_time_us
+    print(summary_df)
+
+    analysis_filename = os.path.join(target_folder, 'analysis.csv')
+    summary_df.to_csv(analysis_filename)
+
+    print('done')

--- a/torch/_dynamo/vasiliy_debug_analyze_subgraphs_utils.py
+++ b/torch/_dynamo/vasiliy_debug_analyze_subgraphs_utils.py
@@ -1,0 +1,155 @@
+import collections
+import gc
+from typing import Callable, Tuple
+
+import torch
+import torch.utils.benchmark as benchmark
+from torch.profiler import profile, ProfilerActivity, record_function
+
+# copied from https://github.com/pytorch/ao/pull/629/files
+# TODO: reuse instead of copy
+def profiler_output_to_filtered_time_by_kernel_name(
+    prof,
+    num_iter: int,
+    num_leaf_tensors: int,
+):
+    """ 
+    Input: 
+      * `prof`: a profiler with captured events
+      * `num_iter`: number of iterations used to capture `prof`
+      * `num_leaf_tensors`: number of leaf tensors to accumulate gradients to
+    Output: a deduplicated list of GPU time in nanoseconds grouped by CPU kernel name,
+      with the microbenchmark overhead filtered out
+
+    Currently assumes that `prof` captured events from a microbenchmark which was
+    set up as follows:
+
+        #
+        # Forward pass 
+        #
+
+        # Expected GPU kernel overhead: none
+        y = func(...)
+
+        # Convenient way to set up the backward pass without caring about shapes
+        y_sum = y.sum()
+
+        # Expected GPU kernel overhead:
+        # * the call to `sum`
+
+        #
+        # Backward pass
+        #
+        y_sum.backward()
+
+        # Expected GPU kernel overhead:
+        # * the call to `aten.fill_` to put a tensor with a single 1.0 value as the input to the backward
+        # * the call to `aten.copy_` to fill the first `grad_output` tensor with 1.0
+        # * the call to `aten.add_` to accumulate grads, once per leaf tensor
+
+    Note that if there are user_annotations in the captured events, `torch.profiler`
+    will include their time in the total GPU time displayed at the bottom of
+    `key_averages.table()`. The filter below excludes them to prevent double
+    counting.
+    """
+    key_averages = prof.key_averages()
+    thresh = 1e-10
+    kernel_name_to_gpu_time_us = collections.defaultdict(float)
+    for e in key_averages:
+
+        # manually filter top-level CPU events with attributed CUDA time
+        # example CPU event row from printing `key_averages`:
+        #                                               aten::addmm         0.83%      76.554us         0.98%      90.846us      90.846us       1.022ms        31.82%       1.022ms       1.022ms             1
+        # and it maps to this CUDA event:
+        #   sm80_xmma_gemm_f32f32_f32f32_f32_tn_n_tilesize256x64...         0.00%       0.000us         0.00%       0.000us       0.000us       1.022ms        31.82%       1.022ms       1.022ms             1
+        if not (e.self_cpu_time_total > thresh and e.self_device_time_total > thresh):
+            continue
+
+        # manually filter expected microbenchmarking overhead, in order of execution
+        if e.key == 'aten::sum':
+            # forward pass sum
+            assert e.count == num_iter, f'unexpected number of iter for {e.key}'
+            continue
+        elif e.key == 'aten::fill_':
+            # filling the forward pass sum with 1.0
+            assert e.count == num_iter, f'unexpected number of iter for {e.key}'
+            continue
+        elif e.key == 'aten::copy_':
+            # copying 1.0 from grad_out of `sum` to grad_out of next op
+            # assert e.count == num_iter, f'unexpected number of iter for {e.key}'
+            # continue
+            # note: uncommented above for subgraph 12, TODO debug why we need it
+            pass
+        elif e.key == 'aten::add_':
+            # accumulating gradients into leaf tensors
+            assert e.count == (num_iter * num_leaf_tensors), f'unexpected number of iter for {e.key}'
+            continue
+        elif e.key == 'cudaDeviceSynchronize':
+            continue
+
+        kernel_name_to_gpu_time_us[e.key] = e.self_device_time_total
+    return kernel_name_to_gpu_time_us
+
+def prof_to_gemm_vs_non_gemm_time(prof, num_iter, num_leaf_tensors):
+    kernel_name_to_gpu_time_us = profiler_output_to_filtered_time_by_kernel_name(prof, num_iter=3, num_leaf_tensors=num_leaf_tensors)
+    trace_gemm_time_us, trace_non_gemm_time_us = 0., 0.
+    for k, v in kernel_name_to_gpu_time_us.items():
+        v = v / num_iter
+        # print(k, v)
+        if k in ('aten::mm', 'aten::addmm', 'aten::_scaled_mm'):
+            trace_gemm_time_us += v
+        else:
+            trace_non_gemm_time_us += v
+    return trace_gemm_time_us, trace_non_gemm_time_us
+
+def benchmark_torch_function_in_microseconds(
+    func: Callable,
+    *args,
+    **kwargs,
+) -> float:
+
+    if True:
+        # warmup
+        for _ in range(2):
+            func(*args, **kwargs)
+        t0 = benchmark.Timer(
+            stmt="func(*args, **kwargs)",
+            globals={"args": args, "kwargs": kwargs, "func": func},
+        )
+        return t0.blocked_autorange().median * 1e6
+
+    if False:
+        n_warmup = 3
+        n_iter = 10
+
+        for _ in range(n_warmup):
+            func(*args, **kwargs)
+
+        t0 = time.time()
+        for _ in range(n_iter):
+            func(*args, **kwargs)
+        t1 = time.time()
+        return (t1 - t0) / n_iter * 1e6
+
+
+def profile_to_file(target_file, func, *args, **kwargs):
+    activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
+    # warm up
+    for _ in range(2):
+        func(*args, **kwargs)
+        torch.cuda.synchronize()
+    with profile(activities=activities) as prof:
+        for _ in range(3):
+            func(*args, **kwargs)
+            torch.cuda.synchronize()
+    prof.export_chrome_trace(target_file)
+    return prof
+
+def reset_memory():
+    torch._dynamo.reset()
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats(device=None)
+
+def get_cuda_mem_allocated_gb():
+    return torch.cuda.max_memory_allocated() / 1e9

--- a/torch/_dynamo/vasiliy_debug_extract_subgraphs.py
+++ b/torch/_dynamo/vasiliy_debug_extract_subgraphs.py
@@ -1,0 +1,524 @@
+# not for land
+
+import csv
+import os
+from typing import List, Any, Optional, Callable
+import sys
+
+import torch
+import torch.nn.functional as F
+
+from torch.utils._pytree import tree_map
+
+graph_tabular_log = torch._logging.getArtifactLogger(__name__, "graph")
+
+# TODO(future): might be nice to have input shapes here, but needs a refactor since
+# they are easiest to get from the subgraph extraction function, but currently summary
+# is generated from the subgraph debug function.
+summary_headers = ['orig_node_name', 'subgraph_idx', 'lin1_shape', 'lin2_shape', 'subgraph_summary']
+
+def maybe_short_name(torch_fn):
+    """
+    Tries to format things like
+
+      '<built-in method cat of type object at 0x7f3f7a202c60>'
+
+    as
+      
+      'torch.cat'
+    """
+    if hasattr(torch_fn, '__name__'):
+        # torch.cat -> cat
+        if hasattr(torch, torch_fn.__name__):
+            if getattr(torch, torch_fn.__name__) == torch_fn:
+                return torch_fn.__name__
+
+        # F.layer_norm -> layer_norm
+        if hasattr(F, torch_fn.__name__):
+            if getattr(F, torch_fn.__name__) == torch_fn:
+                return torch_fn.__name__
+
+        # builtin function mul
+        # note: there is definitely a more generic way to do this
+        if torch_fn.__name__ == 'mul':
+            return 'mul'
+        if torch_fn.__name__ == 'add':
+            return 'add'
+        
+        # activation modules 
+        # note: there is definitely a more generic way to do this
+        if 'torch.nn.modules.activation' in str(torch_fn):
+            return torch_fn.__name__
+
+    return torch_fn
+
+def get_meta_val(n: torch.fx.Node):
+    # from https://fburl.com/code/hcwdl994
+    meta_val = n.meta.get('val', n.meta.get('tensor_meta', n.meta.get('example_value', None)))
+    return meta_val
+
+def get_stack_summary(n: torch.fx.Node):
+    # from https://fburl.com/code/yify7y7f
+    if n.stack_trace:
+        parsed_stack_trace = torch.fx.graph._parse_stack_trace(n.stack_trace)
+        summary = parsed_stack_trace.get_summary_str()
+        return summary
+    return None
+
+def is_first_node_of_dual_linear(gm: torch.fx.GraphModule, n: torch.fx.Node):
+    first_user = list(n.users.items())[0][0]
+    if first_user.op == 'call_module':
+        first_user_mod = getattr(gm, first_user.target)
+        if type(first_user_mod) == torch.nn.Linear:
+            return True
+    return False
+
+def debug_single_linear(
+    gm: torch.fx.GraphModule, 
+    linear_node: torch.fx.Node,
+    linear_mod: torch.nn.Module,
+    debug_logs_filename: str,
+    subgraph_idx: int,
+    summary_results: List[Any],
+):
+    def printme(s):
+        # write both to stdout and log file
+        graph_tabular_log.debug(s)
+        with open(debug_logs_filename, 'a') as f:
+            f.write(s + '\n') 
+
+    printme(f'\ndebugging linear {linear_node.target}')
+    printme(f'\ndebugging details\n')
+
+    prev_input_shape = None
+    prev_node_type = None
+    cur_linear_size = linear_mod.in_features, linear_mod.out_features
+    cur_linear_2_size = None, None
+    next_node_types = []
+
+    # look at the preceding activation
+    for prev_n in linear_node.all_input_nodes:
+        # to get the shape of the input, we need to look at the previous node
+        for prev_prev_n in prev_n.all_input_nodes:
+            prev_input_shape = get_meta_val(prev_prev_n).shape
+            printme(f'prev input shape: {prev_input_shape}')
+        printme(f'prev node: {prev_n.format_node()}')
+        printme(f'prev stack_summary: {get_stack_summary(prev_n)}')
+        if prev_n.op == 'call_module':
+            mod = getattr(gm, prev_n.target)
+            prev_node_type = type(mod)
+            printme(f'prev mod: {mod}')
+        else:
+            prev_node_type = prev_n.target
+
+    # print info about current linear
+    printme(f'cur_linear node: {linear_node.format_node()}')
+    printme(f'cur_linear mod: {linear_mod}')
+    printme(f'cur_linear stack_summary: {get_stack_summary(linear_node)}')
+
+    # if there is a dual linear, print that too
+    linear_node_to_use = linear_node
+    dual_linear = False
+    if is_first_node_of_dual_linear(gm, linear_node):
+        dual_linear = True
+        linear_node_2 = list(linear_node.users.items())[0][0]
+        linear_mod_2 = getattr(gm, linear_node_2.target)
+        cur_linear_2_size = linear_mod_2.in_features, linear_mod_2.out_features
+        printme(f'cur_linear 2 node: {linear_node_2.format_node()}')
+        printme(f'cur_linear 2 mod: {linear_mod_2}')
+        printme(f'cur_linear 2 stack_summary: {get_stack_summary(linear_node_2)}')
+        linear_node_to_use = linear_node_2
+
+    # look at the subsequent ops
+    # note: sometimes this is a view, so might need to look farther
+    printme(f'num users: {len(linear_node_to_use.users)}')
+    for next_n, _ in linear_node_to_use.users.items():
+        for next_n_input in next_n.all_input_nodes:
+            printme(f'next input shape: {get_meta_val(next_n_input).shape}')
+        printme(f'next node: {next_n.format_node()}')
+        printme(f'next stack_summary: {get_stack_summary(next_n)}')
+        if next_n.op == 'call_module':
+            mod = getattr(gm, next_n.target)
+            printme(f'next mod: {mod}')
+            next_node_types.append(type(mod))
+        else:
+            next_node_types.append(next_n.target)
+
+    printme('\ndebugging summary\n')
+    if not dual_linear:
+        linear_shape_str = f'{cur_linear_size}'
+        linear_str = 'Linear'
+    else:
+        linear_shape_str = f'{cur_linear_size} {cur_linear_2_size}'
+        linear_str = 'Linear -> Linear'
+    printme(f'input_shape {prev_input_shape}, (K, N) {linear_shape_str}')
+    subgraph_summary = f'{maybe_short_name(prev_node_type)} -> {linear_str} -> {[maybe_short_name(t) for t in next_node_types]}'
+    printme(subgraph_summary)
+    printme('\n')
+
+    summary_result = [
+        linear_node.target,  # orig_node_name 
+        subgraph_idx,
+        cur_linear_size,
+        cur_linear_2_size,
+        subgraph_summary,
+    ]
+    summary_results.append(summary_result)
+
+
+    # what we want:
+    #
+    # summary for quickly understanding opportunity size wrt float8
+    # * (a) info for gemm speedup estimation: bsz, input shape, gemm M, K, N
+    # * (b) info for needed f8 features: prev_op -> cur_op -> [next_ops]
+    #   * for modules, display module type
+    #   * for functions, display short function name
+    # * info for creating a microbenchmark with representative float8 fusions
+    #   is same as (b)
+    #
+    # long form info for further debugging
+    # * input into previous node, with shape and stride
+    # * previous node, if module then display type
+    # * linear, display weight shape
+    #   * display weight shape
+    #   * display modeling code location, if available
+    # * next node, if module then display type
+
+def extract_linear_subgraph(
+    old_gm: torch.fx.GraphModule, 
+    old_linear_node: torch.fx.Node,
+    old_linear_mod: torch.nn.Module,
+    subgraph_save_filename: str,
+) -> None:
+    """
+    Input: a GraphModule with a `linear_node` calling `linear_mod`.
+
+    This function does the following:
+    * find the subgraph prev_op -> linear_node -> [*next_ops]
+    * create a new GraphModule containing this subgraph
+    * save it to disk for further debugging
+    """
+
+    # to start, create a new module which just calls the linear
+    new_m = torch.nn.Sequential(old_linear_mod)
+    new_gm = torch.fx.symbolic_trace(new_m)
+    new_g = new_gm.graph
+    new_linear_node = list(new_gm.graph.nodes)[1]
+    printme = graph_tabular_log.debug
+    printme(f'new_gm: {new_gm}')
+    printme(f'new_linear_node: {new_linear_node}')
+
+    # copy the linear metadata over
+    new_linear_node.meta = old_linear_node.meta
+    new_linear_node.args[0].meta = old_linear_node.args[0].meta
+
+    # 
+    # step 1: add the preceding activation node
+    #
+    # before: input -> linear
+    # after: input_args -> prev_op -> linear
+
+    # add the node inputs as placeholders, and copy the non-node inputs as is
+    prev_old_arg_to_new_arg = {}
+    def prev_node_map_arg(old_arg):
+        if isinstance(old_arg, torch.fx.Node):
+            if old_arg in prev_old_arg_to_new_arg:
+                return prev_old_arg_to_new_arg[old_arg]
+
+            with new_g.inserting_before(new_linear_node):
+                new_arg = new_g.placeholder(old_arg.name)
+                # copy the metadata over
+                new_arg.meta = old_arg.meta
+            prev_old_arg_to_new_arg[old_arg] = new_arg
+            return new_arg
+        return old_arg
+
+    assert len(old_linear_node.all_input_nodes) == 1, 'unsupported'
+    old_prev_node = old_linear_node.all_input_nodes[0]
+
+    if old_prev_node.op == 'call_module':
+        prev_mod = getattr(old_gm, old_prev_node.target)
+        new_name = 'prev_mod'
+        setattr(new_gm, new_name, prev_mod)
+        new_args = tree_map(prev_node_map_arg, old_prev_node.args)
+        new_kwargs = tree_map(prev_node_map_arg, old_prev_node.kwargs)
+        with new_g.inserting_before(new_linear_node):
+            new_prev_node = new_g.call_module(new_name, new_args, new_kwargs)
+
+    elif old_prev_node.op == 'call_function':
+        new_args = tree_map(prev_node_map_arg, old_prev_node.args)
+        new_kwargs = tree_map(prev_node_map_arg, old_prev_node.kwargs)
+        with new_g.inserting_before(new_linear_node):
+            new_prev_node = new_g.call_function(old_prev_node.target, new_args, new_kwargs)
+
+    else:
+        raise AssertionError('unsupported')
+
+    prev_placeholder = new_linear_node.args[0]
+    new_linear_node.args = (new_prev_node,)
+    new_g.erase_node(prev_placeholder)
+
+    new_prev_node.meta = old_prev_node.meta
+    new_gm.recompile()
+
+    #
+    # step 2 (optional): if there is a dual linear, handle it in a single subgraph
+    #
+    # before: input_args -> prev_op -> linear
+    # after:  input_args -> prev_op -> linear -> linear2
+    #
+    # then, in step 3, next_ops will be after linear2
+
+    # we still need to refer to the first linear in some places,
+    # save it
+    old_old_linear_node = old_linear_node
+    first_new_linear_node = new_linear_node
+
+    if is_first_node_of_dual_linear(old_gm, old_linear_node):
+        old_first_user = list(old_linear_node.users.items())[0][0]
+        old_first_user_mod = getattr(old_gm, old_first_user.target)
+        printme('DUAL LINEAR')
+        dual_linear_name = 'dual_linear'
+        setattr(new_gm, dual_linear_name, old_first_user_mod)
+        new_args, new_kwargs = (new_linear_node,), {}
+
+        with new_g.inserting_after(new_linear_node):
+            new_dual_linear_node = new_g.call_module(dual_linear_name, new_args, new_kwargs)
+        new_dual_linear_node.meta = old_first_user.meta
+
+        # make the following code treat the second linear as the root
+        new_linear_node = new_dual_linear_node
+        old_linear_node = old_first_user
+
+    #
+    # step 3: add the subsequent nodes (can be multiple users)
+    #
+    # before: input_args -> prev_op -> linear
+    # after: input_args -> prev_op -> linear -> next_op_1
+    #                                        -> ...
+    #                                        -> next_op_n
+    
+    # create last_node to ensure graph order matches the original if there
+    # are multiple users of linear's output
+    new_last_node = new_linear_node
+    new_output_nodes = []
+    next_old_arg_to_new_arg = {}
+
+    def next_node_map_arg(old_arg):
+        if isinstance(old_arg, torch.fx.Node):
+            if old_arg in next_old_arg_to_new_arg:
+                # handle the same arg being used multiple times
+                return next_old_arg_to_new_arg[old_arg]
+            if old_arg == old_linear_node:
+                next_old_arg_to_new_arg[old_arg] = new_linear_node
+                return new_linear_node
+            elif old_arg == old_old_linear_node:
+                next_old_arg_to_new_arg[old_arg] = first_new_linear_node
+                return first_new_linear_node
+            elif old_arg == old_prev_node:
+                next_old_arg_to_new_arg[old_arg] = new_prev_node
+                return new_prev_node
+            elif old_arg in prev_old_arg_to_new_arg:
+                return prev_old_arg_to_new_arg[old_arg]
+            else:
+                # this is something else, make it a graph input
+                with new_g.inserting_before(new_linear_node):
+                    new_arg = new_g.placeholder(old_arg.name)
+                    # copy the metadata over
+                    new_arg.meta = old_arg.meta
+                next_old_arg_to_new_arg[old_arg] = new_arg
+                return new_arg
+        return old_arg
+
+    next_node_is_output = False
+    for counter, (old_next_n, _) in enumerate(old_linear_node.users.items()):
+        if old_next_n.op == 'output':
+            # nothing to do
+            next_node_is_output = True
+            break
+
+        new_args = tree_map(next_node_map_arg, old_next_n.args)
+        new_kwargs = tree_map(next_node_map_arg, old_next_n.kwargs)
+        if old_next_n.op == 'call_function':
+            with new_g.inserting_after(new_last_node):
+                new_next_n = new_g.call_function(
+                    old_next_n.target,
+                    new_args,
+                    new_kwargs,
+                )
+            new_output_nodes.append(new_next_n)
+            new_last_node = new_next_n
+        elif old_next_n.op == 'call_module':
+            prev_mod = getattr(old_gm, old_next_n.target)
+            new_name = f'next_mod_{counter}'
+            setattr(new_gm, new_name, prev_mod)
+            with new_g.inserting_after(new_last_node):
+                new_next_n = new_g.call_module(new_name, new_args, new_kwargs)
+            new_output_nodes.append(new_next_n)
+            new_last_node = new_next_n
+        else:
+            assert False, 'unsupported'
+        new_next_n.meta = old_next_n.meta
+        new_gm.recompile()
+        printme(f'after adding next_node, {new_gm}')
+
+    if not next_node_is_output:
+        # reroute graph outputs from `linear` to `new_output_nodes`
+        cur_output_node = list(new_g.nodes)[-1]
+        printme(f'cur_output_node: {cur_output_node.format_node()}')
+
+        if len(new_output_nodes) == 1:
+            new_output_node = new_g.output(new_output_nodes[0])
+        else:
+            new_output_node = new_g.output(tuple(new_output_nodes))
+        printme(f'new_output_node: {cur_output_node.format_node()}')
+        new_g.erase_node(cur_output_node)
+        new_gm.recompile()
+        printme(f'after new output, {new_gm}')
+
+    # ensure every node has metas
+    for n in new_g.nodes:
+        if n.op == 'output':
+            continue
+        assert n.meta is not None and n.meta != {}, f'{n}.meta is {n.meta}!'
+
+    test_inputs = []
+    for node in new_g.nodes:
+        if node.op != 'placeholder':
+            continue
+        meta = get_meta_val(node)
+        test_inputs.append(torch.randn(*meta.shape, dtype=meta.dtype, device='cuda'))
+        printme(f'input shape: {test_inputs[-1].shape}')
+
+    # save subgraph and inputs
+    torch.save((new_gm, test_inputs), subgraph_save_filename)
+
+    # test fwd+bwd
+    test_output = new_gm(*test_inputs)
+    # Unified way to test backward, will work as long as all outputs are of the
+    # same shape
+    test_output = torch.cat([*test_output], dim=0)
+    test_output.sum().backward()
+
+    # Note: cannot verify runnable after save/load here, because loading
+    # from disk in this file seems to try to use device meta as we are inside
+    # of dynamo tracing. Need to load from a separate process to properly test.
+
+def print_and_append_to_logs(logger, filename, s):
+    logger.debug(s)
+    with open(filename, 'a') as f:
+        f.write(s + '\n') 
+
+def debug_linears_for_float8(
+    g: torch.fx.Graph,
+    target_folder: str,
+    linear_mod_filter_fn: Optional[Callable] = None,
+) -> None:
+    """
+    This function:
+    1. looks for subgraphs containing `torch.nn.Linear` modules, including the preceding
+       and subsequent ops
+    2. for each found subgraph
+       - extracts metadata about the subgraph (ops, shapes, modeling code location) and saves it to disk
+       - extracts it into a new `torch.fx.Graphmodule` instance and saves it to disk, this
+         can then be loaded elsewhere to run microbenchmarks
+
+    Inputs:
+    - `g` - the graph to debug, assumed to come from dynamo's pre-dispatch trace and have torch IR
+    - `target_folder` - the folder to save metadata and microbenchmarks to, note that all folder
+      content is overwritten every time the script is run. The contents of this folder will be:
+        target_folder/
+          debug_logs.txt
+          skip_logs.txt
+          summary.csv
+          subgraph_with_inputs_0.pt
+          ...
+          subgraph_with_inputs_(n-1).pt
+    - `linear_mod_filter_fn`: optional filtering function on linears, if it returns false then subgraph
+      extraction is skipped for that linear
+
+    Format of summary.csv (column: example_value):
+      orig_node_name: fn_1
+      subgraph_idx: 0
+      lin1_shape: (2, 3)
+      lin2_shape: (3, 4)  # only applies to dual linear subgraphs
+      subgraph_summary: ReLU -> Linear -> ["cat"]
+
+    Format of subgraph_with_inputs_0.pt: Tuple[nn.Module, Tuple[torch.tensor]]
+    """
+    assert not torch._dynamo.config.inline_inbuilt_nn_modules, \
+        'torch._dynamo.config.inline_inbuilt_nn_modules must be disabled for this script to work!'
+
+    # ensure target folder exists
+    if not os.path.isdir(target_folder):
+        os.makedirs(target_folder)
+
+    # ensure target folder only has file extensions we could have written
+    for root, dirs, files in os.walk(target_folder):
+        for file in files:
+            if not (file.endswith('.txt') or file.endswith('.pt') or file.endswith('.swp') or file.endswith('.csv') or file.endswith('.json')):
+                raise AssertionError(f'unknown file in target_dir: {file}')
+
+    # delete any existing files from previous run for this target_folder
+    for root, dirs, files in os.walk(target_folder):
+        for file in files:
+            os.unlink(os.path.join(root, file))
+
+    debug_logs_filename = os.path.join(target_folder, 'debug_logs.txt')
+    skip_logs_filename = os.path.join(target_folder, 'skip_logs.txt')
+    summary_filename = os.path.join(target_folder, 'summary.csv')
+    summary_results = [summary_headers]
+
+    gm = g.owning_module
+    assert gm is not None, 'unsupported, gm needs to be specified'
+    printme = graph_tabular_log.debug
+    graph_tabular_log.debug("\nstarting linear debug\n")
+
+    def log_skip_linear(n, mod, reason):
+        print_and_append_to_logs(graph_tabular_log, skip_logs_filename, f'SKIP: {reason}')
+        print_and_append_to_logs(graph_tabular_log, skip_logs_filename, f'node: {n.format_node()}')
+        print_and_append_to_logs(graph_tabular_log, skip_logs_filename, f'node.meta: {get_meta_val(n)}')
+        print_and_append_to_logs(graph_tabular_log, skip_logs_filename, f'node.stack: {get_stack_summary(n)}')
+        print_and_append_to_logs(graph_tabular_log, skip_logs_filename, f'mod: {mod}')
+        print_and_append_to_logs(graph_tabular_log, skip_logs_filename, f'\n')
+
+    subgraph_idx = 0
+    for n in gm.graph.nodes:
+        if n.op != 'call_module':
+            continue
+
+        # check for linear
+        module_instance = getattr(gm, n.target)
+        if type(module_instance) != torch.nn.Linear:
+            continue
+
+        if linear_mod_filter_fn is not None and not linear_mod_filter_fn(module_instance):
+            log_skip_linear(n, module_instance, 'failed filter function')
+            continue
+
+        # Note: we special case for linear -> linear,
+        # so if we are at the second linear then skip debug/extract to avoid duplication
+        is_second_linear_of_dual_linear = (
+            n.args[0].op == 'call_module' and
+            type(getattr(gm, n.args[0].target)) == torch.nn.Linear and
+            len(n.args[0].users) == 1
+        )
+        if is_second_linear_of_dual_linear:
+            log_skip_linear(n, module_instance, 'second of dual linear')
+            continue
+
+        # for now, the case where the linear's input is a graph input is not supported
+        is_input_placeholder = n.args[0].op == 'placeholder'
+        if is_input_placeholder:
+            log_skip_linear(n, module_instance, 'input is placeholder')
+            continue
+
+        debug_single_linear(gm, n, module_instance, debug_logs_filename, subgraph_idx, summary_results)
+        subgraph_save_filename = os.path.join(target_folder, f'subgraph_with_inputs_{subgraph_idx}.pt')
+        extract_linear_subgraph(gm, n, module_instance, subgraph_save_filename)
+        subgraph_idx += 1
+
+    with open(summary_filename, 'w') as f:
+        csv.writer(f).writerows(summary_results)
+
+    graph_tabular_log.debug("\nending linear debug\n")


### PR DESCRIPTION
Summary:

Inspects torchdynamo's pre-dispatch traced graph and displays debug information about the ops before + after `torch.nn.Linear` layers in the graph.

Useful for setting up microbenchmarks for float8 fusions.

Test Plan:

```
TORCH_LOGS="+dynamo" pytest test/vasiliy_debug_test.py -s
```

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec