### PR TITLE
[Memory Snapshot][Viz] Show event timestamps if collected

### DIFF
--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -983,6 +983,10 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries) {
       if (elem.stream !== null) {
         text = `${text}, stream ${elem.stream}`;
       }
+      if (elem.timestamp !== null) {
+        var d = new Date(elem.time_us / 1000);
+        text = `${text}, timestamp ${d}`;
+      }
       if (!elem.action.includes('alloc')) {
         text = `${text}\nalloc not recorded, stack trace for free:`;
       }


### PR DESCRIPTION
Summary: Since we've been capturing timestamps for awhile (since https://github.com/pytorch/pytorch/pull/112266), we can surface this into the UI. This can be useful to correlate with timing of other events.

Test Plan:
Ran it locally.

![image](https://github.com/user-attachments/assets/8b3922e8-1ae2-4b09-aa13-20b2b8237064)

Differential Revision: D60673800

Pulled By: aaronenyeshi
