### PR TITLE
Temp disable MKL in  DistributionKernels.cpp

### DIFF
--- a/aten/src/ATen/native/cpu/DistributionKernels.cpp
+++ b/aten/src/ATen/native/cpu/DistributionKernels.cpp
@@ -18,7 +18,8 @@
 #include <limits>
 #include <type_traits>
 
-#if AT_MKL_ENABLED()
+// Disable MKL rng until https://github.com/pytorch/pytorch/issues/132395 is addressed
+#if AT_MKL_ENABLED() && 0
 #include <mkl.h>
 #include <cpuinfo.h>
 #endif
@@ -36,7 +37,8 @@ void bernoulli_tensor_kernel(const TensorBase &self, const TensorBase &p_, std::
   templates::cpu::bernoulli_kernel(self, p_, generator);
 }
 
-#if !AT_MKL_ENABLED()
+// Disable MKL rng until https://github.com/pytorch/pytorch/issues/132395 is addressed
+#if !AT_MKL_ENABLED() || 1
 void bernoulli_scalar_kernel_default(const TensorBase &self, double p, std::optional<Generator> gen) {
   CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
   templates::cpu::bernoulli_kernel(self, p, generator);
@@ -104,7 +106,8 @@ static void exponential_kernel_default(TensorIteratorBase& iter, double lambda, 
   templates::cpu::exponential_kernel(iter, lambda, generator);
 }
 
-#if (!AT_MKL_ENABLED() || defined(FBCODE_CAFFE2))
+// Disable MKL rng until https://github.com/pytorch/pytorch/issues/132395 is addressed
+#if (!AT_MKL_ENABLED() || defined(FBCODE_CAFFE2) || 1)
 void exponential_kernel(TensorIteratorBase& iter, double lambda, std::optional<Generator> gen) {
   exponential_kernel_default(iter, lambda, gen);
 }

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -1841,6 +1841,21 @@ class TestDistributions(DistributionsTestCase):
             torch.tensor([[total_count, 0], [0, total_count]], dtype=torch.float64),
         )
 
+    def test_multinomial_sequential_draw(self):
+        # Adapted after script mentioned in https://github.com/pytorch/pytorch/issues/132395
+        torch.manual_seed(0xde0b6b3a764007e8)
+        prob = torch.ones(26)
+        dups_mult = 0
+        perm_counts_mult = {}
+        for _ in range(300_000):
+            p = tuple(torch.multinomial(prob, prob.numel(), replacement=False).tolist())
+            if p in perm_counts_mult:
+                dups_mult += 1
+                perm_counts_mult[p] += 1
+            else:
+                perm_counts_mult[p] = 1
+        self.assertLess(dups_mult, 10)
+
     @set_default_dtype(torch.double)
     def test_categorical_1d(self):
         p = torch.tensor([0.1, 0.2, 0.3], requires_grad=True)

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -1843,7 +1843,7 @@ class TestDistributions(DistributionsTestCase):
 
     def test_multinomial_sequential_draw(self):
         # Adapted after script mentioned in https://github.com/pytorch/pytorch/issues/132395
-        torch.manual_seed(0xde0b6b3a764007e8)
+        torch.manual_seed(0xDE0B6B3A764007E8)
         prob = torch.ones(26)
         dups_mult = 0
         perm_counts_mult = {}


### PR DESCRIPTION
Until https://github.com/pytorch/pytorch/issues/132395 is addressed

Test plan: Add test based on the script below (taken from https://discuss.pytorch.org/t/bug-in-torch-multinomial-generated-distribution-is-modestly-incorrect-edit-this-is-a-regression-and-appears-to-be-due-to-an-analogous-bug-in-tensor-exponential )
```python
import torch

high_bits_for_seed = 16000000000000000000           # to use "good quality" seed
_ = torch.manual_seed (high_bits_for_seed + 2024)

prob = torch.ones (26)
dups_mult = 0
perm_counts_mult = {}
for _ in range (1_000_000):
    p = tuple (torch.multinomial (prob, prob.numel(), replacement=False).tolist())
    if  p in perm_counts_mult:
        dups_mult += 1
        perm_counts_mult[p] += 1
    else:
        perm_counts_mult[p] = 1

print ('duplicate multinomial perms: ', dups_mult)
print ('multiple multinomial perms:  ', (torch.tensor (list (perm_counts_mult.values())) > 1).sum().item())
print ('max of perm_counts_mult:     ', torch.tensor (list (perm_counts_mult.values())).max().item())
print ('len (perm_counts_mult):      ', len (perm_counts_mult))
```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10