### PR TITLE
Remove redundant std::move on return to avoid gcc warning

### DIFF
--- a/functorch/csrc/dim/dim.cpp
+++ b/functorch/csrc/dim/dim.cpp
@@ -1474,7 +1474,7 @@ static mpy::object create_dim(mpy::object name, mpy::handle size) {
     if (!mpy::is_none(size)) {
         d->set_size(mpy::to_int(size));
     }
-    return std::move(d);
+    return d;
 }
 
 static mpy::object create_dimlist(mpy::object name, mpy::handle size) {
@@ -1490,7 +1490,7 @@ static mpy::object create_dimlist(mpy::object name, mpy::handle size) {
             }
         }
     }
-    return std::move(d);
+    return d;
 }
 
 

--- a/functorch/csrc/dim/dim.cpp
+++ b/functorch/csrc/dim/dim.cpp
@@ -1474,7 +1474,7 @@ static mpy::object create_dim(mpy::object name, mpy::handle size) {
     if (!mpy::is_none(size)) {
         d->set_size(mpy::to_int(size));
     }
-    return d;
+    return static_cast<mpy::object>(d);
 }
 
 static mpy::object create_dimlist(mpy::object name, mpy::handle size) {
@@ -1490,7 +1490,7 @@ static mpy::object create_dimlist(mpy::object name, mpy::handle size) {
             }
         }
     }
-    return d;
+    return static_cast<mpy::object>(d);
 }
 
 

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -1260,11 +1260,10 @@ inline Expr pep604union_to_union(const Expr& expr) {
   // In order to support unions with more than 2 operands ((x|y)|z), we need to
   // recursively flatten the tree of | expressions.
   auto members = get_pep604_union_members(expr);
-  auto synthesised_union = Subscript::create(
+  return Subscript::create(
       expr.range(),
       Var::create(expr.range(), Ident::create(expr.range(), "Union")),
       List<Expr>::create(expr.range(), members));
-  return synthesised_union;
 }
 
 } // namespace torch::jit

--- a/torch/csrc/jit/frontend/tree_views.h
+++ b/torch/csrc/jit/frontend/tree_views.h
@@ -1264,7 +1264,7 @@ inline Expr pep604union_to_union(const Expr& expr) {
       expr.range(),
       Var::create(expr.range(), Ident::create(expr.range(), "Union")),
       List<Expr>::create(expr.range(), members));
-  return std::move(synthesised_union);
+  return synthesised_union;
 }
 
 } // namespace torch::jit

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -629,7 +629,7 @@ py::object toPyObject(IValue ivalue) {
     for (const auto i : c10::irange(list.size())) {
       t[i] = toPyObject(IValue{list.get(i)});
     }
-    return std::move(t);
+    return t;
   } else if (ivalue.isTuple()) {
     auto tuple = std::move(ivalue).toTuple();
     const auto& elements = tuple->elements();
@@ -664,7 +664,7 @@ py::object toPyObject(IValue ivalue) {
           .attr("_create_named_tuple")(
               t, unqualName, fieldNames, py::make_tuple(defaults));
     } else {
-      return std::move(t);
+      return t;
     }
   } else if (ivalue.isDevice()) {
     return py::cast(std::move(ivalue).toDevice());
@@ -677,7 +677,7 @@ py::object toPyObject(IValue ivalue) {
       py_dict[toPyObject(IValue{pair.key()})] =
           toPyObject(IValue{pair.value()});
     }
-    return std::move(py_dict);
+    return py_dict;
   } else if (ivalue.isRRef()) {
 #ifdef USE_RPC
     auto RRefPtr =

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -629,7 +629,7 @@ py::object toPyObject(IValue ivalue) {
     for (const auto i : c10::irange(list.size())) {
       t[i] = toPyObject(IValue{list.get(i)});
     }
-    return t;
+    return static_cast<py::object>(t);
   } else if (ivalue.isTuple()) {
     auto tuple = std::move(ivalue).toTuple();
     const auto& elements = tuple->elements();
@@ -664,7 +664,7 @@ py::object toPyObject(IValue ivalue) {
           .attr("_create_named_tuple")(
               t, unqualName, fieldNames, py::make_tuple(defaults));
     } else {
-      return t;
+      return static_cast<py::object>(t);
     }
   } else if (ivalue.isDevice()) {
     return py::cast(std::move(ivalue).toDevice());
@@ -677,7 +677,7 @@ py::object toPyObject(IValue ivalue) {
       py_dict[toPyObject(IValue{pair.key()})] =
           toPyObject(IValue{pair.value()});
     }
-    return py_dict;
+    return static_cast<py::object>(py_dict);
   } else if (ivalue.isRRef()) {
 #ifdef USE_RPC
     auto RRefPtr =

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -1077,7 +1077,7 @@ inline py::object createPyObjectForStack(Stack&& stack) {
     return_values[ret] = toPyObject(std::move(stack[ret]));
   }
 
-  return std::move(return_values);
+  return return_values;
 }
 
 // TODO: Remove once we clean up the GraphExecutor usage.

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -1077,7 +1077,7 @@ inline py::object createPyObjectForStack(Stack&& stack) {
     return_values[ret] = toPyObject(std::move(stack[ret]));
   }
 
-  return return_values;
+  return static_cast<py::object>(return_values);
 }
 
 // TODO: Remove once we clean up the GraphExecutor usage.

--- a/torch/csrc/jit/python/python_arg_flatten.cpp
+++ b/torch/csrc/jit/python/python_arg_flatten.cpp
@@ -117,7 +117,7 @@ py::object cast_sequence(std::vector<py::object> objs) {
   for (const auto i : c10::irange(num_objs)) {
     sequence[i] = std::move(objs[i]);
   }
-  return std::move(sequence);
+  return sequence;
 }
 
 py::object cast_dict(std::vector<py::object> objs) {
@@ -127,7 +127,7 @@ py::object cast_dict(std::vector<py::object> objs) {
     py::tuple obj = py::reinterpret_borrow<py::tuple>(objs[i]);
     sequence[obj[0]] = obj[1];
   }
-  return std::move(sequence);
+  return sequence;
 }
 
 py::object unflatten_rec(

--- a/torch/csrc/jit/python/python_arg_flatten.cpp
+++ b/torch/csrc/jit/python/python_arg_flatten.cpp
@@ -39,7 +39,7 @@ py::object cast_handle_sequence(std::vector<py::handle> objs) {
   for (const auto i : c10::irange(num_objs)) {
     sequence[i] = py::reinterpret_borrow<py::object>(objs[i]);
   }
-  return sequence;
+  return static_cast<py::object>(sequence);
 }
 
 void flatten_rec(PyObject* obj, ParsedArgs& args) {

--- a/torch/csrc/jit/python/python_arg_flatten.cpp
+++ b/torch/csrc/jit/python/python_arg_flatten.cpp
@@ -117,7 +117,7 @@ py::object cast_sequence(std::vector<py::object> objs) {
   for (const auto i : c10::irange(num_objs)) {
     sequence[i] = std::move(objs[i]);
   }
-  return sequence;
+  return static_cast<py::object>(sequence);
 }
 
 py::object cast_dict(std::vector<py::object> objs) {
@@ -127,7 +127,7 @@ py::object cast_dict(std::vector<py::object> objs) {
     py::tuple obj = py::reinterpret_borrow<py::tuple>(objs[i]);
     sequence[obj[0]] = obj[1];
   }
-  return sequence;
+  return static_cast<py::object>(sequence);
 }
 
 py::object unflatten_rec(

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -481,7 +481,7 @@ ExprHandle TensorExprKernel::getVarForShape(const c10::ShapeSymbol& ss) {
   if (it == shapeSymbolToVar_.end()) {
     VarHandle var("ss" + std::to_string(-value), kLong);
     shapeSymbolToVar_.emplace(value, var);
-    return std::move(var);
+    return var;
   }
   return it->second;
 }
@@ -1023,7 +1023,7 @@ ExprHandle TensorExprKernel::getStrideArg(
         kLong);
     strideArgToVar_[std::pair<size_t, size_t>(
         tensor_input_index, stride_index)] = var;
-    return std::move(var);
+    return var;
   }
   return it->second;
 }

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -481,7 +481,7 @@ ExprHandle TensorExprKernel::getVarForShape(const c10::ShapeSymbol& ss) {
   if (it == shapeSymbolToVar_.end()) {
     VarHandle var("ss" + std::to_string(-value), kLong);
     shapeSymbolToVar_.emplace(value, var);
-    return var;
+    return static_cast<ExprHandle>(var);
   }
   return it->second;
 }

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1023,7 +1023,7 @@ ExprHandle TensorExprKernel::getStrideArg(
         kLong);
     strideArgToVar_[std::pair<size_t, size_t>(
         tensor_input_index, stride_index)] = var;
-    return var;
+    return static_cast<ExprHandle>(var);
   }
   return it->second;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132536
* #132535



cc @EikanWang @jgong5