### PR TITLE
[PT2][Optimus] Add unbind_stack_to_cat_pass

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -916,20 +916,24 @@ class BatchPointwiseOpsPreGradFusion(BatchPointwiseOpsFusionFactory):
                     args=(stack_inputs,),
                     kwargs={"inplace": subset[0].kwargs.get("inplace", False)},
                 )
+                batch_op.meta["example_value"] = self.op(
+                    stack_inputs.meta["example_value"],
+                    inplace=subset[0].kwargs.get("inplace", False),
+                )
             else:
                 batch_op = graph.call_function(
                     self.op,
                     args=(stack_inputs,),
                 )
-            if is_node_meta_valid(batch_op):
-                batch_op.meta["example_value"] = self.op(batch_op.meta["example_value"])
+                batch_op.meta["example_value"] = self.op(
+                    stack_inputs.meta["example_value"]
+                )
             unbind_op = graph.call_function(
                 torch.unbind, args=(batch_op,), kwargs={"dim": 0}
             )
-            if is_node_meta_valid(unbind_op):
-                unbind_op.meta["example_value"] = torch.unbind(
-                    unbind_op.meta["example_value"], dim=0
-                )
+            unbind_op.meta["example_value"] = torch.unbind(
+                batch_op.meta["example_value"], dim=0
+            )
             for i, node in enumerate(batch_nodes):
                 with graph.inserting_after(unbind_op):
                     getitem = graph.call_function(operator.getitem, args=(unbind_op, i))

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -53,8 +53,9 @@ pre_grad_pass_names = [
     "mutate_cat_pass",
     "split_cat_pass",
     "unbind_stack_pass",
-    "optimize_cat_inputs_pass",
+    "split_cat_to_slices_pass",
     "unbind_cat_to_view_pass",
+    "split_stack_to_cats_pass",
 ]
 
 post_grad_pass_names = [
@@ -1629,6 +1630,144 @@ def merge_unbind_stack_aten(match: Match, *args, **kwargs):
     counters["inductor"]["unbind_stack_aten_pass"] += 1
 
 
+def update_args_from_split_getitem(
+    graph: torch.fx.Graph,
+    node: torch.fx.Node,
+    getitem_indices: List[int],
+    parents_seen: List[torch.fx.Node],
+    new_cat_args: List[torch.fx.Node],
+    new_cat_args_meta: List[torch.fx.Node],
+    idx_to_getitems: Dict[int, torch.fx.Node],
+    threshold_to_cat: int = 2,
+):
+    split_input, split_size, split_dim = _get_split_args_default(parents_seen[-1])
+    # case 1: the number of getitems is the same as the split size, elimiate the split
+    if len(split_size) == len(getitem_indices) and is_sorted_and_consecutive(
+        getitem_indices
+    ):
+        # we can merge the getitems from the previous parent
+        new_cat_args.append(split_input)
+        new_cat_args_meta.append(split_input.meta["example_value"])
+    elif len(getitem_indices) >= threshold_to_cat and is_sorted_and_consecutive(
+        getitem_indices
+    ):
+        # case 2: the number of getitems is smaller than the split size but larger than the threshold
+        # we need to slice the input of parent
+        slice_list = []  # type: ignore[var-annotated]
+        for i in range(len(split_input.meta["example_value"].shape)):
+            if i != split_dim:
+                slice_list.append(slice(None, None, None))  # start, end, step
+            else:
+                slice_list.append(
+                    slice(getitem_indices[0], getitem_indices[-1] + 1, None)
+                )
+        with graph.inserting_after(node):
+            slice_node = graph.call_function(
+                operator.getitem,
+                args=(split_input, tuple(slice_list)),
+            )
+            slice_node.meta["example_value"] = torch.narrow(
+                split_input.meta["example_value"],
+                split_dim,
+                getitem_indices[0],
+                getitem_indices[-1] + 1,
+            )
+            new_cat_args.append(slice_node)
+            new_cat_args_meta.append(slice_node.meta["example_value"])
+    else:
+        # case 3: the number of getitems is smaller than the threshold, no merge is done
+        # get the getitems based on the indexes
+        for i in getitem_indices:
+            new_cat_args.append(idx_to_getitems[i])
+            new_cat_args_meta.append(idx_to_getitems[i].meta["example_value"])
+
+
+def construct_cat_args(
+    graph: torch.fx.Graph,
+    node: torch.fx.Node,
+    inputs: List[torch.fx.Node],
+    split_dim: int,
+    threshold_to_cat: int = 2,
+) -> Tuple[List[torch.fx.Node], List[torch.Tensor]]:
+    dim = get_arg_value(node, 1, "dim")
+    new_cat_args, parents_seen, getitem_indices, idx_to_getitems = [], [], [], {}  # type: ignore[var-annotated]
+    new_cat_args_meta = []  # type: ignore[var-annotated]
+    for input in inputs:
+        if input.target != operator.getitem:
+            # update the last arg based on getitem_indices and parents_seens
+            if len(parents_seen) > 0:
+                update_args_from_split_getitem(
+                    graph,
+                    node,
+                    getitem_indices,  # type: ignore[arg-type, union-attr]
+                    parents_seen,  # type: ignore[arg-type, union-attr]
+                    new_cat_args,
+                    new_cat_args_meta,
+                    idx_to_getitems,  # type: ignore[arg-type, union-attr]
+                    threshold_to_cat,
+                )
+            new_cat_args.append(input)
+            new_cat_args_meta.append(input.meta["example_value"])
+            # reset the indices array
+            getitem_indices, idx_to_getitems = [], {}
+        else:
+            # get the parent node of the getitem input
+            parent, idx = input.args[0], input.args[1]  # type: ignore[union-attr]
+            # we only check the split parent, and check if the split and stack have same dim
+            if parent.target != torch.split or split_dim != dim:  # type: ignore[union-attr]
+                new_cat_args.append(input)
+                new_cat_args_meta.append(input.meta["example_value"])
+                continue
+            # cannot use parents_seen to check since the first item could be non getitem node
+            if len(parents_seen) == 0:
+                parents_seen.append(parent)
+                idx_to_getitems[idx] = input
+                getitem_indices.append(idx)
+                # case: we only have one getitem input, and it is in the last position
+                if input == inputs[-1]:
+                    new_cat_args.append(input)
+                    new_cat_args_meta.append(input.meta["example_value"])
+                continue
+                # if it is the last input in the tensors, we also check if it can be optimized
+            if parent != parents_seen[-1] or input == inputs[-1]:
+                if input == inputs[-1]:
+                    getitem_indices.append(idx)
+                    idx_to_getitems[idx] = input
+                update_args_from_split_getitem(
+                    graph,
+                    node,
+                    getitem_indices,  # type: ignore[arg-type, union-attr]
+                    parents_seen,  # type: ignore[arg-type, union-attr]
+                    new_cat_args,
+                    new_cat_args_meta,
+                    idx_to_getitems,  # type: ignore[arg-type, union-attr]
+                    threshold_to_cat,
+                )
+                # reset the indices array for the next parent
+                # remember to add the last element since it is the first
+                # item in this round of parent
+                # add the parent to the list of seen parents
+                parents_seen.append(parent)
+                getitem_indices, idx_to_getitems = [idx], {idx: input}
+            else:
+                getitem_indices.append(idx)
+                idx_to_getitems[idx] = input
+    return new_cat_args, new_cat_args_meta
+
+
+def remove_split_children(graph: torch.fx.Graph, inputs: List[torch.fx.Node]):
+    split_nodes = set()
+    for input in inputs:
+        if input.target == operator.getitem:
+            split_nodes.add(input.args[0])  # type: ignore[union-attr]
+        if len(input.users.keys()) == 0:
+            graph.erase_node(input)
+    # check the split node to remove if it has no users
+    for split_node in split_nodes:
+        if len(split_node.users.keys()) == 0:  # type: ignore[union-attr]
+            graph.erase_node(split_node)
+
+
 # ############pattern to be optimized is#########
 
 #               split_node(dim=1)  -> user=multiple
@@ -1647,77 +1786,64 @@ def merge_unbind_stack_aten(match: Match, *args, **kwargs):
 
 @register_graph_pattern(
     CallFunctionVarArgs(torch.cat, users=MULTIPLE),
-    pass_dict=construct_pattern_matcher_pass("optimize_cat_inputs_pass"),
+    pass_dict=construct_pattern_matcher_pass("split_cat_to_slices_pass"),
 )
-def optimize_cat_inputs(match: Match, *args, **kwargs):
-    cat_node = match.nodes[0]
+@register_graph_pattern(
+    CallFunction(
+        torch.cat,
+        getitem_split,
+        dim=Ignored(),
+        _users=MULTIPLE,
+    ),
+    pass_dict=construct_pattern_matcher_pass("split_cat_to_slices_pass"),
+)
+def split_cat_to_slices(match: Match, split_sections: List[int], dim: int):
+    if not isinstance(split_sections, (list, tuple)):  # Unnormalized split
+        return
+    split_nodes = [node for node in match.nodes if node.target == torch.split]
+    if split_nodes:
+        split_node = next(node for node in split_nodes)
+    else:
+        # Handle the case where there are no nodes with a target of torch.split
+        return
+    split_dim = get_arg_value(split_node, 2, "dim") or 0
     graph = match.graph
-    tensors = get_arg_value(cat_node, 0, "tensors")
-    cat_dim = get_arg_value(cat_node, 1, "dim") or 0
-    # find the index of getitems to be cat, the input of cats can be any type
-    new_cat_args, getitem_indices, parents_seen = [], [], []  # type: ignore[var-annotated]
-    idx_to_getitems = {}
-    can_be_optimized = False
-
-    for input in tensors:  # type: ignore[union-attr]
-        if input.target != operator.getitem:
-            new_cat_args.append(input)
-        else:
-            # get the parent node of the getitem input
-            parent, idx = input.args[0], input.args[1]  # type: ignore[union-attr]
-            # we only check the split parent
-            if parent.target != torch.split:
-                new_cat_args.append(input)
-                continue
-            # check if the split and cat have same dim
-            split_input, split_size, split_dim = _get_split_args_default(parent)
-            if split_dim != cat_dim:
-                continue
-            if len(parents_seen) == 0:
-                parents_seen.append(parent)
-                idx_to_getitems[idx] = input
-                getitem_indices.append(idx)
-                continue
-            # if it is the last input in the tensors, we also check if it can be optimized
-            if parent != parents_seen[-1] or input == tensors[-1]:
-                if input == tensors[-1]:
-                    getitem_indices.append(idx)
-                    idx_to_getitems[idx] = input
-                # we need to check the nodes before we move to the next parent
-                # get all the getitems from the parent node
-                if len(split_size) == len(
-                    getitem_indices
-                ) and is_sorted_and_consecutive(getitem_indices):
-                    # we can merge the getitems from the previous parent
-                    new_cat_args.append(parents_seen[-1].args[0])
-                    can_be_optimized = True
-                else:
-                    # get the getitems based on the indexes
-                    for i in getitem_indices:
-                        new_cat_args.append(idx_to_getitems[i])
-                # reset the indices array for the next parent
-                # remember to add the last element since it is the first
-                # item in this round of parent
-                getitem_indices, idx_to_getitems = [idx], {idx: input}
-                # add the parent to the list of seen parents
-                parents_seen.append(parent)
-            else:
-                getitem_indices.append(idx)
-                idx_to_getitems[idx] = input
-
-    if can_be_optimized:
-        new_args = (new_cat_args,)
-        with graph.inserting_after(cat_node):
-            new_cat_node = graph.call_function(
-                torch.cat,
-                args=new_args,
-                kwargs={"dim": cat_dim},
-            )
-            cat_node.replace_all_uses_with(new_cat_node)
-            new_cat_node.meta.update(cat_node.meta)
-            # remove the cat node
+    threshold_to_cat = torch._inductor.config.pre_grad_fusion_options[
+        "split_cat_to_slices_pass"
+    ].get("threshold_to_cat", 10)
+    # get the cat_node and check its inputs and meta data
+    next_users = find_next_users(split_node)
+    for cat_node in next_users:
+        if cat_node.target != torch.cat or not is_node_meta_valid(cat_node):
+            continue
+        cat_inputs = get_arg_value(cat_node, 0, "tensors")  # type: ignore[union-attr]
+        new_cat_args, _ = construct_cat_args(
+            graph, cat_node, cat_inputs, split_dim, threshold_to_cat
+        )
+        # if new cat args has length 1, we can remove the cat node
+        if len(new_cat_args) == 1:
+            cat_node.replace_all_uses_with(new_cat_args[0])
+            # remove inputs of cat_node if they have no users
+            cat_inputs = cat_node.args[0]  # type: ignore[union-attr]
             graph.erase_node(cat_node)
-            counters["inductor"]["optimize_cat_inputs_pass"] += 1
+            remove_split_children(graph, cat_inputs)  # type: ignore[arg-type, union-attr]
+            counters["inductor"]["split_cat_to_slices_pass"] += 1
+            continue
+        if len(new_cat_args) > 2 and len(new_cat_args) < len(cat_inputs):
+            new_args = (new_cat_args,)
+            with graph.inserting_after(cat_node):
+                new_cat_node = graph.call_function(
+                    torch.cat,
+                    args=new_args,
+                    # split and cat have the same dim
+                    kwargs={"dim": split_dim},
+                )
+                cat_node.replace_all_uses_with(new_cat_node)
+                new_cat_node.meta.update(cat_node.meta)
+                # remove the cat node
+                graph.erase_node(cat_node)
+                remove_split_children(graph, cat_inputs)
+                counters["inductor"]["split_cat_to_slices_pass"] += 1
 
 
 # ############pattern to be optimized is#########
@@ -1810,3 +1936,89 @@ def unbind_cat_to_view(match: Match, unbind_input: torch.fx.Node, dim: int):
             if len(cat_input.users.keys()) == 0:  # type: ignore[union-attr]
                 graph.erase_node(cat_input)
         counters["inductor"]["unbind_cat_to_view_pass"] += 1
+
+
+# ############pattern to be optimized is#########
+#    |           |
+#   split       split   (dim=1)
+#   /     \      /   \
+# getitem  ...        getitem      other ops
+#        \      |       /            /
+#       stack(user=mul, dim=1)
+#          |
+
+# ################after transformation#############
+
+#       /           \         ...       /         \
+# getitem    getitem        getitem     getitem   -> user=multiple
+#       \      /
+#       cat(user=mul, dim=1) cat_other_opts
+#          \                  /
+#                  cat
+#                   |
+#                  view
+#                   |
+
+
+@register_graph_pattern(
+    CallFunction(
+        torch.stack,
+        getitem_split,
+        dim=Ignored(),
+        _users=MULTIPLE,
+    ),
+    pass_dict=construct_pattern_matcher_pass("split_stack_to_cats_pass"),
+)
+def split_stack_to_cats(match: Match, split_sections: List[int], dim: int):
+    if not isinstance(split_sections, (list, tuple)):  # Unnormalized split
+        return
+    split_node = next(node for node in match.nodes if node.target == torch.split)
+    split_dim = get_arg_value(split_node, 2, "dim") or 0
+    graph = match.graph
+    threshold_to_cat = torch._inductor.config.pre_grad_fusion_options[
+        "split_stack_to_cats_pass"
+    ].get("threshold_to_cat", 10)
+    # get the stack_node and check its inputs and meta data
+    next_users = find_next_users(split_node)
+    for stack_node in next_users:
+        if stack_node.target != torch.stack or not is_node_meta_valid(stack_node):
+            continue
+        inputs = get_arg_value(stack_node, 0, "tensors")  # type: ignore[union-attr]
+        new_cat_args, new_cat_args_meta = construct_cat_args(
+            graph, stack_node, inputs, split_dim, threshold_to_cat
+        )
+        # get the view shape
+        stack_shape = stack_node.meta["example_value"].shape
+        # case 1: only one node in the new cat args, don't need to cat
+        if len(new_cat_args) == 1:
+            stack_node.replace_all_uses_with(new_cat_args[0])
+            stack_inputs = stack_node.args[0]  # type: ignore[union-attr]
+            # remove stack node
+            graph.erase_node(stack_node)
+            # check the input of stack node, and remove nodes that have no users
+            remove_split_children(graph, stack_inputs)  # type: ignore[arg-type]
+            counters["inductor"]["split_stack_to_cats_pass"] += 1
+            continue
+        if len(new_cat_args) > 2 and len(new_cat_args) < len(inputs):
+            with graph.inserting_after(stack_node):
+                cat_node = graph.call_function(
+                    torch.cat,
+                    args=(new_cat_args,),
+                    kwargs={"dim": split_dim},
+                )
+                cat_node.meta["example_value"] = torch.cat(  # type: ignore[arg-type]
+                    new_cat_args_meta, dim=split_dim
+                )
+                # reshape the cat node to the stack node shape
+                reshape_node = graph.call_function(
+                    torch.Tensor.view,
+                    args=(cat_node, *stack_shape),  # type: ignore[arg-type]
+                )
+                stack_node.replace_all_uses_with(reshape_node)
+                reshape_node.meta.update(stack_node.meta)
+                stack_inputs = stack_node.args[0]  # type: ignore[union-attr]
+                # remove stack node
+                graph.erase_node(stack_node)
+                # check the input of stack node, and remove nodes that have no users
+                remove_split_children(graph, stack_inputs)  # type: ignore[arg-type]
+                counters["inductor"]["split_stack_to_cats_pass"] += 1


### PR DESCRIPTION
Summary: We observe the stack mpde can be transformed to cat node to elimiate split nodes, which could further enable the unbind cat optimization, thus we add a more advanced pattern to do the graph transformation

Test Plan:
# unit test

```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 test //caffe2/test/inductor:split_cat_fx_passes
```
Buck UI: https://www.internalfb.com/buck2/de6c1cda-3d74-4a30-8980-7b209b6fe5dc
Test UI: https://www.internalfb.com/intern/testinfra/testrun/12103424042268125
Network: Up: 485KiB  Down: 728KiB  (reSessionID-2f2c01c3-79bb-4e37-b5be-fb77ec09b264)
Jobs completed: 29. Time elapsed: 5:19.8s.
Cache hits: 0%. Commands: 4 (cached: 0, remote: 0, local: 4)
Tests finished: Pass 9. Fail 0. Fatal 0. Skip 1. Build failure 0

# benchmark

```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "ig_ctr" --flow_id 584880697
```
P1503698962

before and after graph transformation
https://www.internalfb.com/intern/diffing/?paste_number=1504050718

Differential Revision: D60411560


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang