### PR TITLE
[inductor] fix passthough_args when compile_only.

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -994,7 +994,9 @@ def _transform_cuda_paths(lpaths: List[str]) -> None:
 
 
 def get_cpp_torch_cuda_options(
-    cuda: bool, aot_mode: bool = False
+    cuda: bool,
+    aot_mode: bool = False,
+    compile_only: bool = False,
 ) -> Tuple[List[str], List[str], List[str], List[str], List[str], List[str], List[str]]:
     definations: List[str] = []
     include_dirs: List[str] = []
@@ -1050,7 +1052,7 @@ def get_cpp_torch_cuda_options(
         else:
             include_dirs.append(os.path.join(build_paths.cuda(), "include"))
 
-    if aot_mode and cuda and config.is_fbcode():
+    if aot_mode and cuda and config.is_fbcode() and not compile_only:
         if torch.version.hip is None:
             # TODO: make static link better on Linux.
             passthough_args = ["-Wl,-Bstatic -lcudart_static -Wl,-Bdynamic"]
@@ -1111,7 +1113,9 @@ class CppTorchCudaOptions(CppTorchOptions):
             cuda_libraries_dirs,
             cuda_libraries,
             cuda_passthough_args,
-        ) = get_cpp_torch_cuda_options(cuda=cuda, aot_mode=aot_mode)
+        ) = get_cpp_torch_cuda_options(
+            cuda=cuda, aot_mode=aot_mode, compile_only=compile_only
+        )
 
         if compile_only:
             cuda_libraries_dirs = []


### PR DESCRIPTION
Fix still pass `cudart_static` libraries via `passthough_args` , when `compile_only`.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang