### PR TITLE
Fix a typo in the example code.

### DIFF
--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -72,7 +72,7 @@ using forward_t = decltype(X::forward(nullptr, std::declval<Args>()...));
 ///   static variable_list forward(AutogradContext *ctx, int n, Variable var) {
 ///      // Save data for backward in context
 ///      ctx->saved_data["n"] = n;
-///      var.mul_(2);
+///      var.mul_(n);
 ///      // Mark var as modified by inplace operation
 ///      ctx->mark_dirty({var});
 ///      return {var};


### PR DESCRIPTION
Since the backward multiples the gradient by `n`, we must change the forward function to multiply the input tensor by `n`.
