### PR TITLE
Use VSL_BRNG_PHILOX4X32X10 for MKL exponential and bernoulli to avoid duplicated permutations under a low number of iterations

### DIFF
--- a/aten/src/ATen/native/cpu/DistributionKernels.cpp
+++ b/aten/src/ATen/native/cpu/DistributionKernels.cpp
@@ -37,8 +37,7 @@ void bernoulli_tensor_kernel(const TensorBase &self, const TensorBase &p_, std::
   templates::cpu::bernoulli_kernel(self, p_, generator);
 }
 
-// Disable MKL rng until https://github.com/pytorch/pytorch/issues/132395 is addressed
-#if !AT_MKL_ENABLED() || 1
+#if !AT_MKL_ENABLED()
 void bernoulli_scalar_kernel_default(const TensorBase &self, double p, std::optional<Generator> gen) {
   CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
   templates::cpu::bernoulli_kernel(self, p, generator);
@@ -50,11 +49,12 @@ void bernoulli_scalar_kernel(const TensorBase &self, double p, std::optional<Gen
 #else
 void bernoulli_scalar_kernel(const TensorBase &self, double p, std::optional<Generator> gen) {
   CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
-  int64_t seed;
+  uint32_t params[2];
   {
     // See Note [Acquire lock when using random generators]
     std::lock_guard<std::mutex> lock(generator->mutex_);
-    seed = generator->random();
+    params[0] = generator->random();
+    params[1] = generator->random();
   }
   int64_t n = self.numel();
   bool contig = self.is_contiguous();
@@ -75,7 +75,7 @@ void bernoulli_scalar_kernel(const TensorBase &self, double p, std::optional<Gen
       int64_t len = end - begin;
       if (len > 0) {
         VSLStreamStatePtr stream;
-        vslNewStream(&stream, VSL_BRNG_MCG31, seed);
+        vslNewStreamEx(&stream, VSL_BRNG_PHILOX4X32X10, 2, params);
         vslSkipAheadStream(stream, begin);
         viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, len,
           sample_int_ptr + begin, p);
@@ -106,8 +106,7 @@ static void exponential_kernel_default(TensorIteratorBase& iter, double lambda, 
   templates::cpu::exponential_kernel(iter, lambda, generator);
 }
 
-// Disable MKL rng until https://github.com/pytorch/pytorch/issues/132395 is addressed
-#if (!AT_MKL_ENABLED() || defined(FBCODE_CAFFE2) || 1)
+#if (!AT_MKL_ENABLED() || defined(FBCODE_CAFFE2))
 void exponential_kernel(TensorIteratorBase& iter, double lambda, std::optional<Generator> gen) {
   exponential_kernel_default(iter, lambda, gen);
 }
@@ -118,14 +117,12 @@ void exponential_kernel(TensorIteratorBase &iter, double lambda, std::optional<G
   Tensor self = iter.tensor(0);
   if (lambda > 0 && !std::isinf(lambda) && !std::isnan(lambda)) {
     CPUGeneratorImpl* generator = get_generator_or_default<CPUGeneratorImpl>(gen, detail::getDefaultCPUGenerator());
-    int64_t seed;
+    uint32_t params[2];
     {
       // See Note [Acquire lock when using random generators]
       std::lock_guard<std::mutex> lock(generator->mutex_);
-      if (self.scalar_type() == at::kDouble)
-        seed = generator->random64();
-      else
-        seed = generator->random();
+      params[0] = generator->random();
+      params[1] = generator->random();
     }
     int64_t n = self.numel();
     bool contig = self.is_contiguous();
@@ -163,13 +160,13 @@ void exponential_kernel(TensorIteratorBase &iter, double lambda, std::optional<G
         if (len > 0) {
           VSLStreamStatePtr stream;
           if constexpr (std::is_same<scalar_t, double>::value) {
-            vslNewStream(&stream, VSL_BRNG_MCG31, seed);
+            vslNewStreamEx(&stream, VSL_BRNG_PHILOX4X32X10, 2, params);
             vslSkipAheadStream(stream, begin);
             vdRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF, stream, len,
               (double *)(sample_ptr + begin), eps, 1./lambda);
             vslDeleteStream(&stream);
           } else {
-            vslNewStream(&stream, VSL_BRNG_MCG31, seed);
+            vslNewStreamEx(&stream, VSL_BRNG_PHILOX4X32X10, 2, params);
             vslSkipAheadStream(stream, begin);
             vsRngExponential(VSL_RNG_METHOD_EXPONENTIAL_ICDF, stream, len,
               (float *) (sample_ptr + begin), eps, 1./lambda);

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3344,6 +3344,39 @@ class TestDistributions(DistributionsTestCase):
                 f"Exponential(rate={rate})",
             )
 
+    def test_distribution_duplicated_permutations(self):
+        def test_duplicated_permutations(dist, dtype, sample_size, size, thre_size):
+            sample = dist(torch.empty(sample_size, dtype=dtype))
+            for _ in range(thre_size):
+                test = dist(torch.empty(size, dtype=dtype))
+                allFound = True
+                for s in sample:
+                    if s not in test:
+                        allFound = False
+                        break
+                if not allFound:
+                    continue
+                # Check duplicated permutations
+                sample_list = sample.tolist()
+                test_list = test.tolist()
+                found_indices = [
+                    i
+                    for i in range(size - sample_size + 1)
+                    if test_list[i] == sample_list[0]
+                ]
+                for i in found_indices:
+                    self.assertFalse(test_list[i : i + 100] == sample_list)
+
+        test_duplicated_permutations(
+            lambda x: x.exponential_(), torch.float, 100, 1024 * 1024 * 2, 10240
+        )
+        test_duplicated_permutations(
+            lambda x: x.exponential_(), torch.double, 100, 1024 * 1024 * 2, 10240
+        )
+        test_duplicated_permutations(
+            lambda x: x.bernoulli_(), torch.int32, 100, 1024 * 1024 * 2, 10240
+        )
+
     @set_default_dtype(torch.double)
     def test_laplace(self):
         loc = torch.randn(5, 5, requires_grad=True)


### PR DESCRIPTION
Fixes #132395

Use `VSL_BRNG_PHILOX4X32X10` instead of  `VSL_BRNG_MCG31` for MKL exponential.

Single core (fp32):
BRNG | shape | time/ms
-- | -- | --
VSL_BRNG_MCG31 | (1024*2048) | 1.26
VSL_BRNG_PHILOX4X32X10 | (1024*2048) | 1.17

10 cores (fp32):
BRNG | shape | time/ms
-- | -- | --
VSL_BRNG_MCG31 | (1024*2048) | 0.138
VSL_BRNG_PHILOX4X32X10 | (1024*2048) | 0.125

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10