### PR TITLE
[inductor] unificate SUBPROCESS_DECODE_ARGS variable in cpp_builder.py

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -170,7 +170,7 @@ def _is_gcc(cpp_compiler: str) -> bool:
 def _is_msvc_cl(cpp_compiler: str) -> bool:
     if not _IS_WINDOWS:
         return False
-    SUBPROCESS_DECODE_ARGS = ("oem",) if _IS_WINDOWS else ()
+
     try:
         output_msg = (
             subprocess.check_output([cpp_compiler, "/help"], stderr=subprocess.STDOUT)
@@ -205,7 +205,6 @@ def is_msvc_cl() -> bool:
 
 
 def get_compiler_version_info(compiler: str) -> str:
-    SUBPROCESS_DECODE_ARGS = ("oem",) if _IS_WINDOWS else ()
     env = os.environ.copy()
     env["LC_ALL"] = "C"  # Don't localize output
     try:


### PR DESCRIPTION
[inductor] unificate SUBPROCESS_DECODE_ARGS variable in cpp_builder.py


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang