### PR TITLE
[DeviceMesh] Add a private _flatten() API for device_mesh

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -579,16 +579,6 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         flattned_dp_tp_mesh = dp_tp_mesh._flatten()
         self.assertEqual(dp_tp_mesh.mesh.flatten(), flattned_dp_tp_mesh.mesh)
 
-        # Test flatten non-contiguous dims with swapping order
-        # We sort the order of the mesh_dim_names in the mesh to flatten based on
-        # order of the mesh_dim_names in the root mesh, since we do not want to create
-        # DeviceMesh([0, 4, 1, 5], mesh_dim_names=('tp_dp',)) or DeviceMesh([2, 6, 3, 7], mesh_dim_names=('tp_dp',)).
-        # No matter the order of slice given, the result should be
-        # DeviceMesh([0, 1, 4, 5], mesh_dim_names=('dp_tp',) or DeviceMesh([2, 3, 6, 7], mesh_dim_names=('dp_tp',)).
-        tp_dp_mesh = mesh_3d["tp", "dp"]
-        flattned_tp_dp_mesh = tp_dp_mesh._flatten()
-        self.assertEqual(flattned_dp_tp_mesh, flattned_tp_dp_mesh)
-
 
 class TestMeshEnv(DTensorTestBase):
     @property

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -691,6 +691,11 @@ else:
             """
             Returns a 1D DeviceMesh created from flattening the current DeviceMesh.
             """
+            if not self.mesh_dim_names:
+                raise RuntimeError(
+                    "Cannot flatten a DeviceMesh without mesh_dim_names!"
+                )
+
             flatten_mesh = _mesh_resources.create_flatten_mesh(self)
             return flatten_mesh
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -117,7 +117,7 @@ else:
             root_mesh = _mesh_resources.get_root_mesh(device_mesh)
             flatten_dims_in_root = [
                 root_mesh.mesh_dim_names.index(flattened_mesh_dim_name)
-                for flattened_mesh_dim_name in device_mesh.mesh_dim_names
+                for flattened_mesh_dim_name in not_none(device_mesh.mesh_dim_names)
             ]
             # sort dims to flatten based on the order of the dims in the root mesh.
             flatten_dims_in_root.sort()
@@ -144,7 +144,7 @@ else:
                 )
                 if cur_rank in mesh_nd:
                     res_flattened_mesh = flattened_mesh
-            self.child_to_root_mapping[res_flattened_mesh] = root_mesh
+            self.child_to_root_mapping[res_flattened_mesh] = root_mesh  # type: ignore[possibly-undefined]
 
             return res_flattened_mesh
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -122,8 +122,6 @@ else:
                 not_none(root_mesh.mesh_dim_names).index(flattened_mesh_dim_name)
                 for flattened_mesh_dim_name in not_none(device_mesh.mesh_dim_names)
             ]
-            # sort dims to flatten based on the order of the dims in the root mesh.
-            flatten_dims_in_root.sort()
             flatten_mesh_dim_names = "_".join(
                 [
                     not_none(root_mesh.mesh_dim_names)[dim]

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -116,13 +116,16 @@ else:
         def create_flatten_mesh(self, device_mesh: "DeviceMesh") -> "DeviceMesh":
             root_mesh = _mesh_resources.get_root_mesh(device_mesh)
             flatten_dims_in_root = [
-                root_mesh.mesh_dim_names.index(flattened_mesh_dim_name)
+                not_none(root_mesh.mesh_dim_names).index(flattened_mesh_dim_name)
                 for flattened_mesh_dim_name in not_none(device_mesh.mesh_dim_names)
             ]
             # sort dims to flatten based on the order of the dims in the root mesh.
             flatten_dims_in_root.sort()
             flatten_mesh_dim_names = "_".join(
-                [root_mesh.mesh_dim_names[dim] for dim in flatten_dims_in_root]
+                [
+                    not_none(root_mesh.mesh_dim_names)[dim]
+                    for dim in flatten_dims_in_root
+                ]
             )
             flattened_mesh_dim_size = math.prod(device_mesh.mesh.size())
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -692,15 +692,14 @@ else:
 
         def _flatten(self) -> "DeviceMesh":
             """
-            Returns a 1D DeviceMesh created from flattening the current DeviceMesh.
+            Returns a 1D DeviceMesh by flattening the current DeviceMesh.
             """
             if not self.mesh_dim_names:
                 raise RuntimeError(
                     "Cannot flatten a DeviceMesh without mesh_dim_names!"
                 )
 
-            flatten_mesh = _mesh_resources.create_flatten_mesh(self)
-            return flatten_mesh
+            return _mesh_resources.create_flatten_mesh(self)
 
     def init_device_mesh(
         device_type: str,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132779
* __->__ #132632

Adds a new private API to flatten a DeviceMesh to a 1D DeviceMesh such that:
```
mesh_3d = init_device_mesh(
    self.device_type, (2, 2, 2), mesh_dim_names=("dp", "cp", "tp"),
)

dp_cp_mesh = mesh_3d["dp", "cp"]
# flattened_mesh on rank 0, 2, 4, 6 is DeviceMesh([0, 2, 4, 6], mesh_dim_names=('dp_cp',))
# flattened_mesh on rank 1, 3, 5, 7 is DeviceMesh([1, 3, 5, 7], mesh_dim_names=('dp_cp',))
flattened_dp_cp_mesh = dp_cp_mesh._flatten()
```


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l