### PR TITLE
[Compile] Speedup int8-to-float conversion on aarch64

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -188,18 +188,6 @@ struct VecConvert<
   }
 };
 
-template <typename src_t>
-struct VecConvert<
-    float,
-    1,
-    src_t,
-    1,
-    typename std::enable_if_t<is_8bit_integer_v<src_t>,
-        void>> {
-  static inline VectorizedN<float, 1> apply(const VectorizedN<src_t, 1>& src) {
-    return convert_int8_to_float<src_t>(src[0]);
-  }
-};
 
 template <typename dst_t>
 struct VecConvert<
@@ -217,6 +205,22 @@ struct VecConvert<
   }
 };
 
+#endif /* defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER) */
+
+
+#if (defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)) || defined(CPU_CAPABILITY_NEON)
+template <typename src_t>
+struct VecConvert<
+    float,
+    1,
+    src_t,
+    1,
+    typename std::enable_if_t<is_8bit_integer_v<src_t>,
+        void>> {
+  static inline VectorizedN<float, 1> apply(const VectorizedN<src_t, 1>& src) {
+    return convert_int8_to_float<src_t>(src[0]);
+  }
+};
 #endif
 
 template <typename src_t>

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -1338,4 +1338,32 @@ Vectorized<c10::quint8> inline maximum(const Vectorized<c10::quint8>& a, const V
 }
 
 #endif // if defined(CPU_CAPABILITY_AVX2)
+
+#if defined(CPU_CAPABILITY_NEON)
+template <typename T>
+typename std::enable_if_t<std::is_same_v<T, int8_t>, at::vec::Vectorized<float>>
+inline convert_int8_to_float(at::vec::Vectorized<T> src) {
+  // Note: this function only convert inputs number of elements equal to at::vec::Vectorized<float>.size()
+    auto s8x8 = vld1_s8(src.operator const int8_t*());
+    auto s16x8 = vmovl_s8(s8x8);
+
+    auto s32x4_hi = vmovl_s16(vget_high_s16(s16x8));
+    auto s32x4_lo = vmovl_s16(vget_low_s16(s16x8));
+
+    return Vectorized<float>(vcvtq_f32_s32(s32x4_lo), vcvtq_f32_s32(s32x4_hi));
+}
+
+template <typename T>
+typename std::enable_if_t<std::is_same_v<T, uint8_t>, at::vec::Vectorized<float>>
+inline convert_int8_to_float(at::vec::Vectorized<T> src) {
+  // Note: this function only convert inputs number of elements equal to at::vec::Vectorized<float>.size()
+    auto u8x8 = vld1_u8(src.operator const int8_t*());
+    auto u16x8 = vmovl_u8(u8x8);
+    auto u32x4_hi = vmovl_u16(vget_high_u16(u16x8));
+    auto u32x4_lo = vmovl_u16(vget_low_u16(u16x8));
+
+    return Vectorized<float>(vcvtq_f32_u32(u32x4_lo), vcvtq_f32_u32(u32x4_hi));
+}
+
+#endif
 }} // namespace at::vec::CPU_CAPABILITY

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -1357,7 +1357,7 @@ template <typename T>
 typename std::enable_if_t<std::is_same_v<T, uint8_t>, at::vec::Vectorized<float>>
 inline convert_int8_to_float(at::vec::Vectorized<T> src) {
   // Note: this function only convert inputs number of elements equal to at::vec::Vectorized<float>.size()
-    auto u8x8 = vld1_u8(src.operator const int8_t*());
+    auto u8x8 = vld1_u8(src.operator const uint8_t*());
     auto u16x8 = vmovl_u8(u8x8);
     auto u32x4_hi = vmovl_u16(vget_high_u16(u16x8));
     auto u32x4_lo = vmovl_u16(vget_low_u16(u16x8));


### PR DESCRIPTION
With this change following snippet:
```cpp
#include <ATen/cpu/vec/vec.h>

void int8tofloat(int8_t* in, float* out) {
        auto tmp0 = at::vec::Vectorized<int8_t>::loadu(in, 8);
        auto tmp1 = at::vec::convert<float>(tmp0);
        tmp1.store(out);
}
```
Which is core of the algorithm generated by cpu_inductor for the following compiled function:
```python
@torch.compile
def to_float(x):
  return x.to(torch.float)
```


changes from
```assembly
int8tofloat(signed char*, float*):
0000000000000000	stp	x29, x30, [sp, #-0x10]!
0000000000000004	mov	x29, sp
0000000000000008	sub	x9, sp, #0x30
000000000000000c	and	sp, x9, #0xffffffffffffffe0
0000000000000010	adrp	x8, 0 ; 0x0
0000000000000014	ldr	x8, [x8]
0000000000000018	ldr	x8, [x8]
000000000000001c	str	x8, [sp, #0x28]
0000000000000020	ldr	s0, [x0]
0000000000000024	sshll.8h	v0, v0, #0x0
0000000000000028	sshll.4s	v0, v0, #0x0
000000000000002c	scvtf.4s	v0, v0
0000000000000030	str	q0, [sp]
0000000000000034	ldr	s0, [x0, #0x4]
0000000000000038	sshll.8h	v0, v0, #0x0
000000000000003c	sshll.4s	v0, v0, #0x0
0000000000000040	scvtf.4s	v0, v0
0000000000000044	str	q0, [sp, #0x10]
0000000000000048	mov	x8, sp
000000000000004c	ld1.4s	{ v0, v1 }, [x8]
0000000000000050	st1.4s	{ v0, v1 }, [x1]
0000000000000054	ldr	x8, [sp, #0x28]
0000000000000058	adrp	x9, 0 ; 0x0
000000000000005c	ldr	x9, [x9]
0000000000000060	ldr	x9, [x9]
0000000000000064	cmp	x9, x8
0000000000000068	b.ne	0x78
000000000000006c	mov	sp, x29
0000000000000070	ldp	x29, x30, [sp], #0x10
0000000000000074	ret
0000000000000078	bl	0x78
```
to
```assembly
0000000000000000	ldr	d0, [x0]
0000000000000004	sshll.8h	v0, v0, #0x0
0000000000000008	sshll.4s	v1, v0, #0x0
000000000000000c	scvtf.4s	v1, v1
0000000000000010	sshll2.4s	v0, v0, #0x0
0000000000000014	scvtf.4s	v2, v0
0000000000000018	st1.4s	{ v1, v2 }, [x1]
000000000000001c	ret
```

and improves perf of `python3 torchchat.py generate stories110M --num-samples 3 --quantize '{"linear:int8" : {"groupsize" : 0}}' --compile --device cpu` from 56 to 98 tokens per sec on MacBook M1 Pro

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10