### PR TITLE
[export][reland] Convert autocast to HOO

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -5454,7 +5454,8 @@ def forward(self, b_pred, b_t, x, y):
 def forward(self, b_t, x, y):
     submod_3 = self.submod_1
     add_1 = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(True, submod_3, x, b_t, y);  submod_3 = x = b_t = y = None
-    return (add_1,)""",
+    getitem = add_1[0];  add_1 = None
+    return (getitem,)""",
         )
 
         self.assertExpectedInline(
@@ -5464,7 +5465,7 @@ def forward(self, x, b_t, y):
     sub = torch.ops.aten.sub.Tensor(x, 1);  x = None
     add = torch.ops.aten.add.Tensor(sub, b_t);  sub = b_t = None
     add_1 = torch.ops.aten.add.Tensor(add, y);  add = y = None
-    return add_1""",
+    return (add_1,)""",
         )
 
     def test_predispatch_grad_wrappers(self):
@@ -6021,7 +6022,7 @@ def forward(self, x):
     lt = item < 6
     _assert_scalar_default_3 = torch.ops.aten._assert_scalar.default(lt, "Runtime assertion failed for expression u1 < 6 on node 'lt'");  lt = _assert_scalar_default_3 = None
     foo_unbacked = torch.ops.testlib.foo_unbacked.default(item);  item = None
-    return foo_unbacked""",
+    return (foo_unbacked,)""",
         )
         ep_aot = ep_pre.run_decompositions()
         self.assertExpectedInline(

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -178,21 +178,94 @@ def _set_grad_enabled_tests():
             return _export(mod, args, pre_dispatch=True).module()
 
     return {
-        "ctx_manager": (_get_predispatch_module(SetGradCtxManager(), (x,)), (x,)),
+        "ctx_manager": (
+            SetGradCtxManager(),
+            _get_predispatch_module(SetGradCtxManager(), (x,)),
+            (x,),
+        ),
         "ctx_manager_under_no_grad": (
+            SetGradCtxManager(),
             _get_predispatch_module(SetGradCtxManager(), (x,), False),
             (x,),
         ),
         "ctx_manager_multi_dep": (
+            SetGradCtxManagerMultiDep(),
             _get_predispatch_module(SetGradCtxManagerMultiDep(), (x,)),
             (x,),
         ),
         "ctx_manager_multi_dep_no_grad": (
+            SetGradCtxManagerMultiDep(),
             _get_predispatch_module(SetGradCtxManagerMultiDep(), (x,), False),
             (x,),
         ),
-        "op": (_get_predispatch_module(SetGradOp(), (x,)), (x,)),
-        "op_under_no_grad": (_get_predispatch_module(SetGradOp(), (x,), False), (x,)),
+        "op": (SetGradOp(), _get_predispatch_module(SetGradOp(), (x,)), (x,)),
+        "op_under_no_grad": (
+            SetGradOp(),
+            _get_predispatch_module(SetGradOp(), (x,), False),
+            (x,),
+        ),
+    }
+
+
+def _with_autocast_tests():
+    from torch.export._trace import _export
+
+    class WithAutocastOp(torch.nn.Module):
+        def forward(self, x):
+            x = x + 1
+            with torch.autocast(device_type="cpu", enabled=True):
+                c = x.sin().sum()
+            with torch.autocast(device_type="cpu", enabled=False):
+                d = c + 1
+            with torch.autocast(device_type="cpu", enabled=True):
+                e = d - 1
+            return d, e
+
+    class WithAutocastOpMultiDep(torch.nn.Module):
+        def forward(self, x):
+            x = x + 1
+            with torch.autocast(device_type="cpu", enabled=True):
+                c1 = x.sin().sum()
+                c2 = x.cos().sum()
+            with torch.autocast(device_type="cpu", enabled=False):
+                d1 = c1 + 1
+                d2 = c2 + 1
+            with torch.autocast(device_type="cpu", enabled=True):
+                e1 = d1 - 1
+                e2 = d2 - 1
+            return d1, d2, e1, e2
+
+    class SplitAutocastOp(torch.nn.Module):
+        def forward(self, x):
+            x = x + 1
+            with torch.autocast(device_type="cpu", enabled=True):
+                c = x.sin().sum()
+            d = c + 1
+            with torch.autocast(device_type="cpu", enabled=True):
+                e = d - 1
+            return d, e
+
+    x = torch.randn(2, 2)
+
+    def _get_predispatch_module(mod, args):
+        return _export(mod, args, pre_dispatch=True).module()
+
+    return {
+        "ctx_manager": (
+            WithAutocastOp(),
+            _get_predispatch_module(WithAutocastOp(), (x,)),
+            (x,),
+        ),
+        "ctx_manager_multi_dep": (
+            WithAutocastOpMultiDep(),
+            _get_predispatch_module(WithAutocastOpMultiDep(), (x,)),
+            (x,),
+        ),
+        "ctx_manager_split": (
+            SplitAutocastOp(),
+            _get_predispatch_module(SplitAutocastOp(), (x,)),
+            (x,),
+        ),
     }
 
 
@@ -257,12 +330,14 @@ class TestPasses(TestCase):
         super().setUp()
         self.SEQUENTIAL_SPLIT_INLINE_TESTS = _sequential_split_inline_tests()
         self.SET_GRAD_ENABLED_TESTS = _set_grad_enabled_tests()
+        self.WITH_AUTOCAST_TESTS = _with_autocast_tests()
 
         init_torchbind_implementations()
 
     def tearDown(self):
         self.SEQUENTIAL_SPLIT_INLINE_TESTS.clear()
         self.SET_GRAD_ENABLED_TESTS.clear()
+        self.WITH_AUTOCAST_TESTS.clear()
         super().tearDown()
 
     def test_runtime_assert_one_dim(self) -> None:
@@ -655,14 +730,15 @@ def forward(self, token, obj_attr, x):
         ep = torch.export.export(func, args=(x,))
         _ExportPassBaseDeprecatedDoNotUse()(ep.graph_module)
 
-    def test_predispatceh_set_grad(self):
+    def test_predispatch_set_grad(self):
         def _check_node_users_in_the_same_graph(gm):
             for node in gm.graph.nodes:
                 for user in node.users:
                     self.assertTrue(user.graph is gm.graph)
 
-        mod, args = self.SET_GRAD_ENABLED_TESTS["op"]
+        mod_orig, mod, args = self.SET_GRAD_ENABLED_TESTS["op"]
         _check_node_users_in_the_same_graph(mod)
+        self.assertEqual(mod_orig(*args), mod(*args))
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -673,13 +749,15 @@ def forward(self, x):
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     submod_4 = self.submod_2
     add_1 = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(False, submod_4, sum_1);  submod_4 = sum_1 = None
-    sub = torch.ops.aten.sub.Tensor(add_1, 1)
-    return pytree.tree_unflatten((add_1, sub), self._out_spec)
+    getitem = add_1[0];  add_1 = None
+    sub = torch.ops.aten.sub.Tensor(getitem, 1)
+    return pytree.tree_unflatten((getitem, sub), self._out_spec)
     """,
         )
 
-        mod, args = self.SET_GRAD_ENABLED_TESTS["op_under_no_grad"]
+        mod_orig, mod, args = self.SET_GRAD_ENABLED_TESTS["op_under_no_grad"]
         _check_node_users_in_the_same_graph(mod)
+        self.assertEqual(mod_orig(*args), mod(*args))
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -690,13 +768,15 @@ def forward(self, x):
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     submod_4 = self.submod_2
     add_1 = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(False, submod_4, sum_1);  submod_4 = sum_1 = None
-    sub = torch.ops.aten.sub.Tensor(add_1, 1)
-    return pytree.tree_unflatten((add_1, sub), self._out_spec)
+    getitem = add_1[0];  add_1 = None
+    sub = torch.ops.aten.sub.Tensor(getitem, 1)
+    return pytree.tree_unflatten((getitem, sub), self._out_spec)
     """,
         )
 
-        mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager"]
+        mod_orig, mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager"]
         _check_node_users_in_the_same_graph(mod)
+        self.assertEqual(mod_orig(*args), mod(*args))
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -707,13 +787,15 @@ def forward(self, x):
     sum_1 = torch.ops.aten.sum.default(sin);  sin = None
     submod_3 = self.submod_1
     add_1 = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(False, submod_3, sum_1);  submod_3 = sum_1 = None
-    sub = torch.ops.aten.sub.Tensor(add_1, 1)
-    return pytree.tree_unflatten((add_1, sub), self._out_spec)
+    getitem = add_1[0];  add_1 = None
+    sub = torch.ops.aten.sub.Tensor(getitem, 1)
+    return pytree.tree_unflatten((getitem, sub), self._out_spec)
     """,
         )
 
-        mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_under_no_grad"]
+        mod_orig, mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_under_no_grad"]
         _check_node_users_in_the_same_graph(mod)
+        self.assertEqual(mod_orig(*args), mod(*args))
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -722,15 +804,18 @@ def forward(self, x):
     add = torch.ops.aten.add.Tensor(x, 1);  x = None
     submod_5 = self.submod_1
     sum_1 = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(True, submod_5, add);  submod_5 = add = None
-    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
+    getitem = sum_1[0];  sum_1 = None
+    add_1 = torch.ops.aten.add.Tensor(getitem, 1);  getitem = None
     submod_6 = self.submod_3
     sub = torch._higher_order_ops.wrap.wrap_with_set_grad_enabled(True, submod_6, add_1);  submod_6 = None
-    return pytree.tree_unflatten((add_1, sub), self._out_spec)
+    getitem_1 = sub[0];  sub = None
+    return pytree.tree_unflatten((add_1, getitem_1), self._out_spec)
     """,
         )
 
-        mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_multi_dep"]
+        mod_orig, mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_multi_dep"]
         _check_node_users_in_the_same_graph(mod)
+        self.assertEqual(mod_orig(*args), mod(*args))
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -751,8 +836,11 @@ def forward(self, x):
     """,  # noqa: B950
         )
 
-        mod, args = self.SET_GRAD_ENABLED_TESTS["ctx_manager_multi_dep_no_grad"]
+        mod_orig, mod, args = self.SET_GRAD_ENABLED_TESTS[
+            "ctx_manager_multi_dep_no_grad"
+        ]
         _check_node_users_in_the_same_graph(mod)
+        self.assertEqual(mod_orig(*args), mod(*args))
         self.assertExpectedInline(
             mod.code.strip("\n"),
             """\
@@ -836,6 +924,158 @@ def forward(self, sin, cos):
     add_2 = torch.ops.aten.add.Tensor(sin, 1);  sin = None
     add_3 = torch.ops.aten.add.Tensor(cos, 1);  cos = None
     return (add_2, add_3)
+    """,
+        )
+
+    def test_predispatch_autocast(self):
+        def _check_node_users_in_the_same_graph(gm):
+            for node in gm.graph.nodes:
+                for user in node.users:
+                    self.assertTrue(user.graph is gm.graph)
+
+        mod_orig, mod, args = self.WITH_AUTOCAST_TESTS["ctx_manager"]
+        _check_node_users_in_the_same_graph(mod)
+        self.assertEqual(mod_orig(*args), mod(*args))
+        self.assertExpectedInline(
+            mod.code.strip("\n"),
+            """\
+def forward(self, x):
+    x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    submod_4 = self.submod_1
+    sum_1 = torch._higher_order_ops.wrap.wrap_with_autocast('cpu', None, True, None, submod_4, add);  submod_4 = add = None
+    getitem = sum_1[0];  sum_1 = None
+    submod_5 = self.submod_2
+    add_1 = torch._higher_order_ops.wrap.wrap_with_autocast('cpu', None, False, None, submod_5, getitem);  submod_5 = getitem = None
+    getitem_1 = add_1[0];  add_1 = None
+    submod_6 = self.submod_3
+    sub = torch._higher_order_ops.wrap.wrap_with_autocast('cpu', None, True, None, submod_6, getitem_1);  submod_6 = None
+    getitem_2 = sub[0];  sub = None
+    return pytree.tree_unflatten((getitem_1, getitem_2), self._out_spec)
+    """,
+        )
+
+        self.assertExpectedInline(
+            mod.submod_1.code.strip("\n"),
+            """\
+def forward(self, add):
+    sin = torch.ops.aten.sin.default(add);  add = None
+    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    return (sum_1,)
+    """,
+        )
+
+        self.assertExpectedInline(
+            mod.submod_2.code.strip("\n"),
+            """\
+def forward(self, sum_1):
+    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
+    return (add_1,)
+    """,
+        )
+
+        self.assertExpectedInline(
+            mod.submod_3.code.strip("\n"),
+            """\
+def forward(self, add_1):
+    sub = torch.ops.aten.sub.Tensor(add_1, 1);  add_1 = None
+    return (sub,)
+    """,
+        )
+
+        mod_orig, mod, args = self.WITH_AUTOCAST_TESTS["ctx_manager_multi_dep"]
+        _check_node_users_in_the_same_graph(mod)
+        self.assertEqual(mod_orig(*args), mod(*args))
+        self.assertExpectedInline(
+            mod.code.strip("\n"),
+            """\
+def forward(self, x):
+    x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    submod_4 = self.submod_1
+    wrap_with_autocast = torch._higher_order_ops.wrap.wrap_with_autocast('cpu', None, True, None, submod_4, add);  submod_4 = add = None
+    sum_1 = wrap_with_autocast[0]
+    sum_2 = wrap_with_autocast[1];  wrap_with_autocast = None
+    submod_5 = self.submod_2
+    wrap_with_autocast_1 = torch._higher_order_ops.wrap.wrap_with_autocast('cpu', None, False, None, submod_5, sum_1, sum_2);  submod_5 = sum_1 = sum_2 = None
+    add_1 = wrap_with_autocast_1[0]
+    add_2 = wrap_with_autocast_1[1];  wrap_with_autocast_1 = None
+    submod_6 = self.submod_3
+    wrap_with_autocast_2 = torch._higher_order_ops.wrap.wrap_with_autocast('cpu', None, True, None, submod_6, add_1, add_2);  submod_6 = None
+    sub = wrap_with_autocast_2[0]
+    sub_1 = wrap_with_autocast_2[1];  wrap_with_autocast_2 = None
+    return pytree.tree_unflatten((add_1, add_2, sub, sub_1), self._out_spec)
+    """,  # noqa: B950
+        )
+
+        self.assertExpectedInline(
+            mod.submod_1.code.strip("\n"),
+            """\
+def forward(self, add):
+    sin = torch.ops.aten.sin.default(add)
+    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    cos = torch.ops.aten.cos.default(add);  add = None
+    sum_2 = torch.ops.aten.sum.default(cos);  cos = None
+    return (sum_1, sum_2)
+    """,
+        )
+
+        self.assertExpectedInline(
+            mod.submod_2.code.strip("\n"),
+            """\
+def forward(self, sum_1, sum_2):
+    add_1 = torch.ops.aten.add.Tensor(sum_1, 1);  sum_1 = None
+    add_2 = torch.ops.aten.add.Tensor(sum_2, 1);  sum_2 = None
+    return (add_1, add_2)
+    """,
+        )
+
+        self.assertExpectedInline(
+            mod.submod_3.code.strip("\n"),
+            """\
+def forward(self, add_1, add_2):
+    sub = torch.ops.aten.sub.Tensor(add_1, 1);  add_1 = None
+    sub_1 = torch.ops.aten.sub.Tensor(add_2, 1);  add_2 = None
+    return (sub, sub_1)
+    """,
+        )
+
+        mod_orig, mod, args = self.WITH_AUTOCAST_TESTS["ctx_manager_split"]
+        _check_node_users_in_the_same_graph(mod)
+        self.assertEqual(mod_orig(*args), mod(*args))
+        self.assertExpectedInline(
+            mod.code.strip("\n"),
+            """\
+def forward(self, x):
+    x, = fx_pytree.tree_flatten_spec(([x], {}), self._in_spec)
+    add = torch.ops.aten.add.Tensor(x, 1);  x = None
+    submod_4 = self.submod_1
+    sum_1 = torch._higher_order_ops.wrap.wrap_with_autocast('cpu', None, True, None, submod_4, add);  submod_4 = add = None
+    getitem = sum_1[0];  sum_1 = None
+    add_1 = torch.ops.aten.add.Tensor(getitem, 1);  getitem = None
+    submod_5 = self.submod_3
+    sub = torch._higher_order_ops.wrap.wrap_with_autocast('cpu', None, True, None, submod_5, add_1);  submod_5 = None
+    getitem_1 = sub[0];  sub = None
+    return pytree.tree_unflatten((add_1, getitem_1), self._out_spec)
+    """,
+        )
+
+        self.assertExpectedInline(
+            mod.submod_1.code.strip("\n"),
+            """\
+def forward(self, add):
+    sin = torch.ops.aten.sin.default(add);  add = None
+    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    return (sum_1,)
+    """,
+        )
+
+        self.assertExpectedInline(
+            mod.submod_3.code.strip("\n"),
+            """\
+def forward(self, add_1):
+    sub = torch.ops.aten.sub.Tensor(add_1, 1);  add_1 = None
+    return (sub,)
     """,
         )
 

--- a/torch/_export/passes/replace_autocast_with_hop_pass.py
+++ b/torch/_export/passes/replace_autocast_with_hop_pass.py
@@ -1,0 +1,212 @@
+# mypy: allow-untyped-defs
+import contextlib
+import copy
+from typing import List
+
+import torch
+from torch._higher_order_ops.wrap import wrap_with_autocast
+
+from ..utils import node_inline_, nodes_filter, nodes_first, nodes_map, sequential_split
+from .replace_with_hop_pass_util import _replace_with_hop_helper
+
+
+def _is_autocast_node(node: torch.fx.Node):
+    return (
+        node
+        and node.op == "call_function"
+        and node.target
+        in [
+            torch.amp.autocast_mode._enter_autocast,
+            torch.amp.autocast_mode._exit_autocast,
+        ]
+    )
+
+
+def _is_enter_autocast_node(node: torch.fx.Node):
+    return (
+        node
+        and node.op == "call_function"
+        and node.target == torch.amp.autocast_mode._enter_autocast
+    )
+
+
+def _is_exit_autocast_node(node: torch.fx.Node):
+    return (
+        node
+        and node.op == "call_function"
+        and node.target == torch.amp.autocast_mode._exit_autocast
+    )
+
+
+def _is_autocast_sub_mod(node: torch.fx.Node):
+    """
+    Check if the first non-placeholder node is `torch.amp.autocast_mode._enter_autocast`.
+    """
+    if node.op == "call_module":
+        assert isinstance(node.target, str)
+        subgm = getattr(node.graph.owning_module, node.target)
+        first_non_ph = nodes_first(
+            subgm.graph.nodes, lambda node: node.op != "placeholder"
+        )
+        if (
+            first_non_ph
+            and first_non_ph.op == "call_function"
+            and first_non_ph.target == torch.amp.autocast_mode._enter_autocast
+        ):
+            # TODO: check if current auto-cast type is the same as the args of
+            # _enter_autocast. If so, return False, i.e. do not create a submodule.
+            return True
+    return False
+
+
+def _check_valid_autocast_block(enter_autocast_node, exit_autocast_node):
+    assert _is_enter_autocast_node(enter_autocast_node)
+    assert _is_exit_autocast_node(exit_autocast_node)
+    assert exit_autocast_node.args[0] == enter_autocast_node
+
+
+def _replace_with_hop(node: torch.fx.Node):
+    assert node.op == "call_module"
+    graph: torch.fx.Graph = node.graph
+    gm: torch.fx.GraphModule = graph.owning_module
+    assert isinstance(node.target, str)
+    sub_gm = getattr(gm, node.target)
+    sub_graph = sub_gm.graph
+    autocast_nodes = nodes_filter(sub_graph.nodes, _is_autocast_node)
+    if len(autocast_nodes) > 0:
+        assert len(autocast_nodes) > 1  # need at least an enter node and an exist node
+        enter_autocast_node = autocast_nodes[0]
+        exit_autocast_node = autocast_nodes[-1]
+        _check_valid_autocast_block(enter_autocast_node, exit_autocast_node)
+
+        _replace_with_hop_helper(
+            node, enter_autocast_node, _is_autocast_node, wrap_with_autocast
+        )
+        sub_graph.erase_node(exit_autocast_node)
+        sub_graph.erase_node(enter_autocast_node)
+
+
+def _split_autocast(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    """
+    split_autocast creates a new graph module that splits the input graph module into multiple submodules
+    based on the `_enter_autocast` and `_exit_autocast` nodes. It doesn't mutate the input graph module.
+
+    Nodes between the **outer-most** `_enter_autocast` and `_exit_autocast(_enter_autocast)` are splitted
+    into a submodule. Nested autocast regions are not splitted.
+    `_enter_autocast` and `_exit_autocast(_enter_autocast)` nodes are in the submodule as well.
+
+    Below is an example of splitting. A, B, C, D, E are blocks of non-autocast nodes in the original graph
+    module. Nodes marked with the same number are grouped into the same submodule.
+    A               # 0
+    enter_autocast  # 1
+    B               # 1
+    exit_autocast   # 1
+    C               # 2
+    enter_autocast  # 3
+    D               # 3
+    exit_autocast   # 3
+    E               # 4
+    """
+    enter_autocast_node_stack: List[torch.fx.Node] = []
+    first_node_after_outer_most_exit: bool = False
+
+    def node_call_back(node: torch.fx.Node):
+        nonlocal enter_autocast_node_stack, first_node_after_outer_most_exit
+        if first_node_after_outer_most_exit or (
+            len(enter_autocast_node_stack) == 0 and _is_enter_autocast_node(node)
+        ):
+            assert len(enter_autocast_node_stack) == 0
+            first_node_after_outer_most_exit = False
+            if _is_enter_autocast_node(node):
+                enter_autocast_node_stack.append(node)
+            return True
+        if _is_exit_autocast_node(node):
+            assert len(enter_autocast_node_stack) > 0
+            last_enter_autocast_node = enter_autocast_node_stack.pop()
+            assert node.args[0] == last_enter_autocast_node
+            if len(enter_autocast_node_stack) == 0:
+                # next node should be in the next submodule since
+                # autocast block ends
+                first_node_after_outer_most_exit = True
+        return False
+
+    return sequential_split(gm, node_call_back)
+
+
+def _sequential_split_and_maybe_inline_subgraphs(
+    gm: torch.fx.GraphModule, graph_signature
+):
+    """
+    Helper function for replace_autocast_with_hop_pass().
+    Split the graph module into multiple subgraphs based on the autocast nodes.
+    For each subgraph, decides whether to construct a HOO subgraph, or inline the calls
+    back into the parent graph module.
+    Nodes between `_enter_autocast` and `_exit_autocast(_enter_autocast)` are considered
+    as a subgraph.
+    """
+    need_replacing = any(_is_autocast_node(node) for node in gm.graph.nodes)
+    if not need_replacing:
+        return gm, graph_signature
+
+    # split_autocast returns a new graph module that could have different output
+    # args names. We need to fix the graph signature.
+    new_gm = _split_autocast(gm)
+
+    # TODO (shangdiy): can merge the block below with replace_set_grad_with_hop_pass.
+    replace_ctx = contextlib.nullcontext()
+    new_signature = None
+    if graph_signature is not None:
+        new_signature = copy.deepcopy(graph_signature)
+        new_gm_out_node = next(reversed(new_gm.graph.find_nodes(op="output")))
+        assert new_gm_out_node.op == "output" and len(new_gm_out_node.args[0]) == len(
+            new_signature.output_specs
+        )
+        for arg_node, out_spec in zip(
+            new_gm_out_node.args[0], new_signature.output_specs
+        ):
+            if arg_node is None:
+                assert out_spec.arg.value is None
+            elif out_spec.arg.name != arg_node.name:
+                out_spec.arg.name = arg_node.name
+
+        replace_ctx = new_gm._set_replace_hook(new_signature.get_replace_hook())  # type: ignore[assignment]
+
+    with replace_ctx:
+
+        def _maybe_inline_or_replace_with_hop(node: torch.fx.Node):
+            if _is_autocast_sub_mod(node):
+                _replace_with_hop(node)
+            else:
+                assert node.op == "call_module"
+                assert isinstance(node.target, str)
+                node_inline_(node)
+
+        nodes_map(
+            list(new_gm.graph.nodes),
+            lambda node: (
+                _maybe_inline_or_replace_with_hop(node)
+                if node.op == "call_module"
+                else node
+            ),
+        )
+    new_gm.recompile()
+    return new_gm, new_signature
+
+
+# TODO (shangdiy): can merge the block below with replace_set_grad_with_hop_pass.
+def replace_autocast_with_hop_pass(gm: torch.fx.GraphModule, graph_signature):
+    new_gm, new_signature = _sequential_split_and_maybe_inline_subgraphs(
+        gm, graph_signature
+    )
+    # recursively call
+    for node in new_gm.graph.nodes:
+        if node.op == "get_attr":
+            subgm = getattr(new_gm, node.target)
+            if not isinstance(subgm, torch.fx.GraphModule):
+                continue
+            new_subgm, _ = replace_autocast_with_hop_pass(subgm, None)
+            setattr(new_gm, node.target, new_subgm)
+
+    new_gm.recompile()
+    new_gm.graph.lint()
+    return new_gm, new_signature

--- a/torch/_export/passes/replace_set_grad_with_hop_pass.py
+++ b/torch/_export/passes/replace_set_grad_with_hop_pass.py
@@ -5,14 +5,8 @@ import copy
 import torch
 from torch._higher_order_ops.wrap import wrap_with_set_grad_enabled
 
-from ..utils import (
-    node_inline_,
-    node_replace_,
-    nodes_filter,
-    nodes_first,
-    nodes_map,
-    sequential_split,
-)
+from ..utils import node_inline_, nodes_filter, nodes_first, nodes_map, sequential_split
+from .replace_with_hop_pass_util import _replace_with_hop_helper
 
 
 def _is_set_grad_enabled_node(node: torch.fx.Node):
@@ -54,66 +48,9 @@ def _replace_with_hop(node: torch.fx.Node):
     if len(set_grad_nodes) > 0:
         assert len(set_grad_nodes) == 1
         set_grad_node = set_grad_nodes[0]
-        enable_grad_val = set_grad_node.args[0]
-        with graph.inserting_before(node):
-            get_attr_node = graph.get_attr(node.target)
-            get_attr_node.meta["nn_module_stack"] = copy.copy(
-                set_grad_node.meta.get("nn_module_stack", {})
-            )
-            output_node = next(iter(reversed(sub_gm.graph.nodes)), None)
-            # Split_module pass intentially doesn't add output node
-            # if the graph doesn't return anything.
-            # TODO (tmanlaibaatar) Figure out if this is right behaviour
-            # for split_module
-            if isinstance(output_node, torch.fx.Node) and output_node.op != "output":
-                output_node = None
-            if output_node is not None:
-                assert len(output_node.args) == 1
-                output_args = output_node.args[0]
-                if isinstance(output_args, (tuple, list)):
-                    call_func_node = graph.call_function(
-                        wrap_with_set_grad_enabled,
-                        (enable_grad_val, get_attr_node, *node.args),
-                        {},
-                    )
-                    # Create the metadata
-                    call_func_node.meta["val"] = tuple(
-                        arg.meta["val"] for arg in output_args
-                    )
-                    call_func_node.meta["nn_module_stack"] = copy.copy(
-                        set_grad_node.meta.get("nn_module_stack", {})
-                    )
-                    call_func_node.meta["torch_fn"] = (
-                        f"{wrap_with_set_grad_enabled.__name__}",
-                        f"{wrap_with_set_grad_enabled.__class__.__name__}.{wrap_with_set_grad_enabled.__name__}",
-                    )
-                    node_replace_(node, call_func_node, delete_old=True)
-
-                    # Rename the name of getitem nodes to the actual name of its contents
-                    # for passing verifier and better readability, also propagate metadata
-                    for get_item_node in call_func_node.users.keys():
-                        idx: int = get_item_node.args[1]
-                        output_node = output_args[idx]
-                        get_item_node._rename(output_node.name)
-                        get_item_node.meta = output_node.meta
-                        pass
-
-                elif isinstance(output_args, torch.fx.Node):
-                    call_func_node = graph.create_node(
-                        "call_function",
-                        wrap_with_set_grad_enabled,
-                        (enable_grad_val, get_attr_node, *node.args),
-                        {},
-                        output_args.name,
-                    )
-                    call_func_node.meta = output_args.meta
-                    node_replace_(node, call_func_node, delete_old=True)
-                else:
-                    raise NotImplementedError(
-                        f"repalce_set_grad_with_hop_pass doesnt' support output type {type(output_args)}"
-                    )
-            else:
-                node.graph.erase_node(node)
+        _replace_with_hop_helper(
+            node, set_grad_node, _is_set_grad_enabled_node, wrap_with_set_grad_enabled
+        )
         sub_graph.erase_node(set_grad_node)
 
 

--- a/torch/_export/passes/replace_with_hop_pass_util.py
+++ b/torch/_export/passes/replace_with_hop_pass_util.py
@@ -1,0 +1,99 @@
+# mypy: allow-untyped-defs
+
+import copy
+import operator
+from typing import Callable
+
+import torch
+from torch._ops import HigherOrderOperator
+
+from ..utils import node_replace_
+
+
+def _replace_with_hop_helper(
+    node: torch.fx.Node,
+    enter_block_node: torch.fx.Node,
+    node_filter: Callable,
+    wrap_hoo: HigherOrderOperator,
+):
+    graph: torch.fx.Graph = node.graph
+    gm: torch.fx.GraphModule = graph.owning_module
+    assert isinstance(node.target, str)
+    sub_gm = getattr(gm, node.target)
+
+    def set_hoo_node_meta(call_func_node):
+        call_func_node.meta["nn_module_stack"] = copy.copy(
+            enter_block_node.meta.get("nn_module_stack", {})
+        )
+        call_func_node.meta["torch_fn"] = (
+            f"{wrap_hoo.__name__}",
+            f"{wrap_hoo.__class__.__name__}.{wrap_hoo.__name__}",
+        )
+        if isinstance(output_args, (tuple, list)):
+            call_func_node.meta["val"] = tuple(arg.meta["val"] for arg in output_args)
+        elif isinstance(output_args, torch.fx.Node):
+            call_func_node.meta["val"] = (output_args.meta["val"],)
+
+    with graph.inserting_before(node):
+        get_attr_node = graph.get_attr(node.target)
+        get_attr_node.meta["nn_module_stack"] = copy.copy(
+            enter_block_node.meta.get("nn_module_stack", {})
+        )
+        output_node = next(iter(reversed(sub_gm.graph.nodes)), None)
+        # Split_module pass intentially doesn't add output node
+        # if the graph doesn't return anything.
+        # TODO (tmanlaibaatar) Figure out if this is right behaviour
+        # for split_module
+        if isinstance(output_node, torch.fx.Node) and output_node.op != "output":
+            output_node = None
+        if output_node is not None:
+            assert len(output_node.args) == 1
+            output_args = output_node.args[0]
+            enter_block_node_args = enter_block_node.args
+            if isinstance(output_args, (tuple, list)):
+                call_func_node = graph.call_function(
+                    wrap_hoo,
+                    (*enter_block_node_args, get_attr_node, *node.args),
+                    {},
+                )
+                # Create the metadata
+                set_hoo_node_meta(call_func_node)
+                node_replace_(node, call_func_node)
+
+                # Rename the name of getitem nodes to the actual name of its contents
+                # for passing verifier and better readability, also propagate metadata
+                for get_item_node in call_func_node.users.keys():
+                    idx: int = get_item_node.args[1]
+                    output_node = output_args[idx]
+                    get_item_node._rename(output_node.name)
+                    get_item_node.meta = output_node.meta
+                    pass
+
+            elif isinstance(output_args, torch.fx.Node):
+                call_func_node = graph.create_node(
+                    "call_function",
+                    wrap_hoo,
+                    (*enter_block_node_args, get_attr_node, *node.args),
+                    {},
+                    output_args.name,
+                )
+                # Modify the subgraph to output a singleton list.
+                output_node.args = ((output_args,),)
+                # Add in an extra `getitem(wrap_hoo, 0)` node to the toplevel graph.
+                get_item_node = graph.create_node(
+                    "call_function",
+                    operator.getitem,
+                    (call_func_node, 0),
+                    {},
+                )
+                # Create the metadata
+                get_item_node.meta = output_args.meta
+                set_hoo_node_meta(call_func_node)
+                node_replace_(node, get_item_node)
+            else:
+                raise NotImplementedError(
+                    f"repalce_with_hop_pass doesnt' support output type {type(output_args)}"
+                )
+        else:
+            # TODO (shangdiy): remove this line, since the export graph can be non-functional
+            node.graph.erase_node(node)

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -772,6 +772,9 @@ def _export_to_aten_ir(
     constants.update(lift_constants_pass(gm, export_graph_signature, constant_attrs))
 
     if pre_dispatch:
+        from torch._export.passes.replace_autocast_with_hop_pass import (
+            replace_autocast_with_hop_pass,
+        )
         from torch._export.passes.replace_set_grad_with_hop_pass import (
             replace_set_grad_with_hop_pass,
         )
@@ -782,6 +785,10 @@ def _export_to_aten_ir(
         # and the constant_tensor is passed as input of the set grad hop, the placeholder's
         # meta["val"] will be None and fails our verifier for placeholder.
         gm, export_graph_signature = replace_set_grad_with_hop_pass(
+            gm, export_graph_signature
+        )
+
+        gm, export_graph_signature = replace_autocast_with_hop_pass(
             gm, export_graph_signature
         )
 


### PR DESCRIPTION
Summary:
Reland of D60206382.

Suggested in https://github.com/pytorch/pytorch/issues/128394.

If there's an autocast context manager, the predispatch (strict) graph can look something like:

```
class <lambda>(torch.nn.Module):
    def forward(self, x: "f32[1]"):
        ...
        _enter_autocast = torch.amp.autocast_mode._enter_autocast('cuda', torch.bfloat16, True, None)
        mm: "f32[8, 8]" = torch.ops.aten.mm.default(rand, rand_1);  rand = rand_1 = None
        _exit_autocast = torch.amp.autocast_mode._exit_autocast(_enter_autocast);  _enter_autocast = None
        return (mm_1,)
```

But the operator `torch.amp.autocast_mode._enter_autocast` is not a valid ATen op. We remove these nodes by turning autocast into a higher order operator and make a submodule for the blocks between `_enter_autocast` and `_exit_autocast`.

Some potential followup improvement:
1) Merge some of the duplicated logic with `replace_set_grad_with_hop_pass.py`
2) Check the current autocast status (any enabled? dtype?) and not create a submodule if the autocast args matches current autocast status.

Test Plan:
CI

```
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export -- -r "test_predispatch_autocast"
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export -- -r "test_predispatch_set_grad"
```

Verified that now we can export the llama model in  gh issue 128394 and the gemma model in  gh issue 131829 without error.

Differential Revision: D60770038
