### PR TITLE
Fix issues in activation_memory_budget for float8

### DIFF
--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1290,6 +1290,7 @@ def get_default_op_list() -> OpTypes:
         aten._flash_attention_forward,
         aten._efficient_attention_forward,
         aten.upsample_bilinear2d,
+        aten._scaled_mm,
     ]  # noqa: E501,B950
 
     fusible_ops = recomputable_ops | set(random_ops)
@@ -1459,7 +1460,9 @@ def estimate_runtime(node):
                 return hint_int(d, fallback=4096)
 
             shape = [realize_symbol(s) for s in shape]
-            return x.meta["val"].new_zeros(shape)
+            return x.meta["val"].new_empty_strided(
+                shape, stride=x.meta["tensor_meta"].stride
+            )
         elif isinstance(x, fx.Node) and isinstance(x.meta["val"], torch.SymInt):
             return hint_int(x.meta["val"], fallback=4096)
         elif isinstance(x, fx.Node) and isinstance(x.meta["val"], torch.SymFloat):


### PR DESCRIPTION
Summary:
When using activation_memory_budget for float8 training, two issues were noticed:

- When `aggressive_options` (https://fburl.com/code/m1yoskxw) is called , all fp8 gemms (the scaled_mm op) are saved for recomputation.
- After adding "scaled_mm" in the `compute_intensive_ops`, we got the next error from `estimate_runtime`: `mat2 must be col_major` from `meta_scaled_mm`.
To fix it, modified `materialize_arg` to also include the stride of the original tensor.

Test Plan: Run float8 training with `activation_memory_budget`.

Differential Revision: D60777297
