### PR TITLE
Add `test_public_bindings` to merge rules for ONNX team

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -1,21 +1,24 @@
 - name: ONNX exporter
   patterns:
   - .ci/caffe2/*
-  - .ci/onnx/*
   - .ci/docker/common/install_onnx.sh
+  - .ci/onnx/*
   - aten/src/ATen/core/interned_strings.h
   - benchmarks/dynamo/**
+  - caffe2/python/onnx/**
+  - docs/source/_static/img/onnx/**
   - docs/source/onnx.rst
   - docs/source/onnx*
   - docs/source/scripts/onnx/**
-  - docs/source/_static/img/onnx/**
   - scripts/onnx/**
-  - test/onnx/**
   - test/onnx_caffe2/**
+  - test/onnx/**
+  - test/test_public_bindings.py
+  - third_party/onnx
   - tools/onnx/**
-  - torch/_dynamo/backends/onnxrt.py
   - torch/_C/__init__.pyi.in
   - torch/_C/_onnx.pyi
+  - torch/_dynamo/backends/onnxrt.py
   - torch/_logging/**
   - torch/csrc/jit/passes/onnx.*
   - torch/csrc/jit/passes/onnx/**
@@ -24,8 +27,6 @@
   - torch/csrc/onnx/**
   - torch/onnx/**
   - torch/testing/_internal/common_methods_invocations.py
-  - third_party/onnx
-  - caffe2/python/onnx/**
   approved_by:
   - justinchuby
   - liqunfu


### PR DESCRIPTION
The ONNX team is refactoring the torch.onnx exporter (e.g. https://github.com/pytorch/pytorch/pull/132530) and is introducing internal modules that have additional dependencies. We will only need to change the `private_allowlist` entries. They will not break importability of public modules as we will delay import internal modules that have these dependencies.
