### PR TITLE
[Quantizer] Fix Maxpool2d share q params

### DIFF
--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -76,7 +76,6 @@ def _supported_symmetric_quantized_operators() -> Dict[str, List[OperatorPattern
         ],
         "linear": [[torch.nn.Linear], [F.linear]],
         "add": [[torch.add]],
-        "max_pool2d": [[torch.nn.MaxPool2d], [F.max_pool2d]],
         "adaptive_avg_pool2d": [
             [torch.nn.AdaptiveAvgPool2d],
             [F.adaptive_avg_pool2d],
@@ -256,7 +255,6 @@ class XNNPACKQuantizer(Quantizer):
         "adaptive_avg_pool2d",
         # TODO: move this to BoltNNQuantizer?
         "gru_io_only",
-        "max_pool2d",
         "add_relu",
         "add",
         "mul_relu",

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
@@ -633,56 +633,6 @@ def _annotate_gru_io_only(
     return annotated_partitions
 
 
-@register_annotator("max_pool2d")
-def _annotate_max_pool2d(
-    gm: torch.fx.GraphModule,
-    quantization_config: Optional[QuantizationConfig],
-    filter_fn: Optional[Callable[[Node], bool]] = None,
-) -> Optional[List[List[Node]]]:
-    module_partitions = get_source_partitions(
-        gm.graph, [torch.nn.MaxPool2d, torch.nn.functional.max_pool2d], filter_fn
-    )
-    maxpool_partitions = list(itertools.chain.from_iterable(module_partitions.values()))
-    annotated_partitions = []
-    for maxpool_partition in maxpool_partitions:
-        annotated_partitions.append(maxpool_partition.nodes)
-        output_node = maxpool_partition.output_nodes[0]
-        maxpool_node = None
-        for n in maxpool_partition.nodes:
-            if n.target == torch.ops.aten.max_pool2d.default:
-                maxpool_node = n
-        assert (
-            maxpool_node is not None
-        ), "XNNPACKQuantizer only works with torch.ops.aten.max_pool2d.default, "
-        "please make sure you are exporting the model correctly"
-        if _is_annotated([output_node, maxpool_node]):  # type: ignore[list-item]
-            continue
-
-        input_act = maxpool_node.args[0]  # type: ignore[union-attr]
-        assert isinstance(input_act, Node)
-
-        # only annotate maxpool when the output of the input node is annotated
-        if (
-            "quantization_annotation" not in input_act.meta
-            or not input_act.meta["quantization_annotation"]._annotated
-            or input_act.meta["quantization_annotation"].output_qspec is None
-        ):
-            continue
-        # input and output of maxpool will share quantization parameter with input of maxpool
-        act_qspec = SharedQuantizationSpec(input_act)
-        # act_qspec = get_act_qspec(quantization_config)
-        maxpool_node.meta["quantization_annotation"] = QuantizationAnnotation(  # type: ignore[union-attr]
-            input_qspec_map={
-                input_act: act_qspec,
-            },
-            _annotated=True,
-        )
-        output_node.meta["quantization_annotation"] = QuantizationAnnotation(
-            output_qspec=act_qspec,
-            _annotated=True,
-        )
-    return annotated_partitions
-
 
 @register_annotator("adaptive_avg_pool2d")
 def _annotate_adaptive_avg_pool2d(
@@ -1049,6 +999,7 @@ def _is_share_obs_or_fq_op(op: Callable) -> bool:
     return op in [
         torch.ops.aten.hardtanh.default,
         torch.ops.aten.hardtanh_.default,
+        torch.ops.aten.max_pool2d.default,
         torch.ops.aten.mean.default,
         torch.ops.aten.mean.dim,
         torch.ops.aten.permute.default,

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
@@ -633,7 +633,6 @@ def _annotate_gru_io_only(
     return annotated_partitions
 
 
-
 @register_annotator("adaptive_avg_pool2d")
 def _annotate_adaptive_avg_pool2d(
     gm: torch.fx.GraphModule,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132705
* __->__ #132704

There seems to be a bug in the code for sharing q params for maxpool2d. This case occurs when output_node = maxpool_node. When this happens we overwrite the node's "quantization_annotation" metadata. This fix ensures that qparams are indeed shared across input and output

Differential Revision: [D60492341](https://our.internmc.facebook.com/intern/diff/D60492341/)