### PR TITLE
[Quantizer] Fix getattr for quantizing constants

### DIFF
--- a/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py
@@ -689,13 +689,10 @@ def _is_input_large_scalar(node: Node, gm: torch.fx.GraphModule):
     since histc op (in HistogramObserver) only works for values up to certain upper bound
     """
     if node.op == "get_attr":
-        if hasattr(gm, node.target):  # type: ignore[arg-type]
-            tensor = getattr(gm, node.target)  # type: ignore[arg-type]
-        else:
-            qualified_name = str(node.target)
-            module_path, _, name = qualified_name.rpartition(".")
-            submod = gm.get_submodule(module_path)
-            tensor = getattr(submod, name)
+        qualified_name = str(node.target)
+        module_path, _, name = qualified_name.rpartition(".")
+        submod = gm.get_submodule(module_path)
+        tensor = getattr(submod, name)
         # torch.histc works until this upper bound
         HISTC_UPPER_BOUND = 3.4028235e15
         return tensor.numel() == 1 and abs(tensor.item()) > HISTC_UPPER_BOUND


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132705
* #132704

Mobilebert quantization was failing because there were embedding constants that could not be accessed through getattr(). 


It seems that we have to search the submodule for the embeddings. Which we do here. This is just to help get around looking at unlifted attrs to check if they are large scalars

Differential Revision: [D60492338](https://our.internmc.facebook.com/intern/diff/D60492338/)