### PR TITLE
[export] Fix import in D60427208

### DIFF
--- a/torch/_export/db/logging.py
+++ b/torch/_export/db/logging.py
@@ -1,11 +1,11 @@
 # mypy: allow-untyped-defs
 
-from .examples import all_examples
-from torch._utils_internal import log_export_usage
-
-ALL_EXAMPLES = all_examples()
 
 def exportdb_error_message(case_name: str):
+    from .examples import all_examples
+    from torch._utils_internal import log_export_usage
+
+    ALL_EXAMPLES = all_examples()
     # Detect whether case_name is really registered in exportdb.
     if case_name in ALL_EXAMPLES:
         url_case_name = case_name.replace("_", "-")


### PR DESCRIPTION
Summary:
D60427208 broke APS release by failing our NE  deterministric test. https://www.internalfb.com/intern/test/562950111197340/

This Diff fixes it.

Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//aps_models/ads/gmp/tests/ne/e2e_deterministic_tests:gmp_e2e_ne_tests -- --filter-text test_mtml_instagram_model_474023725_single_gpu_with_ir
```

Differential Revision: D60790203
