### PR TITLE
[DeviceMesh] Create new group for 1D mesh when default backend is 'gloo' and 'cuda' is available

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -186,11 +186,11 @@ class DeviceMeshTest(DTensorTestBase):
 
     @with_comms
     def test_from_group_with_global_pg(self):
-        # Simple test: check `from_group` for a global PG vs. directly
+        # Simple test: check `from_group` from a mesh pg vs. directly
         # initializing via `init_device_mesh`
-        global_pg = _get_default_group()
-        ref_global_mesh = init_device_mesh("cuda", (self.world_size,))
-        global_mesh = DeviceMesh.from_group(global_pg, "cuda")
+        ref_global_mesh = init_device_mesh(self.device_type, (self.world_size,))
+        mesh_pg = ref_global_mesh.get_group()
+        global_mesh = DeviceMesh.from_group(mesh_pg, self.device_type)
         self.assertEqual(ref_global_mesh, global_mesh)
         self.assertEqual(ref_global_mesh._dim_group_infos, global_mesh._dim_group_infos)
         self.assertEqual(

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -50,6 +50,20 @@ def _set_env_var(addr="localhost", port="25364", world_size=1, rank=0):
     os.environ["RANK"] = f"{rank}"
 
 
+class DeviceMeshTestGlooBackend(DTensorTestBase):
+    @property
+    def backend(self):
+        return "gloo"
+
+    @with_comms
+    def test_device_mesh_reuse_default_group(self):
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        if torch.cuda.is_available():
+            self.assertNotEqual(mesh.get_group(), _get_default_group())
+        else:
+            self.assertEqual(mesh.get_group(), _get_default_group())
+
+
 class DeviceMeshTest(DTensorTestBase):
     @property
     def world_size(self):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -58,10 +58,13 @@ class DeviceMeshTestGlooBackend(DTensorTestBase):
     @with_comms
     def test_device_mesh_reuse_default_group(self):
         mesh = init_device_mesh(self.device_type, (self.world_size,))
+        mesh_group = mesh.get_group()
+        default_group = _get_default_group()
         if torch.cuda.is_available():
-            self.assertNotEqual(mesh.get_group(), _get_default_group())
+            self.assertNotEqual(mesh_group, default_group)
+            self.assertEqual(get_world_size(mesh_group), get_world_size(default_group))
         else:
-            self.assertEqual(mesh.get_group(), _get_default_group())
+            self.assertEqual(mesh_group, default_group)
 
 
 class DeviceMeshTest(DTensorTestBase):

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -308,8 +308,7 @@ else:
                 ranks = list(range(get_world_size()))
                 dim_group = (
                     new_group(backend="cpu:gloo,cuda:nccl", ranks=ranks)
-                    if self.device_type == "cuda"
-                    and torch.cuda.is_available()
+                    if torch.cuda.is_available()
                     and get_backend(default_group) == "gloo"
                     else default_group
                 )

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -309,6 +309,7 @@ else:
                 dim_group = (
                     new_group(backend="cpu:gloo,cuda:nccl", ranks=ranks)
                     if self.device_type == "cuda"
+                    and torch.cuda.is_available()
                     and get_backend(default_group) == "gloo"
                     else default_group
                 )

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -10323,7 +10323,6 @@ class DistributedTest:
             model = TwoLinLayerNet().cuda()
             ddp_model = torch.nn.parallel.DistributedDataParallel(model, device_mesh=device_mesh)
             self.assertEqual(ddp_model.device_mesh, device_mesh)
-            self.assertEqual(ddp_model.device_mesh.get_group(mesh_dim=0), pg)
 
             with self.assertRaisesRegex(
                 RuntimeError, "Cannot specify both process_group and device_mesh arguments."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132709

More context in [#132471](https://github.com/pytorch/pytorch/issues/132471) and https://github.com/pytorch/pytorch/issues/132366. 

TLDR:
When cuda is available and users move tensors to cuda, we cannot really reuse the default pg if default pg is gloo, as lots of collectives are not supported on gloo for cuda tensors. For example, `dtensor.full_tensor()` would result in a mysterious SIGTERM when all_gather a cuda tensor using gloo. Without the change in this PR, users would have to know the context and explicitly move the cuda tensor to cpu before invoking most collectives, which I think is not so ideal UX. 

Therefore, given most collectives are not supported on gloo for cuda tensors, we should init a new pg if the default pg is gloo when torch.cuda.is_available() and device_type is cuda. 
 
cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l