### PR TITLE
[profiler] Only parse kineto requests and build tree when required

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -509,6 +509,9 @@ class TestProfiler(TestCase):
         # rerun to avoid initial start overhead
         with _profile(use_cuda=use_cuda, use_kineto=True) as p:
             self.payload(use_cuda=use_cuda)
+
+        self.assertTrue("aten::mm" in str(p))
+
         output = p.key_averages().table(
             sort_by="self_cuda_time_total" if use_cuda else "self_cpu_time_total",
             row_limit=-1,
@@ -1856,6 +1859,7 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
             for i in range(100):
                 torch.add(1, 2)
                 prof.step()
+        # print(prof.key_averages())
         for ev in prof.key_averages():
             if ev.key == "aten::add":
                 return ev.count

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -224,8 +224,11 @@ class profile:
             self.use_device: Optional[str] = "cuda"
         else:
             self.use_device = use_device
-        # TODO Consider changing function_events into data structure with size cap
-        self.function_events: Optional[EventList] = None
+        # TODO Consider changing _function_events into data structure with size cap
+        self._function_events: Optional[EventList] = None
+        self._old_function_events: Optional[EventList] = None
+        # Function event processing is done lazily
+        self._needs_processing = False
         self.entered = False
         self.record_shapes = record_shapes
         self.with_flops = with_flops
@@ -346,9 +349,10 @@ class profile:
             if hasattr(device_module, "synchronize"):
                 device_module.synchronize()
 
-        old_function_events: Optional[EventList] = None
-        if self.function_events and self.acc_events:
-            old_function_events = self.function_events
+        if self._function_events and self.acc_events:
+            self._old_function_events = self._function_events
+        self._function_events = None
+        self._needs_processing = True
 
         t0 = perf_counter_ns()
 
@@ -358,45 +362,69 @@ class profile:
         self.profiling_end_time_ns = t0
 
         _run_on_profiler_stop()
+
+        self._stats.profiling_window_duration_sec = (
+            (self.profiling_end_time_ns - self.profiling_start_time_ns) * 1.0 / 1e9
+        )
+
+        # If we plan to accumulate events we should post process the function events
+        # right away to retain the state across mulitple start/stop calls
+        if self.acc_events:
+            self._ensure_function_events()
+        return False
+
+    def __repr__(self):
+        if self._needs_processing:
+            self._ensure_function_events()
+        if self._function_events is None:
+            return "<unfinished torch.autograd.profile>"
+        return repr(self._function_events)
+
+    def __str__(self):
+        if self._needs_processing:
+            self._ensure_function_events()
+        if self._function_events is None:
+            return "<unfinished torch.autograd.profile>"
+        return str(self._function_events)
+
+    def _ensure_function_events(self):
+        """Process function events lazily if required"""
+        if self._function_events is not None:
+            return
+        self._needs_processing = False
+
         t0 = perf_counter_ns()
-        parsed_results = self._parse_kineto_results(self.kineto_results)
+        parsed_results = []
+        if self.kineto_results:
+            parsed_results = self._parse_kineto_results(self.kineto_results)
         t1 = perf_counter_ns()
         self._stats.parse_kineto_call_duration_us = int((t1 - t0) / 1000)
 
-        self.function_events = EventList(
+        self._function_events = EventList(
             parsed_results,
             use_device=self.use_device,
             profile_memory=self.profile_memory,
             with_flops=self.with_flops,
         )
         t0 = perf_counter_ns()
-        self.function_events._build_tree()
+        self._function_events._build_tree()
         t1 = perf_counter_ns()
         self._stats.function_events_build_tree_call_duration_us = int((t1 - t0) / 1000)
+        self._stats.number_of_events = len(self._function_events)
 
-        self._stats.number_of_events = len(self.function_events)
-        self._stats.profiling_window_duration_sec = (
-            (self.profiling_end_time_ns - self.profiling_start_time_ns) * 1.0 / 1e9
-        )
+        if self._old_function_events and self.acc_events:
+            for evt in self._old_function_events:
+                self._function_events.append(evt)
+            self._old_function_events = None
 
-        if old_function_events:
-            for evt in old_function_events:
-                self.function_events.append(evt)
-        return False
-
-    def __repr__(self):
-        if self.function_events is None:
-            return "<unfinished torch.autograd.profile>"
-        return repr(self.function_events)
-
-    def __str__(self):
-        if self.function_events is None:
-            return "<unfinished torch.autograd.profile>"
-        return str(self.function_events)
-
-    def _check_finish(self):
-        if self.function_events is None:
+        if self._function_events is None:
             raise RuntimeError("Profiler didn't finish running")
+
+    @property
+    def function_events(self):
+        if self._function_events is None or self._needs_processing:
+            self._ensure_function_events()
+        return self._function_events
 
     def table(
         self,
@@ -408,9 +436,9 @@ class profile:
         header=None,
         top_level_events_only=False,
     ):
-        self._check_finish()
-        assert self.function_events is not None
-        return self.function_events.table(
+        self._ensure_function_events()
+        assert self._function_events is not None
+        return self._function_events.table(
             sort_by=sort_by,
             row_limit=row_limit,
             max_src_column_width=max_src_column_width,
@@ -427,19 +455,19 @@ class profile:
         Exports the collected trace in Chrome JSON format. If kineto is enabled, only
         last cycle in schedule is exported.
         """
-        self._check_finish()
         if kineto_available():
             self.kineto_results.save(path)  # type: ignore[union-attr]
         else:
-            return self.function_events.export_chrome_trace(path)  # type: ignore[union-attr]
+            self._ensure_function_events()
+            return self._function_events.export_chrome_trace(path)  # type: ignore[union-attr]
 
     export_chrome_trace.__doc__ = EventList.export_chrome_trace.__doc__
 
     def export_stacks(self, path: str, metric: str = "self_cpu_time_total"):
-        self._check_finish()
-        assert self.function_events is not None, "Expected profiling results"
+        self._ensure_function_events()
+        assert self._function_events is not None, "Expected profiling results"
         assert self.with_stack, "export_stacks() requires with_stack=True"
-        return self.function_events.export_stacks(path, metric)
+        return self._function_events.export_stacks(path, metric)
 
     def toggle_collection_dynamic(
         self, enabled: bool, activities: Iterable[ProfilerActivity]
@@ -450,16 +478,18 @@ class profile:
         return _toggle_collection_dynamic(enabled, set(activities))
 
     def key_averages(self, group_by_input_shape=False, group_by_stack_n=0):
-        self._check_finish()
-        assert self.function_events is not None, "Expected profiling results"
-        return self.function_events.key_averages(group_by_input_shape, group_by_stack_n)
+        self._ensure_function_events()
+        assert self._function_events is not None, "Expected profiling results"
+        return self._function_events.key_averages(
+            group_by_input_shape, group_by_stack_n
+        )
 
     key_averages.__doc__ = EventList.key_averages.__doc__
 
     def total_average(self):
-        self._check_finish()
-        assert self.function_events is not None, "Expected profiling results"
-        return self.function_events.total_average()
+        self._ensure_function_events()
+        assert self._function_events is not None, "Expected profiling results"
+        return self._function_events.total_average()
 
     total_average.__doc__ = EventList.total_average.__doc__
 
@@ -469,9 +499,9 @@ class profile:
 
         The total time is a sum of all self times across all the events.
         """
-        self._check_finish()
-        assert self.function_events is not None
-        return self.function_events.self_cpu_time_total
+        self._ensure_function_events()
+        assert self._function_events is not None
+        return self._function_events.self_cpu_time_total
 
     def _parse_kineto_results(self, result: _ProfilerResult):
         # result.events() has most of the events - PyTorch op-level and device-level events


### PR DESCRIPTION
To avoid high overheads of constructing datastructure in python when the user is simply saving trace to a file, we only process things lazily.

## Details
1. Delay function event parsing, add a flag to denote when needed.
1. Make profiler.function_events a computed property so code using `prof.function_events` does not need to change.
1. Fix coverage for `str(prof)` in profiler tests.

## Test run
Test program
```
import torch
from torch.profiler import profile, record_function, ProfilerActivity


def payload(use_cuda=False):
    x = torch.randn(10, 10)
    if use_cuda:
        x = x.cuda()
    y = torch.randn(10, 10)
    if use_cuda:
        y = y.cuda()
    z = torch.mm(x, y)
    z = z + y
    if use_cuda:
        z = z.cpu()

with profile(activities=[ProfilerActivity.CPU], record_shapes=True) as prof:
    with record_function("model_inference"):
        payload()

prof.export_chrome_trace("/tmp/test_trace.json")
#print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=10))
```

The print "this is computing events" will happen lazily.

```
>]$ python3 profiler_test.py
Brian: this is computing function events
----------------------  ------------  ------------  ------------  ------------  ------------  ------------
                  Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
----------------------  ------------  ------------  ------------  ------------  ------------  ------------
       model_inference         6.77%     441.628us       100.00%       6.523ms       6.523ms             1
           aten::randn         1.86%     121.108us        46.93%       3.061ms       1.530ms             2
              aten::mm        45.36%       2.959ms        45.44%       2.964ms       2.964ms             1
         aten::normal_        44.72%       2.917ms        44.72%       2.917ms       1.458ms             2
             aten::add         0.87%      56.646us         0.87%      56.646us      56.646us             1
           aten::empty         0.35%      22.808us         0.35%      22.808us      11.404us             2
    aten::resolve_conj         0.08%       5.173us         0.08%       5.173us       1.724us             3
----------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 6.523ms

$> python3 profiler_test.py
(pytorch) [bcoutinho@devgpu038.ftw6 /data/users/bcoutinho/pytorch (profiler_optimize_parsing)]$
$>ls -a profiler_test.py
$> ls -l /tmp/test_trace.json
-rw-r--r-- 1 bcoutinho users 16471 Aug  5 16:10 /tmp/test_trace.json
```
## Unit test
Updates some tests and they all pass now.
`pytest test/profiler/test_profiler.py`

Also 
`python test/test_autograd.py TestAutogradWithCompiledAutograd.test_record_function`