### PR TITLE
Added dist utility API to get backend from a device object

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -278,11 +278,11 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
     @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 1 GPU")
     @skip_if_lt_x_gpu(1)
-    def test_nccl_dist_backend_error(self):
-        current_device = torch.device('cuda')
+    def test_nccl_dist_backend_str_error(self):
+        current_device = torch.device("cuda")
         tensor_ = torch.randn(5, device=current_device)
         backend = dist.get_backend_from_device(tensor_.device)
-        assert (backend == 'nccl')
+        assert backend == "nccl"
 
 
     @requires_nccl()

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -276,6 +276,16 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         self.assertIsInstance(cm.exception, RuntimeError)
 
     @requires_nccl()
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 1 GPU")
+    @skip_if_lt_x_gpu(1)
+    def test_nccl_dist_backend_error(self):
+        current_device = torch.device('cuda:2')
+        tensor_ = torch.randn(5, device=current_device)
+        backend = dist.get_backend_from_device(tensor_.device)
+        assert (backend == 'nccl')
+
+
+    @requires_nccl()
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_abort_pg(self):
         # Disable ASYNC_ERROR_HANDLING for this test to ensure we can programmatically

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -279,7 +279,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 1 GPU")
     @skip_if_lt_x_gpu(1)
     def test_nccl_dist_backend_error(self):
-        current_device = torch.device('cuda:2')
+        current_device = torch.device('cuda')
         tensor_ = torch.randn(5, device=current_device)
         backend = dist.get_backend_from_device(tensor_.device)
         assert (backend == 'nccl')

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -289,7 +289,7 @@ class Backend(str):
         tensor_ = torch.randn(5, device=current_device)
         get_backend_from_device(tensor_.device) -> returns 'nccl'
         """
-        return Backend.default_device_backend_map[device.type] if device.type in Backend.default_device_backend_map else "Unknown device type"
+        return Backend.default_device_backend_map.get(device.type, "Unknown device type")
 
 
     @classmethod

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -289,7 +289,9 @@ class Backend(str):
         tensor_ = torch.randn(5, device=current_device)
         get_backend_from_device(tensor_.device) -> returns 'nccl'
         """
-        return Backend.default_device_backend_map.get(device.type, "Unknown device type")
+        return Backend.default_device_backend_map.get(
+            device.type, "Unknown device type"
+        )
 
 
     @classmethod

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -223,7 +223,7 @@ def supports_complex(reduceOp: ReduceOp) -> bool:
     eg. DDP based Multi Process Test cases, Mesh() etc.
 
     current_device = torch.device('cuda:0')
-    torch.randn(5, device=current_device)
+    tensor_ = torch.randn(5, device=current_device)
     get_backend_from_device(tensor_.device) -> returns 'nccl'
 '''
 def get_backend_from_device(device) -> str:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -217,6 +217,24 @@ def supports_complex(reduceOp: ReduceOp) -> bool:
     ]
     return reduceOp not in denyList
 
+'''
+    A utility function to get backend name string from a device object.
+    This API get handy in generalizing code flows.
+    eg. DDP based Multi Process Test cases, Mesh() etc.
+
+    current_device = torch.device('cuda:0')
+    tensor_ = torch.randn(5, device=cuda_device)
+    backend = get_backend_from_device(tensor_.device)
+                returns 'nccl'
+'''
+def get_backend_from_device(device) -> str:
+    if "cuda" in device:
+        return "nccl"
+    elif "hpu" in device:
+        return "hccl"
+    else :
+        return "gloo"
+
 
 class Backend(str):
     """

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -223,14 +223,13 @@ def supports_complex(reduceOp: ReduceOp) -> bool:
     eg. DDP based Multi Process Test cases, Mesh() etc.
 
     current_device = torch.device('cuda:0')
-    tensor_ = torch.randn(5, device=cuda_device)
-    backend = get_backend_from_device(tensor_.device)
-                returns 'nccl'
+    torch.randn(5, device=current_device)
+    get_backend_from_device(tensor_.device) -> returns 'nccl'
 '''
 def get_backend_from_device(device) -> str:
-    if "cuda" in device:
+    if device.type == "cuda":
         return "nccl"
-    elif "hpu" in device:
+    elif device.type == "hpu":
         return "hccl"
     else :
         return "gloo"

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -217,7 +217,9 @@ def supports_complex(reduceOp: ReduceOp) -> bool:
     ]
     return reduceOp not in denyList
 
-'''
+
+def get_backend_from_device(device) -> str:
+    """
     A utility function to get backend name string from a device object.
     This API get handy in generalizing code flows.
     eg. DDP based Multi Process Test cases, Mesh() etc.
@@ -225,8 +227,9 @@ def supports_complex(reduceOp: ReduceOp) -> bool:
     current_device = torch.device('cuda:0')
     tensor_ = torch.randn(5, device=current_device)
     get_backend_from_device(tensor_.device) -> returns 'nccl'
-'''
-def get_backend_from_device(device) -> str:
+
+    """
+
     if device.type == "cuda":
         return "nccl"
     elif device.type == "hpu":

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -218,26 +218,6 @@ def supports_complex(reduceOp: ReduceOp) -> bool:
     return reduceOp not in denyList
 
 
-def get_backend_from_device(device) -> str:
-    """
-    A utility function to get backend name string from a device object.
-    This API get handy in generalizing code flows.
-    eg. DDP based Multi Process Test cases, Mesh() etc.
-
-    current_device = torch.device('cuda:0')
-    tensor_ = torch.randn(5, device=current_device)
-    get_backend_from_device(tensor_.device) -> returns 'nccl'
-
-    """
-
-    if device.type == "cuda":
-        return "nccl"
-    elif device.type == "hpu":
-        return "hccl"
-    else :
-        return "gloo"
-
-
 class Backend(str):
     """
     An enum-like class for backends.
@@ -297,6 +277,20 @@ class Backend(str):
         if value == Backend.UNDEFINED:
             value = name.lower()
         return value
+
+    @staticmethod
+    def get_default_backend(device) -> str:
+        """
+        A utility function to get backend name string from a device object.
+        This API get handy in generalizing code flows.
+        eg. DDP based Multi Process Test cases, Mesh() etc.
+
+        current_device = torch.device('cuda:0')
+        tensor_ = torch.randn(5, device=current_device)
+        get_backend_from_device(tensor_.device) -> returns 'nccl'
+        """
+        return Backend.default_device_backend_map[device.type] if device.type in Backend.default_device_backend_map else "Unknown device type"
+
 
     @classmethod
     def register_backend(


### PR DESCRIPTION
Added a utility API to get backend comm string from a device object.
get_backend_from_device() API get handy in generalizing code flows.
    eg. DDP based Multi Process Test cases, Mesh() etc.

    current_device = torch.device('cuda:0')
    tensor_ = torch.randn(5, device=current_device )
    backend = get_backend_from_device(tensor_.device)
                returns 'nccl'

Resolving suggestion from
https://github.com/pytorch/pytorch/pull/131758#discussion_r1698347333

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o