### PR TITLE
Let torch.cpu.current_device() return the device index

### DIFF
--- a/torch/cpu/__init__.py
+++ b/torch/cpu/__init__.py
@@ -171,9 +171,9 @@ def set_device(device: _device_t) -> None:
     """
 
 
-def current_device() -> str:
-    r"""Returns current device for cpu. Always 'cpu'.
+def current_device() -> int:
+    r"""Returns current device for cpu. Always 0.
 
     N.B. This function only exists to facilitate device-agnostic code
     """
-    return "cpu"
+    return 0

--- a/torch/distributed/checkpoint/optimizer.py
+++ b/torch/distributed/checkpoint/optimizer.py
@@ -99,12 +99,7 @@ def _is_nested_tensor(val: torch.Tensor) -> bool:
 def _alloc_tensor(
     props: TensorProperties, size: Sequence[int], device_type: str = "cuda"
 ) -> torch.Tensor:
-    if device_type == "cpu":
-        device = cast(torch.device, _get_device_module(device_type).current_device())
-    else:
-        device = torch.device(
-            device_type, _get_device_module(device_type).current_device()
-        )
+    device = torch.device(device_type, _get_device_module(device_type).current_device())
 
     return torch.empty(
         size=size,


### PR DESCRIPTION
Summary: Change the torch.cpu.current_device() behavior to return device index instead of string. (align with torch.cuda.current_device()).

Test Plan: OSS CIs.

Differential Revision: D60803063


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn