### PR TITLE
fix dtype mismatch in lobpcg eigen solver

### DIFF
--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -787,7 +787,10 @@ class LOBPCG:
             torch.norm(R, 2, (0,))
             * (torch.norm(X, 2, (0,)) * (A_norm + E[: X.shape[-1]] * B_norm)) ** -1
         )
-        converged = rerr < tol
+        if rerr.is_complex:
+            converged = rerr.real < tol  # this is a norm so imag is 0.0
+        else:
+            converged = rerr < tol
         count = 0
         for b in converged:
             if not b:

--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -787,10 +787,7 @@ class LOBPCG:
             torch.norm(R, 2, (0,))
             * (torch.norm(X, 2, (0,)) * (A_norm + E[: X.shape[-1]] * B_norm)) ** -1
         )
-        if rerr.is_complex:
-            converged = rerr.real < tol  # this is a norm so imag is 0.0
-        else:
-            converged = rerr < tol
+        converged = rerr.real < tol  # this is a norm so imag is 0.0
         count = 0
         for b in converged:
             if not b:


### PR DESCRIPTION
Fixes #132761

If rerr value is_complex, test against the real part. Since the rerr variable holds a norm calculation, the imaginary part will be 0.0.
