### PR TITLE
[export][fx] More robust DCE pass

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -560,6 +560,9 @@ class X86InductorQuantTestCase(QuantizationTestCase):
         m = prepare_qat_pt2e(m, quantizer) if is_qat else prepare_pt2e(m, quantizer)
         # Calibrate
         m(*example_inputs)
+        torch._export.utils.remove_proxy_from_state_dict(
+            m.__dict__["_buffers"], in_place=True
+        )
         prepare_model = copy.deepcopy(m)
         m = convert_pt2e(m)
         convert_model = copy.deepcopy(m)

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -42,8 +42,8 @@ from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.fx.experimental import symbolic_shapes
 from torch.utils import _pytree as pytree
 from torch.utils._pytree import treespec_dumps, treespec_loads
-from torch.utils._sympy.value_ranges import ValueRanges
 from torch.utils._sympy.numbers import int_oo
+from torch.utils._sympy.value_ranges import ValueRanges
 
 from .schema import (  # type: ignore[attr-defined]
     Argument,
@@ -93,7 +93,7 @@ from .schema import (  # type: ignore[attr-defined]
     UserOutputSpec,
 )
 from .union import _Union
-
+from ..utils import remove_proxy_from_state_dict
 
 __all__ = [
     "serialize",
@@ -1400,9 +1400,13 @@ class ExportedProgramSerializer(metaclass=Final):
         # Test canonical form is well defined.
         canonicalize(serialized_ep)
 
+        # Proxy cannot be dumped, so we remove them.
+        new_state_dict = remove_proxy_from_state_dict(
+            exported_program.state_dict, in_place=False
+        )
         return _SerializedProgram(
             serialized_ep,
-            serialize_torch_artifact(exported_program.state_dict),
+            serialize_torch_artifact(new_state_dict),
             serialize_torch_artifact(constants),
             serialize_torch_artifact(exported_program.example_inputs),
         )

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -612,3 +612,24 @@ def placeholder_naming_pass(
             ):
                 constants[new_name] = constant
                 del constants[name]
+
+
+def remove_proxy_from_state_dict(state_dict: Dict, in_place: bool) -> Dict:
+    """
+    If `in_place` is false, remove a new copy of `state_dict` with "proxy" removed from `v.__dict__`.
+    `v` is the values in the dictionary.
+    If `in_place` is true, modify `state_dict` in place.
+    """
+    if in_place:
+        for k, v in state_dict.items():
+            if "proxy" in v.__dict__:
+                state_dict[k] = v.clone().detach()
+        return state_dict
+    else:
+        new_state_dict = {}
+        for k, v in state_dict.items():
+            if "proxy" in v.__dict__:
+                new_state_dict[k] = v.clone().detach()
+            else:
+                new_state_dict[k] = v
+        return new_state_dict

--- a/torch/export/_remove_effect_tokens_pass.py
+++ b/torch/export/_remove_effect_tokens_pass.py
@@ -16,20 +16,6 @@ from .graph_signature import (
 )
 
 
-def _is_impure_node(node: torch.fx.Node) -> bool:
-    """
-    Check the schema of node target to detect side-effectful nodes.
-    """
-    if node.is_impure():
-        return True
-
-    if node.op == "call_function":
-        schema = getattr(node.target, "_schema", None)
-        schema_mutable = schema is not None and schema.is_mutable
-        return schema_mutable
-    return False
-
-
 def _remove_effect_tokens_from_graph_helper(
     ep, num_tokens, input_token_names, output_token_names
 ):
@@ -129,7 +115,7 @@ def _remove_effect_tokens_from_graph_helper(
         assert inp_token.name in input_token_names
         ep.graph.erase_node(inp_token)
 
-    ep.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
+    ep.graph.eliminate_dead_code()
 
 
 def _remove_effect_tokens(ep: ExportedProgram) -> ExportedProgram:

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -49,7 +49,6 @@ from torch._guards import detect_fake_mode
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._utils_internal import log_export_usage
-from torch.export._remove_effect_tokens_pass import _is_impure_node
 from torch.export.dynamic_shapes import _combine_args
 from torch.export.exported_program import OutputKind
 from torch.fx._utils import first_call_function_nn_module_stack
@@ -1531,7 +1530,7 @@ def _export_to_aten_ir_make_fx(
                 record_module_stack=True,
                 pre_dispatch=True,
             )(*flat_args)
-            gm.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
+            gm.graph.eliminate_dead_code()
 
         return gm, None
 

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -9,7 +9,7 @@ from torch._export.utils import _check_input_constraints_for_graph
 from torch.export.unflatten import _assign_attr, _AttrKind
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 
-from ._remove_effect_tokens_pass import _is_impure_node, _remove_effect_tokens
+from ._remove_effect_tokens_pass import _remove_effect_tokens
 from .exported_program import (
     ExportedProgram,
     ExportGraphSignature,
@@ -185,7 +185,7 @@ def _unlift(
     )
     gm.graph._codegen = _get_codegen(in_spec, out_spec, forward_arg_names)
     gm.graph.lint()
-    gm.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
+    gm.graph.eliminate_dead_code()
     gm.recompile()
     return gm
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -47,9 +47,6 @@ _side_effectful_functions: Set[Callable] = {
     torch._assert_async,
     _ops.aten._assert_async.msg,
     _ops.aten._assert_scalar.default,
-    _ops.aten.copy_.default,
-    _ops.aten.set_.source_Tensor,
-    _ops.aten.index_put_.default,
     _ops.aten.sym_constrain_range.default,
     _ops.aten.sym_constrain_range_for_size.default,
     _ops.profiler._record_function_enter,
@@ -650,9 +647,11 @@ class Node(_NodeBase):
         if self.op in {"placeholder", "output"}:
             return True
 
-        # Check if an impure function.
+        # Check if an impure function based on schema.
         if self.op == "call_function":
-            return self.target in _side_effectful_functions
+            schema = getattr(self.target, "_schema", None)
+            schema_mutable = schema is not None and schema.is_mutable
+            return schema_mutable or self.target in _side_effectful_functions
 
         # Check if an impure module.
         if self.op == "call_module":

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -398,6 +398,25 @@ class Proxy:
         # we peephole optimize to the method invocation
         return Attribute(self, k)
 
+    def __getstate__(self) -> Dict:
+        raise NotImplementedError(
+            """__getstate__ not implemented for Proxy. """
+            """Proxy is created for {self.node.name}, {self.node.target}. Please remove "proxy" from __dict__."""
+        )
+
+    def __deepcopy__(self, memo) -> Dict:
+        raise NotImplementedError(
+            """__deepcopy__ not implemented for Proxy. """
+            """Proxy is created for {self.node.name}, {self.node.target}. Please remove "proxy" from __dict__."""
+        )
+
+    def __setstate__(self, d):
+        # This is called when being unpickled/loaded.
+        raise NotImplementedError(
+            """__setstate__ not implemented for Proxy. """
+            """Proxy is created for {self.node.name}, {self.node.target}. Please remove "proxy" from __dict__."""
+        )
+
     def __call__(self, *args, **kwargs) -> 'Proxy':
         return self.tracer.create_proxy('call_method', '__call__', (self,) + args, kwargs)
 


### PR DESCRIPTION
Summary:
- make default DCE pass check schema,
- need to rebase onto https://github.com/pytorch/pytorch/pull/131651 after it's in phabricator (for now the change is manually added).

- mark Proxy dump as NotImplemented for better error msg

- Remove Proxy from tensors when dumping models, as Proxy cannot be dumped.

More details in https://docs.google.com/document/d/1G5vmTXjzxoyVGRI2kpA1gQukK_Glyg2NrE0Oh6Nlg9A/edit?usp=sharing.

Test Plan:
CI
```
- buck2 run 'fbcode//mode/dev-nosan'  fbcode//caffe2/test/quantization:test_quantization -- -r  qat_conv2d
- test_export.py
- buck2 run 'fbcode//mode/dev-nosan' fbcode//modai/test:test_modai -- -r test_qat_stinson_htp_export
- buck2 run 'fbcode//mode/dev-nosan' fbcode//vizard_projects/ml_depth/tests:test_model -- -r test_qat_model_et
- buck2 run 'fbcode//mode/dev-nosan'  fbcode//caffe2/test:fx -- -r dce
- buck2 run 'fbcode//mode/dev-nosan' fbcode//bolt/nn/executorch/backends/tests:qnn_test -- -r test_qat_bias=False,use_3d_input=False
- buck2 run 'fbcode//mode/dev-nosan' fbcode//bolt/nn/executorch/backends/tests:qnn_test -- -r test_qat_bias=True,use_3d_input=False
- buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test/quantization:test_quantization -- -r  test_fold_bn_erases_bn_node
```

Reviewed By: angelayi

Differential Revision: D60319175
