### PR TITLE
[compiled autograd][cpp node] No recompiles from saved int scalars

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1672,7 +1672,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved_dynamic, m) {
         # compiles for 10 (static) and 100 (dynamic)
         self.check_output_and_recompiles(fn, 2)
 
-    def test_autograd_cpp_node_saved_int(self):
+    def test_autograd_cpp_node_saved_scalar(self):
         cpp_source = """
 struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutogradFunction> {
   static constexpr bool is_traceable = true;
@@ -1696,7 +1696,7 @@ struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutog
     c10::SymInt y = ctx->saved_data["int"].toSymInt();
     c10::SymInt ys = ctx->saved_data["symint"].toSymInt();
 
-    torch::autograd::variable_list grad_inputs(4);
+    torch::autograd::variable_list grad_inputs(2);
     grad_inputs[0] = x + y + ys;
     return grad_inputs;
   }
@@ -1706,13 +1706,13 @@ torch::Tensor custom_op_backed_by_autograd_fn(const torch::Tensor& x, int64_t y)
   return CustomOpAutogradFunction::apply(x, y);
 }
 
-TORCH_LIBRARY(test_autograd_cpp_node_saved_int, m) {
+TORCH_LIBRARY(test_autograd_cpp_node_saved_scalar, m) {
     m.def("custom_op_backed_by_autograd_fn", custom_op_backed_by_autograd_fn);
 }
         """
 
         module = torch.utils.cpp_extension.load_inline(
-            name="test_autograd_cpp_node_saved_int",
+            name="test_autograd_cpp_node_saved_scalar",
             cpp_sources=cpp_source,
             functions="custom_op_backed_by_autograd_fn",
             verbose=True,
@@ -1721,7 +1721,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved_int, m) {
         def fn():
             for y in [1, 2, 3, 1]:
                 x = torch.ones(10, 10, requires_grad=True)
-                out = torch.ops.test_autograd_cpp_node_saved_int.custom_op_backed_by_autograd_fn(
+                out = torch.ops.test_autograd_cpp_node_saved_scalar.custom_op_backed_by_autograd_fn(
                     x, y
                 )
                 loss = out.sum()

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1616,7 +1616,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved, m) {
 
         self.check_output_and_recompiles(fn, 2)
 
-    def test_autograd_cpp_node_saved_dynamic_tensor(self):
+    def test_autograd_cpp_node_saved_dynamic(self):
         cpp_source = """
 struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutogradFunction> {
   static constexpr bool is_traceable = true;

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -83,7 +83,7 @@ class AutogradCompilerInstance:
         return GetItemSource(LocalSource(name), idx)
 
     def begin_capture(
-        self, inputs: List[torch.Tensor], sizes: List[int], int_scalars: Tuple[int]
+        self, inputs: List[torch.Tensor], sizes: List[int], scalars: Tuple[int]
     ):
         counters["compiled_autograd"]["captures"] += 1
         self.fx_tracer.root = torch.nn.Module()
@@ -112,15 +112,15 @@ class AutogradCompilerInstance:
         ]
         self.bind_tensors_to_proxies(sizes, sizes_proxy)
 
-        int_scalars = [
+        scalars = [
             self.shape_env.create_unspecified_symint_and_symbol(
                 val,
                 self.source("scalars", idx),
                 DimDynamic.DYNAMIC,
             )
-            for idx, val in enumerate(int_scalars)
+            for idx, val in enumerate(scalars)
         ]
-        self.bind_tensors_to_proxies(int_scalars, scalars_proxy)
+        self.bind_tensors_to_proxies(scalars, scalars_proxy)
 
         # TODO(jansel): are all these modes needed?
         self.stack.enter_context(decompose({}))
@@ -129,7 +129,7 @@ class AutogradCompilerInstance:
         self.stack.enter_context(self.proxy_mode)
         self.stack.enter_context(disable_autocast_cache())
         self.stack.enter_context(preserve_node_meta())
-        return inputs, sizes, int_scalars
+        return inputs, sizes, scalars
 
     def proxy_call_backward(
         self,

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -11,7 +11,6 @@
 #include <torch/csrc/utils/torch_dispatch_mode.h>
 #include <typeindex>
 #include <vector>
-#include <ATen/ops/tensor.h>
 
 // see [Note: Compiled Autograd]
 
@@ -277,10 +276,6 @@ class CompiledNodeArgs {
       }
     } else if (iv.isTensor()) {
       collect(iv.toTensor());
-    } else if (iv.isInt()) {
-      collect(at::tensor(iv.toInt()));
-    } else if (iv.isDouble()) {
-      collect(at::tensor(iv.toDouble()));
     } else {
       try {
         collect(static_cast<uint64_t>(at::IValue::hash(iv)));

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -280,13 +280,13 @@ class CompiledNodeArgs {
       collect(m.at(k));
     }
   }
-  void collect(const at::IValue& iv) {
+  void collect(const at::IValue& iv, bool nested = false) {
     // used by AutogradContext::saved_data from CppNode
     if (iv.isList()) {
       c10::List<at::IValue> list = iv.toList();
       collect_size(list.size());
       for (auto&& value : list) {
-        collect(value);
+        collect(value, true);
       }
     } else if (iv.isGenericDict()) {
       c10::Dict<at::IValue, at::IValue> ordered_dict = iv.toGenericDict();
@@ -294,11 +294,12 @@ class CompiledNodeArgs {
       // NOLINTNEXTLINE(modernize-loop-convert)
       for (auto it = ordered_dict.begin(); it != ordered_dict.end(); it++) {
         collect(it->key());
-        collect(it->value());
+        collect(it->value(), true);
       }
     } else if (iv.isTensor()) {
       collect(iv.toTensor());
-    } else if (iv.isInt() || iv.isSymInt()) {
+    } else if (!nested && (iv.isInt() || iv.isSymInt())) {
+      // can't lift ivalues nested in collections
       _compiler.lifted_ivalue_args.args.emplace_back(&iv);
     } else {
       try {

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -11,6 +11,7 @@
 #include <torch/csrc/utils/torch_dispatch_mode.h>
 #include <typeindex>
 #include <vector>
+#include <ATen/ops/tensor.h>
 
 // see [Note: Compiled Autograd]
 
@@ -276,6 +277,10 @@ class CompiledNodeArgs {
       }
     } else if (iv.isTensor()) {
       collect(iv.toTensor());
+    } else if (iv.isInt()) {
+      collect(at::tensor(iv.toInt()));
+    } else if (iv.isDouble()) {
+      collect(at::tensor(iv.toDouble()));
     } else {
       try {
         collect(static_cast<uint64_t>(at::IValue::hash(iv)));

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -393,10 +393,6 @@ void set_ivalue_proxies(
       arg.proxy = at::IValue(
           py::cast<c10::SymInt>(PyList_GET_ITEM(fake_ivalue_args, i)));
       TORCH_INTERNAL_ASSERT(arg.proxy.isSymInt());
-    } else if (arg.actual_ptr->isDouble()) {
-      arg.proxy = at::IValue(
-          py::cast<c10::SymFloat>(PyList_GET_ITEM(fake_ivalue_args, i)));
-      TORCH_INTERNAL_ASSERT(arg.proxy.isSymFloat());
     } else {
       TORCH_INTERNAL_ASSERT(false, "Unexpected lifted ivalue type");
     }

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -363,6 +363,46 @@ static struct PyModuleDef _module = {
     -1,
     _methods};
 
+PyObject* wrap_lifted_ivalue_args(
+    const std::vector<LiftedIValueArg>& lifted_ivalue_args) {
+  PyObject* pyints =
+      PyTuple_New(static_cast<Py_ssize_t>(lifted_ivalue_args.size()));
+  size_t idx = 0;
+  for (const auto& arg : lifted_ivalue_args) {
+    if (arg.actual_ptr->isInt() || arg.actual_ptr->isSymInt()) {
+      PyTuple_SET_ITEM(
+          pyints, idx++, PyLong_FromSsize_t(arg.actual_ptr->toInt()));
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Unexpected lifted ivalue type");
+    }
+  }
+  return pyints;
+}
+
+void set_ivalue_proxies(
+    PyObject* fake_ivalue_args,
+    std::vector<LiftedIValueArg>& lifted_ivalue_args) {
+  TORCH_INTERNAL_ASSERT(PyList_Check(fake_ivalue_args));
+  TORCH_INTERNAL_ASSERT(
+      static_cast<size_t>(PyList_Size(fake_ivalue_args)) ==
+      lifted_ivalue_args.size());
+
+  for (const auto& i : c10::irange(lifted_ivalue_args.size())) {
+    auto& arg = lifted_ivalue_args[i];
+    if (arg.actual_ptr->isInt() || arg.actual_ptr->isSymInt()) {
+      arg.proxy = at::IValue(
+          py::cast<c10::SymInt>(PyList_GET_ITEM(fake_ivalue_args, i)));
+      TORCH_INTERNAL_ASSERT(arg.proxy.isSymInt());
+    } else if (arg.actual_ptr->isDouble()) {
+      arg.proxy = at::IValue(
+          py::cast<c10::SymFloat>(PyList_GET_ITEM(fake_ivalue_args, i)));
+      TORCH_INTERNAL_ASSERT(arg.proxy.isSymFloat());
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Unexpected lifted ivalue type");
+    }
+  }
+}
+
 static TraceState call_begin_capture(
     PyObject* self,
     CacheNode& cache,
@@ -371,11 +411,20 @@ static TraceState call_begin_capture(
   static PyObject* method_name = PyUnicode_InternFromString("begin_capture");
   THPObjectPtr pyinput(THPVariable_WrapList(compiler_call.tensor_args.inputs));
   THPObjectPtr pysizeinput(cache.wrap_dynamic_inputs());
+  THPObjectPtr pyivalueargsinput(
+      wrap_lifted_ivalue_args(compiler_call.lifted_ivalue_args.args));
   THPObjectPtr pyresult(check(PyObject_CallMethodObjArgs(
-      self, method_name, pyinput.get(), pysizeinput.get(), nullptr)));
+      self,
+      method_name,
+      pyinput.get(),
+      pysizeinput.get(),
+      pyivalueargsinput.get(),
+      nullptr)));
 
-  PyObject *fake_inputs{nullptr}, *fake_sizes{nullptr};
-  check(PyArg_ParseTuple(pyresult.get(), "OO", &fake_inputs, &fake_sizes));
+  PyObject *fake_inputs{nullptr}, *fake_sizes{nullptr},
+      *fake_ivalue_args{nullptr};
+  check(PyArg_ParseTuple(
+      pyresult.get(), "OOO", &fake_inputs, &fake_sizes, &fake_ivalue_args));
 
   variable_list proxy_inputs = THPVariable_UnpackList(fake_inputs);
   TORCH_INTERNAL_ASSERT(
@@ -386,6 +435,7 @@ static TraceState call_begin_capture(
     arg.proxy_tensor = proxy_inputs[i];
   }
 
+  set_ivalue_proxies(fake_ivalue_args, compiler_call.lifted_ivalue_args.args);
   return TraceState(cache.unwrap_dynamic_inputs(fake_sizes), num_outputs);
 }
 
@@ -418,6 +468,7 @@ CacheNode* _compiled_autograd_impl(
     const edge_list& output_edges,
     THPObjectPtr* graph_arg_inputs,
     THPObjectPtr* graph_arg_sizes,
+    THPObjectPtr* graph_arg_ivalue_args,
     THPObjectPtr* graph_arg_hooks) {
   std::unordered_map<Node*, int>& dependencies = graph_task.dependencies_;
   std::vector<std::shared_ptr<Node>> worklist{graph_root};
@@ -621,6 +672,8 @@ CacheNode* _compiled_autograd_impl(
 
   *graph_arg_inputs = THPVariable_WrapList(compiler_call.tensor_args.inputs);
   *graph_arg_sizes = wrap_int_list(compiler_call.dyn_size_inputs);
+  *graph_arg_ivalue_args =
+      wrap_lifted_ivalue_args(compiler_call.lifted_ivalue_args.args);
   *graph_arg_hooks = convert_hook_list(compiler_call.hooks);
   return cache;
 }
@@ -640,6 +693,7 @@ variable_list compiled_autograd(
 
   THPObjectPtr inputs;
   THPObjectPtr sizes;
+  THPObjectPtr ivalue_args;
   THPObjectPtr hooks;
   CacheNode* cache = _compiled_autograd_impl(
       graph_root,
@@ -648,6 +702,7 @@ variable_list compiled_autograd(
       output_edges,
       &inputs,
       &sizes,
+      &ivalue_args,
       &hooks);
 
   THPObjectPtr pyresult(check(PyObject_CallFunctionObjArgs(
@@ -655,6 +710,7 @@ variable_list compiled_autograd(
       cache->compiled_fn.get(),
       inputs.get(),
       sizes.get(),
+      ivalue_args.get(),
       hooks.get(),
       NULL)));
   variable_list outputs = THPVariable_UnpackList(pyresult);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133048
* __->__ #132771

Addresses https://github.com/pytorch/pytorch/issues/130170 for int scalars saved from forward pass of a custom c++ autograd function

Currently, any non-tensors passed in ctx->saved_data is specialized on by compiled autograd. To stop specializing on int values, we lift the ints. We also require user code to use IValue::toSymInt instead of IValue::toInt in order to swap the SymInt to proxy during compiled autograd tracing

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang