### PR TITLE
[DeviceMesh] Allow flatten API to take in a name for the flatten dim

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -573,6 +573,12 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         dp_cp_mesh = mesh_3d["dp", "cp"]
         flattened_dp_cp_mesh = dp_cp_mesh._flatten()
         self.assertEqual(dp_cp_mesh.mesh.flatten(), flattened_dp_cp_mesh.mesh)
+        self.assertEqual(flattened_dp_cp_mesh.mesh_dim_names, ("dp_cp",))
+
+        # Test flatten mesh with mesh_dim_name provided
+        flattened_dp_cp_mesh_2 = dp_cp_mesh._flatten(mesh_dim_name="dpcp")
+        self.assertEqual(flattened_dp_cp_mesh.mesh_dim_names, ("dpcp",))
+        self.assertNotEqual(flattened_dp_cp_mesh, flattened_dp_cp_mesh_2)
 
         # Test flatten non-contiguous dims
         dp_tp_mesh = mesh_3d["dp", "tp"]

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -577,7 +577,7 @@ class TestDeviceMeshGetItem(DTensorTestBase):
 
         # Test flatten mesh with mesh_dim_name provided
         flattened_dp_cp_mesh_2 = dp_cp_mesh._flatten(mesh_dim_name="dpcp")
-        self.assertEqual(flattened_dp_cp_mesh.mesh_dim_names, ("dpcp",))
+        self.assertEqual(flattened_dp_cp_mesh_2.mesh_dim_names, ("dpcp",))
         self.assertNotEqual(flattened_dp_cp_mesh, flattened_dp_cp_mesh_2)
 
         # Test flatten non-contiguous dims

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -113,7 +113,11 @@ else:
 
             return res_submesh
 
-        def create_flatten_mesh(self, device_mesh: "DeviceMesh") -> "DeviceMesh":
+        def create_flatten_mesh(
+            self,
+            device_mesh: "DeviceMesh",
+            mesh_dim_name: Optional[str],
+        ) -> "DeviceMesh":
             root_mesh = _mesh_resources.get_root_mesh(device_mesh)
             flatten_dims_in_root = [
                 not_none(root_mesh.mesh_dim_names).index(flattened_mesh_dim_name)
@@ -121,12 +125,16 @@ else:
             ]
             # sort dims to flatten based on the order of the dims in the root mesh.
             flatten_dims_in_root.sort()
-            flatten_mesh_dim_names = "_".join(
-                [
-                    not_none(root_mesh.mesh_dim_names)[dim]
-                    for dim in flatten_dims_in_root
-                ]
-            )
+            if mesh_dim_name:
+                flatten_mesh_dim_name = mesh_dim_name
+            else:
+                flatten_mesh_dim_name = "_".join(
+                    [
+                        not_none(root_mesh.mesh_dim_names)[dim]
+                        for dim in flatten_dims_in_root
+                    ]
+                )
+
             flattened_mesh_dim_size = math.prod(device_mesh.mesh.size())
 
             remained_dims_in_root = list(range(root_mesh.mesh.ndim))
@@ -143,7 +151,7 @@ else:
                 flattened_mesh = DeviceMesh(
                     root_mesh.device_type,
                     mesh_nd,
-                    mesh_dim_names=(flatten_mesh_dim_names,),
+                    mesh_dim_names=(flatten_mesh_dim_name,),
                 )
                 if cur_rank in mesh_nd:
                     res_flattened_mesh = flattened_mesh
@@ -690,16 +698,21 @@ else:
             """
             return self._coordinate_on_dim if self._coordinate_on_dim else None
 
-        def _flatten(self) -> "DeviceMesh":
+        def _flatten(self, *, mesh_dim_name: Optional[str] = None) -> "DeviceMesh":
             """
             Returns a 1D DeviceMesh by flattening the current DeviceMesh.
+            If no mesh_dim_name is assigned for the flatten mesh, the default is a string
+            concatenating the mesh_dim_names with each mesh_dim_name separated by an underscore.
+
+            For example, if you have a 2D DeviceMesh with mesh_dim_names=("dp", "cp"), the default
+            flatten_mesh_dim_name will be "dp_cp".
             """
             if not self.mesh_dim_names:
                 raise RuntimeError(
                     "Cannot flatten a DeviceMesh without mesh_dim_names!"
                 )
 
-            return _mesh_resources.create_flatten_mesh(self)
+            return _mesh_resources.create_flatten_mesh(self, mesh_dim_name)
 
     def init_device_mesh(
         device_type: str,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132779
* #132632

The main motivation for allowing a custom mesh dim name is that the name combining the mesh_dim_names might not be intuitive to users if users want to re-use the flatten result through slicing. 

```
mesh_3d = init_device_mesh("cuda", (2,2,2), mesh_dim_names=("dp","cp","tp")
fsdp_mesh = mesh_3d["dp", "cp"].flatten()

# Without the ability of naming the flatten mesh, users could do:
model = Model(...)
fully_shard(model, device_mesh=fsdp_mesh)
fully_shard(model, device_mesh=mesh_3d["dp_cp"]

# if we allow naming for flatten mesh
fsdp_mesh = mesh_3d["dp", "cp"].flatten(mesh_dim_name="fsdp")
fully_shard(model, device_mesh=mesh_3d["fsdp"]

# For an EP use case:
mesh_3d = init_device_mesh("cuda", (2,2,2), mesh_dim_names=("dp","ep0","ep1")
tp_mesh = mesh_3d["ep0", "ep1"].flatten()

# Without the ability of naming the flatten mesh, users could do:
parallelize(model, device_mesh=tp_mesh)
parallelize(model, device_mesh=mesh_3d["ep0_ep1"]

# if we allow naming for flatten mesh
tp_mesh = mesh_3d["ep0", "ep1"].flatten(mesh_dim_name="tp")
parallelize(model, device_mesh=mesh_3d["tp"])
```

Keeping this change in a separate PR, since there are some questions that need to be resolved for allowing users to pass in a flatten mesh dim name. 

1. Two flattened mesh with the same mesh tensor would be considered different, because `mesh_dim_names` is a part of the equal check for DeviceMesh. 
2. Because of 1, do we want to create new pg for two flattened mesh with the same mesh tensor with different mesh_dim_names? 

If we want to align with the overall DeviceMesh assumption, then the two flattened mesh with two different mesh_dim_name would be considered different, and they would have different underlying pgs. 

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o 