### PR TITLE
Only store necessary tensor_dict fields in node meta

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -398,7 +398,7 @@ class DecoratorTests(torch._dynamo.test_case.TestCase):
                     )
                 elif compiles == 1:
                     self.assertFalse(
-                        "_dynamo_statc_input_type" in input_node.meta["tensor_dict"]
+                        "_dynamo_static_input_type" in input_node.meta["tensor_dict"]
                     )
                 else:
                     raise RuntimeError(f"Unexpected number of compiles: {compiles}")

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7099,10 +7099,8 @@ utils_device.CURRENT_DEVICE == None""".split(
 
         a = torch.randn([3, 3])
         a.tag = "a"
-        a.frog = "ribbity ribbit"
         b = torch.randn([3, 3])
         b.tag = "b"
-        b.frog = "ribbit"
 
         exported = torch._dynamo.export(foo)(a, b)
         out_graph = exported[0]
@@ -7110,14 +7108,11 @@ utils_device.CURRENT_DEVICE == None""".split(
         nodes = list(out_graph.graph.nodes)
         placeholders = [node for node in nodes if node.op == "placeholder"]
         all_tags = []
-        all_frogs = []
         for placeholder in placeholders:
             if "tensor_dict" in placeholder.meta:
                 all_tags.append(placeholder.meta["tensor_dict"]["tag"])
-                all_frogs.append(placeholder.meta["tensor_dict"]["frog"])
 
         self.assertEqual(all_tags, ["a", "b"])
-        self.assertEqual(all_frogs, ["ribbity ribbit", "ribbit"])
 
     def test_tagging_tensors_mix_used_unused_structure(self):
         def pre_attention_state_ops(input, mems, state):

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -68,6 +68,7 @@ from .source import (
     TensorPropertySource,
 )
 from .utils import (
+    _extract_tensor_dict,
     checkpoint_params,
     CleanupHook,
     clone_inputs,
@@ -807,7 +808,7 @@ class OutputGraph:
                 vt = self.root_tx.output.side_effects.track_object_existing(target, vt)
 
                 assert "tensor_dict" not in vt.proxy.node.meta
-                vt.proxy.node.meta["tensor_dict"] = target.__dict__.copy()
+                vt.proxy.node.meta["tensor_dict"] = _extract_tensor_dict(target)
 
                 return vt
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2920,3 +2920,18 @@ def does_not_override_dict_iter_methods(user_cls):
         and user_cls.keys in (dict.keys, collections.OrderedDict.keys)
         and user_cls.__iter__ in (dict.__iter__, collections.OrderedDict.__iter__)
     )
+
+
+# Helper function to extract relevant parts of a tensor's __dict__ to store in node meta.
+# To avoid ref cycles, it's important that no tensors are present here, so leave those out.
+def _extract_tensor_dict(t):
+    tensor_dict = {}
+
+    KEYS_TO_COPY = [
+        "_dynamo_static_input_type",
+    ]
+    for key in KEYS_TO_COPY:
+        if key in t.__dict__:
+            tensor_dict[key] = copy.copy(t[key])
+
+    return tensor_dict

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2925,13 +2925,13 @@ def does_not_override_dict_iter_methods(user_cls):
 # Helper function to extract relevant parts of a tensor's __dict__ to store in node meta.
 # To avoid ref cycles, it's important that no tensors are present here, so leave those out.
 def _extract_tensor_dict(t):
-    tensor_dict = {}
-
     KEYS_TO_COPY = [
         "_dynamo_static_input_type",
+        "tag",
     ]
-    for key in KEYS_TO_COPY:
-        if key in t.__dict__:
-            tensor_dict[key] = copy.copy(t.__dict__[key])
+
+    tensor_dict = {
+        key: copy.copy(t.__dict__[key]) for key in KEYS_TO_COPY if key in t.__dict__
+    }
 
     return tensor_dict

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2932,6 +2932,6 @@ def _extract_tensor_dict(t):
     ]
     for key in KEYS_TO_COPY:
         if key in t.__dict__:
-            tensor_dict[key] = copy.copy(t[key])
+            tensor_dict[key] = copy.copy(t.__dict__[key])
 
     return tensor_dict

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -73,6 +73,7 @@ from ..trace_rules import (
     is_numpy_type_info,
 )
 from ..utils import (
+    _extract_tensor_dict,
     build_checkpoint_variable,
     clone_input,
     common_constant_types,
@@ -1149,9 +1150,9 @@ class VariableBuilder:
                 source_i = GetItemSource(base=source, index=i, index_is_slice=False)
                 # access unpacked tensor from this list instead of from a lifted arg
                 self.tx.output.input_source_to_var[source_i] = tensor_variable
-                tensor_variable.proxy.node.meta["tensor_dict"] = value[
-                    i
-                ].__dict__.copy()
+                tensor_variable.proxy.node.meta["tensor_dict"] = _extract_tensor_dict(
+                    value[i]
+                )
 
                 guard = functools.partial(
                     GuardBuilder.TENSOR_MATCH, value=TensorWeakRef(value[i])
@@ -1509,7 +1510,7 @@ class VariableBuilder:
 
         self.tx.output.input_source_to_var[source] = tensor_variable
         assert "tensor_dict" not in tensor_proxy.node.meta
-        tensor_proxy.node.meta["tensor_dict"] = value.__dict__.copy()
+        tensor_proxy.node.meta["tensor_dict"] = _extract_tensor_dict(value)
 
         # Note: this information is conveyed via subclass_type now
         fake_tensor_value = tensor_variable.proxy.node.meta["example_value"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132805

Fixes #132290

This PR attempts a more invasive / complete solution than the one from #132338, which removes immediate tensor fields from the `tensor_dict` copy stored in node meta. The approach taken here is to store only those fields of the `tensor_dict` which are absolutely utilized somewhere else.

So far, this appears to be limited to:
* `_dynamo_static_input_type`
* `tag` (at least in the tests). Discussion at #94080 appears to indicate this is depended on for export

(CI may point out more)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames