### PR TITLE
[NestedTensor] Modify softmax on ragged dimension to allow for 2D nested tensors

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -4296,6 +4296,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
             include_list_of_lists=False,
             include_requires_grad=components_require_grad,
             include_inner_dim_size_1=True,  # (B, *, 1)
+            include_2d_tensor=True,  # (B, *)
         )
         reduce_dim = 1  # ragged
 
@@ -4515,6 +4516,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
             include_list_of_lists=False,
             include_requires_grad=components_require_grad,
             include_inner_dim_size_1=True,  # (B, *, 1)
+            include_2d_tensor=True,  # (B, *)
         )
 
         for tensor_list in tensor_lists:

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -661,8 +661,8 @@ def _softmax_default(func, *args, **kwargs):
     if reduce_on_ragged:
         padded_softmax_values = torch.nn.functional.softmax(
             torch.ops.aten._jagged_to_padded_dense_forward(
-                inp._values.flatten(
-                    start_dim=inp._ragged_idx
+                inp._values.reshape(
+                    inp._values.shape[0], -1
                 ),  # values are required to be 2D tensors for j2pd
                 [inp._offsets],
                 max_lengths=[inp._max_seqlen],  # max length of ragged dimension


### PR DESCRIPTION
Summary:
Modify `softmax` on the ragged dimension, where `ragged_idx == 1`, to allow for 2D nested tensors. This diff now enables a `softmax` operation on tensors of shape `(B, *)`, where `*` is the ragged dimension.

Extend existing `softmax` unit tests to include 2D nested tensors using the `include_2d_tensor=True` keyword argument.

Test Plan:
Verify that existing and modified unit tests pass using the following commands:

```
buck2 run mode/{opt,inplace} //caffe2/test:nested -- --regex test_softmax
```

```
buck2 run mode/{opt,inplace} //caffe2/test:nested -- --regex test_jagged_op
```

Reviewed By: davidberard98

Differential Revision: D60780975
