### PR TITLE
[elastic collectives API] add missing rank tracing support

### DIFF
--- a/torch/distributed/elastic/utils/store.py
+++ b/torch/distributed/elastic/utils/store.py
@@ -9,11 +9,19 @@
 
 from contextlib import contextmanager
 from datetime import timedelta
-from typing import List
+from typing import Callable, Iterable, List, Optional
 
+import torch
+
+
+DistStoreError = torch._C._DistStoreError
 
 _NUM_MEMBERS = "/num_members"
 _LAST_MEMBER_CHECKIN = "/last_member"
+_TRACE = "/TRACE"
+_TRACING_GATE = "/TRACING_GATE"
+_MAX_TRACE_MISSING_RANKS = 16
+
 
 __all__ = ["store_timeout", "get_all", "synchronize", "barrier"]
 
@@ -93,6 +101,46 @@ def synchronize(
         return agent_data
 
 
+def _try_detecting_missing_ranks(
+    store,
+    world_size: int,
+    key_prefix: str,
+    rank: int,
+    rank_decoder: Callable[[int], str],
+    trace_timeout: float,
+) -> Optional[Iterable[str]]:
+    store.set(f"{key_prefix}{rank}{_TRACE}", "<val_ignored>")
+
+    missing_rank_info = set()
+    ranks_missing = 0
+    if rank == 0:
+        for i in range(1, world_size):
+            # reduce noise, assuming in general 8 ranks per node
+            # It is valuable to know that 1 or >1 nodes have timed-out.
+            if ranks_missing >= _MAX_TRACE_MISSING_RANKS:
+                break
+            try:
+                if ranks_missing == 0:
+                    store.wait(
+                        [f"{key_prefix}{i}{_TRACE}"], timedelta(seconds=trace_timeout)
+                    )
+                else:
+                    # use a shortest timeout, some ranks have failed to check-in
+                    store.wait([f"{key_prefix}{i}{_TRACE}"], timedelta(milliseconds=1))
+            except DistStoreError:
+                ranks_missing += 1
+                missing_rank_info.add(rank_decoder(i))
+        store.set(f"{key_prefix}{_TRACING_GATE}", "<val_ignored>")
+        return missing_rank_info
+    else:
+        try:
+            store.wait([f"{key_prefix}{_TRACING_GATE}"])
+            return [f"[<check rank 0 ({rank_decoder(0)}) for missing rank info>]"]
+        except DistStoreError:
+            # in case rank0 is the source of the timeout, original exception will be raised
+            return None
+
+
 def _barrier_nonblocking(store, world_size: int, key_prefix: str) -> str:
     """
     Does all the non-blocking operations for a barrier and returns the final key
@@ -109,7 +157,13 @@ def _barrier_nonblocking(store, world_size: int, key_prefix: str) -> str:
 
 
 def barrier(
-    store, world_size: int, key_prefix: str, barrier_timeout: float = 300
+    store,
+    world_size: int,
+    key_prefix: str,
+    barrier_timeout: float = 300,
+    rank: Optional[int] = None,
+    rank_tracing_decoder: Optional[Callable[[int], str]] = None,
+    trace_timeout: float = 10,
 ) -> None:
     """
     A global lock between agents. This will pause all workers until at least
@@ -120,12 +174,43 @@ def barrier(
 
     Time complexity: O(1) per worker, O(N) globally.
 
+    Optionally, passing rank will enable tracing of missing ranks on timeouts.
+
     Note: Since the data is not removed from the store, the barrier can be used
         once per unique ``key_prefix``.
     """
+
+    if rank is None:
+        assert rank_tracing_decoder is None, "Tracing requires rank information"
 
     with store_timeout(store, barrier_timeout):
         last_member_key = _barrier_nonblocking(
             store=store, world_size=world_size, key_prefix=key_prefix
         )
-        store.wait([last_member_key])
+        try:
+            store.wait([last_member_key])
+        except DistStoreError as e:
+            if rank is None:
+                raise e
+            else:
+                missing_ranks = _try_detecting_missing_ranks(
+                    store,
+                    world_size,
+                    key_prefix,
+                    rank,
+                    rank_tracing_decoder or (lambda x: str(x)),
+                    trace_timeout,
+                )
+                if missing_ranks is not None:
+                    raise DistStoreError(
+                        "Timed out waiting on barrier on "
+                        "rank {}, for key prefix: {} (world_size={}, missing_ranks={}, timeout={})".format(
+                            rank,
+                            key_prefix,
+                            world_size,
+                            f"[{', '.join(missing_ranks)}]",
+                            barrier_timeout,
+                        )
+                    ) from None
+                else:
+                    raise e


### PR DESCRIPTION
Optional option to detect missing ranks (that can be mapped to host info via `rank_tracing_decoder` lambda argument) in store barrier operation. 

This approach has been used in some form already, moving it to collectives API.


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o