### PR TITLE
[export] _PythonPrinter for export's runtime asserts

### DIFF
--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -63,7 +63,7 @@ torch.fx.node.Node.update_kwarg(self, key: str, arg: torch.fx.node.Argument) -> 
 torch.fx.node.map_aggregate(a: torch.fx.node.Argument, fn: Callable[[torch.fx.node.Argument], torch.fx.node.Argument]) -> torch.fx.node.Argument
 torch.fx.node.map_arg(a: torch.fx.node.Argument, fn: Callable[[torch.fx.node.Node], torch.fx.node.Argument]) -> torch.fx.node.Argument
 torch.fx.passes.reinplace.reinplace(gm, *sample_args)
-torch.fx.passes.runtime_assert.insert_deferred_runtime_asserts(gm: torch.fx.graph_module.GraphModule, shape_env: Any, name: str, export: bool = False) -> None
+torch.fx.passes.runtime_assert.insert_deferred_runtime_asserts(gm: torch.fx.graph_module.GraphModule, shape_env: Any, name: str, export: bool = False, sympy_printer: Optional[sympy.printing.printer.Printer] = None) -> None
 torch.fx.passes.split_module.split_module(m: torch.fx.graph_module.GraphModule, root_m: torch.nn.modules.module.Module, split_callback: Callable[[torch.fx.node.Node], int], qualname_map: Optional[Dict[str, str]] = None, keep_original_order: Optional[bool] = False, keep_original_node_name: Optional[bool] = False)
 torch.fx.proxy.Attribute.__init__(self, root: torch.fx.proxy.Proxy, attr: str)
 torch.fx.proxy.Proxy.__init__(self, node: torch.fx.node.Node, tracer: 'Optional[TracerBase]' = None)

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2189,7 +2189,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         em.module()(torch.randn(4, 3))
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(Mod\(s0\*s1, s0 \- 1\), 0\)",
+            r"Runtime assertion failed for expression \(\(x\.size\(0\)\*x\.size\(1\)\) % \(x\.size\(0\) - 1\)\) == 0",
         ):
             em.module()(torch.randn(4, 5))
 
@@ -6096,7 +6096,7 @@ def forward(self, x, y):
         self.assertEqual(out2.shape, torch.ones(11, 4, 3).shape)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(Mod\(s0\*s1, 4\*s0 \- 4\), 0\) on node 'eq.*'",
+            r"Runtime assertion failed for expression \(\(x\.size\(0\)\*x\.size\(1\)\) % \(4\*x\.size\(0\) - 4\)\) == 0",
         ):
             ep.module()(torch.randn(8, 8))  # fail
 
@@ -6115,12 +6115,6 @@ def forward(self, x, y):
             "y": [Dim(f"dy{i}", min=2) for i in range(2)],
             "z": [Dim(f"dz{i}", min=4) for i in range(1)],
         }
-        ep = torch.export._trace._export(
-            FreeReshape(),
-            inputs,
-            dynamic_shapes=dynamic_shapes,
-            allow_complex_guards_as_runtime_asserts=True,
-        )
         ep = export(FreeReshape(), inputs, dynamic_shapes=dynamic_shapes)
         out1 = ep.module()(torch.randn(48, 1), torch.randn(4, 12), torch.randn(48))
         self.assertEqual(out1.shape, torch.ones(48).shape)
@@ -6128,7 +6122,7 @@ def forward(self, x, y):
         self.assertEqual(out2.shape, torch.ones(40).shape)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(s0\*s1, s2\*s3\) on node 'eq.*'",
+            r"Runtime assertion failed for expression \(x\.size\(0\)\*x\.size\(1\)\) == \(y\.size\(0\)\*y\.size\(1\)\)",
         ):  # fail only at runtime
             ep.module()(torch.randn(5, 8), torch.randn(4, 5), torch.randn(30))  # fail
 
@@ -6155,7 +6149,7 @@ def forward(self, x, y):
         self.assertEqual(out1.shape, torch.ones(126).shape)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(s0\*s1\*s2, s3\) on node 'eq.*'",
+            r"Runtime assertion failed for expression \(x\.size\(0\)\*x\.size\(1\)\*x\.size\(2\)\) == y\.size\(0\)",
         ):  # fail only at runtime
             ep.module()(torch.randn(4, 3, 2), torch.randn(10))  # fail
 
@@ -6238,12 +6232,12 @@ def forward(self, x, y):
         )
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Ne\(s0, 20\)",
+            r"Runtime assertion failed for expression x\.size\(0\) != 20",
         ):
             ep.module()(torch.randn(20, 20, 16))
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Ne\(Mod\(s0, 20\), 0\)",
+            r"Runtime assertion failed for expression \(x\.size\(0\) % 20\) != 0",
         ):
             ep.module()(torch.randn(400, 20, 16))
         ep.module()(torch.randn(42, 20, 16))
@@ -6274,17 +6268,17 @@ def forward(self, x, y):
         self.assertEqual(out1.shape, torch.ones(27).shape)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Ne\(s0, s1\)",
+            r"Runtime assertion failed for expression x\.size\(0\) != y\.size\(0\)",
         ):  # fail only at runtime
             ep.module()(torch.randn(4), torch.randn(4))  # fail
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Ne\(s0, s1\**3\)",
+            r"Runtime assertion failed for expression x\.size\(0\) != y\.size\(0\)\*\*3",
         ):
             ep.module()(torch.randn(64), torch.randn(4))  # fail
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression Eq\(s0\**2, 3\*s1\)",
+            r"Runtime assertion failed for expression x\.size\(0\)\*\*2 == \(3\*y\.size\(0\)\)",
         ):
             ep.module()(torch.randn(10), torch.randn(9))  # fail
 
@@ -6530,7 +6524,7 @@ def forward(self, x, y):
         ep.module()(torch.ones(8), torch.ones(5))
         with self.assertRaisesRegex(
             RuntimeError,
-            r"Runtime assertion failed for expression \(s0//2\) \<\= s1",
+            r"Runtime assertion failed for expression \(x\.size\(0\)//2\) \<\= y\.size\(0\)",
         ):
             ep.module()(torch.ones(10), torch.ones(4))
 

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -528,6 +528,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
         _node_metadata_hook,
         _set_node_metadata_hook,
     )
+    from torch._export.utils import get_runtime_asserts_printer
     from torch._functorch._aot_autograd.input_output_analysis import _graph_output_names
 
     if not torch._dynamo.config.do_not_emit_runtime_asserts:
@@ -545,6 +546,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
                     shape_env,
                     f"exported program: {first_call_function_nn_module_stack(gm.graph)}",
                     export=True,
+                    sympy_printer=get_runtime_asserts_printer(shape_env),
                 )
 
     # update output specs

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5602,6 +5602,11 @@ class _PythonPrinter(sympy.printing.str.StrPrinter):
         rhs = self.parenthesize(expr.rhs, sympy.printing.precedence.precedence(expr))
         return f"{lhs} {rel_op} {rhs}"
 
+    def _print_Mod(self, expr):
+        lhs = self.parenthesize(expr.args[0], sympy.printing.precedence.precedence(expr))
+        rhs = self.parenthesize(expr.args[1], sympy.printing.precedence.precedence(expr))
+        return f"{lhs} % {rhs}"
+
 
 def _suggest_torch_checks(e, src_map):
     # extract the unresolved condition on unbacked symints in the error


### PR DESCRIPTION
Prettifies export's runtime asserts, printing expressions with the _PythonPrinter and replacing symbols with prettified sources, to avoid expressions like `Eq(s0*s1, s2)`.

One step this involves for non-strict export is replacing the sources with what they'd look like for strict mode - non-strict contains sources like `L["args"][0][..]` for args, and `L["args"][1][..]` for kwargs, while sources from strict just contain the arg/kwarg name (e.g. `L[<name>][..]`). These sources are used for prettifying in later steps that are independent of strict/non-strict (e.g. run_decompositions()), so we just do a one-time replacement for these sources in non-strict. Kind of hacky, but matches up strict/non-strict and we only worry about it once.

A printer is added to the runtime asserts pass, defaulting to SymExprPrinter.

Export's runtime asserts now look like:
```
"Runtime assertion failed for expression (x.size(0)//2) <= y.size(0)"
```