### PR TITLE
[triton_op] Skip HOP dispatch when possible

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2412,6 +2412,7 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
         expected = torch.empty_like(x)
         self.assertEqual(out, expected)
 
+    @requires_gpu
     def test_capture_triton_disabled_in_triton_op(self):
         import triton
         import triton.language as tl
@@ -2433,6 +2434,8 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
             output = x + y
             tl.store(out_ptr + offsets, output, mask=mask)
 
+        add_kernel_decorated = torch._library.capture_triton(add_kernel)
+
         status = []
 
         @torch._library.triton_op("mylib::add", mutates_args=())
@@ -2445,11 +2448,25 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
             result = torch._library.capture_triton(add_kernel)
             self.assertIs(result, add_kernel)
 
-            return x + y
+            # Smoke test: check that with capture_triton disabled this still does something
+            output = torch.empty_like(x)
+            output2 = torch.empty_like(x)
 
-        x = torch.randn(3)
-        add(x, x)
+            n_elements = output.numel()
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            add_kernel_decorated[grid](x, y, output, n_elements, BLOCK_SIZE=16)
+
+            add_kernel_decorated.run(
+                x, y, output2, n_elements, BLOCK_SIZE=16, grid=grid, warmup=False
+            )
+
+            return output + output2
+
+        x = torch.randn(3, device=GPU_TYPE)
+        y = torch.randn(3, device=GPU_TYPE)
+        z = add(x, y)
         self.assertEqual(status[-1], False)
+        self.assertEqual(z, (x + y) * 2)
 
     @requires_gpu
     @common_utils.parametrize("dynamic", [False, True])

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2413,15 +2413,38 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
         self.assertEqual(out, expected)
 
     def test_capture_triton_disabled_in_triton_op(self):
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def add_kernel(
+            in_ptr0,
+            in_ptr1,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            y = tl.load(in_ptr1 + offsets, mask=mask)
+            output = x + y
+            tl.store(out_ptr + offsets, output, mask=mask)
+
         status = []
 
         @torch._library.triton_op("mylib::add", mutates_args=())
         def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             import torch._higher_order_ops.triton_kernel_wrap
 
-            status.append(
-                torch._higher_order_ops.triton_kernel_wrap.capture_triton_enabled.value
-            )
+            status.append(torch._library.triton.is_capture_triton_enabled())
+
+            # capture_triton should return the kernel directly if disabled
+            result = torch._library.capture_triton(add_kernel)
+            self.assertIs(result, add_kernel)
+
             return x + y
 
         x = torch.randn(3)

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
 import collections
-import contextlib
 import copy
 import dataclasses
 import inspect
@@ -1010,27 +1009,6 @@ class TracingTritonHOPifier(TritonHOPifier):
 tracing_triton_hopifier_singleton = TracingTritonHOPifier()
 
 
-capture_triton_enabled = threading.local()
-capture_triton_enabled_default = True
-
-
-@contextlib.contextmanager
-def set_capture_triton_enabled(enabled: bool):
-    """If triton kernels annotated with @capture_triton should dispatch via HOP
-    or go straight to the triton kernel execution.
-
-    We have this switch because eager-mode performance of HOP dispatch is slow
-    enough to matter (~1ms) and we know that capture_triton isn't necessary in
-    some situations (eager-mode with regular Tensors)
-    """
-    try:
-        prev = getattr(capture_triton_enabled, "value", capture_triton_enabled_default)
-        capture_triton_enabled.value = enabled
-        yield
-    finally:
-        capture_triton_enabled.value = prev
-
-
 class TraceableTritonKernelWrapper:
     def __init__(self, kernel, kernel_idx, grid):
         self.kernel = None
@@ -1042,14 +1020,18 @@ class TraceableTritonKernelWrapper:
         return tracing_triton_hopifier_singleton.call_getitem(self, args)
 
     def run(self, *args, **kwargs):
-        if getattr(capture_triton_enabled, "value", capture_triton_enabled_default):
+        from torch._library.triton import is_capture_triton_enabled
+
+        if is_capture_triton_enabled():
             return tracing_triton_hopifier_singleton.call_run(self, args, kwargs, None)
         else:
             assert self.kernel is not None
             return self.kernel.run(*args, **kwargs)
 
     def __call__(self, *args, **kwargs):
-        if getattr(capture_triton_enabled, "value", capture_triton_enabled_default):
+        from torch._library.triton import is_capture_triton_enabled
+
+        if is_capture_triton_enabled():
             return tracing_triton_hopifier_singleton.call_triton_kernel(
                 self, args, kwargs, None
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132822

The capture_triton decorator returns a function that goes through the
triton kernel wrapper HOP. This is useful for make_fx tracing and
non-strict export. However, the HOP dispatch is slow (~1ms) and not
necessary in certain situations.

This PR skips going through the HOP dispatch for any
capture_triton-wrapped triton kernels that are registered as
implementations to a `@triton_op` custom operator. We do this by
creating a new thread-local flag that controls if the
capture_trition-wrapped triton kernel goes through HOP dispatch or not.

Test Plan:
- new test and existing tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang