### PR TITLE
Disable sparse tests in export

### DIFF
--- a/test/export/test_sparse.py
+++ b/test/export/test_sparse.py
@@ -7,6 +7,7 @@ import sys
 import unittest
 
 import torch
+from torch._dynamo.config import is_fbcode
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -79,6 +80,7 @@ class SparseActivationCSR(torch.nn.Module):
 #
 
 
+@unittest.skipIf(is_fbcode(), "See torch._dynamo.config")
 class TestSparseProp(TestCase):
     def setUp(self):
         TestCase.setUp(self)


### PR DESCRIPTION
Summary: Dynamo doesn't trace through sparse tensors in fbcode. So we should disable tests that run sparse tensors in export. We should do this to make the CI green internally.

Test Plan:
Before:
Tests finished: Pass 1409. Fail 71. Fatal 0. Skip 90. Build failure 0
After:
Tests finished: Pass 1408. Fail 0. Fatal 0. Skip 162. Build failure 0

Differential Revision: D60870543


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames