### PR TITLE
llvm update for backward-breaking APIs in 18 and 19

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -2754,7 +2754,11 @@ void LLVMCodeGenImpl::optimize(llvm::Module& M) {
   // options.
   llvm::PassBuilder PB(&TM);
 
+#if LLVM_VERSION_MAJOR >= 18 && LLVM_VERSION_MAJOR < 19
+  TM.registerPassBuilderCallbacks(PB, false);
+#else
   TM.registerPassBuilderCallbacks(PB);
+#endif
 
   // Register all the basic analyses with the managers.
   PB.registerModuleAnalyses(MAM);

--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -56,7 +56,7 @@ static llvm::JITTargetAddress toAddress(T* Ptr) {
 // Get subtarget features for the host.
 static llvm::SubtargetFeatures getHostSubtargetFeatures() {
   llvm::SubtargetFeatures subtargetFeatures;
-#if LLVM_VERSION_MAJOR >= 18
+#if LLVM_VERSION_MAJOR >= 19
   const auto featureMap = llvm::sys::getHostCPUFeatures();
 #else
   llvm::StringMap<bool> featureMap;


### PR DESCRIPTION
Related to #130661, #129797.  Based on the LLVM tagged releases, these LLVM_VERSION_MAJOR guards are accurate.

cc @EikanWang @jgong5