### PR TITLE
[quant] Speed up dequantize_per_channel

### DIFF
--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -682,12 +682,14 @@ def dequantize_per_channel(
     input, permute_axis_list = _permute_to_axis_zero(input, axis)
     res = torch.zeros_like(input, dtype=out_dtype)
 
-    scales = scales.unsqueeze(1)
+    new_shape = [1] * input.dim()
+    new_shape[0] = scales.shape[0]
+    scales = scales.view(*new_shape)
     if zero_points is not None:
         # TODO: investigate why
         # (input[i] - zero_points[i]).to(out_dtype) * scales[i]
         # failed the test
-        res = (input.to(out_dtype) - zero_points.unsqueeze(1)) * scales
+        res = (input.to(out_dtype) - zero_points.view(*new_shape)) * scales
     else:
         res = input.to(out_dtype) * scales
 

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -682,12 +682,14 @@ def dequantize_per_channel(
     input, permute_axis_list = _permute_to_axis_zero(input, axis)
     res = torch.zeros_like(input, dtype=out_dtype)
 
-    for i in range(input.size(0)):
-        zp = zero_points[i] if zero_points is not None else 0
+    scales = scales.unsqueeze(1)
+    if zero_points is not None:
         # TODO: investigate why
         # (input[i] - zero_points[i]).to(out_dtype) * scales[i]
         # failed the test
-        res[i] = (input[i].to(out_dtype) - zp) * scales[i]
+        res = (input.to(out_dtype) - zero_points.unsqueeze(1)) * scales
+    else:
+        res = input.to(out_dtype) * scales
 
     out = res.permute(tuple(permute_axis_list))
     return out

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -680,7 +680,6 @@ def dequantize_per_channel(
     assert axis < input.dim(), f"Expecting axis to be < {input.dim()}"
     _quant_min_max_bounds_check(quant_min, quant_max, dtype)
     input, permute_axis_list = _permute_to_axis_zero(input, axis)
-    res = torch.zeros_like(input, dtype=out_dtype)
 
     new_shape = [1] * input.dim()
     new_shape[0] = scales.shape[0]

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -684,12 +684,12 @@ def dequantize_per_channel(
 
     new_shape = [1] * input.dim()
     new_shape[0] = scales.shape[0]
-    scales = scales.view(*new_shape)
+    scales = scales.view(new_shape)
     if zero_points is not None:
         # TODO: investigate why
         # (input[i] - zero_points[i]).to(out_dtype) * scales[i]
         # failed the test
-        res = (input.to(out_dtype) - zero_points.view(*new_shape)) * scales
+        res = (input.to(out_dtype) - zero_points.view(new_shape)) * scales
     else:
         res = input.to(out_dtype) * scales
 

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -685,12 +685,11 @@ def dequantize_per_channel(
     new_shape[0] = scales.shape[0]
     scales = scales.view(new_shape)
     if zero_points is not None:
-        # TODO: investigate why
-        # (input[i] - zero_points[i]).to(out_dtype) * scales[i]
-        # failed the test
-        res = (input.to(out_dtype) - zero_points.view(new_shape)) * scales
+        res = (input - zero_points.view(new_shape)) * scales
     else:
-        res = input.to(out_dtype) * scales
+        res = input * scales
+
+    res = res.to(out_dtype)
 
     out = res.permute(tuple(permute_axis_list))
     return out


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #132828

Tensor-wise operations are much faster than looping over tensor elements. Rewrite loop in dequantize_per_channel to use whole-Tensor operations accordingly.

Differential Revision: [D60871396](https://our.internmc.facebook.com/intern/diff/D60871396/)