### PR TITLE
Enable clang-tidy on aten/src/ATen/cpu

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -195,6 +195,8 @@ include_patterns = [
     # and excluding most sub-directories for now.
     'aten/src/ATen/*.h',
     'aten/src/ATen/*.cpp',
+    'aten/src/ATen/cpu/*.h',
+    'aten/src/ATen/cpu/*.cpp',
     'aten/src/ATen/core/*.h',
     'aten/src/ATen/core/*.cpp',
     'aten/src/ATen/cudnn/*.h',

--- a/aten/src/ATen/cpu/Utils.cpp
+++ b/aten/src/ATen/cpu/Utils.cpp
@@ -85,7 +85,7 @@ static uint32_t get_cache_size(int level) {
   if (!processors) {
     return 0;
   }
-  const struct cpuinfo_cache* cache = NULL;
+  const struct cpuinfo_cache* cache = nullptr;
   switch (level) {
     case 1:
       cache = processors[0].cache.l1d;

--- a/aten/src/ATen/cpu/vec/vec.h
+++ b/aten/src/ATen/cpu/vec/vec.h
@@ -15,7 +15,7 @@ inline Vectorized<bool> convert_to_bool(Vectorized<int8_t> x) {
   x.ne(Vectorized<int8_t>(0)).store(buffer);
 
   Vectorized<bool> ret;
-  static_assert(x.size() == ret.size(), "");
+  static_assert(x.size() == ret.size() );
   std::memcpy(ret, buffer, ret.size() * sizeof(bool));
   return ret;
 }

--- a/aten/src/ATen/cpu/vec/vec.h
+++ b/aten/src/ATen/cpu/vec/vec.h
@@ -15,7 +15,7 @@ inline Vectorized<bool> convert_to_bool(Vectorized<int8_t> x) {
   x.ne(Vectorized<int8_t>(0)).store(buffer);
 
   Vectorized<bool> ret;
-  static_assert(x.size() == ret.size() );
+  static_assert(x.size() == ret.size());
   std::memcpy(ret, buffer, ret.size() * sizeof(bool));
   return ret;
 }

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -848,22 +848,22 @@ static inline Vectorized<T> bitwise_binary_op(const Vectorized<T> &a, const Vect
   return Vectorized<T>::loadu(buffer);
 }
 
-template<class T, typename std::enable_if_t<!std::is_base_of<Vectorizedi, Vectorized<T>>::value, int> = 0>
+template<class T, typename std::enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator&(const Vectorized<T>& a, const Vectorized<T>& b) {
   return bitwise_binary_op(a, b, std::bit_and<intmax_t>());
 }
-template<class T, typename std::enable_if_t<!std::is_base_of<Vectorizedi, Vectorized<T>>::value, int> = 0>
+template<class T, typename std::enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator|(const Vectorized<T>& a, const Vectorized<T>& b) {
   return bitwise_binary_op(a, b, std::bit_or<intmax_t>());
 }
-template<class T, typename std::enable_if_t<!std::is_base_of<Vectorizedi, Vectorized<T>>::value, int> = 0>
+template<class T, typename std::enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator^(const Vectorized<T>& a, const Vectorized<T>& b) {
   return bitwise_binary_op(a, b, std::bit_xor<intmax_t>());
 }
 
 #endif // defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)
 
-template<class T, typename std::enable_if_t<!std::is_base_of<Vectorizedi, Vectorized<T>>::value, int> = 0>
+template<class T, typename std::enable_if_t<!std::is_base_of_v<Vectorizedi, Vectorized<T>>, int> = 0>
 inline Vectorized<T> operator~(const Vectorized<T>& a) {
   using int_t = int_same_size_t<T>;
   Vectorized<T> ones(c10::bit_cast<T>((int_t)(~(int_t)0)));  // All bits are 1

--- a/aten/src/ATen/cpu/vec/vec_convert.h
+++ b/aten/src/ATen/cpu/vec/vec_convert.h
@@ -28,13 +28,13 @@ struct VecConvert {
 };
 
 template <typename dst_t, typename src_t>
-inline typename std::enable_if<std::is_same<dst_t, src_t>::value, Vectorized<src_t>>::type
+inline std::enable_if_t<std::is_same_v<dst_t, src_t>, Vectorized<src_t>>
 convert(const Vectorized<src_t>& src) {
   return src;
 }
 
 template <typename dst_t, typename src_t>
-inline typename std::enable_if<!std::is_same<dst_t, src_t>::value, Vectorized<dst_t>>::type
+inline std::enable_if_t<!std::is_same_v<dst_t, src_t>, Vectorized<dst_t>>
 convert(const Vectorized<src_t>& src) {
   return VecConvert<dst_t, 1, src_t, 1>::apply(src);
 }
@@ -56,7 +56,7 @@ template <
     int src_n,
     bool keep = false,
     std::enable_if_t<dst_n == 1, int> = 0>
-inline typename std::conditional<keep, VectorizedN<dst_t, 1>, Vectorized<dst_t>>::type
+inline std::conditional_t<keep, VectorizedN<dst_t, 1>, Vectorized<dst_t>>
 convert(const VectorizedN<src_t, src_n>& src) {
   return VecConvert<dst_t, dst_n, src_t, src_n>::apply(src);
 }

--- a/aten/src/ATen/cpu/vml.h
+++ b/aten/src/ATen/cpu/vml.h
@@ -168,4 +168,3 @@ IMPLEMENT_VML_MKL(log2, Log2)
 
 } // namespace
 } // namespace at::vml
-

--- a/aten/src/ATen/cpu/vml.h
+++ b/aten/src/ATen/cpu/vml.h
@@ -35,8 +35,8 @@
 #include <mkl.h>
 #endif
 
-namespace at {
-namespace vml {
+
+namespace at::vml {
 inline namespace CPU_CAPABILITY {
 
 using namespace vec;
@@ -167,5 +167,5 @@ IMPLEMENT_VML_MKL(log2, Log2)
 #endif
 
 } // namespace
-} // namespace vml
-} // namespace at
+} // namespace at::vml
+


### PR DESCRIPTION
Expands code coverage of clang-tidy to aten/src/ATen/cpu


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10