### PR TITLE
[PT2][Optimus] Update unbind_cat_to_view pass to include more complicated cases

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -1203,8 +1203,10 @@ class TestSplitCatFxPasses(TestCase):
             post_grad_fusion_options={},
         )
         def unbind_cat_to_view(x):
-            x_c = x.view(10, 50, 500)
-            l1_out = torch.unbind(x_c, dim=0)
+            y = x.view(10, 50, 500)
+            z = x.view(10, 50, 500)
+            l1_out = torch.unbind(y, dim=0)
+            l2_out = torch.unbind(z, dim=0)
             item0 = l1_out[0]
             item1 = l1_out[1]
             item2 = l1_out[2]
@@ -1215,6 +1217,19 @@ class TestSplitCatFxPasses(TestCase):
             item7 = l1_out[7]
             item8 = l1_out[8]
             item9 = l1_out[9]
+            item2_0 = l2_out[0]
+            item2_1 = l2_out[1]
+            item2_2 = l2_out[2]
+            item2_3 = l2_out[3]
+            item2_4 = l2_out[4]
+            item2_5 = l2_out[5]
+            item2_6 = l2_out[6]
+            item2_7 = l2_out[7]
+            item2_8 = l2_out[8]
+            item2_9 = l2_out[9]
+            other1 = item7.clone()
+            other2 = item8.clone()
+            other3 = item9.clone()
             cat = torch.cat(
                 [
                     item0,
@@ -1224,10 +1239,23 @@ class TestSplitCatFxPasses(TestCase):
                     item4,
                     item5,
                     item6,
+                    other1,
+                    item2_0,
+                    item2_1,
+                    item2_2,
+                    item2_3,
+                    item2_4,
+                    item2_5,
+                    item2_6,
+                    item2_7,
+                    item2_8,
+                    item2_9,
+                    other2,
+                    other3,
                 ],
                 dim=1,
             )
-            return torch.cat((cat, item7, item8, item9), dim=1)
+            return cat
 
         @torch._inductor.config.patch(
             pre_grad_fusion_options={


### PR DESCRIPTION
Summary: We found recent CMF and IGCTR has more complicated patterns to optimize in order to remove as many stack/cat nodes as possible, we thus design such patterns

Test Plan:
# unit test

```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 test //caffe2/test/inductor:split_cat_fx_passes
```
Test UI: https://www.internalfb.com/intern/testinfra/testrun/3659174939423652
Network: Up: 113KiB  Down: 112KiB  (reSessionID-11c9b598-af3a-4727-8f02-ccb1471d092b)
Jobs completed: 27. Time elapsed: 5:45.8s.
Cache hits: 0%. Commands: 2 (cached: 0, remote: 0, local: 2)
Tests finished: Pass 9. Fail 0. Fatal 0. Skip 1. Build failure 0

# benchmark

### cmf
```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "cmf_shrink" --flow_id 587303213 -n
```
P1515072258

Counter({'pattern_matcher_nodes': 2170, 'pattern_matcher_count': 1766, 'normalization_pass': 402, 'remove_split_with_size_one_pass': 269, 'extern_calls': 193, 'merge_splits_pass': 74, 'normalization_aten_pass': 51, 'fxgraph_cache_miss': 9, 'batch_aten_mul': 6, 'scmerge_split_sections_removed': 5, 'scmerge_split_removed': 3, 'scmerge_cat_removed': 3, 'unbind_stack_pass': 3, 'batch_sigmoid': 2, 'batch_linear': 2, 'batch_aten_sub': 2, 'batch_layernorm': 1, 'scmerge_split_added': 1, 'scmerge_cat_added': 1, 'split_stack_to_cats_pass': 1, 'split_cat_to_slices_pass': 1, 'batch_aten_add': 1, 'batch_relu': 1})

### ig_ctr

```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "ig_ctr" --flow_id 584880697 -n
```
P1515087739

Counter({'pattern_matcher_nodes': 1832, 'pattern_matcher_count': 1564, 'extern_calls': 378, 'normalization_pass': 345, 'normalization_aten_pass': 49, 'fxgraph_cache_miss': 18, 'batch_aten_mul': 6, 'scmerge_cat_removed': 5, 'scmerge_cat_added': 4, 'batch_linear_post_grad': 4, 'scmerge_split_removed': 3, 'unbind_stack_pass': 3, 'unbind_cat_to_view_pass': 3, 'batch_tanh': 2, 'scmerge_split_sections_removed': 2, 'scmerge_split_added': 2, 'split_stack_to_cats_pass': 2, 'split_cat_to_slices_pass': 1})

# e2e

testing the following new patterns
```
                "split_stack_to_cats_pass": {},
                "split_cat_to_slices_pass": {},
                "unbind_cat_to_view_pass": {},
```
Note that you can tune the hyper-parameter "threshold_to_cat " for these patterns, and the minimum value you give should be at least 2. The larger the value, the less aggressive to do the node slicing but to keep the cat, and the default value is 10. You can tune the parameters by setting threshold_to_cat. For example

```
"split_stack_to_cats_pass": {"threshold_to_cat": 10},
"split_cat_to_slices_pass": {"threshold_to_cat": 10},
"unbind_cat_to_view_pass": {"threshold_to_cat": 10},
```

Note that the default value may not be optimal, it's based on my experiments on CMF and IGCTR, you are more than welcome to tune the value to find the best threashold for you. For example, in the cmf local run,
- when "threshold_to_cat" is 2
P1515072258
=============Print full analysis for cmf_shrink================
| Metric             | Value           |
|:-------------------|:----------------|
| Batch size         | 10              |
| Latency            | 156.07 ms       |
| Model size         | 844357184 bytes |
| Flops/example      | 583.53 G        |
| TFLOPS             | 37.39           |
| MFU                | 4.67%           |
| Activation/example | 1707.49 MB      |

- when "threshold_to_cat" is 10
P1515912635
=============Print full analysis for cmf_shrink================
| Metric             | Value           |
|:-------------------|:----------------|
| Batch size         | 10              |
| Latency            | 155.09 ms       |
| Model size         | 844357184 bytes |
| Flops/example      | 583.53 G        |
| TFLOPS             | 37.63           |
| MFU                | 4.70%           |
| Activation/example | 1707.49 MB      |

ads_dper3:164562cbe29f6c5aea4546cf3d463b87
training_platform:5e455c643c52940bb4567017f4c7ba83

## cmf
baseline
f588717948
proposal
f588719502

### QPS and NE results
{F1793304642}
{F1793304664}
{F1793304689}
{F1793304683}

### Compilation time reduction

zoomer link: https://www.internalfb.com/intern/zoomer/?profiling_run_fbid=1045728747213538&tab=pt2_metrics

Compile time for that frame is reduced to 1 min from 9 min.

### trace analysis
baseline trace link
https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2Ff588722004-TrainingApplication%2F0%2Frank-1.Aug_06_00_03_46.3617.pt.trace.json.gz&bucket=pyper_traces

proposal trace link
https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2Ff588723545-TrainingApplication%2F0%2Frank-1.Aug_05_23_54_56.3647.pt.trace.json.gz&bucket=pyper_traces

{F1793312804} {F1793312867}

From the trace, we can see that the green part (introduced by split cat) has been reduced significantly with our new patterns.

Differential Revision: D60750275


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang