### PR TITLE
[CUDAGraph] Warn once if too many distinct sizes

### DIFF
--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -369,9 +369,13 @@ def cudagraphify_impl(
     int_key = [i for i, v in enumerate(inputs) if isinstance(v, int)]
     get_ints: Any = operator.itemgetter(*int_key) if int_key else lambda _: None
 
+    has_warn = False
+
     del inputs
 
     def deferred_cudagraphify(inputs: List[InputType]) -> OutputType:
+        nonlocal has_warn
+
         int_key = get_ints(inputs)
         fn = fn_cache.get(int_key)
         if fn is not None:
@@ -382,7 +386,8 @@ def cudagraphify_impl(
         else:
             log.info("recording cudagraph tree for symint key %s", int_key)
 
-        maybe_warning_due_to_dynamic_shape(fn_cache, int_key)
+        if not has_warn:
+            has_warn = maybe_warning_due_to_dynamic_shape(fn_cache, int_key)
 
         # first get indices we need to check to align, then update our static inputs,
         # and finally copy

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -293,7 +293,7 @@ def log_data_ptr_mismatch(
 def maybe_warning_due_to_dynamic_shape(
     fn_cache: Dict[Tuple[int, ...], Callable[..., Any]],
     new_int_key: Any,
-):
+) -> bool:
     num_cudagraphs = len(fn_cache.keys()) + 1
 
     def warn_msg():
@@ -314,6 +314,9 @@ def maybe_warning_due_to_dynamic_shape(
         > torch._inductor.config.triton.cudagraph_dynamic_shape_warn_limit
     ):
         perf_hint_log.warning(warn_msg())
+        return True
+
+    return False
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Warn once if there are too many distinct sizes for cudagraph, so we can avoid spamming logs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang