### PR TITLE
`nn.ModuleList.__getitem__` overloads

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -318,6 +318,18 @@ class ModuleList(Module):
             idx += len(self)
         return str(idx)
 
+    @overload
+    def __getitem__(self, idx: slice) -> "ModuleList":
+        ...
+
+    @overload
+    def __getitem__(self, idx: int) -> Module:
+        ...
+
+    @overload
+    def __getitem__(self, idx: Union[int, slice]) -> Union[Module, "ModuleList"]:
+        ...
+
     @_copy_to_script_wrapper
     def __getitem__(self, idx: Union[int, slice]) -> Union[Module, "ModuleList"]:
         if isinstance(idx, slice):

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -326,10 +326,6 @@ class ModuleList(Module):
     def __getitem__(self, idx: int) -> Module:
         ...
 
-    @overload
-    def __getitem__(self, idx: Union[int, slice]) -> Union[Module, "ModuleList"]:
-        ...
-
     @_copy_to_script_wrapper
     def __getitem__(self, idx: Union[int, slice]) -> Union[Module, "ModuleList"]:
         if isinstance(idx, slice):


### PR DESCRIPTION
Overloads so that you can get more specific type info based on how you are indexing.

```python
from torch import nn

module_list = nn.ModuleList(32 * [nn.Linear(2, 2)])

# before:
reveal_type(module_list[0])  # Type of "module_list[0]" is "Module | ModuleList"
reveal_type(module_list[:1])  # Type of "module_list[: 1]" is "Module | ModuleList"

# now:
reveal_type(module_list[0])  # Type of "module_list[0]" is "Module"
reveal_type(module_list[:1])  # Type of "module_list[: 1]" is "ModuleList"
```