### PR TITLE
[HOO] add hints_wrapper to support passing context hints

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -2620,7 +2620,9 @@ class GraphModule(torch.nn.Module):
                 res = torch.add(x[0], x[1]["test"])
                 return res
 
-            res = hints_wrapper(outer_body_fn, ((x, {"test" : y}),), {}, hints={"test": True})
+            res = hints_wrapper(
+                outer_body_fn, ((x, {"test": y}),), {}, hints={"test": True}
+            )
             return res
 
         backend = EagerAndRecordGraphs()

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6849,7 +6849,6 @@ def forward(self, x, y):
             if node.op == "call_function":
                 self.assertTrue(False)
 
-<<<<<<< HEAD
     def test_automatic_dynamic_shapes_simple_equality(self):
         # The next 3 test cases tests for automatic dynamic shapes specs, verifying that automatic dynamism
         # leads to replacement symbols being set for equalities, and inferred relationships being checked
@@ -7033,8 +7032,6 @@ def forward(self, x, y):
 
     @testing.expectedFailureNonStrict
     @testing.expectedFailureTrainingIRToRunDecompNonStrict  # unbacked symint not tracked?
-=======
->>>>>>> df62b097c93 (temporarily disable serde test for hints_wrapper)
     @testing.expectedFailureSerDer  # T195866111
     def test_hints_wrapper(self):
         class M(torch.nn.Module):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6849,6 +6849,7 @@ def forward(self, x, y):
             if node.op == "call_function":
                 self.assertTrue(False)
 
+<<<<<<< HEAD
     def test_automatic_dynamic_shapes_simple_equality(self):
         # The next 3 test cases tests for automatic dynamic shapes specs, verifying that automatic dynamism
         # leads to replacement symbols being set for equalities, and inferred relationships being checked
@@ -7032,6 +7033,8 @@ def forward(self, x, y):
 
     @testing.expectedFailureNonStrict
     @testing.expectedFailureTrainingIRToRunDecompNonStrict  # unbacked symint not tracked?
+=======
+>>>>>>> df62b097c93 (temporarily disable serde test for hints_wrapper)
     @testing.expectedFailureSerDer  # T195866111
     def test_hints_wrapper(self):
         class M(torch.nn.Module):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7071,10 +7071,12 @@ def forward(self, x, y):
 class GraphModule(torch.nn.Module):
     def forward(self, x: "f32[2, 4]", y: "f32[4]"):
         add: "f32[2, 4]" = torch.ops.aten.add.Tensor(x, y);  x = None
+
         hints_wrapper_body_graph_0 = self.hints_wrapper_body_graph_0
         hints_wrapper = torch.ops.higher_order.hints_wrapper(hints_wrapper_body_graph_0, (add, y), {}, hints = {'outer_body': True});  hints_wrapper_body_graph_0 = add = y = None
         getitem: "f32[2, 4]" = hints_wrapper[0];  hints_wrapper = None
         return (getitem,)
+
     class hints_wrapper_body_graph_0(torch.nn.Module):
         def forward(self, arg0_1: "f32[2, 4]", arg1_1: "f32[4]"):
             hints_wrapper_body_graph_0 = self.hints_wrapper_body_graph_0
@@ -7082,6 +7084,7 @@ class GraphModule(torch.nn.Module):
             getitem: "f32[2, 4]" = hints_wrapper[0];  hints_wrapper = None
             abs_1: "f32[2, 4]" = torch.ops.aten.abs.default(getitem);  getitem = None
             return (abs_1,)
+
         class hints_wrapper_body_graph_0(torch.nn.Module):
             def forward(self, arg0_1: "f32[2, 4]", arg1_1: "f32[4]"):
                 relu: "f32[2, 4]" = torch.ops.aten.relu.default(arg0_1);  arg0_1 = None

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1510,7 +1510,7 @@ class HintsWrapperHigherOrderVariable(TorchHigherOrderOperatorVariable):
         return _call_function_and_unflatten_output(
             tx, self.value, p_args, p_kwargs, flat_example_value, treespec
         )
-    
+
 
 class OutDtypeHigherOrderVariable(TorchHigherOrderOperatorVariable):
     def call_function(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -578,6 +578,8 @@ class TorchHigherOrderOperatorVariable(VariableTracker):
             return OutDtypeHigherOrderVariable(value, source, **kwargs)
         elif value.__name__ == "wrap":
             return WrapHigherOrderVariable(value, source, **kwargs)
+        elif value.__name__ == "hints_wrapper":
+            return WrapHigherOrderVariable(value, source, **kwargs)
         elif value.__name__ == "flex_attention":
             return FlexAttentionHigherOrderVariable(value, source, **kwargs)
         elif value.__name__ in (
@@ -1353,6 +1355,11 @@ class WrapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             body_r.as_proxy(),
         )
 
+        if self.value.__name__ == "hints_wrapper":
+            if "hints" not in kwargs:
+                unimplemented("key hints not found in kwargs")
+            # make hints into p_kwargs
+            p_kwargs["hints"] = kwargs["hints"].as_python_constant()
         return _call_function_and_unflatten_output(
             tx, self.value, tuple(p_args), p_kwargs, flat_example_value, treespec
         )

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1360,11 +1360,6 @@ class WrapHigherOrderVariable(TorchHigherOrderOperatorVariable):
             body_r.as_proxy(),
         )
 
-        if self.value.__name__ == "hints_wrapper":
-            if "hints" not in kwargs:
-                unimplemented("key hints not found in kwargs")
-            # make hints into p_kwargs
-            p_kwargs["hints"] = kwargs["hints"].as_python_constant()
         return _call_function_and_unflatten_output(
             tx, self.value, tuple(p_args), p_kwargs, flat_example_value, treespec
         )

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -579,7 +579,7 @@ class TorchHigherOrderOperatorVariable(VariableTracker):
         elif value.__name__ == "wrap":
             return WrapHigherOrderVariable(value, source, **kwargs)
         elif value.__name__ == "hints_wrapper":
-            return WrapHigherOrderVariable(value, source, **kwargs)
+            return HintsWrapperHigherOrderVariable(value, source, **kwargs)
         elif value.__name__ == "flex_attention":
             return FlexAttentionHigherOrderVariable(value, source, **kwargs)
         elif value.__name__ in (
@@ -1437,6 +1437,80 @@ class WrapWithSetGradEnabledHigherOrderVariable(TorchHigherOrderOperatorVariable
             tx, self.value, proxy_args, {}, example_value, treespec
         )
 
+
+class HintsWrapperHigherOrderVariable(TorchHigherOrderOperatorVariable):
+    @raise_hard_error_if_graph_break(
+        reason="Hints_wrapper doesn't work unless it is captured completely with torch.compile."
+    )
+    def call_function(
+        self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
+    ) -> "VariableTracker":
+        _check_supported_callable_arg(tx, args[0], "body_fn")
+
+        # inputs
+        if len(args) != 3:
+            unimplemented(
+                f"Expected 3 arguments but got {len(args)}.\n"
+                f"Usage: hints_wrapper(body_fn, args, kwargs, hints).\n"
+                f"kwargs required to be provided explicitly."
+            )
+
+        if not isinstance(args[1], (ListVariable, TupleVariable)):
+            unimplemented(
+                f"Expected a tuple but got {args[1].python_type()}",
+            )
+        operands = args[1].unpack_var_sequence(tx)
+
+        if not isinstance(args[2], ConstDictVariable):
+            unimplemented(
+                f"Expected a dict but got {args[2].python_type()}",
+            )
+
+        if "hints" not in kwargs:
+            raise IncorrectUsage("hints_wrapper - key hints not provided")
+
+        (
+            (body_r, treespec),
+            body_graph,
+            body_lifted_freevars,
+        ) = speculate_subgraph(
+            tx,
+            args[0],  # function
+            operands,
+            args[2].as_python_constant(),
+            "hints_wrapper",
+            source_target=self.value,
+            should_flatten_outputs=True,
+        )
+
+        body_gmod = torch.fx.GraphModule(tx.output.nn_modules, body_graph)
+        body_name = add_subgraph(
+            tx,
+            "hints_wrapper_body",
+            body_gmod,
+        )
+
+        body_node = make_attr(tx, body_name)
+
+        # Since, we call `speculate_subgraph` with `set_subgraph_inputs="automatic`,
+        # all the arguments are lifted.
+        lifted_args = tuple(arg for arg in body_lifted_freevars.keys())
+        p_args = (body_node, lifted_args, {})
+
+        p_kwargs = {}
+        # add hints into p_kwargs
+        p_kwargs["hints"] = kwargs["hints"].as_python_constant()
+
+        flat_example_value = pytree.tree_map_only(
+            torch.fx.Proxy,
+            lambda a: a.node.meta["example_value"],
+            body_r.as_proxy(),
+        )
+
+        return _call_function_and_unflatten_output(
+            tx, self.value, p_args, p_kwargs, flat_example_value, treespec
+        )
+    
 
 class OutDtypeHigherOrderVariable(TorchHigherOrderOperatorVariable):
     def call_function(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -24,7 +24,12 @@ from torch.fx.passes.shape_prop import _extract_tensor_metadata
 from torch.utils import _pytree as pytree
 
 from .. import variables
-from ..exc import UncapturedHigherOrderOpError, unimplemented, Unsupported
+from ..exc import (
+    IncorrectUsage,
+    UncapturedHigherOrderOpError,
+    unimplemented,
+    Unsupported,
+)
 from ..source import AttrSource
 from ..utils import proxy_args_kwargs
 from .dicts import ConstDictVariable

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -4,6 +4,7 @@ from torch._higher_order_ops.flex_attention import (
     flex_attention_backward,
 )
 from torch._higher_order_ops.while_loop import while_loop
+from torch._higher_order_ops.hints_wrap import hints_wrapper
 
 
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "while_loop",
     "flex_attention",
     "flex_attention_backward",
+    "hints_wrapper",
 ]

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -4,7 +4,6 @@ from torch._higher_order_ops.flex_attention import (
     flex_attention_backward,
 )
 from torch._higher_order_ops.while_loop import while_loop
-from torch._higher_order_ops.hints_wrap import hints_wrapper
 
 
 __all__ = [
@@ -12,5 +11,4 @@ __all__ = [
     "while_loop",
     "flex_attention",
     "flex_attention_backward",
-    "hints_wrapper",
 ]

--- a/torch/_higher_order_ops/__init__.py
+++ b/torch/_higher_order_ops/__init__.py
@@ -3,8 +3,8 @@ from torch._higher_order_ops.flex_attention import (
     flex_attention,
     flex_attention_backward,
 )
-from torch._higher_order_ops.while_loop import while_loop
 from torch._higher_order_ops.hints_wrap import hints_wrapper
+from torch._higher_order_ops.while_loop import while_loop
 
 
 __all__ = [

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -1,0 +1,104 @@
+# mypy: allow-untyped-defs
+import copy
+
+import torch.utils._pytree as pytree
+from torch._C import DispatchKey
+from torch._higher_order_ops.utils import (
+    autograd_not_implemented,
+    reenter_make_fx,
+    unique_graph_id,
+)
+from torch._ops import HigherOrderOperator
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode, track_tensor_tree
+
+
+# used for wrapping a function/op with context hints
+class HintsWrapper(HigherOrderOperator):
+    def __init__(self):
+        super().__init__("hints_wrapper")
+
+
+hints_wrapper = HintsWrapper()
+# Override hints_wrapper.__module__ to "torch.ops.higher_order" so that in the generated
+# graph module, hints_wrapper node's target is correctedly printed as torch.ops.higher_order.hints_wrapper
+hints_wrapper.__module__ = "torch.ops.higher_order"
+
+
+class no_hints_kwargs:
+    def __init__(self, kwargs):
+        self.kwargs = copy.copy(kwargs)
+
+    def __enter__(self):
+        if "hints" in self.kwargs:
+            del self.kwargs["hints"]
+        return self.kwargs
+
+    def __exit__(self, *args):
+        pass
+
+
+@hints_wrapper.py_impl(DispatchKey.CompositeExplicitAutograd)
+def hints_wrapper_dense(body_fn, *args, **kwargs):
+    with no_hints_kwargs(kwargs) as kw:
+        return body_fn(*args, **kw)
+
+
+hints_wrapper.py_impl(DispatchKey.Autograd)(
+    autograd_not_implemented(hints_wrapper, deferred_error=True)
+)
+
+
+@hints_wrapper.py_impl(FakeTensorMode)
+def hints_wrapper_fake_tensor_mode(mode, body_func, *args, **kwargs):
+    flat_args = pytree.tree_leaves(args)
+    with mode:
+        with no_hints_kwargs(kwargs) as kw:
+            return body_func(*flat_args, **kw)
+
+
+@hints_wrapper.py_functionalize_impl
+def hints_wrapper_functionalize(ctx, body_fn, *args, **kwargs):
+    unwrapped_args = ctx.unwrap_tensors(args)
+    unwrapped_kwargs = ctx.unwrap_tensors(kwargs)
+    hints = dict()
+    if "hints" in unwrapped_kwargs:
+        hints = unwrapped_kwargs["hints"]
+    with ctx.redispatch_to_next():
+        functional_body_fn = ctx.functionalize(body_fn)
+        outputs = hints_wrapper(
+            functional_body_fn,
+            unwrapped_args,
+            hints=hints,
+        )
+        return ctx.wrap_tensors(outputs)
+
+
+def trace_hints_wrapper(proxy_mode, hints_wrapper, body_fn, *args, **kwargs):
+    flat_args = tuple(pytree.tree_leaves(args))
+    with no_hints_kwargs(kwargs) as kw:
+        body_graph = reenter_make_fx(body_fn)(*flat_args, **kw)
+
+    _, body_graph_name = unique_graph_id(proxy_mode, prefix="hints_wrapper_body_graph")
+    proxy_mode.tracer.root.register_module(body_graph_name, body_graph)
+
+    new_args = (body_graph, *flat_args)
+
+    proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, new_args)
+    proxy_kwargs = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, kwargs)
+
+    out_proxy = proxy_mode.tracer.create_proxy(
+        "call_function", hints_wrapper, proxy_args, proxy_kwargs, name="hints_wrapper"
+    )
+
+    with no_hints_kwargs(kwargs) as kw:
+        out = body_fn(*flat_args, **kw)
+    return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
+
+
+@hints_wrapper.py_impl(ProxyTorchDispatchMode)
+def inner(proxy_mode, body_fn, *args, **kwargs):
+    if proxy_mode.enable_tracing:
+        return trace_hints_wrapper(proxy_mode, hints_wrapper, body_fn, *args, **kwargs)
+    else:
+        return hints_wrapper(body_fn, *args, **kwargs)

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -33,6 +33,13 @@ class HintsWrapper(HigherOrderOperator):
         if not isinstance(hints, dict):
             raise RuntimeError(f"hints must be a dict, got {type(hints)}")
 
+        for k, v in hints.items():
+            if not isinstance(v, (int, float, bool, str)):
+                raise RuntimeError(
+                    "hints must be a dict containing int, float, bool or str "
+                    f"value, got value {v} for key {k}."
+                )
+
         return super().__call__(body_fn, args, kwargs, hints)
 
 

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
-import copy
-
+import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._higher_order_ops.utils import (
@@ -18,30 +17,31 @@ class HintsWrapper(HigherOrderOperator):
     def __init__(self):
         super().__init__("hints_wrapper")
 
+    def __call__(self, body_fn, args, kwargs, hints):
+        if not isinstance(args, tuple):
+            raise RuntimeError(f"args must be a tuple, got {type(args)}")
+
+        if not all(isinstance(t, (torch.Tensor, int, float, bool)) for t in args):
+            raise RuntimeError(
+                "args must be a tuple of tensors, ints, floats, or bools, got "
+                f"{args}"
+            )
+
+        if not isinstance(kwargs, dict):
+            raise RuntimeError(f"kwargs must be a dict, got {type(kwargs)}")
+
+        if not isinstance(hints, dict):
+            raise RuntimeError(f"hints must be a dict, got {type(hints)}")
+
+        return super().__call__(body_fn, args, kwargs, hints)
+
 
 hints_wrapper = HintsWrapper()
-# Override hints_wrapper.__module__ to "torch.ops.higher_order" so that in the generated
-# graph module, hints_wrapper node's target is correctedly printed as torch.ops.higher_order.hints_wrapper
-hints_wrapper.__module__ = "torch.ops.higher_order"
-
-
-class no_hints_kwargs:
-    def __init__(self, kwargs):
-        self.kwargs = copy.copy(kwargs)
-
-    def __enter__(self):
-        if "hints" in self.kwargs:
-            del self.kwargs["hints"]
-        return self.kwargs
-
-    def __exit__(self, *args):
-        pass
 
 
 @hints_wrapper.py_impl(DispatchKey.CompositeExplicitAutograd)
-def hints_wrapper_dense(body_fn, *args, **kwargs):
-    with no_hints_kwargs(kwargs) as kw:
-        return body_fn(*args, **kw)
+def hints_wrapper_dense(body_fn, args, kwargs, hints):
+    return body_fn(*args, **kwargs)
 
 
 hints_wrapper.py_impl(DispatchKey.Autograd)(
@@ -50,55 +50,56 @@ hints_wrapper.py_impl(DispatchKey.Autograd)(
 
 
 @hints_wrapper.py_impl(FakeTensorMode)
-def hints_wrapper_fake_tensor_mode(mode, body_func, *args, **kwargs):
+def hints_wrapper_fake_tensor_mode(mode, body_func, args, kwargs, hints):
     flat_args = pytree.tree_leaves(args)
     with mode:
-        with no_hints_kwargs(kwargs) as kw:
-            return body_func(*flat_args, **kw)
+        return body_func(*flat_args, **kwargs)
 
 
 @hints_wrapper.py_functionalize_impl
-def hints_wrapper_functionalize(ctx, body_fn, *args, **kwargs):
+def hints_wrapper_functionalize(ctx, body_fn, args, kwargs, hints):
     unwrapped_args = ctx.unwrap_tensors(args)
     unwrapped_kwargs = ctx.unwrap_tensors(kwargs)
-    hints = dict()
-    if "hints" in unwrapped_kwargs:
-        hints = unwrapped_kwargs["hints"]
+    unwrapped_hints = ctx.unwrap_tensors(hints)
     with ctx.redispatch_to_next():
         functional_body_fn = ctx.functionalize(body_fn)
         outputs = hints_wrapper(
             functional_body_fn,
             unwrapped_args,
-            hints=hints,
+            unwrapped_kwargs,
+            unwrapped_hints,
         )
         return ctx.wrap_tensors(outputs)
 
 
-def trace_hints_wrapper(proxy_mode, hints_wrapper, body_fn, *args, **kwargs):
+def trace_hints_wrapper(proxy_mode, hints_wrapper, body_fn, args, kwargs, hints):
     flat_args = tuple(pytree.tree_leaves(args))
-    with no_hints_kwargs(kwargs) as kw:
-        body_graph = reenter_make_fx(body_fn)(*flat_args, **kw)
+    body_graph = reenter_make_fx(body_fn)(*flat_args, **kwargs)
 
     _, body_graph_name = unique_graph_id(proxy_mode, prefix="hints_wrapper_body_graph")
     proxy_mode.tracer.root.register_module(body_graph_name, body_graph)
 
-    new_args = (body_graph, *flat_args)
+    new_args: tuple = (body_graph, flat_args, {})
+    # merge hints into kwargs
+    new_kwargs = {}
+    new_kwargs["hints"] = hints
 
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, new_args)
-    proxy_kwargs = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, kwargs)
+    proxy_kwargs = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, new_kwargs)
 
     out_proxy = proxy_mode.tracer.create_proxy(
         "call_function", hints_wrapper, proxy_args, proxy_kwargs, name="hints_wrapper"
     )
 
-    with no_hints_kwargs(kwargs) as kw:
-        out = body_fn(*flat_args, **kw)
+    out = body_fn(*flat_args, **kwargs)
     return track_tensor_tree(out, out_proxy, constant=None, tracer=proxy_mode.tracer)
 
 
 @hints_wrapper.py_impl(ProxyTorchDispatchMode)
-def inner(proxy_mode, body_fn, *args, **kwargs):
+def inner(proxy_mode, body_fn, args, kwargs, hints):
     if proxy_mode.enable_tracing:
-        return trace_hints_wrapper(proxy_mode, hints_wrapper, body_fn, *args, **kwargs)
+        return trace_hints_wrapper(
+            proxy_mode, hints_wrapper, body_fn, args, kwargs, hints
+        )
     else:
-        return hints_wrapper(body_fn, *args, **kwargs)
+        return hints_wrapper(body_fn, args, kwargs, hints)

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -34,6 +34,11 @@ class HintsWrapper(HigherOrderOperator):
             raise RuntimeError(f"hints must be a dict, got {type(hints)}")
 
         for k, v in hints.items():
+            if not isinstance(k, str):
+                raise RuntimeError(
+                    f"hints key must be a str, got {k}."
+                )
+
             if not isinstance(v, (int, float, bool, str)):
                 raise RuntimeError(
                     "hints must be a dict containing int, float, bool or str "

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -30,6 +30,11 @@ class HintsWrapper(HigherOrderOperator):
         if not isinstance(kwargs, dict):
             raise RuntimeError(f"kwargs must be a dict, got {type(kwargs)}")
 
+        if len(kwargs) > 0:
+            raise RuntimeError(
+                f"kwargs except for hints are not supported, got {kwargs}"
+            )
+
         if not isinstance(hints, dict):
             raise RuntimeError(f"hints must be a dict, got {type(hints)}")
 

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -3,11 +3,11 @@ import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey
 from torch._higher_order_ops.utils import (
+    _has_potential_branch_input_alias,
+    _has_potential_branch_input_mutation,
     autograd_not_implemented,
     reenter_make_fx,
     unique_graph_id,
-    _has_potential_branch_input_alias,
-    _has_potential_branch_input_mutation,
     UnsupportedAliasMutationException,
 )
 from torch._ops import HigherOrderOperator
@@ -98,13 +98,13 @@ def hints_wrapper_functionalize(ctx, body_fn, args, kwargs, hints):
         functional_body_fn = ctx.functionalize(body_fn)
         pre_dispatch = hasattr(ctx, "mode") and ctx.mode.pre_dispatch
         if _has_potential_branch_input_mutation(
-                functional_body_fn, unwrapped_args, pre_dispatch=pre_dispatch
+            functional_body_fn, unwrapped_args, pre_dispatch=pre_dispatch
         ):
             raise UnsupportedAliasMutationException(
                 "body_fn of hints_wrapper might be modifying the input!"
             )
         if _has_potential_branch_input_alias(
-                functional_body_fn, unwrapped_args, pre_dispatch=pre_dispatch
+            functional_body_fn, unwrapped_args, pre_dispatch=pre_dispatch
         ):
             raise UnsupportedAliasMutationException(
                 "body_fn of hints_wrapper might be aliasing the input!"

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -35,9 +35,7 @@ class HintsWrapper(HigherOrderOperator):
 
         for k, v in hints.items():
             if not isinstance(k, str):
-                raise RuntimeError(
-                    f"hints key must be a str, got {k}."
-                )
+                raise RuntimeError(f"hints key must be a str, got {k}.")
 
             if not isinstance(v, (int, float, bool, str)):
                 raise RuntimeError(

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -61,6 +61,7 @@ hop_that_doesnt_have_opinfo_test_allowlist = [
     "call_torchbind",
     "triton_kernel_wrapper_mutation",
     "triton_kernel_wrapper_functional",
+    "hints_wrapper",
 ]
 
 torch.library.define(

--- a/torch/testing/_internal/hop_db.py
+++ b/torch/testing/_internal/hop_db.py
@@ -61,7 +61,6 @@ hop_that_doesnt_have_opinfo_test_allowlist = [
     "call_torchbind",
     "triton_kernel_wrapper_mutation",
     "triton_kernel_wrapper_functional",
-    "hints_wrapper",
 ]
 
 torch.library.define(


### PR DESCRIPTION
Fixes #126393

The implementation code is based on feedback here (https://github.com/pytorch/pytorch/pull/121639#issuecomment-2223948842).

Hints are passed as kwargs of hints_wrapper op. It also supports nested hints.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec