### PR TITLE
Force mkl.cmake to search for Module files only

### DIFF
--- a/cmake/public/mkl.cmake
+++ b/cmake/public/mkl.cmake
@@ -1,4 +1,4 @@
-find_package(MKL QUIET)
+find_package(MKL QUIET MODULE)
 
 if(TARGET caffe2::mkl)
   return()


### PR DESCRIPTION
#132853 shows custom op build failures after sourcing oneMKL for CI, which is caused by conflict between local `FindMKL.cmake` and `MKLConfig.cmake` from oneMKL package.
To solve this issue, we force `mkl.cmake` to search for a file called `Find<PackageName>.cmake`.
