### PR TITLE
[NestedTensor] Add support for reducing along multiple non-ragged dimensions for the mean operator in NestedTensor

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -4296,6 +4296,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
             include_list_of_lists=False,
             include_requires_grad=components_require_grad,
             include_inner_dim_size_1=True,  # (B, *, 1)
+            include_2d_tensor=True,  # (B, *)
         )
         reduce_dim = 1  # ragged
 
@@ -4515,6 +4516,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
             include_list_of_lists=False,
             include_requires_grad=components_require_grad,
             include_inner_dim_size_1=True,  # (B, *, 1)
+            include_2d_tensor=True,  # (B, *)
         )
 
         for tensor_list in tensor_lists:

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -6988,8 +6988,10 @@ FORWARD_FAILURES = {
     "var",
     "var.unbiased",
     # === BEGIN UNSUPPORTED SECTION ===
-    # RuntimeError: mean(): not supported for NestedTensor on dim=1
+    # RuntimeError: mean(): not supported when keepdim=False for NestedTensor
     "mean",
+    # NotImplementedError: aten.sum.default
+    "sum",
     # ValueError: expects strided tensor (got torch.jagged tensor)
     "masked.amax",
     "masked.amin",
@@ -7016,12 +7018,12 @@ FORWARD_FAILURES = {
     "jiterator_binary",
     "jiterator_binary_return_by_ref",
     "jiterator_unary",
-    # Bug found: sum() with keepdim=True returns invalid shape
-    "sum",
     # RuntimeError: prod(): keepdim=True must be set for NestedTensor
     "prod",
     # RuntimeError: "jagged_to_padded_dense" not implemented for 'Bool'
     "nanmean",
+    # AssertionError: assert not isinstance(out_ref_component, (list, tuple))
+    "native_layer_norm",
 }
 
 BACKWARD_FAILURES = {
@@ -7043,6 +7045,7 @@ BACKWARD_FAILURES = {
     "pow",
     "sgn",
     "sinc",
+    "softmax",  # IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)
     "special.i1",
     "special.i1e",
 }

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -661,8 +661,8 @@ def _softmax_default(func, *args, **kwargs):
     if reduce_on_ragged:
         padded_softmax_values = torch.nn.functional.softmax(
             torch.ops.aten._jagged_to_padded_dense_forward(
-                inp._values.flatten(
-                    start_dim=inp._ragged_idx
+                inp._values.reshape(
+                    inp._values.shape[0], -1
                 ),  # values are required to be 2D tensors for j2pd
                 [inp._offsets],
                 max_lengths=[inp._max_seqlen],  # max length of ragged dimension


### PR DESCRIPTION
Summary: Add support for reducing across multiple non-ragged dimensions using the `mean` operator in `NestedTensor`. For example, for a nested tensor of shape `(B, *, M, N)`, this diff enables reducing across dimensions `(M, N)` to an output of shape `(B, *)`.

Test Plan:
Verify that existing and modified unit tests pass via the following commands:

```
buck2 run mode/{opt,inplace} //caffe2/test:nested -- --regex test_mean
```

```
buck2 run mode/{opt,inplace} //caffe2/test:nested -- --regex test_jagged_op
```

Differential Revision: D60680005
