### PR TITLE
[BE] Using with_temp_dir for test_distributed_checkpoint

### DIFF
--- a/test/distributed/fsdp/test_distributed_checkpoint.py
+++ b/test/distributed/fsdp/test_distributed_checkpoint.py
@@ -1,7 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
 import sys
-import tempfile
 
 import torch
 from torch import distributed as dist
@@ -22,6 +21,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
 )
+from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -47,6 +47,7 @@ class TestDistributedCheckpoint(FSDPTest):
         return 2
 
     @skip_if_lt_x_gpu(2)
+    @with_temp_dir
     @parametrize("state_dict_type", _DISTRIBUTED_STATE_DICT_IMPLS)
     def test_distributed_checkpoint(self, state_dict_type) -> None:
         with enable_wrap(wrapper_cls=FSDP):
@@ -62,25 +63,21 @@ class TestDistributedCheckpoint(FSDPTest):
             new_params = list(new_model.parameters())
             self.assertNotEqual(params, new_params)
 
-        with tempfile.TemporaryDirectory() as path:
-            paths = [path]
-            dist.broadcast_object_list(paths)
-            path = paths[0]
-            writer = FileSystemWriter(path)
-            reader = FileSystemReader(path)
-            with FSDP.state_dict_type(model, state_dict_type), FSDP.state_dict_type(
-                new_model, state_dict_type
-            ):
-                state_dict = model.state_dict()
+        writer = FileSystemWriter(self.temp_dir)
+        reader = FileSystemReader(self.temp_dir)
+        with FSDP.state_dict_type(model, state_dict_type), FSDP.state_dict_type(
+            new_model, state_dict_type
+        ):
+            state_dict = model.state_dict()
 
-            save_state_dict(state_dict, writer)
+        save_state_dict(state_dict, writer)
 
-            with FSDP.state_dict_type(model, state_dict_type), FSDP.state_dict_type(
-                new_model, state_dict_type
-            ):
-                state_dict = new_model.state_dict()
-                load_state_dict(state_dict, reader)
-                new_model.load_state_dict(state_dict)
+        with FSDP.state_dict_type(model, state_dict_type), FSDP.state_dict_type(
+            new_model, state_dict_type
+        ):
+            state_dict = new_model.state_dict()
+            load_state_dict(state_dict, reader)
+            new_model.load_state_dict(state_dict)
 
         with FullyShardedDataParallel.summon_full_params(
             model


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132934
* #132933
* __->__ #132908

Fixes https://github.com/pytorch/pytorch/issues/113936
Fixes https://github.com/pytorch/pytorch/issues/113937

The original way to broadcast the path seems to cause desync issues.  `with_temp_dir` has been used for other checkpoint related tests without problems. Change the tests to use `with_temp_dir`

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o