### PR TITLE
xpu: support sycl with torch.utils.cpp_extension APIs

### DIFF
--- a/docs/source/cpp_extension.rst
+++ b/docs/source/cpp_extension.rst
@@ -4,6 +4,7 @@ torch.utils.cpp_extension
 .. currentmodule:: torch.utils.cpp_extension
 .. autofunction:: CppExtension
 .. autofunction:: CUDAExtension
+.. autofunction:: SyclExtension
 .. autofunction:: BuildExtension
 .. autofunction:: load
 .. autofunction:: load_inline

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -11,6 +11,7 @@ from torch.utils.cpp_extension import (
     CUDA_HOME,
     CUDAExtension,
     ROCM_HOME,
+    SyclExtension,
 )
 
 
@@ -68,6 +69,15 @@ if torch.backends.mps.is_available():
         extra_compile_args=CXX_FLAGS,
     )
     ext_modules.append(extension)
+
+if torch.xpu.is_available() and USE_NINJA:
+    extension = SyclExtension(
+        "torch_test_cpp_extension.sycl",
+        ["xpu_extension.sycl"],
+        extra_compile_args={"cxx": CXX_FLAGS, "sycl": ["-O2"]},
+    )
+    ext_modules.append(extension)
+
 
 # todo(mkozuki): Figure out the root cause
 if (not IS_WINDOWS) and torch.cuda.is_available() and CUDA_HOME is not None:

--- a/test/cpp_extensions/xpu_extension.sycl
+++ b/test/cpp_extensions/xpu_extension.sycl
@@ -1,0 +1,63 @@
+#include <c10/xpu/XPUStream.h>
+#include <torch/extension.h>
+#include <sycl/sycl.hpp>
+
+void sigmoid_add_kernel(const float* x,
+                        const float* y,
+                        float* output,
+                        const int size,
+                        const sycl::nd_item<3> &item_ct1) {
+    const int index = item_ct1.get_group(2) * item_ct1.get_local_range(2) +
+                      item_ct1.get_local_id(2);
+    if (index < size) {
+        const float sigmoid_x = 1.0f / (1.0f + sycl::native::exp(-x[index]));
+        const float sigmoid_y = 1.0f / (1.0f + sycl::native::exp(-y[index]));
+        output[index] = sigmoid_x + sigmoid_y;
+    }
+}
+
+class SigmoidAddKernel {
+public:
+    void operator()(const sycl::nd_item<3> &item_ct1) const {
+        sigmoid_add_kernel(x, y, output, size, item_ct1);
+    }
+    SigmoidAddKernel(const float* _x, const float* _y, float* _output, int _size):
+        x(_x),
+        y(_y),
+        output(_output),
+        size(_size)
+    {}
+private:
+    const float* x;
+    const float* y;
+    float* output;
+    int size;
+};
+
+void sigmoid_add_xpu(const float* x, const float* y, float* output, int size) {
+    SigmoidAddKernel krn(x, y, output, size);
+    const int threads = 1024;
+    const int blocks = (size + threads - 1) / threads;
+
+    sycl::queue& queue = c10::xpu::getCurrentXPUStream().queue();
+    queue.submit([&](sycl::handler &cgh) {
+        cgh.parallel_for<SigmoidAddKernel>(
+            sycl::nd_range<3>(
+                sycl::range<3>(1, 1, blocks) * sycl::range<3>(1, 1, threads),
+                sycl::range<3>(1, 1, threads)),
+            krn);
+        });
+}
+
+torch::Tensor sigmoid_add(torch::Tensor x, torch::Tensor y) {
+  TORCH_CHECK(x.device().is_xpu(), "x must be a XPU tensor");
+  TORCH_CHECK(y.device().is_xpu(), "y must be a XPU tensor");
+  auto output = torch::zeros_like(x);
+  sigmoid_add_xpu(
+      x.data_ptr<float>(), y.data_ptr<float>(), output.data_ptr<float>(), output.numel());
+  return output;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("sigmoid_add", &sigmoid_add, "sigmoid(x) + sigmoid(y)");
+}

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     shell,
     skipIfTorchDynamo,
+    TEST_XPU,
     xfailIfTorchDynamo,
 )
 
@@ -112,6 +113,22 @@ class TestCppExtensionAOT(common.TestCase):
         mps_output = mps_extension.get_mps_add_output(x.to("mps"), y.to("mps"))
 
         self.assertEqual(cpu_output, mps_output.to("cpu"))
+
+    @unittest.skipIf(not TEST_XPU, "XPU not found")
+    @unittest.skipIf(
+        os.getenv("USE_NINJA", "0") == "0",
+        "sycl extension requires ninja to build",
+    )
+    def test_sycl_extension(self):
+        import torch_test_cpp_extension.sycl as sycl_extension
+
+        x = torch.zeros(100, device="xpu", dtype=torch.float32)
+        y = torch.zeros(100, device="xpu", dtype=torch.float32)
+
+        z = sycl_extension.sigmoid_add(x, y).cpu()
+
+        # 2 * sigmoid(0) = 2 * 0.5 = 1
+        self.assertEqual(z, torch.ones_like(z))
 
     @common.skipIfRocm
     @unittest.skipIf(common.IS_WINDOWS, "Windows not supported")

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -462,6 +462,80 @@ class TestCppExtensionJIT(common.TestCase):
         z = torch.ops.inline_jit_extension_custom_op_cuda.cos_add(x, y)
         self.assertEqual(z, x.cos() + y.cos())
 
+    @unittest.skipIf(not TEST_XPU, "XPU not found")
+    def test_inline_jit_compile_extension_xpu(self):
+        sycl_source = """
+        #include <c10/xpu/XPUStream.h>
+
+        class CosAddKernel {
+        public:
+          void operator()(const sycl::nd_item<3> &item_ct1) const {
+            const int index = item_ct1.get_group(2) * item_ct1.get_local_range(2) +
+                              item_ct1.get_local_id(2);
+            if (index < size) {
+              output[index] = cosf(x[index]) + cosf(y[index]);
+            }
+          }
+          CosAddKernel(const float* _x, const float* _y, float* _output, int _size):
+            x(_x),
+            y(_y),
+            output(_output),
+            size(_size)
+          {}
+        private:
+          const float* x;
+          const float* y;
+          float* output;
+          int size;
+        };
+
+        void cos_add_kernel(
+            const float* x,
+            const float* y,
+            float* output,
+            int size) {
+          CosAddKernel krn(x, y, output, size);
+          const int threads = 1024;
+          const int blocks = (size + threads - 1) / threads;
+
+          sycl::queue& queue = c10::xpu::getCurrentXPUStream().queue();
+          queue.submit([&](sycl::handler &cgh) {
+              cgh.parallel_for<CosAddKernel>(
+                  sycl::nd_range<3>(
+                      sycl::range<3>(1, 1, blocks) * sycl::range<3>(1, 1, threads),
+                      sycl::range<3>(1, 1, threads)),
+              krn);
+          });
+        }
+
+        torch::Tensor cos_add(torch::Tensor x, torch::Tensor y) {
+          auto output = torch::zeros_like(x);
+          const int threads = 1024;
+          const int blocks = (output.numel() + threads - 1) / threads;
+          cos_add_kernel(x.data_ptr<float>(), y.data_ptr<float>(), output.data_ptr<float>(), output.numel());
+          return output;
+        }
+        """
+
+        # Here, the C++ source need only declare the function signature.
+        cpp_source = "torch::Tensor cos_add(torch::Tensor x, torch::Tensor y);"
+
+        module = torch.utils.cpp_extension.load_inline(
+            name="inline_jit_extension_xpu",
+            cpp_sources=cpp_source,
+            sycl_sources=sycl_source,
+            functions=["cos_add"],
+            verbose=True,
+        )
+
+        self.assertEqual(module.cos_add.__doc__.split("\n")[2], "cos_add")
+
+        x = torch.randn(4, 4, device="xpu", dtype=torch.float32)
+        y = torch.randn(4, 4, device="xpu", dtype=torch.float32)
+
+        z = module.cos_add(x, y)
+        self.assertEqual(z, x.cos() + y.cos())
+
     def test_inline_jit_compile_extension_throws_when_functions_is_bad(self):
         with self.assertRaises(ValueError):
             torch.utils.cpp_extension.load_inline(

--- a/torch/utils/_cpp_extension_versioner.py
+++ b/torch/utils/_cpp_extension_versioner.py
@@ -40,6 +40,7 @@ class ExtensionVersioner:
                                 build_arguments,
                                 build_directory,
                                 with_cuda,
+                                with_sycl,
                                 is_python_module,
                                 is_standalone):
         hash_value = 0
@@ -47,6 +48,7 @@ class ExtensionVersioner:
         hash_value = hash_build_arguments(hash_value, build_arguments)
         hash_value = update_hash(hash_value, build_directory)
         hash_value = update_hash(hash_value, with_cuda)
+        hash_value = update_hash(hash_value, with_sycl)
         hash_value = update_hash(hash_value, is_python_module)
         hash_value = update_hash(hash_value, is_standalone)
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -795,12 +795,12 @@ class BuildExtension(build_ext):
                 _append_sycl_std_if_no_std_present(sycl_cflags)
                 host_cflags = extra_cc_cflags + common_cflags + post_cflags
                 append_std17_if_no_std_present(host_cflags)
-                # escaping quoted arguments to pass them thru DPC++ compiler
+                # escaping quoted arguments to pass them thru SYCL compiler
                 host_cflags = [item.replace('"', '\\\\"') for item in host_cflags]
                 host_cflags = ' '.join(host_cflags)
                 # Note the order: shlex.quote sycl_flags first, _wrap_sycl_host_flags
-                # second. Reason is that sycl host flags is quoted space containing
-                # string passed to DPC++ compiler.
+                # second. Reason is that sycl host flags are quoted, space containing
+                # strings passed to SYCL compiler.
                 sycl_cflags = [shlex.quote(f) for f in sycl_cflags]
                 sycl_cflags += _wrap_sycl_host_flags(host_cflags)
                 sycl_dlink_post_cflags = SYCL_DLINK_FLAGS
@@ -1514,10 +1514,11 @@ def load(name,
 
     SYCL support with mixed compilation is provided. Simply pass SYCL source
     files (``.sycl``) along with other sources. Such files will be detected
-    and compiled with icpx (Intel DPC++ sycl compiler) rather than the C++
-    compiler. You can pass additional flags to icpx via ``extra_sycl_cflags``,
-    just like with ``extra_cflags`` for C++. icpx compiler is expected to
-    be found via system PATH environment variable.
+    and compiled with SYCL compiler (such as Intel DPC++ Compiler) rather
+    than the C++ compiler. You can pass additional flags to SYCL compiler
+    via ``extra_sycl_cflags``, just like with ``extra_cflags`` for C++.
+    SYCL compiler is expected to be found via system PATH environment
+    variable.
 
     Args:
         name: The name of the extension to build. This MUST be the same as the
@@ -1526,8 +1527,8 @@ def load(name,
         extra_cflags: optional list of compiler flags to forward to the build.
         extra_cuda_cflags: optional list of compiler flags to forward to nvcc
             when building CUDA sources.
-        extra_sycl_cflags: optional list of compiler flags to forward to icpx
-            when building SYCL sources.
+        extra_sycl_cflags: optional list of compiler flags to forward to SYCL
+            compiler when building SYCL sources.
         extra_ldflags: optional list of linker flags to forward to the build.
         extra_include_paths: optional list of include directories to forward
             to the build.
@@ -2585,7 +2586,7 @@ def _write_ninja_file_to_build_library(path,
         sycl_cflags += extra_sycl_cflags
         _append_sycl_std_if_no_std_present(sycl_cflags)
         host_cflags = cflags
-        # escaping quoted arguments to pass them thru DPC++ compiler
+        # escaping quoted arguments to pass them thru SYCL compiler
         host_cflags = [item.replace('\\"', '\\\\"') for item in host_cflags]
         host_cflags = ' '.join(host_cflags)
         sycl_cflags += _wrap_sycl_host_flags(host_cflags)
@@ -2660,9 +2661,9 @@ def _write_ninja_file(path,
     `cuda_cflags`: list of flags to pass to $nvcc. Can be None.
     `cuda_post_cflags`: list of flags to append to the $nvcc invocation. Can be None.
     `cuda_dlink_post_cflags`: list of flags to append to the $nvcc device code link invocation. Can be None.
-    `sycl_cflags`: list of flags to pass to $icpx. Can be None.
-    `sycl_post_cflags`: list of flags to append to the $icpx invocation. Can be None.
-    `sycl_dlink_post_cflags`: list of flags to append to the $nvcc device code link invocation. Can be Non
+    `sycl_cflags`: list of flags to pass to SYCL compiler. Can be None.
+    `sycl_post_cflags`: list of flags to append to the SYCL compiler invocation. Can be None.
+    `sycl_dlink_post_cflags`: list of flags to append to the SYCL compiler device code link invocation. Can be None.
 e.
     `sources`: list of paths to source files
     `objects`: list of desired paths to objects, one per source.
@@ -2756,7 +2757,7 @@ e.
 
     if with_sycl:
         sycl_compile_rule = ['rule sycl_compile']
-        # icpx compiler does not recognize .sycl extension automatically,
+        # SYCL compiler does not recognize .sycl extension automatically,
         # so we pass '-x c++' explicitly notifying compiler of file format
         sycl_compile_rule.append(
             '  command = $sycl $sycl_cflags -c -x c++ $in -o $out $sycl_post_cflags')

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -503,6 +503,11 @@ def _check_cuda_version(compiler_name: str, compiler_version: TorchVersion) -> N
             )
 
 
+def _append_sycl_std_if_no_std_present(cflags):
+    if not any(flag.startswith('-sycl-std=') for flag in cflags):
+        cflags.append('-sycl-std=2020')
+
+
 def _wrap_sycl_host_flags(cflags):
     host_cxx = get_cxx_compiler()
     host_cflags = [
@@ -781,8 +786,7 @@ class BuildExtension(build_ext):
                 else:
                     sycl_post_cflags = list(extra_postargs)
                 append_std17_if_no_std_present(sycl_cflags)
-                if not any(flag.startswith('-sycl-std=') for flag in sycl_cflags):
-                    sycl_cflags.append('-sycl-std=2020')
+                _append_sycl_std_if_no_std_present(sycl_cflags)
                 host_cflags = extra_cc_cflags + common_cflags + post_cflags
                 append_std17_if_no_std_present(host_cflags)
                 # escaping quoted arguments to pass them thru DPC++ compiler
@@ -2573,8 +2577,7 @@ def _write_ninja_file_to_build_library(path,
     if with_sycl:
         sycl_cflags = cflags + COMMON_SYCL_FLAGS
         sycl_cflags += extra_sycl_cflags
-        if not any(flag.startswith('-sycl-std=') for flag in sycl_cflags):
-            sycl_cflags.append('-sycl-std=2020')
+        _append_sycl_std_if_no_std_present(sycl_cflags)
         host_cflags = cflags
         # escaping quoted arguments to pass them thru DPC++ compiler
         host_cflags = [item.replace('\\"', '\\\\"') for item in host_cflags]

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -282,7 +282,7 @@ COMMON_HIPCC_FLAGS = [
     '-D__HIP_NO_HALF_CONVERSIONS__=1',
 ]
 
-COMMON_SYCL_FLAGS = [
+_COMMON_SYCL_FLAGS = [
     '-fsycl',
     '-fsycl-targets=spir64_gen,spir64',
 ]
@@ -291,14 +291,14 @@ COMMON_SYCL_FLAGS = [
 # minus dg2-* since it lacks hardware support for fp64 and requires
 # special consideration from the user. If needed this platform can
 # be requested thru TORCH_XPU_ARCH_LIST environment variable.
-SYCL_ARCH_LIST = os.environ.get('TORCH_XPU_ARCH_LIST',
-                                'mtl-u,mtl-h,xe2-lpg,xe2-hpg' if IS_WINDOWS else 'pvc,xe-lpg')
+_SYCL_ARCH_LIST = os.environ.get('TORCH_XPU_ARCH_LIST',
+                                 'mtl-u,mtl-h,xe2-lpg,xe2-hpg' if IS_WINDOWS else 'pvc,xe-lpg')
 
-SYCL_DLINK_FLAGS = [
-    *COMMON_SYCL_FLAGS,
+_SYCL_DLINK_FLAGS = [
+    *_COMMON_SYCL_FLAGS,
     '-fsycl-link',
     '--offload-compress',
-    f'-Xs "-device {SYCL_ARCH_LIST}"',
+    f'-Xs "-device {_SYCL_ARCH_LIST}"',
 ]
 
 JIT_EXTENSION_VERSIONER = ExtensionVersioner()
@@ -786,7 +786,7 @@ class BuildExtension(build_ext):
             sycl_cflags = None
             sycl_dlink_post_cflags = None
             if with_sycl:
-                sycl_cflags = extra_cc_cflags + common_cflags + COMMON_SYCL_FLAGS
+                sycl_cflags = extra_cc_cflags + common_cflags + _COMMON_SYCL_FLAGS
                 if isinstance(extra_postargs, dict):
                     sycl_post_cflags = extra_postargs['sycl']
                 else:
@@ -803,7 +803,7 @@ class BuildExtension(build_ext):
                 # strings passed to SYCL compiler.
                 sycl_cflags = [shlex.quote(f) for f in sycl_cflags]
                 sycl_cflags += _wrap_sycl_host_flags(host_cflags)
-                sycl_dlink_post_cflags = SYCL_DLINK_FLAGS
+                sycl_dlink_post_cflags = _SYCL_DLINK_FLAGS
                 sycl_post_cflags = [shlex.quote(f) for f in sycl_post_cflags]
 
             _write_ninja_file_and_compile_objects(
@@ -2582,7 +2582,7 @@ def _write_ninja_file_to_build_library(path,
         cuda_flags = None
 
     if with_sycl:
-        sycl_cflags = cflags + COMMON_SYCL_FLAGS
+        sycl_cflags = cflags + _COMMON_SYCL_FLAGS
         sycl_cflags += extra_sycl_cflags
         _append_sycl_std_if_no_std_present(sycl_cflags)
         host_cflags = cflags
@@ -2590,7 +2590,7 @@ def _write_ninja_file_to_build_library(path,
         host_cflags = [item.replace('\\"', '\\\\"') for item in host_cflags]
         host_cflags = ' '.join(host_cflags)
         sycl_cflags += _wrap_sycl_host_flags(host_cflags)
-        sycl_dlink_post_cflags = SYCL_DLINK_FLAGS
+        sycl_dlink_post_cflags = _SYCL_DLINK_FLAGS
     else:
         sycl_cflags = None
         sycl_dlink_post_cflags = None

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -297,6 +297,7 @@ SYCL_ARCH_LIST = os.environ.get('TORCH_XPU_ARCH_LIST',
 SYCL_DLINK_FLAGS = [
     *COMMON_SYCL_FLAGS,
     '-fsycl-link',
+    '--offload-compress',
     f'-Xs "-device {SYCL_ARCH_LIST}"',
 ]
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -287,7 +287,12 @@ COMMON_SYCL_FLAGS = [
     '-fsycl-targets=spir64_gen,spir64',
 ]
 
-SYCL_ARCH_LIST = os.environ.get('TORCH_XPU_ARCH_LIST', 'pvc,xe-lpg')
+# Setting same default archs as in third_party/torch-xpu-ops project
+# minus dg2-* since it lacks hardware support for fp64 and requires
+# special consideration from the user. If needed this platform can
+# be requested thru TORCH_XPU_ARCH_LIST environment variable.
+SYCL_ARCH_LIST = os.environ.get('TORCH_XPU_ARCH_LIST',
+                                'mtl-u,mtl-h,xe2-lpg,xe2-hpg' if IS_WINDOWS else 'pvc,xe-lpg')
 
 SYCL_DLINK_FLAGS = [
     *COMMON_SYCL_FLAGS,

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1323,11 +1323,13 @@ def load(name,
          sources: Union[str, list[str]],
          extra_cflags=None,
          extra_cuda_cflags=None,
+         extra_sycl_cflags=None,
          extra_ldflags=None,
          extra_include_paths=None,
          build_directory=None,
          verbose=False,
          with_cuda: Optional[bool] = None,
+         with_sycl: Optional[bool] = None,
          is_python_module=True,
          is_standalone=False,
          keep_intermediates=True):
@@ -1366,6 +1368,13 @@ def load(name,
     work fine. If not, setting the ``CUDA_HOME`` environment variable is the
     safest option.
 
+    SYCL support with mixed compilation is provided. Simply pass SYCL source
+    files (``.sycl``) along with other sources. Such files will be detected
+    and compiled with icpx (Intel DPC++ sycl compiler) rather than the C++
+    compiler. You can pass additional flags to icpx via ``extra_sycl_cflags``,
+    just like with ``extra_cflags`` for C++. icpx compiler is expected to
+    be found via system PATH environment variable.
+
     Args:
         name: The name of the extension to build. This MUST be the same as the
             name of the pybind11 module!
@@ -1373,6 +1382,8 @@ def load(name,
         extra_cflags: optional list of compiler flags to forward to the build.
         extra_cuda_cflags: optional list of compiler flags to forward to nvcc
             when building CUDA sources.
+        extra_sycl_cflags: optional list of compiler flags to forward to icpx
+            when building SYCL sources.
         extra_ldflags: optional list of linker flags to forward to the build.
         extra_include_paths: optional list of include directories to forward
             to the build.
@@ -1383,6 +1394,11 @@ def load(name,
             automatically determined based on the existence of ``.cu`` or
             ``.cuh`` in ``sources``. Set it to `True`` to force CUDA headers
             and libraries to be included.
+        with_sycl: Determines whether SYCL headers and libraries are added to
+            the build. If set to ``None`` (default), this value is
+            automatically determined based on the existence of ``.sycl`` in
+            ``sources``. Set it to `True`` to force SYCL headers and
+            libraries to be included.
         is_python_module: If ``True`` (default), imports the produced shared
             library as a Python module. If ``False``, behavior depends on
             ``is_standalone``.
@@ -1416,11 +1432,13 @@ def load(name,
         [sources] if isinstance(sources, str) else sources,
         extra_cflags,
         extra_cuda_cflags,
+        extra_sycl_cflags,
         extra_ldflags,
         extra_include_paths,
         build_directory or _get_build_directory(name, verbose),
         verbose,
         with_cuda,
+        with_sycl,
         is_python_module,
         is_standalone,
         keep_intermediates=keep_intermediates)
@@ -1755,11 +1773,13 @@ def load_inline(name,
         sources,
         extra_cflags,
         extra_cuda_cflags,
+        [],  # extra_sycl_cflags
         extra_ldflags,
         extra_include_paths,
         build_directory,
         verbose,
         with_cuda,
+        False,  # with_sycl
         is_python_module,
         is_standalone=False,
         keep_intermediates=keep_intermediates)
@@ -1769,11 +1789,13 @@ def _jit_compile(name,
                  sources,
                  extra_cflags,
                  extra_cuda_cflags,
+                 extra_sycl_cflags,
                  extra_ldflags,
                  extra_include_paths,
                  build_directory: str,
                  verbose: bool,
                  with_cuda: Optional[bool],
+                 with_sycl: Optional[bool],
                  is_python_module,
                  is_standalone,
                  keep_intermediates=True) -> None:
@@ -1783,6 +1805,8 @@ def _jit_compile(name,
     if with_cuda is None:
         with_cuda = any(map(_is_cuda_file, sources))
     with_cudnn = any('cudnn' in f for f in extra_ldflags or [])
+    if with_sycl is None:
+        with_sycl = any(map(_is_sycl_file, sources))
     old_version = JIT_EXTENSION_VERSIONER.get_version(name)
     version = JIT_EXTENSION_VERSIONER.bump_version_if_changed(
         name,
@@ -1790,6 +1814,7 @@ def _jit_compile(name,
         build_arguments=[extra_cflags, extra_cuda_cflags, extra_ldflags, extra_include_paths],
         build_directory=build_directory,
         with_cuda=with_cuda,
+        with_sycl=with_sycl,
         is_python_module=is_python_module,
         is_standalone=is_standalone,
     )
@@ -1830,11 +1855,13 @@ def _jit_compile(name,
                         sources=sources,
                         extra_cflags=extra_cflags or [],
                         extra_cuda_cflags=extra_cuda_cflags or [],
+                        extra_sycl_cflags=extra_sycl_cflags or [],
                         extra_ldflags=extra_ldflags or [],
                         extra_include_paths=extra_include_paths or [],
                         build_directory=build_directory,
                         verbose=verbose,
                         with_cuda=with_cuda,
+                        with_sycl=with_sycl,
                         is_standalone=is_standalone)
             elif verbose:
                 print('No modifications detected for re-loaded extension '
@@ -1889,11 +1916,15 @@ def _write_ninja_file_and_compile_objects(
         cuda_cflags=cuda_cflags,
         cuda_post_cflags=cuda_post_cflags,
         cuda_dlink_post_cflags=cuda_dlink_post_cflags,
+        sycl_cflags=None,
+        sycl_post_cflags=None,
+        sycl_dlink_post_cflags=None,
         sources=sources,
         objects=objects,
         ldflags=None,
         library_target=None,
-        with_cuda=with_cuda)
+        with_cuda=with_cuda,
+        with_sycl=False)
     if verbose:
         print('Compiling objects...', file=sys.stderr)
     _run_ninja_build(
@@ -1909,11 +1940,13 @@ def _write_ninja_file_and_build_library(
         sources: list[str],
         extra_cflags,
         extra_cuda_cflags,
+        extra_sycl_cflags,
         extra_ldflags,
         extra_include_paths,
         build_directory: str,
         verbose: bool,
         with_cuda: Optional[bool],
+        with_sycl: Optional[bool],
         is_standalone: bool = False) -> None:
     verify_ninja_availability()
 
@@ -1922,6 +1955,8 @@ def _write_ninja_file_and_build_library(
     get_compiler_abi_compatibility_and_version(compiler)
     if with_cuda is None:
         with_cuda = any(map(_is_cuda_file, sources))
+    if with_sycl is None:
+        with_sycl = any(map(_is_sycl_file, sources))
     extra_ldflags = _prepare_ldflags(
         extra_ldflags or [],
         with_cuda,
@@ -1946,9 +1981,11 @@ def _write_ninja_file_and_build_library(
         sources=sources,
         extra_cflags=extra_cflags or [],
         extra_cuda_cflags=extra_cuda_cflags or [],
+        extra_sycl_cflags=extra_sycl_cflags or [],
         extra_ldflags=extra_ldflags or [],
         extra_include_paths=extra_include_paths or [],
         with_cuda=with_cuda,
+        with_sycl=with_sycl,
         is_standalone=is_standalone)
 
     if verbose:
@@ -2287,12 +2324,15 @@ def _write_ninja_file_to_build_library(path,
                                        sources,
                                        extra_cflags,
                                        extra_cuda_cflags,
+                                       extra_sycl_cflags,
                                        extra_ldflags,
                                        extra_include_paths,
                                        with_cuda,
+                                       with_sycl,
                                        is_standalone) -> None:
     extra_cflags = [flag.strip() for flag in extra_cflags]
     extra_cuda_cflags = [flag.strip() for flag in extra_cuda_cflags]
+    extra_sycl_cflags = [flag.strip() for flag in extra_sycl_cflags]
     extra_ldflags = [flag.strip() for flag in extra_ldflags]
     extra_include_paths = [flag.strip() for flag in extra_include_paths]
 
@@ -2360,6 +2400,28 @@ def _write_ninja_file_to_build_library(path,
     else:
         cuda_flags = None
 
+    if with_sycl:
+        sycl_common_cflags = ['-fsycl', '-fsycl-targets=spir64_gen,spir64']
+        sycl_cflags = cflags + sycl_common_cflags
+        sycl_cflags += extra_sycl_cflags
+        # "preview breaking changes" flags allows to support both C++ ABIs
+        sycl_cflags += ['-fpreview-breaking-changes', '-D__INTEL_PREVIEW_BREAKING_CHANGES']
+        if not any(flag.startswith('-sycl-std=') for flag in sycl_cflags):
+            sycl_cflags.append('-sycl-std=2020')
+        host_cxx = get_cxx_compiler()
+        host_cflags = cflags
+        # escaping quoted arguments to pass them thru icpx
+        host_cflags = [item.replace('\\"', '\\\\"') for item in host_cflags]
+        host_cflags = ' '.join(host_cflags)
+        # note that -fsycl-host-compiler-options will be quoted as needed
+        # with shlex.quote below
+        sycl_cflags += [f'-fsycl-host-compiler={host_cxx}', shlex.quote(f'-fsycl-host-compiler-options={host_cflags}')]
+        sycl_arch_list = os.environ.get('TORCH_XPU_ARCH_LIST', 'pvc,xe-lpg')
+        sycl_dlink_post_cflags = sycl_common_cflags + ['-fsycl-link', f'-Xs "-device {sycl_arch_list}"']
+    else:
+        sycl_cflags = None
+        sycl_dlink_post_cflags = None
+
     def object_file_path(source_file: str) -> str:
         # '/path/to/file.cpp' -> 'file'
         file_name = os.path.splitext(os.path.basename(source_file))[0]
@@ -2367,6 +2429,8 @@ def _write_ninja_file_to_build_library(path,
             # Use a different object filename in case a C++ and CUDA file have
             # the same filename but different extension (.cpp vs. .cu).
             target = f'{file_name}.cuda.o'
+        elif _is_sycl_file(source_file) and with_sycl:
+            target = f'{file_name}.sycl.o'
         else:
             target = f'{file_name}.o'
         return target
@@ -2390,11 +2454,15 @@ def _write_ninja_file_to_build_library(path,
         cuda_cflags=cuda_flags,
         cuda_post_cflags=None,
         cuda_dlink_post_cflags=None,
+        sycl_cflags=sycl_cflags,
+        sycl_post_cflags=[],
+        sycl_dlink_post_cflags=sycl_dlink_post_cflags,
         sources=sources,
         objects=objects,
         ldflags=ldflags,
         library_target=library_target,
-        with_cuda=with_cuda)
+        with_cuda=with_cuda,
+        with_sycl=with_sycl)
 
 
 def _write_ninja_file(path,
@@ -2403,18 +2471,27 @@ def _write_ninja_file(path,
                       cuda_cflags,
                       cuda_post_cflags,
                       cuda_dlink_post_cflags,
+                      sycl_cflags,
+                      sycl_post_cflags,
+                      sycl_dlink_post_cflags,
                       sources,
                       objects,
                       ldflags,
                       library_target,
-                      with_cuda) -> None:
+                      with_cuda,
+                      with_sycl) -> None:
     r"""Write a ninja file that does the desired compiling and linking.
 
     `path`: Where to write this file
     `cflags`: list of flags to pass to $cxx. Can be None.
     `post_cflags`: list of flags to append to the $cxx invocation. Can be None.
     `cuda_cflags`: list of flags to pass to $nvcc. Can be None.
-    `cuda_postflags`: list of flags to append to the $nvcc invocation. Can be None.
+    `cuda_post_cflags`: list of flags to append to the $nvcc invocation. Can be None.
+    `cuda_dlink_post_cflags`: list of flags to append to the $nvcc device code link invocation. Can be None.
+    `sycl_cflags`: list of flags to pass to $icpx. Can be None.
+    `sycl_post_cflags`: list of flags to append to the $icpx invocation. Can be None.
+    `sycl_dlink_post_cflags`: list of flags to append to the $nvcc device code link invocation. Can be Non
+e.
     `sources`: list of paths to source files
     `objects`: list of desired paths to objects, one per source.
     `ldflags`: list of flags to pass to linker. Can be None.
@@ -2433,6 +2510,9 @@ def _write_ninja_file(path,
     cuda_cflags = sanitize_flags(cuda_cflags)
     cuda_post_cflags = sanitize_flags(cuda_post_cflags)
     cuda_dlink_post_cflags = sanitize_flags(cuda_dlink_post_cflags)
+    sycl_cflags = sanitize_flags(sycl_cflags)
+    sycl_post_cflags = sanitize_flags(sycl_post_cflags)
+    sycl_dlink_post_cflags = sanitize_flags(sycl_dlink_post_cflags)
     ldflags = sanitize_flags(ldflags)
 
     # Sanity checks...
@@ -2453,6 +2533,9 @@ def _write_ninja_file(path,
             else:
                 nvcc = _join_cuda_home('bin', 'nvcc')
         config.append(f'nvcc = {nvcc}')
+    if with_sycl or sycl_dlink_post_cflags:
+        sycl = 'icx' if IS_WINDOWS else 'icpx'
+        config.append(f'sycl = {sycl}')
 
     if IS_HIP_EXTENSION:
         post_cflags = COMMON_HIP_FLAGS + post_cflags
@@ -2462,6 +2545,10 @@ def _write_ninja_file(path,
         flags.append(f'cuda_cflags = {" ".join(cuda_cflags)}')
         flags.append(f'cuda_post_cflags = {" ".join(cuda_post_cflags)}')
     flags.append(f'cuda_dlink_post_cflags = {" ".join(cuda_dlink_post_cflags)}')
+    if with_sycl:
+        flags.append(f'sycl_cflags = {" ".join(sycl_cflags)}')
+        flags.append(f'sycl_post_cflags = {" ".join(sycl_post_cflags)}')
+    flags.append(f'sycl_dlink_post_cflags = {" ".join(sycl_dlink_post_cflags)}')
     flags.append(f'ldflags = {" ".join(ldflags)}')
 
     # Turn into absolute paths so we can emit them into the ninja build
@@ -2495,11 +2582,25 @@ def _write_ninja_file(path,
         cuda_compile_rule.append(
             f'  command = $nvcc {nvcc_gendeps} $cuda_cflags -c $in -o $out $cuda_post_cflags')
 
+    if with_sycl:
+        sycl_compile_rule = ['rule sycl_compile']
+        # icpx compiler does not recognize .sycl extension automatically,
+        # so we pass '-x c++' explicitly notifying compiler of file format
+        sycl_compile_rule.append(
+            '  command = $sycl $sycl_cflags -c -x c++ $in -o $out $sycl_post_cflags')
+
+
     # Emit one build rule per source to enable incremental build.
     build = []
     for source_file, object_file in zip(sources, objects):
         is_cuda_source = _is_cuda_file(source_file) and with_cuda
-        rule = 'cuda_compile' if is_cuda_source else 'compile'
+        is_sycl_source = _is_sycl_file(source_file) and with_sycl
+        if is_cuda_source:
+            rule = 'cuda_compile'
+        elif is_sycl_source:
+            rule = 'sycl_compile'
+        else:
+            rule = 'compile'
         if IS_WINDOWS:
             source_file = source_file.replace(':', '$:')
             object_file = object_file.replace(':', '$:')
@@ -2508,13 +2609,22 @@ def _write_ninja_file(path,
         build.append(f'build {object_file}: {rule} {source_file}')
 
     if cuda_dlink_post_cflags:
-        devlink_out = os.path.join(os.path.dirname(objects[0]), 'dlink.o')
-        devlink_rule = ['rule cuda_devlink']
-        devlink_rule.append('  command = $nvcc $in -o $out $cuda_dlink_post_cflags')
-        devlink = [f'build {devlink_out}: cuda_devlink {" ".join(objects)}']
-        objects += [devlink_out]
+        cuda_devlink_out = os.path.join(os.path.dirname(objects[0]), 'dlink.o')
+        cuda_devlink_rule = ['rule cuda_devlink']
+        cuda_devlink_rule.append('  command = $nvcc $in -o $out $cuda_dlink_post_cflags')
+        cuda_devlink = [f'build {cuda_devlink_out}: cuda_devlink {" ".join(objects)}']
+        objects += [cuda_devlink_out]
     else:
-        devlink_rule, devlink = [], []
+        cuda_devlink_rule, cuda_devlink = [], []
+
+    if sycl_dlink_post_cflags:
+        sycl_devlink_out = os.path.join(os.path.dirname(objects[0]), 'sycl_dlink.o')
+        sycl_devlink_rule = ['rule sycl_devlink']
+        sycl_devlink_rule.append('  command = $sycl $in -o $out $sycl_dlink_post_cflags')
+        sycl_devlink = [f'build {sycl_devlink_out}: sycl_devlink {" ".join(objects)}']
+        objects += [sycl_devlink_out]
+    else:
+        sycl_devlink_rule, sycl_devlink = [], []
 
     if library_target is not None:
         link_rule = ['rule link']
@@ -2539,7 +2649,9 @@ def _write_ninja_file(path,
     blocks = [config, flags, compile_rule]
     if with_cuda:
         blocks.append(cuda_compile_rule)  # type: ignore[possibly-undefined]
-    blocks += [devlink_rule, link_rule, build, devlink, link, default]
+    if with_sycl:
+        blocks.append(sycl_compile_rule)  # type: ignore[possibly-undefined]
+    blocks += [cuda_devlink_rule, sycl_devlink_rule, link_rule, build, cuda_devlink, sycl_devlink, link, default]
     content = "\n\n".join("\n".join(b) for b in blocks)
     # Ninja requires a new lines at the end of the .ninja file
     content += "\n"
@@ -2562,4 +2674,8 @@ def _is_cuda_file(path: str) -> bool:
     valid_ext = ['.cu', '.cuh']
     if IS_HIP_EXTENSION:
         valid_ext.append('.hip')
+    return os.path.splitext(path)[1] in valid_ext
+
+def _is_sycl_file(path: str) -> bool:
+    valid_ext = ['.sycl']
     return os.path.splitext(path)[1] in valid_ext

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1329,6 +1329,15 @@ def SyclExtension(name, sources, *args, **kwargs):
     All arguments are forwarded to the :class:`setuptools.Extension`
     constructor.
 
+    .. note::
+        The PyTorch python API (as provided in libtorch_python) cannot be built
+        with the flag ``py_limited_api=True``.  When this flag is passed, it is
+        the user's responsibility in their library to not use APIs from
+        libtorch_python (in particular pytorch/python bindings) and to only use
+        APIs from libtorch (aten objects, operators and the dispatcher). For
+        example, to give access to custom ops from python, the library should
+        register the ops through the dispatcher.
+
     Example:
         >>> # xdoctest: +SKIP
         >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_CPP_EXT)
@@ -1367,7 +1376,9 @@ def SyclExtension(name, sources, *args, **kwargs):
     libraries.append("c10_xpu")
     libraries.append("torch")
     libraries.append("torch_cpu")
-    libraries.append("torch_python")
+    if not kwargs.get('py_limited_api', False):
+        # torch_python uses more than the python limited api
+        libraries.append("torch_python")
     libraries.append("torch_xpu")
     kwargs["libraries"] = libraries
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -287,18 +287,21 @@ _COMMON_SYCL_FLAGS = [
     '-fsycl-targets=spir64_gen,spir64',
 ]
 
-# Setting same default archs as in third_party/torch-xpu-ops project
-# minus dg2-* since it lacks hardware support for fp64 and requires
-# special consideration from the user. If needed this platform can
-# be requested thru TORCH_XPU_ARCH_LIST environment variable.
-_SYCL_ARCH_LIST = os.environ.get('TORCH_XPU_ARCH_LIST',
-                                 'mtl-u,mtl-h,xe2-lpg,xe2-hpg' if IS_WINDOWS else 'pvc,xe-lpg')
+def _get_sycl_arch_list():
+    if 'TORCH_XPU_ARCH_LIST' in os.environ:
+        return os.environ.get('TORCH_XPU_ARCH_LIST')
+    arch_list = torch.xpu.get_arch_list()
+    # Dropping dg2-* archs since they lack hardware support for fp64 and require
+    # special consideration from the user. If needed these platforms can
+    # be requested thru TORCH_XPU_ARCH_LIST environment variable.
+    arch_list = [x for x in arch_list if not x.startswith('dg2-')]
+    return ','.join(arch_list)
 
 _SYCL_DLINK_FLAGS = [
     *_COMMON_SYCL_FLAGS,
     '-fsycl-link',
     '--offload-compress',
-    f'-Xs "-device {_SYCL_ARCH_LIST}"',
+    f'-Xs "-device {_get_sycl_arch_list()}"',
 ]
 
 JIT_EXTENSION_VERSIONER = ExtensionVersioner()

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -290,6 +290,8 @@ _COMMON_SYCL_FLAGS = [
 def _get_sycl_arch_list():
     if 'TORCH_XPU_ARCH_LIST' in os.environ:
         return os.environ.get('TORCH_XPU_ARCH_LIST')
+    if not torch.xpu.is_available():
+        return ""
     arch_list = torch.xpu.get_arch_list()
     # Dropping dg2-* archs since they lack hardware support for fp64 and require
     # special consideration from the user. If needed these platforms can


### PR DESCRIPTION
This patch adds support for sycl kernels build via `torch.utils.cpp_extension.load`, `torch.utils.cpp_extension.load_inline` and (new) `class SyclExtension` APIs. Files having `.sycl` extension are considered to have sycl kernels and are compiled with `icpx` (dpc++ sycl compiler from Intel). Files with other extensions, `.cpp`, `.cu`, are handled as before. API supports building sycl along with other file types into single extension.

Note that `.sycl` file extension is a PyTorch convention for files containing sycl code which I propose to adopt. We did follow up with compiler team to introduce such file extension in the compiler, but they are opposed to this. At the same time discussion around sycl file extension and adding sycl language support into such tools as cmake is ongoing. Eventually cmake also considers to introduce some file extension convention for sycl. I hope we can further influence cmake and compiler communities to broader adopt `.sycl` file extension.

By default SYCL kernels are compiled for all Intel GPU devices for which pytorch native aten SYCL kernels are compiled. At the moment `pvc,xe-lpg`. This behavior can be overridden by setting `TORCH_XPU_ARCH_LIST` environment variables to the comma separated list of desired devices to compile for.

Fixes: #132944

CC: @gujinghui @EikanWang @fengyuan14 @guangyey @jgong5


cc @gujinghui @EikanWang @fengyuan14 @guangyey