### PR TITLE
Fix privateuse1 backend name case

### DIFF
--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -131,6 +131,9 @@ std::string get_privateuse1_backend(bool lower_case) {
   // set, and will never be written to.
   auto backend_name =
       name_registered ? privateuse1_backend_name : "privateuseone";
+  auto op_case = lower_case ? ::tolower : ::toupper;
+  std::transform(
+      backend_name.begin(), backend_name.end(), backend_name.begin(), op_case);
   return backend_name;
 }
 

--- a/c10/test/core/Device_test.cpp
+++ b/c10/test/core/Device_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
 #include <c10/util/Exception.h>
 
 // -- Device -------------------------------------------------------
@@ -45,4 +46,11 @@ TEST(DeviceTest, BasicConstruction) {
   for (auto& ds : invalid_device_strings) {
     EXPECT_THROW(make_device(ds), c10::Error) << "Device String: " << ds;
   }
+}
+
+TEST(DeviceTypeTest, PrivateUseOneDeviceType) {
+  c10::register_privateuse1_backend("my_privateuse1_backend");
+  ASSERT_TRUE(c10::is_privateuse1_backend_registered());
+  ASSERT_EQ(c10::get_privateuse1_backend(true), "my_privateuse1_backend");
+  ASSERT_EQ(c10::get_privateuse1_backend(false), "MY_PRIVATEUSE1_BACKEND");
 }


### PR DESCRIPTION
### Problem

`get_privateuse1_backend(bool lower_case)` always returns a lower case name and `lower_case` is not used.

cc: @FFFrog 
