### PR TITLE
Add `torch.Tensor.is_privateuseone`

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1193,6 +1193,7 @@ def gen_pyi(
             "is_mkldnn": ["is_mkldnn: _bool"],
             "is_vulkan": ["is_vulkan: _bool"],
             "is_ipu": ["is_ipu: _bool"],
+            "is_privateuseone": ["is_privateuseone: _bool"],
             "storage_offset": ["def storage_offset(self) -> Union[_int, SymInt]: ..."],
             "to": [
                 (

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1430,6 +1430,16 @@ PyObject* THPVariable_is_xpu(THPVariable* self, void* unused) {
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THPVariable_is_privateuseone(THPVariable* self, void* unused) {
+  HANDLE_TH_ERRORS
+  if (check_has_torch_function((PyObject*)self)) {
+    return handle_torch_function_getter(self, "is_privateuseone");
+  }
+  auto& self_ = THPVariable_Unpack(self);
+  return torch::autograd::utils::wrap(self_.is_privateuseone());
+  END_HANDLE_TH_ERRORS
+}
+
 PyObject* THPVariable_is_sparse(THPVariable* self, void* unused) {
   HANDLE_TH_ERRORS
   if (check_has_torch_function((PyObject*)self)) {
@@ -1692,6 +1702,11 @@ static struct PyGetSetDef THPVariable_properties[] = {
     {"is_xla", (getter)THPVariable_is_xla, nullptr, nullptr, nullptr},
     {"is_xpu", (getter)THPVariable_is_xpu, nullptr, nullptr, nullptr},
     {"is_ipu", (getter)THPVariable_is_ipu, nullptr, nullptr, nullptr},
+    {"is_privateuseone",
+     (getter)THPVariable_is_privateuseone,
+     nullptr,
+     nullptr,
+     nullptr},
     {"is_sparse", (getter)THPVariable_is_sparse, nullptr, nullptr, nullptr},
     {"is_sparse_csr",
      (getter)THPVariable_is_sparse_csr,

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1349,6 +1349,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         Tensor.is_xla.__get__: lambda self: -1,
         Tensor.is_xpu.__get__: lambda self: -1,
         Tensor.is_ipu.__get__: lambda self: -1,
+        Tensor.is_privateuseone.__get__: lambda self: -1,
         Tensor.is_leaf.__get__: lambda self: -1,
         Tensor.retains_grad.__get__: lambda self: -1,
         Tensor.is_meta.__get__: lambda self: -1,


### PR DESCRIPTION
This change creates `torch.Tensor.is_privateuseone` which is congruent with `is_cuda` and `is_cpu`. Useful in situations like: #103100

**Here is the C++ code for `TensorBase.is_privateuseone()` but without its Python binding:**

https://github.com/pytorch/pytorch/blob/24dee99cb712e9aba32d64eda0645e861ab57f91/aten/src/ATen/core/TensorBase.h#L481-L484

```python
>>> import torch
>>> x = torch.tensor([1])
>>> x
tensor([1])
>>> x.is_privateuseone
False
>>> x.is_cpu
True
```

cc: @FFFrog 

