### PR TITLE
[AOTI] Disable split_cat_aten passes

### DIFF
--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -2,7 +2,7 @@
 import copy
 import itertools
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 import torch
 import torch.nn as nn
@@ -84,17 +84,6 @@ def fuse_chunk_reshape_unsqueeze_concat_pass(graph):
     return None
 
 
-pattern_matcher_passes_aten: List[PatternMatcherPass] = [
-    remove_split_with_size_one_pass_aten,
-    merge_getitem_cat_pass_aten,
-    merge_stack_tahn_unbind_pass_aten,
-    merge_splits_pass_aten,
-    mutate_cat_pass_aten,
-    split_cat_pass_aten,
-    unbind_stack_pass_aten,
-]
-
-
 @init_once_fakemode
 def lazy_init():
     from . import efficient_conv_bn_eval, split_cat  # noqa: F401  # noqa: F401
@@ -162,20 +151,6 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
                 example_inputs,
                 "[Pre grad(predispatch IR)] Apply fuse_split_linear_add_pass",
             )
-
-            log.debug(
-                "[Pre grad(predispatch IR)]Before split cat in pre grad pass. graph: %s",
-                gm.graph,
-            )
-            for ind, pattern_matcher_pass_aten in enumerate(
-                pattern_matcher_passes_aten
-            ):
-                pass_execution_and_save(
-                    pattern_matcher_pass_aten.apply,
-                    gm,
-                    example_inputs,
-                    f"[Pre grad(predispatch IR)]Apply split_cat, index: {ind}",
-                )
             pass_execution_and_save(
                 remove_reshape_pass.apply,
                 gm,


### PR DESCRIPTION
Summary: disable passes with negative performance impact

Test Plan: run UT

Differential Revision: D60970288


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang