### PR TITLE
Fix flaky internal mixed_mm tests

### DIFF
--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -140,7 +140,12 @@ class AutoHeuristicTest(TestCase):
     # a choice made by the heuristic might be added to the list of choices
     # and if select_algorithm now creates a new precompile key, it will be
     # different from the precompile key created by autoheuristic
-    @inductor_config.patch(autoheuristic_collect="mixed_mm", autoheuristic_use="")
+    @inductor_config.patch(
+        autoheuristic_collect="mixed_mm",
+        autoheuristic_use="",
+        fx_graph_cache=False,
+        fx_graph_remote_cache=False,
+    )
     def test_global_feedback(self):
         self.run_mixed_mm()
         path = self.get_path_to_autoheuristic_log("mixed_mm")

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -29,7 +29,7 @@ from torch._inductor.virtualized import V
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
-from torch.testing._internal.inductor_utils import HAS_CUDA, IS_A100
+from torch.testing._internal.inductor_utils import HAS_CUDA, IS_A100, IS_BIG_GPU
 from torch.utils import _pytree as pytree
 
 
@@ -277,7 +277,14 @@ class TestPatternMatcher(TestCase):
 
     @unittest.skipIf(not SM80OrLater, "need sm_80")
     @unittest.skipIf(not IS_A100, "heuristic only run on Linux A100")
-    @inductor_config.patch(mixed_mm_choice="heuristic", autoheuristic_use="")
+    @unittest.skipIf(not IS_BIG_GPU, "tests fail on small GPU")
+    @inductor_config.patch(
+        mixed_mm_choice="heuristic",
+        autoheuristic_use="",
+        fx_graph_cache=False,
+        fx_graph_remote_cache=False,
+        shape_padding=False,
+    )
     def test_mixed_mm_heuristic_no(self):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))
@@ -330,7 +337,14 @@ class TestPatternMatcher(TestCase):
 
     @unittest.skipIf(not SM80OrLater, "need sm_80")
     @unittest.skipIf(not IS_A100, "heuristic only run on Linux A100")
-    @inductor_config.patch(mixed_mm_choice="heuristic")
+    @unittest.skipIf(not IS_BIG_GPU, "tests fail on small GPU")
+    @inductor_config.patch(
+        mixed_mm_choice="heuristic",
+        autoheuristic_use="",
+        fx_graph_cache=False,
+        fx_graph_remote_cache=False,
+        shape_padding=False,
+    )
     def test_mixed_mm_heuristic_yes(self):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -112,4 +112,4 @@ IS_H100 = LazyVal(
     and get_gpu_shared_memory() == 232448
 )
 
-IS_BIG_GPU = LazyVal(lambda: is_big_gpu(0))
+IS_BIG_GPU = LazyVal(lambda: HAS_CUDA and is_big_gpu(0))

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -9,7 +9,7 @@ from subprocess import CalledProcessError
 import sys
 import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
 from torch._inductor.codecache import CppCodeCache
-from torch._inductor.utils import get_gpu_shared_memory
+from torch._inductor.utils import get_gpu_shared_memory, is_big_gpu
 from torch.utils._triton import has_triton
 from torch.testing._internal.common_utils import (
     LazyVal,
@@ -111,3 +111,5 @@ IS_H100 = LazyVal(
     lambda: HAS_CUDA
     and get_gpu_shared_memory() == 232448
 )
+
+IS_BIG_GPU = LazyVal(lambda: is_big_gpu(0))


### PR DESCRIPTION
This PR fixes flaky internal tests:
- The AutoHeuristic test was sometimes failing because it required autotuning to happen for mixed_mm which didn't end up happening when there was a fx graph cache hit.
- The tests inside pattern_matcher failed because in some cases pad_mm decided to pad which made the mixed_mm pattern not match anymore (instead of cast -> mm, it was cast -> pad -> mm), and the tests also fail when is_big_gpu is false (which I haven't found an explanation for).

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133015



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang

Differential Revision: [D60972176](https://our.internmc.facebook.com/intern/diff/D60972176)