### PR TITLE
[Inductor][FlexAttention] Support non-divisible sequence lengths

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1588,7 +1588,7 @@ class GraphModule(torch.nn.Module):
         child_7: "i32[]" = l_query_.new_empty([], dtype = torch.int32);  child_7 = None
         child_8: "i32[]" = l_query_.new_empty([], dtype = torch.int32);  child_8 = None
         mask_fn_0 = self.mask_fn_0
-        flex_attention = torch.ops.higher_order.flex_attention(l_query_, l_key_, l_value_, score_mod_0, (l_block_mask_kv_num_blocks, l_block_mask_kv_indices, l_block_mask_full_kv_num_blocks, l_block_mask_full_kv_indices, l_block_mask_q_num_blocks, l_block_mask_q_indices, l_block_mask_full_q_num_blocks, l_block_mask_full_q_indices, 128, 128, mask_fn_0), 0.5, {'ROWS_GUARANTEED_SAFE': False, 'PRESCALE_QK': False, 'OUTPUT_LOGSUMEXP': True}, (), ());  l_query_ = l_key_ = l_value_ = score_mod_0 = l_block_mask_kv_num_blocks = l_block_mask_kv_indices = l_block_mask_full_kv_num_blocks = l_block_mask_full_kv_indices = l_block_mask_q_num_blocks = l_block_mask_q_indices = l_block_mask_full_q_num_blocks = l_block_mask_full_q_indices = mask_fn_0 = None
+        flex_attention = torch.ops.higher_order.flex_attention(l_query_, l_key_, l_value_, score_mod_0, (l_block_mask_kv_num_blocks, l_block_mask_kv_indices, l_block_mask_full_kv_num_blocks, l_block_mask_full_kv_indices, l_block_mask_q_num_blocks, l_block_mask_q_indices, l_block_mask_full_q_num_blocks, l_block_mask_full_q_indices, 128, 128, mask_fn_0), 0.5, {'ROWS_GUARANTEED_SAFE': False, 'PRESCALE_QK': False, 'OUTPUT_LOGSUMEXP': True, 'IS_DIVISIBLE': True}, (), ());  l_query_ = l_key_ = l_value_ = score_mod_0 = l_block_mask_kv_num_blocks = l_block_mask_kv_indices = l_block_mask_full_kv_num_blocks = l_block_mask_full_kv_indices = l_block_mask_q_num_blocks = l_block_mask_q_indices = l_block_mask_full_q_num_blocks = l_block_mask_full_q_indices = mask_fn_0 = None
         out: "f64[2, 2, 128, 4]" = flex_attention[0];  flex_attention = None
         return (out,)
 
@@ -1629,7 +1629,7 @@ class GraphModule(torch.nn.Module):
         fw_graph = self.fw_graph
         joint_graph = self.joint_graph
         mask_graph = self.mask_graph
-        flex_attention_backward = torch.ops.higher_order.flex_attention_backward(primals_1, primals_2, primals_3, getitem_2, getitem_3, tangents_1, full_default_4, fw_graph, joint_graph, (full, full_default, None, None, convert_element_type, convert_element_type_1, None, None, 128, 128, mask_graph), 0.5, {'ROWS_GUARANTEED_SAFE': False, 'PRESCALE_QK': False, 'OUTPUT_LOGSUMEXP': True}, (), ());  primals_1 = primals_2 = primals_3 = getitem_2 = getitem_3 = tangents_1 = full_default_4 = fw_graph = joint_graph = full = full_default = convert_element_type = convert_element_type_1 = mask_graph = None
+        flex_attention_backward = torch.ops.higher_order.flex_attention_backward(primals_1, primals_2, primals_3, getitem_2, getitem_3, tangents_1, full_default_4, fw_graph, joint_graph, (full, full_default, None, None, convert_element_type, convert_element_type_1, None, None, 128, 128, mask_graph), 0.5, {'ROWS_GUARANTEED_SAFE': False, 'PRESCALE_QK': False, 'OUTPUT_LOGSUMEXP': True, 'IS_DIVISIBLE': True}, (), ());  primals_1 = primals_2 = primals_3 = getitem_2 = getitem_3 = tangents_1 = full_default_4 = fw_graph = joint_graph = full = full_default = convert_element_type = convert_element_type_1 = mask_graph = None
         getitem_4: "f64[2, 2, 128, 4]" = flex_attention_backward[0]
         getitem_5: "f64[2, 2, 128, 4]" = flex_attention_backward[1]
         getitem_6: "f64[2, 2, 128, 4]" = flex_attention_backward[2];  flex_attention_backward = None

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1938,6 +1938,7 @@ BlockMask(shape=(1,s1,s2048,s2048),ssparsity=46.88%,s
             return q >= kv
 
         block_mask = create_block_mask(mask_mod, 1, 1, Q_S, KV_S)
+        # block_mask = None
         attention = functools.partial(flex_attention, block_mask=block_mask)
 
         self.run_test_with_call(attention, Q_S=Q_S, KV_S=KV_S)

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -353,13 +353,24 @@ def forward_inner(
     if PRESCALE_QK:
         q = (q * SM_SCALE * RCP_LN2).to(MATMUL_PRECISION)
 
-    # Benchmark shows even we applied mod & mask to each block for non divisible seqlen,
-    # it's on par or slightly faster than only applying to the last block in fwd.
-    # However, we choose different strategy for bwd, where we only apply mod & mask
-    # to the last block because it's faster a lot.
-    if not IS_DIVISIBLE:
-        # loop over k, v and update accumulator until block_n_end
-        for start_n in range(block_n_start, block_n_end):
+    # loop over k, v and update accumulator until block_n_end
+    for start_n in range(block_n_start, block_n_end):
+        if IS_DIVISIBLE:
+            acc, l_i, m_i = fwd_compute_block_mn(
+                q, K_block_ptr, V_block_ptr, Q_LEN, KV_LEN,
+                # accumulated values
+                acc, l_i, m_i,
+                # Offsets
+                off_z, off_h, offs_m, offs_n,
+                MATMUL_PRECISION, RCP_LN2,
+                {{gen_argdefs()}},
+                IS_FULL_BLOCKS,
+            )
+        else:
+            # Benchmark shows even we applied mod & mask to each block for non divisible seqlen,
+            # it's on par or slightly faster than only applying to the last block in fwd.
+            # However, we choose different strategy for bwd, where we only apply mod & mask
+            # to the last block because it's faster a lot.
             acc, l_i, m_i = fwd_compute_block_mn(
                 q, K_block_ptr, V_block_ptr, Q_LEN, KV_LEN,
                 # accumulated values
@@ -371,40 +382,16 @@ def forward_inner(
                 IS_FULL_BLOCKS, True,
             )
 
-            # update pointers
-            offset = get_offset_for_next_block(
-                start_n, kv_indices, kv_num_blocks,
-                SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N
-            )
+        # update pointers
+        offset = get_offset_for_next_block(
+            start_n, kv_indices, kv_num_blocks,
+            SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N
+        )
 
-            V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
-            K_block_ptr = tl.advance(K_block_ptr, (0, offset))
+        V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
+        K_block_ptr = tl.advance(K_block_ptr, (0, offset))
 
-            offs_n = offs_n + offset
-    else:
-        # loop over k, v and update accumulator until block_n_end
-        for start_n in range(block_n_start, block_n_end):
-            acc, l_i, m_i = fwd_compute_block_mn(
-                q, K_block_ptr, V_block_ptr, Q_LEN, KV_LEN,
-                # accumulated values
-                acc, l_i, m_i,
-                # Offsets
-                off_z, off_h, offs_m, offs_n,
-                MATMUL_PRECISION, RCP_LN2,
-                {{gen_argdefs()}},
-                IS_FULL_BLOCKS,
-            )
-
-            # update pointers
-            offset = get_offset_for_next_block(
-                start_n, kv_indices, kv_num_blocks,
-                SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N
-            )
-
-            V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
-            K_block_ptr = tl.advance(K_block_ptr, (0, offset))
-
-            offs_n = offs_n + offset
+        offs_n = offs_n + offset
 
     return acc, l_i, m_i
 

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -439,7 +439,7 @@ def fwd_compute_block_mn(
     if is_last_block:
         # Applying mod to index for last block for non divisible seqlen.
         offs_m = offs_m % Q_LEN
-        offs_m = offs_n % KV_LEN
+        offs_n = offs_n % KV_LEN
     # TODO: Add load mask in modification when M/N Boundary is not safe
     {{ modification(
         subgraph_number=0,
@@ -454,7 +454,7 @@ def fwd_compute_block_mn(
 
     if is_last_block:
         # Mask out the elements that are out of the KV_LEN for non divisible seqlen.
-        post_mod_scores = tl.where(offs_n[None, :] < KV_LEN, post_mod_scores, float("-inf"))
+        post_mod_scores = tl.where(offs_n < KV_LEN, post_mod_scores, float("-inf"))
 
     if not IS_FULL_BLOCKS:
         {{ modification(

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -518,12 +518,9 @@ flex_attention_template = TritonTemplate(
 )
 
 
-# Decide which kernel to use, return true if use flex decoding kernel.
 def _use_flex_decoding(query):
-    if isinstance(query, torch.Tensor):
-        return query.size(-2) < 128
-    else:
-        return V.graph.sizevars.evaluate_expr(sympy.Lt(query.get_size()[-2], 128))
+    # Decide which kernel to use, return true if use flex decoding kernel.
+    return V.graph.sizevars.evaluate_expr(sympy.Lt(query.get_size()[-2], 128))
 
 
 _h100_default_config = {

--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -217,8 +217,12 @@ compute_flex_attention = r"""
         block_shape=(BLOCK_M, BLOCK_DMODEL),
         order=(1, 0)
     )
+
     # load q: it stays in SRAM throughout the inner loop.
-    q = tl.load(Q_block_ptr, boundary_check=(0,))
+    if IS_DIVISIBLE:
+        q = tl.load(Q_block_ptr)
+    else:
+        q = tl.load(Q_block_ptr, boundary_check=(0,))
 
     # ~~~~~~~~~~~~~~ normal blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # We don't know anything "special" about these blocks, so we need to apply
@@ -312,7 +316,10 @@ compute_flex_attention = r"""
         off_hz = tl.program_id(1)
         l_ptrs = LSE + off_hz * Q_LEN + offs_m
         lse = m_i + tl.math.log2(l_i)
-        tl.store(l_ptrs, lse, mask=offs_m < Q_LEN)
+        if IS_DIVISIBLE:
+            tl.store(l_ptrs, lse)
+        else:
+            tl.store(l_ptrs, lse, mask=offs_m < Q_LEN)
  """
 
 
@@ -430,7 +437,10 @@ def fwd_compute_block_mn(
     {{gen_defines() | indent_except_first(1)}}
 
     # -- load k --
-    k = tl.load(K_block_ptr, boundary_check=(1,))
+    if IS_DIVISIBLE:
+        k = tl.load(K_block_ptr)
+    else:
+        k = tl.load(K_block_ptr, boundary_check=(1,))
     # -- compute qk ---
     qk = tl.dot(q, k) # TODO: use cuda matmul when q_len <= 2.
     if not PRESCALE_QK:
@@ -494,7 +504,11 @@ def fwd_compute_block_mn(
     l_i = l_i * alpha + tl.sum(p, 1)
     # # -- scale and update acc --
     acc = acc * alpha[:, None]
-    v = tl.load(V_block_ptr, boundary_check=(0,))
+
+    if IS_DIVISIBLE:
+        v = tl.load(V_block_ptr)
+    else:
+        v = tl.load(V_block_ptr, boundary_check=(0,))
     acc = tl.dot(p.to(MATMUL_PRECISION), v, acc)
 
     # -- update m_i
@@ -964,14 +978,22 @@ flex_attention_backward_template = TritonTemplate(
         offs_m2 = start_m2 + tl.arange(0, BLOCK_M2)
 
         # load Q and do: they stay in SRAM throughout the inner loop.
-        q = tl.load(Q2 + offs_m2[:, None] * stride_qm + offs_k[None, :] * stride_qd, mask=offs_m2[:, None] < Q_LEN)
-        do = tl.load(DO2 + offs_m2[:, None] * stride_dom + offs_k[None, :] * stride_dod, mask=offs_m2[:, None] < Q_LEN)
+        if IS_DIVISIBLE:
+            q = tl.load(Q2 + offs_m2[:, None] * stride_qm + offs_k[None, :] * stride_qd)
+            do = tl.load(DO2 + offs_m2[:, None] * stride_dom + offs_k[None, :] * stride_dod)
+        else:
+            q = tl.load(Q2 + offs_m2[:, None] * stride_qm + offs_k[None, :] * stride_qd, mask=offs_m2[:, None] < Q_LEN)
+            do = tl.load(DO2 + offs_m2[:, None] * stride_dom + offs_k[None, :] * stride_dod, mask=offs_m2[:, None] < Q_LEN)
 
         if PRESCALE_QK:
             q = (q * SM_SCALE * RCP_LN2).to(MATMUL_PRECISION)
 
-        Di = tl.load(DELTA2 + offs_m2, mask=offs_m2 < Q_LEN)
-        lse = tl.load(LSE2 + offs_m2, mask=offs_m2 < Q_LEN)
+        if IS_DIVISIBLE:
+            Di = tl.load(DELTA2 + offs_m2)
+            lse = tl.load(LSE2 + offs_m2)
+        else:
+            Di = tl.load(DELTA2 + offs_m2, mask=offs_m2 < Q_LEN)
+            lse = tl.load(LSE2 + offs_m2, mask=offs_m2 < Q_LEN)
         lse = lse[:, None]
 
         # ~~~~~~~~~~~ fully unmasked blocks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1014,7 +1036,10 @@ flex_attention_backward_template = TritonTemplate(
         # Write back dQ.
         dq_ptrs = DQ2 + offs_m2[:, None] * stride_dqm + offs_k[None, :] * stride_dqd
         dq *= SM_SCALE
-        tl.store(dq_ptrs, dq, mask=offs_m2[:, None] < Q_LEN)
+        if IS_DIVISIBLE:
+            tl.store(dq_ptrs, dq)
+        else:
+            tl.store(dq_ptrs, dq, mask=offs_m2[:, None] < Q_LEN)
     else:
         # THIS BLOCK DOES DK & DV
         SPARSE_Q_MULTIPLE = (SPARSE_Q_BLOCK_SIZE // BLOCK_M1)
@@ -1033,10 +1058,14 @@ flex_attention_backward_template = TritonTemplate(
         offs_n1 = start_n1 + tl.arange(0, BLOCK_N1)
 
         # load K and V: they stay in SRAM throughout the inner loop.
-        k = tl.load(K + offs_n1[:, None] * stride_kn + offs_k[None, :] * stride_kd, mask=offs_n1[:, None] < KV_LEN)
+        if IS_DIVISIBLE:
+            k = tl.load(K + offs_n1[:, None] * stride_kn + offs_k[None, :] * stride_kd)
+            v = tl.load(V + offs_n1[:, None] * stride_vn + offs_k[None, :] * stride_vd)
+        else:
+            k = tl.load(K + offs_n1[:, None] * stride_kn + offs_k[None, :] * stride_kd, mask=offs_n1[:, None] < KV_LEN)
+            v = tl.load(V + offs_n1[:, None] * stride_vn + offs_k[None, :] * stride_vd, mask=offs_n1[:, None] < KV_LEN)
         if PRESCALE_QK:
             k = (k * SM_SCALE * RCP_LN2).to(MATMUL_PRECISION)
-        v = tl.load(V + offs_n1[:, None] * stride_vn + offs_k[None, :] * stride_vd, mask=offs_n1[:, None] < KV_LEN)
 
         for off_g in range(0, GQA_SHARED_HEADS):
             off_hq1 = off_hkv * GQA_SHARED_HEADS + off_g
@@ -1104,7 +1133,10 @@ flex_attention_backward_template = TritonTemplate(
         index_n = offs_n1[:, None]
         index_k = offs_k[None, :]
 
-        tl.store(dv_ptrs, dv, mask=index_n < KV_LEN)
+        if IS_DIVISIBLE:
+            tl.store(dv_ptrs, dv)
+        else:
+            tl.store(dv_ptrs, dv, mask=index_n < KV_LEN)
 
         dk *= SM_SCALE
         mask = index_n < KV_LEN
@@ -1201,7 +1233,10 @@ def bwd_dq_compute_block_mn(
 ):
     {{gen_defines() | indent_except_first(1)}}
 
-    kT = tl.load(kT_ptrs, mask=offs_n2[None, :] < KV_LEN)
+    if IS_DIVISIBLE:
+        kT = tl.load(kT_ptrs)
+    else:
+        kT = tl.load(kT_ptrs, mask=offs_n2[None, :] < KV_LEN)
     qk = tl.dot(q, kT)
     if not PRESCALE_QK:
         qk *= SM_SCALE
@@ -1248,7 +1283,10 @@ def bwd_dq_compute_block_mn(
         post_mod_scores *= RCP_LN2
     p = tl.math.exp2(post_mod_scores - lse)
     # Compute dP and dS.
-    vT = tl.load(vT_ptrs, mask=offs_n2[None, :] < KV_LEN)
+    if IS_DIVISIBLE:
+        vT = tl.load(vT_ptrs)
+    else:
+        vT = tl.load(vT_ptrs, mask=offs_n2[None, :] < KV_LEN)
     dp = tl.dot(do, vT)
     ds = p * (dp - Di[:, None])
     # ~~~~~~~~~~~~~~~~~~~ Apply joint modification  ~~~~~~~~~~~~~~~~~~~
@@ -1370,8 +1408,12 @@ def bwd_dkdv_compute_block_mn(
     {{gen_defines() | indent_except_first(1) }}
 
     # Load LSE before computing qk to reduce pipeline stall.
-    qT = tl.load(qT_ptrs, mask=offs_m1[None, :] < Q_LEN)
-    lse = tl.load(LSE + offs_m1, mask=offs_m1 < Q_LEN)
+    if IS_DIVISIBLE:
+        qT = tl.load(qT_ptrs)
+        lse = tl.load(LSE + offs_m1)
+    else:
+        qT = tl.load(qT_ptrs, mask=offs_m1[None, :] < Q_LEN)
+        lse = tl.load(LSE + offs_m1, mask=offs_m1 < Q_LEN)
     qkT = tl.dot(k, qT)
     if not PRESCALE_QK:
         qkT *= SM_SCALE
@@ -1416,11 +1458,17 @@ def bwd_dkdv_compute_block_mn(
     if not PRESCALE_QK:
         post_mod_scores *= RCP_LN2
     pT = tl.math.exp2(post_mod_scores - lse[None, :])
-    do = tl.load(do_ptrs, mask=offs_m1[:, None] < Q_LEN)
+    if IS_DIVISIBLE:
+        do = tl.load(do_ptrs)
+    else:
+        do = tl.load(do_ptrs, mask=offs_m1[:, None] < Q_LEN)
     # Compute dV.
     ppT = pT
     dv += tl.dot(ppT.to(MATMUL_PRECISION), do)
-    Di = tl.load(DELTA + offs_m1, mask=offs_m1 < Q_LEN)
+    if IS_DIVISIBLE:
+        Di = tl.load(DELTA + offs_m1)
+    else:
+        Di = tl.load(DELTA + offs_m1, mask=offs_m1 < Q_LEN)
     # Compute dP and dS.
     dpT = tl.dot(v, tl.trans(do))
     dsT = pT * (dpT - Di[None, :])

--- a/torch/_inductor/kernel/flex_decoding.py
+++ b/torch/_inductor/kernel/flex_decoding.py
@@ -17,6 +17,7 @@ from .flex_attention import (
     compute_next_offset_func,
     create_indices_fake,
     create_num_blocks_fake_generator,
+    fwd_compute_block_mn,
 )
 
 
@@ -184,7 +185,7 @@ flex_decoding_template = TritonTemplate(
     offs_n = tl.arange(0, BLOCK_N) + off_n
 
     acc, l_i, m_i = forward_inner(
-        q, K_block_ptr, V_block_ptr,
+        q, K_block_ptr, V_block_ptr, Q_LEN, KV_LEN,
         # accumulatd values
         acc, l_i, m_i,
         #offsets
@@ -229,7 +230,7 @@ flex_decoding_template = TritonTemplate(
         offs_n = tl.arange(0, BLOCK_N) + off_n
 
         acc, l_i, m_i = forward_inner(
-            q, K_block_ptr, V_block_ptr,
+            q, K_block_ptr, V_block_ptr, Q_LEN, KV_LEN,
             # accumulatd values
             acc, l_i, m_i,
             #offsets
@@ -284,7 +285,8 @@ flex_decoding_template = TritonTemplate(
     {{store_output(("idx_z", "idx_t", "idx_hq", "idx_m", "idx_d"), "acc", "mask")}}
  """
     + compute_forward_block
-    + compute_next_offset_func,
+    + compute_next_offset_func
+    + fwd_compute_block_mn,
 )
 
 

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -904,11 +904,6 @@ def flex_attention(
     _validate_sdpa_input(query, key, value)
     if query.dim() != 4 or key.dim() != 4 or value.dim() != 4:
         raise NotImplementedError("NYI: query, key, and value must be 4D tensors")
-    if query.size(-2) >= 32:  # use Attention Kernel
-        if query.size(-2) >= 128 and query.size(-2) % 128 != 0:
-            raise NotImplementedError("NYI: S must be <128 or a multiple of 128")
-    if key.size(-2) % 128 != 0:
-        raise NotImplementedError("NYI: L must be a multiple of 128")
     if (not enable_gqa) and query.size(-3) != key.size(-3):
         raise ValueError(
             f"Expect query and key/value to have the same number of heads "

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -834,11 +834,7 @@ def _apply_kernel_options(query, key, value, kernel_options):
     output_logsumexp = any_inputs_require_grad and torch.is_grad_enabled()
     kernel_options["OUTPUT_LOGSUMEXP"] = output_logsumexp
 
-    from torch._inductor.kernel.flex_attention import _use_flex_decoding
-
-    if (
-        query.size(-2) % 128 != 0 or key.size(-2) % 128 != 0
-    ) and not _use_flex_decoding(query):
+    if query.size(-2) >= 128 and (query.size(-2) % 128 != 0 or key.size(-2) % 128 != 0):
         kernel_options["IS_DIVISIBLE"] = False
     else:
         kernel_options["IS_DIVISIBLE"] = True

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -834,6 +834,11 @@ def _apply_kernel_options(query, key, value, kernel_options):
     output_logsumexp = any_inputs_require_grad and torch.is_grad_enabled()
     kernel_options["OUTPUT_LOGSUMEXP"] = output_logsumexp
 
+    if query.size(-2) % 128 != 0 or key.size(-2) % 128 != 0:
+        kernel_options["IS_DIVISIBLE"] = False
+    else:
+        kernel_options["IS_DIVISIBLE"] = True
+
     return kernel_options
 
 

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -834,7 +834,11 @@ def _apply_kernel_options(query, key, value, kernel_options):
     output_logsumexp = any_inputs_require_grad and torch.is_grad_enabled()
     kernel_options["OUTPUT_LOGSUMEXP"] = output_logsumexp
 
-    if query.size(-2) % 128 != 0 or key.size(-2) % 128 != 0:
+    from torch._inductor.kernel.flex_attention import _use_flex_decoding
+
+    if (
+        query.size(-2) % 128 != 0 or key.size(-2) % 128 != 0
+    ) and not _use_flex_decoding(query):
         kernel_options["IS_DIVISIBLE"] = False
     else:
         kernel_options["IS_DIVISIBLE"] = True


### PR DESCRIPTION
Perf benchmark script: https://gist.github.com/yanboliang/7c34a82df611d4ea8869cb9e041bfbfc
* Update ```Q_LEN``` and ```KV_LEN``` to ```8192-9``` for testing non divisible cases.

Run ```python perf_bench.py --partial-mask```.

* Before this PR

| Seqence length        | Forward | Backward |
|---------------------|-----------------|------------------|
| **Divisible(8192)**       | 0.87            | 0.85             |
| **Non-divisible(8192-9)**   | N/A            | N/A             |

* After this PR

| Seqence length        | Forward | Backward |
|---------------------|-----------------|------------------|
| **Divisible(8192)**       | 0.87            | 0.85             |
| **Non-divisible(8192-9)**   | 0.83            | 0.78             |


Memory out of bounds check passed:
* ```PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer --tool memcheck python perf_bench.py --partial-mask```
 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang