### PR TITLE
[PyTorch] Speed up decomposed quantize_per_channel

### DIFF
--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -589,15 +589,13 @@ def quantize_per_channel(
     assert axis < input.dim(), f"Expecting axis to be < {input.dim()}"
     _quant_min_max_bounds_check(quant_min, quant_max, dtype)
     input, permute_axis_list = _permute_to_axis_zero(input, axis)
-    res = torch.zeros_like(input)
 
-    for i in range(input.size(0)):
-        res[i] = torch.clamp(
-            torch.round(input[i] * (1.0 / scales[i])) + zero_points[i],
-            quant_min,
-            quant_max,
-        )
+    new_shape = [1] * input.dim()
+    new_shape[0] = scales.shape[0]
+    scales = scales.view(new_shape)
+    zero_points = zero_points.view(new_shape)
 
+    res = torch.clamp(torch.round(input * (1.0 / scales)) + zero_points, quant_min, quant_max)
     out = res.permute(tuple(permute_axis_list))
     return out.to(dtype)
 

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -595,7 +595,9 @@ def quantize_per_channel(
     scales = scales.view(new_shape)
     zero_points = zero_points.view(new_shape)
 
-    res = torch.clamp(torch.round(input * (1.0 / scales)) + zero_points, quant_min, quant_max)
+    res = torch.clamp(
+        torch.round(input * (1.0 / scales)) + zero_points, quant_min, quant_max
+    )
     out = res.permute(tuple(permute_axis_list))
     return out.to(dtype)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133029

Similar to D60871396 (#132828).

Differential Revision: [D60978385](https://our.internmc.facebook.com/intern/diff/D60978385/)