### PR TITLE
Add support for OneDNN Quantization on s390x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,11 +180,14 @@ endif()
 
 set(CPU_AARCH64 OFF)
 set(CPU_INTEL OFF)
+set(CPU_ZARCH OFF)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|x86_64)")
   set(CPU_INTEL ON)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
   set(CPU_AARCH64 ON)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "s390x")
+  set(CPU_ZARCH ON)
 endif()
 
 # For non-supported platforms, turn USE_DISTRIBUTED off by default. It is not
@@ -311,10 +314,10 @@ option(USE_ROCM_KERNEL_ASSERT "Use Kernel Assert for ROCm" OFF)
 cmake_dependent_option(USE_ITT "Use Intel(R) VTune Profiler ITT functionality"
                        ON "CPU_INTEL" OFF)
 # Ensure that an MKLDNN build is the default for x86 CPUs but optional for
-# AArch64 (dependent on -DUSE_MKLDNN).
+# AArch64 and s390x (dependent on -DUSE_MKLDNN).
 cmake_dependent_option(
-  USE_MKLDNN "Use MKLDNN. Only available on x86, x86_64, and AArch64."
-  "${CPU_INTEL}" "CPU_INTEL OR CPU_AARCH64" OFF)
+  USE_MKLDNN "Use MKLDNN. Only available on x86, x86_64, AArch64, and s390x."
+  "${CPU_INTEL}" "CPU_INTEL OR CPU_AARCH64 OR CPU_ZARCH" OFF)
 cmake_dependent_option(
   USE_MKLDNN_ACL "Use Compute Library for the Arm architecture." OFF
   "USE_MKLDNN AND CPU_AARCH64" OFF)

--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -5,7 +5,9 @@
 #include <ATen/Tensor.h>
 #include <ATen/native/quantized/PackedParams.h>
 #include <ideep.hpp>
+#ifdef USE_FBGEMM
 #include <cpuinfo.h>
+#endif
 
 #include <c10/util/CallOnce.h>
 
@@ -418,6 +420,7 @@ inline bool is_weight_symmetric_quant(
   return is_symmetric;
 }
 
+#ifdef USE_FBGEMM
 // When qengine is x86, use this util func to check if onednn kernel
 // is preferred than fbgemm's to get better performance.
 inline bool should_use_onednn_quant(
@@ -440,6 +443,7 @@ inline bool should_use_onednn_quant(
   return vnni_available && (groups <= 100) && w_sym_quant && opad_all_zero;
 #endif
 }
+#endif
 
 } // onednn_utils
 

--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -5,7 +5,7 @@
 #include <ATen/Tensor.h>
 #include <ATen/native/quantized/PackedParams.h>
 #include <ideep.hpp>
-#ifdef USE_FBGEMM
+#if !defined(__s390x__) && !defined(__powerpc__)
 #include <cpuinfo.h>
 #endif
 
@@ -420,7 +420,6 @@ inline bool is_weight_symmetric_quant(
   return is_symmetric;
 }
 
-#ifdef USE_FBGEMM
 // When qengine is x86, use this util func to check if onednn kernel
 // is preferred than fbgemm's to get better performance.
 inline bool should_use_onednn_quant(
@@ -434,6 +433,9 @@ inline bool should_use_onednn_quant(
   // TODO Support more OSs.
 #if !defined(__linux__)
   return false;
+#elif defined(__s390x__) || defined(__powerpc__)
+  // Return true since these platforms do not support FBGEMM
+  return true;
 #else
   bool vnni_available = cpuinfo_has_x86_avx512vnni();
   bool w_sym_quant =
@@ -443,7 +445,6 @@ inline bool should_use_onednn_quant(
   return vnni_available && (groups <= 100) && w_sym_quant && opad_all_zero;
 #endif
 }
-#endif
 
 } // onednn_utils
 

--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -4,10 +4,8 @@
 #if AT_MKLDNN_ENABLED()
 #include <ATen/Tensor.h>
 #include <ATen/native/quantized/PackedParams.h>
+#include <ATen/cpu/Utils.h>
 #include <ideep.hpp>
-#if !defined(__s390x__) && !defined(__powerpc__)
-#include <cpuinfo.h>
-#endif
 
 #include <c10/util/CallOnce.h>
 
@@ -433,11 +431,8 @@ inline bool should_use_onednn_quant(
   // TODO Support more OSs.
 #if !defined(__linux__)
   return false;
-#elif defined(__s390x__) || defined(__powerpc__)
-  // Return true since these platforms do not support FBGEMM
-  return true;
 #else
-  bool vnni_available = cpuinfo_has_x86_avx512vnni();
+  bool vnni_available = at::cpu::is_cpu_support_avx512_vnni();
   bool w_sym_quant =
       is_weight_symmetric_quant(weight, is_transposed_conv);
   bool opad_all_zero =


### PR DESCRIPTION
This PR adds OneDNN Quantization support for s390x.
mklDNN has had support for s390x for some time, so some of the comments surrounding mklDNN support and x86/arm are outdated with respect to s390x. However, the version of ideep used contains a compilation bug specific to s390x which has not been backported to the 3.4.x version of ideep, so this PR also updates ideep to 3.5.1.



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal