### PR TITLE
[Memory Snapshot] Skip C++ warmup unwind() call if context is not set

### DIFF
--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -126,7 +126,8 @@ void _record_memory_history(
     bool trace_alloc_record_context,
     bool record_cpp_context) {
   c10::cuda::CUDACachingAllocator::CreateContextFn recorder = gather;
-  if (enabled && record_cpp_context) {
+  if (enabled && record_cpp_context &&
+      (trace_alloc_record_context || record_context)) {
     recorder = gather_with_cpp;
     // warm up C++ stack unwinding
     unwind::unwind();
@@ -172,7 +173,7 @@ void _record_memory_history(
       stacks, {"python", "all"}, "expected stacks to be 'python', or 'all'");
 
   c10::cuda::CUDACachingAllocator::CreateContextFn recorder = gather;
-  if (enabled && stacks == "all") {
+  if (enabled && context && stacks == "all") {
     recorder = gather_with_cpp;
     // warm up C++ stack unwinding
     unwind::unwind();


### PR DESCRIPTION
Summary: Should skip C++ warmup `unwind::unwind();` if there is no context set. This call is sometimes causing hanging issues since C++ stack collection is not robust.

Test Plan: CI

Differential Revision: D60965985

Pulled By: aaronenyeshi
