### PR TITLE
Prioritize `OpenBLAS_HOME` when searching for OpenBLAS during build

### DIFF
--- a/cmake/Modules/FindOpenBLAS.cmake
+++ b/cmake/Modules/FindOpenBLAS.cmake
@@ -1,38 +1,64 @@
+IF(DEFINED ENV{OpenBLAS_HOME})
+  FIND_PATH(
+    OpenBLAS_INCLUDE_DIR
+    NAMES cblas.h
+    PATHS
+      $ENV{OpenBLAS_HOME}
+      $ENV{OpenBLAS_HOME}/include
+      $ENV{OpenBLAS_HOME}/include/openblas
+    NO_DEFAULT_PATH
+  )
+  FIND_LIBRARY(
+    OpenBLAS_LIB
+    NAMES openblas
+    PATHS
+      $ENV{OpenBLAS_HOME}
+      $ENV{OpenBLAS_HOME}/lib
+    NO_DEFAULT_PATH
+  )
+ELSEIF(DEFINED ENV{OpenBLAS} AND NOT OpenBLAS_LIB)
+  FIND_LIBRARY(
+    OpenBLAS_LIB
+    NAMES openblas
+    PATHS
+      $ENV{OpenBLAS}
+      $ENV{OpenBLAS}/lib
+    NO_DEFAULT_PATH
+  )
+ENDIF()
+ 
+IF(NOT OpenBLAS_INCLUDE_DIR AND NOT OpenBLAS_LIB)
+  IF(DEFINED ENV{OpenBLAS_HOME} OR DEFINED ENV{OpenBLAS} AND NOT OpenBLAS_FIND_QUIETLY)
+    MESSAGE(STATUS "Could not find OpenBLAS at user-specified location, searching system libraries")
+  ENDIF()
 
+  SET(Open_BLAS_INCLUDE_SEARCH_PATHS
+    /usr/include
+    /usr/include/openblas
+    /usr/include/openblas-base
+    /usr/local/include
+    /usr/local/include/openblas
+    /usr/local/include/openblas-base
+    /usr/local/opt/openblas/include
+    /opt/OpenBLAS/include
+  )
 
-SET(Open_BLAS_INCLUDE_SEARCH_PATHS
-  /usr/include
-  /usr/include/openblas
-  /usr/include/openblas-base
-  /usr/local/include
-  /usr/local/include/openblas
-  /usr/local/include/openblas-base
-  /usr/local/opt/openblas/include
-  /opt/OpenBLAS/include
-  $ENV{OpenBLAS_HOME}
-  $ENV{OpenBLAS_HOME}/include
-  $ENV{OpenBLAS_HOME}/include/openblas
-)
+  SET(Open_BLAS_LIB_SEARCH_PATHS
+    /lib/
+    /lib/openblas-base
+    /lib64/
+    /usr/lib
+    /usr/lib/openblas-base
+    /usr/lib64
+    /usr/local/lib
+    /usr/local/lib64
+    /usr/local/opt/openblas/lib
+    /opt/OpenBLAS/lib
+  )
 
-SET(Open_BLAS_LIB_SEARCH_PATHS
-        /lib/
-        /lib/openblas-base
-        /lib64/
-        /usr/lib
-        /usr/lib/openblas-base
-        /usr/lib64
-        /usr/local/lib
-        /usr/local/lib64
-        /usr/local/opt/openblas/lib
-        /opt/OpenBLAS/lib
-        $ENV{OpenBLAS}
-        $ENV{OpenBLAS}/lib
-        $ENV{OpenBLAS_HOME}
-        $ENV{OpenBLAS_HOME}/lib
- )
-
-FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES cblas.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS})
-FIND_LIBRARY(OpenBLAS_LIB NAMES openblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS})
+  FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES cblas.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS})
+  FIND_LIBRARY(OpenBLAS_LIB NAMES openblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS})
+ENDIF()
 
 SET(OpenBLAS_FOUND ON)
 


### PR DESCRIPTION
Currently `FindOpenBLAS.cmake` searches several other directories before the user-specified `OpenBLAS_HOME` env variable when searching for OpenBLAS. In the case a user has multiple versions of OpenBLAS on their machine with different capabilities (i.e. one with sbgemm and one without), this could select a version other than that specified by the user and lead to a different build than intended.

This change modifies the logic around searching for the library to always prioritize searching the user's chosen OpenBLAS location.
