### PR TITLE
[compiled autograd][cpp node] No recaptures from saved float scalars

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1672,7 +1672,7 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved_dynamic, m) {
         # compiles for 10 (static) and 100 (dynamic)
         self.check_output_and_recompiles(fn, 2)
 
-    def test_autograd_cpp_node_saved_scalar(self):
+    def test_autograd_cpp_node_saved_int(self):
         cpp_source = """
 struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutogradFunction> {
   static constexpr bool is_traceable = true;
@@ -1706,13 +1706,13 @@ torch::Tensor custom_op_backed_by_autograd_fn(const torch::Tensor& x, int64_t y)
   return CustomOpAutogradFunction::apply(x, y);
 }
 
-TORCH_LIBRARY(test_autograd_cpp_node_saved_scalar, m) {
+TORCH_LIBRARY(test_autograd_cpp_node_saved_int, m) {
     m.def("custom_op_backed_by_autograd_fn", custom_op_backed_by_autograd_fn);
 }
         """
 
         module = torch.utils.cpp_extension.load_inline(
-            name="test_autograd_cpp_node_saved_scalar",
+            name="test_autograd_cpp_node_saved_int",
             cpp_sources=cpp_source,
             functions="custom_op_backed_by_autograd_fn",
             verbose=True,
@@ -1729,6 +1729,65 @@ TORCH_LIBRARY(test_autograd_cpp_node_saved_scalar, m) {
                 yield x.grad
 
         self.check_output_and_recompiles(fn, 1)
+
+    def test_autograd_cpp_node_saved_float(self):
+        cpp_source = """
+struct CustomOpAutogradFunction : public torch::autograd::Function<CustomOpAutogradFunction> {
+  static constexpr bool is_traceable = true;
+
+  static torch::Tensor forward(
+      torch::autograd::AutogradContext* ctx,
+      const torch::Tensor& x,
+      double z) {
+    ctx->save_for_backward({x});
+    ctx->saved_data["float"] = z;
+    ctx->saved_data["symfloat"] = c10::SymFloat(z);
+    return x;
+  }
+
+  static torch::autograd::variable_list backward(
+      torch::autograd::AutogradContext *ctx,
+      torch::autograd::variable_list grad_output) {
+    const auto& saved_variables = ctx->get_saved_variables();
+    assert(saved_variables.size() == 1);
+    torch::Tensor x = saved_variables[0];
+    c10::SymFloat z = ctx->saved_data["float"].toSymFloat();
+    c10::SymFloat zs = ctx->saved_data["symfloat"].toSymFloat();
+
+    torch::autograd::variable_list grad_inputs(2);
+    grad_inputs[0] = x + z + zs;
+    return grad_inputs;
+  }
+};
+
+torch::Tensor custom_op_backed_by_autograd_fn(const torch::Tensor& x, double z) {
+  return CustomOpAutogradFunction::apply(x, z);
+}
+
+TORCH_LIBRARY(test_autograd_cpp_node_saved_float, m) {
+    m.def("custom_op_backed_by_autograd_fn", custom_op_backed_by_autograd_fn);
+}
+        """
+
+        module = torch.utils.cpp_extension.load_inline(
+            name="test_autograd_cpp_node_saved_float",
+            cpp_sources=cpp_source,
+            functions="custom_op_backed_by_autograd_fn",
+            verbose=True,
+        )
+
+        def fn():
+            for z in [1.1, 2.2, 3.3, 1.1]:
+                x = torch.ones(10, 10, requires_grad=True)
+                out = torch.ops.test_autograd_cpp_node_saved_float.custom_op_backed_by_autograd_fn(
+                    x, z
+                )
+                loss = out.sum()
+                loss.backward()
+                yield x.grad
+
+        # compiled autograd and dynamo both support symfloat, but not backend
+        self.check_output_and_recompiles(fn, [1, 3])
 
     def test_autograd_cpp_node_data_dependent(self):
         cpp_source = """

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -298,7 +298,8 @@ class CompiledNodeArgs {
       }
     } else if (iv.isTensor()) {
       collect(iv.toTensor());
-    } else if (iv.isInt() || iv.isSymInt()) {
+    } else if (
+        iv.isInt() || iv.isSymInt() || iv.isDouble() || iv.isSymFloat()) {
       _compiler.lifted_ivalue_args.args.emplace_back(&iv);
     } else {
       try {
@@ -607,7 +608,7 @@ class SwapSavedVariables {
       before(iv.toTensor());
     } else {
       stashed_ivalues.save(&iv, at::IValue(iv));
-      if (iv.isInt() || iv.isSymInt()) {
+      if (iv.isInt() || iv.isSymInt() || iv.isDouble() || iv.isSymFloat()) {
         iv = compiler.lifted_ivalue_args.next_proxy(&iv);
       }
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133048
* #132771

Partially addresses https://github.com/pytorch/pytorch/issues/130170 for float scalars saved from forward pass of a custom c++ autograd function. With this PR, compiled autograd no longer recaptures when the float value changes, but downstream support isn't there yet: https://github.com/pytorch/pytorch/blob/4bdb4bbd864690d2d742d11574b661178bc2de0f/torch/_dynamo/config.py#L58-L61

Currently, any non-tensors passed in ctx->saved_data is specialized on by compiled autograd. To stop specializing on float values, we lift the float. We also require user code to use IValue::toSymFloat instead of IValue::toDouble in order to swap the SymFloat to proxy during compiled autograd tracing

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang