### PR TITLE
[DDP][FSDP2] keep DTensor params for replicate(fully_shard)

### DIFF
--- a/test/distributed/_composable/test_replicate.py
+++ b/test/distributed/_composable/test_replicate.py
@@ -255,6 +255,7 @@ class ReplicateTest(MultiProcessTestCase):
 
 
 class ReplicateFullyShardInit(ReplicateTest):
+    @skip_if_lt_x_gpu(2)
     def test_replicate_fully_shard_init(self):
         class ToyModel(nn.Module):
             def __init__(self, dim: int):
@@ -267,9 +268,6 @@ class ReplicateFullyShardInit(ReplicateTest):
                 self.proj = nn.Linear(dim, dim, bias=False)
 
             def forward(self, x: torch.Tensor):
-                assert isinstance(
-                    self.linears[0].weight.data, DTensor
-                ), f"{type(self.linears[0].weight.data)=}"
                 y = self.linears(x)
                 y = self.proj(y)
                 return y

--- a/test/distributed/_composable/test_replicate.py
+++ b/test/distributed/_composable/test_replicate.py
@@ -7,7 +7,9 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from torch import nn
+from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed._composable.replicate import replicate
+from torch.distributed._tensor import DTensor
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     skip_if_lt_x_gpu,
@@ -250,6 +252,44 @@ class ReplicateTest(MultiProcessTestCase):
             RuntimeError, "Expected device_id to be int or torch.device"
         ):
             replicate(model, device_id=[torch.device("cpu")])
+
+
+class ReplicateFullyShardInit(ReplicateTest):
+    def test_replicate_fully_shard_init(self):
+        class ToyModel(nn.Module):
+            def __init__(self, dim: int):
+                super().__init__()
+                self.linears = nn.Sequential(
+                    nn.Linear(dim, dim, bias=False),
+                    nn.Linear(dim, dim, bias=False),
+                    nn.Linear(dim, dim, bias=False),
+                )
+                self.proj = nn.Linear(dim, dim, bias=False)
+
+            def forward(self, x: torch.Tensor):
+                assert isinstance(
+                    self.linears[0].weight.data, DTensor
+                ), f"{type(self.linears[0].weight.data)=}"
+                y = self.linears(x)
+                y = self.proj(y)
+                return y
+
+        self._init_pg()
+        torch.cuda.set_device(self.rank)
+        dim = 3
+        bz = 2
+        model = ToyModel(dim).cuda()
+        for linear in model.linears:
+            fully_shard(linear)
+        fully_shard(model.linears)
+        replicate(model, device_id=torch.cuda.current_device())
+        for linear in model.linears:
+            self.assertTrue(isinstance(linear.weight, DTensor))
+        inp = torch.rand(bz, dim)
+        # trigger lazy init
+        model(inp).sum()
+        for linear in model.linears:
+            self.assertTrue(isinstance(linear.weight, DTensor))
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -86,9 +86,12 @@ class _ReplicateState(_State):
         device_mesh = kwargs.get("device_mesh", None)
         self.module = module
         ignored_params = {p for m in ignored_modules for p in m.parameters()}
+        for submodule in module.modules():
+            if _is_fully_sharded(submodule):
+                ignored_params.update(submodule.parameters())
         from torch.distributed.tensor.parallel.ddp import _localize_dtensor
 
-        _localize_dtensor(module)
+        _localize_dtensor(module, ignored_params=ignored_params)
         self._collect_params(module, ignored_modules, ignored_params)
 
         if "device_id" in kwargs:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #132954
* __->__ #133059

current status: for `replicate(fully_shard)`, DDP lazy_init will convert DTensor into local tensor, and that breaks FSDP unshard

this PR keeps FSDP params untouched during DDP lazy_init
I came across it because of a CI error in FSDP2's unit test #132978
thanks @awgu for fix proposal 

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o