### PR TITLE
Turn off Function Event Accumulation by Default

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1841,11 +1841,16 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
                         "profiling out of range",
                     )
 
-    def _schedule_helper(self, warmup, active, repeat):
+    def _schedule_helper(self, warmup, active, repeat, acc_events=True):
         with profile(
             schedule=torch.profiler.schedule(
-                skip_first=0, wait=0, warmup=warmup, active=active, repeat=repeat
-            )
+                skip_first=0,
+                wait=0,
+                warmup=warmup,
+                active=active,
+                repeat=repeat,
+            ),
+            acc_events=acc_events,
         ) as prof:
             for i in range(100):
                 torch.add(1, 2)
@@ -1863,6 +1868,12 @@ assert KinetoStepTracker.current_step() == initial_step + 2 * niters
         self.assertEqual(self._schedule_helper(warmup=1, active=5, repeat=0), 83)
         self.assertEqual(self._schedule_helper(warmup=10, active=10, repeat=4), 40)
         self.assertEqual(self._schedule_helper(warmup=50, active=1, repeat=0), 1)
+        self.assertEqual(
+            self._schedule_helper(warmup=0, active=5, repeat=0, acc_events=False), 0
+        )
+        self.assertEqual(
+            self._schedule_helper(warmup=10, active=10, repeat=4, acc_events=False), 10
+        )
 
     def _step_helper_func(self, prof):
         time.sleep(0.1)

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -95,6 +95,8 @@ class _KinetoProfile:
             representation of AI/ML workloads and enable replay benchmarks, simulators, and emulators.
             When this argument is included the observer start() and stop() will be called for the
             same time window as PyTorch profiler.
+        acc_events (bool): Enable the accumulation of FunctionEvents across multiple profiling cycles
+
 
     .. note::
         This API is experimental and subject to change in the future.
@@ -116,6 +118,7 @@ class _KinetoProfile:
         with_modules: bool = False,
         experimental_config: Optional[_ExperimentalConfig] = None,
         execution_trace_observer: Optional[_ITraceObserver] = None,
+        acc_events: bool = False,
     ):
         self.activities = set(activities) if activities else supported_activities()
         self.record_shapes = record_shapes
@@ -125,6 +128,7 @@ class _KinetoProfile:
         self.with_modules = with_modules
         self.experimental_config = experimental_config
         self.execution_trace_observer = execution_trace_observer
+        self.acc_events = acc_events
         self.profiler: Optional[prof.profile] = None
         self.mem_tl: Optional[MemoryProfileTimeline] = None
         self.use_device = None
@@ -148,7 +152,7 @@ class _KinetoProfile:
         self.stop_trace()
 
     def prepare_trace(self):
-        if self.profiler is None:
+        if (self.profiler is None) or (not self.acc_events):
             self.profiler = prof.profile(
                 use_cpu=(ProfilerActivity.CPU in self.activities),
                 use_device=self.use_device,
@@ -159,6 +163,7 @@ class _KinetoProfile:
                 with_modules=self.with_modules,
                 use_kineto=True,
                 experimental_config=self.experimental_config,
+                acc_events=self.acc_events,
             )
         self.profiler._prepare_trace()
 
@@ -478,6 +483,7 @@ class profile(_KinetoProfile):
             representation of AI/ML workloads and enable replay benchmarks, simulators, and emulators.
             When this argument is included the observer start() and stop() will be called for the
             same time window as PyTorch profiler. See the examples section below for a code sample.
+        acc_events (bool): Enable the accumulation of FunctionEvents across multiple profiling cycles
         use_cuda (bool):
             .. deprecated:: 1.8.1
                 use ``activities`` instead.
@@ -595,6 +601,7 @@ class profile(_KinetoProfile):
         with_modules: bool = False,
         experimental_config: Optional[_ExperimentalConfig] = None,
         execution_trace_observer: Optional[_ITraceObserver] = None,
+        acc_events: bool = False,
         # deprecated:
         use_cuda: Optional[bool] = None,
     ):
@@ -620,6 +627,7 @@ class profile(_KinetoProfile):
             with_modules=with_modules,
             experimental_config=experimental_config,
             execution_trace_observer=execution_trace_observer,
+            acc_events=acc_events,
         )
 
         if schedule:


### PR DESCRIPTION
Summary: D56956245 added the ability to accumulate FunctionEvents across multiple cycles in order to perform statistical analysis on them all together. Although this can be useful, it uses too many CPU resources especially for long running jobs. For this reason, lets add a flag to the profiler to turn off this behavior by default, but still allow users to turn it on if they wish.

Test Plan: Changed function count test to have acc_events passed in and check the amount of function events based on if flag is true or not

Differential Revision: D61021490
