### PR TITLE
Fix typo in `mypy.ini`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -40,7 +40,7 @@ files =
     test/test_numpy_interop.py,
     test/test_torch.py,
     test/test_type_hints.py,
-    test/test_type_info.py
+    test/test_type_info.py,
     test/test_utils.py
 
 #


### PR DESCRIPTION
A missing comma in the file list currently leads to errors when running mypy, introduced in #113745 

Fixes #133096 
