### PR TITLE
Add support for LinearOpContext and Conv2dOpContext in quantization pass

### DIFF
--- a/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
+++ b/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
@@ -22,11 +22,12 @@ TORCH_LIBRARY(xnnpack, m) {
         [](SerializationTypeLinearPrePack state)
             -> c10::intrusive_ptr<LinearOpContext> { // __setstate__
           return createLinearClampPrePackOpContext(
-              std::move(std::get<0>(state)),
-              std::move(std::get<1>(state)),
-              std::move(std::get<2>(state)),
-              std::move(std::get<3>(state)));
-        });
+              std::get<0>(state),
+              std::get<1>(state),
+              std::get<2>(state),
+              std::get<3>(state));
+        })
+    .def("unpack", &LinearOpContext::unpack);
 
   m.class_<Conv2dOpContext>(TORCH_SELECTIVE_CLASS("Conv2dOpContext"))
     .def_pickle(
@@ -37,15 +38,16 @@ TORCH_LIBRARY(xnnpack, m) {
         [](SerializationTypeConv2dPrePack state)
             -> c10::intrusive_ptr<Conv2dOpContext> { // __setstate__
           return createConv2dClampPrePackOpContext(
-              std::move(std::get<0>(state)),
-              std::move(std::get<1>(state)),
-              std::move(std::get<2>(state)),
-              std::move(std::get<3>(state)),
-              std::move(std::get<4>(state)),
-              std::move(std::get<5>(state)),
-              std::move(std::get<6>(state)),
-              std::move(std::get<7>(state)));
-        });
+              std::get<0>(state),
+              std::get<1>(state),
+              std::get<2>(state),
+              std::get<3>(state),
+              std::get<4>(state),
+              std::get<5>(state),
+              std::get<6>(state),
+              std::get<7>(state));
+        })
+    .def("unpack", &Conv2dOpContext::unpack);
 
   m.class_<TransposeConv2dOpContext>(TORCH_SELECTIVE_CLASS("TransposeConv2dOpContext"))
     .def_pickle(
@@ -56,15 +58,15 @@ TORCH_LIBRARY(xnnpack, m) {
         [](SerializationTypeTransposeConv2dPrePack state)
             -> c10::intrusive_ptr<TransposeConv2dOpContext> { // __setstate__
           return createConv2dTransposeClampPrePackOpContext(
-              std::move(std::get<0>(state)),
-              std::move(std::get<1>(state)),
-              std::move(std::get<2>(state)),
-              std::move(std::get<3>(state)),
-              std::move(std::get<4>(state)),
-              std::move(std::get<5>(state)),
-              std::move(std::get<6>(state)),
-              std::move(std::get<7>(state)),
-              std::move(std::get<8>(state)));
+              std::get<0>(state),
+              std::get<1>(state),
+              std::get<2>(state),
+              std::get<3>(state),
+              std::get<4>(state),
+              std::get<5>(state),
+              std::get<6>(state),
+              std::get<7>(state),
+              std::get<8>(state));
         });
 
 }

--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -1411,6 +1411,23 @@ class TestConverter(TestCase):
             ep_out, _ = pytree.tree_flatten(ep.module()(*inp))
             self._check_tensor_list_equal(orig_out, ep_out)
 
+    def test_ts2ep_convert_quantized_model_with_opcontext(self):
+        class M(torch.nn.Module):
+            def __init__(self, linear_op):
+                super().__init__()
+                self.linear_op = linear_op
+
+            def forward(self, x):
+                x = torch.ops.prepacked.linear_clamp_run(x, self.linear_op)
+                return x
+
+        linear_op = torch.ops.prepacked.linear_clamp_prepack(
+            torch.randn(10, 10), torch.randn(10)
+        )
+        m = M(linear_op)
+        inp = (torch.randn(1, 10),)
+        self._check_equal_ts_ep_converter(m, inp, ["script"])
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Summary:
Expose unpacking method for Linear/Conv2dOpContext and support linear_clamp_run and conv2d_clamp_run.

```
| suite   |   #models |   #has_ts_model |   #has_sample_inputs |   #ts_can_run |   #can_convert |   #ep_result_correct |   #aoti_can_compile |   #can_package |   #sigmoid_can_run |   #sigmoid_result_correct |
|---------|-----------|-----------------|----------------------|---------------|----------------|----------------------|---------------------|----------------|--------------------|---------------------------|
| EDGEML  |        50 |              36 |                   32 |            30 |             19 |                    7 |                   0 |             19 |                 16 |                         6 |
```

Test Plan:
```
buck2 run mode/dev-nosan sigmoid/inference/ts_migration:main -- --mode test_all --test_suites edgeml
```

Reviewed By: angelayi

Differential Revision: D60871242


