### PR TITLE
[inductor] cpp_builder add dynamo time trace for compile_file

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -262,7 +262,7 @@ def _remove_dir(path_dir: str) -> None:
         os.rmdir(path_dir)
 
 
-def _run_command_line(cmd_line: str, cwd: str) -> bytes:
+def _run_compile_cmd(cmd_line: str, cwd: str) -> bytes:
     cmd = shlex.split(cmd_line)
     try:
         status = subprocess.check_output(args=cmd, cwd=cwd, stderr=subprocess.STDOUT)
@@ -284,9 +284,9 @@ def _run_command_line(cmd_line: str, cwd: str) -> bytes:
     return status
 
 
-def run_command_line(cmd_line: str, cwd: str) -> bytes:
+def run_compile_cmd(cmd_line: str, cwd: str) -> bytes:
     with dynamo_timed("compile_file"):
-        return _run_command_line(cmd_line, cwd)
+        return _run_compile_cmd(cmd_line, cwd)
 
 
 def normalize_path_separator(orig_path: str) -> str:
@@ -1372,7 +1372,7 @@ class CppBuilder:
 
         build_cmd = self.get_command_line()
 
-        status = run_command_line(build_cmd, cwd=_build_tmp_dir)
+        status = run_compile_cmd(build_cmd, cwd=_build_tmp_dir)
 
         _remove_dir(_build_tmp_dir)
         return status, self._target_file


### PR DESCRIPTION
trace `compile_file` time for cpp_builder. 
Ref: https://github.com/pytorch/pytorch/pull/132328/files#diff-c9b517f8db609ffa866804dfa2689188a4fee20abacaa0b0dca91625c1b5cb8dR2224 

<img width="994" alt="image" src="https://github.com/user-attachments/assets/862c7943-79dc-4d06-b398-a09595ad1295">



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang