### PR TITLE
[pytorch][counters] Pybind start() stop() methods to _WaitCounterTracker()

### DIFF
--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -97,12 +97,18 @@ class TestMonitor(TestCase):
         log_event(e)
         self.assertEqual(len(events), 2)
 
-    def test_wait_counter(self) -> None:
+    def test_wait_counter__context_handler(self) -> None:
         wait_counter = _WaitCounter(
             "test_wait_counter",
         )
-        with wait_counter.guard() as wcg:
+        with wait_counter.guard() as _:
             pass
+
+    def test_wait_counter__start_stop(self) -> None:
+        wc_guard = _WaitCounter("test_wait_counter").guard()
+        wc_guard.start()
+        # do something.
+        wc_guard.stop()
 
 
 @skipIfTorchDynamo("Really weird error")

--- a/torch/csrc/monitor/python_init.cpp
+++ b/torch/csrc/monitor/python_init.cpp
@@ -315,6 +315,15 @@ void initMonitorBindings(PyObject* module) {
       .def(
           "__exit__",
           [](const std::shared_ptr<WaitCounterTracker>& self,
+             const pybind11::args&) { self->guard.reset(); })
+      .def(
+          "start",
+          [](const std::shared_ptr<WaitCounterTracker>& self) {
+            self->guard.emplace(self->handle.start());
+          })
+      .def(
+          "stop",
+          [](const std::shared_ptr<WaitCounterTracker>& self,
              const pybind11::args&) { self->guard.reset(); });
 
   py::class_<c10::monitor::WaitCounterHandle>(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133107
* __->__ #133106

add start() and stop() methods to _WaitCounterTracker to avoid indenting giant blocks of code.

per the next diff

Differential Revision: [D60876628](https://our.internmc.facebook.com/intern/diff/D60876628/)