### PR TITLE
Ignore `torch.onnx._internal` in `test_circular_dependencies`

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2231,7 +2231,7 @@ class TestImports(TestCase):
                            "torch.contrib.",  # something weird
                            "torch.testing._internal.distributed.",  # just fails
                            "torch.ao.pruning._experimental.",  # depends on pytorch_lightning, not user-facing
-                           "torch.onnx._internal.fx",  # depends on onnx-script
+                           "torch.onnx._internal",  # depends on onnx-script
                            "torch._inductor.runtime.triton_helpers",  # depends on triton
                            "torch._inductor.codegen.cuda",  # depends on cutlass
                            ]


### PR DESCRIPTION
Ignore the whole `_internal` module as code will depend on onnxscript and onnx.
