### PR TITLE
Fixes issue with enums in a tuple for dynamo

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4577,17 +4577,16 @@ def forward(self, x, b, y):
         self.assertEqual(out, torch.ones(2, 2) + 1)
 
     def test_dynamo_enum_in_tuple(self):
-        from enum import Enum
         class IntEnum(int, Enum):
             X = 0
 
         def fn(tensor):
             return tensor[..., IntEnum.X]
 
-        tensor = torch.rand((5,5))
+        tensor = torch.rand((5, 5))
         graph, _ = torch._dynamo.export(fn)(tensor)
         out = graph(tensor)
-        self.assertEqual(out, tensor[:,0])
+        self.assertEqual(out, tensor[:, 0])
 
 
 common_utils.instantiate_parametrized_tests(ExportTests)

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4576,6 +4576,19 @@ def forward(self, x, b, y):
         out = graph(*inputs)
         self.assertEqual(out, torch.ones(2, 2) + 1)
 
+    def test_dynamo_enum_in_tuple(self):
+        from enum import Enum
+        class IntEnum(int, Enum):
+            X = 0
+
+        def fn(tensor):
+            return tensor[..., IntEnum.X]
+
+        tensor = torch.rand((5,5))
+        graph, _ = torch._dynamo.export(fn)(tensor)
+        out = graph(tensor)
+        self.assertEqual(out, tensor[:,0])
+
 
 common_utils.instantiate_parametrized_tests(ExportTests)
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -492,10 +492,10 @@ class CodeGen:
                 dtype = str(arg.dtype).split(".")[-1]
                 return f"torch.Tensor(size={size}, dtype={dtype})"
             elif isinstance(arg, tuple):
-                if len(arg) == 0:
-                    return "()"
+                if len(arg) == 1:
+                    return f"({_get_repr(arg[0])},)"
                 else:
-                    return "(" + ", ".join(_get_repr(a) for a in arg) + ",)"
+                    return "(" + ", ".join(_get_repr(a) for a in arg) + ")"
             elif isinstance(arg, list):
                 return "[" + ", ".join(_get_repr(a) for a in arg) + "]"
             elif isinstance(arg, slice):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -492,7 +492,11 @@ class CodeGen:
                 dtype = str(arg.dtype).split(".")[-1]
                 return f"torch.Tensor(size={size}, dtype={dtype})"
             elif isinstance(arg, tuple):
-                return "(" + ",".join(_get_repr(a) for a in arg) + ",)"
+                return "(" + ", ".join(_get_repr(a) for a in arg) + ",)"
+            elif isinstance(arg, list):
+                return "[" + ", ".join(_get_repr(a) for a in arg) + "]"
+            elif isinstance(arg, slice):
+                return f"slice({_get_repr(arg.start)}, {_get_repr(arg.stop)}, {_get_repr(arg.step)})"
             else:
                 return blue(repr(arg))
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -492,7 +492,10 @@ class CodeGen:
                 dtype = str(arg.dtype).split(".")[-1]
                 return f"torch.Tensor(size={size}, dtype={dtype})"
             elif isinstance(arg, tuple):
-                return "(" + ", ".join(_get_repr(a) for a in arg) + ",)"
+                if len(arg) == 0:
+                    return "()"
+                else:
+                    return "(" + ", ".join(_get_repr(a) for a in arg) + ",)"
             elif isinstance(arg, list):
                 return "[" + ", ".join(_get_repr(a) for a in arg) + "]"
             elif isinstance(arg, slice):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -491,6 +491,8 @@ class CodeGen:
                 size = list(arg.size())
                 dtype = str(arg.dtype).split(".")[-1]
                 return f"torch.Tensor(size={size}, dtype={dtype})"
+            elif isinstance(arg, tuple):
+                return "(" + ",".join(_get_repr(a) for a in arg) + ",)"
             else:
                 return blue(repr(arg))
 


### PR DESCRIPTION
Currently when tuples values are encountered in dynamo, they are encoded using `repr(arg)`.  This causes an issue if one of the values inside of the tuple will not be properly encoded.  In this case, if an enum is contained inside of a tuple, it will cause invalid python code to be generated

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec