### PR TITLE
[MPS][BE] Delete MacOS-12.3 specific checks

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -26,8 +26,7 @@ namespace at::mps {
 
 // Helper enum to check if a MPSGraph op is supported in a given macOS version
 enum class MacOSVersion : uint32_t {
-  MACOS_VER_13_0_PLUS = 0,
-  MACOS_VER_13_1_PLUS,
+  MACOS_VER_13_1_PLUS = 0,
   MACOS_VER_13_2_PLUS,
   MACOS_VER_13_3_PLUS,
   MACOS_VER_14_0_PLUS,
@@ -79,7 +78,7 @@ class TORCH_API MPSDevice {
 };
 
 TORCH_API bool is_available();
-TORCH_API bool is_macos_13_or_newer(MacOSVersion version = MacOSVersion::MACOS_VER_13_0_PLUS);
+TORCH_API bool is_macos_13_or_newer(MacOSVersion version);
 TORCH_API at::Allocator* GetMPSAllocator(bool useSharedAllocator = false);
 
 } // namespace at::mps

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -12,18 +12,11 @@ namespace at::mps {
 static std::unique_ptr<MPSDevice> mps_device;
 static c10::once_flag mpsdev_init;
 
-static inline MTLLanguageVersion getMetalLanguageVersion(const id<MTLDevice>& device, bool macOS13Plus) {
+static inline MTLLanguageVersion getMetalLanguageVersion(const id<MTLDevice>& device) {
   // MPS Advanced Indexing needs at least Metal 2.0 (support for Argument Buffers and function constants)
   // host_name attribute needs at least Metal 2.2 and ulong needs Metal 2.3 (supported on MacOS 11+
-  MTLLanguageVersion languageVersion = MTLLanguageVersion2_3;
-#if defined(__MAC_13_0)
-  if (macOS13Plus) {
-    languageVersion = MTLLanguageVersion3_0;
-  }
-#endif
-
   TORCH_CHECK([device supportsFamily:MTLGPUFamilyMac2], "Missing Metal support for MTLGPUFamilyMac2");
-  return languageVersion;
+  return MTLLanguageVersion3_0;
 }
 
 MPSDevice* MPSDevice::getInstance() {
@@ -36,7 +29,7 @@ id<MTLLibrary> MPSDevice::getMetalIndexingLibrary() {
   NSError* error = nil;
   if (!_mtl_indexing_library) {
     MTLCompileOptions* options = [MTLCompileOptions new];
-    [options setLanguageVersion:getMetalLanguageVersion(_mtl_device, isMacOS13Plus(MacOSVersion::MACOS_VER_13_0_PLUS))];
+    [options setLanguageVersion:getMetalLanguageVersion(_mtl_device)];
     [options setFastMathEnabled:YES];
     _mtl_indexing_library = [_mtl_device newLibraryWithSource:[NSString stringWithCString:mps::indexing_metal_shaders
                                                                                  encoding:NSASCIIStringEncoding]
@@ -75,13 +68,12 @@ MPSDevice::~MPSDevice() {
 }
 
 MPSDevice::MPSDevice() : _mtl_device(nil), _mtl_indexing_library(nil) {
-  // Check that MacOS 12.3+ version of MPS framework is available
-  // Create the MPSGraph and check method introduced in 12.3+
+  // Check that MacOS 13.0+ version of MPS framework is available
+  // Create the MPSGraph and check method introduced in 13.0
   // which is used by MPS backend.
   id mpsCD = NSClassFromString(@"MPSGraph");
 
-  if ([mpsCD instancesRespondToSelector:@selector
-             (LSTMWithSourceTensor:recurrentWeight:inputWeight:bias:initState:initCell:descriptor:name:)] == NO) {
+  if ([mpsCD instancesRespondToSelector:@selector(cumulativeSumWithTensor:axis:name:)] == NO) {
     return;
   }
 
@@ -112,7 +104,6 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
           isOperatingSystemAtLeastVersion:{.majorVersion = major, .minorVersion = minor, .patchVersion = 0}];
     }
   };
-  static bool _macos_13_0_plus = is_os_version_at_least(13, 0);
   static bool _macos_13_1_plus = is_os_version_at_least(13, 1);
   static bool _macos_13_2_plus = is_os_version_at_least(13, 2);
   static bool _macos_13_3_plus = is_os_version_at_least(13, 3);
@@ -121,8 +112,6 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   static bool _macos_15_0_plus = is_os_version_at_least(15, 0);
 
   switch (version) {
-    case MacOSVersion::MACOS_VER_13_0_PLUS:
-      return _macos_13_0_plus;
     case MacOSVersion::MACOS_VER_13_1_PLUS:
       return _macos_13_1_plus;
     case MacOSVersion::MACOS_VER_13_2_PLUS:

--- a/aten/src/ATen/mps/MPSHooks.mm
+++ b/aten/src/ATen/mps/MPSHooks.mm
@@ -31,7 +31,7 @@ bool MPSHooks::isOnMacOSorNewer(unsigned major, unsigned minor) const {
   TORCH_CHECK(major == 13, "Trying to check for unexpected MacOS major ", major);
   switch (minor) {
     case 0:
-      return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_0_PLUS);
+      return true;
     case 1:
       return is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_1_PLUS);
     case 2:

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1433,15 +1433,11 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
     return std::make_tuple(std::move(output), std::move(hy), std::move(cy));
   }
 #ifdef USE_MPS
-  if (_input.is_mps() && (mps::is_macos_13_or_newer() || num_layers == 1)) {
+  if (_input.is_mps()) {
     std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> output = at::_lstm_mps(_input, hx, _params, has_biases,
             num_layers, dropout_p, train, bidirectional, batch_first);
     std::tuple<Tensor, Tensor, Tensor> return_values = std::make_tuple(std::get<0>(output), std::get<1>(output), std::get<2>(output));
     return return_values;
-  } else if (_input.is_mps()) {
-    TORCH_WARN_ONCE("Native multi-layer LSTM support in MPS available only on MacOS 13 onwards.",
-                    " Falling back to LSTMCell iteration.",
-                    " This may have performance implications.");
   }
 #endif
   // if cells are of different size, that means projections are used

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -68,8 +68,6 @@ static void binaryOpTensor(const Tensor& self,
                            const Tensor& output_,
                            std::string op_name,
                            BinaryOpBlock binaryBlock) {
-  TORCH_CHECK(!(!is_macos_13_or_newer() && self.scalar_type() == ScalarType::Byte),
-              "MPS support binary op with uint8 natively starting from macOS 13.0");
   TORCH_CHECK(!(op_name == "power" && !is_macos_13_or_newer(MacOSVersion::MACOS_VER_13_2_PLUS) &&
                 (self.scalar_type() == ScalarType::Long ||
                  (other.scalar_type() == ScalarType::Long &&
@@ -105,19 +103,6 @@ static void binaryOpTensor(const Tensor& self,
   auto inputDataType = self.scalar_type();
   auto otherDataType = other.scalar_type();
   auto outputDataType = output_.scalar_type();
-  if (!is_macos_13_or_newer()) {
-    // workaround for signed vs. unsigned comparison issue in MacOS 12
-    if (outputDataType == kBool && (inputDataType == kByte || otherDataType == kByte)) {
-      inputDataType = otherDataType = kByte;
-    } else {
-      if (inputDataType == kBool || inputDataType == kByte) {
-        inputDataType = kChar;
-      }
-      if (otherDataType == kBool || otherDataType == kByte) {
-        otherDataType = kChar;
-      }
-    }
-  }
 
   @autoreleasepool {
     string key = op_name + getTensorsStringKey({self, other, output_});

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -406,17 +406,6 @@ Tensor& exponential_mps_(Tensor& self, double lambda, std::optional<Generator> g
 }
 
 Tensor& randperm_out_mps(int64_t n, std::optional<Generator> generator, Tensor& result) {
-  if (!is_macos_13_or_newer()) {
-    TORCH_WARN_ONCE("MPS: randperm op is supported natively starting from macOS 13.0. ",
-                    "Falling back on CPU. This may have performance implications.");
-
-    auto result_cpu = result.to("cpu");
-    at::randperm_out(result_cpu, n);
-    result.resize_as_(result_cpu);
-    result.copy_(result_cpu);
-    return result;
-  }
-
   TORCH_CHECK(n >= 0, "n must be non-negative, got", n);
   TORCH_CHECK(!generator.has_value() || (generator.has_value() && result.device() == generator->device()),
               "Expected a '",

--- a/aten/src/ATen/native/mps/operations/Eye.mm
+++ b/aten/src/ATen/native/mps/operations/Eye.mm
@@ -54,12 +54,6 @@ Tensor& eye_out_mps(int64_t n, int64_t m, Tensor& result) {
   MPSStream* stream = getCurrentMPSStream();
 
   auto outputDataType = result.scalar_type();
-  ScalarType inputDataType = outputDataType;
-  if (!is_macos_13_or_newer() && outputDataType == kBool) {
-    // workaround for unsupported bool constant on macOS 12.
-    inputDataType = kByte;
-  }
-
   // Derive from MPSCachedGraph
   // This structure is used to cache an MPSGraph with certain keys, so that we don't have to compile the same MPSGraph
   // time and time again for the same operation The keys of this structure are based on the inputs and outputs needed
@@ -79,7 +73,7 @@ Tensor& eye_out_mps(int64_t n, int64_t m, Tensor& result) {
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
       MPSGraphTensor* onesTensor = [mpsGraph constantWithScalar:1.0f
                                                           shape:getMPSShape(result)
-                                                       dataType:getMPSDataType(inputDataType)];
+                                                       dataType:getMPSDataType(outputDataType)];
 
       // Here we can call the MPSGraph API needed to execute the operation.
       // The API details can be found here:

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -232,13 +232,6 @@ static Tensor& pad_out_template(Tensor& output,
         endsVec[padIdx] = @(input.size(padIdx) + padding[rightIdx]);
         endMask &= ~(1U << padIdx);
       }
-      // workaround for the right padding bug in Monterey
-    } else if (!is_macos_13_or_newer()) {
-      if (padding[rightIdx] == 1 && padding[leftIdx] == 0) {
-        rightPadVec[padIdx] = @(2);
-        endsVec[padIdx] = @(input.size(padIdx) + 2);
-        endMask &= ~(1U << padIdx);
-      }
     }
   }
   MPSShape* leftPadding = [NSArray arrayWithObjects:leftPadVec.data() count:ndims];

--- a/aten/src/ATen/native/mps/operations/PixelShuffle.mm
+++ b/aten/src/ATen/native/mps/operations/PixelShuffle.mm
@@ -83,24 +83,10 @@ static Tensor pixel_shuffle_helper(const Tensor& self, int64_t factor, bool upsc
 }
 
 Tensor pixel_shuffle_mps(const Tensor& self, int64_t upscale_factor) {
-  if (!is_macos_13_or_newer()) {
-    TORCH_WARN_ONCE("MPS: pixel_shuffle op is supported starting from macOS 13.0. ",
-                    "Falling back on CPU. This may have performance implications.");
-
-    return at::native::pixel_shuffle_cpu(self.to("cpu"), upscale_factor).to("mps");
-  }
-
   return pixel_shuffle_helper(self, upscale_factor, /*upscale=*/true);
 }
 
 Tensor pixel_unshuffle_mps(const Tensor& self, int64_t downscale_factor) {
-  if (!is_macos_13_or_newer()) {
-    TORCH_WARN_ONCE("MPS: pixel_unshuffle op is supported starting from macOS 13.0. ",
-                    "Falling back on CPU. This may have performance implications.");
-
-    return at::native::pixel_unshuffle_cpu(self.to("cpu"), downscale_factor).to("mps");
-  }
-
   return pixel_shuffle_helper(self, downscale_factor, /*upscale=*/false);
 }
 

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -46,12 +46,6 @@ static void pool2d_template(const Tensor& input,
                             const std::optional<int64_t> divisor_override,
                             PoolingOpBlock poolingBlock,
                             const c10::string& op_name) {
-  if (!is_macos_13_or_newer()) {
-    TORCH_CHECK(input.scalar_type() != ScalarType::Long,
-                "MPS: ",
-                op_name,
-                " op with int64 input is supported natively starting from macOS 13.0.");
-  }
   const int64_t ndims = input.ndimension();
   const Tensor& grad_output = *(at::borrow_from_optional_tensor(grad_output_opt));
   const Tensor& indices = *(at::borrow_from_optional_tensor(indices_opt));

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -62,14 +62,6 @@ Tensor repeat_mps(const Tensor& self, IntArrayRef repeats) {
   auto stream = at::mps::getCurrentMPSStream();
   auto inputDataType = getMPSDataType(expanded_tensor);
   auto outputDataType = getMPSDataType(result);
-  if (!is_macos_13_or_newer()) {
-    if (expanded_tensor.scalar_type() == kBool) {
-      inputDataType = MPSDataTypeInt8;
-    }
-    if (result.scalar_type() == kBool) {
-      outputDataType = MPSDataTypeInt8;
-    }
-  }
 
   @autoreleasepool {
     string key = "repeat_mps:" + getTensorsStringKey(self) + ":" + getArrayRefString(repeats);

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -53,10 +53,10 @@ TORCH_IMPL_FUNC(gather_out_mps)
     }
     auto input_type = getMPSDataType(self);
     auto output_type = getMPSDataType(output);
-    if (input_type == MPSDataTypeUInt8 || ((input_type == MPSDataTypeBool && !is_macos_13_or_newer()))) {
+    if (input_type == MPSDataTypeUInt8) {
       input_type = MPSDataTypeInt8;
     }
-    if (output_type == MPSDataTypeUInt8 || ((output_type == MPSDataTypeBool && !is_macos_13_or_newer()))) {
+    if (output_type == MPSDataTypeUInt8) {
       output_type = MPSDataTypeInt8;
     }
     string key = "gather_out_mps" + getTensorsStringKey({self, index, output}) + ":" + std::to_string(dim);

--- a/aten/src/ATen/native/mps/operations/Sort.mm
+++ b/aten/src/ATen/native/mps/operations/Sort.mm
@@ -41,16 +41,6 @@ TORCH_IMPL_FUNC(sort_stable_out_mps)
     return;
   }
 
-  if (!is_macos_13_or_newer()) {
-    TORCH_WARN_ONCE("torch.sort is supported by MPS on MacOS 13+, please upgrade. Falling back to CPU");
-    Tensor cpu_indices = indices.clone().to("cpu");
-    Tensor cpu_values = values.clone().to("cpu");
-    at::sort_out(cpu_values, cpu_indices, self.to(at::Device(kCPU)), false, dim, descending);
-    values.copy_(cpu_values);
-    indices.copy_(cpu_indices);
-    return;
-  }
-
   MPSStream* stream = getCurrentMPSStream();
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -412,19 +412,6 @@ static void where_kernel_mps(TensorIterator& iter) {
   MPSDataType conditionDataType = getMPSScalarType(condition.scalar_type());
   MPSDataType selfDataType = getMPSScalarType(self.scalar_type());
   MPSDataType otherDataType = getMPSScalarType(other.scalar_type());
-  // Workaround for `selectWithPredicateTensor` on macOS Monterey where bool data type may cause a hang
-  // The issue is fixed in macOS Ventura (13.0)
-  if (!is_macos_13_or_newer()) {
-    if (condition.scalar_type() == kBool) {
-      conditionDataType = MPSDataTypeInt8;
-    }
-    if (self.scalar_type() == kBool) {
-      selfDataType = MPSDataTypeInt8;
-    }
-    if (other.scalar_type() == kBool) {
-      otherDataType = MPSDataTypeInt8;
-    }
-  }
 
   @autoreleasepool {
     string key = "where_self_out_mps:" + getTensorsStringKey({cond_bool, self, other});

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -74,9 +74,6 @@ static bool is_empty_tensor(const Tensor& self) {
 }
 
 static void unary_op_noresize(const Tensor& self, const Tensor& output_, std::string op_name, UnaryOpBlock unaryBlock) {
-  TORCH_CHECK(!(!is_macos_13_or_newer() && self.scalar_type() == ScalarType::Byte),
-              "MPS support unary op with uint8 natively starting from macOS 13.0");
-
   auto output = output_;
   bool needsCopyToOutput = false;
   if (needsGather(output)) {
@@ -150,19 +147,8 @@ MPSGraphTensor* trunc_tensor(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
     return inputTensor;
   }
 
-  if (!is_macos_13_or_newer()) {
-    MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 dataType:inputTensor.dataType];
-    MPSGraphTensor* predicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                          secondaryTensor:zeroTensor
-                                                                     name:nil];
-    return [mpsGraph selectWithPredicateTensor:predicateTensor
-                           truePredicateTensor:[mpsGraph ceilWithTensor:inputTensor name:nil]
-                          falsePredicateTensor:[mpsGraph floorWithTensor:inputTensor name:nil]
-                                          name:nil];
-  } else {
-    return [mpsGraph truncateWithTensor:inputTensor name:nil];
-  }
-};
+  return [mpsGraph truncateWithTensor:inputTensor name:nil];
+}
 
 MPSGraphTensor* log1p(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
   MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0 dataType:inputTensor.dataType];
@@ -444,17 +430,6 @@ static void cumulative_op_impl(const Tensor& self,
               "(original dim is ",
               dim,
               ")");
-  if (!is_macos_13_or_newer()) {
-    TORCH_WARN_ONCE(op_name, " supported by MPS on MacOS 13+, please upgrade");
-    Tensor cpu_result;
-    if (cumulativeOpType == MPSCumulativeOpType::CUMSUM) {
-      cpu_result = self.to(at::Device(kCPU)).cumsum(dim, dtype);
-    } else if (cumulativeOpType == MPSCumulativeOpType::CUMPROD) {
-      cpu_result = self.to(at::Device(kCPU)).cumprod(dim, dtype);
-    }
-    at::_copy_from_and_resize(cpu_result, result);
-    return;
-  }
   TORCH_CHECK(!self.is_complex(), "cumulative ops are not yet supported for complex");
   auto input = dtype.has_value() ? self.to(dtype.value()) : self;
 

--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -286,12 +286,6 @@ std::tuple<Tensor, Tensor, Tensor> unique_consecutive_mps(const Tensor& self,
                                                           const bool return_inverse,
                                                           const bool return_counts,
                                                           std::optional<int64_t> dim) {
-  if (!is_macos_13_or_newer()) {
-    TORCH_WARN_ONCE("MPS: unique_consecutive op is supported natively starting from macOS 13.0. ",
-                    "Falling back on CPU. This may have performance implications.");
-    return castToMPS(at::unique_consecutive(self.to("cpu"), return_inverse, return_counts, dim));
-  }
-
   return _unique_impl_mps(self, return_inverse, return_counts, true, dim);
 }
 
@@ -299,12 +293,6 @@ std::tuple<Tensor, Tensor, Tensor> unique_dim_consecutive_mps(const Tensor& self
                                                               int64_t dim,
                                                               const bool return_inverse,
                                                               const bool return_counts) {
-  if (!is_macos_13_or_newer()) {
-    TORCH_WARN_ONCE("MPS: unique_dim_consecutive op is supported natively starting from macOS 13.0. ",
-                    "Falling back on CPU. This may have performance implications.");
-    return castToMPS(at::unique_dim_consecutive(self.to("cpu"), dim, return_inverse, return_counts));
-  }
-
   return _unique_impl_mps(self, return_inverse, return_counts, true, std::make_optional((int64_t)dim));
 }
 
@@ -312,12 +300,6 @@ std::tuple<Tensor, Tensor, Tensor> _unique2_mps(const Tensor& self,
                                                 const bool sorted,
                                                 const bool return_inverse,
                                                 const bool return_counts) {
-  if (!is_macos_13_or_newer()) {
-    TORCH_WARN_ONCE("MPS: _unique2 op is supported natively starting from macOS 13.0. ",
-                    "Falling back on CPU. This may have performance implications.");
-    return castToMPS(at::_unique2(self.to("cpu"), sorted, return_inverse, return_counts));
-  }
-
   return _unique_impl_mps(self, return_inverse, return_counts, false, std::nullopt);
 }
 

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -68,7 +68,7 @@ static Tensor& runViewGraph(ViewCachedGraph* cachedGraph, const at::Tensor& src,
                                               dataType:inputType] autorelease];
     if (needsScatter) {
       auto updatesType = getMPSScalarType(src.scalar_type());
-      if (updatesType == MPSDataTypeUInt8 || (updatesType == MPSDataTypeBool && !is_macos_13_or_newer())) {
+      if (updatesType == MPSDataTypeUInt8) {
         updatesType = MPSDataTypeInt8;
       }
 
@@ -87,7 +87,7 @@ static Tensor& runViewGraph(ViewCachedGraph* cachedGraph, const at::Tensor& src,
     // Workaround for MPSShaderLibrary bug in macOS Monterey
     // This is fixed in macOS Ventura
     auto outputType = getMPSScalarType(output.scalar_type());
-    if (outputType == MPSDataTypeUInt8 || (outputType == MPSDataTypeBool && !is_macos_13_or_newer())) {
+    if (outputType == MPSDataTypeUInt8) {
       outputType = MPSDataTypeInt8;
     }
     MPSGraphTensorData* outputTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer:outputBuffer
@@ -697,7 +697,7 @@ static ViewCachedGraph* createViewGraph(const Tensor& self,
       // Workaround for MPSShaderLibrary bug in macOS Monterey
       // This is fixed in macOS Ventura
       auto inputType = getMPSScalarType(self.scalar_type());
-      if (inputType == MPSDataTypeUInt8 || (inputType == MPSDataTypeBool && !is_macos_13_or_newer())) {
+      if (inputType == MPSDataTypeUInt8) {
         inputType = MPSDataTypeInt8;
       }
 
@@ -709,7 +709,7 @@ static ViewCachedGraph* createViewGraph(const Tensor& self,
       }
       if (needsScatter) {
         auto updatesType = getMPSScalarType(updates.scalar_type());
-        if (updatesType == MPSDataTypeUInt8 || (updatesType == MPSDataTypeBool && !is_macos_13_or_newer())) {
+        if (updatesType == MPSDataTypeUInt8) {
           updatesType = MPSDataTypeInt8;
         }
         newCachedGraph->updatesTensor = mpsGraphRankedPlaceHolder(mpsGraph, updatesType, getMPSShape(self.numel()));


### PR DESCRIPTION
And make MPS device unavailable on Sonoma releases As lots of those checks 2 years old, are no longer validated in CI and probably much more such checks are missing
