### PR TITLE
[export] change deepcopy to copy in _replace_with_hop passes

### DIFF
--- a/torch/_export/passes/replace_with_hop_pass_util.py
+++ b/torch/_export/passes/replace_with_hop_pass_util.py
@@ -115,7 +115,10 @@ def _sequential_split_and_maybe_inline_subgraphs_helper(
     replace_ctx = contextlib.nullcontext()
     new_signature = None
     if graph_signature is not None:
-        new_signature = copy.deepcopy(graph_signature)
+        # Cannot deep copy a real ScriptObject, which is referenced
+        # in the FakeScriptObject. Copy should be good enough to guard
+        # against accidental mutation to original graph_signature.
+        new_signature = copy.copy(graph_signature)
         new_gm_out_node = next(reversed(new_gm.graph.find_nodes(op="output")))
         assert new_gm_out_node.op == "output" and len(new_gm_out_node.args[0]) == len(
             new_signature.output_specs


### PR DESCRIPTION
Summary:
Add back the change in https://github.com/pytorch/pytorch/commit/19897a164781e8bb73c03d8f7947743e8f13a62e.

The change was lost in refactoring due to a bad rebase.

Test Plan:
CI

```
buck2 run 'fbcode//mode/dev-nosan'  fbcode//torchrec/distributed/tests:test_pt2 -- --filter-text test_sharded_quant_fpebc_non_strict_export
```

Differential Revision: D61052687
