### PR TITLE
[CUDAGraph] Enable input mutation support internally

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -764,7 +764,7 @@ class triton:
     cudagraph_trees_history_recording = False
 
     # Enable cudagraph support for mutated inputs from prior cudagraph pool
-    cudagraph_support_input_mutation = False if is_fbcode() else True
+    cudagraph_support_input_mutation = True
 
     # Maximal number of allowed cudagraph re-record for a function and
     # a cudagraph node due to static input tensor address changes or


### PR DESCRIPTION
Summary: This PR enables input mutation support for cudagraph on internal models.

Test Plan: CI

Differential Revision: D61054088


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang