### PR TITLE
[DTensor][Easy] Minor fix to Partial Placement Docstring

### DIFF
--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -399,7 +399,7 @@ class Partial(Placement):
     Args:
         reduce_op (str, optional): The reduction op to be used for the partial DTensor
         to produce Replicated/Sharded DTensor. Only element-wise reduction operations
-        are supportd, including: "sum", "avg", "prod", "max", "min", default: "sum".
+        are supportd, including: "sum", "avg", "product", "max", "min", default: "sum".
 
     ::note:: The ``Partial`` placement can be generated as a result of the DTensor operators,
         and can only be used by the ``DTensor.from_local`` API.


### PR DESCRIPTION
Minor doc fix: The reduce op string for product should be "product" instead of "prod". 
https://github.com/pytorch/pytorch/blob/main/torch/distributed/_functional_collectives.py#L1045



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o