### PR TITLE
Return from monitoring thread on TCPStore failure

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1327,7 +1327,8 @@ void ProcessGroupNCCL::heartbeatMonitor() {
               << logPrefix()
               << "Failed to get exception dump flag from the global store."
               << e.what();
-          break;
+          // We give up for now assuming TCPStore has been torn down.
+          return;
         }
 
         if (checkExceptionDump) {


### PR DESCRIPTION
Summary: Pessimisticly assume that things are being torn down if TCPStore is not available and do not attempt to dump stack traces.

Test Plan:
Seeing crashes in production when Flight Recorder is enabled.
Here's the relevant mast link: https://fburl.com/mlhub/qia257xh

Reviewed By: fduwjj

Differential Revision: D61055124


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k