### PR TITLE
[CI] Build pytorch wheel with Torch XPU Operators on Windows

### DIFF
--- a/.ci/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.ci/pytorch/win-test-helpers/build_pytorch.bat
@@ -24,6 +24,12 @@ call %INSTALLER_DIR%\install_sccache.bat
 if errorlevel 1 goto fail
 if not errorlevel 0 goto fail
 
+if "%USE_XPU%"=="1" (
+  :: Install xpu support packages
+  call %INSTALLER_DIR%\install_xpu.bat
+  if errorlevel 1 exit /b 1
+)
+
 :: Miniconda has been installed as part of the Windows AMI with all the dependencies.
 :: We just need to activate it here
 call %INSTALLER_DIR%\activate_miniconda3.bat
@@ -43,6 +49,16 @@ if "%VC_VERSION%" == "" (
 )
 if errorlevel 1 goto fail
 if not errorlevel 0 goto fail
+
+if "%USE_XPU%"=="1" (
+  :: Activate xpu environment - VS env is required for xpu
+  call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+  if errorlevel 1 exit /b 1
+  :: Reduce build time. Only have MTL self-hosted runner now
+  SET TORCH_XPU_ARCH_LIST=xe-lpg
+  SET USE_KINETO=0
+)
+
 @echo on
 popd
 

--- a/.ci/pytorch/win-test-helpers/installation-helpers/install_xpu.bat
+++ b/.ci/pytorch/win-test-helpers/installation-helpers/install_xpu.bat
@@ -1,0 +1,91 @@
+@echo on
+REM Description: Install Intel Support Packages on Windows
+REM BKM reference: https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu/2-5.html
+
+set XPU_INSTALL_MODE=%~1
+if "%XPU_INSTALL_MODE%"=="" goto xpu_bundle_install_start
+if "%XPU_INSTALL_MODE%"=="bundle" goto xpu_bundle_install_start
+if "%XPU_INSTALL_MODE%"=="driver" goto xpu_driver_install_start
+if "%XPU_INSTALL_MODE%"=="all" goto xpu_driver_install_start
+
+:arg_error
+
+echo Illegal XPU installation mode. The value can be "bundle"/"driver"/"all"
+echo If keep the value as space, will use default "bundle" mode
+exit /b 1
+
+:xpu_driver_install_start
+:: TODO Need more testing for driver installation
+set XPU_DRIVER_LINK=https://downloadmirror.intel.com/830975/gfx_win_101.5972.exe
+curl -o xpu_driver.exe --retry 3 --retry-all-errors -k %XPU_DRIVER_LINK%
+echo "XPU Driver installing..."
+start /wait "Intel XPU Driver Installer" "xpu_driver.exe"
+if errorlevel 1 exit /b 1
+del xpu_driver.exe
+if "%XPU_INSTALL_MODE%"=="driver" goto xpu_install_end
+
+:xpu_bundle_install_start
+
+set XPU_BUNDLE_PARENT_DIR=C:\Program Files (x86)\Intel\oneAPI
+set XPU_BUNDLE_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/9d1a91e2-e8b8-40a5-8c7f-5db768a6a60c/w_intel-for-pytorch-gpu-dev_p_0.5.3.37_offline.exe
+set XPU_PTI_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/9d1a91e2-e8b8-40a5-8c7f-5db768a6a60c/w_intel-pti-dev_p_0.9.0.37_offline.exe
+set XPU_BUNDLE_VERSION=0.5.3+31
+set XPU_PTI_VERSION=0.9.0+36
+set XPU_BUNDLE_PRODUCT_NAME=intel.oneapi.win.intel-for-pytorch-gpu-dev.product
+set XPU_PTI_PRODUCT_NAME=intel.oneapi.win.intel-pti-dev.product
+set XPU_BUNDLE_INSTALLED=0
+set XPU_PTI_INSTALLED=0
+set XPU_BUNDLE_UNINSTALL=0
+set XPU_PTI_UNINSTALL=0
+
+:: Check if XPU bundle is target version or already installed
+if exist "%XPU_BUNDLE_PARENT_DIR%\Installer\installer.exe" goto xpu_bundle_ver_check
+goto xpu_bundle_install
+
+:xpu_bundle_ver_check
+
+"%XPU_BUNDLE_PARENT_DIR%\Installer\installer.exe" --list-products > xpu_bundle_installed_ver.log
+
+for /f "tokens=1,2" %%a in (xpu_bundle_installed_ver.log) do (
+    if "%%a"=="%XPU_BUNDLE_PRODUCT_NAME%" (
+        echo %%a Installed Version: %%b
+        set XPU_BUNDLE_INSTALLED=1
+        if not "%XPU_BUNDLE_VERSION%"=="%%b" (
+            start /wait "Installer Title" "%XPU_BUNDLE_PARENT_DIR%\Installer\installer.exe" --action=remove --eula=accept --silent --product-id %XPU_BUNDLE_PRODUCT_NAME% --product-ver %%b --log-dir uninstall_bundle
+            set XPU_BUNDLE_UNINSTALL=1
+        )
+    )
+    if "%%a"=="%XPU_PTI_PRODUCT_NAME%" (
+        echo %%a Installed Version: %%b
+        set XPU_PTI_INSTALLED=1
+        if not "%XPU_PTI_VERSION%"=="%%b" (
+            start /wait "Installer Title" "%XPU_BUNDLE_PARENT_DIR%\Installer\installer.exe" --action=remove --eula=accept --silent --product-id %XPU_PTI_PRODUCT_NAME% --product-ver %%b --log-dir uninstall_bundle
+            set XPU_PTI_UNINSTALL=1
+        )
+    )
+)
+if errorlevel 1 exit /b 1
+if exist xpu_bundle_installed_ver.log del xpu_bundle_installed_ver.log
+if "%XPU_BUNDLE_INSTALLED%"=="0" goto xpu_bundle_install
+if "%XPU_BUNDLE_UNINSTALL%"=="1" goto xpu_bundle_install
+if "%XPU_PTI_INSTALLED%"=="0" goto xpu_pti_install
+if "%XPU_PTI_UNINSTALL%"=="1" goto xpu_pti_install
+goto xpu_install_end
+
+:xpu_bundle_install
+
+curl -o xpu_bundle.exe --retry 3 --retry-all-errors -k %XPU_BUNDLE_URL%
+echo "XPU Bundle installing..."
+start /wait "Intel Pytorch Bundle Installer" "xpu_bundle.exe" --action=install --eula=accept --silent --log-dir install_bundle
+if errorlevel 1 exit /b 1
+del xpu_bundle.exe
+
+:xpu_pti_install
+
+curl -o xpu_pti.exe --retry 3 --retry-all-errors -k %XPU_PTI_URL%
+echo "XPU PTI installing..."
+start /wait "Intel PTI Installer" "xpu_pti.exe" --action=install --eula=accept --silent --log-dir install_bundle
+if errorlevel 1 exit /b 1
+del xpu_pti.exe
+
+:xpu_install_end

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -11,6 +11,16 @@ on:
         required: true
         type: string
         description: What CUDA version to build with, "cpu" for none.
+      use-xpu:
+        required: false
+        type: boolean
+        default: false
+        description: If set, build with XPU support.
+      vc-year:
+        required: false
+        type: string
+        default: "2019"
+        description: The Visual Studio year to use for building.
       build-with-debug:
         required: false
         type: boolean
@@ -141,7 +151,7 @@ jobs:
           SCCACHE_REGION: us-east-1
           VC_PRODUCT: "BuildTools"
           VC_VERSION: ""
-          VC_YEAR: "2019"
+          VC_YEAR: "${{ inputs.vc-year }}"
           ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
           AWS_DEFAULT_REGION: us-east-1
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -149,6 +159,7 @@ jobs:
           DEBUG: ${{ inputs.build-with-debug && '1' || '0' }}
           TORCH_CUDA_ARCH_LIST: "8.6"
           USE_CUDA: ${{ inputs.cuda-version != 'cpu' && '1' || '0' }}
+          USE_XPU: ${{ inputs.use-xpu == true && '1' || '0' }}
           OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
         run: |
           .ci/pytorch/win-build.sh

--- a/.github/workflows/xpu.yml
+++ b/.github/workflows/xpu.yml
@@ -49,3 +49,12 @@ jobs:
       build-environment: linux-jammy-xpu-py3.9
       docker-image: ${{ needs.linux-jammy-xpu-py3_9-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-xpu-py3_9-build.outputs.test-matrix }}
+
+  windows-xpu-build:
+    name: win-vs2022-xpu-py3
+    uses: ./.github/workflows/_win-build.yml
+    with:
+      build-environment: win-vs2022-xpu-py3
+      cuda-version: cpu
+      use-xpu: true
+      vc-year: '2022'


### PR DESCRIPTION
# Description
This pipeline enables the CI build on Windows with PR labeled with ciflow/xpu. This will build torch binary with Torch XPU Operators on Windows using Vision Studio BuildTools 2022.

# Changes
1. Install xpu batch file (install_xpu.bat) - Check if build machine has oneAPI in environment, and if the version of it is latest. If not, install the latest public released oneAPI in the machine.
2. GHA callable pipeline (_win-build.yml) - Set vc_year and use_xpu as parameter to set build wheel environment.
3.  GHA workflow (xpu.yml) - Add a new windows build job and pass parameters to it.
4.  Build wheels script (.ci/pytorch/win-test-helpers/build_pytorch.bat) - Prepare environment for building, e.g. install oneAPI bundle.

# Note
1. For building wheels on Intel GPU, you need Vision Studio BuildTools version >= 2022
2. This pipeline requires to use Vision Studio BuildTools 2022 to build wheels. For now, we specify "windows.4xlarge.nonephemeral" as build machine label in the yaml file. We will request to add self-hosted runners with Intel GPU and Vision Studio BuildTools 2022 installed soon.

Work for #114850 
