### PR TITLE
[inductor] add FreeLibrary to DLLWrapper for Windows.

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -3020,10 +3020,8 @@ class DLLWrapper:
                 f_dlclose = syms.dlclose
         elif is_windows():
             import ctypes
-            from ctypes import wintypes
 
             kernel32 = ctypes.CDLL("kernel32", use_last_error=True)
-            kernel32.FreeLibrary.argtypes = [wintypes.HMODULE]
 
             f_dlclose = kernel32.FreeLibrary
         else:
@@ -3034,6 +3032,10 @@ class DLLWrapper:
                 f_dlclose.argtypes = [c_void_p]
                 f_dlclose(self.DLL._handle)
             elif is_windows():
+                import ctypes
+                from ctypes import wintypes
+
+                f_dlclose.argtypes = [wintypes.HMODULE]
                 f_dlclose(self.DLL._handle)
         else:
             log.warning(

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -3019,9 +3019,13 @@ class DLLWrapper:
             if hasattr(syms, "dlclose"):
                 f_dlclose = syms.dlclose
         elif is_windows():
-            import _ctypes
+            import ctypes
+            from ctypes import wintypes
 
-            f_dlclose = _ctypes.FreeLibrary
+            kernel32 = ctypes.CDLL("kernel32", use_last_error=True)
+            kernel32.FreeLibrary.argtypes = [wintypes.HMODULE]
+
+            f_dlclose = kernel32.FreeLibrary
         else:
             raise NotImplementedError("Unsupported env, failed to do dlclose!")
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1521,6 +1521,10 @@ def is_linux() -> bool:
     return platform.system() == "Linux"
 
 
+def is_windows():
+    return sys.platform == "win32"
+
+
 def has_free_symbols(itr: Iterable[Any]):
     return any(isinstance(x, sympy.Expr) and not x.is_number for x in itr)
 


### PR DESCRIPTION
For previous PR https://github.com/pytorch/pytorch/pull/132630 . We found `DLLWrapper` class doesn't have `_dlclose` implemention for Windows.

I write a small test project to figure out how to make it works on Windows: https://github.com/xuhancn/ctypes_all_lifecycle/blob/main/pysrc/module_manage.py#L30-L61
Test result: https://github.com/xuhancn/ctypes_all_lifecycle/tree/main?tab=readme-ov-file#ctypes_cyclepy

So, I have port the Windows FreeLibrary implemention to pytorch DLLWrapper in this PR.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang