### PR TITLE
Add `_codecs.encode` and `builtins.bytearray` to `_get_allowed_globals` to support bytes and bytearray serialization

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4133,6 +4133,17 @@ class TestSerialization(TestCase, SerializationMixin):
             y['even'][0] = torch.tensor(-0.25, dtype=dtype)
             self.assertEqual(y['x'][:2].to(dtype=torch.float32), torch.tensor([-0.25, 0.25]))
 
+    @parametrize('byte_literals', (b'byte', bytearray(b'bytearray')))
+    @parametrize('weights_only', (True, False))
+    def test_serialization_byte_literal(self, byte_literals, weights_only):
+        """ Tests that by literal can be serialized.
+        See: https://github.com/pytorch/pytorch/issues/133163"""
+        with tempfile.NamedTemporaryFile() as f:
+            torch.save(byte_literals, f)
+            f.seek(0)
+            y = torch.load(f, weights_only=weights_only)
+            self.assertEqual(y, byte_literals)
+
     @parametrize('filename', (True, False))
     @unittest.skipIf(IS_WINDOWS, "NamedTemporaryFile on windows")
     @unittest.skipIf(IS_FBCODE, "miniz version differs between fbcode and oss")

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4136,7 +4136,7 @@ class TestSerialization(TestCase, SerializationMixin):
     @parametrize('byte_literals', (b'byte', bytearray(b'bytearray')))
     @parametrize('weights_only', (True, False))
     def test_serialization_byte_literal(self, byte_literals, weights_only):
-        """ Tests that by literal can be serialized.
+        """ Tests that byte literal can be serialized.
         See: https://github.com/pytorch/pytorch/issues/133163"""
         with tempfile.NamedTemporaryFile() as f:
             torch.save(byte_literals, f)

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -24,8 +24,9 @@
 
 import functools as _functools
 import warnings
-from collections import Counter, OrderedDict
+
 from _codecs import encode
+from collections import Counter, OrderedDict
 from pickle import (
     APPEND,
     APPENDS,
@@ -160,7 +161,7 @@ def _get_allowed_globals():
         "torch.Tensor": torch.Tensor,
         "torch.device": torch.device,
         "_codecs.encode": encode,  # for bytes
-        "builtins.bytearray": bytearray  # for bytearray
+        "builtins.bytearray": bytearray,  # for bytearray
     }
     # dtype
     for t in torch.storage._dtype_to_storage_type_map().keys():

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -25,6 +25,7 @@
 import functools as _functools
 import warnings
 from collections import Counter, OrderedDict
+from _codecs import encode
 from pickle import (
     APPEND,
     APPENDS,
@@ -158,6 +159,8 @@ def _get_allowed_globals():
         "torch.Size": torch.Size,
         "torch.Tensor": torch.Tensor,
         "torch.device": torch.device,
+        "_codecs.encode": encode,  # for bytes
+        "builtins.bytearray": bytearray  # for bytearray
     }
     # dtype
     for t in torch.storage._dtype_to_storage_type_map().keys():


### PR DESCRIPTION
Fixes #133163

Debugged in collaboration with @hariveliki 

The `byte` type is demanding the global `_codecs.encode`. That means, the following currently works:
```python
import torch

torch.save(b'hello', '/tmp/dummy.pth')

torch.serialization.add_safe_globals([_codecs.encode])
torch.load('/tmp/dummy.pth', weights_only=True)
```

Similarly, `bytearray` needs `builtins.bytearray`.

Following the `torch.loads` docs promise, both types should be supported without `add_safe_globals` as they are both primitive types:
>         weights_only: Indicates whether unpickler should be restricted to
>            loading only tensors, primitive types, dictionaries
>           and any types added via :func:`torch.serialization.add_safe_globals`.

This PR adds both `_codecs.encode` and `builtins.bytearray` to `_get_allowed_globals` and test for saving and loading of both types with and without `weights_only`.

