### PR TITLE
[DeviceMesh] Restrict slicing to be a contiguous or non-contiguous subsequence of the root mesh_dim_names

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -601,12 +601,14 @@ class TestMeshEnv(DTensorTestBase):
         )
 
         dp_cp_mesh = mesh_3d["dp", "cp"]
-        cp_dp_mesh = mesh_3d["cp", "dp"]
+        dp_tp_mesh = mesh_3d["dp", "tp"]
+        cp_tp_mesh = mesh_3d["cp", "tp"]
         dp_mesh = mesh_3d["dp"]
         cp_mesh = mesh_3d["cp"]
         tp_mesh = mesh_3d["tp"]
         self.assertEqual(_mesh_resources.get_root_mesh(dp_cp_mesh), mesh_3d)
-        self.assertEqual(_mesh_resources.get_root_mesh(cp_dp_mesh), mesh_3d)
+        self.assertEqual(_mesh_resources.get_root_mesh(dp_tp_mesh), mesh_3d)
+        self.assertEqual(_mesh_resources.get_root_mesh(cp_tp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(dp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(cp_mesh), mesh_3d)
         self.assertEqual(_mesh_resources.get_root_mesh(tp_mesh), mesh_3d)

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -566,7 +566,7 @@ class TestDeviceMeshGetItem(DTensorTestBase):
 
         with self.assertRaisesRegex(
             KeyError,
-            "Valid mesh_dim_names should be a contiguous or non-contiguous subsequence",
+            "Valid mesh_dim_names should be a subsequence of",
         ):
             cp_dp_mesh = mesh_3d["cp", "dp"]
 

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -510,15 +510,16 @@ else:
                 (mesh_dim_names,) if isinstance(mesh_dim_names, str) else mesh_dim_names
             )
 
+            it = iter(self.mesh_dim_names)
             if mesh_dim_names == self.mesh_dim_names:
                 return self
             elif len(mesh_dim_names) > len(self.mesh_dim_names) or not all(
-                mesh_dim_name in self.mesh_dim_names for mesh_dim_name in mesh_dim_names
+                mesh_dim_name in it for mesh_dim_name in mesh_dim_names
             ):
                 raise KeyError(
                     f"Invalid mesh_dim_name {mesh_dim_names} specified. "
-                    "Valid mesh_dim_names should be a subsequence of valid"
-                    f"mesh_dim_names from {self.mesh_dim_names}."
+                    "Valid mesh_dim_names should be a contiguous or non-contiguous "
+                    f"subsequence of valid mesh_dim_names from {self.mesh_dim_names}."
                 )
 
             submesh = _mesh_resources.create_sub_mesh(self, mesh_dim_names)

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -518,8 +518,7 @@ else:
             ):
                 raise KeyError(
                     f"Invalid mesh_dim_name {mesh_dim_names} specified. "
-                    "Valid mesh_dim_names should be a contiguous or non-contiguous "
-                    f"subsequence of valid mesh_dim_names from {self.mesh_dim_names}."
+                    f"Valid mesh_dim_names should be a subsequence of {self.mesh_dim_names}."
                 )
 
             submesh = _mesh_resources.create_sub_mesh(self, mesh_dim_names)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133277
* #133195
* __->__ #133193

This PR adds restriction for DeviceMesh slicing. No out-of-order subsequence slicing is allowed. To create a flatten mesh_dim_names, only the in-order slicing is allowed. 

```
mesh_3d = init_device_mesh(
    self.device_type, (2,2,2), mesh_dim_names=("dp", "cp", "tp"),
)

# valid 2d slicing
mesh_2d = mesh_3d["dp", "cp"]
mesh_2d = mesh_3d["dp", "tp"]
mesh_2d = mesh_3d["cp", "tp"]

# invalid 2d slicing
mesh_2d = mesh_3d["cp", "dp"]
mesh_2d = mesh_3d["tp", "cp"]
mesh_2d = mesh_3d["tp", "dp"]

# valid way to create dp_cp flatten slice
dp_cp_mesh = mesh_3d["dp", "cp"]._flatten()
# invalid way to create dp_cp flatten slice
dp_cp_mesh = mesh_3d["cp", "dp"]._flatten()
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l