### PR TITLE
[DeviceMesh] Directly retrieve flattened mesh if already created

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -583,6 +583,11 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         flattened_dp_cp_mesh = dp_cp_mesh._flatten()
         self.assertEqual(dp_cp_mesh.mesh.flatten(), flattened_dp_cp_mesh.mesh)
 
+        ref_pg_count = _world.group_count
+        # Calling flatten again should not create a new pg.
+        dp_cp_mesh_2 = dp_cp_mesh._flatten()
+        self.assertEqual(ref_pg_count, _world.group_count)
+
         # Test flatten non-contiguous dims
         dp_tp_mesh = mesh_3d["dp", "tp"]
         flattned_dp_tp_mesh = dp_tp_mesh._flatten()

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -66,6 +66,7 @@ else:
             self.mesh_dim_group_options: Dict[
                 int, Tuple[str, Optional[ProcessGroup.Options]]
             ] = {}
+            self.root_to_flatten_mapping: Dict[DeviceMesh, Dict[str, DeviceMesh]] = {}
 
         def get_current_mesh(self) -> "DeviceMesh":
             if len(self.mesh_stack) == 0:
@@ -128,6 +129,13 @@ else:
                     for dim in flatten_dims_in_root
                 ]
             )
+            # Quick return if the flatten mesh has been created before.
+            if (
+                root_mesh in self.root_to_flatten_mapping
+                and flatten_mesh_dim_names in self.root_to_flatten_mapping[root_mesh]
+            ):
+                return self.root_to_flatten_mapping[root_mesh][flatten_mesh_dim_names]
+
             flattened_mesh_dim_size = math.prod(device_mesh.mesh.size())
 
             remained_dims_in_root = list(range(root_mesh.mesh.ndim))
@@ -149,6 +157,7 @@ else:
                 if cur_rank in mesh_nd:
                     res_flattened_mesh = flattened_mesh
             self.child_to_root_mapping[res_flattened_mesh] = root_mesh  # type: ignore[possibly-undefined]
+            self.root_to_flatten_mapping.setdefault(root_mesh, {})[flatten_mesh_dim_names] = res_flattened_mesh  # type: ignore[possibly-undefined]
 
             return res_flattened_mesh
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133277
* __->__ #133195
* #133193

Add mapping to keep track of root_to_flatten relationship and directly retrieve the flattened mesh if already created (no pg creation). 

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l