### PR TITLE
Scope API for PT2 compile

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -35,6 +35,7 @@ from torch._utils_internal import (
     compile_time_strobelight_meta,
     maybe_upload_prof_stats_to_manifold,
     signpost_event,
+    torch_scope,
 )
 from torch.fx._lazy_graph_module import _use_lazy_graph_module
 from torch.fx.experimental.symbolic_shapes import (
@@ -809,7 +810,10 @@ def _compile(
 
     with _use_lazy_graph_module(config.use_lazy_graph_module), compile_context(
         CompileContext(compile_id)
-    ):
+    ), torch_scope("compile") as tracker:
+        tracker.set_metadata("compile_id", str(compile_id))
+        tracker.set_metadata("co_name", code.co_name)
+        tracker.set_metadata("co_filename", code.co_filename)
         restart_reasons: set[str] = set()
         # This is shared across restarts
         mutated_closure_cell_contents: Set[str] = set()
@@ -1026,6 +1030,7 @@ def _compile(
                 possibly_missed_reinplacing_opportunities,
             )
             record_compilation_metrics(metrics)
+            tracker.set_metadata("metrics", str(vars(metrics)))
             torch._dynamo.callback_handler.run_end_callbacks()
 
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import contextlib
 import functools
 import logging
 import os
@@ -110,6 +111,20 @@ def compile_time_strobelight_meta(phase_name):
 # https://www.internalfb.com/intern/justknobs/?name=pytorch%2Fsignpost#event
 def signpost_event(category: str, name: str, parameters: Dict[str, Any]):
     log.info("%s %s: %r", category, name, parameters)
+
+
+def torch_scope(operation: str):
+    class ScopeContext(contextlib.AbstractContextManager):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def set_metadata(self, key, val):
+            pass
+
+    return ScopeContext()
 
 
 def log_compilation_event(metrics):


### PR DESCRIPTION
Summary:
Adding scope API for PT2 compile operations, which will emit signposts equivalent to the dynamo_compile table.
These signposts can help with error attribution, and and also provide a visualization in the Advanced Tab of JI.

Test Plan:
```
buck2 run @//mode/opt //aps_models/ads/icvr:icvr_launcher mode=mast_random launcher.data_project=ai_observability launcher.fbl_entitlement=ai_infra_training_rnd_tc
```

Test job is here:
https://fburl.com/ai_infra/88270og7
 {F1752076727}

New Job:
https://fburl.com/ai_infra/fjycjqiv

After changing scope name to "PT2"
https://fburl.com/ai_infra/atv72vmy

Reviewed By: ezyang

Differential Revision: D59561111


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames