### PR TITLE
Generalization of FSDP common for non-cuda execution

### DIFF
--- a/test/distributed/_composable/fully_shard/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fully_shard/test_fully_shard_compile.py
@@ -12,7 +12,7 @@ from torch.distributed.fsdp import ShardingStrategy
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     TransformerWithSharedParams,
@@ -75,7 +75,7 @@ class TestCompile(FSDPTest):
         base_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         ref_model = fully_shard(copy.deepcopy(base_model), **fsdp_kwargs)

--- a/test/distributed/_composable/fully_shard/test_fully_shard_model_checkpoint.py
+++ b/test/distributed/_composable/fully_shard/test_fully_shard_model_checkpoint.py
@@ -21,7 +21,7 @@ from torch.testing._internal.common_dist_composable import (
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _zero_model,
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     TransformerWithSharedParams,
@@ -124,7 +124,7 @@ class TestModelCheckpointing(FSDPTest):
         local_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
 
@@ -155,7 +155,7 @@ class TestModelCheckpointing(FSDPTest):
         load_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
         )
         _zero_model(load_model, zero_buffers=True, summon_full=False)
         fully_shard(

--- a/test/distributed/fsdp/test_fsdp_apply.py
+++ b/test/distributed/fsdp/test_fsdp_apply.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     NestedWrappedModule,
@@ -70,7 +70,7 @@ class TestApply(FSDPTest):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_AFTER,
+            DEVICEInitMode.DEVICE_AFTER,
         )
         self._check_apply(nested_wrapped_module)
 
@@ -81,7 +81,7 @@ class TestApply(FSDPTest):
         transformer = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_AFTER,
+            DEVICEInitMode.DEVICE_AFTER,
         )
         self._check_apply(transformer)
 
@@ -92,7 +92,7 @@ class TestApply(FSDPTest):
         transformer = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_AFTER,
+            DEVICEInitMode.DEVICE_AFTER,
         )
         with transformer.summon_full_params(transformer):
             with self.assertRaisesRegex(ValueError, "expected to be in states"):

--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -18,7 +18,7 @@ from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     NestedWrappedModule,
@@ -102,7 +102,7 @@ class TestClipGradNorm(FSDPTest):
         local_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         ddp_model = DDP(local_model, device_ids=[self.rank])
@@ -114,7 +114,7 @@ class TestClipGradNorm(FSDPTest):
             fsdp_model = TransformerWithSharedParams.init(
                 self.process_group,
                 FSDPInitMode.NO_FSDP,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 deterministic=True,
             )
             # Apply `NO_SHARD` to the encoder
@@ -149,7 +149,7 @@ class TestClipGradNorm(FSDPTest):
             fsdp_model = TransformerWithSharedParams.init(
                 self.process_group,
                 FSDPInitMode.RECURSIVE,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 deterministic=True,
                 fsdp_kwargs=fsdp_kwargs,
             )
@@ -277,7 +277,7 @@ class TestClipGradNorm(FSDPTest):
             NestedWrappedModule.init(
                 self.process_group,
                 FSDPInitMode.RECURSIVE,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 deterministic=True,
                 fsdp_kwargs=fsdp_kwargs,
             ),

--- a/test/distributed/fsdp/test_fsdp_comm.py
+++ b/test/distributed/fsdp/test_fsdp_comm.py
@@ -16,7 +16,7 @@ from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     MLP,
@@ -63,7 +63,7 @@ class TestCommunication(FSDPTest):
             model = NestedWrappedModule.init(
                 self.process_group,
                 FSDPInitMode.RECURSIVE,
-                CUDAInitMode.CUDA_AFTER,
+                DEVICEInitMode.DEVICE_AFTER,
                 fsdp_kwargs,
             )
             fsdp_model: FSDP = FSDP(
@@ -75,7 +75,7 @@ class TestCommunication(FSDPTest):
             fsdp_model: FSDP = TransformerWithSharedParams.init(
                 self.process_group,
                 FSDPInitMode.RECURSIVE,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 fsdp_kwargs,
             )
         return fsdp_model

--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -22,7 +22,7 @@ from torch.distributed.utils import _p_assert
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     AlwaysWrapNestedWrappedModule,
-    CUDAInitMode,
+    DEVICEInitMode,
     DummyDDP,
     FSDPInitMode,
     FSDPTest,
@@ -75,17 +75,17 @@ class TestParityWithDDP(FSDPTest):
     PyTorch DDP vs. FullyShardedDataParallel.
     """
 
-    def _get_cuda_init_modes(self, cpu_offload: CPUOffload) -> List[CUDAInitMode]:
+    def _get_device_init_modes(self, cpu_offload: CPUOffload) -> List[DEVICEInitMode]:
         modes = [
-            CUDAInitMode.CUDA_AFTER,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_AFTER,
+            DEVICEInitMode.DEVICE_BEFORE,
         ]
-        # Note that CUDAInitMode.CUDA_NEVER works currently only with CPU
+        # Note that DEVICEInitMode.DEVICE_NEVER works currently only with CPU
         # offload as we explicitly bring the param back to CUDA device. In
         # general, it will not work since we try to all_gather p.data which is
         # on CPU but NCCL only supports GPU.
         if cpu_offload.offload_params:
-            modes.append(CUDAInitMode.CUDA_NEVER)
+            modes.append(DEVICEInitMode.DEVICE_NEVER)
 
         return modes
 
@@ -93,7 +93,7 @@ class TestParityWithDDP(FSDPTest):
         """Returns a subtest configuration that subtests CUDA initialization
         modes and prefetching settings together."""
         return {
-            "cuda_init_mode": self._get_cuda_init_modes(cpu_offload),
+            "device_init_mode": self._get_device_init_modes(cpu_offload),
             "backward_prefetch": [
                 None,
                 BackwardPrefetch.BACKWARD_PRE,
@@ -273,7 +273,7 @@ class TestParamInit(FSDPTest):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_AFTER,
+            DEVICEInitMode.DEVICE_AFTER,
             fsdp_kwargs,
             deterministic=True,
         )
@@ -284,7 +284,7 @@ class TestParamInit(FSDPTest):
         new_fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_AFTER,
+            DEVICEInitMode.DEVICE_AFTER,
             fsdp_kwargs,
             deterministic=True,
         )
@@ -307,7 +307,7 @@ class TestHooks(FSDPTest):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE if cuda_first else CUDAInitMode.CUDA_AFTER,
+            DEVICEInitMode.DEVICE_BEFORE if cuda_first else DEVICEInitMode.DEVICE_AFTER,
         )
         self._test_pre_backward_hook_registration(fsdp_model)
 
@@ -318,7 +318,7 @@ class TestHooks(FSDPTest):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_AFTER,
+            DEVICEInitMode.DEVICE_AFTER,
         )
         self._train_for_several_steps(fsdp_model, num_steps=2, autocast=False)
         state_dict = fsdp_model.state_dict()
@@ -352,7 +352,7 @@ class TestHooks(FSDPTest):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE if cuda_first else CUDAInitMode.CUDA_AFTER,
+            DEVICEInitMode.DEVICE_BEFORE if cuda_first else DEVICEInitMode.DEVICE_AFTER,
             fsdp_kwargs,
         )
         input = fsdp_model.module.get_input(torch.device("cuda"))
@@ -402,7 +402,7 @@ class TestNoGrad(FSDPTest):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_AFTER,
+            DEVICEInitMode.DEVICE_AFTER,
             fsdp_kwargs,
         )
         self._train_for_several_steps(

--- a/test/distributed/fsdp/test_fsdp_grad_acc.py
+++ b/test/distributed/fsdp/test_fsdp_grad_acc.py
@@ -15,7 +15,7 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import (
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     TransformerWithSharedParams,
@@ -129,7 +129,7 @@ class TestGradAcc(FSDPTest):
         fsdp_model: FSDP = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             fsdp_kwargs,
             deterministic=True,
             add_bn=False,  # disable BN since the test uses varying batch sizes

--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -26,7 +26,7 @@ from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     TransformerWithSharedParams,
@@ -384,7 +384,7 @@ class TestFSDPHybridShard(FSDPTest):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             hsdp_kwargs,
             deterministic=True,
         )
@@ -415,7 +415,7 @@ class TestFSDPHybridShard(FSDPTest):
             hsdp_model = TransformerWithSharedParams.init(
                 hsdp_process_groups or self.process_group,
                 FSDPInitMode.RECURSIVE,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 hsdp_kwargs,
                 deterministic=True,
             )
@@ -423,7 +423,7 @@ class TestFSDPHybridShard(FSDPTest):
             model = TransformerWithSharedParams.init(
                 hsdp_process_groups or self.process_group,
                 FSDPInitMode.NO_FSDP,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 {},
                 deterministic=True,
             )

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -14,7 +14,7 @@ from torch.distributed.fsdp._common_utils import _get_module_fsdp_state
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy, transformer_auto_wrap_policy
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     TransformerWithSharedParams,
@@ -147,7 +147,7 @@ class TestFSDPIgnoredModules(FSDPTest):
         model: nn.Module = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         fsdp_kwargs = {"process_group": self.process_group}
@@ -169,7 +169,7 @@ class TestFSDPIgnoredModules(FSDPTest):
         nonwrapped_model: nn.Module = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         if use_auto_wrap:

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -33,7 +33,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     _assert_module_states,
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     FSDPTestMultiThread,
@@ -117,7 +117,7 @@ class TestFSDPMiscMultiProcess(FSDPTest):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_NEVER,
+            DEVICEInitMode.DEVICE_NEVER,
             fsdp_kwargs={"device_id": dev_id},
         )
         _check_device_matches(nested_wrapped_module, dev_id)
@@ -126,7 +126,7 @@ class TestFSDPMiscMultiProcess(FSDPTest):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             fsdp_kwargs={"device_id": dev_id},
         )
         _check_device_matches(nested_wrapped_module, dev_id)
@@ -139,7 +139,7 @@ class TestFSDPMiscMultiProcess(FSDPTest):
             nested_wrapped_module = NestedWrappedModule.init(
                 self.process_group,
                 FSDPInitMode.RECURSIVE,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 fsdp_kwargs={"device_id": torch.device("cuda")},
             )
         _check_device_matches(
@@ -555,7 +555,7 @@ class TestFSDPMiscMultiProcess(FSDPTest):
             nested_wrapped_module = NestedWrappedModule.init(
                 self.process_group,
                 FSDPInitMode.RECURSIVE,
-                CUDAInitMode.CUDA_NEVER,
+                DEVICEInitMode.DEVICE_NEVER,
             )
             fsdp_model = FSDP(nested_wrapped_module, self.process_group)
         devices = {p.device for p in fsdp_model.parameters()}
@@ -581,7 +581,7 @@ class TestFSDPMiscMultiProcess(FSDPTest):
             return NestedWrappedModule.init(
                 self.process_group,
                 FSDPInitMode.NO_FSDP,
-                CUDAInitMode.CUDA_NEVER,
+                DEVICEInitMode.DEVICE_NEVER,
             )
 
         with self.assertRaisesRegex(
@@ -688,7 +688,7 @@ class TestFSDPMiscMultiThread(FSDPTestMultiThread):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             fsdp_kwargs,
         )
         for fsdp_module in FSDP.fsdp_modules(fsdp_model):
@@ -753,7 +753,7 @@ class TestFSDPMiscMultiThread(FSDPTestMultiThread):
                 self.process_group,
                 FSDPInitMode.RECURSIVE,
                 # Move wrapped modules to CUDA before wrapping with FSDP
-                cuda_init_mode=CUDAInitMode.CUDA_BEFORE,
+                device_init_mode=DEVICEInitMode.DEVICE_BEFORE,
                 # Should raise error since rank 1 is given `device_id=0` when
                 # the model is on cuda:1
                 fsdp_kwargs={"device_id": 0},
@@ -949,7 +949,7 @@ class TestFSDPMiscMultiThread(FSDPTestMultiThread):
         model = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             {},
         )
         attr_name = attr_name_and_values[0]

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -31,7 +31,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     subtest_name,
@@ -601,7 +601,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             model = TransformerWithSharedParams.init(
                 self.process_group,
                 FSDPInitMode.NO_FSDP,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 {"mixed_precision": mp_config},
             )
             fsdp_model = FSDP(model, mixed_precision=mp_config)
@@ -827,7 +827,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             model = TransformerWithSharedParams.init(
                 self.process_group,
                 FSDPInitMode.NO_FSDP if use_composable else FSDPInitMode.RECURSIVE,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 {"mixed_precision": mp_config},
             )
             if use_composable:
@@ -957,7 +957,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             model = TransformerWithSharedParams.init(
                 self.process_group,
                 FSDPInitMode.NO_FSDP if use_composable else FSDPInitMode.RECURSIVE,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 {"mixed_precision": mp_config},
             )
             if use_composable:

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -29,7 +29,7 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import (
 from torch.distributed.optim import _NamedOptimizer
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     TransformerWithSharedParams,
@@ -370,7 +370,7 @@ class TestFSDPOptimState(FSDPTest):
         model = TransformerWithSharedParams.init(
             group,
             FSDPInitMode.RECURSIVE if wrap else FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         optim = optim_class(model.parameters(), lr=0.01)

--- a/test/distributed/fsdp/test_fsdp_pure_fp16.py
+++ b/test/distributed/fsdp/test_fsdp_pure_fp16.py
@@ -12,7 +12,7 @@ from torch.distributed.fsdp import (
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     NestedWrappedModule,
@@ -60,7 +60,7 @@ class TestPureFP16(FSDPTest):
         self._test_fsdp_parity(
             NestedWrappedModule,
             FSDPInitMode.RECURSIVE,
-            cuda_init_mode=CUDAInitMode.CUDA_BEFORE,
+            device_init_mode=DEVICEInitMode.DEVICE_BEFORE,
             # Run one iteration to avoid NaN without a gradient scaler
             num_iters=1,
             cpu_offload=cpu_offload,
@@ -101,7 +101,7 @@ class TestPureFP16(FSDPTest):
         model = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_NEVER,
+            DEVICEInitMode.DEVICE_NEVER,
             {},
         )
         fsdp_kwargs = {

--- a/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
+++ b/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
@@ -21,7 +21,7 @@ from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     DummyProcessGroup,
     FSDPInitMode,
     FSDPTest,
@@ -153,13 +153,13 @@ class TestShardGradScaler(TestCase):
 
 class TestShardedGradScalerParityWithDDP(FSDPTest):
     def _get_init_modes_for_test(self, cpu_offload):
-        modes = [CUDAInitMode.CUDA_AFTER, CUDAInitMode.CUDA_BEFORE]
-        # Note that CUDAInitMode.CUDA_NEVER works currently only with CPU
+        modes = [DEVICEInitMode.DEVICE_AFTER, DEVICEInitMode.DEVICE_BEFORE]
+        # Note that DEVICEInitMode.DEVICE_NEVER works currently only with CPU
         # offload as we explicitly bring the param back to CUDA device. In
         # general, it will not work since we try to all_gather p.data which is
         # on CPU but NCCL only supports GPU.
         if cpu_offload.offload_params:
-            modes.append(CUDAInitMode.CUDA_NEVER)
+            modes.append(DEVICEInitMode.DEVICE_NEVER)
 
         return modes
 
@@ -192,11 +192,11 @@ class TestShardedGradScalerParityWithDDP(FSDPTest):
             use_orig = False
             model_cls = NestedWrappedModule  # type: ignore[assignment]
             sharded_grad_scaler_kwargs = None
-        for cuda_init_mode in init_modes:
+        for device_init_mode in init_modes:
             self._test_fsdp_parity(
                 model_cls,
                 FSDPInitMode.RECURSIVE,
-                cuda_init_mode=cuda_init_mode,
+                device_init_mode=device_init_mode,
                 cpu_offload=cpu_offload,
                 sharding_strategy=sharding_strategy,
                 mixed_precision=mp,
@@ -213,7 +213,7 @@ class TestShardedGradScalerParityWithDDP(FSDPTest):
         model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         ref_model = DDP(

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -46,7 +46,7 @@ from torch.testing._internal.common_fsdp import (
     _broadcast_state_dict,
     _get_state_dict,
     _zero_model,
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     get_full_params,
@@ -387,7 +387,7 @@ class TestFSDPStateDict(FSDPTest):
         model_ac = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
         )
         # Manually wrap FSDP without AC
         model_no_ac = deepcopy(model_ac)
@@ -439,7 +439,7 @@ class TestFSDPStateDict(FSDPTest):
             TransformerWithSharedParams.init,
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             {"auto_wrap_policy": auto_wrap_policy},
         )
 
@@ -468,7 +468,7 @@ class TestFSDPStateDict(FSDPTest):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             fsdp_kwargs,
         )
         # Force model parameters and buffers to be nonzero
@@ -485,7 +485,7 @@ class TestFSDPStateDict(FSDPTest):
         new_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
         )
         _zero_model(new_model, zero_buffers=True)
         # Only load the checkpoint on rank 0
@@ -1210,7 +1210,7 @@ class TestFSDPStateDict(FSDPTest):
                 fsdp_model = TransformerWithSharedParams.init(
                     pg,
                     FSDPInitMode.RECURSIVE,
-                    CUDAInitMode.CUDA_BEFORE,
+                    DEVICEInitMode.DEVICE_BEFORE,
                     fsdp_kwargs,
                 )
                 FSDP.set_state_dict_type(fsdp_model, StateDictType.SHARDED_STATE_DICT)
@@ -1240,7 +1240,7 @@ class TestFSDPStateDict(FSDPTest):
         model = TransformerWithSharedParams.init(
             my_pg,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
         )
         with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
             state_dict = model.state_dict()

--- a/test/distributed/fsdp/test_fsdp_traversal.py
+++ b/test/distributed/fsdp/test_fsdp_traversal.py
@@ -6,7 +6,7 @@ from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     NestedWrappedModule,
@@ -36,7 +36,7 @@ class TestTraversal(FSDPTest):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
         )
         modules = FSDP.fsdp_modules(nested_wrapped_module)
         self.assertEqual(

--- a/test/distributed/fsdp/test_fsdp_unshard_params.py
+++ b/test/distributed/fsdp/test_fsdp_unshard_params.py
@@ -22,7 +22,7 @@ from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     NestedWrappedModule,
@@ -125,7 +125,7 @@ class TestUnshardParamsBase(FSDPTest):
         local_model = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             fsdp_kwargs={},
             deterministic=True,
         )
@@ -134,7 +134,7 @@ class TestUnshardParamsBase(FSDPTest):
         fsdp_model = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             fsdp_kwargs={
                 "cpu_offload": cpu_offload,
                 "mixed_precision": mixed_precision,
@@ -434,7 +434,7 @@ class TestUnshardParams(TestUnshardParamsBase):
         model = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         model.buffer = nn.Buffer(torch.ones(1))
@@ -445,7 +445,7 @@ class TestUnshardParams(TestUnshardParamsBase):
             NestedWrappedModule.init(
                 self.process_group,
                 FSDPInitMode.NO_FSDP,
-                CUDAInitMode.CUDA_BEFORE,
+                DEVICEInitMode.DEVICE_BEFORE,
                 deterministic=True,
             ),
             self.process_group,
@@ -554,14 +554,14 @@ class TestUnshardParams(TestUnshardParamsBase):
         model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         ddp_model = DDP(model, device_ids=[self.rank])
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
             fsdp_kwargs={
                 "use_orig_params": use_orig_params,
@@ -611,7 +611,7 @@ class TestUnshardParams(TestUnshardParamsBase):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
             fsdp_kwargs={
                 "use_orig_params": True,
@@ -711,7 +711,7 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
         )
         with self.assertRaisesRegex(NotImplementedError, "is not supported"):
             with FSDP.summon_full_params(
@@ -724,7 +724,7 @@ class TestUnshardParamsErrors(TestUnshardParamsBase):
         nested_wrapped_module = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             {"sharding_strategy": ShardingStrategy.NO_SHARD},
         )
         with self.assertRaisesRegex(NotImplementedError, "is not supported"):

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -31,7 +31,7 @@ from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    CUDAInitMode,
+    DEVICEInitMode,
     FSDPInitMode,
     FSDPTest,
     TransformerWithSharedParams,
@@ -103,7 +103,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         ddp_model = DDP(
@@ -115,7 +115,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
 
     def _get_fsdp_transformer_and_optim(
         self,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         init_optim_before_wrap: bool,
         optim_class: Type[torch.optim.Optimizer],
         multi_tensor: bool,
@@ -145,7 +145,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            cuda_init_mode,
+            device_init_mode,
             deterministic=True,
         )
         if init_optim_before_wrap:
@@ -155,7 +155,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
             fsdp_model = FSDP(model, self.process_group, **fsdp_kwargs)
             fsdp_optim = self._get_optim(fsdp_model, optim_class, multi_tensor)
         if (
-            cuda_init_mode == CUDAInitMode.CUDA_AFTER
+            device_init_mode == DEVICEInitMode.DEVICE_AFTER
             and not fsdp_model.cpu_offload.offload_params
         ):
             fsdp_model = fsdp_model.cuda()
@@ -252,7 +252,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         base_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
         )
         ref_model = FSDP(copy.deepcopy(base_model), self.process_group, **fsdp_kwargs)
@@ -284,9 +284,9 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         sharding_strategy = self._get_sharding_strategy_from_str(sharding_strategy_str)
         self.run_subtests(
             {
-                "cuda_init_mode": [
-                    CUDAInitMode.CUDA_BEFORE,
-                    CUDAInitMode.CUDA_AFTER,
+                "device_init_mode": [
+                    DEVICEInitMode.DEVICE_BEFORE,
+                    DEVICEInitMode.DEVICE_AFTER,
                 ],
                 "init_optim_before_wrap": [False, True],
                 "optim_class": [torch.optim.AdamW],
@@ -320,7 +320,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         sharding_strategy = self._get_sharding_strategy_from_str(sharding_strategy_str)
         for skip_writeback_check in (False, True):
             self._test_diff_hyperparams(
-                cuda_init_mode=CUDAInitMode.CUDA_BEFORE,
+                device_init_mode=DEVICEInitMode.DEVICE_BEFORE,
                 init_optim_before_wrap=False,
                 optim_class=torch.optim.Adam,
                 multi_tensor=False,
@@ -333,7 +333,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
 
     def _test_diff_hyperparams(
         self,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         init_optim_before_wrap: bool,
         optim_class: Type[torch.optim.Optimizer],
         multi_tensor: bool,
@@ -351,14 +351,17 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
                 FSDP. We permit both forms of initialization to give users
                 flexibility.
         """
-        if cuda_init_mode == CUDAInitMode.CUDA_AFTER and cpu_offload.offload_params:
+        if (
+            device_init_mode == DEVICEInitMode.DEVICE_AFTER
+            and cpu_offload.offload_params
+        ):
             return  # not supported
         if skip_writeback_check:
             os.environ[_FSDP_SKIP_WRITEBACK_CHECK] = "1"
         ddp_model = self._get_ddp_transformer(find_unused_params=False)
         ddp_optim = self._get_optim(ddp_model, optim_class, multi_tensor)
         fsdp_model, fsdp_optim = self._get_fsdp_transformer_and_optim(
-            cuda_init_mode=cuda_init_mode,
+            device_init_mode=device_init_mode,
             init_optim_before_wrap=init_optim_before_wrap,
             optim_class=optim_class,
             multi_tensor=multi_tensor,
@@ -397,7 +400,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         ddp_model = self._get_ddp_transformer(find_unused_params=True)
         ddp_optim = self._get_optim(ddp_model, optim_class, multi_tensor)
         fsdp_model, fsdp_optim = self._get_fsdp_transformer_and_optim(
-            cuda_init_mode=CUDAInitMode.CUDA_BEFORE,
+            device_init_mode=DEVICEInitMode.DEVICE_BEFORE,
             init_optim_before_wrap=False,
             optim_class=optim_class,
             multi_tensor=multi_tensor,
@@ -437,7 +440,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
             fsdp_model,
             _,
         ) = self._get_fsdp_transformer_and_optim(  # ignore returned optimizer
-            cuda_init_mode=CUDAInitMode.CUDA_BEFORE,
+            device_init_mode=DEVICEInitMode.DEVICE_BEFORE,
             init_optim_before_wrap=False,
             optim_class=torch.optim.Adam,  # ignored
             multi_tensor=False,  # ignored
@@ -577,7 +580,7 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             fsdp_kwargs=fsdp_kwargs,
             deterministic=True,
         )
@@ -586,7 +589,7 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
         fsdp_model_orig_params = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             fsdp_kwargs=fsdp_kwargs,
             deterministic=True,
         )

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -36,8 +36,8 @@ from torch.nn.modules.batchnorm import _BatchNorm
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    _maybe_cuda,
-    CUDAInitMode,
+    _move_to_device,
+    DEVICEInitMode,
     DummyProcessGroup,
     FSDPInitMode,
     FSDPTest,
@@ -165,7 +165,7 @@ class TestFSDPWrap(FSDPTest):
         return nn.Linear(fin, fout, bias=False)
 
     def _get_already_wrapped_fsdp(
-        self, cuda_init_mode=CUDAInitMode.CUDA_BEFORE, nested=False
+        self, device_init_mode=DEVICEInitMode.DEVICE_BEFORE, nested=False
     ) -> FSDP:
         fn_self = self
 
@@ -173,20 +173,26 @@ class TestFSDPWrap(FSDPTest):
             def __init__(self, nested):
                 super().__init__()
                 # TODO: test the various init modes.
-                move_to_cuda = cuda_init_mode == CUDAInitMode.CUDA_BEFORE
+                move_to_device = device_init_mode == DEVICEInitMode.DEVICE_BEFORE
                 # if nested=True, the FSDP module will be nested one layer deep
                 # and we should pick that up.
                 if nested:
                     self.lin1 = nn.Sequential(
-                        _maybe_cuda(fn_self._get_linear(1, 1), move_to_cuda),
-                        FSDP(_maybe_cuda(fn_self._get_linear(1, 1), move_to_cuda)),
+                        _move_to_device(fn_self._get_linear(1, 1), move_to_device),
+                        FSDP(
+                            _move_to_device(fn_self._get_linear(1, 1), move_to_device)
+                        ),
                     )
                 else:
                     self.lin1 = FSDP(
-                        _maybe_cuda(fn_self._get_linear(1, 1), move_to_cuda)
+                        _move_to_device(fn_self._get_linear(1, 1), move_to_device)
                     )
-                self.lin2 = FSDP(_maybe_cuda(fn_self._get_linear(1, 1), move_to_cuda))
-                self.lin3 = FSDP(_maybe_cuda(fn_self._get_linear(1, 1), move_to_cuda))
+                self.lin2 = FSDP(
+                    _move_to_device(fn_self._get_linear(1, 1), move_to_device)
+                )
+                self.lin3 = FSDP(
+                    _move_to_device(fn_self._get_linear(1, 1), move_to_device)
+                )
 
             def forward(self, input: torch.Tensor) -> torch.Tensor:
                 return self.lin3(self.lin2(self.lin1(input)))
@@ -196,16 +202,18 @@ class TestFSDPWrap(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @parametrize("nested", [True, False])
-    @parametrize("cuda_init_mode", [CUDAInitMode.CUDA_AFTER, CUDAInitMode.CUDA_BEFORE])
-    def test_error_already_wrapped(self, nested, cuda_init_mode):
+    @parametrize(
+        "device_init_mode", [DEVICEInitMode.DEVICE_AFTER, DEVICEInitMode.DEVICE_BEFORE]
+    )
+    def test_error_already_wrapped(self, nested, device_init_mode):
         """
         Test that an error is raised if we attempt to wrap when submodules are
         already FSDP.
         """
         wrapped_fsdp = self._get_already_wrapped_fsdp(
-            nested=nested, cuda_init_mode=cuda_init_mode
+            nested=nested, device_init_mode=device_init_mode
         )
-        if cuda_init_mode == CUDAInitMode.CUDA_AFTER:
+        if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
             wrapped_fsdp = wrapped_fsdp.cuda()
 
         wrapped_module_name = "lin1.1" if nested else "lin1"
@@ -309,24 +317,31 @@ class TestFSDPWrap(FSDPTest):
         [BackwardPrefetch.BACKWARD_POST, BackwardPrefetch.BACKWARD_PRE],
     )
     @parametrize("forward_prefetch", [False, True])
-    @parametrize("cuda_init_mode", [CUDAInitMode.CUDA_AFTER, CUDAInitMode.CUDA_BEFORE])
+    @parametrize(
+        "device_init_mode", [DEVICEInitMode.DEVICE_AFTER, DEVICEInitMode.DEVICE_BEFORE]
+    )
     def test_main_wrap_api(
         self,
         cpu_offload: CPUOffload,
         backward_prefetch: BackwardPrefetch,
         forward_prefetch: bool,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
     ):
-        if cuda_init_mode == CUDAInitMode.CUDA_AFTER and cpu_offload.offload_params:
+        if (
+            device_init_mode == DEVICEInitMode.DEVICE_AFTER
+            and cpu_offload.offload_params
+        ):
             # they don't work together, expected
             return
 
-        move_to_cuda = cuda_init_mode == CUDAInitMode.CUDA_BEFORE
+        move_to_device = device_init_mode == DEVICEInitMode.DEVICE_BEFORE
 
         class Nested(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.nested_lin = _maybe_cuda(nn.Linear(1, 1, bias=False), move_to_cuda)
+                self.nested_lin = _move_to_device(
+                    nn.Linear(1, 1, bias=False), move_to_device
+                )
 
             def forward(self, input):
                 return self.nested_lin(input)
@@ -334,9 +349,9 @@ class TestFSDPWrap(FSDPTest):
         class MyModel(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
-                self.lin1 = _maybe_cuda(nn.Linear(1, 1, bias=False), move_to_cuda)
-                self.lin2 = _maybe_cuda(nn.Linear(1, 1, bias=False), move_to_cuda)
-                self.lin3 = _maybe_cuda(nn.Linear(1, 1, bias=False), move_to_cuda)
+                self.lin1 = _move_to_device(nn.Linear(1, 1, bias=False), move_to_device)
+                self.lin2 = _move_to_device(nn.Linear(1, 1, bias=False), move_to_device)
+                self.lin3 = _move_to_device(nn.Linear(1, 1, bias=False), move_to_device)
                 self.lin4 = Nested()
 
             def forward(self, input):
@@ -353,7 +368,7 @@ class TestFSDPWrap(FSDPTest):
             backward_prefetch=backward_prefetch,
             forward_prefetch=forward_prefetch,
         )
-        if cuda_init_mode == CUDAInitMode.CUDA_AFTER:
+        if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
             wrapped_model = wrapped_model.cuda()
 
         modules_in_fsdp_graph_order = [
@@ -476,7 +491,7 @@ class TestAutoWrap(TestCase):
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             fsdp_kwargs,
         )
         modules = list(fsdp_model.modules())
@@ -508,7 +523,7 @@ class TestAutoWrap(TestCase):
         model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             {},
         )
 
@@ -699,15 +714,20 @@ class TestAutoWrap(TestCase):
         self.assertTrue(isinstance(model.module[1], nn.ModuleList))
 
     @unittest.skipIf(not TEST_CUDA, "Test Requires CUDA")
-    @parametrize("cuda_init_mode", [CUDAInitMode.CUDA_BEFORE, CUDAInitMode.CUDA_AFTER])
+    @parametrize(
+        "device_init_mode", [DEVICEInitMode.DEVICE_BEFORE, DEVICEInitMode.DEVICE_AFTER]
+    )
     @parametrize(
         "cpu_offload",
         [CPUOffload(offload_params=False), CPUOffload(offload_params=True)],
     )
     @parametrize("use_device_id", [True, False])
-    def test_auto_wrap_smoke_test(self, cuda_init_mode, cpu_offload, use_device_id):
+    def test_auto_wrap_smoke_test(self, device_init_mode, cpu_offload, use_device_id):
         # CPU offload and CUDA after don't work together as expected.
-        if cpu_offload.offload_params and cuda_init_mode == CUDAInitMode.CUDA_AFTER:
+        if (
+            cpu_offload.offload_params
+            and device_init_mode == DEVICEInitMode.DEVICE_AFTER
+        ):
             return
 
         device = torch.device("cuda")
@@ -730,7 +750,7 @@ class TestAutoWrap(TestCase):
 
         # NOTE: We move model to CUDA after init with FSDP to simulate real use
         # cases where full model cannot be loaded onto GPU, but their shards can.
-        cuda_after_init = cuda_init_mode == CUDAInitMode.CUDA_AFTER
+        cuda_after_init = device_init_mode == DEVICEInitMode.DEVICE_AFTER
         try:
             sequential = TestFSDPWrap.NestedSequentialModel.get_model(
                 cuda=(not cuda_after_init)

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -5,6 +5,7 @@ import contextlib
 import os
 import re
 import sys
+import time
 import warnings
 from abc import ABC, abstractmethod
 from contextlib import nullcontext
@@ -60,8 +61,28 @@ from torch.testing._internal.common_distributed import (
     run_subtests,
     TEST_SKIPS,
 )
-from torch.testing._internal.common_utils import FILE_SCHEMA, get_cycles_per_ms
+from torch.testing._internal.common_utils import (
+    FILE_SCHEMA,
+    get_cycles_per_ms,
+    TEST_CUDA,
+    TEST_HPU,
+)
 from torch.utils._triton import has_triton
+
+
+DEVICE_COUNT = 4  # default
+
+if TEST_CUDA:
+    DEVICE_TYPE = "cuda"
+    DISTRIBUTED_BACKEND = "nccl"
+    DEVICE_COUNT = torch.cuda.device_count()
+elif TEST_HPU:
+    DEVICE_TYPE = "hpu:0"
+    DISTRIBUTED_BACKEND = "hccl"
+else:
+    DEVICE_TYPE = "cpu"
+    DISTRIBUTED_BACKEND = "gloo"
+    DEVICE_COUNT = 1
 
 
 class FSDPInitMode(Enum):
@@ -73,13 +94,13 @@ class FSDPInitMode(Enum):
     # NONRECURSIVE = auto()
 
 
-class CUDAInitMode(Enum):
-    # Move model to CUDA before passing to the FSDP constructor
-    CUDA_BEFORE = auto()
-    # Move model to CUDA after passing to the FSDP constructor
-    CUDA_AFTER = auto()
+class DEVICEInitMode(Enum):
+    # Move model to DEVICE before passing to the FSDP constructor
+    DEVICE_BEFORE = auto()
+    # Move model to DEVICE after passing to the FSDP constructor
+    DEVICE_AFTER = auto()
     # Keep on CPU
-    CUDA_NEVER = auto()
+    DEVICE_NEVER = auto()
 
 
 class FSDPTestModel(nn.Module, ABC):
@@ -158,7 +179,7 @@ def _zero_model(
 
 def _get_state_dict(model, cpu_offload=False, half=False):
     if not cpu_offload:
-        model = model.cuda()
+        model = model.to(DEVICE_TYPE)
     if half:
         model.half()
 
@@ -182,9 +203,9 @@ def _broadcast_state_dict(rank, state_dict):
     olist = [state_dict if rank == 0 else None]
     dist.broadcast_object_list(olist)
     state_dict = olist[0]
-    # Ensure that the state is on CUDA
+    # Ensure that the state is on DEVICE
     for param_name in state_dict.keys():
-        state_dict[param_name] = state_dict[param_name].cuda()
+        state_dict[param_name] = state_dict[param_name].to(DEVICE_TYPE)
     return state_dict
 
 
@@ -202,8 +223,8 @@ def get_full_params(model: nn.Module, recurse: bool = True):
         return deepcopy(list(model.parameters()))
 
 
-def _maybe_cuda(model: nn.Module, move_to_cuda: bool):
-    return model.cuda() if move_to_cuda else model
+def _move_to_device(model: nn.Module, move_to_device: bool):
+    return model.to(DEVICE_TYPE) if move_to_device else model
 
 
 def _maybe_wrap_fsdp(model: nn.Module, wrap_fsdp: bool, *args, **kwargs):
@@ -237,7 +258,7 @@ class TransformerWithSharedParams(FSDPTestModel):
     def __init__(
         self,
         group: dist.ProcessGroup,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         add_bn: bool,
         deterministic: bool,
     ):
@@ -271,8 +292,8 @@ class TransformerWithSharedParams(FSDPTestModel):
 
         self.bs = 2
         self.bn = torch.nn.BatchNorm1d(self.bs) if add_bn else torch.nn.Identity()
-        if cuda_init_mode == CUDAInitMode.CUDA_BEFORE:
-            self = self.cuda()
+        if device_init_mode == DEVICEInitMode.DEVICE_BEFORE:
+            self = self.to(DEVICE_TYPE)
         if deterministic:
             self.eval()
 
@@ -303,7 +324,7 @@ class TransformerWithSharedParams(FSDPTestModel):
     def init(
         group: dist.ProcessGroup,
         fsdp_init_mode: FSDPInitMode,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         fsdp_kwargs: Optional[Dict[str, Any]] = None,
         deterministic: bool = False,
         add_bn: bool = True,
@@ -318,7 +339,7 @@ class TransformerWithSharedParams(FSDPTestModel):
                 ``ModuleWrapPolicy`` for encoder and decoder layers, but a
                 different auto wrap policy may be specified via
                 ``fsdp_kwargs``.
-            cuda_init_mode (CUDAInitMode): Determines model movement to CUDA.
+            device_init_mode (DEVICEInitMode): Determines model movement to DEVICE.
             fsdp_kwargs (Optional[Dict[str, Any]]): Optional keyword arguments
                 forwarded to the FSDP constructor.
             deterministic (bool): Whether to make the model deterministic
@@ -334,7 +355,7 @@ class TransformerWithSharedParams(FSDPTestModel):
             else:
                 pg = group
             return TransformerWithSharedParams(
-                pg, cuda_init_mode, add_bn, deterministic
+                pg, device_init_mode, add_bn, deterministic
             )
         elif fsdp_init_mode == FSDPInitMode.RECURSIVE:
             # Default to the `ModuleWrapPolicy`
@@ -364,7 +385,7 @@ class TransformerWithSharedParams(FSDPTestModel):
                 tformer_pg = group
 
             m = TransformerWithSharedParams(
-                tformer_pg, cuda_init_mode, add_bn, deterministic
+                tformer_pg, device_init_mode, add_bn, deterministic
             )
             fsdp_model = FSDP(
                 m,
@@ -372,8 +393,8 @@ class TransformerWithSharedParams(FSDPTestModel):
                 auto_wrap_policy=auto_wrap_policy,
                 **fsdp_kwargs,
             )
-            if cuda_init_mode == CUDAInitMode.CUDA_AFTER:
-                fsdp_model = fsdp_model.cuda()
+            if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
+                fsdp_model = fsdp_model.to(DEVICE_TYPE)
             return fsdp_model
         raise ValueError(f"Unsupported FSDP init mode: {fsdp_init_mode}")
 
@@ -386,14 +407,14 @@ class NestedWrappedModule(FSDPTestModel):
         self,
         group: dist.ProcessGroup,
         wrap_fsdp: bool,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         deterministic: bool,
         **fsdp_kwargs,
     ):
         super().__init__()
         self.rank = group.rank()
         self.world_size = group.size()
-        move_to_cuda = cuda_init_mode == CUDAInitMode.CUDA_BEFORE
+        move_to_device = device_init_mode == DEVICEInitMode.DEVICE_BEFORE
 
         def _maybe_wrap(layer):
             if wrap_fsdp:
@@ -403,15 +424,15 @@ class NestedWrappedModule(FSDPTestModel):
         if deterministic:
             torch.manual_seed(0)
         self.module = nn.Sequential(
-            _maybe_cuda(nn.Linear(8, 4), move_to_cuda),
+            _move_to_device(nn.Linear(8, 4), move_to_device),
             _maybe_wrap(
                 nn.Sequential(
-                    _maybe_wrap(_maybe_cuda(nn.Linear(4, 16), move_to_cuda)),
-                    _maybe_cuda(nn.Linear(16, 16), move_to_cuda),
+                    _maybe_wrap(_move_to_device(nn.Linear(4, 16), move_to_device)),
+                    _move_to_device(nn.Linear(16, 16), move_to_device),
                 ),
             ),
-            _maybe_wrap(_maybe_cuda(nn.Linear(16, 4), move_to_cuda)),
-            _maybe_cuda(nn.Linear(4, 8), move_to_cuda),
+            _maybe_wrap(_move_to_device(nn.Linear(16, 4), move_to_device)),
+            _move_to_device(nn.Linear(4, 8), move_to_device),
         )
 
     def get_input(self, device):
@@ -432,7 +453,7 @@ class NestedWrappedModule(FSDPTestModel):
     def init(
         group: dist.ProcessGroup,
         fsdp_init_mode: FSDPInitMode,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         fsdp_kwargs: Optional[Dict[str, Any]] = None,
         deterministic: bool = False,
     ) -> nn.Module:
@@ -445,7 +466,7 @@ class NestedWrappedModule(FSDPTestModel):
                 modules with FSDP but not the top-level module. The model may
                 later be wrapped with a top-level FSDP external to this method
                 if desired.
-            cuda_init_mode (CUDAInitMode): Determines model movement to CUDA.
+            device_init_mode (DEVICEInitMode): Determines model movement to DEVICE.
             fsdp_kwargs (Optional[Dict[str, Any]]): Optional keyword arguments
                 forwarded to the FSDP constructor.
             deterministic (bool): Whether to make the model deterministic
@@ -457,7 +478,7 @@ class NestedWrappedModule(FSDPTestModel):
             return NestedWrappedModule(
                 group,
                 wrap_fsdp=False,
-                cuda_init_mode=cuda_init_mode,
+                device_init_mode=device_init_mode,
                 deterministic=deterministic,
             )
         elif fsdp_init_mode == FSDPInitMode.RECURSIVE:
@@ -465,12 +486,12 @@ class NestedWrappedModule(FSDPTestModel):
             fsdp_model = NestedWrappedModule(
                 group,
                 wrap_fsdp=True,
-                cuda_init_mode=cuda_init_mode,
+                device_init_mode=device_init_mode,
                 deterministic=deterministic,
                 **fsdp_kwargs,
             )
-            if cuda_init_mode == CUDAInitMode.CUDA_AFTER:
-                fsdp_model = fsdp_model.cuda()
+            if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
+                fsdp_model = fsdp_model.to(DEVICE_TYPE)
             return fsdp_model
         raise ValueError(f"Unsupported FSDP init mode: {fsdp_init_mode}")
 
@@ -480,7 +501,7 @@ class AlwaysWrapNestedWrappedModule(NestedWrappedModule):
     def init(
         group: dist.ProcessGroup,
         fsdp_init_mode: FSDPInitMode,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         fsdp_kwargs: Optional[Dict[str, Any]] = None,
         deterministic: bool = False,
     ):
@@ -495,7 +516,7 @@ class AlwaysWrapNestedWrappedModule(NestedWrappedModule):
         ).init(
             group=group,
             fsdp_init_mode=FSDPInitMode.NO_FSDP,
-            cuda_init_mode=cuda_init_mode,
+            device_init_mode=device_init_mode,
             fsdp_kwargs=fsdp_kwargs,
             deterministic=deterministic,
         )
@@ -504,8 +525,8 @@ class AlwaysWrapNestedWrappedModule(NestedWrappedModule):
         elif fsdp_init_mode == FSDPInitMode.RECURSIVE:
             fsdp_kwargs = fsdp_kwargs or {}
             fsdp_model = FSDP(model, auto_wrap_policy=always_wrap_policy, **fsdp_kwargs)
-            if cuda_init_mode == CUDAInitMode.CUDA_AFTER:
-                fsdp_model = fsdp_model.cuda()
+            if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
+                fsdp_model = fsdp_model.to(DEVICE_TYPE)
             return fsdp_model
 
 
@@ -514,7 +535,7 @@ class NonUniformReqGradNWM(NestedWrappedModule):
         self,
         group: dist.ProcessGroup,
         wrap_fsdp: bool,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         deterministic: bool,
         **fsdp_kwargs,
     ):
@@ -527,7 +548,7 @@ class NonUniformReqGradNWM(NestedWrappedModule):
         # have no (non-zero sized) parameter shards.
         self.rank = group.rank()
         self.world_size = group.size()
-        move_to_cuda = cuda_init_mode == CUDAInitMode.CUDA_BEFORE
+        move_to_device = device_init_mode == DEVICEInitMode.DEVICE_BEFORE
 
         def _maybe_wrap(layer):
             if wrap_fsdp:
@@ -537,17 +558,17 @@ class NonUniformReqGradNWM(NestedWrappedModule):
         if deterministic:
             torch.manual_seed(0)
         self.module = nn.Sequential(
-            _maybe_cuda(nn.Linear(8, 4), move_to_cuda),
+            _move_to_device(nn.Linear(8, 4), move_to_device),
             _maybe_wrap(
                 nn.Sequential(
-                    _maybe_wrap(_maybe_cuda(nn.Linear(4, 16), move_to_cuda)),
-                    _maybe_cuda(nn.Linear(16, 16), move_to_cuda),
+                    _maybe_wrap(_move_to_device(nn.Linear(4, 16), move_to_device)),
+                    _move_to_device(nn.Linear(16, 16), move_to_device),
                 ),
             ),
             _maybe_wrap(
                 nn.Sequential(
-                    _maybe_cuda(nn.Linear(16, 4), move_to_cuda),
-                    _maybe_cuda(nn.Linear(4, 8), move_to_cuda),
+                    _move_to_device(nn.Linear(16, 4), move_to_device),
+                    _move_to_device(nn.Linear(4, 8), move_to_device),
                 ),
             ),
         )
@@ -562,7 +583,7 @@ class NonUniformReqGradNWM(NestedWrappedModule):
     def init(
         group: dist.ProcessGroup,
         fsdp_init_mode: FSDPInitMode,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         fsdp_kwargs: Optional[Dict[str, Any]] = None,
         deterministic: bool = False,
     ):
@@ -583,7 +604,7 @@ class NonUniformReqGradNWM(NestedWrappedModule):
             ddp_model = NonUniformReqGradNWM(
                 group,
                 wrap_fsdp=False,
-                cuda_init_mode=cuda_init_mode,
+                device_init_mode=device_init_mode,
                 deterministic=deterministic,
             )
             NonUniformReqGradNWM._set_nonuniform_req_grad(ddp_model, req_grad_pattern)
@@ -594,12 +615,12 @@ class NonUniformReqGradNWM(NestedWrappedModule):
             fsdp_model = NonUniformReqGradNWM(
                 group,
                 wrap_fsdp=True,
-                cuda_init_mode=cuda_init_mode,
+                device_init_mode=device_init_mode,
                 deterministic=deterministic,
                 **fsdp_kwargs,
             )
-            if cuda_init_mode == CUDAInitMode.CUDA_AFTER:
-                fsdp_model = fsdp_model.cuda()
+            if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
+                fsdp_model = fsdp_model.to(DEVICE_TYPE)
             NonUniformReqGradNWM._set_nonuniform_req_grad(fsdp_model, req_grad_pattern)
             return fsdp_model
         raise ValueError(f"Unsupported FSDP init mode: {fsdp_init_mode}")
@@ -629,7 +650,11 @@ class ModuleWithDelay(FSDPTestModel):
     def get_loss(self, input, output):
         loss = self.module.get_loss(input, output)
         if self.delay_after_loss_ms > 0:
-            torch.cuda._sleep(int(self.delay_after_loss_ms * get_cycles_per_ms()))
+            if TEST_HPU:
+                time.sleep(self.delay_before_reduction_ms / 1000)
+            elif TEST_CUDA:
+                torch.cuda._sleep(int(self.delay_after_loss_ms * get_cycles_per_ms()))
+
         return loss
 
     def run_backward(self, loss):
@@ -637,9 +662,12 @@ class ModuleWithDelay(FSDPTestModel):
 
         def _delayed_reduce_scatter(*args, **kwargs):
             if self.delay_before_reduction_ms > 0:
-                torch.cuda._sleep(
-                    int(self.delay_before_reduction_ms * get_cycles_per_ms())
-                )
+                if TEST_CUDA:
+                    torch.cuda._sleep(
+                        int(self.delay_before_reduction_ms * get_cycles_per_ms())
+                    )
+                elif TEST_HPU:
+                    time.sleep(self.delay_before_reduction_ms / 1000)
             return orig_reduce_scatter(*args, **kwargs)
 
         with mock.patch(
@@ -680,7 +708,7 @@ class NestedWrappedModuleWithDelay(ModuleWithDelay):
     def init(  # type: ignore[override]
         group: dist.ProcessGroup,
         fsdp_init_mode: FSDPInitMode,
-        cuda_init_mode: CUDAInitMode = CUDAInitMode.CUDA_AFTER,
+        device_init_mode: DEVICEInitMode = DEVICEInitMode.DEVICE_AFTER,
         fsdp_kwargs: Optional[Dict[str, Any]] = None,
         deterministic: bool = False,
         delay_after_loss_ms: int = 0,
@@ -690,7 +718,7 @@ class NestedWrappedModuleWithDelay(ModuleWithDelay):
             NestedWrappedModule,
             group=group,
             fsdp_init_mode=fsdp_init_mode,
-            cuda_init_mode=cuda_init_mode,
+            device_init_mode=device_init_mode,
             fsdp_kwargs=fsdp_kwargs,
             deterministic=deterministic,
             delay_after_loss_ms=delay_after_loss_ms,
@@ -712,7 +740,7 @@ class MixtureOfExperts(NestedWrappedModule):
         self,
         group: dist.ProcessGroup,
         wrap_fsdp: bool,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         delay_before_free_ms: int,
         deterministic: bool,
         **fsdp_kwargs,
@@ -720,20 +748,20 @@ class MixtureOfExperts(NestedWrappedModule):
         super().__init__(
             group=group,
             wrap_fsdp=wrap_fsdp,
-            cuda_init_mode=cuda_init_mode,
+            device_init_mode=device_init_mode,
             deterministic=deterministic,
         )
         self.group = group
         self.delay_before_free_ms = delay_before_free_ms
         self.wrap_fsdp = wrap_fsdp
-        self.move_to_cuda = cuda_init_mode == CUDAInitMode.CUDA_BEFORE
+        self.move_to_device = device_init_mode == DEVICEInitMode.DEVICE_BEFORE
         if deterministic:
             # Give each rank different expert parameters
             torch.manual_seed(42 + self.rank)
         d_expert = 23
         d_shared = 12
         d_input = 8
-        expert = _maybe_cuda(nn.Linear(d_expert, d_shared), self.move_to_cuda)
+        expert = _move_to_device(nn.Linear(d_expert, d_shared), self.move_to_device)
 
         self.num_expert_params = sum(p.numel() for p in expert.parameters())
         for p in expert.parameters():
@@ -743,7 +771,7 @@ class MixtureOfExperts(NestedWrappedModule):
             # Keep all other parameters the same across ranks
             torch.manual_seed(0)
 
-        shared = _maybe_cuda(nn.Linear(d_shared, d_expert), self.move_to_cuda)
+        shared = _move_to_device(nn.Linear(d_shared, d_expert), self.move_to_device)
 
         if wrap_fsdp:
             # we create a process group of size 1 for the expert params
@@ -754,10 +782,10 @@ class MixtureOfExperts(NestedWrappedModule):
             shared = FSDP(shared, group, **fsdp_kwargs)  # type: ignore[assignment]
 
         self.module = nn.Sequential(
-            _maybe_cuda(nn.Linear(d_input, d_shared), self.move_to_cuda),
+            _move_to_device(nn.Linear(d_input, d_shared), self.move_to_device),
             shared,
             expert,
-            _maybe_cuda(nn.Linear(d_shared, d_input), self.move_to_cuda),
+            _move_to_device(nn.Linear(d_shared, d_input), self.move_to_device),
         )
 
     def forward(self, x):
@@ -767,9 +795,13 @@ class MixtureOfExperts(NestedWrappedModule):
                 orig_reshard = torch.distributed.fsdp._runtime_utils._reshard
 
                 def _delayed_reshard(*args, **kwargs):
-                    torch.cuda._sleep(
-                        int(self.delay_before_free_ms * get_cycles_per_ms())
-                    )
+                    if TEST_CUDA:
+                        torch.cuda._sleep(
+                            int(self.delay_before_free_ms * get_cycles_per_ms())
+                        )
+                    elif TEST_HPU:
+                        time.sleep(self.delay_before_free_ms / 1000)
+
                     return orig_reshard(*args, **kwargs)
 
                 # This patch covers any `import torch..._reshard` uses.
@@ -796,7 +828,7 @@ class MixtureOfExperts(NestedWrappedModule):
     def init(
         group: dist.ProcessGroup,
         fsdp_init_mode: FSDPInitMode,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         fsdp_kwargs: Optional[Dict[str, Any]] = None,
         deterministic: bool = False,
         delay_before_free_ms: int = 0,
@@ -810,7 +842,7 @@ class MixtureOfExperts(NestedWrappedModule):
                 modules with FSDP, including the expert and shared layers, but
                 not the top-level module. The model may later be wrapped with a
                 top-level FSDP external to this method if desired.
-            cuda_init_mode (CUDAInitMode): Determines model movement to CUDA.
+            device_init_mode (DEVICEInitMode): Determines model movement to DEVICE.
             fsdp_kwargs (Optional[Dict[str, Any]]): Optional keyword arguments
                 forwarded to the FSDP constructor.
             deterministic (bool): Whether to make the model deterministic
@@ -824,7 +856,7 @@ class MixtureOfExperts(NestedWrappedModule):
             return MixtureOfExperts(
                 group,
                 wrap_fsdp=False,
-                cuda_init_mode=cuda_init_mode,
+                device_init_mode=device_init_mode,
                 delay_before_free_ms=delay_before_free_ms,
                 deterministic=deterministic,
             )
@@ -833,13 +865,13 @@ class MixtureOfExperts(NestedWrappedModule):
             fsdp_model = MixtureOfExperts(
                 group,
                 wrap_fsdp=True,
-                cuda_init_mode=cuda_init_mode,
+                device_init_mode=device_init_mode,
                 delay_before_free_ms=delay_before_free_ms,
                 deterministic=deterministic,
                 **fsdp_kwargs,
             )
-            if cuda_init_mode == CUDAInitMode.CUDA_AFTER:
-                fsdp_model = fsdp_model.cuda()
+            if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
+                fsdp_model = fsdp_model.to(DEVICE_TYPE)
             return fsdp_model
         raise ValueError(f"Unsupported FSDP init mode: {fsdp_init_mode}")
 
@@ -1091,7 +1123,7 @@ def check_sharded_parity(
 class FSDPTestMultiThread(MultiThreadedTestCase):
     @property
     def world_size(self):
-        return torch.cuda.device_count() if torch.cuda.is_available() else 4
+        return DEVICE_COUNT
 
     def setUp(self):
         super().setUp()
@@ -1118,7 +1150,7 @@ class FSDPTest(MultiProcessTestCase):
 
     @property
     def world_size(self):
-        return min(torch.cuda.device_count(), 8) if torch.cuda.is_available() else 4
+        return DEVICE_COUNT
 
     @property
     def process_group(self):
@@ -1151,8 +1183,6 @@ class FSDPTest(MultiProcessTestCase):
 
         # Specify gloo backend to make 'init_process_group()' succeed,
         # Actual tests will be skipped if there is no enough GPUs.
-        backend = "nccl" if torch.cuda.is_available() else "gloo"
-
         try:
             if fake_pg:
                 store = torch.testing._internal.distributed.fake_pg.FakeStore()
@@ -1165,7 +1195,7 @@ class FSDPTest(MultiProcessTestCase):
             else:
                 dist.init_process_group(
                     init_method=self.init_method,
-                    backend=backend,
+                    backend=DISTRIBUTED_BACKEND,
                     world_size=int(self.world_size),
                     rank=self.rank,
                 )
@@ -1176,10 +1206,10 @@ class FSDPTest(MultiProcessTestCase):
             raise
 
         device_ids = None
-        if torch.cuda.is_available() and torch.cuda.device_count():
-            device_id = self.rank % torch.cuda.device_count()
+        device_id = self.rank % DEVICE_COUNT
+        if TEST_CUDA:
             torch.cuda.set_device(device_id)
-            device_ids = [device_id]
+        device_ids = [device_id]
 
         # Execute barrier prior to running test to ensure that every process
         # has finished initialization and that the following test
@@ -1220,9 +1250,9 @@ class FSDPTest(MultiProcessTestCase):
         optim = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9)
         for _ in range(num_steps):
             optim.zero_grad()
-            with torch.amp.autocast("cuda", enabled=autocast):
+            with torch.amp.autocast(DEVICE_TYPE, enabled=autocast):
                 # Inputs always cuda regardless of cpu offloading, or model.device
-                input = model.module.get_input(torch.device("cuda"))
+                input = model.module.get_input(torch.device(DEVICE_TYPE))
                 if use_pure_fp16 or (mixed_precision and not isinstance(model, FSDP)):
                     if isinstance(input, torch.Tensor):
                         input = input.half()
@@ -1285,7 +1315,7 @@ class FSDPTest(MultiProcessTestCase):
         self,
         model_class: Type[FSDPTestModel],
         fsdp_init_mode: FSDPInitMode,
-        cuda_init_mode: CUDAInitMode,
+        device_init_mode: DEVICEInitMode,
         ref_init_fn: Optional[Callable] = None,
         num_iters: int = 2,
         save_model: bool = True,
@@ -1326,7 +1356,7 @@ class FSDPTest(MultiProcessTestCase):
         model = model_class.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            CUDAInitMode.CUDA_BEFORE,
+            DEVICEInitMode.DEVICE_BEFORE,
             deterministic=True,
             **init_kwargs,
         )
@@ -1363,7 +1393,7 @@ class FSDPTest(MultiProcessTestCase):
             fsdp_model = model_class.init(
                 self.process_group,
                 fsdp_init_mode,
-                cuda_init_mode,
+                device_init_mode,
                 fsdp_kwargs,
                 deterministic=True,
                 **init_kwargs,
@@ -1378,17 +1408,17 @@ class FSDPTest(MultiProcessTestCase):
         if use_pure_fp16:
             # Change the model parameter dtype after FSDP initialization
             fsdp_model = fsdp_model.half()
-        if cuda_init_mode == CUDAInitMode.CUDA_AFTER:
-            fsdp_model = fsdp_model.cuda()
+        if device_init_mode == DEVICEInitMode.DEVICE_AFTER:
+            fsdp_model = fsdp_model.to(DEVICE_TYPE)
         offload_params = cpu_offload is not None and cpu_offload.offload_params
-        # Offloading parameters with `CUDA_AFTER` should raise an error during
+        # Offloading parameters with `DEVICE_AFTER` should raise an error during
         # lazy initialization due to the parameter devices not being CPU;
         # otherwise, all parameter devices should be CPU
         expects_device_error = (
-            offload_params and cuda_init_mode == CUDAInitMode.CUDA_AFTER
+            offload_params and device_init_mode == DEVICEInitMode.DEVICE_AFTER
         )
         expects_cpu_device = (
-            offload_params and cuda_init_mode != CUDAInitMode.CUDA_AFTER
+            offload_params and device_init_mode != DEVICEInitMode.DEVICE_AFTER
         )
         if expects_cpu_device:
             cpu_device = torch.device("cpu")
@@ -1425,7 +1455,7 @@ class FSDPTest(MultiProcessTestCase):
             cpu_device = torch.device("cpu")
             for param in fsdp_model.parameters():
                 self.assertEqual(param.device, cpu_device)
-            fsdp_loss = fsdp_loss.cuda()
+            fsdp_loss = fsdp_loss.to(DEVICE_TYPE)
         fsdp_unsharded_params = get_full_params(fsdp_model)
         # Do not check dtype since the reference DDP loss may not be the same
         # dtype as the FSDP loss in the case of mixed precision
@@ -1510,9 +1540,9 @@ class NestedLinear(nn.Module):
     def __init__(self, fsdp_wrap):
         super().__init__()
         if fsdp_wrap:
-            self.nested_linear = wrap(nn.Linear(10, 10, bias=False).cuda())
+            self.nested_linear = wrap(nn.Linear(10, 10, bias=False).to(DEVICE_TYPE))
         else:
-            self.nested_linear = nn.Linear(10, 10, bias=False).cuda()
+            self.nested_linear = nn.Linear(10, 10, bias=False).to(DEVICE_TYPE)
 
     def forward(self, x):
         return self.nested_linear(x)
@@ -1521,9 +1551,11 @@ class NestedLinear(nn.Module):
 class SkipModel(nn.Module):
     def __init__(self, double_nest):
         super().__init__()
-        self.linear = nn.Linear(10, 10, bias=False).cuda()
-        self.linear_skip = SkipModule().cuda()
-        self.nested_linear = wrap(NestedLinear(fsdp_wrap=double_nest))
+        self.linear = nn.Linear(10, 10, bias=False).to(DEVICE_TYPE)
+        self.linear_skip = SkipModule().to(DEVICE_TYPE)
+        self.nested_linear = wrap(
+            NestedLinear(fsdp_wrap=double_nest), device_id=DEVICE_TYPE
+        )
 
     def forward(self, x):
         x = self.linear(x)


### PR DESCRIPTION
## Motivation
The FSDP common code for FSDP UT execution is mostly written with cuda device in mind. However other devices such the intel Gaudi supports most of the functionality. We are generalizing the base content so that the UT content can be used for non-cuda device execution.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o