### PR TITLE
Make IPC features extendable on third-party devices

### DIFF
--- a/aten/src/ATen/cuda/CudaIPCTypes.cpp
+++ b/aten/src/ATen/cuda/CudaIPCTypes.cpp
@@ -1,12 +1,12 @@
 #include <ATen/MapAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
-#include <torch/csrc/CudaIPCTypes.h>
+#include <ATen/cuda/CudaIPCTypes.h>
 #include <atomic>
 #include <map>
 #include <mutex>
 #include <string>
 
-namespace torch {
+namespace at::cuda::ipc {
 
 namespace {
 
@@ -261,7 +261,7 @@ bool CudaIPCCollect() {
   return freed_memory;
 }
 
-} // namespace torch
+} // namespace at::cuda::ipc
 
 namespace c10 {
 namespace {

--- a/aten/src/ATen/cuda/CudaIPCTypes.h
+++ b/aten/src/ATen/cuda/CudaIPCTypes.h
@@ -1,13 +1,11 @@
 #pragma once
-#ifdef USE_CUDA
 #include <c10/core/Allocator.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAException.h>
 #include <c10/util/Logging.h>
 #include <cuda_runtime_api.h>
-#include <torch/csrc/Export.h>
 #include <cstddef>
-namespace torch {
+namespace at::cuda::ipc {
 
 TORCH_CUDA_CU_API bool CudaIPCCollect();
 
@@ -126,18 +124,16 @@ struct CudaIPCRefCountersFile final {
 };
 
 } // namespace
-} // namespace torch
+} // namespace at::cuda::ipc
 
 namespace c10 {
 namespace {
 class CudaIPCCollectCallback : public FreeMemoryCallback {
  public:
   bool Execute() override {
-    return torch::CudaIPCCollect();
+    return at::cuda::ipc::CudaIPCCollect();
   }
 };
 } // namespace
 
 } // namespace c10
-
-#endif

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -9,6 +9,7 @@
 #include <ATen/cuda/CUDADevice.h>
 #include <ATen/cuda/Exceptions.h>
 #include <ATen/cuda/PeerToPeerAccess.h>
+#include <ATen/MapAllocator.h>
 #include <ATen/cuda/PinnedMemoryAllocator.h>
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
 #include <ATen/detail/CUDAHooksInterface.h>
@@ -18,6 +19,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/util/irange.h>
+#include <torch/csrc/CudaIPCTypes.h>
 
 #if AT_CUDNN_ENABLED()
 #include <ATen/cudnn/cudnn-wrapper.h>
@@ -36,6 +38,7 @@
 #endif
 
 #include <cuda.h>
+#include <cuda_runtime.h>
 
 #include <sstream>
 #include <cstddef>
@@ -464,6 +467,133 @@ bool CUDAHooks::isGPUArch(DeviceIndex device_index, const std::vector<std::strin
 void CUDAHooks::deviceSynchronize(DeviceIndex device_index) const {
   at::DeviceGuard device_guard(at::Device(at::DeviceType::CUDA, device_index));
   c10::cuda::device_synchronize();
+}
+
+std::tuple<size_t, size_t, ptrdiff_t, std::string, std::string, std::string, uint64_t, bool>
+CUDAHooks::StorageShareDevice(const c10::Storage& storage) const {
+    uint64_t ref_counter_offset = 0;
+    bool event_sync_required = false;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    auto shandle = c10::cuda::CUDACachingAllocator::shareIpcHandle(storage.mutable_data());
+    ptrdiff_t offset_bytes = shandle.offset;
+    size_t ipc_memory_handle_size = shandle.handle.size();
+    std::string memory_handle(ipc_memory_handle_size, '\0');
+    std::memcpy(memory_handle.data(), shandle.handle.c_str(), shandle.handle.size());
+
+    // Put Storage Data behind new ref counting context
+    // See Note [CUDA IPC Refcounting implementation explained]
+    at::DataPtr sent_data_ptr = torch::GetNewRefCountedSentData(
+        storage.mutable_data(), storage.device());
+    auto old_data_ptr = storage.set_data_ptr(std::move(sent_data_ptr));
+    auto sent_data =
+        static_cast<torch::CudaIPCSentData*>(storage.data_ptr().get_context());
+    sent_data->set_original_ptr(std::move(old_data_ptr));
+    std::string ref_counter(sent_data->handle().size(), '\0');
+    std::memcpy(ref_counter.data(), (sent_data->handle()).c_str(), sent_data->handle().size());
+    ref_counter_offset = sent_data->offset();
+
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    cudaIpcEventHandle_t ipc_event_handle;
+    if (sent_data->event_sync_required_) {
+        C10_CUDA_CHECK(
+            cudaIpcGetEventHandle(&ipc_event_handle, sent_data->event_));
+    }
+    size_t ipc_event_handle_size = CUDA_IPC_HANDLE_SIZE;
+    std::string event_handle(ipc_event_handle_size, '\0');
+    std::memcpy(event_handle.data(), (char*)&ipc_event_handle, ipc_event_handle_size);
+    event_sync_required = sent_data->event_sync_required_;
+
+    // Return the results as a tuple
+    return std::make_tuple(ipc_memory_handle_size, ipc_event_handle_size,
+                           offset_bytes, std::move(memory_handle),
+                           std::move(event_handle), std::move(ref_counter),
+                           ref_counter_offset, event_sync_required);
+}
+
+
+c10::DataPtr CUDAHooks::StorageNewSharedDevice(c10::DeviceIndex device,
+                                               bool event_sync_required,
+                                               std::string s_ipc_event_handle,
+                                               std::string s_handle,
+                                               std::string ref_counter_handle,
+                                               ptrdiff_t ref_counter_offset,
+                                               ptrdiff_t storage_offset_bytes) const {
+  c10::DataPtr data_ptr;
+  if (event_sync_required) {
+    auto ipc_event_handle = reinterpret_cast<const cudaIpcEventHandle_t*>(
+        s_ipc_event_handle.c_str());
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    cudaEvent_t event;
+    C10_CUDA_CHECK(cudaIpcOpenEventHandle(&event, *ipc_event_handle));
+    C10_CUDA_CHECK(
+        cudaStreamWaitEvent(c10::cuda::getCurrentCUDAStream(device), event, 0));
+    cudaEventDestroy(event);
+  }
+  if (s_handle.empty()) return data_ptr;
+  std::shared_ptr<void> basePtr = c10::cuda::CUDACachingAllocator::getIpcDevPtr(s_handle);
+
+  // Offset the basePtr to reconstruct the real storage
+  // devPtr = basePtr + storage_offset
+  void* devPtr = basePtr.get();
+  devPtr = (char*)devPtr + storage_offset_bytes;
+
+  struct IpcDeleterContext {
+    std::string ref_counter_handle;
+    ptrdiff_t ref_counter_offset{};
+    c10::DeviceIndex device{-1};
+    torch::CudaIPCReceivedData received_data;
+  };
+
+  auto ctx = std::make_unique<IpcDeleterContext>();
+  ctx->ref_counter_handle = std::move(ref_counter_handle);
+  ctx->ref_counter_offset = ref_counter_offset;
+  ctx->device = device;
+  ctx->received_data.shared_ptr_ = std::move(basePtr);
+
+  auto cur_device = at::cuda::current_device();
+
+  data_ptr = c10::DataPtr(
+      devPtr,
+      ctx.release(),
+      +[](void* ctx_) {
+        std::unique_ptr<IpcDeleterContext> ctx(
+            static_cast<IpcDeleterContext*>(ctx_));
+        ctx->received_data.shared_ptr_.reset();
+        // Sync default stream to make sure all operations related to the
+        // storage is finished (otherwise another process may reuse memory and
+        // corrupt data)
+
+        // Ideally all shared memory reference counting could be replaced by
+        // sending untriggered CUDA event from the producer to consumer and
+        // using this event as the criteria of memory release. However, CUDA
+        // (atm 10.1) does not support the creation of untriggered events and
+        // performance impact of having thousands of shared events is unknown.
+
+        at::cuda::stream_synchronize(
+            c10::cuda::getCurrentCUDAStream(ctx->device));
+
+        // We don't want to break existing code, so resource deletion is best
+        // effort basis. Exception expected if producer process terminated
+        // before consumer released data.
+        int flags =
+            at::ALLOCATOR_MAPPED_SHAREDMEM | at::ALLOCATOR_MAPPED_NOCREATE;
+        try {
+          auto sptr = at::RefcountedMapAllocator::makeDataPtr(
+              ctx->ref_counter_handle.c_str(),
+              flags,
+              sizeof(int64_t) * torch::CUDA_IPC_REF_COUNTER_FILE_SIZE,
+              nullptr);
+          *(static_cast<int64_t*>(sptr.get()) + ctx->ref_counter_offset) -= 1;
+        } catch (c10::Error& err) {
+          // Already warned inside of producer process
+        }
+      },
+      at::Device(at::DeviceType::CUDA, cur_device));
+  return data_ptr;
+}
+
+int64_t CUDAHooks::getIpcRefCounterFileSize() const {
+  return torch::CUDA_IPC_REF_COUNTER_FILE_SIZE;
 }
 
 // Sigh, the registry doesn't support namespaces :(

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -469,16 +469,14 @@ void CUDAHooks::deviceSynchronize(DeviceIndex device_index) const {
   c10::cuda::device_synchronize();
 }
 
-std::tuple<size_t, size_t, ptrdiff_t, std::string, std::string, std::string, uint64_t, bool>
+std::tuple<size_t, size_t, ptrdiff_t, uint64_t, bool, c10::IPCHandlePimpl>
 CUDAHooks::StorageShareDevice(const c10::Storage& storage) const {
+    std::ostringstream ss1, ss2, ss3;
     uint64_t ref_counter_offset = 0;
     bool event_sync_required = false;
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     auto shandle = c10::cuda::CUDACachingAllocator::shareIpcHandle(storage.mutable_data());
     ptrdiff_t offset_bytes = shandle.offset;
     size_t ipc_memory_handle_size = shandle.handle.size();
-    std::string memory_handle(ipc_memory_handle_size, '\0');
-    std::memcpy(memory_handle.data(), shandle.handle.c_str(), shandle.handle.size());
 
     // Put Storage Data behind new ref counting context
     // See Note [CUDA IPC Refcounting implementation explained]
@@ -488,8 +486,6 @@ CUDAHooks::StorageShareDevice(const c10::Storage& storage) const {
     auto sent_data =
         static_cast<torch::CudaIPCSentData*>(storage.data_ptr().get_context());
     sent_data->set_original_ptr(std::move(old_data_ptr));
-    std::string ref_counter(sent_data->handle().size(), '\0');
-    std::memcpy(ref_counter.data(), (sent_data->handle()).c_str(), sent_data->handle().size());
     ref_counter_offset = sent_data->offset();
 
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
@@ -499,15 +495,17 @@ CUDAHooks::StorageShareDevice(const c10::Storage& storage) const {
             cudaIpcGetEventHandle(&ipc_event_handle, sent_data->event_));
     }
     size_t ipc_event_handle_size = CUDA_IPC_HANDLE_SIZE;
-    std::string event_handle(ipc_event_handle_size, '\0');
-    std::memcpy(event_handle.data(), (char*)&ipc_event_handle, ipc_event_handle_size);
     event_sync_required = sent_data->event_sync_required_;
+
+    ss1.write(shandle.handle.c_str(), CUDA_IPC_HANDLE_SIZE);
+    ss2.write(sent_data->handle().c_str(), sent_data->handle().size());
+    ss3.write((char*)&ipc_event_handle, CUDA_IPC_HANDLE_SIZE);
+    auto ipc_handles = IPCHandlePimpl{ss1.str(), ss2.str(), ss3.str()};
 
     // Return the results as a tuple
     return std::make_tuple(ipc_memory_handle_size, ipc_event_handle_size,
-                           offset_bytes, std::move(memory_handle),
-                           std::move(event_handle), std::move(ref_counter),
-                           ref_counter_offset, event_sync_required);
+                           offset_bytes, ref_counter_offset,
+                           event_sync_required, ipc_handles);
 }
 
 
@@ -523,7 +521,7 @@ c10::DataPtr CUDAHooks::StorageNewSharedDevice(c10::DeviceIndex device,
     auto ipc_event_handle = reinterpret_cast<const cudaIpcEventHandle_t*>(
         s_ipc_event_handle.c_str());
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    cudaEvent_t event;
+    cudaEvent_t event = nullptr;
     C10_CUDA_CHECK(cudaIpcOpenEventHandle(&event, *ipc_event_handle));
     C10_CUDA_CHECK(
         cudaStreamWaitEvent(c10::cuda::getCurrentCUDAStream(device), event, 0));

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -58,6 +58,16 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   bool isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const override;
 #endif
   void deviceSynchronize(DeviceIndex device_index) const override;
+  std::tuple<size_t, size_t, ptrdiff_t, std::string, std::string, std::string, uint64_t, bool>
+  StorageShareDevice(const c10::Storage& storage) const override;
+  c10::DataPtr StorageNewSharedDevice(c10::DeviceIndex device,
+                                      bool event_sync_required,
+                                      std::string s_ipc_event_handle,
+                                      std::string s_handle,
+                                      std::string ref_counter_handle,
+                                      ptrdiff_t ref_counter_offset,
+                                      ptrdiff_t storage_offset_bytes) const override;
+  int64_t getIpcRefCounterFileSize() const override;
 };
 
 } // at::cuda::detail

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -58,7 +58,7 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   bool isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const override;
 #endif
   void deviceSynchronize(DeviceIndex device_index) const override;
-  std::tuple<size_t, size_t, ptrdiff_t, std::string, std::string, std::string, uint64_t, bool>
+  std::tuple<size_t, size_t, ptrdiff_t, uint64_t, bool, c10::IPCHandlePimpl>
   StorageShareDevice(const c10::Storage& storage) const override;
   c10::DataPtr StorageNewSharedDevice(c10::DeviceIndex device,
                                       bool event_sync_required,

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -60,14 +60,14 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   void deviceSynchronize(DeviceIndex device_index) const override;
   std::tuple<size_t, size_t, ptrdiff_t, std::string, std::string, std::string, uint64_t, bool>
   StorageShareDevice(const c10::Storage& storage) const override;
-  c10::DataPtr StorageNewSharedDevice(c10::DeviceIndex device,
-                                      bool event_sync_required,
+  c10::DataPtr StorageNewSharedDevice(bool event_sync_required,
                                       std::string s_ipc_event_handle,
                                       std::string s_handle,
                                       std::string ref_counter_handle,
                                       ptrdiff_t ref_counter_offset,
                                       ptrdiff_t storage_offset_bytes) const override;
   int64_t getIpcRefCounterFileSize() const override;
+  size_t getIpcHandleSize() const override;
 };
 
 } // at::cuda::detail

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -58,7 +58,7 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   bool isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const override;
 #endif
   void deviceSynchronize(DeviceIndex device_index) const override;
-  std::tuple<size_t, size_t, ptrdiff_t, uint64_t, bool, c10::IPCHandlePimpl>
+  std::tuple<size_t, size_t, ptrdiff_t, std::string, std::string, std::string, uint64_t, bool>
   StorageShareDevice(const c10::Storage& storage) const override;
   c10::DataPtr StorageNewSharedDevice(c10::DeviceIndex device,
                                       bool event_sync_required,

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -66,12 +66,20 @@ struct TORCH_API AcceleratorHooksInterface {
   }
 
   virtual const Generator& getDefaultGenerator(
+<<<<<<< HEAD
       [[maybe_unused]] DeviceIndex device_index = -1) const {
+=======
+      C10_UNUSED DeviceIndex device_index = -1) const {
+>>>>>>> 3b2bfc5cd2e... process handle with PIMPL. #suppress-bc-linter
     TORCH_CHECK(false, "Backend doesn`t support getDefaultGenerator()");
   }
 
   virtual Generator getNewGenerator(
+<<<<<<< HEAD
       [[maybe_unused]] DeviceIndex device_index = -1) const {
+=======
+      C10_UNUSED DeviceIndex device_index = -1) const {
+>>>>>>> 3b2bfc5cd2e... process handle with PIMPL. #suppress-bc-linter
     TORCH_CHECK(false, "Backend doesn`t support getNewGenerator()");
   }
 

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -66,20 +66,12 @@ struct TORCH_API AcceleratorHooksInterface {
   }
 
   virtual const Generator& getDefaultGenerator(
-<<<<<<< HEAD
       [[maybe_unused]] DeviceIndex device_index = -1) const {
-=======
-      C10_UNUSED DeviceIndex device_index = -1) const {
->>>>>>> 3b2bfc5cd2e... process handle with PIMPL. #suppress-bc-linter
     TORCH_CHECK(false, "Backend doesn`t support getDefaultGenerator()");
   }
 
   virtual Generator getNewGenerator(
-<<<<<<< HEAD
       [[maybe_unused]] DeviceIndex device_index = -1) const {
-=======
-      C10_UNUSED DeviceIndex device_index = -1) const {
->>>>>>> 3b2bfc5cd2e... process handle with PIMPL. #suppress-bc-linter
     TORCH_CHECK(false, "Backend doesn`t support getNewGenerator()");
   }
 
@@ -102,7 +94,6 @@ struct TORCH_API AcceleratorHooksInterface {
     TORCH_CHECK(false, "Backend doesn't support getIpcRefCounterFileSize");
     return -1;
   };
-
 };
 
 } // namespace at

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -5,6 +5,8 @@
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
+#include <c10/core/Storage.h>
+#include <c10/core/DeviceGuard.h>
 
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
 
@@ -72,6 +74,27 @@ struct TORCH_API AcceleratorHooksInterface {
       [[maybe_unused]] DeviceIndex device_index = -1) const {
     TORCH_CHECK(false, "Backend doesn`t support getNewGenerator()");
   }
+
+  virtual std::tuple<size_t, size_t, ptrdiff_t, std::string, std::string, std::string, uint64_t, bool>
+  StorageShareDevice(const c10::Storage& storage) const {
+    TORCH_CHECK(false, "Backend doesn't support StorageShareDevice");
+  };
+
+  virtual c10::DataPtr StorageNewSharedDevice(c10::DeviceIndex device,
+                                              bool event_sync_required,
+                                              std::string s_ipc_event_handle,
+                                              std::string s_handle,
+                                              std::string ref_counter_handle,
+                                              ptrdiff_t ref_counter_offset,
+                                              ptrdiff_t storage_offset_bytes) const {
+    TORCH_CHECK(false, "Backend doesn't support StorageNewSharedDevice");
+  };
+
+  virtual int64_t getIpcRefCounterFileSize() const {
+    TORCH_CHECK(false, "Backend doesn't support getIpcRefCounterFileSize");
+    return -1;
+  };
+
 };
 
 } // namespace at

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -78,7 +78,7 @@ struct TORCH_API AcceleratorHooksInterface {
   virtual std::tuple<size_t, size_t, ptrdiff_t, std::string, std::string, std::string, uint64_t, bool>
   StorageShareDevice(const c10::Storage& storage) const {
     TORCH_CHECK(false, "Backend doesn't support StorageShareDevice");
-  };
+  }
 
   virtual c10::DataPtr StorageNewSharedDevice(c10::DeviceIndex device,
                                               bool event_sync_required,

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -88,12 +88,12 @@ struct TORCH_API AcceleratorHooksInterface {
                                               ptrdiff_t ref_counter_offset,
                                               ptrdiff_t storage_offset_bytes) const {
     TORCH_CHECK(false, "Backend doesn't support StorageNewSharedDevice");
-  };
+  }
 
   virtual int64_t getIpcRefCounterFileSize() const {
     TORCH_CHECK(false, "Backend doesn't support getIpcRefCounterFileSize");
     return -1;
-  };
+  }
 };
 
 } // namespace at

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -80,8 +80,7 @@ struct TORCH_API AcceleratorHooksInterface {
     TORCH_CHECK(false, "Backend doesn't support StorageShareDevice");
   }
 
-  virtual c10::DataPtr StorageNewSharedDevice(c10::DeviceIndex device,
-                                              bool event_sync_required,
+  virtual c10::DataPtr StorageNewSharedDevice(bool event_sync_required,
                                               std::string s_ipc_event_handle,
                                               std::string s_handle,
                                               std::string ref_counter_handle,
@@ -93,6 +92,10 @@ struct TORCH_API AcceleratorHooksInterface {
   virtual int64_t getIpcRefCounterFileSize() const {
     TORCH_CHECK(false, "Backend doesn't support getIpcRefCounterFileSize");
     return -1;
+  }
+
+  virtual size_t getIpcHandleSize() const {
+    TORCH_CHECK(false, "Backend doesn't support getIpcHandleSize");
   }
 };
 

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -662,7 +662,6 @@ def libtorch_sources(gencode_pattern = ":generate-code[{}]"):
     )
 
 libtorch_cuda_core_sources = [
-    "torch/csrc/CudaIPCTypes.cpp",
     "torch/csrc/cuda/comm.cpp",
     "torch/csrc/cuda/memory_snapshot.cpp",
     "torch/csrc/cuda/CUDAPluggableAllocator.cpp",
@@ -1458,6 +1457,7 @@ aten_native_source_list = sorted(aten_native_source_non_codegen_list + aten_nati
 # These are cpp files which need to go in the torch_cuda_cu library
 # .cu files can be found via glob
 aten_cuda_cu_source_list = [
+    "aten/src/ATen/cuda/CudaIPCTypes.cpp",
     "aten/src/ATen/cuda/CUDABlas.cpp",
     "aten/src/ATen/cuda/CUDASparseBlas.cpp",
     "aten/src/ATen/cuda/CublasHandlePool.cpp",

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -16,6 +16,12 @@
 
 namespace c10 {
 
+struct IPCHandlePimpl {
+  std::string memory_handle;
+  std::string ref_counter_handle;
+  std::string event_handle;
+};
+
 struct Storage;
 
 C10_API bool isSharedStorageAlias(

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -16,12 +16,6 @@
 
 namespace c10 {
 
-struct IPCHandlePimpl {
-  std::string memory_handle;
-  std::string ref_counter_handle;
-  std::string event_handle;
-};
-
 struct Storage;
 
 C10_API bool isSharedStorageAlias(

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -63,7 +63,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
         size_bytes_(std::move(size_bytes)),
         size_bytes_is_heap_allocated_(size_bytes_.is_heap_allocated()),
         resizable_(resizable),
-        received_cuda_(false),
+        received_device_(false),
         allocator_(allocator) {
     if (resizable) {
       TORCH_INTERNAL_ASSERT(
@@ -251,12 +251,12 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
 
   // This method can be used only after storage construction and cannot be used
   // to modify storage status
-  void set_received_cuda(bool received_cuda) {
-    received_cuda_ = received_cuda;
+  void set_received_device(bool received_device) {
+    received_device_ = received_device;
   }
 
-  bool received_cuda() {
-    return received_cuda_;
+  bool received_device() {
+    return received_device_;
   }
 
   impl::PyObjectSlot* pyobj_slot() {
@@ -329,7 +329,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   bool resizable_;
   // Identifies that Storage was received from another process and doesn't have
   // local to process cuda memory allocation
-  bool received_cuda_;
+  bool received_device_;
   // All special checks in data/data_ptr calls are guarded behind this single
   // boolean. This is for performance: .data/.data_ptr calls are commonly in the
   // hot-path.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1136,6 +1136,7 @@ coverage_ignore_functions = [
     # torch.multiprocessing.reductions
     "fd_id",
     "init_reductions",
+    "rebuild_cuda_tensor",
     "rebuild_device_tensor",
     "rebuild_meta_tensor",
     "rebuild_event",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1136,7 +1136,7 @@ coverage_ignore_functions = [
     # torch.multiprocessing.reductions
     "fd_id",
     "init_reductions",
-    "rebuild_cuda_tensor",
+    "rebuild_device_tensor",
     "rebuild_meta_tensor",
     "rebuild_event",
     "rebuild_nested_tensor",

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -25,7 +25,6 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import (
     IS_CI,
     IS_JETSON,
-    IS_SANDCASTLE,
     IS_WINDOWS,
     load_tests,
     parametrize,
@@ -1267,7 +1266,7 @@ class TestDataLoader(TestCase):
         def _create_dataloader(is_train: bool) -> DataLoader[list[torch.Tensor]]:
             pass
 
-    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    #    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
     @unittest.skipIf(IS_WINDOWS, "No 'resource' module on Windows")
     def test_fd_limit_exceeded(self):
         # See NOTE [ DataLoader on Linux and open files limit ]
@@ -3125,7 +3124,7 @@ class TestDataLoaderPersistentWorkers(TestDataLoader):
         super().setUp()
         self.persistent_workers = True
 
-    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    #    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
     @unittest.skipIf(IS_WINDOWS, "No 'resource' module on Windows")
     def test_fd_limit_exceeded(self):
         # See NOTE [ DataLoader on Linux and open files limit ]
@@ -3187,7 +3186,7 @@ except RuntimeError as e:
                 # and can cache values safely
                 dataset.start = i
 
-    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    #    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
     @unittest.skipIf(IS_WINDOWS, "Needs fork")
     def test_early_exit(self):
         import subprocess

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -369,7 +369,7 @@ class TestTorchDeviceType(TestCase):
                 s0.cuda()
 
             with self.assertRaisesRegex(RuntimeError, r'only available on CUDA'):
-                s0._share_cuda_()
+                s0._share_device_()
 
             with self.assertRaisesRegex(TypeError, r"cannot pin 'torch.storage.UntypedStorage' only CPU memory can be pinned"):
                 s0.pin_memory()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2113,6 +2113,34 @@ __all__.extend(
     name for name in dir(torch) if isinstance(getattr(torch, name), torch.dtype)
 )
 
+
+################################################################################
+# Get Device Module
+################################################################################
+def get_device_module(device: _Optional[_Union[torch.device, str]] = None):
+    """
+    Returns the module associated with a given device(e.g., torch.device('cuda'), "mtia:0", "xpu", ...).
+    If no device is given, return the module for the current accelerator or CPU if none is present.
+    """
+    if isinstance(device, torch.device):
+        device_module_name = device.type
+    elif isinstance(device, str):
+        device_module_name = torch.device(device).type
+    elif device is None:
+        # Using default accelerator type. If no accelerator is available, it automatically returns CPU device.
+        device_module_name = torch._C._get_accelerator().type
+    else:
+        raise RuntimeError(
+            f"Invalid value of device '{device}', expect torch.device, str, or None"
+        )
+    device_module = getattr(torch, device_module_name, None)
+    if device_module is None:
+        raise RuntimeError(
+            f"Device '{device_module_name}' does not have a corresponding module registered as 'torch.{device_module_name}'."
+        )
+    return device_module
+
+
 ################################################################################
 # Import TorchDynamo's lazy APIs to avoid circular dependenices
 ################################################################################
@@ -2688,30 +2716,6 @@ else:
             return importlib.import_module(f".{name}", __name__)
 
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
-
-
-def get_device_module(device: _Optional[_Union[torch.device, str]] = None):
-    """
-    Returns the module associated with a given device(e.g., torch.device('cuda'), "mtia:0", "xpu", ...).
-    If no device is given, return the module for the current accelerator or CPU if none is present.
-    """
-    if isinstance(device, torch.device):
-        device_module_name = device.type
-    elif isinstance(device, str):
-        device_module_name = torch.device(device).type
-    elif device is None:
-        # Using default accelerator type. If no accelerator is available, it automatically returns CPU device.
-        device_module_name = torch._C._get_accelerator().type
-    else:
-        raise RuntimeError(
-            f"Invalid value of device '{device}', expect torch.device, str, or None"
-        )
-    device_module = getattr(torch, device_module_name, None)
-    if device_module is None:
-        raise RuntimeError(
-            f"Device '{device_module_name}' does not have a corresponding module registered as 'torch.{device_module_name}'."
-        )
-    return device_module
 
 
 def _constrain_as_size(

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -7,7 +7,9 @@
 #include <ATen/mps/MPSDevice.h>
 #include <c10/core/CPUAllocator.h>
 #include <c10/core/RefcountedDeleter.h>
+#ifdef USE_CUDA
 #include <c10/cuda/CUDACachingAllocator.h>
+#endif
 #include <libshm.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/DynamicTypes.h>

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -7,8 +7,8 @@
 #include <ATen/mps/MPSDevice.h>
 #include <c10/core/CPUAllocator.h>
 #include <c10/core/RefcountedDeleter.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 #include <libshm.h>
-#include <torch/csrc/CudaIPCTypes.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/StorageMethods.h>

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -7,7 +7,6 @@
 #include <c10/core/CPUAllocator.h>
 #include <c10/util/overflows.h>
 #include <libshm.h>
-#include <torch/csrc/CudaIPCTypes.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/THP.h>

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -5,7 +5,6 @@
 #include <structmember.h>
 
 #include <c10/core/CPUAllocator.h>
-#include <c10/core/Storage.h>
 #include <libshm.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/DynamicTypes.h>
@@ -317,19 +316,21 @@ static PyObject* THPStorage_shareDevice(PyObject* self, PyObject* noargs) {
         [ipc_memory_handle_size,
          ipc_event_handle_size,
          offset_bytes,
+         memory_handle,
+         event_handle,
+         ref_counter,
          ref_counter_offset,
-         event_sync_required,
-         ipc_handles] = at::globalContext()
-                            .getAcceleratorHooksInterface()
-                            .StorageShareDevice(storage);
+         event_sync_required] = at::globalContext()
+                                    .getAcceleratorHooksInterface()
+                                    .StorageShareDevice(storage);
 
     _handle = PyBytes_FromStringAndSize(
-        ipc_handles.memory_handle.c_str(), ipc_memory_handle_size);
+        memory_handle.c_str(), ipc_memory_handle_size);
     _offset_bytes = PyLong_FromSsize_t((Py_ssize_t)offset_bytes);
-    _ref_counter = PyBytes_FromString(ipc_handles.ref_counter_handle.c_str());
+    _ref_counter = PyBytes_FromString(ref_counter.c_str());
     _ref_counter_offset = THPUtils_packUInt64(ref_counter_offset);
-    _event_handle = PyBytes_FromStringAndSize(
-        ipc_handles.event_handle.c_str(), ipc_event_handle_size);
+    _event_handle =
+        PyBytes_FromStringAndSize(event_handle.c_str(), ipc_event_handle_size);
     _event_sync_required = PyBool_FromLong(event_sync_required);
   }
 

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -5,6 +5,7 @@
 #include <structmember.h>
 
 #include <c10/core/CPUAllocator.h>
+#include <c10/core/Storage.h>
 #include <libshm.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/DynamicTypes.h>
@@ -316,21 +317,19 @@ static PyObject* THPStorage_shareDevice(PyObject* self, PyObject* noargs) {
         [ipc_memory_handle_size,
          ipc_event_handle_size,
          offset_bytes,
-         memory_handle,
-         event_handle,
-         ref_counter,
          ref_counter_offset,
-         event_sync_required] = at::globalContext()
-                                    .getAcceleratorHooksInterface()
-                                    .StorageShareDevice(storage);
+         event_sync_required,
+         ipc_handles] = at::globalContext()
+                            .getAcceleratorHooksInterface()
+                            .StorageShareDevice(storage);
 
     _handle = PyBytes_FromStringAndSize(
-        memory_handle.c_str(), ipc_memory_handle_size);
+        ipc_handles.memory_handle.c_str(), ipc_memory_handle_size);
     _offset_bytes = PyLong_FromSsize_t((Py_ssize_t)offset_bytes);
-    _ref_counter = PyBytes_FromString(ref_counter.c_str());
+    _ref_counter = PyBytes_FromString(ipc_handles.ref_counter_handle.c_str());
     _ref_counter_offset = THPUtils_packUInt64(ref_counter_offset);
-    _event_handle =
-        PyBytes_FromStringAndSize(event_handle.c_str(), ipc_event_handle_size);
+    _event_handle = PyBytes_FromStringAndSize(
+        ipc_handles.event_handle.c_str(), ipc_event_handle_size);
     _event_sync_required = PyBool_FromLong(event_sync_required);
   }
 

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -6,7 +6,6 @@
 
 #include <c10/core/CPUAllocator.h>
 #include <libshm.h>
-#include <torch/csrc/CudaIPCTypes.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/THP.h>
@@ -19,12 +18,8 @@
 #include <torch/csrc/Storage.h>
 #include <torch/csrc/StorageSharing.h>
 
-#ifdef USE_CUDA
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda.h>
-#include <cuda_runtime.h>
-#endif
-
+#include <ATen/DeviceAccelerator.h>
+#include <ATen/DeviceGuard.h>
 #include <ATen/MapAllocator.h>
 #include <ATen/StorageUtils.h>
 #include <torch/csrc/utils/python_numbers.h>
@@ -283,20 +278,22 @@ static PyObject* THPStorage_newSharedFd(PyObject* _unused, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPStorage_shareCuda(PyObject* self, PyObject* noargs) {
+static PyObject* THPStorage_shareDevice(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   THPStorage_assertNotNull(self);
-#ifdef USE_CUDA
   const auto& storage = THPStorage_Unpack(self);
+  auto current_device = at::getAccelerator(true).value();
   TORCH_CHECK(
-      storage.device_type() == at::kCUDA,
-      "_share_cuda_: only available on CUDA");
-  c10::StorageImpl* storage_impl = storage.unsafeGetStorageImpl();
+      storage.device_type() == current_device,
+      "_share_device_: only available on ",
+      c10::DeviceTypeName(current_device, false));
 
-  if (storage_impl->received_cuda()) {
-    TORCH_CHECK(
-        false,
-        "Attempted to send CUDA tensor received from another process; this is not currently supported. Consider cloning before sending.");
+  c10::StorageImpl* storage_impl = storage.unsafeGetStorageImpl();
+  if (storage_impl->received_device()) {
+    AT_ERROR(
+        "Attempted to send ",
+        current_device,
+        " tensor received from another process; this is not currently supported. Consider cloning before sending.");
   }
 
   at::DeviceGuard device_guard(storage.device());
@@ -313,35 +310,28 @@ static PyObject* THPStorage_shareCuda(PyObject* self, PyObject* noargs) {
   Py_INCREF(Py_None);
   THPObjectPtr _event_sync_required(Py_None);
   Py_INCREF(Py_None);
+
   if (storage.data()) {
-    auto shandle =
-        c10::cuda::CUDACachingAllocator::shareIpcHandle(storage.mutable_data());
+    auto
+        [ipc_memory_handle_size,
+         ipc_event_handle_size,
+         offset_bytes,
+         memory_handle,
+         event_handle,
+         ref_counter,
+         ref_counter_offset,
+         event_sync_required] = at::globalContext()
+                                    .getAcceleratorHooksInterface()
+                                    .StorageShareDevice(storage);
+
     _handle = PyBytes_FromStringAndSize(
-        shandle.handle.c_str(), (Py_ssize_t)shandle.handle.size());
-    _offset_bytes = PyLong_FromSsize_t((Py_ssize_t)shandle.offset);
-
-    // Put Storage Data behind new ref counting context
-    // See Note [CUDA IPC Refcounting implementation explained]
-    at::DataPtr sent_data_ptr = torch::GetNewRefCountedSentData(
-        storage.mutable_data(), storage.device());
-    auto old_data_ptr = storage.set_data_ptr(std::move(sent_data_ptr));
-    auto sent_data =
-        static_cast<torch::CudaIPCSentData*>(storage.data_ptr().get_context());
-    sent_data->set_original_ptr(std::move(old_data_ptr));
-    _ref_counter = PyBytes_FromString((sent_data->handle()).c_str());
-    _ref_counter_offset = THPUtils_packUInt64(sent_data->offset());
-
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    cudaIpcEventHandle_t ipc_event_handle;
-
-    if (sent_data->event_sync_required_) {
-      C10_CUDA_CHECK(
-          cudaIpcGetEventHandle(&ipc_event_handle, sent_data->event_));
-    }
-
-    _event_handle = PyBytes_FromStringAndSize(
-        (char*)&ipc_event_handle, CUDA_IPC_HANDLE_SIZE);
-    _event_sync_required = PyBool_FromLong(sent_data->event_sync_required_);
+        memory_handle.c_str(), ipc_memory_handle_size);
+    _offset_bytes = PyLong_FromSsize_t((Py_ssize_t)offset_bytes);
+    _ref_counter = PyBytes_FromString(ref_counter.c_str());
+    _ref_counter_offset = THPUtils_packUInt64(ref_counter_offset);
+    _event_handle =
+        PyBytes_FromStringAndSize(event_handle.c_str(), ipc_event_handle_size);
+    _event_sync_required = PyBool_FromLong(event_sync_required);
   }
 
   if (!tuple || !device || !_handle || !size_bytes || !_offset_bytes ||
@@ -365,9 +355,6 @@ static PyObject* THPStorage_shareCuda(PyObject* self, PyObject* noargs) {
   PyTuple_SET_ITEM(tuple.get(), 6, _event_handle.release());
   PyTuple_SET_ITEM(tuple.get(), 7, _event_sync_required.release());
   return tuple.release();
-#else
-  TORCH_CHECK(false, "CUDA is not available");
-#endif
   END_HANDLE_TH_ERRORS
 }
 
@@ -375,16 +362,18 @@ static PyObject* THPStorage_releaseIPCCounter(
     PyObject* _unused,
     PyObject* args) {
   HANDLE_TH_ERRORS
-#ifdef USE_CUDA
   TORCH_CHECK(PyTuple_GET_SIZE(args) == 2, "tuple of 2 items expected");
   PyObject* _ref_counter = PyTuple_GET_ITEM(args, 0);
   PyObject* _ref_counter_offset = PyTuple_GET_ITEM(args, 1);
+  auto device_type = at::getAccelerator(true).value();
   if (!(PyBytes_Check(_ref_counter) &&
         THPUtils_checkLong(_ref_counter_offset))) {
+    std::string function_name = "_release_ipc_counter in " +
+        c10::DeviceTypeName(device_type, false) + " mode";
     THPUtils_invalidArguments(
         args,
         nullptr,
-        "_release_ipc_counter in CUDA mode",
+        function_name.c_str(),
         1,
         "(bytes _ref_counter, int _ref_counter_offset)");
     return nullptr;
@@ -397,38 +386,36 @@ static PyObject* THPStorage_releaseIPCCounter(
   // before consumer released data.
   int flags = at::ALLOCATOR_MAPPED_SHAREDMEM | at::ALLOCATOR_MAPPED_NOCREATE;
   try {
+    int64_t ref_counter_file_size = at::globalContext()
+                                        .getAcceleratorHooksInterface()
+                                        .getIpcRefCounterFileSize();
+
     auto sptr = at::RefcountedMapAllocator::makeDataPtr(
         ref_counter_handle.c_str(),
         flags,
-        sizeof(int64_t) * torch::CUDA_IPC_REF_COUNTER_FILE_SIZE,
+        sizeof(int64_t) * ref_counter_file_size,
         nullptr);
     *(static_cast<int64_t*>(sptr.get()) + ref_counter_offset) -= 1;
   } catch (c10::Error& err) {
     // Already warned inside of producer process
   }
   Py_RETURN_NONE;
-#else
-  TORCH_CHECK(false, "CUDA is not available");
-#endif
   END_HANDLE_TH_ERRORS
 }
 
-#ifdef USE_CUDA
 static std::string THPStorage_bytesAsHandleString(PyObject* handle) {
   HANDLE_TH_ERRORS
   char* buffer = nullptr;
   Py_ssize_t handle_size = 0;
   if (PyBytes_AsStringAndSize(handle, &buffer, &handle_size) == -1) {
-    TORCH_CHECK(handle_size == CUDA_IPC_HANDLE_SIZE, "incorrect handle");
+    TORCH_CHECK(false, "incorrect handle");
   }
   return std::string(buffer, handle_size);
   END_HANDLE_TH_ERRORS_RET("")
 }
-#endif
 
-static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
+static PyObject* THPStorage_newSharedDevice(PyObject* _unused, PyObject* args) {
   HANDLE_TH_ERRORS
-#ifdef USE_CUDA
   TORCH_CHECK(PyTuple_GET_SIZE(args) == 8, "tuple of 8 items expected");
   PyObject* _device = PyTuple_GET_ITEM(args, 0);
   PyObject* _handle = PyTuple_GET_ITEM(args, 1);
@@ -438,15 +425,18 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
   PyObject* _ref_counter_offset = PyTuple_GET_ITEM(args, 5);
   PyObject* _event_handle = PyTuple_GET_ITEM(args, 6);
   PyObject* _event_sync_required = PyTuple_GET_ITEM(args, 7);
+  auto device_type = at::getAccelerator(true).value();
   if (!(THPUtils_checkLong(_device) && THPUtils_checkLong(_size_bytes) &&
         PyBytes_Check(_handle) && PyBytes_Check(_ref_counter) &&
         PyBytes_Check(_event_handle) && THPUtils_checkLong(_offset_bytes) &&
         THPUtils_checkLong(_ref_counter_offset) &&
         PyBool_Check(_event_sync_required))) {
+    std::string function_name =
+        "_new_shared in " + c10::DeviceTypeName(device_type, false) + " mode";
     THPUtils_invalidArguments(
         args,
         nullptr,
-        "_new_shared in CUDA mode",
+        function_name.c_str(),
         1,
         "(int device, bytes handle, int storage_size_bytes, int storage_offset_bytes, bytes _ref_counter, int _ref_counter_offset, bytes event_handle, bool event_sync_required)");
     return nullptr;
@@ -456,98 +446,31 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
       (size_t)THPUtils_unpackLong(_size_bytes) / sizeof(uint8_t);
   ptrdiff_t storage_offset_bytes =
       (ptrdiff_t)THPUtils_unpackLong(_offset_bytes);
-
-  const auto device = c10::checked_convert<c10::DeviceIndex>(
+  const auto device_index = c10::checked_convert<c10::DeviceIndex>(
       THPUtils_unpackLong(_device), "c10::DeviceIndex");
-  at::cuda::CUDAGuard device_guard(device);
-
-  if (PyObject_IsTrue(_event_sync_required)) {
-    // Ensure that producer prepared all tensor's data
-    std::string s_ipc_event_handle =
-        THPStorage_bytesAsHandleString(_event_handle);
-    if (s_ipc_event_handle.empty()) {
-      return nullptr;
-    }
-    auto ipc_event_handle = reinterpret_cast<const cudaIpcEventHandle_t*>(
-        s_ipc_event_handle.c_str());
-    cudaEvent_t event = nullptr;
-    C10_CUDA_CHECK(cudaIpcOpenEventHandle(&event, *ipc_event_handle));
-    C10_CUDA_CHECK(
-        cudaStreamWaitEvent(c10::cuda::getCurrentCUDAStream(device), event, 0));
-  }
-
-  std::string s_handle = THPStorage_bytesAsHandleString(_handle);
-  if (s_handle.empty()) {
+  auto device = at::Device(device_type, device_index);
+  at::DeviceGuard device_guard(device);
+  std::string s_ipc_event_handle =
+      THPStorage_bytesAsHandleString(_event_handle);
+  bool event_sync_required = PyObject_IsTrue(_event_sync_required);
+  if (event_sync_required && s_ipc_event_handle.empty())
     return nullptr;
-  }
-  std::shared_ptr<void> basePtr =
-      c10::cuda::CUDACachingAllocator::getIpcDevPtr(s_handle);
-
-  // Offset the basePtr to reconstruct the real storage
-  // devPtr = basePtr + storage_offset
-  void* devPtr = basePtr.get();
-  devPtr = (char*)devPtr + storage_offset_bytes;
-
+  std::string s_handle = THPStorage_bytesAsHandleString(_handle);
   std::string ref_counter_handle = PyBytes_AS_STRING(_ref_counter);
   ptrdiff_t ref_counter_offset =
       (ptrdiff_t)THPUtils_unpackLong(_ref_counter_offset);
 
-  struct IpcDeleterContext {
-    std::string ref_counter_handle;
-    ptrdiff_t ref_counter_offset{};
-    c10::DeviceIndex device{-1};
-    torch::CudaIPCReceivedData received_data;
-  };
-
-  auto ctx = std::make_unique<IpcDeleterContext>();
-  ctx->ref_counter_handle = std::move(ref_counter_handle);
-  ctx->ref_counter_offset = ref_counter_offset;
-  ctx->device = device;
-  ctx->received_data.shared_ptr_ = std::move(basePtr);
-
-  auto cur_device = at::cuda::current_device();
-  c10::DataPtr data_ptr(
-      devPtr,
-      ctx.release(),
-      +[](void* ctx_) {
-        std::unique_ptr<IpcDeleterContext> ctx(
-            static_cast<IpcDeleterContext*>(ctx_));
-        ctx->received_data.shared_ptr_.reset();
-
-        // Sync default stream to make sure all operations related to the
-        // storage is finished (otherwise another process may reuse memory and
-        // corrupt data)
-
-        // Ideally all shared memory reference counting could be replaced by
-        // sending untriggered CUDA event from the producer to consumer and
-        // using this event as the criteria of memory release. However, CUDA
-        // (atm 10.1) does not support the creation of untriggered events and
-        // performance impact of having thousands of shared events is unknown.
-
-        // TODO: Instead of cudaStreamSynchronize it is possible to add Stream
-        // Callback and release counter inside of it (need to check performance
-        // impact)
-        at::cuda::stream_synchronize(
-            c10::cuda::getCurrentCUDAStream(ctx->device));
-
-        // We don't want to break existing code, so resource deletion is best
-        // effort basis. Exception expected if producer process terminated
-        // before consumer released data.
-        int flags =
-            at::ALLOCATOR_MAPPED_SHAREDMEM | at::ALLOCATOR_MAPPED_NOCREATE;
-        try {
-          auto sptr = at::RefcountedMapAllocator::makeDataPtr(
-              ctx->ref_counter_handle.c_str(),
-              flags,
-              sizeof(int64_t) * torch::CUDA_IPC_REF_COUNTER_FILE_SIZE,
-              nullptr);
-          *(static_cast<int64_t*>(sptr.get()) + ctx->ref_counter_offset) -= 1;
-        } catch (c10::Error& err) {
-          // Already warned inside of producer process
-        }
-      },
-      at::Device(at::DeviceType::CUDA, cur_device));
-
+  auto data_ptr =
+      at::globalContext().getAcceleratorHooksInterface().StorageNewSharedDevice(
+          device_index,
+          event_sync_required,
+          s_ipc_event_handle,
+          s_handle,
+          ref_counter_handle,
+          ref_counter_offset,
+          storage_offset_bytes);
+  if (s_handle.empty())
+    return nullptr;
   auto base = c10::make_intrusive<at::StorageImpl>(
       c10::StorageImpl::use_byte_size_t(),
       storage_size,
@@ -556,15 +479,12 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
       /*resizable=*/false);
 
   base->set_resizable(false);
-  base->set_received_cuda(true);
 
+  base->set_received_device(true);
   return THPStorage_NewWithStorage(
       THPStorageClass,
       std::move(base),
       c10::impl::PyInterpreterStatus::TAGGED_BY_US);
-#else
-  TORCH_CHECK(false, "CUDA is not available");
-#endif
   END_HANDLE_TH_ERRORS
 }
 
@@ -649,12 +569,12 @@ static PyMethodDef THPStorage_sharingMethods[] = {
      THPStorage_newWithWeakPtr,
      METH_O | METH_CLASS,
      nullptr},
-    {"_share_cuda_", THPStorage_shareCuda, METH_NOARGS, nullptr},
-    {"_new_shared_cuda",
-     THPStorage_newSharedCuda,
+    {"_share_device_", THPStorage_shareDevice, METH_NOARGS, nullptr},
+    {"_new_shared_device",
+     THPStorage_newSharedDevice,
      METH_VARARGS | METH_STATIC,
      nullptr},
-    {"_release_ipc_counter_cuda",
+    {"_release_ipc_counter_device",
      THPStorage_releaseIPCCounter,
      METH_VARARGS | METH_STATIC,
      nullptr},

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -16,6 +16,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <ATen/cuda/CachingHostAllocator.h>
+#include <ATen/cuda/CudaIPCTypes.h>
 #include <ATen/cuda/Sleep.h>
 #include <ATen/cuda/detail/CUDAHooks.h>
 #include <ATen/cuda/jiterator.h>
@@ -31,7 +32,6 @@
 #endif
 #include <c10/util/irange.h>
 
-#include <torch/csrc/CudaIPCTypes.h>
 #include <torch/csrc/Generator.h>
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
 #include <torch/csrc/cuda/GdsFile.h>
@@ -469,7 +469,7 @@ PyObject* THCPModule_cudaSynchronize(PyObject* _unused, PyObject* noargs) {
 
 PyObject* THCPModule_cudaIPCCollect(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  torch::CudaIPCCollect();
+  at::cuda::ipc::CudaIPCCollect();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -5,7 +5,7 @@ import threading
 from multiprocessing import reduction
 from multiprocessing.util import register_after_fork
 from typing import Union
-from typing_extensions import deprecated
+from typing_extensions import deprecated as _deprecated
 
 import torch
 from torch._namedtensor_internals import check_serializing_named_tensor
@@ -153,7 +153,7 @@ def rebuild_meta_tensor(
     return t
 
 
-@deprecated(
+@_deprecated(
     "`torch.multiprocessing.reductions.rebuild_cuda_tensor` is deprecated."
     "Please use `torch.multiprocessing.reductions.rebuild_device_tensor` instead.",
     category=FutureWarning,

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -5,6 +5,7 @@ import threading
 from multiprocessing import reduction
 from multiprocessing.util import register_after_fork
 from typing import Union
+from typing_extensions import deprecated
 
 import torch
 from torch._namedtensor_internals import check_serializing_named_tensor
@@ -150,6 +151,47 @@ def rebuild_meta_tensor(
         t.requires_grad = requires_grad
 
     return t
+
+
+@deprecated(
+    "`torch.multiprocessing.reductions.rebuild_cuda_tensor` is deprecated."
+    "Please use `torch.multiprocessing.reductions.rebuild_device_tensor` instead.",
+    category=FutureWarning,
+)
+def rebuild_cuda_tensor(
+    tensor_cls,
+    tensor_size,
+    tensor_stride,
+    tensor_offset,
+    storage_cls,
+    dtype,
+    storage_device,
+    storage_handle,
+    storage_size_bytes,
+    storage_offset_bytes,
+    requires_grad,
+    ref_counter_handle,
+    ref_counter_offset,
+    event_handle,
+    event_sync_required,
+):
+    return rebuild_device_tensor(
+        tensor_cls,
+        tensor_size,
+        tensor_stride,
+        tensor_offset,
+        storage_cls,
+        dtype,
+        storage_device,
+        storage_handle,
+        storage_size_bytes,
+        storage_offset_bytes,
+        requires_grad,
+        ref_counter_handle,
+        ref_counter_offset,
+        event_handle,
+        event_sync_required,
+    )
 
 
 def rebuild_device_tensor(

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -151,7 +151,7 @@ class _StorageBase:
         raise NotImplementedError
 
     @classmethod
-    def _release_ipc_counter_cuda(cls, *args, **kwargs) -> Self:
+    def _release_ipc_counter_device(cls, *args, **kwargs) -> Self:
         raise NotImplementedError
 
     @classmethod
@@ -176,14 +176,14 @@ class _StorageBase:
     def _set_cdata(self, *args, **kwargs):
         raise NotImplementedError
 
-    def _share_cuda_(self, *args, **kwargs):
+    def _share_device_(self, *args, **kwargs):
         raise NotImplementedError
 
     def is_shared(self) -> _bool:
         raise NotImplementedError
 
     @classmethod
-    def _new_shared_cuda(cls, *args, **kwargs) -> Self:
+    def _new_shared_device(cls, *args, **kwargs) -> Self:
         raise NotImplementedError
 
     def _shared_incref(self, *args, **kwargs):
@@ -1432,8 +1432,8 @@ class TypedStorage:
     def _set_cdata(self, *args, **kwargs):
         return self._untyped_storage._set_cdata(*args, **kwargs)
 
-    def _share_cuda_(self, *args, **kwargs):
-        return self._untyped_storage._share_cuda_(*args, **kwargs)
+    def _share_device_(self, *args, **kwargs):
+        return self._untyped_storage._share_device_(*args, **kwargs)
 
     def is_shared(self):
         _warn_typed_storage_removal()
@@ -1444,8 +1444,8 @@ class TypedStorage:
         return self._untyped_storage.is_shared()
 
     @classmethod
-    def _new_shared_cuda(cls, *args, **kwargs):
-        return torch.UntypedStorage._new_shared_cuda(*args, **kwargs)
+    def _new_shared_device(cls, *args, **kwargs):
+        return torch.UntypedStorage._new_shared_device(*args, **kwargs)
 
     def _share_filename_cpu_(self, *args, **kwargs):
         (
@@ -1460,8 +1460,8 @@ class TypedStorage:
         return self
 
     @classmethod
-    def _release_ipc_counter(cls, *args, device=None, **kwargs):
-        return torch.UntypedStorage._release_ipc_counter_cuda(*args, **kwargs)
+    def _release_ipc_counter(cls, *args, **kwargs):
+        return torch.UntypedStorage._release_ipc_counter_device(*args, **kwargs)
 
     def _shared_incref(self, *args, **kwargs):
         return self._untyped_storage._shared_incref(*args, **kwargs)
@@ -1521,7 +1521,7 @@ class _LegacyStorage(TypedStorage, metaclass=_LegacyStorageMeta):
 
     @classmethod
     def _release_ipc_counter(cls, *args, **kwargs):
-        return torch.UntypedStorage._release_ipc_counter_cuda(*args, **kwargs)
+        return torch.UntypedStorage._release_ipc_counter_device(*args, **kwargs)
 
     @classmethod
     def _new_shared_filename(cls, manager, obj, size):


### PR DESCRIPTION
Fixes #133210
Currently, tensor inter-process communication only supports cuda device. I hope to refactor this part of the code to be compatible with third-party device IPC features.

This PR makes IPC features extendable on third-party devices, and by the way fixed the bug that there is no cudaEventDestroy after calling cudaIpcOpenEventHandle.
