### PR TITLE
Migrate nightly.yml to use runner determinator

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,20 +17,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-label-type:
+    name: get-label-type
+    uses: ./.github/workflows/_runner-determinator.yml
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+
   docs-build:
     name: docs build
     uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
     with:
-      runner: "amz2023.linux.2xlarge"
+      runner: "${{ needs.get-label-type.outputs.label-type }}amz2023.linux.2xlarge"
       build-environment: linux-jammy-py3.8-gcc11
       docker-image-name: pytorch-linux-jammy-py3.8-gcc11
 
   docs-push:
     name: docs push
     uses: ./.github/workflows/_docs.yml
-    needs: docs-build
+    needs:
+      - docs-build
+      - get-label-type
     with:
-      runner_prefix: "amz2023."
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       build-environment: linux-jammy-py3.8-gcc11
       docker-image: ${{ needs.docs-build.outputs.docker-image }}
       push: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.event.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Updates the nightly.yml jobs to use the runner determinator script.

Closes: pytorch/ci-infra#260
