### PR TITLE
Pin sympy to 1.13.1

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -315,6 +315,6 @@ PyGithub==2.3.0
 
 sympy==1.12.1 ; python_version == "3.8"
 sympy==1.13.1 ; python_version >= "3.9"
-#Description: The Z3 Theorem Prover Project
+#Description: Required by coremltools, also pinned in .github/requirements/pip-requirements-macOS.txt
 #Pinned versions:
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -312,3 +312,9 @@ lxml==5.0.0
 # Python-3.9 binaries
 
 PyGithub==2.3.0
+
+sympy==1.12.1 ; python_version == "3.8"
+sympy==1.13.1 ; python_version >= "3.9"
+#Description: The Z3 Theorem Prover Project
+#Pinned versions:
+#test that import:

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -18,7 +18,7 @@ pytest-rerunfailures==10.3
 pytest-flakefinder==1.1.0
 scipy==1.10.1
 sympy==1.12.1 ; python_version == "3.8"
-sympy>=1.13.0 ; python_version >= "3.9"
+sympy==1.13.1 ; python_version >= "3.9"
 unittest-xml-reporting<=3.2.0,>=2.0.0
 xdoctest==1.1.0
 filelock==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ setuptools
 types-dataclasses
 typing-extensions>=4.8.0
 sympy==1.12.1 ; python_version == "3.8"
-sympy>=1.13.0 ; python_version >= "3.9"
+sympy==1.13.1 ; python_version >= "3.9"
 filelock
 networkx
 jinja2

--- a/setup.py
+++ b/setup.py
@@ -1138,7 +1138,7 @@ def main():
         "filelock",
         "typing-extensions>=4.8.0",
         'sympy==1.12.1 ; python_version == "3.8"',
-        'sympy>=1.13.0 ; python_version >= "3.9"',
+        'sympy==1.13.1 ; python_version >= "3.9"',
         "networkx",
         "jinja2",
         "fsspec",


### PR DESCRIPTION
Sympy 1.13.2 release yesterday, and it results in test failures on windows and mac

https://hud.pytorch.org/hud/pytorch/pytorch/454713fe9d11c3b70c28f1aaba74f5158f92d1ec/1?per_page=100

Hopefully these are the places it needs to get pinned