### PR TITLE
Add a reference for the LRScheduler class

### DIFF
--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -223,7 +223,7 @@ Below table is showing the stability status for fused implementations:
 How to adjust learning rate
 ---------------------------
 
-:mod:`torch.optim.lr_scheduler` provides several methods to adjust the learning
+:class:`torch.optim.lr_scheduler.LRScheduler` provides several methods to adjust the learning
 rate based on the number of epochs. :class:`torch.optim.lr_scheduler.ReduceLROnPlateau`
 allows dynamic learning rate reducing based on some validation measurements.
 
@@ -286,6 +286,7 @@ algorithms.
     :toctree: generated
     :nosignatures:
 
+    lr_scheduler.LRScheduler
     lr_scheduler.LambdaLR
     lr_scheduler.MultiplicativeLR
     lr_scheduler.StepLR


### PR DESCRIPTION
The `LRScheduler` class provides methods to adjusts the learning rate during optimization (as updated in this PR). Also, as a note, all the classes of lr_scheduluer are already provided in the `How to adjust learning rate` section.

Fixes #127884
