### PR TITLE
[inductor] Fix test_codecache::test_inductor_counters

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -9,6 +9,7 @@ from typing import List
 from unittest import mock
 
 import torch
+import torch._inductor.compile_fx
 from torch._dynamo import reset
 from torch._dynamo.utils import counters
 from torch._inductor import config, metrics
@@ -26,10 +27,7 @@ from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import clear_inductor_caches, fresh_inductor_cache
 from torch.testing._internal.common_cuda import SM80OrLater
-from torch.testing._internal.common_device_type import (
-    expectedFailureXPU,
-    largeTensorTest,
-)
+from torch.testing._internal.common_device_type import largeTensorTest
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -443,39 +441,54 @@ class TestFxGraphCache(TestCase):
         self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
         self.assertEqual(metrics.generated_kernel_count, 2)
 
-    @expectedFailureXPU
-    @requires_gpu()
-    @requires_triton()
-    @config.patch({"max_autotune": True})
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})
     def test_inductor_counters(self):
         """
         Test that we bump the inductor counters on a cache hit.
         """
+        compile_to_fn = torch._inductor.graph.GraphLowering.compile_to_fn
 
-        def fn(a, b):
-            return torch.mm(a, b)
+        counter_name = "a_test_counter"
+        counter_incr = 7
 
-        a = torch.rand(8, 32, device=GPU_TYPE)
-        b = torch.rand(32, 8, device=GPU_TYPE)
+        def bump_counter(self):
+            # Mock that bumps some arbitrary test counter by a set amount, then calls
+            # the original GraphLowering.compile_to_fn.
+            counters["inductor"][counter_name] += counter_incr
+            return compile_to_fn(self)
 
-        compiled_fn = torch.compile(fn)
+        with mock.patch.object(
+            torch._inductor.graph.GraphLowering, "compile_to_fn", bump_counter
+        ) as mocked:
 
-        counters.clear()
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 0)
+            def fn(a, b):
+                return torch.mm(a, b)
 
-        # Verify the "miss" case.
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+            a = torch.rand(8, 32, device="cpu")
+            b = torch.rand(32, 8, device="cpu")
 
-        # Verify the "hit" case
-        self.reset()
-        counters.clear()
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+            compiled_fn = torch.compile(fn)
+
+            # Verify the "miss" case.
+            counter_val = 2
+            counters["inductor"][counter_name] = counter_val
+            self.assertEqual(fn(a, b), compiled_fn(a, b))
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+            self.assertEqual(
+                counters["inductor"][counter_name], counter_val + counter_incr
+            )
+            mocked.assert_called_once()
+
+            # Verify the "hit" case.
+            self.reset()
+            counter_val = 5
+            counters["inductor"][counter_name] = counter_val
+            self.assertEqual(fn(a, b), compiled_fn(a, b))
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+            self.assertEqual(
+                counters["inductor"][counter_name], counter_val + counter_incr
+            )
 
     @config.patch({"fx_graph_cache": True})
     @config.patch({"fx_graph_remote_cache": False})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133244

Summary: This test is flakey internally, but it's not a great test in the first place since it's relying on the max-autotune step to bump a related counter. Instead of doing that, directly install a mock that bumps a counter specifically for this test. Additionally, test that the caching logic correctly accommodates an arbitrary counter delta (previously the relevant counter is only bumped by +1).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang

Differential Revision: [D61141164](https://our.internmc.facebook.com/intern/diff/D61141164)