### PR TITLE
[AMD][EMU1.4] Add TORCHINDUCTOR_DISABLE_EPILOGUE_FUSION env

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -102,7 +102,7 @@ memory_pool = os.environ.get("TORCHINDUCTOR_MEMORY_POOL", "intermediates")
 benchmark_harness = True
 
 # fuse pointwise into templates
-epilogue_fusion = True
+epilogue_fusion = not (os.environ.get("TORCHINDUCTOR_DISABLE_EPILOGUE_FUSION", "0") == "1")
 
 # do epilogue fusions before other fusions
 epilogue_fusion_first = False


### PR DESCRIPTION
Summary:
config `epilogue_fusion` is enabled by default and currently there is no way to disable it without changing code.

We found that currently on AMD, for a LDM, epilogue_fusion will cause output image to be all black with PT2 max-autotune. Disabling epilogue_fusion recovers output images.

This is definitely a bug in epilogue fusion, which we will plan to fix. This diff adds environment variable TORCHINDUCTOR_DISABLE_EPILOGUE_FUSION to optionally disable epilogue fusion at command line

Test Plan: Manual examining LDM output images.

Differential Revision: D61139343


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang