### PR TITLE
Back out "enable comprehensive padding internally"

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -585,7 +585,8 @@ shape_padding = os.environ.get("TORCHINDUCTOR_SHAPE_PADDING", "1") == "1"
 
 # Control if we will do padding for pointwise/reductions
 comprehensive_padding = (
-    os.environ.get("TORCHINDUCTOR_COMPREHENSIVE_PADDING", "1") == "1"
+    os.environ.get("TORCHINDUCTOR_COMPREHENSIVE_PADDING", "0" if is_fbcode() else "1")
+    == "1"
 )
 pad_channels_last = False
 


### PR DESCRIPTION
Summary:
Original commit changeset: 70bd0d52a409

Original Phabricator Diff: D58425432

Test Plan:
Reverting diff. Multiple model failing, one example failing model:
```
buck2 run mode/opt  -c fbcode.enable_gpu_sections=true -c fbcode.platform=platform010  -c fbcode.nvcc_arch=a100 caffe2/torch/fb/model_transform/experimental/benchmark:mts_gpu_benchmark -- --model-path /home/mlee8/models/587752901_1.input.predictor.disagg.gpu.merge --lower-backend=AOT_INDUCTOR --disable-acc-tracer=True --preset-lowerer disable_new_lowering_weights --aot-inductor-config="{'max_autotune': True , 'aot_inductor.use_runtime_constant_folding': True}"
```

Differential Revision: D61145494


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @ColinPeppler @amjames @desertfire @chauhang