### PR TITLE
[DTensor] Add more aten._foreach ops to _pointwise_ops.py

### DIFF
--- a/torch/distributed/_tensor/ops/_pointwise_ops.py
+++ b/torch/distributed/_tensor/ops/_pointwise_ops.py
@@ -565,11 +565,21 @@ for_each_ops = [
     aten._foreach_neg.default,
     aten._foreach_neg_.default,
     aten._foreach_reciprocal_.default,
-    aten._foreach_sub.List,
+    aten._foreach_sub.Scalar,
     aten._foreach_sub_.Scalar,
+    aten._foreach_sub.List,
+    aten._foreach_sub_.List,
+    aten._foreach_sub.ScalarList,
+    aten._foreach_sub_.ScalarList,
     aten._foreach_sqrt.default,
     aten._foreach_sqrt_.default,
     aten._foreach_zero_.default,
+    aten._foreach_exp.default,
+    aten._foreach_exp_.default,
+    aten._foreach_cos.default,
+    aten._foreach_cos_.default,
+    aten._foreach_log.default,
+    aten._foreach_log_.default,
 ]
 
 for_each_linearity_ops = [


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

Follow up for https://github.com/pytorch/pytorch/pull/132056. Added the missing foreach ops pointed out by @ad8e. 

```
_foreach_sub.Scalar
_foreach_exp
_foreach_exp_
_foreach_cos_
_foreach_log_
```

As @ad8e mentioned, since the list of _foreach ops at https://pytorch.org/cppdocs/api/library_root.html is long and overload-heavy, it could be annoying to manually keep this file updated. We might need to come up with a way to update the list and add associated tests systematically. 

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l