### PR TITLE
Prototype changes to create fake checkpoints with empty storages

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -392,6 +392,7 @@ class Tensor(torch._C.TensorBase):
                 )
                 or self.data_ptr() == 0
             )
+            and self.untyped_storage()._serialize_data
         ):
             arg_wrapper_subclass = (
                 type(self),

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -989,7 +989,10 @@ def _save(obj, zip_file, pickle_module, pickle_protocol, _disable_byteorder_reco
                     storage_dtypes[storage.data_ptr()] = storage_dtype
 
             storage_key = id_map.setdefault(storage._cdata, str(len(id_map)))
-            location = location_tag(storage)
+            if hasattr(storage, "_fake_device"):
+                location = str(storage._fake_device)
+            else:
+                location = location_tag(storage)
             serialized_storages[storage_key] = storage
 
             return ("storage", storage_type, storage_key, location, storage_numel)
@@ -1015,14 +1018,17 @@ def _save(obj, zip_file, pickle_module, pickle_protocol, _disable_byteorder_reco
     for key in sorted(serialized_storages.keys()):
         name = f"data/{key}"
         storage = serialized_storages[key]
+        num_bytes = storage.nbytes()
         # given that we copy things around anyway, we might use storage.cpu()
         # this means to that to get tensors serialized, you need to implement
         # .cpu() on the underlying Storage
-        if storage.device.type != "cpu":
-            storage = storage.cpu()
-        # Now that it is on the CPU we can directly copy it into the zip file
-        num_bytes = storage.nbytes()
-        zip_file.write_record(name, storage, num_bytes)
+        if not storage._serialize_data:
+            zip_file.write_record_metadata(name, num_bytes)
+        else:
+            if storage.device.type != "cpu":
+                storage = storage.cpu()
+            # Now that it is on the CPU we can directly copy it into the zip file
+            zip_file.write_record(name, storage, num_bytes)
 
 
 def load(

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -39,6 +39,7 @@ class _StorageBase:
     is_sparse: _bool = False
     is_sparse_csr: _bool = False
     device: torch.device
+    _serialize_data: _bool = True
 
     def __init__(self, *args, **kwargs):
         pass
@@ -649,6 +650,7 @@ def _get_device_from_module(module: str):
 
 class TypedStorage:
     is_sparse: _bool = False
+    _serialize_data: _bool = True
 
     dtype: torch.dtype
 


### PR DESCRIPTION
New version of #128162, opening just to show dependencies to prevent colab OOM in https://github.com/pytorch/torchtune/pull/1315

with some changes to FakeTensor `__reduce_ex__` (or a subclass of it, TBD how we'll actually do this) such as those [here](https://github.com/pytorch/torchtune/pull/1315/files#diff-734dbb110089223adfc465adb1594c2645bc025171e23c67f7b7bece857edbf0R42-R56), we can do things like 


```python
with FakeTensorMode():
    m = nn.Linear(3, 5, dtype=torch.float16, device='cuda')

sd = m.state_dict()
for v in sd.values():
    v.untyped_storage()._serialize_data = False
    
torch.save(sd, 'bla.pt')
print(torch.load('bla.pt', weights_only=True))
# OrderedDict([('weight', tensor([[0., 0., 0.],
#        [0., 0., 0.],
#        [0., 0., 0.],
#        [0., 0., 0.],
#        [0., 0., 0.]], device='cuda:0', dtype=torch.float16)), ('bias', tensor([0., 0., 0., 0., 0.], device='cuda:0', dtype=torch.float16))])
```