### PR TITLE
[DeviceMesh] Add a _MeshEnv API to check if a mesh is a flatten mesh

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -582,16 +582,26 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         dp_cp_mesh = mesh_3d["dp", "cp"]
         flattened_dp_cp_mesh = dp_cp_mesh._flatten()
         self.assertEqual(dp_cp_mesh.mesh.flatten(), flattened_dp_cp_mesh.mesh)
+        self.assertTrue(_mesh_resources.is_flatten_mesh(flattened_dp_cp_mesh))
 
         ref_pg_count = _world.group_count
+        flattened_dp_cp_mesh_2 = dp_cp_mesh._flatten()
         # Calling flatten again should not create a new pg.
-        dp_cp_mesh_2 = dp_cp_mesh._flatten()
         self.assertEqual(ref_pg_count, _world.group_count)
+        self.assertTrue(_mesh_resources.is_flatten_mesh(flattened_dp_cp_mesh_2))
 
         # Test flatten non-contiguous dims
         dp_tp_mesh = mesh_3d["dp", "tp"]
         flattned_dp_tp_mesh = dp_tp_mesh._flatten()
         self.assertEqual(dp_tp_mesh.mesh.flatten(), flattned_dp_tp_mesh.mesh)
+        self.assertTrue(_mesh_resources.is_flatten_mesh(flattned_dp_tp_mesh))
+
+        self.assertTrue(not _mesh_resources.is_flatten_mesh(mesh_3d["dp", "cp"]))
+        self.assertTrue(not _mesh_resources.is_flatten_mesh(mesh_3d["dp", "tp"]))
+        self.assertTrue(not _mesh_resources.is_flatten_mesh(mesh_3d["cp", "tp"]))
+        self.assertTrue(not _mesh_resources.is_flatten_mesh(mesh_3d["dp"]))
+        self.assertTrue(not _mesh_resources.is_flatten_mesh(mesh_3d["cp"]))
+        self.assertTrue(not _mesh_resources.is_flatten_mesh(mesh_3d["tp"]))
 
 
 class TestMeshEnv(DTensorTestBase):

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -119,7 +119,7 @@ else:
 
         def is_flatten_mesh(self, device_mesh: "DeviceMesh") -> bool:
             root_mesh = self.get_root_mesh(device_mesh)
-            if len(device_mesh.mesh_dim_names) != 1:
+            if not device_mesh.mesh_dim_names or len(device_mesh.mesh_dim_names) != 1:
                 return False
             else:
                 flatten_mesh_dim_name = device_mesh.mesh_dim_names[0]

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -117,6 +117,20 @@ else:
 
             return res_submesh
 
+        def is_flatten_mesh(self, device_mesh: "DeviceMesh") -> bool:
+            root_mesh = self.get_root_mesh(device_mesh)
+            if len(device_mesh.mesh_dim_names) != 1:
+                return False
+            else:
+                flatten_mesh_dim_name = device_mesh.mesh_dim_names[0]
+                return (
+                    root_mesh in self.root_to_flatten_mapping.keys()
+                    and flatten_mesh_dim_name
+                    in self.root_to_flatten_mapping[root_mesh].keys()
+                    and self.root_to_flatten_mapping[root_mesh][flatten_mesh_dim_name]
+                    == device_mesh
+                )
+
         def create_flatten_mesh(self, device_mesh: "DeviceMesh") -> "DeviceMesh":
             root_mesh = _mesh_resources.get_root_mesh(device_mesh)
             flatten_dims_in_root = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133277
* #133195
* #133193

API requested by @fegin. We will also be likely to use it when we reconstruct a slice with a flatten mesh and a regular mesh.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l