### PR TITLE
[ROCm][CK][Inductor] enable dynamic shapes for CK backend to gemm max autotune

### DIFF
--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -99,6 +99,51 @@ class TestCKBackend(TestCase):
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @unittest.skipIf(config.is_fbcode(), "fbcode requires different CK path setup")
     @unittest.mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
+    @parametrize("max_autotune_gemm_backends", ("CK",))
+    @parametrize("autotune_in_subproc", (True,))
+    def test_max_autotune_precompile_matmul_dynamic(
+        self, max_autotune_gemm_backends, autotune_in_subproc
+    ):
+        """
+        Test matmul with dynamic shapes
+        """
+
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+
+        tensor_options = {"device": "cuda", "dtype": torch.bfloat16}
+
+        a = torch.randn(2240, 256, **tensor_options)
+        b = torch.randn(256, 2048, **tensor_options)
+
+        torch._dynamo.mark_dynamic(a, 0)
+
+        assert "rocm" in dir(config)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "autotune_in_subproc": autotune_in_subproc,
+                "max_autotune_gemm_backends": max_autotune_gemm_backends,
+                "compile_threads": 2,
+                "rocm.n_max_profiling_configs": 2,
+                "rocm.ck_dir": self.ck_dir,
+            }
+        ):
+            @torch.compile(dynamic=True)
+            def compiled_mm(a, b):
+                return a @ b
+            Y_compiled = compiled_mm(a, b)
+            Y = a @ b
+            torch.testing.assert_close(Y_compiled, Y)
+
+            a1 = torch.randn(1024, 256, **tensor_options)
+            Y1_compiled = compiled_mm(a1, b)
+            Y1 = a1 @ b
+            torch.testing.assert_close(Y1_compiled, Y1)
+
+    @unittest.skipIf(not torch.version.hip, "ROCM only")
+    @unittest.skipIf(config.is_fbcode(), "fbcode requires different CK path setup")
+    @unittest.mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
     @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))
     def test_max_autotune_precompile_preselected(self, max_autotune_gemm_backends):
         """

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -129,9 +129,11 @@ class TestCKBackend(TestCase):
                 "rocm.ck_dir": self.ck_dir,
             }
         ):
+
             @torch.compile(dynamic=True)
             def compiled_mm(a, b):
                 return a @ b
+
             Y_compiled = compiled_mm(a, b)
             Y = a @ b
             torch.testing.assert_close(Y_compiled, Y)

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -45,14 +45,6 @@ class CKGemmTemplate(CKTemplate):
         auto gemm = {{instance_type}} {};
         auto invoker = gemm.MakeInvoker();
 
-        const ck::index_t M = {{M}};
-        const ck::index_t N = {{N}};
-        const ck::index_t K = {{K}};
-        const ck::index_t LDA = {{ld_a}};
-        const ck::index_t LDB = {{ld_b}};
-        const ck::index_t LDC = {{ld_c}};
-        constexpr auto LDD = ck::Number<{{ld_d}}>{};
-
         auto argument = gemm.MakeArgument(
             reinterpret_cast<const {{a_element_dtype}}*>(X),
             reinterpret_cast<const {{b_element_dtype}}*>(W),
@@ -79,7 +71,6 @@ class CKGemmTemplate(CKTemplate):
             *workspace_size = gemm.GetWorkSpaceSize(&argument);
             return 0;
         }
-        {{null_checks}}
         // run the kernel
         float elapsed_time = invoker.Run(argument, StreamConfig{stream, /* time kernel */ false, /* log level */ kDEBUG_LOG});
         return 0;
@@ -298,7 +289,6 @@ class CKGemmTemplate(CKTemplate):
 * Generated code for CK inductor backend
 * See {type(self).__module__}.{type(self).__qualname__}
 *
-* Problem size M={X.get_layout().size[-2]} N={W.get_layout().size[-1]} K={X.get_layout().size[-1]}
 * Template instance {op}
 *
 * {torch.__version__=}
@@ -315,29 +305,22 @@ class CKGemmTemplate(CKTemplate):
                 outputs=[Y],
                 names_str="X, W, Bias, Y",
                 input_reorder=self.input_reorder,
+                size_args=[
+                    f"ck::index_t {arg}"
+                    for arg in ["M", "N", "K", "LDA", "LDB", "LDC", "LDD"]
+                ],
             ),
             instance_type=instance_type,
-            M=kernel.size(X, -2),
-            K=kernel.size(X, -1),
-            N=kernel.size(W, -1),
             a_element_dtype=op.a_element_dtype,
             b_element_dtype=op.b_element_dtype,
             c_element_dtype=op.c_element_dtype,
             bias_element_dtype=op.ds_element_dtypes[0] if Bias is not None else "",
-            ld_a=kernel.leading_dimension(X),
-            ld_b=kernel.leading_dimension(W),
-            ld_c=kernel.leading_dimension(Y),
-            ld_d=kernel.leading_dimension(Bias),
             alpha=self.alpha,
             beta=self.beta,
             epilogue=f"Bilinear {{ {self.alpha}, {self.beta} }}"
             if Bias is not None
             else "PassThrough {}",
             has_bias=Bias is not None,
-            null_checks="".join(
-                kernel.check_not_null(node)
-                for node in (X, W, Y) + ((Bias,) if Bias is not None else ())
-            ),
             version_comment=version_comment,
         )
 
@@ -420,3 +403,23 @@ class CKGemmTemplate(CKTemplate):
                 choices,
                 op=op,
             )
+
+    def size_args(self):
+        X = self.input_nodes[0]
+        W = self.input_nodes[1]
+        Bias = self.input_nodes[2] if len(self.input_nodes) > 2 else None
+        Y = self.output_node
+
+        M = sympy.expand(X.get_size()[0])
+        K = sympy.expand(X.get_size()[1])
+        N = sympy.expand(W.get_size()[1])
+        LDA = sympy.expand(X.get_stride()[0 if X.get_stride()[1] == 1 else 1])
+        LDB = sympy.expand(W.get_stride()[0 if W.get_stride()[1] == 1 else 1])
+        LDC = sympy.expand(Y.get_stride()[0 if Y.get_stride()[1] == 1 else 1])
+        LDD = (
+            0
+            if Bias is None
+            else sympy.expand(Bias.get_stride()[0 if Bias.get_stride()[1] == 1 else 1])
+        )
+
+        return M, N, K, LDA, LDB, LDC, LDD

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -410,16 +410,16 @@ class CKGemmTemplate(CKTemplate):
         Bias = self.input_nodes[2] if len(self.input_nodes) > 2 else None
         Y = self.output_node
 
-        M = sympy.expand(X.get_size()[0])
-        K = sympy.expand(X.get_size()[1])
-        N = sympy.expand(W.get_size()[1])
-        LDA = sympy.expand(X.get_stride()[0 if X.get_stride()[1] == 1 else 1])
-        LDB = sympy.expand(W.get_stride()[0 if W.get_stride()[1] == 1 else 1])
-        LDC = sympy.expand(Y.get_stride()[0 if Y.get_stride()[1] == 1 else 1])
+        M = X.get_size()[0]
+        K = X.get_size()[1]
+        N = W.get_size()[1]
+        LDA = X.get_stride()[0 if X.get_stride()[1] == 1 else 1]
+        LDB = W.get_stride()[0 if W.get_stride()[1] == 1 else 1]
+        LDC = Y.get_stride()[0 if Y.get_stride()[1] == 1 else 1]
         LDD = (
             0
             if Bias is None
-            else sympy.expand(Bias.get_stride()[0 if Bias.get_stride()[1] == 1 else 1])
+            else Bias.get_stride()[0 if Bias.get_stride()[1] == 1 else 1]
         )
 
         return M, N, K, LDA, LDB, LDC, LDD

--- a/torch/_inductor/codegen/rocm/rocm_benchmark_request.py
+++ b/torch/_inductor/codegen/rocm/rocm_benchmark_request.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import functools
 import logging
-from ctypes import byref, c_size_t, c_void_p
+from ctypes import byref, c_int, c_size_t, c_void_p
 from typing import Any, Callable, Iterable, List, Optional, Union
 
 import torch
@@ -52,6 +52,7 @@ class ROCmBenchmarkRequest(GPUDeviceBenchmarkRequest):
             c_void_p(tensor.data_ptr())
             for tensor in list(input_tensors) + [output_tensor]
         ]
+        size_args = [c_int(arg) for arg in self.extra_args]
         log.debug(
             "make_run_fn: self.kernel_name=%s, self.source_file=%s, self.hash_key=%s, self.DLL=%s, args=%s, self.extra_args=%s",
             self.kernel_name,
@@ -76,7 +77,7 @@ class ROCmBenchmarkRequest(GPUDeviceBenchmarkRequest):
         return functools.partial(
             run_method,
             *args,
-            *self.extra_args,
+            *size_args,
             None,  # null workspace size ptr
             workspace_ptr,  # set workspace ptr,
             stream_ptr,
@@ -93,9 +94,10 @@ class ROCmBenchmarkRequest(GPUDeviceBenchmarkRequest):
         run_method = getattr(self.DLL, self.kernel_name)
         # Retrieve workspace_size and initialize workspace.
         c_workspace_size = c_size_t()
+        size_args = [c_int(arg) for arg in self.extra_args]
         run_method(
             *args,  # input ptrs and output ptrs
-            *self.extra_args,
+            *size_args,
             byref(
                 c_workspace_size
             ),  # set workspace size ptr to retrieve workspace size

--- a/torch/_inductor/codegen/rocm/rocm_kernel.py
+++ b/torch/_inductor/codegen/rocm/rocm_kernel.py
@@ -59,33 +59,6 @@ class ROCmTemplateKernel(ROCmKernel):
             node.get_name(), None
         )
 
-    def check_not_null(self, node: IRNode) -> str:
-        """
-        Generates code to check that a node is not null.
-        """
-
-        if node is None:
-            return ""
-
-        size_str = self.size(node, 0, -1)
-        name_str = self.arg_name(node)
-        if name_str is None:
-            return ""
-
-        res = IndentedBuffer(initial_indent=8)
-        res.tabwidth = 1
-        res.splice(
-            f"""
-            if (!{name_str}) {{
-                int64_t {name_str}_size = {size_str};
-                if ({name_str}_size > 0) {{
-                    throw std::runtime_error("input {name_str} is null but size is not 0!");
-                }}
-            }}
-            """
-        )
-        return res.getvalue()
-
     def def_kernel(
         self,
         inputs: List[IRNode],

--- a/torch/_inductor/codegen/rocm/rocm_kernel.py
+++ b/torch/_inductor/codegen/rocm/rocm_kernel.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, List, Optional, TYPE_CHECKING, Union
 
 from ...ir import Buffer, ChoiceCaller, IRNode, Layout, PrimitiveInfoType, TensorBox
 from ...virtualized import V
-from ..common import IndentedBuffer, Kernel, OpOverrides
+from ..common import Kernel, OpOverrides
 from ..cpp_utils import CppPrinter
 from .rocm_benchmark_request import ROCmBenchmarkRequest
 from .rocm_template_buffer import ROCmTemplateBuffer

--- a/torch/_inductor/codegen/rocm/rocm_template.py
+++ b/torch/_inductor/codegen/rocm/rocm_template.py
@@ -93,7 +93,7 @@ class ROCmTemplate(KernelTemplate):
             self.size_args() if hasattr(self, "size_args") else ()
         )  # subclass should define def size_args()
         size_args_ints = [
-            V.graph.sizevars.symbolic_hint(arg) for arg in size_args
+            V.graph.sizevars.size_hint(arg) for arg in size_args
         ]  # resolve to ints for benchmarking
         bmreq = ROCmBenchmarkRequest(
             kernel_name=kernel_name,

--- a/torch/_inductor/codegen/rocm/rocm_template.py
+++ b/torch/_inductor/codegen/rocm/rocm_template.py
@@ -5,8 +5,6 @@ import logging
 from typing import List, Optional
 from unittest.mock import patch
 
-import sympy
-
 from ...autotune_process import TensorMeta
 from ...ir import Buffer, IRNode, Layout
 from ...utils import IndentedBuffer, unique
@@ -90,15 +88,18 @@ class ROCmTemplate(KernelTemplate):
             call_args,
             expected_args,
         )
-        extra_args = V.graph.sizevars.size_hints(
-            map(sympy.expand, call_args[len(expected_args) :])
-        )
-        # create the BenchmarkRequest
+
+        size_args = (
+            self.size_args() if hasattr(self, "size_args") else ()
+        )  # subclass should define def size_args()
+        size_args_ints = [
+            V.graph.sizevars.symbolic_hint(arg) for arg in size_args
+        ]  # resolve to ints for benchmarking
         bmreq = ROCmBenchmarkRequest(
             kernel_name=kernel_name,
             input_tensor_meta=TensorMeta.from_irnodes(self.input_nodes),
             output_tensor_meta=TensorMeta.from_irnodes(self.output_node),
-            extra_args=extra_args,
+            extra_args=size_args_ints,
             source_code=code,
         )
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -548,7 +548,7 @@ class WrapperCodeGen(CodeGen):
         self.header.splice(
             f"""
                 {aot_config_comment}
-                from ctypes import c_void_p, c_long
+                from ctypes import c_void_p, c_long, c_int
                 import torch
                 import math
                 import random

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -376,7 +376,7 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
                 beta=beta,
             )
 
-    if static_shape and is_nonzero and use_ck_template(layout, m, n, k):
+    if is_nonzero and use_ck_template(layout, m, n, k):
         CKGemmTemplate.add_ck_gemm_choices(
             choices,
             layout,

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -177,7 +177,7 @@ def tuned_mm(mat1, mat2, *, layout=None):
     if static_shape and is_nonzero and use_cutlass_template(layout, m, n, k):
         CUTLASSGemmTemplate.add_cutlass_gemm_choices(choices, layout, [mat1, mat2])
 
-    if static_shape and is_nonzero and use_ck_template(layout, m, n, k):
+    if is_nonzero and use_ck_template(layout, m, n, k):
         CKGemmTemplate.add_ck_gemm_choices(choices, layout, [mat1, mat2])
 
     if use_cpp_packed_gemm_template(layout, mat1, mat2):


### PR DESCRIPTION
This PR enables dynamic shapes for the CK backend for gemm max autotune (see #125453).

This is achieved via unhardcoding the problem sizes from the template body and passing them as parameters instead.

We handle passing the problem sizes for the kernel call as well as for the benchmark call.

# Testing

`pytest test/inductor/test_ck_backend.py [-k dynamic]`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @zjing14 