### PR TITLE
[ONNX] Fix onnx conversion scaled_dot_product_attention

### DIFF
--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -148,7 +148,9 @@ def scaled_dot_product_attention(
     assert (not is_causal) or (
         is_causal and symbolic_helper._is_none(attn_mask)
     ), "is_causal and attn_mask cannot be set at the same time"
-    assert not enable_gqa, "conversion of scaled_dot_product_attention not implemented if enable_gqa is True"
+    assert (
+        not enable_gqa
+    ), "conversion of scaled_dot_product_attention not implemented if enable_gqa is True"
 
     scale = symbolic_helper._maybe_get_const(scale, "f")
     if symbolic_helper._is_none(scale):

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -133,7 +133,7 @@ def quantized_hardswish(g: jit_utils.GraphContext, x, op_scale, op_zero_point):
 # aten_scaled_dot_product_attention
 # NOTE: Need op.Trilu
 @_onnx_symbolic("aten::scaled_dot_product_attention")
-@symbolic_helper.parse_args("v", "v", "v", "v", "f", "b", "v")
+@symbolic_helper.parse_args("v", "v", "v", "v", "f", "b", "v", "b")
 def scaled_dot_product_attention(
     g: jit_utils.GraphContext,
     query: torch._C.Value,
@@ -143,10 +143,12 @@ def scaled_dot_product_attention(
     dropout_p: float = 0.0,
     is_causal: bool = False,
     scale: torch._C.Value | None = None,
+    enable_gqa: bool = False,
 ):
     assert (not is_causal) or (
         is_causal and symbolic_helper._is_none(attn_mask)
     ), "is_causal and attn_mask cannot be set at the same time"
+    assert not enable_gqa, "conversion of scaled_dot_product_attention not implemented if enable_gqa is True"
 
     scale = symbolic_helper._maybe_get_const(scale, "f")
     if symbolic_helper._is_none(scale):


### PR DESCRIPTION
Fixes error message raised by the torch>=2.5: A mismatch between the number of arguments (8) and their descriptors (7) was found at symbolic function 'scaled_dot_product_attention' by adding the newly introduced use_gqa parameter. 

From https://github.com/pytorch/pytorch/pull/132689