### PR TITLE
[ROCm] Prevent accidental enablement of efficient attention.

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -641,7 +641,12 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
       check_all_tensors_on_device,
       check_mem_efficient_hardware_support,
       check_tensor_shapes,
-      check_head_dim_size_mem_efficient);
+#ifdef USE_ROCM
+      check_head_dim_size_flash
+#else
+      check_head_dim_size_mem_efficient
+#endif
+  );
   for (auto& constraint : general_constraints) {
     if (!constraint(params, debug)) {
       return false;

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     IS_FBCODE,
     TEST_WITH_ROCM,
     skipIfRocm,
+    xfailIfRocm,
     skipIfTorchDynamo,
     TEST_FAIRSEQ,
     run_tests,
@@ -1637,10 +1638,9 @@ class TestSDPAFailureModes(NNTestCase):
                 q, k, v, mask, 0.0, False))
 
     @onlyCUDA
+    @xfailIfRocm  # ROCm GPU kernels accepts irregular shapes and thus assertRaises will fail
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support fused SDPA or pre-SM80 hardware")
     def test_unaligned_tensors(self, device):
-        if TEST_WITH_ROCM:  # ROCm GPU kernels does not have strict alignment requirements
-            return
         # The alignment is depdent on arch so we specifiy SM80OrLater
         dtype = torch.float16
         size = SdpaShape(2, 2, 8, 5)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1645,9 +1645,9 @@ class TestSDPAFailureModes(NNTestCase):
         make_tensor = partial(torch.rand, size, device=device, dtype=dtype)
         q, k, v = make_tensor(), make_tensor(), make_tensor()
         with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
-           ctxmgr = self.assertRaises(RuntimeError) if not TEST_WITH_ROCM else contextlib.nullcontext()
-           with ctxmgr:
-               torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
+            ctxmgr = self.assertRaises(RuntimeError) if not TEST_WITH_ROCM else contextlib.nullcontext()
+            with ctxmgr:
+                torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
 
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not support fused SDPA or pre-SM80 hardware")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1743,9 +1743,6 @@ def skipIfRocm(func=None, *, msg="test doesn't currently work on the ROCm stack"
         return dec_fn(func)
     return dec_fn
 
-def xfailIfRocm(func):
-    return unittest.expectedFailure(func) if TEST_WITH_ROCM else func
-
 def runOnRocm(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1743,6 +1743,9 @@ def skipIfRocm(func=None, *, msg="test doesn't currently work on the ROCm stack"
         return dec_fn(func)
     return dec_fn
 
+def xfailIfRocm(func):
+    return unittest.expectedFailure(func) if TEST_WITH_ROCM else func
+
 def runOnRocm(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
Currently Efficient attention and Flash attention share the same set of GPU
kernels on ROCM and have common limitations on head sizes.

Fixes https://github.com/pytorch/pytorch/issues/132004

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang