### PR TITLE
POC: Lazy replacements

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -618,6 +618,21 @@ def forward(self, x_1):
         s0 = shape_env.create_unbacked_symint()
         self.assertRaises(GuardOnDataDependentSymNode, lambda: bool(s0 == 0))
 
+    def test_unbacked_sum_relation(self):
+        shape_env = ShapeEnv()
+        u0 = shape_env.create_unbacked_symint()
+        u1 = shape_env.create_unbacked_symint()
+        u2 = shape_env.create_unbacked_symint()
+        usum = shape_env.create_unbacked_symint()
+        torch._check_is_size(u0)
+        torch._check_is_size(u1)
+        torch._check_is_size(u2)
+        expect_true(u0 + u1 + u2 == usum)
+        self.assertTrue(statically_known_true(u0 <= usum))
+        self.assertTrue(statically_known_true(u0 + u1 <= usum))
+        self.assertTrue(statically_known_true(u0 + u1 + u2 <= usum))
+        self.assertTrue(statically_known_true(u1 + u2 <= usum))
+
     def test_data_dependent_guard_propagate_real_tensors(self):
         shape_env = ShapeEnv()
         s0 = shape_env.create_unbacked_symint()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133332

In https://github.com/pytorch/pytorch/pull/124316 I banned replacements of unbacked SymInts with other SymInts to avoid Inductor code generation problems. However, this has some unintended consequences. Specifically, when we have `u0 + u1 + u2 == u3` where all variables are size-like, we no longer can infer that `u0 + u1 <= u3`. If we had setup the substitution, we would have `u0 + u1 <= u0 + u1 + u2` which is easily solvable.

So the idea behind lazy replacements is that we don't apply these replacements, unless we are trying to determine if something is statically true, in which case we're willing to apply them in the same way we apply axioms.

Unfortunately, as currently written, this makes compile time worse: for 60 features, compile time goes from 100s -> 120s. I'm currently profiling.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>