### PR TITLE
[BE] Skip inductor+profiler test for templates if we didn't run select_autotune

### DIFF
--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -5,6 +5,7 @@ import unittest
 import torch
 import torch._inductor.test_case
 import torch._inductor.utils
+from typing import Callable, Optional
 from torch._inductor import config
 from torch.profiler import ProfilerActivity
 from torch.testing._internal.common_utils import TemporaryFileName
@@ -47,7 +48,7 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
             any(("name" in event and kernel_name == event["name"]) for event in events)
         )
 
-    def _test_profiling_kernel_names(self, fn, args, kernel_name_str: str):
+    def _test_profiling_kernel_names(self, fn, args, kernel_name_str: str, check_fn: Optional[Callable] = None):
         """
         We expect a record_function event to be added on the CPU side, surrounding
         the launch of each triton kernel.
@@ -56,6 +57,9 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
 
         for _ in range(2):
             fn_opt(*args)
+
+        if check_fn is not None:
+            check_fn()
 
         with torch.profiler.profile(
             activities=[ProfilerActivity.CPU], record_shapes=True
@@ -107,7 +111,14 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
 
             args = [torch.rand((4, 4), device="cuda") for _ in range(2)]
 
-            events = self._test_profiling_kernel_names(fn, args, "mm")
+            def check_fn():
+                # test_profiling_kernel_names will check this before asserting mm is in the trace.
+                # reason: sometimes testing runs on machines with not enough SMs, and autotuning is skipped.
+                if torch._dynamo.utils.counters["inductor"]["select_algorithm_autotune"] == 0:
+                    raise unittest.SkipTest("select_algorithm didn't run, we probably won't get profiling data. GPU might not have enough SMs.")
+
+            events = self._test_profiling_kernel_names(fn, args, "mm", check_fn)
+
             event_found = False
             for event in events:
                 if event.name == "triton_tem_fused_mm_0":

--- a/test/inductor/test_profiler.py
+++ b/test/inductor/test_profiler.py
@@ -1,11 +1,11 @@
 # Owner(s): ["module: inductor"]
 import json
 import unittest
+from typing import Callable, Optional
 
 import torch
 import torch._inductor.test_case
 import torch._inductor.utils
-from typing import Callable, Optional
 from torch._inductor import config
 from torch.profiler import ProfilerActivity
 from torch.testing._internal.common_utils import TemporaryFileName
@@ -48,7 +48,9 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
             any(("name" in event and kernel_name == event["name"]) for event in events)
         )
 
-    def _test_profiling_kernel_names(self, fn, args, kernel_name_str: str, check_fn: Optional[Callable] = None):
+    def _test_profiling_kernel_names(
+        self, fn, args, kernel_name_str: str, check_fn: Optional[Callable] = None
+    ):
         """
         We expect a record_function event to be added on the CPU side, surrounding
         the launch of each triton kernel.
@@ -114,8 +116,15 @@ class DynamoProfilerTests(torch._inductor.test_case.TestCase):
             def check_fn():
                 # test_profiling_kernel_names will check this before asserting mm is in the trace.
                 # reason: sometimes testing runs on machines with not enough SMs, and autotuning is skipped.
-                if torch._dynamo.utils.counters["inductor"]["select_algorithm_autotune"] == 0:
-                    raise unittest.SkipTest("select_algorithm didn't run, we probably won't get profiling data. GPU might not have enough SMs.")
+                if (
+                    torch._dynamo.utils.counters["inductor"][
+                        "select_algorithm_autotune"
+                    ]
+                    == 0
+                ):
+                    raise unittest.SkipTest(
+                        "select_algorithm didn't run, we probably won't get profiling data. GPU might not have enough SMs."
+                    )
 
             events = self._test_profiling_kernel_names(fn, args, "mm", check_fn)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133344

Sometimes we don't have enough SMs to do autotuning and then we fall back to aten, in which case we won't run the template kernel and it won't show up in the profile trace.

Differential Revision: [D61222101](https://our.internmc.facebook.com/intern/diff/D61222101/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang