### PR TITLE
Dont pad to aligned multiples/pass in discontiguous tensors to custom ops

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -234,7 +234,11 @@ def mark_nodes_dislike_padding(g: Graph) -> None:
         op = _get_overload_packet(cur)
         if not op:
             continue
-        if op in ops_dislike_padding:
+
+        is_custom_op = isinstance(
+            cur.target, torch._ops.OpOverload
+        ) and not torch._library.utils.is_builtin(node.target)
+        if op in ops_dislike_padding or is_custom_op:
             cur.meta["dislike_padding"] = True
 
         if cur.meta.get("dislike_padding", False):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -237,7 +237,7 @@ def mark_nodes_dislike_padding(g: Graph) -> None:
 
         is_custom_op = isinstance(
             cur.target, torch._ops.OpOverload
-        ) and not torch._library.utils.is_builtin(node.target)
+        ) and not torch._library.utils.is_builtin(cur.target)
         if op in ops_dislike_padding or is_custom_op:
             cur.meta["dislike_padding"] = True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133348

This is basically a poor version of the more complete fix we're doing which is to match strides of custom ops. we had cutlass ops internally which were fixed by this.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang