### PR TITLE
[CI] Do not emit color escape sequence during testing

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -6,6 +6,9 @@
 
 set -ex
 
+# Suppress ANSI color escape sequences
+export TERM=vt100
+
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 


### PR DESCRIPTION
By forcing term to vt100

Fixes problem reported in  https://github.com/pytorch/pytorch/issues/133330 but more broadly it should be fixed on Nova/Infra side
