### PR TITLE
Fix SDPA flop counter for meta tensors

### DIFF
--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -272,7 +272,7 @@ def _offsets_to_lengths(offsets, max_len):
     """
     from torch._subclasses.fake_tensor import FakeTensor
     from torch._subclasses.functional_tensor import FunctionalTensor
-    if not isinstance(offsets, (FakeTensor, FunctionalTensor)):
+    if not isinstance(offsets, (FakeTensor, FunctionalTensor)) and not offsets.is_meta:
         return offsets.diff().tolist()
     return [max_len] * (offsets.size(0) - 1)
 


### PR DESCRIPTION
Currently, flop counter errors out for SDPA when meta tensors are passed. This PR fixes the same.

Differential Revision: D60462626
