### PR TITLE
Add comptime.sleep

### DIFF
--- a/torch/_dynamo/comptime.py
+++ b/torch/_dynamo/comptime.py
@@ -8,6 +8,7 @@
 
 import builtins
 import dis
+import time
 import traceback
 from typing import Optional, Union
 
@@ -290,6 +291,9 @@ class ComptimeContext:
         """
         return self.__tx
 
+    def sleep(self, sec):
+        time.sleep(sec)
+
 
 class _Comptime:
     @staticmethod
@@ -390,6 +394,10 @@ class _Comptime:
             builtins.breakpoint()
 
         comptime(inner)
+
+    @staticmethod
+    def sleep(sec):
+        comptime(lambda ctx: ctx.sleep(ctx.get_local("sec").as_python_constant()))
 
 
 comptime = _Comptime()


### PR DESCRIPTION
Add comp time sleep for NCCL timeout testing. The unit test is not great..

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133374
* #133363
* __->__ #133362


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames