### PR TITLE
Decompose _unsafe_index_put into index_put

### DIFF
--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -614,7 +614,6 @@ aten::_unique
 aten::_unique.out
 aten::_unique2
 aten::_unique2.out
-aten::_unsafe_index_put
 aten::_upsample_bicubic2d_aa
 aten::_upsample_bicubic2d_aa.out
 aten::_upsample_bicubic2d_aa_backward

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -458,6 +458,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.unfold_backward,
             aten.unfold_copy,
             aten._unsafe_index,
+            aten._unsafe_index_put,
             aten._unsafe_masked_index,
             aten._unsafe_masked_index_put_accumulate,
             aten.unsafe_split.Tensor,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3810,6 +3810,11 @@ def _unsafe_index(x, indices):
     return aten.index(x, indices)
 
 
+@register_decomposition([aten._unsafe_index_put])
+def _unsafe_index_put(x, indices, value, accumulate=False):
+    return aten.index_put(x, indices, value, accumulate)
+
+
 @register_decomposition([aten._unsafe_masked_index])
 def _unsafe_masked_index(x, mask, indices, fill):
     for index in indices:


### PR DESCRIPTION
## Description
Create decomposition of _unsafe_index_put (non-core aten) that turns it into index_put (core aten)

## Testing
Phi3 mini + LoRA model successfully passed `to_edge` after failing due to a non-core aten `unsafe_index_put` getting introduced in a decomposition during joint graph calculations. 