### PR TITLE
[export] Do not use export.export for `capture_pre_autograd_graph`

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -66,9 +66,6 @@ def capture_pre_autograd_graph_warning():
     log.warning("|     !!!   WARNING   !!!    |")
     log.warning("+============================+")
     log.warning("capture_pre_autograd_graph() is deprecated and doesn't provide any function guarantee moving forward.")
-    log.warning("Please switch to use torch.export instead.")
-    if config.is_fbcode():
-        log.warning("Unless the unittest is in the blocklist, capture_pre_autograd_graph() will fallback to torch.export.")
 
 
 @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Summary:
Do not use export.export for `capture_pre_autograd_graph` in unittests anymore.

#buildall

Test Plan: CI

Reviewed By: tugsbayasgalan

Differential Revision: D60996041
