### PR TITLE
Added call_hasattr to the TensorVariable class

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8505,6 +8505,32 @@ def ___make_guard_fn():
         self.assertEqual(fn_out, compiled_out)
         self.assertFalse(fn_out)
 
+    def test_tensorvariable_hasattr1(self):
+        def fn(x):
+            if hasattr(x, "foo"):
+                return x + 1
+            return x - 1
+
+        compiled_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+
+        x = torch.randn(3)
+        fn_out = fn(x)
+        compiled_out = compiled_fn(x)
+        self.assertTrue(fn_out.data == compiled_out.data)
+
+    def test_list_hasattr2(self):
+        def fn():
+            x = torch.zeros(3)
+            if hasattr(x, "shape"):
+                return x + 1
+            return x - 1
+
+        compiled_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+
+        fn_out = fn()
+        compiled_out = compiled_fn()
+        self.assertTrue(fn_out.data == compiled_out.data)
+
     def test_torch_objects_as_keys(self):
         remap = {torch.float16: torch.float32}
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8518,7 +8518,7 @@ def ___make_guard_fn():
         compiled_out = compiled_fn(x)
         self.assertTrue(fn_out.data == compiled_out.data)
 
-    def test_list_hasattr2(self):
+    def test_tensorvariable_hasattr2(self):
         def fn():
             x = torch.zeros(3)
             if hasattr(x, "shape"):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8519,6 +8519,33 @@ def ___make_guard_fn():
         self.assertTrue(fn_out.data == compiled_out.data)
 
     def test_tensorvariable_hasattr2(self):
+        def fn(x):
+            if hasattr(x, "foo"):
+                return x + 1
+            return x - 1
+
+        compiled_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+
+        x = torch.randn(3)
+        x.foo = 1
+        fn_out = fn(x)
+        compiled_out = compiled_fn(x)
+        self.assertTrue(fn_out.data == compiled_out.data)
+
+    def test_tensorvariable_hasattr3(self):
+        def fn():
+            x = torch.zeros(3)
+            if hasattr(x, "foo"):
+                return x + 1
+            return x - 1
+
+        compiled_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+
+        fn_out = fn()
+        compiled_out = compiled_fn()
+        self.assertTrue(fn_out.data == compiled_out.data)
+
+    def test_tensorvariable_hasattr4(self):
         def fn():
             x = torch.zeros(3)
             if hasattr(x, "shape"):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -217,6 +217,9 @@ class TensorVariable(VariableTracker):
                 )
         return props
 
+    def call_hasattr(self, tx, name):
+        return variables.ConstantVariable.create(hasattr(self.python_type(), name))
+
     def dynamic_getattr(self, tx: "InstructionTranslator", name):
         fake_val = self.proxy.node.meta["example_value"]
         # For getattrs on tensors without sources,

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -218,7 +218,11 @@ class TensorVariable(VariableTracker):
         return props
 
     def call_hasattr(self, tx, name):
-        return variables.ConstantVariable.create(hasattr(self.proxy, name))
+        try:
+            self.var_getattr(tx, name)
+            return variables.ConstantVariable.create(True)
+        except:
+            return variables.ConstantVariable.create(False)
 
     def dynamic_getattr(self, tx: "InstructionTranslator", name):
         fake_val = self.proxy.node.meta["example_value"]

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -218,7 +218,7 @@ class TensorVariable(VariableTracker):
         return props
 
     def call_hasattr(self, tx, name):
-        return variables.ConstantVariable.create(hasattr(self, name))
+        return variables.ConstantVariable.create(hasattr(self.proxy, name))
 
     def dynamic_getattr(self, tx: "InstructionTranslator", name):
         fake_val = self.proxy.node.meta["example_value"]

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -218,7 +218,7 @@ class TensorVariable(VariableTracker):
         return props
 
     def call_hasattr(self, tx, name):
-        return variables.ConstantVariable.create(hasattr(self.python_type(), name))
+        return variables.ConstantVariable.create(hasattr(self, name))
 
     def dynamic_getattr(self, tx: "InstructionTranslator", name):
         fake_val = self.proxy.node.meta["example_value"]


### PR DESCRIPTION
Attempt at fixing issue #133253

The TensorVariable class did not have a call_hasattr method to check if a tensor variable had an attribute. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec