### PR TITLE
Remove Wno-invalid-partial-specialization from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1036,8 +1036,6 @@ if(NOT MSVC)
 
   append_cxx_flag_if_supported("-Wno-error=old-style-cast" CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-Wconstant-conversion" CMAKE_CXX_FLAGS)
-  append_cxx_flag_if_supported("-Wno-invalid-partial-specialization"
-                               CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-Wno-aligned-allocation-unavailable"
                                CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-Wno-missing-braces" CMAKE_CXX_FLAGS)


### PR DESCRIPTION
The code base is clean enough that Winvalid-partial-specialization can be enabled.