### PR TITLE
Rewording doc string for clip_grad_norm_

### DIFF
--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -43,7 +43,7 @@ def clip_grad_norm_(
 ) -> torch.Tensor:
     r"""Clip the gradient norm of an iterable of parameters.
 
-    The norm is computed over the norms of the individual gradients of all parameters, 
+    The norm is computed over the norms of the individual gradients of all parameters,
     as if the norms of the individual gradients were concatenated into a single vector.
     Gradients are modified in-place.
 

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -43,8 +43,9 @@ def clip_grad_norm_(
 ) -> torch.Tensor:
     r"""Clip the gradient norm of an iterable of parameters.
 
-    The norm is computed over all gradients together, as if they were
-    concatenated into a single vector. Gradients are modified in-place.
+    The norm is computed over the norms of the individual gradients of all parameters, 
+    as if the norms of the individual gradients were concatenated into a single vector.
+    Gradients are modified in-place.
 
     Args:
         parameters (Iterable[Tensor] or Tensor): an iterable of Tensors or a


### PR DESCRIPTION
The doc string for `torch.nn.utils.clip_grad_norm_` needed some clarity, it was earlier unclear that the norm was being computed over the norms of individual gradient parameters.