### PR TITLE
allow `SubConfigProxy` of arbitrary depth

### DIFF
--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -52,7 +52,10 @@ def install_config_module(module: ModuleType) -> None:
                 # a subconfig with `class Blah:` syntax
                 proxy = SubConfigProxy(module, f"{name}.")
                 visit(value, proxy, f"{name}.")
-                setattr(dest, key, proxy)
+                if dest is module:
+                    setattr(dest, key, proxy)
+                else:
+                    dest.__dict__[key] = proxy
             else:
                 raise AssertionError(f"Unhandled config {key}={value} ({type(value)})")
 


### PR DESCRIPTION
Before, having arbitrary depth nested configs like

```
class Foo:
    foo: List[int] = [1, 2, 3]
    class Bar:
        bar: str = "1"
        class Baz:
            baz: int = 1
```

would cause problems beyond the first layer. For example, if we tried

```
from torch._inductor import config as inductor_config


print(inductor_config.Foo)
print(repr(inductor_config.Foo.foo))
print(inductor_config.Foo.Bar)
print(repr(inductor_config.Foo.Bar.bar))
print(inductor_config.Foo.Bar.Baz)
print(repr(inductor_config.Foo.Bar.Baz.baz))
```

we would get some output like

```
<torch.utils._config_module.SubConfigProxy object at 0x7fac65de00a0>
[1, 2, 3]
...
AttributeError: torch._inductor.config.Foo.Bar does not exist
```

Obviously, this is not what we want. With these changes, we get the right values

```
<torch.utils._config_module.SubConfigProxy object at 0x7f840d05bf40>
[1, 2, 3]
<torch.utils._config_module.SubConfigProxy object at 0x7f840cedc940>
'1'
<torch.utils._config_module.SubConfigProxy object at 0x7f840cedc100>
1
```

Fixes #ISSUE_NUMBER
