### PR TITLE
[c10d]add coalesce support for device types other than cuda

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2231,6 +2231,15 @@ class _CoalescingManager:
     def wait(self):
         for work in self.works:
             work.wait()
+# Global set to store coalescing supported device types
+COALESING_SUPPORTED_DTYPES = {"cuda", "hpu"}
+
+def has_coalescing_manager(device_type):
+    """
+    Checks if the given device type has a coalescing feature support.
+    """
+    return device_type in COALESING_SUPPORTED_DTYPES
+
 
 
 @contextlib.contextmanager
@@ -2367,7 +2376,7 @@ def batch_isend_irecv(p2p_op_list):
     _check_p2p_op_list(p2p_op_list)
     group = p2p_op_list[0].group
     device = p2p_op_list[0].tensor.device
-    if device.type == "cuda":
+    if has_coalescing_manager(device.type):
         # NCCL style coalescing
         with _coalescing_manager(group, device, async_ops=True) as cm:
             for p2p_op in p2p_op_list:


### PR DESCRIPTION
- This change allows easy extension of supported device types by updating the `COALESING_SUPPORTED_DTYPES`.
- 'has_coalescing_manager' method can be used in other places as well.

Fixes #ISSUE_NUMBER
cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @yf225 @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @yanboliang @bsochack
