### PR TITLE
Enable batch matmul for result sizes > 2**32 the tensor can be split along batch axis

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -509,7 +509,6 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
   return output;
 }
 
-
 #if defined(__MAC_15_0)
 static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tensor& result) {
   using namespace mps;
@@ -659,8 +658,6 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
   // Check if we need to split the batch to do the computation
   uint64_t resultSize = batch1.size(0) * batch1.size(1) * batch2.size(2);
   if (resultSize > pow(2, 32)) {
-
-
 #if defined(__MAC_15_0)
     result = tiled_bmm_out_mps_impl(batch1, batch2, result);
     return result;

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -533,7 +533,6 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
       uint64_t resElemSize = result.element_size();
       MPSDataType dtype = getMPSDataType(batch1);
 
-      uint64_t maxSupportedElems = pow(2, 32);
       uint64_t elemInMatrix = resRows * resCols;
       uint64_t largestSupportedBatchSize = floor(pow(2, 32) / elemInMatrix);
       uint64_t batchSize = std::min(largestSupportedBatchSize, originalBatchSize);

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -509,6 +509,9 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
   return output;
 }
 
+
+#if !defined(__MAC_15_0) && \
+    (!defined(MAC_OS_X_VERSION_15_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_15_0))
 static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tensor& result) {
   using namespace mps;
 
@@ -608,6 +611,7 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
   });
   return result;
 }
+#endif
 
 static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tensor& result) {
   using namespace mps;
@@ -656,8 +660,15 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
   // Check if we need to split the batch to do the computation
   uint64_t resultSize = batch1.size(0) * batch1.size(1) * batch2.size(2);
   if (resultSize > pow(2, 32)) {
+
+
+#if !defined(__MAC_15_0) && \
+    (!defined(MAC_OS_X_VERSION_15_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_15_0))
     result = tiled_bmm_out_mps_impl(batch1, batch2, result);
     return result;
+#else
+    TORCH_CHECK(false, "Tiling of batch matmul for larger than 2**32 entries only available from MacOS15 onwards");
+#endif
   }
 
   MPSStream* stream = getCurrentMPSStream();

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -544,7 +544,7 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
 
       id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
 
-      MPSNDArrayMatrixMultiplication* matmul = [[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device
+      auto matmul = [[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device
                                                                                           sourceCount:2];
 
       MPSShape* aShape = @[ @(batchSize), @(aRows), @(aCols) ];

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -510,8 +510,7 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
 }
 
 
-#if !defined(__MAC_15_0) && \
-    (!defined(MAC_OS_X_VERSION_15_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_15_0))
+#if defined(__MAC_15_0)
 static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tensor& result) {
   using namespace mps;
 
@@ -662,8 +661,7 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
   if (resultSize > pow(2, 32)) {
 
 
-#if !defined(__MAC_15_0) && \
-    (!defined(MAC_OS_X_VERSION_15_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_15_0))
+#if defined(__MAC_15_0)
     result = tiled_bmm_out_mps_impl(batch1, batch2, result);
     return result;
 #else

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -533,65 +533,62 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
       uint64_t resElemSize = result.element_size();
       MPSDataType dtype = getMPSDataType(batch1);
 
-
-      uint64_t maxSupportedElems = pow(2,32);
+      uint64_t maxSupportedElems = pow(2, 32);
       uint64_t elemInMatrix = resRows * resCols;
-      uint64_t largestSupportedBatchSize = floor(pow(2,32) / elemInMatrix);
+      uint64_t largestSupportedBatchSize = floor(pow(2, 32) / elemInMatrix);
       uint64_t batchSize = std::min(largestSupportedBatchSize, originalBatchSize);
       uint64_t lastBatchSize = originalBatchSize % batchSize;
 
       id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
 
-      MPSMatrixMultiplication *matmul = [[MPSMatrixMultiplication alloc] initWithDevice:device
-                                                                    resultRows:resRows
-                                                                    resultColumns:resCols
-                                                                    interiorColumns:aCols];
+      MPSMatrixMultiplication* matmul = [[MPSMatrixMultiplication alloc] initWithDevice:device
+                                                                             resultRows:resRows
+                                                                          resultColumns:resCols
+                                                                        interiorColumns:aCols];
 
       getMPSProfiler().beginProfileKernel(matmul, " tiled_bmm_mps", {batch1, batch2});
 
+      MPSMatrixDescriptor* aDesc_ = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
+                                                                          columns:aCols
+                                                                         matrices:batchSize
+                                                                         rowBytes:aCols * aElemSize
+                                                                      matrixBytes:aRows * aCols * aElemSize
+                                                                         dataType:dtype];
+      MPSMatrixDescriptor* bDesc_ = [MPSMatrixDescriptor matrixDescriptorWithRows:bRows
+                                                                          columns:bCols
+                                                                         matrices:batchSize
+                                                                         rowBytes:bCols * bElemSize
+                                                                      matrixBytes:bRows * bCols * bElemSize
+                                                                         dataType:dtype];
+      MPSMatrixDescriptor* resDesc_ = [MPSMatrixDescriptor matrixDescriptorWithRows:resRows
+                                                                            columns:resCols
+                                                                           matrices:batchSize
+                                                                           rowBytes:resCols * resElemSize
+                                                                        matrixBytes:resRows * resCols * resElemSize
+                                                                           dataType:dtype];
 
-      MPSMatrixDescriptor *aDesc_ = [MPSMatrixDescriptor matrixDescriptorWithRows: aRows
-                                                                         columns: aCols
-                                                                        matrices: batchSize
-                                                                        rowBytes: aCols * aElemSize
-                                                                     matrixBytes: aRows * aCols * aElemSize
-                                                                        dataType: dtype];
-      MPSMatrixDescriptor *bDesc_ = [MPSMatrixDescriptor matrixDescriptorWithRows: bRows
-                                                                         columns: bCols
-                                                                        matrices: batchSize
-                                                                        rowBytes: bCols * bElemSize
-                                                                     matrixBytes: bRows * bCols * bElemSize
-                                                                        dataType: dtype];
-      MPSMatrixDescriptor *resDesc_ = [MPSMatrixDescriptor matrixDescriptorWithRows: resRows
-                                                                           columns: resCols
-                                                                          matrices: batchSize
-                                                                          rowBytes: resCols * resElemSize
-                                                                       matrixBytes: resRows * resCols * resElemSize
-                                                                          dataType: dtype];
-
-      //Descriptors to use for last batch if it exists
+      // Descriptors to use for last batch if it exists
       //.matrices is a readonly property so we need a separate descriptor.
       MPSMatrixDescriptor *aDescLastBatch, *bDescLastBatch, *resDescLastBatch;
-      if(lastBatchSize != 0) {
-        aDescLastBatch = [MPSMatrixDescriptor matrixDescriptorWithRows: aRows
-                                                           columns: aCols
-                                                          matrices: lastBatchSize
-                                                          rowBytes: aCols * aElemSize
-                                                       matrixBytes: aRows * aCols * aElemSize
-                                                          dataType: dtype];
-        bDescLastBatch = [MPSMatrixDescriptor matrixDescriptorWithRows: bRows
-                                                           columns: bCols
-                                                          matrices: lastBatchSize
-                                                          rowBytes: bCols * bElemSize
-                                                       matrixBytes: bRows * bCols * bElemSize
-                                                          dataType: dtype];
-        resDescLastBatch = [MPSMatrixDescriptor matrixDescriptorWithRows: resRows
-                                                             columns: resCols
-                                                            matrices: lastBatchSize
-                                                            rowBytes: resCols * resElemSize
-                                                         matrixBytes: resRows * resCols * resElemSize
-                                                            dataType: dtype];
-
+      if (lastBatchSize != 0) {
+        aDescLastBatch = [MPSMatrixDescriptor matrixDescriptorWithRows:aRows
+                                                               columns:aCols
+                                                              matrices:lastBatchSize
+                                                              rowBytes:aCols * aElemSize
+                                                           matrixBytes:aRows * aCols * aElemSize
+                                                              dataType:dtype];
+        bDescLastBatch = [MPSMatrixDescriptor matrixDescriptorWithRows:bRows
+                                                               columns:bCols
+                                                              matrices:lastBatchSize
+                                                              rowBytes:bCols * bElemSize
+                                                           matrixBytes:bRows * bCols * bElemSize
+                                                              dataType:dtype];
+        resDescLastBatch = [MPSMatrixDescriptor matrixDescriptorWithRows:resRows
+                                                                 columns:resCols
+                                                                matrices:lastBatchSize
+                                                                rowBytes:resCols * resElemSize
+                                                             matrixBytes:resRows * resCols * resElemSize
+                                                                dataType:dtype];
       }
 
       uint64_t requiredIterations = ceil(float(originalBatchSize) / batchSize);
@@ -599,10 +596,10 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
       auto bDesc = bDesc_;
       auto resDesc = resDesc_;
       for (const auto i : c10::irange(requiredIterations)) {
-        if(i == requiredIterations - 1 && lastBatchSize != 0) {
-            aDesc = aDescLastBatch;
-            bDesc = bDescLastBatch;
-            resDesc = resDescLastBatch;
+        if (i == requiredIterations - 1 && lastBatchSize != 0) {
+          aDesc = aDescLastBatch;
+          bDesc = bDescLastBatch;
+          resDesc = resDescLastBatch;
         }
         const uint64_t aArrayOffset = i * batchSize * aRows * aCols;
         const uint64_t bArrayOffset = i * batchSize * bRows * bCols;
@@ -610,17 +607,15 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
 
         MPSMatrix* aMatrix = [[[MPSMatrix alloc] initWithBuffer:aBuffer
                                                          offset:(batch1.storage_offset() + aArrayOffset) * aElemSize
-                                                          descriptor:aDesc] autorelease];
+                                                     descriptor:aDesc] autorelease];
         MPSMatrix* bMatrix = [[[MPSMatrix alloc] initWithBuffer:bBuffer
                                                          offset:(batch2.storage_offset() + bArrayOffset) * bElemSize
-                                                          descriptor:bDesc] autorelease];
-        MPSMatrix* resMatrix = [[[MPSMatrix alloc] initWithBuffer:resBuffer
-                                                         offset:(result.storage_offset() + resArrayOffset) * resElemSize
-                                                          descriptor:resDesc] autorelease];
-        [matmul encodeToCommandBuffer: commandBuffer
-                           leftMatrix: aMatrix 
-                          rightMatrix: bMatrix
-                         resultMatrix: resMatrix];
+                                                     descriptor:bDesc] autorelease];
+        MPSMatrix* resMatrix =
+            [[[MPSMatrix alloc] initWithBuffer:resBuffer
+                                        offset:(result.storage_offset() + resArrayOffset) * resElemSize
+                                    descriptor:resDesc] autorelease];
+        [matmul encodeToCommandBuffer:commandBuffer leftMatrix:aMatrix rightMatrix:bMatrix resultMatrix:resMatrix];
       }
     }
   });
@@ -661,14 +656,19 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
     }
   }
 
-  //Currently unsupported if the matmul output goes over the 32-bit indexing limit
-  TORCH_CHECK(batch1.size(1) * batch2.size(2) <= pow(2, 32), "Output size of the matrix multiplication is larger than currently supported by the MPS backend: ",
-    batch1.size(1),",", batch2.size(2), ", needs to be less than 2**32 elements. Use `PYTORCH_ENABLE_MPS_FALLBACK=1` as a temporary fix. ",
-    "File a feature request for this use case against the MPS backend at https://github.com/pytorch/pytorch/issues");
+  // Currently unsupported if the matmul output goes over the 32-bit indexing limit
+  TORCH_CHECK(
+      batch1.size(1) * batch2.size(2) <= pow(2, 32),
+      "Output size of the matrix multiplication is larger than currently supported by the MPS backend: ",
+      batch1.size(1),
+      ",",
+      batch2.size(2),
+      ", needs to be less than 2**32 elements. Use `PYTORCH_ENABLE_MPS_FALLBACK=1` as a temporary fix. ",
+      "File a feature request for this use case against the MPS backend at https://github.com/pytorch/pytorch/issues");
 
-  //Check if we need to split the batch to do the computation 
+  // Check if we need to split the batch to do the computation
   uint64_t resultSize = batch1.size(0) * batch1.size(1) * batch2.size(2);
-  if(resultSize > pow(2,32)) {
+  if (resultSize > pow(2, 32)) {
     result = tiled_bmm_out_mps_impl(batch1, batch2, result);
     return result;
   }

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -545,18 +545,17 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
 
         id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
 
-      auto matmul = [[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device
-                                                                                          sourceCount:2];
+        auto matmul = [[MPSNDArrayMatrixMultiplication alloc] initWithDevice:device sourceCount:2];
 
         MPSShape* aShape = @[ @(batchSize), @(aRows), @(aCols) ];
         MPSShape* bShape = @[ @(batchSize), @(bRows), @(bCols) ];
         MPSShape* resShape = @[ @(batchSize), @(resRows), @(resCols) ];
-        MPSNDArrayDescriptor* aDesc_ = [MPSNDArrayDescriptor descriptorWithDataType:dtype shape:aShape];
+        auto aDesc_ = [MPSNDArrayDescriptor descriptorWithDataType:dtype shape:aShape];
         aDesc_.preferPackedRows = true;
-        MPSNDArrayDescriptor* bDesc_ = [MPSNDArrayDescriptor descriptorWithDataType:dtype shape:bShape];
+        auto bDesc_ = [MPSNDArrayDescriptor descriptorWithDataType:dtype shape:bShape];
         bDesc_.preferPackedRows = true;
 
-        MPSNDArrayDescriptor* resDesc_ = [MPSNDArrayDescriptor descriptorWithDataType:dtype shape:resShape];
+        auto resDesc_ = [MPSNDArrayDescriptor descriptorWithDataType:dtype shape:resShape];
         resDesc_.preferPackedRows = true;
 
         getMPSProfiler().beginProfileKernel(matmul, " tiled_bmm_mps", {batch1, batch2});
@@ -590,16 +589,15 @@ static Tensor& tiled_bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2
           const uint64_t bArrayOffset = i * batchSize * bRows * bCols;
           const uint64_t resArrayOffset = i * batchSize * resRows * resCols;
 
-          MPSNDArray* aMatrix = [[[MPSNDArray alloc] initWithBuffer:aBuffer
-                                                             offset:(batch1.storage_offset() + aArrayOffset) * aElemSize
-                                                         descriptor:aDesc] autorelease];
-          MPSNDArray* bMatrix = [[[MPSNDArray alloc] initWithBuffer:bBuffer
-                                                             offset:(batch2.storage_offset() + bArrayOffset) * bElemSize
-                                                         descriptor:bDesc] autorelease];
-          MPSNDArray* resMatrix =
-              [[[MPSNDArray alloc] initWithBuffer:resBuffer
-                                           offset:(result.storage_offset() + resArrayOffset) * resElemSize
-                                       descriptor:resDesc] autorelease];
+          auto aMatrix = [[[MPSNDArray alloc] initWithBuffer:aBuffer
+                                                      offset:(batch1.storage_offset() + aArrayOffset) * aElemSize
+                                                  descriptor:aDesc] autorelease];
+          auto bMatrix = [[[MPSNDArray alloc] initWithBuffer:bBuffer
+                                                      offset:(batch2.storage_offset() + bArrayOffset) * bElemSize
+                                                  descriptor:bDesc] autorelease];
+          auto resMatrix = [[[MPSNDArray alloc] initWithBuffer:resBuffer
+                                                        offset:(result.storage_offset() + resArrayOffset) * resElemSize
+                                                    descriptor:resDesc] autorelease];
 
           [matmul encodeToCommandEncoder:computeEncoder
                            commandBuffer:commandBuffer

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -668,6 +668,11 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
   // Check if we need to split the batch to do the computation
   uint64_t resultSize = batch1.size(0) * batch1.size(1) * batch2.size(2);
   if (resultSize > pow(2, 32)) {
+    TORCH_CHECK(
+        batch1.scalar_type() == kFloat,
+        "Tiling of batch matmul for outputs with more than 2**32 elements is currently only supported for fp32 on MPS backend. ",
+        "Use `PYTORCH_ENABLE_MPS_FALLBACK=1` as a temporary fix. ",
+        "File a feature request for this use case against the MPS backend at https://github.com/pytorch/pytorch/issues");
     result = tiled_bmm_out_mps_impl(batch1, batch2, result);
     return result;
   }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1939,7 +1939,7 @@ class TestMPS(TestCaseMPS):
         output_cpu = torch.bmm(batch1_cpu, batch2_cpu)
         output_mps = torch.bmm(batch1_mps, batch2_mps)
 
-        #Using the low precision comparison for FP16
+        # Using the low precision comparison for FP16
         self.assertEqual(output_cpu, output_mps, atol=1e-2, rtol=1e-2)
         self.assertEqual(output_cpu.size(), output_mps.size())
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1914,6 +1914,33 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(output_cpu, output_mps)
         self.assertEqual(output_cpu.size(), output_mps.size())
 
+    def test_large_bmm_bf16(self):
+        dtype = torch.bfloat16
+        batch1_cpu = torch.randn(11, 20064, 128, dtype=dtype, device='cpu')
+        batch2_cpu = torch.randn(11, 128, 20064, dtype=dtype, device='cpu')
+        batch1_mps = batch1_cpu.detach().clone().to("mps")
+        batch2_mps = batch2_cpu.detach().clone().to("mps")
+
+        output_cpu = torch.bmm(batch1_cpu, batch2_cpu)
+        output_mps = torch.bmm(batch1_mps, batch2_mps)
+
+        self.assertEqual(output_cpu, output_mps)
+        self.assertEqual(output_cpu.size(), output_mps.size())
+
+    def test_large_bmm_fp16(self):
+        dtype = torch.float16
+        batch1_cpu = torch.randn(11, 20064, 128, dtype=dtype, device='cpu')
+        batch2_cpu = torch.randn(11, 128, 20064, dtype=dtype, device='cpu')
+        batch1_mps = batch1_cpu.detach().clone().to("mps")
+        batch2_mps = batch2_cpu.detach().clone().to("mps")
+
+        output_cpu = torch.bmm(batch1_cpu, batch2_cpu)
+        output_mps = torch.bmm(batch1_mps, batch2_mps)
+
+        #Using the low precision comparison for FP16
+        self.assertEqual(output_cpu, output_mps, atol=1e-2, rtol=1e-2)
+        self.assertEqual(output_cpu.size(), output_mps.size())
+
     def test_addr(self):
         A = torch.ones(5, 10).to("mps")
         B = torch.ones(5).to("mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1914,6 +1914,7 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(output_cpu, output_mps)
         self.assertEqual(output_cpu.size(), output_mps.size())
 
+    @xfailIf(product_version < 15.0)
     def test_large_bmm_bf16(self):
         dtype = torch.bfloat16
         batch1_cpu = torch.randn(11, 20064, 128, dtype=dtype, device='cpu')
@@ -1927,6 +1928,7 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(output_cpu, output_mps)
         self.assertEqual(output_cpu.size(), output_mps.size())
 
+    @xfailIf(product_version < 15.0)
     def test_large_bmm_fp16(self):
         dtype = torch.float16
         batch1_cpu = torch.randn(11, 20064, 128, dtype=dtype, device='cpu')


### PR DESCRIPTION
Fixes #131865. Addresses the issue seen when running llama v3.1 8B parameter model on MPS backend where the batch matmul output size can go over the 32-bit indexing limit of MPS tensors, causing an assert.

Test case to reproduce the issue with the dimensions encountered in llama v3.1 and verify this fix works around it:

```
import torch
device='mps'
a = torch.randn([32, 20064, 128], dtype=torch.float32,device=device)
b = torch.randn([32, 128, 20064], dtype=torch.float32, device=device)
res = torch.bmm(a, b)
```

Notably the current change only works as long as the individual output matrix in the bmm does not exceed the number of elements 2**32. This lets us split up the computation along the batch axis to avoid going over the limit. 

Added a TORCH_CHECK to raise an error if the individual matrix dimensions are too large to handle for this op until a more general workaround tiling the matmuls is available.