### PR TITLE
[inductor] Update mutation_region_id to handle triton kernels

### DIFF
--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1772,6 +1772,10 @@ def _update_mutation_region_id(
             torch._higher_order_ops.auto_functionalize.get_mutable_arg_names(mutable_op)
         )
         update_reinplace_id(node.kwargs, names_of_reinplace_targets)
+    elif node.target is torch.ops.higher_order.triton_kernel_wrapper_functional:
+        names_of_reinplace_targets = node.kwargs["tensors_to_clone"]  # type: ignore[assignment]
+        kwargs = node.kwargs["kwargs"]
+        update_reinplace_id(kwargs, names_of_reinplace_targets)  # type: ignore[arg-type]
 
     if is_mutation_op(node):
         graph_meta["barrier_counter"] += 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133445
* #133249

The last PR updated mutation_region_id to handle mutable custom ops.
triton kernels is a simple extension.

Test Plan:
- new tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang