### PR TITLE
[PT2 Efficiency] Log CUDAGraph warmup time to Scuba

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -955,6 +955,9 @@ def _compile(
                 inductor_compile_time = frame_phase_timing[frame_key].get(
                     "inductor_compile", None
                 )
+                cudagraphify_time = frame_phase_timing[frame_key].get(
+                    "cudagraphify", None
+                )
                 code_gen_time = frame_phase_timing[frame_key].get("code_gen", None)
                 non_compliant_ops = {op.__qualname__ for op in output.non_compliant_ops}
                 compliant_custom_ops = {
@@ -975,6 +978,7 @@ def _compile(
                 entire_frame_compile_time = None
                 backend_compile_time = None
                 inductor_compile_time = None
+                cudagraphify_time = None
                 code_gen_time = None
                 non_compliant_ops = set({})
                 compliant_custom_ops = set({})
@@ -1001,6 +1005,7 @@ def _compile(
                 backend_compile_time,
                 inductor_compile_time,
                 code_gen_time,
+                cudagraphify_time,
                 fail_type,
                 fail_reason,
                 fail_user_frame_filename,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -302,13 +302,18 @@ def dynamo_timed(
                                 code_gen_time = frame_phase_timing[compile_id].get(
                                     "code_gen", None
                                 )
+                                cudagraphify_time = frame_phase_timing[compile_id].get(
+                                    "cudagraphify", None
+                                )
                             else:
                                 inductor_compile_time = None
                                 code_gen_time = None
+                                cudagraphify_time = None
                             metrics = BwdCompilationMetrics(
                                 compile_id,
                                 inductor_compile_time,
                                 code_gen_time,
+                                cudagraphify_time,
                                 fail_type,
                                 fail_reason,
                             )
@@ -735,6 +740,7 @@ class CompilationMetrics:
     entire_frame_compile_time_s: Optional[float]
     backend_compile_time_s: Optional[float]
     inductor_compile_time_s: Optional[float]
+    cudagraphify_time_s: Optional[float]
     code_gen_time_s: Optional[float]
     fail_type: Optional[str]
     fail_reason: Optional[str]
@@ -756,6 +762,7 @@ class BwdCompilationMetrics:
     compile_id: str
     inductor_compile_time_s: Optional[float]
     code_gen_time_s: Optional[float]
+    cudagraphify_time_s: Optional[float]
     fail_type: Optional[str]
     fail_reason: Optional[str]
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -992,7 +992,8 @@ def cudagraphify(
         nonlocal compiled_fn
         if compiled_fn is None:
             with dynamo_utils.dynamo_timed(
-                "cudagraphify"
+                "cudagraphify",
+                phase_name="cudagraphify",
             ), dynamo_utils.preserve_rng_state():
                 compiled_fn = cudagraphify_fn(model, new_inputs, static_input_idxs)
         return compiled_fn(new_inputs)


### PR DESCRIPTION
Summary: To better detect nccl timeout, we want to log the CUDAGraph warmup time on different ranks to scuba table "torch_inductor_stats" to better detect CUDAGraph imbalanced warmup issue across ranks.

Test Plan:
```
buck2 run mode/opt //pytorch/benchmark:run -- resnet50 -d cuda -t train --inductor --pt2-triton-cudagraph

Logging inductor compilation metrics: CompilationMetrics(compile_id='0/0', frame_key='1', co_name='forward', co_filename='/data/users/xzhao9/fbsource/buck-out/v2/gen/fbcode/0b30f0b22247298e/pytorch/benchmark/__run__/run-inplace#link-tree/torchbenchmark/util/framework/vision/model_factory.py', co_firstlineno=95, cache_size=0, accumulated_cache_size=0, guard_count=396, shape_env_guard_count=0, graph_op_count=354, graph_node_count=356, graph_input_count=1, start_time=1723607655.8655994, entire_frame_compile_time_s=30.9645254611969, backend_compile_time_s=29.973933219909668, inductor_compile_time_s=21.98824691772461, cudagraphify_time_s=14.838233232498169, code_gen_time_s=None, fail_type=None, fail_reason=None, fail_user_frame_filename=None, fail_user_frame_lineno=None, non_compliant_ops=set(), compliant_custom_ops=set(), restart_reasons=set(), dynamo_time_before_restart_s=0.0, has_guarded_code=True, possibly_missed_reinplacing_opportunities=0)
Logging inductor compilation metrics: BwdCompilationMetrics(compile_id='0/0', inductor_compile_time_s=9.836592197418213, code_gen_time_s=6.073361396789551, cudagraphify_time_s=None, fail_type=None, fail_reason=None)
```

The forward pass cudagraphify time is  cudagraphify_time_s=14.838233232498169
The backward pass cudagraphify time is None.

Differential Revision: D61252624


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @rec