### PR TITLE
[Inductor] short-term fix for needs_fixed_stride_order silent incorrectness

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10575,23 +10575,21 @@ class CommonTemplate:
     def test_mutable_custom_op_fixed_layout(self):
         with torch.library._scoped_library("mylib", "DEF") as lib:
             lib.define(
-                "copy_(Tensor(a!) ret, Tensor tensors, int dim) -> ()",
+                "copy_(Tensor(a!) dst, Tensor src) -> ()",
                 tags=torch.Tag.needs_fixed_stride_order,
             )
 
             @torch.library.impl(lib, "copy_", "Meta")
-            def _(ret, tensors, dim):
+            def _(dst, src):
                 return None
 
-            @torch.library.impl(lib, "copy_", "CPU")
-            def _(ret, tensors, dim):
-                ret.copy_(tensors)
+            @torch.library.impl(lib, "copy_", "CompositeExplicitAutograd")
+            def _(dst, src):
+                dst.copy_(src)
 
             def f(x):
                 full_default_3 = torch.full([3], 7.0, device="cpu")
-                chunk_cat_default_1 = torch.ops.mylib.copy_.default(
-                    full_default_3, x, 0
-                )
+                chunk_cat_default_1 = torch.ops.mylib.copy_.default(full_default_3, x)
                 mul_out = torch.mul(full_default_3, full_default_3)
                 return mul_out
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -991,12 +991,13 @@ class GraphLowering(torch.fx.Interpreter):
                 # We have to OrderedSet the current args because call_function will immediately
                 # evaluate this lowering after creating the fallback, without evaluating
                 # the layout constraint
-                args, kwargs = constrain_to_fx_strides(
-                    self.current_node, *args, **kwargs
+                constrain_fn = functools.partial(
+                    constrain_to_fx_strides, ignore_mutated_args_FIXME=True
                 )
+                args, kwargs = constrain_fn(self.current_node, *args, **kwargs)
                 # Also register the layout constraint so when the fallback
                 # is used again, we can constrain the args to the same layout
-                layout_constraint = constrain_to_fx_strides
+                layout_constraint = constrain_fn
             return layout_constraint, args, kwargs
 
         if target not in lowerings:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2074,26 +2074,35 @@ def constrain_to_fx_strides(fx_node, *args, ignore_mutated_args_FIXME=False, **k
             return ir.ExternKernel.require_stride_order(arg, stride_order)
         return arg
 
+    # There's a silent incorrectness bug where we if we constrain a mutated arg,
+    # we may end up cloning it, writing in-place to the clone, and then using
+    # the original value (instead of the cloned value). Our short-term fix for this
+    # is to never constrain mutated args; longer term we do want to fix this.
+    # https://github.com/pytorch/pytorch/issues/128084
     if ignore_mutated_args_FIXME:
         assert isinstance(fx_node.target, torch._ops.OpOverload)
         schema = fx_node.target._schema
 
+        def maybe_apply_constraint(schema_arg, arg, fx_arg):
+            if schema_arg.alias_info is not None and schema_arg.alias_info.is_write:
+                return arg
+            return apply_constraint(arg, fx_arg)
+
         new_args = []
         new_kwargs = {}
-        schema_args, schema_kwargs = torch._library.utils.schema_args_kwargs(schema)
-        for arg, fx_arg, schema_arg in zip(args, fx_node.args, schema_args):
-            if schema_arg.alias_info is not None and schema_arg.alias_info.is_write:
-                new_args.append(arg)
-            else:
-                new_args.append(apply_constraint(arg, fx_arg))
-        for key in kwargs:
+
+        for idx, (arg, fx_arg) in enumerate(zip(args, fx_node.args)):
+            schema_arg = schema.arguments[idx]
+            new_args.append(maybe_apply_constraint(schema_arg, arg, fx_arg))
+
+        _, schema_kwargs = torch._library.utils.schema_args_kwargs(schema)
+
+        for key in kwargs.keys():
             arg = kwargs[key]
             fx_arg = fx_node.kwargs[key]
             schema_arg = schema_kwargs[key]
-            if schema_arg.alias_info is not None and schema_arg.alias_info.is_write:
-                new_kwargs[key] = arg
-            else:
-                new_kwargs[key] = apply_constraint(arg, fx_arg)
+            new_kwargs[key] = maybe_apply_constraint(schema_arg, arg, fx_arg)
+
         return tuple(new_args), new_kwargs
 
     args = tuple(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2094,7 +2094,7 @@ def constrain_to_fx_strides(fx_node, *args, ignore_mutated_args_FIXME=False, **k
                 new_kwargs[key] = arg
             else:
                 new_kwargs[key] = apply_constraint(arg, fx_arg)
-        return tuple(args), kwargs
+        return tuple(new_args), new_kwargs
 
     args = tuple(
         apply_constraint(arg, fx_arg) for arg, fx_arg in zip(args, fx_node.args)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2095,7 +2095,7 @@ def constrain_to_fx_strides(fx_node, *args, ignore_mutated_args_FIXME=False, **k
             schema_arg = schema.arguments[idx]
             new_args.append(maybe_apply_constraint(schema_arg, arg, fx_arg))
 
-        _, schema_kwargs = torch._library.utils.schema_args_kwargs(schema)
+        schema_kwargs = {arg.name: arg for arg in schema.arguments}
 
         for key in kwargs.keys():
             arg = kwargs[key]

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -177,18 +177,6 @@ def fill_defaults(schema, args, kwargs):
     return tuple(new_args), new_kwargs
 
 
-def schema_args_kwargs(schema):
-    args = []
-    kwargs = {}
-    for i in range(len(schema.arguments)):
-        info = schema.arguments[i]
-        if info.kwarg_only:
-            kwargs[info.name] = info
-            continue
-        args.append(info)
-    return tuple(args), kwargs
-
-
 def zip_schema(
     schema: _C.FunctionSchema, args: Tuple[Any, ...], kwargs: Dict[str, Any]
 ) -> Iterable[Tuple[_C.Argument, Any]]:

--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -177,6 +177,18 @@ def fill_defaults(schema, args, kwargs):
     return tuple(new_args), new_kwargs
 
 
+def schema_args_kwargs(schema):
+    args = []
+    kwargs = {}
+    for i in range(len(schema.arguments)):
+        info = schema.arguments[i]
+        if info.kwarg_only:
+            kwargs[info.name] = info
+            continue
+        args.append(info)
+    return tuple(args), kwargs
+
+
 def zip_schema(
     schema: _C.FunctionSchema, args: Tuple[Any, ...], kwargs: Dict[str, Any]
 ) -> Iterable[Tuple[_C.Argument, Any]]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133639
* __->__ #133452

This is a low-risk short-term fix for
https://github.com/pytorch/pytorch/issues/128084, for the purposes of
2.4.1. The actual fix for that issue is more risky and we'll target 2.5.

needs_fixed_stride_order is silently incorrect with args that are
mutable because it creates clones of those args, writes into them, and
doesn't update the original args.

This PR makes it so that needs_fixed_stride_order doesn't apply to
inputs that are being mutated.

This PR doesn't completely fix the problem, but it makes it less
incorrect: most of the time the input already has the correct strides
but inductor fails to recognize it, and in those cases writing directly
to the input is fine.

Test Plan:
- new test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang