### PR TITLE
[Don't merge] export strict optimize for Windows.

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -118,9 +118,6 @@ def capture_pre_autograd_graph(
 
     capture_pre_autograd_graph_warning()
 
-    if sys.platform == "win32":
-        raise RuntimeError("capture_pre_autograd_graph not yet supported on Windows")
-
     assert isinstance(f, torch.nn.Module), "Expected an nn.Module instance."
 
     if kwargs is None:

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -5,6 +5,7 @@ import functools
 import inspect
 import logging
 import re
+import sys
 import time
 import warnings
 from contextlib import contextmanager, nullcontext
@@ -1873,7 +1874,7 @@ def _export_for_training(
     kwargs: Optional[Dict[str, Any]] = None,
     dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any], List[Any]]] = None,
     *,
-    strict: bool = True,
+    strict: bool = False,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     global _EXPORT_MODULE_HIERARCHY
@@ -1961,7 +1962,7 @@ def _export(
     kwargs: Optional[Dict[str, Any]] = None,
     dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any], List[Any]]] = None,
     *,
-    strict: bool = True,
+    strict: bool = False if sys.platform == "win32" else True,
     preserve_module_call_signature: Tuple[str, ...] = (),
     pre_dispatch: bool = False,
     allow_complex_guards_as_runtime_asserts: bool = False,

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -1874,7 +1874,7 @@ def _export_for_training(
     kwargs: Optional[Dict[str, Any]] = None,
     dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any], List[Any]]] = None,
     *,
-    strict: bool = False,
+    strict: bool = False if sys.platform == "win32" else True,
     preserve_module_call_signature: Tuple[str, ...] = (),
 ) -> ExportedProgram:
     global _EXPORT_MODULE_HIERARCHY


### PR DESCRIPTION
Hi @jerryzh168 @leslie-fang-intel  It doesn't work on Windows:
```cmd
(win_mkl_static) D:\xu_git\dnnl_cb\pytorch>pytest -v test/quantization/pt2e/test_x86inductor_quantizer.py -k test_qat_conv2d
============================================================================================================================ test session starts ============================================================================================================================
platform win32 -- Python 3.10.14, pytest-7.3.2, pluggy-1.5.0 -- C:\Users\Xuhan\.conda\envs\win_mkl_static\python.exe
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('D:\\xu_git\\dnnl_cb\\pytorch\\.hypothesis\\examples')
rootdir: D:\xu_git\dnnl_cb\pytorch
configfile: pytest.ini
plugins: hypothesis-5.35.1, cpp-2.3.0, flakefinder-1.1.0, rerunfailures-14.0, xdist-3.3.1, xdoctest-1.1.0
collected 46 items / 41 deselected / 5 selected
Running 5 items in this shard

test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d FAILED [0.3582s]                                                                                                                                                    [ 20%]
test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d_binary FAILED [0.0695s]                                                                                                                                             [ 40%]
test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d_binary2 FAILED [0.0915s]                                                                                                                                            [ 60%]
test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d_binary_unary FAILED [0.1311s]                                                                                                                                       [ 80%]
test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d_unary FAILED [0.0627s]                                                                                                                                              [100%]

================================================================================================================================= FAILURES ==================================================================================================================================
________________________________________________________________________________________________________________ TestQuantizePT2EX86Inductor.test_qat_conv2d ________________________________________________________________________________________________________________
Traceback (most recent call last):
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 1737, in test_qat_conv2d
    self._test_quantizer(
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 560, in _test_quantizer
    m = prepare_qat_pt2e(m, quantizer) if is_qat else prepare_pt2e(m, quantizer)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\quantize_pt2e.py", line 174, in prepare_qat_pt2e
    _fuse_conv_bn_qat(model)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 625, in _fuse_conv_bn_qat
    m = _fuse_conv_bn_qat_helper(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 657, in _fuse_conv_bn_qat_helper
    match_pattern = _get_aten_graph_module_for_pattern(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\utils.py", line 364, in _get_aten_graph_module_for_pattern
    aten_pattern = capture_pre_autograd_graph(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_export\__init__.py", line 144, in capture_pre_autograd_graph
    m = torch._dynamo.export(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1568, in inner
    graph = rewrite_signature(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1117, in rewrite_signature
    matched_output_elements_positions = produce_matching(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1103, in produce_matching
    raise AssertionError(
AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
Please file an issue along with a paste of the logs from TORCH_LOGS="+export"

To execute this test, run the following from the base repo dir:
    python test\quantization\pt2e\test_x86inductor_quantizer.py TestQuantizePT2EX86Inductor.test_qat_conv2d

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
--------------------------------------------------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------------------------------------------------
W0814 23:29:51.674000 26764 torch\_export\__init__.py:65] +============================+
W0814 23:29:51.674000 26764 torch\_export\__init__.py:66] |     !!!   WARNING   !!!    |
W0814 23:29:51.674000 26764 torch\_export\__init__.py:67] +============================+
W0814 23:29:51.674000 26764 torch\_export\__init__.py:68] capture_pre_autograd_graph() is deprecated and doesn't provide any function guarantee moving forward.
W0814 23:29:51.674000 26764 torch\_export\__init__.py:69] Please switch to use torch.export instead.
____________________________________________________________________________________________________________ TestQuantizePT2EX86Inductor.test_qat_conv2d_binary _____________________________________________________________________________________________________________
Traceback (most recent call last):
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 1860, in test_qat_conv2d_binary
    self._test_quantizer(
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 560, in _test_quantizer
    m = prepare_qat_pt2e(m, quantizer) if is_qat else prepare_pt2e(m, quantizer)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\quantize_pt2e.py", line 174, in prepare_qat_pt2e
    _fuse_conv_bn_qat(model)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 625, in _fuse_conv_bn_qat
    m = _fuse_conv_bn_qat_helper(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 657, in _fuse_conv_bn_qat_helper
    match_pattern = _get_aten_graph_module_for_pattern(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\utils.py", line 364, in _get_aten_graph_module_for_pattern
    aten_pattern = capture_pre_autograd_graph(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_export\__init__.py", line 144, in capture_pre_autograd_graph
    m = torch._dynamo.export(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1568, in inner
    graph = rewrite_signature(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1117, in rewrite_signature
    matched_output_elements_positions = produce_matching(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1103, in produce_matching
    raise AssertionError(
AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
Please file an issue along with a paste of the logs from TORCH_LOGS="+export"

To execute this test, run the following from the base repo dir:
    python test\quantization\pt2e\test_x86inductor_quantizer.py TestQuantizePT2EX86Inductor.test_qat_conv2d_binary

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
____________________________________________________________________________________________________________ TestQuantizePT2EX86Inductor.test_qat_conv2d_binary2 ____________________________________________________________________________________________________________
Traceback (most recent call last):
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 1907, in test_qat_conv2d_binary2
    self._test_quantizer(
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 560, in _test_quantizer
    m = prepare_qat_pt2e(m, quantizer) if is_qat else prepare_pt2e(m, quantizer)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\quantize_pt2e.py", line 174, in prepare_qat_pt2e
    _fuse_conv_bn_qat(model)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 625, in _fuse_conv_bn_qat
    m = _fuse_conv_bn_qat_helper(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 657, in _fuse_conv_bn_qat_helper
    match_pattern = _get_aten_graph_module_for_pattern(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\utils.py", line 364, in _get_aten_graph_module_for_pattern
    aten_pattern = capture_pre_autograd_graph(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_export\__init__.py", line 144, in capture_pre_autograd_graph
    m = torch._dynamo.export(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1568, in inner
    graph = rewrite_signature(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1117, in rewrite_signature
    matched_output_elements_positions = produce_matching(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1103, in produce_matching
    raise AssertionError(
AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
Please file an issue along with a paste of the logs from TORCH_LOGS="+export"

To execute this test, run the following from the base repo dir:
    python test\quantization\pt2e\test_x86inductor_quantizer.py TestQuantizePT2EX86Inductor.test_qat_conv2d_binary2

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
_________________________________________________________________________________________________________ TestQuantizePT2EX86Inductor.test_qat_conv2d_binary_unary __________________________________________________________________________________________________________
Traceback (most recent call last):
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 1949, in test_qat_conv2d_binary_unary
    self._test_quantizer(
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 560, in _test_quantizer
    m = prepare_qat_pt2e(m, quantizer) if is_qat else prepare_pt2e(m, quantizer)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\quantize_pt2e.py", line 174, in prepare_qat_pt2e
    _fuse_conv_bn_qat(model)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 625, in _fuse_conv_bn_qat
    m = _fuse_conv_bn_qat_helper(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 657, in _fuse_conv_bn_qat_helper
    match_pattern = _get_aten_graph_module_for_pattern(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\utils.py", line 364, in _get_aten_graph_module_for_pattern
    aten_pattern = capture_pre_autograd_graph(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_export\__init__.py", line 144, in capture_pre_autograd_graph
    m = torch._dynamo.export(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1568, in inner
    graph = rewrite_signature(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1117, in rewrite_signature
    matched_output_elements_positions = produce_matching(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1103, in produce_matching
    raise AssertionError(
AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
Please file an issue along with a paste of the logs from TORCH_LOGS="+export"

To execute this test, run the following from the base repo dir:
    python test\quantization\pt2e\test_x86inductor_quantizer.py TestQuantizePT2EX86Inductor.test_qat_conv2d_binary_unary

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
_____________________________________________________________________________________________________________ TestQuantizePT2EX86Inductor.test_qat_conv2d_unary _____________________________________________________________________________________________________________
Traceback (most recent call last):
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 1811, in test_qat_conv2d_unary
    self._test_quantizer(
  File "D:\xu_git\dnnl_cb\pytorch\test\quantization\pt2e\test_x86inductor_quantizer.py", line 560, in _test_quantizer
    m = prepare_qat_pt2e(m, quantizer) if is_qat else prepare_pt2e(m, quantizer)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\quantize_pt2e.py", line 174, in prepare_qat_pt2e
    _fuse_conv_bn_qat(model)
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 625, in _fuse_conv_bn_qat
    m = _fuse_conv_bn_qat_helper(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\qat_utils.py", line 657, in _fuse_conv_bn_qat_helper
    match_pattern = _get_aten_graph_module_for_pattern(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\ao\quantization\pt2e\utils.py", line 364, in _get_aten_graph_module_for_pattern
    aten_pattern = capture_pre_autograd_graph(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_export\__init__.py", line 144, in capture_pre_autograd_graph
    m = torch._dynamo.export(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1568, in inner
    graph = rewrite_signature(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1117, in rewrite_signature
    matched_output_elements_positions = produce_matching(
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\_dynamo\eval_frame.py", line 1103, in produce_matching
    raise AssertionError(
AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
Please file an issue along with a paste of the logs from TORCH_LOGS="+export"

To execute this test, run the following from the base repo dir:
    python test\quantization\pt2e\test_x86inductor_quantizer.py TestQuantizePT2EX86Inductor.test_qat_conv2d_unary

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
========================================================================================================================== short test summary info ==========================================================================================================================
FAILED [0.3582s] test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d - AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
FAILED [0.0695s] test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d_binary - AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
FAILED [0.0915s] test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d_binary2 - AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
FAILED [0.1311s] test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d_binary_unary - AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
FAILED [0.0627s] test/quantization/pt2e/test_x86inductor_quantizer.py::TestQuantizePT2EX86Inductor::test_qat_conv2d_unary - AssertionError: Unexpectedly found a <class 'torch.Tensor'> in the outputs.
===================================================================================================================== 5 failed, 41 deselected in 3.18s ======================================================================================================================

(win_mkl_static) D:\xu_git\dnnl_cb\pytorch>
```
