### PR TITLE
[TD] llm retrieval to not use bash -l {0}

### DIFF
--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install requirements
-        shell: bash -l {0}
+        shell: bash
         run: |
           set -euxo pipefail
           ${CONDA_RUN} pip install -r llm-target-determinator/requirements.txt
@@ -50,7 +50,7 @@ jobs:
           ${CONDA_RUN} pip install -e .
 
       - name: Fetch CodeLlama Checkpoint
-        shell: bash -l {0}
+        shell: bash
         run: |
           set -euxo pipefail
           cd "${GITHUB_WORKSPACE}/codellama"
@@ -76,7 +76,7 @@ jobs:
       - name: Run Retriever
         id: run_retriever
         continue-on-error: true  # ghstack not currently supported due to problems getting git diff
-        shell: bash -l {0}
+        shell: bash
         run: |
           set -euxo pipefail
           cd "${GITHUB_WORKSPACE}"/llm-target-determinator


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/129720 swapped the action used to setup miniconda from [conda incubator](https://github.com/conda-incubator/setup-miniconda) to the [custom action](https://github.com/pytorch/test-infra/blob/2aba8f107aca99710cca5cd97b6c16500eb808e2/.github/actions/setup-miniconda/action.yml#L1) we have in test-infra that comes with caching.  

The original miniconda [relies on bash profiles](https://github.com/conda-incubator/setup-miniconda/blob/e5293c8fd23bf30f6ad37a6281c8a924c8938440/README.md?plain=1#L746) to set the environment variables needed to run conda, but the test infra version relies on the user using the env vars that are set during the step.  

This PR changes the job to not use `bash -l {0}` to see if not activating bash profile has an effect on the run.  Unfortunately this failure happens rarely on main so I'm not sure I will be able see if this has an effect.  On the plus side, changing this doesn't seem to have a negative effect on the job, so it should be a noop at worst.  

Example failure: https://github.com/pytorch/pytorch/actions/runs/10389945235/job/28769219135