### PR TITLE
[AOTI][Tooling] A couple fixes / minor updates for initial debug printer (#133016)

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -26,7 +26,6 @@ from .cpp_utils import (
     DTYPE_TO_CPP,
     LAYOUT_TO_ATEN,
 )
-from .debug_utils import DebugPrinterManager
 from .wrapper import EnterSubgraphLine, ExitSubgraphLine, WrapperCodeGen
 
 
@@ -1241,7 +1240,9 @@ class CppWrapperCpu(WrapperCodeGen):
                     piece = f"convert_arrayref_tensor_to_tensor({piece})"
                 wrapped_args.append(piece)
 
-        with DebugPrinterManager(enable_debug_printer, args_to_print, kernel):
+        debug_printer_manager = V.graph.wrapper_code.debug_printer
+        debug_printer_manager.set_printer_args(args_to_print, kernel, None, None)
+        with debug_printer_manager:
             shim_fn = self.get_c_shim_func_name(kernel)
             self.writeline(
                 f"AOTI_TORCH_ERROR_CODE_CHECK({shim_fn}({', '.join(wrapped_args)}));"

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+import functools
 import os
 from typing import List, Optional
 
@@ -10,20 +11,24 @@ from .common import TensorArg
 
 
 class DebugPrinterManager:
+    DEBUG_FILTER_DEFAULT_PRINT_ALL = "default"
+
     def __init__(
         self,
         enable_debug_printer: bool,
-        args_to_print: List[str],
-        kernel_name: str,
+        args_to_print: List[str] | None = None,
+        kernel_name: str = "",
         kernel=None,
-        arg_types: Optional[List[type]] = None,
+        arg_signatures: Optional[List[type]] = None,
     ):
-        self.wrapper = V.graph.wrapper_code
         self.enable_debug_printer = enable_debug_printer
+        if args_to_print is None:
+            args_to_print = []
         self.args_to_print = args_to_print
         self.kernel_name = kernel_name
-        self.arg_types: Optional[List[type]] = None
+        self.arg_signatures: Optional[List[type]] = None
         self.kernel = kernel
+        self.filtered_kernel_names_to_print = self.get_debug_filtered_kernel_names()
 
     def __enter__(self):
         if self.enable_debug_printer:
@@ -32,24 +37,37 @@ class DebugPrinterManager:
                 self.args_to_print,
                 self.kernel_name,
                 before_launch=True,
-                arg_types=self.arg_types,
+                arg_signatures=self.arg_signatures,
             )
 
-    def __exit__(self, args_to_print, kernel_name, arg_types):
+    def __exit__(self, args_to_print, kernel_name, arg_signatures):
         if self.enable_debug_printer:
             self.codegen_intermediate_tensor_value_printer(
                 self.args_to_print,
                 self.kernel_name,
                 before_launch=False,
-                arg_types=self.arg_types,
+                arg_signatures=self.arg_signatures,
             )
 
+    def set_printer_args(
+        self,
+        args_to_print: List[str],
+        kernel_name: str,
+        arg_signatures: Optional[List[type]],
+        kernel,
+    ):
+        self.args_to_print = args_to_print
+        self.kernel_name = kernel_name
+        self.arg_signatures = arg_signatures
+        self.kernel = kernel
+
+    @functools.lru_cache  # noqa: B019
     def get_debug_filtered_kernel_names(self) -> List[str]:
         return [
             x.strip()
             for x in os.environ.get(
                 "AOT_INDUCTOR_FILTERED_KERNELS_TO_PRINT",
-                ",".join(V.graph.all_codegen_kernel_names),
+                self.DEBUG_FILTER_DEFAULT_PRINT_ALL,
             )
             .lower()
             .split(",")
@@ -60,32 +78,29 @@ class DebugPrinterManager:
         args_to_print,
         kernel_name,
         before_launch=True,
-        arg_types: Optional[List[type]] = None,
+        arg_signatures: Optional[List[type]] = None,
     ) -> None:
-        # when invoking this codegen_intermediate_tensor_value_printer function,
-        # we already assured that the AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER env var is set to 1,
-        # so we can directly use get method for filtered kernel info here
-        filtered_kernel_names_to_print = []
-        if V.graph.cpp_wrapper:
-            filtered_kernel_names_to_print = self.get_debug_filtered_kernel_names()
-
         for i, arg in enumerate(args_to_print):
-            if arg_types is not None and not isinstance(arg_types[i], TensorArg):
+            if arg_signatures is not None and not isinstance(
+                arg_signatures[i], TensorArg
+            ):
                 continue
             if (
-                len(filtered_kernel_names_to_print) > 0
-                and kernel_name not in filtered_kernel_names_to_print
+                len(self.filtered_kernel_names_to_print) > 0
+                and self.filtered_kernel_names_to_print[0]
+                != self.DEBUG_FILTER_DEFAULT_PRINT_ALL
+                and kernel_name not in self.filtered_kernel_names_to_print
             ):
                 continue
             launch_prefix = "before_launch" if before_launch else "after_launch"
             if V.graph.cpp_wrapper:
                 if config.abi_compatible:
-                    self.wrapper.writeline(
+                    V.graph.wrapper_code.writeline(
                         f'aoti_torch_print_tensor_handle({arg}, "{launch_prefix} - {kernel_name} - {arg}");'
                     )
                 else:
                     # TODO: add non-abi compatible mode debug printing info
                     pass
             else:
-                line = f"print('{launch_prefix} {kernel_name} - {arg}', {arg})"
-                self.wrapper.writeline(line)
+                line = f"print('{launch_prefix} - {kernel_name} - {arg}', {arg})"
+                V.graph.wrapper_code.writeline(line)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -2799,9 +2799,9 @@ class TritonKernel(SIMDKernel):
 
     def codegen_nan_check(self):
         wrapper = V.graph.wrapper_code
-        _, call_args, _, arg_types = self.args.python_argdefs()
-        for arg, arg_type in zip(call_args, arg_types):
-            if isinstance(arg_type, TensorArg):
+        _, call_args, arg_signatures, _ = self.args.python_argdefs()
+        for arg, arg_signature in zip(call_args, arg_signatures):
+            if isinstance(arg_signature, TensorArg):
                 if V.graph.cpp_wrapper:
                     if config.abi_compatible:
                         wrapper.writeline(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -32,6 +32,7 @@ import torch
 import torch._ops
 from torch import dtype as torch_dtype
 from torch._dynamo.utils import counters, dynamo_timed
+from torch._inductor.codegen.debug_utils import DebugPrinterManager
 from torch._inductor.codegen.multi_kernel import MultiKernelState
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.fx.experimental.symbolic_shapes import ConvertIntKey, DivideByKey, SymTypes
@@ -530,6 +531,11 @@ class WrapperCodeGen(CodeGen):
         self._metas: Dict[str, str] = {}
         self._meta_vars: Set[str] = set()
         self.multi_kernel_state = MultiKernelState()
+
+        # intermediate tensor value printing utility
+        self.debug_printer = DebugPrinterManager(
+            enable_debug_printer=config.aot_inductor.debug_intermediate_value_printer
+        )
 
     def write_constant(self, name: str, hashed: str) -> None:
         self.header.writeline(f"{name} = None  # {hashed}")

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -57,6 +57,8 @@ static c10::Device c10_device(int32_t device_type, int32_t device_index) {
 }
 } // namespace
 
+const int AOTI_TORCH_MAX_NUMEL_TO_PRINT = 64;
+
 int32_t aoti_torch_device_type_cpu() {
   return (int32_t)c10::DeviceType::CPU;
 }
@@ -936,8 +938,6 @@ AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
   at::Tensor* t = tensor_handle_to_tensor_pointer(self);
 
   auto device = t->device();
-  auto min = t->min().item<float>();
-  auto max = t->max().item<float>();
 
   // Display message
   std::cout << "[";
@@ -948,20 +948,23 @@ AOTI_TORCH_EXPORT void aoti_torch_print_tensor_handle(
             << "]:" << std::endl;
 
   // Print exact tensor values for small size tensors
-  const int threshold = 10;
-  if (t->numel() <= threshold) {
+  const int64_t numel = t->numel();
+  if (numel <= AOTI_TORCH_MAX_NUMEL_TO_PRINT) {
     std::cout << *t << "\n";
   }
 
   // Print summary stats of the tensor
-  std::cout << "Min value: " << min << std::endl;
-  std::cout << "Max value: " << max << std::endl;
+  std::cout << "Number of elements: " << numel << std::endl;
+  if (numel > 0) {
+    std::cout << "Mean value: " << t->mean().item() << std::endl;
+    std::cout << "Min value: " << t->min().item<float>() << std::endl;
+    std::cout << "Max value: " << t->max().item<float>() << std::endl;
+  }
   std::cout << "Device: " << device << std::endl;
   std::cout << "Size: " << t->sizes() << std::endl;
   std::cout << "Stride: " << t->strides() << std::endl;
   std::cout << "Dtype: " << t->dtype() << std::endl;
   std::cout << "Layout: " << t->layout() << std::endl;
-  std::cout << "Number of elements: " << t->numel() << std::endl;
   std::cout << "Is contiguous: " << t->is_contiguous() << std::endl;
   std::cout << "Requires grad: " << t->requires_grad() << std::endl;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133482
* #133481
* #133480
* #133479
* #133478
* #133477
* #133476
* #133475
* #133474
* __->__ #133473
* #133472
* #133471

Summary:
Follow up small diff to fix a couple issues:
-  add condition for cuda/gpu case to only print kernel name list in the second pass i.e. when we do the cpp wrapper codegen

- other minor fixes around `AOT_INDUCTOR_FILTERED_KERNELS_TO_PRINT` option

Test Plan:
```
AOT_INDUCTOR_FILTERED_KERNELS_TO_PRINT="triton_poi_fused_0" AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER=1 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1  TORCHINDUCTOR_ABI_COMPATIBLE=1 TORCH_COMPILE_DEBUG=1 TORCH_LOGS="+graph, inductor, +schedule, output_code" buck2 run -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 @//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor -- -r test_addmm_abi_compatible_cuda
```

Differential Revision: D60954888
Approved by: https://github.com/ColinPeppler