### PR TITLE
[CI] Do not emit color escape sequence during testing (#133350)

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -6,6 +6,9 @@
 
 set -ex
 
+# Suppress ANSI color escape sequences
+export TERM=vt100
+
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133482
* #133481
* #133480
* #133479
* #133478
* #133477
* __->__ #133476
* #133475
* #133474
* #133473
* #133472
* #133471

By forcing term to vt100

Fixes problem reported in  https://github.com/pytorch/pytorch/issues/133330 but more broadly it should be fixed on Nova/Infra side
Approved by: https://github.com/zou3519