### PR TITLE
[TunableOp] lazy init TuningContext singleton (#133347)

### DIFF
--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -45,13 +45,8 @@
 
 namespace at::cuda::tunable {
 
-namespace {
-
-TuningContext tuning_context;
-
-} // anonymous namespace
-
 TuningContext* getTuningContext() {
+  static TuningContext tuning_context;
   return &tuning_context;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133482
* #133481
* #133480
* #133479
* __->__ #133478
* #133477
* #133476
* #133475
* #133474
* #133473
* #133472
* #133471

Forward fix after #132464 because TuningContext had been created during static library init, which creates the TuningResultsValidator, which tries to query HIP device properties before the HIP runtime has initialized.
Approved by: https://github.com/zixi-qi