### PR TITLE
[ONNX] Disable op_level_debug tests

### DIFF
--- a/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
+++ b/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
@@ -111,15 +111,6 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
                     )
                 ),
             ),
-            (
-                OrtBackendOptions(
-                    use_aot_autograd=False,
-                    export_options=ExportOptions(
-                        op_level_debug=True,
-                        dynamic_shapes=True,
-                    ),
-                ),
-            ),
         ]
     )
     def test_torch_compile_backend_caching_assert_reused(

--- a/test/onnx/onnx_test_common.py
+++ b/test/onnx/onnx_test_common.py
@@ -294,7 +294,6 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
                     *ref_input_args,
                     **ref_input_kwargs,
                     export_options=torch.onnx.ExportOptions(
-                        op_level_debug=self.op_level_debug,
                         dynamic_shapes=self.dynamic_shapes,
                         diagnostic_options=torch.onnx.DiagnosticOptions(
                             verbosity_level=logging.DEBUG
@@ -308,7 +307,6 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
         if diagnostics.is_onnx_diagnostics_log_artifact_enabled():
             onnx_program.save_diagnostics(
                 f"test_report_{self._testMethodName}"
-                f"_op_level_debug_{self.op_level_debug}"
                 f"_dynamic_axes_{self.dynamic_shapes}"
                 f"_model_type_{self.model_type}"
                 ".sarif"

--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -226,36 +226,6 @@ def xfail_dynamic_fx_test(
     return skip_dec
 
 
-def xfail_op_level_debug_test(
-    error_message: str,
-    model_type: Optional[TorchModelType] = None,
-    reason: Optional[str] = None,
-):
-    """Xfail op level debug test.
-
-    Args:
-        reason: The reason for xfailing op level debug test.
-        model_type (TorchModelType): The model type to xfail dynamic exporting test for.
-            When None, model type is not used to xfail op level debug tests.
-
-    Returns:
-        A decorator for xfailing op level debug test.
-    """
-
-    def skip_dec(func):
-        @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
-            if self.op_level_debug and (
-                not model_type or self.model_type == model_type
-            ):
-                return xfail(error_message, reason)(func)(self, *args, **kwargs)
-            return func(self, *args, **kwargs)
-
-        return wrapper
-
-    return skip_dec
-
-
 def skip_dynamic_fx_test(reason: str, model_type: TorchModelType = None):
     """Skip dynamic exporting test.
 

--- a/test/onnx/test_fx_op_consistency.py
+++ b/test/onnx/test_fx_op_consistency.py
@@ -1974,7 +1974,6 @@ class TestOnnxModelOutputConsistency(onnx_test_common._TestONNXRuntime):
     """
 
     opset_version = -1
-    op_level_debug: bool = False
     dynamic_shapes: bool = False
     model_type: pytorch_test_common.TorchModelType = (
         pytorch_test_common.TorchModelType.TORCH_NN_MODULE

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -124,9 +124,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 return output
 
         tensor_x = torch.rand((64, 1, 28, 28), dtype=torch.float32)
-        onnx_program = dynamo_export(
-            MNISTModel(), tensor_x
-        )
+        onnx_program = dynamo_export(MNISTModel(), tensor_x)
 
         assert_has_diagnostics(
             onnx_program.diagnostic_context,

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -99,10 +99,6 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
                 diagnostics.rules.find_opschema_matched_symbolic_function,
                 name="optional_inputs",
             ),
-            common_utils.subtest(
-                diagnostics.rules.op_level_debugging,
-                name="get_attr_node_in_op_level_debug",
-            ),
         ],
     )
     def test_mnist_exported_with_no_warnings(self, diagnostic_rule):
@@ -129,7 +125,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
 
         tensor_x = torch.rand((64, 1, 28, 28), dtype=torch.float32)
         onnx_program = dynamo_export(
-            MNISTModel(), tensor_x, export_options=ExportOptions(op_level_debug=True)
+            MNISTModel(), tensor_x
         )
 
         assert_has_diagnostics(
@@ -137,26 +133,6 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             diagnostic_rule,
             diagnostics.levels.NONE,
             expected_node="aten.convolution.default",
-        )
-
-    def test_no_warnings_on_complex_dtype_in_op_level_debug(self):
-        class ComplexModel(torch.nn.Module):
-            def forward(self, input):
-                return torch.ops.aten.mul(input, input)
-
-        real = torch.tensor([1, 2], dtype=torch.float32)
-        imag = torch.tensor([3, 4], dtype=torch.float32)
-        x = torch.complex(real, imag)
-
-        onnx_program = dynamo_export(
-            ComplexModel(), x, export_options=ExportOptions(op_level_debug=True)
-        )
-
-        assert_has_diagnostics(
-            onnx_program.diagnostic_context,
-            diagnostics.rules.op_level_debugging,
-            diagnostics.levels.NONE,
-            expected_node="aten.mul.Tensor",
         )
 
     def test_trace_only_op_with_evaluator(self):
@@ -186,28 +162,6 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         x = torch.arange(1.0, 6.0, requires_grad=True)
 
         _ = dynamo_export(TopKModel(), x, export_options=self.export_options)
-
-    def test_unsupported_indices_fake_tensor_generated_with_op_level_debug(self):
-        class EmbedModelWithoutPaddingIdx(torch.nn.Module):
-            def forward(self, input, emb):
-                return torch.nn.functional.embedding(input, emb)
-
-        model = EmbedModelWithoutPaddingIdx()
-        x = torch.randint(4, (4, 3, 2))
-        embedding_matrix = torch.rand(10, 3)
-
-        onnx_program = dynamo_export(
-            model,
-            x,
-            embedding_matrix,
-            export_options=ExportOptions(op_level_debug=True),
-        )
-        assert_has_diagnostics(
-            onnx_program.diagnostic_context,
-            diagnostics.rules.op_level_debugging,
-            diagnostics.levels.WARNING,
-            expected_node="aten.embedding.default",
-        )
 
     def test_unsupported_function_schema_raises_diagnostic_warning_when_found_nearest_match(
         self,

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -45,7 +45,6 @@ def _parameterized_class_attrs_and_values():
     input_values.extend(
         itertools.product(
             (True, False),
-            (True, False),
             (
                 pytorch_test_common.TorchModelType.TORCH_NN_MODULE,
                 pytorch_test_common.TorchModelType.TORCH_EXPORT_EXPORTEDPROGRAM,
@@ -53,7 +52,7 @@ def _parameterized_class_attrs_and_values():
         )
     )
     return {
-        "attrs": ["op_level_debug", "dynamic_shapes", "model_type"],
+        "attrs": ["dynamic_shapes", "model_type"],
         "input_values": input_values,
     }
 
@@ -75,7 +74,6 @@ def _parameterize_class_name(cls: Type, idx: int, input_dicts: Mapping[Any, Any]
     class_name_func=_parameterize_class_name,
 )
 class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
-    op_level_debug: bool
     dynamic_shapes: bool
     model_type: pytorch_test_common.TorchModelType
 
@@ -200,7 +198,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             tensor_x,
             8.0,
             export_options=torch.onnx.ExportOptions(
-                op_level_debug=self.op_level_debug,
                 dynamic_shapes=self.dynamic_shapes,
             ),
         )
@@ -779,7 +776,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
 
                 options = torch.onnx.ExportOptions(
                     dynamic_shapes=self.dynamic_shapes,
-                    op_level_debug=self.op_level_debug,
                 )
                 export_options = _exporter_legacy.ResolvedExportOptions(options)
                 export_options.fx_tracer = (
@@ -910,7 +906,6 @@ def _parameterized_class_attrs_and_values_with_fake_options():
     input_values = []
     input_values.extend(
         itertools.product(
-            (False,),
             (True, False),
             (True, False),
             (True, False),
@@ -922,7 +917,6 @@ def _parameterized_class_attrs_and_values_with_fake_options():
     )
     return {
         "attrs": [
-            "op_level_debug",
             "dynamic_shapes",
             "load_checkpoint_during_init",
             "export_within_fake_mode",
@@ -942,7 +936,6 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
     TODO: Should we merge this with  `TestFxToOnnxWithOnnxRuntime`? Considerably increases export time
     """
 
-    op_level_debug: bool
     dynamic_shapes: bool
     load_checkpoint_during_init: bool
     export_within_fake_mode: bool
@@ -1015,7 +1008,6 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 # Export the model with fake inputs and parameters
                 export_options = torch.onnx.ExportOptions(
                     dynamic_shapes=self.dynamic_shapes,
-                    op_level_debug=self.op_level_debug,
                     fake_context=fake_context,
                 )
 
@@ -1051,7 +1043,6 @@ class TestFxToOnnxFakeTensorWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             if diagnostics.is_onnx_diagnostics_log_artifact_enabled():
                 onnx_program.save_diagnostics(
                     f"test_report_{self._testMethodName}"
-                    f"_op_level_debug_{self.op_level_debug}"
                     f"_dynamic_axes_{self.dynamic_shapes}"
                     f"_load_checkpoint_{self.load_checkpoint_during_init}"
                     f"_export_within_fake_mode_{self.export_within_fake_mode}"

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -910,7 +910,7 @@ def _parameterized_class_attrs_and_values_with_fake_options():
     input_values = []
     input_values.extend(
         itertools.product(
-            (True, False),
+            (False,),
             (True, False),
             (True, False),
             (True, False),


### PR DESCRIPTION
op_level_debug is being deprecated. So we disable the tests.
