### PR TITLE
Bijection and Jacobian for lower Cholesky and positive definite transforms

### DIFF
--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -248,7 +248,7 @@ def _transform_to_simplex(constraint):
     return transforms.SoftmaxTransform()
 
 
-# TODO define a bijection for LowerCholeskyTransform
+@biject_to.register(constraints.lower_cholesky)
 @transform_to.register(constraints.lower_cholesky)
 def _transform_to_lower_cholesky(constraint):
     return transforms.LowerCholeskyTransform()

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -254,6 +254,8 @@ def _transform_to_lower_cholesky(constraint):
     return transforms.LowerCholeskyTransform()
 
 
+@biject_to.register(constraints.positive_definite)
+@biject_to.register(constraints.positive_semidefinite)
 @transform_to.register(constraints.positive_definite)
 @transform_to.register(constraints.positive_semidefinite)
 def _transform_to_positive_definite(constraint):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -1015,6 +1015,8 @@ class PositiveDefiniteTransform(Transform):
 
     domain = constraints.independent(constraints.real, 2)
     codomain = constraints.positive_definite  # type: ignore[assignment]
+    bijective = True
+    sign = +1
 
     def __eq__(self, other):
         return isinstance(other, PositiveDefiniteTransform)
@@ -1026,6 +1028,10 @@ class PositiveDefiniteTransform(Transform):
     def _inverse(self, y):
         y = torch.linalg.cholesky(y)
         return LowerCholeskyTransform().inv(y)
+
+    def log_abs_det_jacobian(self, x, y):
+        K = x.shape[-1]
+        return K * math.log(2.0) + (torch.arange(K + 1, 1, -1) * x.diagonal(dim1=-2, dim2=-1)).sum(dim=-1)
 
 
 class CatTransform(Transform):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -992,6 +992,8 @@ class LowerCholeskyTransform(Transform):
 
     domain = constraints.independent(constraints.real, 2)
     codomain = constraints.lower_cholesky
+    bijective = True
+    sign = +1
 
     def __eq__(self, other):
         return isinstance(other, LowerCholeskyTransform)
@@ -1001,6 +1003,9 @@ class LowerCholeskyTransform(Transform):
 
     def _inverse(self, y):
         return y.tril(-1) + y.diagonal(dim1=-2, dim2=-1).log().diag_embed()
+
+    def log_abs_det_jacobian(self, x, y):
+        return x.diagonal(dim1=-2, dim2=-1).sum(dim=-1)
 
 
 class PositiveDefiniteTransform(Transform):


### PR DESCRIPTION
Implements the `log_abs_det_jacobian` method, sets `bijective=True`, and sets `sign` for the `PositiveDefiniteTransform` and `LowerCholeskyTranform` classes. Additionally registers these transforms with `biject_to`.

I'm happy to make any changes requested if there's something that seems wrong. The Jacobians match those in the [STAN documentation](https://mc-stan.org/docs/reference-manual/transforms.html#covariance-matrices), which uses the same transforms to/from Cholesky factors and positive definite matrices.

Thanks!
