### PR TITLE
 [codemod] Del un at::native::metal @ MPSCNNFullyConnectedOp.h:6 (export D59157302)

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.h
@@ -3,7 +3,6 @@
 #import <ATen/native/metal/mpscnn/MPSCNNConvOp.h>
 #import <Foundation/Foundation.h>
 
-using namespace at::native::metal;
 API_AVAILABLE(ios(11.0), macos(10.13))
 @interface MPSCNNFullyConnectedOp : NSObject<MPSCNNOp>
 + (MPSCNNFullyConnectedOp*)linear:(const Conv2DParams&)params


### PR DESCRIPTION
Manual export of D59157302

Original description:
Removes a using namespace from the global namespace in pursuit of enabling -Wheader-hygiene. Qualifies instances that relied on the using namespace.

cc @r-barnes 

@diff-train-skip-merge