### PR TITLE
Add storage_utils

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -48,6 +48,10 @@ from torch.utils.checkpoint import (
     get_device_states,
 )
 from torch.utils.data import DataLoader
+from torch.utils._storage_utils import (
+    get_storage_id,
+    get_storage_size,
+)
 
 
 # load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
@@ -1245,6 +1249,22 @@ def f(x):
         rs = CapturedTraceback.format_all([tb, CapturedTraceback.extract()])
         self.assertEqual(len(rs), 2)
         self.assertIn("test_captured_traceback_format_all", "".join(rs[0]))
+
+
+class TestStorageUtils(TestCase):
+    def test_storage_id(self):
+        from torch.testing._internal.two_tensor import TwoTensor
+        t1 = torch.randn(1, 2, dtype=torch.float32)
+        t2 = TwoTensor(t1, TwoTensor(t1, t1))
+        i = get_storage_id(t1)
+        self.assertTrue(get_storage_id(t2), (i, (i, i)))
+
+    def test_storage_size(self):
+        from torch.testing._internal.two_tensor import TwoTensor
+        t1 = torch.randn(1, 2, dtype=torch.float32)
+        t2 = TwoTensor(t1, t1)
+        self.assertEqual(get_storage_size(t1), 1 * 2 * 4)
+        self.assertEqual(get_storage_size(t2), 1 * 2 * 4 * 2)
 
 
 if __name__ == "__main__":

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
 )
 from torch.utils._device import set_device
 from torch.utils._pytree import tree_all_only, tree_any
+from torch.utils._storage_utils import get_storage_id, get_storage_size
 from torch.utils._traceback import (
     CapturedTraceback,
     format_traceback_short,
@@ -48,10 +49,6 @@ from torch.utils.checkpoint import (
     get_device_states,
 )
 from torch.utils.data import DataLoader
-from torch.utils._storage_utils import (
-    get_storage_id,
-    get_storage_size,
-)
 
 
 # load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
@@ -1254,6 +1251,7 @@ def f(x):
 class TestStorageUtils(TestCase):
     def test_storage_id(self):
         from torch.testing._internal.two_tensor import TwoTensor
+
         t1 = torch.randn(1, 2, dtype=torch.float32)
         t2 = TwoTensor(t1, TwoTensor(t1, t1))
         i = get_storage_id(t1)
@@ -1261,6 +1259,7 @@ class TestStorageUtils(TestCase):
 
     def test_storage_size(self):
         from torch.testing._internal.two_tensor import TwoTensor
+
         t1 = torch.randn(1, 2, dtype=torch.float32)
         t2 = TwoTensor(t1, t1)
         self.assertEqual(get_storage_size(t1), 1 * 2 * 4)

--- a/torch/utils/_storage_utils.py
+++ b/torch/utils/_storage_utils.py
@@ -1,0 +1,54 @@
+import importlib
+from typing import Union, Tuple, Any
+from functools import lru_cache
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+
+@lru_cache()
+def is_torch_tpu_available(check_device=True):
+    """
+    Checks if `torch_xla` is installed and potentially if a TPU is in the environment
+    Taken from https://github.com/huggingface/transformers/blob/1ecf5f7c982d761b4daaa96719d162c324187c64/src/transformers/utils/import_utils.py#L463.
+    """
+    if importlib.util.find_spec("torch_xla") is not None:
+        if check_device:
+            # We need to check if `xla_device` can be found, will raise a RuntimeError if not
+            try:
+                import torch_xla.core.xla_model as xm
+                _ = xm.xla_device()
+                return True
+            except RuntimeError:
+                return False
+        return True
+    return False
+
+def get_storage_id(tensor: "torch.Tensor") -> Union[int, Tuple[Any, ...]]:
+    """Returns a unique id for plain tensor
+    or a (potentially nested) Tuple of unique id for the flattened Tensor
+    if the input is a wrapper tensor subclass Tensor
+    """
+    if tensor.device.type == "xla" and is_torch_tpu_available():
+        # NOTE: xla tensors dont have storage
+        # use some other unique id to distinguish.
+        # this is a XLA tensor, it must be created using torch_xla's
+        # device. So the following import is safe:
+        import torch_xla
+
+        unique_id = torch_xla._XLAC._xla_get_tensor_id(tensor)
+    elif is_traceable_wrapper_subclass(tensor):
+        attrs, _ = tensor.__tensor_flatten__()
+        unique_id = tuple(get_storage_id(getattr(tensor, attr)) for attr in attrs)
+    else:
+        unique_id = id(tensor.untyped_storage())
+
+    return unique_id
+
+
+def get_storage_size(tensor: "torch.Tensor") -> int:
+    """Get the storage size for the tensor in number of bytes
+    for wrapper tensor subclass Tensors, we'll get the sum of the storage size for all tensor attributes
+    """
+    if is_traceable_wrapper_subclass(tensor):
+        attrs, _ = tensor.__tensor_flatten__()
+        return sum(get_storage_size(getattr(tensor, attr)) for attr in attrs)
+    return tensor.untyped_storage().nbytes()

--- a/torch/utils/_storage_utils.py
+++ b/torch/utils/_storage_utils.py
@@ -1,20 +1,24 @@
 import importlib
-from typing import Union, Tuple, Any
 from functools import lru_cache
+from typing import Any, Tuple, Union
+
+import torch
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 
-@lru_cache()
-def is_torch_tpu_available(check_device=True):
+@lru_cache
+def is_torch_tpu_available(check_device: bool = True) -> bool:
     """
     Checks if `torch_xla` is installed and potentially if a TPU is in the environment
-    Taken from https://github.com/huggingface/transformers/blob/1ecf5f7c982d761b4daaa96719d162c324187c64/src/transformers/utils/import_utils.py#L463.
+    Taken from
+    https://github.com/huggingface/transformers/blob/1ecf5f7c982d761b4daaa96719d162c324187c64/src/transformers/utils/import_utils.py#L463.
     """
     if importlib.util.find_spec("torch_xla") is not None:
         if check_device:
             # We need to check if `xla_device` can be found, will raise a RuntimeError if not
             try:
                 import torch_xla.core.xla_model as xm
+
                 _ = xm.xla_device()
                 return True
             except RuntimeError:
@@ -22,7 +26,8 @@ def is_torch_tpu_available(check_device=True):
         return True
     return False
 
-def get_storage_id(tensor: "torch.Tensor") -> Union[int, Tuple[Any, ...]]:
+
+def get_storage_id(tensor: torch.Tensor) -> Union[int, Tuple[Any, ...]]:
     """Returns a unique id for plain tensor
     or a (potentially nested) Tuple of unique id for the flattened Tensor
     if the input is a wrapper tensor subclass Tensor
@@ -44,7 +49,7 @@ def get_storage_id(tensor: "torch.Tensor") -> Union[int, Tuple[Any, ...]]:
     return unique_id
 
 
-def get_storage_size(tensor: "torch.Tensor") -> int:
+def get_storage_size(tensor: torch.Tensor) -> int:
     """Get the storage size for the tensor in number of bytes
     for wrapper tensor subclass Tensors, we'll get the sum of the storage size for all tensor attributes
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133524

Summary:
Currently [huggingface_hub](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/serialization/_torch.py), [safetensors](https://github.com/huggingface/safetensors/blob/main/bindings/python/py_src/safetensors/torch.py#L11), [accelerate](https://github.com/huggingface/accelerate/blob/a452327e8e04b20779882dc491e00de602d554cb/src/accelerate/utils/modeling.py#L175) all have their own implementation of
`get_storage_id` and `get_storage_size`, `storage_ptr`, which makes assumption on internal implementation details of torch.Tensor, and storage, and does not work for wrapper tensor subclasses

Motivated by https://github.com/huggingface/huggingface_hub/pull/2440#issuecomment-2284248247 maybe it makes more sense to add these as utils in pytorch so they can be maintained by us instead

This PR added
`get_storage_id`: returns a unique identifier for the tensor storage, for tensor subclasses, it returns a nested tuple of unique ids from underlying plain tensors
`get_storage_size`: returns the size in bytes for the underlying storage, for tensor subclasses, it returns the sum of the size from all underlying plain tensors

Test Plan:
python test/test_utils.py TestStorageUtils

Reviewers:

Subscribers:

Tasks:

Tags: