### PR TITLE
[DRAFT] Register mean to decomp to mean.dim since mean has no out variant

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -357,6 +357,7 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.logsumexp.default,
             aten.masked_fill,
             aten.masked_fill_,
+            aten.mean,
             aten.mish,
             aten.mish_,
             aten.mse_loss,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -274,6 +274,11 @@ def mish_backward(grad_output: Tensor, input: Tensor):
     return grad_output * (input_tanh_softplus + out)
 
 
+@register_decomposition([aten.mean.default])
+def mean(x, dim=0, keep_dim=False, *, dtype: torch.dtype=None):
+    return aten.mean.dim(x.flatten(), 0, dtype=dtype)
+
+
 @register_decomposition(aten.silu)
 @out_wrapper()
 @pw_cast_for_opmath

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2453,7 +2453,7 @@ def std(
     return _maybe_convert_to_dtype(a_std, dtype)
 
 
-@register_decomposition(aten.mean)
+# @register_decomposition(aten.mean)
 def mean(
     a: TensorLikeType,
     dim: Optional[DimsType] = None,


### PR DESCRIPTION
`mean.out` was mistakenly matched to `mean.dim`'s out variant and we need to preserve backwards compatibility:
```
>> print(torch.ops.aten.mean._schemas)
{'': aten::mean(Tensor self, *, ScalarType? dtype=None) -> Tensor,
 'dim': aten::mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor,
 'out': aten::mean.out(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!),
 'names_dim': aten::mean.names_dim(Tensor self, str[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor,
 'names_out': aten::mean.names_out(Tensor self, str[1] dim, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)}
```

Decomposing `torch.mean` into torch.mean.dim gets the job done, but there already is a `torch.mean` decomposition that decomposes into primtorch arguments.

Full context: https://fb.workplace.com/groups/1075192433118967/permalink/1483480608956812/