### PR TITLE
Register nll_loss2d decompositions for core aten

### DIFF
--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -381,10 +381,6 @@ aten::new_empty_strided.out
 aten::nextafter
 aten::nextafter.out
 aten::nextafter_
-aten::nll_loss2d_backward
-aten::nll_loss2d_backward.grad_input
-aten::nll_loss2d_forward
-aten::nll_loss2d_forward.output
 aten::normal.Tensor_Tensor
 aten::normal.Tensor_Tensor_out
 aten::normal.Tensor_float

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -378,6 +378,8 @@ def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
             aten.new_full,
             aten.new_ones,
             aten.new_zeros,
+            aten.nll_loss2d_forward,
+            aten.nll_loss2d_backward,
             aten.nll_loss_backward,
             aten.nll_loss_forward,
             aten.norm,


### PR DESCRIPTION
When exporting a training model for Executorch (which requires all ops to be core aten) with cross entropy loss (`torch.nn.CrossEntropyLoss`), we ran into the following error from the fx verifier in `to_edge`:

```
torch._export.verifier.SpecViolationError: Operator torch._ops.aten.nll_loss2d_forward.default is not Aten Canonical.
```
The aten [implementation](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/LossNLL.cpp#L624) of `torch.nn.CrossEntropyLoss` uses `nll_loss2d_forward` for inference and `nll_loss2d_backward` for training, so we need to add the decompositions for both (which already exist) to the list of core aten decompositions.