### PR TITLE
[DTensor] Add naive replicate strategy for aten.triu.default and aten.tril.default

### DIFF
--- a/test/distributed/_tensor/test_dtensor_ops.py
+++ b/test/distributed/_tensor/test_dtensor_ops.py
@@ -459,8 +459,6 @@ dtensor_fails = {
     xfail("trapezoid"),
     xfail("trapz"),
     xfail("triangular_solve"),
-    xfail("tril"),
-    xfail("triu"),
     xfail("unbind"),
     xfail("unfold"),
     xfail("unfold_copy"),

--- a/torch/distributed/_tensor/ops/_math_ops.py
+++ b/torch/distributed/_tensor/ops/_math_ops.py
@@ -425,6 +425,8 @@ def foreach_norm_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> TupleStrateg
         aten.diag_embed.default,
         aten.diag.default,
         aten.diagonal.default,
+        aten.tril.default,
+        aten.triu.default,
     ],
     schema_info=RuntimeSchemaInfo(1),
 )


### PR DESCRIPTION
Shampoo uses triu and tril [here](https://github.com/facebookresearch/optimizers/blob/main/matrix_functions.py#L63). As the matrix input is replicated, we register the naive replicate strategy to unblock.  

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l