### PR TITLE
parametrized test name handles class arguments

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -661,8 +661,8 @@ class parametrize(_TestParametrizer):
             return value.formatted_name
         elif isinstance(value, (int, float, str)):
             return f"{name}_{str(value).replace('.', '_')}"
-        else:
-            return f"{name}{idx}"
+        elif inspect.isclass(value):
+            return f"{name}_{value.__name__}"
 
     def _default_subtest_name(self, idx, values):
         return '_'.join([self._formatted_str_repr(idx, a, v) for a, v in zip(self.arg_names, values)])

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -663,6 +663,8 @@ class parametrize(_TestParametrizer):
             return f"{name}_{str(value).replace('.', '_')}"
         elif inspect.isclass(value):
             return f"{name}_{value.__name__}"
+        else:
+            return f"{name}{idx}"
 
     def _default_subtest_name(self, idx, values):
         return '_'.join([self._formatted_str_repr(idx, a, v) for a, v in zip(self.arg_names, values)])


### PR DESCRIPTION
Previously, parametrized tests with class arguments, for example

```
@parametrize("this_cls", (Foo, Bar))
```

would create parametrized tests with names `test_foo_this_cls0` and `test_foo_this_cls1`. With this change, we instead should get `test_foo_this_cls_Foo` and `test_foo_this_cls_Bar`

Fixes #ISSUE_NUMBER
