### PR TITLE
[BE]: Fix setuptools not installed with Python 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1133,15 +1133,13 @@ def main():
     install_requires = [
         "filelock",
         "typing-extensions>=4.8.0",
+        'setuptools ; python_version >= "3.12"'
         'sympy==1.12.1 ; python_version == "3.8"',
         'sympy==1.13.1 ; python_version >= "3.9"',
         "networkx",
         "jinja2",
         "fsspec",
     ]
-
-    if sys.version_info >= (3, 12, 0):
-        install_requires.append("setuptools")
 
     if BUILD_PYTHON_ONLY:
         install_requires.append(f"{LIBTORCH_PKG_NAME}=={get_torch_version()}")

--- a/setup.py
+++ b/setup.py
@@ -1133,7 +1133,7 @@ def main():
     install_requires = [
         "filelock",
         "typing-extensions>=4.8.0",
-        'setuptools ; python_version >= "3.12"'
+        'setuptools ; python_version >= "3.12"',
         'sympy==1.12.1 ; python_version == "3.8"',
         'sympy==1.13.1 ; python_version >= "3.9"',
         "networkx",


### PR DESCRIPTION
setuptools is not installed correctly for Python 3.12.
See https://github.com/python-poetry/poetry/issues/9630#issuecomment-2291114885
