### PR TITLE
compiled autograd: support accumulate_grad_ in DTensor sharding

### DIFF
--- a/torch/distributed/_tensor/_op_schema.py
+++ b/torch/distributed/_tensor/_op_schema.py
@@ -322,7 +322,9 @@ class OpSchema:
         return_types = self.op._schema.returns
         # all dispatch ops only return Tensor or Tuple[Tensor] for tensor like
         # return types, so this check is enough for tensor like types
-        return isinstance(return_types[0].type, torch.TensorType)
+        return len(return_types) > 0 and isinstance(
+            return_types[0].type, torch.TensorType
+        )
 
     def __hash__(self) -> int:
         # Only hash args and kwargs that op indicates to hash

--- a/torch/distributed/_tensor/ops/_pointwise_ops.py
+++ b/torch/distributed/_tensor/ops/_pointwise_ops.py
@@ -408,6 +408,7 @@ pointwise_ops = [
     aten.silu_backward.default,
     aten.tanh_backward.default,
     aten.threshold_backward.default,
+    torch.ops.inductor.accumulate_grad_.default,
 ]
 
 


### PR DESCRIPTION
I can add a unit test if someone wants, although I'm planning to have this stack culminate in the DTensor + compiled autograd from this issue passing: https://github.com/pytorch/pytorch/issues/127797

`accumulate_grad` should (I think?) have a trivially-pointwise sharding rule. We also need to tweak DTensor to handle ops with no returns.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o