### PR TITLE
compiled autograd: default fakeify backward inputs with static shapes instead of duck sizing

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -76,7 +76,12 @@ class AutogradCompilerInstance:
 
     def wrap_fake(self, x, source):
         assert isinstance(x, torch.Tensor)
-        return self.fake_tensor_mode.from_tensor(x, source=source)
+        symbolic_context = torch._dynamo.variables.builder._automatic_dynamic(
+            x, None, source, static_shapes=True
+        )
+        return self.fake_tensor_mode.from_tensor(
+            x, source=source, symbolic_context=symbolic_context
+        )
 
     @staticmethod
     def source(name, idx) -> GetItemSource:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2239,10 +2239,13 @@ def _automatic_dynamic(
         unimplemented("torch.compile does not support strided NestedTensor")
 
     name = source.name()
-    prior_policy = tx.output.tracing_context.tensor_to_context.get(e, None)
-    shape_env_to_source_to_symbol_cache = (
-        prior_policy.shape_env_to_source_to_symbol_cache if prior_policy else None
-    )
+    if static_shapes:
+        shape_env_to_source_to_symbol_cache = {}
+    else:
+        prior_policy = tx.output.tracing_context.tensor_to_context.get(e, None)
+        shape_env_to_source_to_symbol_cache = (
+            prior_policy.shape_env_to_source_to_symbol_cache if prior_policy else None
+        )
 
     # Get base context if the tensor is a view
     view_base_context: Optional[SymbolicContext] = None


### PR DESCRIPTION
This fixes the problem described [here](https://github.com/pytorch/pytorch/issues/127797#issuecomment-2146290971), by tweaking compiled autograd to default to fakifying with static shapes instead of defaulting to duck sizing.

I think there are some (independent) dynamic shape + compiled autograd issues though, detailed here https://github.com/pytorch/pytorch/issues/133575 (cc @ezyang @penguinwu @bobrenjc93 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @xmfan @yf225 @rec )

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133581
* #133580
* #133574



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames