### PR TITLE
profiler/unwind: include <dlfcn.h> for dladdr

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -37,6 +37,7 @@ Stats stats() {
 #else
 
 #include <c10/util/flat_hash_map.h>
+#include <dlfcn.h>
 #include <elf.h>
 #include <link.h>
 #include <linux/limits.h>


### PR DESCRIPTION
This fixes a compilation error on linux systems using the musl c library.

Fixes #ISSUE_NUMBER
