### PR TITLE
[export] fix test for training ir migration

### DIFF
--- a/torch/ao/quantization/pt2e/port_metadata_pass.py
+++ b/torch/ao/quantization/pt2e/port_metadata_pass.py
@@ -135,6 +135,10 @@ def _port_metadata_for_output_quant_nodes(
         return
 
     node_users = _filter_sym_size_users(node)
+    # some nodes might have side-effects, so they don't have users, but still
+    # are not removed by DCE pass
+    if len(node_users) == 0:
+        return
     if len(node_users) != 1:
         logger.warning(f"Expecting {node} to have single user")  # noqa: G004
     q_node = node_users.pop()


### PR DESCRIPTION
Summary:
Fix quantization pass to be compatible with the new export IR.

Some nodes might have side-effects, so they don't have users, but still are not removed by the DCE pass.

Test Plan:
CI

buck2 run 'fbcode//mode/dev-nosan' fbcode//bolt/nn/executorch/export:export_rle_model  -- -r export_rle_model

Differential Revision: D61223356
