### PR TITLE
[inductor] fix CppPythonBindingsCodeCache code build failed on Windows (long to int64_t).

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2184,12 +2184,23 @@ class CppPythonBindingsCodeCache(CppCodeCache):
             static_assert(std::is_pointer<T>::value, "arg type must be pointer or long");
             return static_cast<T>(_torchinductor_pyobject_tensor_data_ptr(PyTuple_GET_ITEM(args, n)));
         }
+
+        #ifdef _WIN32
         template <> inline int64_t parse_arg<int64_t>(PyObject* args, size_t n) {
             auto result = PyLong_AsSsize_t(PyTuple_GET_ITEM(args, n));
             if(unlikely(result == -1 && PyErr_Occurred()))
                 throw std::runtime_error("expected int arg");
             return result;
         }
+        #else
+        template <> inline long parse_arg<long>(PyObject* args, size_t n) {
+            auto result = PyLong_AsSsize_t(PyTuple_GET_ITEM(args, n));
+            if(unlikely(result == -1 && PyErr_Occurred()))
+                throw std::runtime_error("expected int arg");
+            return result;
+        }
+        #endif
+
         template <> inline uintptr_t parse_arg<uintptr_t>(PyObject* args, size_t n) {
             auto result = PyLong_AsVoidPtr(PyTuple_GET_ITEM(args, n));
             if(unlikely(result == reinterpret_cast<void*>(-1) && PyErr_Occurred()))

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2185,14 +2185,14 @@ class CppPythonBindingsCodeCache(CppCodeCache):
             return static_cast<T>(_torchinductor_pyobject_tensor_data_ptr(PyTuple_GET_ITEM(args, n)));
         }
 
-        #ifdef _WIN32
         template <> inline int64_t parse_arg<int64_t>(PyObject* args, size_t n) {
             auto result = PyLong_AsSsize_t(PyTuple_GET_ITEM(args, n));
             if(unlikely(result == -1 && PyErr_Occurred()))
                 throw std::runtime_error("expected int arg");
             return result;
         }
-        #else
+
+        #ifdef __APPLE__
         template <> inline long parse_arg<long>(PyObject* args, size_t n) {
             auto result = PyLong_AsSsize_t(PyTuple_GET_ITEM(args, n));
             if(unlikely(result == -1 && PyErr_Occurred()))

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2184,7 +2184,7 @@ class CppPythonBindingsCodeCache(CppCodeCache):
             static_assert(std::is_pointer<T>::value, "arg type must be pointer or long");
             return static_cast<T>(_torchinductor_pyobject_tensor_data_ptr(PyTuple_GET_ITEM(args, n)));
         }
-        template <> inline long parse_arg<long>(PyObject* args, size_t n) {
+        template <> inline int64_t parse_arg<int64_t>(PyObject* args, size_t n) {
             auto result = PyLong_AsSsize_t(PyTuple_GET_ITEM(args, n));
             if(unlikely(result == -1 && PyErr_Occurred()))
                 throw std::runtime_error("expected int arg");

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2185,21 +2185,16 @@ class CppPythonBindingsCodeCache(CppCodeCache):
             return static_cast<T>(_torchinductor_pyobject_tensor_data_ptr(PyTuple_GET_ITEM(args, n)));
         }
 
-        template <> inline int64_t parse_arg<int64_t>(PyObject* args, size_t n) {
-            auto result = PyLong_AsSsize_t(PyTuple_GET_ITEM(args, n));
-            if(unlikely(result == -1 && PyErr_Occurred()))
-                throw std::runtime_error("expected int arg");
-            return result;
-        }
-
         #ifdef __APPLE__
         template <> inline long parse_arg<long>(PyObject* args, size_t n) {
+        #else
+        template <> inline int64_t parse_arg<int64_t>(PyObject* args, size_t n) {
+        #endif
             auto result = PyLong_AsSsize_t(PyTuple_GET_ITEM(args, n));
             if(unlikely(result == -1 && PyErr_Occurred()))
                 throw std::runtime_error("expected int arg");
             return result;
         }
-        #endif
 
         template <> inline uintptr_t parse_arg<uintptr_t>(PyObject* args, size_t n) {
             auto result = PyLong_AsVoidPtr(PyTuple_GET_ITEM(args, n));


### PR DESCRIPTION
Test case:
```cmd
pytest test/dynamo/test_dynamic_shapes.py -k test_donated_buffer1_dynamic_shapes
```
Error msg:
```cmd
(win_mkl_static) D:\xu_git\dnnl_cb\pytorch>cl /I C:/Users/Xuhan/.conda/envs/win_mkl_static/Include /I C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include /I C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include/torch/csrc/api/include /I C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include/TH /I C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include/THC /D TORCH_INDUCTOR_CPP_WRAPPER /D C10_USING_CUSTOM_GENERATED_MACROS /D CPU_CAPABILITY_AVX512 /DLL /MD /O2 /std:c++20 /wd4819 /wd4251 /wd4244 /wd4267 /wd4275 /wd4018 /wd4190 /wd4624 /wd4067 /wd4068 /EHsc /openmp /openmp:experimental C:/Users/Xuhan/AppData/Local/Temp/torchinductor_Xuhan/p3/cp3eocnerhprcphyxo3d3aeh7kn6pguwgv6flnhuhavs5zhh3fi4.cpp /arch:AVX512 /LD /FeC:/Users/Xuhan/AppData/Local/Temp/torchinductor_Xuhan/p3/cp3eocnerhprcphyxo3d3aeh7kn6pguwgv6flnhuhavs5zhh3fi4.pyd /link /LIBPATH:C:/Users/Xuhan/.conda/envs/win_mkl_static/libs /LIBPATH:C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/lib torch.lib torch_cpu.lib torch_python.lib sleef.lib c10.lib
Microsoft (R) C/C++ Optimizing Compiler Version 19.37.32825 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

cl : Command line warning D9025 : overriding '/openmp' with '/openmp:experimental'
cp3eocnerhprcphyxo3d3aeh7kn6pguwgv6flnhuhavs5zhh3fi4.cpp
C:/Users/Xuhan/AppData/Local/Temp/torchinductor_Xuhan/p3/cp3eocnerhprcphyxo3d3aeh7kn6pguwgv6flnhuhavs5zhh3fi4.cpp(19): warning C4849: OpenMP 'simdlen' clause ignored in 'simd' directive
C:/Users/Xuhan/AppData/Local/Temp/torchinductor_Xuhan/p3/cp3eocnerhprcphyxo3d3aeh7kn6pguwgv6flnhuhavs5zhh3fi4.cpp(55): error C2338: static_assert failed: 'arg type must be pointer or long'
C:/Users/Xuhan/AppData/Local/Temp/torchinductor_Xuhan/p3/cp3eocnerhprcphyxo3d3aeh7kn6pguwgv6flnhuhavs5zhh3fi4.cpp(79): note: see reference to function template instantiation 'T parse_arg<int64_t>(PyObject *,size_t)' being compiled
        with
        [
            T=int64_t
        ]
C:/Users/Xuhan/AppData/Local/Temp/torchinductor_Xuhan/p3/cp3eocnerhprcphyxo3d3aeh7kn6pguwgv6flnhuhavs5zhh3fi4.cpp(56): error C2440: 'static_cast': cannot convert from 'void *' to 'int64_t'
C:/Users/Xuhan/AppData/Local/Temp/torchinductor_Xuhan/p3/cp3eocnerhprcphyxo3d3aeh7kn6pguwgv6flnhuhavs5zhh3fi4.cpp(56): note: There is no context in which this conversion is possible
```

Discussed with @jansel , and I change the template code `long` to `int64_t`. it fixed.
<img width="851" alt="image" src="https://github.com/user-attachments/assets/93d9d26e-addd-4435-ad48-8c99e4759c3b">

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @ezyang @chauhang @penguinwu @voznesenskym @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire