### PR TITLE
Remove AMD restrictions on triton hashing

### DIFF
--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -39,12 +39,6 @@ def has_triton() -> bool:
 
 @functools.lru_cache(None)
 def triton_backend():
-    import torch
-
-    if torch.version.hip:
-        # Does not work with ROCm
-        return None
-
     from triton.compiler.compiler import make_backend
     from triton.runtime.driver import driver
 
@@ -54,12 +48,6 @@ def triton_backend():
 
 @functools.lru_cache(None)
 def triton_hash_with_backend():
-    import torch
-
-    if torch.version.hip:
-        # Does not work with ROCm
-        return None
-
     from triton.compiler.compiler import triton_key
 
     backend = triton_backend()


### PR DESCRIPTION
Summary: When we added these functions, AMD's triton checkout was very old, it appears to have caught up. Remove restrictions.

Test Plan: unit tests

Differential Revision: D61351473


