### PR TITLE
Workaround ASAN failure

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -197,6 +197,30 @@ class TORCH_API PytorchLLVMJITImpl {
 
     // Register implementations of intrinsics
     registerIntrinsics(JD, Mangle, intrinsics);
+
+    // Work around UBSAN crashes which reads 8 byte in front of every function.
+    // Placing a dummy variable with 8 bytes first ensures there is readable
+    // memory before code for the first function is emitted. See also:
+    // - https://reviews.llvm.org/D148665
+    // - https://github.com/llvm/llvm-project/issues/65253
+    {
+      std::unique_ptr<llvm::LLVMContext> ctx =
+          std::make_unique<llvm::LLVMContext>();
+      std::unique_ptr<llvm::Module> module_ =
+          std::make_unique<llvm::Module>("__asan_workaround_fill", *ctx);
+      llvm::Type* type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*ctx), 8);
+      module_->getOrInsertGlobal("__asan_workaround_fill", type, [&]() {
+        return new llvm::GlobalVariable(
+            *module_,
+            type,
+            true,
+            llvm::GlobalVariable::InternalLinkage,
+            llvm::Constant::getNullValue(type),
+            "__asan_workaround_fill");
+      });
+      assertSuccess(LLJ->addIRModule(
+          ThreadSafeModule(std::move(module_), std::move(ctx))));
+    }
   }
 
   void addModule(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> C) {


### PR DESCRIPTION
Summary:
ASAN in llvm 17.x and newer reads 8 bytes in front of every function called. This means the JIT must not place a function immediately at the beginning of a freshly `mmap`ed page. This adds an 8 byte sized dummy variable as the first thing to work around the problem.

See also:
- https://reviews.llvm.org/D148665
- https://github.com/llvm/llvm-project/issues/65253

Test Plan:
- `servicelab create cogwheel_adfinder_ubsan_multi_trial_test --local-commit`: https://www.internalfb.com/servicelab/experiment/3701354882
- sandcastle

Differential Revision: D61348865


cc @EikanWang @jgong5