### PR TITLE
[export] Device remapping in export

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6772,6 +6772,7 @@ def forward(self, x, y):
             if node.op == "call_function":
                 self.assertTrue(False)
 
+    @unittest.skipIf(not TEST_CUDA, "requires cuda")
     def test_exported_program_move_to_device(self):
         class Model(torch.nn.Module):
             def __init__(self, size=4, h_dim=10, **kwargs):
@@ -6781,16 +6782,32 @@ def forward(self, x, y):
             def forward(self, x):
                 _, states = self.rnn(x)
                 return states
-
+        # move the exported program from cpu to cuda:0
         mod = Model()
         example_inputs = (torch.rand(1, 10, 4),)
         ep = export(mod, example_inputs)
-        new_device = torch.device("cuda:0")
-        ep.move_to(device=new_device)
+        location = torch.device("cuda:0")
+        ep.move_to(location=location)
         gm = ep.module()
-        test_inputs = (torch.rand(1, 10, 4).to(new_device),)
+        test_inputs = (torch.rand(1, 10, 4).to("cuda:0"),)
         outputs = gm(*test_inputs)
-        self.assertEqual(outputs.device, new_device)
+        self.assertEqual(outputs.device, torch.device("cuda:0"))
+        # move it back to cpu
+        location = "cpu"
+        ep.move_to(location=location)
+        gm = ep.module()
+        test_inputs = (torch.rand(1, 10, 4).to("cpu"),)
+        outputs = gm(*test_inputs)
+        self.assertEqual(outputs.device, torch.device("cpu")) 
+        # move it to cuda:0 again
+        # mod = Model()
+        # ep = export(mod, example_inputs)
+        location = {"cpu":"cuda:0"}
+        ep.move_to(location=location)
+        gm = ep.module()
+        test_inputs = (torch.rand(1, 10, 4).to("cuda:0"),)
+        outputs = gm(*test_inputs)
+        self.assertEqual(outputs.device, torch.device("cuda:0")) 
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6772,6 +6772,26 @@ def forward(self, x, y):
             if node.op == "call_function":
                 self.assertTrue(False)
 
+    def test_exported_program_move_to_device(self):
+        class Model(torch.nn.Module):
+            def __init__(self, size=4, h_dim=10, **kwargs):
+                super(Model, self).__init__(**kwargs)
+                self.rnn = torch.nn.GRU(size, h_dim, batch_first=True)
+
+            def forward(self, x):
+                _, states = self.rnn(x)
+                return states
+
+        mod = Model()
+        example_inputs = (torch.rand(1, 10, 4),)
+        ep = export(mod, example_inputs)
+        new_device = torch.device("cuda:0")
+        ep.move_to(device=new_device)
+        gm = ep.module()
+        test_inputs = (torch.rand(1, 10, 4).to(new_device),)
+        outputs = gm(*test_inputs)
+        self.assertEqual(outputs.device, new_device)
+
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
 class TestOneOffModelExportResult(TestCase):

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -16,6 +16,7 @@ from torch.quantization._quantized_conversions import (
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import (
     SM53OrLater,
+    SM90OrLater,
     _get_torch_cuda_version,
     PLATFORM_SUPPORTS_FP8
 )
@@ -664,6 +665,7 @@ class TestFP8MatmulCuda(TestCase):
             )
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
+    @unittest.skipIf(not SM90OrLater, "rowwise implementation is currently sm90 specific")
     @skipIfRocm()
     @parametrize("base_dtype", [torch.bfloat16])
     def test_scaled_mm_vs_emulated_row_wise(self, base_dtype):

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -281,7 +281,7 @@ def _verify_exported_program_signature(exported_program) -> None:
     if len(input_node_names) != len(gs.input_specs):
         raise SpecViolationError(
             f"Number of graph inputs ({len(input_node_names)}) "
-            f"does not match number of inputs in the graph signature ({len(gs.user_inputs)})"
+            f"does not match number of inputs in the graph signature ({len(gs.input_specs)})"
         )
 
     for input_spec, node in zip(gs.input_specs, input_node_names):

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -72,6 +72,10 @@ def is_same_dict(inductor_dict, optimus_dict):
     return True
 
 
+def normalize_node_kwargs_pass(graph):
+    return None
+
+
 def fuse_parallel_linear_pass(graph):
     return None
 
@@ -127,6 +131,13 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
                 example_inputs,
                 "[Pre grad(predispatch IR)]Apply normalization pass",
             )
+            # normalize kwargs, must be called as the first pass
+            pass_execution_and_save(
+                normalize_node_kwargs_pass,
+                gm,
+                example_inputs,
+                "[Pre grad(predispatch IR)]Apply normalize_node_kwargs_pass",
+            )
             pass_execution_and_save(
                 fuse_chunk_reshape_unsqueeze_concat_pass,
                 gm,
@@ -138,6 +149,12 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
                 gm,
                 example_inputs,
                 "[Pre grad(predispatch IR)] Apply group_batch_fusion",
+            )
+            pass_execution_and_save(
+                normalize_node_kwargs_pass,
+                gm,
+                example_inputs,
+                "[Pre grad(predispatch IR)]Apply normalize_node_kwargs_pass",
             )
             pass_execution_and_save(
                 fuse_chunk_squeeze_cat_pass.apply,

--- a/torch/ao/quantization/pt2e/port_metadata_pass.py
+++ b/torch/ao/quantization/pt2e/port_metadata_pass.py
@@ -135,6 +135,10 @@ def _port_metadata_for_output_quant_nodes(
         return
 
     node_users = _filter_sym_size_users(node)
+    # some nodes might have side-effects, so they don't have users, but still
+    # are not removed by DCE pass
+    if len(node_users) == 0:
+        return
     if len(node_users) != 1:
         logger.warning(f"Expecting {node} to have single user")  # noqa: G004
     q_node = node_users.pop()

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -1161,25 +1161,27 @@ class ExportedProgram:
             verifiers=verifiers if verifiers is not None else self.verifiers,
         )
 
-    def _move_to(self, device: torch.device):
-        # change all the nodes with burnt-in device to the new device
+    def _move_to(self, location: Union[torch.device, str, Dict[str, str]]):
+        # move all the tensors and parameters to the new location
+        for k, v in self.state_dict.items():
+            if isinstance(location, dict):        
+                location = location[str(v.device)]
+            if isinstance(v, torch.nn.Parameter):
+                self._state_dict[k] = torch.nn.Parameter(v.to(location))
+            else:
+                self._state_dict[k] = v.to(location)
+        # change all the nodes with burnt-in device to the new location
         for node in self.graph.nodes:
             if "device" in node.kwargs:
                 kwargs = node.kwargs.copy()
-                kwargs["device"] = device
+                kwargs["device"] = location
                 node.kwargs = kwargs
-        # move all the tensors and parameters to the new device
-        for k, v in self.state_dict.items():
-            if isinstance(v, torch.nn.Parameter):
-                self._state_dict[k] = torch.nn.Parameter(v.to(device))
-            else:
-                self._state_dict[k] = v.to(device)
 
-    def move_to(self, device: torch.device):
+    def move_to(self, location: Union[torch.device, str, Dict[str, str]]):
         """
         Moves the ExportedProgram to the specified device.
         """
-        self._move_to(device)
+        self._move_to(location)
 
 
 def _get_shape_env(gm):

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -7913,6 +7913,10 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
         ("cub::BLOCK_STORE_WARP_TRANSPOSE", ("hipcub::BLOCK_STORE_WARP_TRANSPOSE", CONV_SPECIAL_FUNC, API_RUNTIME)),
         ("cub::BLOCK_LOAD_DIRECT", ("hipcub::BLOCK_LOAD_DIRECT", CONV_SPECIAL_FUNC, API_RUNTIME)),
         ("cub::BLOCK_STORE_DIRECT", ("hipcub::BLOCK_STORE_DIRECT", CONV_SPECIAL_FUNC, API_RUNTIME)),
+        (
+            "cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY",
+            ("hipcub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY", CONV_SPECIAL_FUNC, API_RUNTIME)
+        ),
         ("cub::BlockReduce", ("hipcub::BlockReduce", CONV_SPECIAL_FUNC, API_RUNTIME)),
         ("cub::BlockScan", ("hipcub::BlockScan", CONV_SPECIAL_FUNC, API_RUNTIME)),
         ("cub::BlockLoad", ("hipcub::BlockLoad", CONV_SPECIAL_FUNC, API_RUNTIME)),


### PR DESCRIPTION
Implemented `move_to()` method in the `ExportedProgram` class.  The user has to explicitly call this method to move the exported program from one `torch.device` to another one. 

This is particularly needed when the exported program has nodes with  "burnt in" device kwarg. For example in #121761

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang