### PR TITLE
[inductor] Fix needs_fixed_stride_order silent incorrectness

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -38,7 +38,7 @@ from torch._dynamo.testing import (
     same,
     skipIfPy312,
 )
-from torch._dynamo.utils import ifdynstaticdefault, counters
+from torch._dynamo.utils import counters, ifdynstaticdefault
 from torch._inductor.aoti_eager import (
     aoti_compile_with_persistent_cache,
     aoti_eager_cache_dir,
@@ -10603,24 +10603,6 @@ class CommonTemplate:
             compiled_inductor_out = compiled_inductor_f(x)
             self.assertEqual(compiled_inductor_out, eager_out)
             self.assertEqual(counters["inductor"]["require_stride_order_clones"], 0)
-
-            # def f_with_views(x):
-            #     full_default_3 = torch.full([10], 7.0, device="cpu")
-            #     y = full_default_3[::2]
-            #     y = y[:3]
-            #     chunk_cat_default_1 = torch.ops.mylib.copy_.default(
-            #         y, x, 0
-            #     )
-            #     mul_out = torch.mul(y, y)
-            #     return mul_out
-
-            # x = torch.arange(3, dtype=torch.float, device="cpu")
-            # eager_out = f_with_views(x)
-
-            # compiled_inductor_f = torch.compile(f_with_views, backend="inductor", fullgraph=True)
-            # compiled_inductor_out = compiled_inductor_f(x)
-            # self.assertEqual(compiled_inductor_out, eager_out)
-            # self.assertEqual(counters["inductor"]["require_stride_order_clones"], 1)
 
     @requires_gpu()
     @config.patch(implicit_fallbacks=True)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -78,7 +78,7 @@ from .virtualized import ops, V
 log = logging.getLogger(__name__)
 lowerings: Dict[torch._ops.OpOverload, Callable[..., Any]] = {}
 layout_constraints: Dict[torch._ops.OpOverload, Callable[..., Any]] = {}
-requires_fx_strides: Set[torch._ops.OpOverload] = set() 
+requires_fx_strides: Set[torch._ops.OpOverload] = set()
 fallbacks: Set[torch._ops.OpOverload] = set()
 aten = torch.ops.aten
 tr_c10d = torch.ops.tr_c10d


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133638
* #133452

Fixes #128084

The approach is two-fold (based on what Elias suggested in the comment
thread):
1. We realize unrealized Tensors and ensure they are the right stride.
2. If we can't ensure they have the right stride (if the tensors are
   already in an incorrect stride with FixedLayout, or if there's a
   view), then we require the correct stride on use via a clone and then
   copy_ back the result of the mutation.

We can improve this based on use cases (if the tensor is a view, then we
can require the base of the view to have the right stride order). The
view case isn't very common so I'm ignoring it for now.

Test Plan:
- tests

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang