### PR TITLE
Change default runner's AMI to Amazon 2023 AMI - Part 1

### DIFF
--- a/.github/lf-canary-scale-config.yml
+++ b/.github/lf-canary-scale-config.yml
@@ -31,6 +31,7 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -42,6 +43,7 @@ runner_types:
     is_ephemeral: false
     max_available: 450
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -53,6 +55,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -64,6 +67,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -75,6 +79,7 @@ runner_types:
     is_ephemeral: true
     max_available: 50
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -86,6 +91,7 @@ runner_types:
     is_ephemeral: true
     max_available: 300
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -97,6 +103,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -106,8 +113,9 @@ runner_types:
     disk_size: 150
     instance_type: c5.24xlarge
     is_ephemeral: false
-    max_available: 250
+    max_available: 500
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -119,6 +127,7 @@ runner_types:
     is_ephemeral: false
     max_available: 3120
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -130,6 +139,7 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -141,6 +151,7 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -152,6 +163,7 @@ runner_types:
     is_ephemeral: false
     max_available: 400
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -163,6 +175,7 @@ runner_types:
     is_ephemeral: false
     max_available: 250
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -174,6 +187,7 @@ runner_types:
     is_ephemeral: false
     max_available: 300
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -185,6 +199,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -196,6 +211,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -207,6 +223,7 @@ runner_types:
     is_ephemeral: false
     max_available: 2400
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -218,6 +235,7 @@ runner_types:
     is_ephemeral: false
     max_available: 50
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -229,6 +247,7 @@ runner_types:
     instance_type: c5.large
     is_ephemeral: false
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -240,6 +259,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
@@ -251,6 +271,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
@@ -262,6 +283,7 @@ runner_types:
     is_ephemeral: false
     max_available: 100
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64

--- a/.github/lf-scale-config.yml
+++ b/.github/lf-scale-config.yml
@@ -31,6 +31,7 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -42,6 +43,7 @@ runner_types:
     is_ephemeral: false
     max_available: 450
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -53,6 +55,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -64,6 +67,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -75,6 +79,7 @@ runner_types:
     is_ephemeral: true
     max_available: 50
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -86,6 +91,7 @@ runner_types:
     is_ephemeral: true
     max_available: 300
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -97,6 +103,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -106,8 +113,9 @@ runner_types:
     disk_size: 150
     instance_type: c5.24xlarge
     is_ephemeral: false
-    max_available: 250
+    max_available: 500
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -119,6 +127,7 @@ runner_types:
     is_ephemeral: false
     max_available: 3120
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -130,6 +139,7 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -141,6 +151,7 @@ runner_types:
     is_ephemeral: false
     max_available: 1000
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -152,6 +163,7 @@ runner_types:
     is_ephemeral: false
     max_available: 400
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -163,6 +175,7 @@ runner_types:
     is_ephemeral: false
     max_available: 250
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -174,6 +187,7 @@ runner_types:
     is_ephemeral: false
     max_available: 300
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -185,6 +199,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -196,6 +211,7 @@ runner_types:
     is_ephemeral: false
     max_available: 150
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -207,6 +223,7 @@ runner_types:
     is_ephemeral: false
     max_available: 2400
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -218,6 +235,7 @@ runner_types:
     is_ephemeral: false
     max_available: 50
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -229,6 +247,7 @@ runner_types:
     instance_type: c5.large
     is_ephemeral: false
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-x86_64
@@ -240,6 +259,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
@@ -251,6 +271,7 @@ runner_types:
     is_ephemeral: false
     max_available: 200
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
@@ -262,6 +283,7 @@ runner_types:
     is_ephemeral: false
     max_available: 100
     os: linux
+    ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64
     variants:
       amz2023:
         ami: al2023-ami-2023.5.20240701.0-kernel-6.1-arm64


### PR DESCRIPTION
Upgrades the LF scale configs to change the default AMI in accordance with the Amazon 2023 rollout plan.

This PR will be merged on Monday Aug 19 in the morning, and over the next 2-3 days as new linux runners are spun up (and old ones spun down) they'll start using this new AMI

This PR will be paired with https://github.com/pytorch/test-infra/pull/5558, which will be merged after this one