### PR TITLE
Update source matcher to use torch_fn

### DIFF
--- a/test/fx/test_source_matcher_utils.py
+++ b/test/fx/test_source_matcher_utils.py
@@ -15,6 +15,10 @@ from torch.fx.passes.utils.source_matcher_utils import (
     check_subgraphs_connected,
     get_source_partitions,
 )
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 from torch.testing._internal.jit_utils import JitTestCase
 
 
@@ -227,3 +231,197 @@ class TestSourceMatcher(JitTestCase):
         legalized_gm = legalize_graph(gm)
         with fake_inputs[0].fake_mode:
             torch.fx.Interpreter(legalized_gm).run(*fake_inputs)
+
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
+    @parametrize("strict", (True, False))
+    def test_module_partitioner_linear_relu_linear_torch_fn_export(self, strict: bool):
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear1 = torch.nn.Linear(3, 3)
+                self.relu = torch.nn.ReLU()
+                self.linear2 = torch.nn.Linear(3, 5)
+
+            def forward(self, x):
+                x = self.linear1(x)
+                x = self.linear1(x)
+                x = self.relu(x)
+                x = self.linear2(x)
+                return x
+
+        inputs = (torch.randn(3, 3),)
+        gm = torch.export.export(M(), inputs, strict=strict).module()
+        gm.graph.eliminate_dead_code()
+
+        module_partitions = get_source_partitions(gm.graph, ["linear", "relu"])
+
+        self.assertEqual(len(module_partitions), 2)
+        self.assertEqual(len(module_partitions["linear"]), 3)
+        self.assertEqual(len(module_partitions["relu"]), 1)
+
+        self.assertFalse(
+            check_subgraphs_connected(
+                module_partitions["linear"][0],
+                module_partitions["relu"][0],
+            )
+        )
+        self.assertTrue(
+            check_subgraphs_connected(
+                module_partitions["linear"][1],
+                module_partitions["relu"][0],
+            )
+        )
+        self.assertFalse(
+            check_subgraphs_connected(
+                module_partitions["linear"][2],
+                module_partitions["relu"][0],
+            )
+        )
+
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
+    @parametrize("strict", (True, False))
+    def test_module_partitioner_conv_relu_maxpool_torch_fn_export(self, strict: bool):
+        class M(torch.nn.Module):
+            def __init__(self, constant_tensor: torch.Tensor) -> None:
+                super().__init__()
+                self.constant_tensor = constant_tensor
+                self.conv1 = torch.nn.Conv2d(
+                    in_channels=3, out_channels=16, kernel_size=3, padding=1
+                )
+                self.conv2 = torch.nn.Conv2d(
+                    in_channels=16, out_channels=16, kernel_size=3, padding=1
+                )
+                self.conv3 = torch.nn.Conv2d(
+                    in_channels=16, out_channels=16, kernel_size=3, padding=1
+                )
+                self.relu = torch.nn.ReLU()
+                self.maxpool = torch.nn.MaxPool2d(kernel_size=3)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                a = self.conv1(x)
+                b = self.conv2(a)
+                c = a + self.constant_tensor
+                z = self.conv3(b + c)
+                return self.maxpool(self.relu(z))
+
+        inputs = (torch.randn(1, 3, 256, 256),)
+        gm = torch.export.export(
+            M(torch.ones(1, 16, 256, 256)), inputs, strict=strict
+        ).module()
+        gm.graph.eliminate_dead_code()
+
+        module_partitions = get_source_partitions(
+            gm.graph, ["conv2d", "relu", "max_pool2d"]
+        )
+
+        self.assertEqual(len(module_partitions), 3)
+        self.assertEqual(len(module_partitions["conv2d"]), 3)
+        self.assertEqual(len(module_partitions["relu"]), 1)
+        self.assertEqual(len(module_partitions["max_pool2d"]), 1)
+
+        self.assertFalse(
+            check_subgraphs_connected(
+                module_partitions["conv2d"][0],
+                module_partitions["relu"][0],
+            )
+        )
+        self.assertFalse(
+            check_subgraphs_connected(
+                module_partitions["conv2d"][1],
+                module_partitions["relu"][0],
+            )
+        )
+        self.assertTrue(
+            check_subgraphs_connected(
+                module_partitions["conv2d"][2],
+                module_partitions["relu"][0],
+            )
+        )
+        self.assertFalse(
+            check_subgraphs_connected(
+                module_partitions["max_pool2d"][0],
+                module_partitions["relu"][0],
+            )
+        )
+        self.assertTrue(
+            check_subgraphs_connected(
+                module_partitions["relu"][0],
+                module_partitions["max_pool2d"][0],
+            )
+        )
+
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
+    @parametrize("strict", (True, False))
+    def test_module_partitioner_functional_conv_relu_conv_torch_fn_export(
+        self, strict: bool
+    ):
+        class FunctionalConv2d(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.stride = (1, 1)
+                self.padding = (0, 0)
+                self.dilation = (1, 1)
+                self.groups = 1
+
+            def forward(self, x, weight, bias):
+                return torch.nn.functional.conv2d(
+                    x,
+                    weight,
+                    bias,
+                    self.stride,
+                    self.padding,
+                    self.dilation,
+                    self.groups,
+                )
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv1 = FunctionalConv2d()
+                self.conv2 = FunctionalConv2d()
+
+            def forward(self, x, weight, bias):
+                x = self.conv1(x, weight, bias)
+                x = torch.nn.functional.relu(x)
+                x = self.conv2(x, weight, bias)
+                return x
+
+        inputs = (torch.randn(1, 3, 5, 5), torch.rand(3, 3, 3, 3), torch.rand(3))
+        gm = torch.export.export(M(), inputs, strict=strict).module()
+        gm.graph.eliminate_dead_code()
+
+        module_partitions = get_source_partitions(gm.graph, ["conv2d"])
+
+        self.assertEqual(len(module_partitions), 1)
+        self.assertEqual(len(module_partitions["conv2d"]), 2)
+
+    @unittest.skipIf(not is_dynamo_supported(), "Dynamo not supported")
+    @parametrize("strict", (True, False))
+    def test_module_partitioner_functional_linear_relu_linear_torch_fn_export(
+        self, strict: bool
+    ):
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(self, x, weight, bias):
+                x = torch.nn.functional.linear(x, weight, bias)
+                x = torch.nn.functional.linear(x, weight, bias)
+                x = torch.nn.functional.relu(x)
+                x = torch.nn.functional.linear(x, weight, bias)
+                x = torch.nn.functional.linear(x, weight, bias)
+                x = torch.nn.functional.relu(x)
+                return x
+
+        inputs = (torch.randn(1, 5), torch.rand((5, 5)), torch.zeros(5))
+        gm = torch.export.export(M(), inputs, strict=strict).module()
+        gm.graph.eliminate_dead_code()
+
+        module_partitions = get_source_partitions(gm.graph, ["linear", "relu"])
+
+        self.assertEqual(len(module_partitions), 2)
+        self.assertEqual(len(module_partitions["linear"]), 4)
+        self.assertEqual(len(module_partitions["relu"]), 2)
+
+
+instantiate_parametrized_tests(TestSourceMatcher)


### PR DESCRIPTION
Updating the source matcher to also accept pattern matching on the torch_fn metadata, which exists in both strict and non-strict export. We want to replace the use of source_fn_stack with torch_fn, as it's not possible for us to get source_fn_stack in non-strict export.