### PR TITLE
Add onnx and onnxscript to CI requirements

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -318,3 +318,13 @@ sympy==1.13.1 ; python_version >= "3.9"
 #Description: Required by coremltools, also pinned in .github/requirements/pip-requirements-macOS.txt
 #Pinned versions:
 #test that import:
+
+onnx==1.16.1
+#Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
+#Pinned versions:
+#test that import:
+
+onnxscript==0.1.0.dev20240816
+#Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
+#Pinned versions:
+#test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -324,7 +324,7 @@ onnx==1.16.1
 #Pinned versions:
 #test that import:
 
-onnxscript==0.1.0.dev20240816
+onnxscript==0.1.0.dev20240817
 #Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
 #Pinned versions:
 #test that import:

--- a/torch/onnx/_internal/fx/fx_onnx_interpreter.py
+++ b/torch/onnx/_internal/fx/fx_onnx_interpreter.py
@@ -554,7 +554,7 @@ class FxOnnxInterpreter:
                 )
 
         with diagnostic.log_section(logging.DEBUG, "ONNX Graph:"):
-            diagnostic.debug("```\n%s\n```", onnxscript_graph.torch_graph)
+            diagnostic.debug("```\n%s\n```", onnxscript_graph.torch_graph)  # type: ignore[attr-defined]
 
         return onnxscript_graph
 
@@ -655,7 +655,7 @@ class FxOnnxInterpreter:
         # function signature in OpSchema, and find the best matched overload.
         symbolic_fn = onnxfunction_dispatcher.dispatch(
             node=node,
-            onnx_args=onnx_args,
+            onnx_args=onnx_args,  # type: ignore[arg-type]
             onnx_kwargs=onnx_kwargs,
             diagnostic_context=self.diagnostic_context,
         )
@@ -781,7 +781,7 @@ class FxOnnxInterpreter:
 
         outputs: onnxscript_graph_building.TorchScriptTensor | tuple[
             onnxscript_graph_building.TorchScriptTensor, ...
-        ] = parent_onnxscript_graph.add_module_call(
+        ] = parent_onnxscript_graph.add_module_call(  # type: ignore[assignment]
             unique_module_name, sub_onnxscript_graph, onnx_args
         )
 

--- a/torch/onnx/_internal/fx/serialization.py
+++ b/torch/onnx/_internal/fx/serialization.py
@@ -61,7 +61,7 @@ def _create_tensor_proto_with_external_data(
 
     tensor_proto = onnx.TensorProto()  # type: ignore[attr-defined]
     tensor_proto.name = name
-    tensor_proto.data_type = scalar_type.onnx_type()
+    tensor_proto.data_type = scalar_type.onnx_type()  # type: ignore[assignment]
 
     tensor_proto.dims.extend(tensor.shape)
     tensor_proto.data_location = onnx.TensorProto.EXTERNAL  # type: ignore[attr-defined]


### PR DESCRIPTION
Add onnx and onnxscript to requirements-ci.txt to allow for `test_public_bindings` and mypy to function when checking `torch.onnx._internal` code as @malfet suggested.
