### PR TITLE
Move the layout constraint registration of aten._scaled_mm.default to module scope

### DIFF
--- a/torch/_inductor/kernel/mm_scaled.py
+++ b/torch/_inductor/kernel/mm_scaled.py
@@ -225,6 +225,9 @@ def scaled_mm_options(  # type: ignore[no-untyped-def]
     )
 
 
+add_layout_constraint(aten._scaled_mm.default, constrain_to_fx_strides)
+
+
 @register_lowering(aten._scaled_mm.default, type_promotion_kind=None)  # type: ignore[misc]
 def tuned_scaled_mm(
     mat_a: TensorBox,
@@ -237,7 +240,6 @@ def tuned_scaled_mm(
     use_fast_accum: bool = False,
     layout: Optional[Layout] = None,
 ) -> TensorBox:
-    add_layout_constraint(aten._scaled_mm.default, constrain_to_fx_strides)
     m, n, k, layout, mat_a, mat_b = mm_args(
         mat_a, mat_b, layout=layout, out_dtype=out_dtype
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133669

During Inductor lowering, layout constraints for an op is applied before the op's lowering is called. Currently `add_layout_constraint(aten._scaled_mm.default, constrain_to_fx_strides)` is called inside `aten._scaled_mm.default`'s lowering. This means that if the first `_scaled_mm` to be lowered relies on the layout constraint, it won't be applied and the generated code would fail. The issue won't manifest if the first `_scaled_mm` doesn't rely on the layout constraint.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang