### PR TITLE
[SymmetricMemory] make buffer_ptrs_dev, signal_pad_ptrs_dev, buffer_size, and signal_pad_size accessible in python

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1046,9 +1046,19 @@ This class does not support ``__members__`` property.)");
           &::c10d::symmetric_memory::get_symmetric_memory)
       .def_property_readonly("rank", &SymmetricMemory::get_rank)
       .def_property_readonly("world_size", &SymmetricMemory::get_world_size)
-      .def("get_buffer_ptrs_dev", [](c10::intrusive_ptr<SymmetricMemory> symm_mem) {
+      .def_property_readonly(
+          "buffer_ptrs_dev",
+          [](c10::intrusive_ptr<SymmetricMemory> symm_mem) {
             return reinterpret_cast<uintptr_t>(symm_mem->get_buffer_ptrs_dev());
           })
+      .def_property_readonly(
+          "signal_pad_ptrs_dev",
+          [](c10::intrusive_ptr<SymmetricMemory> symm_mem) {
+            return reinterpret_cast<uintptr_t>(symm_mem->get_buffer_ptrs_dev());
+          })
+      .def_property_readonly("buffer_size", &SymmetricMemory::get_buffer_size)
+      .def_property_readonly(
+          "signal_pad_size", &SymmetricMemory::get_signal_pad_size)
       .def(
           "get_buffer",
           &SymmetricMemory::get_buffer,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133680

These allows us to experiment with creative applications with triton.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o