### PR TITLE
Back out "[export] fix test for training ir migration"

### DIFF
--- a/torch/ao/quantization/pt2e/port_metadata_pass.py
+++ b/torch/ao/quantization/pt2e/port_metadata_pass.py
@@ -135,10 +135,6 @@ def _port_metadata_for_output_quant_nodes(
         return
 
     node_users = _filter_sym_size_users(node)
-    # some nodes might have side-effects, so they don't have users, but still
-    # are not removed by DCE pass
-    if len(node_users) == 0:
-        return
     if len(node_users) != 1:
         logger.warning(f"Expecting {node} to have single user")  # noqa: G004
     q_node = node_users.pop()


### PR DESCRIPTION
Summary:
Original commit changeset: 0a1cb57e0338

Original Phabricator Diff: D61223356

Test Plan: buck2 run 'fbcode//mode/dev-nosan' fbcode//bolt/nn/executorch/export:export_rle_model -- -r  test_export_rle_model

Reviewed By: tugsbayasgalan

Differential Revision: D61395818
