### PR TITLE
[inductor] Fix test_cudagraph_trees_expandable_segments.py for internal

### DIFF
--- a/test/inductor/test_cudagraph_trees_expandable_segments.py
+++ b/test/inductor/test_cudagraph_trees_expandable_segments.py
@@ -15,7 +15,10 @@ pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
 
 if HAS_CUDA and not TEST_WITH_ASAN:
-    from inductor.test_cudagraph_trees import CudaGraphTreeTests  # noqa: F401
+    try:
+        from .test_cudagraph_trees import CudaGraphTreeTests
+    except ImportError:
+        from test_cudagraph_trees import CudaGraphTreeTests  # noqa: F401
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 


### PR DESCRIPTION
Summary:
These tests aren't running internally because the outer test harness is crashing without listing the tests. To fix we need:
* Add a target for the tools/stats/ folder since this test imports it
* Add a dependence to that target so it's included in the par
* Fix up the relative import syntax, which is somehow different internally vs. fbcode (not sure why this works, but many other tests are doing it)

Test Plan: `buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/inductor:cudagraph_trees_expandable_segments -- --run-disabled`

Differential Revision: D61396711


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang