### PR TITLE
[PT2][Optimus] Add move reshape out of split stack pass

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -57,6 +57,7 @@ pre_grad_pass_names = [
     "unbind_cat_to_view_pass",
     "split_stack_to_cats_pass",
     "unbind_stack_to_slices_pass",
+    "move_reshape_out_of_split_stack_pass",
 ]
 
 post_grad_pass_names = [
@@ -167,7 +168,7 @@ def normalize_split_base(
     if split_input is None or split_dim is None or split_size is None:
         log.debug("couldn't find split args")
         return
-    if "example_value" not in split_node.meta:
+    if not is_node_meta_valid(split_node):
         log.debug("example value absent for node: %s", split_node)
         return
     assert isinstance(split_node.meta["example_value"], (list, tuple))
@@ -227,7 +228,7 @@ def remove_split_with_size_one(match: Match, *args, **kwargs):
     if split_input is None or split_dim is None or split_size is None:
         log.debug("couldn't find split args")
         return
-    if "example_value" not in split_node.meta:
+    if not is_node_meta_valid(split_node):
         log.debug("example value absent for node: %s", split_node)
         return
     assert isinstance(split_node.meta["example_value"], (list, tuple))
@@ -272,7 +273,7 @@ def normalize_unbind_default(match: Match, *args, **kwargs):
     if input is None:
         log.debug("couldn't find unbind args")
         return
-    if "example_value" not in input.meta:
+    if not is_node_meta_valid(input):
         log.debug("example value absent for node: %s", input)
         return
     ndim = input.meta["example_value"].ndim
@@ -312,7 +313,7 @@ def normalize_cat_default(match: Match, *args, **kwargs):
         return
     assert isinstance(tensors, (list, tuple))
     for tensor in itertools.chain([cat_node], tensors):
-        if "example_value" not in tensor.meta:
+        if not is_node_meta_valid(tensor):
             log.debug("example value absent for node: %s", tensor)
             return
 
@@ -367,7 +368,7 @@ def normalize_stack_default(match: Match, *args, **kwargs):
 
     # A bug in pytorch, some nodes miss the example_value metadata
     for tensor in itertools.chain([node], tensors):
-        if "example_value" not in tensor.meta:
+        if not is_node_meta_valid(tensor):
             log.debug("example value absent for node: %s", tensor)
             return
 
@@ -433,6 +434,27 @@ def normalize_squeeze_default(match: Match, *args, **kwargs):
     squeeze_node.replace_all_uses_with(new_squeeze_node)
     new_squeeze_node.meta.update(squeeze_node.meta)
     match.graph.erase_node(squeeze_node)
+
+
+@register_graph_pattern(
+    CallMethodVarArgs("reshape", users=MULTIPLE),
+    pass_dict=construct_pattern_matcher_pass("normalization_pass"),
+)
+def normalize_reshape_default(match: Match, *args, **kwargs):
+    reshape_node = match.nodes[0]
+    if not is_node_meta_valid(reshape_node):
+        log.debug("example value absent for node: %s", reshape_node)
+        return
+    reshape_input = get_arg_value(reshape_node, 0)
+
+    with match.graph.inserting_after(reshape_node):
+        new_reshape_node = match.graph.call_function(
+            torch.reshape,
+            args=(reshape_input, tuple(reshape_node.meta["example_value"].shape)),
+        )
+    reshape_node.replace_all_uses_with(new_reshape_node)
+    new_reshape_node.meta.update(reshape_node.meta)
+    match.graph.erase_node(reshape_node)
 
 
 class TorchSplit(CallFunction):
@@ -1248,6 +1270,25 @@ getitem_split = ListOf(
 )
 
 
+reshape_getitem_split = ListOf(
+    CallFunction(
+        torch.reshape,
+        CallFunction(
+            operator.getitem,
+            TorchSplit(
+                Ignored(),
+                KeywordArg("split_sections"),
+            ),
+            Ignored(),
+            _users=MULTIPLE,
+        ),
+        Arg(),
+        _users=MULTIPLE,
+    ),
+    partial=True,
+)
+
+
 @register_graph_pattern(
     CallFunction(
         [torch.stack, torch.cat],
@@ -1748,12 +1789,11 @@ def reshape_cat_node(
     else:
         permute_node = unbind_input
     with graph.inserting_after(permute_node):
-        cat_shape_list = list(cat_shape)
         reshape_node = graph.call_function(
-            torch.reshape, args=(permute_node, tuple(cat_shape_list))
+            torch.reshape, args=(permute_node, tuple(cat_shape))
         )
         reshape_node.meta["example_value"] = torch.reshape(
-            permute_node.meta["example_value"], tuple(cat_shape_list)
+            permute_node.meta["example_value"], tuple(cat_shape)
         )  # type: ignore[arg-type]
     return reshape_node
 
@@ -1967,7 +2007,8 @@ def split_cat_to_slices(match: Match, split_sections: List[int], dim: int):
             threshold_to_cat,
             update_args_from_split_getitem,
         )
-        # if new cat args has length 1, we can remove the cat node
+        # At least one node would be in the returned new_cat_args
+        # case 1: if new cat args has length 1, we can remove the cat node
         if len(new_cat_args) == 1:
             cat_node.replace_all_uses_with(new_cat_args[0])
             # remove inputs of cat_node if they have no users
@@ -2043,6 +2084,7 @@ def unbind_cat_to_view(match: Match, unbind_input: torch.fx.Node, dim: int):
             update_args_from_unbind_getitem,
         )
         # get the view shape
+        # At least one node would be in the returned new_cat_args
         # case 1: only one node in the new cat args, don't need to cat
         if len(new_cat_args) == 1:
             cat_node.replace_all_uses_with(new_cat_args[0])
@@ -2124,6 +2166,41 @@ def reshape_cat_node_to_stack(
     remove_split_unbind_children(graph, stack_inputs)  # type: ignore[arg-type]
 
 
+def convert_reshape_cat_arg_to_stack(
+    graph: torch.fx.Graph,
+    cat_node: torch.fx.Node,
+    stack_node: torch.fx.Node,
+    stack_node_shape: torch.Size,
+    stack_dim: int,
+    split_dim: int,
+) -> torch.fx.Node:
+    # reshape the cat node to the stack node shape
+    cat_shape = cat_node.meta["example_value"].shape
+    if stack_dim != split_dim:
+        permute_list = list(range(len(cat_shape)))
+        permute_list[stack_dim], permute_list[split_dim] = (
+            permute_list[split_dim],
+            permute_list[stack_dim],
+        )
+        permute_node = graph.call_function(
+            torch.permute,
+            args=(cat_node, permute_list),
+        )
+        permute_node.meta["example_value"] = torch.permute(
+            cat_node.meta["example_value"], permute_list
+        )
+    else:
+        permute_node = cat_node
+    reshape_node = graph.call_function(
+        torch.Tensor.view,
+        args=(permute_node, tuple(stack_node_shape)),  # type: ignore[arg-type]
+    )
+    reshape_node.meta["example_value"] = torch.Tensor.view(
+        permute_node.meta["example_value"], tuple(stack_node_shape)  # type: ignore[arg-type]
+    )
+    return reshape_node
+
+
 # ############pattern to be optimized is#########
 #    |           |
 #   split       split   (dim=1)
@@ -2178,6 +2255,7 @@ def split_stack_to_cats(match: Match, split_sections: List[int], dim: int):
             threshold_to_cat,
             update_args_from_split_getitem,
         )
+        # At least one node would be in the returned new_cat_args
         # case 1: only one node in the new cat args, don't need to cat
         if len(new_cat_args) == 1:
             reshape_cat_node_to_stack(graph, new_cat_args[0], stack_node, split_dim)
@@ -2249,6 +2327,7 @@ def unbind_stack_to_slices(match: Match, unbind_input: torch.fx.Node, dim: int):
             update_args_from_unbind_getitem,
         )
         unbind_dim = get_arg_value(unbind_node, 1, "dim") or 0
+        # At least one node would be in the returned new_cat_args
         # case 1: only one node in the new cat args, don't need to cat
         if len(new_cat_args) == 1:
             reshape_cat_node_to_stack(graph, new_cat_args[0], stack_node, unbind_dim)
@@ -2268,3 +2347,168 @@ def unbind_stack_to_slices(match: Match, unbind_input: torch.fx.Node, dim: int):
                 )
                 reshape_cat_node_to_stack(graph, new_cat_node, stack_node, unbind_dim)
             counters["inductor"]["unbind_stack_to_slices_pass"] += 1
+
+
+# ############pattern to be optimized is#########
+#                   input
+#                     |
+#               split(dim=1)  -> user=multiple
+#                  \         \
+# others    getitem        getitem
+#  \          \               /
+#  reshape     reshape      reshape     other_op
+#  \          \             /         /
+#                stack(user=mul, dim=0)
+#                      |
+
+# ################after transformation#############
+#                          input
+#                           |
+#                         permute
+#                           |
+#                         reshape   others
+#                           |    /
+#                          cat (dim=0)
+#                           |
+
+
+def get_view_shape_list(cat_arg: torch.fx.Node, stack_dim: int) -> List[int]:
+    # cat_arg must be the split input
+    view_shape_list = []
+    for user in cat_arg.users.keys():
+        if user.target == torch.split:
+            for getitem in user.users.keys():
+                if getitem.target == operator.getitem:
+                    reshape_user = [
+                        user
+                        for user in getitem.users.keys()
+                        if user.target == torch.reshape
+                    ]
+                    if len(reshape_user) > 0:
+                        view_shape_list = list(
+                            reshape_user[0]
+                            .meta["example_value"]
+                            .unsqueeze(stack_dim)
+                            .shape
+                        )
+                        view_shape_list[stack_dim] = -1
+                        return view_shape_list
+    return view_shape_list
+
+
+@register_graph_pattern(
+    CallFunction(
+        torch.stack,
+        reshape_getitem_split,
+        dim=Ignored(),
+        _users=MULTIPLE,
+    ),
+    pass_dict=construct_pattern_matcher_pass("move_reshape_out_of_split_stack_pass"),
+)
+def move_reshape_out_of_split_stack(match: Match, *args, **kwargs):
+    split_node = next(node for node in match.nodes if node.target == torch.split)
+    split_dim = _get_dim(split_node)
+    split_users = list(split_node.users.keys())
+    stack_nodes = [node for node in match.nodes if node.target == torch.stack]
+    graph = match.graph
+    threshold_to_cat = torch._inductor.config.pre_grad_fusion_options[
+        "move_reshape_out_of_split_stack_pass"
+    ].get("threshold_to_cat", 10)
+    for stack_node in stack_nodes:
+        if not is_node_meta_valid(stack_node):
+            log.debug("example value absent for node: %s", stack_node)
+            continue
+        stack_dim = _get_dim(stack_node)
+        stack_inputs = get_arg_value(stack_node, 0, "tensors")  # type: ignore[union-attr]
+        inputs = []
+        for stack_input in stack_inputs:
+            if stack_input.target != torch.reshape:
+                inputs.append(stack_input)
+            else:
+                inputs.append(stack_input.args[0])  # type: ignore[union-attr]
+        new_cat_args, new_cat_args_meta = construct_cat_args(
+            graph,
+            stack_node,
+            inputs,
+            split_node,
+            threshold_to_cat,
+            update_args_from_split_getitem,
+        )
+        # At least one node would be in the returned new_cat_args
+        # case 1: only one node in the new cat args, don't need to cat
+        if len(new_cat_args) == 1:
+            reshape_node = convert_reshape_cat_arg_to_stack(
+                graph,
+                new_cat_args[0],
+                stack_node,
+                stack_node.meta["example_value"].shape,
+                stack_dim,
+                split_dim,
+            )
+            stack_node.replace_all_uses_with(reshape_node)
+            # remove stack node
+            graph.erase_node(stack_node)
+            # check the input of stack node, and remove nodes that have no users
+            remove_split_unbind_children(graph, stack_inputs)  # type: ignore[arg-type]
+            remove_split_unbind_children(graph, split_users)  # type: ignore[arg-type]
+            counters["inductor"]["move_reshape_out_of_split_stack_pass"] += 1
+            continue
+        if len(new_cat_args) > 1 and len(new_cat_args) < len(inputs):
+            # decompose the cat args into multiple stack nodes, i.e., we stack
+            # all the nodes exist in the stack inputs and reshape the rest followed by a cat
+            stack_node_input, stack_node_input_meta, cat_inputs = [], [], []  # type: ignore[var-annotated]
+            for cat_arg in new_cat_args:
+                if cat_arg not in stack_inputs:
+                    if len(stack_node_input) > 0:
+                        with graph.inserting_after(stack_node):
+                            decomposed_stack_node = graph.call_function(
+                                torch.stack,
+                                args=(stack_node_input,),
+                                kwargs={"dim": stack_dim},
+                            )
+                            decomposed_stack_node.meta["example_value"] = torch.stack(
+                                stack_node_input_meta, dim=stack_dim
+                            )
+                            cat_inputs.append(decomposed_stack_node)
+                    # cat_arg must be the split input
+                    view_shape_list = get_view_shape_list(cat_arg, stack_dim)
+                    stack_node_shape = torch.reshape(cat_arg.meta["example_value"], tuple(view_shape_list)).shape  # type: ignore[union-attr]
+                    cat_inputs.append(
+                        convert_reshape_cat_arg_to_stack(
+                            graph,
+                            cat_arg,
+                            stack_node,
+                            stack_node_shape,
+                            stack_dim,
+                            split_dim,
+                        )
+                    )
+                    stack_node_input, stack_node_input_meta = [], []
+                else:
+                    stack_node_input.append(cat_arg)
+                    stack_node_input_meta.append(cat_arg.meta["example_value"])
+
+            if len(stack_node_input) > 0:
+                with graph.inserting_after(stack_node):
+                    decomposed_stack_node = graph.call_function(
+                        torch.stack,
+                        args=(stack_node_input,),
+                        kwargs={"dim": stack_dim},
+                    )
+                    decomposed_stack_node.meta["example_value"] = torch.stack(
+                        stack_node_input_meta, dim=stack_dim
+                    )
+                    cat_inputs.append(decomposed_stack_node)
+
+            with graph.inserting_after(stack_node):
+                cat_node = graph.call_function(
+                    torch.cat,
+                    args=(cat_inputs,),
+                    kwargs={"dim": stack_dim},
+                )
+                stack_node.replace_all_uses_with(cat_node)
+                cat_node.meta.update(stack_node.meta)
+                graph.erase_node(stack_node)
+                remove_split_unbind_children(graph, stack_inputs)  # type: ignore[arg-type]
+                remove_split_unbind_children(graph, split_users)  # type: ignore[arg-type]
+            counters["inductor"]["move_reshape_out_of_split_stack_pass"] += 1


### PR DESCRIPTION
Summary: We observed a  new pattern in CMF where reshape nodes are in the middle of split stack patter, introducing massive triton_fused_stack_xxx kernels, leading to increased compilation time, we thus move it outside of the pattern, and elimate such split stack nodes.

Test Plan:
# unit test
```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 test //caffe2/test/inductor:split_cat_fx_passes
```

Buck UI: https://www.internalfb.com/buck2/2fb51ae7-832e-436b-b6b7-a81599390182
Test UI: https://www.internalfb.com/intern/testinfra/testrun/14918173811074971
Network: Up: 10MiB  Down: 5.4GiB  (reSessionID-96a20105-fdc6-4b4f-b465-813a84a71eba)
Jobs completed: 304618. Time elapsed: 25:24.7s.
Cache hits: 99%. Commands: 120772 (cached: 120410, remote: 357, local: 5)
Tests finished: Pass 9. Fail 0. Fatal 0. Skip 1. Build failure 0

# benchmark

```
CUDA_VISIBLE_DEVICES=3 OC_CAUSE=1 buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "cmf_shrink" --flow_id 587303213
```
P1529578588
graph diffing: https://www.internalfb.com/intern/diffing/?paste_number=1529577762

Counter({'pattern_matcher_nodes': 2123, 'pattern_matcher_count': 1715, 'normalization_pass': 404, 'remove_split_with_size_one_pass': 269, 'extern_calls': 193, 'merge_splits_pass': 74, 'normalization_aten_pass': 47, 'fxgraph_cache_miss': 9, 'batch_aten_mul': 6, 'scmerge_split_sections_removed': 5, 'scmerge_split_removed': 4, 'scmerge_cat_removed': 4, 'unbind_stack_pass': 4, 'batch_sigmoid': 2, 'batch_linear': 2, 'move_reshape_out_of_split_stack_pass': 2, 'batch_aten_sub': 2, 'batch_layernorm': 1, 'scmerge_split_added': 1, 'scmerge_cat_added': 1, 'split_stack_to_cats_pass': 1, 'split_cat_to_slices_pass': 1, 'batch_aten_add': 1, 'batch_relu': 1})

Trace link: https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Ftest%2Fcmf_shrink.Aug_15_10_55_41_trace.json.gz&bucket=pyper_traces

The triton_fused_stack_xxx has been reduced significantly, we can see from the trace that the green part becomes smaller
{F1806406290}

# e2e
ads_dper3:68464f2dc5e849ba2670482079cecaaa
training_platform:8643db0c3453f2658aa7be7d73974ea0

baseline:
f588719502

proposal:
f592116164

Differential Revision: D61249205


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang