### PR TITLE
[easy] Fix type annotation for `ExportedProgram.run_decompositions`

### DIFF
--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -1005,7 +1005,7 @@ class ExportedProgram:
     def run_decompositions(
         self,
         decomp_table: Optional[Dict[torch._ops.OperatorBase, Callable]] = None,
-        _preserve_ops: Tuple[torch._ops.OpOverload] = (),  # type: ignore[assignment]
+        _preserve_ops: Tuple[torch._ops.OpOverload, ...] = (),
     ) -> "ExportedProgram":
         """
         Run a set of decompositions on the exported program and returns a new


### PR DESCRIPTION
Fix the tuple type annotation.
