### PR TITLE
Consolidate the format for `--max-acc-splits` flag

### DIFF
--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -53,8 +53,8 @@ class _SplitterSettingBase:
             help="Minimum size limit of an accelerator subgraph.",
         )
         parser.add_argument(
-            "--max-acc_splits",
-            "--max-acc_splits",
+            "--max-acc-splits",
+            "--max_acc_splits",
             required=False,
             type=int,
             help="Enforce a maximum number of split subgraphs.",


### PR DESCRIPTION
fixes the partial export of [lowering] Add max_acc_splits (#133041) ([D60133589](https://www.internalfb.com/diff/D60133589))
