### PR TITLE
[c10d] Land CudaEventCache with roll out flags

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -481,18 +481,16 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(
   // Creates the CUDA event wrappers
   // Note: The actual events are lazily created when first recorded to with
   // DEFAULT_FLAGS = cudaEventDisableTiming.
-  if (enableTiming) {
-    if (cudaEventCacheEnabled) {
-      ncclStartEvent_ =
-          ProcessGroupNCCL::CUDAEventCache::get().create(enableTiming);
-    } else {
-      ncclStartEvent_ = std::make_shared<at::cuda::CUDAEvent>(cudaEventDefault);
-    }
-  }
   if (cudaEventCacheEnabled) {
+    ncclStartEvent_ = enableTiming
+        ? ProcessGroupNCCL::CUDAEventCache::get().create(enableTiming)
+        : nullptr;
     ncclEndEvent_ =
         ProcessGroupNCCL::CUDAEventCache::get().create(enableTiming);
   } else {
+    ncclStartEvent_ = enableTiming
+        ? std::make_shared<at::cuda::CUDAEvent>(cudaEventDefault)
+        : nullptr;
     ncclEndEvent_ = std::make_shared<at::cuda::CUDAEvent>(
         enableTiming ? cudaEventDefault : cudaEventDisableTiming);
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -110,6 +110,12 @@ static std::vector<std::string> TORCH_NCCL_COORD_CHECK_MILSEC = {
 static std::vector<std::string> TORCH_NCCL_LOG_CPP_STACK_ON_UNCLEAN_SHUTDOWN = {
     "TORCH_NCCL_LOG_CPP_STACK_ON_UNCLEAN_SHUTDOWN"};
 
+// Control whether to use CudaEventCache for the collective in watchdog thread.
+// We noticed in the past when cuda global lock is held, destroying CudaEvent
+// can cause a hang.
+static std::vector<std::string> TORCH_NCCL_CUDA_EVENT_CACHE = {
+    "TORCH_NCCL_CUDA_EVENT_CACHE"};
+
 static std::vector<std::string> TORCH_NCCL_NAN_CHECK = {"TORCH_NCCL_NAN_CHECK"};
 
 constexpr const char* NCCL_BACKEND_NAME = "nccl";
@@ -263,6 +269,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
         const std::optional<std::vector<at::Tensor>>& inputs = std::nullopt,
         bool desyncDebug = false,
         bool enableTiming = false,
+        bool cudaEventCacheEnabled = false,
         DebugLevel distDebugLevel = DebugLevel::Off);
     // Copy constructor doing partial copy without outputs_. Cleanup thread
     // monitors and removes finished works. However it will deadlock when
@@ -421,6 +428,25 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     std::optional<uint64_t> trace_id_;
     DebugLevel distDebugLevel_;
     friend class ProcessGroupNCCL;
+  };
+
+  class CUDAEventCache {
+   public:
+    CUDAEventCache();
+    ~CUDAEventCache();
+    std::shared_ptr<at::cuda::CUDAEvent> create(int device, bool timing);
+    static CUDAEventCache& get();
+
+   private:
+    struct Device {
+      std::mutex mutex;
+      // NOTE: We intentionaly store raw pointers so that
+      // we do not attempt to destroy the event objects on process exit,
+      // because cuda may be gone.
+      std::vector<at::cuda::CUDAEvent*>
+          events[2]; // 0 for timing=false, 1 for timing=true
+    };
+    std::vector<Device> caches_;
   };
 
   struct Options : Backend::Options {
@@ -963,6 +989,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   // We gate the heartbeat monitor thread so that we can roll it out gradually.
   std::atomic<bool> monitorThreadEnabled_;
+
+  // We gate the cudaEventCache so that we can roll it out gradually.
+  std::atomic<bool> cudaEventCacheEnabled_;
 
   // Monitor thread which checks the heartbeat of Watchdog thread.
   // If the monitor thread finds there is no heartbeat, it will dump debug info

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -433,20 +433,16 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   class CUDAEventCache {
    public:
     CUDAEventCache();
-    ~CUDAEventCache();
-    std::shared_ptr<at::cuda::CUDAEvent> create(int device, bool timing);
+    std::shared_ptr<at::cuda::CUDAEvent> create(bool timing);
     static CUDAEventCache& get();
 
    private:
-    struct Device {
-      std::mutex mutex;
-      // NOTE: We intentionaly store raw pointers so that
-      // we do not attempt to destroy the event objects on process exit,
-      // because cuda may be gone.
-      std::vector<at::cuda::CUDAEvent*>
-          events[2]; // 0 for timing=false, 1 for timing=true
-    };
-    std::vector<Device> caches_;
+    std::mutex cacheMutex_;
+    // NOTE: We intentionaly store raw pointers so that
+    // we do not attempt to destroy the event objects on process exit,
+    // because cuda may be gone.
+    std::vector<at::cuda::CUDAEvent*>
+        eventsArray_[2]; // 0 for timing=false, 1 for timing=true
   };
 
   struct Options : Backend::Options {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133727

@zdevito added a cache for CudaEvent in https://github.com/pytorch/pytorch/pull/122732. And we want to productionize it with a flag in this PR.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o @xmfan