### PR TITLE
[Don't merge] try to use long for all platforms.

### DIFF
--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -83,7 +83,7 @@ LAYOUT_TO_ATEN = {
 
 _IS_WINDOWS = sys.platform == "win32"
 
-INDEX_TYPE = "int64_t" if _IS_WINDOWS else "long"
+INDEX_TYPE = "long"
 
 GemmBlocking = namedtuple("GemmBlocking", ["block_m", "block_n", "block_k"])
 
@@ -222,7 +222,7 @@ class CppCSEVariable(CSEVariable):
 
 class CppPrinter(ExprPrinter):
     def _print_Integer(self, expr):
-        return f"{int(expr)}LL" if _IS_WINDOWS else f"{int(expr)}L"
+        return f"{int(expr)}L"
 
     def _print_Where(self, expr):
         c = self.paren(self.doprint(expr.args[0]))


### PR DESCRIPTION
Another solution for https://github.com/pytorch/pytorch/pull/133615, use long for all plartform. 
It is regression on my local env:

<img width="1893" alt="image" src="https://github.com/user-attachments/assets/fffb42c0-d5ce-496b-8ca6-0f9a77202624">

Test case:
```cmd
pytest -v test\inductor\test_cpu_cpp_wrapper.py -k test_linear_with_pointwise_batch_size_384_in_features_196_out_features_384_bias_False_epilogue_add_cpu_bfloat16_cpp_wrapper
```
Error:
```cmd
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] Exception C++ compile error
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0]
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] Command:
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] cl /I C:/Users/Xuhan/.conda/envs/win_mkl_static/Include /I C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include /I C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include/torch/csrc/api/include /I C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include/TH /I C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include/THC /D TORCH_INDUCTOR_CPP_WRAPPER /D C10_USING_CUSTOM_GENERATED_MACROS /D CPU_CAPABILITY_AVX512 /DLL /MD /O2 /std:c++20 /wd4819 /wd4251 /wd4244 /wd4267 /wd4275 /wd4018 /wd4190 /wd4624 /wd4067 /wd4068 /EHsc /openmp /openmp:experimental C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp /arch:AVX512 /LD /FeC:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.pyd /link /LIBPATH:C:/Users/Xuhan/.conda/envs/win_mkl_static/libs /LIBPATH:C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/lib torch.lib torch_cpu.lib torch_python.lib sleef.lib c10.lib
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0]
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] Output:
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] Microsoft (R) C/C++ Optimizing Compiler Version 19.37.32825 for x64
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] Copyright (C) Microsoft Corporation.  All rights reserved.
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0]
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] cl : Command line warning D9025 : overriding '/openmp' with '/openmp:experimental'
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(266): error C2672: 'c10::div_floor_integer': no matching overloaded function found
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include\c10/util/generic_math.h(60): note: could be 'scalar_t c10::div_floor_integer(scalar_t,scalar_t)'
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(266): note: 'scalar_t c10::div_floor_integer(scalar_t,scalar_t)': template parameter 'scalar_t' is ambiguous
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(266): note: could be 'long'
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(266): note: or       'int64_t'
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(266): note: 'scalar_t c10::div_floor_integer(scalar_t,scalar_t)': could not deduce template argument for 'scalar_t' from 'long'
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(275): warning C4849: OpenMP 'simdlen' clause ignored in 'simd' directive
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(276): error C2672: 'c10::div_floor_integer': no matching overloaded function found
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/.conda/envs/win_mkl_static/lib/site-packages/torch/include\c10/util/generic_math.h(60): note: could be 'scalar_t c10::div_floor_integer(scalar_t,scalar_t)'
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(276): note: 'scalar_t c10::div_floor_integer(scalar_t,scalar_t)': template parameter 'scalar_t' is ambiguous
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(276): note: could be 'long'
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(276): note: or       'int64_t'
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(276): note: 'scalar_t c10::div_floor_integer(scalar_t,scalar_t)': could not deduce template argument for 'scalar_t' from 'long'
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0] C:/Users/Xuhan/AppData/Local/Temp/tmpo81lnf8k/i3/ci37f3cje66berd5dcmbqpbffb4eej35aeow7wpqas6svisj5hy5.cpp(276): error C3015: initialization in OpenMP 'for' statement has improper form
E0817 07:13:53.522000 22656 torch\_inductor\select_algorithm.py:1305] [0/0]  for benchmark choice DataProcessorChoiceCallerWrapper(<torch._inductor.codegen.cpp_template_kernel.CppTemplateCaller object at 0x000001D6F4CE09D0>)
```

I considered something about `long`: https://www.ccoderun.ca/programming/2017-03-10_sizeof/
<img width="966" alt="image" src="https://github.com/user-attachments/assets/d223b259-a828-4c1f-975b-c92e2b2c1cf1">

On Windows x64, `long` still size 4. and size 8 on Linux and MacOS. We will lost precision on Windows. So still need use int64_t rather than long.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang