### PR TITLE
[Don't merge] Use long as index type for all platfroms

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -325,7 +325,11 @@ class ExprPrinterTests(InductorTestCase):
         s2 = sympy.Symbol("s2", integer=True)
         expr = FloorDiv(s1, s2)
         self.assertEqual(pexpr(expr), "(s1 // s2)")
-        self.assertEqual(cexpr(expr), "c10::div_floor_integer(s1, s2)")
+        self.assertEqual(
+            # div_floor_integer only support int64_t type.
+            cexpr(expr),
+            "c10::div_floor_integer(static_cast<int64_t>(s1), static_cast<int64_t>(s2))",
+        )
 
         s1 = sympy.Symbol("s1", integer=True)
         s2 = sympy.S(-1)

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -83,7 +83,7 @@ LAYOUT_TO_ATEN = {
 
 _IS_WINDOWS = sys.platform == "win32"
 
-INDEX_TYPE = "int64_t" if _IS_WINDOWS else "long"
+INDEX_TYPE = "long"
 
 GemmBlocking = namedtuple("GemmBlocking", ["block_m", "block_n", "block_k"])
 
@@ -222,7 +222,7 @@ class CppCSEVariable(CSEVariable):
 
 class CppPrinter(ExprPrinter):
     def _print_Integer(self, expr):
-        return f"{int(expr)}LL" if _IS_WINDOWS else f"{int(expr)}L"
+        return f"{int(expr)}L"
 
     def _print_Where(self, expr):
         c = self.paren(self.doprint(expr.args[0]))
@@ -236,7 +236,7 @@ class CppPrinter(ExprPrinter):
         if div != 1:
             div = self.paren(self.doprint(div))
             if expr.is_integer:
-                x = f"c10::div_floor_integer({x}, {div})"
+                x = f"c10::div_floor_integer(static_cast<int64_t>({x}), static_cast<int64_t>({div}))"
             else:
                 x = f"c10::div_floor_floating(static_cast<double>({x}), static_cast<double>({div}))"
         mod = self.paren(self.doprint(mod))
@@ -247,7 +247,7 @@ class CppPrinter(ExprPrinter):
         x = self.paren(self.doprint(x))
         div = self.paren(self.doprint(div))
         if expr.is_integer:
-            return f"c10::div_floor_integer({x}, {div})"
+            return f"c10::div_floor_integer(static_cast<int64_t>({x}), static_cast<int64_t>({div}))"
         return f"c10::div_floor_floating(static_cast<double>({x}), static_cast<double>({div}))"
 
     def _print_floor(self, expr):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2403,8 +2403,7 @@ if (py_{buf_name}.get() == NULL) {{
             else:
                 return "true" if val else "false"
         elif isinstance(val, int):
-            # uint64_t is long on Linux, but long long on MacOS and Windows
-            return f"{val}LL" if sys.platform in ["darwin", "win32"] else f"{val}L"
+            return f"{val}L"
         elif isinstance(val, str):
             return f'"{val}"'
         elif isinstance(


### PR DESCRIPTION
Another solution for https://github.com/pytorch/pytorch/pull/133615, use long for all plartform. 
### Major changes:
**1. Use `long` type as index type for all OSs: `Windows`, `Linux` and `MacOS`.**
It is equal revert this PR: https://github.com/pytorch/pytorch/pull/132491/files
**2. Use static_cast<long>(`constant`) to conver constant to `div_floor_integer` args type(`int64_t`).**
It will solve issue, which occurs on Linux and Windows.
```cmd
'scalar_t c10::div_floor_integer(scalar_t,scalar_t)': could not deduce template argument for 'scalar_t' from 'long'
```
**3. Remove append double L to `int` to conver type to `int64_t`(`long long`)**
It is acturaly impact on type correctness, we use item 2 instead of it.
**4. Update UT (`test/inductor/test_indexing.py`) for the changes.**

Intermediate temporary PRs of development:
https://github.com/pytorch/pytorch/pull/133732
https://github.com/pytorch/pytorch/pull/133765

**I have mirror PR use `int64_t` for this one: https://github.com/pytorch/pytorch/pull/133782/files, it always failed on MacOS.**
Tried a lot for this direction, step by step. And it also failed on `sympy` expr.
Attempt PRs for `int64_t` index type:
https://github.com/pytorch/pytorch/pull/133752
https://github.com/pytorch/pytorch/pull/133757
https://github.com/pytorch/pytorch/pull/133763
https://github.com/pytorch/pytorch/pull/133764
https://github.com/pytorch/pytorch/pull/133782

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang