### PR TITLE
[inductor] fix uncaught exception when checking for openmp on macos

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -737,7 +737,7 @@ def is_conda_llvm_openmp_installed() -> bool:
         command = "conda list llvm-openmp --json"
         output = subprocess.check_output(command.split()).decode("utf8")
         return len(json.loads(output)) > 0
-    except subprocess.SubprocessError:
+    except (subprocess.SubprocessError, FileNotFoundError):
         return False
 
 


### PR DESCRIPTION
When using `torch.compile` on macos, if `conda` is not installed `is_conda_llvm_openmp_installed` currently raises `FileNotFoundError` instead of returning `False` causing compilation to fail.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov