### PR TITLE
[ONNX] Remove logging apis from public

### DIFF
--- a/docs/source/onnx_torchscript.rst
+++ b/docs/source/onnx_torchscript.rst
@@ -702,8 +702,6 @@ Functions
 .. autofunction:: unregister_custom_op_symbolic
 .. autofunction:: select_model_mode_for_export
 .. autofunction:: is_in_onnx_export
-.. autofunction:: enable_log
-.. autofunction:: disable_log
 .. autofunction:: torch.onnx.verification.find_mismatch
 
 Classes

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -517,37 +517,3 @@ def dynamo_export(
         return dynamo_export(
             model, *model_args, export_options=export_options, **model_kwargs
         )
-
-
-# TODO(justinchuby): Deprecate these logging functions in favor of the new diagnostic module.
-
-# Returns True iff ONNX logging is turned on.
-is_onnx_log_enabled = _C._jit_is_onnx_log_enabled
-
-
-def enable_log() -> None:
-    r"""Enables ONNX logging."""
-    _C._jit_set_onnx_log_enabled(True)
-
-
-def disable_log() -> None:
-    r"""Disables ONNX logging."""
-    _C._jit_set_onnx_log_enabled(False)
-
-
-"""Sets output stream for ONNX logging.
-
-Args:
-    stream_name (str, default "stdout"): Only 'stdout' and 'stderr' are supported
-        as ``stream_name``.
-"""
-set_log_stream = _C._jit_set_onnx_log_output_stream
-
-
-"""A simple logging facility for ONNX exporter.
-
-Args:
-    args: Arguments are converted to string, concatenated together with a newline
-        character appended to the end, and flushed to output stream.
-"""
-log = _C._jit_onnx_log

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -36,8 +36,6 @@ __all__ = [
     "select_model_mode_for_export",
     "register_custom_op_symbolic",
     "unregister_custom_op_symbolic",
-    "disable_log",
-    "enable_log",
     # Base error
     "OnnxExporterError",
     # Dynamo Exporter

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -139,14 +139,14 @@ def disable_apex_o2_state_dict_hook(model: torch.nn.Module | torch.jit.ScriptFun
 
 @contextlib.contextmanager
 def setup_onnx_logging(verbose: bool):
-    is_originally_enabled = torch.onnx.is_onnx_log_enabled()
+    is_originally_enabled = _C._jit_is_onnx_log_enabled
     if is_originally_enabled or verbose:
-        torch.onnx.enable_log()
+        _C._jit_set_onnx_log_enabled(True)
     try:
         yield
     finally:
         if not is_originally_enabled:
-            torch.onnx.disable_log()
+            _C._jit_set_onnx_log_enabled(False)
 
 
 @contextlib.contextmanager
@@ -1125,7 +1125,7 @@ def _model_to_graph(
             module=module,
         )
     except Exception as e:
-        torch.onnx.log("Torch IR graph at exception: ", graph)
+        _C._jit_onnx_log("Torch IR graph at exception: ", graph)
         raise
 
     is_script = isinstance(model, (torch.jit.ScriptFunction, torch.jit.ScriptModule))
@@ -1452,7 +1452,7 @@ def _get_module_attributes(module):
         try:
             attrs[k] = getattr(module, k)
         except AttributeError:
-            torch.onnx.log(f"Skipping module attribute '{k}'")
+            _C._jit_onnx_log(f"Skipping module attribute '{k}'")
             continue
     return attrs
 
@@ -1642,7 +1642,7 @@ def _export(
                 custom_opsets,
             )
             if verbose:
-                torch.onnx.log("Exported graph: ", graph)
+                _C._jit_onnx_log("Exported graph: ", graph)
             onnx_proto_utils._export_file(proto, f, export_type, export_map)
     finally:
         assert GLOBALS.in_onnx_export

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -140,12 +140,12 @@ def disable_apex_o2_state_dict_hook(model: torch.nn.Module | torch.jit.ScriptFun
 @contextlib.contextmanager
 def setup_onnx_logging(verbose: bool):
     is_originally_enabled = _C._jit_is_onnx_log_enabled
-    if is_originally_enabled or verbose:
+    if is_originally_enabled or verbose:  # type: ignore[truthy-function]
         _C._jit_set_onnx_log_enabled(True)
     try:
         yield
     finally:
-        if not is_originally_enabled:
+        if not is_originally_enabled:  # type: ignore[truthy-function]
             _C._jit_set_onnx_log_enabled(False)
 
 


### PR DESCRIPTION
Remove

- torch.onnx.enable_log
- torch.onnx.disable_log
- torch.onnx.set_log_stream
- torch.onnx.log

Because they are not meant for public consumption and has been marked for deprecation.
