### PR TITLE
remove StrobelightCompileTimeProfiler.profile_compile_time from stacktrace when strobelight profiling not enabled

### DIFF
--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -82,7 +82,7 @@ def compile_time_strobelight_meta(phase_name):
         def wrapper_function(*args, **kwargs):
             if "skip" in kwargs:
                 kwargs["skip"] = kwargs["skip"] + 1
-                
+
             if not StrobelightCompileTimeProfiler.enabled:
                 return function(*args, **kwargs)
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -82,6 +82,10 @@ def compile_time_strobelight_meta(phase_name):
         def wrapper_function(*args, **kwargs):
             if "skip" in kwargs:
                 kwargs["skip"] = kwargs["skip"] + 1
+                
+            if not StrobelightCompileTimeProfiler.enabled:
+                return function(*args, **kwargs)
+
             return StrobelightCompileTimeProfiler.profile_compile_time(
                 function, phase_name, *args, **kwargs
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133831

