### PR TITLE
[DeviceMesh] Add DeviceMesh slicing support for flatten mesh dim

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -561,10 +561,9 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         # Check on the current dp_local_rank, whether the cp mesh tensor is the same.
         self.assertEqual(dp_cp_mesh.mesh[dp_local_rank], cp_mesh.mesh)
 
-        mesh_dim_names = ("cp", "dp")
         with self.assertRaisesRegex(
             KeyError,
-            "Invalid slice",
+            "Invalid mesh_dim_names",
         ):
             cp_dp_mesh = mesh_3d["cp", "dp"]
 

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -561,9 +561,10 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         # Check on the current dp_local_rank, whether the cp mesh tensor is the same.
         self.assertEqual(dp_cp_mesh.mesh[dp_local_rank], cp_mesh.mesh)
 
+        mesh_dim_names = ("cp", "dp")
         with self.assertRaisesRegex(
             KeyError,
-            "Valid mesh_dim_names should be a subsequence of",
+            "Invalid slice",
         ):
             cp_dp_mesh = mesh_3d["cp", "dp"]
 
@@ -577,12 +578,16 @@ class TestDeviceMeshGetItem(DTensorTestBase):
 
         # Test flatten contiguous dims
         dp_cp_mesh = mesh_3d["dp", "cp"]
+        # print(f"{dp_cp_mesh}")
         flattened_dp_cp_mesh = dp_cp_mesh._flatten()
+        # print(f"{dp_cp_mesh.mesh.flatten()=}, {flattened_dp_cp_mesh.mesh=}")
         self.assertEqual(dp_cp_mesh.mesh.flatten(), flattened_dp_cp_mesh.mesh)
         self.assertEqual(flattened_dp_cp_mesh.mesh_dim_names[0], "dp_cp")
         root_mesh = _mesh_resources.get_root_mesh(dp_cp_mesh)
         self.assertEqual(root_mesh, mesh_3d)
-        flatten_mesh_root_dims = _mesh_resources.flatten_name_to_root_dims[root_mesh]["dp_cp"]
+        flatten_mesh_root_dims = _mesh_resources.flatten_name_to_root_dims[root_mesh][
+            "dp_cp"
+        ]
         self.assertEqual(flatten_mesh_root_dims, (0, 1))
 
         ref_pg_count = _world.group_count
@@ -598,8 +603,38 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         self.assertEqual(flattened_dp_tp_mesh.mesh_dim_names[0], "dp_tp")
         root_mesh = _mesh_resources.get_root_mesh(dp_tp_mesh)
         self.assertEqual(root_mesh, mesh_3d)
-        flatten_mesh_root_dims = _mesh_resources.flatten_name_to_root_dims[root_mesh]["dp_tp"]
+        flatten_mesh_root_dims = _mesh_resources.flatten_name_to_root_dims[root_mesh][
+            "dp_tp"
+        ]
         self.assertEqual(flatten_mesh_root_dims, (0, 2))
+
+    @with_comms
+    def test_reconstruct_mesh_with_flatten_dim(self):
+        mesh_3d = init_device_mesh(
+            self.device_type, (2, 2, 2), mesh_dim_names=("replicate", "shard", "cp")
+        )
+        shard_cp_mesh = mesh_3d["shard", "cp"]._flatten()
+        hsdp_mesh = mesh_3d["replicate", "shard_cp"]
+        expected_mesh_tensor = torch.tensor(
+            [[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int
+        )
+        self.assertEqual(hsdp_mesh.mesh, expected_mesh_tensor)
+        self.assertEqual(shard_cp_mesh.get_group(), mesh_3d["shard_cp"].get_group())
+        self.assertEqual(
+            shard_cp_mesh.get_group(), mesh_3d.get_group(mesh_dim="shard_cp")
+        )
+
+        mesh_3d = init_device_mesh(
+            self.device_type, (2, 2, 2), mesh_dim_names=("dp", "cp", "tp")
+        )
+        dp_cp_mesh = mesh_3d["dp", "cp"]._flatten()
+        spmd_mesh = mesh_3d["dp_cp", "tp"]
+        expected_mesh_tensor = torch.tensor(
+            [[0, 1], [2, 3], [4, 5], [6, 7]], dtype=torch.int
+        )
+        self.assertEqual(spmd_mesh.mesh, expected_mesh_tensor)
+        self.assertEqual(dp_cp_mesh.get_group(), mesh_3d["dp_cp"].get_group())
+        self.assertEqual(dp_cp_mesh.get_group(), mesh_3d.get_group(mesh_dim="dp_cp"))
 
 
 class TestMeshEnv(DTensorTestBase):

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -578,9 +578,7 @@ class TestDeviceMeshGetItem(DTensorTestBase):
 
         # Test flatten contiguous dims
         dp_cp_mesh = mesh_3d["dp", "cp"]
-        # print(f"{dp_cp_mesh}")
         flattened_dp_cp_mesh = dp_cp_mesh._flatten()
-        # print(f"{dp_cp_mesh.mesh.flatten()=}, {flattened_dp_cp_mesh.mesh=}")
         self.assertEqual(dp_cp_mesh.mesh.flatten(), flattened_dp_cp_mesh.mesh)
         self.assertEqual(flattened_dp_cp_mesh.mesh_dim_names[0], "dp_cp")
         root_mesh = _mesh_resources.get_root_mesh(dp_cp_mesh)

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -4,7 +4,6 @@ import logging
 import math
 import threading
 from functools import reduce
-from itertools import chain
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
@@ -275,9 +274,10 @@ else:
             # The slice mesh_dim_names should consist either the device_mesh's mesh_dim_names
             # or its flattened mesh's mesh_dim_names.
             self.flatten_name_to_root_dims.setdefault(device_mesh, {})
+            flatten_name_to_root_dims = self.flatten_name_to_root_dims[device_mesh]
             valid_mesh_dim_names = [
                 *device_mesh.mesh_dim_names,
-                *self.flatten_name_to_root_dims[device_mesh].keys(),
+                *flatten_name_to_root_dims,
             ]
 
             if not all(
@@ -289,24 +289,28 @@ else:
                     f"Valid mesh_dim_names are {valid_mesh_dim_names}."
                 )
 
-            # Validate the order of the slice mesh dim indexes.
+            # Validate the order of the slice mesh dim indices.
             # This needs to be in ascending order.
-            slice_mesh_dims = [
-                self.flatten_name_to_root_dims[device_mesh][mesh_dim_name]
-                if mesh_dim_name in self.flatten_name_to_root_dims[device_mesh]
-                else (device_mesh.mesh_dim_names.index(mesh_dim_name),)
-                for mesh_dim_name in mesh_dim_names
-            ]
-            slice_mesh_dims_iter = chain(*slice_mesh_dims)
-            mesh_dims_iter = iter(range(len(device_mesh.mesh_dim_names)))
-            if not all(
-                slice_mesh_dim in mesh_dims_iter
-                for slice_mesh_dim in slice_mesh_dims_iter
-            ):
-                raise KeyError(
-                    f"Invalid slice {mesh_dim_names}. ",
-                    "Please check the order of the slice dims. ",
-                )
+            curr_idx = -1
+            slice_mesh_dims = []
+            for mesh_dim_name in mesh_dim_names:
+                if mesh_dim_name in flatten_name_to_root_dims:
+                    mesh_indices = flatten_name_to_root_dims[mesh_dim_name]
+                    # TODO: this doesn't allow non-contiguous slicing with flatten dim yet. next_idx
+                    # should be mesh_indices[0] once we support non-contiguous slicing with flatten dim.
+                    next_idx = mesh_indices[-1]
+                    slice_mesh_dims.append(mesh_indices)
+                else:
+                    next_idx = device_mesh.mesh_dim_names.index(mesh_dim_name)
+                    slice_mesh_dims.append((next_idx,))
+                if next_idx <= curr_idx:
+                    raise KeyError(
+                        f"Invalid mesh_dim_names {mesh_dim_names} specified. ",
+                        f"Found mesh dim indices to slice: {slice_mesh_dims}. ",
+                        "Mesh dim indices should be in ascending order.",
+                    )
+                curr_idx = next_idx
+
             return slice_mesh_dims
 
     _mesh_resources: _MeshEnv = _MeshEnv()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #134048
* __->__ #133839

Add DeviceMesh slicing support such that we could do the following:
```
mesh_3d = init_device_mesh(
    self.device_type, (2, 2, 2), mesh_dim_names=("replicate", "shard", "cp")
)
shard_cp_mesh = mesh_3d["shard", "cp"]._flatten()
hsdp_mesh = mesh_3d["replicate", "shard_cp"]
# we can get the corresponding group of the flatten mesh through

group = shard_cp_mesh.get_group()
# or
group = mesh_3d["shard_cp"].get_group()
# or
mesh_3d.get_group(mesh_dim="shard_cp")
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l