### PR TITLE
[cpu] Modify inductor opt flag --- ffast-math

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -447,11 +447,11 @@ def _get_optimization_cflags() -> List[str]:
         return ["O2"]
     else:
         cflags = ["O0", "g"] if config.aot_inductor.debug_compile else ["O3", "DNDEBUG"]
-        cflags.append("ffast-math")
-        cflags.append("fno-finite-math-only")
+        # subset of ffast-math
+        cflags.extend(["fno-math-errno", "fno-rounding-math", "fno-signaling-nans", "fcx-limited-range", "fexcess-precision=fast"])
 
-        if not config.cpp.enable_unsafe_math_opt_flag:
-            cflags.append("fno-unsafe-math-optimizations")
+        if config.cpp.enable_unsafe_math_opt_flag:
+            cflags.append("funsafe-math-optimizations")
         if not config.cpp.enable_floating_point_contract_flag:
             cflags.append("ffp-contract=off")
 


### PR DESCRIPTION
Fixes #126848.

For CPU inductor path, instead of using the optimization flag `-ffast-math`, the functional issue can be avoided by using its detailed options: `-fno-math-errno, -funsafe-math-optimizations, -ffinite-math-only, -fno-rounding-math, -fno-signaling-nans, -fcx-limited-range and -fexcess-precision=fast`.

### Validation on 3 benchmark suites

FP32
![image](https://github.com/user-attachments/assets/ffe210e3-48e7-4dfd-b7b4-029755eb528d)
Outlier models (speedup<0.8):
- single-socket multi-threads
  - hrnet_w18: 0.33
  - resnest101e: 0.71
  - swsl_resnext101_32x16d: 0.05
- single-core single-thread
  - hrnet_w18: 0.30
  - resnest101e: 0.61
  - swsl_resnext101_32x16d: 0.05

BF16
![image](https://github.com/user-attachments/assets/cbb57abf-d93e-48b8-afcc-d926e7e63ef5)
Outlier models (speedup<0.8):
- single-socket multi-threads
  - MT5ForConditionalGeneration: 0.75
  - mobilenetv2_100: 0.73
- single-core single-thread
  - MT5ForConditionalGeneration: 0.71
  - mobilenetv2_100: 0.66

TODO: continue to analyze the outlier models.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov