### PR TITLE
Update test_control_flow.py to device-agnostic.

### DIFF
--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -698,7 +698,7 @@ class WhileLoopTests(TestCase):
 
 class AssociativeScanTests(TestCase):
     @requires_gpu
-    @parametrize("device", [torch.device("cuda")])
+    @parametrize("device", [GPU_TYPE])
     @parametrize("backend", ["inductor"])
     def test_pointwise_associative_scan_CUDA_flip(self, device, backend):
         def fct(x: torch.Tensor, y: torch.Tensor):


### PR DESCRIPTION
Fixes #133841 

This PR makes the `test_pointwise_associative_scan_CUDA_flip` also work on XPU. 


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang