### PR TITLE
Add int8 support to bsr_dense_addmm and bsr_dense_mm Triton kernels. Add _int_bsr_dense_addmm.

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -3980,7 +3980,7 @@ class TestSparseCompressedTritonKernels(TestCase):
         self.assertEqual(d.get(key5), (key5, 567), **assertEqualOptions)
 
     @suppress_warnings
-    @parametrize("op", ['bsr_dense_addmm', 'bsr_dense_mm', 'bsr_dense_linear'])
+    @parametrize("op", ['bsr_dense_addmm', 'bsr_dense_mm', 'bsr_dense_linear', '_int_bsr_dense_addmm'])
     @parametrize("blocksize", [16, '16x32', 32])
     @onlyCUDA
     @skipIfRocm
@@ -3988,22 +3988,34 @@ class TestSparseCompressedTritonKernels(TestCase):
     @dtypesIfCUDA(torch.half, *[torch.bfloat16] if SM80OrLater else [], torch.float, torch.int8)
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "Test requires Triton")
     def test_triton_kernel(self, op, device, dtype, blocksize):
-        from torch.sparse._triton_ops import bsr_dense_addmm, bsr_dense_mm
+        from torch.sparse._triton_ops import bsr_dense_addmm, bsr_dense_mm, _int_bsr_dense_addmm
         from torch.sparse._triton_ops_meta import (create_blocked_tensor, get_meta,
                                                    optimize_bsr_dense_addmm, dump)
 
         def bsr_dense_linear(input, weights, bias=None):
             return torch.nn.functional.linear(input, weights, bias=bias).transpose(-1, -2)
 
-        operation = dict(bsr_dense_addmm=bsr_dense_addmm, bsr_dense_mm=bsr_dense_mm, bsr_dense_linear=bsr_dense_linear)[op]
+        operation = dict(bsr_dense_addmm=bsr_dense_addmm, bsr_dense_mm=bsr_dense_mm, bsr_dense_linear=bsr_dense_linear,
+                         _int_bsr_dense_addmm=_int_bsr_dense_addmm)[op]
 
-        def reference(input, mat1, mat2, beta=1, alpha=1):
+        def reference(input, mat1, mat2, beta=1, alpha=1, op=op):
             assert mat1.layout is torch.strided
             assert mat2.layout is torch.strided
             if dtype is torch.int8:
+                if op == '_int_bsr_dense_addmm':
+                    return beta * input + alpha * torch._int_mm(mat1, mat2)
                 # workaround RuntimeError: "addmm_cuda" not implemented for 'Char'
-                return beta * input + alpha * (mat1.cpu() @ mat2.cpu()).to(device)
+                return beta * input + alpha * torch._int_mm(mat1, mat2).to(torch.int8)
             return beta * input + alpha * (mat1 @ mat2)
+
+        if op == '_int_bsr_dense_addmm':
+            # _int_bsr_dense_addmm is same as bsr_dense_addmm except
+            # with int8 inputs, _int_bsr_dense_addmm returns int32
+            # result. This is covered by operation and reference
+            # definitions above and all other definitions below are
+            # identical between _int_bsr_dense_addmm and
+            # bsr_dense_addmm.
+            op = 'bsr_dense_addmm'
 
         def nc_copy(t, axes=(-1,)):
             """Return a copy of input.
@@ -4108,28 +4120,33 @@ class TestSparseCompressedTritonKernels(TestCase):
                 result = operation(*args, **kwargs)
                 self.assertEqual(result, expected)
 
-    @parametrize("op", ['bsr_dense_addmm'])
+    @parametrize("op", ['bsr_dense_addmm', '_int_bsr_dense_addmm'])
     @onlyCUDA
     @skipIfRocm
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.int8)
     @dtypesIfCUDA(torch.half, *[torch.bfloat16] if SM80OrLater else [], torch.float, torch.int8)
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "Test requires Triton")
     def test_triton_tune(self, op, device, dtype):
-        from torch.sparse._triton_ops import bsr_dense_addmm
-        from torch.sparse._triton_ops_meta import (create_blocked_tensor, tune_bsr_dense_addmm, get_meta)
+        from torch.sparse._triton_ops import bsr_dense_addmm, _int_bsr_dense_addmm
+        from torch.sparse._triton_ops_meta import (create_blocked_tensor, tune_bsr_dense_addmm, tune__int_bsr_dense_addmm, get_meta)
 
-        operation = dict(bsr_dense_addmm=bsr_dense_addmm)[op]
-        tuner = dict(bsr_dense_addmm=tune_bsr_dense_addmm)[op]
+        operation = dict(bsr_dense_addmm=bsr_dense_addmm, _int_bsr_dense_addmm=_int_bsr_dense_addmm)[op]
+        tuner = dict(bsr_dense_addmm=tune_bsr_dense_addmm,
+                     _int_bsr_dense_addmm=tune__int_bsr_dense_addmm)[op]
 
-        M, K, N = 16, 16, 32
+        if op == '_int_bsr_dense_addmm':
+            M, K, N = 32, 32, 32
+            blocksize = (32, 32)
+        else:
+            M, K, N = 16, 16, 32
+            blocksize = (16, 16)
         sparsity = 1.0
-        blocksize = (16, 16)
         bsr = create_blocked_tensor(0, M, K, blocksize, sparsity, dtype, device).to_sparse_bsr(blocksize)
         sparsity = 1 - bsr._nnz() * blocksize[0] * blocksize[1] / (M * K)
         input = make_tensor(K, N, dtype=dtype, device=device)
         dense = make_tensor(K, N, dtype=dtype, device=device)
 
-        if op == 'bsr_dense_addmm':
+        if op in {'bsr_dense_addmm', '_int_bsr_dense_addmm'}:
             args = (input, bsr, dense)
 
             def get_current_meta():

--- a/torch/sparse/_triton_ops.py
+++ b/torch/sparse/_triton_ops.py
@@ -1159,6 +1159,7 @@ def bsr_dense_addmm(
         torch.bfloat16: tl.float32,
         torch.float32: tl.float64,
         torch.float64: tl.float64,
+        torch.int8: tl.int8,
     }[out.dtype]
 
     n_batches = dense.size(0)
@@ -1626,7 +1627,7 @@ if has_triton():
         if not skip_checks:
             check_bsr_layout(f_name, bsr)
             check_device(f_name, bsr, dense.device)
-            check_dtype(f_name, bsr, dense.dtype)
+            check_dtype(f_name, bsr, dense.dtype, (torch.int8,))
             check_mm_compatible_shapes(f_name, bsr, dense)
 
             n = dense.size(-1)
@@ -2354,7 +2355,7 @@ if has_triton():
             # do block mm
             output_acc_block += tl.dot(
                 values_block, dense_block, allow_tf32=allow_tf32, out_dtype=acc_dtype
-            )
+            ).to(acc_dtype)
 
             # move val/col_index ptrs to the next block in the row
             values_block_ptrs += values_nnz_stride

--- a/torch/sparse/_triton_ops_meta.py
+++ b/torch/sparse/_triton_ops_meta.py
@@ -97,7 +97,7 @@ tune_bsr_dense_addmm to learn how to register a custom set of optimal
 kernel parameters for addmm-based operations.
 
 """
-__all__ = ["get_meta", "tune_bsr_dense_addmm"]
+__all__ = ["get_meta", "tune_bsr_dense_addmm", "tune__int_bsr_dense_addmm"]
 
 import inspect
 import itertools
@@ -173,7 +173,7 @@ def get_meta(op, key, device_name=None, version=(0, torch.float16, 0.5), exact=F
                 "num_warps",
             )
             meta = dict(zip(names, values))
-        elif op == "bsr_dense_addmm":
+        elif op in {"bsr_dense_addmm", "_int_bsr_dense_addmm"}:
             meta = dict(
                 zip(("GROUP_SIZE_ROW", "SPLIT_N", "num_stages", "num_warps"), values)
             )
@@ -568,7 +568,7 @@ def optimize_scatter_mm(
     )
 
 
-def tune_bsr_dense_addmm(
+def tune__int_bsr_dense_addmm(
     input,
     bsr,
     dense,
@@ -580,6 +580,33 @@ def tune_bsr_dense_addmm(
     verbose=False,
     force=False,
 ):
+    return tune_bsr_dense_addmm(
+        input,
+        bsr,
+        dense,
+        beta=beta,
+        alpha=alpha,
+        out=out,
+        store=store,
+        verbose=verbose,
+        force=force,
+        opname="_int_bsr_dense_addmm",
+    )
+
+
+def tune_bsr_dense_addmm(
+    input,
+    bsr,
+    dense,
+    *,
+    beta=1,
+    alpha=1,
+    out=None,
+    store=False,
+    verbose=False,
+    force=False,
+    opname=None,
+):
     """Tune bsr_dense_addmm kernel parameters against the given inputs.
 
     When store is True, the tuning results will be stored in the
@@ -587,7 +614,13 @@ def tune_bsr_dense_addmm(
     """
     import triton
 
-    from torch.sparse._triton_ops import bsr_dense_addmm
+    if opname is None:
+        opname = "bsr_dense_addmm"
+
+    if opname == "_int_bsr_dense_addmm":
+        from torch.sparse._triton_ops import _int_bsr_dense_addmm as bsr_dense_addmm
+    else:
+        from torch.sparse._triton_ops import bsr_dense_addmm
 
     N = dense.shape[-1]
     values = bsr.values()
@@ -612,12 +645,10 @@ def tune_bsr_dense_addmm(
 
     # For tuning, for an initial state, use parameters from the
     # database if available, otherwise, use the reference parameters.
-    initial_meta = get_meta("bsr_dense_addmm", key, version=version, exact=True)
+    initial_meta = get_meta(opname, key, version=version, exact=True)
     if initial_meta is None:
         may_skip_update = False
-        initial_meta = get_meta(
-            "bsr_dense_addmm", key, version=(0, dtype, 0.5), exact=True
-        )
+        initial_meta = get_meta(opname, key, version=(0, dtype, 0.5), exact=True)
         if initial_meta is None:
             initial_meta = reference_meta
     elif not force:
@@ -676,7 +707,7 @@ def tune_bsr_dense_addmm(
     ):
         device_name = torch.cuda.get_device_name()
         update(
-            "bsr_dense_addmm",
+            opname,
             device_name,
             version,
             key,
@@ -699,6 +730,7 @@ def optimize_bsr_dense_addmm(
     sparsity=0.5,
     force=False,
     verbose=False,
+    opname=None,
 ):
     torch.manual_seed(0)
     bsr = create_blocked_tensor(
@@ -715,6 +747,7 @@ def optimize_bsr_dense_addmm(
         store=True,
         force=force,
         verbose=verbose,
+        opname=opname,
     )
 
 
@@ -755,7 +788,7 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True):
                     optimize_scatter_mm(
                         M, K, N, BM, BK, force=force, sparsity=sparsity, dtype=dtype
                     )
-                elif op == "bsr_dense_addmm":
+                elif op in {"bsr_dense_addmm", "_int_bsr_dense_addmm"}:
                     if M == K and N == 50432:
                         continue
                     print(f"{M, K, N, (BM, BK)=}")
@@ -772,6 +805,7 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True):
                             sparsity=sparsity,
                             dtype=dtype,
                             verbose=verbose,
+                            opname=op,
                         )
                 else:
                     raise NotImplementedError(op)
@@ -6185,4 +6219,7 @@ _operation_device_version_data: Dict[Any, Dict] = {
 if __name__ == "__main__":
     for dtype in [torch.float16, torch.bfloat16, torch.float32]:
         for op in ["bsr_dense_addmm"]:
+            main(op=op, force=False, dtype=dtype)
+    for dtype in [torch.int8]:
+        for op in ["_int_bsr_dense_addmm"]:
             main(op=op, force=False, dtype=dtype)


### PR DESCRIPTION
As in the title. In addition, the PR introduces `_int_bsr_dense_addmm` that is equivalent to `bsr_dense_addmm` except for int8 inputs the operation result is int32 tensor (similar to existing `_int_mm`).

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #134035
* __->__ #133855

