### PR TITLE
Add multi-cache autotune test

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -269,6 +269,10 @@ lintrunner==0.12.5
 #Pinned versions: 0.12.5
 #test that import:
 
+redis>=4.0.0
+#Description: redis database
+#test that import: anything that tests OSS caching/mocking (inductor/test_codecache.py, inductor/test_max_autotune.py)
+
 rockset==1.0.3
 #Description: queries Rockset
 #Pinned versions: 1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ jinja2
 fsspec
 lintrunner
 ninja
-redis
 # setuptools was removed from default python install
 setuptools ; python_version >= "3.12"
 packaging

--- a/test/inductor/mock_cache.py
+++ b/test/inductor/mock_cache.py
@@ -131,12 +131,6 @@ _CACHE_CONFIG_EN = (
 )
 
 
-def _has_redis():
-    import importlib
-
-    return importlib.util.find_spec("redis") is not None
-
-
 class PatchCaches(contextlib.AbstractContextManager):
     num_init = 0
     num_put = 0
@@ -186,15 +180,6 @@ class PatchCaches(contextlib.AbstractContextManager):
 
     @classmethod
     def setUp(cls):
-        # If we don't have redis available then fake it since we'll be mocking it anyway.
-        if not _has_redis():
-
-            class FakeRedisModule:
-                class Redis:
-                    pass
-
-            sys.modules["redis"] = FakeRedisModule()
-
         # If this test is using PatchCaches then disable all the caches by
         # default, letting the tests turn them on explicitly. This is because
         # tests using PatchCaches will often want to check stats explicitly.


### PR DESCRIPTION
Summary:
The existing tests didn't cover a case where we had multiple autotunes in a single graph.  Add a test to demonstrate that case.

Also added a test dependency on redis and removed the "fake redis" from the previous PR (#133579)

Test Plan: unit tests

Reviewed By: oulgen

Differential Revision: D61178861


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang