### PR TITLE
support mutations on global sets of constants. 

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3306,6 +3306,17 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(fn(z), fn_opt(z))
 
+    def test_add_global_set(self):
+        ss = set()
+
+        # Add tests that expected guards are inserted (follow animesh tests)
+        @torch.compile(fullgraph=True)
+        def fn(x):
+            ss.add(x)
+            return x
+
+        self.assertEqual(fn(torch.ones(1)), torch.ones(1))
+
     def test_is_init_in_compile_vmapped_mutated_tensor_tensor(self):
         def fn(z):
             x = z.clone()

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3309,7 +3309,6 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
     def test_add_global_set(self):
         ss = set()
 
-        # Add tests that expected guards are inserted (follow animesh tests)
         @torch.compile(fullgraph=True)
         def fn(x):
             ss.add(x)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3307,11 +3307,7 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(z), fn_opt(z))
 
     def test_add_global_set(self):
-        # This fail with enable_cpp_guard_manager = True.
-        torch._dynamo.config.enable_cpp_guard_manager = False
-
         ss = set()
-
         cnts = torch._dynamo.testing.CompileCounter()
 
         @torch.compile(backend=cnts, fullgraph=True)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3307,12 +3307,13 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(z), fn_opt(z))
 
     def test_add_global_set(self):
-        # This fail with enable_cpp_guard_manager = True. 
-        torch._dynamo.config.enable_cpp_guard_manager =False
+        # This fail with enable_cpp_guard_manager = True.
+        torch._dynamo.config.enable_cpp_guard_manager = False
 
         ss = set()
 
         cnts = torch._dynamo.testing.CompileCounter()
+
         @torch.compile(backend=cnts, fullgraph=True)
         def fn(x):
             ss.add("ji")
@@ -3340,7 +3341,7 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         fn(x)
         self.assertEqual(cnts.frame_count, 3)
 
-         # This should recompile.
+        # This should recompile.
         ss.discard("ji")
         fn(x)
         self.assertEqual(cnts.frame_count, 4)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3307,14 +3307,53 @@ class DefaultsTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(fn(z), fn_opt(z))
 
     def test_add_global_set(self):
-        ss = set()
+        # torch._dynamo.config.enable_cpp_guard_manager =False
 
-        @torch.compile(fullgraph=True)
+        ss = set()
+        # ss.add(1)
+        # ss.add(2)
+
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnts, fullgraph=True)
         def fn(x):
-            ss.add(x)
+            ss.add("ji")
+            f = 1
+            if ss.__contains__("hi"):
+                f = 2
+            x = x * f
             return x
 
-        self.assertEqual(fn(torch.ones(1)), torch.ones(1))
+        x = torch.ones(10)
+        fn(x)
+        self.assertEqual(cnts.frame_count, 1)
+
+        print(ss)
+        # This should  recompile.
+        fn(x)
+        self.assertEqual(cnts.frame_count, 2)
+
+        # y = torch.ones(10)
+
+        # self.assertEqual(cnts.frame_count, 1)
+
+        # # The set is mutated, hence we should recompile.
+        # ss.add(torch.ones(11))
+        # print(fn(x))
+        # print(cnts.frame_count)
+        # self.assertEqual(cnts.frame_count, 2)
+
+        # opt_fn = torch.compile(backend=cnts, fullgraph=True)(fn)
+        # self.assertEqual(cnts.frame_count, 1)
+
+        # # This should recompile due to change in ss.
+        # ss.add(torch.ones(100))
+        # self.assertEqual(cnts.frame_count, 2)
+
+        # self.assertEqual(opt_fn(param, param), fn(param, param))
+        # self.assertEqual(cnts.frame_count, 2)  # Recompiles
+
+        # self.assertEqual(fn(torch.ones(1)), torch.ones(1))
 
     def test_is_init_in_compile_vmapped_mutated_tensor_tensor(self):
         def fn(z):

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -369,7 +369,7 @@ numpy_default_int = "int64"
 use_numpy_random_stream = False
 
 # Use C++ guard manager
-enable_cpp_guard_manager = os.environ.get("TORCHDYNAMO_CPP_GUARD_MANAGER", "1") == "1"
+enable_cpp_guard_manager = os.environ.get("TORCHDYNAMO_CPP_GUARD_MANAGER", "0") == "1"
 
 # Inline inbuilt nn modules
 inline_inbuilt_nn_modules = not is_fbcode()

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -539,17 +539,15 @@ class VariableBuilder:
             result = CustomizedDictVariable.wrap(self, value)
             result.source = self.source
             return self.tx.output.side_effects.track_object_existing(value, result)
-        elif istype(
-            value, (dict, collections.defaultdict, collections.OrderedDict, set)
-        ):
+        elif istype(value, set):
+            self.install_guards(GuardBuilder.CONSTANT_MATCH)
+            result = ConstantVariable.create(value=value)
+            return self.set_source_and_track_mutable(value, result)
+        elif istype(value, (dict, collections.defaultdict, collections.OrderedDict)):
             self.install_guards(GuardBuilder.SEQUENCE_LENGTH)
 
-            # A set in dynamo is a dictionary with no values associated to keys.
-            is_set = istype(value, set)
-
             # Optimization for the common case strings, ints, etc
-            all_keys = value if is_set else value.keys()
-            all_const = all(ConstantVariable.is_literal(k) for k in all_keys)
+            all_const = all(ConstantVariable.is_literal(k) for k in value.keys())
             if all_const:
                 # TODO(anijain2305) - Do we have to guard on all the keys? Can
                 # keys be guarded lazily, similar to values?
@@ -571,9 +569,6 @@ class VariableBuilder:
                 # So, instead we guard on the key order. While guarding on key
                 # order, we just save the indices and use it to access keys and
                 # values. Indices are cheap to save.
-
-                # Do we need to guard on key order for sets?
-                # if not is_set:
                 self.tx.output.guard_on_key_order.add(self.source.name())
 
             # We need all the keys to be hashable. We do this within the
@@ -591,23 +586,9 @@ class VariableBuilder:
 
                 return key, value
 
-            def build_set_keys(i, k):
-                if all_const:
-                    key = ConstantVariable.create(k)
-                    source_key = k
-                else:
-                    source_key = ConstDictKeySource(self.get_source(), i)
-                    key = LazyVariableTracker.create(k, source_key)
-
-                source_value = GetItemSource(self.get_source(), source_key)
-                return key
-
-            if is_set:
-                result = [build_set_keys(i, k) for i, k in enumerate(value)]
-            else:
-                result = dict(
-                    build_key_value(i, k, v) for i, (k, v) in enumerate(value.items())
-                )
+            result = dict(
+                build_key_value(i, k, v) for i, (k, v) in enumerate(value.items())
+            )
 
             if istype(value, collections.defaultdict):
                 factory_source = AttrSource(self.source, "default_factory")
@@ -619,8 +600,6 @@ class VariableBuilder:
                     ),
                     source=self.source,
                 )
-            elif is_set:
-                result = SetVariable(result, source=self.source)
             else:
                 result = ConstDictVariable(result, type(value), source=self.source)
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -539,7 +539,7 @@ class VariableBuilder:
             result = CustomizedDictVariable.wrap(self, value)
             result.source = self.source
             return self.tx.output.side_effects.track_object_existing(value, result)
-        elif istype(value, set) and  ConstantVariable.is_literal(value):
+        elif istype(value, set) and ConstantVariable.is_literal(value):
             self.install_guards(GuardBuilder.EQUALS_MATCH)
             result = ConstantVariable.create(value=value)
             return self.set_source_and_track_mutable(value, result)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -540,7 +540,7 @@ class VariableBuilder:
             result.source = self.source
             return self.tx.output.side_effects.track_object_existing(value, result)
         elif istype(value, set):
-            self.install_guards(GuardBuilder.CONSTANT_MATCH)
+            self.install_guards(GuardBuilder.EQUALS_MATCH)
             result = ConstantVariable.create(value=value)
             return self.set_source_and_track_mutable(value, result)
         elif istype(value, (dict, collections.defaultdict, collections.OrderedDict)):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -539,7 +539,7 @@ class VariableBuilder:
             result = CustomizedDictVariable.wrap(self, value)
             result.source = self.source
             return self.tx.output.side_effects.track_object_existing(value, result)
-        elif istype(value, set):
+        elif istype(value, set) and  ConstantVariable.is_literal(value):
             self.install_guards(GuardBuilder.EQUALS_MATCH)
             result = ConstantVariable.create(value=value)
             return self.set_source_and_track_mutable(value, result)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -443,7 +443,7 @@ class SetVariable(ConstDictVariable):
     ) -> "VariableTracker":
         from . import ListVariable, TupleVariable
 
-        # We foward the calls to the dictionary model
+        # We forward the calls to the dictionary model
         if name == "add":
             assert not kwargs
             assert len(args) == 1


### PR DESCRIPTION
Disabling cpp guards to find unit tests that i need to update for now. 
this should only land on top of the cpp guards fix. and test_add_global_set should be updated
to run on cpp guards on.

Fix  https://github.com/pytorch/pytorch/issues/133509
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133874



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames