### PR TITLE
Repro for trace FSDP2 + AC

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_compile.py
@@ -634,6 +634,7 @@ class TestFullyShardCompile(FSDPTest):
             model_args = ModelArgs(
                 vocab_size=vocab_size,
                 n_layers=3,
+                checkpoint_activations=True,
             )
             model = Transformer(model_args)
             for layer_id, mod in enumerate(model.layers):

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -198,7 +198,7 @@ class Transformer(nn.Module):
         h = self.dropout(h)
         for layer in self.layers:
             if self.checkpoint_activations:
-                h = torch.utils.checkpoint.checkpoint(layer, h, use_reentrant=False)
+                h = torch.utils.checkpoint.checkpoint(layer, h, use_reentrant=True)
             else:
                 h = layer(h)
         h = self.norm(h)


### PR DESCRIPTION
Test command:
- `pytest -rA test/distributed/_composable/fsdp/test_fully_shard_compile.py::TestFullyShardCompile::test_transformer_backend_inductor`

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #133886



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o