### PR TITLE
[BE][Ez][Bugfix] Update minimum typing_extenions to '>4.10.0'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1135,7 +1135,7 @@ def main():
         )
     install_requires = [
         "filelock",
-        "typing-extensions>=4.8.0",
+        "typing-extensions>=4.10.0",
         'setuptools ; python_version >= "3.12"',
         'sympy==1.12.1 ; python_version == "3.8"',
         'sympy==1.13.1 ; python_version >= "3.9"',


### PR DESCRIPTION
Fixes #133883 since we require newer typing_extension features now as a result of https://github.com/pytorch/pytorch/commit/cf60fe53a83bafec0857d5b49c2054de6ba4cddc
