### PR TITLE
[Inductor] short-term fix for needs_fixed_stride_order silent incorrectness (#133452)

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import functools
 import itertools
 import logging
 import operator
@@ -934,12 +935,13 @@ class GraphLowering(torch.fx.Interpreter):
                 # We have to set the current args because call_function will immediately
                 # evaluate this lowering after creating the fallback, without evaluating
                 # the layout constraint
-                args, kwargs = constrain_to_fx_strides(
-                    self.current_node, *args, **kwargs
+                constrain_fn = functools.partial(
+                    constrain_to_fx_strides, ignore_mutated_args_FIXME=True
                 )
+                args, kwargs = constrain_fn(self.current_node, *args, **kwargs)
                 # Also register the layout constraint so when the fallback
                 # is used again, we can constrain the args to the same layout
-                layout_constraint = constrain_to_fx_strides
+                layout_constraint = constrain_fn
             return layout_constraint, args, kwargs
 
         if target not in lowerings:


### PR DESCRIPTION
This is a low-risk short-term fix for
https://github.com/pytorch/pytorch/issues/128084, for the purposes of 2.4.1. The actual fix for that issue is more risky and we'll target 2.5.

needs_fixed_stride_order is silently incorrect with args that are mutable because it creates clones of those args, writes into them, and doesn't update the original args.

This PR makes it so that needs_fixed_stride_order doesn't apply to inputs that are being mutated.

This PR doesn't completely fix the problem, but it makes it less incorrect: most of the time the input already has the correct strides but inductor fails to recognize it, and in those cases writing directly to the input is fine.

Test Plan:
- new test

Pull Request resolved: https://github.com/pytorch/pytorch/pull/133452
Approved by: https://github.com/eellison

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang