### PR TITLE
Fix `torch._C` submodules population

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -953,7 +953,7 @@ if not TYPE_CHECKING:
         module_name = module.__name__
         for name in dir(module):
             member = getattr(module, name)
-            member_name = member.__name__
+            member_name = getattr(member, "__name__", "")
             if inspect.ismodule(member) and member_name.startswith(module_name):
                 sys.modules.setdefault(member_name, member)
                 # Recurse for submodules (e.g., `_C._dynamo.eval_frame`)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -944,20 +944,22 @@ if not TYPE_CHECKING:
     # non-standard, and attributes of those submodules cannot be pickled since
     # pickle expect to be able to import them as "from _C.sub import attr"
     # which fails with "_C is not a package
-    def _import_extension_to_sys_modules(module, module_name, memo=None):
+    def _import_extension_to_sys_modules(module, memo=None):
         if memo is None:
             memo = set()
         if module in memo:
             return
         memo.add(module)
+        module_name = module.__name__
         for name in dir(module):
             member = getattr(module, name)
-            if inspect.ismodule(member):
-                sys.modules.setdefault(f"{module_name}.{name}", member)
+            member_name = member.__name__
+            if inspect.ismodule(member) and member_name.startswith(module_name):
+                sys.modules.setdefault(member_name, member)
                 # Recurse for submodules (e.g., `_C._dynamo.eval_frame`)
-                _import_extension_to_sys_modules(member, f"{module_name}.{name}", memo)
+                _import_extension_to_sys_modules(member, memo)
 
-    _import_extension_to_sys_modules(_C, f"{__name__}._C")
+    _import_extension_to_sys_modules(_C)
     del _import_extension_to_sys_modules
 
 ################################################################################


### PR DESCRIPTION
This fixes regression introduced by https://github.com/pytorch/pytorch/pull/132216 that on some Python runtimes failed with 
```
>   from torch._C._dynamo.guards import GlobalStateGuard
E   ModuleNotFoundError: No module named 'torch._C._dynamo.guards'; 'torch._C._dynamo' is not a package

c:\users\malfet\git\pytorch\torch\_dynamo\convert_frame.py:28: ModuleNotFoundError
```

Simplify it by always registering submodules by its primary name and do not try to add submodules which are not part of the same namespace as parent. Otherwise module can be registered by alias, rather than by primary name.


