### PR TITLE
Back out "[1/N] Fix clang-tidy warnings in inductor (#131979)"

### DIFF
--- a/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
@@ -64,8 +64,8 @@ std::vector<at::Tensor> unpack_tensors(
     const c10::Device& device) {
   std::vector<at::Tensor> inputs;
   for (size_t idx = 0; idx < stack.size(); idx++) {
-    const auto& ivalue = stack[idx];
-    const auto& ivalue_arg = arguments[idx];
+    auto ivalue = stack[idx];
+    auto ivalue_arg = arguments[idx];
     if (ivalue.isTensor()) {
       unpack_tensor_ivalue(ivalue, device, inputs);
     } else if (ivalue.isTensorList()) {
@@ -117,10 +117,12 @@ std::vector<ParameterMetadata> unpack_input_parameters(
     if (stack[idx].isScalar()) {
       // Beyond c10::Scalar, the floating value and interger value are also
       // represented as Scalar.
-      inputs_metadata.emplace_back(stack[idx].toScalar(), arg_order);
+      inputs_metadata.push_back(
+          ParameterMetadata(stack[idx].toScalar(), arg_order));
     } else if (stack[idx].isTensorList()) {
       // tensor list
-      inputs_metadata.emplace_back(stack[idx].toTensorList().vec(), arg_order);
+      inputs_metadata.push_back(
+          ParameterMetadata(stack[idx].toTensorList().vec(), arg_order));
     } else if (stack[idx].isOptionalTensorList()) {
       // optional tensor list: std::vector<std::optional<at::Tensor>>
       std::vector<at::Tensor> tensor_list;
@@ -129,23 +131,27 @@ std::vector<ParameterMetadata> unpack_input_parameters(
           tensor_list.push_back(item.toOptional<at::Tensor>().value());
         }
       }
-      inputs_metadata.emplace_back(tensor_list, arg_order);
+      inputs_metadata.push_back(ParameterMetadata(tensor_list, arg_order));
     } else if (
         *arguments[idx].real_type() ==
         *c10::getTypePtr<std::optional<at::Tensor>>()) {
       // optional tensor
       if (stack[idx].toOptional<at::Tensor>().has_value()) {
-        inputs_metadata.emplace_back(
-            stack[idx].toOptional<at::Tensor>().value(), arg_order);
+        inputs_metadata.push_back(ParameterMetadata(
+            stack[idx].toOptional<at::Tensor>().value(), arg_order));
       }
     } else if (stack[idx].isTensor()) {
-      inputs_metadata.emplace_back(stack[idx].toTensor(), arg_order);
+      inputs_metadata.push_back(
+          ParameterMetadata(stack[idx].toTensor(), arg_order));
     } else if (stack[idx].isString()) {
-      inputs_metadata.emplace_back(stack[idx].toStringRef(), arg_order);
+      inputs_metadata.push_back(
+          ParameterMetadata(stack[idx].toStringRef(), arg_order));
     } else if (stack[idx].isBool()) {
-      inputs_metadata.emplace_back(c10::Scalar(stack[idx].toBool()), arg_order);
+      inputs_metadata.push_back(
+          ParameterMetadata(c10::Scalar(stack[idx].toBool()), arg_order));
     } else if (stack[idx].isDevice()) {
-      inputs_metadata.emplace_back(stack[idx].toDevice(), arg_order);
+      inputs_metadata.push_back(
+          ParameterMetadata(stack[idx].toDevice(), arg_order));
     } else {
       TORCH_CHECK_NOT_IMPLEMENTED(
           false,
@@ -233,7 +239,7 @@ void AOTIPythonKernelHolder::cache_hit(
 
   auto outputs = aoti_kernel_metadata.kernel_runner_->run(inputs);
   for (auto& output : outputs) {
-    stack->emplace_back(output);
+    stack->push_back(output);
   }
 }
 
@@ -337,7 +343,8 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
           auto tensor_metadata = build_tensor_metadata(metadata);
           test_list_metadata.push_back(tensor_metadata);
         }
-        parameter_metadata_list.emplace_back(test_list_metadata, arg_idx);
+        parameter_metadata_list.push_back(
+            ParameterMetadata(test_list_metadata, arg_idx));
       } else if (is_scalar) {
         // Scalar
         auto metadata = item_metadata.cast<py::dict>();
@@ -360,12 +367,14 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
               dtype_value);
         }
 
-        parameter_metadata_list.emplace_back(c10::Scalar(scalar), arg_idx);
+        parameter_metadata_list.push_back(
+            ParameterMetadata(c10::Scalar(scalar), arg_idx));
       } else if (is_string) {
         // String
         auto metadata = item_metadata.cast<py::dict>();
         auto str_value = metadata["string_value"].cast<std::string>();
-        parameter_metadata_list.emplace_back(str_value, arg_idx);
+        parameter_metadata_list.push_back(
+            ParameterMetadata(str_value, arg_idx));
       } else if (is_dtype) {
         // Dtype
         auto metadata = item_metadata.cast<py::dict>();
@@ -373,8 +382,8 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
         TORCH_INTERNAL_ASSERT(THPDtype_Check(dtype_value_obj.ptr()));
         auto dtype_value =
             reinterpret_cast<THPDtype*>(dtype_value_obj.ptr())->scalar_type;
-        parameter_metadata_list.emplace_back(
-            c10::Scalar(static_cast<int>(dtype_value)), arg_idx);
+        parameter_metadata_list.push_back(ParameterMetadata(
+            c10::Scalar(static_cast<int>(dtype_value)), arg_idx));
       } else if (is_device) {
         // Device
         auto metadata = item_metadata.cast<py::dict>();
@@ -386,20 +395,21 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
               metadata["device_index_value"].cast<c10::DeviceIndex>();
           device.set_index(device_index_value);
         }
-        parameter_metadata_list.emplace_back(device, arg_idx);
+        parameter_metadata_list.push_back(ParameterMetadata(device, arg_idx));
       } else if (is_layout) {
         auto metadata = item_metadata.cast<py::dict>();
         auto layout_value_obj = metadata["layout_value"].cast<py::object>();
         TORCH_INTERNAL_ASSERT(THPLayout_Check(layout_value_obj.ptr()));
         auto layout_value =
             reinterpret_cast<THPLayout*>(layout_value_obj.ptr())->layout;
-        parameter_metadata_list.emplace_back(
-            c10::Scalar(static_cast<int>(layout_value)), arg_idx);
+        parameter_metadata_list.push_back(ParameterMetadata(
+            c10::Scalar(static_cast<int>(layout_value)), arg_idx));
       } else {
         // Tensor
         auto metadata = item_metadata.cast<py::dict>();
         auto tensor_metadata = build_tensor_metadata(metadata);
-        parameter_metadata_list.emplace_back(tensor_metadata, arg_idx);
+        parameter_metadata_list.push_back(
+            ParameterMetadata(tensor_metadata, arg_idx));
       }
     }
 
@@ -470,12 +480,9 @@ std::string AOTIPythonKernelHolder::produce_aoti_kernel_lib(
       schema.overload_name().empty() ? "default" : schema.overload_name();
   auto pos = qualified_name.find("::");
   TORCH_INTERNAL_ASSERT(pos != std::string::npos, qualified_name);
-  std::string ns_str(
-      qualified_name.begin(),
-      qualified_name.begin() + static_cast<ptrdiff_t>(pos));
+  std::string ns_str(qualified_name.begin(), qualified_name.begin() + pos);
   std::string func_name(
-      qualified_name.begin() + static_cast<ptrdiff_t>(pos + strlen("::")),
-      qualified_name.end());
+      qualified_name.begin() + pos + strlen("::"), qualified_name.end());
 
   py::gil_scoped_acquire gil;
   py::handle op_py_func = op.getPythonOp(pyinterpreter_, [&]() -> PyObject* {

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
@@ -1,7 +1,6 @@
 #if !defined(C10_MOBILE) && !defined(ANDROID)
 #include <torch/csrc/inductor/aoti_eager/kernel_meta_info.h>
 #include <iostream>
-#include <utility>
 
 namespace torch::inductor {
 
@@ -26,8 +25,8 @@ TensorMetadata::TensorMetadata(
       dtype_(dtype),
       device_(device),
       dispatch_key_set_(dispatch_key_set),
-      sizes_(std::move(sizes)),
-      strides_(std::move(strides)),
+      sizes_(sizes),
+      strides_(strides),
       requires_grad_(requires_grad) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       !is_symbolic_, "Not support symbolic shape now");
@@ -95,24 +94,25 @@ bool TensorMetadata::operator==(const TensorMetadata& other) const {
 std::ostream& operator<<(
     std::ostream& stream,
     const TensorMetadata& tensor_metadata) {
-  stream << "is_symbolic_: " << tensor_metadata.is_symbolic_ << '\n';
-  stream << "dtype_: " << tensor_metadata.dtype_ << '\n';
-  stream << "device_: " << tensor_metadata.device_ << '\n';
+  stream << "is_symbolic_: " << tensor_metadata.is_symbolic_ << std::endl;
+  stream << "dtype_: " << tensor_metadata.dtype_ << std::endl;
+  stream << "device_: " << tensor_metadata.device_ << std::endl;
   stream << "sizes_: ";
   for (const auto& size : tensor_metadata.sizes_) {
     stream << size << " ";
   }
-  stream << '\n';
+  stream << std::endl;
   stream << "strides_: ";
   for (const auto& stride : tensor_metadata.strides_) {
     stream << stride << " ";
   }
 
-  stream << "requires_grad_: " << tensor_metadata.requires_grad_ << '\n';
-  stream << "dispatch_key_set_: " << tensor_metadata.dispatch_key_set_ << '\n';
+  stream << "requires_grad_: " << tensor_metadata.requires_grad_ << std::endl;
+  stream << "dispatch_key_set_: " << tensor_metadata.dispatch_key_set_
+         << std::endl;
   stream << "tensor_check_: " << tensor_metadata.tensor_check_.has_value()
-         << '\n';
-  stream << '\n';
+         << std::endl;
+  stream << std::endl;
   return stream;
 }
 
@@ -138,9 +138,8 @@ ParameterMetadata::ParameterMetadata(
     uint64_t input_order)
     : tag_(TENSOR_LIST), order_(input_order) {
   std::vector<TensorMetadata> tensor_metadata_list;
-  tensor_metadata_list.reserve(tensor_list.size());
   for (const auto& tensor : tensor_list) {
-    tensor_metadata_list.emplace_back(tensor);
+    tensor_metadata_list.push_back(TensorMetadata(tensor));
   }
   value_ = tensor_metadata_list;
 }
@@ -148,17 +147,23 @@ ParameterMetadata::ParameterMetadata(
 ParameterMetadata::ParameterMetadata(
     const c10::Scalar& scalar,
     uint64_t input_order)
-    : tag_(SCALAR), value_(scalar), order_(input_order) {}
+    : tag_(SCALAR), order_(input_order) {
+  value_ = scalar;
+}
 
 ParameterMetadata::ParameterMetadata(
     const std::string& str,
     uint64_t input_order)
-    : tag_(STRING), value_(str), order_(input_order) {}
+    : tag_(STRING), order_(input_order) {
+  value_ = str;
+}
 
 ParameterMetadata::ParameterMetadata(
     const c10::Device& device,
     uint64_t input_order)
-    : tag_(DEVICE), value_(device), order_(input_order) {}
+    : tag_(DEVICE), order_(input_order) {
+  value_ = device;
+}
 
 bool ParameterMetadata::operator==(const ParameterMetadata& other) const {
   // Same type

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
@@ -51,6 +51,7 @@ struct TensorMetadata {
 
   TensorMetadata()
       : is_symbolic_(false),
+        dtype_(c10::ScalarType::Undefined),
         device_(c10::DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES),
         sizes_({}),
         strides_({}) {}
@@ -115,7 +116,7 @@ struct ParameterMetadata {
   // same tag. For example, an operation with two input tensors, the first
   // tensor is a optional tensor and the second tensor is a tensor. The first
   // tensor will have the order 0 and the second tensor will have the order 1.
-  uint64_t order_{};
+  uint64_t order_;
 
   ParameterMetadata() : tag_(INVALID) {}
   ParameterMetadata(TensorMetadata tensor_metadata, uint64_t input_order);

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -57,7 +57,7 @@ AOTIModelContainerRunner::AOTIModelContainerRunner(
       model_so_->sym("AOTInductorModelContainerGetCallSpec"));
 
   // Hack to find the json file name from the model so file
-  size_t lastindex = model_so_path.find_last_of('.');
+  size_t lastindex = model_so_path.find_last_of(".");
   std::string json_filename = model_so_path.substr(0, lastindex) + ".json";
 
   if (fs::exists(json_filename)) {
@@ -174,8 +174,8 @@ void AOTIModelContainerRunner::swap_constant_buffer() {
 }
 
 std::vector<std::string> AOTIModelContainerRunner::get_call_spec() {
-  const char* in_spec = nullptr;
-  const char* out_spec = nullptr;
+  const char* in_spec;
+  const char* out_spec;
   AOTI_RUNTIME_ERROR_CODE_CHECK(
       get_call_spec_func_(container_handle_, &in_spec, &out_spec));
   return {in_spec, out_spec};

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cpu.cpp
@@ -10,7 +10,7 @@ AOTIModelContainerRunnerCpu::AOTIModelContainerRunnerCpu(
     size_t num_models)
     : AOTIModelContainerRunner(model_so_path, num_models, "cpu", "") {}
 
-AOTIModelContainerRunnerCpu::~AOTIModelContainerRunnerCpu() = default;
+AOTIModelContainerRunnerCpu::~AOTIModelContainerRunnerCpu() {}
 
 std::vector<at::Tensor> AOTIModelContainerRunnerCpu::run(
     std::vector<at::Tensor>& inputs) {

--- a/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner_cuda.cpp
@@ -14,7 +14,7 @@ AOTIModelContainerRunnerCuda::AOTIModelContainerRunnerCuda(
           device_str,
           cubin_dir) {}
 
-AOTIModelContainerRunnerCuda::~AOTIModelContainerRunnerCuda() = default;
+AOTIModelContainerRunnerCuda::~AOTIModelContainerRunnerCuda() {}
 
 std::vector<at::Tensor> AOTIModelContainerRunnerCuda::run(
     std::vector<at::Tensor>& inputs) {

--- a/torch/csrc/inductor/aoti_torch/c/shim.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim.h
@@ -533,7 +533,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_index_put_out(
     AtenTensorHandle self,
     const AtenTensorHandle* indices,
     const uint32_t num_indices,
-    const AtenTensorHandle& values,
+    const AtenTensorHandle values,
     bool accumulate);
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_view_as_real(

--- a/torch/csrc/inductor/aoti_torch/mkldnn_tensor.cpp
+++ b/torch/csrc/inductor/aoti_torch/mkldnn_tensor.cpp
@@ -6,7 +6,8 @@
 #include <ideep.hpp>
 #endif
 
-namespace torch::aot_inductor {
+namespace torch {
+namespace aot_inductor {
 
 #if AT_MKLDNN_ENABLED()
 
@@ -44,4 +45,5 @@ at::Tensor mkldnn_tensor_from_data_ptr(
 
 #endif
 
-} // namespace torch::aot_inductor
+} // namespace aot_inductor
+} // namespace torch

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -14,7 +14,7 @@ namespace torch::aot_inductor {
 
 void OSSProxyExecutor::prefill_stack_with_static_arguments(
     int index,
-    const at::TypePtr& schema_arg_type,
+    at::TypePtr schema_arg_type,
     const nlohmann::json& serialized_arg,
     OSSOpKernel& op_kernel) {
   auto& stack = op_kernel.stack_;
@@ -29,7 +29,7 @@ void OSSProxyExecutor::prefill_stack_with_static_arguments(
       TORCH_CHECK(serialized_arg_type == "as_tensor");
       stack.emplace_back();
       dynamic_args.emplace_back(
-          index, DynamicArgType::TensorType, 1, serialized_arg_val);
+          index, DynamicArgType::TensorType, 1, std::move(serialized_arg_val));
       break;
     }
     // TODO: handle the other input types
@@ -73,7 +73,7 @@ void OSSProxyExecutor::get_output_info_from_serialized(
     auto& serialized_output_val = serialized_output.begin().value();
 
     auto& schema_return = schema_returns[output_index];
-    const at::TypePtr& schema_return_type = schema_return.real_type();
+    at::TypePtr schema_return_type = schema_return.real_type();
 
     switch (schema_return_type->kind()) {
       case c10::TypeKind::TensorType: {
@@ -126,6 +126,8 @@ OSSProxyExecutor::OSSProxyExecutor(const std::string& json_path, bool is_cpu) {
     int device_idx = -1;
     device_ = std::make_unique<c10::Device>(c10::DeviceType::CUDA, device_idx);
   }
+
+  std::string extern_kernel_nodes_serialized;
 
   std::ifstream json_file(json_path);
   TORCH_CHECK(json_file.is_open());

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
@@ -81,7 +81,7 @@ class OSSProxyExecutor : public ProxyExecutor {
  private:
   void prefill_stack_with_static_arguments(
       int index,
-      const at::TypePtr& schema_arg_type,
+      at::TypePtr schema_arg_type,
       const nlohmann::json& thrift_arg,
       OSSOpKernel& op_kernel);
 

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -893,7 +893,7 @@ AOTITorchError aoti_torch_index_put_out(
     AtenTensorHandle self,
     const AtenTensorHandle* indices,
     const uint32_t num_indices,
-    const AtenTensorHandle& values,
+    const AtenTensorHandle values,
     bool accumulate) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<at::Tensor>> indices_;

--- a/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
+++ b/torch/csrc/inductor/aoti_torch/tensor_converter.cpp
@@ -1,7 +1,8 @@
 #include <torch/csrc/inductor/aoti_torch/tensor_converter.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 
-namespace torch::aot_inductor {
+namespace torch {
+namespace aot_inductor {
 
 std::vector<AtenTensorHandle> unsafe_alloc_new_handles_from_tensors(
     std::vector<at::Tensor>& tensors) {
@@ -44,4 +45,5 @@ std::vector<at::Tensor> alloc_tensors_by_stealing_from_handles(
   return result;
 }
 
-} // namespace torch::aot_inductor
+} // namespace aot_inductor
+} // namespace torch

--- a/torch/csrc/inductor/inductor_ops.cpp
+++ b/torch/csrc/inductor/inductor_ops.cpp
@@ -10,7 +10,8 @@
 
 #include <ATen/FunctionalTensorWrapper.h>
 
-namespace torch::inductor {
+namespace torch {
+namespace inductor {
 using namespace at;
 
 Tensor _mm_plus_mm_out(
@@ -110,4 +111,5 @@ TORCH_LIBRARY_FRAGMENT(inductor, m) {
       {at::Tag::pt2_compliant_tag});
 }
 
-} // namespace torch::inductor
+} // namespace inductor
+} // namespace torch

--- a/torch/csrc/inductor/resize_storage_bytes.cpp
+++ b/torch/csrc/inductor/resize_storage_bytes.cpp
@@ -7,7 +7,8 @@
 #include <ATen/native/cuda/Resize.h>
 #endif
 
-namespace torch::inductor {
+namespace torch {
+namespace inductor {
 using namespace at;
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -62,4 +63,5 @@ TORCH_LIBRARY_IMPL(inductor, Functionalize, m) {
       "resize_storage_bytes_", TORCH_FN(resize_storage_bytes__functionalize));
 }
 
-} // namespace torch::inductor
+} // namespace inductor
+} // namespace torch


### PR DESCRIPTION
Summary:
Original commit changeset: cc9392e5fce2

Original Phabricator Diff: D60464909

Differential Revision: D61501052
