### PR TITLE
[report_exportability] Avoid re-exporting duplicated modules

### DIFF
--- a/torch/_export/tools.py
+++ b/torch/_export/tools.py
@@ -91,10 +91,15 @@ def report_exportability(
     all_submod_names = [name for name, _ in mod.named_modules() if name != ""]
     submod_inputs = _generate_inputs_for_submodules(mod, all_submod_names, args, kwargs)
 
+    tried_module_types = set()
     report: Dict[str, Optional[Exception]] = {}
 
     def try_export(module, module_name, args, kwargs):
-        nonlocal submod_inputs, report, strict, pre_dispatch
+        nonlocal submod_inputs, report, strict, pre_dispatch, tried_module_types
+
+        if type(module) in tried_module_types:
+            return
+        tried_module_types.add(type(module))
 
         if args is not None or kwargs is not None:
             try:


### PR DESCRIPTION
Summary:
Skip re-exporting modules with the duplicated types to speed up the exportability tests. 

In real models, there are many duplicated modules, and mostly have the same export issues.

Test Plan: Existing CI

Differential Revision: D61504630


