### PR TITLE
[export] training ir migration, fix export_rle_model

### DIFF
--- a/torch/ao/quantization/pt2e/port_metadata_pass.py
+++ b/torch/ao/quantization/pt2e/port_metadata_pass.py
@@ -135,6 +135,8 @@ def _port_metadata_for_output_quant_nodes(
         return
 
     node_users = _filter_sym_size_users(node)
+    if len(node.users) == 0:
+        return
     if len(node_users) != 1:
         logger.warning(f"Expecting {node} to have single user")  # noqa: G004
     q_node = node_users.pop()


### PR DESCRIPTION
Summary:
- exir.capture + to_edge is deprecated. We need to use the export + to_edge.
- Fix quantization pass to be compatible with the new export IR. In the quantization pass, some nodes might have side-effects, so they don't have users, but still are not removed by the DCE pass. We need to consider it.
- now export_rle_model works with the default `capture_pre_autograd_graph`, it should also work with the new training it

Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//bolt/nn/executorch/export:export_rle_model  -- -r export_rle_model
```

Differential Revision: D61485834
