### PR TITLE
test_execution_trace.py: Use instantiate_device_type_tests to run GPU tests on HPU as well

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -34,9 +34,11 @@ from torch.profiler import (
     supported_activities,
 )
 from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
+    skipIfHpu,
     skipIfTorchDynamo,
     TestCase,
 )
@@ -47,7 +49,7 @@ Json = Dict[str, Any]
 
 
 class TestExecutionTrace(TestCase):
-    def payload(self, use_cuda=False):
+    def payload(self, device, use_device=False):
         u = torch.randn(3, 4, 5, requires_grad=True)
         with record_function("## TEST 1 ##", "1, 2, 3"):
             inf_val = float("inf")
@@ -67,17 +69,17 @@ class TestExecutionTrace(TestCase):
                 nan_val,
             )
             x = torch.randn(10, 10, requires_grad=True)
-            if use_cuda:
-                x = x.cuda()
+            if use_device:
+                x = x.to(device)
             y = torch.randn(10, 10, requires_grad=True)
-            if use_cuda:
-                y = y.cuda()
+            if use_device:
+                y = y.to(device)
             z = x + y + x * y + x * y
             z.backward(z)
             gelu = nn.GELU()
             m = torch.randn(2)
             _ = gelu(m)
-            if use_cuda:
+            if use_device:
                 z = z.cpu()
             _record_function_with_args_exit(rf_handle)
 
@@ -117,14 +119,19 @@ class TestExecutionTrace(TestCase):
         )
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
-    def test_execution_trace_with_kineto(self):
+    @skipIfHpu
+    def test_execution_trace_with_kineto(self, device):
         trace_called_num = 0
 
         def trace_handler(p):
             nonlocal trace_called_num
             trace_called_num += 1
 
-        use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        # use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        )
         # Create a temp file to save execution trace and kineto data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
@@ -145,7 +152,7 @@ class TestExecutionTrace(TestCase):
         ) as p:
             for idx in range(10):
                 with record_function(f"## LOOP {idx} ##"):
-                    self.payload(use_cuda=use_cuda)
+                    self.payload(device, use_device=use_device)
                 p.step()
             self.assertEqual(fp.name, p.execution_trace_observer.get_output_file_path())
 
@@ -190,8 +197,12 @@ class TestExecutionTrace(TestCase):
             f"  rf_ids_kineto = {rf_ids_kineto}\n",
         )
 
-    def test_execution_trace_alone(self):
-        use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+    def test_execution_trace_alone(self, device):
+        # use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        )
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
@@ -203,7 +214,7 @@ class TestExecutionTrace(TestCase):
         for idx in range(5):
             expected_loop_events += 1
             with record_function(f"## LOOP {idx} ##"):
-                self.payload(use_cuda=use_cuda)
+                self.payload(device, use_device=use_device)
         et.stop()
 
         assert fp.name == et.get_output_file_path()
@@ -231,14 +242,15 @@ class TestExecutionTrace(TestCase):
         sys.version_info >= (3, 12), "torch.compile is not supported on python 3.12+"
     )
     @unittest.skipIf(not TEST_CUDA or not has_triton(), "need CUDA and triton to run")
-    def test_execution_trace_with_pt2(self):
+    @skipIfHpu
+    def test_execution_trace_with_pt2(self, device):
         @torchdynamo.optimize("inductor")
         def fn(a, b, c):
             x = torch.nn.functional.linear(a, b)
             x = x + c
             return x.cos()
 
-        a, b, c = (torch.randn(4, 4, requires_grad=True).to("cuda") for _ in range(3))
+        a, b, c = (torch.randn(4, 4, requires_grad=True).to(device) for _ in range(3))
 
         inputs = [a, b, c]
         with torch._inductor.config.patch(compile_threads=1):
@@ -275,8 +287,12 @@ class TestExecutionTrace(TestCase):
                         assert len(n["outputs"]["values"]) == 0
         assert found_captured_triton_kernel_node
 
-    def test_execution_trace_start_stop(self):
-        use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+    def test_execution_trace_start_stop(self, device):
+        # use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        )
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
@@ -294,7 +310,7 @@ class TestExecutionTrace(TestCase):
             if et._execution_trace_running:
                 expected_loop_events += 1
             with record_function(f"## LOOP {idx} ##"):
-                self.payload(use_cuda=use_cuda)
+                self.payload(device, use_device=use_device)
 
         assert fp.name == et.get_output_file_path()
         et.unregister_callback()
@@ -310,8 +326,12 @@ class TestExecutionTrace(TestCase):
         assert found_root_node
         assert loop_count == expected_loop_events
 
-    def test_execution_trace_repeat_in_loop(self):
-        use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+    def test_execution_trace_repeat_in_loop(self, device):
+        # use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        )
         iter_list = {3, 4, 6, 8}
         expected_loop_events = len(iter_list)
         output_files = []
@@ -324,7 +344,7 @@ class TestExecutionTrace(TestCase):
                 et = ExecutionTraceObserver().register_callback(fp.name)
                 et.start()
             with record_function(f"## LOOP {idx} ##"):
-                self.payload(use_cuda=use_cuda)
+                self.payload(device, use_device=use_device)
             if idx in iter_list:
                 et.stop()
                 et.unregister_callback()
@@ -343,7 +363,8 @@ class TestExecutionTrace(TestCase):
             assert found_root_node
         assert event_count == expected_loop_events
 
-    def test_execution_trace_no_capture(self):
+    @skipIfHpu
+    def test_execution_trace_no_capture(self, device):
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
         et = ExecutionTraceObserver().register_callback(fp.name)
@@ -358,7 +379,8 @@ class TestExecutionTrace(TestCase):
         assert found_root_node
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/124500")
-    def test_execution_trace_nested_tensor(self):
+    @skipIfHpu
+    def test_execution_trace_nested_tensor(self, device):
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
 
@@ -382,6 +404,8 @@ class TestExecutionTrace(TestCase):
                 found_cos = True
         assert found_cos
 
+
+instantiate_device_type_tests(TestExecutionTrace, globals())
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
**MOTIVATION**

We recently integrated support for Intel Gaudi devices (identified as 'hpu') into the common_device_type framework via the pull request at https://github.com/pytorch/pytorch/pull/126970. This integration allows tests to be automatically instantiated for Gaudi devices upon loading the relevant library. Building on this development, the current pull request extends the utility of these hooks by adapting selected CUDA tests to operate on Gaudi devices. Additionally, we have confirmed that these modifications do not interfere with the existing tests on CUDA devices. 


**CHANGES**

- Add support for HPU devices within the payload function.
- Use instantiate_device_type_tests with targeted attributes to generate device-specific test instances.
- Expand the supported_activities() function to include checks for torch.profiler.ProfilerActivity.HPU.
- Apply skipIfHPU decorator to bypass tests that are not yet compatible with HPU devices.

