### PR TITLE
test_execution_trace.py: Use instantiate_device_type_tests to run GPU tests on HPU as well

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -394,7 +394,10 @@ class TestExecutionTrace(TestCase):
                 found_cos = True
         assert found_cos
 
-instantiate_device_type_tests(TestExecutionTrace, globals())
+devices = ["cpu", "cuda"]
+if TEST_HPU:
+    devices.append("hpu")
+instantiate_device_type_tests(TestExecutionTrace, globals(),only_for=devices)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -195,7 +195,6 @@ class TestExecutionTrace(TestCase):
         )
 
     def test_execution_trace_alone(self, device):
-        #use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
         use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
@@ -318,7 +317,6 @@ class TestExecutionTrace(TestCase):
         assert loop_count == expected_loop_events
 
     def test_execution_trace_repeat_in_loop(self, device):
-        #use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
         use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
         iter_list = {3, 4, 6, 8}
         expected_loop_events = len(iter_list)

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -33,6 +33,7 @@ from torch.profiler import (
     record_function,
     supported_activities,
 )
+from torch.testing._internal.common_utils import run_tests, TestCase, TEST_HPU, skipIfHpu
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
@@ -40,14 +41,16 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TestCase,
 )
-from torch.utils._triton import has_triton
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
+
+from torch.utils._triton import has_triton
 
 Json = Dict[str, Any]
 
 
 class TestExecutionTrace(TestCase):
-    def payload(self, use_cuda=False):
+    def payload(self, device, use_device=False):
         u = torch.randn(3, 4, 5, requires_grad=True)
         with record_function("## TEST 1 ##", "1, 2, 3"):
             inf_val = float("inf")
@@ -67,17 +70,17 @@ class TestExecutionTrace(TestCase):
                 nan_val,
             )
             x = torch.randn(10, 10, requires_grad=True)
-            if use_cuda:
-                x = x.cuda()
+            if use_device:
+                x = x.to(device)
             y = torch.randn(10, 10, requires_grad=True)
-            if use_cuda:
-                y = y.cuda()
+            if use_device:
+                y = y.to(device)
             z = x + y + x * y + x * y
             z.backward(z)
             gelu = nn.GELU()
             m = torch.randn(2)
             _ = gelu(m)
-            if use_cuda:
+            if use_device:
                 z = z.cpu()
             _record_function_with_args_exit(rf_handle)
 
@@ -117,14 +120,16 @@ class TestExecutionTrace(TestCase):
         )
 
     @unittest.skipIf(not kineto_available(), "Kineto is required")
-    def test_execution_trace_with_kineto(self):
+    @skipIfHpu
+    def test_execution_trace_with_kineto(self, device):
         trace_called_num = 0
 
         def trace_handler(p):
             nonlocal trace_called_num
             trace_called_num += 1
 
-        use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        #use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
         # Create a temp file to save execution trace and kineto data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
@@ -145,7 +150,7 @@ class TestExecutionTrace(TestCase):
         ) as p:
             for idx in range(10):
                 with record_function(f"## LOOP {idx} ##"):
-                    self.payload(use_cuda=use_cuda)
+                    self.payload(device, use_device=use_device)
                 p.step()
             self.assertEqual(fp.name, p.execution_trace_observer.get_output_file_path())
 
@@ -190,8 +195,9 @@ class TestExecutionTrace(TestCase):
             f"  rf_ids_kineto = {rf_ids_kineto}\n",
         )
 
-    def test_execution_trace_alone(self):
-        use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+    def test_execution_trace_alone(self, device):
+        #use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
@@ -203,7 +209,7 @@ class TestExecutionTrace(TestCase):
         for idx in range(5):
             expected_loop_events += 1
             with record_function(f"## LOOP {idx} ##"):
-                self.payload(use_cuda=use_cuda)
+                self.payload(device, use_device=use_device)
         et.stop()
 
         assert fp.name == et.get_output_file_path()
@@ -230,15 +236,17 @@ class TestExecutionTrace(TestCase):
     @unittest.skipIf(
         sys.version_info >= (3, 12), "torch.compile is not supported on python 3.12+"
     )
-    @unittest.skipIf(not TEST_CUDA or not has_triton(), "need CUDA and triton to run")
-    def test_execution_trace_with_pt2(self):
+    
+    @unittest.skipIf(not TEST_CUDA or not has_triton(), "need CUDA and triton to run")    
+    @skipIfHpu
+    def test_execution_trace_with_pt2(self, device):
         @torchdynamo.optimize("inductor")
         def fn(a, b, c):
             x = torch.nn.functional.linear(a, b)
             x = x + c
             return x.cos()
 
-        a, b, c = (torch.randn(4, 4, requires_grad=True).to("cuda") for _ in range(3))
+        a, b, c = (torch.randn(4, 4, requires_grad=True).to(device) for _ in range(3))
 
         inputs = [a, b, c]
         with torch._inductor.config.patch(compile_threads=1):
@@ -275,8 +283,9 @@ class TestExecutionTrace(TestCase):
                         assert len(n["outputs"]["values"]) == 0
         assert found_captured_triton_kernel_node
 
-    def test_execution_trace_start_stop(self):
-        use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+    def test_execution_trace_start_stop(self, device):
+        #use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
@@ -294,7 +303,7 @@ class TestExecutionTrace(TestCase):
             if et._execution_trace_running:
                 expected_loop_events += 1
             with record_function(f"## LOOP {idx} ##"):
-                self.payload(use_cuda=use_cuda)
+                self.payload(device, use_device=use_device)
 
         assert fp.name == et.get_output_file_path()
         et.unregister_callback()
@@ -310,8 +319,9 @@ class TestExecutionTrace(TestCase):
         assert found_root_node
         assert loop_count == expected_loop_events
 
-    def test_execution_trace_repeat_in_loop(self):
-        use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+    def test_execution_trace_repeat_in_loop(self, device):
+        #use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
+        use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
         iter_list = {3, 4, 6, 8}
         expected_loop_events = len(iter_list)
         output_files = []
@@ -324,7 +334,7 @@ class TestExecutionTrace(TestCase):
                 et = ExecutionTraceObserver().register_callback(fp.name)
                 et.start()
             with record_function(f"## LOOP {idx} ##"):
-                self.payload(use_cuda=use_cuda)
+                self.payload(device, use_device=use_device)
             if idx in iter_list:
                 et.stop()
                 et.unregister_callback()
@@ -343,7 +353,8 @@ class TestExecutionTrace(TestCase):
             assert found_root_node
         assert event_count == expected_loop_events
 
-    def test_execution_trace_no_capture(self):
+    @skipIfHpu
+    def test_execution_trace_no_capture(self, device):
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
         et = ExecutionTraceObserver().register_callback(fp.name)
@@ -358,7 +369,8 @@ class TestExecutionTrace(TestCase):
         assert found_root_node
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/124500")
-    def test_execution_trace_nested_tensor(self):
+    @skipIfHpu
+    def test_execution_trace_nested_tensor(self, device):
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
 
@@ -382,6 +394,7 @@ class TestExecutionTrace(TestCase):
                 found_cos = True
         assert found_cos
 
+instantiate_device_type_tests(TestExecutionTrace, globals())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -128,7 +128,6 @@ class TestExecutionTrace(TestCase):
             nonlocal trace_called_num
             trace_called_num += 1
 
-        #use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
         use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
         # Create a temp file to save execution trace and kineto data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
@@ -284,7 +283,6 @@ class TestExecutionTrace(TestCase):
         assert found_captured_triton_kernel_node
 
     def test_execution_trace_start_stop(self, device):
-        #use_cuda = torch.profiler.ProfilerActivity.CUDA in supported_activities()
         use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -33,18 +33,18 @@ from torch.profiler import (
     record_function,
     supported_activities,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase, TEST_HPU, skipIfHpu
 from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
+    skipIfHpu,
     skipIfTorchDynamo,
+    TEST_HPU,
     TestCase,
 )
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
-
-
 from torch.utils._triton import has_triton
+
 
 Json = Dict[str, Any]
 
@@ -128,7 +128,10 @@ class TestExecutionTrace(TestCase):
             nonlocal trace_called_num
             trace_called_num += 1
 
-        use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        )
         # Create a temp file to save execution trace and kineto data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
@@ -195,7 +198,10 @@ class TestExecutionTrace(TestCase):
         )
 
     def test_execution_trace_alone(self, device):
-        use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        )
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
@@ -234,8 +240,7 @@ class TestExecutionTrace(TestCase):
     @unittest.skipIf(
         sys.version_info >= (3, 12), "torch.compile is not supported on python 3.12+"
     )
-    
-    @unittest.skipIf(not TEST_CUDA or not has_triton(), "need CUDA and triton to run")    
+    @unittest.skipIf(not TEST_CUDA or not has_triton(), "need CUDA and triton to run")
     @skipIfHpu
     def test_execution_trace_with_pt2(self, device):
         @torchdynamo.optimize("inductor")
@@ -282,7 +287,10 @@ class TestExecutionTrace(TestCase):
         assert found_captured_triton_kernel_node
 
     def test_execution_trace_start_stop(self, device):
-        use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        )
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
@@ -317,7 +325,10 @@ class TestExecutionTrace(TestCase):
         assert loop_count == expected_loop_events
 
     def test_execution_trace_repeat_in_loop(self, device):
-        use_device = torch.profiler.ProfilerActivity.CUDA or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        use_device = (
+            torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.HPU in supported_activities()
+        )
         iter_list = {3, 4, 6, 8}
         expected_loop_events = len(iter_list)
         output_files = []
@@ -390,10 +401,11 @@ class TestExecutionTrace(TestCase):
                 found_cos = True
         assert found_cos
 
+
 devices = ["cpu", "cuda"]
 if TEST_HPU:
     devices.append("hpu")
-instantiate_device_type_tests(TestExecutionTrace, globals(),only_for=devices)
+instantiate_device_type_tests(TestExecutionTrace, globals(), only_for=devices)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
**MOTIVATION**

We recently integrated support for Intel Gaudi devices (identified as 'hpu') into the common_device_type framework via the pull request at https://github.com/pytorch/pytorch/pull/126970. This integration allows tests to be automatically instantiated for Gaudi devices upon loading the relevant library. Building on this development, the current pull request extends the utility of these hooks by adapting selected CUDA tests to operate on Gaudi devices. Additionally, we have confirmed that these modifications do not interfere with the existing tests on CUDA devices. 


**CHANGES**

- Add support for HPU devices within the payload function.
- Use instantiate_device_type_tests with targeted attributes to generate device-specific test instances.
- Expand the supported_activities() function to include checks for torch.profiler.ProfilerActivity.HPU.
- Apply skipIfHPU decorator to bypass tests that are not yet compatible with HPU devices.
