### PR TITLE
[export] Add ability to run eagerly on UnflattenedModule

### DIFF
--- a/test/export/test_unflatten.py
+++ b/test/export/test_unflatten.py
@@ -22,6 +22,7 @@ from torch._export.utils import (
 from torch._higher_order_ops.torchbind import enable_torchbind_tracing
 from torch.export import Constraint, Dim, export, FlatArgsAdapter, unflatten
 from torch.export._trace import DEFAULT_EXPORT_DYNAMO_CONFIG
+from torch.export.unflatten import _disable_interpreter
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
@@ -895,6 +896,77 @@ class TestUnflatten(TestCase):
         self.assertEqual(fn_count_sym_size(unflat.graph), 1)
         self.assertEqual(fn_count_sym_size(unflat.m1.graph), 1)
         self.assertEqual(fn_count_sym_size(unflat.m2.graph), 0)
+
+    def test_unflatten_eager(self):
+        class NestedChild(torch.nn.Module):
+            def forward(self, x):
+                return x / x
+
+        class Child1(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.nested = NestedChild()
+                self.register_parameter(
+                    "child1param", torch.nn.Parameter(torch.ones(2, 3))
+                )
+
+            def forward(self, x):
+                x = self.nested(x)
+                return x + self.child1param
+
+        class Child2(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.child2buffer = torch.nn.Buffer(torch.ones(2, 3))
+
+            def forward(self, x):
+                return x - self.child2buffer
+
+        class MyModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.foo = Child1()
+                self.bar = Child2()
+                self.register_parameter(
+                    "rootparam", torch.nn.Parameter(torch.ones(2, 3))
+                )
+
+            def forward(self, x):
+                x = x * self.rootparam
+                x = self.foo(x)
+                x = self.bar(x)
+                return x
+
+        orig_eager = MyModule()
+        export_module = export(orig_eager, (torch.rand(2, 3),), {})
+        with _disable_interpreter():
+            unflattened = unflatten(export_module)
+
+        self.assertEqual(unflattened._run_with_interpeter, False)
+        self.assertEqual(unflattened.foo._run_with_interpeter, False)
+
+        inputs = (torch.rand(2, 3),)
+
+        # Compare the root modules and all submodules
+        self.compare_outputs(orig_eager, unflattened, inputs)
+        self.compare_outputs(orig_eager.foo, unflattened.foo, inputs)
+        self.compare_outputs(orig_eager.bar, unflattened.bar, inputs)
+        self.compare_outputs(orig_eager.foo.nested, unflattened.foo.nested, inputs)
+
+        # Check state dicts are equal
+        orig_state_dict = orig_eager.state_dict()
+        exported_state_dict = unflattened.state_dict()
+        for name, value in orig_state_dict.items():
+            self.assertTrue(torch.allclose(value, exported_state_dict[name]))
+
+        # Check composability with symbolic trace, as torchrec ddp uses symbolic
+        # tracer
+        symbolic_traced = torch.fx.symbolic_trace(unflattened, concrete_args=inputs)
+        self.assertTrue(torch.allclose(orig_eager(*inputs), symbolic_traced(*inputs)))
+
+        # torch.compile submodule
+        unflattened.foo = torch.compile(unflattened.foo, fullgraph=True)
+        self.compare_outputs(orig_eager, unflattened, inputs)
 
 
 if __name__ == "__main__":

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -3,6 +3,7 @@ import abc
 import copy
 import operator
 from collections import defaultdict
+from contextlib import contextmanager
 from copy import deepcopy
 from enum import Enum
 from typing import Any, cast, Dict, List, Optional, Set, Tuple, Union
@@ -34,6 +35,20 @@ class _AttrKind(Enum):
     PARAMETER = "parameter"
     BUFFER = "buffer"
     CONSTANT = "constant"
+
+
+RUN_WITH_INTERPRETER = True
+
+
+@contextmanager
+def _disable_interpreter():
+    global RUN_WITH_INTERPRETER
+    old_flag = RUN_WITH_INTERPRETER
+    RUN_WITH_INTERPRETER = False
+    try:
+        yield
+    finally:
+        RUN_WITH_INTERPRETER = old_flag
 
 
 # Assign attribute 'from_obj' to the qualified name 'target' on 'to_module
@@ -87,13 +102,18 @@ class InterpreterModule(torch.nn.Module):
         super().__init__()
         self.graph = graph
         self.graph.owning_module = self
+        self._run_with_interpeter = RUN_WITH_INTERPRETER
 
     def forward(self, *args, **kwargs):
         assert self.graph_module is not None, "Didn't finalize this InterpreterModule"
-        if torch.compiler.is_dynamo_compiling():
+        if not is_fx_tracing() and (
+            torch.compiler.is_dynamo_compiling() or not self._run_with_interpeter
+        ):
             # Dynamo cannot trace through torch.fx.Interpreter, so fall back to
             # GraphModule codegen in this instance.
-            return self.graph_module(*args, **kwargs)
+            # Patch the codegened forward to run with this InterpreterModule,
+            # so attribute accesses, etc. are on this module instead.
+            return type(self.graph_module).forward(self, *args, **kwargs)
         else:
             if kwargs:
                 # Handle **kwargs. FX only natively supports positional
@@ -186,6 +206,7 @@ class UnflattenedModule(torch.nn.Module):
         self.flat_args_adapter = flat_args_adapter
         # Flag to indicate whether args have been adapted.
         self.adapted = False
+        self._run_with_interpeter = RUN_WITH_INTERPRETER
 
         _inplace_buffer_mutations(export_graph, self.graph_signature)
         _outline_submodules(export_graph, self)
@@ -480,9 +501,12 @@ class UnflattenedModule(torch.nn.Module):
             _check_input_constraints_for_graph(
                 self.input_placeholders, new_flat_args_with_path, self.range_constraints
             )
-        tree_out = torch.fx.Interpreter(self, graph=self.graph).run(
-            *flat_args, enable_io_processing=False
-        )
+        if torch.compiler.is_dynamo_compiling() and not self._run_with_interpreter:
+            tree_out = torch.fx.GraphModule(self, self.graph)(*flat_args)
+        else:
+            tree_out = torch.fx.Interpreter(self, graph=self.graph).run(
+                *flat_args, enable_io_processing=False
+            )
         return pytree.tree_unflatten(tree_out, signature.out_spec)
 
     def print_readable(


### PR DESCRIPTION
Summary:
Added the contextmanager, `_disable_interpreter`, which is meant to put around a call to `unflatten`. This will generate an UnflattendModule and sub-InterpreterModules which will not use torch.fx.Interpreter to run eagerly. We want to have this as a state of the module instead of a contextmanager around running the module because it's not clear where we are calling the unflattened module.

This seems to improve the performance: https://fb.workplace.com/groups/1075192433118967/posts/1473590629945810/?comment_id=1473621763276030

Test Plan: CI

Differential Revision: D60939034
