### PR TITLE
Fix the warning for cat operators with same qparams

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/TensorShape.cpp
+++ b/aten/src/ATen/native/quantized/cpu/TensorShape.cpp
@@ -163,10 +163,11 @@ Tensor cat_quantized_cpu(const ITensorListRef& qxs, int64_t dim) {
   TORCH_CHECK(is_valid_quantization_scheme(materialized[0]),
               "Only per-tensor quantization is supported in 'cat'!");
 
-  if (all_inputs_sharing_qparams(materialized)) {
+  if (!all_inputs_sharing_qparams(materialized)) {
       // TODO: if possible change this warning to an error T194501002
       TORCH_WARN("All inputs of this cat operator must share the same quantization parameters. Otherwise large numerical inaccuracies may occur.");
-  }  check_cat_no_zero_dim(materialized);
+  }
+  check_cat_no_zero_dim(materialized);
   dim = legacy_cat_wrap_dim(dim, materialized);
   double _scale = materialized[0].get().q_scale();
   int64_t _zero_point = materialized[0].get().q_zero_point();


### PR DESCRIPTION
Summary:
Currently the warning is printed when the cat inputs have same qparam, leading to a flood of warnings.
This diff emits the warning only when cat inputs don't have the same qparam.

Test Plan: CI

Reviewed By: aprotopopov

Differential Revision: D60638609


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10