### PR TITLE
[1/N refactor NCCLPG error logs] Make NCCL PG error messages more accurate and simpler

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1742,7 +1742,7 @@ void ProcessGroupNCCL::watchdogHandler() {
             if (!shouldDump_.load()) {
               LOG(ERROR)
                   << logPrefix()
-                  << "First watchdog to set the dump signal to TCPStore.";
+                  << "Broadcasting the dump signal of flight-recorder to other processes via TCPStore.";
             }
             // signal the monitor thread to start dumping
             shouldDump_.store(true);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -205,7 +205,7 @@ inline at::DeviceIndex getIndexFromDeviceKey(const std::string& deviceKey) {
   try {
     index = std::stoi(deviceKey);
   } catch (const std::invalid_argument& e) {
-    LOG(WARNING) << c10::str(
+    LOG(ERROR) << c10::str(
         "Invalid deviceKey: ", deviceKey, ",", e.what(), ".");
   } catch (const std::out_of_range& e) {
     LOG(ERROR) << "Out of range: " << e.what();
@@ -539,8 +539,8 @@ void ProcessGroupNCCL::WorkNCCL::checkAndSetException() {
   std::unique_lock<std::mutex> lock(mutex_);
   exception_ = exception_ptr;
   if (exception_) {
-    LOG(ERROR) << logPrefix()
-               << "found async exception when checking for NCCL errors: "
+    LOG(ERROR) << logPrefix() << "Collective " << *this
+               << " raised the following async exception: "
                << getExceptionMsgFromExceptionPtr(exception_);
   }
 }
@@ -1407,15 +1407,12 @@ void ProcessGroupNCCL::heartbeatMonitor() {
             " seconds without making progress in monitoring enqueued collectives. ",
             "This typically indicates a NCCL/CUDA API hang blocking the watchdog, ",
             "and could be triggered by another thread holding the GIL inside a ",
-            "CUDA api, or other deadlock-prone behaviors.",
+            "CUDA api (for example, CudaEventDestroy), or other deadlock-prone behaviors.",
             "If you suspect the watchdog is not actually stuck and a longer timeout would help, ",
             "you can either increase the timeout (TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC) to a larger value "
             "or disable the heartbeat monitor (TORCH_NCCL_ENABLE_MONITORING=0)."
             "If either of aforementioned helps, feel free to file an issue to PyTorch about the short timeout "
-            "or false positive abort; otherwise, please attempt to debug the hang. "
-            "workMetaList_.size() = ",
-            workMetaList_.size(),
-            "");
+            "or false positive abort; otherwise, please attempt to debug the hang. ");
         break;
       }
     }
@@ -1732,8 +1729,9 @@ void ProcessGroupNCCL::watchdogHandler() {
             ", last completed NCCL work: ",
             pgStatus_->lastCompletedSeq,
             ".");
-        // try to dump flight records if exception happens.
-        // Flight recorder behavior should be independent of desync Debug
+        // try to notify other ranks via global TCPStore to dump the flight
+        // recorder if exception happens. Flight recorder behavior is
+        // independent of desync Debug.
         if (dumpOnException_) {
           try {
             auto rank = globalRank();
@@ -1742,8 +1740,9 @@ void ProcessGroupNCCL::watchdogHandler() {
                 reinterpret_cast<uint8_t*>(&rank) + sizeof(rank));
             globalStore_->set(std::string(EXCEPTION_DUMP), vec);
             if (!shouldDump_.load()) {
-              LOG(ERROR) << logPrefix()
-                         << "First watchdog to set the dump signal.";
+              LOG(ERROR)
+                  << logPrefix()
+                  << "First watchdog to set the dump signal to TCPStore.";
             }
             // signal the monitor thread to start dumping
             shouldDump_.store(true);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -1081,7 +1081,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   // Whether or not to dump debug info on exception including both watchdog
   // timeout and nccl errors.
-  bool dumpOnException_;
+  bool dumpOnTimeoutOrEx_;
 
   // Whether or not to enable nan check for input tensors to collectives.
   bool enableNanCheck_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #134036
* __->__ #134017

We did a thorough review on all the error messages we are logging inside PGNCCL, and we want to make log message simpler and more accurate, this is the first PR for this effort.


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o