### PR TITLE
Fix out_tensor device in diag_test.py

### DIFF
--- a/benchmarks/operator_benchmark/pt/diag_test.py
+++ b/benchmarks/operator_benchmark/pt/diag_test.py
@@ -30,7 +30,7 @@ class DiagBenchmark(op_bench.TorchBenchmarkBase):
             "diagonal": diagonal,
             "out": out,
             "out_tensor": torch.tensor(
-                (),
+                (), device=device,
             ),
         }
         self.set_module_name("diag")

--- a/benchmarks/operator_benchmark/pt/diag_test.py
+++ b/benchmarks/operator_benchmark/pt/diag_test.py
@@ -30,7 +30,8 @@ class DiagBenchmark(op_bench.TorchBenchmarkBase):
             "diagonal": diagonal,
             "out": out,
             "out_tensor": torch.tensor(
-                (), device=device,
+                (),
+                device=device,
             ),
         }
         self.set_module_name("diag")


### PR DESCRIPTION
This benchmark fails if device='cuda' but out_tensor is on cpu
