### PR TITLE
Migrate fuse_chunk_reshape_concat_pass to PT2

### DIFF
--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -88,6 +88,10 @@ def fuse_chunk_reshape_unsqueeze_concat_pass(graph):
     return None
 
 
+def fuse_chunk_reshape_concat_pass(graph):
+    return None
+
+
 def remove_noop_pass(graph):
     return None
 
@@ -151,6 +155,12 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
                 gm,
                 example_inputs,
                 "[Pre grad(predispatch IR)]Apply remove_noop pass",
+            )
+            pass_execution_and_save(
+                fuse_chunk_reshape_concat_pass,
+                gm,
+                example_inputs,
+                "[Pre grad(predispatch IR)] Apply fuse_chunk_reshape_concat_pass",
             )
             pass_execution_and_save(
                 group_batch_fusion_passes,


### PR DESCRIPTION
Summary:
This is part of the work of dper pass migration https://fburl.com/gdoc/wxwykxns
This pass has ~2.4% perf impact for adfinder_reels_ctr_model

Test Plan: Still in test

Differential Revision: D60789747


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang