### PR TITLE
Disable duck sizing by default

### DIFF
--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -72,7 +72,7 @@ validate_shape_env_version_key = False
 symbol_guard_limit_before_specialize: Optional[int] = None
 
 # This flag changes whether we should use the same symbolic variable to represent input sizes that are the same.
-use_duck_shape = True
+use_duck_shape = False
 
 from torch.utils._config_module import install_config_module
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -2424,7 +2424,11 @@ class ShapeEnv:
         # to: torch._subclasses.fake_tensor._ShapeEnvSettings
     ):
         if duck_shape is None:
-            duck_shape = config.use_duck_shape
+            # TODO: Delete and simplify this logic post-rollout
+            if not torch._utils_internal.justknobs_check("pytorch/dynamo:disable_default_duck_sizing"):
+                duck_shape = True
+            else:
+                duck_shape = config.use_duck_shape
 
         self.settings = ShapeEnvSettings(
             # Not directly used by ShapeEnv; indirectly used by FakeTensor


### PR DESCRIPTION
FIXES https://github.com/pytorch/pytorch/issues/129456
JK: https://www.internalfb.com/intern/justknobs/?name=pytorch%2Fdynamo#disable_default_duck_sizing

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134029



cc @ezyang @penguinwu @bobrenjc93 @voznesenskym @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec