### PR TITLE
Clean up RemoteCache classes

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -35,9 +35,9 @@ from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
 
 
 try:
-    from .mock_cache import PatchCaches
+    from .mock_cache import global_stats, PatchCaches
 except ImportError:
-    from mock_cache import PatchCaches  # @manual
+    from mock_cache import global_stats, PatchCaches  # @manual
 
 
 torch.set_float32_matmul_precision("high")
@@ -258,7 +258,7 @@ class TestMaxAutotune(TestCase):
             op: str,
             inputs: str,
             benchmark: Callable[[Any], Dict[ChoiceCaller, float]],
-        ) -> Dict[ChoiceCaller, float]:
+        ) -> Optional[Dict[ChoiceCaller, float]]:
             if benchmark is not None:
                 return benchmark(choices)
 
@@ -723,9 +723,6 @@ class TestMaxAutotuneRemoteCache(TestCase):
     def test_max_autotune_remote_caching(self, dynamic: bool):
         from unittest.mock import patch
 
-        if not config.is_fbcode():
-            self.skipTest("Redis for autotune is currently broken")
-
         def mm(a, b):
             a = torch.sin(a)
             return a @ b
@@ -756,22 +753,20 @@ class TestMaxAutotuneRemoteCache(TestCase):
                         torch.compile(mm, dynamic=dynamic)(a, b)
                     reset()
 
-                PatchCaches.update()
-                PatchCaches.report()
-                self.assertEqual(PatchCaches.num_get_hit, 3)
-                self.assertEqual(PatchCaches.num_get_miss, 1)
-                self.assertEqual(PatchCaches.num_put, 1)
+                global_stats.report()
+                self.assertEqual(global_stats.autotune.num_get_hit, 3)
+                self.assertEqual(global_stats.autotune.num_get_miss, 1)
+                self.assertEqual(global_stats.autotune.num_put, 1)
 
-            PatchCaches.reset()
+            global_stats.reset()
             for _ in range(4):
                 with fresh_inductor_cache():
                     torch.compile(f, dynamic=dynamic)(x, y)
                 reset()
-            PatchCaches.update()
-            PatchCaches.report()
-            self.assertEqual(PatchCaches.num_get_hit, 3)
-            self.assertEqual(PatchCaches.num_get_miss, 1)
-            self.assertEqual(PatchCaches.num_put, 1)
+            global_stats.report()
+            self.assertEqual(global_stats.autotune.num_get_hit, 3)
+            self.assertEqual(global_stats.autotune.num_get_miss, 1)
+            self.assertEqual(global_stats.autotune.num_put, 1)
 
 
 class TestBenchmarkRequest(BenchmarkRequest):
@@ -796,6 +791,7 @@ class TestBenchmarkRequest(BenchmarkRequest):
         if not self.multi_device:
             assert visible_devices == self.parent_visible_devices
         else:
+            assert self.parent_visible_devices is not None
             valid_devices = self.parent_visible_devices.split(",")
             assert visible_devices in valid_devices
 

--- a/torch/_VF.py
+++ b/torch/_VF.py
@@ -20,12 +20,12 @@ import torch
 class VFModule(types.ModuleType):
     vf: types.ModuleType
 
-    def __init__(self, name):
+    def __init__(self, name: str):
         super().__init__(name)
         self.vf = torch._C._VariableFunctions
 
-    def __getattr__(self, attr):
-        return getattr(self.vf, attr)
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.vf, name)
 
 
 sys.modules[__name__] = VFModule(__name__)

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -262,7 +262,7 @@ class FXGraphCacheLoadable:
         # That is, AOTAutograd and Inductor never create new guards based on symints with different sources
         # than those passed to it by inductor.
         result = FxGraphCache._lookup_graph(
-            self.fx_graph_cache_key, example_inputs, local=True, remote_cache=False
+            self.fx_graph_cache_key, example_inputs, local=True, remote_cache=None
         )
         if result is None:
             log.info("FXGraphCache cache miss for key %s", self.fx_graph_cache_key)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -68,7 +68,7 @@ T = TypeVar("T")
 if TYPE_CHECKING:
     from collections.abc import KeysView
 
-    from .remote_cache import RemoteCacheBackend
+    from .remote_cache import JsonDataTy, RemoteCache
 
 
 """
@@ -142,16 +142,16 @@ if config.is_fbcode():
     )
 else:
 
-    def log_global_cache_errors(*args: Any, **kwargs: Any) -> None:
+    def log_global_cache_errors(*args: Any, **kwargs: Any) -> None:  # type: ignore[misc]
         pass
 
-    def log_global_cache_stats(*args: Any, **kwargs: Any) -> None:
+    def log_global_cache_stats(*args: Any, **kwargs: Any) -> None:  # type: ignore[misc]
         pass
 
-    def log_global_cache_vals(*args: Any, **kwargs: Any) -> None:
+    def log_global_cache_vals(*args: Any, **kwargs: Any) -> None:  # type: ignore[misc]
         pass
 
-    def use_global_cache() -> bool:
+    def use_global_cache() -> bool:  # type: ignore[misc]
         return False
 
 
@@ -443,7 +443,7 @@ def write_text(text: str) -> str:
 
 
 def write_atomic(
-    path: str,
+    path_: str,
     content: Union[str, bytes],
     make_dirs: bool = False,
     encode_utf_8: bool = False,
@@ -453,7 +453,7 @@ def write_atomic(
     assert isinstance(
         content, (str, bytes)
     ), "Only strings and byte arrays can be saved in the cache"
-    path = Path(path)
+    path = Path(path_)
     if make_dirs:
         path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.parent / f".{os.getpid()}.{threading.get_ident()}.tmp"
@@ -694,7 +694,7 @@ def torch_key() -> bytes:
 
     from libfb.py import parutil
 
-    return parutil.get_file_contents("torch/src_hash.txt").rstrip()
+    return parutil.get_file_contents("torch/src_hash.txt").rstrip().encode("ascii")
 
 
 def get_inductor_root() -> str:
@@ -837,8 +837,10 @@ def cudagraph_post_compile(
 
         from .compile_fx import cudagraphify
 
+        current_callable = compiled_graph.current_callable
+        assert current_callable is not None
         compiled_graph.current_callable = cudagraphify(
-            compiled_graph.current_callable,
+            current_callable,
             static_input_idxs=static_input_idxs,
             device_index=next(iter(compiled_graph.device_idxs)),
             stack_traces=stack_traces,
@@ -1000,7 +1002,7 @@ class FxGraphCache:
         key: str,
         example_inputs: List[torch.Tensor],
         local: bool,
-        remote_cache: Optional[Any],
+        remote_cache: Optional[RemoteCache[JsonDataTy]],
     ) -> Optional[CompiledFxGraph]:
         """
         Lookup a compiled graph in the cache by key. On a hit, return the
@@ -1028,8 +1030,12 @@ class FxGraphCache:
 
             if remote_cache:
                 try:
-                    if (data := remote_cache.get(key)) is not None:
-                        yield pickle.loads(data)
+                    if (cache_data := remote_cache.get(key)) is not None:
+                        assert isinstance(cache_data, dict)
+                        data = cache_data["data"]
+                        assert isinstance(data, (str, bytes))
+                        content = base64.b64decode(data)
+                        yield pickle.loads(content)
                 except Exception:
                     log.warning(
                         "fx graph cache unable to load compiled graph", exc_info=True
@@ -1179,7 +1185,7 @@ class FxGraphCache:
         compiled_graph: CompiledFxGraph,
         example_inputs: List[torch.Tensor],
         local: bool,
-        remote_cache: Optional[RemoteCacheBackend],
+        remote_cache: Optional[RemoteCache[JsonDataTy]],
     ) -> None:
         """
         Store a serialized CompiledFxGraph on disk.
@@ -1227,15 +1233,11 @@ class FxGraphCache:
 
             if remote_cache:
                 time_taken_ms = int((disk_compiled_graph._time_taken_ns or 0) // 1e6)
-                cache_data = (
-                    {
-                        "data": content,
-                        "time_taken_ms": time_taken_ms,
-                    }
-                    if config.is_fbcode()
-                    else content
-                )
-                remote_cache.put(key, cache_data)  # type: ignore[arg-type]
+                cache_data: JsonDataTy = {
+                    "data": base64.b64encode(content).decode("ascii"),
+                    "time_taken_ms": time_taken_ms,
+                }
+                remote_cache.put(key, cache_data)
         except Exception:
             log.warning("fx graph unable to write to cache", exc_info=True)
             counters["inductor"]["fxgraph_cache_write_error"] += 1
@@ -1296,20 +1298,22 @@ class FxGraphCache:
             cache_info["key"] = key
             cache_info["components"] = debug_lines
 
-            remote_cache: Optional[RemoteCacheBackend] = None
+            remote_cache: Optional[RemoteCache[JsonDataTy]] = None
             if remote:
                 cache_id = "fx-graph-v1"
                 try:
                     if config.is_fbcode():
-                        from torch._inductor.fb.remote_cache import (
-                            FbRemoteFxGraphCacheBackend,
-                        )
+                        from torch._inductor.fb.remote_cache import FbRemoteFxGraphCache
 
-                        remote_cache = FbRemoteFxGraphCacheBackend(cache_id)
+                        remote_cache = FbRemoteFxGraphCache(cache_id)
                     else:
-                        from torch._inductor.remote_cache import RedisRemoteCacheBackend
+                        from torch._inductor.remote_cache import RemoteFxGraphCache
 
-                        remote_cache = RedisRemoteCacheBackend(cache_id)
+                        remote_cache = RemoteFxGraphCache(cache_id)
+                except ModuleNotFoundError as e:
+                    # No need for a stack trace on this error
+                    remote_cache = None
+                    log.warning("Unable to create a remote cache: %s", e)
                 except Exception:
                     remote_cache = None
                     log.warning("Unable to create a remote cache", exc_info=True)
@@ -1458,14 +1462,18 @@ class CompiledFxGraph:
         self.metrics_deltas = metrics_deltas
         self.counter_deltas = counter_deltas
         self.guards_expr = None
+        self.cudagraph_info = None
+        self.fx_kwargs = {}
+        self.inputs_to_check = ()
+        self.boxed_forward_device_index = None
 
     def __call__(self, inputs: List[Any]) -> Any:
         assert self.current_callable is not None
         return self.current_callable(inputs)
 
 
-def run_command_and_check(cmd: str) -> None:
-    cmd = shlex.split(cmd)
+def run_command_and_check(cmd_: str) -> None:
+    cmd = shlex.split(cmd_)
     try:
         subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:

--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -1,32 +1,140 @@
+from __future__ import annotations
+
+import json
 import os
+import typing
 from abc import abstractmethod
-from typing import Optional
+from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union
+from typing_extensions import override, TypeAlias
+
+from torch._inductor import config
 
 
-class RemoteCacheBackend:
+try:
+    import redis
+except ImportError:
+    redis = None  # type: ignore[assignment]
+
+
+if config.is_fbcode():
+    from rfe.scubadata.scubadata_py3 import (  # type: ignore[import-not-found]
+        Sample as Sample_,
+    )
+
+    Sample: TypeAlias = Sample_
+else:
+    Sample: TypeAlias = Type[object]  # type: ignore[misc,no-redef]
+
+
+_T = TypeVar("_T")
+_U = TypeVar("_U")
+
+
+class RemoteCacheBackend(Generic[_T]):
     """
-    A backend implementation for accessing a remote/distributed cache.
+    A backend implementation for accessing a remote/distributed cache.  Only
+    works with bytes in/out.  For structured data use a RemoteCache.
     """
 
-    def __init__(self, cache_id: str) -> None:
+    @abstractmethod
+    def get(self, key: str) -> Optional[_T]:
         pass
 
     @abstractmethod
-    def get(self, key: str) -> Optional[object]:
+    def put(self, key: str, data: _T) -> None:
+        pass
+
+
+# Serde that encodes from _T to _U and decodes from _U to _T.
+class RemoteCacheSerde(Generic[_T, _U]):
+    @abstractmethod
+    def encode(self, data: _T) -> _U:
         pass
 
     @abstractmethod
-    def put(self, key: str, data: bytes) -> None:
+    def decode(self, data: _U) -> _T:
         pass
 
 
-class RedisRemoteCacheBackend(RemoteCacheBackend):
+JsonDataTy = Optional[
+    Union[int, float, str, bool, Dict[str, "JsonDataTy"], List["JsonDataTy"]]
+]
+
+
+class RemoteCacheJsonSerde(RemoteCacheSerde[JsonDataTy, bytes]):
+    def encode(self, data: JsonDataTy) -> bytes:
+        return bytes(json.dumps(data), "ascii")
+
+    def decode(self, data: bytes) -> JsonDataTy:
+        return json.loads(data)
+
+
+class RemoteCachePassthroughSerde(RemoteCacheSerde[_T, _T]):
+    def encode(self, data: _T) -> _T:
+        return data
+
+    def decode(self, data: _T) -> _T:
+        return data
+
+
+class RemoteCache(Generic[_T]):
+    backend_override_cls: Optional[Callable[[], RemoteCacheBackend[Any]]] = None
+
+    def __init__(
+        self, backend: RemoteCacheBackend[_U], serde: RemoteCacheSerde[_T, _U]
+    ) -> None:
+        # Support for testing.
+        if (override_cls := self.__class__.backend_override_cls) is not None:
+            self.backend = override_cls()
+        else:
+            self.backend = backend
+        self.serde = serde
+
+    def get(self, key: str) -> Optional[_T]:
+        sample = self._create_sample()
+        result = self._get(key, sample)
+        self._log_sample(sample)
+        return result
+
+    def put(self, key: str, value: _T) -> None:
+        sample = self._create_sample()
+        self._put(key, value, sample)
+        self._log_sample(sample)
+
+    def _decode(self, data: _U, sample: Optional[Sample]) -> _T:
+        return self.serde.decode(data)
+
+    def _encode(self, value: _T, sample: Optional[Sample]) -> Any:  # returns _U
+        return self.serde.encode(value)
+
+    def _get(self, key: str, sample: Optional[Sample]) -> Optional[_T]:
+        if data := self.backend.get(key):
+            return self._decode(data, sample)
+        return None
+
+    def _put(self, key: str, value: _T, sample: Optional[Sample]) -> None:
+        data = self._encode(value, sample)
+        self.backend.put(key, data)
+
+    def _create_sample(self) -> Optional[Sample]:
+        return None
+
+    def _log_sample(self, sample: Optional[Sample]) -> None:
+        pass
+
+
+class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
     """
     A Redis implementation of a remote/distributed cache.
     """
 
+    _key_fmt: str
+    _redis: Optional[redis.Redis] = None
+
     def __init__(self, cache_id: str) -> None:
-        import redis
+        if not redis:
+            # We had trouble importing redis - just skip init.
+            return
 
         self._key_fmt = f"pt2:{cache_id}:{{key}}"
         self._redis = redis.Redis(
@@ -34,14 +142,57 @@ class RedisRemoteCacheBackend(RemoteCacheBackend):
             port=int(os.environ.get("TORCHINDUCTOR_REDIS_PORT", 6379)),
         )
 
-    def _get_key(self, key: str) -> str:
+    def __get_key(self, key: str) -> str:
         return self._key_fmt.format(key=key)
 
+    @override
     def get(self, key: str) -> Optional[bytes]:
-        value = self._redis.get(self._get_key(key))
+        if not self._redis:
+            # Either redis wasn't found or we already had some trouble...
+            return None
+
+        try:
+            value = self._redis.get(self.__get_key(key))
+        except redis.exceptions.ConnectionError:
+            # Redis is lazy and doesn't actually attempt to connect until the
+            # first use. Mark is as unavailable now.
+            self._redis = None
+            return None
+
         # In theory redis.get() can return an Awaitable as well...
         assert value is None or isinstance(value, bytes)
         return value
 
+    @override
     def put(self, key: str, data: bytes) -> None:
-        self._redis.set(self._get_key(key), data)
+        if not self._redis:
+            # Either redis wasn't found or we already had some trouble...
+            return
+
+        try:
+            self._redis.set(self.__get_key(key), data)
+        except redis.exceptions.ConnectionError:
+            # Redis is lazy and doesn't actually attempt to connect until the
+            # first use. Mark is as unavailable now.
+            self._redis = None
+
+
+class RedisRemoteCache(RemoteCache[JsonDataTy]):
+    def __init__(self, key: str) -> None:
+        # Special test handling: If we're just going to override the backend
+        # anyway don't require redis
+        if self.__class__.backend_override_cls:
+            # This is totally bogus but it works for now...
+            backend = typing.cast(RemoteCacheBackend[bytes], None)
+        else:
+            backend = RedisRemoteCacheBackend(key)
+        serde = RemoteCacheJsonSerde()
+        super().__init__(backend, serde)
+
+
+class RemoteAutotuneCache(RedisRemoteCache):
+    pass
+
+
+class RemoteFxGraphCache(RedisRemoteCache):
+    pass


### PR DESCRIPTION
Summary:
The existing RemoteCacheBackend classes were a bit haphazard - some of them accepted bytes only, some accepted objects, some returned different types of objects than were passed in.

Update them to be more consistent:

1. RemoteCacheBackend is an implementation of a backend: Redis, Memcache, Manifold, LocalFile

2. RemoteCacheSerde is an implementation of a serde protocol - to turn structured objects (dict, list, etc) into bytes: RemoteCacheJsonSerde (json encoding), RemoteCachePassthroughSerde (strictly bytes only)

3. RemoteCache is the cache implementation itself, mixing a RemoteCacheBackend along with an RemoteCacheSerde to provide structured caching.

Other than simply reorganizing the existing cache code this also fixes the Redis autotune caching for OSS.

Test Plan: unit tests

Reviewed By: oulgen

Differential Revision: D61178859


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang