### PR TITLE
Update pt2e numeric debugger to use node.meta["custom"] field

### DIFF
--- a/docs/source/quantization-support.rst
+++ b/docs/source/quantization-support.rst
@@ -154,7 +154,7 @@ PT2 Export (pt2e) Numeric Debugger
     :template: classtemplate.rst
 
     generate_numeric_debug_handle
-    CUSOTM_KEY
+    CUSTOM_KEY
     NUMERIC_DEBUG_HANDLE_KEY
     prepare_for_propagation_comparison
     extract_results_from_loggers

--- a/docs/source/quantization-support.rst
+++ b/docs/source/quantization-support.rst
@@ -154,6 +154,7 @@ PT2 Export (pt2e) Numeric Debugger
     :template: classtemplate.rst
 
     generate_numeric_debug_handle
+    CUSOTM_KEY
     NUMERIC_DEBUG_HANDLE_KEY
     prepare_for_propagation_comparison
     extract_results_from_loggers

--- a/test/quantization/pt2e/test_numeric_debugger.py
+++ b/test/quantization/pt2e/test_numeric_debugger.py
@@ -9,9 +9,9 @@ import torch
 from torch._export import capture_pre_autograd_graph
 from torch.ao.quantization import (
     compare_results,
+    CUSTOM_KEY,
     extract_results_from_loggers,
     generate_numeric_debug_handle,
-    CUSTOM_KEY,
     NUMERIC_DEBUG_HANDLE_KEY,
     prepare_for_propagation_comparison,
 )
@@ -28,8 +28,13 @@ def _extract_debug_handles(model) -> Dict[torch.fx.Node, int]:
     debug_handle_map: Dict[torch.fx.Node, int] = {}
 
     for node in model.graph.nodes:
-        if CUSTOM_KEY in node.meta and NUMERIC_DEBUG_HANDLE_KEY in node.meta[CUSTOM_KEY]:
-            debug_handle_map[str(node)] = node.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY]
+        if (
+            CUSTOM_KEY in node.meta
+            and NUMERIC_DEBUG_HANDLE_KEY in node.meta[CUSTOM_KEY]
+        ):
+            debug_handle_map[str(node)] = node.meta[CUSTOM_KEY][
+                NUMERIC_DEBUG_HANDLE_KEY
+            ]
 
     return debug_handle_map
 
@@ -124,7 +129,9 @@ class TestNumericDebugger(TestCase):
 
         self.assertEqual(debug_handle_map, debug_handle_map_ref)
 
-    @unittest.skip("All nodes' meta are preserved but the first arg for the first node seems to be dropped")
+    @unittest.skip(
+        "All nodes' meta are preserved but the first arg for the first node seems to be dropped"
+    )
     def test_run_decompositions_preserve_handle(self):
         m = TestHelperModules.Conv2dThenConv1d()
         example_inputs = m.example_inputs()
@@ -138,7 +145,9 @@ class TestNumericDebugger(TestCase):
         debug_handle_map = _extract_debug_handles(m_copy)
 
         # checking the map still has the same ids, the node may change
-        self.assertEqual(set(debug_handle_map.values()), set(debug_handle_map_ref.values()))
+        self.assertEqual(
+            set(debug_handle_map.values()), set(debug_handle_map_ref.values())
+        )
 
     def test_prepare_for_propagation_comparison(self):
         m = TestHelperModules.Conv2dThenConv1d()

--- a/test/quantization/pt2e/test_numeric_debugger.py
+++ b/test/quantization/pt2e/test_numeric_debugger.py
@@ -11,6 +11,7 @@ from torch.ao.quantization import (
     compare_results,
     extract_results_from_loggers,
     generate_numeric_debug_handle,
+    CUSTOM_KEY,
     NUMERIC_DEBUG_HANDLE_KEY,
     prepare_for_propagation_comparison,
 )
@@ -27,8 +28,8 @@ def _extract_debug_handles(model) -> Dict[torch.fx.Node, int]:
     debug_handle_map: Dict[torch.fx.Node, int] = {}
 
     for node in model.graph.nodes:
-        if NUMERIC_DEBUG_HANDLE_KEY in node.meta:
-            debug_handle_map[str(node)] = node.meta[NUMERIC_DEBUG_HANDLE_KEY]
+        if CUSTOM_KEY in node.meta and NUMERIC_DEBUG_HANDLE_KEY in node.meta[CUSTOM_KEY]:
+            debug_handle_map[str(node)] = node.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY]
 
     return debug_handle_map
 
@@ -47,8 +48,8 @@ class TestNumericDebugger(TestCase):
         unique_ids = set()
         count = 0
         for n in m.graph.nodes:
-            if NUMERIC_DEBUG_HANDLE_KEY in n.meta:
-                unique_ids.add(n.meta[NUMERIC_DEBUG_HANDLE_KEY])
+            if CUSTOM_KEY in n.meta and NUMERIC_DEBUG_HANDLE_KEY in n.meta[CUSTOM_KEY]:
+                unique_ids.add(n.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY])
                 count += 1
         self.assertEqual(len(unique_ids), count)
 
@@ -69,9 +70,9 @@ class TestNumericDebugger(TestCase):
         m = prepare_pt2e(m, quantizer)
         debug_handle_map = _extract_debug_handles(m)
         res_counter = Counter(debug_handle_map.values())
-        repeated_debug_handle_ids = [2, 3, 6]
+        repeated_debug_handle_ids = [3, 4, 7]
         # 3 ids were repeated because we copy over the id from node to its output observer
-        # torch.ops.aten.conv2d.default, torch.ops.aten.squeeze.dim, torch.ops.aten.conv1d.default
+        # torch.ops.aten.conv2d.default, torch.ops.aten.squeeze.dim and torch.ops.aten.conv1d.default
         for dh_id in repeated_debug_handle_ids:
             self.assertEqual(res_counter[dh_id], 2)
 
@@ -81,7 +82,7 @@ class TestNumericDebugger(TestCase):
         res_counter = Counter(debug_handle_map.values())
         # same set of ids where repeated, because we copy over the id from observer/fake_quant to
         # dequantize node
-        repeated_debug_handle_ids = [2, 3, 6]
+        repeated_debug_handle_ids = [3, 4, 7]
         for dh_id in repeated_debug_handle_ids:
             self.assertEqual(res_counter[dh_id], 2)
 
@@ -122,6 +123,22 @@ class TestNumericDebugger(TestCase):
         debug_handle_map = _extract_debug_handles(m_export)
 
         self.assertEqual(debug_handle_map, debug_handle_map_ref)
+
+    @unittest.skip("All nodes' meta are preserved but the first arg for the first node seems to be dropped")
+    def test_run_decompositions_preserve_handle(self):
+        m = TestHelperModules.Conv2dThenConv1d()
+        example_inputs = m.example_inputs()
+        m = torch.export.export(m, example_inputs)
+        generate_numeric_debug_handle(m)
+
+        debug_handle_map_ref = _extract_debug_handles(m)
+
+        m_copy = copy.copy(m)
+        m_copy = m_copy.run_decompositions()
+        debug_handle_map = _extract_debug_handles(m_copy)
+
+        # checking the map still has the same ids, the node may change
+        self.assertEqual(set(debug_handle_map.values()), set(debug_handle_map_ref.values()))
 
     def test_prepare_for_propagation_comparison(self):
         m = TestHelperModules.Conv2dThenConv1d()

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -11,10 +11,10 @@ from .fuser_method_mappings import *  # noqa: F403
 from .observer import *  # noqa: F403
 from .pt2e._numeric_debugger import (  # noqa: F401
     compare_results,
+    CUSTOM_KEY,
     extract_results_from_loggers,
     generate_numeric_debug_handle,
     NUMERIC_DEBUG_HANDLE_KEY,
-    CUSTOM_KEY,
     prepare_for_propagation_comparison,
 )
 from .pt2e.export_utils import (

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -14,6 +14,7 @@ from .pt2e._numeric_debugger import (  # noqa: F401
     extract_results_from_loggers,
     generate_numeric_debug_handle,
     NUMERIC_DEBUG_HANDLE_KEY,
+    CUSTOM_KEY,
     prepare_for_propagation_comparison,
 )
 from .pt2e.export_utils import (
@@ -162,6 +163,7 @@ __all__ = [
     "swap_module",
     "weight_observer_range_neg_127_to_127",
     "generate_numeric_debug_handle",
+    "CUSTOM_KEY",
     "NUMERIC_DEBUG_HANDLE_KEY",
     "prepare_for_propagation_comparison",
     "extract_results_from_loggers",

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -6,10 +6,7 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import torch
-from torch.ao.quantization import (
-    CUSTOM_KEY,
-    NUMERIC_DEBUG_HANDLE_KEY,
-)
+from torch.ao.quantization import CUSTOM_KEY, NUMERIC_DEBUG_HANDLE_KEY
 from torch.ao.quantization.backend_config import (
     BackendConfig,
     get_native_backend_config,
@@ -232,12 +229,15 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
 
             node.replace_all_uses_with(dequantized_node)
             # propagate numeric debug handle from observer/fake_quant node to dequantize node
-            if CUSTOM_KEY in node.meta and NUMERIC_DEBUG_HANDLE_KEY in node.meta[CUSTOM_KEY]:
+            if (
+                CUSTOM_KEY in node.meta
+                and NUMERIC_DEBUG_HANDLE_KEY in node.meta[CUSTOM_KEY]
+            ):
                 if CUSTOM_KEY not in dequantized_node.meta:
                     dequantized_node.meta[CUSTOM_KEY] = {}
-                dequantized_node.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY] = node.meta[CUSTOM_KEY][
-                    NUMERIC_DEBUG_HANDLE_KEY
-                ]
+                dequantized_node.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY] = node.meta[
+                    CUSTOM_KEY
+                ][NUMERIC_DEBUG_HANDLE_KEY]
             graph.erase_node(node)
     elif is_dynamic:
         # uint8/int8/fp16 dynamic quantization

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -6,7 +6,10 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import torch
-from torch.ao.quantization import NUMERIC_DEBUG_HANDLE_KEY
+from torch.ao.quantization import (
+    CUSTOM_KEY,
+    NUMERIC_DEBUG_HANDLE_KEY,
+)
 from torch.ao.quantization.backend_config import (
     BackendConfig,
     get_native_backend_config,
@@ -229,8 +232,10 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
 
             node.replace_all_uses_with(dequantized_node)
             # propagate numeric debug handle from observer/fake_quant node to dequantize node
-            if NUMERIC_DEBUG_HANDLE_KEY in node.meta:
-                dequantized_node.meta[NUMERIC_DEBUG_HANDLE_KEY] = node.meta[
+            if CUSTOM_KEY in node.meta and NUMERIC_DEBUG_HANDLE_KEY in node.meta[CUSTOM_KEY]:
+                if CUSTOM_KEY not in dequantized_node.meta:
+                    dequantized_node.meta[CUSTOM_KEY] = {}
+                dequantized_node.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY] = node.meta[CUSTOM_KEY][
                     NUMERIC_DEBUG_HANDLE_KEY
                 ]
             graph.erase_node(node)

--- a/torch/ao/quantization/pt2e/_numeric_debugger.py
+++ b/torch/ao/quantization/pt2e/_numeric_debugger.py
@@ -105,7 +105,10 @@ def prepare_for_propagation_comparison(model: GraphModule) -> GraphModule:
     # don't change the original model
     model = copy.deepcopy(model)
     for n in model.graph.nodes:
-        if CUSTOM_KEY not in n.meta or NUMERIC_DEBUG_HANDLE_KEY not in n.meta[CUSTOM_KEY]:
+        if (
+            CUSTOM_KEY not in n.meta
+            or NUMERIC_DEBUG_HANDLE_KEY not in n.meta[CUSTOM_KEY]
+        ):
             continue
         numeric_debug_handle = n.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY]
         _insert_logger(model, n, numeric_debug_handle)

--- a/torch/ao/quantization/pt2e/_numeric_debugger.py
+++ b/torch/ao/quantization/pt2e/_numeric_debugger.py
@@ -9,7 +9,8 @@ from torch.fx import GraphModule, Node
 from torch.nn import functional as F
 
 
-NUMERIC_DEBUG_HANDLE_KEY = "_numeric_debug_handle"
+NUMERIC_DEBUG_HANDLE_KEY = "numeric_debug_handle"
+CUSTOM_KEY = "custom"
 
 log = logging.getLogger(__name__)
 
@@ -20,8 +21,14 @@ def generate_numeric_debug_handle(graph_module: GraphModule) -> None:
     """
     unique_id = 0
     for node in graph_module.graph.nodes:
-        if node.op != "placeholder" and NUMERIC_DEBUG_HANDLE_KEY not in node.meta:
-            node.meta[NUMERIC_DEBUG_HANDLE_KEY] = unique_id
+        if node.op in ["output", "placehodler"]:
+            continue
+
+        if CUSTOM_KEY not in node.meta:
+            node.meta[CUSTOM_KEY] = {}
+
+        if NUMERIC_DEBUG_HANDLE_KEY not in node.meta[CUSTOM_KEY]:
+            node.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY] = unique_id
             unique_id += 1
 
 
@@ -98,9 +105,9 @@ def prepare_for_propagation_comparison(model: GraphModule) -> GraphModule:
     # don't change the original model
     model = copy.deepcopy(model)
     for n in model.graph.nodes:
-        if NUMERIC_DEBUG_HANDLE_KEY not in n.meta:
+        if CUSTOM_KEY not in n.meta or NUMERIC_DEBUG_HANDLE_KEY not in n.meta[CUSTOM_KEY]:
             continue
-        numeric_debug_handle = n.meta[NUMERIC_DEBUG_HANDLE_KEY]
+        numeric_debug_handle = n.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY]
         _insert_logger(model, n, numeric_debug_handle)
 
     model.recompile()

--- a/torch/ao/quantization/pt2e/prepare.py
+++ b/torch/ao/quantization/pt2e/prepare.py
@@ -465,9 +465,9 @@ def _maybe_insert_output_observer_for_node(
         ):
             if CUSTOM_KEY not in new_output.meta:
                 new_output.meta[CUSTOM_KEY] = {}
-            new_output.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY] = node.meta[CUSTOM_KEY][
-                NUMERIC_DEBUG_HANDLE_KEY
-            ]
+            new_output.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY] = node.meta[
+                CUSTOM_KEY
+            ][NUMERIC_DEBUG_HANDLE_KEY]
         return new_output
     return None
 

--- a/torch/ao/quantization/pt2e/prepare.py
+++ b/torch/ao/quantization/pt2e/prepare.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 import torch
 from torch._subclasses import FakeTensor
 from torch.ao.quantization import (
+    CUSTOM_KEY,
     NUMERIC_DEBUG_HANDLE_KEY,
     ObserverOrFakeQuantize,
     QConfigMapping,
@@ -459,9 +460,12 @@ def _maybe_insert_output_observer_for_node(
         if (
             isinstance(node, Node)
             and isinstance(new_output, Node)
-            and NUMERIC_DEBUG_HANDLE_KEY in node.meta
+            and CUSTOM_KEY in node.meta
+            and NUMERIC_DEBUG_HANDLE_KEY in node.meta[CUSTOM_KEY]
         ):
-            new_output.meta[NUMERIC_DEBUG_HANDLE_KEY] = node.meta[
+            if CUSTOM_KEY not in new_output.meta:
+                new_output.meta[CUSTOM_KEY] = {}
+            new_output.meta[CUSTOM_KEY][NUMERIC_DEBUG_HANDLE_KEY] = node.meta[CUSTOM_KEY][
                 NUMERIC_DEBUG_HANDLE_KEY
             ]
         return new_output


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134040

Summary:
With https://github.com/pytorch/pytorch/pull/131912 we now have a "custom" field in node.meta that can be preserved
in

* copy/deepcopy
* run_decompositions()
* serialization
* re-exporting

So we refactored numeric debugger to use this.

Test Plan:
python test/test_quantization.py TestNumericDebugger

Reviewers:

Subscribers:

Tasks:

Tags: