### PR TITLE
kill sharing of constraints

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -2734,7 +2734,7 @@ def forward(self, x):
         y = torch.randn(10, 3, 4)
         with self.assertRaisesRegex(
             torch._dynamo.exc.UserError,
-            ".*x.*size.*1.* = 3 is not equal to .*y.*size.*2.* = 4",
+            ".*y.*size.*2.* = 4 is not equal to .*x.*size.*1.* = 3",
         ):
             torch.export.export(
                 bar,

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1760,6 +1760,7 @@ class GuardBuilder(GuardBuilderBase):
             ]
 
         if output_graph.export_constraints:
+            names: Dict[str, Tuple[int, int]] = {}
             source_pairs: List[Tuple[Source, Source]] = []
             derived_equalities: List[  # type: ignore[type-arg]
                 Tuple[Source, Union[Source, Symbol], Callable]
@@ -1771,6 +1772,7 @@ class GuardBuilder(GuardBuilderBase):
                         constraint,
                         get_sources,
                         output_graph.shape_env,
+                        names,
                         source_pairs,
                         derived_equalities,
                         phantom_symbols,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2426,39 +2426,27 @@ def _automatic_dynamic(
     t_id = id(e)
     dim2constraint = {}
 
-    def update_dim2constraint(dim, constraint_range, debug_name):
+    def update_dim2constraint(dim, constraint_range, name):
         if dim in dim2constraint:
             from torch.fx.experimental.symbolic_shapes import StrictMinMaxConstraint
 
-            old_constraint_range, old_debug_name = dim2constraint[dim]
+            old_constraint_range, old_name = dim2constraint[dim]
             new_constraint_range = StrictMinMaxConstraint(
                 vr=constraint_range.vr & old_constraint_range.vr,
                 warn_only=False,
             )
-            # It is possible for (non-None) old_debug_name and debug_name to be different
+            # It is possible for (non-None) old_name and name to be different
             # but this will only happen the corresponding Dims can be derived equal.
-            new_debug_name = old_debug_name or debug_name
-            dim2constraint[dim] = new_constraint_range, new_debug_name
+            new_name = old_name or name
+            dim2constraint[dim] = new_constraint_range, new_name
         else:
-            dim2constraint[dim] = constraint_range, debug_name
+            dim2constraint[dim] = constraint_range, name
 
     if tx.output.export_constraints:
         for constraint in tx.output.export_constraints:
             if constraint.t_id == t_id:
                 update_dim2constraint(
-                    constraint.dim, constraint.constraint_range, constraint.debug_name
-                )
-            if constraint.shared is not None and constraint.shared.t_id == t_id:
-                # We process constraint ranges for each shared dimension separately
-                # so that we can directly check range constraint violations on them
-                # without looking up which other shared dimensions have this info.
-                # In other words, for this t_id, we will have processed all of its
-                # constraint ranges, no matter where / how they were specified, by
-                # by the end of this loop.
-                update_dim2constraint(
-                    constraint.shared.dim,
-                    constraint.constraint_range,
-                    constraint.debug_name,
+                    constraint.dim, constraint.constraint_range, constraint.name
                 )
 
     dynamic_sizes = []
@@ -2530,11 +2518,10 @@ def _automatic_dynamic(
                 constraint_size = None
                 constraint_stride = None
         else:
-            constraint_size, debug_name = constraint
+            constraint_size, name_ = constraint
             constraint_stride = None
-            if debug_name is not None:
-                dim_name = f"{name}.size()[{i}]"
-                tx.output.shape_env.source_name_to_debug_name[dim_name] = debug_name
+            dim_name = f"{name}.size()[{i}]"
+            tx.output.shape_env.source_name_to_debug_name[dim_name] = name_
         constraint_sizes.append(constraint_size)
         constraint_strides.append(constraint_stride)
 

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -227,7 +227,7 @@ def dims(*names: str, min: Optional[int] = None, max: Optional[int] = None):
 @dataclasses.dataclass
 class _ConstraintTarget:
     """
-    This represents input tensor dimensions.  Don't create this
+    This represents input tensor dimensions.  Do not create this
     class directly; instead, use :func:`dynamic_dim`.
     """
 
@@ -235,43 +235,17 @@ class _ConstraintTarget:
     dim: int
 
 
-class _ConstraintFactory(type):
-    """
-    Metaclass that ensures a private constructor for :class:`_Constraint`
-    """
-
-    def __call__(cls, *args, **kwargs):
-        raise TypeError(
-            f"{cls.__module__}.{cls.__qualname__} has no public constructor. "
-            f"Please use torch.export.dynamic_dim() to create one"
-        )
-
-    def _create(cls, t_id, dim, constraint_range, shared=None, debug_name=None):
-        return super().__call__(t_id, dim, constraint_range, shared, debug_name)
-
-
-def _create_constraint(t_id, dim, constraint_range, shared=None, debug_name=None):
-    return _Constraint._create(t_id, dim, constraint_range, shared, debug_name)
-
-
 @dataclasses.dataclass
-class _Constraint(_ConstraintTarget, metaclass=_ConstraintFactory):
+class _Constraint(_ConstraintTarget):
+    """
+    This represents a Dim describing a constraint target.
+
+    `name` is the name of the Dim.
+    `constraint_range` contains the min/max bounds of the Dim.
     """
 
-    .. warning::
-        Do not construct :class:`_Constraint` directly, use :func:`dynamic_dim` instead.
-
-    This represents constraints on input tensor dimensions, e.g., requiring
-    them to be fully polymorphic or within some range.
-
-    """
-
-    # NOTE(avik): In the future, this could be Union[StrictMinMaxConstraint, <other kinds>]
+    name: str
     constraint_range: "StrictMinMaxConstraint"
-    # Represent that `constraint_range` is shared with another _ConstraintTarget, which
-    # typically arises because of a specified equality with another dynamic dimension.
-    shared: Optional[_ConstraintTarget] = None
-    debug_name: Optional[str] = None
 
     def _clone_with_range(self, lower=0, upper=None):
         # Import sympy locally
@@ -286,12 +260,11 @@ class _Constraint(_ConstraintTarget, metaclass=_ConstraintFactory):
             vr=self.constraint_range.vr & ValueRanges(lower=lower, upper=upper),
             warn_only=False,
         )
-        return _create_constraint(
+        return _Constraint(
             self.t_id,
             self.dim,
+            self.name,
             constraint_range,
-            self.shared,
-            self.debug_name,
         )
 
     def __ge__(self, lower):
@@ -333,33 +306,6 @@ class _Constraint(_ConstraintTarget, metaclass=_ConstraintFactory):
             "max": self.constraint_range.vr.upper,
         }
 
-    def __eq__(self, other):
-        if not isinstance(other, _Constraint):
-            raise TypeError(
-                "A dynamic dim can be specified equal only to another dynamic dim. "
-                f"Equality with {type(other)} is not supported."
-            )
-
-        # import sympy locally
-        from torch.fx.experimental.symbolic_shapes import StrictMinMaxConstraint
-
-        constraint_range = StrictMinMaxConstraint(
-            vr=self.constraint_range.vr & other.constraint_range.vr,
-            warn_only=False,
-        )
-        if self.debug_name is None:
-            debug_name = other.debug_name
-        else:
-            assert other.debug_name is None or self.debug_name == other.debug_name
-            debug_name = self.debug_name
-        return _create_constraint(
-            self.t_id,
-            self.dim,
-            constraint_range,
-            shared=_ConstraintTarget(other.t_id, other.dim),
-            debug_name=debug_name,
-        )
-
 
 @dataclasses.dataclass
 class _PhantomRoot:
@@ -385,23 +331,15 @@ class _DerivedConstraint(_ConstraintTarget):
     This represents a derived Dim, whose root is either a regular constraint target
     (which directly specifies the shape of some input dimension) or a phantom root
     (which does so indirectly).
+
+    It can be thought of as a subclass of `_Constraint`, except that it does not
+    support <, <=, >, >= operations.
     """
 
-    # NOTE: This is not currently a subclass of _Constraint because we do not support
-    # `shared` for derived `Dim`s. Indeed, sharing is a necessary concept only for
-    # legacy constraints based on `dynamic_dim`: equality can be expressed simply by
-    # reusing the same (derived or normal) `Dim`.
+    name: str
+    constraint_range: "StrictMinMaxConstraint"
     root: Union[_ConstraintTarget, _PhantomRoot]
     fn: Callable
-    constraint_range: "StrictMinMaxConstraint"
-    debug_name: Optional[str] = None
-
-    @property
-    def shared(self):
-        # Some code paths expect a union of _Constraint and _DerivedConstraint.
-        # Thus we expose a `shared` field that is always None.
-        # TODO(avik): clean this up
-        return None
 
     @property
     def serializable_spec(self):
@@ -512,11 +450,13 @@ def dynamic_dim(t: torch.Tensor, index: int, debug_name: Optional[str] = None):
     from torch.utils._sympy.numbers import int_oo
     from torch.utils._sympy.value_ranges import ValueRanges
 
-    return _create_constraint(
+    name = debug_name or f"dynamic_dim_{id(t)}_{index}"
+
+    return _Constraint(
         id(t),
         index,
+        name,
         StrictMinMaxConstraint(vr=ValueRanges(lower=0, upper=int_oo), warn_only=False),
-        debug_name=debug_name,
     )
 
 
@@ -524,6 +464,7 @@ def _process_equalities(
     constraint: Constraint,
     get_sources: Callable[[int, int], List["Source"]],
     shape_env: "ShapeEnv",
+    names: Dict[str, Tuple[int, int]],
     source_pairs: List[Tuple["Source", "Source"]],
     derived_equalities: List[Tuple["Source", Union["Source", "Symbol"], Callable]],
     phantom_symbols: Dict[str, "Symbol"],
@@ -538,14 +479,14 @@ def _process_equalities(
     # constraints that make src0 "equal" to src1, ..., srcN.
     source_pairs.extend((source, other_source) for other_source in other_sources)
     if not isinstance(constraint, _DerivedConstraint):
-        if constraint.shared is not None:
-            # Moreover, when t.size()[dim] is specified equal to t'.size()[dim']
-            # and t'.size()[dim'] maps to src1', ..., srcN', we add
-            # constraints that also make src0 "equal" to src1', ..., srcN'.
-            other_sources = get_sources(constraint.shared.t_id, constraint.shared.dim)
+        if constraint.name in names:
+            shared_t_id, shared_dim = names[constraint.name]
+            other_sources = get_sources(shared_t_id, shared_dim)
             source_pairs.extend(
                 (source, other_source) for other_source in other_sources
             )
+        else:
+            names[constraint.name] = (constraint.t_id, constraint.dim)
     else:
         # branch based on the root of the _DerivedConstraint
         if not isinstance(constraint.root, _PhantomRoot):
@@ -962,26 +903,26 @@ def _process_dynamic_shapes(
             constraint = _DerivedConstraint(
                 id(tensor),
                 i,
-                root,
-                dim.fn,  # type: ignore[attr-defined]
+                dim.__name__,
                 StrictMinMaxConstraint(
                     vr=ValueRanges(lower=dim.min, upper=dim.max),
                     warn_only=False,
                 ),
-                debug_name=dim.__name__,
+                root,
+                dim.fn,  # type: ignore[attr-defined]
             )
             if isinstance(root, _PhantomRoot):
                 # NOTE(avik): since we have not processed all inputs yet, we may replace this
                 # with a root that does represent an input shape dimension later (see below)
                 derived_constraints_with_phantom_root.append(constraint)
         elif isinstance(dim, _StaticDim):
-            constraint = _create_constraint(
+            constraint = _Constraint(  # type: ignore[assignment]
                 id(tensor),
                 i,
+                dim.__name__,
                 StrictMinMaxConstraint(
                     vr=ValueRanges(lower=dim.value, upper=dim.value), warn_only=False  # type: ignore[attr-defined]
                 ),
-                debug_name=dim.__name__,
             )
         else:
             constraint = dynamic_dim(tensor, i, debug_name=dim.__name__)
@@ -1030,17 +971,7 @@ def _process_dynamic_shapes(
             derived_constraint_with_phantom_root.root = symbols[phantom_root_name][0]
 
     for dynamic_dims in symbols.values():
-        if all(
-            isinstance(dynamic_dim, _DerivedConstraint) for dynamic_dim in dynamic_dims
-        ):
-            constraints.extend(dynamic_dims)
-        else:
-            primary, *others = dynamic_dims
-            if others:
-                for other in others:
-                    constraints.append(primary == other)  # type: ignore[arg-type]
-            else:
-                constraints.append(primary)
+        constraints.extend(dynamic_dims)
 
     return constraints  # type: ignore[return-value]
 


### PR DESCRIPTION
Summary:
Previously, reuse of the same `Dim` was encoded by "sharing" internal constraints among constraint targets. This kind of sharing, implemented using `shared` fields between `_Constraint`s, was originally motivated by `dynamic_dim`, specifically to support `==` between `dynamic_dim`s, but we no longer need to maintain this overcomplicated structure: we can simply use names of `Dims` to directly encode sharing information.

Thus this PR vastly simplifies the structure of `_Constraint` by removing `shared` fields. As a result, both `_Constraint` and its moral subclass, `_DerivedConstraint`, are 1-1 with `Dim` and its moral subclass, `DerivedDim`.

Note that this will break `==` over `dynamic_dim`, so an immediate follow-up will be to remove `dynamic_dim` entirely from our public API. (It's been more than 6 months since the deprecation warning anyway.) I just didn't want to deal with that process in the same PR.

Test Plan: existing

Differential Revision: D61559413


cc @rec