### PR TITLE
Fix `Extension` attribute name in `CppExtension` example

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -944,7 +944,7 @@ def CppExtension(name, sources, *args, **kwargs):
         ...             name='extension',
         ...             sources=['extension.cpp'],
         ...             extra_compile_args=['-g'],
-        ...             extra_link_flags=['-Wl,--no-as-needed', '-lm'])
+        ...             extra_link_args=['-Wl,--no-as-needed', '-lm'])
         ...     ],
         ...     cmdclass={
         ...         'build_ext': BuildExtension
@@ -998,7 +998,7 @@ def CUDAExtension(name, sources, *args, **kwargs):
         ...                 sources=['extension.cpp', 'extension_kernel.cu'],
         ...                 extra_compile_args={'cxx': ['-g'],
         ...                                     'nvcc': ['-O2']},
-        ...                 extra_link_flags=['-Wl,--no-as-needed', '-lcuda'])
+        ...                 extra_link_args=['-Wl,--no-as-needed', '-lcuda'])
         ...     ],
         ...     cmdclass={
         ...         'build_ext': BuildExtension


### PR DESCRIPTION
Hi! It seems there's a typo in `CppExtension` example. I think it should say `extra_link_args` instead of `extra_link_flags`. Not that I spent a few hours debugging missing kernels inside a library's fatbin or anything :D. 

Please see `Extension` definition inside setuptools:
https://github.com/pypa/setuptools/blob/ebddeb36f72c9d758b5cc0e9f81f8a66aa837d96/setuptools/_distutils/extension.py#L62

Thanks!
Błażej
