### PR TITLE
Cherry-Picking don't resolve conflicts

### DIFF
--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -170,7 +170,7 @@ def create_cherry_pick_branch(
 
     # We might want to support ghstack later
     # We don't want to resolve conflicts here.
-    repo._run_git("cherry-pick", "-x",  commit_sha)
+    repo._run_git("cherry-pick", "-x", commit_sha)
     repo.push(branch=cherry_pick_branch, dry_run=False)
 
     return cherry_pick_branch

--- a/.github/scripts/cherry_pick.py
+++ b/.github/scripts/cherry_pick.py
@@ -169,7 +169,8 @@ def create_cherry_pick_branch(
     repo.create_branch_and_checkout(branch=cherry_pick_branch)
 
     # We might want to support ghstack later
-    repo._run_git("cherry-pick", "-x", "-X", "theirs", commit_sha)
+    # We don't want to resolve conflicts here.
+    repo._run_git("cherry-pick", "-x",  commit_sha)
     repo.push(branch=cherry_pick_branch, dry_run=False)
 
     return cherry_pick_branch


### PR DESCRIPTION
During cherry-picking we want to use default setting and fail if there is merge conflict
Here an example of invalid conflict resolution:
https://github.com/pytorch/pytorch/pull/131194
and cherry-pick
https://github.com/pytorch/pytorch/pull/133590
