### PR TITLE
[DeviceMesh] Allow _flatten() to take in an optional mesh_dim_name

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -606,6 +606,11 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         ]
         self.assertEqual(flatten_mesh_root_dims, (0, 2))
 
+        # Test flatten with a flattened mesh_dim_name
+        cp_tp_mesh = mesh_3d["cp", "tp"]
+        cp_tp_mesh._flatten("dummy")
+        self.assertEqual(mesh_3d["dummy"].mesh_dim_names[0], "dummy")
+
     @with_comms
     def test_reconstruct_mesh_with_flatten_dim(self):
         mesh_3d = init_device_mesh(

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -159,19 +159,41 @@ else:
 
             return res_submesh
 
-        def create_flatten_mesh(self, device_mesh: "DeviceMesh") -> "DeviceMesh":
+        def create_flatten_mesh(
+            self, device_mesh: "DeviceMesh", mesh_dim_name: Optional[str] = None
+        ) -> "DeviceMesh":
             root_mesh = _mesh_resources.get_root_mesh(device_mesh)
+
             flatten_dims_in_root = [
                 not_none(root_mesh.mesh_dim_names).index(flattened_mesh_dim_name)
                 for flattened_mesh_dim_name in not_none(device_mesh.mesh_dim_names)
             ]
-            flatten_mesh_dim_name = "_".join(
-                [
-                    not_none(root_mesh.mesh_dim_names)[dim]
-                    for dim in flatten_dims_in_root
+
+            # Check whether the mesh_dim_name for flattened mesh is valid.
+            if mesh_dim_name:
+                self.flatten_name_to_root_dims.setdefault(root_mesh, {})
+                invalid_dim_names = [
+                    *root_mesh.mesh_dim_names,
+                    *self.flatten_name_to_root_dims[root_mesh].keys(),
                 ]
-            )
+                if mesh_dim_name in invalid_dim_names:
+                    raise RuntimeError(
+                        f"{mesh_dim_name} already exists for submesh of the {root_mesh}. ",
+                        f"The mesh_dim_names of submesh and flattened mesh are {invalid_dim_names}. "
+                        f"Please specify another valid mesh_dim_name.",
+                    )
+                else:
+                    flatten_mesh_dim_name = mesh_dim_name
+            else:
+                flatten_mesh_dim_name = "_".join(
+                    [
+                        not_none(root_mesh.mesh_dim_names)[dim]
+                        for dim in flatten_dims_in_root
+                    ]
+                )
             # Quick return if the flatten mesh has been created before.
+            # TODO: If we decide to restrict flatten initialization once, we should remove
+            # this check and throw an error if the flatten mesh is already created before.
             if (
                 root_mesh in self.root_to_flatten_mapping
                 and flatten_mesh_dim_name in self.root_to_flatten_mapping[root_mesh]
@@ -200,7 +222,7 @@ else:
                     res_flattened_mesh = flattened_mesh
             self.child_to_root_mapping[res_flattened_mesh] = root_mesh  # type: ignore[possibly-undefined]
             self.root_to_flatten_mapping.setdefault(root_mesh, {})[flatten_mesh_dim_name] = res_flattened_mesh  # type: ignore[possibly-undefined]
-            self.flatten_name_to_root_dims.setdefault(root_mesh, {})[flatten_mesh_dim_name] = tuple(flatten_dims_in_root)  # type: ignore[possibly-undefined]
+            self.flatten_name_to_root_dims[root_mesh][flatten_mesh_dim_name] = tuple(flatten_dims_in_root)  # type: ignore[possibly-undefined]
 
             return res_flattened_mesh
 
@@ -804,19 +826,25 @@ else:
             """
             return self._coordinate_on_dim if self._coordinate_on_dim else None
 
-        def _flatten(self) -> "DeviceMesh":
+        def _flatten(self, mesh_dim_name: Optional[str] = None) -> "DeviceMesh":
             """
-            Returns a 1D DeviceMesh by flattening the current DeviceMesh. The mesh_dim_names
-            of the flattened mesh will be the concatenation of the current mesh_dim_names.
-            For example, flattening a 2D DeviceMesh with mesh_dim_names=("dp", "cp") will create
-            a 1D DeviceMesh with mesh_dim_names=("dp_cp").
+            Returns a 1D DeviceMesh by flattening the current DeviceMesh.
+
+            If no mesh_dim_name is provided, the default is a string concatentaing the mesh_dim_names of the
+            given submesh with each mesh_dim_name separated by "_". For example, if we have a 3D mesh
+            DeviceMesh([[[0, 1], [2, 3]], [[4, 5], [6, 7]]], mesh_dim_names=("dp", "cp", "tp")), calling
+            mesh_3d["dp", "cp"]._flatten() will create a 1D submesh DeviceMesh([0, 1, 2, 3], mesh_dim_names=("dp_cp",))
+            on rank 0, 1, 2, 3 and a 1D submesh DeviceMesh([4, 5, 6, 7], mesh_dim_names=("dp_cp",)) on rank 4, 5, 6, 7.
+
+            After the flattened dimension is created, to access the flattened dimesnion in mesh_3d, one can use the
+            existing slicing method to obtain the flattened mesh through calling mesh_3d["dp_cp"].
             """
             if not self.mesh_dim_names:
                 raise RuntimeError(
                     "Cannot flatten a DeviceMesh without mesh_dim_names!"
                 )
 
-            return _mesh_resources.create_flatten_mesh(self)
+            return _mesh_resources.create_flatten_mesh(self, mesh_dim_name)
 
     def init_device_mesh(
         device_type: str,

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -172,10 +172,10 @@ else:
             # Check whether the mesh_dim_name for flattened mesh is valid.
             if mesh_dim_name:
                 self.flatten_name_to_root_dims.setdefault(root_mesh, {})
-                invalid_dim_names = [
-                    *root_mesh.mesh_dim_names,
+                invalid_dim_names = chain(
+                    *list(not_none(root_mesh.mesh_dim_names)),
                     *self.flatten_name_to_root_dims[root_mesh].keys(),
-                ]
+                )
                 if mesh_dim_name in invalid_dim_names:
                     raise RuntimeError(
                         f"{mesh_dim_name} already exists for submesh of the {root_mesh}. ",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134048

If a mesh_dim_name is given, we will use the given mesh_dim_name to name the new flattened dim. 
Otherwise, the default is a string concatentaing the mesh_dim_names of the given submesh with each mesh_dim_name separated by "_". 

For example, if we have a 3D mesh DeviceMesh([[[0, 1], [2, 3]], [[4, 5], [6, 7]]], mesh_dim_names=("dp", "cp", "tp")), calling mesh_3d["dp", "cp"]._flatten() will create a 1D submesh DeviceMesh([0, 1, 2, 3], mesh_dim_names=("dp_cp",)) on rank 0, 1, 2, 3 and a 1D submesh DeviceMesh([4, 5, 6, 7], mesh_dim_names=("dp_cp",)) on rank 4, 5, 6, 7.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l