### PR TITLE
[export] Schematize nn_module_stack serialization

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -441,6 +441,36 @@ class TestSerialize(TestCase):
             if "aten.sum.dim_IntList" in node.target:
                 self.assertEqual(node.inputs[1].arg.type, "as_ints")
 
+    def test_nn_module_stack_serde_with_commas(self) -> None:
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(2, 2)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(self.linear(x))
+
+        # export the model
+        ep = torch.export.export(M(), (torch.randn(2, 2),))
+        # modify the nn_module_stack to contain comma(,) and semicolon(;)
+        for node in ep.graph.nodes:
+            if nn_module_stack := node.meta.get("nn_module_stack"):
+                for k, (p, t) in nn_module_stack.items():
+                    nn_module_stack[k] = (p + ";semicolon", t + ",comma")
+                node.meta["nn_module_stack"] = nn_module_stack
+        # serialize and deserialize the model
+        buffer = io.BytesIO()
+        save(ep, buffer)
+        buffer.seek(0)
+        loaded_ep = load(buffer)
+        # check that the output is the same
+        inp = (torch.randn(2, 2),)
+        exp_out = ep.module()(*inp)
+        actual_out = loaded_ep.module()(*inp)
+        self.assertEqual(exp_out, actual_out)
+        self.assertEqual(exp_out.requires_grad, actual_out.requires_grad)
+
 
 @unittest.skipIf(IS_WINDOWS, "Windows not supported for this test")
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -10,7 +10,6 @@ import json
 import logging
 import math
 import operator
-import re
 import typing
 import traceback
 
@@ -579,21 +578,23 @@ class GraphModuleSerializer(metaclass=Final):
             ret["stack_trace"] = stack_trace
 
         if nn_module_stack := node.meta.get("nn_module_stack"):
-
-            def export_nn_module_stack(val):
-                assert isinstance(val, tuple) and len(val) == 2
-                path, ty = val
-
+            keys, paths, tys = [], [], []
+            for k, v in nn_module_stack.items():
+                keys.append(k)
+                assert isinstance(v, tuple) and len(v) == 2
+                path, ty = v
                 assert isinstance(path, str)
                 assert isinstance(ty, str)
+                paths.append(path)
+                tys.append(ty)
 
-                return path + "," + ty
+            nn_module_stack_dict = {
+                "key_list": keys,
+                "path_list": paths,
+                "type_list": tys
+            }
 
-            # Serialize to "key,orig_path,type_str"
-            nn_module_list = [
-                f"{k},{export_nn_module_stack(v)}" for k, v in nn_module_stack.items()
-            ]
-            ret["nn_module_stack"] = ST_DELIMITER.join(nn_module_list)
+            ret["nn_module_stack"] = json.dumps(nn_module_stack_dict)
 
         if source_fn_st := node.meta.get("source_fn_stack"):
             source_fn_list = [
@@ -2188,25 +2189,13 @@ class GraphModuleDeserializer(metaclass=Final):
 
         if nn_module_stack_str := metadata.get("nn_module_stack"):
             # Originally serialized to "key,orig_path,type_str"
-            def import_nn_module_stack(key, path, ty):
-                return key, (path, ty)
-
-            # Helper function that splits strings by commas except for those
-            # encapsulated by parens, which are valid traces.
-            # TODO: Currently this is needed due to indexing Sequential
-            # layers introducing names in the form "layer.slice(1, None, None)".
-            # If that naming is improved, this fancier splitting can probably be
-            # reverted to a simple split by comma.
-            def metadata_split(metadata):
-                # Remove the parentheses and commas inside them
-                metadata = re.sub(r'\(.*?\)', '', metadata)
-                # Split the string by comma, except for those inside parentheses
-                return re.split(r'(?<!\()\s*,\s*(?!\()', metadata)
-
-            nn_module_stack = dict(
-                import_nn_module_stack(*metadata_split(item))
-                for item in nn_module_stack_str.split(ST_DELIMITER)
-            )
+            nn_module_stack_dict = json.loads(nn_module_stack_str)
+            nn_module_stack = {
+                key: (path, ty)
+                for key, path, ty in zip(
+                    nn_module_stack_dict["key_list"],
+                    nn_module_stack_dict["path_list"],
+                    nn_module_stack_dict["type_list"])}
             ret["nn_module_stack"] = nn_module_stack
 
         if source_fn_st_str := metadata.get("source_fn_stack"):


### PR DESCRIPTION
`nn_module_stack` was previously serialized to string by adding commas between the module_path and module_type. This error prone when the `nn_module_stack` itself contains commas. 

This PR fixes this by creating a dictionary to store the `nn_module_stack` and serialize it to string via `json.dumps()`

Fixes #131941
