### PR TITLE
Avoid autocast deprecation warning in DataParallel (#130660)

### DIFF
--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -3,7 +3,6 @@ import torch
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, cast
 from ..modules import Module
 from torch.cuda._utils import _get_device_index
-from torch.cuda.amp import autocast
 from torch._utils import ExceptionWrapper
 
 __all__ = ['get_a_var', 'parallel_apply']
@@ -76,7 +75,9 @@ def parallel_apply(
         if stream is None:
             stream = torch.cuda.current_stream(device)
         try:
-            with torch.cuda.device(device), torch.cuda.stream(stream), autocast(enabled=autocast_enabled):
+            with torch.cuda.device(device), torch.cuda.stream(
+                stream
+            ), torch.amp.autocast("cuda", enabled=autocast_enabled):
                 # this also avoids accidental slicing of `input` if it is a Tensor
                 if not isinstance(input, (list, tuple)):
                     input = (input,)


### PR DESCRIPTION
Fixes #130659

Co-authored-by: Yu, Guangye <106960996+guangyey@users.noreply.github.com>
Pull Request resolved: https://github.com/pytorch/pytorch/pull/130660
Approved by: https://github.com/guangyey, https://github.com/fegin, https://github.com/albanD

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o