### PR TITLE
[pytorch] Remove thread naming when torch is imported

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -213,11 +213,6 @@ static PyObject* THPModule_initExtension(
   std::string path = THPUtils_unpackString(shm_manager_path);
   libshm_init(path.c_str());
 
-  // The main thread usually launches CPU/GPU/Accelerator kernels and therefore
-  // becomes latency sensitive. If the thread is named, we can debug performance
-  // issues easier.
-  c10::setThreadName("pt_main_thread");
-
   auto module = THPObjectPtr(PyImport_ImportModule("torch"));
   if (!module)
     throw python_error();


### PR DESCRIPTION
Fixes #133690

The naming was added in #121170 to allow performance debugging of latency critical threads. However the `pt_main_thread` name gets inherited every time a new process or thread is created from the parent one, which defeats the purpose. We need a better way to name the thread that launches kernels on accelerators but for the time being we can let users name the threads in the application code, using: `torch.multiprocessing._set_thread_name("insert_name")`
