### PR TITLE
[Fix] Check name when registering privateuse1 backend

### DIFF
--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -146,11 +146,12 @@ void register_privateuse1_backend(const std::string& backend_name) {
       "torch.register_privateuse1_backend() has already been set! Current backend: ",
       privateuse1_backend_name);
 
-  static const std::array<std::string, 5> types = {
-      "cuda", "hip", "mps", "xpu", "mtia"};
+  static const std::array<std::string, 6> types = {
+      "cpu", "cuda", "hip", "mps", "xpu", "mtia"};
   TORCH_CHECK(
       std::find(types.begin(), types.end(), backend_name) == types.end(),
-      "Cannot register privateuse1 backend with in-tree device name.");
+      "Cannot register privateuse1 backend with in-tree device name: ",
+      backend_name);
 
   privateuse1_backend_name = backend_name;
   // Invariant: once this flag is set, privateuse1_backend_name is NEVER written

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -1,5 +1,6 @@
 #include <c10/core/DeviceType.h>
 #include <c10/util/Exception.h>
+#include <array>
 #include <atomic>
 #include <mutex>
 
@@ -144,6 +145,12 @@ void register_privateuse1_backend(const std::string& backend_name) {
           privateuse1_backend_name == backend_name,
       "torch.register_privateuse1_backend() has already been set! Current backend: ",
       privateuse1_backend_name);
+
+  static const std::array<std::string, 5> types = {
+      "cuda", "hip", "mps", "xpu", "mtia"};
+  TORCH_CHECK(
+      std::find(types.begin(), types.end(), backend_name) == types.end(),
+      "Cannot register privateuse1 backend with in-tree device name.");
 
   privateuse1_backend_name = backend_name;
   // Invariant: once this flag is set, privateuse1_backend_name is NEVER written

--- a/c10/test/core/Device_test.cpp
+++ b/c10/test/core/Device_test.cpp
@@ -54,3 +54,12 @@ TEST(DeviceTypeTest, PrivateUseOneDeviceType) {
   ASSERT_EQ(c10::get_privateuse1_backend(true), "my_privateuse1_backend");
   ASSERT_EQ(c10::get_privateuse1_backend(false), "MY_PRIVATEUSE1_BACKEND");
 }
+
+TEST(DeviceTypeTest, PrivateUseOneRegister) {
+  ASSERT_THROW(c10::register_privateuse1_backend("cpu"), c10::Error);
+  ASSERT_THROW(c10::register_privateuse1_backend("cuda"), c10::Error);
+  ASSERT_THROW(c10::register_privateuse1_backend("hip"), c10::Error);
+  ASSERT_THROW(c10::register_privateuse1_backend("mps"), c10::Error);
+  ASSERT_THROW(c10::register_privateuse1_backend("xpu"), c10::Error);
+  ASSERT_THROW(c10::register_privateuse1_backend("mtia"), c10::Error);
+}


### PR DESCRIPTION
do some checks when registering privateuse1 backend to avoid using in-tree deivce names

cc: @FFFrog 