### PR TITLE
[Doc] Fix typo in `torch/fx/passes/README.md`

### DIFF
--- a/torch/fx/passes/README.md
+++ b/torch/fx/passes/README.md
@@ -8,7 +8,7 @@ This folder contains the pass infrastructure and passes for transforming fx.Grap
     * [partitioner.py](infra/partitioner.py) - backend agnostic FX graph partitioner
 * [utils](utils) - Utility classes and functions
     * [common.py](utils/common.py) - common utility functions
-    * [fuser_utis.py](utils/fuser_utils.py) - utility functions for fusing list of nodes into a single node
+    * [fuser_utils.py](utils/fuser_utils.py) - utility functions for fusing list of nodes into a single node
 * [dialect](dialect) - dialect specific passes
     * [common](dialect/common) - common passes that can be shared by all dialects
         * [cse_pass.py](dialect/common/cse_pass.py) - a CSE pass


### PR DESCRIPTION
Fix typo, `utis` to `utils`, in the utility name.

