### PR TITLE
Remove unneeded nvToolsExt logic

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -175,20 +175,6 @@ if sys.platform == "win32":
             if os.path.exists(p)
         ]
 
-        if not builtins.any(
-            os.path.exists(os.path.join(p, "nvToolsExt64_1.dll")) for p in dll_paths
-        ):
-            nvtoolsext_dll_path = os.path.join(
-                os.getenv(
-                    "NVTOOLSEXT_PATH",
-                    os.path.join(pfiles_path, "NVIDIA Corporation", "NvToolsExt"),
-                ),
-                "bin",
-                "x64",
-            )
-        else:
-            nvtoolsext_dll_path = ""
-
         if cuda_version and builtins.all(
             not glob.glob(os.path.join(p, "cudart64*.dll")) for p in dll_paths
         ):
@@ -201,9 +187,7 @@ if sys.platform == "win32":
         else:
             cuda_path = ""
 
-        dll_paths.extend(
-            p for p in (nvtoolsext_dll_path, cuda_path) if os.path.exists(p)
-        )
+        dll_paths.extend(p for p in (cuda_path,) if os.path.exists(p))
 
         kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
         with_load_library_flags = hasattr(kernel32, "AddDllDirectory")
@@ -314,7 +298,6 @@ def _load_global_deps() -> None:
             "cusparse": "libcusparse.so.*[0-9]",
             "cusolver": "libcusolver.so.*[0-9]",
             "nccl": "libnccl.so.*[0-9]",
-            "nvtx": "libnvToolsExt.so.*[0-9]",
         }
         is_cuda_lib_err = [
             lib for lib in cuda_libs.values() if lib.split(".")[0] in err.args[0]


### PR DESCRIPTION
Remove unneeded nvToolsExt logic on Windows. Currently nvToolsExt is reserved for META builds, which shouldn't involve Windows.
