### PR TITLE
Support __class__ attr for tuple and list variables

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11411,31 +11411,31 @@ fn
         cnts = torch._dynamo.testing.CompileCounter()
 
         def fn(x):
-            reversed_x = []
+            updated_x = []
             for v in x:
-                reversed_x.insert(0, v)
-            return x.__class__(reversed_x)
+                updated_x.append(v + 1)
+            return x.__class__(updated_x)
 
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
 
-        d1 = torch.zero(2, 2)
+        d1 = torch.zeros(2, 2)
         d2 = torch.ones(2, 2)
 
         r = opt_fn((d1, d2))
         self.assertEqual(r.__class__, tuple)
         r1, r2 = r
-        self.assertEqual(r1, torch.ones(2))
-        self.assertEqual(r2, torch.zeros(2))
+        self.assertEqual(r1, torch.ones(2, 2))
+        self.assertEqual(r2, torch.ones(2, 2) + 1)
         self.assertEqual(cnts.frame_count, 1)
 
     def test_list_class(self):
         cnts = torch._dynamo.testing.CompileCounter()
 
         def fn(x):
-            reversed_x = []
+            updated_x = []
             for v in x:
-                reversed_x.insert(0, v)
-            return x.__class__(reversed_x)
+                updated_x.append(v + 1)
+            return x.__class__(updated_x)
 
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
 
@@ -11445,8 +11445,8 @@ fn
         r = opt_fn([d1, d2])
         self.assertEqual(r.__class__, list)
         self.assertEqual(len(r), 2)
-        self.assertEqual(r[0], torch.ones(2))
-        self.assertEqual(r[1], torch.zeros(2))
+        self.assertEqual(r[0], torch.ones(2, 2))
+        self.assertEqual(r[1], torch.ones(2, 2) + 1)
         self.assertEqual(cnts.frame_count, 1)
 
     def test_namedtuple_class(self):
@@ -11455,10 +11455,10 @@ fn
         cnts = torch._dynamo.testing.CompileCounter()
 
         def fn(x):
-            reversed_x = []
+            updated_x = []
             for v in x:
-                reversed_x.insert(0, v)
-            return x.__class__(*reversed_x)
+                updated_x.append(v + 1)
+            return x.__class__(*updated_x)
 
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
 
@@ -11469,8 +11469,8 @@ fn
 
         r = opt_fn(p)
         self.assertEqual(r.__class__, point)
-        self.assertEqual(r.x, torch.ones(2))
-        self.assertEqual(r.y, torch.zeros(2))
+        self.assertEqual(r.x, torch.ones(2, 2))
+        self.assertEqual(r.y, torch.ones(2, 2) + 1)
         self.assertEqual(cnts.frame_count, 1)
 
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11407,6 +11407,72 @@ fn
 
         fn(torch.randn(4))
 
+    def test_tuple_class(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def fn(x):
+            reversed_x = []
+            for v in x:
+                reversed_x.insert(0, v)
+            return x.__class__(reversed_x)
+
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+
+        d1 = torch.zero(2, 2)
+        d2 = torch.ones(2, 2)
+
+        r = opt_fn((d1, d2))
+        self.assertEqual(r.__class__, tuple)
+        r1, r2 = r
+        self.assertEqual(r1, torch.ones(2))
+        self.assertEqual(r2, torch.zeros(2))
+        self.assertEqual(cnts.frame_count, 1)
+
+    def test_list_class(self):
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def fn(x):
+            reversed_x = []
+            for v in x:
+                reversed_x.insert(0, v)
+            return x.__class__(reversed_x)
+
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+
+        d1 = torch.zeros(2, 2)
+        d2 = torch.ones(2, 2)
+
+        r = opt_fn([d1, d2])
+        self.assertEqual(r.__class__, list)
+        self.assertEqual(len(r), 2)
+        self.assertEqual(r[0], torch.ones(2))
+        self.assertEqual(r[1], torch.zeros(2))
+        self.assertEqual(cnts.frame_count, 1)
+
+    def test_namedtuple_class(self):
+        import collections
+
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def fn(x):
+            reversed_x = []
+            for v in x:
+                reversed_x.insert(0, v)
+            return x.__class__(*reversed_x)
+
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+
+        d1 = torch.zeros(2, 2)
+        d2 = torch.ones(2, 2)
+        point = collections.namedtuple("Point", ["x", "y"])
+        p = point(d1, d2)
+
+        r = opt_fn(p)
+        self.assertEqual(r.__class__, point)
+        self.assertEqual(r.x, torch.ones(2))
+        self.assertEqual(r.y, torch.zeros(2))
+        self.assertEqual(cnts.frame_count, 1)
+
 
 class TestTracer(JitTestCase):
     def test_jit_save(self):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -435,7 +435,12 @@ class ListVariable(CommonListMethodsVariable):
 
     def var_getattr(self, tx, name):
         if name == "__class__":
-            return variables.UserDefinedClassVariable(self.python_type())
+            source = AttrSource(self.source, name) if self.source else None
+            class_type = self.python_type()
+            if class_type is list:
+                return variables.BuiltinVariable(class_type, source=source)
+            else:
+                return variables.UserDefinedClassVariable(class_type, source=source)
         return super().var_getattr(tx, name)
 
     def call_hasattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
@@ -532,7 +537,12 @@ class TupleVariable(BaseListVariable):
 
     def var_getattr(self, tx, name):
         if name == "__class__":
-            return variables.UserDefinedClassVariable(self.python_type())
+            source = AttrSource(self.source, name) if self.source else None
+            class_type = self.python_type()
+            if class_type is tuple:
+                return variables.BuiltinVariable(class_type, source=source)
+            else:
+                return variables.UserDefinedClassVariable(class_type, source=source)
         return super().var_getattr(tx, name)
 
     def call_hasattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -433,6 +433,11 @@ class ListVariable(CommonListMethodsVariable):
         else:
             return super().call_method(tx, name, args, kwargs)
 
+    def var_getattr(self, tx, name):
+        if name == "__class__":
+            return variables.UserDefinedClassVariable(self.python_type())
+        return super().var_getattr(tx, name)
+
     def call_hasattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
         if self.python_type() is not list:
             return super().call_hasattr(tx, name)
@@ -524,6 +529,11 @@ class TupleVariable(BaseListVariable):
         kwargs: Dict[str, "VariableTracker"],
     ) -> "VariableTracker":
         return super().call_method(tx, name, args, kwargs)
+
+    def var_getattr(self, tx, name):
+        if name == "__class__":
+            return variables.UserDefinedClassVariable(self.python_type())
+        return super().var_getattr(tx, name)
 
     def call_hasattr(self, tx: "InstructionTranslator", name: str) -> "VariableTracker":
         if self.python_type() is not tuple:
@@ -730,7 +740,7 @@ class NamedTupleVariable(TupleVariable):
         if name not in fields:
             method = check_and_create_method()
             if not method:
-                super().var_getattr(tx, name)
+                return super().var_getattr(tx, name)
             return method
         return self.items[fields.index(name)]
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -410,22 +410,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             )
             cm_obj.call_method(tx, "__init__", args, kwargs)
             return cm_obj
-        elif self.value is list and not kwargs:
-            if len(args) == 0:
-                items = []
-            elif len(args) == 1 and args[0].has_unpack_var_sequence(tx):
-                items = args[0].unpack_var_sequence(tx)
-            else:
-                unimplemented("list() with more than 1 arg not supported")
-            return variables.ListVariable(items, mutable_local=MutableLocal())
-        elif self.value is tuple and not kwargs:
-            if len(args) == 0:
-                items = []
-            elif len(args) == 1 and args[0].has_unpack_var_sequence(tx):
-                items = args[0].unpack_var_sequence(tx)
-            else:
-                unimplemented("tuple() with more than 1 arg not supported")
-            return variables.TupleVariable(items, mutable_local=MutableLocal())
+
         elif is_namedtuple_cls(self.value):
             fields = namedtuple_fields(self.value)
             # check if this a quasi-namedtuple or a real one

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -410,7 +410,22 @@ class UserDefinedClassVariable(UserDefinedVariable):
             )
             cm_obj.call_method(tx, "__init__", args, kwargs)
             return cm_obj
-
+        elif self.value is list and not kwargs:
+            if len(args) == 0:
+                items = []
+            elif len(args) == 1 and args[0].has_unpack_var_sequence(tx):
+                items = args[0].unpack_var_sequence(tx)
+            else:
+                unimplemented("list() with more than 1 arg not supported")
+            return variables.ListVariable(items, mutable_local=MutableLocal())
+        elif self.value is tuple and not kwargs:
+            if len(args) == 0:
+                items = []
+            elif len(args) == 1 and args[0].has_unpack_var_sequence(tx):
+                items = args[0].unpack_var_sequence(tx)
+            else:
+                unimplemented("tuple() with more than 1 arg not supported")
+            return variables.TupleVariable(items, mutable_local=MutableLocal())
         elif is_namedtuple_cls(self.value):
             fields = namedtuple_fields(self.value)
             # check if this a quasi-namedtuple or a real one


### PR DESCRIPTION
Fixes #134086

This supports __class__ attribute for TupleVariable and ListVariable. And allows to construct a tuple or list by using __class__ attribute. This patch also fix a bug in NamedTupleVariable which misses a return on calling super var_getattr.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec