### PR TITLE
cpuinfo git branch fix (main instead of master)

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/cmake/DownloadCpuinfo.cmake
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/cmake/DownloadCpuinfo.cmake
@@ -11,7 +11,7 @@ project(cpuinfo-download NONE)
 include(ExternalProject)
 ExternalProject_Add(cpuinfo
   GIT_REPOSITORY https://github.com/pytorch/cpuinfo.git
-  GIT_TAG master
+  GIT_TAG main
   SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/cpuinfo"
   BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/cpuinfo"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
I was trying to compile qnnpack from source (in `pytorch/aten/src/ATen/native/quantized/cpu/qnnpack/`) and I got this error:

```bash
#15 0.788 [1/9] Creating directories for 'cpuinfo'
#15 2.191 [2/9] Performing download step (git clone) for 'cpuinfo'
#15 2.191 FAILED: cpuinfo-prefix/src/cpuinfo-stamp/cpuinfo-download 
#15 2.191 cd /sysroot/root/pytorch/aten/src/ATen/native/quantized/cpu/qnnpack/deps && /usr/bin/cmake -P /sysroot/root/pytorch/aten/src/ATen/native/quantized/cpu/qnnpack/build/deps/cpuinfo-download/cpuinfo-prefix/tmp/cpuinfo-gitclone.cmake && /usr/bin/cmake -E touch /sysroot/root/pytorch/aten/src/ATen/native/quantized/cpu/qnnpack/build/deps/cpuinfo-download/cpuinfo-prefix/src/cpuinfo-stamp/cpuinfo-download
#15 2.191 Cloning into 'cpuinfo'...
#15 2.191 fatal: invalid reference: master
```
cpuinfo `master` branch has been renamed to `main` so it needs to also be updated in `pytorch/aten/src/ATen/native/quantized/cpu/qnnpack/cmake/DownloadCpuinfo.cmake`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10