### PR TITLE
[fp8 rowwise] Fix bias calculation being done in low precision

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -191,7 +191,7 @@ void f8f8bf16_rowwise_impl(
       cutlass::multiplies,
       cute::conditional_t< // Second stage output type.
           USE_BIAS,
-          ElementBias,
+          ElementComputeEpilogue,
           ElementOutput>,
       ElementComputeEpilogue, // Second stage input types.
       cutlass::FloatRoundStyle::round_to_nearest>;
@@ -202,7 +202,7 @@ void f8f8bf16_rowwise_impl(
   using ComputeBias = cutlass::epilogue::fusion::Sm90Compute<
       cutlass::plus,
       ElementOutput, // Final (optional) stage output type.
-      ElementBias, // Final stage input types.
+      ElementComputeEpilogue, // Final stage input types.
       cutlass::FloatRoundStyle::round_to_nearest>;
 
   using EVTComputeBias =


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #134114
* #134113
* __->__ #134112
* #134111
* #134110

The compute dtype for the bias addition was set to ElementBias. Thus, for a bf16 bias, we would cast the fp32 accum to bf16 and _then_ add the bias. It is however (slightly?) more accurate to first add the bias in fp32 and only cast at the end.