### PR TITLE
Remove skip ci recommendation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,11 +117,6 @@ conda activate pytorch-deps
 
   Next run `python setup.py clean`. After that, you can install in `develop` mode again.
 
-* If a commit is simple and doesn't affect any code (keep in mind that some docstrings contain code
-  that is used in tests), you can add `[skip ci]` (case sensitive) somewhere in your commit message to
-  [skip all build / test steps](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/).
-  Note that changing the pull request body or title on GitHub itself has no effect.
-
 * If you run into errors when running `python setup.py develop`, here are some debugging steps:
   1. Run `printf '#include <stdio.h>\nint main() { printf("Hello World");}'|clang -x c -; ./a.out` to make sure
   your CMake works and can compile this simple Hello World program without errors.


### PR DESCRIPTION
Using `skip ci` is no longer a recommendation practices.

