### PR TITLE
Make DTensor sharding propagation for `scaled_dot_product_efficient_attention` and `scaled_dot_product_flash_attention` more conservatively cached

### DIFF
--- a/torch/distributed/_tensor/ops/_matrix_ops.py
+++ b/torch/distributed/_tensor/ops/_matrix_ops.py
@@ -10,6 +10,7 @@ from torch.distributed._tensor._op_schema import (
     OpStrategy,
     PlacementList,
     PlacementStrategy,
+    RuntimeSchemaInfo,
 )
 from torch.distributed._tensor.ops._einsum_strategy import gen_einsum_strategies
 from torch.distributed._tensor.ops.utils import (
@@ -161,7 +162,9 @@ def baddmm_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrategy:
     return _addmm_like_strategy("bmk,bkn->bmn", mesh, op_schema)
 
 
-@register_op_strategy(aten._scaled_dot_product_flash_attention.default)
+@register_op_strategy(
+    aten._scaled_dot_product_flash_attention.default, schema_info=RuntimeSchemaInfo(5)
+)
 def scaled_dot_product_flash_attention_strategy(
     mesh: DeviceMesh, op_schema: OpSchema
 ) -> OpStrategy:
@@ -334,7 +337,10 @@ def constant_pad_nd_strategy(mesh: DeviceMesh, op_schema: OpSchema) -> OpStrateg
     )
 
 
-@register_op_strategy(aten._scaled_dot_product_efficient_attention.default)
+@register_op_strategy(
+    aten._scaled_dot_product_efficient_attention.default,
+    schema_info=RuntimeSchemaInfo(4),
+)
 def scaled_dot_product_efficient_attention_strategy(
     mesh: DeviceMesh, op_schema: OpSchema
 ) -> OpStrategy:


### PR DESCRIPTION
Fixes #134050

### The issue

The current `DTensor` sharding propagation caching policy for  `aten.scaled_dot_product_efficient_attention` (default) can result in silently incorrect gradients or trigger an IMA after cuda kernel launch in mixed `require_grad` configurations. Please see issue #134050 for a full description of the observed failure patterns along with reproduction. Note `aten.scaled_dot_product_flash_attention` presents a similar concern so this PR addresses both [as discussed here.](https://github.com/pytorch/pytorch/issues/134050#issuecomment-2299887602)


### Remediation

While there are a number of ways this could be addressed, the most straightforward remediation is to modify the sharding propagation caching policy of [`aten._scaled_dot_product_efficient_attention.default`](https://github.com/pytorch/pytorch/blob/b03381cac28ec118f710eb3e808a3c1a6391abe2/torch/distributed/_tensor/ops/_matrix_ops.py#L337-L340), registering it with `schema_info=RuntimeSchemaInfo(4)` to prevent cache sharing between differing `compute_log_sumexp` values i.e.

```python
@register_op_strategy(aten._scaled_dot_product_efficient_attention.default, schema_info=RuntimeSchemaInfo(4))
def scaled_dot_product_efficient_attention_strategy(
...
```

[As discussed here](https://github.com/pytorch/pytorch/issues/134050#issuecomment-2299887602),  since `aten::_scaled_dot_product_flash_attention` could be affected by a similar issue wrt `return_debug_mask`, this PR adjusts the sharding propagation caching policy for that op as well.


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o