### PR TITLE
torch _utils_internal: make justknobs_feature

### DIFF
--- a/test/test_utils_internal.py
+++ b/test/test_utils_internal.py
@@ -1,0 +1,122 @@
+# Owner(s): ["module: unknown"]
+
+import os
+
+from torch._utils_internal import justknobs_feature
+from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
+    load_tests,
+)
+
+
+# load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
+# sharding on sandcastle. This line silences flake warnings
+load_tests = load_tests
+
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestJustKnob(TestCase):
+    def test_justknob_feature(self):
+        with self.subTest("OSS is True"):
+            self.assertTrue(justknobs_feature("testname"))
+        with self.subTest("OSS default=True"):
+            self.assertTrue(justknobs_feature("testname", default=True))
+        with self.subTest("OSS default=False"):
+            self.assertFalse(justknobs_feature("testname", default=False))
+        with self.subTest("OSS config=True, default=False"):
+            self.assertTrue(
+                justknobs_feature("testname", config_value=True, default=False)
+            )
+        with self.subTest("OSS config=None, default=False"):
+            self.assertFalse(
+                justknobs_feature("testname", config_value=None, default=False)
+            )
+        with self.subTest("OSS config=False, default=True"):
+            self.assertFalse(
+                justknobs_feature("testname", config_value=False, default=True)
+            )
+        with self.subTest("OSS env is missing, config=False, default=True"):
+            self.assertFalse(
+                justknobs_feature(
+                    "testname", config_value=False, env_name="NOTDEFINED", default=False
+                )
+            )
+        with self.subTest("OSS env is missing, default=False"):
+            self.assertFalse(
+                justknobs_feature("testname", env_name="NOTDEFINED", default=False)
+            )
+        with self.subTest("OSS env overrides config, config=False, default=False"):
+            os.environ["FEATURE_ENV"] = "1"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+        with self.subTest("OSS env overrides default, , default=False"):
+            os.environ["FEATURE_ENV"] = "1"
+            self.assertTrue(
+                justknobs_feature("testname", env_name="FEATURE_ENV", default=False)
+            )
+        with self.subTest("OSS env truthy, config=False, default=False"):
+            os.environ["FEATURE_ENV"] = "1"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+            os.environ["FEATURE_ENV"] = "true"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+            os.environ["FEATURE_ENV"] = "TRUE"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+            os.environ["FEATURE_ENV"] = "very weird true"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+        with self.subTest("OSS env false, config=True, default=True"):
+            os.environ["FEATURE_ENV"] = "0"
+            self.assertFalse(
+                justknobs_feature(
+                    "testname", config_value=True, env_name="FEATURE_ENV", default=True
+                )
+            )
+            os.environ["FEATURE_ENV"] = "false"
+            self.assertFalse(
+                justknobs_feature(
+                    "testname", config_value=True, env_name="FEATURE_ENV", default=True
+                )
+            )
+            os.environ["FEATURE_ENV"] = "FALSE"
+            self.assertFalse(
+                justknobs_feature(
+                    "testname", config_value=True, env_name="FEATURE_ENV", default=True
+                )
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -155,6 +155,61 @@ def export_api_rollout_check() -> bool:
     return False
 
 
+def justknobs_feature(
+    name: str, config_value=None, env_name=None, default: bool = True
+):
+    """Returns whether or not a specific justknob feature is enabled.
+
+    This is a slightly higher level API then justknobs_check, designed to make it "easy" to do the right thing.
+    The primary thing it does, is allow configuration to override JK by default, while retaining some features to force this
+    the other way during sevs.
+
+    The preference order (i.e. who wins first) in OSS (and FB) is
+    - Environment Variable if specified
+    - Config is specified
+    - JK (FB), or default (OSS)
+
+
+    Quickstart
+    Have a config variable
+    Make a JK which is set to your "enabled" value (generally true).
+    Use this feature to check it (if you set the JK to be false, change the default).
+    If you have an env variable, also use the function to check it.
+
+    Arguments:
+        name - This should correspond 1:1 to a JK name internally to FB.
+        env_name - If this is set, we'll try and read the value from environment variables
+        config_value - If this is set to anything other than None, we'll use this value by
+            default. Note that within FB, there is some functionality to force override these
+            configs
+        default - This is the value to return in OSS. This avoids having to write weird double
+            negatives within justknobs and the config code, if you just want to have the
+            killswitch work by having feature return True to turn off features
+
+    Requirements:
+        Don't use this at import time - Simply pass in the existing config
+    """
+    if env_name is not None and ((env := os.getenv(env_name)) is not None):
+        env = env.upper()
+        if env in ("1", "TRUE"):
+            return True
+        if env in ("0", "FALSE"):
+            return False
+        log.error(
+            "Difficulty parsing env variable %s=%s for feature %s - Assuming env variable means true and returning True",
+            env_name,
+            env,
+            name,
+        )
+        # We could return default here, but that was confusing to log.
+        return True
+    if config_value is not None:
+        return config_value
+    if not default:
+        return not justknobs_check(name)
+    return justknobs_check(name)
+
+
 def justknobs_check(name: str) -> bool:
     """
     This function can be used to killswitch functionality in FB prod,


### PR DESCRIPTION
justknobs_feature is designed to be a more full replacement for justknobs_check, in particular, handling relatively common mistakes with env variables and config values.

Also added tests
```
(pytorch-deps) clr@clr-fedora-MJ0J4X74clr-fedora-MJ0J4X74clr-fedora-MJ0J4X74clr-fed:~/pytorch$ python test/test_utils_internal.py
E0821 15:27:15.459000 2485309 torch/_utils_internal.py:191] Difficulty parsing env variable FEATURE_ENV=VERY WEIRD TRUE for feature testname - Assuming env variable means true and returning True
.
----------------------------------------------------------------------
Ran 1 test in 0.008s

OK
```

You can use it to be as simple or complex as you want - i.e.
```
a = justknobs_feature("//foo:bar")
b = justknobs_features("//foo:bar, config_value=config.foo.bar, env_name="FORCE_FOO_BAR", default=False)
