### PR TITLE
[PyTorch Pin Memory Allocator] Optimize the free list implementation and add lock sharding

### DIFF
--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -30,19 +30,16 @@ struct HostBlock {
   ska::flat_hash_set<S> streams_; // streams on which the block was used
 };
 
-/**
- * ComparatorSize is used for lookup support in the set of host memory blocks
- * using the block size.
- */
 template <typename B>
-struct ComparatorSize {
-  bool operator()(const B* a, const B* b) const {
-    if (a->size_ != b->size_) {
-      return a->size_ < b->size_;
-    }
-    return (uintptr_t)a->ptr_ < (uintptr_t)b->ptr_;
-  }
+struct alignas(64) FreeBlockList {
+  std::mutex mutex_;
+  std::deque<B*> list_;
 };
+
+namespace {
+  // Max cached block sizes: (1 << MAX_SIZE_INDEX) bytes
+  constexpr size_t MAX_SIZE_INDEX = 64;
+}
 
 /**
  * Note [HostAllocator design]
@@ -81,8 +78,7 @@ struct ComparatorSize {
  * to abstract the caching mechanism. Any backend needs to provide a customized
  * implementation by specializing its own public functions and the related
  * runtime functions. Its template parameter S represents runtime Stream, E
- * denotes runtime Event, B indicates the fundamental memory block, and C
- * signifies the sorting compartor algorithm for the memory blocks.
+ * denotes runtime Event, B indicates the fundamental memory block.
  *
  * For the interface, we provide a CachingHostAllocatorInterface struct as an
  * interface. Any backend needs to derive its own host allocator from this
@@ -111,8 +107,7 @@ struct ComparatorSize {
 template <
     typename S,
     typename E,
-    typename B = HostBlock<S>,
-    typename C = ComparatorSize<B>>
+    typename B = HostBlock<S>>
 struct CachingHostAllocatorImpl {
   virtual ~CachingHostAllocatorImpl() = default;
 
@@ -132,6 +127,7 @@ struct CachingHostAllocatorImpl {
     }
 
     // Round up the allocation to the nearest power of two to improve reuse.
+    // These power of two sizes are also used to index into the free list.
     size_t roundSize = c10::llvm::PowerOf2Ceil(size);
     void* ptr = nullptr;
     allocate_host_memory(roundSize, &ptr);
@@ -171,8 +167,9 @@ struct CachingHostAllocatorImpl {
     }
 
     if (!events) {
-      std::lock_guard<std::mutex> g(free_list_mutex_);
-      free_list_.insert(block);
+      auto index = size_index(block->size_);
+      std::lock_guard<std::mutex> g(free_list_[index].mutex_);
+      free_list_[index].list_.push_back(block);
     } else {
       // restore these events that record by used streams.
       std::lock_guard<std::mutex> g(events_mutex_);
@@ -218,20 +215,26 @@ struct CachingHostAllocatorImpl {
 
     // Remove all elements from the free list, remove them from the blocks
     // list, and free the associated pinned memory allocation. This requires
-    // concurrently holding both the free list mutex and the blocks mutex, and
+    // concurrently holding both the free list mutexes and the blocks mutex, and
     // is the only function that concurrently holds multiple mutexes.
-    std::lock(free_list_mutex_, blocks_mutex_);
-    std::lock_guard<std::mutex> gf(free_list_mutex_, std::adopt_lock);
-    std::lock_guard<std::mutex> gb(blocks_mutex_, std::adopt_lock);
+    for (size_t i = 0; i < free_list_.size(); ++i) {
+      std::lock(free_list_[i].mutex_, blocks_mutex_);
+      std::lock_guard<std::mutex> gf(free_list_[i].mutex_, std::adopt_lock);
+      std::lock_guard<std::mutex> gb(blocks_mutex_, std::adopt_lock);
 
-    std::vector<B*> blocks_to_remove(free_list_.begin(), free_list_.end());
-    free_list_.clear();
-    for (auto* block : blocks_to_remove) {
-      blocks_.erase(block);
-      ptr_to_block_.erase(block->ptr_);
-      free_block(block);
-      delete block;
+      std::vector<B*> blocks_to_remove(free_list_[i].list_.begin(), free_list_[i].list_.end());
+      free_list_[i].list_.clear();
+      for (auto* block : blocks_to_remove) {
+        blocks_.erase(block);
+        ptr_to_block_.erase(block->ptr_);
+        free_block(block);
+        delete block;
+      }
     }
+  }
+
+  inline size_t size_index(size_t size) {
+    return c10::llvm::Log2_64_Ceil(size);
   }
 
   virtual void copy_data(void* dest [[maybe_unused]], const void* src [[maybe_unused]], std::size_t count [[maybe_unused]]) const {
@@ -246,13 +249,12 @@ struct CachingHostAllocatorImpl {
   }
 
   virtual B* get_free_block(size_t size) {
-    std::lock_guard<std::mutex> g(free_list_mutex_);
-    B key(size);
-    auto it = free_list_.lower_bound(&key);
-    if (it != free_list_.end()) {
-      B* block = *it;
+    auto index = size_index(size);
+    std::lock_guard<std::mutex> g(free_list_[index].mutex_);
+    if (free_list_[index].list_.size() > 0) {
+      B* block = free_list_[index].list_.back();
+      free_list_[index].list_.pop_back();
       block->allocated_ = true;
-      free_list_.erase(it);
       return block;
     }
     return nullptr;
@@ -304,8 +306,9 @@ struct CachingHostAllocatorImpl {
       }
 
       if (available) {
-        std::lock_guard<std::mutex> g(free_list_mutex_);
-        free_list_.insert(block);
+        auto index = size_index(block->size_);
+        std::lock_guard<std::mutex> g(free_list_[index].mutex_);
+        free_list_[index].list_.push_back(block);
       }
     }
   }
@@ -337,12 +340,11 @@ struct CachingHostAllocatorImpl {
   ska::flat_hash_set<B*> blocks_; // block list
   ska::flat_hash_map<void*, B*> ptr_to_block_;
 
-  // Note: sharding this mutex seems to be profitable in heavily multi-threaded
-  // scenarios.
-  alignas(64) std::mutex free_list_mutex_;
-  // Note: an alternative datastructure can yield significant wins here in
-  // microbenchmarks.
-  std::set<B*, C> free_list_; // free list
+  // We keep free list as a vector of free lists, one for each power of two
+  // size. This allows us to quickly find a free block of the right size.
+  // We use deque to store per size free list and guard the list with its own
+  // mutex.
+  alignas(64) std::vector<FreeBlockList<B>> free_list_ = std::vector<FreeBlockList<B>>(MAX_SIZE_INDEX);
 
   alignas(64) std::mutex events_mutex_;
   std::deque<std::pair<E, B*>> events_; // event queue paired with block


### PR DESCRIPTION
Summary: This diff addresses the lock contention issue in free list implementation of CachingHost/Pinned allocator. We add a different data structure for free list and also add lock sharding based on allocation size.

Differential Revision: D61623367
