### PR TITLE
Create a JustknobConfig for use in config

### DIFF
--- a/test/test_utils_internal.py
+++ b/test/test_utils_internal.py
@@ -2,7 +2,7 @@
 
 import os
 
-from torch._utils_internal import justknobs_feature
+from torch._utils_internal import justknobs_feature, JustKnobsConfig
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     load_tests,
 )
@@ -16,6 +16,30 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestJustKnob(TestCase):
+    def test_justknob_config(self):
+        with self.subTest("Returns True"):
+            a = JustKnobsConfig()
+            self.assertTrue(a.get())
+        with self.subTest("Returns False"):
+            a = JustKnobsConfig(name="fake_name", default=False)
+            self.assertFalse(a.get())
+        with self.subTest("Returns True via config"):
+            a = JustKnobsConfig(name="fake_name", default=False)
+            a.set(True)
+            self.assertTrue(a.get())
+        with self.subTest("Returns True via env"):
+            os.environ["FAKE_FEATURE"] = "1"
+            a = JustKnobsConfig(
+                name="fake_name", env_name="FAKE_FEATURE", default=False
+            )
+            self.assertTrue(a.get())
+        with self.subTest("Returns same value consistently"):
+            a = JustKnobsConfig(name="fake_name", default=False)
+            a.set(True)
+            self.assertTrue(a.get())
+            a.set(False)
+            self.assertTrue(a.get())
+
     def test_justknob_feature(self):
         with self.subTest("OSS is True"):
             self.assertTrue(justknobs_feature("testname"))
@@ -45,12 +69,14 @@ class TestJustKnob(TestCase):
             self.assertFalse(
                 justknobs_feature("testname", env_name="NOTDEFINED", default=False)
             )
-        with self.subTest("OSS env overrides config, config=False, default=False"):
-            os.environ["FEATURE_ENV"] = "1"
+        with self.subTest(
+            "OSS config overrides env, config=True, env=False, default=False"
+        ):
+            os.environ["FEATURE_ENV"] = "0"
             self.assertTrue(
                 justknobs_feature(
                     "testname",
-                    config_value=False,
+                    config_value=True,
                     env_name="FEATURE_ENV",
                     default=False,
                 )
@@ -65,7 +91,6 @@ class TestJustKnob(TestCase):
             self.assertTrue(
                 justknobs_feature(
                     "testname",
-                    config_value=False,
                     env_name="FEATURE_ENV",
                     default=False,
                 )
@@ -74,7 +99,6 @@ class TestJustKnob(TestCase):
             self.assertTrue(
                 justknobs_feature(
                     "testname",
-                    config_value=False,
                     env_name="FEATURE_ENV",
                     default=False,
                 )
@@ -83,7 +107,6 @@ class TestJustKnob(TestCase):
             self.assertTrue(
                 justknobs_feature(
                     "testname",
-                    config_value=False,
                     env_name="FEATURE_ENV",
                     default=False,
                 )
@@ -92,29 +115,22 @@ class TestJustKnob(TestCase):
             self.assertTrue(
                 justknobs_feature(
                     "testname",
-                    config_value=False,
                     env_name="FEATURE_ENV",
                     default=False,
                 )
             )
-        with self.subTest("OSS env false, config=True, default=True"):
+        with self.subTest("OSS env false, default=True"):
             os.environ["FEATURE_ENV"] = "0"
             self.assertFalse(
-                justknobs_feature(
-                    "testname", config_value=True, env_name="FEATURE_ENV", default=True
-                )
+                justknobs_feature("testname", env_name="FEATURE_ENV", default=True)
             )
             os.environ["FEATURE_ENV"] = "false"
             self.assertFalse(
-                justknobs_feature(
-                    "testname", config_value=True, env_name="FEATURE_ENV", default=True
-                )
+                justknobs_feature("testname", env_name="FEATURE_ENV", default=True)
             )
             os.environ["FEATURE_ENV"] = "FALSE"
             self.assertFalse(
-                justknobs_feature(
-                    "testname", config_value=True, env_name="FEATURE_ENV", default=True
-                )
+                justknobs_feature("testname", env_name="FEATURE_ENV", default=True)
             )
 
 

--- a/test/test_utils_internal.py
+++ b/test/test_utils_internal.py
@@ -1,0 +1,122 @@
+# Owner(s): ["module: unknown"]
+
+import os
+
+from torch._utils_internal import justknobs_feature
+from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
+    load_tests,
+)
+
+
+# load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
+# sharding on sandcastle. This line silences flake warnings
+load_tests = load_tests
+
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestJustKnob(TestCase):
+    def test_justknob_feature(self):
+        with self.subTest("OSS is True"):
+            self.assertTrue(justknobs_feature("testname"))
+        with self.subTest("OSS default=True"):
+            self.assertTrue(justknobs_feature("testname", default=True))
+        with self.subTest("OSS default=False"):
+            self.assertFalse(justknobs_feature("testname", default=False))
+        with self.subTest("OSS config=True, default=False"):
+            self.assertTrue(
+                justknobs_feature("testname", config_value=True, default=False)
+            )
+        with self.subTest("OSS config=None, default=False"):
+            self.assertFalse(
+                justknobs_feature("testname", config_value=None, default=False)
+            )
+        with self.subTest("OSS config=False, default=True"):
+            self.assertFalse(
+                justknobs_feature("testname", config_value=False, default=True)
+            )
+        with self.subTest("OSS env is missing, config=False, default=True"):
+            self.assertFalse(
+                justknobs_feature(
+                    "testname", config_value=False, env_name="NOTDEFINED", default=False
+                )
+            )
+        with self.subTest("OSS env is missing, default=False"):
+            self.assertFalse(
+                justknobs_feature("testname", env_name="NOTDEFINED", default=False)
+            )
+        with self.subTest("OSS env overrides config, config=False, default=False"):
+            os.environ["FEATURE_ENV"] = "1"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+        with self.subTest("OSS env overrides default, , default=False"):
+            os.environ["FEATURE_ENV"] = "1"
+            self.assertTrue(
+                justknobs_feature("testname", env_name="FEATURE_ENV", default=False)
+            )
+        with self.subTest("OSS env truthy, config=False, default=False"):
+            os.environ["FEATURE_ENV"] = "1"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+            os.environ["FEATURE_ENV"] = "true"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+            os.environ["FEATURE_ENV"] = "TRUE"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+            os.environ["FEATURE_ENV"] = "very weird true"
+            self.assertTrue(
+                justknobs_feature(
+                    "testname",
+                    config_value=False,
+                    env_name="FEATURE_ENV",
+                    default=False,
+                )
+            )
+        with self.subTest("OSS env false, config=True, default=True"):
+            os.environ["FEATURE_ENV"] = "0"
+            self.assertFalse(
+                justknobs_feature(
+                    "testname", config_value=True, env_name="FEATURE_ENV", default=True
+                )
+            )
+            os.environ["FEATURE_ENV"] = "false"
+            self.assertFalse(
+                justknobs_feature(
+                    "testname", config_value=True, env_name="FEATURE_ENV", default=True
+                )
+            )
+            os.environ["FEATURE_ENV"] = "FALSE"
+            self.assertFalse(
+                justknobs_feature(
+                    "testname", config_value=True, env_name="FEATURE_ENV", default=True
+                )
+            )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -155,6 +155,61 @@ def export_api_rollout_check() -> bool:
     return False
 
 
+def justknobs_feature(
+    name: str, config_value=None, env_name=None, default: bool = True
+):
+    """Returns whether or not a specific justknob feature is enabled.
+
+    This is a slightly higher level API then justknobs_check, designed to make it "easy" to do the right thing.
+    The primary thing it does, is allow configuration to override JK by default, while retaining some features to force this
+    the other way during sevs.
+
+    The preference order (i.e. who wins first) in OSS (and FB) is
+    - Environment Variable if specified
+    - Config is specified
+    - JK (FB), or default (OSS)
+
+
+    Quickstart
+    Have a config variable
+    Make a JK which is set to your "enabled" value (generally true).
+    Use this feature to check it (if you set the JK to be false, change the default).
+    If you have an env variable, also use the function to check it.
+
+    Arguments:
+        name - This should correspond 1:1 to a JK name internally to FB.
+        env_name - If this is set, we'll try and read the value from environment variables
+        config_value - If this is set to anything other than None, we'll use this value by
+            default. Note that within FB, there is some functionality to force override these
+            configs
+        default - This is the value to return in OSS. This avoids having to write weird double
+            negatives within justknobs and the config code, if you just want to have the
+            killswitch work by having feature return True to turn off features
+
+    Requirements:
+        Don't use this at import time - Simply pass in the existing config
+    """
+    if env_name is not None and ((env := os.getenv(env_name)) is not None):
+        env = env.upper()
+        if env in ("1", "TRUE"):
+            return True
+        if env in ("0", "FALSE"):
+            return False
+        log.error(
+            "Difficulty parsing env variable %s=%s for feature %s - Assuming env variable means true and returning True",
+            env_name,
+            env,
+            name,
+        )
+        # We could return default here, but that was confusing to log.
+        return True
+    if config_value is not None:
+        return config_value
+    if not default:
+        return not justknobs_check(name)
+    return justknobs_check(name)
+
+
 def justknobs_check(name: str) -> bool:
     """
     This function can be used to killswitch functionality in FB prod,


### PR DESCRIPTION
This is designed to be a more ergonomic interface on top of justknob_feature (see https://github.com/pytorch/pytorch/pull/134151 for just the PR with the base commits).

The idea is that people stop having to think about this as much, and can just do JustkobsConfig("//the:thing", "FORCE_THING") and it'll do the right thing.

Primarily sending this to see how people feel about the API, and using it for new config changes.