### PR TITLE
Re-enable skipped compiled autograd eager tests

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -2477,8 +2477,8 @@ known_failures_re = re.compile(
 skipped_tests = {
     # These test unconventional usage of saved tensor hooks do not leak or crash
     # Running these tests succeed, but somehow cause other tests to fail
-    "test_saved_tensor_hooks_extra_exit_during_bw_no_crash",
-    "test_saved_tensor_hooks_extra_enter_during_bw_no_leak",
+    # "test_saved_tensor_hooks_extra_exit_during_bw_no_crash",
+    # "test_saved_tensor_hooks_extra_enter_during_bw_no_leak",
 }
 
 known_failing_tests = {


### PR DESCRIPTION
Originally disabled in: https://github.com/pytorch/pytorch/pull/131700#discussion_r1727153445, but the failure is no longer in CI

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #134361
* __->__ #134163
* #134162
* #134290
* #134286
* #134205
* #134200
* #134186



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang