### PR TITLE
[wip/rfc][dynamo] Flag to skip all guards

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -374,6 +374,11 @@ enable_cpp_guard_manager = os.environ.get("TORCHDYNAMO_CPP_GUARD_MANAGER", "1") 
 # Inline inbuilt nn modules
 inline_inbuilt_nn_modules = not is_fbcode()
 
+# Skips all guards, thereby removing the guard eval overhead. This should be used for debugging purposes or when the
+# user is completely sure that there will not be any recompilations for the compiled objects. Using it incorrectly can
+# lead to crashes or worse silent incorrectness bugs.
+unsafe_skip_all_guards = True
+
 
 def default_debug_dir_root():
     # [@compile_ignored: debug]

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -377,7 +377,7 @@ inline_inbuilt_nn_modules = not is_fbcode()
 # Skips all guards, thereby removing the guard eval overhead. This should be used for debugging purposes or when the
 # user is completely sure that there will not be any recompilations for the compiled objects. Using it incorrectly can
 # lead to crashes or worse silent incorrectness bugs.
-unsafe_skip_all_guards = True
+unsafe_skip_all_guards = False
 
 
 def default_debug_dir_root():

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2848,10 +2848,19 @@ def install_guard(*guards, skip=0):
     """
     from torch._guards import TracingContext
 
-    collect_debug_stack = guards_log.isEnabledFor(
-        logging.DEBUG
-    ) or verbose_guards_log.isEnabledFor(logging.DEBUG)
-    add = TracingContext.get().guards_context.dynamo_guards.add
-    for guard in guards:
-        assert isinstance(guard, Guard)
-        add(guard, collect_debug_stack=collect_debug_stack, skip=skip + 1)
+    if not config.unsafe_skip_all_guards:
+        collect_debug_stack = guards_log.isEnabledFor(
+            logging.DEBUG
+        ) or verbose_guards_log.isEnabledFor(logging.DEBUG)
+        add = TracingContext.get().guards_context.dynamo_guards.add
+        for guard in guards:
+            assert isinstance(guard, Guard)
+            add(guard, collect_debug_stack=collect_debug_stack, skip=skip + 1)
+    else:
+        torch._dynamo.utils.warn_once(
+            "torch._dynamo.config.unsafe_skip_all_guards is set to True. This will skip "
+            "adding any guard on the Dynamo graphs. This is unsafe and should only be used "
+            "for debugging purposes. Or when the user is sure that there is only one graph "
+            "and there are no more recompilations possible. Using it incorrectly can lead "
+            "to crashes or silent bugs."
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134174
* #134181
* #134039
* #134016
* #133742

This is a requested feature by the users. What i have seen is users want something like `export` but not really `export`. They want the user friendliness of torch.compile but tight control over the fixed overheads.

The users are aware of the risks here and the responsibility/danger that comes with this flag. 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec