### PR TITLE
[CI][dashboard] Disable USE_MKLDNN_ACL for aarch64

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -98,11 +98,11 @@ else
   fi
 fi
 
-if [[ "$BUILD_ENVIRONMENT" == *aarch64* ]]; then
-  export USE_MKLDNN=1
-  export USE_MKLDNN_ACL=1
-  export ACL_ROOT_DIR=/ComputeLibrary
-fi
+# if [[ "$BUILD_ENVIRONMENT" == *aarch64* ]]; then
+  # export USE_MKLDNN=1
+  # export USE_MKLDNN_ACL=1
+  # export ACL_ROOT_DIR=/ComputeLibrary
+# fi
 
 if [[ "$BUILD_ENVIRONMENT" == *libtorch* ]]; then
   POSSIBLE_JAVA_HOMES=()

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -698,10 +698,12 @@ test_inductor_get_core_number() {
 
 test_inductor_set_cpu_affinity(){
   #set jemalloc
+  JEMALLOC_LIB="$(find /usr/lib -name libjemalloc.so.2)"
+  export LD_PRELOAD="$JEMALLOC_LIB":"$LD_PRELOAD"
   if [[ "${TEST_CONFIG}" != *aarch64* ]]; then
-    JEMALLOC_LIB="$(find /usr/lib -name libjemalloc.so.2)"
+    # Use Intel OpenMP for x86
     IOMP_LIB="$(dirname "$(which python)")/../lib/libiomp5.so"
-    export LD_PRELOAD="$JEMALLOC_LIB":"$IOMP_LIB":"$LD_PRELOAD"
+    export LD_PRELOAD="$IOMP_LIB":"$LD_PRELOAD"
     export MALLOC_CONF="oversize_threshold:1,background_thread:true,metadata_thp:auto,dirty_decay_ms:-1,muzzy_decay_ms:-1"
     export KMP_AFFINITY=granularity=fine,compact,1,0
     export KMP_BLOCKTIME=1


### PR DESCRIPTION
Summary: This likely caused a slow/unstable dashboard run on aarch64.
