### PR TITLE
[XPU] Fix patch for old llvm package error for triton xpu

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -54,13 +54,19 @@ def patch_init_py(
 def patch_setup_py(path: Path) -> None:
     with open(path) as f:
         orig = f.read()
-    orig = check_and_replace(
-        orig,
-        "https://tritonlang.blob.core.windows.net/llvm-builds/",
-        "https://oaitriton.blob.core.windows.net/public/llvm-builds/",
-    )
-    with open(path, "w") as f:
-        f.write(orig)
+    try:
+        orig = check_and_replace(
+            orig,
+            "https://tritonlang.blob.core.windows.net/llvm-builds/",
+            "https://oaitriton.blob.core.windows.net/public/llvm-builds/",
+        )
+        with open(path, "w") as f:
+            f.write(orig)
+    except RuntimeError as e:
+        print(
+            f"Applying patch_setup_py() for llvm-build package failed: {e}.",
+            "If you are trying to build a newer version of Triton, you can ignore this.",
+        )
 
 
 def build_triton(
@@ -105,8 +111,7 @@ def build_triton(
             check_call(["git", "checkout", commit_hash], cwd=triton_basedir)
 
         # TODO: remove this and patch_setup_py() once we have a proper fix for https://github.com/triton-lang/triton/issues/4527
-        if device not in ["xpu"]:
-            patch_setup_py(triton_pythondir / "setup.py")
+        patch_setup_py(triton_pythondir / "setup.py")
 
         if build_conda:
             with open(triton_basedir / "meta.yaml", "w") as meta:

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -105,7 +105,8 @@ def build_triton(
             check_call(["git", "checkout", commit_hash], cwd=triton_basedir)
 
         # TODO: remove this and patch_setup_py() once we have a proper fix for https://github.com/triton-lang/triton/issues/4527
-        patch_setup_py(triton_pythondir / "setup.py")
+        if device not in ["xpu"]:
+            patch_setup_py(triton_pythondir / "setup.py")
 
         if build_conda:
             with open(triton_basedir / "meta.yaml", "w") as meta:


### PR DESCRIPTION
Fixes #134199

The PR #133694 does a workaround to replace the str `"https://tritonlang.blob.core.windows.net/llvm-builds/"` with  `"https://oaitriton.blob.core.windows.net/public/llvm-builds/"` in `triton/python/setup.py`. However, in [newer version of Triton](https://github.com/triton-lang/triton/commit/06e6799f4eba6035ec35c528e8fefd3d4d724b6f), it has already been changed to `"https://oaitriton.blob.core....` and don't need to be replaced.  But formerly, this will throw a runtime error.

This PR makes the `check_and_replace` logic won't fail in such a scenario. Both the old link and the newer link could work.

Also note that the `.ci/docker/common/install_triton.sh` does not need the fix, because its `sed` command won't be in effect if there is no such pattern. 



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @EikanWang @fengyuan14 @guangyey