### PR TITLE
[DTensor] Add aten.any.default,dim,out to linear_reduction_strategy

### DIFF
--- a/test/distributed/_tensor/test_math_ops.py
+++ b/test/distributed/_tensor/test_math_ops.py
@@ -26,6 +26,10 @@ class DistMathOpsTest(DTensorTestBase):
         shard_spec = [Shard(0)]
 
         tensor = torch.randn(12, 8, 8)
+        # TODO: check `all` correctness and test `all` on a bool tensor
+        if op_str in ("any"):
+            # test out a bool tensor for any
+            tensor = tensor < 0
         dtensor = distribute_tensor(tensor, device_mesh, shard_spec)
 
         op = getattr(tensor, op_str)
@@ -51,7 +55,7 @@ class DistMathOpsTest(DTensorTestBase):
 
     @with_comms
     def test_linear_op_reductions(self):
-        for op_str in ("all", "sum", "prod", "max", "min"):
+        for op_str in ("all", "sum", "prod", "max", "min", "any"):
             self.linear_op_reductions(op_str)
 
     @with_comms

--- a/torch/distributed/_tensor/ops/_math_ops.py
+++ b/torch/distributed/_tensor/ops/_math_ops.py
@@ -320,6 +320,9 @@ LINEAR_REDUCTION_OP_MAP = {
     aten.min.default: "min",
     aten.min.dim: "min",
     aten.min.out: "min",
+    aten.any.default: "sum",
+    aten.any.dim: "sum",
+    aten.any.out: "sum",
 }
 
 


### PR DESCRIPTION
For `aten.any`, we can use `reduce_op="sum"` as the linear reduction op. 

When we do `all_reduce` with `reduce_op="sum"` on bool tensor, if one rank returns `torch.Tensor([True]) `, then the reduction result is `torch.Tensor([True]) `. Only when all ranks return `torch.Tensor([False]) ` would the reduction result be `torch.Tensor([False]) `. This matches with `any`'s behavior.



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @tianyu-l