### PR TITLE
Runtime Estimator for estimating GPU compute time

### DIFF
--- a/test/distributed/_tools/test_runtime_estimator.py
+++ b/test/distributed/_tools/test_runtime_estimator.py
@@ -135,7 +135,7 @@ class TestRuntimeEstimator(TestCase):
     ):
         """Runs a basic GPT-2 model"""
         vocab_size = 8192
-        bsz, seq_len = 64, 1024
+        bsz, seq_len = 8, 1024
         model_args = ModelArgs(
             n_layers=4,
             n_heads=12,
@@ -147,7 +147,6 @@ class TestRuntimeEstimator(TestCase):
 
         args = self._init_model_and_args("Transformer", model_args, bsz)
         actual_runtime = self._measure_actual_cuda_time(self._train_step, args)
-
         with FakeTensorMode():
             fake_args = self._init_model_and_args("Transformer", model_args, bsz)
             benchmark_estimate = self._runtime_estimate(
@@ -176,7 +175,6 @@ class TestRuntimeEstimator(TestCase):
         model_args = ConvArgs(img_sz, num_classes)
         args = self._init_model_and_args("CNN", model_args, bsz)
         actual_runtime = self._measure_actual_cuda_time(self._train_step, args)
-        print(torch.cuda.max_memory_allocated())
         with FakeTensorMode():
             fake_args = self._init_model_and_args("CNN", model_args, bsz)
             benchmark_estimate = self._runtime_estimate(

--- a/test/distributed/_tools/test_runtime_estimator.py
+++ b/test/distributed/_tools/test_runtime_estimator.py
@@ -1,0 +1,176 @@
+# Owner(s): ["module: unknown"]
+import unittest
+from dataclasses import dataclass
+from typing import Any, Callable, cast, Tuple, Union
+
+import torch
+from torch import nn, optim
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.distributed._tools.runtime_estimator import RuntimeEstimator
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    ModelArgs,
+    Transformer,
+)
+
+
+@dataclass
+class ConvArgs:
+    image_size: int
+    num_classes: int
+
+
+class SimpleCNN(nn.Module):
+    def __init__(self, conv_args: ConvArgs):
+        super().__init__()
+        image_size = conv_args.image_size
+        num_classes = conv_args.num_classes
+        self.image_size = image_size
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(64, 128, kernel_size=5)
+        self.conv3 = nn.Conv2d(128, 256, kernel_size=3)
+        self.conv4 = nn.Conv2d(256, 512, kernel_size=3)
+        self.fc1_size = self._calculate_fc1_size()
+        self.fc1 = nn.Linear(self.fc1_size, 1024)
+        self.fc2 = nn.Linear(1024, 512)
+        self.fc3 = nn.Linear(512, num_classes)
+
+    def _calculate_fc1_size(self):
+        size = self.image_size
+        size = (size - 5 + 1) // 2  # conv1 and pool
+        size = (size - 5 + 1) // 2  # conv2 and pool
+        size = size - 3 + 1  # conv3
+        size = (size - 3 + 1) // 2  # conv4 and pool
+        return 512 * size * size
+
+    def forward(self, x):
+        x = self.pool(nn.functional.relu(self.conv1(x)))
+        x = self.pool(nn.functional.relu(self.conv2(x)))
+        x = nn.functional.relu(self.conv3(x))
+        x = self.pool(nn.functional.relu(self.conv4(x)))
+        x = x.view(-1, self.fc1_size)
+        x = nn.functional.relu(self.fc1(x))
+        x = nn.functional.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+
+class TestRuntimeEstimator(TestCase):
+    def _train_step(
+        self,
+        model: nn.Module,
+        optimizer: optim.Optimizer,
+        inp: torch.Tensor,
+    ):
+        out = model(inp)
+        loss = out.sum()
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+
+    def _measure_actual_cuda_time(
+        self,
+        func: Callable,
+        args: Tuple[Any, ...],
+    ) -> float:
+        num_iters = 5
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        for _ in range(num_iters):
+            func(*args)
+        end_event.record()
+        torch.cuda.synchronize()
+        measured_time = start_event.elapsed_time(end_event) / num_iters
+        return measured_time
+
+    def _runtime_estimate(
+        self,
+        estimate_mode: str,
+        func: Callable,
+        args: Tuple[Any, ...],
+    ) -> float:
+        runtime_estimator = RuntimeEstimator()
+        with runtime_estimator(estimate_mode_type=estimate_mode):
+            func(*args)
+        return runtime_estimator.total_runtime
+
+    def _init_model_and_args(
+        self,
+        model_type: str,
+        model_args: Union[ConvArgs, ModelArgs],
+        bsz: int,
+    ) -> Tuple[nn.Module, optim.Optimizer, torch.Tensor]:
+        if model_type == "Transformer":
+            model_args = cast(ModelArgs, model_args)
+            model = Transformer(model_args)
+            optimizer = optim.Adam(model.parameters(), lr=1e-2)
+            inp = torch.randint(0, model_args.vocab_size, (bsz, model_args.max_seq_len))
+        elif model_type == "CNN":
+            model_args = cast(ConvArgs, model_args)
+            model = SimpleCNN(model_args)
+            optimizer = optim.SGD(model.parameters(), lr=1e-2)
+            inp = torch.randn(bsz, 3, model_args.image_size, model_args.image_size)
+        else:
+            raise NotImplementedError("Only Transformer and CNN is supported")
+        return (model, optimizer, inp)
+
+    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_transformer_runtime(
+        self,
+    ):
+        dev = torch.cuda.current_device()
+        vocab_size = 8192
+        bsz, seq_len = 32, 1024
+        model_args = ModelArgs(
+            n_layers=2,
+            n_heads=16,
+            vocab_size=vocab_size,
+            max_seq_len=seq_len,
+            dropout_p=0.1,
+        )
+        with torch.device(dev):
+            args = self._init_model_and_args("Transformer", model_args, bsz)
+            actual_runtime = self._measure_actual_cuda_time(self._train_step, args)
+
+            with FakeTensorMode():
+                fake_args = self._init_model_and_args("Transformer", model_args, bsz)
+                estimated_runtime = self._runtime_estimate(
+                    "operator-level-cost-model", self._train_step, fake_args
+                )
+        accuracy = actual_runtime / estimated_runtime
+        print(
+            f"Actual: {actual_runtime} Estimated: {estimated_runtime} Accuracy: {accuracy}"
+        )
+        self.assertAlmostEqual(accuracy, 1.0, delta=0.15)
+
+    @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_conv_model_runtime(
+        self,
+    ):
+        dev = torch.cuda.current_device()
+        num_classes = 10
+        bsz, img_sz = 32, 224
+        model_args = ConvArgs(img_sz, num_classes)
+        with torch.device(dev):
+            args = self._init_model_and_args("CNN", model_args, bsz)
+            actual_runtime = self._measure_actual_cuda_time(self._train_step, args)
+
+            with FakeTensorMode():
+                fake_args = self._init_model_and_args("CNN", model_args, bsz)
+                estimated_runtime = self._runtime_estimate(
+                    "operator-level-cost-model", self._train_step, fake_args
+                )
+        accuracy = actual_runtime / estimated_runtime
+        print(
+            f"Actual: {actual_runtime} Estimated: {estimated_runtime} Accuracy: {accuracy}"
+        )
+        self.assertAlmostEqual(accuracy, 1.0, delta=0.15)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/_tools/test_runtime_estimator.py
+++ b/test/distributed/_tools/test_runtime_estimator.py
@@ -171,12 +171,12 @@ class TestRuntimeEstimator(TestCase):
         self,
     ):
         """Runs a simple CNN model"""
-        num_classes = 1024
-        bsz, img_sz = 256, 512
+        num_classes = 100
+        bsz, img_sz = 256, 128
         model_args = ConvArgs(img_sz, num_classes)
         args = self._init_model_and_args("CNN", model_args, bsz)
         actual_runtime = self._measure_actual_cuda_time(self._train_step, args)
-
+        print(torch.cuda.max_memory_allocated())
         with FakeTensorMode():
             fake_args = self._init_model_and_args("CNN", model_args, bsz)
             benchmark_estimate = self._runtime_estimate(

--- a/torch/distributed/_tools/__init__.py
+++ b/torch/distributed/_tools/__init__.py
@@ -2,3 +2,4 @@ from .fsdp2_mem_tracker import FSDPMemTracker
 from .mem_tracker import MemTracker
 from .memory_tracker import MemoryTracker
 from .mod_tracker import ModTracker
+from .runtime_estimator import RuntimeEstimator

--- a/torch/distributed/_tools/runtime_estimator.py
+++ b/torch/distributed/_tools/runtime_estimator.py
@@ -394,7 +394,7 @@ class RuntimeEstimator(TorchDispatchMode):
         out = func(*args, **kwargs)
         op_time = 0.0
         func_packet = func._overloadpacket
-        if func_packet not in _VIEW_OPS:
+        if func_packet not in _IGNORE_OPS:
             flat_args_kwargs, args_spec = pytree.tree_flatten((args, kwargs))
             flat_outs, out_spec = pytree.tree_flatten(out)
             transfer_time = get_transfer_time(flat_args_kwargs, flat_outs)

--- a/torch/distributed/_tools/runtime_estimator.py
+++ b/torch/distributed/_tools/runtime_estimator.py
@@ -1,0 +1,464 @@
+import time
+from collections import defaultdict
+from typing import Any, Callable, Dict, List, Set
+
+import torch
+import torch.utils._pytree as pytree
+from torch._guards import active_fake_mode
+from torch._inductor.utils import get_device_tflops, get_gpu_dram_gbps
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.distributed._tools.mod_tracker import ModTracker
+from torch.utils._mode_utils import no_dispatch
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils.flop_counter import flop_registry
+from typing_extensions import Self
+
+aten = torch.ops.aten
+
+# No fall-back kernel needed/exists for view ops
+_VIEW_OPS = {
+    aten.lift_fresh,
+    aten.t,
+    aten.transpose,
+    aten.view,
+    aten.detach,
+    aten._unsafe_view,
+    aten.split,
+    aten.adjoint,
+    aten.as_strided,
+    aten.diagonal,
+    aten.expand,
+    aten.expand_as,
+    aten.movedim,
+    aten.permute,
+    aten.select,
+    aten.squeeze,
+    aten.mT,
+    aten.mH,
+    aten.real,
+    aten.imag,
+    aten.view_as,
+    aten.unflatten,
+    aten.unfold,
+    aten.unbind,
+    aten.unsqueeze,
+    aten.vsplit,
+    aten.hsplit,
+    aten.split_with_sizes,
+    aten.swapaxes,
+    aten.swapdims,
+    aten.chunk,
+}
+# We can ignore benchmarking tensor create ops
+_CREATE_OPS = {
+    aten.randint,
+    aten.randn,
+    aten.rand,
+    aten.randn_like,
+    aten.rand_like,
+    aten.randint_like,
+    aten.arange,
+    aten.ones_like,
+    aten.zeros_like,
+}
+
+_IGNORE_OPS = _VIEW_OPS | _CREATE_OPS
+
+__all__ = ["RuntimeEstimator"]
+
+
+class RuntimeEstimator(TorchDispatchMode):
+    """
+    Estimates the GPU runtime in milliseconds using various estimation methods under the ``FakeTensorMode``.
+
+    This class provides a ``TorchDispatchMode`` based context manager that can be used to estimate the eager
+    runtime of PyTorch functions. It supports two estimation modes, benchmarking (`operator-level-benchmark`) and
+    roofline cost modeling (`operator-level-cost-model`).
+    For modules executed under this context manager, it agggregates the forward and backward operation runtimes
+    and also records their execution orders.
+
+    Attributes:
+        mod_runtimes (Dict[str, Dict[str, float]]): A dictionary of module runtimes. The key to the outer dictionary
+            is the fully qualified name (FQN) of the module. For each module the forward and backward runtimes of the
+            operations are aggregated in the inner dictionary keyed by 'fw' and 'bw'.
+        mod_fw_pre_order (List[str]): List of module FQNs in pre-forward execution order.
+        mod_bw_pre_order (List[str]): List of module FQNs in pre-backward execution order.
+        mod_fw_post_order (List[str]): List of module FQNs in post-forward execution order.
+        mod_bw_post_order (List[str]): List of module FQNs in post-backward execution order.
+        total_runtime (float): The total estimated runtime in milliseconds.
+
+    Note:
+        1) The benchmarking estimate mode will execute kernels on GPU and assumes that every operation can run in
+            isolation with causing an OOM. It is also designed to be used under ``FakeTensorMode``.
+        2) Currently wrapper tensor sub-classes such as ``DTensor`` won't produce correct estimates. We plan to support
+            them in future PRs.
+        3) We only estimate the compute time, if your code has communication, it will not be considered. Again, we will
+            support this in future PRs.
+
+    Example usage:
+
+        .. code-block:: python
+
+            runtime_estimator = RuntimeEstimator()
+            with FakeTensorMode():
+                module = ...
+                optimizer = ...
+                inp = ...
+                with runtime_estimator(estimate_mode_type="operator-level-cost-model"):
+                    loss = module(inp)
+                    loss.backward()
+                    optimizer.step()
+                    optimizer.zero_grad()
+                runtime_estimator.display_modulewise_stats()
+    """
+
+    _gpu_memory_bandwidth = get_gpu_dram_gbps()
+    _float_types: Set[torch.dtype] = {
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float64,
+    }
+    _no_fallback_kernel: Set[torch._ops._OpNamespace] = set()
+    fake_mode: FakeTensorMode
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._estimate: Callable
+        self._estimate_mode_type: str
+        self._mod_tracker = ModTracker()
+        self.mod_runtimes: Dict[str, Dict[str, float]] = defaultdict(
+            lambda: defaultdict(lambda: 0.0)
+        )
+        self.mod_fw_pre_order: List[str] = []
+        self.mod_bw_pre_order: List[str] = []
+        self.mod_fw_post_order: List[str] = []
+        self.mod_bw_post_order: List[str] = []
+        self.total_runtime: float = 0.0
+
+    # Adapted from: https://github.com/pytorch/pytorch/blob/9b902b3ee3bd608a19543362b66bf06c373dd374/torch/_subclasses/fake_tensor.py#L1969  # noqa
+    # NB: returns fake tensors
+    @classmethod
+    def _maybe_run_and_benchmark_fallback_kernel(  # type: ignore[no-untyped-def]
+        cls,
+        func,
+        args,
+        kwargs,
+        orig_not_implemented_exception,
+    ):
+        """
+        Runs and benchmarks a fallback kernel for a given function.
+
+        Args:
+            func (Callable): The function to benchmark.
+            args (Tuple): The arguments to pass to the function.
+            kwargs (Dict[str, Any]): The keyword arguments to pass to the function.
+            orig_not_implemented_exception (Exception): The original exception to raise if the fallback kernel
+                is not implemented.
+
+        Returns:
+            Tuple[Any, float]: A tuple containing the result of the function and the mean operation time.
+        """
+        # these should all be supported, just to be safe
+        # avoid fallback for operators which inplace modify metadata
+        # because the input fake tensors would be umodified
+        if torch.Tag.inplace_view in func.tags:  # type: ignore[attr-defined]
+            raise orig_not_implemented_exception
+
+        inp_impls = {}
+        flat_args, args_spec = pytree.tree_flatten((args, kwargs))
+        # Don't use in_kernel_invocation_manager(fake_mode) as we want to do
+        # REAL compute (not with meta device)
+        with no_dispatch():
+
+            def to_real_tensor(e):
+                if cls.fake_mode.is_our_fake(e):
+                    if e.dtype in cls._float_types:
+                        out = torch.rand_like(e, device=e.fake_device)
+                    else:
+                        out = torch.ones_like(e, device=e.fake_device)
+                    if e.is_sparse:
+                        out._coalesced_(e.is_coalesced())
+                    inp_impls[id(out)] = e
+                    return out
+                return e
+
+            flat_args = [to_real_tensor(a) for a in flat_args]
+            args, kwargs = pytree.tree_unflatten(flat_args, args_spec)
+            r = func(*args, **kwargs)
+            num_iters = 5
+            start_events = [
+                torch.cuda.Event(enable_timing=True) for _ in range(num_iters)
+            ]
+            end_events = [
+                torch.cuda.Event(enable_timing=True) for _ in range(num_iters)
+            ]
+            cpu_start = time.time()
+            for i in range(num_iters):
+                start_events[i].record(torch.cuda.current_stream())
+                func(*args, **kwargs)
+                end_events[i].record(torch.cuda.current_stream())
+            cpu_end = time.time()
+            torch.cuda.synchronize()
+            cpu_time = (cpu_end - cpu_start) / 1000
+            total_op_time = sum(
+                (
+                    start_events[i].elapsed_time(end_events[i])
+                    for i in range(2, num_iters)
+                )
+            )
+            mean_op_time = (total_op_time - cpu_time) / num_iters
+
+        storages = set()
+
+        for e in flat_args:
+            if isinstance(e, torch.Tensor):
+                if not e.is_sparse:
+                    storages.add(e._typed_storage()._cdata)
+
+        # TODO: also check metadata change on inputs
+        # proper aliasing/metadata relationship between outputs and inputs will
+        # not be set up, bc of conversion to device, unless we can reuse an
+        # input impl
+
+        def map_out(e):
+            if id(e) not in inp_impls and (
+                isinstance(e, torch.Tensor)
+                and not e.is_sparse
+                and e._typed_storage()._cdata in storages
+            ):
+                raise orig_not_implemented_exception
+
+            if isinstance(e, torch.Tensor):
+                if id(e) in inp_impls:
+                    return inp_impls[id(e)]
+                else:
+                    return cls.fake_mode.fake_tensor_converter.from_real_tensor(
+                        cls.fake_mode, e
+                    )
+            else:
+                return e
+
+        return (pytree.tree_map(map_out, r), mean_op_time)
+
+    @classmethod
+    def _benchmark_estimate(cls, func, args, kwargs, res) -> float:  # type: ignore[no-untyped-def]
+        """
+        Estimates the runtime of a function using benchmarking.
+
+        Args:
+            func: The function to estimate.
+            args: The arguments to pass to the function.
+            kwargs: The keyword arguments to pass to the function.
+            res: The result of the function.
+
+        Returns:
+            float: The estimated runtime of the function in seconds.
+        """
+        assert isinstance(
+            cls.fake_mode, FakeTensorMode
+        ), "Initialize/Assign FakeTensorMode before using this function"
+        mean_op_time = 0.0
+        if func._overloadpacket not in _IGNORE_OPS:
+            try:
+                res, mean_op_time = cls._maybe_run_and_benchmark_fallback_kernel(
+                    func,
+                    args,
+                    kwargs,
+                    NotImplementedError,
+                )
+                return mean_op_time
+            except NotImplementedError:
+                cls._no_fallback_kernel.add(func._overloadpacket)
+        return mean_op_time
+
+    # Adapted from: https://github.com/pytorch/pytorch/blob/9b902b3ee3bd608a19543362b66bf06c373dd374/torch/_inductor/scheduler.py#L589  # noqa
+    @classmethod
+    def _roofline_estimate(cls, func, args, kwargs, out) -> float:  # type: ignore[no-untyped-def]
+        """
+        Estimates the runtime of a function using a roofline cost model.
+
+        Args:
+            func: The function to estimate.
+            args: The arguments to pass to the function.
+            kwargs: The keyword arguments to pass to the function.
+            out: The output of the function.
+
+        Returns:
+            float: The estimated runtime of the function in seconds.
+        """
+
+        def get_num_bytes(t: torch.Tensor) -> int:
+            st = t.untyped_storage()
+            num_bytes = st.size() * st.element_size()
+            return num_bytes
+
+        def get_compute_time(func_packet, args, kwargs, out, out_dtypes):
+            if func_packet in flop_registry:
+                assert (
+                    len(out_dtypes) == 1
+                ), f"Only support single out dtype got {out_dtypes} for {func_packet}"
+                dtype = out_dtypes.pop()
+                # We can expect to achieve 75% of theoretical peak flops
+                factor = 0.75
+                # This actually gives peta-FLOPs/s hence multiply by 1e15
+                # instead of 1e12 to get the FLOPs/s
+                gpu_flops = get_device_tflops(dtype) * 1e15
+                flop_count_func = flop_registry[func_packet]
+                # We divide by a factor of 2 to get the MACs
+                # (multiply and accumulate)
+                flop_count = flop_count_func(*args, **kwargs, out_val=out) / 2
+                # We multiply by 1e9 to get the time in nano seconds
+                compute_time = (flop_count / (factor * gpu_flops)) * 1e9
+                return compute_time
+            return 0.0
+
+        def get_transfer_time(flat_args_kwargs, flat_outs):
+            read_bytes = sum(
+                get_num_bytes(t)
+                for t in flat_args_kwargs
+                if isinstance(t, torch.Tensor)
+            )
+            write_bytes = sum(
+                get_num_bytes(t) for t in flat_outs if isinstance(t, torch.Tensor)
+            )
+            counted_bytes = read_bytes + write_bytes
+            # The GPU memory bandwidth is in GB/s so the transfer time
+            # is in nano seconds
+            transfer_time = counted_bytes / cls._gpu_memory_bandwidth
+            return transfer_time
+
+        op_time = 0.0
+        func_packet = func._overloadpacket
+        if func_packet not in _VIEW_OPS:
+
+            flat_args_kwargs, args_spec = pytree.tree_flatten((args, kwargs))
+            flat_outs, out_spec = pytree.tree_flatten(out)
+            transfer_time = get_transfer_time(flat_args_kwargs, flat_outs)
+
+            out_dtypes = {
+                t.dtype
+                for t in flat_outs
+                if isinstance(t, torch.Tensor) and t.dtype in cls._float_types
+            }
+
+            args, kwargs = pytree.tree_unflatten(flat_args_kwargs, args_spec)
+            out = pytree.tree_unflatten(flat_outs, out_spec)
+
+            compute_time = get_compute_time(func_packet, args, kwargs, out, out_dtypes)
+            # We get the estimated time as the max of the transfer time and
+            # compute time. We divide by 1e6 to get the time in ms
+            op_time = max(transfer_time, compute_time) / 1e6
+
+        return op_time
+
+    def display_modulewise_stats(self, depth: int = 2):
+        """
+        Displays module-wise statistics collected by ``RuntimeEstimator``.
+
+        Prints the pre-forward and pre-backward execution orders.
+        Displays the module-wise forward and backward runtimes in milliseconds.
+
+        Args:
+            depth (int): The maximum depth of module hierarchy to display (default to 2).
+        """
+        print("Pre-Forward Execution Order: ")
+        for mod_fqn in self.mod_fw_pre_order:
+            mod_depth = mod_fqn.count(".") + 1
+            if mod_depth > depth:
+                continue
+            print(mod_fqn)
+        print("Pre-Backward Execution Order: ")
+        for mod_fqn in self.mod_bw_pre_order:
+            mod_depth = mod_fqn.count(".") + 1
+            if mod_depth > depth:
+                continue
+            print(mod_fqn)
+        for mod_fqn, runtimes in self.mod_runtimes.items():
+            mod_depth = mod_fqn.count(".") + 1
+            if mod_depth > depth:
+                continue
+            print(
+                f"{mod_fqn} fw: {runtimes.get('fw', 0.0):.3f}ms bw: {runtimes.get('bw', 0.0):.3f}ms"
+            )
+
+    def __torch_dispatch__(self, func, types, args=..., kwargs=None):  # type: ignore[no-untyped-def]
+        res = func(*args, **kwargs or {})
+        # FIXME: @sanketpurandare: flatten tensors by desugaring the tensor subclasses
+        op_time = self._estimate(func, args, kwargs, res)
+        for par in self._mod_tracker.parents:
+            if self._mod_tracker.is_bw:
+                self.mod_runtimes[par]["bw"] += op_time
+            else:
+                self.mod_runtimes[par]["fw"] += op_time
+        self.total_runtime += op_time
+        return res
+
+    def __call__(self, estimate_mode_type: str) -> Self:
+        """
+        Sets the estimate mode type.
+
+        Currently supported modes:
+            - "operator-level-benchmark": Estimates runtime using operator benchmarking.
+            - "operator-level-cost-model": Estimates runtime using roofline cost model.
+
+        Args:
+            estimate_mode_type (str): The type of estimate mode to use.
+
+        Returns:
+            RuntimeEstimator: The runtime estimator instance.
+
+        Raises:
+            NotImplementedError: If the estimate mode type is not supported.
+        """
+        if estimate_mode_type == "operator-level-benchmark":
+            self._estimate = RuntimeEstimator._benchmark_estimate
+        elif estimate_mode_type == "operator-level-cost-model":
+            self._estimate = RuntimeEstimator._roofline_estimate
+        else:
+            raise NotImplementedError(
+                f"estimate_mode_type {estimate_mode_type} not supported"
+            )
+        self._estimate_mode_type = estimate_mode_type
+        return self
+
+    def __enter__(self) -> Self:
+        fake_mode = active_fake_mode()
+        assert isinstance(
+            fake_mode, FakeTensorMode
+        ), "No FakeTensorMode found, designed to used under FakeTensorMode"
+        RuntimeEstimator.fake_mode = fake_mode
+        self.total_runtime = 0.0
+        self.mod_runtimes = defaultdict(lambda: defaultdict(lambda: 0.0))
+        self.mod_fw_pre_order.clear()
+        self.mod_bw_pre_order.clear()
+        self.mod_fw_post_order.clear()
+        self.mod_bw_post_order.clear()
+        self._mod_tracker.register_user_hooks(
+            pre_fw_hook=lambda mod, inp: self.mod_fw_pre_order.append(
+                self._mod_tracker.get_known_fqn(mod)
+            ),
+            pre_bw_hook=lambda mod, g_out: self.mod_bw_pre_order.append(
+                self._mod_tracker.get_known_fqn(mod)
+            ),
+            post_fw_hook=lambda mod, inp, out: self.mod_fw_post_order.append(
+                self._mod_tracker.get_known_fqn(mod)
+            ),
+            post_bw_hook=lambda mod, g_inp: self.mod_bw_post_order.append(
+                self._mod_tracker.get_known_fqn(mod)
+            ),
+        )
+        self._mod_tracker.__enter__()
+        super().__enter__()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        print(
+            f"Estimated ({self._estimate_mode_type})"
+            f"total_time: {self.total_runtime:.3f} ms"
+        )
+        if len(self._no_fallback_kernel) > 0:
+            print("no_fallback_kernel: ", list(self._no_fallback_kernel))
+        super().__exit__(*args)
+        self._mod_tracker.clear_user_hooks()
+        self._mod_tracker.__exit__()


### PR DESCRIPTION
This PR adds a basic Runtime Estimator for single-device models.
It estimates the GPU runtime in milliseconds using various estimation methods under the ``FakeTensorMode``.
It provides a ``TorchDispatchMode`` based context manager that can estimate the eager runtime of PyTorch functions. It supports two estimation modes, benchmarking (`operator-level-benchmark`) and roofline cost modeling (`operator-level-cost-model`).
For modules executed under this context manager, it agggregates the forward and backward operation runtimes and records their execution orders.

```
import torch
from torch import nn, optim
from torch._subclasses.fake_tensor import FakeTensorMode
from torch.distributed._tools.runtime_estimator import RuntimeEstimator
from torch.testing._internal.distributed._tensor.common_dtensor import (
    ModelArgs,
    Transformer,
)

if __name__ == "__main__":
    def _train_step(
        model: nn.Module,
        optimizer: optim.Optimizer,
        inp: torch.Tensor,
    ):
        out = model(inp)
        loss = out.sum()
        loss.backward()
        optimizer.step()
        optimizer.zero_grad()

    dev = torch.cuda.current_device()
    vocab_size = 8192
    bsz, seq_len = 32, 1024
    model_args = ModelArgs(
        n_layers=4,
        n_heads=12,
        vocab_size=vocab_size,
        max_seq_len=seq_len,
        dim=768,
        dropout_p=0.1,
    )
    runtime_estimator = RuntimeEstimator()
    
    with FakeTensorMode():
        with torch.device(dev):
            model = Transformer(model_args)
        optimizer = optim.Adam(model.parameters(), lr=1e-2, foreach=True)
        inp = torch.randint(0, model_args.vocab_size, (bsz, model_args.max_seq_len), device=dev)
        with runtime_estimator("operator-level-benchmark"):
            _train_step(model, optimizer, inp)
        with runtime_estimator("operator-level-cost-model"):
            _train_step(model, optimizer, inp)

    # Actual model runtime
    with torch.device(dev):
        model = Transformer(model_args)
    optimizer = optim.Adam(model.parameters(), lr=1e-2, foreach=True)
    inp = torch.randint(0, model_args.vocab_size, (bsz, model_args.max_seq_len), device=dev)
    warmup_iters, actual_iters = 2, 5
    start_event = torch.cuda.Event(enable_timing=True)
    end_event = torch.cuda.Event(enable_timing=True)
    for _ in range(warmup_iters):
        _train_step(model, optimizer, inp)
    start_event.record()
    for _ in range(actual_iters):
        _train_step(model, optimizer, inp)
    end_event.record()
    torch.cuda.synchronize()
    measured_time = start_event.elapsed_time(end_event) / actual_iters
    print(f"Actual total_time: {measured_time:.3f} ms")
  ```
  
  
<img width="506" alt="Screenshot 2024-08-26 at 11 27 15 PM" src="https://github.com/user-attachments/assets/04d243c9-21a6-4389-8c20-80958980788c">


@weifengpy @xuanzhang816 @gnadathur
cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o