### PR TITLE
.github/merge_rules.yaml: added multiprocessing to Distributed

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -282,9 +282,11 @@
   - torch/_C/_distributed*
   - torch/csrc/distributed/**
   - torch/testing/_internal/distributed/**
+  - torch/multiprocessing/**
   - test/distributed/**
   - test/cpp/dist_autograd/**
   - test/cpp/rpc/**
+  - test/*multiprocessing*
   approved_by:
   - wconstab
   - mrshenli


### PR DESCRIPTION
This allows the Distributed team to approve changes to torch.multiprocessing which is used by torchelastic/run.


Example PR: https://github.com/pytorch/pytorch/pull/133707
