### PR TITLE
[export] Make move_to_device_pass function public

### DIFF
--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -720,3 +720,5 @@ API Reference
 .. automodule:: torch.export.custom_obj
 
 .. automodule:: torch.export.experimental
+.. automodule:: torch.export.passes
+.. autofunction:: torch.export.passes.move_to_device_pass

--- a/test/export/test_passes.py
+++ b/test/export/test_passes.py
@@ -18,7 +18,6 @@ from torch._export.non_strict_utils import (
     _gather_constant_attrs,
 )
 from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
-from torch._export.passes.move_to_device_pass import move_to_device_pass
 from torch._export.passes.replace_set_grad_with_hop_pass import (
     _is_set_grad_enabled_node,
     _is_set_grad_enabled_sub_mod,
@@ -42,6 +41,7 @@ from torch.export._remove_auto_functionalized_pass import (
     unsafe_remove_auto_functionalized_pass,
 )
 from torch.export._remove_effect_tokens_pass import _remove_effect_tokens
+from torch.export.passes import move_to_device_pass
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.passes.infra.partitioner import Partition
 from torch.fx.passes.operator_support import OperatorSupport

--- a/torch/export/passes/__init__.py
+++ b/torch/export/passes/__init__.py
@@ -2,20 +2,10 @@ from typing import Dict, Union
 
 import torch
 import torch.utils._pytree as pytree
-from torch.export import ExportedProgram
+from torch.export.exported_program import ExportedProgram
 
 
-def _get_new_device(
-    curr_device: torch.device,
-    location: Union[torch.device, str, Dict[str, str]],
-) -> str:
-    if isinstance(location, dict):
-        if str(curr_device) in location.keys():
-            return location[str(curr_device)]
-        else:
-            return str(curr_device)
-    else:
-        return str(location)
+__all__ = ["move_to_device_pass"]
 
 
 def move_to_device_pass(
@@ -34,6 +24,19 @@ def move_to_device_pass(
     Returns:
         ExportedProgram: The moved exported program.
     """
+
+    def _get_new_device(
+        curr_device: torch.device,
+        location: Union[torch.device, str, Dict[str, str]],
+    ) -> str:
+        if isinstance(location, dict):
+            if str(curr_device) in location.keys():
+                return location[str(curr_device)]
+            else:
+                return str(curr_device)
+        else:
+            return str(location)
+
     # move all the state_dict
     for k, v in ep.state_dict.items():
         if isinstance(v, torch.nn.Parameter):


### PR DESCRIPTION
Summary:
This is a follow-up of https://github.com/pytorch/pytorch/pull/133660

Here we make the `move_to_device_pass()` function publich so users can call it by `from torch.export.passes import move_to_device_pass`

Test Plan: CI

Differential Revision: D61671310
