### PR TITLE
[AOTI][Tooling][5/n] Add UserDefinedTritonKernel debug printing support

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5105,9 +5105,20 @@ class UserDefinedTritonKernel(ExternKernel):
         ]
         # Call to kernel
         self.codegen_comment(wrapper)
-        wrapper.generate_user_defined_triton_kernel(
-            new_name, raw_args, self.grid, configs, triton_meta, kernel.constexprs
-        )
+
+        call_args = [
+            raw_arg.get_name()
+            for i, raw_arg in enumerate(raw_args)
+            if i not in kernel.constexprs
+            and isinstance(raw_arg, IRNode)
+            and raw_arg is not None
+        ]
+        debug_printer_manager = V.graph.wrapper_code.debug_printer
+        debug_printer_manager.set_printer_args(call_args, new_name, None, kernel)
+        with debug_printer_manager:
+            wrapper.generate_user_defined_triton_kernel(
+                new_name, raw_args, self.grid, configs, triton_meta, kernel.constexprs
+            )
 
     def get_unbacked_symbol_uses(self) -> OrderedSet[sympy.Symbol]:
         # add unbacked symbols used in the grid to the ones used


### PR DESCRIPTION
Summary:
1. Add user defined triton kernel support for debug printer
2. Add unit test case for user written triton kernel debug printing path

Test Plan:
```
$ AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER=1 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1  TORCHINDUCTOR_ABI_COMPATIBLE=1 TORCH_COMPILE_DEBUG=1 TORCH_LOGS="+graph, inductor, +schedule, output_code" buck2 run -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 @//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor -- -r test_aoti_debug_printer_user_defined_triton_kernel_abi_compatible_cuda
```

Differential Revision: D61624289


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov