### PR TITLE
line by line logging

### DIFF
--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -38,7 +38,14 @@ register_log("fsdp", ["torch.distributed.fsdp", "torch.distributed._composable.f
 register_log("dtensor", ["torch.distributed._tensor", "torch.distributed.tensor"])
 register_log("onnx", "torch.onnx")
 register_log(
-    "export", ["torch._dynamo", "torch.export", *DYNAMIC, "torch._export.converter"]
+    "export",
+    [
+        "torch._dynamo",
+        "torch.export",
+        *DYNAMIC,
+        "torch._export.converter",
+        "torch._export.non_strict_utils",
+    ],
 )
 
 register_artifact(

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -23,6 +23,7 @@ from torch._export.db.logging import (
 from torch._export.non_strict_utils import (
     _fakify_script_objects,
     _gather_constant_attrs,
+    _NonStrictTorchFunctionHandler,
     make_constraints,
     make_fake_inputs,
     produce_guards_and_solve_constraints,
@@ -58,7 +59,6 @@ from torch.export.exported_program import OutputKind
 from torch.fx._utils import first_call_function_nn_module_stack
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import (
-    _DataDependentErrorHandlerNonStrict,
     ConstraintViolationError,
     free_unbacked_symbols,
     GuardOnDataDependentSymNode,
@@ -1827,7 +1827,7 @@ def _non_strict_export(
             _is_torch_jit_trace=_is_torch_jit_trace,
         )
 
-    with fake_mode, _DataDependentErrorHandlerNonStrict(), torch._dynamo.config.patch(
+    with fake_mode, _NonStrictTorchFunctionHandler(), torch._dynamo.config.patch(
         assume_static_by_default=False
     ):
         with _fakify_script_objects(mod, fake_args, fake_kwargs, fake_mode) as (

--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -52,6 +52,14 @@ extended_debug_create_symbol = os.environ.get(
 # [@compile_ignored: debug]
 extended_debug_cpp = os.environ.get("TORCHDYNAMO_EXTENDED_DEBUG_CPP", "") != ""
 
+# Give extended debug information (line of code) when a torch function
+# is called during export.  This is useful for showing progress and detecting
+# where export might be stuck. Currently only works for strict=False.
+# [@compile_ignored: debug]
+extended_debug_current_loc = (
+    os.environ.get("TORCHEXPORT_EXTENDED_DEBUG_CURRENT_LOC", "0") == "1"
+)
+
 # [@compile_ignored: debug] Show a warning for every specialization
 print_specializations = False
 


### PR DESCRIPTION
Summary:
Today there is no good mechanism to detect progress of non-strict export line-by-line in user code. This caused some pain recently in trying to find the exact line of user code that was triggering a bug where the process appeared stuck because deep down something was calling some symbolic shapes code that was suffering some exponential blowup.

This PR adds a environment variable for extended debugging that will log the line of user code corresponding to every torch function call. It only works in non-strict export for now. Prefix setting this environment variable with `TORCH_LOGS`  enabled for `export` logs at `DEBUG` level (i.e., with a `+` prefix), i.e.,.:

```
TORCHEXPORT_EXTENDED_DEBUG_CURRENT_LOC=1 TORCH_LOGS="+export" ...
```

This will show logs with something like:
```
...
prim::device called at .../example.py:4284 in foo
TensorBase.item called at .../example.py:4277 in bar
...
```

We already have an existing place to intercept torch functions where we process data-dependent errors in non-strict, so parking the logging there. An alternative place we could be doing this is where we add `stack_trace` metadata when generating code, but unfortunately at least the example that motivated this gets stuck before generating code, so that would be too late.

Test Plan: ran it on some sample commands

Differential Revision: D61692156
