### PR TITLE
Disable reorder_for_locality when checking accuracy on XPU.

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2686,6 +2686,11 @@ class BenchmarkRunner:
         if self.args.backend == "torchao":
             return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
 
+        # avoid reorder_for_locality for xpu device when checking accuracy currently.
+        # This is because reordering the order of random kernels will lead to different results on xpu device.
+        if current_device == "xpu":
+            inductor_config.reorder_for_locality = False
+
         with self.pick_grad(name, self.args.training):
             # Collect the fp64 reference outputs to be used later for accuracy checking.
             fp64_outputs = None


### PR DESCRIPTION
Temp use, not for upstream.

It is because the random generator will output different result if the order is changed.

Fixes #ISSUE_NUMBER


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec