### PR TITLE
[ONNX] Update exporter logic

### DIFF
--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 
 import torch
+from torch.onnx._internal.exporter import testing as onnx_testing
 from torch.testing._internal import common_utils
 
 
@@ -31,48 +32,45 @@ class SampleModelForDynamicShapes(torch.nn.Module):
 class TestExportAPIDynamo(common_utils.TestCase):
     """Tests for the ONNX exporter API when dynamo=True."""
 
+    def assert_export(self, *args, **kwargs):
+        onnx_program = torch.onnx.export(*args, **kwargs, dynamo=True)
+        assert onnx_program is not None
+        onnx_testing.assert_onnx_program(onnx_program)
+
     def test_args_normalization_with_no_kwargs(self):
-        onnx_program = torch.onnx.export(
+        self.assert_export(
             SampleModelTwoInputs(),
             (torch.randn(1, 1, 2), torch.randn(1, 1, 2)),
-            dynamo=True,
         )
-        torch.onnx.testing.assert_onnx_program(onnx_program)
 
     def test_dynamic_axes_enable_dynamic_shapes_with_fully_specified_axes(self):
-        onnx_program = torch.onnx.export(
+        self.assert_export(
             SampleModelForDynamicShapes(),
             (torch.randn(2, 2, 3), {"b": torch.randn(2, 2, 3)}),
             dynamic_axes={
                 "x": {0: "customx_dim_0", 1: "customx_dim_1", 2: "customx_dim_2"},
                 "b": {0: "customb_dim_0", 1: "customb_dim_1", 2: "customb_dim_2"},
             },
-            dynamo=True,
         )
-        torch.onnx.testing.assert_onnx_program(onnx_program)
 
     def test_dynamic_axes_enable_dynamic_shapes_with_default_axe_names(self):
-        onnx_program = torch.onnx.export(
+        self.assert_export(
             SampleModelForDynamicShapes(),
             (torch.randn(2, 2, 3), {"b": torch.randn(2, 2, 3)}),
             dynamic_axes={
                 "x": [0, 1, 2],
                 "b": [0, 1, 2],
             },
-            dynamo=True,
         )
-        torch.onnx.testing.assert_onnx_program(onnx_program)
 
     def test_dynamic_axes_supports_partial_dynamic_shapes(self):
-        onnx_program = torch.onnx.export(
+        self.assert_export(
             SampleModelForDynamicShapes(),
             (torch.randn(2, 2, 3), {"b": torch.randn(2, 2, 3)}),
             dynamic_axes={
                 "b": [0, 1, 2],
             },
-            dynamo=True,
         )
-        torch.onnx.testing.assert_onnx_program(onnx_program)
 
     def test_saved_f_exists_after_export(self):
         with common_utils.TemporaryFileName(suffix=".onnx") as path:
@@ -86,10 +84,9 @@ class TestExportAPIDynamo(common_utils.TestCase):
             def forward(self, x):
                 return x
 
-        onnx_program = torch.onnx.export(
+        self.assert_export(
             torch.jit.script(ScriptModule()), (torch.randn(1, 1, 2),), dynamo=True
         )
-        torch.onnx.testing.assert_onnx_program(onnx_program)
 
     def test_dynamic_shapes_with_fully_specified_axes(self):
         exported_program = torch.export.export(
@@ -112,11 +109,10 @@ class TestExportAPIDynamo(common_utils.TestCase):
             },
         )
 
-        onnx_program = torch.onnx.export(exported_program, dynamo=True)
-        torch.onnx.testing.assert_onnx_program(onnx_program)
+        self.assert_export(exported_program, dynamo=True)
 
     def test_partial_dynamic_shapes(self):
-        onnx_program = torch.onnx.export(
+        self.assert_export(
             SampleModelForDynamicShapes(),
             (
                 torch.randn(2, 2, 3),
@@ -130,9 +126,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
                     2: torch.export.Dim("customb_dim_2"),
                 },
             },
-            dynamo=True,
         )
-        torch.onnx.testing.assert_onnx_program(onnx_program)
 
 
 if __name__ == "__main__":

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -84,9 +84,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
             def forward(self, x):
                 return x
 
-        self.assert_export(
-            torch.jit.script(ScriptModule()), (torch.randn(1, 1, 2),), dynamo=True
-        )
+        self.assert_export(torch.jit.script(ScriptModule()), (torch.randn(1, 1, 2),))
 
     def test_dynamic_shapes_with_fully_specified_axes(self):
         exported_program = torch.export.export(
@@ -109,7 +107,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
             },
         )
 
-        self.assert_export(exported_program, dynamo=True)
+        self.assert_export(exported_program)
 
     def test_partial_dynamic_shapes(self):
         self.assert_export(

--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import os
 
 import torch
-from torch.onnx._internal import exporter
 from torch.testing._internal import common_utils
 
 
@@ -38,26 +37,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
             (torch.randn(1, 1, 2), torch.randn(1, 1, 2)),
             dynamo=True,
         )
-        assert onnx_program
-        exporter.verify_onnx_program(onnx_program)
-
-    def test_args_normalization_with_kwargs(self):
-        onnx_program = torch.onnx.export(
-            SampleModelTwoInputs(),
-            (torch.randn(1, 1, 2), {"b": torch.randn(1, 1, 2)}),
-            dynamo=True,
-        )
-        assert onnx_program
-        exporter.verify_onnx_program(onnx_program)
-
-    def test_args_normalization_with_empty_dict_at_the_tail(self):
-        onnx_program = torch.onnx.export(
-            SampleModelTwoInputs(),
-            (torch.randn(1, 1, 2), {"b": torch.randn(1, 1, 2)}),
-            dynamo=True,
-        )
-        assert onnx_program
-        exporter.verify_onnx_program(onnx_program)
+        torch.onnx.testing.assert_onnx_program(onnx_program)
 
     def test_dynamic_axes_enable_dynamic_shapes_with_fully_specified_axes(self):
         onnx_program = torch.onnx.export(
@@ -69,8 +49,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
             },
             dynamo=True,
         )
-        assert onnx_program
-        exporter.verify_onnx_program(onnx_program)
+        torch.onnx.testing.assert_onnx_program(onnx_program)
 
     def test_dynamic_axes_enable_dynamic_shapes_with_default_axe_names(self):
         onnx_program = torch.onnx.export(
@@ -82,8 +61,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
             },
             dynamo=True,
         )
-        assert onnx_program
-        exporter.verify_onnx_program(onnx_program)
+        torch.onnx.testing.assert_onnx_program(onnx_program)
 
     def test_dynamic_axes_supports_partial_dynamic_shapes(self):
         onnx_program = torch.onnx.export(
@@ -94,8 +72,7 @@ class TestExportAPIDynamo(common_utils.TestCase):
             },
             dynamo=True,
         )
-        assert onnx_program
-        exporter.verify_onnx_program(onnx_program)
+        torch.onnx.testing.assert_onnx_program(onnx_program)
 
     def test_saved_f_exists_after_export(self):
         with common_utils.TemporaryFileName(suffix=".onnx") as path:
@@ -112,8 +89,50 @@ class TestExportAPIDynamo(common_utils.TestCase):
         onnx_program = torch.onnx.export(
             torch.jit.script(ScriptModule()), (torch.randn(1, 1, 2),), dynamo=True
         )
-        assert onnx_program
-        exporter.verify_onnx_program(onnx_program)
+        torch.onnx.testing.assert_onnx_program(onnx_program)
+
+    def test_dynamic_shapes_with_fully_specified_axes(self):
+        exported_program = torch.export.export(
+            SampleModelForDynamicShapes(),
+            (
+                torch.randn(2, 2, 3),
+                torch.randn(2, 2, 3),
+            ),
+            dynamic_shapes={
+                "x": {
+                    0: torch.export.Dim("customx_dim_0"),
+                    1: torch.export.Dim("customx_dim_1"),
+                    2: torch.export.Dim("customx_dim_2"),
+                },
+                "b": {
+                    0: torch.export.Dim("customb_dim_0"),
+                    1: torch.export.Dim("customb_dim_1"),
+                    2: torch.export.Dim("customb_dim_2"),
+                },
+            },
+        )
+
+        onnx_program = torch.onnx.export(exported_program, dynamo=True)
+        torch.onnx.testing.assert_onnx_program(onnx_program)
+
+    def test_partial_dynamic_shapes(self):
+        onnx_program = torch.onnx.export(
+            SampleModelForDynamicShapes(),
+            (
+                torch.randn(2, 2, 3),
+                torch.randn(2, 2, 3),
+            ),
+            dynamic_shapes={
+                "x": None,
+                "b": {
+                    0: torch.export.Dim("customb_dim_0"),
+                    1: torch.export.Dim("customb_dim_1"),
+                    2: torch.export.Dim("customb_dim_2"),
+                },
+            },
+            dynamo=True,
+        )
+        torch.onnx.testing.assert_onnx_program(onnx_program)
 
 
 if __name__ == "__main__":

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "symbolic_helper",
     "utils",
     "errors",
+    "testing",
     # All opsets
     "symbolic_caffe2",
     "symbolic_opset7",
@@ -63,6 +64,7 @@ from torch._C import _onnx as _C_onnx
 from torch._C._onnx import OperatorExportTypes, TensorProtoDataType, TrainingMode
 
 from ._exporter_states import ExportTypes
+from ._internal.exporter import testing
 from ._internal.onnxruntime import (
     is_onnxrt_backend_supported,
     OrtBackend as _OrtBackend,
@@ -149,7 +151,7 @@ def export(
     | torch.export.ExportedProgram
     | torch.jit.ScriptModule
     | torch.jit.ScriptFunction,
-    args: tuple[Any, ...],
+    args: tuple[Any, ...] = (),
     f: str | os.PathLike | None = None,
     *,
     kwargs: dict[str, Any] | None = None,

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -7,7 +7,6 @@ __all__ = [
     "symbolic_helper",
     "utils",
     "errors",
-    "testing",
     # All opsets
     "symbolic_caffe2",
     "symbolic_opset7",
@@ -64,7 +63,6 @@ from torch._C import _onnx as _C_onnx
 from torch._C._onnx import OperatorExportTypes, TensorProtoDataType, TrainingMode
 
 from ._exporter_states import ExportTypes
-from ._internal.exporter import testing
 from ._internal.onnxruntime import (
     is_onnxrt_backend_supported,
     OrtBackend as _OrtBackend,

--- a/torch/onnx/_internal/exporter/__init__.py
+++ b/torch/onnx/_internal/exporter/__init__.py
@@ -4,13 +4,14 @@ __all__ = [
     "analyze",
     "export",
     "exported_program_to_ir",
-    "verify_onnx_program",
     "export_compat",
+    "testing",
+    "verification",
 ]
 
+from . import _testing as testing, _verification as verification
 from ._analysis import analyze
 from ._compat import export_compat
 from ._core import export, exported_program_to_ir
 from ._onnx_program import ONNXProgram
 from ._registration import ONNXRegistry
-from ._verification import verify_onnx_program

--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -65,8 +65,8 @@ def _construct_named_inputs_and_attrs(
     #   b. Depending on param.is_input, Record named_inputs[param.name] = arg or named_attrs[param.name] = arg
     #   c. Handle kwargs as well
     #   d. Fill in None if the input is not provided
-    named_inputs = {}
-    named_attrs = {}
+    named_inputs: dict[str, Any] = {}
+    named_attrs: dict[str, Any] = {}
     reversed_args_stack = list(reversed(args))
     for param in signature.params:
         if isinstance(param, _schemas.Parameter):
@@ -318,7 +318,7 @@ def _construct_node(
             consistency with the other functions.
         named_attrs: The mapping of attribute names to their values.
     """
-    inputs: list[Any] = []
+    inputs: list[ir.Value | None] = []
     # Flatten variadic inputs
     for value in named_inputs.values():
         if isinstance(value, Sequence):

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -1180,6 +1180,8 @@ def export(
 
     profile_result = _maybe_stop_profiler_and_get_result(profiler)
 
+    assert onnx_program.exported_program is not None
+
     if not verify:
         # Return if verification is not requested
         if report:

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -906,6 +906,9 @@ def _exported_program_to_onnx_program(
 
     # TODO: Decide if we should keep mutated buffers as inputs/outputs
 
+    # TODO(justinchuby): Remove the hack
+    _ir_passes.add_torchlib_common_imports(model)
+
     return _onnx_program.ONNXProgram(model, exported_program)
 
 
@@ -922,7 +925,7 @@ def export(
     | torch.fx.GraphModule
     | torch.jit.ScriptModule
     | torch.jit.ScriptFunction,
-    args: tuple[Any, ...],
+    args: tuple[Any, ...] = (),
     kwargs: dict[str, Any] | None = None,
     *,
     registry: _registration.ONNXRegistry | None = None,
@@ -1281,18 +1284,18 @@ def export(
         export_status.output_accuracy = True
         for verification_result in verification_results:
             # TODO(justinchuby): The threshold is arbitrary right now
-            if verification_result.absolute_difference >= 5e-3:
+            if verification_result.max_abs_diff >= 5e-3:
                 logger.warning(
                     "Output '%s' has a large absolute difference of %f. ",
                     verification_result.name,
-                    verification_result.absolute_difference,
+                    verification_result.max_abs_diff,
                 )
                 export_status.output_accuracy = False
-            if verification_result.relative_difference >= 1e-1:
+            if verification_result.max_rel_diff >= 1e-1:
                 logger.warning(
                     "Output '%s' has a large relative difference of %f. ",
                     verification_result.name,
-                    verification_result.relative_difference,
+                    verification_result.max_rel_diff,
                 )
                 export_status.output_accuracy = False
         if export_status.output_accuracy:

--- a/torch/onnx/_internal/exporter/_decomp.py
+++ b/torch/onnx/_internal/exporter/_decomp.py
@@ -40,8 +40,35 @@ def get_onnx_implemented_overloads(
     return registered_ops
 
 
+def get_preserve_ops() -> set[torch._ops.OpOverload]:
+    """Return a set of CompositeImplicitAutograd ops that should be preserved."""
+    aten = torch.ops.aten
+    # NOTE: Keep this list sorted
+    # NOTE: Do _not_ retain aten.linear as its decomposition is addmm, which is Gemm and is preferable for accuracy
+    return {
+        aten._upsample_bilinear2d_aa.default,
+        aten._upsample_nearest_exact1d.vec,
+        aten._upsample_nearest_exact2d.vec,
+        aten._upsample_nearest_exact3d.vec,
+        aten.group_norm.default,
+        aten.instance_norm.default,
+        aten.upsample_bilinear2d.default,
+        aten.upsample_bilinear2d.vec,
+        aten.upsample_linear1d.default,
+        aten.upsample_linear1d.vec,
+        aten.upsample_nearest1d.default,
+        aten.upsample_nearest1d.vec,
+        aten.upsample_nearest2d.default,
+        aten.upsample_nearest2d.vec,
+        aten.upsample_nearest3d.default,
+        aten.upsample_nearest3d.vec,
+        aten.upsample_trilinear3d.default,
+        aten.upsample_trilinear3d.vec,
+    }
+
+
 def create_onnx_friendly_decomposition_table(
-    registry,
+    onnx_registered_ops: set[torch._ops.OperatorBase],
 ) -> dict[torch._ops.OperatorBase, Callable]:
     """
     This function creates a dictionary of op overloads and their decomposition functions
@@ -50,14 +77,13 @@ def create_onnx_friendly_decomposition_table(
     built-in aten-to-aten decomposition.
 
     Args:
-        registry: The ONNX registry for PyTorch.
+        onnx_registered_ops: All ops that have an ONNX decomposition implemented.
 
     Returns:
         Dict[torch._ops.OperatorBase, Callable]: A dictionary that maps op overloads to their corresponding
         decomposition functions.
     """
     decomposition_table: dict[torch._ops.OperatorBase, Callable] = {}
-    onnx_registered_ops = set(get_onnx_implemented_overloads(registry))
 
     # NOTE: If we import torch._decomp, we will get RuntimeError: Only a single
     # TORCH_LIBRARY can be used to register the namespace nvprims; please put all of your

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -48,9 +48,16 @@ def _ort_session_initializer(model: str | bytes) -> ort.InferenceSession:
 
 
 class ONNXProgram:
-    """A substitute class for `torch.onnx.ONNXProgram`."""
+    """A class to represent an ONNX program that is callable with torch tensors."""
 
-    def __init__(self, model: ir.Model, exported_program: torch.export.ExportedProgram):
+    def __init__(
+        self, model: ir.Model, exported_program: torch.export.ExportedProgram | None
+    ):
+        """Initialize the ONNX program with the specified model and exported program.
+        Args:
+            model: The ONNX model.
+            exported_program: The exported program that produced the ONNX model. Optional.
+        """
         self.model: ir.Model = model
         self.exported_program = exported_program
         self._inference_session: ort.InferenceSession | None = None

--- a/torch/onnx/_internal/exporter/_reporting.py
+++ b/torch/onnx/_internal/exporter/_reporting.py
@@ -124,7 +124,8 @@ def format_verification_infos(
         The formatted verification result.
     """
     return "\n".join(
-        f"`{info.name}`: `abs_diff={info.absolute_difference:e}`, `rel_diff={info.relative_difference:e}`"
+        f"`{info.name}`: `max_abs_diff={info.max_abs_diff:e}`, `max_rel_diff={info.max_rel_diff:e}`, "
+        f"`abs_diff_hist={info.abs_diff_hist}`, `rel_diff_hist={info.rel_diff_hist}`"
         for info in verification_infos
     )
 

--- a/torch/onnx/_internal/exporter/_testing.py
+++ b/torch/onnx/_internal/exporter/_testing.py
@@ -25,7 +25,7 @@ def assert_onnx_program(
 ) -> None:
     """Assert that the ONNX model produces the same output as the PyTorch ExportedProgram.
     Args:
-        program: The :class:`torch_onnx.ONNXProgram` to verify.
+        program: The ``ONNXProgram`` to verify.
         rtol: Relative tolerance.
         atol: Absolute tolerance.
         args: The positional arguments to pass to the program.

--- a/torch/onnx/_internal/exporter/_testing.py
+++ b/torch/onnx/_internal/exporter/_testing.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 def assert_onnx_program(
-    program: _onnx_program.ONNXProgram | None,
+    program: _onnx_program.ONNXProgram,
     *,
     rtol: float | None = None,
     atol: float | None = None,
@@ -33,8 +33,6 @@ def assert_onnx_program(
         kwargs: The keyword arguments to pass to the program.
             If None, the default example inputs in the ExportedProgram will be used.
     """
-    if program is None:
-        raise ValueError("The program is None. Please provide a program to verify.")
     exported_program = program.exported_program
     if exported_program is None:
         raise ValueError(

--- a/torch/onnx/_internal/exporter/_testing.py
+++ b/torch/onnx/_internal/exporter/_testing.py
@@ -1,0 +1,68 @@
+"""Test utilities for ONNX export."""
+
+from __future__ import annotations
+
+
+__all__ = ["assert_onnx_program"]
+
+from typing import Any, TYPE_CHECKING
+
+import torch
+from torch.utils import _pytree
+
+
+if TYPE_CHECKING:
+    from torch.onnx._internal.exporter import _onnx_program
+
+
+def assert_onnx_program(
+    program: _onnx_program.ONNXProgram | None,
+    *,
+    rtol: float | None = None,
+    atol: float | None = None,
+    args: tuple[Any, ...] | None = None,
+    kwargs: dict[str, Any] | None = None,
+) -> None:
+    """Assert that the ONNX model produces the same output as the PyTorch ExportedProgram.
+    Args:
+        program: The :class:`torch_onnx.ONNXProgram` to verify.
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        args: The positional arguments to pass to the program.
+            If None, the default example inputs in the ExportedProgram will be used.
+        kwargs: The keyword arguments to pass to the program.
+            If None, the default example inputs in the ExportedProgram will be used.
+    """
+    if program is None:
+        raise ValueError("The program is None. Please provide a program to verify.")
+    exported_program = program.exported_program
+    if exported_program is None:
+        raise ValueError(
+            "The ONNXProgram does not contain an ExportedProgram. "
+            "To verify the ONNX program, initialize ONNXProgram with an ExportedProgram, "
+            "or assign the ExportedProgram to the ONNXProgram.exported_program attribute."
+        )
+    if args is None and kwargs is None:
+        # User did not provide example inputs, use the default example inputs
+        if exported_program.example_inputs is None:
+            raise ValueError(
+                "No example inputs provided and the exported_program does not contain example inputs. "
+                "Please provide arguments to verify the ONNX program."
+            )
+        args, kwargs = exported_program.example_inputs
+    if args is None:
+        args = ()
+    if kwargs is None:
+        kwargs = {}
+    torch_module = exported_program.module()
+    torch_outputs, _ = _pytree.tree_flatten(torch_module(*args, **kwargs))
+    onnx_outputs = program(*args, **kwargs)
+    # TODO(justinchuby): Include output names in the error message
+    torch.testing.assert_close(
+        tuple(onnx_outputs),
+        tuple(torch_outputs),
+        rtol=rtol,
+        atol=atol,
+        equal_nan=True,
+        check_device=False,
+    )

--- a/torch/onnx/_internal/exporter/_verification.py
+++ b/torch/onnx/_internal/exporter/_verification.py
@@ -1,11 +1,18 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+
+__all__ = [
+    "VerificationInfo",
+    "verify_onnx_program",
+]
+
 import dataclasses
+import math
 from typing import Any, TYPE_CHECKING
 
 import torch
-from torch.utils import _pytree as pytree
+from torch.utils import _pytree
 
 
 if TYPE_CHECKING:
@@ -15,8 +22,10 @@ if TYPE_CHECKING:
 @dataclasses.dataclass
 class VerificationInfo:
     name: str
-    absolute_difference: float
-    relative_difference: float
+    max_abs_diff: float
+    max_rel_diff: float
+    abs_diff_hist: tuple[torch.Tensor, torch.Tensor]
+    rel_diff_hist: tuple[torch.Tensor, torch.Tensor]
     expected_dtype: torch.dtype
     actual_dtype: torch.dtype
     # NOTE: We don't need to include shape because the expected shape is already known
@@ -26,16 +35,24 @@ class VerificationInfo:
 def _compare_tensors(
     expected: torch.Tensor,
     actual: torch.Tensor,
-) -> tuple[float, float]:
+) -> tuple[float, float, torch.Tensor, torch.Tensor]:
     # Move tensors to the same device
     expected = expected.detach().cpu()
     actual = actual.detach().cpu()
-    absolute_difference = torch.abs(expected - actual).max().item()
+    if expected.numel() == 0 or actual.numel() == 0:
+        return math.inf, math.inf, torch.tensor(math.inf), torch.tensor(math.inf)
+    if expected.dtype == torch.bool:
+        expected = expected.to(torch.float32)
+        actual = actual.to(torch.float32)
+    abs_diff = torch.abs(expected - actual)
     eps = 1e-7
-    relative_difference = (
-        (torch.abs(expected - actual) / (torch.abs(expected) + eps)).max().item()
-    )
-    return absolute_difference, relative_difference
+    normalizer = torch.abs(expected) + eps
+    rel_diff = abs_diff / normalizer
+
+    max_absolute_difference = abs_diff.max().item()
+    max_relative_difference = rel_diff.max().item()
+
+    return max_absolute_difference, max_relative_difference, abs_diff, rel_diff
 
 
 def verify_onnx_program(
@@ -44,6 +61,11 @@ def verify_onnx_program(
     kwargs: dict[str, Any] | None = None,
 ) -> list[VerificationInfo]:
     exported_program = onnx_program.exported_program
+    if exported_program is None:
+        raise ValueError(
+            "The ONNX program does not contain an exported_program. "
+            "Please provide an exported_program to verify the ONNX program."
+        )
     if args is None and kwargs is None:
         # User did not provide example inputs, use the default example inputs
         if exported_program.example_inputs is None:
@@ -57,21 +79,28 @@ def verify_onnx_program(
     if kwargs is None:
         kwargs = {}
     torch_module = exported_program.module()
-    torch_outputs, _ = pytree.tree_flatten(torch_module(*args, **kwargs))
+    torch_outputs, _ = _pytree.tree_flatten(torch_module(*args, **kwargs))
     onnx_outputs = onnx_program(*args, **kwargs)
     results = []
     for torch_output, onnx_output, output_val in zip(
         torch_outputs, onnx_outputs, onnx_program.model.graph.outputs
     ):
         name = output_val.name
-        absolute_difference, relative_difference = _compare_tensors(
+        max_abs_diff, max_rel_diff, abs_diff, rel_diff = _compare_tensors(
             torch_output, onnx_output
         )
+        abs_diff = abs_diff.flatten()
+        rel_diff = rel_diff.flatten()
+        bins = torch.tensor([0.0, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1.0, 10])
+        abs_diff_hist = torch.histogram(abs_diff, bins=bins)
+        rel_diff_hist = torch.histogram(rel_diff, bins=bins)
         results.append(
             VerificationInfo(
                 name=str(name),
-                absolute_difference=absolute_difference,
-                relative_difference=relative_difference,
+                max_abs_diff=max_abs_diff,
+                max_rel_diff=max_rel_diff,
+                abs_diff_hist=abs_diff_hist,
+                rel_diff_hist=rel_diff_hist,
                 expected_dtype=torch_output.dtype,
                 actual_dtype=onnx_output.dtype,
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134304

Sync the exporter logic with torch-onnx at https://github.com/justinchuby/torch-onnx/compare/v0.1.12...v0.1.15.

https://github.com/pytorch/pytorch/issues/129277

- Create a `testing` module to facilitate testing model accuracy. The model is internal
- Improve decomp table
- Improve model verification logic
- Add tests

The next PRs will enable OpInfo tests and clean up existing code.