### PR TITLE
Make relationship between outputs and inputs of auto_functionalize static and not depending on addresses of new inputs passed

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1002,7 +1002,7 @@ def forward(self, arg0_1: "f32[3][1]cpu", arg1_1: "f32[3][1]cpu", arg2_1: "f32[3
                     graph_aot,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu"):
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = arg1_1, y = arg0_1, _x_base_adrs = 377569152, _y_base_adrs = 377099744, _all_bases = [arg1_1, arg0_1], _all_bases_adrs = [377569152, 377099744])
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = arg1_1, y = arg0_1, _all_bases = [arg1_1, arg0_1], _observe_mutation_from = [['x'], ['y']])
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1]
         getitem_2: "f32[2][1]cpu" = auto_functionalized[2];  auto_functionalized = None
         add: "f32[2][1]cpu" = torch.ops.aten.add.Tensor(getitem_1, getitem_2)
@@ -1073,7 +1073,7 @@ def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu"):
 def forward(self, arg0_1: "f32[2][1]cpu"):
         select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
         select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1)
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _x_base_adrs = 370991840, _y_base_adrs = 370991840, _all_bases = [arg0_1], _all_bases_adrs = [370991840]);  select = select_1 = None
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _all_bases = [arg0_1], _observe_mutation_from = [['x', 'y']]);  select = select_1 = None
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1];  auto_functionalized = None
         copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, getitem_1);  arg0_1 = getitem_1 = copy_ = None
         return ()""",
@@ -1150,7 +1150,7 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
 def forward(self, arg0_1: "f32[2][1]cpu"):
         select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
         select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1)
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _x_base_adrs = 377540320, _y_base_adrs = 377540320, _all_bases = [arg0_1], _all_bases_adrs = [377540320]);  select = select_1 = None
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _all_bases = [arg0_1], _observe_mutation_from = [['x', 'y']]);  select = select_1 = None
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1];  auto_functionalized = None
         copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, getitem_1);  arg0_1 = copy_ = None
         select_2: "f32[][]cpu" = torch.ops.aten.select.int(getitem_1, 0, 0)
@@ -1232,7 +1232,7 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
 def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu", arg2_1: "f32[2][1]cpu"):
         select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
         select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg1_1, 0, 0)
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = [select_1, arg2_1], _x_base_adrs = 376224688, _y_base_adrs = [110925232, 377414032], _all_bases = [arg0_1, arg1_1, arg2_1], _all_bases_adrs = [376224688, 110925232, 377414032]);  select = select_1 = None
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = [select_1, arg2_1], _all_bases = [arg0_1, arg1_1, arg2_1], _observe_mutation_from = [['x'], [('y', 0)], [('y', 1)]]);  select = select_1 = None
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1]
         getitem_2: "f32[2][1]cpu" = auto_functionalized[2]
         getitem_3: "f32[2][1]cpu" = auto_functionalized[3];  auto_functionalized = None

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1002,7 +1002,7 @@ def forward(self, arg0_1: "f32[3][1]cpu", arg1_1: "f32[3][1]cpu", arg2_1: "f32[3
                     graph_aot,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu"):
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = arg1_1, y = arg0_1, _all_bases = [arg1_1, arg0_1], _observe_mutation_from = [['x'], ['y']])
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, _x_meta = [(2,), (1,), 0, 0], _y_meta = [(2,), (1,), 0, 1], _all_bases = [arg1_1, arg0_1])
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1]
         getitem_2: "f32[2][1]cpu" = auto_functionalized[2];  auto_functionalized = None
         add: "f32[2][1]cpu" = torch.ops.aten.add.Tensor(getitem_1, getitem_2)
@@ -1018,8 +1018,9 @@ def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu"):
                     graph_inductor,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu"):
-        foo_default = torch.ops.mylib.foo.default(arg1_1, arg0_1);  foo_default = None
-
+        as_strided_default: "f32[2][1]cpu" = torch.ops.aten.as_strided.default(arg1_1, [2], [1], 0)
+        as_strided_default_1: "f32[2][1]cpu" = torch.ops.aten.as_strided.default(arg0_1, [2], [1], 0)
+        foo_default = torch.ops.mylib.foo.default(as_strided_default, as_strided_default_1);  as_strided_default = as_strided_default_1 = foo_default = None
         add: "f32[2][1]cpu" = torch.ops.aten.add.Tensor(arg1_1, arg0_1);  arg1_1 = arg0_1 = None
         return (add,)""",
                     ignore_comments=True,
@@ -1071,9 +1072,7 @@ def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu"):
                     graph_aot,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu"):
-        select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
-        select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1)
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _all_bases = [arg0_1], _observe_mutation_from = [['x', 'y']]);  select = select_1 = None
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, _x_meta = [(), (), 0, 0], _y_meta = [(), (), 1, 0], _all_bases = [arg0_1])
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1];  auto_functionalized = None
         copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, getitem_1);  arg0_1 = getitem_1 = copy_ = None
         return ()""",
@@ -1088,17 +1087,9 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
                     graph_inductor,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu"):
-        select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
-
-        select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1)
-
-        as_strided_default: "f32[2][1]cpu" = torch.ops.aten.as_strided.default(select_1, [2], [1], 0);  select_1 = None
-        clone_default: "f32[2][1]cpu" = torch.ops.aten.clone.default(as_strided_default);  as_strided_default = None
-        as_strided_default_1: "f32[][]cpu" = torch.ops.aten.as_strided.default(clone_default, [], [], 1);  clone_default = None
-        foo_default = torch.ops.mylib.foo.default(select, as_strided_default_1);  select = foo_default = None
-        as_strided_scatter_default: "f32[2][1]cpu" = torch.ops.aten.as_strided_scatter.default(arg0_1, as_strided_default_1, [], [], 1);  as_strided_default_1 = None
-
-        copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, as_strided_scatter_default);  arg0_1 = as_strided_scatter_default = copy_ = None
+        as_strided_default: "f32[][]cpu" = torch.ops.aten.as_strided.default(arg0_1, [], [], 0)
+        as_strided_default_1: "f32[][]cpu" = torch.ops.aten.as_strided.default(arg0_1, [], [], 1);  arg0_1 = None
+        foo_default = torch.ops.mylib.foo.default(as_strided_default, as_strided_default_1);  as_strided_default = as_strided_default_1 = foo_default = None
         return ()""",
                     ignore_comments=True,
                     ignore_empty_lines=True,
@@ -1148,9 +1139,7 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
                     graph_aot,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu"):
-        select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
-        select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1)
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _all_bases = [arg0_1], _observe_mutation_from = [['x', 'y']]);  select = select_1 = None
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, _x_meta = [(), (), 0, 0], _y_meta = [(), (), 1, 0], _all_bases = [arg0_1])
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1];  auto_functionalized = None
         copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, getitem_1);  arg0_1 = copy_ = None
         select_2: "f32[][]cpu" = torch.ops.aten.select.int(getitem_1, 0, 0)
@@ -1167,20 +1156,11 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
                     graph_inductor,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu"):
-        select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
-
-        select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1)
-
-        as_strided_default: "f32[2][1]cpu" = torch.ops.aten.as_strided.default(select_1, [2], [1], 0);  select_1 = None
-        clone_default: "f32[2][1]cpu" = torch.ops.aten.clone.default(as_strided_default);  as_strided_default = None
-        as_strided_default_1: "f32[][]cpu" = torch.ops.aten.as_strided.default(clone_default, [], [], 1);  clone_default = None
-        foo_default = torch.ops.mylib.foo.default(select, as_strided_default_1);  select = foo_default = None
-        as_strided_scatter_default: "f32[2][1]cpu" = torch.ops.aten.as_strided_scatter.default(arg0_1, as_strided_default_1, [], [], 1);  as_strided_default_1 = None
-
-        copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, as_strided_scatter_default);  arg0_1 = copy_ = None
-
-        select_2: "f32[][]cpu" = torch.ops.aten.select.int(as_strided_scatter_default, 0, 0)
-        select_3: "f32[][]cpu" = torch.ops.aten.select.int(as_strided_scatter_default, 0, 1);  as_strided_scatter_default = None
+        as_strided_default: "f32[][]cpu" = torch.ops.aten.as_strided.default(arg0_1, [], [], 0)
+        as_strided_default_1: "f32[][]cpu" = torch.ops.aten.as_strided.default(arg0_1, [], [], 1)
+        foo_default = torch.ops.mylib.foo.default(as_strided_default, as_strided_default_1);  as_strided_default = as_strided_default_1 = foo_default = None
+        select_2: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
+        select_3: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1);  arg0_1 = None
         return (select_2, select_3)""",
                     ignore_comments=True,
                     ignore_empty_lines=True,
@@ -1204,12 +1184,13 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
             @torch._dynamo.disable
             def foo_impl(x, y):
                 x.sin_()
+                print(y[0])
                 y[0].sin_()
+                print(y[0])
 
             def f(x, y, z):
                 a = x[0]
                 b = z[0]
-                # is it allowed to pass x instead of y here?
                 torch.ops.mylib.foo(a, [b, y])
 
             orig_args = [torch.randn(2), torch.randn(2), torch.randn(2)]
@@ -1219,7 +1200,7 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
             eager_args = pytree.tree_map_only(torch.Tensor, torch.clone, orig_args)
             result3 = f(*eager_args)
 
-            self.assertEqual(inductor_args, eager_args)
+            self.assertEqual(inductor_args[2], eager_args[2])
             self.assertEqual(inductor_args, aot_eager_args)
 
             self.assertEqual(result3, result1)
@@ -1230,9 +1211,7 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
                     graph_aot,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu", arg2_1: "f32[2][1]cpu"):
-        select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
-        select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg1_1, 0, 0)
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = [select_1, arg2_1], _all_bases = [arg0_1, arg1_1, arg2_1], _observe_mutation_from = [['x'], [('y', 0)], [('y', 1)]]);  select = select_1 = None
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, _x_meta = [(), (), 0, 0], _y_meta = 2, _y_meta_0 = [(), (), 0, 1], _y_meta_1 = [(2,), (1,), 0, 2], _all_bases = [arg0_1, arg1_1, arg2_1])
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1]
         getitem_2: "f32[2][1]cpu" = auto_functionalized[2]
         getitem_3: "f32[2][1]cpu" = auto_functionalized[3];  auto_functionalized = None
@@ -1251,15 +1230,10 @@ def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu", arg2_1: "f32[2
                     graph_inductor,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu", arg2_1: "f32[2][1]cpu"):
-        select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
-
-        select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg1_1, 0, 0)
-
-        foo_default = torch.ops.mylib.foo.default(select, [select_1, arg2_1]);  select = select_1 = foo_default = None
-
-        copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, arg0_1);  arg0_1 = copy_ = None
-        copy__1: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg1_1, arg1_1);  arg1_1 = copy__1 = None
-        copy__2: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg2_1, arg2_1);  arg2_1 = copy__2 = None
+        as_strided_default: "f32[][]cpu" = torch.ops.aten.as_strided.default(arg0_1, [], [], 0);  arg0_1 = None
+        as_strided_default_1: "f32[][]cpu" = torch.ops.aten.as_strided.default(arg1_1, [], [], 0);  arg1_1 = None
+        as_strided_default_2: "f32[2][1]cpu" = torch.ops.aten.as_strided.default(arg2_1, [2], [1], 0);  arg2_1 = None
+        foo_default = torch.ops.mylib.foo.default(as_strided_default, [as_strided_default_1, as_strided_default_2]);  as_strided_default = as_strided_default_1 = as_strided_default_2 = foo_default = None
         return ()""",
                     ignore_comments=True,
                     ignore_empty_lines=True,

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1002,12 +1002,10 @@ def forward(self, arg0_1: "f32[3][1]cpu", arg1_1: "f32[3][1]cpu", arg2_1: "f32[3
                     graph_aot,
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu"):
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = arg1_1, y = arg0_1, _x_base = arg1_1, _y_base = arg0_1, _all_bases = [arg1_1, arg0_1])
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = arg1_1, y = arg0_1, _x_base_adrs = 377569152, _y_base_adrs = 377099744, _all_bases = [arg1_1, arg0_1], _all_bases_adrs = [377569152, 377099744])
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1]
         getitem_2: "f32[2][1]cpu" = auto_functionalized[2];  auto_functionalized = None
-
         add: "f32[2][1]cpu" = torch.ops.aten.add.Tensor(getitem_1, getitem_2)
-
         copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, getitem_2);  arg0_1 = getitem_2 = copy_ = None
         copy__1: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg1_1, getitem_1);  arg1_1 = getitem_1 = copy__1 = None
         return (add,)""",
@@ -1074,10 +1072,8 @@ def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu"):
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu"):
         select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
-
         select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1)
-
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _x_base = arg0_1, _y_base = arg0_1, _all_bases = [arg0_1]);  select = select_1 = None
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _x_base_adrs = 370991840, _y_base_adrs = 370991840, _all_bases = [arg0_1], _all_bases_adrs = [370991840]);  select = select_1 = None
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1];  auto_functionalized = None
         copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, getitem_1);  arg0_1 = getitem_1 = copy_ = None
         return ()""",
@@ -1153,13 +1149,10 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu"):
         select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
-
         select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 1)
-
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _x_base = arg0_1, _y_base = arg0_1, _all_bases = [arg0_1]);  select = select_1 = None
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = select_1, _x_base_adrs = 377540320, _y_base_adrs = 377540320, _all_bases = [arg0_1], _all_bases_adrs = [377540320]);  select = select_1 = None
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1];  auto_functionalized = None
         copy_: "f32[2][1]cpu" = torch.ops.aten.copy_.default(arg0_1, getitem_1);  arg0_1 = copy_ = None
-
         select_2: "f32[][]cpu" = torch.ops.aten.select.int(getitem_1, 0, 0)
         select_3: "f32[][]cpu" = torch.ops.aten.select.int(getitem_1, 0, 1);  getitem_1 = None
         return (select_2, select_3)""",
@@ -1238,10 +1231,8 @@ def forward(self, arg0_1: "f32[2][1]cpu"):
                     """\
 def forward(self, arg0_1: "f32[2][1]cpu", arg1_1: "f32[2][1]cpu", arg2_1: "f32[2][1]cpu"):
         select: "f32[][]cpu" = torch.ops.aten.select.int(arg0_1, 0, 0)
-
         select_1: "f32[][]cpu" = torch.ops.aten.select.int(arg1_1, 0, 0)
-
-        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = [select_1, arg2_1], _x_base = arg0_1, _y_base = [arg1_1, arg2_1], _all_bases = [arg0_1, arg1_1, arg2_1]);  select = select_1 = None
+        auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.mylib.foo.default, x = select, y = [select_1, arg2_1], _x_base_adrs = 376224688, _y_base_adrs = [110925232, 377414032], _all_bases = [arg0_1, arg1_1, arg2_1], _all_bases_adrs = [376224688, 110925232, 377414032]);  select = select_1 = None
         getitem_1: "f32[2][1]cpu" = auto_functionalized[1]
         getitem_2: "f32[2][1]cpu" = auto_functionalized[2]
         getitem_3: "f32[2][1]cpu" = auto_functionalized[3];  auto_functionalized = None

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6021,7 +6021,7 @@ def forward(self, x, b_t, y):
             """\
 def forward(self, x):
     cos = torch.ops.aten.cos.default(x)
-    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _all_bases = [x, cos], _observe_mutation_from = [['x'], ['z']]);  x = cos = None
+    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, _x_meta = [(5,), (1,), 0, 0], _z_meta = [(5,), (1,), 0, 1], _all_bases = [x, cos]);  x = cos = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_1 = torch.ops.aten.cos.default(getitem_3)
     return (getitem_3, getitem_3, cos_1)""",
@@ -6033,7 +6033,7 @@ def forward(self, x):
             """\
 def forward(self, x):
     cos = torch.ops.aten.cos.default(x)
-    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _all_bases = [x, cos], _observe_mutation_from = [['x'], ['z']]);  x = cos = None
+    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, _x_meta = [(5,), (1,), 0, 0], _z_meta = [(5,), (1,), 0, 1], _all_bases = [x, cos]);  x = cos = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_1 = torch.ops.aten.cos.default(getitem_3)
     return (getitem_3, getitem_3, cos_1)""",
@@ -6056,7 +6056,7 @@ def forward(self, x):
 def forward(self, x):
     cos = torch.ops.aten.cos.default(x)
     cos_1 = torch.ops.aten.cos.default(x);  x = None
-    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = cos, z = cos_1, _all_bases = [cos, cos_1], _observe_mutation_from = [['x'], ['z']]);  cos = cos_1 = None
+    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, _x_meta = [(5,), (1,), 0, 0], _z_meta = [(5,), (1,), 0, 1], _all_bases = [cos, cos_1]);  cos = cos_1 = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_2 = torch.ops.aten.cos.default(getitem_3);  getitem_3 = None
     return (cos_2,)""",

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6021,7 +6021,7 @@ def forward(self, x, b_t, y):
             """\
 def forward(self, x):
     cos = torch.ops.aten.cos.default(x)
-    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _x_base = x, _z_base = cos, _all_bases = [x, cos]);  x = cos = None
+    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _x_base_adrs = 1220240816, _z_base_adrs = 1220240336, _all_bases = [x, cos], _all_bases_adrs = [1220240816, 1220240336]);  x = cos = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_1 = torch.ops.aten.cos.default(getitem_3)
     return (getitem_3, getitem_3, cos_1)""",
@@ -6033,7 +6033,7 @@ def forward(self, x):
             """\
 def forward(self, x):
     cos = torch.ops.aten.cos.default(x)
-    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _x_base = x, _z_base = cos, _all_bases = [x, cos]);  x = cos = None
+    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _x_base_adrs = 356979488, _z_base_adrs = 356981120, _all_bases = [x, cos], _all_bases_adrs = [356979488, 356981120]);  x = cos = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_1 = torch.ops.aten.cos.default(getitem_3)
     return (getitem_3, getitem_3, cos_1)""",
@@ -6056,7 +6056,7 @@ def forward(self, x):
 def forward(self, x):
     cos = torch.ops.aten.cos.default(x)
     cos_1 = torch.ops.aten.cos.default(x);  x = None
-    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = cos, z = cos_1, _x_base = cos, _z_base = cos_1, _all_bases = [cos, cos_1]);  cos = cos_1 = None
+    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = cos, z = cos_1, _x_base_adrs = 356790896, _z_base_adrs = 356651696, _all_bases = [cos, cos_1], _all_bases_adrs = [356790896, 356651696]);  cos = cos_1 = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_2 = torch.ops.aten.cos.default(getitem_3);  getitem_3 = None
     return (cos_2,)""",

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6021,7 +6021,7 @@ def forward(self, x, b_t, y):
             """\
 def forward(self, x):
     cos = torch.ops.aten.cos.default(x)
-    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _x_base_adrs = 1220240816, _z_base_adrs = 1220240336, _all_bases = [x, cos], _all_bases_adrs = [1220240816, 1220240336]);  x = cos = None
+    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _all_bases = [x, cos], _observe_mutation_from = [['x'], ['z']]);  x = cos = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_1 = torch.ops.aten.cos.default(getitem_3)
     return (getitem_3, getitem_3, cos_1)""",
@@ -6033,7 +6033,7 @@ def forward(self, x):
             """\
 def forward(self, x):
     cos = torch.ops.aten.cos.default(x)
-    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _x_base_adrs = 356979488, _z_base_adrs = 356981120, _all_bases = [x, cos], _all_bases_adrs = [356979488, 356981120]);  x = cos = None
+    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = x, z = cos, _all_bases = [x, cos], _observe_mutation_from = [['x'], ['z']]);  x = cos = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_1 = torch.ops.aten.cos.default(getitem_3)
     return (getitem_3, getitem_3, cos_1)""",
@@ -6056,7 +6056,7 @@ def forward(self, x):
 def forward(self, x):
     cos = torch.ops.aten.cos.default(x)
     cos_1 = torch.ops.aten.cos.default(x);  x = None
-    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = cos, z = cos_1, _x_base_adrs = 356790896, _z_base_adrs = 356651696, _all_bases = [cos, cos_1], _all_bases_adrs = [356790896, 356651696]);  cos = cos_1 = None
+    auto_functionalized = torch.ops.higher_order.auto_functionalized(torch.ops.testlib.foo.default, x = cos, z = cos_1, _all_bases = [cos, cos_1], _observe_mutation_from = [['x'], ['z']]);  cos = cos_1 = None
     getitem_3 = auto_functionalized[3];  auto_functionalized = None
     cos_2 = torch.ops.aten.cos.default(getitem_3);  getitem_3 = None
     return (cos_2,)""",

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -96,13 +96,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
 
         def f(x):
             out = torch.empty_like(x)
-            _, new_out = auto_functionalized(
-                sin._opoverload,
-                x=x,
-                out=out,
-                _all_bases=[out],
-                _observe_mutation_from=[["out"]],
-            )
+            _, new_out = torch.ops.higher_order.auto_functionalized(sin._opoverload, x = x, _out_meta = [(3,), (1,), 0, 0], _all_bases = [out])
             y = out * new_out
             return new_out, y
 
@@ -116,7 +110,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         # IF THIS NUMBER GOES TO ZERO, PLEASE FIND ANOTHER EXAMPLE
         self.assertEqual(num_reinplacing_failures(), 1)
 
-    def get_clone_count(self, graph):
+    def get_not_inplaced_count(self, graph):
         counter = 0
         for node in graph.nodes:
             if node.target == torch.ops.higher_order.auto_functionalized:
@@ -126,12 +120,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
     def test_view_inplaced(self):
         def f(arg0_1):
             select = torch.ops.aten.select.int(arg0_1, 0, 0)
-            auto_functionalized = torch.ops.higher_order.auto_functionalized(
-                torch.ops.test_view.boo.default,
-                x=select,
-                _all_bases=[arg0_1],
-                _observe_mutation_from=[["x"]],
-            )
+            auto_functionalized = torch.ops.higher_order.auto_functionalized( torch.ops.test_view.boo.default, _x_meta = [(), (), 0, 0], _all_bases = [arg0_1])
             getitem_1 = auto_functionalized[1]
             copy_ = torch.ops.aten.copy_.default(arg0_1, getitem_1)
             return ()
@@ -140,19 +129,14 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         gm = make_fx(f, tracing_mode="fake")(x1)
         reinplace_inplaceable_ops_core(gm.graph)
 
-        self.assertEqual(self.get_clone_count(gm.graph), 0)
+        self.assertEqual(self.get_not_inplaced_count(gm.graph), 0)
 
     # introduce a view another_view that is used `after` the copy
     def test_view_inplaced2(self):
         def f(arg0_1):
             select = torch.ops.aten.select.int(arg0_1, 0, 0)
             another_view = arg0_1[2]
-            auto_functionalized = torch.ops.higher_order.auto_functionalized(
-                torch.ops.test_view.boo.default,
-                x=select,
-                _all_bases=[arg0_1],
-                _observe_mutation_from=[["x"]],
-            )
+            auto_functionalized = torch.ops.higher_order.auto_functionalized( torch.ops.test_view.boo.default, _x_meta = [(), (), 0, 0], _all_bases = [arg0_1])
             getitem_1 = auto_functionalized[1]
             copy_ = torch.ops.aten.copy_.default(arg0_1, getitem_1)
             return another_view
@@ -161,19 +145,14 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         gm = make_fx(f, tracing_mode="fake")(x1)
         reinplace_inplaceable_ops_core(gm.graph)
 
-        self.assertEqual(self.get_clone_count(gm.graph), 0)
+        self.assertEqual(self.get_not_inplaced_count(gm.graph), 0)
 
     # introduce a view another_view that is used `before` the copy
     def test_views_not_inplaced(self):
         def f(arg0_1):
             select = torch.ops.aten.select.int(arg0_1, 0, 0)
             another_view = arg0_1[2]
-            auto_functionalized = torch.ops.higher_order.auto_functionalized(
-                torch.ops.test_view.boo.default,
-                x=select,
-                _all_bases=[arg0_1],
-                _observe_mutation_from=[["x"]],
-            )
+            auto_functionalized = torch.ops.higher_order.auto_functionalized( torch.ops.test_view.boo.default, _x_meta = [(), (), 0, 0], _all_bases = [arg0_1])
             getitem_1 = auto_functionalized[1]
             use_another_view = another_view * 10
             copy_ = torch.ops.aten.copy_.default(arg0_1, getitem_1)
@@ -183,19 +162,14 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         gm = make_fx(f, tracing_mode="fake")(x1)
         reinplace_inplaceable_ops_core(gm.graph)
 
-        self.assertEqual(self.get_clone_count(gm.graph), 1)
+        self.assertEqual(self.get_not_inplaced_count(gm.graph), 1)
 
-    # a view over input with out copy node, inplace not allowed
+    # a view over input without copy node, inplace not allowed
     def test_views_not_inplaced2(self):
         def f(arg0_1):
             select = torch.ops.aten.select.int(arg0_1, 0, 0)
             another_view = arg0_1[2]
-            auto_functionalized = torch.ops.higher_order.auto_functionalized(
-                torch.ops.test_view.boo.default,
-                x=select,
-                _all_bases=[arg0_1],
-                _observe_mutation_from=[["x"]],
-            )
+            auto_functionalized = torch.ops.higher_order.auto_functionalized( torch.ops.test_view.boo.default, _x_meta = [(), (), 0, 0], _all_bases = [arg0_1])
             getitem_1 = auto_functionalized[1]
             return
 
@@ -203,7 +177,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         gm = make_fx(f, tracing_mode="fake")(x1)
         reinplace_inplaceable_ops_core(gm.graph)
 
-        self.assertEqual(self.get_clone_count(gm.graph), 1)
+        self.assertEqual(self.get_not_inplaced_count(gm.graph), 1)
 
     # no copy nodes, view over local, with a use for another view
     def test_views_not_inplaced3(self):
@@ -211,12 +185,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             a = torch.ones(10)
             select = a[0]
             another_view = a[2]
-            auto_functionalized = torch.ops.higher_order.auto_functionalized(
-                torch.ops.test_view.boo.default,
-                x=select,
-                _all_bases=[a],
-                _observe_mutation_from=[["x"]],
-            )
+            auto_functionalized = torch.ops.higher_order.auto_functionalized( torch.ops.test_view.boo.default, _x_meta = [(), (), 0, 0], _all_bases = [arg0_1])
             getitem_1 = auto_functionalized[1]
             return another_view
 
@@ -224,7 +193,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         gm = make_fx(f, tracing_mode="fake")(x1)
         reinplace_inplaceable_ops_core(gm.graph)
 
-        self.assertEqual(self.get_clone_count(gm.graph), 1)
+        self.assertEqual(self.get_not_inplaced_count(gm.graph), 1)
 
     def test_multi_output_intermediate(self):
         for requires_grad in [False, True]:

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -100,9 +100,8 @@ class TestReinplacingPassCorrectness(InductorTestCase):
                 sin._opoverload,
                 x=x,
                 out=out,
-                _out_base_adrs=1,
                 _all_bases=[out],
-                _all_bases_adrs=[1],
+                _observe_mutation_from=[["out"]],
             )
             y = out * new_out
             return new_out, y
@@ -130,8 +129,8 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             auto_functionalized = torch.ops.higher_order.auto_functionalized(
                 torch.ops.test_view.boo.default,
                 x=select,
-                _x_base=arg0_1,
                 _all_bases=[arg0_1],
+                _observe_mutation_from=[["x"]],
             )
             getitem_1 = auto_functionalized[1]
             copy_ = torch.ops.aten.copy_.default(arg0_1, getitem_1)
@@ -151,8 +150,8 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             auto_functionalized = torch.ops.higher_order.auto_functionalized(
                 torch.ops.test_view.boo.default,
                 x=select,
-                _x_base=arg0_1,
                 _all_bases=[arg0_1],
+                _observe_mutation_from=[["x"]],
             )
             getitem_1 = auto_functionalized[1]
             copy_ = torch.ops.aten.copy_.default(arg0_1, getitem_1)
@@ -172,8 +171,8 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             auto_functionalized = torch.ops.higher_order.auto_functionalized(
                 torch.ops.test_view.boo.default,
                 x=select,
-                _x_base=arg0_1,
                 _all_bases=[arg0_1],
+                _observe_mutation_from=[["x"]],
             )
             getitem_1 = auto_functionalized[1]
             use_another_view = another_view * 10
@@ -194,8 +193,8 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             auto_functionalized = torch.ops.higher_order.auto_functionalized(
                 torch.ops.test_view.boo.default,
                 x=select,
-                _x_base=arg0_1,
                 _all_bases=[arg0_1],
+                _observe_mutation_from=[["x"]],
             )
             getitem_1 = auto_functionalized[1]
             return
@@ -215,8 +214,8 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             auto_functionalized = torch.ops.higher_order.auto_functionalized(
                 torch.ops.test_view.boo.default,
                 x=select,
-                _x_base=a,
                 _all_bases=[a],
+                _observe_mutation_from=[["x"]],
             )
             getitem_1 = auto_functionalized[1]
             return another_view

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -97,7 +97,12 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         def f(x):
             out = torch.empty_like(x)
             _, new_out = auto_functionalized(
-                sin._opoverload, x=x, out=out, _out_base=out, _all_bases=[out]
+                sin._opoverload,
+                x=x,
+                out=out,
+                _out_base_adrs=1,
+                _all_bases=[out],
+                _all_bases_adrs=[1],
             )
             y = out * new_out
             return new_out, y

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -140,7 +140,8 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
     # ./fx_passes/README.md for a discussion of mutation invariants.
     reinplace_inplaceable_ops(gm.graph)
     decompose_auto_functionalized(gm.graph)
-
+    remove_self_clone(gm.graph)
+    
     comms.reinplace_fsdp_all_gather(gm.graph)
 
     gm.recompile()
@@ -731,6 +732,11 @@ def view_noop(arg, size):
 def true_noop(*args, **kwargs):
     return True
 
+def remove_self_clone(graph: torch.fx.Graph):
+     for node in graph.nodes:
+        if node.target == aten.copy_.default and node.args[0] == node.args[1]:
+            node.replace_all_uses_with(node.args[0])
+            graph.erase_node(node)
 
 def remove_noop_ops(graph: torch.fx.Graph):
     """

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -495,9 +495,23 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             return not any_use_of_views_after_node(
                 node, shared_view_nodes, copy_node=None, mutated_arg=mutated_arg
             )
+    
+    def log_inplace_results(node_name, old_tensors_to_clone, tensors_to_clone, possibly_missed_reinplacing_opportunities):
+        log.info(
+            "For node %s, attempted to reinplace %s. We were unable to reinplace %s; "
+            "%s (if non-empty) are possible missed reinplacing opportunities that may be bad for "
+            "memory usage and performance.",
+            node_name,
+            old_tensors_to_clone,
+            tensors_to_clone,
+            possibly_missed_reinplacing_opportunities,
+        )
+        torch._dynamo.utils.counters["inductor"][
+            "possibly_missed_reinplacing_opportunities"
+        ] += len(possibly_missed_reinplacing_opportunities)
 
     replace_dict: Dict[torch.fx.Node, torch.fx.Node] = {}
-
+    
     def reinplace_and_refine_tensors_to_clone(old_tensors_to_clone, kwargs, node_name):
         tensors_to_clone: List[str] = []
         storage_of_reinplaced_args = set()
@@ -545,18 +559,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     possibly_missed_reinplacing_opportunities.append(arg)
                 tensors_to_clone.append(arg)
 
-        log.info(
-            "For node %s, attempted to reinplace %s. We were unable to reinplace %s; "
-            "%s (if non-empty) are possible missed reinplacing opportunities that may be bad for "
-            "memory usage and performance.",
-            node_name,
-            old_tensors_to_clone,
-            tensors_to_clone,
-            possibly_missed_reinplacing_opportunities,
-        )
-        torch._dynamo.utils.counters["inductor"][
-            "possibly_missed_reinplacing_opportunities"
-        ] += len(possibly_missed_reinplacing_opportunities)
+        log_inplace_results(node_name, old_tensors_to_clone, tensors_to_clone, possibly_missed_reinplacing_opportunities)
         return tensors_to_clone
 
     for node in graph.nodes:
@@ -571,17 +574,99 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     replace_dict[copy_node] = copy_node.args[0]
                 node.target = inplaceable_op.inplace_op
         elif node.target == torch.ops.higher_order.auto_functionalized:
-            _mutable_op = node.args[0]
-            from torch._higher_order_ops.auto_functionalize import get_mutable_arg_names
+            from torch._higher_order_ops.auto_functionalize import deserialize_view_meta, ViewInfo,get_mutable_arg_names
 
+            _mutable_op = node.args[0]
             tensors_to_clone = get_mutable_arg_names(_mutable_op)
+            
+            kwargs = node.kwargs
+            all_bases: List[Tensor] = kwargs["_all_bases"]
+            args_view_info = deserialize_view_meta(tensors_to_clone, kwargs, all_bases, pop_args=False)
+
             # Don't try to reinplace Optional[Tensor] args that are None.
             tensors_to_clone = [
-                t for t in tensors_to_clone if node.kwargs[t] is not None
+                t for t in tensors_to_clone if args_view_info[t] is not None
             ]
-            tensors_to_clone = reinplace_and_refine_tensors_to_clone(
-                tensors_to_clone, node.kwargs, _mutable_op._name
-            )
+            
+            old_tensors_to_clone = tensors_to_clone 
+            possibly_missed_reinplacing_opportunities = []
+
+
+            # for each base in all_bases check if its in-placable.
+            inplaceable_bases = [can_inplace(node, arg) for arg in all_bases]
+
+            # In general if a base satisfy inplace requirements then all views on top it is also inplacable.
+
+            # Note1: One exception is when two bases in all_bases shares storage, in that case this means thats some pass
+            # have changed auto_functionalize, like CSE. To avoid mutating same storage by the custom op. we only 
+            # allow inplacing one arg in such condition. 
+
+            storage_to_inplace_once = set()
+            seen_storage = set()
+            for i, base in enumerate(all_bases):
+                storage = get_node_storage(base) 
+                if storage in seen_storage:
+                    storage_to_inplace_once.add(storage)
+                else:
+                    seen_storage.add(storage)
+            
+            seen_storage = None
+
+            # only include inplaced_storage for storages in storage_to_inplace_once
+            inplaced_storage = set()
+            
+            do_not_clone = []
+            for arg_name in tensors_to_clone:
+                view_info = args_view_info[arg_name]
+                if  isinstance(view_info, (list, tuple)):
+    
+                    unique_storages = {get_node_storage(item_view.base) for item_view in view_info}
+
+                    # see Note1
+                    if any( (storage in storage_to_inplace_once and storage in inplaced_storage) for storage in unique_storages):
+                        # we do not consider this in possibly_missed_reinplacing_opportunities
+                        return False
+                       
+                    # if any two items in the list shares storage we do not inplace. 
+                    # TODO revisit this, why not?
+                    unique_storages = {get_node_storage(item_view.base) for item_view in view_info}
+                    if len(unique_storages) != len(view_info):
+                        possibly_missed_reinplacing_opportunities.append(arg_name)
+                        return False
+    
+                    # if any of the item in the list is has non inplaceable base we do not inplace. 
+                    if any(not inplaceable_bases[item_view.base_index] for item_view in view_info):
+                        possibly_missed_reinplacing_opportunities.append(arg_name)
+                        return False
+
+                    for item_view in view_info:
+                        if get_node_storage(item_view.base) in storage_to_inplace_once:
+                            inplaced_storage.add(storage)
+
+                    # we inplace this arg yeey!
+                    do_not_clone.append(arg_name)
+           
+                else:
+                    # arg is a single tensor
+                    storage = get_node_storage(view_info.base)
+                    if storage in storage_to_inplace_once and storage in inplaced_storage:
+                        # we do not consider this in possibly_missed_reinplacing_opportunities
+                        continue
+
+                    if not inplaceable_bases[view_info.base_index]:
+                        possibly_missed_reinplacing_opportunities.append(arg_name)
+                        continue
+                    
+                    if storage in storage_to_inplace_once:
+                         inplaced_storage.add(storage)
+                            
+                    # we inplace this arg yeey!
+                    do_not_clone.append(arg_name)
+
+            for t in do_not_clone:
+                tensors_to_clone.remove(t)
+            
+            log_inplace_results(_mutable_op._name, old_tensors_to_clone, tensors_to_clone, possibly_missed_reinplacing_opportunities)
 
             # Stash the metadata. There is a pass later on where we decompose
             # auto_functionalized into clones + a mutable op; this metadata
@@ -605,7 +690,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             # This pass iterates over them and sees which ones are safe
             # to eliminate (i.e. no longer need the clones)
             tensors_to_clone = reinplace_and_refine_tensors_to_clone(
-                node.kwargs["tensors_to_clone"], node.kwargs["kwargs"], kernel_name
+                node.kwargs["tensors_to_clone"], kernel_name,kwargs= node.kwargs["kwargs"]
             )
 
             kwargs = dict(node.kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134315
* #133045
* #134248

In the previous diff, auto_functionalize used to have the form
```
[x', y'] = auto_functionalize( foo, x, y, _arg0_base=x, _arg1_base = y, _all_bases=[x,y])
```
Which can be read as auto_functionalize
1)  has two outputs len(all_bases)
2) the first output starts with all_bases[0] `x` then it will observe the mutation from each arg that have arg_base =`x`
In this case the mutation on arg0.
3) same for the second output, it will be start with y and observe the mutations of the arg1. 


Now one problem with the above is if a pass run and decided that y=x
then we get :
```
[x', y'] = auto_functionalize( foo, x, x, _arg0_base=x, _arg1_base = x,_ all_bases=[x,x])
```
This is problematic because 
1) x' now start with x and observe both mutations of first and second arg of foo, because _arg0_base=x and _arg1_base = x which changes the semantics of the function. and make it wrong even if do not re-inplace anything!
2) same for y' it starts with x but observe both mutations. 

**Solution**
Make the relationships between the outputs and the args that we need to observe their mutations static and not
changeable. 
```
[x', y'] = auto_functionalize( foo, x, y, _all_bases=[x,y], _observe_mutation_from=[[arg0],[arg1])
```
we use the addresses recorded at the time of the functionlization to know for each base, which args need to have their mutations observed 
1) x' output starts with x and observe mutations of arg0
2) y' output starts with  and observe mutations of arg1

if we do CSE we get 
```
[x', y'] = auto_functionalize( foo, x, x, _all_bases=[x,x], _observe_mutation_from=[[arg0],[arg1])
```
1) x' output starts with x and observe mutations of arg0
2) y' output starts with x and observe mutations of arg1

this makes inductor/test_inplacing_pass.py::TestReinplacingPassCorrectness::test_multi_output_intermediate
 pass. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @rec