### PR TITLE
[profiler][UT] instantiate profiler UTs for devices and enable UTs for xpu profiler

### DIFF
--- a/test/profiler/test_cpp_thread.py
+++ b/test/profiler/test_cpp_thread.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: profiler"]
 
 import os
+import unittest
 from unittest import skipIf
 
 import torch
@@ -32,6 +33,7 @@ else:
 KinetoProfiler = None
 IterationCount = 5
 ActivateIteration = 2
+device = None
 
 
 def blueprint(text):
@@ -56,17 +58,20 @@ class PythonProfilerEventHandler(cpp.ProfilerEventHandler):
             KinetoProfiler.step()
 
     def emulateTraining(self, iteration: int, thread_id: int) -> None:
+        global device
         # blueprint(f"training iteration {iteration} in thread {thread_id}")
-        device = torch.device("cuda")
-        # device = torch.device("cpu")
+        torch_device = getattr(torch, device)
+        assert hasattr(torch_device, "synchronize")
+        sync_func = torch_device.synchronize
+
         with torch.autograd.profiler.record_function("user_function"):
             a = torch.ones(1, device=device)
             b = torch.ones(1, device=device)
             torch.add(a, b).cpu()
-            torch.cuda.synchronize()
+            sync_func()
 
 
-class CppThreadTest(TestCase):
+class CppThreadTestCUDA(TestCase):
     ThreadCount = 20  # set to 2 for debugging
     EventHandler = None
     TraceObject = None
@@ -74,8 +79,8 @@ class CppThreadTest(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super(TestCase, cls).setUpClass()
-        CppThreadTest.EventHandler = PythonProfilerEventHandler()
-        cpp.ProfilerEventHandler.Register(CppThreadTest.EventHandler)
+        CppThreadTestCUDA.EventHandler = PythonProfilerEventHandler()
+        cpp.ProfilerEventHandler.Register(CppThreadTestCUDA.EventHandler)
 
     @classmethod
     def tearDownClass(cls):
@@ -85,6 +90,8 @@ class CppThreadTest(TestCase):
     def setUp(self) -> None:
         if not torch.cuda.is_available():
             self.skipTest("Test machine does not have cuda")
+        global device
+        device = "cuda"
 
         # this clears off events from initialization
         self.start_profiler(False)
@@ -103,7 +110,7 @@ class CppThreadTest(TestCase):
         )
 
     def set_trace(self, trace_obj) -> None:
-        CppThreadTest.TraceObject = trace_obj
+        CppThreadTestCUDA.TraceObject = trace_obj
 
     def assert_text(self, condition, text, msg):
         if condition:
@@ -114,7 +121,7 @@ class CppThreadTest(TestCase):
 
     def check_trace(self, expected, mem=False) -> None:
         blueprint("verifying trace")
-        event_list = CppThreadTest.TraceObject.events()
+        event_list = CppThreadTestCUDA.TraceObject.events()
         for key, values in expected.items():
             count = values[0]
             min_count = count * (ActivateIteration - 1)
@@ -160,7 +167,7 @@ class CppThreadTest(TestCase):
         IS_WINDOWS,
         "Failing on windows cuda, see https://github.com/pytorch/pytorch/pull/130037 for slightly more context",
     )
-    def test_with_enable_profiler_in_child_thread(self) -> None:
+    def test_with_enable_profiler_in_child_thread_cuda(self) -> None:
         self.start_profiler(False)
         cpp.start_threads(self.ThreadCount, IterationCount, True)
         self.check_trace(
@@ -174,7 +181,7 @@ class CppThreadTest(TestCase):
         IS_WINDOWS,
         "Failing on windows cuda, see https://github.com/pytorch/pytorch/pull/130037 for slightly more context",
     )
-    def test_without_enable_profiler_in_child_thread(self) -> None:
+    def test_without_enable_profiler_in_child_thread_cuda(self) -> None:
         self.start_profiler(False)
         cpp.start_threads(self.ThreadCount, IterationCount, False)
         self.check_trace(
@@ -188,7 +195,146 @@ class CppThreadTest(TestCase):
         IS_WINDOWS,
         "Failing on windows cuda, see https://github.com/pytorch/pytorch/pull/130037 for slightly more context",
     )
-    def test_profile_memory(self) -> None:
+    def test_profile_memory_cuda(self) -> None:
+        self.start_profiler(True)
+        cpp.start_threads(self.ThreadCount, IterationCount, True)
+        self.check_trace(
+            {
+                "aten::add": [self.ThreadCount, "CPU"],
+            },
+            mem=True,
+        )
+
+
+# Here duplicate the CppThreadTest to enable the xpu cases because the
+# instantiate_device_type_tests will call class method setUpClass.
+# In function setUpClass, the instantiated class(e.g CppThreadTestCPU, CppThreadTestXPU)
+# needs to be called to get it member EventHandler, while in this period,
+# the input class in argument cls is CppThreadTest, which is not defined any more.
+# We cannot detect which instantiated class is being created in setUpClass, so duplicate here
+# for enabling xpu test cases
+class CppThreadTestXPU(TestCase):
+    ThreadCount = 20  # set to 2 for debugging
+    EventHandler = None
+    TraceObject = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(TestCase, cls).setUpClass()
+        CppThreadTestXPU.EventHandler = PythonProfilerEventHandler()
+        cpp.ProfilerEventHandler.Register(CppThreadTestXPU.EventHandler)
+
+    @classmethod
+    def tearDownClass(cls):
+        if not is_fbcode():
+            torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
+
+    def setUp(self) -> None:
+        if not torch.xpu.is_available():
+            self.skipTest("Test machine does not have xpu")
+        global device
+        device = "xpu"
+
+        # this clears off events from initialization
+        self.start_profiler(False)
+        cpp.start_threads(1, IterationCount, False)
+
+    def start_profiler(self, profile_memory):
+        global KinetoProfiler
+        KinetoProfiler = torch.profiler.profile(
+            schedule=torch.profiler.schedule(
+                wait=1, warmup=1, active=ActivateIteration, repeat=1
+            ),
+            on_trace_ready=self.set_trace,
+            with_stack=True,
+            profile_memory=profile_memory,
+            record_shapes=True,
+        )
+
+    def set_trace(self, trace_obj) -> None:
+        CppThreadTestXPU.TraceObject = trace_obj
+
+    def assert_text(self, condition, text, msg):
+        if condition:
+            print(f"\33[32m{text}\33[0m")
+        else:
+            print(f"\33[31m{text}\33[0m")
+        self.assertTrue(condition, msg)
+
+    def check_trace(self, expected, mem=False) -> None:
+        blueprint("verifying trace")
+        event_list = CppThreadTestXPU.TraceObject.events()
+        for key, values in expected.items():
+            count = values[0]
+            min_count = count * (ActivateIteration - 1)
+            device = values[1]
+            filtered = filter(
+                lambda ev: ev.name == key
+                and str(ev.device_type) == f"DeviceType.{device}",
+                event_list,
+            )
+
+            if mem:
+                actual = 0
+                for ev in filtered:
+                    sev = str(ev)
+                    has_cuda_memory_usage = (
+                        sev.find("xpu_memory_usage=0 ") < 0
+                        and sev.find("xpu_memory_usage=") > 0
+                    )
+                    if has_cuda_memory_usage:
+                        actual += 1
+                self.assert_text(
+                    actual >= min_count,
+                    f"{key}: {actual} >= {min_count}",
+                    "not enough event with xpu_memory_usage set",
+                )
+            else:
+                actual = len(list(filtered))
+                if count == 1:  # test_without
+                    count *= ActivateIteration
+                    self.assert_text(
+                        actual == count,
+                        f"{key}: {actual} == {count}",
+                        "baseline event count incorrect",
+                    )
+                else:
+                    self.assert_text(
+                        actual >= min_count,
+                        f"{key}: {actual} >= {min_count}",
+                        "not enough event recorded",
+                    )
+
+    @unittest.skip(
+        reason="The XPU Profiler will not cover this case for now. Will support it in next period."
+    )
+    def test_with_enable_profiler_in_child_thread_xpu(self) -> None:
+        self.start_profiler(False)
+        cpp.start_threads(self.ThreadCount, IterationCount, True)
+        self.check_trace(
+            {
+                "aten::add": [self.ThreadCount, "CPU"],
+                "user_function": [self.ThreadCount, "XPU"],
+            }
+        )
+
+    @unittest.skip(
+        reason="The XPU Profiler will not cover this case for now. Will support it in next period."
+    )
+    def test_without_enable_profiler_in_child_thread_xpu(self) -> None:
+        self.start_profiler(False)
+        cpp.start_threads(self.ThreadCount, IterationCount, False)
+        self.check_trace(
+            {
+                "aten::add": [1, "CPU"],
+                "user_function": [1, "XPU"],
+            }
+        )
+
+    @unittest.skip(
+        reason="The XPU Profiler will not cover this case for now. Will support it in next period."
+    )
+    def test_profile_memory_xpu(self) -> None:
         self.start_profiler(True)
         cpp.start_threads(self.ThreadCount, IterationCount, True)
         self.check_trace(

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -41,6 +41,7 @@ from torch.testing._internal.common_utils import (
     skipIfHpu,
     skipIfTorchDynamo,
     TEST_HPU,
+    TEST_XPU,
     TestCase,
 )
 from torch.utils._triton import has_triton
@@ -131,6 +132,7 @@ class TestExecutionTrace(TestCase):
 
         use_device = (
             torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.XPU in supported_activities()
             or torch.profiler.ProfilerActivity.HPU in supported_activities()
         )
         # Create a temp file to save execution trace and kineto data.
@@ -202,6 +204,7 @@ class TestExecutionTrace(TestCase):
         use_device = (
             torch.profiler.ProfilerActivity.CUDA
             or torch.profiler.ProfilerActivity.HPU in supported_activities()
+            or torch.profiler.ProfilerActivity.XPU in supported_activities()
         )
         # Create a temp file to save execution trace data.
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
@@ -241,8 +244,10 @@ class TestExecutionTrace(TestCase):
     @unittest.skipIf(
         sys.version_info >= (3, 12), "torch.compile is not supported on python 3.12+"
     )
-    @unittest.skipIf(not TEST_CUDA or not has_triton(), "need CUDA and triton to run")
-    @skipIfHpu
+    @unittest.skipIf(
+        (not has_triton()) or (not TEST_CUDA and not TEST_XPU),
+        "need triton and device(CUDA or XPU) availability to run",
+    )
     def test_execution_trace_with_pt2(self, device):
         @torchdynamo.optimize("inductor")
         def fn(a, b, c):
@@ -290,6 +295,7 @@ class TestExecutionTrace(TestCase):
     def test_execution_trace_start_stop(self, device):
         use_device = (
             torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.XPU in supported_activities()
             or torch.profiler.ProfilerActivity.HPU in supported_activities()
         )
         # Create a temp file to save execution trace data.
@@ -328,6 +334,7 @@ class TestExecutionTrace(TestCase):
     def test_execution_trace_repeat_in_loop(self, device):
         use_device = (
             torch.profiler.ProfilerActivity.CUDA
+            or torch.profiler.ProfilerActivity.XPU in supported_activities()
             or torch.profiler.ProfilerActivity.HPU in supported_activities()
         )
         iter_list = {3, 4, 6, 8}
@@ -361,8 +368,7 @@ class TestExecutionTrace(TestCase):
             assert found_root_node
         assert event_count == expected_loop_events
 
-    @skipIfHpu
-    def test_execution_trace_no_capture(self, device):
+    def test_execution_trace_no_capture(self):
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
         et = ExecutionTraceObserver().register_callback(fp.name)
@@ -377,8 +383,7 @@ class TestExecutionTrace(TestCase):
         assert found_root_node
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/124500")
-    @skipIfHpu
-    def test_execution_trace_nested_tensor(self, device):
+    def test_execution_trace_nested_tensor(self):
         fp = tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False)
         fp.close()
 
@@ -404,9 +409,13 @@ class TestExecutionTrace(TestCase):
 
 
 devices = ["cpu", "cuda"]
+if TEST_XPU:
+    devices.append("xpu")
 if TEST_HPU:
     devices.append("hpu")
-instantiate_device_type_tests(TestExecutionTrace, globals(), only_for=devices)
+instantiate_device_type_tests(
+    TestExecutionTrace, globals(), allow_xpu="xpu" in devices, only_for=devices
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -3,12 +3,20 @@ import functools
 import gc
 import itertools as it
 import textwrap
+import unittest
 from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 import torch
 from torch._C._profiler import _EventType, _TensorMetadata
 from torch.profiler import _memory_profiler, _utils
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    ALLOW_XPU_PROFILING_TEST,
+    DEVICE_LIST_SUPPORT_PROFILING_TEST,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 from torch.utils import _pytree as pytree
 
 
@@ -1553,14 +1561,21 @@ class TestMemoryProfilerE2E(TestCase):
             destroy                    GRADIENT                    13(v0)         1024 kB""",
         )
 
-    def test_memory_timeline_no_id(self) -> None:
+
+@skipIfTorchDynamo("TorchDynamo changes Python calls that memory profiling relies on.")
+class TestMemoryProfilerTimeline(TestCase):
+    @unittest.skipIf(
+        torch.xpu.is_available(),
+        "The XPU Profiler will not cover this case for now. Will support it in next period.",
+    )
+    def test_memory_timeline_no_id(self, device) -> None:
         # On CPU the default behavior is to simply forward to malloc. That
         # means that when we free `x` the allocator doesn't actually know how
         # many bytes are in the allocation, and thus there's no point to
         # calling `c10::reportMemoryUsageToProfiler`. So in order to test that
-        # memory profiler processes this case correctly we need to use CUDA
+        # memory profiler processes this case correctly we need to use device
         # where we do always keep a record.
-        x = torch.ones((1024,), device="cuda" if torch.cuda.is_available() else "cpu")
+        x = torch.ones((1024,), device=device)
 
         with profile() as prof:
             # We never see `x` used so we don't know the storage is for a
@@ -1595,7 +1610,7 @@ class TestMemoryProfilerE2E(TestCase):
         actual = [(action, size) for _, action, _, size in memory_profile.timeline]
 
         # See above.
-        if not torch.cuda.is_available():
+        if device == "cpu":
             expected = expected[2:]
             for event in expected:
                 self.assertTrue(
@@ -1608,6 +1623,13 @@ class TestMemoryProfilerE2E(TestCase):
                 f"expected does not match actual: {actual}",
             )
 
+
+instantiate_device_type_tests(
+    TestMemoryProfilerTimeline,
+    globals(),
+    only_for=DEVICE_LIST_SUPPORT_PROFILING_TEST,
+    allow_xpu=ALLOW_XPU_PROFILING_TEST,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -260,7 +260,10 @@ class TestProfilerTree(TestCase):
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
-    @unittest.skipIf(torch.cuda.is_available(), "Test not working for CUDA")
+    @unittest.skipIf(
+        torch.cuda.is_available() or torch.xpu.is_available(),
+        "Test not working for CUDA and XPU",
+    )
     def test_profiler_experimental_tree(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)
         with torch.profiler.profile() as p:
@@ -315,7 +318,10 @@ class TestProfilerTree(TestCase):
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
-    @unittest.skipIf(torch.cuda.is_available(), "Test not working for CUDA")
+    @unittest.skipIf(
+        torch.cuda.is_available() or torch.xpu.is_available(),
+        "Test not working for CUDA and XPU",
+    )
     def test_profiler_experimental_tree_with_record_function(self):
         with torch.profiler.profile() as p:
             with torch.autograd.profiler.record_function("Top level Annotation"):
@@ -365,7 +371,10 @@ class TestProfilerTree(TestCase):
 
     # TODO: Add logic for CUDA version of test
     @ProfilerTree.test
-    @unittest.skipIf(torch.cuda.is_available(), "Test not working for CUDA")
+    @unittest.skipIf(
+        torch.cuda.is_available() or torch.xpu.is_available(),
+        "Test not working for CUDA and XPU",
+    )
     def test_profiler_experimental_tree_with_memory(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)
         with torch.profiler.profile(profile_memory=True) as p:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -384,7 +384,7 @@ class DeviceTypeTestBase(TestCase):
         try:
             return cls.get_primary_device()
         except Exception:
-            # For CUDATestBase, XLATestBase, and possibly others, the primary device won't be available
+            # For CUDATestBase, XPUTestBase, XLATestBase, and possibly others, the primary device won't be available
             # until setUpClass() sets it. Call that manually here if needed.
             if hasattr(cls, "setUpClass"):
                 cls.setUpClass()
@@ -667,7 +667,7 @@ class XPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def setUpClass(cls):
-        cls.primary_device = "xpu:0"
+        cls.primary_device = f"xpu:{torch.xpu.current_device()}"
 
     def _should_stop_test_suite(self):
         return False

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -301,6 +301,11 @@ if os.getenv("DISABLED_TESTS_FILE", ""):
 
 NATIVE_DEVICES = ('cpu', 'cuda', 'xpu', 'meta', torch._C._get_privateuse1_backend_name())
 
+# used for managing devices testing for torch profiler UTs
+# for now cpu, cuda and xpu are added for testing torch profiler UTs
+DEVICE_LIST_SUPPORT_PROFILING_TEST = ('cpu', 'cuda', 'xpu')
+ALLOW_XPU_PROFILING_TEST = True
+
 check_names = ['orin', 'concord', 'galen', 'xavier', 'nano', 'jetson', 'tegra']
 IS_JETSON = any(name in platform.platform() for name in check_names)
 


### PR DESCRIPTION
This PR enables the profiler related UT to be device-agnostic. It instantiates the profiler UTs for different device types and enable them on XPU backend.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal