### PR TITLE
Fix namespace issues with qnnpack

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/convolution-operator-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/convolution-operator-tester.h
@@ -22,7 +22,6 @@
 #include <qnnpack_func.h>
 
 #include "test_utils.h"
-using namespace qnnpack::testing;
 
 class ConvolutionOperatorTester {
  public:
@@ -465,7 +464,7 @@ class ConvolutionOperatorTester {
     return this->iterations_;
   }
 
-  void testQ8(const Mode mode = Mode::Static) const {
+  void testQ8(const qnnpack::testing::Mode mode = qnnpack::testing::Mode::Static) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto s32rng =
@@ -686,7 +685,7 @@ class ConvolutionOperatorTester {
                                        per_channel(),
                                        &convolution)));
       switch (mode) {
-        case Mode::Static: {
+        case qnnpack::testing::Mode::Static: {
           ASSERT_EQ(
               pytorch_qnnp_status_success,
               pytorch_qnnp_setup_convolution_ndhwc_q8(
@@ -711,7 +710,7 @@ class ConvolutionOperatorTester {
           convolution = nullptr;
         } break;
 
-        case Mode::Runtime:
+        case qnnpack::testing::Mode::Runtime:
         {
           auto packW = std::unique_ptr<qnnpack::PrePackConvWeights>(
               new qnnpack::PrePackConvWeights(

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/convolution.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/convolution.cc
@@ -12,6 +12,8 @@
 
 #include "convolution-operator-tester.h"
 
+using namespace qnnpack::testing;
+
 _STATIC_AND_RUNTIME_TEST(CONVOLUTION_OP, zero_batch,
   ConvolutionOperatorTester()
       .batchSize(0)

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/deconvolution-operator-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/deconvolution-operator-tester.h
@@ -22,7 +22,6 @@
 #include <qnnpack_func.h>
 
 #include "test_utils.h"
-using namespace qnnpack::testing;
 
 class DeconvolutionOperatorTester {
  public:
@@ -346,7 +345,7 @@ class DeconvolutionOperatorTester {
     return this->iterations_;
   }
 
-  void testQ8(const Mode mode = Mode::Static) const {
+  void testQ8(const qnnpack::testing::Mode mode = qnnpack::testing::Mode::Static) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto s32rng =
@@ -514,7 +513,7 @@ class DeconvolutionOperatorTester {
               &deconvolution));
 
       switch (mode) {
-        case Mode::Static: {
+        case qnnpack::testing::Mode::Static: {
           ASSERT_EQ(
               pytorch_qnnp_status_success,
               pytorch_qnnp_setup_deconvolution2d_nhwc_q8(
@@ -538,7 +537,7 @@ class DeconvolutionOperatorTester {
           deconvolution = nullptr;
         } break;
 
-        case Mode::Runtime:
+        case qnnpack::testing::Mode::Runtime:
         {
           auto packW = std::unique_ptr<qnnpack::PrePackConvWeights>(
               new qnnpack::PrePackConvWeights(

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/test_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/test_utils.h
@@ -23,10 +23,10 @@ enum class Mode {
   }
 
 #define _STATIC_TEST(TestClass, test_name, test_body)                   \
-  _MAKE_TEST(TestClass, test_name##_static, test_body, Mode::Static)
+  _MAKE_TEST(TestClass, test_name##_static, test_body, qnnpack::testing::Mode::Static)
 
 #define _RUNTIME_TEST(TestClass, test_name, test_body)                  \
-  _MAKE_TEST(TestClass, test_name##_runtime, test_body, Mode::Runtime)
+  _MAKE_TEST(TestClass, test_name##_runtime, test_body, qnnpack::testing::Mode::Runtime)
 
 #define _STATIC_AND_RUNTIME_TEST(TestClass, test_name, test_body) \
   _STATIC_TEST(TestClass, test_name, test_body)                   \


### PR DESCRIPTION
After this I think all `using namespace` will have been eliminated from PyTorch header files. Internally, `-Wheader-hygiene` will prevent more from being added.

Test Plan: Sandcastle

Differential Revision: D61679037


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10