### PR TITLE
[Minimizer] for sequential mode, respect find_all setting

### DIFF
--- a/torch/fx/passes/net_min_base.py
+++ b/torch/fx/passes/net_min_base.py
@@ -490,7 +490,10 @@ class _MinimizerBase:
                 if len(node_list) == 0:
                     report.append(f"User exclusion : {node.name}")
                     self.print_report(report)
-                    return culprits
+                    if not self.settings.find_all:
+                        return culprits
+                    else:
+                        continue
 
             cur_nodes: NodeSet = {node}
 


### PR DESCRIPTION
Summary: Currently, for sequential mode, minimizer search terminates after a node is excluded via the user defined exclusion_fn. However, on some occasions we would like the search to continue past that for the remaining nodes. In this diff I am changing the termination criteria to respect the find_all setting, where we continue sequential search if it is set.

Test Plan: CI

Differential Revision: D61720262
