### PR TITLE
[aot_inductor] add commit info for triton cache file

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -213,6 +213,11 @@ class CacheBase:
             else:
                 system["device"]["name"] = device_properties.gcnArchName
                 system["version"]["hip"] = torch.version.hip
+
+            if config.is_fbcode() and config.triton_cache_key_with_commit_hash:
+                if config.triton_cache_key_with_commit_hash is not None:
+                    system["version"]["commit"] = config.triton_cache_key_with_commit_hash
+
         except (AssertionError, RuntimeError):
             # If cuda is not installed, none of the above config is relevant.
             system = {}

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -57,6 +57,9 @@ autotune_remote_cache: Optional[bool] = autotune_remote_cache_default()
 # Force disabled all inductor level caching -- This will override any other caching flag
 force_disable_caches = os.environ.get("TORCHINDUCTOR_FORCE_DISABLE_CACHES") == "1"
 
+# Add hg commit hash to the cache key
+triton_cache_key_with_commit_hash = False
+
 # sleep in inductor for testing
 sleep_sec_TESTING_ONLY: Optional[int] = None
 


### PR DESCRIPTION
We need a way record the commit info into cache system info.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov