### PR TITLE
[inductor] calibration inductor windows uts (2/N)

### DIFF
--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -13,7 +13,7 @@ from torch.testing._internal.inductor_utils import HAS_CPU
 
 
 class TestCompileWorker(TestCase):
-    @skipIfWindows("pass_fds not supported on Windows.")
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
     def test_basic_jobs(self):
         pool = SubprocPool(2)
         try:
@@ -24,7 +24,7 @@ class TestCompileWorker(TestCase):
         finally:
             pool.shutdown()
 
-    @skipIfWindows("pass_fds not supported on Windows.")
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
     def test_exception(self):
         pool = SubprocPool(2)
         try:
@@ -37,7 +37,7 @@ class TestCompileWorker(TestCase):
         finally:
             pool.shutdown()
 
-    @skipIfWindows("pass_fds not supported on Windows.")
+    @skipIfWindows(msg="pass_fds not supported on Windows.")
     def test_crash(self):
         pool = SubprocPool(2)
         try:

--- a/test/inductor/test_compile_worker.py
+++ b/test/inductor/test_compile_worker.py
@@ -8,10 +8,12 @@ from torch._inductor.compile_worker.subproc_pool import (
     SubprocPool,
 )
 from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_utils import skipIfWindows
 from torch.testing._internal.inductor_utils import HAS_CPU
 
 
 class TestCompileWorker(TestCase):
+    @skipIfWindows("pass_fds not supported on Windows.")
     def test_basic_jobs(self):
         pool = SubprocPool(2)
         try:
@@ -22,6 +24,7 @@ class TestCompileWorker(TestCase):
         finally:
             pool.shutdown()
 
+    @skipIfWindows("pass_fds not supported on Windows.")
     def test_exception(self):
         pool = SubprocPool(2)
         try:
@@ -34,6 +37,7 @@ class TestCompileWorker(TestCase):
         finally:
             pool.shutdown()
 
+    @skipIfWindows("pass_fds not supported on Windows.")
     def test_crash(self):
         pool = SubprocPool(2)
         try:


### PR DESCRIPTION
skip unsupported UTs of `test\inductor\test_compile_worker.py`.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang