### PR TITLE
[Dynamo] Set config.skip_fsdp_guards=False by default

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -312,7 +312,7 @@ skip_torchrec = True
 optimize_ddp_lazy_compile = False
 
 # Whether to skip guarding on FSDP-managed modules
-skip_fsdp_guards = True
+skip_fsdp_guards = False
 # Whether to apply torch._dynamo.disable() to FSDP2 hooks.
 # Defaults to True. If Traceable FSDP2 is used, set this to False.
 skip_fsdp_hooks = True


### PR DESCRIPTION
@anijain2305 on why it was `config.skip_fsdp_guards=True` by default before: "I think this was to avoid high guard overhead. Turning off this flag will increase guard overhead. But, we have moved to C++ guards, so this should be much less concerning compared to before."

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134377



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec