### PR TITLE
[ARM] Fix infinite recursion in unwind

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -573,11 +573,7 @@ def run_test(
 
 def try_set_cpp_stack_traces(env, command, set=True):
     # Print full c++ stack traces during retries
-    # Don't do it for macos inductor tests as it makes them
-    # segfault for some reason
-    if not (
-        IS_MACOS and len(command) >= 2 and command[2].startswith(INDUCTOR_TEST_PREFIX)
-    ):
+    if not (len(command) >= 2 and command[2].startswith(INDUCTOR_TEST_PREFIX)):
         env = env or {}
         env["TORCH_SHOW_CPP_STACKTRACES"] = "1" if set else "0"
     return env

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -573,9 +573,8 @@ def run_test(
 
 def try_set_cpp_stack_traces(env, command, set=True):
     # Print full c++ stack traces during retries
-    if not (len(command) >= 2 and command[2].startswith(INDUCTOR_TEST_PREFIX)):
-        env = env or {}
-        env["TORCH_SHOW_CPP_STACKTRACES"] = "1" if set else "0"
+    env = env or {}
+    env["TORCH_SHOW_CPP_STACKTRACES"] = "1" if set else "0"
     return env
 
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -170,7 +170,7 @@ static PyObject* THPModule_initExtension(
     PyObject* _unused,
     PyObject* shm_manager_path) {
   HANDLE_TH_ERRORS
-#if !defined(FBCODE_CAFFE2)
+#if !defined(FBCODE_CAFFE2) && !defined(__aarch64__)
   if (torch::get_cpp_stacktraces_enabled()) {
     c10::SetStackTraceFetcher([]() -> std::string {
       auto tb = torch::CapturedTraceback::gather(false, false, true);

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -7,29 +7,29 @@
     !__has_include("ext/stdio_filebuf.h")
 namespace torch::unwind {
 std::vector<void*> unwind() {
-  TORCH_CHECK(
-      false,
+  TORCH_WARN_ONCE(
       "record_context_cpp is not support on non-linux non-x86_64 platforms");
+  return {};
 }
 
 std::optional<std::pair<std::string, uint64_t>> libraryFor(void* addr) {
-  TORCH_CHECK(
-      false,
+  TORCH_WARN_ONCE(
       "record_context_cpp is not support on non-linux non-x86_64 platforms");
+  return {};
 }
 
 #ifndef FBCODE_CAFFE2
 std::vector<Frame> symbolize(const std::vector<void*>& frames, Mode mode) {
-  TORCH_CHECK(
-      false,
+  TORCH_WARN_ONCE(
       "record_context_cpp is not support on non-linux non-x86_64 platforms");
+  return {};
 }
 #endif
 
 Stats stats() {
-  TORCH_CHECK(
-      false,
+  TORCH_WARN_ONCE(
       "record_context_cpp is not support on non-linux non-x86_64 platforms");
+  return {};
 }
 
 } // namespace torch::unwind


### PR DESCRIPTION
Fixes #119905

The `TORCH_SHOW_CPP_STACKTRACES=1` setting on ARM causes infinite recursive unwind because on failure a `StackTraceFetcher` attempts to unwind the <ins>failed instruction</ins>: https://github.com/pytorch/pytorch/blob/5ad759ca33ba8299cf7e1a6bb1dff7c9a5555e29/torch/csrc/profiler/combined_traceback.cpp#L25
then the unwind itself fails:
https://github.com/pytorch/pytorch/blob/5ad759ca33ba8299cf7e1a6bb1dff7c9a5555e29/torch/csrc/profiler/unwind/unwind.cpp#L10-L12
and it causes another attempt to unwind the failure in `unwind()`...

In summary, the executed instruction is equivalent to:
```C++
std::vector<void*> unwind() {
  // some instructions ...
  return unwind();
}
```
This PR replaces `TORCH_CHECK` by `TORCH_WARN_ONCE` as it will not cause an uncontrolled recursion. The only side effect would be an empty back-trace. 

Huge thanks to @nWEIdia who found the root cause!

cc @malfet @snadampal @milpuz01