### PR TITLE
[inductor] fix test torch package working with trace on windows

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -85,6 +85,8 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.jit_utils import JitTestCase
 from torch.testing._internal.logging_utils import logs_to_string
 
+_IS_WINDOWS = sys.platform == "win32"
+
 
 HAS_OPTREE = importlib.util.find_spec("optree")
 if HAS_OPTREE:
@@ -7190,7 +7192,11 @@ utils_device.CURRENT_DEVICE == None""".split(
         )
         from torch import package
 
-        path = "/tmp/MyPickledModule.pt"
+        if _IS_WINDOWS:
+            tmp_root = tempfile.gettempdir()
+            path = os.path.join(tmp_root, "MyPickledModule.pt")
+        else:
+            path = "/tmp/MyPickledModule.pt"
         package_name = "MyPickledModule"
         resource_name = "MyPickledModule.pkl"
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -85,8 +85,6 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.jit_utils import JitTestCase
 from torch.testing._internal.logging_utils import logs_to_string
 
-_IS_WINDOWS = sys.platform == "win32"
-
 
 HAS_OPTREE = importlib.util.find_spec("optree")
 if HAS_OPTREE:
@@ -7192,11 +7190,8 @@ utils_device.CURRENT_DEVICE == None""".split(
         )
         from torch import package
 
-        if _IS_WINDOWS:
-            tmp_root = tempfile.gettempdir()
-            path = os.path.join(tmp_root, "MyPickledModule.pt")
-        else:
-            path = "/tmp/MyPickledModule.pt"
+        tmp_root = tempfile.gettempdir()
+        path = os.path.join(tmp_root, "MyPickledModule.pt")
         package_name = "MyPickledModule"
         resource_name = "MyPickledModule.pkl"
 


### PR DESCRIPTION
Current temporary directory path is hard code. Fixed by get temporary directory path by API.

Reproduce UTs: 
```cmd
python test/dynamo/test_dynamic_shapes.py -v -k test_torch_package_working_with_trace_dynamic_shapes
```

Error message:
```cmd
________________________________________________________________________________________________ DynamicShapesMiscTests.test_torch_package_working_with_trace_dynamic_shapes ________________________________________________________________________________________________
Traceback (most recent call last):
  File "D:\xu_git\dnnl_cb\pytorch\test\dynamo\test_misc.py", line 7199, in test_torch_package_working_with_trace
    with package.PackageExporter(path) as exp:
  File "C:\Users\Xuhan\.conda\envs\win_mkl_static\lib\site-packages\torch\package\package_exporter.py", line 237, in __init__
    self.zip_file = torch._C.PyTorchFileWriter(f)
RuntimeError: Parent directory /tmp does not exist.

To execute this test, run the following from the base repo dir:
    python test\dynamo\test_dynamic_shapes.py DynamicShapesMiscTests.test_torch_package_working_with_trace_dynamic_shapes

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
========================================================================================================================== short test summary info ==========================================================================================================================
FAILED [0.0080s] test/dynamo/test_dynamic_shapes.py::DynamicShapesMiscTests::test_torch_package_working_with_trace_dynamic_shapes - RuntimeError: Parent directory /tmp does not exist.
==================================================================================================================== 1 failed, 1665 deselected in 4.00s =====================================================================================================================
```

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec