### PR TITLE
[inductor] calibration inductor windows uts (3/N)

### DIFF
--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -22,6 +22,7 @@ from torch._dynamo.trace_rules import (
 )
 from torch._dynamo.utils import hashable, is_safe_constant, istype
 from torch._dynamo.variables import TorchInGraphFunctionVariable, UserFunctionVariable
+from torch.testing._internal.common_utils import skipIfWindows
 
 
 try:
@@ -437,6 +438,9 @@ class TestModuleSurviveSkipFiles(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(
         not torch.distributed.is_available(),
         "need to import MLP module from distributed",
+    )
+    @skipIfWindows(
+        msg="AssertionError: False is not true : MLP did not survive skip files"
     )
     def test_module_survive_skip_files(self):
         from torch.testing._internal.common_fsdp import MLP


### PR DESCRIPTION
skip Windows UT of `test/dynamo/test_trace_rules.py`


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec