### PR TITLE
fix bump up of seqCollective_ in function ProcessGroupNCCL::pointToPoint()

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3065,6 +3065,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
 
   // Bump the logical operation counter regardless of whether this op is
   // coalesced or individual
+  seqCollective_++;
   op_id_++;
 
   auto ncclComm = getNCCLComm(key, device, opType, p2pRank, isSendRecvSelf);


### PR DESCRIPTION
Summary:
fix bump up of `seqCollective_` in function `ProcessGroupNCCL::pointToPoint()` to solve the problem of unmatched send/recv and wait in execution trace.
![image](https://github.com/user-attachments/assets/f252d42d-fcb0-4df0-bfc7-0e79d3c7761c)

Test Plan: buck2 run mode/dev-nosan kineto/libkineto/fb/integration_tests:pytorch_execution_trace_integration_test

Differential Revision: 

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @shengfukevin @briancoutinho 