### PR TITLE
Revert "[CD] fix xpu nightly wheel test env (#134395)"

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -116,6 +116,12 @@ if [[ "$PACKAGE_TYPE" == libtorch ]]; then
   cd /tmp/libtorch
 fi
 
+if [[ "$GPU_ARCH_TYPE" == xpu ]]; then
+  # Refer https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu/2-5.html
+  source /opt/intel/oneapi/pytorch-gpu-dev-0.5/oneapi-vars.sh
+  source /opt/intel/oneapi/pti/latest/env/vars.sh
+fi
+
 # Test the package
 /builder/check_binary.sh
 


### PR DESCRIPTION
This reverts commit 96738c9d756fbd64e6f2eba67f711d3e18f1630c.

Merged without pytorchmergebot command by mistake
