### PR TITLE
[CD] fix xpu nightly wheel test env (#134395)

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -116,12 +116,6 @@ if [[ "$PACKAGE_TYPE" == libtorch ]]; then
   cd /tmp/libtorch
 fi
 
-if [[ "$GPU_ARCH_TYPE" == xpu ]]; then
-  # Refer https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu/2-5.html
-  source /opt/intel/oneapi/pytorch-gpu-dev-0.5/oneapi-vars.sh
-  source /opt/intel/oneapi/pti/latest/env/vars.sh
-fi
-
 # Test the package
 /builder/check_binary.sh
 


### PR DESCRIPTION
Due to the https://github.com/pytorch/builder/pull/1972 landed, it will source xpu env duplicated in nightly wheel test.
Works for https://github.com/pytorch/pytorch/issues/114850

Realnd of #134395 to be landed with pytorchmergebot