### PR TITLE
Update partitioner's is_fusible heuristic to respect triton kernels

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -9,8 +9,13 @@ from torch._dynamo.utils import counters
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
 from torch._inductor.fx_passes.reinplace import reinplace_inplaceable_ops_core
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
-from torch.testing._internal.common_utils import IS_LINUX
-from torch.testing._internal.inductor_utils import HAS_CUDA
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    IS_LINUX,
+    parametrize,
+    subtest,
+)
+from torch.testing._internal.inductor_utils import HAS_CUDA, HAS_GPU
 from torch.testing._internal.logging_utils import logs_to_string
 
 
@@ -34,6 +39,30 @@ def sin(x: torch.Tensor, result: torch.Tensor) -> None:
 def sin_cos(x: torch.Tensor, out_sin: torch.Tensor, out_cos: torch.Tensor) -> None:
     out_sin.copy_(x.sin())
     out_cos.copy_(x.cos())
+
+
+if HAS_GPU:
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def sin_kernel(
+        in_ptr0,
+        out_ptr,
+        n_elements,
+        BLOCK_SIZE: "tl.constexpr",
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(in_ptr0 + offsets, mask=mask)
+        output = tl.sin(x)
+        tl.store(out_ptr + offsets, output, mask=mask)
+
+    def sin_triton(x, out):
+        n_elements = x.numel()
+        sin_kernel[(n_elements,)](x, out, n_elements, BLOCK_SIZE=4)
 
 
 class TestReinplacingPassCorrectness(InductorTestCase):
@@ -182,14 +211,21 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         # Both list inputs failed to reinplace. So we should have emitted clones for them.
         self.assertEqual(post_grad_graphs.count("aten.clone"), 2)
 
-    def test_partitioner_recomputes_factory(self):
+    @parametrize(
+        "sin_op",
+        [
+            subtest(sin, name="sin_op"),
+            subtest(sin_triton, name="sin_triton"),
+        ],
+    )
+    def test_partitioner_recomputes_factory(self, sin_op):
         factory_op = torch.ones_like
 
         class MySin(torch.autograd.Function):
             @staticmethod
             def forward(ctx, x):
                 out = factory_op(x)
-                sin(x, out)
+                sin_op(x, out)
                 ctx.save_for_backward(out)
                 return out
 
@@ -197,7 +233,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             def backward(ctx, grad):
                 (saved,) = ctx.saved_tensors
                 out = factory_op(grad)
-                sin(saved, out)
+                sin_op(saved, out)
                 return out
 
         @torch.compile(backend="inductor")
@@ -208,6 +244,8 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         y = f(x)
         self.assertEqual(num_reinplacing_failures(), 0)
 
+
+instantiate_parametrized_tests(TestReinplacingPassCorrectness)
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_CUDA:

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -823,12 +823,24 @@ def solve_min_cut(
                     return True
         return False
 
+    def can_fuse_into_triton_kernel_wrapper_functional(a, b):
+        if b.target != torch.ops.higher_order.triton_kernel_wrapper_functional:
+            return False
+        mutable_arg_names = b.kwargs["tensors_to_clone"]
+        for name in mutable_arg_names:
+            arg = b.kwargs["kwargs"][name]
+            if a is arg:
+                return True
+        return False
+
     def is_fusible(a, b):
         # We can perform "memory fusion" into a cat, but cat cannot be a
         # producer to a fusion
         if get_aten_target(b) == aten.cat:
             return True
         if can_fuse_into_auto_functionalized(a, b):
+            return True
+        if can_fuse_into_triton_kernel_wrapper_functional(a, b):
             return True
         return op_types.is_fusible(a) and op_types.is_fusible(b)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134491
* #134490
* #134466
* #134364

mutated arguments to triton kernels are fusible into the triton kernel.

Test Plan:
- new test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang