### PR TITLE
Use ephemeral runners for linux nightly builds (#134367)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -11,6 +11,7 @@ self-hosted-runner:
     - linux.4xlarge
     - linux.12xlarge
     - linux.24xlarge
+    - linux.24xlarge.ephemeral
     - linux.arm64.2xlarge
     - linux.4xlarge.nvidia.gpu
     - linux.8xlarge.nvidia.gpu

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -64,7 +64,7 @@ jobs:
       runs_on: linux.s390x
       ALPINE_IMAGE: "docker.io/s390x/alpine"
       {%- elif "conda" in build_environment and config["gpu_arch_type"] == "cuda" %}
-      runs_on: linux.24xlarge
+      runs_on: linux.24xlarge.ephemeral
       {%- endif %}
       build_name: !{{ config["build_name"] }}
       build_environment: !{{ build_environment }}

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -13,7 +13,7 @@ on:
         description: The build environment
       runs_on:
         required: false
-        default: linux.12xlarge
+        default: linux.12xlarge.ephemeral
         type: string
         description: Hardware to run this "build"job on, linux.12xlarge or linux.arm64.2xlarge.
       timeout-minutes:

--- a/.github/workflows/generated-linux-binary-conda-nightly.yml
+++ b/.github/workflows/generated-linux-binary-conda-nightly.yml
@@ -358,12 +358,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-2.4
       DESIRED_PYTHON: "3.9"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_9-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -426,12 +421,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-2.4
       DESIRED_PYTHON: "3.9"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_9-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -494,12 +484,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.4-2.4
       DESIRED_PYTHON: "3.9"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_9-cuda12_4
       build_environment: linux-binary-conda
     secrets:
@@ -621,12 +606,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-2.4
       DESIRED_PYTHON: "3.10"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_10-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -689,12 +669,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-2.4
       DESIRED_PYTHON: "3.10"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_10-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -757,12 +732,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.4-2.4
       DESIRED_PYTHON: "3.10"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_10-cuda12_4
       build_environment: linux-binary-conda
     secrets:
@@ -884,12 +854,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-2.4
       DESIRED_PYTHON: "3.11"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_11-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -952,12 +917,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-2.4
       DESIRED_PYTHON: "3.11"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_11-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -1020,12 +980,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.4-2.4
       DESIRED_PYTHON: "3.11"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_11-cuda12_4
       build_environment: linux-binary-conda
     secrets:
@@ -1147,12 +1102,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-2.4
       DESIRED_PYTHON: "3.12"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_12-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -1215,12 +1165,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-2.4
       DESIRED_PYTHON: "3.12"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_12-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -1283,12 +1228,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.4-2.4
       DESIRED_PYTHON: "3.12"
-<<<<<<< HEAD
-      runs_on: linux.24xlarge
-=======
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
       runs_on: linux.24xlarge.ephemeral
->>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_12-cuda12_4
       build_environment: linux-binary-conda
     secrets:

--- a/.github/workflows/generated-linux-binary-conda-nightly.yml
+++ b/.github/workflows/generated-linux-binary-conda-nightly.yml
@@ -110,7 +110,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-2.4
       DESIRED_PYTHON: "3.8"
-      runs_on: linux.24xlarge
+      runs_on: linux.24xlarge.ephemeral
       build_name: conda-py3_8-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -173,7 +173,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-2.4
       DESIRED_PYTHON: "3.8"
-      runs_on: linux.24xlarge
+      runs_on: linux.24xlarge.ephemeral
       build_name: conda-py3_8-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -236,7 +236,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.4-2.4
       DESIRED_PYTHON: "3.8"
-      runs_on: linux.24xlarge
+      runs_on: linux.24xlarge.ephemeral
       build_name: conda-py3_8-cuda12_4
       build_environment: linux-binary-conda
     secrets:

--- a/.github/workflows/generated-linux-binary-conda-nightly.yml
+++ b/.github/workflows/generated-linux-binary-conda-nightly.yml
@@ -358,7 +358,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-2.4
       DESIRED_PYTHON: "3.9"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_9-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -421,7 +426,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-2.4
       DESIRED_PYTHON: "3.9"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_9-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -484,7 +494,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.4-2.4
       DESIRED_PYTHON: "3.9"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_9-cuda12_4
       build_environment: linux-binary-conda
     secrets:
@@ -606,7 +621,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-2.4
       DESIRED_PYTHON: "3.10"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_10-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -669,7 +689,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-2.4
       DESIRED_PYTHON: "3.10"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_10-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -732,7 +757,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.4-2.4
       DESIRED_PYTHON: "3.10"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_10-cuda12_4
       build_environment: linux-binary-conda
     secrets:
@@ -854,7 +884,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-2.4
       DESIRED_PYTHON: "3.11"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_11-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -917,7 +952,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-2.4
       DESIRED_PYTHON: "3.11"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_11-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -980,7 +1020,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.4-2.4
       DESIRED_PYTHON: "3.11"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_11-cuda12_4
       build_environment: linux-binary-conda
     secrets:
@@ -1102,7 +1147,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.8-2.4
       DESIRED_PYTHON: "3.12"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_12-cuda11_8
       build_environment: linux-binary-conda
     secrets:
@@ -1165,7 +1215,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.1-2.4
       DESIRED_PYTHON: "3.12"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_12-cuda12_1
       build_environment: linux-binary-conda
     secrets:
@@ -1228,7 +1283,12 @@ jobs:
       GPU_ARCH_TYPE: cuda
       DOCKER_IMAGE: pytorch/conda-builder:cuda12.4-2.4
       DESIRED_PYTHON: "3.12"
+<<<<<<< HEAD
       runs_on: linux.24xlarge
+=======
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}amz2023."
+      runs_on: linux.24xlarge.ephemeral
+>>>>>>> ff77c67d16d (Use ephemeral runners for linux nightly builds (#134367))
       build_name: conda-py3_12-cuda12_4
       build_environment: linux-binary-conda
     secrets:


### PR DESCRIPTION
Cherry-Pick of #134367
Should be landed with pytorch/test-infra#5590
Pull Request resolved: #134367
Approved by: https://github.com/kit1980, https://github.com/malfet, https://github.com/seemethere