### PR TITLE
[export] Skip unsupported models in export benchmark

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2679,6 +2679,12 @@ class BenchmarkRunner:
             output_csv(output_filename, headers, fields)
             return accuracy_status
 
+        if self.args.export and (
+            name in self.skip_models_due_to_control_flow
+            or name in self.skip_models_due_to_export_unsupported
+        ):
+            return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
+
         if name in self.skip_accuracy_checks_large_models_dashboard:
             return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
 

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -191,6 +191,10 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         return self._skip["control_flow"]
 
     @property
+    def skip_models_due_to_export_unsupported(self):
+        return self._skip["export_unsupported"]
+
+    @property
     def guard_on_nn_module_models(self):
         return {
             "vision_maskrcnn",

--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -219,12 +219,20 @@ skip:
   control_flow:
     - cm3leon_generate
     - detectron2_fcos_r_50_fpn
+    - doctr_reco_predictor
     - fastNLP_Bert
     - hf_Longformer
     - hf_Reformer
     - hf_T5_generate
     - opacus_cifar10
     - speech_transformer
+    - timm_efficientdet
+
+  export_unsupported:
+    # unsupported: inline in skipfiles: DistributedDataParallel
+    - moco
+    # unsupported: call_method NNModuleVariable() flatten_parameters
+    - tts_angular
 
   # Models that should only run in --multiprocess mode
   multiprocess:


### PR DESCRIPTION
To improve the pass rate of export on OSS dashboard. We skip models with unsupported control flow and other known issues when running benchmark with `--export`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec