### PR TITLE
Fix docstring for torch.signal.windows.nuttall

### DIFF
--- a/torch/signal/windows/windows.py
+++ b/torch/signal/windows/windows.py
@@ -750,7 +750,7 @@ Computes the minimum 4-term Blackman-Harris window according to Nuttall.
 .. math::
     w_n = 1 - 0.36358 \cos{(z_n)} + 0.48917 \cos{(2z_n)} - 0.13659 \cos{(3z_n)} + 0.01064 \cos{(4z_n)}
 
-where ``z_n = 2 \u03c0 n/ M``.
+where :math:`z_n = 2 \pi \frac{n}{M}`.
     """,
     """
 

--- a/torch/signal/windows/windows.py
+++ b/torch/signal/windows/windows.py
@@ -750,7 +750,7 @@ Computes the minimum 4-term Blackman-Harris window according to Nuttall.
 .. math::
     w_n = 1 - 0.36358 \cos{(z_n)} + 0.48917 \cos{(2z_n)} - 0.13659 \cos{(3z_n)} + 0.01064 \cos{(4z_n)}
 
-where :math:`z_n = 2 \pi \frac{n}{M}`.
+where :math:`z_n = \frac{2 \pi n}{M}`.
     """,
     """
 


### PR DESCRIPTION
This partially fixes regression introduced by https://github.com/pytorch/pytorch/pull/124771 but also just improves `z_n` rendering, by using MathML
In 2.3 it was [rendered](https://pytorch.org/docs/2.3/generated/torch.signal.windows.nuttall.html#torch.signal.windows.nuttall)
as 
<img width="177" alt="image" src="https://github.com/user-attachments/assets/2c15d1f9-13ad-483f-bb66-41fa3fa4ba9c">


With this change it'll be [rendered](https://docs-preview.pytorch.org/pytorch/pytorch/134512/generated/torch.signal.windows.nuttall.html#torch.signal.windows.nuttall) as 
```math
z_n = \frac{2 \pi n}{M}
```