### PR TITLE
[CUDA][P2P] Check device capability in `requires_cuda_p2p_access`

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -28,7 +28,9 @@ from torch.testing._internal.common_utils import (
 
 def requires_cuda_p2p_access():
     cuda_p2p_access_available = (
-        torch.cuda.is_available() and torch.cuda.device_count() >= 2
+        torch.cuda.is_available()
+        and torch.cuda.get_device_capability() >= (8, 0)
+        and torch.cuda.device_count() >= 2
     )
     num_devices = torch.cuda.device_count()
     for i in range(num_devices - 1):


### PR DESCRIPTION
Tests seem to fail on e.g., Volta without this given the compile time meacros used e.g., in https://github.com/pytorch/pytorch/blob/79b7fff18820e4f62a02534a961d5930040e3475/torch/csrc/distributed/c10d/intra_node_comm.cu#L487

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @ptrblck @msaroufim