### PR TITLE
[export][training ir migration] quantized_decomposed.quantize_per_tensor decomposition

### DIFF
--- a/test/quantization/pt2e/test_xnnpack_quantizer.py
+++ b/test/quantization/pt2e/test_xnnpack_quantizer.py
@@ -4,6 +4,7 @@ import operator
 
 import torch
 import torch._dynamo as torchdynamo
+from torch._utils_internal import capture_pre_autograd_graph_using_training_ir
 from torch.ao.ns.fx.utils import compute_sqnr
 from torch.ao.quantization import (
     default_dynamic_fake_quant,
@@ -680,6 +681,20 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             torch.ops.quantized_decomposed.quantize_per_tensor.default: 0,
             torch.ops.quantized_decomposed.dequantize_per_tensor.default: 1,
         }
+
+        capture_pre_autograd_graph_node_occurrence = None
+        if capture_pre_autograd_graph_using_training_ir():
+            capture_pre_autograd_graph_node_occurrence = {
+                # input and output are using quantize_per_tensor and weight is using quantize_per_channel
+                # In training IR, the decomposition is different.
+                # `torch.ops.quantized_decomposed.quantize_per_tensor.default` nodes becomes
+                # `torch.ops.quantized_decomposed.quantize_per_tensor.tensor` nodes.
+                torch.ops.quantized_decomposed.quantize_per_tensor.tensor: 2,
+                torch.ops.quantized_decomposed.dequantize_per_tensor.tensor: 2,
+                # note: quantize op for weights are const propagated
+                torch.ops.quantized_decomposed.quantize_per_tensor.default: 0,
+                torch.ops.quantized_decomposed.dequantize_per_tensor.default: 0,
+            }
         act_affine_quant_obs = observer.PlaceholderObserver.with_args(
             dtype=torch.qint8,
             qscheme=torch.per_tensor_affine,
@@ -703,6 +718,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             [],
             True,
             qconfig_mapping,
+            capture_pre_autograd_graph_node_occurrence=capture_pre_autograd_graph_node_occurrence,
         )
 
     def test_gru(self):

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1247,6 +1247,7 @@ class PT2EQuantizationTestCase(QuantizationTestCase):
         export_with_dynamic_shape=False,
         is_qat=False,
         is_debug_mode=False,
+        capture_pre_autograd_graph_node_occurrence=None,
     ):
         # resetting dynamo cache
         torch._dynamo.reset()
@@ -1305,6 +1306,10 @@ class PT2EQuantizationTestCase(QuantizationTestCase):
             for k, v in PT2EQuantizationTestCase._MAP_TO_FX_TRACED_OPS.items():
                 if k in expected_node_occurrence:
                     node_occurrence[ns.call_function(v)] = expected_node_occurrence[k]
+            if capture_pre_autograd_graph_node_occurrence is not None:
+                node_occurrence = {
+                    ns.call_function(k): v for k, v in capture_pre_autograd_graph_node_occurrence.items()
+                }
             self.checkGraphModuleNodes(m_fx, expected_node_occurrence=node_occurrence)
             fx_quant_output = m_fx(*example_inputs)
             self.assertEqual(fx_quant_output, pt2_quant_output)


### PR DESCRIPTION
Summary:
In graph of  TestXNNPACKQuantizer.test_dynamic_linear_with_con test, some quantized_decomposed.quantize_per_tensor.default ops are becoming quantized_decomposed.dequantize_per_tensor.tensor ops when using the new training ir.

This is because we lift params/buffers before calling make_fx. So previously, for the graph that’s passed to make_fx,`graph.L__self___linear1.weight` is a tensor
now in training ir, graph.L__self___linear1.weight is a FakeTensor. This caused the node overload to be different.

Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test/quantization:test_quantization -- -r test_dynamic_linear_with_conv
```

Differential Revision: D61364547
