### PR TITLE
dynamo: Only log if we've disabled eval_frame once.

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -104,7 +104,7 @@ def _maybe_set_eval_frame(callback: DynamoCallback):
     from torch._C._dynamo.eval_frame import set_eval_frame
 
     if not justknobs_check("pytorch/compiler:enable_compiler_set_eval_frame"):
-        log.warning(
+        torch._dynamo.utils.warn_once(
             "Dynamo disabled by Justknob: enable_compiler_set_eval_frame, skipping set_eval_frame"
         )
         return callback

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -235,7 +235,8 @@ def justknobs_feature(
             killswitch work by having feature return True to turn off features
 
     Requirements:
-        Don't use this at import time - Simply pass in the existing config
+        WARNING - Don't use this at import time - Simply pass in the existing config.
+        If you want to use this at config time, use JustKnobsConfig
     """
     if config_value is not None:
         return config_value


### PR DESCRIPTION
This spams logs pretty badly otherwise


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec