### PR TITLE
[EZ] Restore `test_unicode_comments`

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15636,7 +15636,7 @@ dedent """
     def test_unicode_comments(self):
         @torch.jit.script
         def test(self, a):
-            # shrug
+            # 🤷🤷🤷🤷
             return torch.nn.functional.relu(a)
 
     def test_get_set_state_with_tensors(self):


### PR DESCRIPTION
This reverts changes introduced by test_jit.py by https://github.com/pytorch/pytorch/commit/43737bd78a4c7a120d8175941d54e8348e706068 and adds lint suppression for this it

As test name suggests it should have an unicode comment to make sure our parser can handle it

Part of the fix for https://github.com/pytorch/pytorch/issues/134422