### PR TITLE
[internal tests] Skip test_custom_op_add_abi_compatible_cuda

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3559,7 +3559,7 @@ CUDA_TEST_FAILURES = {
     # quantized unsupported for GPU
     "test_quantized_linear": fail_cuda(is_skip=True),
     "test_quanatized_int8_linear": fail_cuda(is_skip=True),
-    "test_custom_op_add": fail_non_abi_compatible_cuda(is_skip=True),
+    "test_custom_op_add": fail_cuda(is_skip=True),
     # fp8 to be re-enabled for AOTI
     "test_fp8": fail_cuda(is_skip=True),
     # non-abi compatible mode debug printer is not supported yet


### PR DESCRIPTION
Summary: See T197749225. This test is failing internally. Skip for now to get the tests green

Test Plan: `buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/inductor:test_aot_inductor -- --exact 'caffe2/test/inductor:test_aot_inductor - test_custom_op_add_abi_compatible_cuda (caffe2.test.inductor.test_aot_inductor.AOTInductorTestABICompatibleCuda)' --run-disabled`

Differential Revision: D61858960


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang