### PR TITLE
[CD] Fix docker builds by installing setuptools

### DIFF
--- a/.ci/docker/manywheel/build_scripts/build.sh
+++ b/.ci/docker/manywheel/build_scripts/build.sh
@@ -117,6 +117,8 @@ find /opt/_internal \
   -print0 | xargs -0 rm -f
 
 for PYTHON in /opt/python/*/bin/python; do
+    # install setuptools since python 3.12 its required to use distutils
+    $PYTHON -m pip install setuptools
     # Smoke test to make sure that our Pythons work, and do indeed detect as
     # being manylinux compatible:
     $PYTHON $MY_DIR/manylinux1-check.py

--- a/.ci/docker/manywheel/build_scripts/build.sh
+++ b/.ci/docker/manywheel/build_scripts/build.sh
@@ -117,8 +117,8 @@ find /opt/_internal \
   -print0 | xargs -0 rm -f
 
 for PYTHON in /opt/python/*/bin/python; do
-    # install setuptools since python 3.12 its required to use distutils
-    $PYTHON -m pip install setuptools
+    # install setuptools since python 3.12 is required to use distutils
+    $PYTHON -m pip install setuptools==68.2.2
     # Smoke test to make sure that our Pythons work, and do indeed detect as
     # being manylinux compatible:
     $PYTHON $MY_DIR/manylinux1-check.py

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -12,11 +12,13 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
     paths:
       - '.ci/docker/manywheel/*'
+      - '.ci/docker/manywheel/build_scripts/*'
       - '.ci/docker/common/*'
       - .github/workflows/build-manywheel-images.yml
   pull_request:
     paths:
       - '.ci/docker/manywheel/*'
+      - '.ci/docker/manywheel/build_scripts/*'
       - '.ci/docker/common/*'
       - .github/workflows/build-manywheel-images.yml
 


### PR DESCRIPTION
Seeing failures like this:
``` 
#49 844.6 //build_scripts/manylinux1-check.py:6: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
.....
[python 3/3] RUN bash build_scripts/build.sh && rm -r build_scripts:
846.9 ...it did, yay.
846.9 + for PYTHON in '/opt/python/*/bin/python'
846.9 + /opt/python/cpython-3.12.0/bin/python build_scripts/manylinux1-check.py
847.0 Traceback (most recent call last):
847.0   File "//build_scripts/manylinux1-check.py", line 55, in <module>
847.0     if is_manylinux1_compatible():
847.0        ^^^^^^^^^^^^^^^^^^^^^^^^^^
847.0   File "//build_scripts/manylinux1-check.py", line 6, in is_manylinux1_compatible
847.0     from distutils.util import get_platform
847.0 ModuleNotFoundError: No module named 'distutils'
------
```
PR: https://github.com/pytorch/pytorch/pull/134455
