### PR TITLE
Switch XNNPack tests to use _export_for_training (#4867)

### DIFF
--- a/test/quantization/pt2e/test_xnnpack_quantizer.py
+++ b/test/quantization/pt2e/test_xnnpack_quantizer.py
@@ -4,7 +4,7 @@ import operator
 
 import torch
 import torch._dynamo as torchdynamo
-from torch._export import capture_pre_autograd_graph
+from torch.export import export_for_training
 from torch.ao.ns.fx.utils import compute_sqnr
 from torch.ao.quantization import (
     default_dynamic_fake_quant,
@@ -361,7 +361,7 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
         )
         example_inputs = (torch.randn(2, 2),)
         m = M().eval()
-        m = capture_pre_autograd_graph(m, example_inputs)
+        m = export_for_training(m, example_inputs).module()
         m = prepare_pt2e(m, quantizer)
         # Use a linear count instead of names because the names might change, but
         # the order should be the same.
@@ -497,10 +497,10 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
         example_inputs = (torch.randn(1, 3, 5, 5),)
 
         # program capture
-        m = capture_pre_autograd_graph(
+        m = export_for_training(
             m,
             example_inputs,
-        )
+        ).module()
 
         m = prepare_pt2e(m, quantizer)
         m(*example_inputs)
@@ -754,10 +754,10 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             model_fx = _convert_to_reference_decomposed_fx(model_fx)
 
             with torchdynamo.config.patch(allow_rnn=True):
-                model_graph = capture_pre_autograd_graph(
+                model_graph = export_for_training(
                     model_graph,
                     example_inputs,
-                )
+                ).module()
             quantizer = XNNPACKQuantizer()
             quantization_config = get_symmetric_quantization_config(
                 is_per_channel=False, is_dynamic=False
@@ -818,10 +818,10 @@ class TestXNNPACKQuantizer(PT2EQuantizationTestCase):
             model_fx = _convert_to_reference_decomposed_fx(model_fx)
 
             with torchdynamo.config.patch(allow_rnn=True):
-                model_graph = capture_pre_autograd_graph(
+                model_graph = export_for_training(
                     model_graph,
                     example_inputs,
-                )
+                ).module()
             quantizer = XNNPACKQuantizer()
             quantization_config = get_symmetric_quantization_config(
                 is_per_channel=False, is_dynamic=False
@@ -995,10 +995,10 @@ class TestXNNPACKQuantizerModels(PT2EQuantizationTestCase):
             m = torchvision.models.resnet18().eval()
             m_copy = copy.deepcopy(m)
             # program capture
-            m = capture_pre_autograd_graph(
+            m = export_for_training(
                 m,
                 example_inputs,
-            )
+            ).module()
 
             quantizer = XNNPACKQuantizer()
             quantization_config = get_symmetric_quantization_config(is_per_channel=True)


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/executorch/pull/4867

Differential Revision: D61684468


