### PR TITLE
[cuSPARSE] Add ability to query `CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID` for a given workload

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3363,6 +3363,10 @@
   dispatch:
     CUDA: _cslt_sparse_mm_search
 
+- func: _cslt_sparse_mm_max_alg_id(Tensor compressed_A, Tensor dense_B, Tensor? bias=None, Tensor? alpha=None, ScalarType? out_dtype=None, bool transpose_result=False) -> int
+  dispatch:
+    CUDA: _cslt_sparse_mm_max_alg_id
+
 - func: _sparse_semi_structured_tile(Tensor input, str algorithm="", bool use_cutlass=True) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
   dispatch:
     CUDA: _sparse_semi_structured_tile

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3363,9 +3363,9 @@
   dispatch:
     CUDA: _cslt_sparse_mm_search
 
-- func: _cslt_sparse_mm_max_alg_id(Tensor compressed_A, Tensor dense_B, Tensor? bias=None, Tensor? alpha=None, ScalarType? out_dtype=None, bool transpose_result=False) -> int
+- func: _cslt_sparse_mm_get_attr(str attr_name, Tensor compressed_A, Tensor dense_B, Tensor? bias=None, Tensor? alpha=None, ScalarType? out_dtype=None, bool transpose_result=False) -> int
   dispatch:
-    CUDA: _cslt_sparse_mm_max_alg_id
+    CUDA: _cslt_sparse_mm_get_attr
 
 - func: _sparse_semi_structured_tile(Tensor input, str algorithm="", bool use_cutlass=True) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
   dispatch:

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -368,9 +368,9 @@ at::Tensor _cslt_sparse_mm(
         out_dtype_opt,
         transpose_result,
         (int) alg_id,
-	CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID,
+        CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID,
         false,
-	false);
+        false);
     return std::get<1>(result);
 }
 
@@ -394,7 +394,7 @@ int64_t _cslt_sparse_mm_search(
         alg_id_int,
         CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID,
         true,
-	false);
+        false);
     return (int64_t) std::get<0>(result);
 }
 
@@ -436,9 +436,9 @@ int64_t _cslt_sparse_mm_get_attr(
         out_dtype_opt,
         transpose_result,
         alg_id_int,
-	attr_enum,
+        attr_enum,
         true,
-	true);
+        true);
     return (int64_t) std::get<2>(result);
 }
 

--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -476,6 +476,19 @@ int64_t _cslt_sparse_mm_search(
     TORCH_CHECK(false, "cuSPARSELt not supported on your machine.");
 }
 
+int64_t _cslt_sparse_mm_get_attr(
+    c10::string_view attr_name,
+    const Tensor& compressed_A,
+    const Tensor& dense_B,
+    const std::optional<Tensor>& bias_opt,
+    const std::optional<Tensor>& alpha_opt,
+    const std::optional<c10::ScalarType> out_dtype_opt,
+    bool transpose_result
+)
+{
+    TORCH_CHECK(false, "cuSPARSELt not supported on your machine.");
+}
+
 } // namespace at::native
 
 #endif

--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -45,7 +45,7 @@ ignored_c_binding_in_graph_function_names = {
     # Ignored and go through rules defined at `trace_rules.check`.
     "torch._functionalize_are_all_mutations_under_no_grad_or_inference_mode",
     "torch._cslt_sparse_mm_search",
-    "torch._cslt_sparse_mm_max_alg_id",
+    "torch._cslt_sparse_mm_get_attr",
     "torch._C._abort",
     "torch._C._mps_is_on_macos_or_newer",
     "torch._C._swap_tensor_impl",

--- a/test/dynamo/test_trace_rules.py
+++ b/test/dynamo/test_trace_rules.py
@@ -45,6 +45,7 @@ ignored_c_binding_in_graph_function_names = {
     # Ignored and go through rules defined at `trace_rules.check`.
     "torch._functionalize_are_all_mutations_under_no_grad_or_inference_mode",
     "torch._cslt_sparse_mm_search",
+    "torch._cslt_sparse_mm_max_alg_id",
     "torch._C._abort",
     "torch._C._mps_is_on_macos_or_newer",
     "torch._C._swap_tensor_impl",

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -65,6 +65,7 @@ aten::_copy_from_and_resize
 aten::_copy_from_and_resize.out
 aten::_cslt_compress
 aten::_cslt_sparse_mm
+aten::_cslt_sparse_mm_get_attr
 aten::_cslt_sparse_mm_search
 aten::_ctc_loss
 aten::_ctc_loss.Tensor

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1089,7 +1089,7 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
 
         A_compressed = torch._cslt_compress(A)
 
-        max_alg_id = torch._cslt_sparse_mm_max_alg_id(A_compressed, B.t())
+        max_alg_id = torch._cslt_sparse_mm_get_attr('CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID', A_compressed, B.t())
         for alg_id in range(max_alg_id):
             # alg_id=3 not supported for float32 dtype
             if dtype == torch.float32 and alg_id == 3:
@@ -1109,11 +1109,7 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
 
         A_compressed = torch._cslt_compress(A)
         alg_id = torch._cslt_sparse_mm_search(A_compressed, B.t())
-        # for cuSPARSELt v0.4.0 there is a bug where although there are 5 alg_ids, we run into an error
-        # when setting using the last one (4)
-        # in cuSPARSELt v0.5.0 there are only 4 alg_ids total, so we should remove the +1 here when we update.
-        # TODO Move this into the cuSPARSELt backend
-        max_alg_id = torch._cslt_sparse_mm_max_alg_id(A_compressed, B.t())
+        max_alg_id = torch._cslt_sparse_mm_get_attr('CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID', A_compressed, B.t())
         assert alg_id in range(max_alg_id + 1)
 
     def test_cusparselt_backend(self):

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -53,7 +53,7 @@ FUNCTIONAL_OPS_THAT_CANNOT_GET_AN_OUT_VARIANT = [
     "_assert_async",  # no return
     "_assert_async.msg",  # no return
     "_cslt_sparse_mm_search",  # returns an int
-    "_cslt_sparse_mm_max_alg_id",  # returns an int
+    "_cslt_sparse_mm_get_attr",  # returns an int
     "_assert_scalar",  # no return
     "_dimI",  # returns an int
     "_dimV",  # returns an int

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -53,6 +53,7 @@ FUNCTIONAL_OPS_THAT_CANNOT_GET_AN_OUT_VARIANT = [
     "_assert_async",  # no return
     "_assert_async.msg",  # no return
     "_cslt_sparse_mm_search",  # returns an int
+    "_cslt_sparse_mm_max_alg_id",  # returns an int
     "_assert_scalar",  # no return
     "_dimI",  # returns an int
     "_dimV",  # returns an int


### PR DESCRIPTION
Also use this value in tests instead of the previous hardcoded value of `4`

CC @syed-ahmed 

cc @alexsamardzic @nikitaved @pearu @cpuhrsch @amjames @bhosmer @jcaip @ptrblck @msaroufim @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @rec