### PR TITLE
Allow optional positional arguments for `torch.func.functional_call`

### DIFF
--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -738,6 +738,8 @@ class TestStatelessFunctionalAPI(TestCase):
         self.assertEqual(res, other_inp)
         res_1 = functional_call(mod, a, (), {'inp': inp, 'other_inp': other_inp})
         self.assertEqual(res, res_1)
+        res_2 = functional_call(mod, a, kwargs={'inp': inp, 'other_inp': other_inp})
+        self.assertEqual(res, res_2)
 
     def test_functional_call_tuple_dicts(self):
         mod = MockModule()

--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -12,7 +12,7 @@ from torch._functorch.utils import exposed_in
 def functional_call(
     module: "torch.nn.Module",
     parameter_and_buffer_dicts: Union[Dict[str, Tensor], Sequence[Dict[str, Tensor]]],
-    args: Union[Any, Tuple],
+    args: Optional[Union[Any, Tuple]] = None,
     kwargs: Optional[Dict[str, Any]] = None,
     *,
     tie_weights: bool = True,

--- a/torch/nn/utils/stateless.py
+++ b/torch/nn/utils/stateless.py
@@ -186,7 +186,7 @@ def _reparametrize_module(
 def functional_call(
     module: "torch.nn.Module",
     parameters_and_buffers: Dict[str, Tensor],
-    args: Union[Any, Tuple],
+    args: Optional[Union[Any, Tuple]] = None,
     kwargs: Optional[Dict[str, Any]] = None,
     *,
     tie_weights: bool = True,
@@ -264,7 +264,7 @@ def functional_call(
 def _functional_call(
     module: "torch.nn.Module",
     parameters_and_buffers: Dict[str, Tensor],
-    args: Union[Any, Tuple],
+    args: Optional[Union[Any, Tuple]] = None,
     kwargs: Optional[Dict[str, Any]] = None,
     *,
     tie_weights: bool = True,
@@ -290,7 +290,9 @@ def _functional_call(
         )
     if kwargs is None:
         kwargs = {}
-    if not isinstance(args, tuple):
+    if args is None:
+        args = ()
+    elif not isinstance(args, tuple):
         args = (args,)
     with _reparametrize_module(
         module, parameters_and_buffers, tie_weights=tie_weights, strict=strict


### PR DESCRIPTION
This PR resolves #134408. Add an additional test and have passed the local test.

Do you think we should add a post-check to ensure `args` and `kwargs` are not both `None`? It seems to be possible to have modules without inputs.

This PR does not include any such post-check.

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki