### PR TITLE
[Inductor][CPP] Fix Index name error

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3382,11 +3382,13 @@ class TilingSelect:
                                     and _node.target in ["index_expr", "load", "store"]
                                 ):
                                     return False
-                                arg_idx = 1 if _node.target == "index_expr" else 2
+                                get_index_node = _node.args[
+                                    1 if _node.target == "index_expr" else 2
+                                ]
                                 return (
-                                    isinstance(_node.args[arg_idx], torch.fx.node.Node)
-                                    and _node.args[arg_idx].target == "get_index"
-                                    and isinstance(_node.args[arg_idx].args[0], str)
+                                    isinstance(get_index_node, torch.fx.node.Node)
+                                    and get_index_node.target == "get_index"
+                                    and isinstance(get_index_node.args[0], str)
                                 )
 
                             if can_get_index_name(_node):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134645

**Summary**

Fix the comment: https://github.com/pytorch/pytorch/pull/122961#issuecomment-2313930242. For all of the cases we see in the 3 test suits (TorchBench, Timms, Huggingface) we expect:

* `_node` is a FX Node with target in ["index_expr", "load", "store"]
* `_node.args[1 if _node.target == "index_expr" else 2]` is another FX node with target `get_index`
* `_node.args[1 if _node.target == "index_expr" else 2].args[0]` is a str for the name of this index expression

It seems not true in some FB internal testcase from the failure log posted in above link. So, add the condition check to work around it.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang