### PR TITLE
fix flakiness in update_hint_benchmark.py

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -109,6 +109,10 @@ class BenchmarkBase(ABC):
             CompileTimeInstructionCounter.clear()
             self._work()
             count = CompileTimeInstructionCounter.value()
+            if count == 0:
+                raise RuntimeError(
+                    "compile time instruction count is 0, please check your benchmarks"
+                )
             print(f"compile time instruction count for iteration {i} is {count}")
             results.append(count)
 

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/update_hint_benchmark.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/update_hint_benchmark.py
@@ -20,7 +20,6 @@ class Benchmark(BenchmarkBase):
         torch.manual_seed(0)
 
         self.splits = torch.randint(10, (self.N,))
-        print(self.splits)
         sz = self.splits.sum().item()
         self.input = torch.randn(sz)
 

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/update_hint_benchmark.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/update_hint_benchmark.py
@@ -1,4 +1,4 @@
-import random
+import gc
 import sys
 
 from benchmark_base import BenchmarkBase
@@ -17,13 +17,17 @@ class Benchmark(BenchmarkBase):
 
     def _prepare_once(self):
         torch._dynamo.config.capture_scalar_outputs = True
-        random.seed(42)
+        torch.manual_seed(0)
+
         self.splits = torch.randint(10, (self.N,))
+        print(self.splits)
         sz = self.splits.sum().item()
         self.input = torch.randn(sz)
 
     def _prepare(self):
         torch._dynamo.reset()
+        gc.collect()
+        gc.disable()
 
     def _work(self):
         @torch.compile(fullgraph=True)

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/update_hint_benchmark.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/update_hint_benchmark.py
@@ -37,8 +37,7 @@ class Benchmark(BenchmarkBase):
                 torch._check(x <= self.N)
             return a.split(xs)
 
-        for i in range(1000):
-            f(self.input, self.splits)
+        f(self.input, self.splits)
 
 
 def main():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134649
* #134635
* #133834
```
compile time instruction count for iteration 1 is 10732129038
compile time instruction count for iteration 2 is 10719776783
compile time instruction count for iteration 3 is 10729546868
compile time instruction count for iteration 4 is 10737655132
compile time instruction count for iteration 5 is 10732564252
compile time instruction count for iteration 6 is 10728721234
compile time instruction count for iteration 7 is 10733354271
compile time instruction count for iteration 8 is 10719588972
compile time instruction count for iteration 9 is 10706311856
```
1. add torch.manual_seed(0), inputs was not the same across iterations
2. disable gc. 
3. remove loop (not needed since compilation happen once only)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec