### PR TITLE
[AOTI][Tooling] Follow up to print location of saved file path for `torch.pickle_save()`

### DIFF
--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import functools
+import logging
 from enum import Enum
 from typing import List, Optional
 
@@ -9,6 +10,9 @@ from .. import config
 from ..virtualized import V
 from .common import TensorArg
 from .multi_kernel import MultiKernel
+
+
+log = logging.getLogger(__name__)
 
 
 # AOTI debug printing related configs
@@ -37,7 +41,7 @@ class DebugPrinterManager:
         self.kernel_name = kernel_name
         self.arg_signatures: Optional[List[type]] = None
         self.kernel = kernel
-        self.filtered_kernel_names_to_print = self.get_debug_filtered_kernel_names()
+        self.filtered_kernel_names_to_print = self._get_debug_filtered_kernel_names()
 
     def __enter__(self):
         self._perform_debug_print_or_save_helper(
@@ -81,6 +85,15 @@ class DebugPrinterManager:
                 arg_signatures=self.arg_signatures,
             )
 
+    @functools.lru_cache  # noqa: B019
+    def _get_debug_filtered_kernel_names(self) -> List[str]:
+        if config.aot_inductor.filtered_kernel_names is None:
+            return []
+        return [
+            x.strip()
+            for x in config.aot_inductor.filtered_kernel_names.lower().split(",")
+        ]
+
     def set_printer_args(
         self,
         args_to_print_or_save: List[str],
@@ -90,20 +103,14 @@ class DebugPrinterManager:
     ):
         # Note: MultiKernel debug printing is not supported for now
         if isinstance(kernel, MultiKernel):
+            log.info(
+                "MultiKernel type is not supported in AOTI debug printer tool yet."
+            )
             self.debug_printer_level = IntermediateValueDebuggingLevel.OFF
         self.args_to_print_or_save = args_to_print_or_save
         self.kernel_name = kernel_name
         self.arg_signatures = arg_signatures
         self.kernel = kernel
-
-    @functools.lru_cache  # noqa: B019
-    def get_debug_filtered_kernel_names(self) -> List[str]:
-        if config.aot_inductor.filtered_kernel_names is None:
-            return []
-        return [
-            x.strip()
-            for x in config.aot_inductor.filtered_kernel_names.lower().split(",")
-        ]
 
     def codegen_intermediate_tensor_value_save(
         self,
@@ -143,7 +150,8 @@ class DebugPrinterManager:
             ):
                 continue
             if self.debug_printer_level == IntermediateValueDebuggingLevel.PRINT_ONLY:
-                # when debug printing is enabled i.e. DEFAULT_PRINT level, check if filtered kernel name list is provided
+                # when debug printing is enabled i.e. IntermediateValueDebuggingLevel.PRINT_ONLY,
+                # check if filtered kernel name list is provided
                 if (
                     len(self.filtered_kernel_names_to_print) > 0
                     and kernel_name not in self.filtered_kernel_names_to_print

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1007,11 +1007,13 @@ AOTI_TORCH_EXPORT void aoti_torch_save_tensor_handle(
   std::string cwd = fs::current_path().string();
   std::string tmp_folder = cwd + "/tmp/aoti_torch/";
   if (!fs::exists(tmp_folder)) {
-    std::cout << "Path does not exist, creating it..." << tmp_folder
-              << std::endl;
+    std::cout
+        << "aoti_torch_save_tensor_handle: Path does not exist, creating it..."
+        << tmp_folder << std::endl;
 
     if (!fs::create_directories(tmp_folder)) {
-      std::cout << "Error creating directory: " << tmp_folder << std::endl;
+      std::cout << "aoti_torch_save_tensor_handle: Error creating directory: "
+                << tmp_folder << std::endl;
       return;
     }
   }
@@ -1022,6 +1024,9 @@ AOTI_TORCH_EXPORT void aoti_torch_save_tensor_handle(
   std::ofstream fout(tensor_filepath_to_save, std::ios::out | std::ios::binary);
   fout.write(bytes.data(), bytes.size());
   fout.close();
+
+  std::cout << "aoti_torch_save_tensor_handle: Saved tensor to: "
+            << tensor_filepath_to_save << std::endl;
 #endif // !defined(C10_MOBILE)
 }
 


### PR DESCRIPTION
Summary:
- Follow up to add torch.pickle_save() log for saved file path

- Minor debug printer code refine

Test Plan: CI

Differential Revision: D61883239


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang