### PR TITLE
[export] Log to torch_export_usage using Logger

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -10,6 +10,7 @@ in torch._dynamo.convert_frame.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import functools
 import inspect
@@ -1295,7 +1296,7 @@ def export(
     Note - this headerdoc was authored by ChatGPT, with slight modifications by the author.
     """
     if _log_export_usage:
-        log_export_usage(event="export.private_api", flags={"_dynamo"})
+        asyncio.run(log_export_usage(event="export.private_api", flags={"_dynamo"}))
 
     # Deal with "local variable referenced before assignment"
     _f = f

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -132,7 +132,8 @@ def capture_pre_autograd_graph(
         print_export_warning()
         module = torch.export._trace._export_for_training(f, args, kwargs, dynamic_shapes=dynamic_shapes, strict=True).module()
     else:
-        log_export_usage(event="export.private_api", flags={"capture_pre_autograd_graph"})
+        import asyncio
+        asyncio.run(log_export_usage(event="export.private_api", flags={"capture_pre_autograd_graph"}))
 
         # Do not decompose dropout for exported models, because in eval mode the dropout
         # op disappears from the graph, which makes it difficult to switch to train mode.

--- a/torch/_export/db/logging.py
+++ b/torch/_export/db/logging.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import asyncio
 
 
 def exportdb_error_message(case_name: str):
@@ -12,10 +13,10 @@ def exportdb_error_message(case_name: str):
         return f"See {case_name} in exportdb for unsupported case. \
                 https://pytorch.org/docs/main/generated/exportdb/index.html#{url_case_name}"
     else:
-        log_export_usage(
+        asyncio.run(log_export_usage(
             event="export.error.casenotregistered",
             message=case_name,
-        )
+        ))
         return f"{case_name} is unsupported."
 
 

--- a/torch/_export/tools.py
+++ b/torch/_export/tools.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import asyncio
 import logging
 import warnings
 from typing import Any, Dict, Iterable, Optional, Tuple
@@ -83,8 +84,7 @@ def report_exportability(
             'submod_2': None
         }
     """
-
-    log_export_usage(event="export.report_exportability")
+    asyncio.run(log_export_usage(event="export.report_exportability"))
 
     kwargs = kwargs or {}
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -124,7 +124,7 @@ def set_pytorch_distributed_envs_from_justknobs():
     pass
 
 
-def log_export_usage(**kwargs):
+async def log_export_usage(**kwargs):
     pass
 
 


### PR DESCRIPTION
Summary:
We need to use logger so we can dual inject into both scuba table and hive table.

For now we still leave the old scuba ingestion path, but it will be deleted once the new logging works reliably.

TODO: add unit test

Test Plan: Running on devserver logs to scuba and hive tables.

Differential Revision: D61688773


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec