### PR TITLE
[CPU][flash attention] make the stride of output align with input

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -888,7 +888,7 @@ _scaled_dot_product_flash_attention_cpu(
           (attn_mask.value().dim() == 2 || attn_mask.value().dim() == 4),
     "scaled_dot_product_attention_flash_attention: Attention mask dim in {2, 4}");
 
-  at::Tensor output = at::empty({batchSize, qSize, num_head, headSize}, query.options());
+  at::Tensor output = at::empty_like(query, query.options()).transpose(1, 2);
   const auto accumulate_dtype = toOpMathType(dtype);
   at::Tensor logsumexp = at::empty({batchSize, qSize, num_head},
       query.options().dtype(accumulate_dtype));

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -870,7 +870,6 @@ _scaled_dot_product_flash_attention_cpu(
   int64_t batchSize = query.size(0);
   int64_t qSize = query.size(2);
   int64_t num_head = query.size(1);
-  int64_t headSize = query.size(3);
 
   TORCH_CHECK(c10::isFloatingType(dtype),
     "scaled_dot_product_attention_flash_attention: Expected data type in FP32, FP64, BF16, FP16, but got ", dtype, " instead.");

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5188,11 +5188,7 @@ def meta__scaled_dot_product_flash_attention_for_cpu(
     max_seqlen_batch_q = query.size(2)
     head_dim = query.size(3)
 
-    attention = torch.empty(
-        (batch_size, max_seqlen_batch_q, num_heads, head_dim),
-        dtype=query.dtype,
-        device=query.device,
-    ).transpose(1, 2)
+    attention = torch.empty_like(query)
     logsumexp = torch.empty(
         (
             batch_size,


### PR DESCRIPTION
Fixes #133671

Currently, the output of CPU flash attention has a fixed layout, no matter what the input is. This PR makes the stride of output align with input q/k/v, which is the same behavior as math backend.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10