### PR TITLE
[aoti] Package additional metadata

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1706,9 +1706,20 @@ class AotCodeCompiler:
             # Currently, this only support serializing extern nodes in fbcode
             # Eventually, we should also have a serializer for OSS.
             if serialized_extern_kernel_nodes:
-                output_json = os.path.splitext(input_path)[0] + ".json"
-                with open(output_json, "w") as f:
+                extern_kernel_nodes_json = os.path.splitext(input_path)[0] + ".json"
+                with open(extern_kernel_nodes_json, "w") as f:
                     f.write(serialized_extern_kernel_nodes)
+
+            # Save user provided metadata
+            if len(config.aot_inductor.metadata) > 0:
+                meta_json = os.path.splitext(input_path)[0] + "_metadata.json"
+                for k, v in config.aot_inductor.metadata.items():
+                    assert isinstance(k, str) and isinstance(
+                        v, (str)
+                    ), "Metadata must only contain strings"
+
+                with open(meta_json, "w") as f:
+                    f.write(json.dumps(config.aot_inductor.metadata))
 
             output_so = (
                 config.aot_inductor.output_path

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -946,6 +946,9 @@ class aot_inductor:
 
     package: bool = False
 
+    # Dictionary of metadata users might want to save to pass to the runtime.
+    metadata: Dict[str, str] = {}
+
 
 class cuda:
     # CUDA arch to use for CUDA template kernel compilation.

--- a/torch/_inductor/package/package.py
+++ b/torch/_inductor/package/package.py
@@ -129,7 +129,7 @@ def compile_so(aoti_dir: str, aoti_files: List[str], so_path: str) -> str:
 
     linker_options = BuildOptionsBase(**linker_flags)
     so_builder = CppBuilder(
-        name=os.path.split(so_path)[-1],
+        name=file_name,
         sources=[output_o, consts_o],
         BuildOption=linker_options,
         output_dir=so_path,

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -42,6 +42,7 @@ class TORCH_API AOTIModelContainerRunner {
   void swap_constant_buffer();
 
   std::vector<std::string> get_call_spec();
+  std::unordered_map<std::string, std::string> get_metadata();
 
  protected:
   AOTIModelContainerRunner(
@@ -80,6 +81,7 @@ class TORCH_API AOTIModelContainerRunner {
 
  private:
   std::unique_ptr<torch::aot_inductor::ProxyExecutor> proxy_executor_;
+  std::unordered_map<std::string, std::string> metadata_;
 };
 
 using CreateAOTIModelRunnerFunc = std::shared_ptr<AOTIModelContainerRunner> (*)(

--- a/torch/csrc/inductor/aoti_runner/pybind.cpp
+++ b/torch/csrc/inductor/aoti_runner/pybind.cpp
@@ -17,6 +17,7 @@ void initAOTIRunnerBindings(PyObject* module) {
       .def(py::init<const std::string&, int>())
       .def("run", &AOTIModelContainerRunnerCpu::run)
       .def("get_call_spec", &AOTIModelContainerRunnerCpu::get_call_spec)
+      .def("get_metadata", &AOTIModelContainerRunnerCpu::get_metadata)
       .def(
           "get_constant_names_to_original_fqns",
           &AOTIModelContainerRunnerCpu::getConstantNamesToOriginalFQNs)
@@ -35,6 +36,7 @@ void initAOTIRunnerBindings(PyObject* module) {
            const std::string&>())
       .def("run", &AOTIModelContainerRunnerCuda::run)
       .def("get_call_spec", &AOTIModelContainerRunnerCuda::get_call_spec)
+      .def("get_metadata", &AOTIModelContainerRunnerCuda::get_metadata)
       .def(
           "get_constant_names_to_original_fqns",
           &AOTIModelContainerRunnerCuda::getConstantNamesToOriginalFQNs)


### PR DESCRIPTION
We want to package additional user-provided metadata inside of the AOTI package so that users can reference this information in some outside wrapper. The main use-case is for torchchat, where we will store the device used during export time and model name, so that the torchchat wrapper can just automatically select which AOTIRunner to use, and which model weights to load. Currently, the metadata can only be a Dict[str, str], and will be stored as a json file in the AOTI package.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang