### PR TITLE
[ONNX][DORT] Lazy-import `onnxruntime`

### DIFF
--- a/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
+++ b/test/onnx/dynamo/test_dynamo_with_onnxruntime_backend.py
@@ -51,17 +51,19 @@ class TestDynamoWithONNXRuntime(onnx_test_common._TestONNXRuntime):
         OrtBackend.clear_cached_instances()
 
     def test_get_ort_device_type(self):
+        from onnxruntime.capi import _pybind_state as ORTC
+
         self.assertEqual(
             torch.onnx._internal.onnxruntime._get_ort_device_type("cuda"),
-            torch.onnx._internal.onnxruntime.ORTC.OrtDevice.cuda(),
+            ORTC.OrtDevice.cuda(),
         )
         self.assertEqual(
             torch.onnx._internal.onnxruntime._get_ort_device_type("cpu"),
-            torch.onnx._internal.onnxruntime.ORTC.OrtDevice.cpu(),
+            ORTC.OrtDevice.cpu(),
         )
         self.assertEqual(
             torch.onnx._internal.onnxruntime._get_ort_device_type("maia"),
-            torch.onnx._internal.onnxruntime.ORTC.OrtDevice.npu(),
+            ORTC.OrtDevice.npu(),
         )
 
     def test_torch_compile_backend_registration(self):

--- a/test/onnx/test_lazy_import.py
+++ b/test/onnx/test_lazy_import.py
@@ -10,13 +10,21 @@ from torch.testing._internal import common_utils
 
 
 class TestLazyONNXRuntime(pytorch_test_common.ExportTestCase):
-
     def test_onnxruntime_is_lazily_imported(self):
-
         with tempfile.TemporaryDirectory() as wd:
-            r = subprocess.run([sys.executable, '-Ximporttime', '-c', 'import sys, torch.onnx'], capture_output=True, text=True, cwd=wd, check=True)
+            r = subprocess.run(
+                [sys.executable, "-Ximporttime", "-c", "import sys, torch.onnx"],
+                capture_output=True,
+                text=True,
+                cwd=wd,
+                check=True,
+            )
 
-        self.assertTrue(' onnxruntime' not in r.stderr, f'`onnxruntime` should not be imported, full importtime: {r.stderr}')
+        # Note the extra space here, which makes sure we're checking for `onnxruntime`, not `torch.onnx._internal.onnxruntime`.
+        self.assertTrue(
+            " onnxruntime" not in r.stderr,
+            f"`onnxruntime` should not be imported, full importtime: {r.stderr}",
+        )
 
 
 if __name__ == "__main__":

--- a/test/onnx/test_lazy_import.py
+++ b/test/onnx/test_lazy_import.py
@@ -9,22 +9,28 @@ import pytorch_test_common
 from torch.testing._internal import common_utils
 
 
-class TestLazyONNXRuntime(pytorch_test_common.ExportTestCase):
-    def test_onnxruntime_is_lazily_imported(self):
+class TestLazyONNXPackages(pytorch_test_common.ExportTestCase):
+    def _test_package_is_lazily_imported(self, pkg, torch_pkg="torch.onnx"):
         with tempfile.TemporaryDirectory() as wd:
             r = subprocess.run(
-                [sys.executable, "-Ximporttime", "-c", "import sys, torch.onnx"],
+                [sys.executable, "-Ximporttime", "-c", "import torch.onnx"],
                 capture_output=True,
                 text=True,
                 cwd=wd,
                 check=True,
             )
 
-        # Note the extra space here, which makes sure we're checking for `onnxruntime`, not `torch.onnx._internal.onnxruntime`.
+        # The extra space makes sure we're checking the package, not any package containing its name.
         self.assertTrue(
-            " onnxruntime" not in r.stderr,
-            f"`onnxruntime` should not be imported, full importtime: {r.stderr}",
+            f" {pkg}" not in r.stderr,
+            f"`{pkg}` should not be imported, full importtime: {r.stderr}",
         )
+
+    def test_onnxruntime_is_lazily_imported(self):
+        self._test_package_is_lazily_imported("onnxruntime")
+
+    def test_onnxscript_is_lazily_imported(self):
+        self._test_package_is_lazily_imported("onnxscript")
 
 
 if __name__ == "__main__":

--- a/test/onnx/test_lazy_import.py
+++ b/test/onnx/test_lazy_import.py
@@ -1,5 +1,9 @@
 # Owner(s): ["module: onnx"]
 
+import subprocess
+import sys
+import tempfile
+
 import pytorch_test_common
 
 from torch.testing._internal import common_utils
@@ -7,10 +11,7 @@ from torch.testing._internal import common_utils
 
 class TestLazyONNXRuntime(pytorch_test_common.ExportTestCase):
 
-    def test_lazy_import_(self):
-        import subprocess
-        import sys
-        import tempfile
+    def test_onnxruntime_is_lazily_imported(self):
 
         with tempfile.TemporaryDirectory() as wd:
             r = subprocess.run([sys.executable, '-Ximporttime', '-c', 'import sys, torch.onnx'], capture_output=True, text=True, cwd=wd, check=True)

--- a/test/onnx/test_lazy_import.py
+++ b/test/onnx/test_lazy_import.py
@@ -1,0 +1,22 @@
+# Owner(s): ["module: onnx"]
+
+import pytorch_test_common
+
+from torch.testing._internal import common_utils
+
+
+class TestLazyONNXRuntime(pytorch_test_common.ExportTestCase):
+
+    def test_lazy_import_(self):
+        import subprocess
+        import sys
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as wd:
+            r = subprocess.run([sys.executable, '-Ximporttime', '-c', 'import sys, torch.onnx'], capture_output=True, text=True, cwd=wd, check=True)
+
+        self.assertTrue(' onnxruntime' not in r.stderr, f'`onnxruntime` should not be imported, full importtime: {r.stderr}')
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/torch/onnx/_internal/fx/torch_export_graph_extractor.py
+++ b/torch/onnx/_internal/fx/torch_export_graph_extractor.py
@@ -12,6 +12,7 @@ import torch._dynamo
 import torch.fx
 from torch.onnx._internal import _exporter_legacy, io_adapter
 from torch.onnx._internal.diagnostics import infra
+from torch.onnx._internal.fx import analysis, passes
 
 
 if TYPE_CHECKING:
@@ -106,9 +107,6 @@ class TorchExport(_exporter_legacy.FXGraphExtractor):
         fx_module: torch.fx.GraphModule,
         fx_module_args: Sequence[Any],
     ):
-        # TODO: Import here to prevent circular dependency
-        from torch.onnx._internal.fx import analysis, passes
-
         diagnostic_context = options.diagnostic_context
 
         # ONNX does not support concept of (implicit) type promotion.

--- a/torch/onnx/_internal/fx/torch_export_graph_extractor.py
+++ b/torch/onnx/_internal/fx/torch_export_graph_extractor.py
@@ -12,7 +12,6 @@ import torch._dynamo
 import torch.fx
 from torch.onnx._internal import _exporter_legacy, io_adapter
 from torch.onnx._internal.diagnostics import infra
-from torch.onnx._internal.fx import analysis, passes
 
 
 if TYPE_CHECKING:
@@ -107,6 +106,9 @@ class TorchExport(_exporter_legacy.FXGraphExtractor):
         fx_module: torch.fx.GraphModule,
         fx_module_args: Sequence[Any],
     ):
+        # TODO: Import here to prevent circular dependency
+        from torch.onnx._internal.fx import analysis, passes
+
         diagnostic_context = options.diagnostic_context
 
         # ONNX does not support concept of (implicit) type promotion.

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -37,23 +37,15 @@ if TYPE_CHECKING:
     import onnxruntime
     from onnxruntime.capi import _pybind_state as ORTC
 
-try:
     import torch.onnx
     import torch.onnx._internal
     import torch.onnx._internal._exporter_legacy
     import torch.onnx._internal.diagnostics
     import torch.onnx._internal.fx.decomposition_table
-    import torch.onnx._internal.fx.passes
-    from torch.onnx._internal.fx import fx_onnx_interpreter
-    from torch.onnx._internal.fx.type_utils import (
-        _TORCH_DTYPE_TO_NUMPY_DTYPE,
-        _TORCH_DTYPE_TO_ONNX_TENSOR_ELEMENT_TYPE,
-        from_python_type_to_onnx_tensor_element_type,
-    )
+    import torch.onnx._internal.fx.passes  # noqa: TCH004
 
-    _SUPPORT_ONNXRT = None
-except ImportError:
-    _SUPPORT_ONNXRT = False
+
+_SUPPORT_ONNXRT: Optional[bool] = None
 
 __all__ = [
     "is_onnxrt_backend_supported",
@@ -94,6 +86,17 @@ def is_onnxrt_backend_supported() -> bool:
             # This is not use directly in DORT but needed by underlying exporter,
             # so we still need to check if it exists.
             importlib.import_module("onnxscript")
+
+            import torch.onnx  # noqa: F401
+            import torch.onnx._internal  # noqa: F401
+            import torch.onnx._internal._exporter_legacy  # noqa: F401
+            import torch.onnx._internal.diagnostics  # noqa: F401
+            from torch.onnx._internal.fx import (  # noqa: F401
+                decomposition_table,
+                fx_onnx_interpreter,
+                passes,
+                type_utils,
+            )
 
             _SUPPORT_ONNXRT = True
         except ImportError:
@@ -356,6 +359,8 @@ def _get_ortvalues_from_torch_tensors(
 ) -> Tuple[torch.Tensor, ...]:
     from onnxruntime.capi import _pybind_state as ORTC
 
+    from torch.onnx._internal.fx.type_utils import _TORCH_DTYPE_TO_NUMPY_DTYPE
+
     ortvalues = ORTC.OrtValueVector()
     ortvalues.reserve(len(tensors))
     dtypes = []
@@ -593,6 +598,11 @@ class OrtExecutionInfoPerSession:
         )
 
     def is_supported(self, *args):
+        from torch.onnx._internal.fx.type_utils import (
+            _TORCH_DTYPE_TO_ONNX_TENSOR_ELEMENT_TYPE,
+            from_python_type_to_onnx_tensor_element_type,
+        )
+
         # Compare the args and the input schema in ONNX model and
         # return the first match.
         if len(args) != len(self.input_value_infos):
@@ -753,6 +763,10 @@ class OrtBackend:
     def __init__(self, options: Optional[OrtBackendOptions] = None):
         from onnxruntime.capi import _pybind_state as ORTC
 
+        import torch.onnx
+        import torch.onnx._internal._exporter_legacy
+        import torch.onnx._internal.fx.decomposition_table
+
         self._options: Final = OrtBackendOptions() if options is None else options
 
         # options.export_options contains information shared between exporter and DORT.
@@ -876,6 +890,8 @@ class OrtBackend:
         """
         import onnxruntime
 
+        from torch.onnx._internal.fx import fx_onnx_interpreter, passes
+
         cached_execution_info_per_session = (
             self._all_ort_execution_info.search_reusable_session_execution_info(
                 graph_module, *args
@@ -894,7 +910,7 @@ class OrtBackend:
             # It's first time seeing such as graph. Let's make a new session
             # (type: onnxruntime.InferenceSession) for it.
 
-            graph_module = torch.onnx._internal.fx.passes.MovePlaceholderToFront(
+            graph_module = passes.MovePlaceholderToFront(
                 self._resolved_onnx_exporter_options.diagnostic_context,
                 graph_module,
             ).run()
@@ -942,7 +958,7 @@ class OrtBackend:
             # Cast FX variables if they will result schema-mismatch when searching
             # for ONNX operator. E.g., add(double_tensor, int_tensor) is fine in PyTorch,
             # but ONNX expects add(double_tensor, double_tensor).
-            graph_module = torch.onnx._internal.fx.passes.InsertTypePromotion(
+            graph_module = passes.InsertTypePromotion(
                 self._resolved_onnx_exporter_options.diagnostic_context, graph_module
             ).run()
             # Start the per-node exporting process. It's conceptually a for loop

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -35,7 +35,6 @@ from torch.utils import _pytree
 if TYPE_CHECKING:
     import onnx
     import onnxruntime
-
     from onnxruntime.capi import _pybind_state as ORTC
 
 try:
@@ -572,7 +571,7 @@ class OrtExecutionInfoPerSession:
         example_outputs: Union[Tuple[torch.Tensor, ...], torch.Tensor],
     ):
         # Carrier of ONNX model and its executor.
-        self.session: "onnxruntime.InferenceSession" = session
+        self.session: onnxruntime.InferenceSession = session
         # For the ONNX model stored in self.session, self.input_names[i] is the
         # name of the i-th positional input.
         self.input_names: Tuple[str, ...] = input_names
@@ -584,9 +583,9 @@ class OrtExecutionInfoPerSession:
         self.output_value_infos: Tuple[onnx.ValueInfoProto, ...] = output_value_infos  # type: ignore[name-defined]
         # For the ONNX model stored in self.session, self.input_devices[i] is the
         # i-th positional input's device.
-        self.input_devices: Tuple["ORTC.OrtDevice", ...] = input_devices
+        self.input_devices: Tuple[ORTC.OrtDevice, ...] = input_devices
         # Similar to self.input_devices, but for outputs.
-        self.output_devices: Tuple["ORTC.OrtDevice", ...] = output_devices
+        self.output_devices: Tuple[ORTC.OrtDevice, ...] = output_devices
         # This is the outputs of executing the original torch.fx.GraphModule with example inputs
         # (i.e., args passed into OrtBackend._ort_acclerated_call).
         self.example_outputs: Union[Tuple[torch.Tensor, ...], torch.Tensor] = (

--- a/torch/onnx/_internal/onnxruntime.py
+++ b/torch/onnx/_internal/onnxruntime.py
@@ -354,7 +354,7 @@ def _get_onnx_devices(
 
 def _get_ortvalues_from_torch_tensors(
     tensors: Tuple[torch.Tensor, ...], devices: Tuple["ORTC.OrtDevice", ...]
-) -> Tuple[torch.Tensor, ...]:    
+) -> Tuple[torch.Tensor, ...]:
     from onnxruntime.capi import _pybind_state as ORTC
 
     ortvalues = ORTC.OrtValueVector()


### PR DESCRIPTION
Currently, if installed, `onnxruntime` will be imported when importing `torch._inductor` (which will be imported by some other library, e.g. transformer-engine):

```
  /mnt/c.py(53)<module>()
-> from torch._inductor.utils import maybe_profile
  /usr/local/lib/python3.10/site-packages/torch/_inductor/utils.py(49)<module>()
-> import torch._export
  /usr/local/lib/python3.10/site-packages/torch/_export/__init__.py(25)<module>()
-> import torch._dynamo
  /usr/local/lib/python3.10/site-packages/torch/_dynamo/__init__.py(2)<module>()
-> from . import convert_frame, eval_frame, resume_execution
  /usr/local/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py(48)<module>()
-> from . import config, exc, trace_rules
  /usr/local/lib/python3.10/site-packages/torch/_dynamo/trace_rules.py(52)<module>()
-> from .variables import (
  /usr/local/lib/python3.10/site-packages/torch/_dynamo/variables/__init__.py(38)<module>()
-> from .higher_order_ops import (
  /usr/local/lib/python3.10/site-packages/torch/_dynamo/variables/higher_order_ops.py(14)<module>()
-> import torch.onnx.operators
  /usr/local/lib/python3.10/site-packages/torch/onnx/__init__.py(62)<module>()
-> from ._internal.onnxruntime import (
  /usr/local/lib/python3.10/site-packages/torch/onnx/_internal/onnxruntime.py(37)<module>()
-> import onnxruntime  # type: ignore[import]
```


This issue breaks generated triton kernel because it imported torch, and unexpected runtime libraries as well.

I've also added a test for this specific case under `test/onnx`, perhaps we should add more somewhere else?

Related issue: https://github.com/huggingface/accelerate/pull/3056