### PR TITLE
[AOTI] Fix test_aoti_inference CPU build issue

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1480,8 +1480,6 @@ elif [[ "${TEST_CONFIG}" == *inductor* ]]; then
   test_inductor_shard "${SHARD_NUMBER}"
   if [[ "${SHARD_NUMBER}" == 1 ]]; then
     if [[ "${BUILD_ENVIRONMENT}" != linux-jammy-py3.8-gcc11-build ]]; then
-      # Temporarily skip test_inductor_aoti due to https://github.com/pytorch/pytorch/issues/130311
-      test_inductor_aoti
       test_inductor_distributed
     fi
   fi

--- a/test/cpp/aoti_inference/aoti_custom_class.cpp
+++ b/test/cpp/aoti_inference/aoti_custom_class.cpp
@@ -29,12 +29,14 @@ MyAOTIClass::MyAOTIClass(
     const std::string& model_path,
     const std::string& device)
     : lib_path_(model_path), device_(device) {
-  if (device_ == "cuda") {
-    runner_ = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
-        model_path.c_str());
-  } else if (device_ == "cpu") {
+  if (device_ == "cpu") {
     runner_ = std::make_unique<torch::inductor::AOTIModelContainerRunnerCpu>(
         model_path.c_str());
+#if defined(USE_CUDA) || defined(USE_ROCM)
+  } else if (device_ == "cuda") {
+    runner_ = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+        model_path.c_str());
+#endif
   } else {
     throw std::runtime_error("invalid device: " + device);
   }

--- a/test/cpp/aoti_inference/compile_model.py
+++ b/test/cpp/aoti_inference/compile_model.py
@@ -86,7 +86,7 @@ def compile_model(device, data):
 
 def main():
     data = {}
-    for device in ["cuda", "cpu"]:
+    for device in ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]:
         compile_model(device, data)
     torch.jit.script(TensorSerializer(data)).save("script_data.pt")
 

--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -35,12 +35,14 @@ void test_aoti(const std::string& device, bool use_runtime_constant_folding) {
       data_loader.attr(outputs_attr.c_str()).toTensorList().vec();
 
   std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
-  if (device == "cuda") {
-    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
-        model_so_path);
-  } else if (device == "cpu") {
+  if (device == "cpu") {
     runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCpu>(
         model_so_path);
+#if defined(USE_CUDA) || defined(USE_ROCM)
+  } else if (device == "cuda") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+        model_so_path);
+#endif
   } else {
     testing::AssertionFailure() << "unsupported device: " << device;
   }
@@ -111,12 +113,14 @@ void test_aoti_constants_update(
   real_map.emplace("L__self___w_add", new at::Tensor(add_tensors));
 
   std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
-  if (device == "cuda") {
-    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
-        model_so_path);
-  } else if (device == "cpu") {
+  if (device == "cpu") {
     runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCpu>(
         model_so_path);
+#if defined(USE_CUDA) || defined(USE_ROCM)
+  } else if (device == "cuda") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+        model_so_path);
+#endif
   } else {
     testing::AssertionFailure() << "unsupported device: " << device;
   }
@@ -197,12 +201,14 @@ void test_aoti_double_buffering(
   real_map.emplace("L__self___w_add", new at::Tensor(add_tensors));
 
   std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
-  if (device == "cuda") {
-    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
-        model_so_path.c_str());
-  } else if (device == "cpu") {
+  if (device == "cpu") {
     runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCpu>(
-        model_so_path.c_str());
+        model_so_path);
+#if defined(USE_CUDA) || defined(USE_ROCM)
+  } else if (device == "cuda") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+        model_so_path);
+#endif
   } else {
     testing::AssertionFailure() << "unsupported device: " << device;
   }

--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -247,6 +247,7 @@ void test_aoti_double_buffering(
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 }
 
+#if defined(USE_CUDA) || defined(USE_ROCM)
 void test_aoti_double_buffering_with_tensor_constants() {
   torch::NoGradGuard no_grad;
 
@@ -285,6 +286,7 @@ void test_aoti_double_buffering_with_tensor_constants() {
   actual_output_tensors = runner->run(input_tensors);
   ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
 }
+#endif
 
 } // namespace
 

--- a/test/cpp/aoti_inference/test.py
+++ b/test/cpp/aoti_inference/test.py
@@ -35,7 +35,7 @@ data_with_tensor_constants = {}
 
 # Basice AOTI model test generation.
 def generate_basic_tests():
-    for device in ["cpu", "cuda"]:
+    for device in ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]:
         for use_runtime_constant_folding in [True, False]:
             if device == "cpu" and use_runtime_constant_folding:
                 # We do not test runtime const folding for cpu mode.
@@ -74,6 +74,9 @@ def generate_basic_tests():
 
 # AOTI model which will create additional tensors during autograd.
 def generate_test_with_additional_tensors():
+    if not torch.cuda.is_available():
+        return
+
     model = NetWithTensorConstants()
     x = torch.randn((30, 1), device="cuda")
     y = torch.randn((30, 1), device="cuda")


### PR DESCRIPTION
Summary: Fixes https://github.com/pytorch/pytorch/issues/130311. We need to guard CUDA-only code in test_aoti_inference with macros so that it won't fail for CPU-only platform.