### PR TITLE
[RFC] Make fr trace script a console scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1098,6 +1098,7 @@ def configure_extension_build():
             "convert-caffe2-to-onnx = caffe2.python.onnx.bin.conversion:caffe2_to_onnx",
             "convert-onnx-to-caffe2 = caffe2.python.onnx.bin.conversion:onnx_to_caffe2",
             "torchrun = torch.distributed.run:main",
+            "torch-dist-fr-trace = tools.flight_recorder.fr_trace:main",
         ],
         "torchrun.logs_specs": [
             "default = torch.distributed.elastic.multiprocessing:DefaultLogsSpecs",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134729
* #134780
* #134528

We want to make fr analyzer script a command after users `pip install torch`, that's why we want to mimic what torchrun is doing.