### PR TITLE
Skip docstest for skip_data context manager because NamedTemporaryFile doesn't work properly on Windows

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -300,6 +300,7 @@ class skip_data:
         materialize_fake_tensors: Whether to materialize FakeTensors.
 
     Example:
+        >>> # xdoctest: +SKIP("NamedTemporaryFile on Windows")
         >>> import tempfile
         >>> t = torch.randn(2, 3)
         >>> with tempfile.NamedTemporaryFile() as f:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134742
* #134504

