### PR TITLE
make make_fx collective test single threaded

### DIFF
--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -384,15 +384,19 @@ class TestGradCollectives(MultiThreadedTestCase):
         self.assertIsNone(x.grad)
 
 
-class TestMakeFx(MultiThreadedTestCase):
-    @property
-    def world_size(self):
-        # make_fx is not thread-safe due to patching nd mutating global states.
-        return 1
-
+class TestMakeFx(TestCase):
     def setUp(self):
-        super().setUp()
-        self._spawn_threads()
+        # make_fx is not thread-safe due to patching nd mutating global states
+        # so create a fake_pg.
+        self.rank = 0
+        self.world_size = 2
+        store = FakeStore()
+        dist.init_process_group(
+            backend="fake",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
 
     def tearDown(self):
         super().tearDown()

--- a/test/distributed/test_functional_api.py
+++ b/test/distributed/test_functional_api.py
@@ -387,7 +387,8 @@ class TestGradCollectives(MultiThreadedTestCase):
 class TestMakeFx(MultiThreadedTestCase):
     @property
     def world_size(self):
-        return 2
+        # make_fx is not thread-safe due to patching nd mutating global states.
+        return 1
 
     def setUp(self):
         super().setUp()
@@ -396,8 +397,6 @@ class TestMakeFx(MultiThreadedTestCase):
     def tearDown(self):
         super().tearDown()
 
-        # race condition with threads causes is_fx_tracing flag to be set incorrectly.
-        torch.fx._symbolic_trace._is_fx_tracing_flag = False
         self.assertFalse(torch.fx._symbolic_trace.is_fx_tracing())
 
     def test_all_reduce_tracing(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133731
* __->__ #134775

make_fx is not thread-safe due to mutating and patching global states. It's difficult and low roi to make it thread-safe so just turn the tracing test into a single-thread test.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o