### PR TITLE
[AOTI][Tooling][5/n] Refactor the debug printer call to a level lower

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1213,8 +1213,10 @@ class CppWrapperCpu(WrapperCodeGen):
 
         args_to_print_or_save = None
         debug_printer_manager = V.graph.wrapper_code.debug_printer
-        debug_printer_level = debug_printer_manager.debug_printer_level
-        if debug_printer_level != IntermediateValueDebuggingLevel.OFF:
+        if (
+            debug_printer_manager.debug_printer_level
+            != IntermediateValueDebuggingLevel.OFF
+        ):
             args_to_print_or_save = []
 
         for x in args:
@@ -1231,7 +1233,10 @@ class CppWrapperCpu(WrapperCodeGen):
                 ):
                     # TODO: The current way to find a 'tensor' type arg is hacky also as mentioned above
                     # Find a more reliable way to detect tensor kernel args for extern kernel calls
-                    if debug_printer_level != IntermediateValueDebuggingLevel.OFF:
+                    if (
+                        debug_printer_manager.debug_printer_level
+                        != IntermediateValueDebuggingLevel.OFF
+                    ):
                         if piece.startswith(("buf", "arg")):
                             args_to_print_or_save.append(piece)
                     piece = f"convert_arrayref_tensor_to_tensor({piece})"

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -395,9 +395,9 @@ class CppWrapperCuda(CppWrapperCpu):
             call_args = [arg for i, arg in enumerate(call_args) if i not in equal_to_1]
             arg_types = [t for i, t in enumerate(arg_types) if i not in equal_to_1]
 
-        call_args = self.generate_args_decl(call_args, arg_types)
+        call_args_str = self.generate_args_decl(call_args, arg_types)
         kernel_args_var = f"kernel_args_var_{next(self.kernel_callsite_id)}"
-        self.writeline(f"void* {kernel_args_var}[] = {{{call_args}}};")
+        self.writeline(f"void* {kernel_args_var}[] = {{{call_args_str}}};")
         stream = (
             "stream"
             if V.graph.aot_mode
@@ -410,19 +410,23 @@ class CppWrapperCuda(CppWrapperCpu):
         )
 
         kernel_var_name = f"kernels.{kernel_name}" if V.graph.aot_mode else kernel_name
-        self.writeline(f"if ({grid_var}.is_non_zero()) {{")
-        self.writeline(
-            DeferredCudaKernelLine(
-                kernel_name,
-                r"    launchKernel({}, {}, {}, {}, %s, %s, {}, {});".format(
-                    kernel_var_name,
-                    f"{grid_var}.grid_x",
-                    f"{grid_var}.grid_y",
-                    f"{grid_var}.grid_z",
-                    kernel_args_var,
-                    stream,
+        # add debug printer code for all triton kernel related calls
+        debug_printer_manager = V.graph.wrapper_code.debug_printer
+        debug_printer_manager.set_printer_args(call_args, kernel_name, arg_types, None)
+        with debug_printer_manager:
+            self.writeline(f"if ({grid_var}.is_non_zero()) {{")
+            self.writeline(
+                DeferredCudaKernelLine(
+                    kernel_name,
+                    r"    launchKernel({}, {}, {}, {}, %s, %s, {}, {});".format(
+                        kernel_var_name,
+                        f"{grid_var}.grid_x",
+                        f"{grid_var}.grid_y",
+                        f"{grid_var}.grid_z",
+                        kernel_args_var,
+                        stream,
+                    ),
+                    ("num_warps", "shared_mem"),
                 ),
-                ("num_warps", "shared_mem"),
-            ),
-        )
-        self.writeline("}")
+            )
+            self.writeline("}")

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -6,9 +6,10 @@ import logging
 from enum import Enum
 from typing import List, Optional
 
+from torch import dtype as torch_dtype
+
 from .. import config
 from ..virtualized import V
-from .common import TensorArg
 from .multi_kernel import MultiKernel
 
 
@@ -121,8 +122,9 @@ class DebugPrinterManager:
     ) -> None:
         for i, arg in enumerate(args_to_save):
             if arg_signatures is not None and not isinstance(
-                arg_signatures[i], TensorArg
+                arg_signatures[i], torch_dtype
             ):
+                # infer from the arg data type (has torch.dtype) to see if it is a tensor type
                 continue
             launch_prefix = "before_launch" if before_launch else "after_launch"
             if V.graph.cpp_wrapper:
@@ -146,8 +148,9 @@ class DebugPrinterManager:
     ) -> None:
         for i, arg in enumerate(args_to_print):
             if arg_signatures is not None and not isinstance(
-                arg_signatures[i], TensorArg
+                arg_signatures[i], torch_dtype
             ):
+                # infer from the arg data type (has torch.dtype) to see if it is a tensor type
                 continue
             if self.debug_printer_level == IntermediateValueDebuggingLevel.PRINT_ONLY:
                 # when debug printing is enabled i.e. IntermediateValueDebuggingLevel.PRINT_ONLY,

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1376,18 +1376,7 @@ class SIMDScheduling(BaseScheduling):
                     node.mark_run()
 
         self.codegen_comment(node_schedule)
-
-        _, call_args, arg_signatures, _ = (
-            final_kernel.args.python_argdefs()
-            if not isinstance(final_kernel, MultiKernel)
-            else [None, [], None, None]
-        )
-        debug_printer_manager = V.graph.wrapper_code.debug_printer
-        debug_printer_manager.set_printer_args(
-            call_args, kernel_name, arg_signatures, final_kernel
-        )
-        with debug_printer_manager:
-            final_kernel.call_kernel(final_kernel.kernel_name)
+        final_kernel.call_kernel(final_kernel.kernel_name)
 
         if config.nan_asserts:
             final_kernel.codegen_nan_check()
@@ -1510,15 +1499,7 @@ class SIMDScheduling(BaseScheduling):
             kernel_name = self.define_kernel(src_code, node_schedule, kernel)
 
         self.codegen_comment(node_schedule)
-
-        # debug printing values of intermediate tensors
-        _, call_args, arg_signatures, _ = kernel.args.python_argdefs()
-        debug_printer_manager = V.graph.wrapper_code.debug_printer
-        debug_printer_manager.set_printer_args(
-            call_args, kernel_name, arg_signatures, kernel
-        )
-        with debug_printer_manager:
-            kernel.call_kernel(kernel_name, template_node.node)
+        kernel.call_kernel(kernel_name, template_node.node)
 
         V.graph.removed_buffers |= kernel.removed_buffers
         V.graph.inplaced_to_remove |= kernel.inplaced_to_remove


### PR DESCRIPTION
Summary:
1. Move the debug printer call a level lower -> at here
:https://www.internalfb.com/code/fbsource/[931d7bbb9e7cf2dcb926f42718f56fc940903eec]/fbcode/caffe2/torch/_inductor/codegen/cpp_wrapper_cuda.py?lines=335
2. Add UT for validating debug printer for user defined triton kernel codegen

The benefit of having the debug printer call happens at a more centralized place is 1) reduce the duplicate debug printer related logic code scattered everywhere in the codebase 2) it can handle more triton kernel codegen path as long as it invokes this `generate_kernel_call()` for example,  it can automatically handle/support user_defined_kernel 's debug printing which is a pretty common use case we encounter in debugging

Test Plan:
```AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER=2 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1  TORCHINDUCTOR_ABI_COMPATIBLE=1 TORCH_COMPILE_DEBUG=1 TORCH_LOGS="+graph, inductor, +schedule, output_code" buck2 run -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 @//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor -- -r test_aoti_debug_printer_user_defined_triton_kernel_abi_compatible_cuda```

Also verified that templateKernel codegen path still works

Differential Revision: D61949020


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang