### PR TITLE
[MPS] Fallback conv to CPU for max size > 2**16

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -79,6 +79,7 @@ class TORCH_API MPSDevice {
 
 TORCH_API bool is_available();
 TORCH_API bool is_macos_13_or_newer(MacOSVersion version);
+TORCH_API bool is_mps_fallback_enabled();
 TORCH_API at::Allocator* GetMPSAllocator(bool useSharedAllocator = false);
 
 } // namespace at::mps

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 
 #include <c10/util/CallOnce.h>
+#include <c10/util/env.h>
 
 #include <ATen/mps/IndexKernels.h>
 #include <ATen/mps/MPSAllocatorInterface.h>
@@ -145,6 +146,10 @@ bool is_available() {
 
 bool is_macos_13_or_newer(MacOSVersion version) {
   return MPSDevice::getInstance()->isMacOS13Plus(version);
+}
+
+bool is_mps_fallback_enabled() {
+  return c10::utils::check_env("PYTORCH_ENABLE_MPS_FALLBACK") == true;
 }
 
 } // namespace at::mps

--- a/aten/src/ATen/mps/MPSFallback.mm
+++ b/aten/src/ATen/mps/MPSFallback.mm
@@ -90,7 +90,6 @@ TORCH_LIBRARY_IMPL(aten, MPS, m) {
   m.impl("linalg_svd.U", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("im2col", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>()); // Used in  preprocessing by nn.Unfold
   m.impl("col2im", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
-  m.impl("_slow_conv2d_forward", slow_conv2d_forward_mps);
   m.impl("upsample_nearest3d.vec", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
 }
 

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -3,6 +3,7 @@
 #include <ATen/Config.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorOperators.h>
+#include <ATen/mps/MPSDevice.h>
 #include <ATen/native/ConvolutionMM3d.h>
 #include <ATen/native/ConvUtils.h>
 #include <ATen/native/Pool.h>
@@ -13,6 +14,7 @@
 #include <c10/util/accumulate.h>
 #include <c10/util/irange.h>
 #include <c10/macros/Macros.h>
+#include <algorithm>
 #include <limits>
 #include <utility>
 
@@ -588,6 +590,22 @@ struct ConvParams {
       return false;
     }
     return true;
+#else
+    return false;
+#endif
+  }
+
+  bool use_mps_with_fallback(const at::Tensor& input, const at::Tensor& weight) const {
+#ifdef USE_MPS
+    // MPS does not support channel sizes > 2^16 https://github.com/pytorch/pytorch/issues/129207
+    std::vector<T> output_size;
+    if (transposed) {
+      output_size = conv_input_size(at::symint::sizes<T>(input), at::symint::sizes<T>(weight), padding, output_padding, stride, dilation, groups);
+    } else {
+      output_size = conv_output_size(at::symint::sizes<T>(input), at::symint::sizes<T>(weight), padding, stride, dilation);
+    }
+    auto max_output_size = *std::max_element(output_size.begin(), output_size.end());
+    return use_mps(input, weight) && mps::is_mps_fallback_enabled() && max_output_size > (1 << 16);
 #else
     return false;
 #endif
@@ -1253,7 +1271,7 @@ ConvBackend _select_conv_backend(
       !params.is_dilated()) {
     // fast path for grouped conv3d
     return ConvBackend::Slow3d;
-  } else if (input.device().is_cpu() || input.is_cuda()) {
+  } else if (input.device().is_cpu() || input.is_cuda() || params.use_mps_with_fallback(input, weight)) {
     // backends without support for groups
     if (params.transposed) {
       if (input.ndimension() == 4) {


### PR DESCRIPTION
MPS does not currently support more than `2**16` channels. This was reported as a silent correctness bug in #129207, and #129484 added safety checking.

This PR adds support for transparently falling back to the CPU when `PYTORCH_ENABLE_MPS_FALLBACK` is set.

See also #134770 for alternative fix proposal for #134416. It is certainly less complicated than this PR, and might be a good enough solution until a more permanent fix lands in MPS.

#### TODO

- [ ] Get feedback on approach
- [ ] Add tests

Fixes #134416

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @kulinseth @albanD @malfet @DenisVieriu97 @jhavukainen