### PR TITLE
Switch nanmedian to not cuda synchronize

### DIFF
--- a/aten/src/ATen/native/cuda/Sorting.cpp
+++ b/aten/src/ATen/native/cuda/Sorting.cpp
@@ -21,6 +21,9 @@
 #include <ATen/ops/median_native.h>
 #include <ATen/ops/nanmedian_native.h>
 #include <ATen/ops/where.h>
+#include <ATen/ops/rsub.h>
+#include <ATen/ops/div.h>
+#include <ATen/ops/index.h>
 #endif
 
 namespace at::native {
@@ -146,8 +149,8 @@ Tensor median_impl(const Tensor& self, bool ignore_nan) {
     return at::where(sorted[-1].isnan(), sorted[-1], sorted[k]);
   } else {
     // For torch.nanmedian return the middle element among the non-nan values
-    int64_t k = ((size - 1) - sorted.isnan().sum().item<int64_t>()) / 2;
-    return sorted[k].clone();  // Clone so we aren't keeping `sorted` alive
+    Tensor k = at::div(at::rsub(sorted.isnan().sum(), (size - 1)), 2).to(kLong);
+    return at::index(sorted, {k});
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #134823
* __->__ #134819
* #134818
* #134813



cc @malfet

Generally, this seems to be faster.

![image](https://github.com/user-attachments/assets/43a86c6f-236d-4ba1-aae0-14e3d88ae401)

And as an added benefit, it works great with cudagraphs and such :)