### PR TITLE
[Inductor] tune the buffer realization heuristic after pointwise constant folding change

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -398,6 +398,7 @@ warn_mix_layout = os.environ.get("TORCHINDUCTOR_WARN_MIX_LAYOUT") == "1"
 # smaller threshold
 realize_reads_threshold = 4
 realize_opcount_threshold = 30
+realize_opusers_threshold = 5
 
 # Threshold to prevent excessive accumulation of ops in one buffer during lowering
 realize_acc_reads_threshold = 8

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6390,14 +6390,14 @@ class StorageBox(MutableBox):
         that is used multiple times.
         """
 
-        def should_realize_on_cpu(loops: Union[Pointwise, Reduction], users):
+        def should_realize_on_cpu(loops: Union[Pointwise, Reduction]):
             """
             The heuristic for realizing reused result of heavy ops on cpu
             """
             heavy_ops = ["exp", "sigmoid"]  # a list of heavy ops
             fn_str = loops.inner_fn_str()
             multi_users = (
-                users > 5
+                users > config.realize_opusers_threshold
                 and self.inner_fn_opcount() > config.realize_opcount_threshold - 2
             )
             return any((op + "(") in fn_str for op in heavy_ops) or multi_users
@@ -6408,7 +6408,7 @@ class StorageBox(MutableBox):
             and (
                 self.num_reads() > config.realize_reads_threshold
                 or self.has_large_inner_fn()
-                or (is_cpu(self.data) and should_realize_on_cpu(self.data, users))
+                or (is_cpu(self.data) and should_realize_on_cpu(self.data))
             )
         ):
             self.realize()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6403,6 +6403,7 @@ class StorageBox(MutableBox):
             and isinstance(self.data, (Pointwise, Reduction))
             and (
                 self.num_reads() > config.realize_reads_threshold
+                or users > config.realize_opusers_threshold
                 or self.has_large_inner_fn()
                 or (is_cpu(self.data) and should_realize_on_cpu(self.data))
             )

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6396,7 +6396,10 @@ class StorageBox(MutableBox):
             """
             heavy_ops = ["exp", "sigmoid"]  # a list of heavy ops
             fn_str = loops.inner_fn_str()
-            multi_users = (users > 5 and self.inner_fn_opcount() > config.realize_opcount_threshold - 2)
+            multi_users = (
+                users > 5
+                and self.inner_fn_opcount() > config.realize_opcount_threshold - 2
+            )
             return any((op + "(") in fn_str for op in heavy_ops) or multi_users
 
         if (


### PR DESCRIPTION
Fixes [#130953](https://github.com/pytorch/pytorch/issues/130953).

The issue is related to buffer realization and reuse. For example, before the regression, one buffer could be reused across the next 6 attention layers without re-computation. However, after the regression commit https://github.com/pytorch/pytorch/commit/b7d287fbec0a05a3d4c9524006e6bfd1de6a71a0, an additional add operation was fused into the Pointwise node , making the buffer non-reusable and causing 6 re-computations.

In this PR, we try to tune the buffer realization heuristic.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov