### PR TITLE
[Dynamo] Support for proxying frozen dataclasses

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10178,13 +10178,13 @@ def ___make_guard_fn():
         inps = (torch.ones(2, 2), torch.ones(2, 2))
         actual = fn_opt(*inps)
         expected = fn(*inps)
-    
+
     def test_frozen_dataclass_default_value(self):
         @dataclasses.dataclass(frozen=True)
         class TestDataClass:
             x: torch.Tensor
             y: torch.Tensor
-            z: int = dataclasses.field(default=5) 
+            z: int = dataclasses.field(default=5)
             a: int = 6
 
         @allow_in_graph
@@ -10201,15 +10201,14 @@ def ___make_guard_fn():
         expected = fn(*inps)
 
         self.assertEqual(actual, expected)
-    
+
     def test_frozen_dataclass_default_factory(self):
         @dataclasses.dataclass(frozen=True)
         class TestDataClass:
             x: torch.Tensor
             y: torch.Tensor
-            z: int = dataclasses.field(default_factory=list) 
+            z: int = dataclasses.field(default_factory=list)
             a: int = dataclasses.field(default_factory=lambda: [5])
-
 
         @allow_in_graph
         def inner_fn(dc):
@@ -10231,9 +10230,8 @@ def ___make_guard_fn():
         class TestDataClass:
             x: torch.Tensor
             y: torch.Tensor
-            z: int = dataclasses.field(kw_only=True) 
+            z: int = dataclasses.field(kw_only=True)
             a: int = dataclasses.field(kw_only=True)
-
 
         @allow_in_graph
         def inner_fn(dc):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10141,6 +10141,44 @@ def ___make_guard_fn():
             "L__self___foo_bar_test_buf": "foo_bar.test_buf",
         }
         self.assertEqual(expected_fqn, gm.meta["dynamo_flat_name_to_original_fqn"])
+    
+    def test_proxy_frozen_dataclass(self):
+        @dataclasses.dataclass(frozen=True)
+        class TestDataClass:
+            x: torch.Tensor
+            y: torch.Tensor
+
+
+        @allow_in_graph
+        def inner_fn(dc):
+            return dc.x + dc.y
+
+        def fn(x, y):
+            dc = TestDataClass(x, y)
+            return inner_fn(dc)
+        
+        fn_opt= torch.compile(fullgraph=True)(fn)
+        inps = (torch.ones(2, 2), torch.ones(2, 2))
+        actual = fn_opt(*inps)
+        expected = fn(*inps)
+
+        self.assertEqual(actual, expected)
+    
+    def test_reconstruct_frozen_dataclass(self):
+        @dataclasses.dataclass(frozen=True)
+        class TestDataClass:
+            x: torch.Tensor
+            y: torch.Tensor
+
+        def fn(x, y):
+            dc = TestDataClass(x, y)
+            torch._dynamo.graph_break()
+            return dc.x + dc.y
+
+        fn_opt = torch.compile()(fn)
+        inps = (torch.ones(2, 2), torch.ones(2, 2))
+        actual = fn_opt(*inps)
+        expected = fn(*inps)
 
     def test_shape_env_no_recording(self):
         main = ShapeEnv(should_record_events=False)

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10141,13 +10141,12 @@ def ___make_guard_fn():
             "L__self___foo_bar_test_buf": "foo_bar.test_buf",
         }
         self.assertEqual(expected_fqn, gm.meta["dynamo_flat_name_to_original_fqn"])
-    
+
     def test_proxy_frozen_dataclass(self):
         @dataclasses.dataclass(frozen=True)
         class TestDataClass:
             x: torch.Tensor
             y: torch.Tensor
-
 
         @allow_in_graph
         def inner_fn(dc):
@@ -10156,14 +10155,14 @@ def ___make_guard_fn():
         def fn(x, y):
             dc = TestDataClass(x, y)
             return inner_fn(dc)
-        
-        fn_opt= torch.compile(fullgraph=True)(fn)
+
+        fn_opt = torch.compile(fullgraph=True)(fn)
         inps = (torch.ones(2, 2), torch.ones(2, 2))
         actual = fn_opt(*inps)
         expected = fn(*inps)
 
         self.assertEqual(actual, expected)
-    
+
     def test_reconstruct_frozen_dataclass(self):
         @dataclasses.dataclass(frozen=True)
         class TestDataClass:

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -44,6 +44,7 @@ from torch._dynamo.testing import (
     CompileCounter,
     CompileCounterWithBackend,
     expectedFailureDynamic,
+    requiresPy310,
     same,
     skipIfNotPy311,
     unsupported,
@@ -10225,6 +10226,7 @@ def ___make_guard_fn():
 
         self.assertEqual(actual, expected)
 
+    @requiresPy310
     def test_frozen_dataclass_kw_only(self):
         @dataclasses.dataclass(frozen=True)
         class TestDataClass:
@@ -10246,7 +10248,7 @@ def ___make_guard_fn():
         actual = fn_opt(*inps)
         expected = fn(*inps)
 
-        # self.assertEqual(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_shape_env_no_recording(self):
         main = ShapeEnv(should_record_events=False)

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -17,13 +17,14 @@ from .bytecode_transformation import (
 from .codegen import PyCodegen
 from .exc import unimplemented
 from .source import GlobalSource, LocalSource, Source
-from .utils import nn_module_new, object_new
+from .utils import is_frozen_dataclass, nn_module_new, object_new
 from .variables.base import (
     is_side_effect_safe,
     MutableLocalBase,
     MutableLocalSource,
     VariableTracker,
 )
+from .variables.user_defined import FrozenDataClassVariable
 
 
 class MutableSideEffects(MutableLocalBase):
@@ -285,6 +286,8 @@ class SideEffects:
             variable_cls = variables.UnspecializedNNModuleVariable
         elif issubclass(user_cls, MutableMapping):
             variable_cls = variables.MutableMappingVariable
+        elif is_frozen_dataclass(user_cls):
+            variable_cls = FrozenDataClassVariable
         else:
             variable_cls = variables.UserDefinedObjectVariable
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -372,6 +372,13 @@ def skipIfPy312(fn):
     return fn
 
 
+def requiresPy310(fn):
+    if sys.version_info >= (3, 10):
+        return fn
+    else:
+        unittest.skip(fn)
+
+
 # Controls tests generated in test/inductor/test_torchinductor_dynamic_shapes.py
 # and test/dynamo/test_dynamic_shapes.py
 def expectedFailureDynamic(fn):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -30,6 +30,7 @@ import uuid
 import warnings
 import weakref
 from contextlib import contextmanager
+from dataclasses import is_dataclass
 from functools import lru_cache
 from types import MethodWrapperType
 from typing import (
@@ -2313,9 +2314,13 @@ def import_submodule(mod: types.ModuleType):
 
 
 def object_has_getattribute(value: Any):
+    return class_has_getattribute(type(value))
+
+
+def class_has_getattribute(cls: type):
     try:
         if isinstance(
-            inspect.getattr_static(type(value), "__getattribute__"),
+            inspect.getattr_static(cls, "__getattribute__"),
             types.FunctionType,
         ):
             return True
@@ -2958,6 +2963,16 @@ def to_fake_tensor(t, fake_mode):
 
     return fake_mode.from_tensor(
         t, static_shapes=False, symbolic_context=symbolic_context, source=source
+    )
+
+
+# NB: this works for both classes and instances
+def is_frozen_dataclass(value):
+    return (
+        not object_has_getattribute(value)
+        and not class_has_getattribute(value)
+        and is_dataclass(value)
+        and value.__dataclass_params__.frozen
     )
 
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1136,8 +1136,8 @@ class VariableBuilder:
             return MutableMappingVariable(value, source=self.source)
         elif is_frozen_dataclass(value):
             self.install_guards(GuardBuilder.TYPE_MATCH)
-            # NB: don't support mutation
-            return FrozenDataClassVariable.create(self.tx, value, source=self.source)
+            result = FrozenDataClassVariable.create(self.tx, value, source=self.source)
+            return self.tx.output.side_effects.track_object_existing(value, result)
         else:
             return self.wrap_user_defined(value)
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -82,6 +82,7 @@ from ..utils import (
     get_fake_value,
     get_locals_to_steal,
     get_static_address_type,
+    is_frozen_dataclass,
     is_function_or_wrapper,
     is_lru_cache_wrapped_function,
     is_namedtuple,
@@ -193,6 +194,7 @@ from .torch_function import (
     TorchFunctionModeVariable,
 )
 from .user_defined import (
+    FrozenDataClassVariable,
     KeyedJaggedTensorVariable,
     MutableMappingVariable,
     SourcelessGraphModuleVariable,
@@ -1132,6 +1134,10 @@ class VariableBuilder:
         elif issubclass(type(value), MutableMapping):
             self.install_guards(GuardBuilder.TYPE_MATCH)
             return MutableMappingVariable(value, source=self.source)
+        elif is_frozen_dataclass(value):
+            self.install_guards(GuardBuilder.TYPE_MATCH)
+            # NB: don't support mutation
+            return FrozenDataClassVariable.create(self.tx, value, source=self.source)
         else:
             return self.wrap_user_defined(value)
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -671,16 +671,6 @@ def _call_hasattr_customobj(
     )
 
 
-class DataClassVariable(ConstDictVariable):
-    """
-    This class doesn't appear to be used anywhere.
-    It used to be used to deal with transformers.file_utils.ModelOutput
-    from huggingface.
-
-    Keeping since we wish to support dataclasses in general in the future
-    """
-
-
 class CustomizedDictVariable(ConstDictVariable):
     @staticmethod
     def is_matching_cls_hf(cls):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -465,6 +465,8 @@ class UserDefinedClassVariable(UserDefinedVariable):
                     if field.name in kwargs:
                         var_tracker = kwargs[field.name]
                     else:
+                        if not field.init:
+                            continue
                         assert field.default is not dataclasses.MISSING
                         var_tracker = SourcelessBuilder.create(tx, field.default)
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1209,9 +1209,9 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
         field_map = {}
         for field in fields(value):
             if hasattr(value, field.name):
-                field_map[field.name] = VariableBuilder(tx, AttrSource(source, field.name))(
-                    getattr(value, field.name)
-                )
+                field_map[field.name] = VariableBuilder(
+                    tx, AttrSource(source, field.name)
+                )(getattr(value, field.name))
 
         return FrozenDataClassVariable(value, fields=field_map, source=source)
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2,6 +2,7 @@
 
 import collections
 import contextlib
+import dataclasses
 import enum
 import functools
 import inspect
@@ -39,6 +40,7 @@ from ..utils import (
     check_constant_args,
     get_custom_getattr,
     has_torch_function,
+    is_frozen_dataclass,
     is_namedtuple_cls,
     is_utils_checkpoint,
     is_wrapper_or_member_descriptor,
@@ -452,6 +454,25 @@ class UserDefinedClassVariable(UserDefinedVariable):
 
             assert all(x is not None for x in items)
             return variables.NamedTupleVariable(items, self.value)
+        elif is_frozen_dataclass(self.value) and self.is_standard_new():
+            fields = dataclasses.fields(self.value)
+            items = list(args)
+            items.extend([None] * (len(fields) - len(items)))
+
+            var_tracker_kwargs = {}
+            for field, var_tracker in zip(fields, items):
+                if var_tracker is None:
+                    if field.name in kwargs:
+                        var_tracker = kwargs[field.name]
+                    else:
+                        assert field.default is not dataclasses.MISSING
+                        var_tracker = SourcelessBuilder.create(tx, field.default)
+
+                    var_tracker_kwargs[field.name] = var_tracker
+
+            var = tx.output.side_effects.track_object_new_from_user_defined_class(self)
+            var.call_method(tx, "__init__", args, kwargs)
+            return var
         elif (
             self.is_standard_new()
             and SideEffects.cls_supports_mutation_side_effects(self.value)
@@ -1173,6 +1194,48 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             tx,
             ODictGetItemSource(self.source, index),
         )(collections.OrderedDict.__getitem__(self.value, key.as_python_constant()))
+
+
+class FrozenDataClassVariable(UserDefinedObjectVariable):
+    @staticmethod
+    def create(tx, value, source):
+        from dataclasses import fields
+
+        assert is_frozen_dataclass(value)
+
+        from .builder import VariableBuilder
+
+        field_map = {}
+        for field in fields(value):
+            field_map[field.name] = VariableBuilder(tx, AttrSource(source, field.name))(
+                getattr(value, field.name)
+            )
+
+        return FrozenDataClassVariable(value, fields=field_map, source=source)
+
+    def __init__(self, value, fields=None, **kwargs) -> None:
+        super().__init__(value, **kwargs)
+        if fields is None:
+            fields = {}
+        self.fields = fields
+
+    def as_proxy(self):
+        from dataclasses import fields
+
+        args = []
+        for field in fields(self.value):
+            args.append(self.fields[field.name].as_proxy())
+
+        return self.python_type()(*args)
+
+    # NB: This is called during __init__ for a frozen dataclass
+    # use this to accumulate the most up-to-date field values
+    def method_setattr_standard(self, tx: "InstructionTranslator", name, value):
+        self.fields[name.as_python_constant()] = value
+        return super().method_setattr_standard(tx, name, value)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.value_type.__name__})"
 
 
 class SourcelessGraphModuleVariable(UserDefinedObjectVariable):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -465,9 +465,8 @@ class UserDefinedClassVariable(UserDefinedVariable):
                     if field.name in kwargs:
                         var_tracker = kwargs[field.name]
                     else:
-                        if not field.init:
+                        if not field.init or field.default is dataclasses.MISSING:
                             continue
-                        assert field.default is not dataclasses.MISSING
                         var_tracker = SourcelessBuilder.create(tx, field.default)
 
                     var_tracker_kwargs[field.name] = var_tracker
@@ -1209,9 +1208,10 @@ class FrozenDataClassVariable(UserDefinedObjectVariable):
 
         field_map = {}
         for field in fields(value):
-            field_map[field.name] = VariableBuilder(tx, AttrSource(source, field.name))(
-                getattr(value, field.name)
-            )
+            if hasattr(value, field.name):
+                field_map[field.name] = VariableBuilder(tx, AttrSource(source, field.name))(
+                    getattr(value, field.name)
+                )
 
         return FrozenDataClassVariable(value, fields=field_map, source=source)
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/133858

Details: Previously Dynamo would treat dataclasses as UserDefinedVariables. This was non-desirable if we would like to proxy the value into the graph, which is needed for TensorSubclassMetadata. To rectify this, frozen dataclasses are now able to be proxied similarly to NamedTuples. We require the object to be frozen, because if arbitrary mutation were allowed, we would need to replay those mutations in the graph after construction of the object.

For tracing construction of the variable, the generated `__init__` for the dataclass uses `object.__setattr__` because frozen dataclasses throw errors on the usual `__setattr__` invocation. With this treatment, no special handling is needed in dynamo for frozen dataclass construction.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134846



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec