### PR TITLE
Patch XNNPACK CMakeLists

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -564,6 +564,13 @@ if(USE_XNNPACK AND NOT USE_SYSTEM_XNNPACK)
     set(__caffe2_CMAKE_POSITION_INDEPENDENT_CODE_FLAG ${CMAKE_POSITION_INDEPENDENT_CODE})
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+    if(IOS)
+        # Workaround for compile flags ending up in the link interface for XNNPACK.
+        # TODO Remove this after landing fix upstream and updating.
+        find_package(Python COMPONENTS Interpreter)
+        execute_process(COMMAND ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/third_party/patch_xnnpack_cmake.py")
+    endif()
+
     add_subdirectory(
       "${XNNPACK_SOURCE_DIR}"
       "${CONFU_DEPENDENCIES_BINARY_DIR}/XNNPACK")

--- a/third_party/patch_xnnpack_cmake.py
+++ b/third_party/patch_xnnpack_cmake.py
@@ -1,0 +1,20 @@
+import os
+
+from pathlib import Path
+
+# Workaround for compile flags ending up in the link interface for XNNPACK.
+# TODO Remove this after landing fix upstream and updating.
+TO_PATCH = "TARGET_LINK_LIBRARIES(XNNPACK PUBLIC xnnpack-base)"
+PATCH_REPLACEMENT = "TARGET_LINK_LIBRARIES(XNNPACK PRIVATE xnnpack-base)"
+
+def patch_xnnpack_cmake():
+    xnnpack_cmakelists_path = Path(os.path.dirname(os.path.realpath(__file__))).parent / "third_party" / "XNNPACK" / "CMakeLists.txt"
+    with open(xnnpack_cmakelists_path, "r") as f:
+        contents = f.read()
+        contents = contents.replace(TO_PATCH, PATCH_REPLACEMENT)
+        
+    with open(xnnpack_cmakelists_path, "w") as f:
+        f.write(contents)
+
+if __name__ == "__main__":
+    patch_xnnpack_cmake()


### PR DESCRIPTION
XNNPACK library made changes to their CMakeLists in a way that sets compile flags on targets that depend on XNNPACK. While this likely unintended on their end, this change patches the XNNPACK CMakeLists at build time to work around the issue. Once this is fixed upstream, we can remove this patch.