### PR TITLE
[torch][ao] Repro assigning conv2d debug handle to weights and bias

### DIFF
--- a/torch/ao/quantization/pt2e/_numeric_debugger.py
+++ b/torch/ao/quantization/pt2e/_numeric_debugger.py
@@ -1,10 +1,11 @@
 import copy
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 from torch.ao.ns.fx.utils import compute_sqnr
+from torch.export import ExportedProgram
 from torch.fx import GraphModule, Node
 from torch.nn import functional as F
 
@@ -15,7 +16,7 @@ CUSTOM_KEY = "custom"
 log = logging.getLogger(__name__)
 
 
-def generate_numeric_debug_handle(graph_module: GraphModule) -> None:
+def generate_numeric_debug_handle(graph_module: Union[GraphModule, ExportedProgram]) -> None:
     """Attach numeric_debug_handle_id for all nodes in the model except for placeholder node
     The graph nodes of input model is modified inplace.
     """


### PR DESCRIPTION
Summary:
Test related to: https://github.com/pytorch/pytorch/issues/134778

I found a test case that shows that re-exporting the same model again
moves debug handles in surprising ways, for example:
the conv2d debug handle moved from just the conv2d, to the weights
and biases.

If you enable a quantizer like XNNPackQuantizer, it still happens for conv + bias,
but not for the weights.

Test Plan: This isn't a real test, but is the basis for an investigation as to why this occurs and how to fix it

Differential Revision: D62007054
