### PR TITLE
Adds Error Handling Bindings to Cudart

### DIFF
--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -96,6 +96,20 @@ void initCudartBindings(PyObject* module) {
         py::gil_scoped_release no_gil;
         return C10_CUDA_ERROR_HANDLED(cudaStreamDestroy((cudaStream_t)ptr));
       });
+    cudart.def(
+      "cuda"
+      "GetLastError",
+      []() -> cudaError_t {
+        py::gil_scoped_release no_gil;
+        return C10_CUDA_ERROR_HANDLED(cudaGetLastError());
+      });
+      cudart.def(
+      "cuda"
+      "PeekAtLastError",
+      []() -> cudaError_t {
+        py::gil_scoped_release no_gil;
+        return C10_CUDA_ERROR_HANDLED(cudaPeekAtLastError());
+      });
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION < 12000
   // cudaProfilerInitialize is no longer needed after CUDA 12:
   // https://forums.developer.nvidia.com/t/cudaprofilerinitialize-is-deprecated-alternative/200776/3


### PR DESCRIPTION
As far as I can tell, these are not exposed in torch, but might be useful for users. This is coming up in specific cases where async error handling in cuda is producing errors in certain edge cases for large model training.

Tested:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/66c03ee1-b683-4b73-a6ce-5dca1f0310fc">