### PR TITLE
[inductor] preload icx built in math libs

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -840,18 +840,21 @@ def perload_icx_libomp_win(cpp_compiler: str) -> None:
             ).decode(*SUBPROCESS_DECODE_ARGS)
             omp_path = output.rstrip()
             if os.path.isfile(omp_path):
+                os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
                 omp_module = cdll.LoadLibrary(omp_path)
                 return True
         except subprocess.SubprocessError:
             pass
         return False
 
-    if _load_icx_built_in_lib_by_name(cpp_compiler, "libiomp5md.dll"):
-        os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
-
+    """
+    Intel Compiler implenmented more math libraries than clang, for performance proposal.
+    We need preload them like openmp library.
+    """
     preload_list = [
-        "svml_dispmd.dll",
-        "libmmd.dll",
+        "libiomp5md.dll",  # openmp
+        "svml_dispmd.dll",  # svml library
+        "libmmd.dll",  # libm
     ]
 
     for lib_name in preload_list:


### PR DESCRIPTION
Intel Compiler implenmented more math libraries than clang, for performance proposal.
We need preload them like openmp library.

reproduce UT:
```cmd
pytest test/inductor/test_cpu_cpp_wrapper.py -v -k test_silu_cpu_dynamic_shapes_cpp_wrapper
```

Depends of module:
<img width="804" alt="Image" src="https://github.com/user-attachments/assets/9a672e03-ebf5-4ebb-b182-09180e6f7841">

Local test pass:
<img width="857" alt="image" src="https://github.com/user-attachments/assets/afbb8c1c-8fcc-4d64-a3ad-c8521b137d2d">


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang