### PR TITLE
rationalize STATIC vs. None

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2014,7 +2014,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
             + re.escape(
                 "specified at `dynamic_shapes[0]['k']['k'][0]` "
                 "(expected either a list/tuple of dimensions, or a dict mapping indices to dimensions,"
-                " where each dimension is None, an int, a Dim, Dim.AUTO, or Dim.STATIC)"
+                " where each dimension is an int, a Dim, Dim.AUTO, or Dim.STATIC)"
             ),
         ):
             export(M(), inputs, dynamic_shapes=dynamic_shapes)

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -136,10 +136,10 @@ def make_fake_inputs(
 
     combined_args = _combine_args(nn_module, args, kwargs)
     _check_dynamic_shapes(combined_args, dynamic_shapes)
-    _dynamic_shapes = _transform_shapes_for_default_dynamic(
+    transformed_dynamic_shapes = _transform_shapes_for_default_dynamic(
         combined_args, dynamic_shapes
     )
-    constraints = _process_dynamic_shapes(combined_args, _dynamic_shapes)
+    constraints = _process_dynamic_shapes(combined_args, transformed_dynamic_shapes)
     t_constraints: Dict[int, Dict[int, Constraint]] = defaultdict(dict)
     for constraint in constraints:
         t_constraints[constraint.t_id][constraint.dim] = constraint
@@ -216,7 +216,14 @@ def make_fake_inputs(
             phantom_symbols=list(phantom_symbols.values()),
             warn_only=False,
         )
-        return fake_mode, fake_args, fake_kwargs, equalities_inputs, original_signature
+        return (
+            fake_mode,
+            fake_args,
+            fake_kwargs,
+            equalities_inputs,
+            original_signature,
+            transformed_dynamic_shapes,
+        )
 
 
 def _flatten_dynamic_shapes(

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -42,6 +42,7 @@ register_log(
     [
         "torch._dynamo",
         "torch.export",
+        "torch.export.dynamic_shapes",
         *DYNAMIC,
         "torch._export.converter",
         "torch._export.non_strict_utils",

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -537,7 +537,7 @@ def _export_to_torch_ir(
     kwargs = kwargs or {}
     combined_args = _combine_args(f, args, kwargs)
     _check_dynamic_shapes(combined_args, dynamic_shapes)
-    _dynamic_shapes = _transform_shapes_for_default_dynamic(
+    transformed_dynamic_shapes = _transform_shapes_for_default_dynamic(
         combined_args, dynamic_shapes
     )
 
@@ -549,7 +549,7 @@ def _export_to_torch_ir(
             ), _ignore_backend_decomps():
                 gm_torch_level, _ = torch._dynamo.export(
                     f,
-                    dynamic_shapes=_dynamic_shapes,  # type: ignore[arg-type]
+                    dynamic_shapes=transformed_dynamic_shapes,  # type: ignore[arg-type]
                     tracing_mode="symbolic",
                     disable_constraint_solver=disable_constraint_solver,
                     # currently the following 2 flags are tied together for export purposes,
@@ -1676,6 +1676,7 @@ def _non_strict_export(
         fake_kwargs,
         equalities_inputs,
         original_signature,
+        transformed_dynamic_shapes,
     ) = make_fake_inputs(
         mod,
         args,
@@ -1691,7 +1692,7 @@ def _non_strict_export(
         return produce_guards_and_solve_constraints(
             fake_mode=fake_mode,
             gm=gm,
-            dynamic_shapes=dynamic_shapes,
+            dynamic_shapes=transformed_dynamic_shapes,
             equalities_inputs=equalities_inputs,
             original_signature=original_signature,
             _is_torch_jit_trace=_is_torch_jit_trace,


### PR DESCRIPTION
Summary:
A bit of refactoring to prepare to remove `None` as a way to specify static dimensions in dynamic shapes, given we already have `Dim.STATIC` for the same purpose. We will now warn whenever this happens. However no tests were modified because problematic uses of `None` still need to behave as they do today, until we are ready to remove support. It should be easy to port tests by replacing the warning function to raise instead.

Note that other uses of `None`, such as for entire values (tensor or non-tensor) remain as is. Moving forward this should be the only purpose of `None` (at least externally).

Finally, there's a bit of confusion in our representation now because `AUTO` also internally transforms to `None`. Renamed dynamic_shapes to transformed_dynamic_shapes where this happens. Overall the two forms (pre and post transformation) have different properties so should probably not be represented in the same format in the future.

Test Plan: existing

Differential Revision: D62040729
