### PR TITLE
Fix for Tracing Models with Backpropagation

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1429,6 +1429,27 @@ struct TORCH_API WeakIValue final {
         is_intrusive_ptr == rhs.is_intrusive_ptr;
   }
 
+  void debugPrint() const {
+    if (tag != IValue::Tag::Tensor)
+      return;
+    
+    auto impl = static_cast<at::TensorImpl*>(payload.as_intrusive_ptr);
+    const auto& storage = impl->unsafe_storage();
+
+    std::cout << "[Value] Tensor [impl = " << impl << ", storage = " << storage.unsafeGetStorageImpl();
+  }
+
+  bool is_alias_of(at::TensorImpl* rhs) const {
+    if (tag != IValue::Tag::Tensor)
+      return false;
+
+    auto impl = static_cast<const at::TensorImpl*>(payload.as_intrusive_ptr);
+    if (impl->has_storage() && rhs->has_storage() && impl->storage().is_alias_of(rhs->storage()))
+      return TensorImpl::is_generic_tensor_metadata_equal(impl, rhs);
+
+    return false;
+  }
+
   IValue lock() const {
     if (!is_intrusive_ptr) {
       IValue::Payload newPayload;

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1429,6 +1429,7 @@ struct TORCH_API WeakIValue final {
         is_intrusive_ptr == rhs.is_intrusive_ptr;
   }
 
+#if 0
   void debugPrint() const {
     if (tag != IValue::Tag::Tensor)
       return;
@@ -1438,6 +1439,7 @@ struct TORCH_API WeakIValue final {
 
     std::cout << "[Value] Tensor [impl = " << impl << ", storage = " << storage.unsafeGetStorageImpl();
   }
+#endif
 
   bool is_alias_of(at::TensorImpl* rhs) const {
     if (tag != IValue::Tag::Tensor)

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1433,7 +1433,7 @@ struct TORCH_API WeakIValue final {
   void debugPrint() const {
     if (tag != IValue::Tag::Tensor)
       return;
-    
+
     auto impl = static_cast<at::TensorImpl*>(payload.as_intrusive_ptr);
     const auto& storage = impl->unsafe_storage();
 

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -596,8 +596,8 @@ void TensorImpl::copy_generic_tensor_metadata(
   dest_impl->refresh_device_policy();
 }
 
-// This functions returns true when lhs and rhs tensor generic metadata equal
-// one another. In particular this is checking equality for the generic properties when
+// This function returns true when lhs and rhs tensor generic metadata equal
+// one another. In particular, this is checking equality for the generic properties when
 // calling TensorImpl::copy_generic_tensor_metadata.
 bool TensorImpl::is_generic_tensor_metadata_equal(
     const TensorImpl* lhs,

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -597,8 +597,8 @@ void TensorImpl::copy_generic_tensor_metadata(
 }
 
 // This function returns true when lhs and rhs tensor generic metadata equal
-// one another. In particular, this is checking equality for the generic properties when
-// calling TensorImpl::copy_generic_tensor_metadata.
+// one another. In particular, this is checking equality for the generic
+// properties when calling TensorImpl::copy_generic_tensor_metadata.
 bool TensorImpl::is_generic_tensor_metadata_equal(
     const TensorImpl* lhs,
     const TensorImpl* rhs) {
@@ -607,25 +607,27 @@ bool TensorImpl::is_generic_tensor_metadata_equal(
     return false;
 
   for (size_t i = 0; i < size; ++i) {
-    if (lhs->sizes_and_strides_.size_at_unchecked(i) != rhs->sizes_and_strides_.size_at_unchecked(i) ||
-        lhs->sizes_and_strides_.stride_at_unchecked(i) != rhs->sizes_and_strides_.stride_at_unchecked(i))
+    if (lhs->sizes_and_strides_.size_at_unchecked(i) !=
+            rhs->sizes_and_strides_.size_at_unchecked(i) ||
+        lhs->sizes_and_strides_.stride_at_unchecked(i) !=
+            rhs->sizes_and_strides_.stride_at_unchecked(i))
       return false;
   }
 
-  return
-    lhs->has_symbolic_sizes_strides_ == rhs->has_symbolic_sizes_strides_ &&
-    lhs->storage_offset_ == rhs->storage_offset_ &&
-    lhs->data_type_ == rhs->data_type_ &&
-    lhs->device_opt_ == rhs->device_opt_ &&
-    lhs->is_contiguous_ == rhs->is_contiguous_ &&
-    lhs->is_channels_last_contiguous_ == rhs->is_channels_last_contiguous_ &&
-    lhs->is_channels_last_3d_contiguous_ == rhs->is_channels_last_3d_contiguous_ &&
-    lhs->is_channels_last_ == rhs->is_channels_last_ &&
-    lhs->is_channels_last_3d_ == rhs->is_channels_last_3d_ &&
-    lhs->is_non_overlapping_and_dense_ == rhs->is_non_overlapping_and_dense_ &&
-    lhs->is_wrapped_number_ == rhs->is_wrapped_number_ &&
-    lhs->reserved_ == rhs->reserved_ &&
-    lhs->numel_ == rhs->numel_;
+  return lhs->has_symbolic_sizes_strides_ == rhs->has_symbolic_sizes_strides_ &&
+      lhs->storage_offset_ == rhs->storage_offset_ &&
+      lhs->data_type_ == rhs->data_type_ &&
+      lhs->device_opt_ == rhs->device_opt_ &&
+      lhs->is_contiguous_ == rhs->is_contiguous_ &&
+      lhs->is_channels_last_contiguous_ == rhs->is_channels_last_contiguous_ &&
+      lhs->is_channels_last_3d_contiguous_ ==
+      rhs->is_channels_last_3d_contiguous_ &&
+      lhs->is_channels_last_ == rhs->is_channels_last_ &&
+      lhs->is_channels_last_3d_ == rhs->is_channels_last_3d_ &&
+      lhs->is_non_overlapping_and_dense_ ==
+      rhs->is_non_overlapping_and_dense_ &&
+      lhs->is_wrapped_number_ == rhs->is_wrapped_number_ &&
+      lhs->reserved_ == rhs->reserved_ && lhs->numel_ == rhs->numel_;
 }
 
 void TensorImpl::copy_tensor_metadata_except_version_counter(

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -596,6 +596,38 @@ void TensorImpl::copy_generic_tensor_metadata(
   dest_impl->refresh_device_policy();
 }
 
+// This functions returns true when lhs and rhs tensor generic metadata equal
+// one another. In particular this is checking equality for the generic properties when
+// calling TensorImpl::copy_generic_tensor_metadata.
+bool TensorImpl::is_generic_tensor_metadata_equal(
+    const TensorImpl* lhs,
+    const TensorImpl* rhs) {
+  const size_t size = lhs->sizes_and_strides_.size();
+  if (size != rhs->sizes_and_strides_.size())
+    return false;
+
+  for (size_t i = 0; i < size; ++i) {
+    if (lhs->sizes_and_strides_.size_at_unchecked(i) != rhs->sizes_and_strides_.size_at_unchecked(i) ||
+        lhs->sizes_and_strides_.stride_at_unchecked(i) != rhs->sizes_and_strides_.stride_at_unchecked(i))
+      return false;
+  }
+
+  return
+    lhs->has_symbolic_sizes_strides_ == rhs->has_symbolic_sizes_strides_ &&
+    lhs->storage_offset_ == rhs->storage_offset_ &&
+    lhs->data_type_ == rhs->data_type_ &&
+    lhs->device_opt_ == rhs->device_opt_ &&
+    lhs->is_contiguous_ == rhs->is_contiguous_ &&
+    lhs->is_channels_last_contiguous_ == rhs->is_channels_last_contiguous_ &&
+    lhs->is_channels_last_3d_contiguous_ == rhs->is_channels_last_3d_contiguous_ &&
+    lhs->is_channels_last_ == rhs->is_channels_last_ &&
+    lhs->is_channels_last_3d_ == rhs->is_channels_last_3d_ &&
+    lhs->is_non_overlapping_and_dense_ == rhs->is_non_overlapping_and_dense_ &&
+    lhs->is_wrapped_number_ == rhs->is_wrapped_number_ &&
+    lhs->reserved_ == rhs->reserved_ &&
+    lhs->numel_ == rhs->numel_;
+}
+
 void TensorImpl::copy_tensor_metadata_except_version_counter(
     const TensorImpl* src_impl,
     TensorImpl* dest_impl,

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2779,7 +2779,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     storage_access_should_throw_ = true;
   }
 
-  static bool is_generic_tensor_metadata_equal(const TensorImpl* lhs, const TensorImpl* rhs);
+  static bool is_generic_tensor_metadata_equal(
+      const TensorImpl* lhs,
+      const TensorImpl* rhs);
 
  public:
   void set_custom_sizes_strides(SizesStridesPolicy policy) {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2779,6 +2779,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     storage_access_should_throw_ = true;
   }
 
+  static bool is_generic_tensor_metadata_equal(const TensorImpl* lhs, const TensorImpl* rhs);
+
  public:
   void set_custom_sizes_strides(SizesStridesPolicy policy) {
     custom_sizes_strides_ = static_cast<uint8_t>(policy);

--- a/test/jit/test_trace_autograd.py
+++ b/test/jit/test_trace_autograd.py
@@ -1,9 +1,9 @@
 # Owner(s): ["oncall: jit"]
 
 import torch
-
 from torch.testing._internal.common_utils import skipIfTorchDynamo
 from torch.testing._internal.jit_utils import JitTestCase
+
 
 if __name__ == "__main__":
     raise RuntimeError(
@@ -12,12 +12,13 @@ if __name__ == "__main__":
         "instead."
     )
 
+
 @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
 class TestTraceAutograd(JitTestCase):
     def validateTrace(self, model):
         inputs = torch.FloatTensor(2, 3, 4).uniform_(0, 10)
         traced = torch.jit.trace(model, inputs)
-        self.assertEqual(abs(traced(inputs) - model(inputs)).sum(), 0.)
+        self.assertEqual(abs(traced(inputs) - model(inputs)).sum(), 0.0)
 
     def test_autograd_sqrt(self):
         class Model(torch.nn.Module):

--- a/test/jit/test_trace_autograd.py
+++ b/test/jit/test_trace_autograd.py
@@ -1,0 +1,66 @@
+# Owner(s): ["oncall: jit"]
+
+import torch
+
+from torch.testing._internal.common_utils import skipIfTorchDynamo
+from torch.testing._internal.jit_utils import JitTestCase
+
+if __name__ == "__main__":
+    raise RuntimeError(
+        "This test file is not meant to be run directly, use:\n\n"
+        "\tpython test/test_jit.py TESTNAME\n\n"
+        "instead."
+    )
+
+@skipIfTorchDynamo("Not a suitable test for TorchDynamo")
+class TestTraceAutograd(JitTestCase):
+    def test_autograd_sqrt(self):
+        class Model(torch.nn.Module):
+            def forward(self, inputs):
+                x = inputs[0].detach().requires_grad_()
+                with torch.enable_grad():
+                    loss = torch.sqrt(x).sum()
+                    return torch.autograd.grad([loss], [x])[0]
+
+        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
+
+    def test_autograd_rsqrt(self):
+        class Model(torch.nn.Module):
+            def forward(self, inputs):
+                x = inputs[0].detach().requires_grad_()
+                with torch.enable_grad():
+                    loss = torch.rsqrt(x).sum()
+                    return torch.autograd.grad([loss], [x])[0]
+
+        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
+
+    def test_autograd_pow(self):
+        class Model(torch.nn.Module):
+            def forward(self, inputs):
+                x = inputs[0].detach().requires_grad_()
+                with torch.enable_grad():
+                    loss = torch.pow(x, 2).sum()
+                    return torch.autograd.grad([loss], [x])[0]
+
+        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
+
+    def test_autograd_mean(self):
+        class Model(torch.nn.Module):
+            def forward(self, inputs):
+                x = inputs[0].detach().requires_grad_()
+                with torch.enable_grad():
+                    loss = torch.mean(x).sum()
+                    return torch.autograd.grad([loss], [x])[0]
+
+        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
+
+    def test_autograd_matmul(self):
+        class Model(torch.nn.Module):
+            def forward(self, inputs):
+                x = inputs[0].detach().requires_grad_()
+                with torch.enable_grad():
+                    loss = torch.matmul(x, x.transpose(-2, -1)).sum()
+                    return torch.autograd.grad([loss], [x])[0]
+
+        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
+        

--- a/test/jit/test_trace_autograd.py
+++ b/test/jit/test_trace_autograd.py
@@ -14,6 +14,11 @@ if __name__ == "__main__":
 
 @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
 class TestTraceAutograd(JitTestCase):
+    def validateTrace(self, model):
+        inputs = torch.FloatTensor(2, 3, 4).uniform_(0, 10)
+        traced = torch.jit.trace(model, inputs)
+        self.assertEqual(abs(traced(inputs) - model(inputs)).sum(), 0.)
+
     def test_autograd_sqrt(self):
         class Model(torch.nn.Module):
             def forward(self, inputs):
@@ -22,7 +27,7 @@ class TestTraceAutograd(JitTestCase):
                     loss = torch.sqrt(x).sum()
                     return torch.autograd.grad([loss], [x])[0]
 
-        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
+        self.validateTrace(Model())
 
     def test_autograd_rsqrt(self):
         class Model(torch.nn.Module):
@@ -32,7 +37,7 @@ class TestTraceAutograd(JitTestCase):
                     loss = torch.rsqrt(x).sum()
                     return torch.autograd.grad([loss], [x])[0]
 
-        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
+        self.validateTrace(Model())
 
     def test_autograd_pow(self):
         class Model(torch.nn.Module):
@@ -42,7 +47,7 @@ class TestTraceAutograd(JitTestCase):
                     loss = torch.pow(x, 2).sum()
                     return torch.autograd.grad([loss], [x])[0]
 
-        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
+        self.validateTrace(Model())
 
     def test_autograd_mean(self):
         class Model(torch.nn.Module):
@@ -52,7 +57,7 @@ class TestTraceAutograd(JitTestCase):
                     loss = torch.mean(x).sum()
                     return torch.autograd.grad([loss], [x])[0]
 
-        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
+        self.validateTrace(Model())
 
     def test_autograd_matmul(self):
         class Model(torch.nn.Module):
@@ -62,5 +67,4 @@ class TestTraceAutograd(JitTestCase):
                     loss = torch.matmul(x, x.transpose(-2, -1)).sum()
                     return torch.autograd.grad([loss], [x])[0]
 
-        torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
-        
+        self.validateTrace(Model())

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -76,7 +76,7 @@ from jit.test_sparse import TestSparse  # noqa: F401
 from jit.test_tensor_methods import TestTensorMethods  # noqa: F401
 from jit.test_dataclasses import TestDataclasses  # noqa: F401
 from jit.test_generator import TestGenerator  # noqa: F401
-from jit.test_trace_autograd import TestTraceAutograd # noqa: F401
+from jit.test_trace_autograd import TestTraceAutograd  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -76,6 +76,7 @@ from jit.test_sparse import TestSparse  # noqa: F401
 from jit.test_tensor_methods import TestTensorMethods  # noqa: F401
 from jit.test_dataclasses import TestDataclasses  # noqa: F401
 from jit.test_generator import TestGenerator  # noqa: F401
+from jit.test_trace_autograd import TestTraceAutograd # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -153,8 +153,8 @@ Value* TracingState::getValue(const IValue& var) {
       auto& value_map = env_stack.at(env_stack.size() - 1 - i);
       auto it = value_map.find(var);
       if (it == value_map.end()) {
-        // If we can't find corresponding TensorImpl based on it's hashed ptr, perform search by
-        // try to find a tensor based on matching storage alias and metadata...
+        // If we can't find corresponding TensorImpl based on ptr hash, perform search by
+        // trying to find a tensor based on matching storage alias and metadata...
         it = value_map.begin();
         for (; it != value_map.end(); ++it) {
           if (it->first.is_alias_of(ten.unsafeGetTensorImpl())) {

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -581,7 +581,7 @@ void TracingState::setValue(const IValue& v, Value* value) {
     env_stack.back()[v] = value;
 
     // Hold tensor reference for the duration of tracing so that
-    // temporary Variables (i.e. created by SavedVariable::unpackSaved via make_variable)
+    // temporary Variables (i.e. created in SavedVariable::unpack when calling make_variable)
     // are not released too early
     backup_.push_back(var);
     

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -156,9 +156,10 @@ Value* TracingState::getValue(const IValue& var) {
         if (!ten.requires_grad())
           continue;
         else {
-          // If we can't find a corresponding TensorImpl based on ptr hash which requires a gradient,
-          // perform linear search based on matching storage alias and metadata since this tensor could
-          // be created by SavedVariable::unpack() via make_variable
+          // If we can't find a corresponding TensorImpl based on ptr hash which
+          // requires a gradient, perform linear search based on matching
+          // storage alias and metadata since this tensor could be created by
+          // SavedVariable::unpack() via make_variable
           it = value_map.begin();
           for (; it != value_map.end(); ++it) {
             if (it->first.is_alias_of(ten.unsafeGetTensorImpl())) {
@@ -185,9 +186,9 @@ Value* TracingState::getValue(const IValue& var) {
     // Didn't find it. Bake in a constant
     if (ten.requires_grad()) {
 #if 0
-      std::cout << "[DEBUG][TracingState::getValue] Failed to find mapped node for Tensor [impl = " 
-                << ten.unsafeGetTensorImpl() 
-                << ", storage = " 
+      std::cout << "[DEBUG][TracingState::getValue] Failed to find mapped node for Tensor [impl = "
+                << ten.unsafeGetTensorImpl()
+                << ", storage = "
                 << ten.unsafeGetTensorImpl()->unsafe_storage().unsafeGetStorageImpl() << "]" << std::endl;
 
       std::cout << "EnvStack contains following tensors: " << std::endl;
@@ -586,15 +587,18 @@ void TracingState::setValue(const IValue& v, Value* value) {
     AT_ASSERT(var.defined());
     env_stack.back()[v] = value;
 
-    // Hold tensor reference requiring gradient for the duration of tracing so that
-    // temporary Variables (i.e. created in SavedVariable::unpack when calling make_variable)
-    // are not released too early
+    // Hold tensor reference requiring gradient for the duration of tracing so
+    // that temporary Variables (i.e. created in SavedVariable::unpack when
+    // calling make_variable) are not released too early
     if (var.requires_grad()) {
-      auto is_equal = [var](const at::Tensor& t) { return t.unsafeGetTensorImpl() == var.unsafeGetTensorImpl(); };
-      if (auto it = std::find_if(backup_.begin(), backup_.end(), is_equal); it == backup_.end())
+      auto is_equal = [var](const at::Tensor& t) {
+        return t.unsafeGetTensorImpl() == var.unsafeGetTensorImpl();
+      };
+      if (auto it = std::find_if(backup_.begin(), backup_.end(), is_equal);
+          it == backup_.end())
         backup_.push_back(var);
     }
-    
+
     // If the value comes from a CallFunction or CallMethod, it may not have
     // shape information attached. For debuggability, we enhance the type
     // information by assigning the concrete value's tupe to the jit::Value.

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -91,6 +91,11 @@ struct TORCH_API TracingState
   using Frame =
       std::unordered_map<WeakIValue, Value*, WeakIValueHasher, WeakIValueEq>;
   std::vector<Frame> env_stack;
+
+  // Keep reference to tensors during tracing so that temporary
+  // tensors created from make_variable (called in SavedVariable::unpack) do not
+  // get released during tracing.
+  std::vector<at::Tensor> backup_;
 };
 
 // This is meant to be used as a thread local place, where we can store extra

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -92,9 +92,9 @@ struct TORCH_API TracingState
       std::unordered_map<WeakIValue, Value*, WeakIValueHasher, WeakIValueEq>;
   std::vector<Frame> env_stack;
 
-  // Keep reference to tensors requiring gradient during tracing so that temporary
-  // tensors created from make_variable (called in SavedVariable::unpack) do not
-  // get released during tracing.
+  // Keep reference to tensors requiring gradient during tracing so that
+  // temporary tensors created from make_variable (called in
+  // SavedVariable::unpack) do not get released during tracing.
   std::vector<at::Tensor> backup_;
 };
 

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -92,7 +92,7 @@ struct TORCH_API TracingState
       std::unordered_map<WeakIValue, Value*, WeakIValueHasher, WeakIValueEq>;
   std::vector<Frame> env_stack;
 
-  // Keep reference to tensors during tracing so that temporary
+  // Keep reference to tensors requiring gradient during tracing so that temporary
   // tensors created from make_variable (called in SavedVariable::unpack) do not
   // get released during tracing.
   std::vector<at::Tensor> backup_;


### PR DESCRIPTION
**Fix for Tracing Models with Backpropagation (#120820)**

***Issue Description***
This PR addresses critical issues encountered when tracing models involving backpropagation. The current implementation fails for seemingly simple scenarios, such as:
```
import torch

class Model(torch.nn.Module):
    def forward(self, inputs):
        x = inputs[0].detach().requires_grad_()
        with torch.enable_grad():
            loss = torch.sqrt(x).sum()
            return torch.autograd.grad([loss], [x])[0]

torch.jit.trace(Model(), torch.FloatTensor(2, 3, 4).uniform_(0, 10))
```

This results in a misleading error as no constants are used during the model computation:
```
RuntimeError: Cannot insert a Tensor that requires grad as a constant. Consider making it a parameter or input, or detaching the gradient
```


***Root Cause Analysis***
The problem stems from the `TracingState`'s use of `IWeakValue` to `Value` mappings:
```
using Frame = std::unordered_map<WeakIValue, Value*, WeakIValueHasher, WeakIValueEq>;
std::vector<Frame> env_stack;
```

Tensors use the `TensorImpl` address as a hash. However, backward function implementations (e.g., `SqrtBackward0::apply()`) create new `TensorImpl` instances when unpacking `SavedVariable` members via `make_variable`:
```
// in SavedVariable::unpack() function...
Variable var;
if (grad_fn) {
    var = make_variable(data, Edge(std::move(grad_fn), output_nr_));
} else { ...
```
These new instances aren't pre-registered in the tracing state `env_stack`, leading to lookup failures and the observed error.


***Solution***
To resolve this, we've implemented a two-step lookup process in the `TracingState`:

1. First, attempt to find the `TensorImpl` using the existing hash-based lookup.
2. If not found, perform a secondary linear search to find a matching `TensorImpl` based on storage alias and tensor metadata equality (e.g. storage alias and a copy of metadata properties are both performed by `make_variable`)

This approach ensures compatibility with tensors created during backpropagation, allowing successful tracing of models with gradient computation.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @thiagocrepaldi - I'm bringing this PR to your attention given you discussed this particular issue with my colleague @DavidMinorNV in the past. Feel free to add any reviewers for feedback.
