### PR TITLE
[TorchElastic] make torch elastic not have to realize TCPStore backend type and rely on c10d to decide which backend to use

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -206,16 +206,6 @@ class CreateBackendTest(TestCase):
 
         self._assert_create_backend_returns_backend()
 
-    def test_create_backend_returns_backend_with_libuv(self) -> None:
-        self._params.config["use_libuv"] = "true"
-
-        self._assert_create_backend_returns_backend()
-
-    def test_create_backend_returns_backend_without_libuv(self) -> None:
-        self._params.config["use_libuv"] = "false"
-
-        self._assert_create_backend_returns_backend()
-
     def test_create_backend_raises_error_if_store_is_unreachable(self) -> None:
         self._params.config["is_host"] = "false"
         self._params.config["read_timeout"] = "2"

--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -131,6 +131,7 @@ class DistributedUtilTest(TestCase):
         wait_for_workers = False
         localhost = socket.gethostname()
 
+        os.environ["USE_LIBUV"] = "0"
         store = create_c10d_store(
             is_server=True,
             server_addr=localhost,
@@ -138,10 +139,12 @@ class DistributedUtilTest(TestCase):
             timeout=2,
             world_size=world_size,
             wait_for_workers=wait_for_workers,
-            use_libuv=False,
         )
         self.assertFalse(store.libuvBackend)
+        del os.environ["USE_LIBUV"]
+        assert "USE_LIBUV" not in os.environ
 
+        # libuv backend is enabled by default
         store = create_c10d_store(
             is_server=True,
             server_addr=localhost,
@@ -149,7 +152,6 @@ class DistributedUtilTest(TestCase):
             timeout=2,
             world_size=world_size,
             wait_for_workers=wait_for_workers,
-            use_libuv=True,
         )
         self.assertTrue(store.libuvBackend)
 

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -144,8 +144,6 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
     else:
         is_host = _matches_machine_hostname(host)
 
-    use_libuv = params.get_as_bool("use_libuv", False)
-
     # The timeout
     read_timeout = cast(int, params.get_as_int("read_timeout", 60))
     if read_timeout <= 0:
@@ -161,7 +159,6 @@ def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
                 is_master=is_server,
                 multi_tenant=True,
                 timeout=timedelta(seconds=read_timeout),
-                use_libuv=use_libuv,
             )
 
             if is_server:

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -1115,7 +1115,6 @@ class DynamicRendezvousHandler(RendezvousHandler):
             bootstrap_store_info.master_port,
             is_master=True,
             multi_tenant=True,
-            use_libuv=True,
         )
 
     @property

--- a/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
@@ -122,6 +122,7 @@ def create_rdzv_handler(params: RendezvousParameters) -> RendezvousHandler:
         timeout = int(params.config["timeout"])
     else:
         timeout = _default_timeout_seconds
+
     return StaticTCPRendezvous(
         master_addr, master_port, rank, world_size, run_id, timeout
     )

--- a/torch/distributed/elastic/utils/distributed.py
+++ b/torch/distributed/elastic/utils/distributed.py
@@ -10,6 +10,7 @@ import datetime
 import os
 import socket
 from contextlib import closing
+from typing import Optional
 
 import torch.distributed as dist
 from torch.distributed.elastic.utils.logging import get_logger
@@ -34,7 +35,11 @@ def create_c10d_store(
     timeout: float = (60 * 10),  # 10 min
     wait_for_workers: bool = True,
     retries=3,
+    use_libuv: Optional[bool] = None,
 ):
+    if use_libuv is not None:
+        logger.warning("argument use_libuv is deprecated and ignored.")
+
     # check os.environ for use_libuv
     use_libuv = os.environ.get("USE_LIBUV", "1") == "1"  # libuv is the default option
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #134882

D53335860 and D56435815 added an option to torch elastic allowing users to choose a TCPStore backend type to use via
1) explicit argument passing in user code when instantiating `MastRendezvousHandler`
2) pass `--use_libuv` command line argument to `torchrun`.

The motivation was to offer a quick way to roll back to non-libuv TCPStore backend since we were making libuv the default in `c10d` code. Now we think that it's better to have torch elastic to not realize the TCPStore backend type but rely on `c10d`'s mechanism to decide which backend to use for torch elastic as well. In this sense, the TCPStore backend type used by torch elastic will be identical to that in pytorch.

PyTorch TCPStore uses the environment variable `USE_LIBUV` to determine the backend type:
when `USE_LIBUV="0"`, the non-libuv backend will be used.
when `USE_LIBUV="1"`, the libuv backend will be used. And this is the default option.

Differential Revision: [D58259590](https://our.internmc.facebook.com/intern/diff/D58259590/)

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @dzhulgakov