### PR TITLE
[cuDNN][64-bit indexing] cuDNN v9.3+ supports non-batch-splittable convolutions with > 2**31 elements

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -422,11 +422,11 @@ struct ConvParams {
   // that maybe the compiledWithCuDNN() check sometimes segfaults (though I can't imagine how)
 #if !defined(C10_MOBILE)
     if (needs_64bit_indexing_no_split(input, weight)) {
-      long cudnn_version = detail::getCUDAHooks().versionCuDNN();
+      static long cudnn_version = detail::getCUDAHooks().versionCuDNN();
       if (!(cudnn_version >= 90300 && at::native::cudnnv8_enabled_check_debug())) {
         TORCH_WARN_ONCE("cuDNN cannot be used for large non-batch-splittable convolutions"
-			" if the V8 API is not enabled or before cuDNN version 9.3+."
-			" Consider upgrading cuDNN and/or enabling the V8 API for better efficiency.");
+                        " if the V8 API is not enabled or before cuDNN version 9.3+."
+                        " Consider upgrading cuDNN and/or enabling the V8 API for better efficiency.");
         return false;
       }
     }


### PR DESCRIPTION
For longstanding issues such as #95024

cc @csarofeen @ptrblck @xwang233 @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10