### PR TITLE
Update unbacked symints in masked_select more precisely

### DIFF
--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -27,6 +27,7 @@ from torch._subclasses.fake_tensor import (
 )
 from torch.fx.operator_schemas import normalize_function
 from torch.utils._stats import count_label
+from torch.utils._sympy.numbers import IntInfinity
 from torch.utils._sympy.value_ranges import bound_sympy
 
 
@@ -472,6 +473,9 @@ def masked_select(fake_mode, func, self, mask):
                     sym_range = bound_sympy(
                         sym_node.expr, sym_node.shape_env.var_to_range
                     )
+                    if isinstance(sym_range.upper, IntInfinity):
+                        num_elements = sys.maxsize - 1
+                        break
                     num_elements *= int(sym_range.upper)
     if num_elements > 2:
         maxval = num_elements

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -29,6 +29,7 @@ from torch.fx.operator_schemas import normalize_function
 from torch.utils._stats import count_label
 from torch.utils._sympy.value_ranges import bound_sympy
 
+
 pytree = torch.utils._pytree
 
 __all__ = [
@@ -468,7 +469,9 @@ def masked_select(fake_mode, func, self, mask):
                     num_elements *= size
                 elif isinstance(size, torch.SymInt):
                     sym_node = size.node
-                    sym_range = bound_sympy(sym_node.expr, sym_node.shape_env.var_to_range)
+                    sym_range = bound_sympy(
+                        sym_node.expr, sym_node.shape_env.var_to_range
+                    )
                     num_elements *= int(sym_range.upper)
     if num_elements > 2:
         maxval = num_elements

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -2,6 +2,7 @@
 
 import functools
 import itertools
+import math
 import sys
 from typing import Callable, Union
 
@@ -463,20 +464,12 @@ def masked_select(fake_mode, func, self, mask):
     if not has_free_symbols(self.numel()):
         num_elements = int(self.numel())
     else:
-        if len(self.shape) != 0:
-            num_elements = 1
-            for size in self.shape:
-                if isinstance(size, int):
-                    num_elements *= size
-                elif isinstance(size, torch.SymInt):
-                    sym_node = size.node
-                    sym_range = bound_sympy(
-                        sym_node.expr, sym_node.shape_env.var_to_range
-                    )
-                    if isinstance(sym_range.upper, IntInfinity):
-                        num_elements = sys.maxsize - 1
-                        break
-                    num_elements *= int(sym_range.upper)
+        prod_node = math.prod(self.shape).node
+        prod_range = bound_sympy(prod_node.expr, prod_node.shape_env.var_to_range)
+        if isinstance(prod_range.upper, IntInfinity):
+            num_elements = sys.maxsize - 1
+        else:
+            num_elements = prod_range.upper
     if num_elements > 2:
         maxval = num_elements
 

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -28,8 +28,6 @@ from torch._subclasses.fake_tensor import (
 )
 from torch.fx.operator_schemas import normalize_function
 from torch.utils._stats import count_label
-from torch.utils._sympy.numbers import IntInfinity
-from torch.utils._sympy.value_ranges import bound_sympy
 
 
 pytree = torch.utils._pytree
@@ -457,6 +455,8 @@ def masked_select(fake_mode, func, self, mask):
         _constrain_range_for_size,
         has_free_symbols,
     )
+    from torch.utils._sympy.numbers import IntInfinity
+    from torch.utils._sympy.value_ranges import bound_sympy
 
     # If num elements is expressed symbolically, calculate
     # the concrete value based on upper bounds. Otherwise,


### PR DESCRIPTION
## Summary
At the moment, the fake impl for `masked_select` simply sets the upper range while updating its size-like SymInt to `sys.maxsize`(9223372036854775807, max value for an unsigned int64) if the there are any SymInts in the original input tensor shape. This PR constrains the range more intelligently by using the upper ranges of each SymInt in the input tensor shape.

This solves an issue where a model being lowered to Executorch errors during memory planning because the memory allocated for `masked_select` ended up exceeded the 64-bit address space (`INT_MAX * size(dtype)`).

## Test plan
- Passes existing unit tests (tests case where upper bound is inf)
- Added unit test to verify upper bound reduction calculation
- Tested end-to-end by exporting with TORCH_LOGS="export" and ensuring that the range for `masked_select`'s SymInt size has the correct upper bound