### PR TITLE
[dynamo] do not raise an unimplemented error with boolean masking setitem

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4565,11 +4565,6 @@ def forward(self, x, b, y):
     return pytree.tree_unflatten([x], self._out_spec)""",  # NOQA: B950
         )
 
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported, "boolean masking setitem backwards"
-        ):
-            gm, _ = torch._dynamo.export(fn)(x, b, y)
-
     def test_dynamo_list_index(self):
         def fn(x, in_list):
             return x + in_list.index(2)

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4565,6 +4565,8 @@ def forward(self, x, b, y):
     return pytree.tree_unflatten([x], self._out_spec)""",  # NOQA: B950
         )
 
+        gm, _ = torch._dynamo.export(fn)(x, b, y)
+
     def test_dynamo_list_index(self):
         def fn(x, in_list):
             return x + in_list.index(2)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -874,15 +874,20 @@ class TensorVariable(VariableTracker):
             else:
                 return False
 
-        if (
-            has_bool_key(key)
-            and isinstance(value, TensorVariable)
-            and value.requires_grad
-            and torch.is_grad_enabled()
-        ):
-            unimplemented(
-                "boolean masking setitem backwards, see https://github.com/pytorch/pytorch/issues/114123"
-            )
+        # cudagraph breaks on boolean masking setitem, but there's no need
+        # to raise an error here. The user can still use the boolean mask.
+        # Further discussion here:
+        # - https://github.com/pytorch/pytorch/issues/114123
+        # - https://github.com/pytorch/pytorch/issues/134241
+        # if (
+        #     has_bool_key(key)
+        #     and isinstance(value, TensorVariable)
+        #     and value.requires_grad
+        #     and torch.is_grad_enabled()
+        # ):
+        #     unimplemented(
+        #         "boolean masking setitem backwards, see https://github.com/pytorch/pytorch/issues/114123"
+        #     )
         from ..symbolic_convert import InstructionTranslator
 
         tx = InstructionTranslator.current_tx()

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -874,20 +874,6 @@ class TensorVariable(VariableTracker):
             else:
                 return False
 
-        # cudagraph breaks on boolean masking setitem, but there's no need
-        # to raise an error here. The user can still use the boolean mask.
-        # Further discussion here:
-        # - https://github.com/pytorch/pytorch/issues/114123
-        # - https://github.com/pytorch/pytorch/issues/134241
-        # if (
-        #     has_bool_key(key)
-        #     and isinstance(value, TensorVariable)
-        #     and value.requires_grad
-        #     and torch.is_grad_enabled()
-        # ):
-        #     unimplemented(
-        #         "boolean masking setitem backwards, see https://github.com/pytorch/pytorch/issues/114123"
-        #     )
         from ..symbolic_convert import InstructionTranslator
 
         tx = InstructionTranslator.current_tx()


### PR DESCRIPTION
Cudagraph breaks on boolean masking setitem, however the code runs fine. There is no need to raise an unimplemented error here, since it already warns that its an incompatible op.


Fixes #134241


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec