### PR TITLE
[WIP] add rpath of sycl libraries location in python env to avoid manually activating sycl environment

### DIFF
--- a/c10/xpu/CMakeLists.txt
+++ b/c10/xpu/CMakeLists.txt
@@ -39,6 +39,11 @@ if(NOT BUILD_LIBTORCHLESS)
 
   # ---[ Dependency of c10_xpu
   target_link_libraries(c10_xpu PUBLIC c10 torch::xpurt)
+  if(LINUX)
+    target_link_options(c10_xpu PRIVATE "-Wl,-rpath,$ORIGIN")
+    target_link_options(c10_xpu PRIVATE "-Wl,-rpath,$ORIGIN/../../../../")
+    target_link_options(c10_xpu PRIVATE "-Wl,--disable-new-dtags")
+  endif()
   target_include_directories(
       c10_xpu PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1073,6 +1073,9 @@ if(USE_XPU)
       # Linux
       target_link_libraries(torch_xpu PRIVATE
         "-Wl,--whole-archive,\"$<TARGET_FILE:torch_xpu_ops>\" -Wl,--no-whole-archive")
+      target_link_options(torch_xpu PRIVATE "-Wl,-rpath,$ORIGIN")
+      target_link_options(torch_xpu PRIVATE "-Wl,-rpath,$ORIGIN/../../../../")
+      target_link_options(torch_xpu PRIVATE "-Wl,--disable-new-dtags")
     endif()
 
     # Set cached ${ATen_XPU_INCLUDE_DIRS} to torch
@@ -1491,6 +1494,11 @@ endif()
 
 if(USE_XPU)
   target_link_libraries(torch PUBLIC torch_xpu_library)
+  if(LINUX)
+    target_link_options(torch PRIVATE "-Wl,-rpath,$ORIGIN")
+    target_link_options(torch PRIVATE "-Wl,-rpath,$ORIGIN/../../../../")
+    target_link_options(torch PRIVATE "-Wl,--disable-new-dtags")
+  endif()
 endif()
 
 if(PRINT_CMAKE_DEBUG_INFO)

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -418,6 +418,11 @@ endif()
 target_compile_definitions(torch_python PRIVATE "-DTHP_BUILD_MAIN_LIB")
 
 target_link_libraries(torch_python PRIVATE ${TORCH_LIB} ${TORCH_PYTHON_LINK_LIBRARIES})
+if(USE_XPU AND LINUX)
+  target_link_options(torch_python PRIVATE "-Wl,-rpath,$ORIGIN")
+  target_link_options(torch_python PRIVATE "-Wl,-rpath,$ORIGIN/../../../../")
+  target_link_options(torch_python PRIVATE "-Wl,--disable-new-dtags")
+endif()
 
 target_compile_definitions(torch_python PRIVATE ${TORCH_PYTHON_COMPILE_DEFINITIONS})
 


### PR DESCRIPTION
Target at 2.6.