### PR TITLE
Improvements for associative_scan - lifted_args for combine_mode='generic'

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1307,7 +1307,7 @@ def forward(self, pred_1, x_1):
             (get_scan_combine_fn("add", True), torch.cumsum),
             (get_scan_combine_fn("mul", True), torch.cumprod),
         ]:
-            result = scan_fct(op, x, 0, reverse=reverse, combine_mode=combine_mode)
+            result = scan_fct(op, x, dim=0, reverse=reverse, combine_mode=combine_mode)
             result_exp = _fake_associative_scan(op, xs=x, dim=0, reverse=reverse)
             self.assertEqual(result, result_exp)
             if not reverse:
@@ -1319,7 +1319,7 @@ def forward(self, pred_1, x_1):
         cumsum1 = scan_fct(
             get_scan_combine_fn("add", True),
             x,
-            0,
+            dim=0,
             reverse=reverse,
             combine_mode=combine_mode,
         )
@@ -1550,7 +1550,7 @@ def forward(self, pred_1, x_1):
                 (get_scan_combine_fn("mul", True), torch.cumprod),
             ]:
                 result = associative_scan(
-                    op, x, rnd_scan_dim, reverse=reverse, combine_mode=combine_mode
+                    op, x, dim=rnd_scan_dim, reverse=reverse, combine_mode=combine_mode
                 )
                 result_exp = _fake_associative_scan(
                     op, x, rnd_scan_dim, reverse=reverse
@@ -1623,7 +1623,7 @@ def forward(self, pred_1, x_1):
         result1 = associative_scan(
             get_scan_combine_fn("s5_operator", True),
             elements,
-            0,
+            dim=0,
             combine_mode=combine_mode,
             reverse=reverse,
         )
@@ -1695,7 +1695,7 @@ def forward(self, pred_1, x_1):
         result1 = associative_scan(
             get_scan_combine_fn("tuple_fct", True),
             inp,
-            0,
+            dim=0,
             reverse=reverse,
             combine_mode=combine_mode,
         )
@@ -1768,7 +1768,7 @@ def forward(self, pred_1, x_1):
             torch._dynamo.exc.Unsupported,
             "Observed exception.*",
         ):
-            result = associative_scan(fct_wrong_pytree, inp, 0, combine_mode="generic")
+            result = associative_scan(fct_wrong_pytree, inp, dim=0, combine_mode="generic")
 
     @unittest.skipIf(not SM70OrLater, "triton")
     @requires_cuda
@@ -1802,7 +1802,7 @@ def forward(self, pred_1, x_1):
         result = associative_scan(
             get_scan_combine_fn("complex_pointwise", True),
             inp,
-            0,
+            dim=0,
             combine_mode=combine_mode,
             reverse=reverse,
         )
@@ -1901,7 +1901,7 @@ def forward(self, pred_1, x_1):
             o = associative_scan(
                 get_scan_combine_fn("add", True),
                 inp,
-                1,
+                dim=1,
                 reverse=reverse,
                 combine_mode=combine_mode,
             )
@@ -1940,14 +1940,14 @@ def forward(self, pred_1, x_1):
             o1 = associative_scan(
                 get_scan_combine_fn("add", True),
                 inp,
-                1,
+                dim=1,
                 combine_mode=combine_mode,
                 reverse=reverse,
             )
             o2 = associative_scan(
                 get_scan_combine_fn("add", True),
                 o1,
-                1,
+                dim=1,
                 combine_mode=combine_mode,
                 reverse=reverse,
             )
@@ -1992,14 +1992,14 @@ def forward(self, pred_1, x_1):
             o1 = associative_scan(
                 get_scan_combine_fn("add", True),
                 inp,
-                1,
+                dim=1,
                 combine_mode=combine_mode,
                 reverse=reverse,
             )
             o2 = associative_scan(
                 get_scan_combine_fn("add", True),
                 o1,
-                0,
+                dim=0,
                 combine_mode=combine_mode,
                 reverse=reverse,
             )
@@ -2123,7 +2123,7 @@ def forward(self, pred_1, x_1):
             out = associative_scan(
                 get_scan_combine_fn("non_pointwise", True),
                 x,
-                0,
+                dim=0,
                 reverse=reverse,
                 combine_mode="pointwise",
             )
@@ -2146,7 +2146,7 @@ def forward(self, pred_1, x_1):
         result1 = associative_scan(
             get_scan_combine_fn("non_pointwise", True),
             x,
-            0,
+            dim=0,
             reverse=reverse,
             combine_mode="generic",
         )
@@ -2879,7 +2879,7 @@ def forward(self, L_init_ : torch.Tensor, L_xs_ : torch.Tensor):
         unittest.skip,
         lambda params: (params["combine_mode"] == "pointwise"),
     )
-    def test_pointwise_associative_scan_freevars(self, reverse, device, combine_mode):
+    def test_associative_scan_freevars(self, reverse, device, combine_mode):
         H = torch.rand(2, device=device, requires_grad=True)
 
         def fct_1freevars(x: torch.Tensor, y: torch.Tensor):
@@ -2892,7 +2892,7 @@ def forward(self, L_init_ : torch.Tensor, L_xs_ : torch.Tensor):
 
         for fct in [fct_1freevars, fct_2freevars]:
             result = associative_scan(
-                fct, inp, 0, reverse=reverse, combine_mode=combine_mode
+                fct, inp, dim=0, reverse=reverse, combine_mode=combine_mode
             )
             expected_result = _fake_associative_scan(fct, inp, 0, reverse=reverse)
             self.assertEqual(result, expected_result)
@@ -2909,7 +2909,7 @@ def forward(self, L_init_ : torch.Tensor, L_xs_ : torch.Tensor):
         unittest.skip,
         lambda params: (params["combine_mode"] == "pointwise"),
     )
-    def test_pointwise_associative_scan_freevars_pytree(
+    def test_associative_scan_freevars_pytree(
         self, reverse, device, combine_mode
     ):
         xf = torch.randn(2, 2, device=device, requires_grad=True)
@@ -2937,7 +2937,7 @@ def forward(self, L_init_ : torch.Tensor, L_xs_ : torch.Tensor):
         inp = {"i": x, "j": ([y], [{"o": z}])}
 
         result = associative_scan(
-            fct_pointwise, inp, 0, reverse=reverse, combine_mode=combine_mode
+            fct_pointwise, inp, dim=0, reverse=reverse, combine_mode=combine_mode
         )
         expected_result = _fake_associative_scan(fct_pointwise, inp, 0, reverse=reverse)
         self.assertEqual(result, expected_result)

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -2117,7 +2117,9 @@ def forward(self, pred_1, x_1):
         x = torch.randn(3, 10, 2, device=device)
         # Expected to fail, as the pointwise combine_mode does not allow non-pointwise operations
         with self.assertRaisesRegex(
-            Exception,
+            # Exception,
+            # "For combine_mode='pointwise', the combine_fn needs to be pointwise",
+            torch._dynamo.exc.UncapturedHigherOrderOpError,
             "For combine_mode='pointwise', the combine_fn needs to be pointwise",
         ):
             out = associative_scan(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1040,20 +1040,34 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
         args: List[VariableTracker],
         kwargs: Dict[str, VariableTracker],
     ) -> VariableTracker:
-        from .builder import wrap_fx_proxy
+        from .builder import SourcelessBuilder, wrap_fx_proxy
+        from torch._higher_order_ops.associative_scan import (
+            first_slice_copy
+        )
 
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
 
-        def arg_extractor(combine_fn, input, dim, lifted_args):
-            return combine_fn, input, dim, lifted_args
+        def arg_extractor(combine_fn, xs, dim, additional_inputs):
+            return combine_fn, xs, dim, additional_inputs
 
-        combine_fn, input, dim, lifted_args = arg_extractor(*args, **kwargs)
+        combine_fn, xs, dim, additional_inputs = arg_extractor(*args, **kwargs)
 
         if xs.python_type() != list:
             unimplemented(
                 f"Expected xs to be a list of tensors but got {xs.python_type()}",
             )
         assert isinstance(xs, torch._dynamo.variables.lists.BaseListVariable)
+
+        dim_fake = (
+            dim.as_proxy()
+            if type(dim.as_proxy()) == int
+            else get_fake_value(dim.as_proxy().node, tx)
+        )
+        scan_length = get_fake_value(xs.items[0].as_proxy().node, tx).size()[dim_fake]
+        if scan_length == 0:
+            unimplemented(
+                "scan() operator doesn't support zero-sized tensors during tracing."
+            )
 
         # Trace the subgraph
         # TODO: Fix these pointless new_empty calls appearing in the dynamo output graph.
@@ -1078,12 +1092,22 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
             )
             for leaf in itertools.chain(xs.items, xs.items)
         ]
+        
+        # The sub_args_inp is a slice of original input, e.g. if input.size is (3, 4), and scan dim=0
+        # the sub_args_inp shape will be (4, ).
+        # sub_args_inp = [
+        #     _make_inlined(tx, first_slice_copy)(inp, dim) for inp in xs.items
+        # ]
+        sub_args_additional_inputs = [
+            t.call_method(tx, "clone", args=(), kwargs={})
+            for t in additional_inputs.items
+        ]
+        sub_args = sub_args_inp + sub_args_additional_inputs
         (
             (combine_result, combine_treespec),
             combine_graph,
             combine_lifted_freevars,
-        ) = speculate_subgraph(
-            tx,
+        ) = speculate_subgraph(tx,
             combine_fn,
             sub_args,
             sub_kwargs={},
@@ -1092,7 +1116,22 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
             set_subgraph_inputs="flatten_manual",
         )
         
-        lifted_args = tuple(arg for arg in combine_lifted_freevars.keys())
+        # key in the combine_lifted_freevars are proxies in the root tracer.
+        # We use root tracer's proxies to create scan op's inputs.
+        def _check_phs_position_match(
+            combine_graph: torch.fx.Graph, lifted_proxies: list[torch.fx.Proxy]
+        ):
+            lifted_phs = [
+                node for node in combine_graph.nodes if node.op == "placeholder"
+            ][-len(lifted_proxies) :]
+            for ph, lifted_proxy in zip(lifted_phs, lifted_proxies):
+                if ph is not lifted_proxy.node:
+                    unimplemented(
+                        "The postion lifted freevars doesn't match the order of placeholders in subgraph."
+                    )
+
+        _check_phs_position_match(combine_graph, list(combine_lifted_freevars.values()))
+        combine_freevars_proxy = list(combine_lifted_freevars.keys())
 
         if combine_result.python_type() != list:
             unimplemented(
@@ -1101,6 +1140,7 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
         xs_proxy = xs.as_proxy()
         combine_result_proxy = combine_result.as_proxy()
+        additional_inputs_proxy = additional_inputs.as_proxy() + combine_freevars_proxy
         for result, inp_proxy in zip(combine_result_proxy, xs_proxy):
             inp_meta = inp_proxy.node.meta["example_value"]
             combine_result_meta = result.node.meta["example_value"]
@@ -1122,7 +1162,7 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
             make_attr(tx, combine_fn_name),
             xs_proxy,
             dim.as_proxy(),
-            lifted_args,
+            additional_inputs_proxy,
         )
 
         with tx.fake_mode:

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1044,10 +1044,10 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
         args, kwargs = LazyVariableTracker.realize_all((args, kwargs))
 
-        def arg_extractor(combine_fn, xs, dim):
-            return combine_fn, xs, dim
+        def arg_extractor(combine_fn, input, dim, lifted_args):
+            return combine_fn, input, dim, lifted_args
 
-        combine_fn, xs, dim = arg_extractor(*args, **kwargs)
+        combine_fn, input, dim, lifted_args = arg_extractor(*args, **kwargs)
 
         if xs.python_type() != list:
             unimplemented(
@@ -1091,11 +1091,8 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
             source_target=self.value,
             set_subgraph_inputs="flatten_manual",
         )
-
-        if combine_lifted_freevars:
-            unimplemented(
-                f"Combine fn had unexpected freevars: {combine_lifted_freevars}"
-            )
+        
+        lifted_args = tuple(arg for arg in combine_lifted_freevars.keys())
 
         if combine_result.python_type() != list:
             unimplemented(
@@ -1125,6 +1122,7 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
             make_attr(tx, combine_fn_name),
             xs_proxy,
             dim.as_proxy(),
+            lifted_args,
         )
 
         with tx.fake_mode:

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import functools
 import itertools
-from typing import Callable, List
+from typing import Callable, List, Tuple
 
 import torch
 import torch._prims_common as utils
@@ -73,8 +73,8 @@ class AssociativeScanOp(HigherOrderOperator):
     def __init__(self):
         super().__init__("associative_scan")
 
-    def __call__(self, combine_fn, xs, dim):
-        return super().__call__(combine_fn, xs, dim)
+    def __call__(self, combine_fn, xs, dim, lifted_args=()):
+        return super().__call__(combine_fn, xs, dim, lifted_args)
 
 
 associative_scan_op = AssociativeScanOp()
@@ -138,7 +138,12 @@ def associative_scan(
     if not torch._dynamo.is_compiling():
         with _set_compilation_env(), torch._dynamo.utils.disable_cache_limit():
             return torch.compile(associative_scan, fullgraph=True)(
-                combine_fn, xs, dim, reverse=reverse, combine_mode=combine_mode
+                combine_fn,
+                xs,
+                dim,
+                reverse=reverse,
+                combine_mode=combine_mode,
+                lifted_args=lifted_args,
             )
 
     leaves, spec = pytree.tree_flatten(xs)
@@ -166,7 +171,7 @@ def associative_scan(
     out = combine_fn(
         pytree.tree_unflatten(leaves, spec),
         pytree.tree_unflatten(leaves, spec),
-        *lifted_args
+        *lifted_args,
     )
     out_leaves, tree_out = pytree.tree_flatten(out)
     if len(leaves) != len(out_leaves):
@@ -252,7 +257,7 @@ def generic_associative_scan(operator, elems_flat, dim=0, lifted_args=()):
         reduced_elems = operator(
             *[aten.slice(elem, dim, 0, -1, 2) for elem in elems],
             *[aten.slice(elem, dim, 1, None, 2) for elem in elems],
-            *lifted_args
+            *lifted_args,
         )
 
         # Recursively compute scan for partially reduced tensors.
@@ -262,13 +267,13 @@ def generic_associative_scan(operator, elems_flat, dim=0, lifted_args=()):
             even_elems = operator(
                 *[aten.slice(e, dim, 0, -1) for e in odd_elems],
                 *[aten.slice(e, dim, 2, None, 2) for e in elems],
-                *lifted_args
+                *lifted_args,
             )
         else:
             even_elems = operator(
                 *odd_elems,
                 *[aten.slice(e, dim, 2, None, 2) for e in elems],
-                *lifted_args
+                *lifted_args,
             )
 
         # The first element of a scan is the same as the first element
@@ -294,7 +299,12 @@ def generic_associative_scan(operator, elems_flat, dim=0, lifted_args=()):
 
 
 def trace_associative_scan(
-    proxy_mode, func_overload, combine_fn: Callable, xs: List[torch.Tensor], dim: int, lifted_args: Tuple[torch.Tensor],
+    proxy_mode,
+    func_overload,
+    combine_fn: Callable,
+    xs: List[torch.Tensor],
+    dim: int,
+    lifted_args: Tuple[torch.Tensor],
 ):
     with disable_proxy_modes_tracing():
         sample_xs = [
@@ -306,7 +316,7 @@ def trace_associative_scan(
             )
             for x in itertools.chain(xs, xs)
         ]
-        combine_graph = reenter_make_fx(combine_fn)(*sample_xs)
+        combine_graph = reenter_make_fx(combine_fn)(*sample_xs, *lifted_args)
 
     outputs = None
     for node in combine_graph.graph.nodes:
@@ -336,7 +346,7 @@ def trace_associative_scan(
 
     proxy_mode.tracer.root.register_module(combine_graph_name, combine_graph)
 
-    args = (combine_graph, xs, dim)
+    args = (combine_graph, xs, dim, lifted_args)
     proxy_args = pytree.tree_map(proxy_mode.tracer.unwrap_proxy, args)
     out_proxy = proxy_mode.tracer.create_proxy(
         "call_function", func_overload, proxy_args, {}, name="associative_scan"

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -116,7 +116,7 @@ def associative_scan(
             Note: ``combine_mode=pointwise`` is more efficient than ``combine_mode=generic``.
         lifted_args (Tuple of tensors): A tuple of lifted parameters from the global scope.
             This parameter will be populated internally.
-
+            Note: lifted arguments are currently only supported for ``combine_mode=generic`
 
     Example::
 

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -86,6 +86,7 @@ def associative_scan(
     dim: int,
     reverse: bool = False,
     combine_mode: str = "pointwise",
+    lifted_args: Tuple = (),
 ) -> torch.Tensor:
     r"""
     Performs an inclusive scan with an associative combine function.
@@ -113,6 +114,8 @@ def associative_scan(
             and ``xs`` must be CUDA tensors.
             In all other cases ``combine_mode=generic`` should be used.
             Note: ``combine_mode=pointwise`` is more efficient than ``combine_mode=generic``.
+        lifted_args (Tuple of tensors): A tuple of lifted parameters from the global scope.
+            This parameter will be populated internally.
 
 
     Example::
@@ -163,6 +166,7 @@ def associative_scan(
     out = combine_fn(
         pytree.tree_unflatten(leaves, spec),
         pytree.tree_unflatten(leaves, spec),
+        *lifted_args
     )
     out_leaves, tree_out = pytree.tree_flatten(out)
     if len(leaves) != len(out_leaves):
@@ -179,9 +183,9 @@ def associative_scan(
     )
 
     if combine_mode == "generic":
-        result_flat = generic_associative_scan(combine_fn, leaves, dim)
+        result_flat = generic_associative_scan(combine_fn, leaves, dim, lifted_args)
     else:
-        result_flat = associative_scan_op(combine_fn, leaves, dim)
+        result_flat = associative_scan_op(combine_fn, leaves, dim, lifted_args)
 
     if reverse:
         result_flat = [torch.flip(elem, [dim]) for elem in result_flat]
@@ -189,7 +193,7 @@ def associative_scan(
     return pytree.tree_unflatten(result_flat, spec)
 
 
-def generic_associative_scan(operator, elems_flat, dim=0):
+def generic_associative_scan(operator, elems_flat, dim=0, lifted_args=()):
     r"""
     This function performs the associative_scan operation.
     The algorithm works by recursively collecting neighbours of ``elems_flat`` and subsequently
@@ -204,7 +208,8 @@ def generic_associative_scan(operator, elems_flat, dim=0):
             ``xs`` provided to ``associative_scan``.
             All inputs are expected to have the same shape.
         dim (int): the dimension to scan over
-
+        lifted_args (Tuple of tensors): A tuple of lifted parameters from the global scope.
+            This parameter will be populated internally.
 
     Example::
 
@@ -247,6 +252,7 @@ def generic_associative_scan(operator, elems_flat, dim=0):
         reduced_elems = operator(
             *[aten.slice(elem, dim, 0, -1, 2) for elem in elems],
             *[aten.slice(elem, dim, 1, None, 2) for elem in elems],
+            *lifted_args
         )
 
         # Recursively compute scan for partially reduced tensors.
@@ -256,11 +262,13 @@ def generic_associative_scan(operator, elems_flat, dim=0):
             even_elems = operator(
                 *[aten.slice(e, dim, 0, -1) for e in odd_elems],
                 *[aten.slice(e, dim, 2, None, 2) for e in elems],
+                *lifted_args
             )
         else:
             even_elems = operator(
                 *odd_elems,
                 *[aten.slice(e, dim, 2, None, 2) for e in elems],
+                *lifted_args
             )
 
         # The first element of a scan is the same as the first element
@@ -286,7 +294,7 @@ def generic_associative_scan(operator, elems_flat, dim=0):
 
 
 def trace_associative_scan(
-    proxy_mode, func_overload, combine_fn: Callable, xs: List[torch.Tensor], dim: int
+    proxy_mode, func_overload, combine_fn: Callable, xs: List[torch.Tensor], dim: int, lifted_args: Tuple[torch.Tensor],
 ):
     with disable_proxy_modes_tracing():
         sample_xs = [
@@ -341,7 +349,7 @@ def trace_associative_scan(
 
 
 @associative_scan_op.py_impl(DispatchKey.CompositeExplicitAutograd)
-def associative_scan_op_dense(combine_fn, xs, dim):
+def associative_scan_op_dense(combine_fn, xs, dim, lifted_args):
     raise NotImplementedError("associative_scan is not implemented for eager")
 
 
@@ -351,22 +359,21 @@ associative_scan_op.py_impl(DispatchKey.Autograd)(
 
 
 @associative_scan_op.py_impl(ProxyTorchDispatchMode)
-def associative_scan_proxy_mode(mode, combine_fn, xs, dim):
-    return trace_associative_scan(mode, associative_scan_op, combine_fn, xs, dim)
+def associative_scan_proxy_mode(mode, combine_fn, xs, dim, lifted_args):
+    return trace_associative_scan(mode, associative_scan_op, combine_fn, xs, dim, lifted_args)
 
 
 @associative_scan_op.py_impl(FakeTensorMode)
-def assoiciative_scan_fake_tensor_mode(mode, combine_fn, xs, dim):
+def assoiciative_scan_fake_tensor_mode(mode, combine_fn, xs, dim, lifted_args):
     with mode:
         return [x.clone() for x in xs]
 
 
 @associative_scan_op.py_functionalize_impl
-def associative_scan_functionalize(ctx, combine_fn, xs, dim):
+def associative_scan_functionalize(ctx, combine_fn, xs, dim, lifted_args):
     unwrapped_xs = ctx.unwrap_tensors(xs)
+    unwrapped_lifted_args = ctx.unwrap_tensors(lifted_args)
     with ctx.redispatch_to_next() as m:
-        functional_combine_fn = ctx.functionalize(
-            _maybe_run_with_interpreter(combine_fn)
-        )
-        ret = associative_scan_op(functional_combine_fn, unwrapped_xs, dim)
+        functional_combine_fn = ctx.functionalize(combine_fn)
+        ret = associative_scan_op(functional_combine_fn, unwrapped_xs, dim, unwrapped_lifted_args)
     return ctx.wrap_tensors(ret)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6393,10 +6393,10 @@ def while_loop(cond_fn, body_fn, carried_inputs, additional_inputs):
 
 
 @register_lowering(associative_scan_op, type_promotion_kind=None)
-def associative_scan(combine_fn: ir.Subgraph, input, dim: int, lifted_args: Tuple[torch.Tensor]):
+def associative_scan(combine_fn: ir.Subgraph, xs, dim: int, additional_inputs: Tuple[torch.Tensor]):
     from .subgraph_lowering import InputDescriptor, lower_pointwise_subgraph
 
-    if lifted_args != ():
+    if additional_inputs != ():
         raise RuntimeError(
             "Unable to generate code for associative_scan op, because there are lifted arguments"
         )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6393,10 +6393,10 @@ def while_loop(cond_fn, body_fn, carried_inputs, additional_inputs):
 
 
 @register_lowering(associative_scan_op, type_promotion_kind=None)
-def associative_scan(combine_fn: ir.Subgraph, xs, dim: int, additional_inputs: Tuple[torch.Tensor]):
+def associative_scan(combine_fn: ir.Subgraph, xs, dim: int, additional_inputs: List[torch.Tensor]):
     from .subgraph_lowering import InputDescriptor, lower_pointwise_subgraph
 
-    if additional_inputs != ():
+    if len(additional_inputs) > 0:
         raise RuntimeError(
             "Unable to generate code for associative_scan op, because there are lifted arguments"
         )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6393,8 +6393,13 @@ def while_loop(cond_fn, body_fn, carried_inputs, additional_inputs):
 
 
 @register_lowering(associative_scan_op, type_promotion_kind=None)
-def associative_scan(combine_fn: ir.Subgraph, xs, dim: int):
+def associative_scan(combine_fn: ir.Subgraph, input, dim: int, lifted_args: Tuple[torch.Tensor]):
     from .subgraph_lowering import InputDescriptor, lower_pointwise_subgraph
+
+    if lifted_args != ():
+        raise RuntimeError(
+            "Unable to generate code for associative_scan op, because there are lifted arguments"
+        )
 
     subgraph_inputs = [
         InputDescriptor(dtype=x.get_dtype(), device=x.get_device())


### PR DESCRIPTION
This PR is part of a series of improvements for associative_scan and implements lifted arguments for the `combine_fn`, if the `combine_mode='generic'` is used.

@ydwu4 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @rec