### PR TITLE
add __all__ to amp public interface

### DIFF
--- a/torch/amp/__init__.py
+++ b/torch/amp/__init__.py
@@ -8,6 +8,7 @@ from .autocast_mode import (
 )
 from .grad_scaler import GradScaler
 
+
 __all__ = [
     "autocast",
     "custom_bwd",

--- a/torch/amp/__init__.py
+++ b/torch/amp/__init__.py
@@ -7,3 +7,11 @@ from .autocast_mode import (
     is_autocast_available,
 )
 from .grad_scaler import GradScaler
+
+__all__ = [
+    "autocast",
+    "custom_bwd",
+    "custom_fwd",
+    "GradScaler",
+    "is_autocast_available",
+]


### PR DESCRIPTION
While migrating from `torch.cuda.amp.GradScaler()` to `torch.amp.GradScaler('cuda') `  pylance throws and error.

This resolves GradScaler is not exported from module torch.amp reportPrivateImportUsage pylance error

<img width="953" alt="Screenshot 2024-09-02 at 6 17 54 PM" src="https://github.com/user-attachments/assets/bb1496d2-7764-4a91-8b08-8f7504b9e95f">


cc @mcarilli @ptrblck @leslie-fang-intel @jgong5