### PR TITLE
[inductor] add openmp config for intel conpiler on Linux.

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -961,7 +961,6 @@ def _get_openmp_args(
                 libs.append("gomp")
             elif _is_intel_compiler(cpp_compiler):
                 cflags.append("fiopenmp")
-                libs.append("libiomp5")
             else:
                 cflags.append("fopenmp")
                 libs.append("gomp")

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -959,6 +959,9 @@ def _get_openmp_args(
                 # TODO: fix issue, can't find omp.h
                 cflags.append("fopenmp")
                 libs.append("gomp")
+            elif _is_intel_compiler(cpp_compiler):
+                cflags.append("fiopenmp")
+                libs.append("libiomp5")
             else:
                 cflags.append("fopenmp")
                 libs.append("gomp")


### PR DESCRIPTION
Config `openmp` for Intel Compiler on Linux.

Base on this PR, we can confirm the Intel optimized libraries are work built well.
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/838d5114-c778-4961-9cfe-39a814647089">


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang