### PR TITLE
[Intel GPU] Enable pin_out for XPU in native::_to_copy

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -338,7 +338,8 @@ Tensor _to_copy(
         options);
   }
 
-  bool pin_out = (non_blocking && (self.is_cuda() || self.is_privateuseone())
+  bool pin_out = (non_blocking
+                  && (self.is_cuda() || self.is_xpu() || self.is_privateuseone())
                   && options.device().is_cpu() && (options.layout() == c10::kStrided));
 
   if (memory_format == MemoryFormat::Preserve) {


### PR DESCRIPTION
Align semantics defined in https://pytorch.org/docs/stable/generated/torch.Tensor.to.html#torch.Tensor.to, "When non_blocking, tries to convert asynchronously with respect to host if possible."

Without the logic, asynchronous D2H with a pageable memory will leads to crash sometime.

cc @frank-wei @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @EikanWang @guangyey