### PR TITLE
Enable frozen dataclasses in FSDP

### DIFF
--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -232,9 +232,11 @@ def _apply_to_tensors(fn, container):
             return fn(x)
         elif hasattr(x, "__dataclass_fields__"):
             dc = dataclasses.replace(x)
-            for f in dataclasses.fields(dc):
-                name = f.name
-                setattr(dc, name, apply(getattr(dc, name)))
+            changes = {
+                f.name: apply(getattr(dc, f.name))
+                for f in dataclasses.fields(dc):
+            }
+            dc = dataclasses.replace(dc, **changes)
             return dc
         elif isinstance(x, OrderedDict):
             od = x.__class__()

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -234,7 +234,7 @@ def _apply_to_tensors(fn, container):
             dc = dataclasses.replace(x)
             changes = {
                 f.name: apply(getattr(dc, f.name))
-                for f in dataclasses.fields(dc):
+                for f in dataclasses.fields(dc)
             }
             dc = dataclasses.replace(dc, **changes)
             return dc


### PR DESCRIPTION
Enables FSDP with frozen dataclasses. Previously if using frozen dataclasses, FSDP forward would fail with `dataclasses.FrozenInstanceError`:
```
Traceback (most recent call last):
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/barrel/barrel/pipes/vlams/pipe/vlam_training_module.py", line 8
8, in train_step
    model_output: transformers.modeling_outputs.CausalLMOutputWithPast = self._model(
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/nn/modules/module.py", line 
1553, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/nn/modules/module.py", line 
1562, in _call_impl
    return forward_call(*args, **kwargs)
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/distributed/fsdp/fully_shard
ed_data_parallel.py", line 847, in forward
    args, kwargs = _root_pre_forward(self, self, args, kwargs)
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/distributed/fsdp/_runtime_ut
ils.py", line 594, in _root_pre_forward
    return _root_cast_forward_input(state, module, args, kwargs)
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/distributed/fsdp/_runtime_ut
ils.py", line 612, in _root_cast_forward_input
    args, kwargs = _cast_forward_inputs(input_dtype, *args, **kwargs)
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/distributed/utils.py", line 
74, in _cast_forward_inputs
    return (_apply_to_tensors(cast_fn, args), _apply_to_tensors(cast_fn, kwargs))
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/distributed/utils.py", line 
255, in _apply_to_tensors
    return apply(container)
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/distributed/utils.py", line 
251, in apply
    return type(x)(apply(el) for el in x)
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/distributed/utils.py", line 
251, in <genexpr>
    return type(x)(apply(el) for el in x)
  File "/scratch/nikolay_nikolov/.cache/bazel/_bazel_nikolay_nikolov/79bf5e678fbb2019f1e30944a206f079/execroot/barrel/bazel-out/k8-opt/bin/barrel/pipes/vlams/train.runfiles/pip-core_torch/site-packages/torch/distributed/utils.py", line 
235, in apply
    setattr(dc, name, apply(getattr(dc, name)))
  File "<string>", line 4, in __setattr__
dataclasses.FrozenInstanceError: cannot assign to field 'input_ids'
```

Happy for a developer to take over to merge the PR

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o