### PR TITLE
autolabel aotinductor->export

### DIFF
--- a/.github/label_to_label.yml
+++ b/.github/label_to_label.yml
@@ -32,6 +32,10 @@
   then:
   - "module: higher order operators"
 - any:
+  - "module: aotinductor"
+  then:
+  - "oncall: export"
+- any:
   - "module: dynamo"
   - "module: pt2-dispatcher"
   - "module: inductor"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135040

"module: aotinductor" will automatically add "oncall: export".

Test Plan:
- none