### PR TITLE
[BE][optim] Make pyright recognize exported symbols

### DIFF
--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -6,22 +6,22 @@ enough, so that more sophisticated ones can also be easily integrated in the
 future.
 """
 
-from torch.optim import lr_scheduler, swa_utils
-from torch.optim._adafactor import Adafactor
-from torch.optim.adadelta import Adadelta
-from torch.optim.adagrad import Adagrad
-from torch.optim.adam import Adam
-from torch.optim.adamax import Adamax
-from torch.optim.adamw import AdamW
-from torch.optim.asgd import ASGD
-from torch.optim.lbfgs import LBFGS
-from torch.optim.nadam import NAdam
-from torch.optim.optimizer import Optimizer
-from torch.optim.radam import RAdam
-from torch.optim.rmsprop import RMSprop
-from torch.optim.rprop import Rprop
-from torch.optim.sgd import SGD
-from torch.optim.sparse_adam import SparseAdam
+from torch.optim import lr_scheduler as lr_scheduler, swa_utils as swa_utils
+from torch.optim._adafactor import Adafactor as Adafactor
+from torch.optim.adadelta import Adadelta as Adadelta
+from torch.optim.adagrad import Adagrad as Adagrad
+from torch.optim.adam import Adam as Adagrad
+from torch.optim.adamax import Adamax as Adamax
+from torch.optim.adamw import AdamW as AdamW
+from torch.optim.asgd import ASGD as ASGD
+from torch.optim.lbfgs import LBFGS as LBFGS
+from torch.optim.nadam import NAdam as NAdam
+from torch.optim.optimizer import Optimizer as Optimizer
+from torch.optim.radam import RAdam as RAdam
+from torch.optim.rmsprop import RMSprop as RMSprop
+from torch.optim.rprop import Rprop as Rprop
+from torch.optim.sgd import SGD as SGD
+from torch.optim.sparse_adam import SparseAdam as SparseAdam
 
 
 Adafactor.__module__ = "torch.optim"

--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -10,7 +10,7 @@ from torch.optim import lr_scheduler as lr_scheduler, swa_utils as swa_utils
 from torch.optim._adafactor import Adafactor as Adafactor
 from torch.optim.adadelta import Adadelta as Adadelta
 from torch.optim.adagrad import Adagrad as Adagrad
-from torch.optim.adam import Adam as Adagrad
+from torch.optim.adam import Adam as Adam
 from torch.optim.adamax import Adamax as Adamax
 from torch.optim.adamw import AdamW as AdamW
 from torch.optim.asgd import ASGD as ASGD


### PR DESCRIPTION
Follows pattern introduced by https://github.com/pytorch/pytorch/pull/80955 which [pyright](https://github.com/microsoft/pyright) prefers over `__all__` symbol, see https://github.com/microsoft/pylance-release/issues/2953#issuecomment-1168956296
Fixes https://github.com/pytorch/pytorch/issues/134985
