### PR TITLE
Fix SVG graph generations

### DIFF
--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -164,7 +164,15 @@ def create_fx_from_snodes(snodes: List[BaseSchedulerNode]) -> fx.Graph:
 
         if isinstance(snode, FusedSchedulerNode):
             for x in snode.snodes:
+                # op node
                 buf_to_fx_node[x.get_name()] = fx_node
+                # buf node
+                if x.node and hasattr(x.node, "name"):
+                    buf_to_fx_node[x.node.name] = fx_node
+        else:
+            if snode.node and hasattr(snode.node, "name"):
+                buf_to_fx_node[snode.node.name] = fx_node
+        # op node
         buf_to_fx_node[name] = fx_node
 
         if first_node is None:

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -167,11 +167,18 @@ def create_fx_from_snodes(snodes: List[BaseSchedulerNode]) -> fx.Graph:
                 # op node
                 buf_to_fx_node[x.get_name()] = fx_node
                 # buf node
-                if x.node and hasattr(x.node, "name"):
-                    buf_to_fx_node[x.node.name] = fx_node
+                node = x.node
+                assert isinstance(node, (ir.ComputedBuffer, ir.TemplateBuffer))
+                if isinstance(node, ir.ComputedBuffer):
+                    node_name = node.get_computed_buffer_name()
+                else:
+                    node_name = node.name
+                buf_to_fx_node[node_name] = fx_node
         else:
             if snode.node and hasattr(snode.node, "name"):
                 buf_to_fx_node[snode.node.name] = fx_node
+            else:
+                raise RuntimeError("Unknown node type", snode)
         # op node
         buf_to_fx_node[name] = fx_node
 

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -167,18 +167,15 @@ def create_fx_from_snodes(snodes: List[BaseSchedulerNode]) -> fx.Graph:
                 # op node
                 buf_to_fx_node[x.get_name()] = fx_node
                 # buf node
-                node = x.node
-                assert isinstance(node, (ir.ComputedBuffer, ir.TemplateBuffer))
-                if isinstance(node, ir.ComputedBuffer):
-                    node_name = node.get_computed_buffer_name()
+                if x.node and hasattr(x.node, "name") and x.node.name:
+                    buf_to_fx_node[x.node.name] = fx_node
                 else:
-                    node_name = node.name
-                buf_to_fx_node[node_name] = fx_node
+                    raise RuntimeError("Can't obtain name for this node", x)
         else:
             if snode.node and hasattr(snode.node, "name"):
                 buf_to_fx_node[snode.node.name] = fx_node
             else:
-                raise RuntimeError("Unknown node type", snode)
+                raise RuntimeError("Can't obtain name for this node", snode)
         # op node
         buf_to_fx_node[name] = fx_node
 


### PR DESCRIPTION
Fixes #135036

Before this PR:
<img width="697" alt="image" src="https://github.com/user-attachments/assets/1a204b71-a408-424a-8855-8d95424fd2e5">

The root cause of this issue is that inductor seperates buffers(SchedulerBuffer) and operations(SchedulerNode) in scheduling https://github.com/pytorch/pytorch/pull/130831. The data dependencies should be obtained from the buffer reads and writes. The [compute_dependencies](https://github.com/pytorch/pytorch/blob/main/torch/_inductor/scheduler.py#L1775) only focus on which buffers are accessed(read and writes) by which nodes accrossing nodes. It means schedulerbuffer.users may not be direct data dependecies. So, we can't simply reuse schedulerbuffer.users. We have to build direct data dependencies by ourself.


After this PR:
<img width="407" alt="image" src="https://github.com/user-attachments/assets/82bed046-05ab-447b-9bb9-c95ab954dc86">


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang