### PR TITLE
[aarch64] install ninja to build Triton wheel for arm

### DIFF
--- a/.ci/docker/manywheel/Dockerfile_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_aarch64
@@ -70,6 +70,9 @@ RUN cd ~/ \
 RUN yum install -y cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake
 
+#install ninja
+RUN yum install -y ninja-build
+
 FROM base as openssl
 # Install openssl (this must precede `build python` step)
 # (In order to have a proper SSL module, Python is compiled

--- a/.ci/docker/manywheel/Dockerfile_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_aarch64
@@ -71,8 +71,11 @@ RUN yum install -y cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 #install ninja
-RUN yum install -y ninja-build && \
-    ln -s /usr/bin/ninja-build /usr/bin/ninja
+RUN cd ~/ && \
+    wget https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux-aarch64.zip && \
+    unzip ninja-linux-aarch64.zip && \
+    mv -f ./ninja /usr/bin/ninja && \
+    rm ninja-linux-aarch64.zip
 
 FROM base as openssl
 # Install openssl (this must precede `build python` step)

--- a/.ci/docker/manywheel/Dockerfile_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_aarch64
@@ -71,7 +71,8 @@ RUN yum install -y cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 #install ninja
-RUN yum install -y ninja-build
+RUN yum install -y ninja-build && \
+    ln -s /usr/bin/ninja-build /usr/bin/ninja
 
 FROM base as openssl
 # Install openssl (this must precede `build python` step)

--- a/.ci/docker/manywheel/Dockerfile_cuda_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_cuda_aarch64
@@ -34,7 +34,6 @@ RUN yum install -y \
   zstd \
   libgomp \
   sudo \
-  ninja-build \
   gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
 
 # Ensure the expected devtoolset is used

--- a/.ci/docker/manywheel/Dockerfile_cuda_aarch64
+++ b/.ci/docker/manywheel/Dockerfile_cuda_aarch64
@@ -34,6 +34,7 @@ RUN yum install -y \
   zstd \
   libgomp \
   sudo \
+  ninja-build \
   gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
 
 # Ensure the expected devtoolset is used


### PR DESCRIPTION
Fix build failure in the triton arm workflow in https://hud.pytorch.org/pr/133701, where Docker image is unable to find ninja at https://github.com/triton-lang/triton/blob/main/python/setup.py#L382. 

`2024-09-04T17:07:04.7510597Z   File "/tmp/tmp7xhqiiay/triton/python/setup.py", line 366, in build_extension
2024-09-04T17:07:04.7511718Z     "-DCMAKE_MAKE_PROGRAM=" +
2024-09-04T17:07:04.7512515Z TypeError: can only concatenate str (not "NoneType") to str`

the output is tested as a temp docker image for - https://github.com/pytorch/pytorch/pull/133701