### PR TITLE
[PT2] Directly set meta.val in group_batch_fusion_aten

### DIFF
--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -12,7 +12,6 @@ from torch.fx.experimental.optimization import (
     matches_module_pattern,
     replace_node_module,
 )
-from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 from torch.fx.passes.graph_transform_observer import GraphTransformObserver
 from torch.fx.passes.shape_prop import ShapeProp
 from torch.nn import functional as F
@@ -168,10 +167,6 @@ def pre_grad_passes(gm: torch.fx.GraphModule, example_inputs=None):
                 gm,
                 example_inputs,
                 "[Pre grad(predispatch IR)] Apply group_batch_fusion",
-            )
-            # update node.meta after group batch fusion
-            FakeTensorProp(module=gm, mode=detect_fake_mode(example_inputs)).propagate(
-                *example_inputs
             )
             pass_execution_and_save(
                 normalize_node_kwargs_pass,


### PR DESCRIPTION
Summary: instead of using FakeTensorProp after the pass

Differential Revision: D62162640


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang