### PR TITLE
[Intel GPU][Windows] Fix overriding default CMAKE_CXX_FLAGS

### DIFF
--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -43,7 +43,9 @@ IF(NOT MKLDNN_FOUND)
       endif()
     endif()
     if(LINUX)
-      set(ABI_NEUTRAL_FLAGS -fpreview-breaking-changes)
+      set(DNNL_CXX_FLAGS "-fpreview-breaking-changes")
+    else()
+      set(DNNL_CXX_FLAGS "/EHsc")
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       SOURCE_DIR ${MKLDNN_ROOT}
@@ -51,7 +53,7 @@ IF(NOT MKLDNN_FOUND)
       BUILD_IN_SOURCE 0
       CMAKE_ARGS  -DCMAKE_C_COMPILER=icx
       -DCMAKE_CXX_COMPILER=${SYCL_CXX_DRIVER}
-      -DCMAKE_CXX_FLAGS=${ABI_NEUTRAL_FLAGS}
+      -DCMAKE_CXX_FLAGS=${DNNL_CXX_FLAGS}
       -DDNNL_GPU_RUNTIME=SYCL
       -DDNNL_CPU_RUNTIME=THREADPOOL
       -DDNNL_BUILD_TESTS=OFF

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -43,9 +43,7 @@ IF(NOT MKLDNN_FOUND)
       endif()
     endif()
     if(LINUX)
-      set(DNNL_CXX_FLAGS "-fpreview-breaking-changes")
-    else()
-      set(DNNL_CXX_FLAGS "/EHsc")
+      set(DNNL_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpreview-breaking-changes")
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       SOURCE_DIR ${MKLDNN_ROOT}

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -45,8 +45,6 @@ IF(NOT MKLDNN_FOUND)
     set(DNNL_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     if(LINUX)
       set(DNNL_CXX_FLAGS "${DNNL_CXX_FLAGS} -fpreview-breaking-changes")
-    else()
-
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       SOURCE_DIR ${MKLDNN_ROOT}

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -42,8 +42,11 @@ IF(NOT MKLDNN_FOUND)
         list(APPEND DNNL_MAKE_COMMAND "--" "-l" "$ENV{MAX_JOBS}")
       endif()
     endif()
+    set(DNNL_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     if(LINUX)
-      set(DNNL_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpreview-breaking-changes")
+      set(DNNL_CXX_FLAGS "${DNNL_CXX_FLAGS} -fpreview-breaking-changes")
+    else()
+
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       SOURCE_DIR ${MKLDNN_ROOT}

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -42,9 +42,10 @@ IF(NOT MKLDNN_FOUND)
         list(APPEND DNNL_MAKE_COMMAND "--" "-l" "$ENV{MAX_JOBS}")
       endif()
     endif()
-    set(DNNL_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     if(LINUX)
-      set(DNNL_CXX_FLAGS "${DNNL_CXX_FLAGS} -fpreview-breaking-changes")
+      set(DNNL_CXX_FLAGS "-DCMAKE_CXX_FLAGS=-fpreview-breaking-changes")
+    else()
+      set(DNNL_CXX_FLAGS "")
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       SOURCE_DIR ${MKLDNN_ROOT}
@@ -52,7 +53,7 @@ IF(NOT MKLDNN_FOUND)
       BUILD_IN_SOURCE 0
       CMAKE_ARGS  -DCMAKE_C_COMPILER=icx
       -DCMAKE_CXX_COMPILER=${SYCL_CXX_DRIVER}
-      -DCMAKE_CXX_FLAGS=${DNNL_CXX_FLAGS}
+      ${DNNL_CXX_FLAGS}
       -DDNNL_GPU_RUNTIME=SYCL
       -DDNNL_CPU_RUNTIME=THREADPOOL
       -DDNNL_BUILD_TESTS=OFF


### PR DESCRIPTION
The root cause is that `/EHsc` is part of the default `CMAKE_CXX_FLAGS` in CMake. 
Fix to not override the default `CMAKE_CXX_FLAGS`. 

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal