### PR TITLE
[Inductor][CPP] Avoid mistake wgt tensor delete

### DIFF
--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -172,6 +172,33 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
     @patches
     @torch.no_grad
     @unittest.skipIf(not TEST_MKL, "Test requires MKL")
+    @parametrize("in_features", (1000,))
+    @parametrize("out_features", (1024,))
+    @parametrize("bias", (True,))
+    @dtypes(torch.float,)
+    def test_linear_wgt_multi_users(self, in_features, out_features, bias, dtype):
+        class M(torch.nn.Module):
+            def __init__(self, bias):
+                super().__init__()
+                self.embeddings = torch.nn.Embedding(out_features, in_features)
+                self.linear = torch.nn.Linear(in_features, out_features, bias)
+                self.linear.weight = self.embeddings.weight
+
+            def forward(self, x):
+                x = self.embeddings(x)
+                return self.linear(x)
+
+        counters.clear()
+        mod = M(bias=bias).to(dtype=dtype).eval()
+        v = torch.LongTensor([[1, 2, 4, 5], [4, 3, 2, 9]])
+        with verify(dtype) as (atol, rtol):
+            self.common(mod, (v,), atol=atol, rtol=rtol)
+        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+
+    @inductor_config.patch({"freezing": True})
+    @patches
+    @torch.no_grad
+    @unittest.skipIf(not TEST_MKL, "Test requires MKL")
     @parametrize("bias", (True, False))
     @dtypes(torch.float)
     def test_linear_input_transpose(self, bias, dtype):

--- a/test/inductor/test_cpu_select_algorithm.py
+++ b/test/inductor/test_cpu_select_algorithm.py
@@ -175,7 +175,9 @@ class TestSelectAlgorithm(BaseTestSelectAlgorithm):
     @parametrize("in_features", (1000,))
     @parametrize("out_features", (1024,))
     @parametrize("bias", (True,))
-    @dtypes(torch.float,)
+    @dtypes(
+        torch.float,
+    )
     def test_linear_wgt_multi_users(self, in_features, out_features, bias, dtype):
         class M(torch.nn.Module):
             def __init__(self, bias):

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -680,8 +680,46 @@ class CppPackedGemmTemplate(CppTemplate):
                 # non-retraceable. To support retracing, we can add a repack node to the
                 # FX graph. For example:
                 # mkldnn._linear_pointwise <- repack_linear_wgt <- packed_wgt_for_template
+                wgt_tensor_users = 0
+                wgt_tensor = V.graph.constants[W_node.get_name()]
                 for node in reversed(V.graph.graph.nodes):
-                    if node.name == W_node.get_name() and len(node.users) == 1:
+                    # Case may happen when the wgt tensor is used by more than 1 get_attr node
+                    # https://github.com/pytorch/pytorch/issues/134998
+                    if node.op == "get_attr" and hasattr(
+                        V.graph.module, node.name
+                    ):  # wgt might already be deleted
+                        comp_tensor = getattr(V.graph.module, node.name)
+                        if (
+                            wgt_tensor.is_mkldnn == comp_tensor.is_mkldnn
+                            and wgt_tensor.dtype == comp_tensor.dtype
+                            and wgt_tensor.device == comp_tensor.device
+                            and (
+                                (
+                                    not wgt_tensor.is_mkldnn
+                                    and (
+                                        wgt_tensor.untyped_storage().data_ptr()
+                                        == comp_tensor.untyped_storage().data_ptr()
+                                    )
+                                )
+                                or (
+                                    wgt_tensor.is_mkldnn
+                                    and (
+                                        torch.ops.mkldnn.data_ptr(wgt_tensor)
+                                        == torch.ops.mkldnn.data_ptr(comp_tensor)
+                                    )
+                                )
+                            )
+                        ):
+                            wgt_tensor_users += 1
+
+                for node in reversed(V.graph.graph.nodes):
+                    # The wgt tensor has been used by only 1 get_attr node
+                    # The get_attr node has only 1 user fx node
+                    if (
+                        node.name == W_node.get_name()
+                        and len(node.users) == 1
+                        and wgt_tensor_users == 1
+                    ):
                         del V.graph.constants[node.name]
                         delattr(V.graph.module, node.name)
                         delattr(V.graph.graph.owning_module, node.name)

--- a/torch/_inductor/codegen/cpp_gemm_template.py
+++ b/torch/_inductor/codegen/cpp_gemm_template.py
@@ -680,8 +680,7 @@ class CppPackedGemmTemplate(CppTemplate):
                 # non-retraceable. To support retracing, we can add a repack node to the
                 # FX graph. For example:
                 # mkldnn._linear_pointwise <- repack_linear_wgt <- packed_wgt_for_template
-                wgt_tensor_users = 0
-                wgt_tensor = V.graph.constants[W_node.get_name()]
+                W_tensor_users = 0
                 for node in reversed(V.graph.graph.nodes):
                     # Case may happen when the wgt tensor is used by more than 1 get_attr node
                     # https://github.com/pytorch/pytorch/issues/134998
@@ -690,27 +689,27 @@ class CppPackedGemmTemplate(CppTemplate):
                     ):  # wgt might already be deleted
                         comp_tensor = getattr(V.graph.module, node.name)
                         if (
-                            wgt_tensor.is_mkldnn == comp_tensor.is_mkldnn
-                            and wgt_tensor.dtype == comp_tensor.dtype
-                            and wgt_tensor.device == comp_tensor.device
+                            W.is_mkldnn == comp_tensor.is_mkldnn
+                            and W.dtype == comp_tensor.dtype
+                            and W.device == comp_tensor.device
                             and (
                                 (
-                                    not wgt_tensor.is_mkldnn
+                                    not W.is_mkldnn
                                     and (
-                                        wgt_tensor.untyped_storage().data_ptr()
+                                        W.untyped_storage().data_ptr()
                                         == comp_tensor.untyped_storage().data_ptr()
                                     )
                                 )
                                 or (
-                                    wgt_tensor.is_mkldnn
+                                    W.is_mkldnn
                                     and (
-                                        torch.ops.mkldnn.data_ptr(wgt_tensor)
+                                        torch.ops.mkldnn.data_ptr(W)
                                         == torch.ops.mkldnn.data_ptr(comp_tensor)
                                     )
                                 )
                             )
                         ):
-                            wgt_tensor_users += 1
+                            W_tensor_users += 1
 
                 for node in reversed(V.graph.graph.nodes):
                     # The wgt tensor has been used by only 1 get_attr node
@@ -718,7 +717,7 @@ class CppPackedGemmTemplate(CppTemplate):
                     if (
                         node.name == W_node.get_name()
                         and len(node.users) == 1
-                        and wgt_tensor_users == 1
+                        and W_tensor_users == 1
                     ):
                         del V.graph.constants[node.name]
                         delattr(V.graph.module, node.name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #135101
* __->__ #135100

**Summary**
Fix issue: https://github.com/pytorch/pytorch/issues/134998: Previously, we only checked if the `get_attr` FX node for the weight had a single user node. However, two `get_attr` nodes may share the same tensor and should not be deleted in such cases. In this PR, we add the count of users for tensor along with the num of users for nodes to decide whether this tensor can be deleted or not.

**TestPlan**
```
 python test/inductor/test_cpu_select_algorithm.py -k test_linear_wgt_multi_users
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang