### PR TITLE
[export] Expand coverage to more copied sym ops for unflattener.

### DIFF
--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -866,7 +866,15 @@ class _ModuleFrame:
                     self.parent_call_module.insert_arg(0, self.parent.remap_input(x))
             return self.node_to_placeholder[x]
         elif x.op == "call_function" and (
-            x.target == torch.ops.aten.sym_size.int
+            x.target
+            in (
+                torch.ops.aten.sym_size.int,
+                torch.ops.aten.item.default,
+                torch.ops.aten.unbind.int,
+                torch.ops.aten.sum.dim_IntList,
+                torch.ops.aten.view.default,
+                torch.ops.aten.diff.default,
+            )
             or (hasattr(x.target, "__module__") and x.target.__module__ == "_operator")
         ):
             # export deduplicates sym_size nodes, and may need to re-copy them


### PR DESCRIPTION
Test Plan:
buck2 test 'fbcode//mode/opt' fbcode//torchrec/ir/tests:test_serializer -- --run-disabled

```
File changed: fbcode//caffe2/torch/export/unflatten.py
Buck UI: https://www.internalfb.com/buck2/2e0377e7-e2b6-4bd0-8133-a787245165a0
Test UI: https://www.internalfb.com/intern/testinfra/testrun/5066549824883887
Network: Up: 0B  Down: 0B
Jobs completed: 16. Time elapsed: 10.2s.
Tests finished: Pass 6. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D62190172
