### PR TITLE
[ONNX] Support output_names in dynamic_axes when dynamo=True

### DIFF
--- a/test/onnx/exporter/test_api.py
+++ b/test/onnx/exporter/test_api.py
@@ -72,6 +72,28 @@ class TestExportAPIDynamo(common_utils.TestCase):
             },
         )
 
+    def test_dynamic_axes_supports_output_names(self):
+        self.assert_export(
+            SampleModelForDynamicShapes(),
+            (torch.randn(2, 2, 3), {"b": torch.randn(2, 2, 3)}),
+            dynamic_axes={
+                "b": [0, 1, 2],
+            },
+        )
+        onnx_program = torch.onnx.export(
+            SampleModelForDynamicShapes(),
+            (
+                torch.randn(2, 2, 3),
+                torch.randn(2, 2, 3),
+            ),
+            input_names=["x", "b"],
+            output_names=["x_out", "b_out"],
+            dynamic_axes={"b": [0, 1, 2], "b_out": [0, 1, 2]},
+            dynamo=True,
+        )
+        assert onnx_program is not None
+        onnx_testing.assert_onnx_program(onnx_program)
+
     def test_saved_f_exists_after_export(self):
         with common_utils.TemporaryFileName(suffix=".onnx") as path:
             _ = torch.onnx.export(

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -30,9 +30,10 @@ def _signature(model) -> inspect.Signature:
 
 def _from_dynamic_axes_to_dynamic_shapes(
     model,
+    *,
     dynamic_axes=None,
+    output_names: set[str],
     input_names: Sequence[str] | None = None,
-    output_names: Sequence[str] | None = None,
 ) -> dict[str, Any] | None:
     """
 
@@ -52,9 +53,6 @@ def _from_dynamic_axes_to_dynamic_shapes(
 
     if input_names is None:
         input_names = []
-
-    if output_names is None:
-        output_names = []
 
     sig = _signature(model)
     if len(input_names) > len(sig.parameters):
@@ -158,7 +156,10 @@ def export_compat(
         args, kwargs = _get_torch_export_args(args, kwargs)
         if dynamic_shapes is None and dynamic_axes is not None:
             dynamic_shapes = _from_dynamic_axes_to_dynamic_shapes(
-                model, dynamic_axes, input_names, output_names
+                model,
+                dynamic_axes=dynamic_axes,
+                input_names=input_names,
+                output_names=set(output_names or ()),
             )
 
     should_convert_version = False

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -72,13 +72,13 @@ def _from_dynamic_axes_to_dynamic_shapes(
     # for the exported program
     dynamic_shapes_to_exported_program = {}
     for input_name, axes in dynamic_axes.items():
-        # input_name can be either from inptu_names or from the model inputs
+        if input_name in output_names:
+            # User specified an output name as a dynamic axis, so we skip it
+            continue
+        # input_name can be either from input_names or from the model inputs
         if input_name not in input_names_to_model_inputs:
-            if input_name in output_names:
-                # User specified an output name as a dynamic axis, so we skip it
-                continue
             raise ValueError(
-                f"dynamix axis: {input_name} is not found in the input names: {input_names}"
+                f"dynamic axis: {input_name} is not found in the input names: {input_names}"
             )
         model_input_name = input_names_to_model_inputs[input_name]
         if isinstance(axes, dict):


### PR DESCRIPTION
Previous to this PR, if output_names shows in dynamic_axes, it errors when we turn it to dynamic_shapes of torch.export, as we only recognized input_names.