### PR TITLE
Allow cross-device copies for cpu scalars in refs

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -308,13 +308,16 @@ class MiscTests(torch._inductor.test_case.TestCase):
         )
 
     def test_scalar_device_movement(self):
+        if not torch._dynamo.config.assume_static_by_default:
+            self.skipTest("Doesn't work with symints")
+
         def add_fn(a, b, out):
             res = torch.add(a, b, out=out)
             return res
 
-        res = add_fn(2, 3, torch.tensor(0.))
+        res = add_fn(2, 3, torch.tensor(0.0))
         add_fn = torch.compile(add_fn, backend="eager", fullgraph=True)
-        res_compiled = add_fn(2, 3, torch.tensor(0.))
+        res_compiled = add_fn(2, 3, torch.tensor(0.0))
         self.assertEqual(res, res_compiled)
 
     @skipIfNNModuleInlined("fails internal CI")

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -307,6 +307,16 @@ class MiscTests(torch._inductor.test_case.TestCase):
             "Graph break for an optree C/C++ function optree._C.PyCapsule.flatten. Consider using torch.utils._pytree - https://github.com/pytorch/pytorch/blob/main/torch/utils/_pytree.py",
         )
 
+    def test_scalar_device_movement(self):
+        def add_fn(a, b, out):
+            res = torch.add(a, b, out=out)
+            return res
+
+        res = add_fn(2, 3, torch.tensor(0.))
+        add_fn = torch.compile(add_fn, backend="eager", fullgraph=True)
+        res_compiled = add_fn(2, 3, torch.tensor(0.))
+        self.assertEqual(res, res_compiled)
+
     @skipIfNNModuleInlined("fails internal CI")
     @unittest.skipIf(IS_FBCODE, "inline cpp_extension doesn't work in fbcode")
     def test_cpp_extension_recommends_custom_ops(self):

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -186,7 +186,7 @@ def _maybe_resize_out(
 
 
 def is_cpu_scalar(x: TensorLikeType) -> bool:
-    return x.shape == () and x.device.type == "cpu"
+    return x.dim == 0 and x.device.type == "cpu"
 
 
 def _safe_copy_out(

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -186,7 +186,7 @@ def _maybe_resize_out(
 
 
 def is_cpu_scalar(x: TensorLikeType) -> bool:
-    return x.dim == 0 and x.device.type == "cpu"
+    return x.dim() == 0 and x.device.type == "cpu"
 
 
 def _safe_copy_out(

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -185,11 +185,15 @@ def _maybe_resize_out(
         return out
 
 
+def is_cpu_scalar(x: TensorLikeType) -> bool:
+    return x.shape == () and x.device.type == "cpu"
+
+
 def _safe_copy_out(
     *, copy_from: TensorLikeType, copy_to: TensorLikeType, exact_dtype: bool = False
 ):
     # Checks same device
-    if copy_from.device != copy_to.device:
+    if not is_cpu_scalar(copy_from) and copy_from.device != copy_to.device:
         msg = (
             f"Attempting to copy from device {copy_from.device} "
             f"to device {copy_to.device}, but cross-device copies are not allowed!"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135140

This copies our eager-mode behavior where someone can do torch.add(a, b, out=c)
where a and b are CPU scalar tensors and c is a CUDA tensor.

Fixes https://github.com/pytorch/pytorch/issues/121619 by side effect (we get into a situation where we're writing a CPU scalar into a FakeTensor that is actually a meta tensor)

Test Plan:
- new test

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec