### PR TITLE
Add ciflow/trunk to dependabot PRs

### DIFF
--- a/.github/label_to_label.yml
+++ b/.github/label_to_label.yml
@@ -48,3 +48,12 @@
   - "module: dynamic shapes"
   then:
   - "oncall: pt2"
+# For dependabot PRs, the practice is for PyTorch-repo admins to merge the PR
+# instead of using pytorchbot so that the vulnerability issue can be marked as
+# resolved. This rule is here to ensure that we don't forget to add ciflow/trunk
+# to such PRs and cause trunk failure, i.e. #135068
+- any:
+  # This is the default label that dependabot adds to all its PR
+  - "dependency issue"
+  then:
+  - "ciflow/trunk"


### PR DESCRIPTION
An easy way to add `ciflow/trunk` to dependabot PRs by reusing the `label_to_label.yml` mechanism.  Other alternatives looks more complicated including:

1. Add `dependabot.yml` https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels.  This requires setting https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem while I want to add `ciflow/trunk` to add dependabot PR regardless of the package type.
2.  Update test-infra auto label bot.  This should work but requires code change and also special gating logic for only pytorch.
