### PR TITLE
[FR] Add version based logic to FR script and make traces print can be filtered

### DIFF
--- a/tools/flight_recorder/components/config_manager.py
+++ b/tools/flight_recorder/components/config_manager.py
@@ -19,7 +19,21 @@ class JobConfig:
         )
 
         self.parser.add_argument(
-            "-d", "--dir", help="Directory with flight recorder dumps"
+            "-d", "--dir", required=True, help="Directory with flight recorder dumps"
+        )
+        self.parser.add_argument(
+            "--selected-ranks",
+            default=None,
+            nargs="+",
+            type=int,
+            help="List of ranks we want to show traces for.",
+        )
+        self.parser.add_argument(
+            "--pg-filters",
+            default=None,
+            nargs="+",
+            type=str,
+            help="List of filter strings",
         )
         self.parser.add_argument("-o", "--output", default=None)
         self.parser.add_argument(
@@ -34,4 +48,13 @@ class JobConfig:
     def parse_args(
         self: "JobConfig", args: Optional[Sequence[str]]
     ) -> argparse.Namespace:
-        return self.parser.parse_args(args)
+        args = self.parser.parse_args(args)
+        if args.selected_ranks is not None:
+            assert (
+                args.just_print_entries
+            ), "Not support selecting ranks without printing entries"
+        if args.pg_filters is not None:
+            assert (
+                args.just_print_entries
+            ), "Not support selecting pg filters without printing entries"
+        return args

--- a/tools/flight_recorder/components/loader.py
+++ b/tools/flight_recorder/components/loader.py
@@ -8,7 +8,7 @@ import gc
 import os
 import pickle
 import time
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 
 def read_dump(prefix: str, filename: str) -> Dict[str, Union[str, int, List[Any]]]:
@@ -35,13 +35,16 @@ def read_dump(prefix: str, filename: str) -> Dict[str, Union[str, int, List[Any]
     }
 
 
-def read_dir(prefix: str, folder: str) -> Dict[str, Dict[str, Any]]:
+def read_dir(prefix: str, folder: str) -> Tuple[Dict[str, Dict[str, Any]], str]:
     gc.disable()
     details = {}
     t0 = time.time()
+    version = ""
     for root, _, files in os.walk(folder):
         for f in files:
             details[f] = read_dump(prefix, os.path.join(root, f))
+            if not version:
+                version = str(details[f]["version"])
     tb = time.time()
     print(f"loaded {len(files)} files in {tb - t0}s")
-    return details
+    return details, version

--- a/tools/flight_recorder/components/utils.py
+++ b/tools/flight_recorder/components/utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import argparse
 import math
 from typing import Any, Dict, List, Set, Tuple
 
@@ -214,21 +215,34 @@ def just_print_entries(
     _groups: Dict[str, Group],
     _memberships: Dict[str, Set[Any]],
     _pg_guids: Dict[Tuple[str, int], str],
+    args: argparse.Namespace,
 ) -> None:
     rows = []
     ranks = sorted(all_entries.keys())
-    headers = [f"Rank {rank}" for rank in ranks]
+    headers = [
+        f"Rank {rank}"
+        for rank in ranks
+        if args.selected_ranks is None or rank in args.selected_ranks
+    ]
     progress = True
     while progress:
         progress = False
         row = []
         for rank in ranks:
+            if args.selected_ranks is not None and rank not in args.selected_ranks:
+                continue
             if len(all_entries[rank]) == 0:
                 row.append("")
             else:
                 entry = all_entries[rank].pop(0)
                 pg_name = _pg_guids[(entry["process_group"][0], rank)]
-                row.append(str(Op(entry, _memberships, pg_name)))
+                if (
+                    args.pg_filters is None
+                    or entry["process_group"][1] in args.pg_filters
+                ):
+                    row.append(str(Op(entry, _memberships, pg_name)))
+                else:
+                    row.append("")
                 progress = True
         if progress:
             rows.append(row)
@@ -248,23 +262,29 @@ def check_no_missing_dump_files(
     ), f"Missing dump files from ranks {all_ranks - dumps_ranks}"
 
 
-def check_version(versions: Dict[str, Any]) -> None:
-    for rank, version in versions.items():  # noqa: PERF102
-        major, minor = map(int, version.split("."))
-        # assert major == 2, f"Rank {rank} unsupported version {version}"
-        # assert minor >= 0, f"Rank {rank} unsupported version {version}"
+def check_version(version_by_ranks: Dict[str, str], version: str) -> None:
+    for rank, v in version_by_ranks.items():
+        assert (
+            v == version
+        ), f"Rank {rank} has different version {v} from the given version {version}"
 
 
-def sort_trace_from_beginning(
+def get_version_detail(version: str) -> Tuple[int, int]:
+    version = version.split(".")
+    assert len(version) == 2, f"Invalid version {version}"
+    major, minor = map(int, version)
+    return major, minor
+
+
+def align_trace_from_beginning(
     entries: Dict[int, List[Dict[str, Any]]]
 ) -> Dict[int, List[Dict[str, Any]]]:
     """
-    Sorts the trace entries by record ID for entries.
+    Align the trace entries by record ID for entries.
     This function takes a dictionary of rank names to lists of trace entries as input.
     Each trace entry is a dictionary containing information about a collective operation,
     including its unique identifier (`record_id` is monotonically increasing as we write into the ring buffer).
-    The function first sorts the entries in each rank by their `record_id` values.
-    Then, it finds the largest starting point across all ranks by taking the maximum
+    The function finds the largest starting point across all ranks by taking the maximum
     `record_id` value of the first entry in each rank. Finally, it filters out any
     entries with `record_id` values less than the maximum starting point.
     The function returns the updated dictionary of sorted and filtered trace entries.

--- a/tools/flight_recorder/fr_trace.py
+++ b/tools/flight_recorder/fr_trace.py
@@ -40,8 +40,8 @@ from tools.flight_recorder.components.types import types
 def main(args: Optional[Sequence[str]] = None) -> None:
     config = JobConfig()
     args = config.parse_args(args)
-    details = read_dir(args.prefix, args.dir)
-    db = build_db(details, args)
+    details, version = read_dir(args.prefix, args.dir)
+    db = build_db(details, args, version)
     if args.output:
         with open(args.output, "wb") as f:
             pickle.dump((types, db), f)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135154

This PR makes version passing around the version, so that we can have different behaviors for different versions of FR dump. This PR also adds the logic of filtering to certain PG(desc) and ranks to show their traces.

Some minor refactors to make the name more accurate and util function working.


<img width="1180" alt="image" src="https://github.com/user-attachments/assets/4ef8a2d6-1296-4a45-b9a7-6d3b48fbe233">

