### PR TITLE
[Inductor][Precompile cache] Lookup cache before calling precompile inside the precompiling future

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1308,6 +1308,8 @@ class AlgorithmSelectorCache(PersistentCache):
         # first to benchmark it. share a single precompilation function for all lowerings
         # of a particular key
         self.precompile_cache: Dict[str, Callable[[], None]] = {}
+        # cache for avoiding precompiling same choice source file coming from different ops
+        self.choice_precompile_cache: Dict[str, bool] = {}
         # list of callbacks that are called after benchmarking
         self.feedback_saver_fns: List[
             Callable[
@@ -1433,14 +1435,9 @@ class AlgorithmSelectorCache(PersistentCache):
                 with restore_stdout_stderr(initial_stdout, initial_stderr):
                     start_time = time.time()
 
-                    if self.lookup(
-                        [choice],
-                        name,
-                        inputs_key,
-                        benchmark=None,
-                    ):
-                        return time.time() - start_time
-
+                    if self.choice_precompile_cache.get(choice.hash_key()):
+                        return float(0)
+                    self.choice_precompile_cache[choice.hash_key()] = True
                     choice.precompile()
                     return time.time() - start_time
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1432,6 +1432,15 @@ class AlgorithmSelectorCache(PersistentCache):
             def precompile_with_captured_stdout(choice):
                 with restore_stdout_stderr(initial_stdout, initial_stderr):
                     start_time = time.time()
+
+                    if self.lookup(
+                        [choice],
+                        name,
+                        inputs_key,
+                        benchmark=None,
+                    ):
+                        return time.time() - start_time
+
                     choice.precompile()
                     return time.time() - start_time
 


### PR DESCRIPTION
(quoting @aakhundov)

Previously, in the CK backend to GEMM Max Autotune, we've pulled out the literal problem shapes from the codegen and now passing the shapes as arguments to the generated kernel launcher function

The codegen now should be deduplicated, uniqueness factors are now down to CK Universal Gemm template parameters.

To actually benefit from the deduplication and the cache hit for the subsequently precompiled kernels for the subsequently graph-lowered GEMM ops (mm, addmm, and friends) in the model graph, we need to tweak the async precompile feature (which is enabled by default since ~2 months ago). If we're checking for the cache hit outside the async job, then we'll likely end up not hitting any cache during graph lowering, as it will be all done before the first batch of the kernels are async-precompiled. As a result, we'll have a whole bunch of async jobs actually compiling the kernels when they get a slot in the thread pool, and all the deduplication will be in vain. 

The solution is to do the cache hit check at precompilation site, i.e. inside the precompiling future. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @eellison 