### PR TITLE
[PT2][inductor][Optimus] Add pad_aten_mm_pass pattern to resolve long computation kernel in LCE

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -9,6 +9,7 @@ from torch._inductor.fx_passes.pad_mm import (
     get_pad_cache,
     get_padded_length,
     should_pad_common,
+    should_pad_mm_bf16,
 )
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_inductor_cache, is_big_gpu, run_and_get_code
@@ -448,6 +449,39 @@ class PadMMTest(TestCase):
         FileCheck().check_count("exclude_pad:False", 3, exactly=True).run(
             repr(get_pad_cache().get_local_cache())
         )
+
+    @fresh_inductor_cache()
+    @inductor_config.patch(
+        post_grad_fusion_options={"pad_aten_mm_pass": {"k_threshold_to_pad": 8388608}}
+    )
+    def test_pad_mm_bf16(self):
+        m = 2
+        n = 13
+        k = 15691904
+        mat1 = torch.ones((m, k), device="cuda", dtype=torch.bfloat16)
+        mat2 = torch.ones((k, n), device="cuda", dtype=torch.bfloat16)
+        expected_alignment = get_alignment_size(mat1)
+
+        assert expected_alignment == 8, "Alignment for bfloat16 should be 8"
+        assert should_pad_common(
+            mat1, mat2
+        ), "This should pass the common padding criteria"
+        assert should_pad_mm_bf16(
+            mat1.dtype, m, n, k
+        ), "This should pass the should_pad_mm_bf16 padding criteria"
+
+        @torch.compile()
+        def mm(mat1, mat2):
+            return torch.mm(mat1, mat2)
+
+        res2, (code,) = run_and_get_code(mm, mat1, mat2)
+        mm_expected_result = torch.mm(mat1, mat2)
+        # in call code, expect to see a single pad per input, and then we should see padded allocation for output
+        FileCheck().check("del async_compile").check_count(
+            ".run(", 2, exactly=True
+        ).check("empty_strided_cuda((8, 16)").run(code)
+
+        assert torch.allclose(res2, mm_expected_result), "MM results are not identical"
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -65,6 +65,7 @@ post_grad_pass_names = [
     "decompose_mm_pass",
     "unbind_stack_aten_pass",
     "shape_padding_multiplier",
+    "pad_aten_mm_pass",
 ]
 
 for pass_name in pre_grad_pass_names:


### PR DESCRIPTION
Summary:
We observed another long computation issue for OBA_AFOC pyper model, thus adding a pattern to avoid the perf regression

- Only happens in A100
- Do not want to use force_shape_pad since it will pad all GEMMs, which may not be optimal. Optimus pass has more flexisibility to customized GEMM shape and do corresponding padding
- To enable, we pass the pass to config, where "k_threshold_to_pad" can be customized

inductor_config.patch(post_grad_fusion_options={"pad_aten_mm_pass": {"k_threshold_to_pad" : 8388608}})

Test Plan:
# unit test

```
buck2 test mode/opt //caffe2/test/inductor:pad_mm
```
Buck UI: https://www.internalfb.com/buck2/58b0f272-f405-45be-bc8d-aec2dc4d5841
Test UI: https://www.internalfb.com/intern/testinfra/testrun/10133099209954651
Network: Up: 9.0KiB  Down: 142B  (reSessionID-8eb71a37-a5ca-4aff-a4f1-93ade3e47e4e)
Jobs completed: 9. Time elapsed: 3:18.0s.
Cache hits: 0%. Commands: 3 (cached: 0, remote: 0, local: 3)
Tests finished: Pass 17. Fail 0. Fatal 0. Skip 0. Build failure 0

# e2e test
see [D62388582](https://www.internalfb.com/diff/D62388582)

Differential Revision: D62220158


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov