### PR TITLE
Dynamo support for collective broadcast op

### DIFF
--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -149,6 +149,7 @@ def broadcast(self: torch.Tensor, src: int, group: RANK_TYPES, tag: str = ""):
         group (ProcessGroup or List[int]): The process group to work on.
         tag (str, optional): A unique identifier for the collective. Default: empty string
     """
+   
     group_name = _resolve_group_name(group, tag)
     tensor = torch.ops._c10d_functional.broadcast(self, src, group_name)
     return _maybe_wrap_tensor(tensor)
@@ -1126,6 +1127,23 @@ def all_gather_inplace(
     return tensor_list
 
 
+def broadcast_inplace(
+    tensor: torch.Tensor,
+    src: int,
+    group=None,
+    async_op=False,
+    tag: str = "",
+):
+    assert (
+        not async_op
+    ), "Can't remap async version of inplace op to functional collective"
+    group = group or dist.group.WORLD
+    assert group is not None
+
+    return tensor.copy_(broadcast(tensor, src, group, tag))
+
+
+
 from torch.distributed.distributed_c10d import (
     _all_gather_base as legacy_all_gather_base,
     _reduce_scatter_base as legacy_reduce_scatter_base,
@@ -1133,6 +1151,7 @@ from torch.distributed.distributed_c10d import (
     all_gather_into_tensor as legacy_allgather,
     all_reduce as legacy_allreduce,
     all_to_all_single as legacy_all_to_all_single,
+    broadcast as legacy_broadcast,
     reduce_scatter_tensor as legacy_reducescatter,
 )
 
@@ -1147,4 +1166,5 @@ traceable_collective_remaps = {
     legacy_all_gather: all_gather_inplace,
     legacy_reduce_scatter_base: reduce_scatter_tensor_inplace,
     legacy_all_gather_base: all_gather_tensor_inplace,
+    legacy_broadcast: broadcast_inplace,
 }

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -149,7 +149,6 @@ def broadcast(self: torch.Tensor, src: int, group: RANK_TYPES, tag: str = ""):
         group (ProcessGroup or List[int]): The process group to work on.
         tag (str, optional): A unique identifier for the collective. Default: empty string
     """
-   
     group_name = _resolve_group_name(group, tag)
     tensor = torch.ops._c10d_functional.broadcast(self, src, group_name)
     return _maybe_wrap_tensor(tensor)

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1142,7 +1142,6 @@ def broadcast_inplace(
     return tensor.copy_(broadcast(tensor, src, group, tag))
 
 
-
 from torch.distributed.distributed_c10d import (
     _all_gather_base as legacy_all_gather_base,
     _reduce_scatter_base as legacy_reduce_scatter_base,


### PR DESCRIPTION
Add dynamo path for `torch.distributed.boardcast`.

This PR is a requirement for https://github.com/pytorch/xla/pull/7956.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o