### PR TITLE
[dynamo] Fix FunctionCtx.saved_tensors attr access

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -5854,6 +5854,12 @@ def forward(self, s0 : torch.SymInt, s1 : torch.SymInt, L_x_ : torch.Tensor):
         out = f(x)
         self.assertEqual(torch.flip(torch.cumsum(torch.flip(x, [0]), 0), [0]), out[0])
 
+    def test_raw_function_ctx(self):
+        @torch.compile(backend="eager")
+        def f():
+            _ = torch.autograd.function.FunctionCtx()
+        f()
+
 
 instantiate_parametrized_tests(ReproTests)
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -744,7 +744,7 @@ class VariableBuilder:
         elif isinstance(value, torch.autograd.function.FunctionCtx):
             actual_saved_tensors = None
             try:
-                actual_saved_tensors = value.saved_tensors
+                actual_saved_tensors = getattr(value, "saved_tensors", ())
             except RuntimeError:
                 pass
 


### PR DESCRIPTION
FIXES #135118 

We're assuming that all FunctionCtx passed into dynamo are also BackwardCFunction, and the assumption dates back from a while ago. An easy fix to prevent this from always crashing at compile time is to match eager and return an empty tuple. But fundamentally, I think we're modeling the wrong class here

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135173



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec