### PR TITLE
self.sharded_param.device = cuda while

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -105,7 +105,7 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
 
         # lazy init without error
         inp = torch.rand((mlp_dim, mlp_dim), device="cuda")
-        model(inp)
+        model(inp).sum().backward()
 
         state_dict = model.state_dict()
         for name, dtensor in state_dict.items():

--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -721,6 +721,8 @@ class FSDPParam:
         self._sharded_param_data = local_tensor.view(-1)
         assert isinstance(self.sharded_param, DTensor)  # mypy
         self.sharded_param._local_tensor = local_tensor[: self.sharded_size[0]]
+        if torch.distributed.get_rank() == 0:
+            print(f"{self.sharded_param.device.type=} {self.sharded_param._local_tensor.device.type=}")
 
     def __repr__(self):
         return f"FSDPParam(fqn={self._param_fqn}, orig_size={self._orig_size})"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135179
* #135067

repro the error: `pytest -s test/distributed/_composable/fsdp/test_fully_shard_state_dict.py -k test_dp_state_dict_cpu_offload`

```
File "/data/users/weif/pytorch/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py", line 108, in test_dp_state_dict_cpu_offload
    model(inp).sum().backward()
  File "/home/weif/local/pytorch/torch/_tensor.py", line 522, in backward
    torch.autograd.backward(
  File "/home/weif/local/pytorch/torch/autograd/__init__.py", line 347, in backward
    _engine_run_backward(
  File "/home/weif/local/pytorch/torch/autograd/graph.py", line 818, in _engine_run_backward
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/home/weif/local/pytorch/torch/autograd/function.py", line 307, in apply
    return user_fn(self, *args)
  File "/home/weif/local/pytorch/torch/distributed/_composable/fsdp/_fsdp_param_group.py", line 613, in backward
    ctx.param_group.post_backward()
  File "/home/weif/local/pytorch/torch/distributed/_composable/fsdp/_fsdp_param_group.py", line 377, in post_backward
    ) = foreach_reduce(
  File "/home/weif/local/pytorch/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/home/weif/local/pytorch/torch/distributed/_composable/fsdp/_fsdp_collectives.py", line 401, in foreach_reduce
    fsdp_param.sharded_param.grad = new_sharded_dtensor_grad
RuntimeError: attempting to assign a gradient with device type 'cpu' to a tensor with device type 'cuda'. Please ensure that the gradient and the tensor are on the same device
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o