### PR TITLE
Porting to GCC 15

### DIFF
--- a/caffe2/utils/string_utils.cc
+++ b/caffe2/utils/string_utils.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 namespace caffe2 {
 


### PR DESCRIPTION
uint8_t is found on cstdint header
