### PR TITLE
Add missing input "eps" to adam docs

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -253,7 +253,8 @@ Adam.__doc__ = (
        \begin{aligned}
             &\rule{110mm}{0.4pt}                                                                 \\
             &\textbf{input}      : \gamma \text{ (lr)}, \beta_1, \beta_2
-                \text{ (betas)},\theta_0 \text{ (params)},f(\theta) \text{ (objective)}          \\
+                \text{ (betas)},\theta_0 \text{ (params)},f(\theta) \text{ (objective)}
+                \: \epsilon \text{ (epsilon)}                                                    \\
             &\hspace{13mm}      \lambda \text{ (weight decay)},  \: \textit{amsgrad},
                 \:\textit{maximize}                                                              \\
             &\textbf{initialize} :  m_0 \leftarrow 0 \text{ ( first moment)},

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -253,10 +253,9 @@ Adam.__doc__ = (
        \begin{aligned}
             &\rule{110mm}{0.4pt}                                                                 \\
             &\textbf{input}      : \gamma \text{ (lr)}, \beta_1, \beta_2
-                \text{ (betas)},\theta_0 \text{ (params)},f(\theta) \text{ (objective)}
-                \: \epsilon \text{ (epsilon)}                                                    \\
+                \text{ (betas)},\theta_0 \text{ (params)},f(\theta) \text{ (objective)}          \\
             &\hspace{13mm}      \lambda \text{ (weight decay)},  \: \textit{amsgrad},
-                \:\textit{maximize}                                                              \\
+                \:\textit{maximize},  \: \epsilon \text{ (epsilon)}                              \\
             &\textbf{initialize} :  m_0 \leftarrow 0 \text{ ( first moment)},
                 v_0\leftarrow 0 \text{ (second moment)},\: \widehat{v_0}^{max}\leftarrow 0\\[-1.ex]
             &\rule{110mm}{0.4pt}                                                                 \\


### PR DESCRIPTION
Minor fix for missing input argument in the Adam optimizer docs page. 
