### PR TITLE
Fix dynamo benchmark skip logic for cpu device

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_amp_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_amp_freezing_torchbench_inference.csv
@@ -130,6 +130,10 @@ hf_Bert_large,pass,0
 
 
 
+hf_BigBird,pass,0
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -139,6 +143,10 @@ hf_GPT2,pass,0
 
 
 hf_GPT2_large,pass_due_to_skip,0
+
+
+
+hf_T5,pass,0
 
 
 
@@ -167,6 +175,10 @@ maml,pass_due_to_skip,0
 
 
 maml_omniglot,pass,0
+
+
+
+mnasnet1_0,pass,0
 
 
 
@@ -239,6 +251,10 @@ resnet50_quantized_qat,fail_to_run,0
 
 
 resnext50_32x4d,pass,0
+
+
+
+shufflenet_v2_x1_0,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_freezing_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_freezing_huggingface_inference.csv
@@ -126,6 +126,10 @@ MobileBertForQuestionAnswering,pass,0
 
 
 
+OPTForCausalLM,pass,0
+
+
+
 PLBartForCausalLM,pass,0
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_aot_inductor_freezing_torchbench_inference.csv
@@ -130,6 +130,10 @@ hf_Bert_large,pass,0
 
 
 
+hf_BigBird,pass,0
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -139,6 +143,10 @@ hf_GPT2,pass,0
 
 
 hf_GPT2_large,pass_due_to_skip,0
+
+
+
+hf_T5,pass,0
 
 
 
@@ -167,6 +175,10 @@ maml,pass_due_to_skip,0
 
 
 maml_omniglot,pass,0
+
+
+
+mnasnet1_0,pass,0
 
 
 
@@ -239,6 +251,10 @@ resnet50_quantized_qat,fail_to_run,0
 
 
 resnext50_32x4d,pass,0
+
+
+
+shufflenet_v2_x1_0,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_huggingface_inference.csv
@@ -130,6 +130,10 @@ MobileBertForQuestionAnswering,pass,0
 
 
 
+OPTForCausalLM,pass,0
+
+
+
 PLBartForCausalLM,pass,0
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_torchbench_inference.csv
@@ -138,6 +138,10 @@ hf_Bert_large,pass,0
 
 
 
+hf_BigBird,pass,19
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -150,7 +154,15 @@ hf_GPT2_large,pass_due_to_skip,0
 
 
 
+hf_Longformer,pass,4
+
+
+
 hf_Reformer,pass,5
+
+
+
+hf_T5,pass,0
 
 
 
@@ -175,6 +187,10 @@ llama,pass,0
 
 
 maml,pass_due_to_skip,0
+
+
+
+mnasnet1_0,pass,0
 
 
 
@@ -255,6 +271,10 @@ resnet50_quantized_qat,pass,2
 
 
 resnext50_32x4d,pass,0
+
+
+
+shufflenet_v2_x1_0,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_huggingface_inference.csv
@@ -130,6 +130,10 @@ MobileBertForQuestionAnswering,pass,0
 
 
 
+OPTForCausalLM,pass,0
+
+
+
 PLBartForCausalLM,pass,0
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_torchbench_inference.csv
@@ -277,6 +277,7 @@ resnext50_32x4d,pass,0
 shufflenet_v2_x1_0,pass,0
 
 
+
 soft_actor_critic,pass,0
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_torchbench_inference.csv
@@ -138,6 +138,10 @@ hf_Bert_large,pass,0
 
 
 
+hf_BigBird,pass,19
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -150,7 +154,15 @@ hf_GPT2_large,pass_due_to_skip,0
 
 
 
+hf_Longformer,pass,4
+
+
+
 hf_Reformer,pass,5
+
+
+
+hf_T5,pass,0
 
 
 
@@ -179,6 +191,10 @@ maml,pass_due_to_skip,0
 
 
 maml_omniglot,pass,0
+
+
+
+mnasnet1_0,pass,0
 
 
 
@@ -256,6 +272,9 @@ resnet50_quantized_qat,pass,2
 
 resnext50_32x4d,pass,0
 
+
+
+shufflenet_v2_x1_0,pass,0
 
 
 soft_actor_critic,pass,0

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_huggingface_inference.csv
@@ -130,6 +130,10 @@ MobileBertForQuestionAnswering,pass,0
 
 
 
+OPTForCausalLM,pass,0
+
+
+
 PLBartForCausalLM,pass,0
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
@@ -138,6 +138,10 @@ hf_Bert_large,pass,0
 
 
 
+hf_BigBird,pass,13
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -150,7 +154,15 @@ hf_GPT2_large,pass_due_to_skip,0
 
 
 
+hf_Longformer,pass,4
+
+
+
 hf_Reformer,pass,5
+
+
+
+hf_T5,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_aot_inductor_amp_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_aot_inductor_amp_freezing_torchbench_inference.csv
@@ -114,6 +114,10 @@ hf_Bert_large,pass,0
 
 
 
+hf_BigBird,pass,0
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -123,6 +127,10 @@ hf_GPT2,pass,0
 
 
 hf_GPT2_large,pass_due_to_skip,0
+
+
+
+hf_T5,pass,0
 
 
 
@@ -155,6 +163,10 @@ maml_omniglot,pass,0
 
 
 mobilenet_v2,pass,0
+
+
+
+mnasnet1_0,pass,0
 
 
 
@@ -223,6 +235,10 @@ resnet50_quantized_qat,fail_to_run,0
 
 
 resnext50_32x4d,pass,0
+
+
+
+shufflenet_v2_x1_0,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_aot_inductor_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_aot_inductor_freezing_torchbench_inference.csv
@@ -114,6 +114,10 @@ hf_Bert_large,pass,0
 
 
 
+hf_BigBird,pass,0
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -123,6 +127,10 @@ hf_GPT2,pass,0
 
 
 hf_GPT2_large,pass_due_to_skip,0
+
+
+
+hf_T5,pass,0
 
 
 
@@ -151,6 +159,10 @@ maml,pass_due_to_skip,0
 
 
 maml_omniglot,pass,0
+
+
+
+mnasnet1_0,pass,0
 
 
 
@@ -223,6 +235,10 @@ resnet50_quantized_qat,fail_to_run,0
 
 
 resnext50_32x4d,pass,0
+
+
+
+shufflenet_v2_x1_0,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_huggingface_inference.csv
@@ -130,6 +130,10 @@ MobileBertForQuestionAnswering,pass,0
 
 
 
+OPTForCausalLM,pass,0
+
+
+
 PLBartForCausalLM,pass,0
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
@@ -122,6 +122,10 @@ hf_Bert_large,pass,0
 
 
 
+hf_BigBird,pass,13
+
+
+
 hf_DistilBert,pass,0
 
 
@@ -134,7 +138,15 @@ hf_GPT2_large,pass_due_to_skip,0
 
 
 
+hf_Longformer,pass,4
+
+
+
 hf_Reformer,pass,5
+
+
+
+hf_T5,pass,0
 
 
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4275,7 +4275,6 @@ def run(runner, args, original_dir=None):
         runner.skip_models.update(runner.slow_models)
 
     if args.devices == ["cpu"]:
-        runner.skip_models.update(runner.very_slow_models)
         runner.skip_models.update(runner.skip_models_for_cpu)
     elif args.devices == ["cuda"]:
         runner.skip_models.update(runner.skip_models_for_cuda)

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2370,7 +2370,11 @@ class BenchmarkRunner:
         return set()
 
     @property
-    def skip_models_for_freezing(self):
+    def skip_models_for_freezing_cpu(self):
+        return set()
+
+    @property
+    def skip_models_for_freezing_cuda(self):
         return set()
 
     @property
@@ -4283,7 +4287,10 @@ def run(runner, args, original_dir=None):
         runner.skip_models.update(runner.skip_multiprocess_models)
 
     if args.freezing:
-        runner.skip_models.update(runner.skip_models_for_freezing)
+        if args.devices == ["cpu"]:
+            runner.skip_models.update(runner.skip_models_for_freezing_cpu)
+        elif args.devices == ["cuda"]:
+            runner.skip_models.update(runner.skip_models_for_freezing_cuda)
 
     if args.no_skip:
         runner.skip_models.clear()

--- a/benchmarks/dynamo/huggingface.py
+++ b/benchmarks/dynamo/huggingface.py
@@ -353,6 +353,10 @@ class HuggingfaceRunner(BenchmarkRunner):
         return self._skip["all"]
 
     @property
+    def skip_models_for_cpu(self):
+        return self._skip["device"]["cpu"]
+
+    @property
     def fp32_only_models(self):
         return self._config["only_fp32"]
 

--- a/benchmarks/dynamo/huggingface.py
+++ b/benchmarks/dynamo/huggingface.py
@@ -353,10 +353,6 @@ class HuggingfaceRunner(BenchmarkRunner):
         return self._skip["all"]
 
     @property
-    def skip_models_for_cpu(self):
-        return self._skip["device"]["cpu"]
-
-    @property
     def fp32_only_models(self):
         return self._config["only_fp32"]
 
@@ -505,7 +501,7 @@ class HuggingfaceRunner(BenchmarkRunner):
                 return 4e-3, cosine
             if (
                 current_device == "cpu"
-                and name in self._config["tolerance"]["higher_inference"]
+                and name in self._config["tolerance"]["higher_inference_cpu"]
             ):
                 return 4e-3, cosine
         return 1e-3, cosine

--- a/benchmarks/dynamo/huggingface.yaml
+++ b/benchmarks/dynamo/huggingface.yaml
@@ -10,11 +10,6 @@ skip:
     - GPTJForCausalLM
     - GPTJForQuestionAnswering
 
-  device:
-    cpu:
-      # OOMs
-      - OPTForCausalLM
-
   control_flow:
     - AllenaiLongformerBase
 
@@ -71,6 +66,7 @@ batch_size:
     TrOCRForCausalLM: 2
     XGLMForCausalLM: 4
     XLNetLMHeadModel: 2
+    YituTechConvBert: 2
 
 
 tolerance:

--- a/benchmarks/dynamo/huggingface.yaml
+++ b/benchmarks/dynamo/huggingface.yaml
@@ -10,6 +10,9 @@ skip:
     - GPTJForCausalLM
     - GPTJForQuestionAnswering
 
+  device:
+    cpu: []
+
   control_flow:
     - AllenaiLongformerBase
 

--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -377,10 +377,16 @@ def get_skip_tests(suite, device, is_training: bool):
     module = importlib.import_module(suite)
     os.chdir(original_dir)
 
-    if hasattr(module, "SKIP"):
-        skip_tests.update(module.SKIP)
-    if is_training and hasattr(module, "SKIP_TRAIN"):
-        skip_tests.update(module.SKIP_TRAIN)
+    if suite == "torchbench":
+        skip_tests.update(module.TorchBenchmarkRunner().skip_models)
+        if is_training:
+            skip_tests.update(
+                module.TorchBenchmarkRunner().skip_not_suitable_for_training_models
+            )
+        if device == "cpu":
+            skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cpu)
+        elif device == "cuda":
+            skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cuda)
 
     skip_tests = (f"-x {name}" for name in skip_tests)
     skip_str = " ".join(skip_tests)

--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -438,7 +438,7 @@ def generate_commands(args, dtypes, suites, devices, compilers, output_dir):
                     if args.enable_cpu_launcher:
                         launcher_cmd = f"python -m torch.backends.xeon.run_cpu {args.cpu_launcher_args}"
                     cmd = f"{launcher_cmd} benchmarks/dynamo/{suite}.py --{testing} --{dtype} -d{device} --output={output_filename}"
-                    cmd = f"{cmd} {base_cmd} {args.extra_args} --no-skip --dashboard"
+                    cmd = f"{cmd} {base_cmd} {args.extra_args} --dashboard"
                     skip_tests_str = get_skip_tests(suite, device, args.training)
                     cmd = f"{cmd} {skip_tests_str}"
 

--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -377,21 +377,10 @@ def get_skip_tests(suite, device, is_training: bool):
     module = importlib.import_module(suite)
     os.chdir(original_dir)
 
-    if suite == "torchbench":
-        skip_tests.update(module.TorchBenchmarkRunner().skip_models)
-        if is_training:
-            skip_tests.update(
-                module.TorchBenchmarkRunner().skip_not_suitable_for_training_models
-            )
-        if device == "cpu":
-            skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cpu)
-        elif device == "cuda":
-            skip_tests.update(module.TorchBenchmarkRunner().skip_models_for_cuda)
-    else:
-        if hasattr(module, "SKIP"):
-            skip_tests.update(module.SKIP)
-        if is_training and hasattr(module, "SKIP_TRAIN"):
-            skip_tests.update(module.SKIP_TRAIN)
+    if hasattr(module, "SKIP"):
+        skip_tests.update(module.SKIP)
+    if is_training and hasattr(module, "SKIP_TRAIN"):
+        skip_tests.update(module.SKIP_TRAIN)
 
     skip_tests = (f"-x {name}" for name in skip_tests)
     skip_str = " ".join(skip_tests)

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -138,8 +138,12 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         return self._skip["device"]["cuda"]
 
     @property
-    def skip_models_for_freezing(self):
-        return self._skip["freezing"]
+    def skip_models_for_freezing_cuda(self):
+        return self._skip["freezing"]["cuda"]
+
+    @property
+    def skip_models_for_freezing_cpu(self):
+        return self._skip["freezing"]["cpu"]
 
     @property
     def slow_models(self):

--- a/benchmarks/dynamo/torchbench.yaml
+++ b/benchmarks/dynamo/torchbench.yaml
@@ -191,6 +191,7 @@ skip:
       - hf_Whisper
       - stable_diffusion_text_encoder
       - llava
+      - moco
 
     cuda: []
 
@@ -232,10 +233,13 @@ skip:
 
   # for these models, conv-batchnorm fusing causes big numerical churn.
   # Skip them
+  # mnasnet1_0 and shufflenet_v2_x1_0 can pass on cpu, moco cuda only.
   freezing:
-    - mnasnet1_0
-    - moco
-    - shufflenet_v2_x1_0
+    cuda:
+      - mnasnet1_0
+      - moco
+      - shufflenet_v2_x1_0
+    cpu: []
 
 
 


### PR DESCRIPTION
Fixes #132380, adjust torchbench and huggingface skip models list, then we can remove `--no-skip` when running benchmarks on 3 suites.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec