### PR TITLE
[inductor] check intel compiler minimal version

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -217,7 +217,7 @@ def _is_intel_compiler(cpp_compiler: str) -> bool:
                     )
 
                 # version check
-                icx_ver = re.search(r"release (\d+[.]\d+)", output_msg)
+                icx_ver = re.search(r"(\d+[.]\d+[.]\d+[.]\d+)", output_msg)
                 print("icx_ver: ", icx_ver)
         return is_intel_compiler
     except FileNotFoundError as exc:

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -215,6 +215,10 @@ def _is_intel_compiler(cpp_compiler: str) -> bool:
                     raise RuntimeError(
                         "Please use icx-cl, due to torch.compile only support MSVC-like CLI (compiler flags syntax)."
                     )
+
+                # version check
+                icx_ver = re.search(r"release (\d+[.]\d+)", output_msg)
+                print("icx_ver: ", icx_ver)
         return is_intel_compiler
     except FileNotFoundError as exc:
         return False

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -201,7 +201,10 @@ def _is_msvc_cl(cpp_compiler: str) -> bool:
 
 @functools.lru_cache(None)
 def _is_intel_compiler(cpp_compiler: str) -> bool:
-    def check_minimal_version(compiler_version: TorchVersion) -> None:
+    def _check_minimal_version(compiler_version: TorchVersion) -> None:
+        """
+        On Windows: early version icx has `-print-file-name` and can't preload correctly for inductor.
+        """
         min_version = "2024.2.1" if _IS_WINDOWS else "0.0.0"
         if compiler_version < TorchVersion(min_version):
             raise RuntimeError(
@@ -224,12 +227,12 @@ def _is_intel_compiler(cpp_compiler: str) -> bool:
                         "Please use icx-cl, due to torch.compile only support MSVC-like CLI (compiler flags syntax)."
                     )
 
-            # version check
+            # Version check
             icx_ver_search = re.search(r"(\d+[.]\d+[.]\d+[.]\d+)", output_msg)
             if icx_ver_search is not None:
                 icx_ver = icx_ver_search.group(1)
-                check_minimal_version(TorchVersion(icx_ver))
-                # print(f"{icx_ver.major}.{icx_ver.minor}.{icx_ver.micro}")
+                _check_minimal_version(TorchVersion(icx_ver))
+
         return is_intel_compiler
     except FileNotFoundError as exc:
         return False

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -24,6 +24,7 @@ from torch._dynamo.utils import dynamo_timed
 from torch._inductor import config, exc
 from torch._inductor.cpu_vec_isa import invalid_vec_isa, VecISA
 from torch._inductor.runtime.runtime_utils import cache_dir
+from torch.torch_version import Version
 
 
 if config.is_fbcode():
@@ -216,9 +217,11 @@ def _is_intel_compiler(cpp_compiler: str) -> bool:
                         "Please use icx-cl, due to torch.compile only support MSVC-like CLI (compiler flags syntax)."
                     )
 
-                # version check
-                icx_ver = re.search(r"(\d+[.]\d+[.]\d+[.]\d+)", output_msg)
-                print("icx_ver: ", icx_ver)
+            # version check
+            icx_ver_search = re.search(r"(\d+[.]\d+[.]\d+[.]\d+)", output_msg)
+            if icx_ver_search is not None:
+                icx_ver = Version(icx_ver_search.group(1))
+                # print(f"{icx_ver.major}.{icx_ver.minor}.{icx_ver.micro}")
         return is_intel_compiler
     except FileNotFoundError as exc:
         return False

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -203,7 +203,7 @@ def _is_msvc_cl(cpp_compiler: str) -> bool:
 def _is_intel_compiler(cpp_compiler: str) -> bool:
     def _check_minimal_version(compiler_version: TorchVersion) -> None:
         """
-        On Windows: early version icx has `-print-file-name` and can't preload correctly for inductor.
+        On Windows: early version icx has `-print-file-name` issue, and can't preload correctly for inductor.
         """
         min_version = "2024.2.1" if _IS_WINDOWS else "0.0.0"
         if compiler_version < TorchVersion(min_version):


### PR DESCRIPTION
On Windows: early version icx has `-print-file-name` issue, and can't preload correctly for inductor. Add minimal version check for Intel compiler.


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang