### PR TITLE
[merge rules] Add ONNX team to docs/source/conf.py

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -5,6 +5,7 @@
   - .ci/docker/common/install_onnx.sh
   - aten/src/ATen/core/interned_strings.h
   - benchmarks/dynamo/**
+  - docs/source/conf.py
   - docs/source/onnx.rst
   - docs/source/onnx*
   - docs/source/scripts/onnx/**


### PR DESCRIPTION
We would like to update/clean up the `coverage_ignore_functions` entries.
