### PR TITLE
[inductor] Fix gen_transposed_tile_load_store - need_define VLA build issue on MSVC

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -3073,6 +3073,13 @@ class CppTile2DKernel(CppVecKernel):
                 f"alignas({factor}) {DTYPE_TO_CPP[dtype]} {tile_var}"
                 f"[{cexpr_index(self.outer_num_elems * self.inner_num_elems)}];"
             )
+            """
+            MSVC don't support dynamic array(VLA). Please use std::unique_ptr to instead of it.
+            Ref: https://stackoverflow.com/questions/56555406/creating-dynamic-sized-array-using-msvc-c-compiler
+            MSVC is the only one compiler, which not support VLA. And MSVC can't get good inductor performance.
+            So, we can use unique_ptr make it works on MSVC.
+            For other compilers, we continue to use VLA to get best performence.
+            """
             tile_var_buff_ptr = f"{tile_var}_buff"
             define_lines_unique_ptr = [
                 f"std::unique_ptr<{DTYPE_TO_CPP[dtype]}, decltype(inductor_free)*> {tile_var_buff_ptr}(({DTYPE_TO_CPP[dtype]}*) "  # noqa: B950

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include <omp.h>
+#include <stdexcept>
 
 // WARNING: be extra careful when including more ATen/c10 header files here!
 // Because AOTInductor generated code will copy-paste this cpp_prefix.h for
@@ -39,6 +40,29 @@
 // For calc_erfinv
 #include <ATen/native/Math.h>
 #endif
+
+void* inductor_alloc_aligned(size_t nbytes, size_t alignment) {
+  if (nbytes == 0) {
+    return nullptr;
+  }
+
+  void* data;
+#if defined(_MSC_VER)
+  data = _aligned_malloc(nbytes, alignment);
+#else
+  throw std::runtime_error ("It is only use for MSVC workaround VLA.");
+#endif
+
+  return data;
+}
+
+void inductor_free(void* data) {
+#ifdef _MSC_VER
+  _aligned_free(data);
+#else
+  throw std::runtime_error ("It is only use for MSVC workaround VLA.");
+#endif
+}
 
 typedef at::Half half;
 typedef at::BFloat16 bfloat16;


### PR DESCRIPTION
Recent PR: https://github.com/pytorch/pytorch/pull/131745 bring new VLA logical in cpp codegen. And it will raise build fail error on MSVC and error code is `Compiler Error C2131`: https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2131?view=msvc-170

reproduce UT:
```cmd
pytest test\inductor\test_torchinductor_dynamic_shapes.py -v -k test_large_block_sizes_dynamic_shapes_cpu
```

Original generated code:
```c++
alignas(16) float tmp1[static_cast<int64_t>(((-256LL)*(c10::div_floor_integer(static_cast<int64_t>(ks1), static_cast<int64_t>(16LL)))) + (16LL*ks1))];
```
MSVC only support C89, but VLA is need C99. We can use `std::unique_ptr` to instead of it. Reference to https://github.com/pytorch/pytorch/pull/134221

Changes:
* use unique_ptr replace vla for MSVC.
* add inductor_alloc_aligned and inductor_free for unique_ptr malloc aligned memory.
* add runtime check for inductor_alloc_aligned and inductor_free.

New genarated code:
```c++
std::unique_ptr<float, decltype(inductor_free)*> tmp1_buff((float*) inductor_alloc_aligned(sizeof(float) * static_cast<int64_t>(((-256LL)*(c10::div_floor_integer(static_cast<int64_t>(ks1), static_cast<int64_t>(16LL)))) + (16LL*ks1)), 16), inductor_free);
float* tmp1 = tmp1_buff.get();
```
Local test pass:
<img width="856" alt="image" src="https://github.com/user-attachments/assets/27131c70-5572-4b38-920a-8c9c50174146">


cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang