### PR TITLE
[ONNX] Delete ONNXProgramSerializer

### DIFF
--- a/docs/source/onnx_dynamo.rst
+++ b/docs/source/onnx_dynamo.rst
@@ -28,7 +28,6 @@ The exporter is designed to be modular and extensible. It is composed of the fol
   - **FX Graph Extractor**: :class:`FXGraphExtractor` extracts the FX graph from the PyTorch model.
   - **Fake Mode**: :class:`ONNXFakeContext` is a context manager that enables fake mode for large scale models.
   - **ONNX Program**: :class:`ONNXProgram` is the output of the exporter that contains the exported ONNX graph and diagnostics.
-  - **ONNX Program Serializer**: :class:`ONNXProgramSerializer` serializes the exported model to a file.
   - **ONNX Diagnostic Options**: :class:`DiagnosticOptions` has a set of options that control the diagnostics emitted by the exporter.
 
 Dependencies
@@ -142,9 +141,6 @@ API Reference
 .. autofunction:: torch.onnx.enable_fake_mode
 
 .. autoclass:: torch.onnx.ONNXProgram
-    :members:
-
-.. autoclass:: torch.onnx.ONNXProgramSerializer
     :members:
 
 .. autoclass:: torch.onnx.ONNXRuntimeOptions

--- a/test/onnx/dynamo/test_exporter_api.py
+++ b/test/onnx/dynamo/test_exporter_api.py
@@ -7,10 +7,7 @@ import onnx
 import torch
 from torch.onnx import dynamo_export, ExportOptions, ONNXProgram
 from torch.onnx._internal import _exporter_legacy
-from torch.onnx._internal._exporter_legacy import (
-    ONNXProgramSerializer,
-    ResolvedExportOptions,
-)
+from torch.onnx._internal._exporter_legacy import ResolvedExportOptions
 from torch.testing._internal import common_utils
 
 
@@ -74,40 +71,6 @@ class TestDynamoExportAPI(common_utils.TestCase):
         buffer = io.BytesIO()
         dynamo_export(SampleModel(), torch.randn(1, 1, 2)).save(buffer)
         onnx.load(buffer)
-
-    def test_save_to_file_using_specified_serializer(self):
-        expected_buffer = "I am not actually ONNX"
-
-        class CustomSerializer(ONNXProgramSerializer):
-            def serialize(
-                self, onnx_program: ONNXProgram, destination: io.BufferedIOBase
-            ) -> None:
-                destination.write(expected_buffer.encode())
-
-        with common_utils.TemporaryFileName() as path:
-            dynamo_export(SampleModel(), torch.randn(1, 1, 2)).save(
-                path, serializer=CustomSerializer()
-            )
-            with open(path) as fp:
-                self.assertEqual(fp.read(), expected_buffer)
-
-    def test_save_to_file_using_specified_serializer_without_inheritance(self):
-        expected_buffer = "I am not actually ONNX"
-
-        # NOTE: Inheritance from `ONNXProgramSerializer` is not required.
-        # Because `ONNXProgramSerializer` is a Protocol class.
-        class CustomSerializer:
-            def serialize(
-                self, onnx_program: ONNXProgram, destination: io.BufferedIOBase
-            ) -> None:
-                destination.write(expected_buffer.encode())
-
-        with common_utils.TemporaryFileName() as path:
-            dynamo_export(SampleModel(), torch.randn(1, 1, 2)).save(
-                path, serializer=CustomSerializer()
-            )
-            with open(path) as fp:
-                self.assertEqual(fp.read(), expected_buffer)
 
     def test_save_sarif_log_to_file_with_successful_export(self):
         with common_utils.TemporaryFileName(suffix=".sarif") as path:

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -44,7 +44,6 @@ __all__ = [
     "DiagnosticOptions",
     "ExportOptions",
     "ONNXProgram",
-    "ONNXProgramSerializer",
     "ONNXRuntimeOptions",
     "InvalidExportOptionsError",
     "OnnxExporterError",
@@ -109,7 +108,6 @@ from ._internal._exporter_legacy import (  # usort: skip. needs to be last to av
     DiagnosticOptions,
     ExportOptions,
     ONNXProgram,
-    ONNXProgramSerializer,
     ONNXRuntimeOptions,
     InvalidExportOptionsError,
     OnnxExporterError,
@@ -127,7 +125,6 @@ ExportTypes.__module__ = "torch.onnx"
 JitScalarType.__module__ = "torch.onnx"
 ExportOptions.__module__ = "torch.onnx"
 ONNXProgram.__module__ = "torch.onnx"
-ONNXProgramSerializer.__module__ = "torch.onnx"
 ONNXRuntimeOptions.__module__ = "torch.onnx"
 dynamo_export.__module__ = "torch.onnx"
 InvalidExportOptionsError.__module__ = "torch.onnx"


### PR DESCRIPTION
## Context

Fixes #135182 

## BC Breaking

With the introduction of [ONNX IR](https://github.com/microsoft/onnxscript/blob/main/onnxscript/ir/README.md), ONNXProgram.model (ir.Model) is now serizalized instead.

textproto, onnxtext, and json format are supported by default when calling ONNXProgram.save() with a correspoinding file extension.