### PR TITLE
[TCPStore] use wait counters

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/WaitCounter.h>
 #include <c10/util/irange.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -32,53 +33,6 @@
 
 namespace c10d {
 namespace detail {
-
-class timing_guard {
-  Counter& counter_;
-  typedef std::chrono::time_point<std::chrono::high_resolution_clock>
-      time_point;
-  time_point start_;
-
- public:
-  timing_guard(Counter& counter)
-      : counter_(counter), start_(std::chrono::high_resolution_clock::now()) {}
-
-  ~timing_guard() {
-    stop();
-  }
-
-  void stop() {
-    if (start_ != time_point()) {
-      auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(
-                      std::chrono::high_resolution_clock::now() - start_)
-                      .count();
-      counter_.update(diff);
-      start_ = time_point();
-    }
-  }
-};
-
-void Counter::update(double val) {
-  count_ += 1;
-
-  auto delta = val - mean_;
-  mean_ += delta / count_;
-
-  auto delta2 = val - mean_;
-  m2_ += delta2 * delta2;
-}
-
-std::unordered_map<std::string, double> Counter::observe() const {
-  std::unordered_map<std::string, double> res;
-  res["count"] = (double)count_;
-  res["mean"] = mean_;
-  if (count_ >= 2) {
-    res["sample_variance"] = m2_ / (count_ - 1);
-  } else {
-    res["sample_variance"] = std::nan("1");
-  }
-  return res;
-}
 
 // Manages the lifecycle of a server daemon.
 class TCPServer {
@@ -317,6 +271,8 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
       addr_{std::move(host)},
       numWorkers_{opts.numWorkers},
       usingLibUv_{opts.useLibUV} {
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__init);
+
   if (opts.useLibUV) {
     TORCH_CHECK(
         ::c10d::detail::is_libuv_tcpstore_backend_available(),
@@ -421,7 +377,7 @@ TCPStore::TCPStore(std::string host, const TCPStoreOptions& opts)
 TCPStore::~TCPStore() = default;
 
 void TCPStore::waitForWorkers() {
-  detail::timing_guard tguard(clientCounters_["waitForWorkers"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__waitForWorkers);
   if (numWorkers_ == std::nullopt) {
     return;
   }
@@ -491,7 +447,7 @@ void TCPStore::_splitSet(
 }
 
 void TCPStore::set(const std::string& key, const std::vector<uint8_t>& data) {
-  detail::timing_guard tguard(clientCounters_["set"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__set);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   detail::SendBuffer buffer(*client_, detail::QueryType::SET);
   buffer.appendString(keyPrefix_ + key);
@@ -503,7 +459,7 @@ std::vector<uint8_t> TCPStore::compareSet(
     const std::string& key,
     const std::vector<uint8_t>& expectedValue,
     const std::vector<uint8_t>& desiredValue) {
-  detail::timing_guard tguard(clientCounters_["compareSet"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__compareSet);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   detail::SendBuffer buffer(*client_, detail::QueryType::COMPARE_SET);
   buffer.appendString(keyPrefix_ + key);
@@ -515,7 +471,7 @@ std::vector<uint8_t> TCPStore::compareSet(
 }
 
 std::vector<uint8_t> TCPStore::get(const std::string& key) {
-  detail::timing_guard tguard(clientCounters_["get"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__get);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   return doGet(keyPrefix_ + key);
 }
@@ -530,13 +486,13 @@ std::vector<uint8_t> TCPStore::doGet(const std::string& key) {
 }
 
 int64_t TCPStore::add(const std::string& key, int64_t value) {
-  detail::timing_guard tguard(clientCounters_["add"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__add);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   return incrementValueBy(keyPrefix_ + key, value);
 }
 
 bool TCPStore::deleteKey(const std::string& key) {
-  detail::timing_guard tguard(clientCounters_["deleteKey"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__delete);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   detail::SendBuffer buffer(*client_, detail::QueryType::DELETE_KEY);
   buffer.appendString(keyPrefix_ + key);
@@ -564,7 +520,7 @@ int64_t TCPStore::getNumKeys() {
 }
 
 bool TCPStore::check(const std::vector<std::string>& keys) {
-  detail::timing_guard tguard(clientCounters_["check"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__check);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   detail::SendBuffer buffer(*client_, detail::QueryType::CHECK);
   buffer.appendValue(keys.size());
@@ -591,7 +547,7 @@ void TCPStore::wait(const std::vector<std::string>& keys) {
 void TCPStore::wait(
     const std::vector<std::string>& keys,
     const std::chrono::milliseconds& timeout) {
-  detail::timing_guard tguard(clientCounters_["wait"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__wait);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   std::vector<std::string> prefixedKeys{};
   prefixedKeys.reserve(keys.size());
@@ -652,7 +608,7 @@ void TCPStore::doWait(
 void TCPStore::append(
     const std::string& key,
     const std::vector<uint8_t>& data) {
-  detail::timing_guard tguard(clientCounters_["append"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__append);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   detail::SendBuffer buffer(*client_, detail::QueryType::APPEND);
   buffer.appendString(keyPrefix_ + key);
@@ -662,7 +618,7 @@ void TCPStore::append(
 
 std::vector<std::vector<uint8_t>> TCPStore::multiGet(
     const std::vector<std::string>& keys) {
-  detail::timing_guard tguard(clientCounters_["multiGet"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__multiGet);
   const std::lock_guard<std::mutex> lock(activeOpLock_);
   std::vector<std::string> prefixedKeys;
   prefixedKeys.reserve(keys.size());
@@ -689,7 +645,7 @@ std::vector<std::vector<uint8_t>> TCPStore::multiGet(
 void TCPStore::multiSet(
     const std::vector<std::string>& keys,
     const std::vector<std::vector<uint8_t>>& values) {
-  detail::timing_guard tguard(clientCounters_["multiSet"]);
+  STATIC_SCOPED_WAIT_COUNTER(pytorch.wait_counter.TCPStore__multiSet);
   TORCH_CHECK(
       keys.size() == values.size(),
       "multiSet keys and values vectors must be of same size");
@@ -706,15 +662,6 @@ void TCPStore::multiSet(
 
 bool TCPStore::hasExtendedApi() const {
   return true;
-}
-
-std::unordered_map<std::string, std::unordered_map<std::string, double>>
-TCPStore::collectClientCounters() const noexcept {
-  std::unordered_map<std::string, std::unordered_map<std::string, double>> res;
-  for (const auto& kv : clientCounters_) {
-    res[kv.first] = kv.second.observe();
-  }
-  return res;
 }
 
 std::string TCPStore::repr() const {

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -18,30 +18,6 @@ struct SocketAddress {
   std::uint16_t port{};
 };
 
-class Counter {
- public:
-  void update(double val);
-  std::unordered_map<std::string, double> observe() const;
-
-  double mean() const noexcept {
-    return mean_;
-  }
-  int64_t count() const noexcept {
-    return count_;
-  }
-  double variance() const noexcept {
-    return m2_ / static_cast<double>(count_);
-  }
-  double sample_variance() const noexcept {
-    return m2_ / static_cast<double>(count_ - 1);
-  }
-
- private:
-  int64_t count_ = 0;
-  double mean_ = 0;
-  double m2_ = 0;
-};
-
 } // namespace detail
 
 struct TCPStoreOptions {
@@ -130,9 +106,6 @@ class TORCH_API TCPStore : public Store {
     return addr_.port;
   }
 
-  std::unordered_map<std::string, std::unordered_map<std::string, double>>
-  collectClientCounters() const noexcept;
-
   bool isLibUvBackend() const noexcept {
     return usingLibUv_;
   }
@@ -162,7 +135,6 @@ class TORCH_API TCPStore : public Store {
   const std::string initKey_ = "init/";
   const std::string keyPrefix_ = "/";
   std::mutex activeOpLock_;
-  std::unordered_map<std::string, detail::Counter> clientCounters_;
   bool usingLibUv_ = true;
 };
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1552,15 +1552,10 @@ Example::
           py::arg("master_listen_fd") = py::none(),
           py::arg("use_libuv") = true,
           py::call_guard<py::gil_scoped_release>())
-      .def(
-          "collect_client_counters",
-          &::c10d::TCPStore::collectClientCounters,
-          "Return a dict of counters for tcp store client")
       .def_property_readonly(
           "host",
           &::c10d::TCPStore::getHost,
           R"(Gets the hostname on which the store listens for requests.)")
-
       .def_property_readonly(
           "port",
           &::c10d::TCPStore::getPort,


### PR DESCRIPTION
This replaces the existing TCPStore counters with the new shared wait counters. There's no users of the tcpstore counters so should be completely safe to remove.

Test plan:

Existing tests + build

There's no OSS backend for wait counters so can't write any tests with them currently.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o