### PR TITLE
[Inductor][CPP] Fix the issue of view dtype

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1907,6 +1907,16 @@ class CPUReproTests(TestCase):
         res = cfn(x, bit_num)
         self.assertEqual(res_aten_eager, res)
 
+    def test_view_dtype(self):
+        def f(x):
+            return x.view(torch.int32) >> 2
+
+        input = torch.ones(16, 16)
+        res_aten_eager = f(input)
+        cfn = torch.compile(f)
+        res = cfn(input)
+        self.assertEqual(res_aten_eager, res)
+
     @patch("torch.cuda.is_available", lambda: False)
     def test_scatter_using_atomic_add(self):
         def fn(a, dim, index, b):

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -344,6 +344,8 @@ def deduce_output_dtype_by_name(
     ):
         buf_name = args[1]
         return V.graph.get_dtype(buf_name)  # type: ignore[arg-type]
+    elif op_name == "to_dtype_bitcast":
+        return kwargs["dtype"] if "dtype" in kwargs else args[-2]
     return None
 
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1627,7 +1627,7 @@ class CppVecOverrides(CppOverrides):
             )
             octype = "bool" if output_mask else cdtype
             octype = (
-                DTYPE_TO_CPP[args[1]]
+                DTYPE_TO_CPP[args[-2]]
                 if (scalar_func.__name__ == "to_dtype_bitcast")
                 else octype
             )

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1626,6 +1626,11 @@ class CppVecOverrides(CppOverrides):
                 "signbit",
             )
             octype = "bool" if output_mask else cdtype
+            octype = (
+                DTYPE_TO_CPP[args[1]]
+                if (scalar_func.__name__ == "to_dtype_bitcast")
+                else octype
+            )
             with code.indent():
                 for argidx, arg in enumerate(args):
                     if isinstance(arg, CppCSEVariable):
@@ -1650,9 +1655,9 @@ class CppVecOverrides(CppOverrides):
                 else:
                     load_args = f"tmpbuf_out.data(), {size}"
                     if n_vec == 1:
-                        load_fn = f"at::vec::Vectorized<{cdtype}>::loadu"
+                        load_fn = f"at::vec::Vectorized<{octype}>::loadu"
                     else:
-                        load_fn = f" at::vec::VectorizedN<{cdtype}, {n_vec}>::loadu"
+                        load_fn = f" at::vec::VectorizedN<{octype}, {n_vec}>::loadu"
                 code.writeline(f"return {load_fn}({load_args});")
             code.writeline("()")
             return code


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #135304
* __->__ #135301

**Summary**
Fix issue: https://github.com/pytorch/pytorch/issues/135160, it's a regression introduced by https://github.com/pytorch/pytorch/pull/134569, where the dtype of `to_dtype_bitcast` was incorrectly handled when using the scalarize implementation.

**TestPlan**
```
python -u -m pytest -s -v test/inductor/test_cpu_repro.py -k test_view_dtype
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang