### PR TITLE
[inductor] Fix loop split optimization

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4187,7 +4187,7 @@ class CppScheduling(BaseScheduling):
                     if (
                         isinstance(split_number, sympy.core.numbers.Integer)
                         and isinstance(split_var, sympy.core.symbol.Symbol)
-                        and split_var.name.startswith("q")
+                        and split_var in original_body.iter_vars
                         and divide_index_name is not None
                         and all(
                             stride_at_vec_range(expr, split_var) == 1

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4187,6 +4187,7 @@ class CppScheduling(BaseScheduling):
                     if (
                         isinstance(split_number, sympy.core.numbers.Integer)
                         and isinstance(split_var, sympy.core.symbol.Symbol)
+                        and split_var.name.startswith("q")
                         and divide_index_name is not None
                         and all(
                             stride_at_vec_range(expr, split_var) == 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #135335
* __->__ #135303


Fix https://github.com/pytorch/pytorch/issues/135274.

Improve the check whether the div expr matches: add a check whether `split_var` is in `original_body.iter_vars`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang