### PR TITLE
[Inductor][CPP] Enhance the implementation of scalarize

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1615,8 +1615,8 @@ class CppVecOverrides(CppOverrides):
             assert isinstance(kernel, CppVecKernel)
             code = BracesBuffer()
             code.writeline("[&]()")
+            assert isinstance(args[0], CppCSEVariable)
             vec_dtype = args[0].dtype
-            n_vec = kernel._get_num_vectors(vec_dtype)
             size = kernel.tail_size if kernel.tail_size else kernel.tiling_factor
             scalar_args = []
             cdtype = DTYPE_TO_CPP[vec_dtype]
@@ -1631,6 +1631,7 @@ class CppVecOverrides(CppOverrides):
                 if (scalar_func.__name__ == "to_dtype_bitcast")
                 else octype
             )
+            n_vec = kernel._get_num_vectors(vec_dtype if output_mask else octype)
             with code.indent():
                 for argidx, arg in enumerate(args):
                     if isinstance(arg, CppCSEVariable):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135304
* #135301

**Summary**
Further enhance the implementation of `scalarize`:

- We assume `args[0]` is `CppCSEVariable` in current implementation, adding assert for it.
- `n_vec` should be calculated with output dtype for general case since it's used to load the result.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov