### PR TITLE
check compilation status before query cudnn version in conv

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -421,6 +421,9 @@ struct ConvParams {
   // cudnn and miopen are guaranteed not to be on mobile, and T102591915 / T110194934 suggest
   // that maybe the compiledWithCuDNN() check sometimes segfaults (though I can't imagine how)
 #if !defined(C10_MOBILE)
+    if (!detail::getCUDAHooks().compiledWithCuDNN()) {
+      return false;
+    }
     if (needs_64bit_indexing_no_split(input, weight)) {
       static long cudnn_version = detail::getCUDAHooks().versionCuDNN();
       if (!(cudnn_version >= 90300 && at::native::cudnnv8_enabled_check_debug())) {
@@ -429,9 +432,6 @@ struct ConvParams {
                         " Consider upgrading cuDNN and/or enabling the V8 API for better efficiency.");
         return false;
       }
-    }
-    if (!detail::getCUDAHooks().compiledWithCuDNN()) {
-      return false;
     }
     if (!input.is_cuda() || !cudnn_enabled) {
       return false;


### PR DESCRIPTION
This PR is created for fixing the https://github.com/pytorch/pytorch/issues/135322.  The cudnn compilation status should be check firstly before querying version, otherwise, conv may trigger runtimeerror before any check in other non-cuda backends.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135332



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @EikanWang @fengyuan14 @guangyey