### PR TITLE
Add more robust check in weight_only Unpickler

### DIFF
--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -133,6 +133,12 @@ def _get_user_allowed_globals():
         rc[f"{module}.{name}"] = f
     return rc
 
+def _is_user_allowed_or_subclass(inst):
+    for user_allowed in _get_user_allowed_globals().values():
+        if (inst is user_allowed
+            or (isinstance(user_allowed, type) and issubclass(type(inst), user_allowed))):
+            return True
+    return False
 
 def _tensor_rebuild_functions():
     return {
@@ -257,7 +263,7 @@ class Unpickler:
                 cls = self.stack.pop()
                 if cls is torch.nn.Parameter:
                     self.append(torch.nn.Parameter(*args))
-                elif cls in _get_user_allowed_globals().values():
+                elif _is_user_allowed_or_subclass(cls):
                     self.append(cls.__new__(cls, *args))
                 else:
                     raise UnpicklingError(
@@ -285,7 +291,7 @@ class Unpickler:
                     inst.__setstate__(state)
                 elif type(inst) is OrderedDict:
                     inst.__dict__.update(state)
-                elif type(inst) in _get_user_allowed_globals().values():
+                elif _is_user_allowed_or_subclass(inst):
                     if hasattr(inst, "__setstate__"):
                         inst.__setstate__(state)
                     else:


### PR DESCRIPTION
### Problem

When loading weights with weights_only=True, certain types (e.g., np.dtype[int32]) can be subclasses of user-allowed globals (e.g., np.dtype) but are not handled properly, which leads to load failures.

Example error:
```
_pickle.UnpicklingError: Weights only load failed. Re-running `torch.load` with `weights_only` set to `False` will likely
succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
Please file an issue with the following so that we can make `weights_only=True` compatible with your use case: WeightsUnpi
ckler error: Can only build Tensor, parameter or OrderedDict objects, but got  <class 'numpy.dtype[int32]'>                
```
even though 
```
torch.serialization.add_safe_globals([np.dtype])
```
### Solution

This PR adds a helper function `_is_user_allowed_or_subclass` to check if an instance is a user-allowed type or its subclass. This replaces the previous direct comparison, enabling more flexible type checking during unpickling