### PR TITLE
[ROCm] Modify hipify script to work with Windows paths

### DIFF
--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -138,7 +138,7 @@ class GeneratedFileCleaner:
 
 
 # Follow UNIX convention for paths to use '/' instead of '\\' on Windows
-def to_unix_path(path: str) -> str:
+def _to_unix_path(path: str) -> str:
     return path.replace(os.sep, '/')
 
 def match_extensions(filename: str, extensions: Iterable) -> bool:
@@ -177,8 +177,8 @@ def matched_files_iter(
                 dirs.remove("third_party")
                 dirs.append("third_party/nvfuser")
         for filename in filenames:
-            filepath = to_unix_path(os.path.join(abs_dirpath, filename))
-            rel_filepath = to_unix_path(os.path.join(rel_dirpath, filename))
+            filepath = _to_unix_path(os.path.join(abs_dirpath, filename))
+            rel_filepath = _to_unix_path(os.path.join(rel_dirpath, filename))
             # We respect extensions, UNLESS you wrote the entire
             # filename verbatim, in which case we always accept it
             if (
@@ -825,7 +825,7 @@ def preprocessor(
         hipify_result.current_state = CurrentState.DONE
         return hipify_result
 
-    rel_filepath = to_unix_path(os.path.relpath(filepath, output_directory))
+    rel_filepath = _to_unix_path(os.path.relpath(filepath, output_directory))
 
     with open(fin_path, encoding='utf-8') as fin:
         if fin.readline() == HIPIFY_C_BREADCRUMB:
@@ -1117,8 +1117,8 @@ def hipify(
     if not os.path.exists(output_directory):
         shutil.copytree(project_directory, output_directory)
 
-    includes = map(to_unix_path, includes)
-    ignores = map(to_unix_path, ignores)
+    includes = map(_to_unix_path, includes)
+    ignores = map(_to_unix_path, ignores)
 
     all_files = list(matched_files_iter(output_directory, includes=includes,
                                         ignores=ignores, extensions=extensions,

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -137,6 +137,10 @@ class GeneratedFileCleaner:
                 os.rmdir(d)
 
 
+# Follow UNIX convention for paths to use '/' instead of '\\' on Windows
+def to_unix_path(path: str) -> str:
+    return path.replace(os.sep, '/')
+
 def match_extensions(filename: str, extensions: Iterable) -> bool:
     """Helper method to see if filename ends with certain extension"""
     return any(filename.endswith(e) for e in extensions)
@@ -173,8 +177,8 @@ def matched_files_iter(
                 dirs.remove("third_party")
                 dirs.append("third_party/nvfuser")
         for filename in filenames:
-            filepath = os.path.join(abs_dirpath, filename)
-            rel_filepath = os.path.join(rel_dirpath, filename)
+            filepath = to_unix_path(os.path.join(abs_dirpath, filename))
+            rel_filepath = to_unix_path(os.path.join(rel_dirpath, filename))
             # We respect extensions, UNLESS you wrote the entire
             # filename verbatim, in which case we always accept it
             if (
@@ -821,7 +825,7 @@ def preprocessor(
         hipify_result.current_state = CurrentState.DONE
         return hipify_result
 
-    rel_filepath = os.path.relpath(filepath, output_directory)
+    rel_filepath = to_unix_path(os.path.relpath(filepath, output_directory))
 
     with open(fin_path, encoding='utf-8') as fin:
         if fin.readline() == HIPIFY_C_BREADCRUMB:
@@ -1112,6 +1116,9 @@ def hipify(
     # Copy from project directory to output directory if not done already.
     if not os.path.exists(output_directory):
         shutil.copytree(project_directory, output_directory)
+
+    includes = map(to_unix_path, includes)
+    ignores = map(to_unix_path, ignores)
 
     all_files = list(matched_files_iter(output_directory, includes=includes,
                                         ignores=ignores, extensions=extensions,

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -1117,8 +1117,8 @@ def hipify(
     if not os.path.exists(output_directory):
         shutil.copytree(project_directory, output_directory)
 
-    includes = map(_to_unix_path, includes)
-    ignores = map(_to_unix_path, ignores)
+    includes = list(map(_to_unix_path, includes))
+    ignores = list(map(_to_unix_path, ignores))
 
     all_files = list(matched_files_iter(output_directory, includes=includes,
                                         ignores=ignores, extensions=extensions,


### PR DESCRIPTION
This change modifies the `hipify_python.py` script to properly detect all directories, `include` and `ignore` paths during hipification process on Windows, by changing the path syntax convention to a UNIX-like one.

Since in many places the script assumes a UNIX-like convention by using paths with forward slashes `/`, I decided to accommodate for it by converting Windows paths to UNIX-like ones. By doing it so, the number of changes to the file is limited. Moreover this early-on unification allows for the rest of the code to have a battle-tested linux-like behaviour.

Another option would be to use `Path` object from `pathlib` to represent all paths in the script, however, it would impact a broader share of a code and would hence require a more meticulous evaluation in terms of non-altered logic and edge cases.

 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd