### PR TITLE
[release] Fix env file passing to aarch64 builds

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -153,7 +153,10 @@ export DOCKER_IMAGE="$DOCKER_IMAGE"
 
 
 export USE_GOLD_LINKER="${USE_GOLD_LINKER}"
-export USE_GLOO_WITH_OPENSSL="ON"
+
+if [[ "\$BUILD_ENVIRONMENT" != *aarch64* ]]; then
+  export USE_GLOO_WITH_OPENSSL="ON"
+fi
 # =================== The above code will be executed inside Docker container ===================
 EOL
 

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -142,19 +142,20 @@ export PYTORCH_BUILD_NUMBER="$PYTORCH_BUILD_NUMBER"
 export OVERRIDE_PACKAGE_VERSION="$PYTORCH_BUILD_VERSION"
 export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS:-}"
 
-# TODO: We don't need this anymore IIUC
-export TORCH_PACKAGE_NAME='torch'
-export TORCH_CONDA_BUILD_FOLDER='pytorch-nightly'
-export ANACONDA_USER='pytorch'
 
-export USE_FBGEMM=1
-export PIP_UPLOAD_FOLDER="$PIP_UPLOAD_FOLDER"
-export DOCKER_IMAGE="$DOCKER_IMAGE"
-
-
-export USE_GOLD_LINKER="${USE_GOLD_LINKER}"
 
 if [[ "\$BUILD_ENVIRONMENT" != *aarch64* ]]; then
+  # TODO: We don't need this anymore IIUC
+  export TORCH_PACKAGE_NAME='torch'
+  export TORCH_CONDA_BUILD_FOLDER='pytorch-nightly'
+  export ANACONDA_USER='pytorch'
+
+  export USE_FBGEMM=1
+  export PIP_UPLOAD_FOLDER="$PIP_UPLOAD_FOLDER"
+  export DOCKER_IMAGE="$DOCKER_IMAGE"
+
+
+  export USE_GOLD_LINKER="${USE_GOLD_LINKER}"
   export USE_GLOO_WITH_OPENSSL="ON"
 fi
 # =================== The above code will be executed inside Docker container ===================

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -271,7 +271,7 @@ jobs:
           )
           docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .circleci/scripts/binary_populate_env.sh"
           if [[ ${BUILD_ENVIRONMENT} == *"aarch64"* ]]; then
-            docker exec -t "${container_name}" bash -c "bash /builder/aarch64_linux/aarch64_ci_build.sh"
+            docker exec -t "${container_name}" bash -c "source ${BINARY_ENV_FILE} && bash /builder/aarch64_linux/aarch64_ci_build.sh"
           else
             docker exec -t "${container_name}" bash -c "source ${BINARY_ENV_FILE} && bash /builder/${{ inputs.PACKAGE_TYPE }}/build.sh"
           fi


### PR DESCRIPTION
Passes env file to aarch64 builds. This will fix issue that these binaries are missing triton constraint. We expect every wheel to have same constraint like this:
```
Requires-Dist: triton (==3.0.0) ; platform_system == "Linux" and platform_machine == "x86_64" and python_version < "3.13"
```

I do see this constraint is executed here:
https://github.com/pytorch/pytorch/actions/runs/10734375372/job/29769442792#step:16:163

```
export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="nvidia-cuda-nvrtc-cu12==12.1.105; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-cuda-runtime-cu12==12.1.105; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-cuda-cupti-cu12==12.1.105; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-cudnn-cu12==9.1.0.70; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-cublas-cu12==12.1.3.1; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-cufft-cu12==11.0.2.54; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-curand-cu12==10.3.2.106; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-cusolver-cu12==11.4.5.107; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-cusparse-cu12==12.1.0.106; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-nccl-cu12==2.21.5; platform_system == 'Linux' and platform_machine == 'x86_64' | nvidia-nvtx-cu12==12.1.105; platform_system == 'Linux' and platform_machine == 'x86_64' | pytorch-triton==3.0.0+757b6a61e7; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.13'"
```
But its not getting picked up by build because we don't set the env var.

Test: Running ``ciflow/binaries_wheel`` aarch64 CPU and CUDA builds

Please note: To fix the binary before releasing to pypi, I had to inject this constraint into staged binary. However we want to properly fix it, so injection is not required.