### PR TITLE
TunableOp: Performance Improvement

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -266,6 +266,9 @@ endif()
 
 if(USE_CUDA)
   list(APPEND ATen_CUDA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/cuda)
+  # Next two lines are needed because TunableOp uses third-party/fmt
+  list(APPEND ATen_CUDA_INCLUDE $<TARGET_PROPERTY:fmt::fmt-header-only,INTERFACE_INCLUDE_DIRECTORIES>)
+  list(APPEND ATen_CUDA_DEPENDENCY_LIBS fmt::fmt-header-only)
   list(APPEND ATen_CUDA_CU_SRCS
     ${cuda_cu}
     ${native_cuda_cu}
@@ -309,6 +312,9 @@ if(USE_ROCM)
   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/hip)
   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/include)
   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/library/include)
+  # Next two lines are needed because TunableOp uses third-party/fmt
+  list(APPEND ATen_HIP_INCLUDE $<TARGET_PROPERTY:fmt::fmt-header-only,INTERFACE_INCLUDE_DIRECTORIES>)
+  list(APPEND ATen_HIP_DEPENDENCY_LIBS fmt::fmt-header-only)
   list(APPEND ATen_HIP_SRCS
     ${ATen_HIP_SRCS}
     ${hip_hip}

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -82,7 +82,14 @@ struct GemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    return c10::str(transa, transb, "_", m, "_", n, "_", k);
+    char buf[256];
+    int ret;
+
+    ret = snprintf(buf, 256, "%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
+
+    TORCH_CHECK(ret > 0 && ret < 256, "TunableOp: Signature formatting error occured. Return value = ", ret);
+
+    return std::string(buf);
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -22,7 +22,7 @@
 #include <ATen/ops/allclose.h>
 #include <ATen/ops/from_blob.h>
 #endif
-#include <cstdio>
+#include <fmt/printf.h>
 
 namespace at::cuda::tunable {
 
@@ -82,15 +82,7 @@ struct GemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    const int buf_len = 64;
-    char buf[buf_len];
-    int ret;
-
-    ret = snprintf(buf, buf_len, "%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
-
-    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
-
-    return std::string(buf, ret);
+    return fmt::sprintf("%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
   }
 
   size_t GetSizeA() const {
@@ -167,15 +159,7 @@ private:
 template <typename T>
 struct GemmAndBiasParams : OpParams {
   std::string Signature() const override {
-    const int buf_len = 64;
-    char buf[buf_len];
-    int ret;
-
-    ret = snprintf(buf, buf_len, "%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
-
-    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
-
-    return std::string(buf, ret);
+    return fmt::sprintf("%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -245,15 +229,7 @@ struct GemmStridedBatchedParams : OpParams {
   }
 
   std::string Signature() const override {
-    const int buf_len = 64;
-    char buf[buf_len];
-    int ret;
-
-    ret = snprintf(buf, buf_len, "%c%c_%ld_%ld_%ld_B_%ld", transa, transb, m, n, k, batch);
-
-    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
-
-    return std::string(buf, ret);
+    return fmt::sprintf("%c%c_%ld_%ld_%ld_B_%ld", transa, transb, m, n, k, batch);
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -82,12 +82,13 @@ struct GemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    char buf[256];
+    const int buf_len = 64;
+    char buf[buf_len];
     int ret;
 
-    ret = snprintf(buf, 256, "%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
+    ret = snprintf(buf, buf_len, "%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
 
-    TORCH_CHECK(ret > 0 && ret < 256, "TunableOp: Signature formatting error occured. Return value = ", ret);
+    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
 
     return std::string(buf);
   }

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -167,7 +167,15 @@ private:
 template <typename T>
 struct GemmAndBiasParams : OpParams {
   std::string Signature() const override {
-    return c10::str(transa, transb, "_", m, "_", n, "_", k);
+    const int buf_len = 64;
+    char buf[buf_len];
+    int ret;
+
+    ret = snprintf(buf, buf_len, "%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
+
+    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
+
+    return std::string(buf, ret);
   }
 
   size_t GetSize(bool duplicate_inputs) const {
@@ -237,7 +245,15 @@ struct GemmStridedBatchedParams : OpParams {
   }
 
   std::string Signature() const override {
-    return c10::str(transa, transb, "_", m, "_", n, "_", k, "_B_", batch);
+    const int buf_len = 64;
+    char buf[buf_len];
+    int ret;
+
+    ret = snprintf(buf, buf_len, "%c%c_%ld_%ld_%ld_B_%ld", transa, transb, m, n, k, batch);
+
+    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
+
+    return std::string(buf, ret);
   }
 
   size_t GetSizeA() const {
@@ -322,7 +338,15 @@ struct ScaledGemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    return c10::str(transa, transb, "_", m, "_", n, "_", k);
+    const int buf_len = 64;
+    char buf[buf_len];
+    int ret;
+
+    ret = snprintf(buf, buf_len, "%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
+
+    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
+
+    return std::string(buf, ret);
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -90,7 +90,7 @@ struct GemmParams : OpParams {
 
     TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
 
-    return std::string(buf);
+    return std::string(buf, ret);
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -30,15 +30,15 @@ enum class BlasOp {
   T = 1
 };
 
-inline std::string BlasOpToString(BlasOp op) {
+inline char BlasOpToString(BlasOp op) {
   switch (op) {
     case BlasOp::N:
-      return "N";
+      return 'N';
     case BlasOp::T:
-      return "T";
+      return 'T';
   }
   TORCH_CHECK(false, "unrecognized BlasOp");
-  return "N";
+  return 'N';
 }
 
 namespace detail {

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -22,6 +22,7 @@
 #include <ATen/ops/allclose.h>
 #include <ATen/ops/from_blob.h>
 #endif
+#include <cstdio>
 
 namespace at::cuda::tunable {
 

--- a/aten/src/ATen/cuda/tunable/GemmCommon.h
+++ b/aten/src/ATen/cuda/tunable/GemmCommon.h
@@ -314,15 +314,7 @@ struct ScaledGemmParams : OpParams {
   }
 
   std::string Signature() const override {
-    const int buf_len = 64;
-    char buf[buf_len];
-    int ret;
-
-    ret = snprintf(buf, buf_len, "%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
-
-    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
-
-    return std::string(buf, ret);
+    return fmt::sprintf("%c%c_%ld_%ld_%ld", transa, transb, m, n, k);
   }
 
   size_t GetSizeA() const {

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -574,13 +574,15 @@ auto GetHipBlasLtTypeStringAndOps() {
 
   int returned_algo_count = heuristic_result.size();
   std::vector<std::pair<std::string, std::unique_ptr<Callable<ParamsT>>>> ret;
+  const int buf_len = 32;
+  char buf[buf_len];
+  int val;
   for (int i = 0; i < returned_algo_count; i++) {
     auto algo = heuristic_result[i].algo;
     int algo_index = hipblaslt_ext::getIndexFromAlgo(algo);
     auto callable = std::make_unique<HipblasltGemmOp<AT, BT, CT, ALayout, BLayout, ParamsT>>(algo);
-    std::string type_string = c10::str(
-        "Gemm_Hipblaslt_", _charFromhipblasOp(transa_outer), _charFromhipblasOp(transb_outer), "_", algo_index);
-    ret.emplace_back(type_string, std::move(callable));
+    val = snprintf(buf, buf_len, "Gemm_Hipblaslt_%c%c_%d", _charFromhipblasOp(transa_outer), _charFromhipblasOp(transb_outer), algo_index);
+    ret.emplace_back(std::string(buf, val), std::move(callable));
   }
 
   return ret;

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -9,6 +9,7 @@
 #include <ATen/cuda/tunable/GemmCommon.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/util/StringUtil.h>
+#include <fmt/printf.h>
 
 #include <hipblaslt/hipblaslt.h>
 #include <hipblaslt/hipblaslt-ext.hpp>
@@ -574,15 +575,12 @@ auto GetHipBlasLtTypeStringAndOps() {
 
   int returned_algo_count = heuristic_result.size();
   std::vector<std::pair<std::string, std::unique_ptr<Callable<ParamsT>>>> ret;
-  const int buf_len = 32;
-  char buf[buf_len];
-  int val;
   for (int i = 0; i < returned_algo_count; i++) {
     auto algo = heuristic_result[i].algo;
     int algo_index = hipblaslt_ext::getIndexFromAlgo(algo);
     auto callable = std::make_unique<HipblasltGemmOp<AT, BT, CT, ALayout, BLayout, ParamsT>>(algo);
-    val = snprintf(buf, buf_len, "Gemm_Hipblaslt_%c%c_%d", _charFromhipblasOp(transa_outer), _charFromhipblasOp(transb_outer), algo_index);
-    ret.emplace_back(std::string(buf, val), std::move(callable));
+    std::string type_string = fmt::sprintf("Gemm_Hipblaslt_%c%c_%d", _charFromhipblasOp(transa_outer), _charFromhipblasOp(transb_outer), algo_index);
+    ret.emplace_back(type_string, std::move(callable));
   }
 
   return ret;

--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -196,9 +196,14 @@ auto GetRocBlasGemmTypeStringAndOps() {
   std::sort(solutions.begin(), solutions.end());
 
   std::vector<std::pair<std::string, std::unique_ptr<Callable<GemmParams<T>>>>> ret;
+  const int buf_len = 32;
+  char buf[buf_len];
+  int val;
   for (size_t i = 0; i < solutions.size(); ++i) {
     auto callable = std::make_unique<RocblasGemmOp<T>>(solutions[i]);
-    ret.emplace_back(std::make_pair(c10::str("Gemm_Rocblas_", solutions[i]), std::move(callable)));
+    val = snprintf(buf, buf_len, "Gemm_Rocblas_%d", solutions[i]);
+    TORCH_CHECK(val > 0 && val < buf_len, "TunableOp: Signature formatting error occured. Return value = ", val);
+    ret.emplace_back(std::make_pair(std::string(buf), std::move(callable)));
   }
   return ret;
 }

--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -7,7 +7,7 @@
 #include <ATen/cuda/tunable/TunableOp.h>
 #include <ATen/cuda/tunable/GemmCommon.h>
 #include <c10/util/StringUtil.h>
-#include <cstdio>
+#include <fmt/printf.h>
 
 #define ROCBLAS_BETA_FEATURES_API
 #include <rocblas/rocblas.h>
@@ -196,14 +196,9 @@ auto GetRocBlasGemmTypeStringAndOps() {
   std::sort(solutions.begin(), solutions.end());
 
   std::vector<std::pair<std::string, std::unique_ptr<Callable<GemmParams<T>>>>> ret;
-  const int buf_len = 32;
-  char buf[buf_len];
-  int val;
   for (size_t i = 0; i < solutions.size(); ++i) {
     auto callable = std::make_unique<RocblasGemmOp<T>>(solutions[i]);
-    val = snprintf(buf, buf_len, "Gemm_Rocblas_%d", solutions[i]);
-    TORCH_CHECK(val > 0 && val < buf_len, "TunableOp: Signature formatting error occured. Return value = ", val);
-    ret.emplace_back(std::make_pair(std::string(buf, val), std::move(callable)));
+    ret.emplace_back(std::make_pair(fmt::sprintf("Gemm_Rocblas_%d", solutions[i]), std::move(callable)));
   }
   return ret;
 }

--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -7,6 +7,7 @@
 #include <ATen/cuda/tunable/TunableOp.h>
 #include <ATen/cuda/tunable/GemmCommon.h>
 #include <c10/util/StringUtil.h>
+#include <cstdio>
 
 #define ROCBLAS_BETA_FEATURES_API
 #include <rocblas/rocblas.h>

--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -203,7 +203,7 @@ auto GetRocBlasGemmTypeStringAndOps() {
     auto callable = std::make_unique<RocblasGemmOp<T>>(solutions[i]);
     val = snprintf(buf, buf_len, "Gemm_Rocblas_%d", solutions[i]);
     TORCH_CHECK(val > 0 && val < buf_len, "TunableOp: Signature formatting error occured. Return value = ", val);
-    ret.emplace_back(std::make_pair(std::string(buf), std::move(callable)));
+    ret.emplace_back(std::make_pair(std::string(buf, val), std::move(callable)));
   }
   return ret;
 }

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -47,16 +47,17 @@ static OstreamPtr get_stream(std::string filename) {
 
 }
 
-static void TunableLog(int level, const std::string& msg) {
+template<class... Types>
+static void TunableLog(int level, Types... args) {
   static const char *env_file = getenv("PYTORCH_TUNABLEOP_VERBOSE_FILENAME");
   static const char *env_verbose = getenv("PYTORCH_TUNABLEOP_VERBOSE");
   static int level_user = env_verbose ? atoi(env_verbose) : 0;
   static auto streamptr = detail::get_stream(env_file ? env_file : "err");
   if (level_user >= level) {
-    (*streamptr) << msg <<std::endl;
+    (*streamptr) << c10::str(args...) << std::endl;
   }
 }
-#define TUNABLE_LOGV(LEVEL, ...) TunableLog(LEVEL, c10::str(__VA_ARGS__))
+#define TUNABLE_LOGV(LEVEL, ...) TunableLog(LEVEL, __VA_ARGS__)
 #define TUNABLE_LOG1(...) TUNABLE_LOGV(1, __VA_ARGS__)
 #define TUNABLE_LOG2(...) TUNABLE_LOGV(2, __VA_ARGS__)
 #define TUNABLE_LOG3(...) TUNABLE_LOGV(3, __VA_ARGS__)

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -222,7 +222,7 @@ class GemmTunableOp : public TunableOp<GemmParams<T>, StreamTimer> {
     char buf[256];
     int ret;
 
-    ret = snprintf(buf, 256, "GemmTunableOp_%s_%c_%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
+    ret = snprintf(buf, 256, "GemmTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
 
     TORCH_CHECK(ret > 0 && ret < 256, "TunableOp: Signature formatting error occured. Return value = ", ret);
 

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -219,7 +219,14 @@ class GemmTunableOp : public TunableOp<GemmParams<T>, StreamTimer> {
   }
 
   std::string Signature() override {
-    return c10::str("GemmTunableOp_", TypeName<T>(T{}), "_", BlasOpToString(ALayout), BlasOpToString(BLayout));
+    char buf[256];
+    int ret;
+
+    ret = snprintf(buf, 256, "GemmTunableOp_%s_%c_%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
+
+    TORCH_CHECK(ret > 0 && ret < 256, "TunableOp: Signature formatting error occured. Return value = ", ret);
+
+    return std::string(buf);
   }
 };
 

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -135,57 +135,57 @@ inline bool IsZero(c10::complex<float> v) {
 }
 
 template <typename T>
-inline std::string TypeName(T v) {
+inline const char* TypeName(T v) {
   return "unknown";
 }
 
 template <>
-inline std::string TypeName(float v) {
+inline const char* TypeName(float v) {
   return "float";
 }
 
 template <>
-inline std::string TypeName(double v) {
+inline const char* TypeName(double v) {
   return "double";
 }
 
 template <>
-inline std::string TypeName(BFloat16 v) {
+inline const char* TypeName(BFloat16 v) {
   return "BFloat16";
 }
 
 template <>
-inline std::string TypeName(Half v) {
+inline const char* TypeName(Half v) {
   return "Half";
 }
 
 template <>
-inline std::string TypeName(Float8_e4m3fn v) {
+inline const char* TypeName(Float8_e4m3fn v) {
   return "Float8_e4m3fn";
 }
 
 template <>
-inline std::string TypeName(Float8_e5m2 v) {
+inline const char* TypeName(Float8_e5m2 v) {
   return "Float8_e5m2";
 }
 
 template <>
-inline std::string TypeName(Float8_e4m3fnuz v) {
+inline const char* TypeName(Float8_e4m3fnuz v) {
   return "Float8_e4m3fnuz";
 }
 
 template <>
-inline std::string TypeName(Float8_e5m2fnuz v) {
+inline const char* TypeName(Float8_e5m2fnuz v) {
   return "Float8_e5m2fnuz";
 }
 
 template <>
-inline std::string TypeName(c10::complex<double> v) {
+inline const char* TypeName(c10::complex<double> v) {
   return "c10::complex<double>";
 }
 
 template <>
-inline std::string TypeName(c10::complex<float> v) {
+inline const char* TypeName(c10::complex<float> v) {
   return "c10::complex<float>";
 }
 

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -227,7 +227,7 @@ class GemmTunableOp : public TunableOp<GemmParams<T>, StreamTimer> {
 
     TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
 
-    return std::string(buf);
+    return std::string(buf, ret);
   }
 };
 

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -253,7 +253,15 @@ class GemmAndBiasTunableOp : public TunableOp<GemmAndBiasParams<T>, StreamTimer>
   }
 
   std::string Signature() override {
-    return c10::str("GemmAndBiasTunableOp_", TypeName<T>(T{}), "_", BlasOpToString(ALayout), BlasOpToString(BLayout));
+    const int buf_len = 64;
+    char buf[buf_len];
+    int ret;
+
+    ret = snprintf(buf, buf_len, "GemmAndBiasTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
+
+    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
+
+    return std::string(buf, ret);
   }
 };
 
@@ -286,7 +294,15 @@ class GemmStridedBatchedTunableOp : public TunableOp<GemmStridedBatchedParams<T>
   }
 
   std::string Signature() override {
-    return c10::str("GemmStridedBatchedTunableOp_", TypeName<T>(T{}), "_", BlasOpToString(ALayout), BlasOpToString(BLayout));
+    const int buf_len = 64;
+    char buf[buf_len];
+    int ret;
+
+    ret = snprintf(buf, buf_len, "GemmStridedBatchedTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
+
+    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
+
+    return std::string(buf, ret);
   }
 };
 
@@ -304,11 +320,19 @@ class ScaledGemmTunableOp : public TunableOp<ScaledGemmParams<CT>, StreamTimer> 
   }
 
   std::string Signature() override {
-    return c10::str("ScaledGemmTunableOp",
-            "_", TypeName<AT>(AT{}),
-            "_", TypeName<BT>(BT{}),
-            "_", TypeName<CT>(CT{}),
-            "_", BlasOpToString(ALayout), BlasOpToString(BLayout));
+    const int buf_len = 128;
+    char buf[buf_len];
+    int ret;
+
+    ret = snprintf(buf, buf_len, "ScaledGemmTunableOp_%s_%s_%s_%c%c",
+            TypeName<AT>(AT{}),
+            TypeName<BT>(BT{}),
+            TypeName<CT>(CT{}),
+            BlasOpToString(ALayout), BlasOpToString(BLayout));
+
+    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
+
+    return std::string(buf, ret);
   }
 };
 

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -22,7 +22,7 @@
 #include <c10/util/Float8_e5m2.h>
 #include <c10/util/Float8_e5m2fnuz.h>
 #include <c10/util/StringUtil.h>
-#include <cstdio>
+#include <fmt/printf.h>
 
 namespace at::cuda::tunable {
 
@@ -219,15 +219,7 @@ class GemmTunableOp : public TunableOp<GemmParams<T>, StreamTimer> {
   }
 
   std::string Signature() override {
-    const int buf_len = 64;
-    char buf[buf_len];
-    int ret;
-
-    ret = snprintf(buf, buf_len, "GemmTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
-
-    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
-
-    return std::string(buf, ret);
+    return fmt::sprintf("GemmTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
   }
 };
 
@@ -253,15 +245,7 @@ class GemmAndBiasTunableOp : public TunableOp<GemmAndBiasParams<T>, StreamTimer>
   }
 
   std::string Signature() override {
-    const int buf_len = 64;
-    char buf[buf_len];
-    int ret;
-
-    ret = snprintf(buf, buf_len, "GemmAndBiasTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
-
-    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
-
-    return std::string(buf, ret);
+    return fmt::sprintf("GemmAndBiasTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
   }
 };
 
@@ -294,15 +278,7 @@ class GemmStridedBatchedTunableOp : public TunableOp<GemmStridedBatchedParams<T>
   }
 
   std::string Signature() override {
-    const int buf_len = 64;
-    char buf[buf_len];
-    int ret;
-
-    ret = snprintf(buf, buf_len, "GemmStridedBatchedTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
-
-    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
-
-    return std::string(buf, ret);
+    return fmt::sprintf("GemmStridedBatchedTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
   }
 };
 
@@ -320,19 +296,11 @@ class ScaledGemmTunableOp : public TunableOp<ScaledGemmParams<CT>, StreamTimer> 
   }
 
   std::string Signature() override {
-    const int buf_len = 128;
-    char buf[buf_len];
-    int ret;
-
-    ret = snprintf(buf, buf_len, "ScaledGemmTunableOp_%s_%s_%s_%c%c",
-            TypeName<AT>(AT{}),
-            TypeName<BT>(BT{}),
-            TypeName<CT>(CT{}),
-            BlasOpToString(ALayout), BlasOpToString(BLayout));
-
-    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
-
-    return std::string(buf, ret);
+    return fmt::sprintf("ScaledGemmTunableOp_%s_%s_%s_%c%c",
+      TypeName<AT>(AT{}),
+      TypeName<BT>(BT{}),
+      TypeName<CT>(CT{}),
+      BlasOpToString(ALayout), BlasOpToString(BLayout));
   }
 };
 

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -219,12 +219,13 @@ class GemmTunableOp : public TunableOp<GemmParams<T>, StreamTimer> {
   }
 
   std::string Signature() override {
-    char buf[256];
+    const int buf_len = 64;
+    char buf[buf_len];
     int ret;
 
-    ret = snprintf(buf, 256, "GemmTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
+    ret = snprintf(buf, buf_len, "GemmTunableOp_%s_%c%c", TypeName<T>(T{}), BlasOpToString(ALayout), BlasOpToString(BLayout));
 
-    TORCH_CHECK(ret > 0 && ret < 256, "TunableOp: Signature formatting error occured. Return value = ", ret);
+    TORCH_CHECK(ret > 0 && ret < buf_len, "TunableOp: Signature formatting error occured. Return value = ", ret);
 
     return std::string(buf);
   }

--- a/aten/src/ATen/cuda/tunable/TunableGemm.h
+++ b/aten/src/ATen/cuda/tunable/TunableGemm.h
@@ -22,6 +22,7 @@
 #include <c10/util/Float8_e5m2.h>
 #include <c10/util/Float8_e5m2fnuz.h>
 #include <c10/util/StringUtil.h>
+#include <cstdio>
 
 namespace at::cuda::tunable {
 


### PR DESCRIPTION
This PR reduces the overhead on the CPU side by eliminating the use of c10::str in creating signatures. Instead we use fmt library. TunableOp overhead on the CPU are reduced by around ~40%. The improvement is most noticeable on small GEMMs. This PR does not contain any bug fixes or new features.
