### PR TITLE
[ONNX] Handle mixed sequence inputs properly

### DIFF
--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import copy
 import inspect
 import logging
-from typing import Any, Mapping, Sequence, TYPE_CHECKING, Union
+from typing import Any, Iterable, Mapping, Sequence, TYPE_CHECKING, Union
 
 import onnxscript
 from onnxscript import evaluator, ir
@@ -29,12 +29,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# TODO(justinchuby): Update ValidAttributeType to ir_convenience.SupportedAttrTypes
 ValidAttributeType = Union[
     ir.TensorProtocol, int, float, bool, str, Sequence[int], Sequence[float], None
 ]
 
-AllowedArgType = Union[ir.Value, Sequence[ir.Value], ValidAttributeType]
+AllowedArgType = Union[
+    ir.Value, Sequence[ir.Value | ValidAttributeType], ValidAttributeType
+]
 
 
 # Logic for adapting inputs from general Python or PyTorch inputs to ONNX ir.Value
@@ -181,13 +182,103 @@ def _resolve_parameter_dtypes(
     return type_binding
 
 
-def _process_python_constants_and_sequences(
+def _determine_input_dtype(
+    param: _schemas.Parameter,
+    arg: AllowedArgType,
+    type_binding: Mapping[_schemas.TypeConstraintParam, ir.TypeProtocol],
+) -> ir.DataType:
+    """Determine the dtype of the input that is a mix of Python constants and ir.Value."""
+    if param.type_constraint in type_binding:
+        # A known dtype is available because it was resolved
+        return type_binding[param.type_constraint].dtype
+    if len(param.type_constraint.allowed_types) == 1:
+        # Only one type is allowed by the type constraint
+        return next(iter(param.type_constraint.allowed_types)).dtype
+
+    # No dtype information available. Infer from the Python constant or (in the Sequence case)
+    # from a mix of Python constants and ir.Value
+    if isinstance(arg, bool):
+        return ir.DataType.BOOL
+    if isinstance(arg, float):
+        return ir.DataType.FLOAT
+    if isinstance(arg, int):
+        return ir.DataType.INT64
+    if isinstance(arg, str):
+        return ir.DataType.STRING
+    if isinstance(arg, (ir.Tensor, ir.TensorProtocol)):
+        return arg.dtype
+    if arg is None:
+        return ir.DataType.UNDEFINED
+
+    # Handle sequences
+    if isinstance(arg, (tuple, list)):
+        if len(arg) == 0:
+            # Special case: Treat empty sequence as INT64 as they are typically used for shape
+            return ir.DataType.INT64
+
+        # Try to obtain the dtype from one of the values
+        for val in arg:
+            if isinstance(val, ir.Value) and val.dtype is not None:
+                return val.dtype
+
+        if any(isinstance(val, float) for val in arg):
+            # If any float is present, the dtype is float
+            return ir.DataType.FLOAT
+        elif any(isinstance(val, int) for val in arg):
+            # Otherwise if any int is present, the dtype is int
+            return ir.DataType.INT64
+
+    raise ValueError(
+        f"Could not determine the dtype for the input '{param.name}'. "
+        f"param={param}, arg={arg}, param_type_constraint={param.type_constraint}, "
+        f"type_binding={type_binding}"
+    )
+
+
+def _allowed_types_are_sequence_types(allowed_types: Iterable[ir.TypeProtocol]) -> bool:
+    """Check if all allowed types are Sequence types."""
+    return all(isinstance(t, ir.SequenceType) for t in allowed_types)
+
+
+def _get_or_create_constant(
+    constant_farm: dict[
+        tuple[
+            bool | int | float | str | tuple[int] | tuple[float],
+            ir.DataType,
+        ],
+        ir.Value,
+    ],
+    arg: bool
+    | int
+    | float
+    | str
+    | tuple[int]
+    | tuple[float]
+    | tuple[bool]
+    | list[int]
+    | list[float]
+    | list[bool],
+    dtype: ir.DataType,
+    opset: onnxscript.values.Opset,
+) -> ir.Value:
+    if isinstance(arg, (tuple, list)):
+        # Make the arg hashable
+        arg = tuple(arg)
+    constant_value = constant_farm.get((arg, dtype))  # type: ignore[arg-type]
+    if constant_value is None:
+        constant_tensor = ir.tensor(value=arg, dtype=dtype)  # type: ignore[arg-type]
+        constant_value = opset.Constant(value=constant_tensor)
+        constant_farm[(arg, dtype)] = constant_value  # type: ignore[arg-type,index]
+    return constant_value
+
+
+def _process_python_constants(
     signature: _schemas.OpSignature,
     named_inputs: dict[str, AllowedArgType],
     type_binding: Mapping[_schemas.TypeConstraintParam, ir.TypeProtocol],
     constant_farm: dict[
         tuple[
-            bool | int | float | str | ir.TensorProtocol | tuple[int] | tuple[float],
+            bool | int | float | str | tuple[int] | tuple[float],
             ir.DataType,
         ],
         ir.Value,
@@ -206,7 +297,7 @@ def _process_python_constants_and_sequences(
         opset: The Opset to use for creating Constant nodes.
 
     Returns:
-        None
+        A mapping of parameter names to Python constants converted to constant Nodes.
     """
     # 3. Convert Python constants to Constant nodes based on the dtype information;
     #    construct sequences
@@ -225,78 +316,126 @@ def _process_python_constants_and_sequences(
         if isinstance(arg, ir.Value):
             # TODO(justinchuby): Cast the ir.Value here if needed
             continue
+
         if (
             isinstance(arg, Sequence)
             and len(arg) > 0
-            and all(isinstance(val, ir.Value) for val in arg)
+            and any(isinstance(val, ir.Value) for val in arg)
         ):
             # Skip the sequence of ir.Value. This is a variadic input or a Sequence input
-            # NOTE: Variadic operators like Max can be called with mixed ir.Value and Python constants
-            # like `Max(0, ir.Value())`
-            # We need to convert the Python constants to Constant nodes
-            # NOTE: Important to check that arg is not empty because we need to treat it as list[int] or list[float]
+            # It will be handled by _process_python_sequences
             continue
-            # if param.variadic:
-            #     # FXIME: Handle variadic inputs and sequence inputs differently
-            #     raise NotImplementedError
-            # TODO: Find a way to recursively build constants. Maybe extract the logic out.
-            # FIXME: I am here
+        if param.variadic:
+            # Handled by _process_python_sequences
+            continue
+        if _allowed_types_are_sequence_types(param.type_constraint.allowed_types):
+            # Handled by _process_python_sequences
+            continue
 
+        dtype = _determine_input_dtype(param, arg, type_binding)
+
+        if arg is None:
+            constant_value = None
+        elif isinstance(arg, (ir.Tensor, ir.TensorProtocol)):
+            constant_value = opset.Constant(value=arg)
+        else:
+            # Deduplicate the constants
+            constant_value = _get_or_create_constant(constant_farm, arg, dtype, opset)
+
+        named_inputs[param.name] = constant_value
+    return named_inputs  # type: ignore[return-value]
+
+
+def _process_python_sequences(
+    signature: _schemas.OpSignature,
+    named_inputs: dict[str, AllowedArgType],
+    type_binding: Mapping[_schemas.TypeConstraintParam, ir.TypeProtocol],
+    constant_farm: dict[
+        tuple[
+            bool | int | float | str | ir.TensorProtocol | tuple[int] | tuple[float],
+            ir.DataType,
+        ],
+        ir.Value,
+    ],
+    opset: onnxscript.values.Opset,
+):
+    """Handle three types of sequences.
+
+    1. Variadic inputs
+    2. Sequence input of ir.Value,
+    3. Sequence of Python constants that contains ir.Value
+    """
+    for name, arg in named_inputs.items():
+        param = signature.params_map[name]
         assert isinstance(
             param, _schemas.Parameter
         ), f"Expected Parameter, got {type(param)}"
 
-        if param.type_constraint in type_binding:
-            # A known dtype is available
-            dtype = type_binding[param.type_constraint].dtype
-        elif len(param.type_constraint.allowed_types) == 1:
-            # Only one type is allowed
-            dtype = next(iter(param.type_constraint.allowed_types)).dtype
-        else:
-            # No dtype information available. Infer from the Python constant
-            if isinstance(arg, bool):
-                dtype = ir.DataType.BOOL
-            elif isinstance(arg, float):
-                dtype = ir.DataType.FLOAT
-            elif isinstance(arg, int):
-                dtype = ir.DataType.INT64
-            elif isinstance(arg, str):
-                dtype = ir.DataType.STRING
-            elif isinstance(arg, (tuple, list)) and all(
-                isinstance(val, int) for val in arg
-            ):
-                dtype = ir.DataType.INT64
-            elif isinstance(arg, (tuple, list)) and any(
-                isinstance(val, float) for val in arg
-            ):
-                # NOTE: if any float is present, the dtype is float
-                dtype = ir.DataType.FLOAT
-            elif isinstance(arg, (ir.Tensor, ir.TensorProtocol)):
-                dtype = arg.dtype
-            elif arg is None:
-                dtype = ir.DataType.UNDEFINED
-            else:
-                raise TypeError(
-                    f"Constant input '{arg}' of type '{type(arg)}' is not supported"
-                )
+        if not isinstance(arg, (tuple, list)):
+            continue
 
-        if arg is None:
-            constant_value = None
-        elif not isinstance(arg, (ir.Tensor, ir.TensorProtocol)):
-            # Deduplicate the constants
-            if isinstance(arg, (tuple, list)):
-                # Make the arg hashable
-                arg = tuple(arg)  # noqa: PLW2901
-            constant_value = constant_farm.get((arg, dtype))  # type: ignore[arg-type]
-            if constant_value is None:
-                constant_tensor = ir.tensor(value=arg, dtype=dtype)  # type: ignore[arg-type]
-                constant_value = opset.Constant(value=constant_tensor)
-                constant_farm[(arg, dtype)] = constant_value  # type: ignore[arg-type,index]
-        else:
-            constant_value = opset.Constant(value=arg)
+        if len(arg) == 0:
+            # Skip empty sequences
+            continue
 
-        named_inputs[param.name] = constant_value
-    return named_inputs  # type: ignore[return-value]
+        # 1. Sequence input of ir.Value
+        if _allowed_types_are_sequence_types(param.type_constraint.allowed_types):
+            # Turn the list into a Sequence node
+            # Constant op creation will be handled by the variadic case below when calling
+            # the SequenceConstruct op.
+            named_inputs[name] = opset.SequenceConstruct(*arg)
+            continue
+
+        # 2. Variadic inputs
+        # NOTE: Variadic operators like Max can be called with mixed ir.Value and Python constants
+        # like `Max(0, ir.Value())`
+        # We need to convert the Python constants to Constant nodes
+        if param.variadic:
+            if all(isinstance(val, ir.Value) for val in arg):
+                # Skip the variadic input if all values are ir.Value
+                continue
+
+            dtype = _determine_input_dtype(param, arg, type_binding)
+            new_args = []
+            for val in arg:
+                if isinstance(val, ir.Value):
+                    new_args.append(val)
+                else:
+                    constant_tensor = ir.tensor(value=val, dtype=dtype)  # type: ignore[arg-type]
+                    constant_value = opset.Constant(value=constant_tensor)
+                    new_args.append(constant_value)
+            named_inputs[name] = new_args
+            continue
+        else:
+            # 3. Concat the list as a single input
+            # E.g. [Value, 42] should be converted to op.Concat(Value, Constant(42))
+            # when the expected input type is INT64
+            # We assume this only happens for 1D cases
+            if all(isinstance(val, ir.Value) for val in arg):
+                named_inputs[name] = opset.Concat(*arg)
+                continue
+
+            dtype = _determine_input_dtype(param, arg, type_binding)
+            new_args = []
+            for val in arg:
+                if isinstance(val, ir.Value):
+                    new_args.append(val)
+                elif val is None:
+                    # Skip None values
+                    continue
+                elif isinstance(arg, (ir.Tensor, ir.TensorProtocol)):
+                    new_args.append(opset.Constant(value=val))
+                else:
+                    # Turn the Python constant into 1D tensor for the constant
+                    assert isinstance(
+                        val, (bool, int, float)
+                    ), f"Expected int or float, got {type(val)}"
+                    new_args.append(
+                        _get_or_create_constant(constant_farm, [arg], dtype, opset)
+                    )
+            named_inputs[name] = opset.Concat(*new_args)
+            continue
+    return named_inputs
 
 
 def _construct_node(
@@ -368,9 +507,17 @@ class OpRecorder(evaluator.Evaluator):
         """
         type_binding = _resolve_parameter_dtypes(op_signature, named_inputs)
         try:
-            converted_named_inputs = _process_python_constants_and_sequences(
+            converted_named_inputs = _process_python_constants(
                 op_signature, named_inputs, type_binding, self.constant_farm, self.opset
             )
+            converted_named_inputs = _process_python_sequences(
+                op_signature,
+                converted_named_inputs,
+                type_binding,
+                self.constant_farm,
+                self.opset,
+            )
+
         except Exception as e:
             raise errors.GraphConstructionError(
                 f"Error processing Python constants for operator '{op_signature.domain}::{op_signature.name}'. "
@@ -418,10 +565,10 @@ class OpRecorder(evaluator.Evaluator):
                     # dtypes are available
                     if src_input.dtype == target_type.dtype:
                         # Same type. No cast needed
-                        return src_input  # type: ignore[return-value]
+                        return src_input  # type: ignore[union-attr,return-value]
                     else:
                         # Create a Cast node
-                        return self.opset.Cast(src_input, to=target_type.dtype)  # type: ignore[union-attr,return-value]
+                        return self.opset.Cast(src_input, to=target_type.dtype)  # type: ignore[return-value]
 
             outputs = self._call_op(op_signature, named_inputs, named_attrs)
             if len(outputs) == 1:

--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -34,7 +34,7 @@ ValidAttributeType = Union[
 ]
 
 AllowedArgType = Union[
-    ir.Value, Sequence[ir.Value | ValidAttributeType], ValidAttributeType
+    ir.Value, Sequence[Union[ir.Value, ValidAttributeType]], ValidAttributeType
 ]
 
 

--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -261,9 +261,9 @@ def _get_or_create_constant(
     dtype: ir.DataType,
     opset: onnxscript.values.Opset,
 ) -> ir.Value:
-    if isinstance(arg, (tuple, list)):
+    if isinstance(arg, list):
         # Make the arg hashable
-        arg = tuple(arg)
+        arg = tuple(arg)  # type: ignore[assignment]
     constant_value = constant_farm.get((arg, dtype))  # type: ignore[arg-type]
     if constant_value is None:
         constant_tensor = ir.tensor(value=arg, dtype=dtype)  # type: ignore[arg-type]
@@ -340,7 +340,7 @@ def _process_python_constants(
             constant_value = opset.Constant(value=arg)
         else:
             # Deduplicate the constants
-            constant_value = _get_or_create_constant(constant_farm, arg, dtype, opset)
+            constant_value = _get_or_create_constant(constant_farm, arg, dtype, opset)  # type: ignore[arg-type]
 
         named_inputs[param.name] = constant_value
     return named_inputs  # type: ignore[return-value]
@@ -431,7 +431,7 @@ def _process_python_sequences(
                         val, (bool, int, float)
                     ), f"Expected int or float, got {type(val)}"
                     new_args.append(
-                        _get_or_create_constant(constant_farm, [arg], dtype, opset)
+                        _get_or_create_constant(constant_farm, [arg], dtype, opset)  # type: ignore[arg-type]
                     )
             named_inputs[name] = opset.Concat(*new_args)
             continue
@@ -512,7 +512,7 @@ class OpRecorder(evaluator.Evaluator):
             )
             converted_named_inputs = _process_python_sequences(
                 op_signature,
-                converted_named_inputs,
+                converted_named_inputs,  # type: ignore[arg-type]
                 type_binding,
                 self.constant_farm,
                 self.opset,

--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -565,10 +565,10 @@ class OpRecorder(evaluator.Evaluator):
                     # dtypes are available
                     if src_input.dtype == target_type.dtype:
                         # Same type. No cast needed
-                        return src_input  # type: ignore[union-attr,return-value]
+                        return src_input  # type: ignore[return-value]
                     else:
                         # Create a Cast node
-                        return self.opset.Cast(src_input, to=target_type.dtype)  # type: ignore[return-value]
+                        return self.opset.Cast(src_input, to=target_type.dtype)  # type: ignore[union-attr,return-value]
 
             outputs = self._call_op(op_signature, named_inputs, named_attrs)
             if len(outputs) == 1:


### PR DESCRIPTION
Previously, when an input contains a mixture of `Value` and python constants like `[SymbolicTensor('sym_size_int_3', type=Tensor(INT64), shape=[], producer=node_Shape_0, index=0), 512]`, we get errors like

```pytb
Traceback (most recent call last):
  File "/Users/justinc/Documents/GitHub/torch-onnx/src/torch_onnx/_building.py", line 367, in _call_op
    converted_named_inputs = _process_python_constants_and_sequences(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/justinc/Documents/GitHub/torch-onnx/src/torch_onnx/_building.py", line 275, in _process_python_constants_and_sequences
    raise TypeError(
TypeError: Constant input '[SymbolicTensor('sym_size_int_3', type=Tensor(INT64), shape=[], producer=node_Shape_0, index=0), 512]' of type '<class 'list'>' is not supported
```

This PR updates Sequence handling to support this case, as well as variadic inputs and ONNX Sequence inputs.

Synced from https://github.com/justinchuby/torch-onnx/pull/187