### PR TITLE
[FlexAttention] Skip very small block size unit tests on H100 due to Triton bug

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -6,7 +6,7 @@ import string
 from collections import namedtuple
 from contextlib import nullcontext
 from typing import Callable, Optional
-from unittest import expectedFailure, skip, skipUnless
+from unittest import expectedFailure, skip, skipIf, skipUnless
 from unittest.mock import patch
 
 import torch
@@ -526,6 +526,7 @@ class TestFlexAttention(InductorTestCase):
     def test_builtin_score_mods(self, dtype: torch.dtype, score_mod: Callable):
         self.run_test(score_mod, dtype)
 
+    @skipIf(torch.cuda.get_device_capability() >= (9, 0), "H100 Triton bug")
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.parametrize("score_mod", test_score_mods)
@@ -540,6 +541,7 @@ class TestFlexAttention(InductorTestCase):
         )
         self.run_test_with_call(attention, dtype, B, H, 64, D, B, H, 64, D)
 
+    @skipIf(torch.cuda.get_device_capability() >= (9, 0), "H100 Triton bug")
     @supported_platform
     @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.parametrize("score_mod", test_score_mods)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -526,8 +526,8 @@ class TestFlexAttention(InductorTestCase):
     def test_builtin_score_mods(self, dtype: torch.dtype, score_mod: Callable):
         self.run_test(score_mod, dtype)
 
-    @skipIf(torch.cuda.get_device_capability() >= (9, 0), "H100 Triton bug")
     @supported_platform
+    @skipIf(torch.cuda.get_device_capability() >= (9, 0), "H100 Triton bug")
     @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.parametrize("score_mod", test_score_mods)
     def test_builtin_score_mods_seqlen_lt_default_sparse_block_size(
@@ -541,8 +541,8 @@ class TestFlexAttention(InductorTestCase):
         )
         self.run_test_with_call(attention, dtype, B, H, 64, D, B, H, 64, D)
 
-    @skipIf(torch.cuda.get_device_capability() >= (9, 0), "H100 Triton bug")
     @supported_platform
+    @skipIf(torch.cuda.get_device_capability() >= (9, 0), "H100 Triton bug")
     @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.parametrize("score_mod", test_score_mods)
     def test_builtin_score_mods_seqlen_lt_custom_sparse_block_size(

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -6,7 +6,7 @@ import string
 from collections import namedtuple
 from contextlib import nullcontext
 from typing import Callable, Optional
-from unittest import expectedFailure, skip, skipIf, skipUnless
+from unittest import expectedFailure, skip, skipUnless
 from unittest.mock import patch
 
 import torch
@@ -39,6 +39,15 @@ supported_platform = skipUnless(
     and has_triton()
     and torch.cuda.get_device_capability() >= (8, 0),
     "Requires CUDA and Triton",
+)
+
+# Use this decorator only when hitting Triton bugs on H100
+running_on_a100_only = skipUnless(
+    torch.cuda.is_available()
+    and torch.version.hip is None
+    and has_triton()
+    and torch.cuda.get_device_capability() == (8, 0),
+    "Requires A100 and Triton",
 )
 
 Tolerances = namedtuple("Tolerances", ["atol", "rtol"])
@@ -526,8 +535,7 @@ class TestFlexAttention(InductorTestCase):
     def test_builtin_score_mods(self, dtype: torch.dtype, score_mod: Callable):
         self.run_test(score_mod, dtype)
 
-    @supported_platform
-    @skipIf(torch.cuda.get_device_capability() >= (9, 0), "H100 Triton bug")
+    @running_on_a100_only
     @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.parametrize("score_mod", test_score_mods)
     def test_builtin_score_mods_seqlen_lt_default_sparse_block_size(
@@ -541,8 +549,7 @@ class TestFlexAttention(InductorTestCase):
         )
         self.run_test_with_call(attention, dtype, B, H, 64, D, B, H, 64, D)
 
-    @supported_platform
-    @skipIf(torch.cuda.get_device_capability() >= (9, 0), "H100 Triton bug")
+    @running_on_a100_only
     @common_utils.parametrize("dtype", test_dtypes_fast)
     @common_utils.parametrize("score_mod", test_score_mods)
     def test_builtin_score_mods_seqlen_lt_custom_sparse_block_size(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135393



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang