### PR TITLE
[ONNX] Support FakeTensor in ONNXProgram

### DIFF
--- a/test/onnx/pytorch_test_common.py
+++ b/test/onnx/pytorch_test_common.py
@@ -346,28 +346,6 @@ def skipDtypeChecking(func):
     return wrapper
 
 
-def skip_if_fake_model_and_inititalizer(reason: Optional[str] = None):
-    """skip test with models using ExportedProgram as input.
-
-    Args:
-        reason: The reason for skip the ONNX export test.
-
-    Returns:
-        A decorator for skip tests.
-    """
-
-    def skip_dec(func):
-        @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
-            if kwargs["use_fake_mode"] and kwargs["include_initializer"]:
-                return unittest.SkipTest(reason)
-            return func(self, *args, **kwargs)
-
-        return wrapper
-
-    return skip_dec
-
-
 def xfail_if_model_type_is_exportedprogram(
     error_message: str, reason: Optional[str] = None
 ):

--- a/test/onnx/test_fx_to_onnx.py
+++ b/test/onnx/test_fx_to_onnx.py
@@ -664,7 +664,6 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
             onnx_program.save(tmp_onnx_file.name)
             onnx.checker.check_model(tmp_onnx_file.name, full_check=True)
 
-    @pytorch_test_common.skip_if_fake_model_and_inititalizer("segfault")
     @common_utils.parametrize(
         "include_initializer",
         [
@@ -746,6 +745,7 @@ class TestFxToOnnx(pytorch_test_common.ExportTestCase):
         onnx_program = torch.onnx.dynamo_export(
             model, tensor_x, export_options=export_options
         )
+        onnx_program.apply_weights(state_dict)
         with tempfile.NamedTemporaryFile(suffix=".onnx") as tmp_onnx_file:
             onnx_program.save(
                 tmp_onnx_file.name,

--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -509,6 +509,7 @@ class ONNXProgram:
         self._diagnostic_context = diagnostic_context
         self._fake_context = fake_context
         self._export_exception = export_exception
+        self._state_dict = {}
 
     def __call__(
         self,
@@ -549,7 +550,7 @@ class ONNXProgram:
                 if isinstance(model_with_state_dict, torch.nn.Module):
                     model_state = model_with_state_dict.state_dict()
                 else:
-                    model_state = None
+                    model_state = self._state_dict
                 self.save(
                     onnx_model,
                     model_state=model_state,
@@ -723,6 +724,13 @@ class ONNXProgram:
         ), "model_with_state_dict must be specified."
         return self._output_adapter.apply(model_outputs, model=model_with_state_dict)  # type: ignore[return-value]
 
+    def apply_weights(self, state_dict: dict[str, torch.Tensor]) -> None:
+        """Apply the weights from the specified state dict to the ONNX model.
+        Args:
+            state_dict: The state dict containing the weights to apply to the ONNX model.
+        """
+        self._state_dict = state_dict
+
     def save(
         self,
         destination: str | io.BufferedIOBase,
@@ -750,6 +758,9 @@ class ONNXProgram:
         assert (
             include_initializers is True or model_state is None
         ), "Cannot specify both `include_initializers=False` and `model_state`."
+
+        if self._state_dict and model_state is None:
+            model_state = self._state_dict
 
         # Add initializers when symbolic tracing is enabled
         _model_state_files: list[str | io.BytesIO | dict[str, Any]] = []

--- a/torch/onnx/_internal/_exporter_legacy.py
+++ b/torch/onnx/_internal/_exporter_legacy.py
@@ -509,7 +509,7 @@ class ONNXProgram:
         self._diagnostic_context = diagnostic_context
         self._fake_context = fake_context
         self._export_exception = export_exception
-        self._state_dict = {}
+        self._state_dict: dict[str, torch.Tensor] = {}
 
     def __call__(
         self,

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -117,6 +117,14 @@ class TorchTensor(ir.Tensor):
         # Implement tobytes to support native PyTorch types so we can use types like bloat16
         # Reading from memory directly is also more efficient because
         # it avoids copying to a NumPy array
+        import torch._subclasses.fake_tensor
+
+        if isinstance(self.raw, torch._subclasses.fake_tensor.FakeTensor):
+            raise TypeError(
+                f"Cannot take content out from the FakeTensor ('{self.name}'). Please replace the tensor "
+                "with a tensor backed by real data using ONNXProgram.apply_weights() "
+                "or save the model without initializers by setting include_initializers=False."
+            )
         tensor = self.raw.detach().cpu().contiguous()
         return bytes(
             (ctypes.c_ubyte * tensor.element_size() * tensor.numel()).from_address(

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -16,8 +16,6 @@ from typing import Any, Callable, Literal, Sequence
 
 import onnxscript
 import onnxscript.evaluator
-import onnxscript.function_libs
-import onnxscript.function_libs.torch_lib
 from onnxscript import ir
 from onnxscript.ir import convenience as ir_convenience
 

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -11,12 +11,16 @@ import logging
 import os
 import tempfile
 import textwrap
+import warnings
 from typing import Callable, Sequence, TYPE_CHECKING
 
 import torch
 from torch.onnx._internal._lazy_import import onnx, onnxscript_apis, onnxscript_ir as ir
 from torch.utils import _pytree
 
+
+# NOTE: DO NOT import module from torch.onnx._internal to this module in the global scope
+# because ONNXProgram is exposed to the public API
 
 if TYPE_CHECKING:
     import onnxruntime as ort
@@ -124,6 +128,22 @@ ONNXProgram(
         When `external_data` is `True` or the model is larger than 2GB,
         the weights are saved as external data in a separate file.
 
+        Initializer (model weights) serialization behaviors:
+        - include_initializers=True, keep_initializers_as_inputs=False (default):
+            The initializers are included in the saved model.
+        - include_initializers=True, keep_initializers_as_inputs=True:
+            The initializers are included in the saved model and kept as model inputs.
+            Choose this option if you want the ability to override the model weights
+            during inference.
+        - include_initializers=False, keep_initializers_as_inputs=False:
+            The initializers are not included in the saved model and are not listed
+            as model inputs. Choose this option if you want to attach the initializers
+            to the ONNX model in a separate, post-processing, step.
+        - include_initializers=False, keep_initializers_as_inputs=True:
+            The initializers are not included in the saved model but are listed as model
+            inputs. Choose this option if you want to supply the initializers during
+            inference and want to minimize the size of the saved model.
+
         Args:
             destination: The path to save the ONNX model to.
             include_initializers: Whether to include the initializers in the saved model.
@@ -142,7 +162,7 @@ ONNXProgram(
         if not include_initializers:
             self.model.graph.initializers.clear()
         if keep_initializers_as_inputs:
-            self.model.graph.inputs.extend(self.model.graph.initializers.values())  # type: ignore[arg-type]
+            self.model.graph.inputs.extend(original_initializers.values())  # type: ignore[arg-type]
 
         # Save the model to disk
         if (
@@ -159,6 +179,24 @@ ONNXProgram(
         if keep_initializers_as_inputs:
             self.model.graph.inputs.clear()
             self.model.graph.inputs.extend(original_inputs)
+
+    def apply_weights(self, state_dict: dict[str, torch.Tensor]) -> None:
+        """Apply the weights from the specified state dict to the ONNX model.
+        Args:
+            state_dict: The state dict containing the weights to apply to the ONNX model.
+        """
+        from torch.onnx._internal.exporter import _core
+
+        for name, tensor in state_dict.items():
+            if name in self.model.graph.initializers:
+                self.model.graph.initializers[name].const_value = _core.TorchTensor(
+                    tensor, name
+                )
+            else:
+                warnings.warn(
+                    f"Weight '{name}' not found in the model. Skipped applying.",
+                    stacklevel=1,
+                )
 
     def initialize_inference_session(
         self,

--- a/torch/onnx/_internal/exporter/_onnx_program.py
+++ b/torch/onnx/_internal/exporter/_onnx_program.py
@@ -195,6 +195,7 @@ ONNXProgram(
             else:
                 warnings.warn(
                     f"Weight '{name}' not found in the model. Skipped applying.",
+                    category=torch.onnx.errors.OnnxExporterWarning,
                     stacklevel=1,
                 )
 


### PR DESCRIPTION
Sync with https://github.com/justinchuby/torch-onnx/compare/v0.1.20...v0.1.21 to support FakeTensors in ONNXProgram. Specifically, this PR implements the `apply_weights` method to allow users to supply a dictionary of concrete tensors to replace FakeTensors in the exported model weights.

An error is raised when users try to serialize a FakeTensor to avoid segfaults.

Also fixed a bug in `.save()` when `keep_initializers_as_inputs` is True and `include_initializers` is False. 