### PR TITLE
Implement unfold_backward on MPS

### DIFF
--- a/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
+++ b/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
@@ -59,7 +59,7 @@ kernel void unfold_backward(
   const auto out_dim_idx = pos[dim];
   const auto left_fold_idx = max(0L, (out_dim_idx - size) / step);
   const auto right_fold_idx = min(in_dim_size - 1, out_dim_idx / step);
-  // Shift grad_in to start of unfold wndows
+  // Shift grad_in to start of unfold windows
   pos[dim] = 0;
   grad_in += offset_from_coord(pos, input_strides, ndim);
   float rc = 0;

--- a/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
+++ b/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
@@ -1,0 +1,46 @@
+#include <metal_stdlib>
+
+ulong offset_from_coord(thread ulong* idx, constant ulong* strides, uint ndim) {
+   ulong rc = 0;
+   for(uint i = 0; i < ndim; ++i) {
+     rc += idx[i] * strides[i];
+   }
+   return rc;
+}
+
+void pos_from_index(ulong idx, thread ulong* pos, constant ulong* sizes, uint ndim) {
+  for(uint i = 0; i < ndim; ++i) {
+    pos[i] = idx % sizes[i];
+    idx /= sizes[i];
+  }
+}
+
+
+// Consider out = in.unfold(dim, size, step), then
+// out.shape[dim] == (in.shape[dim] - size) / step + 1,
+// out.shape[-1] == size.
+// out.ndim) == in.ndim) + 1
+//
+// unfold_backward receives grad_in and returns grad_out such that
+// grad_in.shape == out.shape,
+// grad_out.shape == in.shape.
+
+kernel void unfold_backward_float(
+    constant float *grad_in,
+    device float* grad_out,
+    constant ulong* input_strides,
+    constant ulong* output_sizes,
+    constant ulong* output_strides,
+    constant uint4& dim_size_step_ndim,
+    uint thread_index [[thread_position_in_grid]]) {
+    auto dim_idx = dim_size_step_ndim.x;
+    auto size = dim_size_step_ndim.y;
+    auto step = dim_size_step_ndim.z;
+    auto ndim = dim_size_step_ndim.w;
+    auto dim_idx_size = (output_sizes[dim_idx] - size) / step + 1;
+    ulong pos[16];
+    pos_from_index(thread_index, pos, output_sizes, ndim);
+    auto output_offs = offset_from_coord(pos, output_strides, ndim);
+    pos[ndim] = size;
+    grad_out[output_offs] = 1.0 * thread_index;
+}

--- a/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
+++ b/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
@@ -33,12 +33,12 @@ void pos_from_thread_index(
 // grad_out.shape == in.shape.
 
 // For each index in grad_out find the elements contributing to it and sum them
-// up. Such algorithm requires no synchonization between threads. I.e.
+// up. Such algorithm requires no synchronization between threads. I.e.
 // grad_out[...,out_dim_idx,...] accumulates all values
 // grad_in[...,in_dim_idx,...,in_last_idx], where in_dim_idx is range
-// [(out_dim_idx - size) / step, out_dim_idx / step] clampd to (0, in_dim_size)
-// and in_last_idx is out_dim_idx - in_dim_idx * step and
-// and accumulation step is skipped if in_last_idx is outside of [0, size] range
+// [(out_dim_idx - size) / step, out_dim_idx / step] clamped to (0, in_dim_size)
+// and in_last_idx is out_dim_idx - in_dim_idx * step.
+// Accumulation step is skipped if in_last_idx is outside of [0, size] range
 template <typename T>
 kernel void unfold_backward(
     constant T* grad_in,

--- a/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
+++ b/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
@@ -8,12 +8,18 @@ ulong offset_from_coord(thread ulong* idx, constant ulong* strides, uint ndim) {
    return rc;
 }
 
+ulong2 divmod(long x, ulong y) {
+  return ulong2(x/y, x%y);
+}
+
 void pos_from_index(ulong idx, thread ulong* pos, constant ulong* sizes, uint ndim) {
   for(uint i = 0; i < ndim; ++i) {
-    pos[i] = idx % sizes[i];
-    idx /= sizes[i];
+    auto rc = divmod(idx, sizes[i]);
+    pos[i] = rc.y;
+    idx = rc.x;
   }
 }
+
 
 
 // Consider out = in.unfold(dim, size, step), then
@@ -37,10 +43,17 @@ kernel void unfold_backward_float(
     auto size = dim_size_step_ndim.y;
     auto step = dim_size_step_ndim.z;
     auto ndim = dim_size_step_ndim.w;
-    auto dim_idx_size = (output_sizes[dim_idx] - size) / step + 1;
     ulong pos[16];
     pos_from_index(thread_index, pos, output_sizes, ndim);
-    auto output_offs = offset_from_coord(pos, output_strides, ndim);
-    pos[ndim] = size;
-    grad_out[output_offs] = 1.0 * thread_index;
+    const auto output_offs = offset_from_coord(pos, output_strides, ndim);
+
+    auto dim_idx_size = (output_sizes[dim_idx] - size) / step + 1;
+    auto rc = divmod(pos[dim_idx], step);
+    if (rc.x >= dim_idx_size or rc.y >= size) {
+      grad_out[output_offs] = 0.0;
+    }
+    pos[dim_idx_size] = rc.x;
+    pos[ndim] = rc.y;
+    const auto input_offs = offset_from_coord(pos, input_strides, ndim + 1);
+    grad_out[output_offs] = grad_in[input_offs];
 }

--- a/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
+++ b/aten/src/ATen/native/mps/kernels/UnfoldBackward.metal
@@ -1,77 +1,91 @@
 #include <metal_stdlib>
 using namespace metal;
 
-ulong offset_from_coord(thread ulong* idx, constant ulong* strides, uint ndim) {
-   ulong rc = 0;
-   for(uint i = 0; i < ndim; ++i) {
-     rc += idx[i] * strides[i];
-   }
-   return rc;
+// Given coordinates and strides, calculates offset from the start of the
+// tensors
+long offset_from_coord(thread long* idx, constant long* strides, uint ndim) {
+  long rc = 0;
+  for (uint i = 0; i < ndim; ++i) {
+    rc += idx[i] * strides[i];
+  }
+  return rc;
 }
 
-ulong2 divmod(long x, ulong y) {
-  return ulong2(x/y, x%y);
-}
-
-void pos_from_index(ulong idx, thread ulong* pos, constant ulong* sizes, uint ndim) {
-  for(uint i = 0; i < ndim; ++i) {
-    auto rc = divmod(idx, sizes[i]);
-    pos[i] = rc.y;
-    idx = rc.x;
+// Given thread index calculates position in the ndim tensor
+void pos_from_thread_index(
+    long idx,
+    thread long* pos,
+    constant long* sizes,
+    uint ndim) {
+  for (uint i = 0; i < ndim; ++i) {
+    pos[i] = idx % sizes[i];
+    idx /= sizes[i];
   }
 }
-
-
 
 // Consider out = in.unfold(dim, size, step), then
 // out.shape[dim] == (in.shape[dim] - size) / step + 1,
 // out.shape[-1] == size.
-// out.ndim) == in.ndim) + 1
+// out.ndim == in.ndim + 1
 //
 // unfold_backward receives grad_in and returns grad_out such that
 // grad_in.shape == out.shape,
 // grad_out.shape == in.shape.
 
-template<typename T>
+// For each index in grad_out find the elements contributing to it and sum them
+// up. Such algorithm requires no synchonization between threads. I.e.
+// grad_out[...,out_dim_idx,...] accumulates all values
+// grad_in[...,in_dim_idx,...,in_last_idx], where in_dim_idx is range
+// [(out_dim_idx - size) / step, out_dim_idx / step] clampd to (0, in_dim_size)
+// and in_last_idx is out_dim_idx - in_dim_idx * step and
+// and accumulation step is skipped if in_last_idx is outside of [0, size] range
+template <typename T>
 kernel void unfold_backward(
-    constant T *grad_in,
+    constant T* grad_in,
     device T* grad_out,
-    constant ulong* input_strides,
-    constant ulong* output_sizes,
-    constant ulong* output_strides,
+    constant long* input_strides,
+    constant long* output_sizes,
+    constant long* output_strides,
     constant uint4& dim_size_step_ndim,
     uint thread_index [[thread_position_in_grid]]) {
-    auto dim = dim_size_step_ndim.x;
-    auto size = dim_size_step_ndim.y;
-    auto step = dim_size_step_ndim.z;
-    auto ndim = dim_size_step_ndim.w;
-    ulong pos[16];
-    pos_from_index(thread_index, pos, output_sizes, ndim);
-    const auto output_offs = offset_from_coord(pos, output_strides, ndim);
-    auto grad_in_dim_size = (output_sizes[dim] - size) / step + 1;
-    float rc = 0;
-    const auto grad_out_idx = pos[dim];
-    auto left_fold_idx = grad_out_idx > size ? (grad_out_idx - size) / step : 0UL;
-    auto right_fold_idx = min(grad_in_dim_size - 1, grad_out_idx / step);
-    for(auto idx = left_fold_idx; idx <= right_fold_idx; ++idx) {
-        pos[dim] = idx;
-        pos[ndim] = grad_out_idx - idx * step;
-        if (pos[ndim] >= size) continue;
-         auto input_offset = offset_from_coord(pos, input_strides, ndim + 1);
-         rc += grad_in[input_offset];
+  auto dim = dim_size_step_ndim.x;
+  auto size = dim_size_step_ndim.y;
+  auto step = dim_size_step_ndim.z;
+  auto ndim = dim_size_step_ndim.w;
+  long pos[16];
+  pos_from_thread_index(thread_index, pos, output_sizes, ndim);
+  const auto output_offs = offset_from_coord(pos, output_strides, ndim);
+  const auto in_dim_size = max(1L, (output_sizes[dim] - size) / step + 1);
+  const auto out_dim_idx = pos[dim];
+  const auto left_fold_idx = max(0L, (out_dim_idx - size) / step);
+  const auto right_fold_idx = min(in_dim_size - 1, out_dim_idx / step);
+  // Shift grad_in to start of unfold wndows
+  pos[dim] = 0;
+  grad_in += offset_from_coord(pos, input_strides, ndim);
+  float rc = 0;
+  const auto in_dim_stride = input_strides[dim];
+  const auto in_last_dim_stride = input_strides[ndim];
+  for (auto in_dim_idx = left_fold_idx; in_dim_idx <= right_fold_idx;
+       ++in_dim_idx) {
+    const auto in_last_idx = out_dim_idx - in_dim_idx * step;
+    if (in_last_idx < 0 || in_last_idx >= size) {
+      continue;
     }
-    grad_out[output_offs] = static_cast<T>(rc);
+    rc +=
+        grad_in[in_dim_idx * in_dim_stride + in_last_idx * in_last_dim_stride];
+  }
+  grad_out[output_offs] = static_cast<T>(rc);
 }
 
-#define INSTANTIATE_UNFOLD_BACKWARD(DTYPE)                        \
+#define INSTANTIATE_UNFOLD_BACKWARD(DTYPE)                      \
   template [[host_name("unfold_backward_" #DTYPE)]] kernel void \
   unfold_backward<DTYPE>(                                       \
-      constant DTYPE *,                    \
-      device DTYPE *,                     \
-      constant ulong*, \
-      constant ulong*, \
-      constant ulong*, \
-      constant uint4&, \
+      constant DTYPE*,                                          \
+      device DTYPE*,                                            \
+      constant long*,                                           \
+      constant long*,                                           \
+      constant long*,                                           \
+      constant uint4&,                                          \
       uint thread_index [[thread_position_in_grid]])
 
 INSTANTIATE_UNFOLD_BACKWARD(float);

--- a/aten/src/ATen/native/mps/operations/UnfoldBackward.mm
+++ b/aten/src/ATen/native/mps/operations/UnfoldBackward.mm
@@ -9,8 +9,6 @@
 // unfold_backward, the algorithm is described in
 // /native/cpu/UnfoldBackwardKernel.cpp
 
-#include <ATen/mps/MPSProfiler.h>
-
 namespace at::native {
 namespace {
 
@@ -42,9 +40,6 @@ void unfold_backward_metal(
   auto stream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(stream->queue(), ^() {
     @autoreleasepool {
-      if (getMPSProfiler().isCaptureEnabled()) {
-        getMPSProfiler().startCapture("unfold_backward", stream);
-      }
       auto computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:unfoldBackwardPSO];
       std::array<uint32_t, 4> dim_size_step_ndim = {static_cast<uint32_t>(dim), static_cast<uint32_t>(size), static_cast<uint32_t>(step), static_cast<uint32_t>(grad_out.ndimension())};
@@ -55,9 +50,6 @@ void unfold_backward_metal(
       mtl_setBytes(computeEncoder, grad_out.strides(), 4);
       mtl_setBytes(computeEncoder, dim_size_step_ndim, 5);
       mtl_dispatch1DJob(computeEncoder, unfoldBackwardPSO, grad_out.numel());
-      if (getMPSProfiler().isCapturing()) {
-        getMPSProfiler().stopCapture(stream);
-      }
     }
   });
 }

--- a/aten/src/ATen/native/mps/operations/UnfoldBackward.mm
+++ b/aten/src/ATen/native/mps/operations/UnfoldBackward.mm
@@ -1,0 +1,60 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/native/UnfoldBackward.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+// Note on naming: it is unconventional.
+// grad_in does not mean that it is a gradient wrt to input,
+// grad_in/grad_out is just an input/output of unfold_backward kernel.
+//
+// unfold_backward, the algorithm is described in
+// /native/cpu/UnfoldBackwardKernel.cpp
+
+namespace at::native {
+namespace {
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/UnfoldBackward_metallib.h>
+#endif
+
+void unfold_backward_metal(
+  Tensor& grad_out,
+  const Tensor& grad_in,
+  int64_t dim,
+  int64_t size,
+  int64_t step
+) {
+  dim = maybe_wrap_dim(dim, grad_out.dim());
+  // last dim stores the folds
+  auto last_dim = maybe_wrap_dim(-1, grad_in.dim());
+
+  auto grad_in_dim_stride = ensure_nonempty_stride(grad_in, dim);
+  auto grad_in_last_dim_stride = ensure_nonempty_stride(grad_in, last_dim);
+  auto grad_in_dim_size = ensure_nonempty_size(grad_in, dim);
+
+  auto grad_out_dim_stride = ensure_nonempty_stride(grad_out, dim);
+
+  using namespace mps;
+  auto unfoldBackwardPSO = lib.getPipelineStateForFunc("unfold_backward_" + scalarToMetalTypeString(grad_in));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = stream->commandEncoder();
+      [computeEncoder setComputePipelineState:unfoldBackwardPSO];
+      std::array<uint32_t, 4> dim_size_step_ndim = {static_cast<uint32_t>(dim), static_cast<uint32_t>(step), static_cast<uint32_t>(size), static_cast<uint32_t>(grad_out.ndimension())};
+      mtl_setBuffer(computeEncoder, grad_in, 0);
+      mtl_setBuffer(computeEncoder, grad_out, 1);
+      mtl_setBytes(computeEncoder, grad_in.strides(), 2);
+      mtl_setBytes(computeEncoder, grad_out.sizes(), 3);
+      mtl_setBytes(computeEncoder, grad_out.strides(), 4);
+      mtl_setBytes(computeEncoder, dim_size_step_ndim, 5);
+      mtl_dispatch1DJob(computeEncoder, unfoldBackwardPSO, grad_out.numel());
+    }
+  });
+}
+
+} // anonymous namespace
+REGISTER_DISPATCH(unfold_backward_stub, &unfold_backward_metal);
+} // namespace at::native
+

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10176,7 +10176,7 @@
 - func: unfold_backward(Tensor grad_in, SymInt[] input_sizes, int dim, int size, int step) -> Tensor
   variants: function
   dispatch:
-    CPU, CUDA: unfold_backward
+    CPU, CUDA, MPS: unfold_backward
   autogen: unfold_backward.out
 
 - func: equal(Tensor self, Tensor other) -> bool

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -85,7 +85,6 @@ def mps_ops_grad_modifier(ops):
         '_segment_reduce': [torch.float16, torch.float32],
         '_chunk_cat': [torch.float16, torch.float32],
         'unfold_copy': [torch.float16, torch.float32],  # unfold_backward is not implemented
-        'unfold': [torch.float16, torch.float32],
         'sparse.mmreduce': [torch.float32],  # csr not supported
         'unique_consecutive': [torch.float16, torch.float32],
         'special_modified_bessel_i0': [torch.float16, torch.float32],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -84,7 +84,6 @@ def mps_ops_grad_modifier(ops):
         '__getitem__': [torch.float16],
         '_segment_reduce': [torch.float16, torch.float32],
         '_chunk_cat': [torch.float16, torch.float32],
-        'unfold_copy': [torch.float16, torch.float32],  # unfold_backward is not implemented
         'sparse.mmreduce': [torch.float32],  # csr not supported
         'unique_consecutive': [torch.float16, torch.float32],
         'special_modified_bessel_i0': [torch.float16, torch.float32],


### PR DESCRIPTION
This PR adds native implementation of unfold_backward as metal shader, mostly copy-n-paste of algorithms used in CUDA and CPU implementations, i.e. considering `out = in.unfold(dim, size, step)`, then following holds true:
* `out.shape[dim] == (in.shape[dim] - size) / step + 1`
* `out.shape[-1] == size`
* `out.ndim == in.ndim + 1`
`unfold_backward` Metal kernel  receives `grad_in` and returns `grad_out` such that:
* `grad_in.shape == out.shape`
* `grad_out.shape == in.shape`

For each index in `grad_out` find the elements contributing to it and sum them up. Such algorithm requires no synchronization between threads.
That is `grad_out[...,out_dim_idx,...]` accumulates all values `grad_in[...,in_dim_idx,...,in_last_idx]`, where `in_dim_idx` is range [`(out_dim_idx - size) / step`, `out_dim_idx / step`] clamped to (0, `in_dim_size`) and `in_last_idx` are equal `out_dim_idx - in_dim_idx * step` . Accumulation step is skipped if `in_last_idx` is outside of [0, size] range.


This operator has been requested 16 times on https://github.com/pytorch/pytorch/issues/77764

