### PR TITLE
[Distributed] Improve efficiency of NaN checker

### DIFF
--- a/torch/csrc/distributed/c10d/NanCheck.cu
+++ b/torch/csrc/distributed/c10d/NanCheck.cu
@@ -15,6 +15,11 @@ namespace c10d {
 // Using ulong2 as a "byte pack", with 16 bytes, for efficient data load
 typedef ulong2 BytePack;
 
+// AMD HIP doesn't define `__trap()`, using `assert` instead
+#ifdef USE_ROCM
+#define __trap() assert(0)
+#endif
+
 //// Start of templated functions for checking NaNs inside a BytePack
 
 // (i) General implementation (aka fallback)


### PR DESCRIPTION
Some customers would like to run the NaN checks on the fly, so we are improving its efficiency.

## Benchmarking
Allreduce 2G floats. `TORCH_NCCL_NAN_CHECK=1`
Red kernel: ncclAllreduce
Blue kernel: Nan check

<img width="1093" alt="Screenshot 2024-09-06 at 10 00 05 PM" src="https://github.com/user-attachments/assets/5501bc31-024f-4115-adb2-dd66eb4025d3">

## Comparison with torch ops:
Let's say a user manually check for NaNs with the following torch ops before all-reduce:
```
torch.any(torch.isnan(x))
```
<img width="1091" alt="Screenshot 2024-09-06 at 10 14 53 PM" src="https://github.com/user-attachments/assets/1f8b5f63-c955-4612-bb96-241b6c69959b">

So our perf is on-par with torch ops.

## Changes
- Load from vidmem using "big packs" of 16 bytes
- Bump `blockDim.x` from 256 to 512
- Separate loads and checks into two loops, each of 8 iterations
- Unroll the loops
- Templated functions for checking NaN in a "big pack" based on dtype

cc @XilunWu @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o
Special thanks to @jbachan from NCCL!