### PR TITLE
Missing import failure case for libfb.py

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -589,7 +589,7 @@ if is_fbcode():
             )
         else:
             global_cache_dir = parutil.get_dir_path("fb/cache")
-    except (ValueError, ModuleNotFoundError):
+    except (ValueError, ModuleNotFoundError, ImportError):
         global_cache_dir = None
 
 else:


### PR DESCRIPTION
Summary:
Inspired from D62237502

Note that on fbsource/arvr, adding parutil as a fbcode dependency deosn't work

Test Plan:
Local code failing now runs again
```
buck2 run arvr/mode/win/vs2022/cpp20/cuda12_5/opt //arvr/projects/nimble/research/Ctrl-R/tests/pytorch:testTorchscriptGpu
```

For the rest CI

Reviewed By: laithsakka

Differential Revision: D62316703


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov