### PR TITLE
[inductor] Use nontrivial_read_count for num_reads()-based heuristics

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -403,11 +403,11 @@ warn_mix_layout = os.environ.get("TORCHINDUCTOR_WARN_MIX_LAYOUT") == "1"
 # control store vs recompute heuristic
 # For fanouts, rematerialization can lead to exponential blowup. So, have
 # smaller threshold
-realize_reads_threshold = 4
+realize_reads_threshold = 3
 realize_opcount_threshold = 30
 
 # Threshold to prevent excessive accumulation of ops in one buffer during lowering
-realize_acc_reads_threshold = 8
+realize_acc_reads_threshold = 6
 
 # fallback to eager for random/dropout, this is slow but useful for debugging
 fallback_random = False

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -598,7 +598,7 @@ class Loops(IRNode):
         return OrderedSet(self.inner_fn_opcount().read_buffers)
 
     def num_reads(self):
-        return len(self.inner_fn_opcount().read_buffers)
+        return self.inner_fn_opcount().nontrivial_read_count
 
     def get_reduction_size(self):
         raise NotImplementedError(
@@ -6382,10 +6382,7 @@ class StorageBox(MutableBox):
         """
         Called on buffers we expect to be forced to realize later.
         """
-        if (
-            isinstance(self.data, (Pointwise, Reduction))
-            and self.data.inner_fn_opcount().nontrivial_read_count > 1
-        ):
+        if isinstance(self.data, (Pointwise, Reduction)) and self.num_reads() > 1:
             self.realize()
 
     def has_exceeded_max_reads(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135426

This seems better to use as it excludes scalar loads, doing a perf run to check.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov