### PR TITLE
Fix return type of `nansum` example.

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10665,7 +10665,7 @@ Keyword args:
 Example::
 
     >>> torch.nansum(torch.tensor([1., float("nan")]))
-    1.0
+    tensor(1.)
     >>> a = torch.tensor([[1, 2], [3., float("nan")]])
     >>> torch.nansum(a)
     tensor(6.)


### PR DESCRIPTION
One of the examples in the documentation of `torch.nansum` contains a wrong return type. This fixes it.