### PR TITLE
Fix: Change device index type in warning message from int8_t to int16…

### DIFF
--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -370,7 +370,7 @@ void mallocAsync(
         OutOfMemoryError,
         false,
         "Allocation on device ",
-        device,
+        (int16_t) device,
         " would exceed allowed memory. (out of memory)",
         "\nCurrently allocated     : ",
         format_size(pytorch_used_bytes[device]),


### PR DESCRIPTION
…_twqwa1wq

### Description

This PR changes the type of `device` in warning message from `int8_t` to `int16_t`. This modification prevents the truncation of `device` in warning messages, ensuring that the full warning message is displayed correctly.

### Testing

https://github.com/pytorch/pytorch/blob/c0436c57015cf1755c1de5b4039466cd52a8dcc0/test/test_cuda.py#L293

 
