### PR TITLE
Forward more metadata functions to the inner XLA tensor.

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -490,8 +490,14 @@ c10::Device FunctionalTensorWrapper::device_custom() const {
 at::IntArrayRef FunctionalTensorWrapper::sizes_custom() const {
   return value_.unsafeGetTensorImpl()->sizes();
 }
+int64_t FunctionalTensorWrapper::size_custom(int64_t d) const {
+  return value_.unsafeGetTensorImpl()->size(d);
+}
 at::IntArrayRef FunctionalTensorWrapper::strides_custom() const {
   return value_.unsafeGetTensorImpl()->strides();
+}
+int64_t FunctionalTensorWrapper::storage_offset_custom() const {
+  return value_.unsafeGetTensorImpl()->storage_offset();
 }
 int64_t FunctionalTensorWrapper::dim_custom() const {
   return value_.unsafeGetTensorImpl()->dim();
@@ -507,6 +513,9 @@ c10::SymIntArrayRef FunctionalTensorWrapper::sym_sizes_custom() const {
 }
 c10::SymIntArrayRef FunctionalTensorWrapper::sym_strides_custom() const {
   return value_.unsafeGetTensorImpl()->sym_strides();
+}
+c10::SymInt FunctionalTensorWrapper::sym_numel_custom() const {
+  return value_.unsafeGetTensorImpl()->sym_numel();
 }
 c10::SymInt FunctionalTensorWrapper::sym_size_custom(int64_t d) const {
   return value_.unsafeGetTensorImpl()->sym_size(d);

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -217,13 +217,16 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   // so that if the inner tensor has a custom implementation
   // we make sure to call that implementation.
   at::IntArrayRef sizes_custom() const override;
+  int64_t size_custom(int64_t d) const override;
   at::IntArrayRef strides_custom() const override;
+  int64_t storage_offset_custom() const override;
   int64_t dim_custom() const override;
   int64_t numel_custom() const override;
   bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
   c10::SymIntArrayRef sym_sizes_custom() const override;
   c10::SymInt sym_size_custom(int64_t d) const override;
   c10::SymIntArrayRef sym_strides_custom() const override;
+  c10::SymInt sym_numel_custom() const override;
   c10::SymInt sym_storage_offset_custom() const override;
   c10::Device device_custom() const override;
   c10::Layout layout_impl() const override;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #135498
* #135237
* __->__ #135497

This PR overrides more tensor metadata functions to the inner tensor inside
`FunctionalTensorWrapper`. This is necessary so that we don't have to look at 2 different
metadata, i.e. `FunctionalTensorWrapper`'s and whatever is the `TensorImpl` of its inner
tensor.

We should probably override all `*_custom` functions, but I will leave those for a future
PR. This one takes care of other trivial ones that already have a sym/not-sym counterpart
covered.