### PR TITLE
Fix doc build after #135461

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -820,12 +820,12 @@ coverage_ignore_functions = [
     "gen_tvar",
     # torch.fx.experimental.shape_inference.infer_shape
     "infer_shape",
-    "mksym"
+    "mksym",
     # torch.fx.experimental.shape_inference.infer_symbol_values
-    "calculate_value"
-    "infer_symbol_values"
-    "solve_equation"
-    "update_equation"
+    "calculate_value",
+    "infer_symbol_values",
+    "solve_equation",
+    "update_equation",
     # torch.fx.experimental.optimization
     "extract_subgraph",
     "fuse",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -818,6 +818,14 @@ coverage_ignore_functions = [
     "gen_nat_constraints",
     "gen_tensor_dims",
     "gen_tvar",
+    # torch.fx.experimental.shape_inference.infer_shape
+    "infer_shape",
+    "mksym"
+    # torch.fx.experimental.shape_inference.infer_symbol_values
+    "calculate_value"
+    "infer_symbol_values"
+    "solve_equation"
+    "update_equation"
     # torch.fx.experimental.optimization
     "extract_subgraph",
     "fuse",

--- a/docs/source/fx.experimental.rst
+++ b/docs/source/fx.experimental.rst
@@ -54,7 +54,7 @@ torch.fx.experimental.symbolic_shapes
     is_accessor_node
 
 torch.fx.experimental.proxy_tensor
--------------------------------------
+----------------------------------
 
 .. currentmodule:: torch.fx.experimental.proxy_tensor
 .. automodule:: torch.fx.experimental.proxy_tensor

--- a/docs/source/fx.rst
+++ b/docs/source/fx.rst
@@ -1149,9 +1149,8 @@ API Reference
 .. py:module:: torch.fx.experimental.schema_type_annotation
 .. py:module:: torch.fx.experimental.sym_node
 .. py:module:: torch.fx.experimental.shape_inference
-.. py:module:: torch.fx.experimental.shape_inference.infer_symbol_values
-.. py:module:: torch.fx.experimental.shape_inference
 .. py:module:: torch.fx.experimental.shape_inference.infer_shape
+.. py:module:: torch.fx.experimental.shape_inference.infer_symbol_values
 .. py:module:: torch.fx.experimental.unification.core
 .. py:module:: torch.fx.experimental.unification.dispatch
 .. py:module:: torch.fx.experimental.unification.match

--- a/docs/source/fx.rst
+++ b/docs/source/fx.rst
@@ -1148,6 +1148,10 @@ API Reference
 .. py:module:: torch.fx.experimental.rewriter
 .. py:module:: torch.fx.experimental.schema_type_annotation
 .. py:module:: torch.fx.experimental.sym_node
+.. py:module:: torch.fx.experimental.shape_inference
+.. py:module:: torch.fx.experimental.shape_inference.infer_symbol_values
+.. py:module:: torch.fx.experimental.shape_inference
+.. py:module:: torch.fx.experimental.shape_inference.infer_shape
 .. py:module:: torch.fx.experimental.unification.core
 .. py:module:: torch.fx.experimental.unification.dispatch
 .. py:module:: torch.fx.experimental.unification.match


### PR DESCRIPTION
Fix broken doc build after https://github.com/pytorch/pytorch/pull/135461 by ack-ing the missing experimental doc, i.e. https://github.com/pytorch/pytorch/actions/runs/10774227660/job/29877022226