### PR TITLE
[amdsmi][torch] Update amdsmi API usages

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1122,7 +1122,8 @@ def _get_amdsmi_power_draw(device: Optional[Union[Device, int]] = None) -> int:
 
 def _get_amdsmi_clock_rate(device: Optional[Union[Device, int]] = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return amdsmi.amdsmi_get_clock_info(handle, amdsmi.AmdSmiClkType.GFX)["cur_clk"]
+    clk_info = amdsmi.amdsmi_get_clock_info(handle, amdsmi.AmdSmiClkType.GFX)
+    return clk_info["clk"] if "clk" in clk_info else clk_info["cur_clk"]
 
 
 def memory_usage(device: Optional[Union[Device, int]] = None) -> int:


### PR DESCRIPTION
Summary: In ROCm 6.2.0 there were API name changes-- we check if the new APIs exist and use them in this diff; see https://github.com/ROCm/amdsmi/commit/7b2463abe01739cc6e9d88438fefc84bdbe4a1d5 for the changes

Test Plan: CI

Differential Revision: D62325661
