### PR TITLE
[ONNX] Drop final None values as inputs for nodes in exporter graph

### DIFF
--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -465,7 +465,7 @@ def _construct_node(
         else:
             inputs.append(value)
 
-    # If final inputs are None, strip them in the graph
+    # If final inputs are None, strip them from the node inputs
     for input in reversed(inputs):
         if input is not None:
             break

--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -465,6 +465,12 @@ def _construct_node(
         else:
             inputs.append(value)
 
+    # If final inputs are None, strip them in the graph
+    for input in reversed(inputs):
+        if input is not None:
+            break
+        inputs.pop()
+
     # Construct and filter out None attributes
     attributes = [
         attr


### PR DESCRIPTION
When value for an optional input is not provided, it is defaulted to `None`, which gets translates to "" in the onnx graph. To avoid this, if we have a list of inputs and the final few are all `None`, strip them in the graph.