### PR TITLE
[ONNX] Improves documentation of ONNX exporter

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -13,7 +13,35 @@ The exported model can be consumed by any of the many
 `runtimes that support ONNX <https://onnx.ai/supported-tools.html#deployModel>`_, including
 Microsoft's `ONNX Runtime <https://www.onnxruntime.ai>`_.
 
-**There are two flavors of ONNX exporter API that you can use, as listed below:**
+**There are two flavors of ONNX exporter API that you can use, as listed below.**
+Both can be called through function :func:`torch.onnx.export`.
+Next example shows how to export a simple model.
+
+.. code-block:: python
+
+    import torch
+
+    class MyModel(torch.nn.Module):
+        def __init__(self):
+            super(MyModel, self).__init__()
+            self.conv1 = torch.nn.Conv2d(1, 128, 5)
+
+        def forward(self, x):
+            return torch.relu(self.conv1(x))
+
+    input_tensor = torch.rand((1, 1, 128, 128), dtype=torch.float32)
+
+    model = MyModel()
+
+    torch.onnx.export(
+        model,                  # model to export
+        (input_tensor,),        # inputs of the model,
+        "my_model.onnx",        # filename of the ONNX model
+        input_names=["input"],  # Rename inputs for the ONNX model
+        dynamo=True             # True or False to select the exporter to use
+    )
+
+Next sections introduces the two versions of the exporter.
 
 TorchDynamo-based ONNX Exporter
 -------------------------------

--- a/docs/source/onnx_dynamo.rst
+++ b/docs/source/onnx_dynamo.rst
@@ -44,6 +44,9 @@ They can be installed through `pip <https://pypi.org/project/pip/>`_:
 
   pip install --upgrade onnx onnxscript
 
+`onnxruntime <https://onnxruntime.ai>`_ can then be used to execute the model
+on a large variety of processors.
+
 A simple example
 ----------------
 
@@ -74,9 +77,9 @@ See below a demonstration of exporter API in action with a simple Multilayer Per
 
   model = MLPModel()
   tensor_x = torch.rand((97, 8), dtype=torch.float32)
-  onnx_program = torch.onnx.dynamo_export(model, tensor_x)
+  onnx_program = torch.onnx.export(model, (tensor_x,), dynamo=True)
 
-As the code above shows, all you need is to provide :func:`torch.onnx.dynamo_export` with an instance of the model and its input.
+As the code above shows, all you need is to provide :func:`torch.onnx.export` with an instance of the model and its input.
 The exporter will then return an instance of :class:`torch.onnx.ONNXProgram` that contains the exported ONNX graph along with extra information.
 
 The in-memory model available through ``onnx_program.model_proto`` is an ``onnx.ModelProto`` object in compliance with the `ONNX IR spec <https://github.com/onnx/onnx/blob/main/docs/IR.md>`_.
@@ -85,6 +88,17 @@ The ONNX model may then be serialized into a `Protobuf file <https://protobuf.de
 .. code-block:: python
 
   onnx_program.save("mlp.onnx")
+
+Two functions exist to export the model to ONNX based on TorchDynamo engine.
+They slightly differ in the way they produce the :class:`ExportedProgram`.
+:func:`torch.onnx.dynamo_export` was introduced with PyTorch 2.1 and
+:func:`torch.onnx.export` was extended with PyTorch 2.5 to easily switch
+from TorchScript to TorchDynamo. To call the former function,
+the last line of the previous example can be replaced by the following one.
+
+.. code-block:: python
+
+  onnx_program = torch.onnx.dynamo_export(model, tensor_x)
 
 Inspecting the ONNX model using GUI
 -----------------------------------
@@ -109,9 +123,14 @@ By expanding it, the function body is shown.
 
 The function body is a sequence of ONNX operators or other functions.
 
-Diagnosing issues with SARIF
-----------------------------
+When the conversion fails
+-------------------------
 
+Function :func:`torch.onnx.export` should called a second time with
+parameter ``report=True``. A markdown report is generated to help the user
+to resolve the issue.
+
+Function :func:`torch.onnx.dynamo_export` generates a report using 'SARIF' format.
 ONNX diagnostics goes beyond regular logs through the adoption of
 `Static Analysis Results Interchange Format (aka SARIF) <https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html>`__
 to help users debug and improve their model using a GUI, such as

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -284,7 +284,9 @@ def export(
             This is required for models with large weights that exceed the ONNX file size limit (2GB).
             When False, the weights are saved in the ONNX file with the model architecture.
         dynamic_shapes: A dictionary of dynamic shapes for the model inputs. Refer to
-            :func:`torch.export.export` for more details.
+            :func:`torch.export.export` for more details. This is only used (and preferred) when dynamo is True.
+            Only one parameter `dynamic_axes` or `dynamic_shapes` should be set
+            at the same time.
         report: Whether to generate a markdown report for the export process.
         verify: Whether to verify the exported model using ONNX Runtime.
         profile: Whether to profile the export process.
@@ -363,6 +365,12 @@ def export(
         )
     else:
         from torch.onnx.utils import export
+
+        if dynamic_shapes:
+            raise ValueError(
+                "The exporter only supports dynamic shapes "
+                "through parameter dynamic_axes when dynamo=False."
+            )
 
         export(
             model,


### PR DESCRIPTION
The PR updates the documentation to reflect the changes introduced in pytorch 2.5 and related to onnx exporter.

Cherry-pick of https://github.com/pytorch/pytorch/pull/13537 into release/2.5