### PR TITLE
Fix the use of fsspec transactions

### DIFF
--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -5,10 +5,8 @@ import io
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, Optional, Union
+from typing import Generator, Optional, Union, TYPE_CHECKING
 
-import fsspec
-from fsspec import AbstractFileSystem
 from fsspec.core import url_to_fs
 
 from torch.distributed.checkpoint.filesystem import (
@@ -16,6 +14,9 @@ from torch.distributed.checkpoint.filesystem import (
     FileSystemReader,
     FileSystemWriter,
 )
+
+if TYPE_CHECKING:
+    from fsspec import AbstractFileSystem
 
 
 __all__ = [
@@ -33,9 +34,21 @@ class FileSystem(FileSystemBase):
         self, path: Union[str, os.PathLike], mode: str
     ) -> Generator[io.IOBase, None, None]:
         assert self.fs is not None
-        with self.fs.transaction:
-            with fsspec.open(str(path), mode) as stream:
+        path = os.fspath(path)
+
+        # fsspec does not support concurrent transactions, and not all
+        # AbstractFileSystem have working rollback implementations, so
+        # just manually delete the file if necessary on errors.
+        with self.fs.open(path, mode) as stream:
+            try:
                 yield stream
+            except:  # noqa: B001,E722
+                if "w" or "+" or "a" in mode:  # cleanup file if not read-only
+                    try:
+                        self.rm_file(path)
+                    except:  # noqa: B001,E722
+                        pass
+                raise
 
     def concat_path(
         self, path: Union[str, os.PathLike], suffix: str
@@ -51,7 +64,7 @@ class FileSystem(FileSystemBase):
     ) -> None:
         self.fs.rename(path, new_path)
 
-    def mkdir(self, path: [str, os.PathLike]) -> None:
+    def mkdir(self, path: Union[str, os.PathLike]) -> None:
         self.fs.makedirs(path, exist_ok=True)
 
     @classmethod

--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -5,7 +5,7 @@ import io
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, Optional, Union, TYPE_CHECKING
+from typing import Generator, Optional, TYPE_CHECKING, Union
 
 from fsspec.core import url_to_fs
 
@@ -14,6 +14,7 @@ from torch.distributed.checkpoint.filesystem import (
     FileSystemReader,
     FileSystemWriter,
 )
+
 
 if TYPE_CHECKING:
     from fsspec import AbstractFileSystem


### PR DESCRIPTION
fsspec transactions do not support concurrency and assumes that there is at most 1 running transaction per filesystem. This is *not* true in our usage, where because of multi-threading we usually have multiple concurrent transactions running at once.

Previously, this would just (unsafely) pass but lead to hard-to-debug race conditions (since the commit of one transaction will blow away the state of the other transaction). In fsspec 2024.3.0, trying to commit concurrent transactions will actually crash (see the code at https://github.com/fsspec/filesystem_spec/blob/76ca4a68885d572880ac6800f079738df562f02c/fsspec/transaction.py#L39 -- because each filesystem can have a single transaction, this tear-down logic will error).

Instead, let's manually handle committing / discarding changes to the file. This does this "the old-fashioned way" instead of using `fsspec`'s commit/rollback behavior because the internal PathManagerFileSystem used for `iopath` does not properly support that behavior.

I don't have a minimal test-case, but in Meta this solves a broken test on `fsspec >= 2024.3.0`:

Before: https://www.internalfb.com/intern/testinfra/testrun/7318349626774607
After: https://www.internalfb.com/intern/testinfra/testrun/2251800062722633

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @soulitzer @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn