### PR TITLE
[Inductor] simplify indexing_exprs in LoopBody._init_with_copy

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -3422,7 +3422,6 @@ class CPUReproTests(TestCase):
                 dtype if dtype else torch.float32,
             )
 
-    @config.patch("cpp.enable_tiling_heuristics", False)
     def test_group_norm_vec(self):
         class M(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -115,7 +115,11 @@ class LoopBody:
         where we are just reordering/merging/splitting the args of an
         existing LoopBody.
         """
-        self.indexing_exprs = other.indexing_from_args(args)
+        indexing_exprs = other.indexing_from_args(args)
+        self.indexing_exprs = {
+            name: V.graph.sizevars.simplify_with_ranges(expr, self.var_ranges)
+            for name, expr in indexing_exprs.items()
+        }
         self.subblocks = {k: v.clone(self) for k, v in other.subblocks.items()}
         self.indirect_vars = other.indirect_vars
         self.indirect_var_ranges = other.indirect_var_ranges


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #135335
* __->__ #135574


This PR uses `var_ranges` information to simplify `indexing_exprs` in `LoopBody._init_with_copy` to to reduce occurrences of `FloorDiv` and `ModularIndexing` in the `indexing_exprs`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang