### PR TITLE
Fix test_triton_kernel_float64_constant

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -1556,7 +1556,7 @@ def forward(self, x_1, output_1):
         def f(x):
             return x * (0.12 * x.shape[0])
 
-        x = torch.ones(200, device=GPU_TYPE, dtype=torch.float64)
+        x = torch.ones(200, device=GPU_TYPE, dtype=dtype)
 
         eager_out = f(x)
         compiled_out = torch.compile(f, dynamic=True)(x)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135583

Summary: Landed https://github.com/pytorch/pytorch/pull/135260 too soon and the test in that PR doesn't do exactly what I tested (actually test different dtypes).

Test Plan: `python test/inductor/test_triton_kernels.py -k float64_constant`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang