### PR TITLE
[ts_converter] Prevent decomposition on quantize_per_tensor

### DIFF
--- a/test/export/test_converter.py
+++ b/test/export/test_converter.py
@@ -9,6 +9,7 @@ import torch.utils._pytree as pytree
 from torch._dynamo.test_case import TestCase
 from torch._export.converter import TS2EPConverter
 from torch.export import ExportedProgram
+from torch.testing import FileCheck
 from torch.testing._internal.common_quantized import override_quantized_engine
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests
 from torch.testing._internal.torchbind_impls import (
@@ -1367,7 +1368,7 @@ class TestConverter(TestCase):
         IS_WINDOWS,
         "Windows does not support qnnpack",
     )
-    def test_ts2ep_convert_quantized_model(self):
+    def test_ts2ep_convert_quantized_model1(self):
         class Standalone(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1405,6 +1406,17 @@ class TestConverter(TestCase):
             ts_model = torch.jit.script(model)
             converter = TS2EPConverter(ts_model, inp)
             ep = converter.convert()
+
+            FileCheck().check_count(
+                "torch.ops.quantized_decomposed.quantize_per_tensor.default",
+                3,
+                exactly=True,
+            ).run(ep.graph_module.code)
+            FileCheck().check_count(
+                "torch.ops.quantized_decomposed.dequantize_per_tensor.default",
+                3,
+                exactly=True,
+            ).run(ep.graph_module.code)
 
             orig_out, _ = pytree.tree_flatten(original_ts_model(*inp))
             ep_out, _ = pytree.tree_flatten(ep.module()(*inp))

--- a/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
+++ b/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
@@ -6,11 +6,6 @@ from typing import List, Optional, Tuple, Union
 import torch
 import torch.export._trace
 from torch._ops import OpOverload
-from torch.ao.quantization.fx._decomposed import (
-    dequantize_per_channel,
-    dequantize_per_tensor,
-    quantize_per_tensor,
-)
 from torch.ao.quantization.utils import calculate_qmin_qmax
 from torch.fx.graph_module import _assign_attr
 
@@ -51,7 +46,7 @@ def insert_quantized_node(
     qscheme: Optional[torch.qscheme],
 ) -> torch.fx.Node:
     return gm.graph.call_function(
-        quantize_per_tensor,
+        torch.ops.quantized_decomposed.quantize_per_tensor.default,
         (
             val_node,
             scale_node,
@@ -74,7 +69,7 @@ def get_dequantized(
     qscheme: Optional[torch.qscheme],
 ) -> torch.Tensor:
     if qscheme is torch.per_tensor_affine:
-        return dequantize_per_tensor(
+        return torch.ops.quantized_decomposed.dequantize_per_tensor.default(
             val,
             scale,
             zero_point,
@@ -83,7 +78,7 @@ def get_dequantized(
             dtype,
         )
     elif qscheme is torch.per_channel_affine:
-        return dequantize_per_channel(
+        return torch.ops.quantized_decomposed.dequantize_per_channel(
             val,
             scale,
             zero_point,
@@ -109,7 +104,7 @@ def insert_dequantized_node(
 ) -> torch.fx.Node:
     if qscheme is torch.per_tensor_affine:
         return gm.graph.call_function(
-            dequantize_per_tensor,
+            torch.ops.quantized_decomposed.dequantize_per_tensor.default,
             (
                 val_node,
                 scale_node,
@@ -121,7 +116,7 @@ def insert_dequantized_node(
         )
     elif qscheme is torch.per_channel_affine:
         return gm.graph.call_function(
-            dequantize_per_channel,
+            torch.ops.quantized_decomposed.dequantize_per_channel,
             (
                 val_node,
                 scale_node,

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -42,7 +42,7 @@ def _quant_min_max_bounds_check(quant_min, quant_max, dtype):
 
 
 quantized_decomposed_lib.define(
-    "quantize_per_tensor(Tensor input, float scale, int zero_point, "
+    "quantize_per_tensor(Tensor input, Scalar scale, Scalar zero_point, "
     "int quant_min, int quant_max, ScalarType dtype) -> Tensor"
 )
 
@@ -215,7 +215,7 @@ def quantize_per_tensor_tensor2_meta(
 # matching in the future
 # We will revisit this later if we found there are no use cases for it
 quantized_decomposed_lib.define(
-    "dequantize_per_tensor(Tensor input, float scale, int zero_point, "
+    "dequantize_per_tensor(Tensor input, Scalar scale, Scalar zero_point, "
     "int quant_min, int quant_max, ScalarType dtype, *, ScalarType? out_dtype=None) -> Tensor"
 )
 


### PR DESCRIPTION
Summary:
It seems like directly using the quantize_per_tensor function results
in it being decomposed (example: P1580440448). Replacing it with the actual
aten op fixes the issue.

However, we have to change the signature of the
operators because we now encounter SymFloats being passed to these operators.
The reason is because torchscript code looks something like this:
```
quant_scale_tensor = getattr("quant_scale")
quant_scale_float = float(quant_scale_tensor)
quantized = quantize_per_tensor(x, quant_scale_float, ...)
```
which we convert to:
```
quant_scale_tensor = getattr("quant_scale")
quant_scale_symfloat = quant_scale_tensor.to(dtype=torch.float).item()
quantized = quantize_per_tensor(x, quant_scale_symfloat, ...)
```

So now, a SymFloat is being passed to quantize_per_tensor, which causes an
error becuase quantize_per_tensor's signature expects a "float", not a
"SymFloat". Changing the signature to "Scalar" fixes the issue.
Possibly a smarter way to do things is to const-prop the graph and then the
float version of quant_scale will just be inlined... but it seems weird to do
const-prop while converting

Test Plan: CI

Differential Revision: D62451506
