### PR TITLE
Revert "[fx] Bypass custom __setattr__ in Node.__init__ (#135079)" (#…

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -816,10 +816,10 @@ class _FindNodesLookupTable:
     def find_nodes(self, *, op: str, target: Optional['Target'] = None):
         if op == "call_function":
             assert target is not None
-            return [*self.table[(op, target)].keys()]
+            return dict(self.table[(op, target)]).keys()
 
         if target is None:
-            return [*self.table[(op, None)].keys()]
+            return dict(self.table[(op, None)]).keys()
 
         # op is call_method, get_attr, call_module
         return [node for node in self.table[(op, None)].keys() if node.target == target]

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -168,16 +168,6 @@ class Node(_NodeBase):
     """
     _args: Tuple['Argument', ...]
     _kwargs: Dict[str, 'Argument']
-    graph: 'Graph'
-    name: str
-    op: str
-    target: 'Target'
-    _input_nodes: Dict['Node', None]
-    users: Dict['Node', None]
-    type: Optional[Any]
-    _sort_key: Any
-    _repr_fn: Optional[Callable[['Node'], str]]
-    meta: Dict[str, Any]
 
     @compatibility(is_backward_compatible=True)
     def __init__(self, graph: 'Graph', name: str, op: str, target: 'Target',
@@ -209,7 +199,11 @@ class Node(_NodeBase):
                 annotation of values in the generated code or for other types
                 of analyses.
         """
+        super().__init__()
+        self.graph = graph
+        self.name = name  # unique name of value being created
         assert op in _legal_ops
+        self.op = op  # the kind of operation = placeholder|call_method|call_module|call_function|get_attr
         if op == 'call_function':
             if not callable(target):
                 raise ValueError(f'Node [graph = {graph}, name = \'{name}\'] target {target} has type {torch.typename(target)} '
@@ -218,22 +212,13 @@ class Node(_NodeBase):
             if not isinstance(target, str):
                 raise ValueError(f'Node [graph = {graph}, name = \'{name}\'] target {target} has type {torch.typename(target)} '
                                  'but a str is expected')
-        super().__init__()
-
-        # bypass Node.__setattr__ for perf and so that it doesn't need to handle half-built objects
-        assign = object.__setattr__
-
-        assign(self, "graph", graph)
-        assign(self, "name", name)  # unique name of value being created
-        assign(self, "op", op)  # the kind of operation = placeholder|call_method|call_module|call_function|get_attr
-
-        assign(self, "target", target)  # for method/module/function, the name of the method/module/function/attr
+        self.target = target  # for method/module/function, the name of the method/module/function/attr
         # being invoked, e.g add, layer1, or torch.add
 
         # All `Node`-valued inputs. Key is the Node, value is don't-care.
         # The public API for this is `all_input_nodes`, this private attribute
         # should not be accessed directly.
-        assign(self, "_input_nodes", {})
+        self._input_nodes : Dict[Node, None] = {}
         self.__update_args_kwargs(args, kwargs)
 
         # All of the nodes that use the value produced by this Node
@@ -241,8 +226,7 @@ class Node(_NodeBase):
         # would appear once here, but represents two uses.
         #
         # Is a dict to act as an "ordered set". Keys are significant, value dont-care
-        assign(self, "users", {})
-
+        self.users : Dict[Node, None] = {}
         # Type expression representing the output value of this node.
         # This should contain the same class of Type objects that would appear
         # as type annotations for function inputs/outputs.
@@ -253,15 +237,15 @@ class Node(_NodeBase):
         # generated function return type. (Note this is a special case. ``return``
         # does not produce a value, it's more of a notation. Thus, this value
         # describes the type of args[0] in the ``return`` node.
-        assign(self, "type", return_type)
-        assign(self, "_sort_key", ())
+        self.type : Optional[Any] = return_type
+        self._sort_key: Any = ()
 
         # If set, use this fn to print this node
-        assign(self, "_repr_fn", None)
+        self._repr_fn : Optional[Callable[[Node], str]] = None
 
         # Dictionary to store metadata passes need to do their
         # transformations. This metadata is preserved across node copies
-        assign(self, "meta", {})
+        self.meta : Dict[str, Any] = {}
 
     def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
@@ -506,14 +490,14 @@ class Node(_NodeBase):
         # Clear prior users and input_nodes
         for old_use in self._input_nodes.keys():
             old_use.users.pop(self)
-        object.__setattr__(self, "_input_nodes", {})  # bypass Node.__setattr__
+        self._input_nodes = {}
 
         # We do three things in a single pass of the args
         # - Normalize list->immutable_list, dict->immutable_dict, etc
         # - Populate self._input_nodes
         # - Populate arg.users[self] for each arg
-        object.__setattr__(self, "_args", map_aggregate(new_args, update_users_and_input_nodes))
-        object.__setattr__(self, "_kwargs", map_aggregate(new_kwargs, update_users_and_input_nodes))
+        self._args = map_aggregate(new_args, update_users_and_input_nodes)  # type: ignore[assignment]
+        self._kwargs = map_aggregate(new_kwargs, update_users_and_input_nodes)  # type: ignore[assignment]
 
     def __repr__(self) -> str:
         if self._repr_fn:
@@ -756,24 +740,23 @@ class Node(_NodeBase):
         self.graph._graph_namespace._rename_object(self, name)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name in _setattr_custom_handling:
-            if name == "name":
-                m = self.graph.owning_module
-                if getattr(m, "_replace_hook", None):
-                    assert isinstance(value, str)
-                    for user in self.users:
-                        m._replace_hook(old=self, new=value, user=user)
-            elif name in ("op", "target"):
-                table = getattr(self.graph, "_find_nodes_lookup_table", None)
-                if table and self in table:
-                    self.graph._find_nodes_lookup_table.remove(self)
-                    object.__setattr__(self, name, value)
-                    self.graph._find_nodes_lookup_table.insert(self)
-                    return
-
+        if name == 'name' and hasattr(self, "name"):
+            m = self.graph.owning_module
+            if getattr(m, "_replace_hook", None):
+                assert isinstance(value, str)
+                for user in self.users:
+                    m._replace_hook(old=self, new=value, user=user)
+        update = False
+        if (
+                hasattr(self, name) and
+                hasattr(self.graph, "_find_nodes_lookup_table") and
+                self in self.graph._find_nodes_lookup_table
+        ):
+            update = True
+            self.graph._find_nodes_lookup_table.remove(self)
         object.__setattr__(self, name, value)
-
-_setattr_custom_handling = dict.fromkeys(["name", "op", "target"])
+        if update:
+            self.graph._find_nodes_lookup_table.insert(self)
 
 @compatibility(is_backward_compatible=True)
 def map_arg(a: Argument, fn: Callable[[Node], Argument]) -> Argument:


### PR DESCRIPTION
…135562)

This reverts commit 66da3b3b2acacb116a9b23e91b24934830eaf6b8.

#135079 breaks internal tests and needs to be reverted. Revert with mergebot doesn't work as this PR is technically part of the stack, but, according to @jansel, it should be possible to revert it individually. Pull Request resolved: https://github.com/pytorch/pytorch/pull/135562 Approved by: https://github.com/jansel, https://github.com/seemethere

