### PR TITLE
Improved replacement of ephemerally-sourced symbols

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1799,6 +1799,16 @@ class GraphModule(torch.nn.Module):
 
         fn(torch.ones(4), x, torch.ones(4))
 
+    def test_ephemeral_source_symbol_evaporates_with_slice_view(self):
+        @torch.compile(backend="eager", dynamic=True)
+        def f(t):
+            return t._base + 1
+
+        x_a = torch.randn(4, 4, requires_grad=True)
+        x = TwoTensor(x_a, x_a.clone())
+        out = f(x[3])
+        self.assertEqual(out.shape, x_a.shape)
+
 
 instantiate_parametrized_tests(SubclassTests)
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -4967,7 +4967,20 @@ class ShapeEnv:
                     self._set_replacement(rhs, self._find(lhs), "trivial_rhs")
                 else:
                     r = try_solve(expr, free[0], floordiv_inequality=False)
-                    if r is not None and all(t.is_integer for t in sympy.preorder_traversal(r[1])):
+
+                    def _sym_ok(t):
+                        is_reciprocal = (
+                            isinstance(t, sympy.Pow) and
+                            t.args[1] == -1
+                        )
+                        is_mul_w_reciprocal = (
+                            isinstance(t, sympy.Mul) and
+                            isinstance(t.args[1], sympy.Pow) and
+                            t.args[1].args[1] == -1
+                        )
+                        return t.is_integer or is_reciprocal or is_mul_w_reciprocal
+
+                    if r is not None and all(_sym_ok(t) for t in sympy.preorder_traversal(r[1])):
                         new_var = self._find(r[1])
                         ok = len(free_unbacked_symbols(new_var)) == 0
                         if ok:

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -112,8 +112,6 @@ ASSOCIATIVE_OPS = {"minimum", "maximum", "mul", "add", "and_", "or_"}
 
 
 def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
-    from torch.utils._sympy.value_ranges import ValueRanges
-
     # Special cases
     if isinstance(expr, sympy.Pow) and isinstance(
         expr.args[1], sympy.core.numbers.Half
@@ -121,24 +119,6 @@ def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
         return analysis.sqrt(args[0])
     if isinstance(expr, ToFloat):
         return analysis.to_dtype(args[0], torch.float64)
-    # s0 ** -1 AKA 1/s0
-    if (
-        isinstance(expr, sympy.Pow)
-        and len(args) == 2
-        and expr.args[0].is_integer
-        and expr.args[0].is_positive
-        and (
-            args[1].lower
-            if isinstance(args[1], ValueRanges) and args[1].is_singleton()
-            else args[1]
-        )
-        == -1
-    ):
-        from torch.utils._sympy.value_ranges import ValueRanges
-
-        # NB: This is a loose bound; it'd be more accurate to compute
-        # analysis.reciprocal() but this ensures we keep integer ranges.
-        return ValueRanges(0, 1)
 
     # These handlers are special because they take an extra dtype argument
     # specifying what they should convert to, and we need to appropriately set

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -112,6 +112,8 @@ ASSOCIATIVE_OPS = {"minimum", "maximum", "mul", "add", "and_", "or_"}
 
 
 def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
+    from torch.utils._sympy.value_ranges import ValueRanges
+
     # Special cases
     if isinstance(expr, sympy.Pow) and isinstance(
         expr.args[1], sympy.core.numbers.Half
@@ -125,8 +127,12 @@ def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
         and len(args) == 2
         and expr.args[0].is_integer
         and expr.args[0].is_positive
-        and args[1].is_singleton()
-        and args[1].lower == -1
+        and (
+            args[1].lower
+            if isinstance(args[1], ValueRanges) and args[1].is_singleton()
+            else args[1]
+        )
+        == -1
     ):
         from torch.utils._sympy.value_ranges import ValueRanges
 

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -119,6 +119,20 @@ def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
         return analysis.sqrt(args[0])
     if isinstance(expr, ToFloat):
         return analysis.to_dtype(args[0], torch.float64)
+    # s0 ** -1 AKA 1/s0
+    if (
+        isinstance(expr, sympy.Pow)
+        and len(args) == 2
+        and expr.args[0].is_integer
+        and expr.args[0].is_positive
+        and args[1].is_singleton()
+        and args[1].lower == -1
+    ):
+        from torch.utils._sympy.value_ranges import ValueRanges
+
+        # NB: This is a loose bound; it'd be more accurate to compute
+        # analysis.reciprocal() but this ensures we keep integer ranges.
+        return ValueRanges(0, 1)
 
     # These handlers are special because they take an extra dtype argument
     # specifying what they should convert to, and we need to appropriately set


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135635

**TL;DR:** This PR does the following:
* Uses `CleanDiv` instead of `FloorDiv` in more places when we know it holds to get strictly more information:
    * In `_try_isolate_lhs()`, if we know that `lhs` and `rhs` are integers, we can solve via `CleanDiv` instead of `/`
        * The PR teaches `_try_isolate_lhs()` how to handle `CleanDiv(numer, denom)` where the `denom` component contains the thing we're trying to isolate. This happens in practice for `slice()` and `view()` views
    * In the `infer_size()` util used by various views (including `view()` and `reshape()`), use `CleanDiv` for inferring the `-1` dimension from the `total size / product of other dims`
        * We also learn that all components of the product are >= 1, so provide that information as well

**Background:** During subclass fake-ification, subclass instances that are views go through the process of "view replay" to reconstruct the base -> view relationship in fake land. Part of view replay involves symbolicizing any closed-over ints in the original view function. For example, a slice view `x[3]` will have a `3` baked in as an arg to slice in the saved view func; we want to symbolicize this 3 for dynamic shapes support.

In practice, before the view is replayed, all closed-over ints are replaced with SymInts with "ephemeral sources" that are intended to disappear when we [assert](https://github.com/pytorch/pytorch/blob/49e0b88aab0fd124c318fe1c59fbbd8726298338/torch/_subclasses/meta_utils.py#L1073-L1078) the subclass size / stride / storage offset match the allocated, non-ephemeral outer symbolic values. For this to work, we rely on the [SymInt replacement logic](https://github.com/pytorch/pytorch/blob/49e0b88aab0fd124c318fe1c59fbbd8726298338/torch/fx/experimental/symbolic_shapes.py#L4740-L4744) (e.g. replace `s1` with `s0 * 5` if `Eq(s1, s0*5)` is found to be true), and [prioritize ephemerally-sourced SymInts](https://github.com/pytorch/pytorch/blob/49e0b88aab0fd124c318fe1c59fbbd8726298338/torch/fx/experimental/symbolic_shapes.py#L4909-L4921) to be replaced first.

**Problem:** In certain cases, the SymInt replacement logic does not apply, and an ephemerally-sourced SymInt lives for longer than originally designed, resulting in guard time errors like those reported [here](https://github.com/pytorch/pytorch/pull/133337#issuecomment-2302417084) and in #128649.
```
AssertionError: s7 (could be from ['<ephemeral: symint_visitor_fn>', '<ephemeral: symint_visitor_fn>']) not in {s3: ["L['nt']._values.size()[0]", "L['nt']._values.size()[0]"], s0: ["L['nt'].size()[1]"], s6: ["L['nt'].size()[2]", "L['nt']._values.size()[1]"], s1: ["L['nt']._values.size()[0]"], s7: []}.  If this assert is failing, it could be due to the issue described in https://github.com/pytorch/pytorch/pull/90665
```

**Solution:** For each of the error cases, we can identify why a particular SymInt replacement is not made and enhance the logic to support such replacements. This PR addresses this for `slice()` and `view()` views that have been encountered in practice. For example:
```python
@torch.compile(backend="eager", dynamic=True)
def f(t):
    return t._base + 1

x_a = torch.randn(4, 4, requires_grad=True)
x = TwoTensor(x_a, x_a.clone())
out = f(x[3])
```
The input to the compiled func is a subclass view produced by `slice()`. Fake-ification of this subclass view does the following:
1. Allocates non-ephemeral size / stride / storage offset symbols for the outer subclass metadata. Since the slice is contiguous with shape `(4)`, we get `(s0)` for the shape, `(1)` for the stride, and `s1` for the storage offset.
2. Perform view replay on a fake-ified base to reconstruct the base -> view relationship. The captured `3` arg to `slice()` is replaced with an ephemerally-sourced SymInt `s2` before the view func is replayed. The output of view replay has shape `(s0)`, stride `(1)`, and `s0 * s2` for the storage offset.
3. [Asserts](https://github.com/pytorch/pytorch/blob/49e0b88aab0fd124c318fe1c59fbbd8726298338/torch/_subclasses/meta_utils.py#L1073-L1078) that the output of view replay has the shape metadata allocated in step (1). Since we have `Eq(s1, s0 * s2)` from the storage offset assert and `s2` is ephemeral, we should replace `s2` with `CleanDiv(s1, s0)`. Before this PR, this replacement was not supported since `s1/s0` is not guaranteed to be an integer. With `CleanDiv`, we have the integer guarantee and the replacement can happen.
https://github.com/pytorch/pytorch/blob/49e0b88aab0fd124c318fe1c59fbbd8726298338/torch/fx/experimental/symbolic_shapes.py#L4969-L4970

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec