### PR TITLE
Preserve dynamic src length in multi_head_attention_forward

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6162,7 +6162,7 @@ def multi_head_attention_forward(
     #
     q = q.view(tgt_len, bsz * num_heads, head_dim).transpose(0, 1)
     if static_k is None:
-        k = k.view(k.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+        k = k.view(src_len, bsz * num_heads, head_dim).transpose(0, 1)
     else:
         # TODO finish disentangling control flow so we don't do in-projections when statics are passed
         assert (
@@ -6173,7 +6173,7 @@ def multi_head_attention_forward(
         ), f"expecting static_k.size(2) of {head_dim}, but got {static_k.size(2)}"
         k = static_k
     if static_v is None:
-        v = v.view(v.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+        v = v.view(src_len, bsz * num_heads, head_dim).transpose(0, 1)
     else:
         # TODO finish disentangling control flow so we don't do in-projections when statics are passed
         assert (


### PR DESCRIPTION
When exporting a PyTorch model to ONNX, if you want to extract the size of a specific dimension of a tensor:

Using b = a.shape[0] will result in b being fixed as a constant in the ONNX model.
On the other hand, using b, _, _ = a.shape allows b to change dynamically with the input.
I encountered this issue while using nn.MultiheadAttention, and I found that making a small modification resolved the problem.

I have provided a minimal reproducible example, which results in an error under the current Python version. However, after modifying the code as indicated in the pull request, it runs correctly.

Additionally, I am very curious about the conditions under which a value is exported as a constant in ONNX. If anyone could kindly explain this to me or point me towards relevant learning resources, I would be immensely grateful.

```python
import torch
import torch.nn as nn
import onnxruntime as ort
import numpy as np

export_shape = (249, 1, 1000)
test_shape = (150, 1, 1000)


class MyModule(nn.Module):
    def __init__(self):
        super(MyModule, self).__init__()
        self.hidden_size = 500
        self.num_heads = 4
        self.attention = nn.MultiheadAttention(
            embed_dim=2 * self.hidden_size, num_heads=self.num_heads
        )

    def forward(self, input_x):
        return self.attention(input_x, input_x, input_x)


def export_onnx():
    input_x = torch.randn(export_shape)

    model = MyModule()
    model.eval()

    torch.onnx.export(
        model,
        input_x,
        "test.onnx",
        input_names=["x"],
        output_names=["y"],
        dynamic_axes={
            "x": {0: "batch"},
            "y": {0: "batch"},
        },
    )


def infer_by_onnx(shape):
    input_x = torch.randn(shape)

    sess_options = ort.SessionOptions()
    sess_options.intra_op_num_threads = 1
    sess_options.inter_op_num_threads = 1
    ort_sess = ort.InferenceSession(
        "./test.onnx",
        sess_options=sess_options,
        providers=ort.get_available_providers(),
    )

    y = ort_sess.run(["y"], {"x": input_x.numpy()})[0]


def test_onnx():
    infer_by_onnx(export_shape)
    infer_by_onnx(test_shape)


if __name__ == "__main__":
    export_onnx()
    test_onnx()

```