### PR TITLE
[ROCm] Use ieee precision for fp32 in flex attention

### DIFF
--- a/torch/_inductor/kernel/flex_attention.py
+++ b/torch/_inductor/kernel/flex_attention.py
@@ -56,7 +56,7 @@ def maybe_realize(args: List[Optional[IRNode]]):
 
 
 def get_float32_precision():
-    if torch.get_float32_matmul_precision() == "highest":
+    if torch.get_float32_matmul_precision() == "highest" or torch.version.hip:
         return "'ieee'"
     else:
         return "'tf32'"


### PR DESCRIPTION
https://github.com/pytorch/pytorch/commit/3bebc09be9845c0779f190489e8d4caa9e2653c8

Brought in a change to flex_attention to allow TF32 precision, this largely lacks support on ROCm side and we should use ieee.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang