### PR TITLE
[MPS] Add native im2col

### DIFF
--- a/aten/src/ATen/mps/MPSFallback.mm
+++ b/aten/src/ATen/mps/MPSFallback.mm
@@ -88,7 +88,6 @@ TORCH_LIBRARY_IMPL(aten, MPS, m) {
   m.impl("embedding_renorm_", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("linalg_svd", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("linalg_svd.U", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
-  m.impl("im2col", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>()); // Used in  preprocessing by nn.Unfold
   m.impl("col2im", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());
   m.impl("_slow_conv2d_forward", slow_conv2d_forward_mps);
   m.impl("upsample_nearest3d.vec", torch::CppFunction::makeFromBoxedFunction<&mps_fallback>());

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -227,6 +227,10 @@ std::string scalarToMetalTypeString(const c10::ScalarType& scalar_type) {
       return "uchar";
     case ScalarType::Bool:
       return "bool";
+    case ScalarType::ComplexHalf:
+      return "half2";
+    case ScalarType::ComplexFloat:
+      return "float2";
     default:
       TORCH_CHECK(false, "Undefined type ", scalar_type);
       return "Undefined";

--- a/aten/src/ATen/native/mps/operations/Im2Col.mm
+++ b/aten/src/ATen/native/mps/operations/Im2Col.mm
@@ -117,7 +117,7 @@ static void im2col_out_mps_template(Tensor& output,
 
   if (input.dim() == 3) {
     batched_input = false;
-    input = input.view({1, input.size(0), input.size(1), input.size(2)});
+    input = input.unsqueeze(0);
   }
 
   int64_t batch_size = input.size(0);
@@ -171,7 +171,7 @@ static void im2col_out_mps_template(Tensor& output,
     }
   });
   if (!batched_input) {
-    output.resize_({n_output_plane, output_length});
+    output = output.squeeze(0);
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/Im2Col.mm
+++ b/aten/src/ATen/native/mps/operations/Im2Col.mm
@@ -148,7 +148,7 @@ static void im2col_out_mps_template(Tensor& output,
       std::array<int64_t, 4> input_sizes = {input_width, input_height, n_input_plane, batch_size};
       std::array<int64_t, 4> input_strides = {input.stride(3), input.stride(2), input.stride(1), input.stride(0)};
       std::array<int64_t, 4> output_strides = {output.stride(2), output.stride(1), output.stride(0), output_width};
-      getMPSProfiler().beginProfileKernel(im2colPSO, "im2col", {input});
+      getMPSProfiler().beginProfileKernel(im2colPSO, "im2col", {input, output});
 
       if (getMPSProfiler().isCaptureEnabled()) {
         getMPSProfiler().startCapture("im2col", stream);

--- a/aten/src/ATen/native/mps/operations/Im2Col.mm
+++ b/aten/src/ATen/native/mps/operations/Im2Col.mm
@@ -1,0 +1,179 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/mps/MPSProfiler.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/empty_like.h>
+#include <ATen/ops/col2im_native.h>
+#include <ATen/ops/im2col_native.h>
+#endif
+
+namespace at::native {
+using namespace mps;
+static MetalShaderLibrary lib(R"IM2COL_METAL(
+template<typename T>
+kernel void im2col(
+    constant T               * inputData       [[buffer(0)]],
+    device   T               * outputData      [[buffer(1)]],
+    constant uint4           & kernel_dilation [[buffer(2)]],
+    constant int4            & padding_stride  [[buffer(3)]],
+    constant ulong4          & input_strides   [[buffer(4)]],
+    constant ulong4          & output_strides  [[buffer(5)]],
+    uint3                      thread_index    [[thread_position_in_grid]]) {
+    const auto N = thread_index.z;
+    const auto C = thread_index.y;
+    const auto L = thread_index.x;
+    const auto output_width = output_strides.w;
+    const auto o_x = L % output_width;
+    const auto o_y = L / output_width;
+    auto i_x = o_x * padding_stride.z - padding_stride.x;
+    auto i_y = o_y * padding_stride.w - padding_stride.y;
+    ulong kernel_size = kernel_dilation.x * kernel_dilation.y;
+    ulong I_C = C / (kernel_size);
+    ulong inp_offs = C % kernel_size;
+    const auto i = inp_offs / kernel_dilation.x;
+    const auto j = inp_offs % kernel_dilation.x;
+    i_x += i * kernel_dilation.z;
+    i_y += j * kernel_dilation.w;
+    const auto val = inputData[N*input_strides.w + I_C*input_strides.z + i_y * input_strides.y + i_x * input_strides.x];
+    outputData[L * output_strides.x + C * output_strides.y + N * output_strides.z ] = val;
+}
+
+#define INSTANTIATE_IM2COL(DTYPE)                                          \
+template                                                                   \
+[[host_name("im2col_" #DTYPE)]]                                            \
+kernel void im2col<DTYPE>(                                                 \
+    constant DTYPE           * inputData       [[buffer(0)]],              \
+    device   DTYPE           * outputData      [[buffer(1)]],              \
+    constant uint4           & kernel_dilation [[buffer(2)]],              \
+    constant int4            & padding_stride  [[buffer(3)]],              \
+    constant ulong4          & input_strides   [[buffer(4)]],              \
+    constant ulong4          & output_strides  [[buffer(5)]],              \
+    uint3                      thread_index  [[thread_position_in_grid]])
+
+INSTANTIATE_IM2COL(float);
+)IM2COL_METAL");
+
+namespace {
+static void im2col_out_mps_template(
+    Tensor& output,
+    const Tensor& input_,
+    IntArrayRef kernel_size,
+    IntArrayRef dilation,
+    IntArrayRef padding,
+    IntArrayRef stride) {
+  TORCH_CHECK(
+      kernel_size.size() == 2,
+      "It is expected kernel_size equals to 2, but got size ",
+      kernel_size.size());
+
+  TORCH_CHECK(
+      dilation.size() == 2,
+      "It is expected dilation equals to 2, but got size ",
+      dilation.size());
+
+  TORCH_CHECK(
+      padding.size() == 2,
+      "It is expected padding equals to 2, but got size ",
+      padding.size());
+
+  TORCH_CHECK(
+      stride.size() == 2,
+      "It is expected stride equals to 2, but got size ",
+      stride.size());
+
+  const auto kernel_height = kernel_size[0];
+  int64_t kernel_width = kernel_size[1];
+  int64_t dilation_height = dilation[0];
+  int64_t dilation_width = dilation[1];
+  int64_t pad_height = padding[0];
+  int64_t pad_width = padding[1];
+  int64_t stride_height = stride[0];
+  int64_t stride_width = stride[1];
+
+  Tensor input = input_.contiguous();
+
+  bool batched_input = true;
+
+  if (input.dim() == 3) {
+    batched_input = false;
+    input = input.view({1, input.size(0), input.size(1), input.size(2)});
+  }
+
+  int64_t batch_size = input.size(0);
+  int64_t n_input_plane = input.size(1);
+  int64_t input_height = input.size(2);
+  int64_t input_width = input.size(3);
+
+  int64_t output_height = (input_height + 2 * pad_height -
+                           (dilation_height * (kernel_height - 1) + 1)) /
+          stride_height + 1;
+  int64_t output_width = (input_width + 2 * pad_width -
+                          (dilation_width * (kernel_width - 1) + 1)) /
+          stride_width + 1;
+  int64_t n_output_plane = n_input_plane * kernel_width * kernel_height;
+  int64_t output_length = output_height * output_width;
+
+  output.resize_({batch_size, n_output_plane, output_length});
+  auto stream = getCurrentMPSStream();
+  auto device = MPSDevice::getInstance()->device();
+  auto im2colPSO = lib.getPipelineStateForFunc("im2col_" + mps::scalarToMetalTypeString(input));
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      std::array<int32_t, 4> kernel_dilation = {static_cast<int32_t>(kernel_width), static_cast<int32_t>(kernel_height), static_cast<int32_t>(dilation_width), static_cast<int32_t>(dilation_height)};
+      std::array<int32_t, 4> padding_stride = {static_cast<int32_t>(pad_width), static_cast<int32_t>(pad_height), static_cast<int32_t>(stride_width), static_cast<int32_t>(stride_height)};
+      std::array<int64_t, 4> input_strides = {input.stride(3), input.stride(2), input.stride(1), input.stride(0)};
+      std::array<int64_t, 4> output_strides = {output.stride(2), output.stride(1), output.stride(0), output_width};
+      getMPSProfiler().beginProfileKernel(im2colPSO, "im2col", {input});
+
+      if (getMPSProfiler().isCaptureEnabled()) {
+        getMPSProfiler().startCapture("im2col", stream);
+      }
+      auto computeEncoder = stream->commandEncoder();
+      [computeEncoder setComputePipelineState:im2colPSO];
+      mtl_setBuffer(computeEncoder, input, 0);
+      mtl_setBuffer(computeEncoder, output, 1);
+      mtl_setBytes(computeEncoder, kernel_dilation, 2);
+      mtl_setBytes(computeEncoder, padding_stride, 3);
+      mtl_setBytes(computeEncoder, input_strides, 4);
+      mtl_setBytes(computeEncoder, output_strides, 5);
+      [computeEncoder dispatchThreads:MTLSizeMake(output_length, n_output_plane, batch_size)
+                      threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+      if (getMPSProfiler().isCapturing()) {
+        getMPSProfiler().stopCapture(stream);
+      }
+      getMPSProfiler().endProfileKernel(im2colPSO);
+    }
+  });
+  if (!batched_input) {
+    output.resize_({n_output_plane, output_length});
+  }
+}
+
+} // anonymous namespace
+Tensor& im2col_out_mps(const Tensor& input,
+    IntArrayRef kernel_size,
+    IntArrayRef dilation,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    Tensor& output) {
+  im2col_out_mps_template(
+      output, input, kernel_size, dilation, padding, stride);
+  return output;
+}
+
+Tensor im2col_mps(
+    const Tensor& input,
+    IntArrayRef kernel_size,
+    IntArrayRef dilation,
+    IntArrayRef padding,
+    IntArrayRef stride) {
+  Tensor output = at::empty_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  im2col_out_mps_template(
+      output, input, kernel_size, dilation, padding, stride);
+  return output;
+}
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Im2Col.mm
+++ b/aten/src/ATen/native/mps/operations/Im2Col.mm
@@ -11,8 +11,6 @@
 #include <ATen/ops/im2col_native.h>
 #endif
 
-// #define _CAPTURE_KERNEL 1
-
 namespace at::native {
 using namespace mps;
 static MetalShaderLibrary lib(R"IM2COL_METAL(
@@ -152,11 +150,9 @@ static void im2col_out_mps_template(Tensor& output,
       std::array<int64_t, 4> output_strides = {output.stride(2), output.stride(1), output.stride(0), output_width};
       getMPSProfiler().beginProfileKernel(im2colPSO, "im2col", {input});
 
-#if _CAPTURE_KERNEL
       if (getMPSProfiler().isCaptureEnabled()) {
         getMPSProfiler().startCapture("im2col", stream);
       }
-#endif
       auto computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:im2colPSO];
       mtl_setBuffer(computeEncoder, input, 0);
@@ -168,11 +164,9 @@ static void im2col_out_mps_template(Tensor& output,
       mtl_setBytes(computeEncoder, input_sizes, 6);
       [computeEncoder dispatchThreads:MTLSizeMake(output_length, n_input_plane, batch_size)
                 threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
-#if _CAPTURE_KERNEL
       if (getMPSProfiler().isCapturing()) {
         getMPSProfiler().stopCapture(stream);
       }
-#endif
       getMPSProfiler().endProfileKernel(im2colPSO);
     }
   });

--- a/aten/src/ATen/native/mps/operations/Im2Col.mm
+++ b/aten/src/ATen/native/mps/operations/Im2Col.mm
@@ -78,7 +78,9 @@ kernel void im2col<DTYPE>(                                                 \
 
 INSTANTIATE_IM2COL(bool);
 INSTANTIATE_IM2COL(float);
+INSTANTIATE_IM2COL(float2);
 INSTANTIATE_IM2COL(half);
+INSTANTIATE_IM2COL(half2);
 #if __METAL_VERSION__ >= 310
 INSTANTIATE_IM2COL(bfloat);
 #endif

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13043,12 +13043,14 @@
   dispatch:
     CPU: im2col_out_cpu
     CUDA: im2col_out_cuda
+    MPS: im2col_out_mps
 
 - func: im2col(Tensor self, int[2] kernel_size, int[2] dilation, int[2] padding, int[2] stride) -> Tensor
   python_module: nn
   dispatch:
     CPU: im2col_cpu
     CUDA: im2col_cuda
+    MPS: im2col_mps
 
 - func: isfinite(Tensor self) -> Tensor
   variants: function, method


### PR DESCRIPTION
It's called from `torch.unfold` and one of the few remaining vestiges in `MPSFallback.mm`

Strongly inspired by CUDA implementation from https://github.com/pytorch/pytorch/blob/09519eb1959978af7f2f909acf768485772596ab/aten/src/ATen/native/cuda/im2col.cuh#L40-L61