### PR TITLE
[DSD] Fix distributed state dict full_state_dict option hang during set_state_dict

### DIFF
--- a/test/distributed/_composable/test_composability/test_2d_composability.py
+++ b/test/distributed/_composable/test_composability/test_2d_composability.py
@@ -337,7 +337,7 @@ class TestFullyShard2DTraining(FSDPTest):
         self.assertEqual(loss_no_cp2, loss_cp2)
 
     @skip_if_lt_x_gpu(4)
-    def test_2d_set_full_state_dict(self):
+    def test_fully_shard_tp_2d_set_full_state_dict(self):
         dummy_model = SimpleModel().cuda()
         mesh_2d = init_device_mesh(
             "cuda",
@@ -371,7 +371,7 @@ class TestFullyShard2DTraining(FSDPTest):
         set_optimizer_state_dict(
             model, optimizers=optim, optim_state_dict=full_osd, options=options
         )
-    
+
         # check after setting full state dict, the model and optim default sharded state dict
         # are the same as the initial default sharded state dict.
         new_msd = get_model_state_dict(model)

--- a/test/distributed/_composable/test_composability/test_2d_composability.py
+++ b/test/distributed/_composable/test_composability/test_2d_composability.py
@@ -818,26 +818,5 @@ class TestNew2dParallelStateDict(DTensorTestBase):
 
 instantiate_parametrized_tests(TestNew2dParallelStateDict)
 
-
-class TestDummyModel(torch.nn.Module):
-    def __init__(self) -> None:
-        super().__init__()
-        torch.manual_seed(0)
-        self.net1 = nn.Linear(8, 16)
-        # self.net2 = nn.Linear(16, 32)
-        # self.net3 = nn.Linear(32, 64)
-        # self.net4 = nn.Linear(64, 8)
-
-    def forward(self, x):
-        x = F.relu(self.net1(x))
-        # x = F.relu(self.net2(x))
-        # x = F.relu(self.net3(x))
-        # x = F.relu(self.net4(x))
-        return x
-
-    def get_input(self):
-        return torch.rand(8, 8, device="cuda")
-
-
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_composable/test_composability/test_2d_composability.py
+++ b/test/distributed/_composable/test_composability/test_2d_composability.py
@@ -357,8 +357,8 @@ class TestFullyShard2DTraining(FSDPTest):
         model(model.get_input()).sum().backward()
         optim.step()
         # ref_msd, ref_osd are both the default sharded state dict
-        ref_msd = copy.deepcopy(model.state_dict())
-        ref_osd = copy.deepcopy(optim.state_dict())
+        ref_msd = copy.deepcopy(get_model_state_dict(model))
+        ref_osd = copy.deepcopy(get_optimizer_state_dict(model, optimizers=optim))
 
         options = StateDictOptions(
             full_state_dict=True, cpu_offload=True, broadcast_from_rank0=True
@@ -371,8 +371,11 @@ class TestFullyShard2DTraining(FSDPTest):
         set_optimizer_state_dict(
             model, optimizers=optim, optim_state_dict=full_osd, options=options
         )
-        new_msd = model.state_dict()
-        new_osd = optim.state_dict()
+    
+        # check after setting full state dict, the model and optim default sharded state dict
+        # are the same as the initial default sharded state dict.
+        new_msd = get_model_state_dict(model)
+        new_osd = get_optimizer_state_dict(model, optimizers=optim)
         self.assertEqual(ref_msd, new_msd)
         self.assertEqual(ref_osd, new_osd)
 

--- a/test/distributed/_composable/test_composability/test_2d_composability.py
+++ b/test/distributed/_composable/test_composability/test_2d_composability.py
@@ -342,7 +342,7 @@ class TestFullyShard2DStateDict(DTensorTestBase):
     def backend(self):
         # need to specify gloo backend for testing cpu offload
         return "cpu:gloo,cuda:nccl"
-    
+
     @with_comms
     @skip_if_lt_x_gpu(4)
     def test_fully_shard_tp_2d_set_full_state_dict(self):

--- a/test/distributed/_composable/test_composability/test_2d_composability.py
+++ b/test/distributed/_composable/test_composability/test_2d_composability.py
@@ -336,6 +336,14 @@ class TestFullyShard2DTraining(FSDPTest):
         loss_cp2 = train_step(model_cp, optim_cp, inp)
         self.assertEqual(loss_no_cp2, loss_cp2)
 
+
+class TestFullyShard2DStateDict(DTensorTestBase):
+    @property
+    def backend(self):
+        # need to specify gloo backend for testing cpu offload
+        return "cpu:gloo,cuda:nccl"
+    
+    @with_comms
     @skip_if_lt_x_gpu(4)
     def test_fully_shard_tp_2d_set_full_state_dict(self):
         dummy_model = SimpleModel().cuda()
@@ -589,6 +597,11 @@ class TestNew2dParallelTraining(DTensorTestBase):
 # TODO: update all state dict unit tests to use distributed.checkpoint.state_dict,
 # and consolidate all the state_dict test in test.distributed.checkpoint.
 class TestNew2dParallelStateDict(DTensorTestBase):
+    @property
+    def backend(self):
+        # need to specify gloo backend for testing cpu offload
+        return "cpu:gloo,cuda:nccl"
+
     @with_comms
     @skip_if_lt_x_gpu(4)
     def test_fsdp_2d_extension(self):

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -28,6 +28,7 @@ if dist.is_available() or TYPE_CHECKING:
     from torch.distributed import distributed_c10d
     from torch.distributed._shard.sharded_tensor import ShardedTensor
     from torch.distributed.tensor import distribute_tensor, DTensor, Replicate
+    from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
 
 
 def _identity_func(
@@ -551,8 +552,14 @@ def _distribute_tensors(
 
         local_state = _local_state[0]
         full_tensor = _local_state[1]
-        local_state_dict[key] = distribute_tensor(
-            full_tensor, local_state.device_mesh, local_state.placements
+
+        shape, offset = compute_local_shape_and_global_offset(
+            full_tensor.shape, local_state.device_mesh, local_state.placements
+        )
+        slices = [slice(offset[i], shape[i] + offset[i]) for i in range(len(shape))]
+        local_tensor = full_tensor[slices]
+        local_state_dict[key] = DTensor.from_local(
+            local_tensor, local_state.device_mesh, local_state.placements
         )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #135763
* __->__ #135725



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn

Fix https://github.com/pytorch/pytorch/issues/134095
This fix distributed state dict full_state_dict option hang during set_state_dict. We switch `_distribute_tensors` in _state_dict_utils.py to use `DTensor.from_local` instead of `distribute_tensor` to support FSDP2+TP 2D strided sharding use case, as `distribute_tensor` cannot handle strided sharding yet. `distribute_tensor` incurs a scatter behind the scenes, while `DTensor.from_local` takes the local slice from the full tensor on each rank to create the DTensor (no collective).  This means it's the user's responsibility to make sure the full_tensor from the full_state_dict is the same across all ranks. 