### PR TITLE
Fix attr check for quantization spec

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -600,6 +600,14 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
     def test_fixed_qparams_qspec_observer_dedup(self):
         class BackendAQuantizer(Quantizer):
             def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                act_qspec = FixedQParamsQuantizationSpec(
+                    dtype=torch.uint8,
+                    quant_min=0,
+                    quant_max=255,
+                    qscheme=torch.per_tensor_affine,
+                    scale=1.0 / 256.0,
+                    zero_point=0,
+                )
                 for node in model.graph.nodes:
                     if (
                         node.op == "call_function"
@@ -607,14 +615,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                     ):
                         input_act = node.args[0]
                         assert isinstance(input_act, Node)
-                        act_qspec = FixedQParamsQuantizationSpec(
-                            dtype=torch.uint8,
-                            quant_min=0,
-                            quant_max=255,
-                            qscheme=torch.per_tensor_affine,
-                            scale=1.0 / 256.0,
-                            zero_point=0,
-                        )
                         node.meta["quantization_annotation"] = QuantizationAnnotation(
                             input_qspec_map={
                                 input_act: act_qspec,
@@ -630,13 +630,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                         assert isinstance(input_act, Node)
                         input_act1 = node.args[1]
                         assert isinstance(input_act, Node)
-                        act_qspec = QuantizationSpec(
-                            observer_or_fake_quant_ctr=observer.default_observer,
-                            dtype=torch.uint8,
-                            quant_min=0,
-                            quant_max=255,
-                            qscheme=torch.per_tensor_affine,
-                        )
                         node.meta["quantization_annotation"] = QuantizationAnnotation(
                             input_qspec_map={
                                 input_act0: act_qspec,

--- a/torch/ao/quantization/pt2e/prepare.py
+++ b/torch/ao/quantization/pt2e/prepare.py
@@ -143,7 +143,10 @@ def _union_input_edge_with(
     # TODO: add assertions for types of root qspecs
     if (
         root_qspec is not None
-        and all(_has_same_attr(root_qspec, input_edge_root_qspec, attr) for attr in ["dtype", "is_dynamic", "quant_min", "quant_max", "qscheme", "ch_axis", "scale", "zero_point"])
+        and all(
+            _has_same_attr(root_qspec, input_edge_root_qspec, attr) for attr in
+            ["dtype", "is_dynamic", "quant_min", "quant_max", "qscheme", "ch_axis", "scale", "zero_point"]
+        )
     ):
         # the input arg to the node should reuse the existing output observer for arg
         # since dtype is the same (we may want to extend this to be a more strict check

--- a/torch/ao/quantization/pt2e/prepare.py
+++ b/torch/ao/quantization/pt2e/prepare.py
@@ -97,15 +97,16 @@ def _unwrap_shared_qspec(
         return _unwrap_shared_qspec(qspec, edge_or_node_to_qspec, shared_with_map)
     return qspec
 
-def _has_same_attr(qspec_a: QuantizationSpecBase, qspec_b: QuantizationSpecBase, attr_name: str):
+
+def _has_same_attr(
+    qspec_a: QuantizationSpecBase, qspec_b: QuantizationSpecBase, attr_name: str
+):
     return (
         hasattr(qspec_a, attr_name)
         and hasattr(qspec_b, attr_name)
         and getattr(qspec_a, attr_name) == getattr(qspec_b, attr_name)
-    ) or (
-        not hasattr(qspec_a, attr_name) and
-        not hasattr(qspec_b, attr_name)
-    )
+    ) or (not hasattr(qspec_a, attr_name) and not hasattr(qspec_b, attr_name))
+
 
 def _get_edge_or_node_to_qspec(
     model: torch.fx.GraphModule,
@@ -141,12 +142,18 @@ def _union_input_edge_with(
         qspec = edge_or_node_to_qspec[edge_or_node]
         root_qspec = _unwrap_shared_qspec(qspec, edge_or_node_to_qspec, shared_with_map)
     # TODO: add assertions for types of root qspecs
-    if (
-        root_qspec is not None
-        and all(
-            _has_same_attr(root_qspec, input_edge_root_qspec, attr) for attr in
-            ["dtype", "is_dynamic", "quant_min", "quant_max", "qscheme", "ch_axis", "scale", "zero_point"]
-        )
+    if root_qspec is not None and all(
+        _has_same_attr(root_qspec, input_edge_root_qspec, attr)
+        for attr in [
+            "dtype",
+            "is_dynamic",
+            "quant_min",
+            "quant_max",
+            "qscheme",
+            "ch_axis",
+            "scale",
+            "zero_point",
+        ]
     ):
         # the input arg to the node should reuse the existing output observer for arg
         # since dtype is the same (we may want to extend this to be a more strict check


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #135736

Summary:
Previously we only checked dtype and is_dynamic to decide if two quantization spec are equivalent
this may not work in some cases, e.g. when people use different qscheme or quant_min/quant_max

This PR added checks for other fields as well

Test Plan:
regression tests

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D62530974](https://our.internmc.facebook.com/intern/diff/D62530974)