### PR TITLE
Fix  dynamic shapes for workspace

### DIFF
--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -61,9 +61,6 @@ test_failures_cuda_wrapper = {
     "test_mm_plus_mm2_cuda_dynamic_shapes": test_torchinductor.TestFailure(
         ("cuda_wrapper",), is_skip=True
     ),
-    "test_consecutive_split_cumprod_cuda_dynamic_shapes": test_torchinductor.TestFailure(
-        ("cuda_wrapper",), is_skip=True
-    ),
 }
 
 

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -440,13 +440,13 @@ class CppWrapperCuda(CppWrapperCpu):
         if config.triton.autotune_at_compile_time:
             self.kernel_autotune_calls.writeline(line)
         if zero_fill:
-            # TODO: remove this function to use the default WrapperCodegen behavior after service platform has zero_() symbol
-            # default behavior is f"workspace.zero_(){self.ending}"
             if isinstance(nbytes, sympy.Expr):
                 self.writeline(
                     f"workspace.zero_(){self.ending}"
                 )
             else:
+                # TODO: remove this function to use the default WrapperCodegen behavior after service platform has zero_() symbol
+                # default behavior is f"workspace.zero_(){self.ending}"
                 self.writeline(
                     f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_zero_(workspace.get())){self.ending}"
                 )

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -442,8 +442,13 @@ class CppWrapperCuda(CppWrapperCpu):
         if zero_fill:
             # TODO: remove this function to use the default WrapperCodegen behavior after service platform has zero_() symbol
             # default behavior is f"workspace.zero_(){self.ending}"
-            self.writeline(
-                f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_zero_(workspace.get())){self.ending}"
-            )
+            if isinstance(nbytes, sympy.Expr):
+                self.writeline(
+                    f"workspace.zero_(){self.ending}"
+                )
+            else:
+                self.writeline(
+                    f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_zero_(workspace.get())){self.ending}"
+                )
             if config.triton.autotune_at_compile_time:
                 self.kernel_autotune_calls.writeline(f"workspace.zero_(){self.ending}")

--- a/torch/_inductor/codegen/cpp_wrapper_cuda.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cuda.py
@@ -441,9 +441,7 @@ class CppWrapperCuda(CppWrapperCpu):
             self.kernel_autotune_calls.writeline(line)
         if zero_fill:
             if isinstance(nbytes, sympy.Expr):
-                self.writeline(
-                    f"workspace.zero_(){self.ending}"
-                )
+                self.writeline(f"workspace.zero_(){self.ending}")
             else:
                 # TODO: remove this function to use the default WrapperCodegen behavior after service platform has zero_() symbol
                 # default behavior is f"workspace.zero_(){self.ending}"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1490,6 +1490,8 @@ class WrapperCodeGen(CodeGen):
         return SymbolicCallArg(expr, tree.numel)
 
     def generate_workspace_allocation(self, nbytes, device, zero_fill):
+        if isinstance(nbytes, sympy.Expr):
+            nbytes = V.graph.sizevars.size_hint(nbytes)
         line = self.make_allocation(
             "workspace", device, torch.uint8, shape=(nbytes,), stride=(1,)
         )


### PR DESCRIPTION
Fixes #131337

The code before fix is buggy because we generate code that looks like this `workspace = empty_strided_cuda((32*((255 + s0) // 256), ), (1, ), torch.uint8)` when doing triton autotune and `s0` is not defined. 

The solution approach is to use `V.graph.sizevars.size_hint(nbytes)` to realize the workspace size for triton autotune. Note that we only realize it for triton autotune code, but not for the cpp cuda code.

We also generate slightly different cpp code. 
When `nbytes` is int, we generate something like:
```cpp 
RAIIAtenTensorHandle workspace(workspace_handle);
AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_zero_(workspace.get()));
```
When `nbytes` is symbolic, we generate something like:
```cpp
    at::Tensor workspace = at::detail::empty_strided_cuda({8L*(c10::div_floor_integer(static_cast<int64_t>((255L + s0)), static_cast<int64_t>(256L))), }, {1L, }, at::kByte, c10::DeviceType::CUDA);
    workspace.zero_();
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang

Test Plan:
```
python test/inductor/test_cuda_cpp_wrapper.py DynamicShapesCudaWrapperCudaTests.test_consecutive_split_cumprod_cuda_dynamic_shapes_cuda_wrapper
```