### PR TITLE
xpu: fix 3rd party builds on systems with cmake<3.25

### DIFF
--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -49,7 +49,10 @@ find_file(
   )
 
 # Find SYCL library fullname.
-if(LINUX)
+# Don't use if(LINUX) here since this requires cmake>=3.25 and file is installed
+# and used by other projects.
+# See: https://cmake.org/cmake/help/v3.25/variable/LINUX.html
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   find_library(
     SYCL_LIBRARY
     NAMES sycl-preview


### PR DESCRIPTION
Cmake LINUX variable is available on starting from cmake 3.25. Better to use CMAKE_SYSTEM_NAME instead to relax cmake version requirement.

See: https://cmake.org/cmake/help/v3.25/variable/LINUX.html
Fixes: #135766