### PR TITLE
[Inductor] Fix needs_fixed_stride_order test on XPU

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -1035,7 +1035,7 @@ def forward(self, x_1, output_1):
         @register_lowering(torch.ops.mylib.weird_op_with_lowering)
         def _(x):
             return empty_strided(
-                x.shape, (2, 1), dtype=x.dtype, device=torch.device("cuda:0")
+                x.shape, (2, 1), dtype=x.dtype, device=torch.device(GPU_TYPE + ":0")
             )
 
         # Triton kernel that has different behavior depending on the input strides.
@@ -1068,7 +1068,7 @@ def forward(self, x_1, output_1):
             arange_out(x, y)
             return x + y
 
-        x = torch.randn(2, 2, device="cuda")
+        x = torch.randn(2, 2, device=GPU_TYPE)
         eager_out = f(x)
 
         compiled_inductor_f = torch.compile(f, backend="inductor", fullgraph=True)


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/135530 introduced a new cuda-specific test for the `needs_fixed_stride_order` parameter which fails on XPU due to lack of CUDA. This PR updates the parameters for the test to be device agnostic and allows the test to pass on XPU. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @etaf 