### PR TITLE
Support rms_norm() for NJT

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
+++ b/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
@@ -230,7 +230,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatchedDecomposition, m) {
   m.impl("reshape", native::reshape_symint);
   OP_DECOMPOSE(resolve_conj);
   OP_DECOMPOSE(resolve_neg);
-  OP_DECOMPOSE(rms_norm);
+  m.impl("rms_norm", native::rms_norm_symint);
   OP_DECOMPOSE(row_stack);
   OP_DECOMPOSE(rrelu);
   OP_DECOMPOSE(rrelu_);

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -281,11 +281,6 @@ Tensor rms_norm(
     IntArrayRef normalized_shape,
     const std::optional<Tensor>& weight_opt /* optional */,
     std::optional<double> eps) {
-
-  // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
-  const Tensor& weight = *weight_maybe_owned;
-
   std::vector<int64_t> dims_to_reduce;
   for (const auto i : c10::irange(normalized_shape.size())) {
     dims_to_reduce.push_back(input.dim() - i - 1);

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -263,6 +263,19 @@ std::tuple<Tensor, Tensor, Tensor> math_native_layer_norm(
   return std::make_tuple(out, mean, rstd);
 }
 
+Tensor rms_norm_symint(
+    const Tensor& input,
+    c10::SymIntArrayRef normalized_shape,
+    const std::optional<Tensor>& weight_opt /* optional */,
+    std::optional<double> eps) {
+  // See [Note: hacky wrapper removal for optional tensor]
+  c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
+  const Tensor& weight = *weight_maybe_owned;
+  _check_rms_norm_inputs_symint(input, normalized_shape, weight);
+
+  return at::native::rms_norm(input, C10_AS_INTARRAYREF_SLOW(normalized_shape), weight_opt, eps);
+}
+
 Tensor rms_norm(
     const Tensor& input,
     IntArrayRef normalized_shape,
@@ -272,9 +285,6 @@ Tensor rms_norm(
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
-  auto bias_opt = std::optional<Tensor>();
-  const Tensor& bias = *at::borrow_from_optional_tensor(bias_opt);
-  (void) _check_layer_norm_inputs(input, normalized_shape, weight, bias, /*calc_mn=*/false);
 
   std::vector<int64_t> dims_to_reduce;
   for (const auto i : c10::irange(normalized_shape.size())) {

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -273,14 +273,6 @@ Tensor rms_norm_symint(
   const Tensor& weight = *weight_maybe_owned;
   _check_rms_norm_inputs_symint(input, normalized_shape, weight);
 
-  return at::native::rms_norm(input, C10_AS_INTARRAYREF_SLOW(normalized_shape), weight_opt, eps);
-}
-
-Tensor rms_norm(
-    const Tensor& input,
-    IntArrayRef normalized_shape,
-    const std::optional<Tensor>& weight_opt /* optional */,
-    std::optional<double> eps) {
   std::vector<int64_t> dims_to_reduce;
   for (const auto i : c10::irange(normalized_shape.size())) {
     dims_to_reduce.push_back(input.dim() - i - 1);

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -274,7 +274,8 @@ Tensor rms_norm(
   const Tensor& weight = *weight_maybe_owned;
   auto bias_opt = std::optional<Tensor>();
   const Tensor& bias = *at::borrow_from_optional_tensor(bias_opt);
-  (void) _check_layer_norm_inputs(input, normalized_shape, weight, bias);
+
+  (void) _check_layer_norm_inputs(input, normalized_shape, weight, bias, /*calc_mn=*/false);
 
   std::vector<int64_t> dims_to_reduce;
   for (const auto i : c10::irange(normalized_shape.size())) {

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -274,7 +274,6 @@ Tensor rms_norm(
   const Tensor& weight = *weight_maybe_owned;
   auto bias_opt = std::optional<Tensor>();
   const Tensor& bias = *at::borrow_from_optional_tensor(bias_opt);
-
   (void) _check_layer_norm_inputs(input, normalized_shape, weight, bias, /*calc_mn=*/false);
 
   std::vector<int64_t> dims_to_reduce;

--- a/aten/src/ATen/native/layer_norm.h
+++ b/aten/src/ATen/native/layer_norm.h
@@ -112,12 +112,6 @@ Tensor rms_norm_symint(
     const std::optional<Tensor>& weight_opt /* optional */,
     std::optional<double> eps);
 
-Tensor rms_norm(
-    const Tensor& input,
-    IntArrayRef normalized_shape,
-    const std::optional<Tensor>& weight_opt /* optional */,
-    std::optional<double> eps);
-
 using forward_fn = void (*)(
     const Tensor& /* X */,
     const Tensor& /* gamma */,

--- a/aten/src/ATen/native/layer_norm.h
+++ b/aten/src/ATen/native/layer_norm.h
@@ -106,6 +106,12 @@ void layer_norm_cpu_out(
     int64_t M,
     int64_t N);
 
+Tensor rms_norm_symint(
+    const Tensor& input,
+    c10::SymIntArrayRef normalized_shape,
+    const std::optional<Tensor>& weight_opt /* optional */,
+    std::optional<double> eps);
+
 Tensor rms_norm(
     const Tensor& input,
     IntArrayRef normalized_shape,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3289,7 +3289,9 @@
   autogen: native_layer_norm_backward.out
   tags: core
 
-- func: rms_norm(Tensor input, int[] normalized_shape, Tensor? weight=None, float? eps=None) -> Tensor
+- func: rms_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight=None, float? eps=None) -> Tensor
+  dispatch:
+    CompositeImplicitAutograd: rms_norm_symint
 
 - func: nan_to_num(Tensor self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor
   variants: function, method

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -1424,12 +1424,15 @@ def mean_dim(func, *args, **kwargs):
         func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
     )
 
-    if len(new_kwargs["dim"]) > 1:
-        raise RuntimeError(
-            "mean(): not supported across multiple dimensions for NestedTensor"
-        )
-
     inp = new_kwargs.pop("input")
+
+    if len(new_kwargs["dim"]) > 1 and (
+        inp._ragged_idx in new_kwargs["dim"] or 0 in new_kwargs["dim"]
+    ):
+        raise RuntimeError(
+            "mean(): not supported across multiple dimensions for NestedTensor "
+            "when either the batch dim or ragged dim is included"
+        )
 
     (
         new_kwargs["dim"],

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -346,7 +346,7 @@ def jagged_torch_function(func, *args, **kwargs):
 
         return inp.reshape(*new_shape)
 
-    # Handle input validation for rms_norm because it's CompositeImplicit.
+    # Handle nested-specific input validation for CompositeImplicit rms_norm
     if func.__name__ == "rms_norm":
 
         def _rms_norm_sig(input, normalized_shape, weight=None, eps=None):
@@ -358,14 +358,6 @@ def jagged_torch_function(func, *args, **kwargs):
 
         inp = new_kwargs.pop("input")
         normalized_shape = new_kwargs.pop("normalized_shape")
-
-        num_non_normalized = inp.dim() - len(normalized_shape)
-        if num_non_normalized < 0 or inp.shape[num_non_normalized:] != normalized_shape:
-            raise ValueError(
-                f"rms_morm(): Given normalized_shape={normalized_shape}, expected input with "
-                f"shape [*, {', '.join(str(s) for s in normalized_shape)}], but got input of "
-                f"size {inp.shape}"
-            )
 
         # can't normalize over the ragged dim (yet)
         max_normalizable = inp.dim() - inp._ragged_idx - 1

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -346,6 +346,37 @@ def jagged_torch_function(func, *args, **kwargs):
 
         return inp.reshape(*new_shape)
 
+    # Handle input validation for rms_norm because it's CompositeImplicit.
+    if func.__name__ == "rms_norm":
+
+        def _rms_norm_sig(input, normalized_shape, weight=None, eps=None):
+            pass
+
+        _, new_kwargs = normalize_function(  # type: ignore[misc]
+            _rms_norm_sig, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
+        )
+
+        inp = new_kwargs.pop("input")
+        normalized_shape = new_kwargs.pop("normalized_shape")
+
+        num_non_normalized = inp.dim() - len(normalized_shape)
+        if num_non_normalized < 0 or inp.shape[num_non_normalized:] != normalized_shape:
+            raise ValueError(
+                f"rms_morm(): Given normalized_shape={normalized_shape}, expected input with "
+                f"shape [*, {', '.join(str(s) for s in normalized_shape)}], but got input of "
+                f"size {inp.shape}"
+            )
+
+        # can't normalize over the ragged dim (yet)
+        max_normalizable = inp.dim() - inp._ragged_idx - 1
+        if len(normalized_shape) > max_normalizable:
+            raise ValueError(
+                "rms_norm(): Normalization over the ragged dim not supported for nested tensors"
+            )
+
+        with torch._C.DisableTorchFunctionSubclass():
+            return func(*args, **kwargs)
+
     raise NotImplementedError(func)
 
 
@@ -395,7 +426,7 @@ def prim_layout_default(func, *args, **kwargs):
 def tensor_attr_unsupported_getter(func, *args, **kwargs):
     if func == torch.ops.aten.size.default:
         raise RuntimeError(
-            "NestedTensors does not support directly calling torch.ops.aten.size "
+            "NestedTensor does not support directly calling torch.ops.aten.size; "
             "please use `nested_tensor.size()` instead."
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #133021
* #135888
* __->__ #135872
* #125947

`rms_norm()` is a nice-to-have for ViT :)

This PR:
* SymInt-ifies `rms_norm()`, allowing NJT to use the same decomp.
* Adds torch_function-based input validation logic for nested-specific stuff (no normalization supported over the ragged dim for now) on the python NJT side.
* Adds multi-dim support (on non-ragged, non-batch dims) to `mean()` for NJT.