### PR TITLE
[trymerge] Manually close merged PR when Github fails

### DIFF
--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -168,6 +168,14 @@ def gh_post_commit_comment(
     )
 
 
+def gh_close_pr(org: str, repo: str, pr_num: int, dry_run: bool = False) -> None:
+    url = f"{GITHUB_API_URL}/repos/{org}/{repo}/pulls/{pr_num}"
+    if dry_run:
+        print(f"Dry run closing PR {pr_num}")
+    else:
+        gh_fetch_url(url, method="PATCH", data={"state": "closed"})
+
+
 def gh_delete_comment(org: str, repo: str, comment_id: int) -> None:
     url = f"{GITHUB_API_URL}/repos/{org}/{repo}/issues/comments/{comment_id}"
     gh_fetch_url(url, method="DELETE")

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1527,7 +1527,6 @@ def manually_close_merged_pr(
             gh_post_pr_comment(pr.org, pr.project, pr.pr_num, comment, dry_run)
             gh_close_pr(pr.org, pr.project, pr.pr_num, dry_run)
 
-    pr = GitHubPR(pr.org, pr.project, pr.pr_num)  # Refresh the PR
     message = (
         f"This PR (#{pr.pr_num}) was merged in {merge_commit_sha} but it is still open, likely due to a Github bug, "
         "so mergebot is closing it manually.  If you think this is a mistake, please feel free to reopen and contact Dev Infra."


### PR DESCRIPTION
Manually close merged PR when Github fails to do it.

Consequences of current design:
Sleeping for 1 min uses up the machine, might result in race conditions, results in merging label to removed a bit later, pr still left open if this api fails too (ie no async clean up job)

Tested in https://github.com/malfet/deleteme/pull/92 by removing the part of the commit message that has "resolved #pr num"