### PR TITLE
[aoti] Add warning to ask users to switch to new API

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -216,6 +216,20 @@ def capture_pre_autograd_graph(
     return module
 
 
+# We only want to print this once to avoid flooding logs in workflows where aot_compile_warning
+# is called multiple times.
+@lru_cache
+def aot_compile_warning():
+    from torch._inductor import config
+
+    log.warning("+============================+")
+    log.warning("|     !!!   WARNING   !!!    |")
+    log.warning("+============================+")
+    log.warning(
+        "torch._export.aot_compile() is being deprecated, please switch to "
+        "directly calling torch._inductor.aoti_compile_and_package(torch.export.export()) instead.")
+
+
 def aot_compile(
     f: Callable,
     args: Tuple[Any],
@@ -265,6 +279,8 @@ def aot_compile(
     from torch.export._trace import _export_to_torch_ir
     from torch._inductor.decomposition import select_decomp_table
     from torch._inductor import config
+
+    aot_compile_warning()
 
     if config.is_predispatch:
         gm = torch.export._trace._export(f, args, kwargs, dynamic_shapes, pre_dispatch=True).module()

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -41,7 +41,22 @@ def aoti_compile_and_package(
     """
     Compiles the exported program with AOTInductor, and packages it into a .pt2
     artifact specified by the input package_path. To load the package, you can
-    call `torch._inductor.package.load_package(package_path)`.
+    call `torch._inductor.aoti_load_package(package_path)`.
+
+    To compile and save multiple models into a single .pt2 artifact, you can do
+    the following:
+    ```
+    ep1 = torch.export.export(M1(), ...)
+    aoti_file1 = torch._inductor.aot_compile(ep1, ...)
+    ep2 = torch.export.export(M2(), ...)
+    aoti_file2 = torch._inductor.aot_compile(ep2, ...)
+
+    from torch._inductor.package import package_aoti, load_package
+    package_aoti("my_package.pt2", {"model1": aoti_file1, "model2": aoti_file2})
+
+    compiled_model1 = load_package("my_package.pt2", "model1")
+    compiled_model2 = load_package("my_package.pt2", "model2")
+    ```
 
     Args:
         exported_program: An exported program created through a call from torch.export
@@ -81,6 +96,27 @@ def aoti_compile_and_package(
     res = package_aoti(package_path, aoti_files)
     assert res == package_path
     return package_path
+
+
+def aoti_load_package(path: str) -> Any:  # type: ignore[type-arg]
+    """
+    Loads the model from the PT2 package.
+
+    If multiple models were packaged into the PT2, this will load the default
+    model. To load a specific model, you can directly call the load API
+    ```
+    from torch._inductor.package import load_package
+
+    compiled_model1 = load_package("my_package.pt2", "model1")
+    compiled_model2 = load_package("my_package.pt2", "model2")
+    ```
+
+    Args:
+        path: Path to the .pt2 package
+    """
+    from torch._inductor.package import load_package
+
+    return load_package(path)
 
 
 def aot_compile(

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -40,7 +40,18 @@ def aoti_compile_and_package(
 ) -> str:
     """
     Compiles the exported program with AOTInductor, and packages it into a .pt2
-    file specified by the input package_path.
+    artifact specified by the input package_path. To load the package, you can
+    call `torch._inductor.package.load_package(package_path)`.
+
+    Args:
+        exported_program: An exported program created through a call from torch.export
+        args: Example positional inputs
+        kwargs: Optional example keyword inputs
+        package_path: Optional specified path to the generated .pt2 artifact.
+        inductor_configs: Optional dictionary of configs to control inductor.
+
+    Returns:
+        Path to the generated artifact
     """
     from torch._inductor.package import package_aoti
     from torch.export import ExportedProgram


### PR DESCRIPTION
Instead of the following:
```
so_path = torch._export.aot_compile(...)
torch._export.aot_load(so_path)
```

The recommended path is to:
```
ep = torch.export.export(...)
pt2_path = torch._inductor.aoti_compile_and_package(ep, ...)
torch._inductor.package.load_package(pt2_path)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang