### PR TITLE
Make functional_tensor.py not depend on _inductor.config.py

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -3,7 +3,7 @@
 from typing import List
 
 import torch
-import torch._inductor.config as inductor_config
+import torch._functorch.config as functorch_config
 from functorch import make_fx
 from torch import Tensor
 from torch._dynamo.utils import counters
@@ -306,7 +306,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
     def test_multi_output_intermediate(self):
         for requires_grad in [False, True]:
             for enable_v2 in [False, True]:
-                with inductor_config.patch(
+                with functorch_config.patch(
                     {"enable_auto_functionalized_v2": enable_v2}
                 ):
                     counters.clear()
@@ -355,7 +355,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(num_reinplacing_failures(), 0)
 
     def test_lists_functionalize_v2(self):
-        with inductor_config.patch({"enable_auto_functionalized_v2": True}):
+        with functorch_config.patch({"enable_auto_functionalized_v2": True}):
 
             @torch.library.custom_op("mylib::mutate_op", mutates_args={"y"})
             def mutate_op(y: List[Tensor]) -> None:
@@ -381,7 +381,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             self.assertEqual(post_grad_graphs.count("aten.clone"), 0)
 
     def test_lists_old_functionalize(self):
-        with inductor_config.patch({"enable_auto_functionalized_v2": False}):
+        with functorch_config.patch({"enable_auto_functionalized_v2": False}):
 
             @torch.library.custom_op("mylib::mutate_op", mutates_args={"y"})
             def mutate_op(y: List[Tensor]) -> None:

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -42,6 +42,10 @@ static_weight_shapes = True
 # Applies CSE to the graph before partitioning
 cse = True
 
+# Enable auto_functionalized_v2 (enabled by default)
+enable_auto_functionalized_v2 = (
+    os.environ.get("TORCHDYNAMO_AUTO_FUNCTIONALIZED_V2", "0") == "1"
+)
 
 enable_autograd_cache = os.environ.get("ENABLE_AOT_AUTOGRAD_CACHE", "0") == "1"
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -24,12 +24,6 @@ def autotune_remote_cache_default() -> Optional[bool]:
         return False
     return None
 
-
-# Enable auto_functionalized_v2 (enabled by default)
-enable_auto_functionalized_v2 = (
-    os.environ.get("TORCHDYNAMO_AUTO_FUNCTIONALIZED_V2", "0") == "1"
-)
-
 # add some debug printouts
 debug = False
 

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, ContextManager, Dict, List, Optional, Tuple, Union
 
 import torch
-import torch._inductor.config as inductor_config
+import torch._functorch.config as functorch_config
 import torch.utils._pytree as pytree
 from torch._C import _functionalization_reapply_views_tls as _reapply_views
 from torch._ops import _get_dispatch_mode_pre_dispatch
@@ -471,7 +471,7 @@ class FunctionalTensorMode(TorchDispatchMode):
             # it doesn't matter what mode we use here because
             # the implementation of do_auto_functionalize doesn't
             # interact with FunctionalTensorMode at all
-            if self.export or not inductor_config.enable_auto_functionalized_v2:
+            if self.export or not functorch_config.enable_auto_functionalized_v2:
                 return do_auto_functionalize(func, args, kwargs)
             else:
                 return do_auto_functionalize_v2(func, args, kwargs)


### PR DESCRIPTION
Summary:
This is the third issue with having this dependency from functional_tensor.py into _inductor.config.py 
all of the issues were around the function is_fbcode.

the current failure is
```
AttributeError: partially initialized module 'torch' has no attribute 'version' (most likely due to a circular import)
```

those failure have been going on since  D62215095 landed.
to easily mitigate for now just moving the config to somewhere else.

Differential Revision: D62614252


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang