### PR TITLE
[NO REVIEW NEEDED]

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -6,7 +6,7 @@ import torch
 
 
 def is_fbcode() -> bool:
-    return not hasattr(torch.version, "git_version")
+    return hasattr(torch, "version") and not hasattr(torch.version, "git_version")
 
 
 def fx_graph_remote_cache_default() -> Optional[bool]:
@@ -387,7 +387,7 @@ autoheuristic_log_path = os.environ.get(
 )
 
 # Disabled by default on ROCm, opt-in if model utilises NHWC convolutions
-layout_opt_default = "1" if not torch.version.hip else "0"
+layout_opt_default = "1" if hasattr(torch, "version") and torch.version.hip else "0"
 layout_optimization = (
     os.environ.get("TORCHINDUCTOR_LAYOUT_OPTIMIZATION", layout_opt_default) == "1"
 )


### PR DESCRIPTION
Summary:
When torch.deploy is used torch.version is not available,
Since https://www.internalfb.com/diff/D62215095 landed there has been many silence errors due to the
dependency between functional_tensor and config.
see
https://fburl.com/logarithm/ol5kx0ee

all of them are due torch.version attribute not available this diff
mitigate the issue.

ideally we should discuss why torch.version os  not available
in torch.deploy and make it so.

Test Plan: buck test multipy/runtime:test_deploy_embedded_cuda_interp_without_cuda_available -- --run-disabled TorchpyTest.AcquireMultipleSessionsInDifferentPackages

Differential Revision: D62616340


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang