### PR TITLE
[AO][Inductor] Enable WOQ fusion pattern with permute

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -2600,7 +2600,9 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     y = y.reshape(*x.shape[:-1], y.shape[-1])
                     return y
                 else:
-                    return torch.nn.functional.linear(x, weight.to(dtype=x.dtype)) * scales
+                    return (
+                        torch.nn.functional.linear(x, weight.to(dtype=x.dtype)) * scales
+                    )
 
         x_shape = (1, 1, 256)
         s_shape = 12
@@ -2608,8 +2610,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             (256, 256, 1),  # linear dispatching to mm
             (256, 32, 1),  # linear dispatching to bmm
         ]
-        # is_permutes = [False, True]
-        is_permutes = [True,]
+        is_permutes = [False, True]
         for x_stride, is_permute in itertools.product(x_strides, is_permutes):
             mod = M(is_permute=is_permute).eval()
             x = torch.randn(x_shape, dtype=torch.bfloat16).as_strided(x_shape, x_stride)

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -2585,19 +2585,35 @@ class TestPatternMatcher(TestPatternMatcherBase):
     @skipIfNoDynamoSupport
     def test_woq_int8(self):
         class M(torch.nn.Module):
-            def forward(self, x, weight, scales):
-                return torch.nn.functional.linear(x, weight.to(dtype=x.dtype)) * scales
+            def __init__(self, is_permute):
+                super().__init__()
+                self.is_permute = is_permute
 
-        mod = M().eval()
+            def forward(self, x, weight, scales):
+                if self.is_permute:
+                    weight = weight.t()
+                    m = torch.mm(
+                        x.reshape(-1, x.shape[-1]),
+                        weight.to(x.dtype),
+                    )
+                    y = m * scales.to(m.dtype)
+                    y = y.reshape(*x.shape[:-1], y.shape[-1])
+                    return y
+                else:
+                    return torch.nn.functional.linear(x, weight.to(dtype=x.dtype)) * scales
+
         x_shape = (1, 1, 256)
-        w_shape = (12, 256)
         s_shape = 12
         x_strides = [
             (256, 256, 1),  # linear dispatching to mm
             (256, 32, 1),  # linear dispatching to bmm
         ]
-        for x_stride in x_strides:
+        # is_permutes = [False, True]
+        is_permutes = [True,]
+        for x_stride, is_permute in itertools.product(x_strides, is_permutes):
+            mod = M(is_permute=is_permute).eval()
             x = torch.randn(x_shape, dtype=torch.bfloat16).as_strided(x_shape, x_stride)
+            w_shape = (12, 256)
             w = torch.randint(-128, 127, w_shape, dtype=torch.int8)
             s = torch.randn(s_shape, dtype=torch.bfloat16)
 

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -89,13 +89,13 @@ class ConstantFolder(torch.fx.Interpreter):
         if (
             node.target == torch.ops.prims.convert_element_type.default
             and (
-                is_const_source(node.args[0], self.lifted_constants)
+                is_const_source(node.args[0], self.lifted_constants)  # type: ignore[arg-type]
                 or (
                     isinstance(node.args[0], torch.fx.Node)
                     and node.args[0].target == torch.ops.aten.permute.default
-                    and is_const_source(node.args[0].args[0], self.lifted_constants)
+                    and is_const_source(node.args[0].args[0], self.lifted_constants)  # type: ignore[arg-type]
                 )
-            )  # type: ignore[arg-type]
+            )
             and node.args[0].meta["val"].dtype == torch.int8  # type: ignore[union-attr]
             and node.args[1] == torch.bfloat16
         ):

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -89,6 +89,8 @@ class ConstantFolder(torch.fx.Interpreter):
         def is_woq_int8_pattern(node: torch.fx.node.Node) -> bool:
             return (
                 node.target == torch.ops.prims.convert_element_type.default  # type: ignore[return-value]
+                and isinstance(node.args[0], torch.fx.Node)
+                and "val" in node.args[0].meta
                 and node.args[0].meta["val"].dtype == torch.int8  # type: ignore[union-attr]
                 and node.args[1] == torch.bfloat16
             )

--- a/torch/_inductor/constant_folding.py
+++ b/torch/_inductor/constant_folding.py
@@ -88,11 +88,19 @@ class ConstantFolder(torch.fx.Interpreter):
     def is_impure(self, node: torch.fx.node.Node) -> bool:
         if (
             node.target == torch.ops.prims.convert_element_type.default
-            and is_const_source(node.args[0], self.lifted_constants)  # type: ignore[arg-type]
+            and (
+                is_const_source(node.args[0], self.lifted_constants)
+                or (
+                    isinstance(node.args[0], torch.fx.Node)
+                    and node.args[0].target == torch.ops.aten.permute.default
+                    and is_const_source(node.args[0].args[0], self.lifted_constants)
+                )
+            )  # type: ignore[arg-type]
             and node.args[0].meta["val"].dtype == torch.int8  # type: ignore[union-attr]
             and node.args[1] == torch.bfloat16
         ):
-            # For int8_weight -> dq -> bf16_weight
+            # Case 1: int8_weight -> dq -> bf16_weight
+            # Case 2: int8_weight -> permute -> dq -> bf16_weight
             return True
         if node.target in [
             torch.ops.quantized_decomposed.dequantize_per_channel.default,

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1560,6 +1560,25 @@ def _register_woq_mm_int8_pattern3():
     )
     _register_woq_lowering(_woq_pattern, aten._weight_int8pack_mm.default, aten.reshape)
 
+def _register_woq_mm_int8_pattern4():
+    _woq_pattern = CallFunction(
+        aten.mul.Tensor,
+        CallFunction(
+            aten.mm.default,
+            KeywordArg("x"),
+            CallFunction(
+                prims.convert_element_type.default,
+                CallFunction(
+                    aten.permute.default,
+                    KeywordArg("weight"),
+                    Arg(),
+                ),
+                Arg(),
+            ),
+        ),
+        KeywordArg("scales"),
+    )
+    _register_woq_lowering(_woq_pattern, aten._weight_int8pack_mm.default, aten.reshape)
 
 def _register_quantization_lowerings():
     _register_quantization_unary_fusion()
@@ -1573,6 +1592,7 @@ def _register_woq_lowerings():
     _register_woq_mm_int8_pattern1()
     _register_woq_mm_int8_pattern2()
     _register_woq_mm_int8_pattern3()
+    _register_woq_mm_int8_pattern4()
 
 
 def _is_valid_dequant_promotion_pattern(dtype=torch.float32):

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1560,6 +1560,7 @@ def _register_woq_mm_int8_pattern3():
     )
     _register_woq_lowering(_woq_pattern, aten._weight_int8pack_mm.default, aten.reshape)
 
+
 def _register_woq_mm_int8_pattern4():
     _woq_pattern = CallFunction(
         aten.mul.Tensor,
@@ -1579,6 +1580,7 @@ def _register_woq_mm_int8_pattern4():
         KeywordArg("scales"),
     )
     _register_woq_lowering(_woq_pattern, aten._weight_int8pack_mm.default, aten.reshape)
+
 
 def _register_quantization_lowerings():
     _register_quantization_unary_fusion()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ pytorch/pytorch#135928

**Summary**
Fix https://github.com/pytorch/pytorch/issues/135831 and https://github.com/pytorch/ao/issues/890. The root cause of the numerical failure was that the customized woq-int8 kernel was not triggered due to changes in the pattern. After re-adding the fusion pattern, the accuracy check now passes. I will open a separate TorchAO PR to enable these unit tests in TorchAO.

**Test Plan**
```
python test/inductor/test_mkldnn_pattern_matcher.py -k test_woq_int8
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang