### PR TITLE
[Pytorch] Consolidate Strobelight compile time profiler between OSS and fbcode

### DIFF
--- a/torch/_strobelight/examples/compile_time_profile_example.py
+++ b/torch/_strobelight/examples/compile_time_profile_example.py
@@ -1,11 +1,10 @@
 # mypy: allow-untyped-defs
 import torch
-from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfiler
+from torch._utils_internal import enable_compiletime_strobelight
 
 
 if __name__ == "__main__":
-    # You can pass TORCH_COMPILE_STROBELIGHT=True instead.
-    StrobelightCompileTimeProfiler.enable()
+    enable_compiletime_strobelight()
 
     def fn(x, y, z):
         return x * y + z

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -12,17 +12,6 @@ from torch._strobelight.compile_time_profiler import StrobelightCompileTimeProfi
 
 log = logging.getLogger(__name__)
 
-if os.environ.get("TORCH_COMPILE_STROBELIGHT", False):
-    import shutil
-
-    if not shutil.which("strobeclient"):
-        log.info(
-            "TORCH_COMPILE_STROBELIGHT is true, but seems like you are not on a FB machine."
-        )
-    else:
-        log.info("Strobelight profiler is enabled via environment variable")
-        StrobelightCompileTimeProfiler.enable()
-
 # this arbitrary-looking assortment of functionality is provided here
 # to have a central place for overrideable behavior. The motivating
 # use is the FB build environment, where this source file is replaced
@@ -73,6 +62,15 @@ def throw_abstract_impl_not_imported_error(opname, module, context):
             f"The operator specified that you may need to import the '{module}' "
             f"Python module to load the fake impl. {context}"
         )
+
+
+def enable_compiletime_strobelight():
+    StrobelightCompileTimeProfiler.enable()
+
+
+if os.environ.get("TORCH_COMPILE_STROBELIGHT", False):
+    log.info("Strobelight profiler is enabled via environment variable")
+    enable_compiletime_strobelight()
 
 
 # NB!  This treats "skip" kwarg specially!!


### PR DESCRIPTION
Summary:
Move towards consolidating strobelight profiler implementations between OSS and fbcode. This change is a first step towards that.

- Created a new function to abstract out compile time profiling enablement. This function allows profiler to switch between different function profilers (e.g. Thrift based or CLI based)
- Both OSS and Fbcode now use one compile time profiler in torch/_strobelight

Test Plan:
Tested OSS with following commands:
```
python torch/_strobelight/examples/compile_time_profile_example.py
python torch/_strobelight/examples/cli_function_profiler_example.py

TORCH_COMPILE_STROBELIGHT=TRUE TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 python benchmarks/dynamo/huggingface.py --ci --accuracy --timing --explain --inductor --device cuda --training --amp  --only XLNetLMHeadModel
```

See test commands for fbcode in comments.

Differential Revision: D62444551
