### PR TITLE
OpenReg: Fix issue when copying on the same device

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
@@ -42,6 +42,7 @@ def _openreg_kernel_fallback(op, *args, **kwargs):
         if from_.device.type == to_.device.type:
             assert from_.device.type == "openreg"
             op = torch.ops.aten.copy_.default
+            args = to_, from_
             # handled below as a regular copy
         elif from_.device.type == "openreg":
             args, _ = prepare_for_sending((from_,), {})

--- a/test/cpp_extensions/open_registration_extension/test/test_openreg.py
+++ b/test/cpp_extensions/open_registration_extension/test/test_openreg.py
@@ -51,6 +51,10 @@ class TestOpenReg(TestCase):
         b = a.to(device="openreg").add(2).to(device="cpu")
         self.assertEqual(b, a + 2)
 
+    def test_copy_same_device(self):
+        a = torch.ones(10, device="openreg").clone()
+        self.assertEqual(a, torch.ones(10, device="openreg"))
+
     def test_data_dependent_output(self):
         cpu_a = torch.randn(10)
         a = cpu_a.to(device="openreg")


### PR DESCRIPTION
Current copy gets wrong value when src and dst are both openreg.

cc @albanD @FFFrog