### PR TITLE
[pytorch][monitoring] Dynamic backend for WaitCounter

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -127,6 +127,7 @@ if(NOT BUILD_LIBTORCHLESS)
 
   if(LINUX)
     target_link_libraries(c10 PRIVATE Threads::Threads)
+    target_link_libraries(c10 PRIVATE dl)
   endif()
 
   if(ANDROID)

--- a/c10/util/WaitCounter.h
+++ b/c10/util/WaitCounter.h
@@ -36,6 +36,9 @@ class WaitCounterBackendFactoryIf {
 
 C10_API void registerWaitCounterBackend(
     std::unique_ptr<WaitCounterBackendFactoryIf>);
+
+C10_API std::vector<std::shared_ptr<WaitCounterBackendFactoryIf>>
+getRegisteredWaitCounterBackends();
 } // namespace detail
 
 // A handle to a wait counter.

--- a/c10/util/WaitCounterDynamicBackend.h
+++ b/c10/util/WaitCounterDynamicBackend.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace c10::monitor::detail {
+
+struct WaitCounterDynamicBackend {
+  void* self{nullptr};
+  intptr_t (*start)(void* self, int64_t nowUs){nullptr};
+  void (*stop)(void* self, int64_t nowUs, intptr_t ctx){nullptr};
+  void (*destroy)(void* self){nullptr};
+};
+
+using WaitCounterDynamicBackendInit =
+    void (*)(WaitCounterDynamicBackend*, const char* key, std::size_t keyLen);
+
+// This name needs to be updated if anything in the API above is changed.
+constexpr std::string_view kWaitCounterDynamicBackendInitFn =
+    "c10_monitor_wait_counter_dynamic_backend_init_v1";
+} // namespace c10::monitor::detail

--- a/c10/util/build.bzl
+++ b/c10/util/build.bzl
@@ -43,6 +43,10 @@ def define_targets(rules):
             "//c10:using_glog": ["@com_github_glog//:glog"],
             "//conditions:default": [],
         }),
+        linkopts = rules.select({
+            "@bazel_tools//src/conditions:windows": [],
+            "//conditions:default": ["-ldl"],
+        }),
         # This library uses flags and registration. Do not let the
         # linker remove them.
         alwayslink = True,


### PR DESCRIPTION
Summary: This implements a default backend proxy that tries to look up a backend via dlsym. What this enables is dynamically loading a module with a backend implementation without having it statically linked with the application.

Differential Revision: D62549295
