### PR TITLE
[No merge] Just test this case for XPU

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -312,6 +312,7 @@ class TestProfiler(TestCase):
 
         torch._C._set_graph_executor_optimize(prev_opt)
 
+    # TODO: No merge. Just test this case with XPU
     @parametrize(
         "name,thread_spec",
         {


### PR DESCRIPTION
No merge this PR because it is used to test the following cases for XPU.
```
profiler/test_profiler.py::TestProfilerMultithreaded::test_source_multithreaded_basic_work_in_main_thread_True
```
No we suspect there is conflict between XPU and these cases.

cc @gujinghui @EikanWang @fengyuan14 @guangyey