### PR TITLE
[ROCm] Skip pointwise associative scan tests due to regression

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1333,10 +1333,7 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and (
-                params["device"] == torch.device("cpu")
-                or torch.version.hip
-            )
+            and (params["device"] == torch.device("cpu") or torch.version.hip)
         ),
     )
     def test_associative_scan_compile(
@@ -1559,10 +1556,7 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and (
-                params["device"] == torch.device("cpu")
-                or torch.version.hip
-            )
+            and (params["device"] == torch.device("cpu") or torch.version.hip)
         ),
     )
     def test_associative_scan_dim(self, combine_mode, reverse, device):
@@ -1636,10 +1630,7 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and (
-                params["device"] == torch.device("cpu")
-                or torch.version.hip
-            )
+            and (params["device"] == torch.device("cpu") or torch.version.hip)
         ),
     )
     def test_associative_scan_binary_operator(self, combine_mode, reverse, device):
@@ -1715,10 +1706,7 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and (
-                params["device"] == torch.device("cpu")
-                or torch.version.hip
-            )
+            and (params["device"] == torch.device("cpu") or torch.version.hip)
         ),
     )
     def test_associative_scan_tuple(self, combine_mode, reverse, device):
@@ -1815,10 +1803,7 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and (
-                params["device"] == torch.device("cpu")
-                or torch.version.hip
-            )
+            and (params["device"] == torch.device("cpu") or torch.version.hip)
         ),
     )
     def test_associative_scan_complex_pytree(self, combine_mode, reverse, device):
@@ -1926,10 +1911,7 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and (
-                params["device"] == torch.device("cpu")
-                or torch.version.hip
-            )
+            and (params["device"] == torch.device("cpu") or torch.version.hip)
         ),
     )
     def test_associative_scan_downstream_scan_matmul(
@@ -1969,10 +1951,7 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and (
-                params["device"] == torch.device("cpu")
-                or torch.version.hip
-            )
+            and (params["device"] == torch.device("cpu") or torch.version.hip)
         ),
     )
     def test_associative_scan_downstream_scan_scan(
@@ -2024,10 +2003,7 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and (
-                params["device"] == torch.device("cpu")
-                or torch.version.hip
-            )
+            and (params["device"] == torch.device("cpu") or torch.version.hip)
         ),
     )
     def test_associative_scan_downstream_scan_scan_different_dim(

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -1333,7 +1333,10 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and params["device"] == torch.device("cpu")
+            and (
+                params["device"] == torch.device("cpu")
+                or torch.version.hip
+            )
         ),
     )
     def test_associative_scan_compile(
@@ -1556,7 +1559,10 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and params["device"] == torch.device("cpu")
+            and (
+                params["device"] == torch.device("cpu")
+                or torch.version.hip
+            )
         ),
     )
     def test_associative_scan_dim(self, combine_mode, reverse, device):
@@ -1630,7 +1636,10 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and params["device"] == torch.device("cpu")
+            and (
+                params["device"] == torch.device("cpu")
+                or torch.version.hip
+            )
         ),
     )
     def test_associative_scan_binary_operator(self, combine_mode, reverse, device):
@@ -1706,7 +1715,10 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and params["device"] == torch.device("cpu")
+            and (
+                params["device"] == torch.device("cpu")
+                or torch.version.hip
+            )
         ),
     )
     def test_associative_scan_tuple(self, combine_mode, reverse, device):
@@ -1803,7 +1815,10 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and params["device"] == torch.device("cpu")
+            and (
+                params["device"] == torch.device("cpu")
+                or torch.version.hip
+            )
         ),
     )
     def test_associative_scan_complex_pytree(self, combine_mode, reverse, device):
@@ -1911,7 +1926,10 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and params["device"] == torch.device("cpu")
+            and (
+                params["device"] == torch.device("cpu")
+                or torch.version.hip
+            )
         ),
     )
     def test_associative_scan_downstream_scan_matmul(
@@ -1951,7 +1969,10 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and params["device"] == torch.device("cpu")
+            and (
+                params["device"] == torch.device("cpu")
+                or torch.version.hip
+            )
         ),
     )
     def test_associative_scan_downstream_scan_scan(
@@ -2003,7 +2024,10 @@ def forward(self, pred_1, x_1):
         unittest.skip,
         lambda params: (
             params["combine_mode"] == "pointwise"
-            and params["device"] == torch.device("cpu")
+            and (
+                params["device"] == torch.device("cpu")
+                or torch.version.hip
+            )
         ),
     )
     def test_associative_scan_downstream_scan_scan_different_dim(


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/133012 caused a regression on ROCm causing pointwise scan tests to fail

```
ERROR: test_pointwise_associative_scan_tuple_reverse_True_combine_mode_pointwise_cuda
ERROR: test_pointwise_associative_scan_tuple_reverse_False_combine_mode_pointwise_cuda
ERROR: test_pointwise_associative_scan_complex_pytree_reverse_True_combine_mode_pointwise_cuda
ERROR: test_pointwise_associative_scan_complex_pytree_reverse_False_combine_mode_pointwise_cuda 
ERROR: test_pointwise_associative_scan_binary_operator_reverse_True_combine_mode_pointwise_cuda 
ERROR: test_pointwise_associative_scan_binary_operator_reverse_False_combine_mode_pointwise_cuda
```

Skipping temporarily while triage is underway.

Full log: https://ossci-raw-job-status.s3.amazonaws.com/log/30067645445

```
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/_inductor/graph.py", line 1020, in call_function
    out = lowerings[target](*args, **kwargs)  # type: ignore[index]
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/_inductor/lowering.py", line 363, in wrapped
    out = decomp_fn(*args, **kwargs)
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/_inductor/lowering.py", line 6245, in associative_scan
    raise RuntimeError("Unable to generate code for associative_scan op")
torch._inductor.exc.LoweringException: RuntimeError: Unable to generate code for associative_scan op
```

NOTE: even "eager" backend fails
```
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/_higher_order_ops/associative_scan.py", line 338, in associative_scan_op_dense
    raise NotImplementedError("associative_scan is not implemented for eager")
NotImplementedError: associative_scan is not implemented for eager
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @hongxiayang