### PR TITLE
[export] enable custom tag metadata re-export test

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -36,6 +36,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     parametrize,
     run_tests,
+    skipIfCrossRef,
     TemporaryFileName,
     TestCase,
 )
@@ -1355,36 +1356,48 @@ class TestSerializeCustomClass(TestCase):
                 self.assertTrue(node.meta["custom"]["quantization_tag"] == "foo")
         self.assertTrue(counter > 1)
 
-    # TODO For some reason, this doesn't work on Windows ONLY.
-    # def test_custom_tag_metadata_reexport(self):
-    #     class Foo(torch.nn.Module):
-    #         def forward(self, x):
-    #             return x + x
-    #
-    #     f = Foo()
-    #
-    #     inputs = (torch.zeros(4, 4),)
-    #     ep = export(f, inputs)
-    #
-    #     new_gm = copy.deepcopy(ep.graph_module)
-    #     new_gm.meta["custom"] = {}
-    #     new_gm.meta["custom"]["f"] = "bar"
-    #
-    #     for node in new_gm.graph.nodes:
-    #         if node.op == "call_function" and node.target == torch.ops.aten.add.Tensor:
-    #             node.meta["custom"] = {}
-    #             node.meta["custom"]["quantization_tag"] = "foo"
-    #
-    #     new_ep = ep._update(new_gm, ep.graph_signature)
-    #     new_ep = torch.export.export(new_ep.module(), inputs)
-    #
-    #     self.assertEqual(new_ep.graph_module.meta["custom"]["f"], "bar")
-    #     counter = 0
-    #     for node in new_ep.graph.nodes:
-    #         if node.op == "call_function" and node.target == torch.ops.aten.add.Tensor:
-    #             counter += 1
-    #             self.assertTrue(node.meta["custom"]["quantization_tag"] == "foo")
-    #     self.assertEqual(counter, 1)
+    @skipIfCrossRef
+    def test_custom_tag_metadata_re_export(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = torch.nn.Parameter(torch.rand(4, 2))
+                self.b = torch.nn.Parameter(torch.rand(4))
+
+            def forward(self, x):
+                out = torch.nn.functional.linear(x, self.w, self.b)
+                return out
+
+        f = Foo()
+        inputs = (torch.zeros(1, 2),)
+        ep = export(f, inputs)
+
+        new_gm = copy.deepcopy(ep.graph_module)
+        new_gm.meta["custom"] = {}
+        new_gm.meta["custom"]["f"] = "bar"
+
+        for node in new_gm.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target == torch.ops.aten.linear.default
+            ):
+                node.meta["custom"] = {}
+                node.meta["custom"]["quantization_tag"] = "foo"
+
+        new_ep = ep._update(new_gm, ep.graph_signature)
+        new_ep = torch.export.export(new_ep.module(), inputs)
+        self.assertEqual(new_ep.graph_module.meta["custom"]["f"], "bar")
+
+        # the custom field should be preserved after re-export and
+        # should not be copied to other nodes
+        counter = 0
+        for node in new_ep.graph.nodes:
+            if "custom" in node.meta:
+                counter += 1
+                self.assertTrue(node.meta["custom"]["quantization_tag"] == "foo")
+                self.assertTrue(node.target == torch.ops.aten.linear.default)
+
+        self.assertEqual(counter, 1)
 
     def test_custom_tag_metadata_copy(self):
         class Foo(torch.nn.Module):


### PR DESCRIPTION
Improves and enables a commented out test originally introduced in #131912

In `test_custom_tag_metadata_re_export()`, we check the added "custom" metadata to given nodes is preserved and not copied to other nodes after re-exporting