### PR TITLE
Update getProfilerConfig interface

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -875,7 +875,7 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject* args) {
   unpacked.input_tuple = PyTuple_New(num_args);
   flags.needs_input_grad = PyTuple_New(num_args);
   bool profiler_need_input = torch::autograd::profiler::profilerEnabled() &&
-      torch::autograd::profiler::getProfilerConfig().report_input_shapes;
+      torch::autograd::profiler::getProfilerConfig()->reportInputShapes();
 
   for (const auto i : c10::irange(num_args)) {
     PyObject* arg = PyTuple_GET_ITEM(args, i);

--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -159,7 +159,7 @@ c10::intrusive_ptr<JitFuture> sendMessageWithAutograd(
   if (!forceDisableProfiling) {
     switch (torch::profiler::impl::profilerType()) {
       case torch::profiler::impl::ActiveProfilerType::LEGACY: {
-        auto profilerConfig = torch::autograd::profiler::getProfilerConfig();
+        auto profilerConfig = *torch::autograd::profiler::getProfilerConfig();
         auto msgWithProfiling = getMessageWithProfiling(
             std::move(msg),
             rpc::MessageType::RUN_WITH_PROFILING_REQ,

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -39,13 +39,18 @@ ProfilerConfig::ProfilerConfig(
     bool with_flops,
     bool with_modules,
     ExperimentalConfig experimental_config)
-    : state{state},
+    : AbstractProfilerConfig(),
+      state{state},
       experimental_config{std::move(experimental_config)},
       report_input_shapes{report_input_shapes},
       profile_memory{profile_memory},
       with_stack{with_stack},
       with_flops{with_flops},
       with_modules{with_modules} {}
+
+bool ProfilerConfig::reportInputShapes() const {
+    return report_input_shapes;
+}
 
 bool ProfilerConfig::disabled() const {
   return state == torch::profiler::impl::ProfilerState::Disabled;
@@ -174,12 +179,12 @@ TORCH_API ActiveProfilerType profilerType() {
                               : state_ptr->profilerType();
 }
 
-torch::profiler::impl::ProfilerConfig getProfilerConfig() {
+const torch::profiler::impl::AbstractProfilerConfig* getProfilerConfig() {
   auto* state_ptr = ProfilerStateBase::get(/*global=*/false);
   TORCH_CHECK(
       state_ptr,
       "Tried to access profiler config, but profiler is not enabled!");
-  return state_ptr->config();
+  return &state_ptr->config();
 }
 
 } // namespace impl

--- a/torch/csrc/profiler/orchestration/observer.h
+++ b/torch/csrc/profiler/orchestration/observer.h
@@ -87,7 +87,26 @@ struct TORCH_API ExperimentalConfig {
   bool adjust_timestamps;
 };
 
-struct TORCH_API ProfilerConfig {
+struct TORCH_API AbstractProfilerConfig {
+  /*
+  * This class is created to support custom profiling configurations
+  * on various platforms. It defines a common interface and shared state
+  * for different profiler implementations.
+  */
+  virtual ~AbstractProfilerConfig() = default;
+  AbstractProfilerConfig(const AbstractProfilerConfig&) = default;
+  AbstractProfilerConfig& operator=(const AbstractProfilerConfig&) = default;
+  AbstractProfilerConfig(AbstractProfilerConfig&&) = default;
+  AbstractProfilerConfig& operator=(AbstractProfilerConfig&&) = default;
+
+  virtual bool reportInputShapes() const = 0;
+
+protected:
+  // Protected default constructor
+  AbstractProfilerConfig() = default;
+};
+
+struct TORCH_API ProfilerConfig : public AbstractProfilerConfig {
   ProfilerConfig(
       ProfilerState state,
       bool report_input_shapes = false,
@@ -107,6 +126,8 @@ struct TORCH_API ProfilerConfig {
   bool with_stack;
   bool with_flops;
   bool with_modules;
+
+  bool reportInputShapes() const override;
 
   // For serialization
   at::IValue toIValue() const;
@@ -159,7 +180,7 @@ struct TORCH_API ProfilerStateBase : public c10::MemoryReportingInfoBase {
 // Note: The following are only for the active *thread local* profiler.
 TORCH_API bool profilerEnabled();
 TORCH_API ActiveProfilerType profilerType();
-TORCH_API ProfilerConfig getProfilerConfig();
+TORCH_API const AbstractProfilerConfig* getProfilerConfig();
 
 } // namespace impl
 } // namespace profiler

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -224,7 +224,7 @@ PyObject* RecordFunctionFast_enter(PyObject* selfGeneric, PyObject* unused) {
     std::vector<at::IValue> args;
     std::unordered_map<std::string, at::IValue> kwargs;
     bool profiler_need_input = torch::autograd::profiler::profilerEnabled() &&
-        torch::autograd::profiler::getProfilerConfig().report_input_shapes;
+        torch::autograd::profiler::getProfilerConfig()->reportInputShapes();
     // parse through args if they exist
     if (self->input_values != nullptr && profiler_need_input) {
       THPObjectPtr input_fast(


### PR DESCRIPTION
Fixes #132738

### Update

The getProfilerConfig interface returns a pointer to abstract class `AbstractProfilierConfig`. Then `ProfilerConfig`  inherits from that class. `NpuProfilerConfig` in `torch_npu` can do the same. This enables profiler compatibility across different platforms.


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o