### PR TITLE
[PT2][Inductor][Optimus] Skip dynamic shape reshape node normalization

### DIFF
--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -7,6 +7,7 @@ from typing_extensions import TypeAlias
 
 import torch
 from torch._dynamo.utils import counters
+from torch.fx.experimental.symbolic_shapes import free_symbols
 
 from ..pattern_matcher import (
     Arg,
@@ -446,6 +447,9 @@ def normalize_reshape_default(match: Match, *args, **kwargs):
     reshape_node = match.nodes[0]
     if not is_node_meta_valid(reshape_node):
         log.debug("example value absent for node: %s", reshape_node)
+        return
+    if free_symbols(reshape_node.meta["example_value"].shape):
+        log.debug("dynamic shape not supported: %s", reshape_node)
         return
     reshape_input = get_arg_value(reshape_node, 0)
 


### PR DESCRIPTION
Summary: see context on https://fb.workplace.com/groups/1075192433118967/permalink/1501925720445634/

Test Plan:
# local reproduce
```
buck2 run mode/opt //scripts/jackiexu0313/pt2:local_model_with_pt2 -- --test_mode batch-split --model_type "att_afoc" --flow_id 642123069
```

# e2e

Differential Revision: D62701368


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov