### PR TITLE
Revert D62609535: Multisect successfully blamed "D62609535: Use a better decomposition for split_with_sizes (#135728)" for one test failure

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1409,17 +1409,14 @@ def split_with_sizes(
         sum(split_sizes) == self.shape[dim],
         lambda: f"Split sizes add up to {sum(split_sizes)} but got the tensor's size of {self.shape[dim]}",
     )
-
+    num_splits = len(split_sizes)
     splits = []
-    offset = self.storage_offset()
+    start_idx = 0
 
-    for split_size in split_sizes:
-        new_shape = list(self.shape)
-        new_shape[dim] = split_size
-        # We reimplement narrow here to avoid a lot of checks in the
-        # decomposition of narrow which calls slice_in_dim and slice
-        splits.append(self.as_strided(new_shape, self.stride(), offset))
-        offset = offset + self.stride()[dim] * split_size
+    for i in range(num_splits):
+        length = split_sizes[i]
+        splits.append(self.narrow(dim, start_idx, length))
+        start_idx += length
     return splits
 
 


### PR DESCRIPTION
Summary:
This diff reverts D62609535
D62609535: Use a better decomposition for split_with_sizes (#135728) by generatedunixname499836121 causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_mtia_adfinder_placement_pruned_test#test_flow_with_verification](https://www.internalfb.com/intern/test/844425044353282/)

Here's the Multisect link:
https://www.internalfb.com/multisect/10134306
Here are the tasks that are relevant to this breakage:
T191383430: 10+ tests unhealthy for ads_mtia_inference

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Test Plan: NA

Reviewed By: StellarrZ

Differential Revision: D62703865
