### PR TITLE
[MPS] Add upsample_bicubic2d as Metal op

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -858,8 +858,9 @@ id<MTLLibrary> MetalShaderLibrary::compileLibrary(const std::string& src) {
   MTLCompileOptions* options = compile_options;
   if (!options) {
     options = [[MTLCompileOptions new] autorelease];
+    // Need 3.0 for atomic oprations, 3.1 introduces bfloat support
     [options setLanguageVersion:is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) ? MTLLanguageVersion3_1
-                                                                                        : MTLLanguageVersion2_3];
+                                                                                        : MTLLanguageVersion3_0];
     [options setFastMathEnabled:(!fast_math || std::stoi(fast_math) == 0) ? NO : YES];
   }
 

--- a/aten/src/ATen/native/mps/operations/UpSample.mm
+++ b/aten/src/ATen/native/mps/operations/UpSample.mm
@@ -16,6 +16,7 @@
 #include <ATen/ops/_upsample_nearest_exact2d_backward.h>
 #include <ATen/ops/_upsample_nearest_exact2d_backward_native.h>
 #include <ATen/ops/_upsample_nearest_exact2d_native.h>
+#include <ATen/ops/upsample_bicubic2d_native.h>
 #include <ATen/ops/upsample_bilinear2d.h>
 #include <ATen/ops/upsample_bilinear2d_backward.h>
 #include <ATen/ops/upsample_bilinear2d_backward_native.h>
@@ -216,6 +217,174 @@ static void upsample_out_template(const Tensor& input,
   }
 }
 
+static MetalShaderLibrary lib(R"UPSAMPLE_METAL(
+#include <metal_stdlib>
+using namespace metal;
+
+
+// Based on
+// https://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
+template <typename accscalar_t>
+accscalar_t cubic_convolution1(
+    accscalar_t x,
+    accscalar_t A) {
+  return ((A + 2) * x - (A + 3)) * x * x + 1;
+}
+
+template <typename accscalar_t>
+accscalar_t cubic_convolution2(
+    accscalar_t x,
+    accscalar_t A) {
+  return ((A * x - 5 * A) * x + 8 * A) * x - 4 * A;
+}
+
+template <typename accscalar_t>
+void get_cubic_upsampling_coefficients(
+    accscalar_t coeffs[4],
+    accscalar_t t) {
+  accscalar_t A = -0.75;
+
+  accscalar_t x1 = t;
+  coeffs[0] = cubic_convolution2<accscalar_t>(x1 + 1.0, A);
+  coeffs[1] = cubic_convolution1<accscalar_t>(x1, A);
+
+  // opposite coefficients
+  accscalar_t x2 = 1.0 - t;
+  coeffs[2] = cubic_convolution1<accscalar_t>(x2, A);
+  coeffs[3] = cubic_convolution2<accscalar_t>(x2 + 1.0, A);
+}
+
+template <typename scalar_t, typename accscalar_t>
+accscalar_t cubic_interp1d(
+    scalar_t x0,
+    scalar_t x1,
+    scalar_t x2,
+    scalar_t x3,
+    accscalar_t t) {
+  accscalar_t coeffs[4];
+  get_cubic_upsampling_coefficients<accscalar_t>(coeffs, t);
+
+  return x0 * coeffs[0] + x1 * coeffs[1] + x2 * coeffs[2] + x3 * coeffs[3];
+}
+
+template <typename accscalar_t>
+accscalar_t area_pixel_compute_source_index(
+    accscalar_t scale,
+    int dst_index,
+    bool align_corners,
+    bool cubic) {
+  if (align_corners) {
+    return scale * dst_index;
+  } else {
+    accscalar_t src_idx = scale * (dst_index + static_cast<accscalar_t>(0.5)) -
+        static_cast<accscalar_t>(0.5);
+    // See Note[Follow Opencv resize logic]
+    return (!cubic && src_idx < static_cast<accscalar_t>(0))
+        ? static_cast<accscalar_t>(0)
+        : src_idx;
+  }
+}
+
+template <typename scalar_t>
+scalar_t upsample_get_value_bounded(
+    constant scalar_t *data,
+    long2 dim,
+    ulong2 strides,
+    long y, long x) {
+  int access_y = max(min(y, dim.y - 1), 0L);
+  int access_x = max(min(x, dim.x - 1), 0L);
+  return data[access_y * strides.y + access_x * strides.x];
+}
+
+template<typename T>
+kernel void upsample_bicubic2d(
+    constant T               * inputData       [[buffer(0)]],
+    device   T               * outputData      [[buffer(1)]],
+    constant ulong4          & input_strides   [[buffer(2)]],
+    constant ulong4          & output_strides  [[buffer(3)]],
+    constant long4           & input_sizes     [[buffer(4)]],
+    constant long4           & output_sizes    [[buffer(5)]],
+    uint3                      thread_index    [[thread_position_in_grid]]) {
+    bool align_corners = false;
+    float width_scale = input_sizes.x * 1.0 / output_sizes.x;
+    float height_scale = input_sizes.y * 1.0 / output_sizes.y;
+    auto output_x = thread_index.x;
+    auto output_y = thread_index.y;
+  auto real_x = area_pixel_compute_source_index(
+      width_scale, output_x, align_corners, /*cubic=*/true);
+  int in_x = floor(real_x);
+  auto t_x = real_x - in_x;
+
+  auto real_y = area_pixel_compute_source_index(
+      height_scale, output_y, align_corners, /*cubic=*/true);
+  int in_y = floor(real_y);
+  auto t_y = real_y - in_y;
+  float coefficients[4];
+      for (int k = 0; k < 4; k++) {
+        coefficients[k] = cubic_interp1d(
+            upsample_get_value_bounded<T>(
+                inputData, input_sizes.xy, input_strides.xy, in_y - 1 + k, in_x - 1),
+            upsample_get_value_bounded<T>(
+                inputData, input_sizes.xy, input_strides.xy, in_y - 1 + k, in_x + 0),
+            upsample_get_value_bounded<T>(
+                inputData, input_sizes.xy, input_strides.xy, in_y - 1 + k, in_x + 1),
+            upsample_get_value_bounded<T>(
+                inputData, input_sizes.xy, input_strides.xy, in_y - 1 + k, in_x + 2),
+            t_x);
+      }
+      auto inp = static_cast<T>(cubic_interp1d(
+          coefficients[0],
+          coefficients[1],
+          coefficients[2],
+          coefficients[3],
+          t_y));
+    outputData[output_x * output_strides.x + output_y * output_strides.y ] = inp;
+}
+#define INSTANTIATE_UPSAMPLE_BICUBIC(DTYPE)                                          \
+template                                                                   \
+[[host_name("upsample_bicubic2d_" #DTYPE)]]                                            \
+kernel void upsample_bicubic2d<DTYPE>(                                                 \
+    constant DTYPE           * inputData       [[buffer(0)]],              \
+    device   DTYPE           * outputData      [[buffer(1)]],              \
+    constant ulong4          & input_strides   [[buffer(2)]],              \
+    constant ulong4          & output_strides  [[buffer(3)]],              \
+    constant long4           & input_sizes     [[buffer(4)]],              \
+    constant long4           & output_sizes    [[buffer(5)]],              \
+    uint3                      thread_index  [[thread_position_in_grid]])
+
+
+INSTANTIATE_UPSAMPLE_BICUBIC(float);
+)UPSAMPLE_METAL");
+static void upsample_bicubic_out_template(const Tensor& input,
+                                          IntArrayRef output_size,
+                                          bool align_corners,
+                                          std::optional<double> scale_h_opt,
+                                          std::optional<double> scale_w_opt,
+                                          const Tensor& output) {
+  if (input.numel() == 0) {
+    return;
+  }
+  auto upsamplePSO = lib.getPipelineStateForFunc("upsample_bicubic2d_" + mps::scalarToMetalTypeString(input));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      std::array<int64_t, 4> output_strides = {output.stride(3), output.stride(2), output.stride(1), output.stride(0)};
+      std::array<int64_t, 4> output_sizes = {output.size(3), output.size(2), output.size(1), output.size(0)};
+      std::array<int64_t, 4> input_sizes = {input.size(3), input.size(2), input.size(1), input.size(0)};
+      std::array<int64_t, 4> input_strides = {input.stride(3), input.stride(2), input.stride(1), input.stride(0)};
+      auto computeEncoder = stream->commandEncoder();
+      [computeEncoder setComputePipelineState:upsamplePSO];
+      mtl_setBuffer(computeEncoder, input, 0);
+      mtl_setBuffer(computeEncoder, output, 1);
+      mtl_setBytes(computeEncoder, input_strides, 2);
+      mtl_setBytes(computeEncoder, output_strides, 3);
+      mtl_setBytes(computeEncoder, input_sizes, 4);
+      mtl_setBytes(computeEncoder, output_sizes, 5);
+      [computeEncoder dispatchThreads:MTLSizeMake(output_size[0], output_size[1], 1)
+                threadsPerThreadgroup:MTLSizeMake(8, 8, 1)];
+    }
+  });
+}
 } // namespace mps
 
 TORCH_IMPL_FUNC(upsample_nearest1d_out_mps)
@@ -322,6 +491,16 @@ TORCH_IMPL_FUNC(upsample_bilinear2d_backward_out_mps)
  const Tensor& grad_input) {
   mps::upsample_out_template(
       grad_output, output_size, input_size, scales_h, scales_w, grad_input, align_corners, "bilinear");
+}
+
+TORCH_IMPL_FUNC(upsample_bicubic2d_out_mps)
+(const Tensor& input,
+ IntArrayRef output_size,
+ bool align_corners,
+ std::optional<double> scales_h,
+ std::optional<double> scales_w,
+ const Tensor& output) {
+  mps::upsample_bicubic_out_template(input, output_size, align_corners, scales_h, scales_w, output);
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/UpSample.mm
+++ b/aten/src/ATen/native/mps/operations/UpSample.mm
@@ -559,7 +559,7 @@ static void upsample_bicubic2d_out_template(const Tensor& input,
                                             std::optional<double> scale_h_opt,
                                             std::optional<double> scale_w_opt,
                                             const Tensor& output) {
-  if (input.numel() == 0) {
+  if (output.numel() == 0) {
     return;
   }
   std::array<float, 2> scales = {
@@ -596,6 +596,9 @@ static void upsample_bicubic2d_backward_out_template(const Tensor& grad_input,
                                                      std::optional<double> scale_h_opt,
                                                      std::optional<double> scale_w_opt) {
   grad_input.zero_();
+  if (grad_output.numel() == 0) {
+    return;
+  }
   std::array<float, 2> scales = {
       area_pixel_compute_scale<float>(grad_input.size(3), grad_output.size(3), align_corners, scale_w_opt),
       area_pixel_compute_scale<float>(grad_input.size(2), grad_output.size(2), align_corners, scale_h_opt)};

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12666,6 +12666,7 @@
   dispatch:
     CPU: upsample_bicubic2d_backward_out_cpu
     CUDA: upsample_bicubic2d_backward_out_cuda
+    MPS: upsample_bicubic2d_backward_out_mps
 
 - func: upsample_bicubic2d_backward(Tensor grad_output, SymInt[2] output_size, SymInt[4] input_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor
   python_module: nn

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12654,6 +12654,7 @@
   dispatch:
     CPU: upsample_bicubic2d_out_cpu
     CUDA: upsample_bicubic2d_out_cuda
+    MPS: upsample_bicubic2d_out_mps
 
 - func: upsample_bicubic2d(Tensor self, SymInt[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor
   python_module: nn

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -95,7 +95,6 @@ def mps_ops_grad_modifier(ops):
         'index_fill': [torch.float16, torch.float32],  # missing `aten::_unique`.
         'linalg.lu_factor': [torch.float16, torch.float32],  # missing `aten::lu_unpack`.
         'aminmax': [torch.float32, torch.float16],
-        'nn.functional.interpolatebicubic': None,
 
         # Correctness issues
         'atanh': [torch.float32],

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -95,6 +95,7 @@ def mps_ops_grad_modifier(ops):
         'index_fill': [torch.float16, torch.float32],  # missing `aten::_unique`.
         'linalg.lu_factor': [torch.float16, torch.float32],  # missing `aten::lu_unpack`.
         'aminmax': [torch.float32, torch.float16],
+        'nn.functional.interpolatebicubic': None,
 
         # Correctness issues
         'atanh': [torch.float32],
@@ -739,7 +740,7 @@ def mps_ops_modifier(ops):
         'nn.functional.adaptive_avg_pool3d': None,
         'nn.functional.adaptive_max_pool3d': None,
         'nn.functional.interpolatearea': None,
-        'nn.functional.interpolatebicubic': None,
+        'nn.functional.interpolatebicubic': [torch.uint8],
         'nn.functional.interpolatetrilinear': None,
         'nn.functional.max_unpool1dgrad': None,
         'nn.functional.max_unpool2dgrad': None,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9816,7 +9816,6 @@ class TestNNDeviceType(NNTestCase):
         )
         torch.testing.assert_close(output_f32, output_ui8, atol=1, rtol=0)
 
-    @expectedFailureMPS  # NotImplementedError: aten::upsample_bicubic2d.out https://github.com/pytorch/pytorch/issues/77764
     def test_upsamplingBicubic2d_correctness(self, device):
         # test output against known input: align_corners=False result must match opencv
         in_t = torch.arange(8., device=device).view(1, 2, 2, 2)


### PR DESCRIPTION
More or less literal copy-n-paste of https://github.com/pytorch/pytorch/blob/c33b0580e6a702be0cd5be691b3b465da012aa34/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu#L24
and
https://github.com/pytorch/pytorch/blob/c33b0580e6a702be0cd5be691b3b465da012aa34/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu#L99
Missing `uint8` implementation mimics CUDA behavior
Initial version coded live in https://www.youtube.com/watch?v=shi6Kb5xxvk
Later refinements:
 - Switch from 2D dispatch to 1D one (to match CUDA behavior)
 - Added batch + channel loops
 - Fixed scale computation to match align corners behavior
 - Added backward implementation

Backward implementation again, mimics CUDA, so it has issues precision issue for `torch.half` as well as a somewhat slow simulation of atomic adds using atomic compare and exchange of the pair of adjacent values, i.e.
```metal
emplate <typename T>
static inline void atomic_add_helper(
    device atomic<int>* data,
    long offset,
    float value) {
  auto ptr = data + (offset >> 1);
  auto old = atomic_load_explicit(ptr, memory_order_relaxed);
  union {
    int i;
    T t[2];
  } val;
  do {
    val.i = old;
    val.t[offset & 1] += static_cast<T>(value);
  } while (!atomic_compare_exchange_weak_explicit(
      ptr, &old, val.i, memory_order_relaxed, memory_order_relaxed));
}
```
Bump basic Metal language version to 3.0, as it's supported on MacOS13 and that's the first version that has `atomic_float`