### PR TITLE
[NCCL] Don't override `waitUntilInitialized`'s setting of `comm->initialized_`

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -84,7 +84,9 @@ std::shared_ptr<NCCLComm> NCCLComm::split(
       std::nullopt);
   ++source->ncclCommSplitCounter_;
   comm->rank_ = rank;
-  comm->initialized_ = true;
+  if (!nccl_use_nonblocking()) {
+      comm->initialized_ = true;
+  }
   return comm;
 }
 #endif

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<NCCLComm> NCCLComm::split(
   ++source->ncclCommSplitCounter_;
   comm->rank_ = rank;
   if (!nccl_use_nonblocking()) {
-      comm->initialized_ = true;
+    comm->initialized_ = true;
   }
   return comm;
 }


### PR DESCRIPTION
#133630 sets `initialized_` to `true` which causes previous wait codepaths to skip necessary waits, see also #https://github.com/pytorch/pytorch/issues/136151

CC @shuqiangzhang @wconstab 

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o