### PR TITLE
[FSDP2] Check backend compatibility for cpu offloading

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -20,6 +20,14 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 class TestFullyShardMemory(FSDPTest):
     @property
+    def backend(self):
+        # need to include backend for cpu tensors when running cpu_offload tests
+        if torch.cuda.is_available():
+            return "cuda:nccl,cpu:gloo"
+        else:
+            return "gloo"
+
+    @property
     def world_size(self) -> int:
         return min(2, torch.cuda.device_count())
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -29,8 +29,11 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 class TestFullyShardStateDictMultiProcess(FSDPTest):
     @property
-    def backend(self) -> str:
-        return "cuda:nccl,cpu:gloo"
+    def backend(self):
+        if torch.cuda.is_available():
+            return "cuda:nccl,cpu:gloo"
+        else:
+            return "gloo"
 
     @property
     def world_size(self) -> int:

--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -29,6 +29,10 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 class TestFullyShardStateDictMultiProcess(FSDPTest):
     @property
+    def backend(self) -> str:
+        return "cuda:nccl,cpu:gloo"
+
+    @property
     def world_size(self) -> int:
         return min(8, torch.cuda.device_count())
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -761,6 +761,14 @@ class TestFullyShardSharedParams(FSDPTest):
 
 class TestFullyShardGradientAccumulation(FSDPTest):
     @property
+    def backend(self):
+        # need to include backend for cpu tensors when running cpu_offload tests
+        if torch.cuda.is_available():
+            return "cuda:nccl,cpu:gloo"
+        else:
+            return "gloo"
+
+    @property
     def world_size(self) -> int:
         return min(4, torch.cuda.device_count())
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -234,6 +234,14 @@ class TestFullyShardCastAfterInit(FSDPTestMultiThread):
 
 class TestFullyShard1DTrainingCore(FSDPTest):
     @property
+    def backend(self):
+        # need to include backend for cpu tensors when running cpu_offload tests
+        if torch.cuda.is_available():
+            return "cuda:nccl,cpu:gloo"
+        else:
+            return "gloo"
+
+    @property
     def world_size(self) -> int:
         return min(8, torch.cuda.device_count())
 

--- a/test/distributed/_tools/test_fsdp2_mem_tracker.py
+++ b/test/distributed/_tools/test_fsdp2_mem_tracker.py
@@ -44,6 +44,14 @@ def _reset_mem_stats(dev: torch.device):
 
 class TestTrackerFullyShard1DTrainingCore(FSDPTest):
     @property
+    def backend(self):
+        # need to include backend for cpu tensors when running cpu_offload tests
+        if torch.cuda.is_available():
+            return "cuda:nccl,cpu:gloo"
+        else:
+            return "gloo"
+
+    @property
     def world_size(self) -> int:
         return min(4, torch.cuda.device_count())
 

--- a/torch/distributed/_composable/fsdp/_fsdp_param_group.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param_group.py
@@ -601,7 +601,10 @@ class FSDPParamGroup:
                 f"{[(fsdp_param._param_fqn, fsdp_param.sharded_param.device) for fsdp_param in fsdp_params_not_on_cpu]}\n"
             )
         backend = dist.get_backend()
-        if "cpu" not in dist.Backend.backend_capability[backend]:
+        backend_capability = dist.Backend.backend_capability.get(backend)
+        if (
+            backend_capability and "cpu" not in backend_capability
+        ) or "cpu" not in backend:
             raise RuntimeError(
                 "FSDP CPU offloading requires backend supporting cpu tensors. "
                 f"Found following backend: {backend}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136156

Following up on the issue reported in this [workplace post](https://fburl.com/workplace/nazuez22). 

When cpu offloading is enabled but users init a backend that doesn't support cpu tensors, running `clip_grad_norm_` or any op that requires collective would result in the following error, which is not quite actionable. 
```
'RuntimeError: No backend type associated with device type cpu'.
```

This PR adds an earlier check for backend if cpu offloading is enabled and throws a more explicit error. For example:
```
'RuntimeError: FSDP CPU offloading requires backend supporting cpu tensors. Found following backend: nccl'
```


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o