### PR TITLE
Remove unused video_image targets

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -66,9 +66,7 @@ if args.output_directory:
 includes = [
     "caffe2/operators/*",
     "caffe2/sgd/*",
-    "caffe2/image/*",
     "caffe2/transforms/*",
-    "caffe2/video/*",
     "caffe2/distributed/*",
     "caffe2/queue/*",
     "caffe2/contrib/aten/*",


### PR DESCRIPTION
Summary: Follow-up to D61890322. Removes the actual unused code and more unused targets.

Test Plan: Sandcastle.

Differential Revision: D62756391
