### PR TITLE
[export] Add experimental swap API

### DIFF
--- a/test/export/test_swap.py
+++ b/test/export/test_swap.py
@@ -1,0 +1,229 @@
+# Owner(s): ["oncall: export"]
+# flake8: noqa
+import copy
+import dataclasses
+import unittest
+from contextlib import contextmanager
+from dataclasses import dataclass
+from re import escape
+from typing import Any, List
+
+from parameterized import parameterized_class
+
+import torch
+import torch._dynamo as torchdynamo
+from functorch.experimental.control_flow import cond, map
+from torch import Tensor
+from torch._export.utils import (
+    get_buffer,
+    get_param,
+    is_buffer,
+    is_param,
+    register_dataclass_as_pytree_node,
+)
+from torch._higher_order_ops.torchbind import enable_torchbind_tracing
+from torch.export import Constraint, Dim, export, FlatArgsAdapter, unflatten
+from torch.export._trace import DEFAULT_EXPORT_DYNAMO_CONFIG
+from torch.export.unflatten import _swap_modules
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing import FileCheck
+from torch.testing._internal.common_utils import (
+    find_library_location,
+    IS_FBCODE,
+    IS_MACOS,
+    IS_SANDCASTLE,
+    IS_WINDOWS,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
+from torch.testing._internal.torchbind_impls import init_torchbind_implementations
+from torch.utils._pytree import (
+    LeafSpec,
+    tree_flatten,
+    tree_unflatten,
+    TreeSpec,
+    treespec_dumps,
+    treespec_loads,
+)
+
+
+@unittest.skipIf(IS_WINDOWS, "Windows not supported for this test")
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo isn't support")
+@parameterized_class(
+    [
+        {"strict": False},
+        {"strict": True},
+    ],
+    class_name_func=lambda cls, _, params: f"{cls.__name__}_{'strict' if params['strict'] else 'nonstrict'}",
+)
+class TestSwap(TestCase):
+    def test_unflatten_preserve_signature(self):
+        class NestedChild(torch.nn.Module):
+            def forward(self, zx, y):
+                return {"x": y["key"] + zx[1], "w": y["key"] * zx[1]}
+
+        class Child1(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.nested = NestedChild()
+
+            def forward(self, x, y):
+                z = torch.ones_like(x)
+                xw = self.nested((z, x), y={"key": y})
+                return xw["w"] + z - xw["x"]
+
+        class Child2(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(self, x):
+                return x - 1
+
+        class MyModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.foo = Child1()
+                self.bar = Child2()
+
+            def forward(self, x, y):
+                x = self.foo(x, y)
+                x = self.bar(x)
+                return x
+
+        orig_eager = MyModule()
+        inps = torch.rand(2, 3), torch.rand(2, 3)
+
+        ep = export(
+            orig_eager,
+            inps,
+            {},
+            preserve_module_call_signature=("foo.nested", "bar"),
+            strict=self.strict,
+        )
+
+        swapped_gm = _swap_modules(
+            ep,
+            {"foo.nested": NestedChild(), "bar": Child2()},
+        )
+
+        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+
+    def test_unflatten_preserve_with_unused_input(self):
+        class M1(torch.nn.Module):
+            def forward(self, x, a, b):
+                return x + a, b
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.m1 = M1()
+
+            def forward(self, x, y):
+                a, b = torch.topk(y, 2)
+                return self.m1(x, a, b)[0]
+
+        ep = torch.export.export(
+            M(),
+            (torch.randn(2), torch.randn(5)),
+            preserve_module_call_signature=("m1",),
+            strict=self.strict,
+        )
+
+        swapped_gm = _swap_modules(
+            ep,
+            {"m1": M1()},
+        )
+
+        inps = (torch.randn(2), torch.randn(5))
+        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+
+    def test_nested_leaf(self):
+        class Leaf(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        class Nested(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.leaf = Leaf()
+
+            def forward(self, x):
+                return self.leaf(x) + 2
+
+        class TopLevel(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.nested = Nested()
+
+            def forward(self, x):
+                return self.nested(x) + 3
+
+        ep = torch.export.export(
+            TopLevel(),
+            (torch.randn(3),),
+            strict=self.strict,
+            preserve_module_call_signature=("nested",),
+        )
+
+        swapped_gm = _swap_modules(
+            ep,
+            {"nested": Nested()},
+        )
+
+        inps = (torch.randn(3),)
+        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+
+    def test_dedup_sym_size(self):
+        # Here, sym_size & floor div are used in 3 subgraphs (top-level, m1, m2),
+        # but only one copy of sym_size is created in the initial export graph.
+        # For m1, sym_size & floordiv should be copied as recompute since we preserve the call signature,
+        # but for m2 floordiv should be passed in as a placeholder.
+        # Test that this is preserved, and the unflattened module runs correctly.
+        class M1(torch.nn.Module):
+            def forward(self, x, y):
+                d = x.size(0) // 2
+                return y[:d]
+
+        class M2(torch.nn.Module):
+            def forward(self, x, y):
+                d = x.size(0) // 2
+                return y[:d]
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.m1 = M1()
+                self.m2 = M2()
+
+            def forward(self, x, y):
+                d = x.size(0) // 2
+                m1_res = self.m1(x, y)
+                m2_res = self.m2(x, y)
+                return y[d:] + m1_res + m2_res
+
+        inputs = (torch.ones(10), torch.ones(10))
+        d_ = torch.export.Dim("foo", max=2048)
+        d = 2 * d_
+        ep = torch.export.export(
+            M(),
+            inputs,
+            dynamic_shapes=((d,), (d,)),
+            strict=self.strict,
+            preserve_module_call_signature=("m1",),
+        )
+
+        swapped_gm = _swap_modules(
+            ep,
+            {"m1": M1()},
+        )
+
+        inps = (torch.randn(10), torch.randn(10))
+        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+
+        inps = (torch.randn(20), torch.randn(20))
+        self.assertTrue(torch.allclose(ep.module()(*inps), swapped_gm(*inps)))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import abc
 import copy
+import logging
 import operator
 from collections import defaultdict
 from contextlib import contextmanager
@@ -23,9 +24,14 @@ from torch.export.exported_program import (
 )
 from torch.fx._symbolic_trace import is_fx_tracing
 from torch.fx.graph_module import _print_readable
+from torch.fx.passes.tools_common import legalize_graph, NodeList
+from torch.fx.passes.utils.fuser_utils import erase_nodes, fuse_as_graphmodule
 from torch.utils._pytree import GetAttrKey, SequenceKey
 
 from ._remove_effect_tokens_pass import _remove_effect_tokens
+
+
+log = logging.getLogger(__name__)
 
 
 __all__ = ["InterpreterModule", "UnflattenedModule", "unflatten", "FlatArgsAdapter"]
@@ -35,6 +41,7 @@ class _AttrKind(Enum):
     PARAMETER = "parameter"
     BUFFER = "buffer"
     CONSTANT = "constant"
+    MODULE = "module"
 
 
 RUN_WITH_INTERPRETER = True
@@ -54,7 +61,7 @@ def _disable_interpreter():
 # Assign attribute 'from_obj' to the qualified name 'target' on 'to_module
 # This installs empty Modules where none exist yet if they are subpaths of target
 def _assign_attr(
-    from_obj: Union[torch.Tensor, torch.ScriptObject],
+    from_obj: Union[torch.Tensor, torch.ScriptObject, torch.nn.Module],
     to_module: torch.nn.Module,
     target: str,
     attr_kind: _AttrKind,
@@ -86,6 +93,9 @@ def _assign_attr(
                 torch.ScriptObject,
             ),
         )
+        setattr(to_module, field, from_obj)
+    elif attr_kind == _AttrKind.MODULE:
+        assert isinstance(from_obj, torch.nn.Module)
         setattr(to_module, field, from_obj)
 
 
@@ -1258,3 +1268,178 @@ def _recursive_getattr(obj, attr_path):
         obj = getattr(obj, attr)
 
     return obj
+
+
+def _construct_inputs(
+    gm: torch.fx.GraphModule,
+    signature: ModuleCallSignature,
+    node_name_map: Dict[str, torch.fx.Node],
+) -> Tuple[List[torch.fx.Node], Dict[str, torch.fx.Node]]:
+    tree_unflatten_args: List[Optional[torch.fx.Node]] = []
+    for input_ in signature.inputs:
+        if isinstance(input_, ConstantArgument) and input_.value is None:
+            # Constants should be directly embedded into the graph and not used
+            # as inputs
+            tree_unflatten_args.append(None)
+        elif input_.name not in node_name_map:
+            # For unused inputs
+            tree_unflatten_args.append(None)
+        else:
+            tree_unflatten_args.append(node_name_map[input_.name])
+
+    # Insert unflatten call
+    unflatten_node = _generate_unflatten(gm, tree_unflatten_args, signature.in_spec)
+
+    assert signature.in_spec.num_children == 2
+
+    args_spec = signature.in_spec.children_specs[0]
+    assert args_spec.context is None
+    args_node = gm.graph.call_function(operator.getitem, (unflatten_node, 0))
+    args_nodes = [
+        gm.graph.call_function(operator.getitem, (args_node, i))
+        for i in range(args_spec.num_children)
+    ]
+
+    kwargs_spec = signature.in_spec.children_specs[1]
+    assert kwargs_spec.context is not None
+    kwargs_node = gm.graph.call_function(operator.getitem, (unflatten_node, 1))
+    kwargs_nodes = {
+        k: gm.graph.call_function(operator.getitem, (kwargs_node, k))
+        for k in kwargs_spec.context
+    }
+    return args_nodes, kwargs_nodes
+
+
+def _insert_call_module(
+    gm: torch.fx.GraphModule,
+    args_nodes: List[torch.fx.Node],
+    kwargs_nodes: Dict[str, torch.fx.Node],
+    module_to_swap: torch.nn.Module,
+    name: str,
+) -> torch.fx.Node:
+    _assign_attr(module_to_swap, gm, name, _AttrKind.MODULE)
+    module_node = gm.graph.call_module(name, tuple(args_nodes), kwargs_nodes)  # type: ignore[arg-type]
+    return module_node
+
+
+def _destruct_outputs(
+    gm: torch.fx.GraphModule,
+    signature: ModuleCallSignature,
+    module_node: torch.fx.Node,
+    node_name_map: Dict[str, torch.fx.Node],
+    orig_outputs: Tuple[torch.fx.Node, ...],
+) -> None:
+    flatten_node = _generate_flatten(gm, module_node, signature.out_spec)
+
+    for i, orig_output in enumerate(orig_outputs):
+        # Use Proxy to record getitem access.
+        proxy_out = torch.fx.Proxy(flatten_node)[i].node  # type: ignore[index]
+        orig_output.replace_all_uses_with(proxy_out, propagate_meta=True)
+
+        node_name_map[orig_output.name] = proxy_out
+
+
+def _swap_module_helper(
+    gm: torch.fx.GraphModule,
+    modules_to_swap: Dict[str, torch.nn.Module],
+    module_call_graph: Dict[str, ModuleCallSignature],
+) -> torch.fx.GraphModule:
+    log.debug("Starting graph:")
+    log.debug(gm.graph)
+
+    legalize_graph(gm)
+
+    partitions: Dict[str, NodeList] = defaultdict(list)
+
+    node_name_map: Dict[str, torch.fx.Node] = {
+        node.name: node for node in gm.graph.nodes
+    }
+
+    # TODO: Handle the duplicate module case
+    for node in gm.graph.nodes:
+        if nn_module_stack := node.meta.get("nn_module_stack"):
+            for path, _ in nn_module_stack.values():
+                if path in modules_to_swap:
+                    partitions[path].append(node)
+                    break
+
+    for name, nodes in partitions.items():
+        """
+        Given a graph like the following, and we want to swap out the submodule "foo":
+        graph():
+            %x : [num_users=1] = placeholder[target=x]
+            %y : [num_users=2] = placeholder[target=y]
+            %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%y, %x), kwargs = {}), nn_module_stack = {"foo": ("foo", torch.nn.Module)}
+            %sub : [num_users=1] = call_function[target=torch.ops.aten.sub.Tensor](args = (%y, %add), kwargs = {}), nn_module_stack = {"bar": ("bar", torch.nn.Module)}
+            return (sub,)
+
+        We will first partition out foo's subgraph:
+        graph():
+            %x : [num_users=1] = placeholder[target=x]
+            %y : [num_users=2] = placeholder[target=y]
+            %add : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%y, %x), kwargs = {})
+            return add
+
+        And then insert an unflatten + call_module + flatten to replace the subgraph:
+        graph():
+            %x : [num_users=1] = placeholder[target=x]
+            %y : [num_users=1] = placeholder[target=y]
+
+            %_spec_0 : [num_users=1] = get_attr[target=_spec_0]
+            %tree_unflatten : [num_users=2] = call_function[target=torch.utils._pytree.tree_unflatten](args = ([%x, %y], %_spec_0), kwargs = {})
+            %getitem : [num_users=2] = call_function[target=operator.getitem](args = (%tree_unflatten, 0), kwargs = {})
+            %getitem_1 : [num_users=1] = call_function[target=operator.getitem](args = (%getitem, 0), kwargs = {})
+            %getitem_2 : [num_users=1] = call_function[target=operator.getitem](args = (%getitem, 1), kwargs = {})
+            %getitem_3 : [num_users=0] = call_function[target=operator.getitem](args = (%tree_unflatten, 1), kwargs = {})
+            %foo : [num_users=0] = call_module[target=foo](args = (%getitem_1, %getitem_2), kwargs = {})
+            %_spec_1 : [num_users=1] = get_attr[target=_spec_1]
+            %tree_flatten_spec : [num_users=1] = call_function[target=torch.fx._pytree.tree_flatten_spec](args = (None, %_spec_1), kwargs = {})
+            %getitem_4 : [num_users=1] = call_function[target=operator.getitem](args = (%tree_flatten_spec, 0), kwargs = {})
+
+            %sub : [num_users=1] = call_function[target=torch.ops.aten.sub.Tensor](args = (%y, %getitem_4), kwargs = {})
+            return (%sub,)
+
+        The `tree_unflatten` call will construct tensor inputs into the input
+        format needed by the swapped eager module.
+        The `call_module` node should now reference the swapped torch.nn.Module.
+        The `tree_flatten_spec` call will destruct the eager outputs of the
+        swapped module into tensors.
+        """  # noqa: B950
+
+        submod_name = name.replace(".", "_")
+        sub_gm, orig_inputs, orig_outputs = fuse_as_graphmodule(
+            gm, nodes, f"fused_{submod_name}"
+        )
+
+        log.debug("Fused subgraph nodes:")
+        log.debug(sub_gm.graph)
+
+        signature: ModuleCallSignature = module_call_graph[name]
+
+        args_nodes, kwargs_nodes = _construct_inputs(gm, signature, node_name_map)
+        module_node = _insert_call_module(
+            gm, args_nodes, kwargs_nodes, modules_to_swap[name], name
+        )
+        _destruct_outputs(gm, signature, module_node, node_name_map, orig_outputs)
+
+        erase_nodes(gm, nodes)
+
+        log.debug("Swapped graph:")
+        log.debug(gm.graph)
+
+    legalize_graph(gm)
+
+    gm.recompile()
+
+    return gm
+
+
+def _swap_modules(
+    ep: ExportedProgram, modules_to_swap: Dict[str, torch.nn.Module]
+) -> torch.fx.GraphModule:
+    module_call_graph = {
+        entry.fqn: entry.signature for entry in ep.module_call_graph if entry.signature
+    }
+    gm = ep.module()
+    assert isinstance(gm, torch.fx.GraphModule)
+    return _swap_module_helper(gm, modules_to_swap, module_call_graph)

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -1322,7 +1322,7 @@ def _insert_call_module(
     return module_node
 
 
-def _destruct_outputs(
+def _deconstruct_outputs(
     gm: torch.fx.GraphModule,
     signature: ModuleCallSignature,
     module_node: torch.fx.Node,
@@ -1402,7 +1402,7 @@ def _swap_module_helper(
         The `tree_unflatten` call will construct tensor inputs into the input
         format needed by the swapped eager module.
         The `call_module` node should now reference the swapped torch.nn.Module.
-        The `tree_flatten_spec` call will destruct the eager outputs of the
+        The `tree_flatten_spec` call will deconstruct the eager outputs of the
         swapped module into tensors.
         """  # noqa: B950
 
@@ -1420,7 +1420,7 @@ def _swap_module_helper(
         module_node = _insert_call_module(
             gm, args_nodes, kwargs_nodes, modules_to_swap[name], name
         )
-        _destruct_outputs(gm, signature, module_node, node_name_map, orig_outputs)
+        _deconstruct_outputs(gm, signature, module_node, node_name_map, orig_outputs)
 
         erase_nodes(gm, nodes)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #136191
* __->__ #136190

Prototyped the following API which takes in an ExportedProgram, a dictionary of fqn to modules to swap, and returns a (unlifted) GraphModule
```
_swap_modules(
    ep: ExportedProgram, modules_to_swap: Dict[str, torch.nn.Module]
) -> torch.fx.GraphModule:
```

Differential Revision: [D62879819](https://our.internmc.facebook.com/intern/diff/D62879819)