### PR TITLE
[MPS] Fix 5D+ reductions over negative dimentions

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5729,7 +5729,7 @@ class TestMPS(TestCaseMPS):
         helper(2, 8, 4, 5, dtype=torch.int64)
         helper(2, 8, 4, 5, dtype=torch.bool)
         # Regression test for https://github.com/pytorch/pytorch/issues/136132
-        x = torch.ones(2,4,1,30,1, device='mps').sum(dim=-2)
+        x = torch.ones(2, 4, 1, 30, 1, device='mps').sum(dim=-2)
         self.assertEqual(x.numel(), 8)
         self.assertEqual(x.max().item(), 30.0)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5728,6 +5728,10 @@ class TestMPS(TestCaseMPS):
         helper(2, 8, 4, 5, dtype=torch.int32)
         helper(2, 8, 4, 5, dtype=torch.int64)
         helper(2, 8, 4, 5, dtype=torch.bool)
+        # Regression test for https://github.com/pytorch/pytorch/issues/136132
+        x = torch.ones(2,4,1,30,1, device='mps').sum(dim=-2)
+        self.assertEqual(x.numel(), 8)
+        self.assertEqual(x.max().item(), 30.0)
 
     # Test forward prod
     def test_prod(self):


### PR DESCRIPTION
This fixes bug introduced by https://github.com/pytorch/pytorch/pull/99856 that attempts to speed-up reduction for 5D+ tensor if trailing dimensions are all ones, but introduces crashes/off-by-one errors for wrapped dimensions

Added regresion test case to `TestMPS.test_sum`

Fixes https://github.com/pytorch/pytorch/issues/136132
