### PR TITLE
Delete links to non-existing `run_plan_mpi.cc`

### DIFF
--- a/binaries/CMakeLists.txt
+++ b/binaries/CMakeLists.txt
@@ -35,12 +35,6 @@ if(USE_ROCM)
 
 endif()
 
-if(USE_MPI)
-  caffe2_binary_target("run_plan_mpi.cc")
-  target_link_libraries(run_plan_mpi ${MPI_CXX_LIBRARIES})
-endif()
-
-
 caffe2_binary_target("dump_operator_names.cc")
 caffe2_binary_target("optimize_for_mobile.cc")
 


### PR DESCRIPTION
That were deleted by https://github.com/pytorch/pytorch/pull/125092

Fixes https://github.com/pytorch/pytorch/issues/136199
