### PR TITLE
update cache tests

### DIFF
--- a/test/inductor/mock_cache.py
+++ b/test/inductor/mock_cache.py
@@ -5,11 +5,10 @@ import contextlib
 import dataclasses
 import sys
 import threading
-from typing import Any, Callable, Dict, Generator, Optional, Type, TYPE_CHECKING
+from typing import Any, Callable, Dict, Optional, Type, TYPE_CHECKING
 from typing_extensions import override, Self
 from unittest.mock import patch
 
-import torch
 from torch._inductor import config
 from torch._inductor.remote_cache import RemoteCacheBackend
 
@@ -44,6 +43,28 @@ class Stats:
             )
         )
 
+    def __eq__(self, other: object) -> bool:
+        # Dataclass's default __eq__ checks that the types are the same so can't
+        # be used with _GlobalItemStats.
+        return (
+            isinstance(other, (Stats, _GlobalItemStats))
+            and self.num_put == other.num_put
+            and self.num_get_hit == other.num_get_hit
+            and self.num_get_miss == other.num_get_miss
+        )
+
+
+class _GlobalItemStats(Stats):
+    cache: Dict[str, object]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.cache = {}
+
+    def reset(self) -> None:
+        super().reset()
+        self.cache = {}
+
 
 # The cache states are thread-local so if we're running multiple tests at once
 # they won't cross contaminate. However - it needs to be "global" because we
@@ -51,58 +72,74 @@ class Stats:
 # it's a remote cache).
 
 
-class _GlobalStats(Stats, threading.local):
+class _GlobalStats(threading.local):
     def __init__(self) -> None:
-        self.autotune = Stats()
-        self.fx_graph = Stats()
-        self.triton = Stats()
+        self.autotune_local = _GlobalItemStats()
+        self.autotune_remote = _GlobalItemStats()
+        self.fx_graph = _GlobalItemStats()
+        self.triton = _GlobalItemStats()
 
     def reset(self) -> None:
-        self.autotune.reset()
+        self.autotune_local.reset()
+        self.autotune_remote.reset()
         self.fx_graph.reset()
         self.triton.reset()
 
-    def update(self, name: str, delta: Stats) -> None:
-        stat = getattr(self, name)
-        stat += delta
+    def get_stat(self, name: str) -> _GlobalItemStats:
+        return getattr(self, name)
 
     def report(self):
+        subs = (
+            ("autotune_local", self.autotune_local),
+            ("autotune_remote", self.autotune_remote),
+            ("fx_graph", self.fx_graph),
+            ("triton", self.triton),
+        )
+
         print("Cache Stats:", file=sys.stderr)
-        print(f"  autotune: {self.autotune}", file=sys.stderr)
-        print(f"  fx_graph: {self.fx_graph}", file=sys.stderr)
-        print(f"  triton:   {self.triton}", file=sys.stderr)
+        for name, sub in subs:
+            print(f"  {name}: {sub}", file=sys.stderr)
+
+        print("Cache Entries:", file=sys.stderr)
+        for name, sub in subs:
+            if sub.cache:
+                print(f"  {name}:", file=sys.stderr)
+                for k, v in sorted(sub.cache.items()):
+                    v = repr(v)
+                    if len(v) > 100:
+                        v = v[:100] + "..."
+                    print(f"    {k!r}: {v}", file=sys.stderr)
 
 
 global_stats = _GlobalStats()
 
 
 class MockBackend(RemoteCacheBackend[Any]):
-    def __init__(self, name: str, cache: Dict[str, object]) -> None:
-        self._cache = cache
+    def __init__(self, name: str) -> None:
         self._name = name
 
     @staticmethod
     def with_name(name: str) -> Callable[[], MockBackend]:
-        cache = {}
-
         def wrapper() -> MockBackend:
-            return MockBackend(name, cache)
+            return MockBackend(name)
 
         return wrapper
 
     @override
     def get(self, key: str) -> Optional[Any]:
-        if key in self._cache:
-            global_stats.update(self._name, Stats(num_get_hit=1))
-            return self._cache.get(key)
+        stat = global_stats.get_stat(self._name)
+        if key in stat.cache:
+            stat += Stats(num_get_hit=1)
+            return stat.cache.get(key)
         else:
-            global_stats.update(self._name, Stats(num_get_miss=1))
+            stat += Stats(num_get_miss=1)
             return None
 
     @override
     def put(self, key: str, data: Any) -> None:
-        global_stats.update(self._name, Stats(num_put=1))
-        self._cache[key] = data
+        stat = global_stats.get_stat(self._name)
+        stat += Stats(num_put=1)
+        stat.cache[key] = data
 
 
 # List of configs for each cache
@@ -143,8 +180,14 @@ class PatchCaches(contextlib.AbstractContextManager):
         self._stack.__enter__()
 
         ctx = patch(
+            "torch._inductor.runtime.autotune_cache.LocalAutotuneCache.backend_override_cls",
+            MockBackend.with_name("autotune_local"),
+        )
+        self._stack.enter_context(ctx)
+
+        ctx = patch(
             "torch._inductor.remote_cache.RemoteAutotuneCache.backend_override_cls",
-            MockBackend.with_name("autotune"),
+            MockBackend.with_name("autotune_remote"),
         )
         self._stack.enter_context(ctx)
 
@@ -157,7 +200,7 @@ class PatchCaches(contextlib.AbstractContextManager):
         if config.is_fbcode():
             ctx = patch(
                 "torch._inductor.fb.remote_cache.FbRemoteAutotuneCache.backend_override_cls",
-                MockBackend.with_name("autotune"),
+                MockBackend.with_name("autotune_remote"),
             )
             self._stack.enter_context(ctx)
 
@@ -182,28 +225,3 @@ class PatchCaches(contextlib.AbstractContextManager):
         traceback: Optional[TracebackType],
     ) -> None:
         self._stack.__exit__(exc_type, exc_value, traceback)
-
-
-@contextlib.contextmanager
-def patch_fbcode(state: bool) -> Generator[None, None, None]:
-    if hasattr(torch.version, "git_version"):
-        # Currently non-fbcode
-        if state:
-            old = torch.version.git_version
-            delattr(torch.version, "git_version")
-            try:
-                yield
-            finally:
-                torch.version.git_version = old
-        else:
-            yield
-    else:
-        # Currently fbcode
-        if state:
-            yield
-        else:
-            torch.version.git_version = "12345+"
-            try:
-                yield
-            finally:
-                delattr(torch.version, "git_version")

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -41,9 +41,9 @@ from torch.utils._triton import has_triton
 
 
 try:
-    from .mock_cache import global_stats, patch_fbcode, PatchCaches
+    from .mock_cache import global_stats, PatchCaches, Stats
 except ImportError:
-    from mock_cache import global_stats, patch_fbcode, PatchCaches  # @manual
+    from mock_cache import global_stats, PatchCaches, Stats  # @manual
 
 
 HAS_TRITON = has_triton()
@@ -190,10 +190,12 @@ class TestFxGraphCache(TestCase):
                     self.assertEqual(fn(a, b), compiled_fn(a, b))
                 reset()
 
-        global_stats.report()
-        self.assertEqual(global_stats.fx_graph.num_get_hit, 3)
-        self.assertEqual(global_stats.fx_graph.num_get_miss, 1)
-        self.assertEqual(global_stats.fx_graph.num_put, 1)
+        self.assertEqual(global_stats.fx_graph, Stats(1, 3, 1))
+
+        if config.is_fbcode():
+            # Check that the cache entries seem reasonable
+            for k in global_stats.fx_graph.cache.keys():
+                self.assertRegex(k, r"pt2:fx-graph-v1::[0-9a-z]{52}:c10")
 
     @requires_triton()
     @config.patch({"fx_graph_cache": True})
@@ -800,8 +802,7 @@ class TestAutotuneCache(TestCase):
     @config.patch({"autotune_local_cache": False})
     @config.patch({"autotune_remote_cache": True})
     @config.patch({"max_autotune": True})
-    @parametrize("fbcode", (False,) + (True,) * config.is_fbcode())
-    def test_autotune_cache(self, fbcode: bool):
+    def test_autotune_cache(self):
         class Model(torch.nn.Module):
             def forward(self, x, y, a, b):
                 return x + y, a + b
@@ -815,20 +816,22 @@ class TestAutotuneCache(TestCase):
         b = torch.randn(1000, 100).cuda()
         f_compiled = torch.compile(f, fullgraph=True)
 
-        with PatchCaches(), patch_fbcode(fbcode):
+        with PatchCaches():
             f_compiled(x, y, a, b)
 
-            self.assertEqual(global_stats.autotune.num_get_hit, 0)
-            self.assertEqual(global_stats.autotune.num_get_miss, 2)
-            self.assertEqual(global_stats.autotune.num_put, 2)
+            self.assertEqual(global_stats.autotune_remote, Stats(2, 0, 2))
 
             self.reset()
             f_compiled(x, y, a, b)
 
-        global_stats.report()
-        self.assertEqual(global_stats.autotune.num_get_hit, 2)
-        self.assertEqual(global_stats.autotune.num_get_miss, 2)
-        self.assertEqual(global_stats.autotune.num_put, 2)
+        self.assertEqual(global_stats.autotune_remote, Stats(2, 2, 2))
+
+        if config.is_fbcode():
+            # Check that the cache entries seem reasonable
+            for k in global_stats.autotune_remote.cache.keys():
+                self.assertRegex(k, r"[0-9a-z]{52}\.py")
+            for k in global_stats.triton.cache.keys():
+                self.assertRegex(k, r"triton:[0-9a-f]{64}::[0-9a-f]{64}:c10")
 
 
 class TestUtils(TestCase):

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -35,9 +35,9 @@ from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
 
 
 try:
-    from .mock_cache import global_stats, PatchCaches
+    from .mock_cache import global_stats, PatchCaches, Stats
 except ImportError:
-    from mock_cache import global_stats, PatchCaches  # @manual
+    from mock_cache import global_stats, PatchCaches, Stats  # @manual
 
 
 torch.set_float32_matmul_precision("high")
@@ -770,9 +770,7 @@ class TestMaxAutotuneRemoteCache(TestCase):
                     reset()
 
                 global_stats.report()
-                self.assertEqual(global_stats.autotune.num_get_hit, 3)
-                self.assertEqual(global_stats.autotune.num_get_miss, 1)
-                self.assertEqual(global_stats.autotune.num_put, 1)
+                self.assertEqual(global_stats.autotune_remote, Stats(1, 3, 1))
 
             global_stats.reset()
             for _ in range(4):
@@ -780,9 +778,7 @@ class TestMaxAutotuneRemoteCache(TestCase):
                     torch.compile(f, dynamic=dynamic)(x, y)
                 reset()
             global_stats.report()
-            self.assertEqual(global_stats.autotune.num_get_hit, 3)
-            self.assertEqual(global_stats.autotune.num_get_miss, 1)
-            self.assertEqual(global_stats.autotune.num_put, 1)
+            self.assertEqual(global_stats.autotune_remote, Stats(1, 3, 1))
 
 
 class TestBenchmarkRequest(BenchmarkRequest):

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -81,7 +81,7 @@ class AutotuneCache:
             return
 
         cache_filename = os.path.splitext(filename)[0] + ".best_config"
-        local_cache = RemoteCache(_LocalAutotuneCacheBackend(), RemoteCacheJsonSerde())
+        local_cache = LocalAutotuneCache()
         self.local_cache = (local_cache, cache_filename)
 
     # Set up remote caching information
@@ -235,3 +235,10 @@ class _LocalAutotuneCacheBackend(RemoteCacheBackend[bytes]):
     def put(self, key: str, data: bytes) -> None:
         with open(key, "wb") as fd:
             fd.write(data)
+
+
+class LocalAutotuneCache(RemoteCache[JsonDataTy]):
+    def __init__(self) -> None:
+        backend = _LocalAutotuneCacheBackend()
+        serde = RemoteCacheJsonSerde()
+        super().__init__(backend, serde)


### PR DESCRIPTION
Summary:
- Clean up cache test code a bit.
- Removed patch_fbcode() - it turned out to cause flaky issues (image if it set fbcode=False and then loaded a module for the first time which had a top-level fbcode check).

Test Plan: unit tests

Reviewed By: oulgen

Differential Revision: D62648248


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang