### PR TITLE
attempt to fix real tensor tracing for bool casts

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1534,6 +1534,7 @@ class FakeTensorPropTest(TestCase):
                 value, None, another_optional_value
             )
 
+    @expectedFailurePropagateRealTensors
     def test_unbacked_shape_realloc(self):
         def f(x):
             return x.nonzero()

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -9,7 +9,6 @@ a functionalized version of the graph under compilation.
 """
 
 import collections
-import contextlib
 import logging
 from functools import wraps
 from typing import Callable, DefaultDict, Dict, List, Optional
@@ -163,18 +162,15 @@ def run_functionalized_fw_and_collect_metadata(
         # It doesn't matter if we run this under predispatch or not because it is
         # only for figuring out metadata
         mode = FunctionalTensorMode(_allow_token_discovery=True)
-        suppress_pending = contextlib.nullcontext()
-        fake_mode = detect_fake_mode()
-        if fake_mode and (shape_env := fake_mode.shape_env):
-            suppress_pending = shape_env.ignore_fresh_unbacked_symbols()
-        with disable_above, mode, suppress_pending:
+        with disable_above, mode:
             # precondition: The passed in function already handles unflattening inputs + flattening outputs
             flat_f_args = pytree.tree_map(_to_fun, flat_args)
             flat_f_outs = f(*flat_f_args)
             # We didn't do any tracing, so we don't need to process the
             # unbacked symbols, they will just disappear into the ether.
             # Also, prevent memoization from applying.
-            if fake_mode:
+            if (fake_mode := detect_fake_mode()) and (shape_env := fake_mode.shape_env):
+                shape_env.pending_fresh_unbacked_symbols.clear()
                 fake_mode.epoch += 1
                 fake_mode.reset_nt_tensor_id_counter()
 

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -234,8 +234,12 @@ def trace_cond(proxy_mode, func_overload, pred, true_fn, false_fn, operands):
         isinstance(o, torch.Tensor) for o in operands
     ), "Cond operands must be a list of tensors"
 
-    true_graph = reenter_make_fx(true_fn)(*operands)
-    false_graph = reenter_make_fx(false_fn)(*operands)
+    suppress_pending = contextlib.nullcontext()
+    if (fake_mode := detect_fake_mode()) and (shape_env := fake_mode.shape_env):
+        suppress_pending = shape_env.ignore_fresh_unbacked_symbols()
+    with suppress_pending:
+        true_graph = reenter_make_fx(true_fn)(*operands)
+        false_graph = reenter_make_fx(false_fn)(*operands)
 
     true_outs = []
     false_outs = []
@@ -392,6 +396,11 @@ class CondAutogradOp(torch.autograd.Function):
 
 @cond_op.py_impl(DispatchKey.Autograd)
 def cond_autograd(pred, true_fn, false_fn, operands):
+    suppress_pending = contextlib.nullcontext()
+    if (fake_mode := detect_fake_mode()) and (shape_env := fake_mode.shape_env):
+        shape_env.pending_fresh_unbacked_symbols.clear()
+        suppress_pending = shape_env.ignore_fresh_unbacked_symbols()
+
     # A shortcut for the case where all inputs don't require gradient,
     # we skip tracing the forward and backward graph.
     if pytree.tree_all_only(
@@ -399,15 +408,16 @@ def cond_autograd(pred, true_fn, false_fn, operands):
         lambda t: not t.requires_grad,  # type: ignore[union-attr]
         (pred, operands),
     ):
-        with torch._C._AutoDispatchBelowAutograd():
+        with suppress_pending, torch._C._AutoDispatchBelowAutograd():
             return cond_op(pred, true_fn, false_fn, operands)
 
-    (
-        fw_true_graph,
-        fw_false_graph,
-        joint_true_graph,
-        joint_false_graph,
-    ) = create_fw_bw_graph_branches(true_fn, false_fn, *operands)
+    with suppress_pending:
+        (
+            fw_true_graph,
+            fw_false_graph,
+            joint_true_graph,
+            joint_false_graph,
+        ) = create_fw_bw_graph_branches(true_fn, false_fn, *operands)
     flat_out = CondAutogradOp.apply(
         pred,
         fw_true_graph,

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1937,7 +1937,9 @@ class FakeTensorMode(TorchDispatchMode):
                 # If a data-dependent op is used in a decomposition, we
                 # may need to get the unbacked settings "early"
                 # TODO: Is this really needed?
-                compute_unbacked_bindings(self.shape_env, fake_out, peek=True)
+                compute_unbacked_bindings(
+                    self.shape_env, fake_out, peek=False, real_value=real_out
+                )
 
             return fake_out
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -602,7 +602,7 @@ class DivideByKey:
         return o // self.divisor
 
 
-def compute_unbacked_bindings(shape_env, example_value, old_example_value=None, peek=False):
+def compute_unbacked_bindings(shape_env, example_value, old_example_value=None, peek=False, real_value=None):
     """
     After having run fake tensor propagation and producing example_value
     result, traverse example_value looking for freshly bound unbacked
@@ -712,7 +712,7 @@ def compute_unbacked_bindings(shape_env, example_value, old_example_value=None, 
 
             return r
 
-        symbol_to_path = free_unbacked_symbols_with_path(example_value, ())
+        symbol_to_path = free_unbacked_symbols_with_path(example_value, (), real=real_value)
         if not peek and pending:
             extra = (
                 repr((example_value.stride(), example_value.storage_offset()))

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -166,7 +166,11 @@ def insert_deferred_runtime_asserts(
             for arg in node.args
         ]
         try:
-            node.meta[val_key] = node.target(*fake_args)  # type: ignore[operator]
+            node.meta[val_key] = (
+                None
+                if node.target == torch.ops.aten._assert_scalar.default
+                node.target(*fake_args)  # type: ignore[operator]
+            )
         except NotImplementedError:
             # This can happen when attempting to reify a symbol with an unsupported call_function node,
             # e.g. with NestedTensors + sym_size.int via match_symbol().

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -169,7 +169,7 @@ def insert_deferred_runtime_asserts(
             node.meta[val_key] = (
                 None
                 if node.target == torch.ops.aten._assert_scalar.default
-                node.target(*fake_args)  # type: ignore[operator]
+                else node.target(*fake_args)  # type: ignore[operator]
             )
         except NotImplementedError:
             # This can happen when attempting to reify a symbol with an unsupported call_function node,


### PR DESCRIPTION
Tries to fix #135618, #135630, #135061

From what I understand, #135053 dealt with tracking unbacked bindings in torch.cond subgraphs by totally ignoring fresh unbacked symbols during AOTAutograd's collect_metadata_analysis pass. However in real tensor tracing cases where we trace a `bool()` cast on some condition, we create an unbacked symbool, and need to track the value of that in order to proceed. This resolves that by moving the fresh symbol suppression to torch.cond only (maybe it should be in higher order op helper code instead?).

After that there's some plumbing in real tensor propagation which I'm really not sure about, but putting this up as an example that manages to fix the tests.

I think the major follow up issue is that, because there's a bool() cast, the symbool we create will specialize to the concrete boolean value, e.g. we see this in the logs:
```
propagate_real_tensors evaluate_expr(Eq(u1, 1)) -> 0
runtime_assert False == False [statically known]
```

I think this means when we try to find an unbacked binding for u1 in `track_tensor_tree`, we only see the specialized `False` and we're unable to do so. Settting `peek=False` in the `compute_unbacked_bindings()` call from real tensor prop is an attempt to workaround this by clearing fresh symbols, but I really don't think this is right.