### PR TITLE
[3/3][Inductor] Make CK work in FBCode

### DIFF
--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -103,7 +103,6 @@ class TestCKBackend(TestCase):
             torch.testing.assert_close(Y_compiled, Y)
 
     @unittest.skipIf(not torch.version.hip, "ROCM only")
-    @unittest.skipIf(config.is_fbcode(), "fbcode requires different CK path setup")
     @unittest.mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
     @parametrize("max_autotune_gemm_backends", ("CK",))
     @parametrize("autotune_in_subproc", (True,))
@@ -222,7 +221,6 @@ class TestCKBackend(TestCase):
             torch.testing.assert_close(Y_compiled, Y_eager)
 
     @unittest.skipIf(not torch.version.hip, "ROCM only")
-    @unittest.skipIf(config.is_fbcode(), "fbcode requires different CK path setup")
     @unittest.mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
     @parametrize("max_autotune_gemm_backends", ("CK", "ATen,Triton,CK"))
     @parametrize("x_shape", ([4096, 2048], [2048], [4096, 1]))

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -314,7 +314,7 @@ class CKGemmTemplate(CKTemplate):
 * Template instance {op}
 *
 * {torch.__version__=}
-* {torch.version.git_version=}
+* torch.version.git_version={getattr(torch.version, 'git_version', 'None')}
 */
 """
         epilogue = None

--- a/torch/_inductor/codegen/rocm/compile_command.py
+++ b/torch/_inductor/codegen/rocm/compile_command.py
@@ -20,11 +20,20 @@ def _rocm_include_paths() -> List[str]:
     )
     if not config.rocm.ck_dir:
         log.warning("Unspecified Composable Kernel include dir")
-    ck_include = os.path.join(
-        config.rocm.ck_dir or cpp_extension._join_rocm_home("composable_kernel"),
-        "include",
-    )
-    return [os.path.realpath(rocm_include), os.path.realpath(ck_include)]
+
+    if config.is_fbcode():
+        from libfb.py import parutil
+
+        ck_path = parutil.get_dir_path("composable-kernel-headers")
+        ck_include = os.path.join(ck_path, "include")
+    else:
+        ck_include = os.path.join(
+            config.rocm.ck_dir or cpp_extension._join_rocm_home("composable_kernel"),
+            "include",
+        )
+
+    paths = [os.path.realpath(rocm_include), os.path.realpath(ck_include)]
+    return paths
 
 
 def _rocm_lib_options() -> List[str]:
@@ -42,6 +51,7 @@ def _rocm_lib_options() -> List[str]:
     )
 
     return [
+        "-include __clang_hip_runtime_wrapper.h",
         f"-L{os.path.realpath(rocm_lib_dir)}",
         f"-L{os.path.realpath(hip_lib_dir)}",
         "-lamdhip64",

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1106,6 +1106,10 @@ class cuda:
     cutlass_op_denylist_regex: Optional[str] = "pingpong"
 
 
+if is_fbcode() and torch.version.hip:
+    from triton.fb import build_paths
+
+
 class rocm:
     # Offload arch list for device code compilation, e.g. ["gfx941", "gfx942"].
     # If empty, the `native` arch is used
@@ -1134,7 +1138,9 @@ class rocm:
     print_kernel_resource_usage = False
 
     # Path to ROCm installation, if None, use env variable ROCM_HOME
-    rocm_home: Optional[str] = None
+    rocm_home: Optional[str] = (
+        build_paths.rocm() if is_fbcode() and torch.version.hip else None
+    )
 
     # Path to Composable Kernel library.
     # Install with `pip install git+https://github.com/rocm/composable_kernel@develop`.

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1217,6 +1217,9 @@ def use_ck_template(layout, m, n, k):
         log.warning("Please pip install Composable Kernel package")
         return False
 
+    if config.is_fbcode():
+        config.rocm.ck_dir = ck_package_dirname
+
     if not config.rocm.ck_dir:
         log.warning("Please set TORCHINDUCTOR_CK_DIR env variable")
         return False


### PR DESCRIPTION
Summary:
# Context
Goal: Enable CK for Inductor in FBCode

We split this stack into three diffs to help with review & in case we need to revert anything.

# This Diff
* Gets us to have CK kernels as an option for GEMM autotuning in Inductor.

Reviewed By: zjing14

Differential Revision: D62662705


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang