### PR TITLE
return instead of using skipTest

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -136,7 +136,8 @@ class StoreTestBase:
 
     def _test_append(self, store):
         if not store.has_extended_api():
-            self.skipTest("Store doesn't support extended APIs")
+            # Just return for stores that don't support extended APIs.
+            return
         store.set("foo", "po")
         store.append("foo", "tato")
         store.append("bar", "po")
@@ -149,7 +150,8 @@ class StoreTestBase:
 
     def _test_multi_set(self, store):
         if not store.has_extended_api():
-            self.skipTest("Store doesn't support extended APIs")
+            # Just return for stores that don't support extended APIs.
+            return
         store.multi_set(["foo", "bar"], ["po", "tato"])
         self.assertEqual(b"po", store.get("foo"))
         self.assertEqual(b"tato", store.get("bar"))
@@ -159,7 +161,8 @@ class StoreTestBase:
 
     def _test_multi_get(self, store):
         if not store.has_extended_api():
-            self.skipTest("Store doesn't support extended APIs")
+            # Just return for stores that don't support extended APIs.
+            return
         store.set("foo", "po")
         store.set("bar", "tato")
         v0, v1 = store.multi_get(["foo", "bar"])


### PR DESCRIPTION
Summary:
Return from functions instead of using `skipTest`.
This is mostly to make our test report happier.
Skipped tests still show up in our  Broken test report.

```
OK (skipped=1)
I0917 16:14:24.749060 1018907 StorageDemandControl.cpp:572] Flushing Demand Control ODS counters

Skipped: Store doesn't support extended APIs
```

Test Plan:
Tested locally.
Test shows up as passed instead of skipped.

```
Cache hits: 99%. Commands: 125048 (cached: 124961, remote: 10, local: 77)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D62912065


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k