### PR TITLE
[inductor] Enable parallel compile by default in fbcode

### DIFF
--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -128,6 +128,16 @@ def get_worker_start_method() -> str:
     return config.worker_start_method
 
 
+def get_compile_threads() -> int:
+    """
+    Temporary for internal rollout. Assign config.compile_threads lazily and return it.
+    TODO: remove after rollout.
+    """
+    if config.compile_threads is None:
+        config.compile_threads = config.decide_compile_threads()
+    return config.compile_threads
+
+
 class AsyncCompile:
     def __init__(self) -> None:
         pass
@@ -135,8 +145,8 @@ class AsyncCompile:
     @staticmethod
     @functools.lru_cache(1)
     def pool() -> ThreadPoolExecutor:
-        assert config.compile_threads > 1
-        return ThreadPoolExecutor(config.compile_threads)
+        assert get_compile_threads() > 1
+        return ThreadPoolExecutor(get_compile_threads())
 
     @staticmethod
     def _get_ready():
@@ -146,16 +156,16 @@ class AsyncCompile:
     @staticmethod
     @functools.lru_cache(1)
     def process_pool() -> AnyPool:
-        assert config.compile_threads > 1
+        assert get_compile_threads() > 1
         pool: AnyPool
         if get_worker_start_method() == "subprocess":
             # Wrapper around ProcessPoolExecutor forks in a new process we control
-            pool = SubprocPool(config.compile_threads)
+            pool = SubprocPool(get_compile_threads())
         else:
             pre_fork_setup()
             ctx = multiprocessing.get_context(get_worker_start_method())
             pool = ProcessPoolExecutor(
-                config.compile_threads,
+                get_compile_threads(),
                 mp_context=ctx,
                 initializer=partial(_async_compile_initializer, os.getpid()),
             )
@@ -172,21 +182,21 @@ class AsyncCompile:
 
     @classmethod
     def warm_pool(cls) -> None:
-        if config.compile_threads <= 1:
+        if get_compile_threads() <= 1:
             return
         _compile_start()
-        _warm_process_pool(cls.process_pool(), config.compile_threads)
+        _warm_process_pool(cls.process_pool(), get_compile_threads())
         _compile_end()
 
     @classmethod
     def submit(cls, task: Callable[..., Any]) -> Any:
-        if config.compile_threads <= 1:
+        if get_compile_threads() <= 1:
             return task()
         return cls.pool().submit(task)
 
     def _use_process_pool(self):
         return (
-            config.compile_threads > 1
+            get_compile_threads() > 1
             and self.process_pool().ready_future.done()  # type: ignore[union-attr]
         )
 
@@ -221,7 +231,7 @@ class AsyncCompile:
 
     def cpp(self, source_code: str):
         kernel_code_log.info("CPP Kernel:\n%s", source_code)
-        if config.compile_threads <= 1:
+        if get_compile_threads() <= 1:
             return CppCodeCache.load(source_code).kernel
         else:
             get_result = CppCodeCache.load_async(source_code, submit_fn=self.submit)
@@ -229,7 +239,7 @@ class AsyncCompile:
 
     def cpp_pybinding(self, argtypes: List[str], source_code: str):
         kernel_code_log.info("CPP+Bindings Kernel:\n%s", source_code)
-        if config.compile_threads <= 1:
+        if get_compile_threads() <= 1:
             return CppPythonBindingsCodeCache.load_pybinding(argtypes, source_code)
         else:
             get_result = CppPythonBindingsCodeCache.load_pybinding_async(
@@ -255,7 +265,7 @@ class AsyncCompile:
 
     def halide(self, meta: HalideMeta, source_code: str):
         kernel_code_log.info("Halide Kernel:\n%r\n%s", meta, source_code)
-        if config.compile_threads <= 1:
+        if get_compile_threads() <= 1:
             return HalideCodeCache.generate_halide(meta, source_code)
         else:
             get_result = HalideCodeCache.generate_halide_async(
@@ -277,7 +287,7 @@ class AsyncCompile:
             disable=config.disable_progress,
             delay=0,
         )
-        if config.compile_threads > 1:
+        if get_compile_threads() > 1:
             for key, result in scope.items():
                 if config.verbose_progress and not isinstance(pbar, _Faketqdm):
                     pbar.set_postfix_str(key)

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -182,7 +182,7 @@ class SubprocPool:
                 self.running = False
                 _send_msg(self.write_pipe, -1)
                 self.write_pipe.close()
-            self.process.wait(10)
+            self.process.wait(300)
         except OSError as e:
             log.warning("Ignored OSError in pool shutdown:  %s", e)
         finally:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -576,7 +576,13 @@ def decide_compile_threads() -> int:
         return int(os.environ["TORCHINDUCTOR_COMPILE_THREADS"])
     elif sys.platform == "win32":
         return 1
-    elif is_fbcode():
+    # TODO: For internal rollout, we use a killswitch to disable. The justknob should
+    # not be performed at import, however. So for fbcode, we assign compile_threads to
+    # None below and call this method lazily in async_compile.py. Remove this after
+    # rollout completes.
+    elif is_fbcode() and not torch._utils_internal.justknobs_check(
+        "pytorch/inductor:enable_parallel_compile"
+    ):
         return 1
     else:
         cpu_count = (
@@ -588,7 +594,8 @@ def decide_compile_threads() -> int:
         return min(32, cpu_count)
 
 
-compile_threads = decide_compile_threads()
+# TODO: Set directly after internal rollout.
+compile_threads: Optional[int] = None if is_fbcode() else decide_compile_threads()
 
 # gemm autotuning global cache dir
 if is_fbcode():


### PR DESCRIPTION
Summary: Now that we have subprocess parallel compile on by default, we can change the internal compile_threads default to > 1 with a killswitch. Some jankiness so we can avoid evaluating the justknob at import.

Test Plan: Ran codecache tests with JK on, then canaried locally with JK off

Differential Revision: D62913998


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang