### PR TITLE
OpenReg: support multiple executors

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
@@ -52,6 +52,8 @@ def _openreg_kernel_fallback(op, *args, **kwargs):
     device = get_tensor_device(*args)
     if device is None:
         return _kernel_fallback(op, *args, **kwargs)
+    
+    # Mimicks the DeviceGuard system we have in aten
     with DeviceContext(device):
         return _kernel_fallback(op, *args, **kwargs)
 

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
@@ -30,42 +30,34 @@ _register_same_name("exchangeDevice")
 _register_same_name("malloc", True)
 _register_same_name("free", True)
 
-_openreg_lib = torch.library.Library("_", "IMPL")
+
+# TODO: replace it with implementing torch.openreg.device
+class DeviceContext:
+    def __init__(self, device):
+        self.idx = device.index
+
+    def __enter__(self):
+        self.prev = driver.exec("exchangeDevice", self.idx)
+
+    def __exit__(self, *args):
+        driver.exec("uncheckedSetDevice", self.prev)
 
 
 def _openreg_kernel_fallback(op, *args, **kwargs):
-    log.info("Calling kernel %s", op)
+    def get_tensor_device(*args):
+        for arg in args:
+            if isinstance(arg, torch.Tensor) and arg.device.type == "openreg":
+                return arg.device
 
-    # Special ops needed to avoid infinite recursion
-    if op is torch.ops.aten._copy_from.default:
-        from_, to_ = args
-        if from_.device.type == to_.device.type:
-            assert from_.device.type == "openreg"
-            op = torch.ops.aten.copy_.default
-            args = to_, from_
-            # handled below as a regular copy
-        elif from_.device.type == "openreg":
-            args, _ = prepare_for_sending((from_,), {})
-            host_mem = driver.exec("send_data", *args)
-            return to_.copy_(host_mem)
-        elif to_.device.type == "openreg":
-            args, _ = prepare_for_sending((to_,), {})
-            driver.exec("recv_data", from_, *args)
-            return to_
-        else:
-            raise RuntimeError("Should not happen")
-    elif op is torch.ops.aten.set_.source_Tensor:
-        return torch.ops.aten.set_.source_Storage_storage_offset(
-            args[0],
-            args[1].untyped_storage(),
-            args[1].storage_offset(),
-            args[1].size(),
-            args[1].stride(),
-        )
-    elif op is torch.ops.aten._local_scalar_dense.default:
-        args, _ = prepare_for_sending(args, {})
-        host_mem = driver.exec("send_data", *args)
-        return host_mem.item()
+    device = get_tensor_device(*args)
+    if device is None:
+        return _kernel_fallback(op, *args, **kwargs)
+    with DeviceContext(device):
+        return _kernel_fallback(op, *args, **kwargs)
+
+
+def _kernel_fallback(op, *args, **kwargs):
+    log.info("Calling kernel %s", op)
 
     op_name = None
     post_process = None
@@ -151,4 +143,60 @@ def _openreg_kernel_fallback(op, *args, **kwargs):
     return real_res
 
 
+def copy_from_device(from_):
+    with DeviceContext(from_.device):
+        args, _ = prepare_for_sending((from_,), {})
+        return driver.exec("send_data", *args)
+
+
+def copy_from_host_to_device(from_, to_):
+    with DeviceContext(to_.device):
+        args, _ = prepare_for_sending((to_,), {})
+        driver.exec("recv_data", from_, *args)
+    return to_
+
+
+def _copy_from(from_, to_):
+    if from_.device.type == to_.device.type:
+        assert from_.device.type == "openreg"
+        if from_.device.index == to_.device.index:
+            op = torch.ops.aten.copy_.default
+            return _openreg_kernel_fallback(op, to_, from_)
+        else:
+            host_mem = copy_from_device(from_)
+            return copy_from_host_to_device(host_mem, to_)
+    elif from_.device.type == "openreg":
+        host_mem = copy_from_device(from_)
+        return to_.copy_(host_mem)
+    elif to_.device.type == "openreg":
+        return copy_from_host_to_device(from_, to_)
+    else:
+        raise RuntimeError("Should not happen")
+
+
+def _set_source_tensor(ten1, ten2):
+    return torch.ops.aten.set_.source_Storage_storage_offset(
+        ten1,
+        ten2.untyped_storage(),
+        ten2.storage_offset(),
+        ten2.size(),
+        ten2.stride(),
+    )
+
+
+def _local_scalar_dense(ten):
+    host_mem = copy_from_device(ten)
+    return host_mem.item()
+
+
+_openreg_lib = torch.library.Library("_", "IMPL")
 _openreg_lib.fallback(_openreg_kernel_fallback, dispatch_key="PrivateUse1")
+
+_openreg_lib_aten = torch.library.Library("aten", "IMPL")
+_openreg_lib_aten.impl("_copy_from", _copy_from, dispatch_key="PrivateUse1")
+_openreg_lib_aten.impl(
+    "set_.source_Tensor", _set_source_tensor, dispatch_key="PrivateUse1"
+)
+_openreg_lib_aten.impl(
+    "_local_scalar_dense", _local_scalar_dense, dispatch_key="PrivateUse1"
+)

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
@@ -52,7 +52,7 @@ def _openreg_kernel_fallback(op, *args, **kwargs):
     device = get_tensor_device(*args)
     if device is None:
         return _kernel_fallback(op, *args, **kwargs)
-    
+
     # Mimicks the DeviceGuard system we have in aten
     with DeviceContext(device):
         return _kernel_fallback(op, *args, **kwargs)

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
@@ -90,7 +90,7 @@ class Driver:
         self.curr_stream = 0
         # Constant properties of our device
         self.num_devices = 2
-        # Allocated memory belongs to which deivce
+        # Allocated memory belongs to which device
         self.memory_belong = {}
         self.devices = []
 
@@ -114,7 +114,7 @@ class Driver:
         if cmd in Driver.registry:
             res = Driver.registry[cmd](self, *args)
         else:
-            res = self.run_on_exeuctor(self.curr_device_idx, cmd, *args)
+            res = self.run_on_executor(self.curr_device_idx, cmd, *args)
 
         log.info("Main process result for %s received: %s", cmd, safe_str(res))
         if res == "ERROR":
@@ -122,7 +122,7 @@ class Driver:
         else:
             return res
 
-    def run_on_exeuctor(self, device_idx, cmd, *args):
+    def run_on_executor(self, device_idx, cmd, *args):
         req_queue, ans_queue, _ = self.devices[device_idx]
         validate_send_queue_args(cmd, args)
         req_queue.put((cmd,) + args)
@@ -153,7 +153,7 @@ class Driver:
 
     @register(registry)
     def malloc(self, size):
-        ptr = self.run_on_exeuctor(self.curr_device_idx, "malloc", size)
+        ptr = self.run_on_executor(self.curr_device_idx, "malloc", size)
         self.memory_belong[ptr] = self.curr_device_idx
         return ptr
 
@@ -162,7 +162,7 @@ class Driver:
         device_idx = self.memory_belong.pop(ptr, None)
         if device_idx is None:
             return False
-        return self.run_on_exeuctor(device_idx, "free", ptr)
+        return self.run_on_executor(device_idx, "free", ptr)
 
 
 class _Executor:

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
@@ -159,7 +159,7 @@ class Driver:
 
     @register(registry)
     def free(self, ptr):
-        device_idx = self.memory_belong.pop(ptr)
+        device_idx = self.memory_belong.pop(ptr, None)
         if device_idx is None:
             return False
         return self.run_on_exeuctor(device_idx, "free", ptr)

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_meta_parser.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_meta_parser.py
@@ -51,7 +51,7 @@ def validate_send_queue_args(cmd, args):
         if type(obj) not in VALID_QUEUE_TYPES_OUT:
             if (
                 cmd == "recv_data"
-                and type(obj) is torch.Tensor
+                and type(obj) in [torch.Tensor, OpenRegTensorData]
                 and obj.device.type == "cpu"
             ):
                 # Only HtoD copy command can send cpu Tensors over

--- a/test/cpp_extensions/open_registration_extension/test/test_openreg.py
+++ b/test/cpp_extensions/open_registration_extension/test/test_openreg.py
@@ -57,7 +57,7 @@ class TestOpenReg(TestCase):
 
     def test_cross_diff_devices_copy(self):
         a = torch.ones(10, device="openreg:0").to(device="openreg:1").to(device="cpu")
-        self.assertEqual(a, torch.ones(10, device="openreg"))
+        self.assertEqual(a, torch.ones(10))
 
     def test_data_dependent_output(self):
         cpu_a = torch.randn(10)

--- a/test/cpp_extensions/open_registration_extension/test/test_openreg.py
+++ b/test/cpp_extensions/open_registration_extension/test/test_openreg.py
@@ -55,6 +55,10 @@ class TestOpenReg(TestCase):
         a = torch.ones(10, device="openreg").clone()
         self.assertEqual(a, torch.ones(10, device="openreg"))
 
+    def test_cross_diff_devices_copy(self):
+        a = torch.ones(10, device="openreg:0").to(device="openreg:1").to(device="cpu")
+        self.assertEqual(a, torch.ones(10, device="openreg"))
+
     def test_data_dependent_output(self):
         cpu_a = torch.randn(10)
         a = cpu_a.to(device="openreg")


### PR DESCRIPTION
From PR https://github.com/pytorch/pytorch/pull/135646 we have split the daemon into drvier/executor, however, current executor stands for all devices and allocate memory all together. In order to better simulate device behavior, here we support multiple executors, each executor stands for one device.

cc @albanD @FFFrog