### PR TITLE
Set output num_float_feature to have dynamic dimension

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2737,11 +2737,16 @@ def _index_add(
 @register_decomposition(aten.pad_sequence.default)
 @aten.pad_sequence.default.py_impl(DispatchKey.CompositeImplicitAutograd)
 def pad_sequence(sequences, batch_first=False, padding_value=0.0):
+    from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+
     torch._check(len(sequences) > 0, lambda: "received an empty list of sequences")
     sequences_size = len(sequences)
     max_size = sequences[0].size()
     trailing_dims = max_size[1:]
-    max_len = max(x.size(0) for x in sequences)
+    max_len = sequences[0].size(0)
+    for x in sequences[1:]:
+        if guard_size_oblivious(x.size(0) > max_len):
+            max_len = x.size(0)
     if batch_first:
         out_dims = (sequences_size, max_len)
     else:


### PR DESCRIPTION
Summary: As title. Set num_float_feature to have dynamic dimension and add guard_size_oblivious in pad_sequence fake_implementation

Test Plan: buck2 run mode/opt fbcode//aps_models/ads/gmp:launcher_with_publish -- mode=mtml_ctr_instagram_model/experimental/local_hive_501018263_trec_infer stages.train=false stages.post_train_publish=true stages.gen_inference_module=false inference.serializer=manifold publisher=standalone launcher=local_mp model_metadata.model_entity_id=927138279 inference.serializer.model_export_mode=IR

Differential Revision: D61232780
