### PR TITLE
Revert "[Release only] Temporary disable triton xpu build"

### DIFF
--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         py_vers: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        device: ["cuda", "rocm"]
+        device: ["cuda", "rocm", "xpu"]
         include:
           - device: "rocm"
             rocm_version: "6.2"


### PR DESCRIPTION
Reverts pytorch/pytorch#136206
Branch https://github.com/intel/intel-xpu-backend-for-triton/tree/release/3.1.x has been created. Hence this temporary PR is not required