### PR TITLE
[BE] fix circular import in torch/distributed/utils.py

### DIFF
--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -18,8 +18,6 @@ from typing import (
 import torch
 import torch.distributed as dist
 from torch import nn
-from torch.nn.parallel._functions import _get_stream
-from torch.nn.parallel.scatter_gather import _is_namedtuple
 from torch.nn.utils.rnn import PackedSequence
 
 
@@ -123,6 +121,9 @@ def _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies):
                 device_mod = getattr(torch, device.type, None)
                 if device.type == "cpu" or device_mod is None:
                     return (obj.to(target_device),)
+
+                from torch.nn.parallel._functions import _get_stream
+
                 # Perform CPU -> target_device copies in a background stream. This code is
                 # motivated from similar logic in torch/nn/parallel/_functions.py
                 stream = _get_stream(target_device)
@@ -141,6 +142,9 @@ def _recursive_to(inputs, target_device, use_side_stream_for_tensor_copies):
                         assert isinstance(output, torch.Tensor)
                         output.record_stream(current_stream)  # type: ignore[arg-type]
                 return (output,)
+
+        from torch.nn.parallel.scatter_gather import _is_namedtuple
+
         if _is_namedtuple(obj):
             return [type(obj)(*args) for args in zip(*map(to_map, obj))]
         if isinstance(obj, tuple) and len(obj) > 0:
@@ -228,6 +232,8 @@ def _apply_to_tensors(fn, container):
     """Recursively apply to all tensor in different kinds of container types."""
 
     def apply(x):
+        from torch.nn.parallel.scatter_gather import _is_namedtuple
+
         if isinstance(x, torch.Tensor):
             return fn(x)
         elif hasattr(x, "__dataclass_fields__"):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136286

**Summary**
Fix circular import in `torch/distributed/utils.py` found when running internal test, see D62901023. Curious why this wasn't causing any issue. Is this relevant code deprecated and no longer used?

cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o