### PR TITLE
Introduce _ArglessActivation base class for parameterless activation functions

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -45,6 +45,19 @@ __all__ = [
 ]
 
 
+class ArglessActivation(Module):
+    r"""Base class for activation functions that don't require arguments.
+
+    This class serves as a foundation for simple activation functions in PyTorch,
+    providing a consistent API across various implementations. It overrides the
+    constructor of the base Module class with a no-argument version.
+
+    Subclasses of ArglessActivation should not define their own __init__ method.
+    """
+    def __init__(self) -> None:
+        super().__init__()
+
+
 class Threshold(Module):
     r"""Thresholds each element of the input Tensor.
 
@@ -303,7 +316,7 @@ class ReLU6(Hardtanh):
         return inplace_str
 
 
-class Sigmoid(Module):
+class Sigmoid(ArglessActivation):
     r"""Applies the Sigmoid function element-wise.
 
     .. math::
@@ -367,7 +380,7 @@ class Hardsigmoid(Module):
         return F.hardsigmoid(input, self.inplace)
 
 
-class Tanh(Module):
+class Tanh(ArglessActivation):
     r"""Applies the Hyperbolic Tangent (Tanh) function element-wise.
 
     Tanh is defined as:
@@ -1515,7 +1528,7 @@ class PReLU(Module):
         return f"num_parameters={self.num_parameters}"
 
 
-class Softsign(Module):
+class Softsign(ArglessActivation):
     r"""Applies the element-wise Softsign function.
 
     .. math::
@@ -1538,7 +1551,7 @@ class Softsign(Module):
         return F.softsign(input)
 
 
-class Tanhshrink(Module):
+class Tanhshrink(ArglessActivation):
     r"""Applies the element-wise Tanhshrink function.
 
     .. math::
@@ -1670,7 +1683,7 @@ class Softmax(Module):
         return f"dim={self.dim}"
 
 
-class Softmax2d(Module):
+class Softmax2d(ArglessActivation):
     r"""Applies SoftMax over features to each spatial location.
 
     When given an image of ``Channels x Height x Width``, it will

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -46,14 +46,15 @@ __all__ = [
 
 
 class ArglessActivation(Module):
-    r"""Base class for activation functions that don't require arguments.
+    r"""Base class for activation functions that don't require constructor arguments.
 
-    This class serves as a foundation for simple activation functions in PyTorch,
-    providing a consistent API across various implementations. It overrides the
-    constructor of the base Module class with a no-argument version.
+    This class standardizes the initialization process for simple activation functions.
+    It provides a parameterless constructor that calls the base Module's __init__
+    method, ensuring a consistent initialization across all subclasses.
 
     Subclasses of ArglessActivation should not define their own __init__ method.
     """
+
     def __init__(self) -> None:
         super().__init__()
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -45,14 +45,14 @@ __all__ = [
 ]
 
 
-class ArglessActivation(Module):
+class _ArglessActivation(Module):
     r"""Base class for activation functions that don't require constructor arguments.
 
     This class standardizes the initialization process for simple activation functions.
     It provides a parameterless constructor that calls the base Module's __init__
     method, ensuring a consistent initialization across all subclasses.
 
-    Subclasses of ArglessActivation should not define their own __init__ method.
+    Subclasses of _ArglessActivation should not define their own __init__ method.
     """
 
     def __init__(self) -> None:
@@ -317,7 +317,7 @@ class ReLU6(Hardtanh):
         return inplace_str
 
 
-class Sigmoid(ArglessActivation):
+class Sigmoid(_ArglessActivation):
     r"""Applies the Sigmoid function element-wise.
 
     .. math::
@@ -381,7 +381,7 @@ class Hardsigmoid(Module):
         return F.hardsigmoid(input, self.inplace)
 
 
-class Tanh(ArglessActivation):
+class Tanh(_ArglessActivation):
     r"""Applies the Hyperbolic Tangent (Tanh) function element-wise.
 
     Tanh is defined as:
@@ -1529,7 +1529,7 @@ class PReLU(Module):
         return f"num_parameters={self.num_parameters}"
 
 
-class Softsign(ArglessActivation):
+class Softsign(_ArglessActivation):
     r"""Applies the element-wise Softsign function.
 
     .. math::
@@ -1552,7 +1552,7 @@ class Softsign(ArglessActivation):
         return F.softsign(input)
 
 
-class Tanhshrink(ArglessActivation):
+class Tanhshrink(_ArglessActivation):
     r"""Applies the element-wise Tanhshrink function.
 
     .. math::
@@ -1684,7 +1684,7 @@ class Softmax(Module):
         return f"dim={self.dim}"
 
 
-class Softmax2d(ArglessActivation):
+class Softmax2d(_ArglessActivation):
     r"""Applies SoftMax over features to each spatial location.
 
     When given an image of ``Channels x Height x Width``, it will


### PR DESCRIPTION
Fixes #133683
Fixes #133684
Fixes #133688

This PR introduces a new base class `_ArglessActivation` and refactors five existing activation functions to inherit from it. This change aims to improve documentation consistency and also API consistency with other activation functions that do have parameters and explicitly call `super().__init__()`

Key changes and considerations:
1. Added new class `_ArglessActivation`:
2. Refactored the following classes to inherit from `_ArglessActivation`:
   - Sigmoid
   - Tanh
   - Softsign
   - Tanhshrink
   - Softmax2d
3. Performance consideration:
   - This change introduces a slight overhead for creating a new stack frame and handling an additional function call on every instance creation
   - The impact is expected to be minimal in most use cases

Docs view before:
<img width="425" alt="Screen Shot 2024-09-18 at 3 00 22 PM" src="https://github.com/user-attachments/assets/ca0d1000-44c5-4c52-b344-68f7e170bafe">

Docs view after:
<img width="431" alt="Screen Shot 2024-09-18 at 3 00 52 PM" src="https://github.com/user-attachments/assets/f7ceb8f3-a2a2-4fd6-a2b8-39105a02bcbd">
