### PR TITLE
[Quant][PT2E]change flatten recipe for X86InductorQuantizer

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -2084,7 +2084,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
     @skipIfNoDynamoSupport
     def test_qflatten(self):
         r"""
-        This testcase will quantize Conv2d->AdaptiveAvgPool2d->flatten pattern.
+        This testcase will quantize Conv2d->AdaptiveAvgPool2d->flatten->cat pattern.
         """
 
         class M(torch.nn.Module):
@@ -2099,8 +2099,12 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 self.adaptive_avg_pool2d = torch.nn.AdaptiveAvgPool2d((1, 1))
 
             def forward(self, x):
-                return torch.flatten(
-                    self.adaptive_avg_pool2d(self.relu(self.conv(x))), 1
+                return torch.cat(
+                    [
+                        torch.flatten(
+                            self.adaptive_avg_pool2d(self.relu(self.conv(x))), 1
+                        )
+                    ]
                 )
 
         mod = M().eval()

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -1382,7 +1382,9 @@ class X86InductorQuantizer(Quantizer):
             elif (
                 node.target is torch.ops.aten.flatten.using_ints
                 and len(node.users) > 0
-                and not any(user.target in quantizable_ops for user in node.users.keys())
+                and not any(
+                    user.target in quantizable_ops for user in node.users.keys()
+                )
             ):
                 # Recipe of flatten: check if any users of flatten node are quantizable ops or not
                 return

--- a/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
+++ b/torch/ao/quantization/quantizer/x86_inductor_quantizer.py
@@ -1355,12 +1355,6 @@ class X86InductorQuantizer(Quantizer):
                         return False
                 return True
 
-            def is_any_users_connected_to_quantizable_op(users):
-                for user in list(users.keys()):
-                    if user.target in quantizable_ops:
-                        return True
-                return False
-
             if _skip_annotate([node], filter_fn):
                 return
 
@@ -1388,8 +1382,9 @@ class X86InductorQuantizer(Quantizer):
             elif (
                 node.target is torch.ops.aten.flatten.using_ints
                 and len(node.users) > 0
-                and not is_any_users_connected_to_quantizable_op(node.users)
+                and not any(user.target in quantizable_ops for user in node.users.keys())
             ):
+                # Recipe of flatten: check if any users of flatten node are quantizable ops or not
                 return
             else:
                 input_node = node.all_input_nodes[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136298

This PR modifies the flatten recipe: if none of the users of the flatten node are quantizable ops, int8 flatten will be disabled to avoid unnecessary dtype conversions.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang