### PR TITLE
Use cpython declaration of _PyWeakref_ClearRef

### DIFF
--- a/torch/csrc/utils/python_compat.h
+++ b/torch/csrc/utils/python_compat.h
@@ -35,7 +35,11 @@ PyCode_GetNFreevars(PyCodeObject* code) {
 }
 
 // Provided by CPython but getting the header for them is very hard
+#if IS_PYTHON_3_11_PLUS
+PyAPI_FUNC(void) _PyWeakref_ClearRef(PyWeakReference* self);
+#else
 extern void _PyWeakref_ClearRef(PyWeakReference* self);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
To avoid the DLL inconsistency warning by MSVC:
```
torch/csrc/utils/python_compat.h(38): warning C4273: '_PyWeakref_ClearRef': inconsistent dll linkage
```
 