### PR TITLE
TCPStoreLibUvBackend: trace operations

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -13,6 +13,7 @@
 #include <torch/csrc/distributed/c10d/TCPStore.hpp>
 #include <torch/csrc/distributed/c10d/TCPStoreBackend.hpp>
 #include <torch/csrc/distributed/c10d/logging.h>
+#include <torch/csrc/distributed/c10d/socket_fmt.h>
 
 #ifdef TORCH_USE_LIBUV
 #include <uv.h>
@@ -89,6 +90,7 @@ class UvHandle : public c10::intrusive_ptr_target {
 
 class UvTcpSocket : public UvHandle {
   uv_tcp_t client{};
+  std::string address_{"unknown"};
 
   c10::intrusive_ptr<UvTcpSocket> iptr() {
     return c10::intrusive_ptr<UvTcpSocket>::reclaim_copy(this);
@@ -143,7 +145,24 @@ class UvTcpSocket : public UvHandle {
     }
   }
 
+  const std::string& address() const {
+    return address_;
+  }
+
   void startRead() {
+    struct ::sockaddr_storage addr {};
+    int addrLen{sizeof(struct ::sockaddr_storage)};
+
+    if (int err = uv_tcp_getpeername(
+            &client, reinterpret_cast<struct ::sockaddr*>(&addr), &addrLen)) {
+      C10D_WARNING(
+          "The remote address of the client socket cannot be retrieved. err={}",
+          uv_strerror(err));
+    } else {
+      address_ =
+          formatSockAddr(reinterpret_cast<struct ::sockaddr*>(&addr), addrLen);
+    }
+
     int res = uv_read_start((uv_stream_t*)&client, alloc_buffer, read_callback);
     if (res) {
       C10D_WARNING(
@@ -246,8 +265,8 @@ class UvTcpServer : public UvTcpSocket {
           ", message: ",
           uv_strerror(uv_res));
 
-      uv_res =
-          uv_tcp_bind(res->unsafeGetSocket(), (const struct sockaddr*)&addr, 0);
+      uv_res = uv_tcp_bind(
+          res->unsafeGetSocket(), (const struct ::sockaddr*)&addr, 0);
       TORCH_CHECK(
           uv_res == 0,
           "The server socket has failed to bind. ",
@@ -325,7 +344,7 @@ class UvTcpServer : public UvTcpSocket {
 
     if (uv_tcp_getsockname(
             (uv_tcp_t*)unsafeGetStream(),
-            reinterpret_cast<sockaddr*>(&addr_s),
+            reinterpret_cast<::sockaddr*>(&addr_s),
             &addr_len) != 0) {
       throw std::runtime_error(
           "The port number of the socket cannot be retrieved.");
@@ -753,6 +772,8 @@ class UvClient : public UvTcpSocket {
     if (!stream.read_value(validateNumber))
       return false;
 
+    C10D_TRACE("validate magic:{} address:{}", validateNumber, this->address());
+
     if (validateNumber != c10d::detail::validationMagicNumber)
       return false;
     return true;
@@ -763,6 +784,8 @@ class UvClient : public UvTcpSocket {
     if (!stream.read_value(nonce)) {
       return false;
     }
+
+    C10D_TRACE("ping nonce:{} address:{}", nonce, this->address());
 
     StreamWriter sw(iptr());
     sw.write_value(nonce);
@@ -778,6 +801,8 @@ class UvClient : public UvTcpSocket {
     std::vector<uint8_t> newData;
     if (!stream.read_payload(newData))
       return false;
+
+    C10D_TRACE("set key:{} address:{}", key, this->address());
 
     store->set(key, newData);
     return true;
@@ -796,6 +821,8 @@ class UvClient : public UvTcpSocket {
     if (!stream.read_payload(newValue))
       return false;
 
+    C10D_TRACE("compareAndSet key:{} address:{}", key, this->address());
+
     auto res = store->compareAndSet(key, currentValue, newValue);
     StreamWriter sw(iptr());
     sw.write_vector(res);
@@ -808,6 +835,8 @@ class UvClient : public UvTcpSocket {
     std::string key;
     if (!stream.read_key(key))
       return false;
+
+    C10D_TRACE("get key:{} address:{}", key, this->address());
 
     const auto& data = store->get(key);
     StreamWriter sw(iptr());
@@ -824,6 +853,8 @@ class UvClient : public UvTcpSocket {
     int64_t addVal = 0;
     if (!stream.read_value(addVal))
       return false;
+
+    C10D_TRACE("add key:{} val:{} address:{}", key, addVal, this->address());
 
     addVal = store->add(key, addVal);
     StreamWriter sw(iptr());
@@ -850,6 +881,8 @@ class UvClient : public UvTcpSocket {
       if (!stream.read_key(keys[i]))
         return false;
     }
+
+    C10D_TRACE("check key_count:{} address:{}", key_count, this->address());
 
     // Now we have received all the keys
     StreamWriter sw(iptr());
@@ -881,6 +914,8 @@ class UvClient : public UvTcpSocket {
         return false;
     }
 
+    C10D_TRACE("wait key_count:{} address:{}", key_count, this->address());
+
     if (store->waitKeys(keys, iptr())) {
       StreamWriter sw(iptr());
       sw.write1((uint8_t)WaitResponseType::STOP_WAITING);
@@ -891,6 +926,8 @@ class UvClient : public UvTcpSocket {
   }
 
   bool parse_getnumkeys_command() {
+    C10D_TRACE("getnumkeys address:{}", this->address());
+
     StreamWriter sw(iptr());
     sw.write_value<int64_t>(store->size());
     sw.send();
@@ -902,6 +939,8 @@ class UvClient : public UvTcpSocket {
     std::string key;
     if (!stream.read_key(key))
       return false;
+
+    C10D_TRACE("delete key:{} address:{}", key, this->address());
 
     auto numDeleted = store->deleteKey(key);
     StreamWriter sw(iptr());
@@ -922,6 +961,8 @@ class UvClient : public UvTcpSocket {
       return false;
     }
 
+    C10D_TRACE("append key:{} address:{}", key, this->address());
+
     store->append(key, data);
     return true;
   }
@@ -938,6 +979,8 @@ class UvClient : public UvTcpSocket {
         key_count,
         ", max: ",
         MAX_KEY_COUNT);
+
+    C10D_TRACE("multi_get key_count:{} address:{}", key_count, this->address());
 
     StreamWriter sw(iptr());
     for (const auto _ : c10::irange(key_count)) {
@@ -967,6 +1010,8 @@ class UvClient : public UvTcpSocket {
         ", max: ",
         MAX_KEY_COUNT);
 
+    C10D_TRACE("multi_set key_count:{} address:{}", key_count, this->address());
+
     for (const auto _ : c10::irange(key_count)) {
       (void)_; // Suppress unused variable warning
 
@@ -986,6 +1031,8 @@ class UvClient : public UvTcpSocket {
 
   bool parse_cancel_wait_command() {
     store->clearClientWaitState(iptr());
+
+    C10D_TRACE("cancel_wait key_count:{} address:{}", this->address());
 
     StreamWriter sw(iptr());
     sw.write1((uint8_t)WaitResponseType::WAIT_CANCELED);

--- a/torch/csrc/distributed/c10d/logging.h
+++ b/torch/csrc/distributed/c10d/logging.h
@@ -27,25 +27,22 @@ std::string formatLogMessage(fmt::string_view fmt, T&&... args) {
 } // namespace detail
 } // namespace c10d
 
-#define C10D_ERROR(...)                                                      \
-  LOG_IF(                                                                    \
-      ERROR, c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Error)) \
-      << "[c10d] " << c10d::detail::formatLogMessage(__VA_ARGS__)
+#define C10D_ERROR(...)                                               \
+  if (c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Error)) \
+  LOG(ERROR) << "[c10d] " << c10d::detail::formatLogMessage(__VA_ARGS__)
 
 #define C10D_WARNING(...)                                               \
-  LOG_IF(                                                               \
-      WARNING,                                                          \
-      c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Warning)) \
-      << "[c10d] " << c10d::detail::formatLogMessage(__VA_ARGS__)
+  if (c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Warning)) \
+  LOG(WARNING) << "[c10d] " << c10d::detail::formatLogMessage(__VA_ARGS__)
 
-#define C10D_INFO(...)                                                        \
-  LOG_IF(INFO, c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Info)) \
-      << "[c10d] " << c10d::detail::formatLogMessage(__VA_ARGS__)
+#define C10D_INFO(...)                                               \
+  if (c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Info)) \
+  LOG(INFO) << "[c10d] " << c10d::detail::formatLogMessage(__VA_ARGS__)
 
-#define C10D_DEBUG(...)                                                        \
-  LOG_IF(INFO, c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Debug)) \
-      << "[c10d - debug] " << c10d::detail::formatLogMessage(__VA_ARGS__)
+#define C10D_DEBUG(...)                                               \
+  if (c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Debug)) \
+  LOG(INFO) << "[c10d - debug] " << c10d::detail::formatLogMessage(__VA_ARGS__)
 
-#define C10D_TRACE(...)                                                        \
-  LOG_IF(INFO, c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Trace)) \
-      << "[c10d - trace] " << c10d::detail::formatLogMessage(__VA_ARGS__)
+#define C10D_TRACE(...)                                               \
+  if (c10d::detail::isLogLevelEnabled(c10d::detail::LogLevel::Trace)) \
+  LOG(INFO) << "[c10d - trace] " << c10d::detail::formatLogMessage(__VA_ARGS__)

--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -37,6 +37,7 @@ C10_DIAGNOSTIC_POP()
 #include <torch/csrc/distributed/c10d/error.h>
 #include <torch/csrc/distributed/c10d/exception.h>
 #include <torch/csrc/distributed/c10d/logging.h>
+#include <torch/csrc/distributed/c10d/socket_fmt.h>
 
 #include <c10/util/CallOnce.h>
 
@@ -193,6 +194,43 @@ class SocketImpl {
   Handle hnd_;
   const std::optional<std::string> remote_;
 };
+
+std::string formatSockAddr(const struct ::sockaddr* addr, socklen_t len) {
+  char host[NI_MAXHOST], port[NI_MAXSERV]; // NOLINT
+
+  if (int err = ::getnameinfo(
+          addr, len, host, NI_MAXHOST, port, NI_MAXSERV, NI_NUMERICSERV)) {
+    C10D_WARNING(
+        "The hostname of the client socket cannot be retrieved. err={}", err);
+
+    // if we can't resolve the hostname, display the IP address
+    if (addr->sa_family == AF_INET) {
+      struct sockaddr_in* psai = (struct sockaddr_in*)&addr;
+      char ip[INET_ADDRSTRLEN];
+      if (inet_ntop(addr->sa_family, &(psai->sin_addr), ip, INET_ADDRSTRLEN) !=
+          NULL) {
+        return fmt::format("{}:{}", ip, psai->sin_port);
+      }
+    } else if (addr->sa_family == AF_INET6) {
+      struct sockaddr_in6* psai = (struct sockaddr_in6*)&addr;
+      char ip[INET6_ADDRSTRLEN];
+      if (inet_ntop(
+              addr->sa_family, &(psai->sin6_addr), ip, INET6_ADDRSTRLEN) !=
+          NULL) {
+        return fmt::format("[{}]:{}", ip, psai->sin6_port);
+      }
+    }
+
+    C10_THROW_ERROR(
+        DistNetworkError,
+        fmt::format(
+            "failed to format addr, unknown family={}", addr->sa_family));
+  }
+  if (addr->sa_family == AF_INET) {
+    return fmt::format("{}:{}", host, port);
+  }
+  return fmt::format("[{}]:{}", host, port);
+}
 } // namespace c10d::detail
 
 //
@@ -208,45 +246,10 @@ struct formatter<::addrinfo> {
 
   template <typename FormatContext>
   decltype(auto) format(const ::addrinfo& addr, FormatContext& ctx) const {
-    char host[NI_MAXHOST], port[NI_MAXSERV]; // NOLINT
-
-    int r = ::getnameinfo(
-        addr.ai_addr,
-        addr.ai_addrlen,
-        host,
-        NI_MAXHOST,
-        port,
-        NI_MAXSERV,
-        NI_NUMERICSERV);
-    if (r != 0) {
-      // if we can't resolve the hostname, display the IP address
-      if (addr.ai_family == AF_INET) {
-        struct sockaddr_in* psai = (struct sockaddr_in*)addr.ai_addr;
-        char ip[INET_ADDRSTRLEN];
-        if (inet_ntop(addr.ai_family, &(psai->sin_addr), ip, INET_ADDRSTRLEN) !=
-            NULL) {
-          return fmt::format_to(ctx.out(), "{}:{}", ip, psai->sin_port);
-        }
-      } else if (addr.ai_family == AF_INET6) {
-        struct sockaddr_in6* psai = (struct sockaddr_in6*)addr.ai_addr;
-        char ip[INET6_ADDRSTRLEN];
-        if (inet_ntop(
-                addr.ai_family, &(psai->sin6_addr), ip, INET6_ADDRSTRLEN) !=
-            NULL) {
-          return fmt::format_to(ctx.out(), "[{}]:{}", ip, psai->sin6_port);
-        }
-      }
-      C10_THROW_ERROR(
-          DistNetworkError,
-          fmt::format(
-              "failed to format addr, unknown family={}", addr.ai_family));
-    }
-
-    if (addr.ai_addr->sa_family == AF_INET) {
-      return fmt::format_to(ctx.out(), "{}:{}", host, port);
-    } else {
-      return fmt::format_to(ctx.out(), "[{}]:{}", host, port);
-    }
+    return fmt::format_to(
+        ctx.out(),
+        "{}",
+        c10d::detail::formatSockAddr(addr.ai_addr, addr.ai_addrlen));
   }
 };
 

--- a/torch/csrc/distributed/c10d/socket.h
+++ b/torch/csrc/distributed/c10d/socket.h
@@ -103,7 +103,5 @@ class Socket {
 
   std::unique_ptr<SocketImpl> impl_;
 };
-
 } // namespace detail
-
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/socket_fmt.h
+++ b/torch/csrc/distributed/c10d/socket_fmt.h
@@ -1,0 +1,32 @@
+// (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+/*
+This file should not be included from other .h files and only used in cpp files
+as it exposes the underlying platform specific socket headers.
+*/
+
+#include <string>
+
+#ifdef _WIN32
+#include <mutex>
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <netinet/in.h>
+#endif
+
+namespace c10d {
+namespace detail {
+
+// Returns a human-readable representation of the given socket address.
+std::string formatSockAddr(const struct ::sockaddr* addr, socklen_t len);
+
+} // namespace detail
+} // namespace c10d


### PR DESCRIPTION
Summary:
This logs all operations when tracing log level is enabled for the `TCPStoreLibUvBackend`. This is very useful for debugging collective operations when issues occur as it logs all hosts and the keys that they're modifying. To minimize total data we only log the keys and not the values

This changes the C10D_* macros to be much more efficient -- previously we would always format the log string even if they would never be printed which is very wasteful for detailed tracing. This now gates them with an if statement to achieve the same behavior with no overhead

Test Plan:
```
TORCH_DISTRIBUTED_DEBUG=DETAIL torchrun --nnodes 1 --nproc_per_node 1 --no-python /bin/bash -c "echo foo"
```


```
I0919 09:26:52.352013 34271 TCPStore.cpp:285] [c10d - debug] The server has started on port = 29500.
I0919 09:26:52.352246 34271 socket.cpp:783] [c10d - debug] The client socket will attempt to connect to an IPv6 address of (127.0.0.1, 29500).
I0919 09:26:52.352241 36903 TCPStoreLibUvBackend.cpp:1173] [c10d - debug] Uv main loop running
I0919 09:26:52.352308 34271 socket.cpp:854] [c10d - trace] The client socket is attempting to connect to [localhost]:29500.
I0919 09:26:52.353633 34271 socket.cpp:945] [c10d] The client socket has connected to [localhost]:29500 on SocketImpl(fd=41, addr=[localhost]:45646, remote=[localhost]:29500).
I0919 09:26:52.354422 34271 TCPStore.cpp:321] [c10d - debug] TCP client connected to host 127.0.0.1:29500
I0919 09:26:52.354558 36903 TCPStoreLibUvBackend.cpp:774] [c10d - trace] validate magic:1015412686 address:[localhost]:45646
I0919 09:26:52.354638 36903 TCPStoreLibUvBackend.cpp:789] [c10d - trace] ping nonce:34271 address:[localhost]:45646
I0919 09:26:52.356122 36903 TCPStoreLibUvBackend.cpp:866] [c10d - trace] add key:init/ val:1 address:[localhost]:45646
I0919 09:26:52.356308 36903 TCPStoreLibUvBackend.cpp:930] [c10d - trace] wait key_count:1 address:[localhost]:45646
I0919 09:26:52.356410 36903 TCPStoreLibUvBackend.cpp:846] [c10d - trace] get key:init/ address:[localhost]:45646
I0919 09:26:52.358688 36903 TCPStoreLibUvBackend.cpp:808] [c10d - trace] set key:/none/torchelastic/role_info/0 address:[localhost]:45646
I0919 09:26:52.360177 36903 TCPStoreLibUvBackend.cpp:930] [c10d - trace] wait key_count:1 address:[localhost]:45646
I0919 09:26:52.360296 36903 TCPStoreLibUvBackend.cpp:1004] [c10d - trace] multi_get key_count:1 address:[localhost]:45646
I0919 09:26:52.362076 36903 TCPStoreLibUvBackend.cpp:1036] [c10d - trace] multi_set key_count:1 address:[localhost]:45646
I0919 09:26:52.364001 36903 TCPStoreLibUvBackend.cpp:930] [c10d - trace] wait key_count:1 address:[localhost]:45646
I0919 09:26:52.364091 36903 TCPStoreLibUvBackend.cpp:846] [c10d - trace] get key:/none/torchelastic/assigned_ranks/0 address:[localhost]:45646
```

Differential Revision: D62924454




cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @c-p-i-o