### PR TITLE
Fix docstring in AdamW

### DIFF
--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -271,10 +271,10 @@ AdamW.__doc__ = (
             &\hspace{5mm}\textbf{if} \: amsgrad                                                  \\
             &\hspace{10mm}\widehat{v_t}^{max} \leftarrow \mathrm{max}(\widehat{v_t}^{max},
                 \widehat{v_t})                                                                   \\
-            &\hspace{10mm}\theta_t \leftarrow \theta_t - \gamma \widehat{m_t}/
+            &\hspace{10mm}\theta_t \leftarrow \theta_{t - 1} - \gamma \widehat{m_t}/
                 \big(\sqrt{\widehat{v_t}^{max}} + \epsilon \big)                                 \\
             &\hspace{5mm}\textbf{else}                                                           \\
-            &\hspace{10mm}\theta_t \leftarrow \theta_t - \gamma \widehat{m_t}/
+            &\hspace{10mm}\theta_t \leftarrow \theta_{t - 1} - \gamma \widehat{m_t}/
                 \big(\sqrt{\widehat{v_t}} + \epsilon \big)                                       \\
             &\rule{110mm}{0.4pt}                                                          \\[-1.ex]
             &\bf{return} \:  \theta_t                                                     \\[-1.ex]


### PR DESCRIPTION
The definition of AdamW in the `torch.optim.AdamW` docstring currently sets $$\theta_t \leftarrow \theta_t \ldots$$ in two places. You can't use $$\theta_t$$ to update $$\theta_t$$, so this PR fixes the subscript on the right to be $$t - 1$$. See the Adam docstring for comparison: https://pytorch.org/docs/stable/generated/torch.optim.Adam.html
