### PR TITLE
Remove onnx imports in dynamo

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -4,7 +4,6 @@ import unittest
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
-import torch.onnx.operators
 from torch._dynamo.testing import EagerAndRecordGraphs, normalize_gm, same
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FLASH_ATTENTION

--- a/test/dynamo/test_interop.py
+++ b/test/dynamo/test_interop.py
@@ -2,7 +2,6 @@
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
-import torch.onnx.operators
 
 
 def fn(a, b):

--- a/test/inductor/test_auto_functionalize.py
+++ b/test/inductor/test_auto_functionalize.py
@@ -6,7 +6,6 @@ import torch
 import torch._dynamo.testing
 import torch._inductor.config as inductor_config
 import torch._inductor.test_case
-import torch.onnx.operators
 import torch.utils._pytree as pytree
 import torch.utils.cpp_extension
 from torch import Tensor

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -11,7 +11,6 @@ from typing import Dict, List, Optional, TYPE_CHECKING
 import torch._C
 import torch.fx
 import torch.nn
-import torch.onnx.operators
 from torch._dynamo.utils import get_fake_value
 from torch._dynamo.variables import ConstantVariable
 from torch._dynamo.variables.base import VariableTracker

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -11,7 +11,6 @@ import torch._C
 import torch._refs
 import torch.fx
 import torch.nn
-import torch.onnx.operators
 from torch._guards import TracingContext
 from torch._logging import warning_once
 from torch._streambase import _StreamBase
@@ -97,7 +96,6 @@ supported_ctx_manager_classes = dict.fromkeys(
 
 REWRITE_OPS_TO_TENSOR_SIZE_METHOD = dict.fromkeys(
     [
-        torch.onnx.operators.shape_as_tensor,
         torch._shape_as_tensor,
     ]
 )

--- a/torch/onnx/operators.py
+++ b/torch/onnx/operators.py
@@ -10,38 +10,34 @@ file is kept purely for backward-compatibility.
 """
 
 import torch
-import torch.onnx
 
 
-def shape_as_tensor(x):
-    """Get the shape of a tensor as a tensor.
+"""Get the shape of a tensor as a tensor.
 
-    Args:
-        x (Tensor): The input tensor.
+Args:
+    x (Tensor): The input tensor.
 
-    Returns:
-        Tensor: A tensor of shape [len(x.shape)] containing the size of each dimension of x.
+Returns:
+    Tensor: A tensor of shape [len(x.shape)] containing the size of each dimension of x.
 
-    Example:
-        >>> x = torch.randn(2, 3)
-        >>> shape_as_tensor(x)
-        tensor([2, 3])
+Example:
+    >>> x = torch.randn(2, 3)
+    >>> shape_as_tensor(x)
+    tensor([2, 3])
 
-    """
-    return torch._shape_as_tensor(x)
+"""
+shape_as_tensor = torch._shape_as_tensor
 
+"""Reshape a tensor to the given shape.
 
-def reshape_from_tensor_shape(x, shape):
-    """Reshape a tensor to the given shape.
+This function is used to make dynamic size operations traceable when exporting models via ONNX.
+This function is kept for backward-compatibility. It is implemented directly in ATen.
 
-    This function is used to make dynamic size operations traceable when exporting models via ONNX.
-    This function is kept for backward-compatibility. It is implemented directly in ATen.
+Parameters:
+    x (Tensor): the tensor to be reshaped.
+    shape (Tensor): the target shape.
 
-    Parameters:
-        x (Tensor): the tensor to be reshaped.
-        shape (Tensor): the target shape.
-
-    Returns:
-        Tensor: the reshaped tensor.
-    """
-    return torch._reshape_from_tensor(x, shape)
+Returns:
+    Tensor: the reshaped tensor.
+"""
+reshape_from_tensor_shape = torch._reshape_from_tensor

--- a/torch/onnx/operators.py
+++ b/torch/onnx/operators.py
@@ -9,7 +9,9 @@ Since then we have implemented these directly in ATen, so this
 file is kept purely for backward-compatibility.
 """
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []
 
 import torch
 

--- a/torch/onnx/operators.py
+++ b/torch/onnx/operators.py
@@ -9,6 +9,8 @@ Since then we have implemented these directly in ATen, so this
 file is kept purely for backward-compatibility.
 """
 
+__all__ = []
+
 import torch
 
 

--- a/torch/onnx/operators.py
+++ b/torch/onnx/operators.py
@@ -1,5 +1,5 @@
 # mypy: allow-untyped-defs
-r"""This file provides a location for operators that help exporting models via onnx.
+"""This file provides a location for operators that help exporting models via onnx.
 
 E.g. `shape_as_tensor` and `reshape_from_tensor_shape`
 are to make all dynamic sizes operations traceable.

--- a/torch/onnx/operators.py
+++ b/torch/onnx/operators.py
@@ -11,6 +11,7 @@ file is kept purely for backward-compatibility.
 
 from __future__ import annotations
 
+
 __all__: list[str] = []
 
 import torch


### PR DESCRIPTION
Remove imports of the ``torch.onnx.operators`` module in dynamo. Since ONNX depends on dynamo, this import line causes a circular dependency. Judging from the source they are not actually needed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @rec @xadupre @gramalingam @titaiwangms 