### PR TITLE
[ROCm][Inductor][CK] FP8 gemm

### DIFF
--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -46,6 +46,8 @@ DTYPE_TO_CPP = {
     torch.complex64: "c10::complex<float>",
     torch.float8_e4m3fn: "float8_e4m3fn",
     torch.float8_e5m2: "float8_e5m2",
+    torch.float8_e4m3fnuz: "float8_e4m3fnuz",
+    torch.float8_e5m2fnuz: "float8_e5m2fnuz",
 }
 
 DTYPE_TO_ATEN = {

--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -26,8 +26,8 @@ class CKTemplate(ROCmTemplate):
             """
                 // HIP headers
 
-                #include <hip/hip_bfloat16.h>
-                #include <hip/hip_fp8.h>
+                // #include <hip/hip_bf16.h>
+                // #include <hip/hip_fp8.h>
 
                 // CK headers
 

--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -27,6 +27,7 @@ class CKTemplate(ROCmTemplate):
                 // HIP headers
 
                 #include <hip/hip_bfloat16.h>
+                #include <hip/hip_fp8.h>
 
                 // CK headers
 

--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -67,6 +67,7 @@ class CKTemplate(ROCmTemplate):
                 using PassThrough = ck::tensor_operation::element_wise::PassThrough;
                 using Bilinear = ck::tensor_operation::element_wise::Bilinear;
                 using Scale = ck::tensor_operation::element_wise::Scale;
+                using MultiplyMultiply = ck::tensor_operation::element_wise::MultiplyMultiply;
 
                 // see "composable_kernel/include/ck/utility/data_type.hpp"
                 using F8  = ck::f8_t;

--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -24,11 +24,6 @@ class CKTemplate(ROCmTemplate):
         res = super().header()
         res.splice(
             """
-                // HIP headers
-
-                // #include <hip/hip_bf16.h>
-                // #include <hip/hip_fp8.h>
-
                 // CK headers
 
                 #ifdef DEBUG_LOG

--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -66,6 +66,7 @@ class CKTemplate(ROCmTemplate):
 
                 using PassThrough = ck::tensor_operation::element_wise::PassThrough;
                 using Bilinear = ck::tensor_operation::element_wise::Bilinear;
+                using Scale = ck::tensor_operation::element_wise::Scale;
 
                 // see "composable_kernel/include/ck/utility/data_type.hpp"
                 using F8  = ck::f8_t;

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -260,6 +260,9 @@ class CKGemmTemplate(CKTemplate):
             scale_x = self.input_nodes[2]
             scale_w = self.input_nodes[3]
             op.c_elementwise_op = "Scale"
+        else:
+            scale_x = None
+            scale_w = None
 
         # This parameter is converted into tuple because of change
         # from DeviceGemm_Xdl_CShuffleV3 to DeviceGemmMultiD_Xdl_CShuffle_V3.

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -254,6 +254,10 @@ class CKGemmTemplate(CKTemplate):
         Y = self.output_node
         Bias = self.input_nodes[2] if 3 == len(self.input_nodes) else None
 
+        if len(self.input_nodes) == 4:
+            scale_x = self.input_nodes[2]
+            scale_w = self.input_nodes[3]
+
         op = copy.deepcopy(op)
 
         # This parameter is converted into tuple because of change
@@ -302,9 +306,9 @@ class CKGemmTemplate(CKTemplate):
             globals=self.globals().getvalue(),
             instance_definition=instance_definition,
             kernel_definition=kernel.def_kernel(
-                inputs=[X, W, Bias],  # type: ignore[list-item]
+                inputs=[X, W, scale_x, scale_w, Bias],  # type: ignore[list-item]
                 outputs=[Y],
-                names_str="X, W, Bias, Y",
+                names_str="X, W, inv_scale_x, inv_scale_w, Bias, Y",
                 input_reorder=self.input_reorder,
                 size_args=[
                     f"ck::index_t {arg}"
@@ -391,6 +395,7 @@ class CKGemmTemplate(CKTemplate):
         """
         Add Composable Kernel Universal GEMM instance choices to the auto-tuning list.
         """
+        print(f"{input_nodes=}")
         template = CKGemmTemplate(
             input_nodes,
             layout,
@@ -408,7 +413,7 @@ class CKGemmTemplate(CKTemplate):
     def size_args(self):
         X = self.input_nodes[0]
         W = self.input_nodes[1]
-        Bias = self.input_nodes[2] if len(self.input_nodes) > 2 else None
+        Bias = self.input_nodes[2] if len(self.input_nodes) == 3 else None
         Y = self.output_node
 
         M = X.get_size()[0]

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -271,8 +271,14 @@ class CKGemmTemplate(CKTemplate):
             else:
                 op.c_elementwise_op = "MultiplyMultiply"
                 op.c_shuffle_dtype = "F32"
-                op.ds_layouts = (torch_layout_to_ck_layout(scale_x.get_layout()), torch_layout_to_ck_layout(scale_w.get_layout()))
-                op.ds_element_dtypes = (self._TORCH_DTYPE_TO_CK[scale_x.get_layout().dtype], self._TORCH_DTYPE_TO_CK[scale_w.get_layout().dtype])
+                op.ds_layouts = (
+                    torch_layout_to_ck_layout(scale_x.get_layout()),
+                    torch_layout_to_ck_layout(scale_w.get_layout()),
+                )
+                op.ds_element_dtypes = (
+                    self._TORCH_DTYPE_TO_CK[scale_x.get_layout().dtype],
+                    self._TORCH_DTYPE_TO_CK[scale_w.get_layout().dtype],
+                )
                 op.c_shuffle_block_transfer_scalar_per_vector_n_per_block += (1, 1)
         else:
             scale_x = None
@@ -352,12 +358,24 @@ class CKGemmTemplate(CKTemplate):
             b_elementwise_op="PassThrough {}",
             epilogue=epilogue,
             has_bias=Bias is not None,
-            ds_size=1 if Bias is not None else 2 if op.c_elementwise_op == "MultiplyMultiply" else 0,
+            ds_size=1
+            if Bias is not None
+            else 2
+            if op.c_elementwise_op == "MultiplyMultiply"
+            else 0,
             ds_names=", ".join(
-                ["Bias"] if Bias is not None else ["inv_scale_x", "inv_scale_w"] if op.c_elementwise_op == "MultiplyMultiply" else []
+                ["Bias"]
+                if Bias is not None
+                else ["inv_scale_x", "inv_scale_w"]
+                if op.c_elementwise_op == "MultiplyMultiply"
+                else []
             ),
             ds_strides=", ".join(
-                ["LDD"] if Bias is not None else ["0", "0"] if op.c_elementwise_op == "MultiplyMultiply" else []
+                ["LDD"]
+                if Bias is not None
+                else ["0", "0"]
+                if op.c_elementwise_op == "MultiplyMultiply"
+                else []
             ),
             version_comment=version_comment,
         )

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -352,7 +352,7 @@ class CKGemmTemplate(CKTemplate):
             b_elementwise_op="PassThrough {}",
             epilogue=epilogue,
             has_bias=Bias is not None,
-            ds_size=1 if Bias is not None else 2 if scale_x is not None else 0,
+            ds_size=1 if Bias is not None else 2 if op.c_elementwise_op == "MultiplyMultiply" else 0,
             ds_names=", ".join(
                 ["Bias"] if Bias is not None else ["inv_scale_x", "inv_scale_w"] if op.c_elementwise_op == "MultiplyMultiply" else []
             ),

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -322,13 +322,13 @@ class CKGemmTemplate(CKTemplate):
         if op.c_elementwise_op == "Bilinear":
             epilogue = f"Bilinear {{ {self.alpha}, {self.beta} }}"
 
-        if op.c_elementwise_op == "Scale":
+        elif op.c_elementwise_op == "Scale":
             epilogue = "Scale { (inv_scale_w && inv_scale_x) ? (*inv_scale_w * *inv_scale_x) : 1.0f }"
 
-        if op.c_elementwise_op == "MultiplyMultiply":
+        elif op.c_elementwise_op == "MultiplyMultiply":
             epilogue = "MultiplyMultiply {}"
 
-        if op.c_elementwise_op == "PassThrough":
+        elif op.c_elementwise_op == "PassThrough":
             epilogue = "PassThrough {}"
 
         assert epilogue is not None, "CK GEMM epilogue is not set"

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -324,8 +324,12 @@ class CKGemmTemplate(CKTemplate):
             bias_element_dtype=op.ds_element_dtypes[0] if Bias is not None else "",
             alpha=self.alpha,
             beta=self.beta,
-            a_elementwise_op="Scale { inv_scale_x ? *inv_scale_x : 1.0f }" if scale_x is not None else "PassThrough {}",
-            b_elementwise_op="Scale { inv_scale_w ? *inv_scale_w : 1.0f }" if scale_w is not None else "PassThrough {}",
+            a_elementwise_op="Scale { inv_scale_x ? *inv_scale_x : 1.0f }"
+            if scale_x is not None
+            else "PassThrough {}",
+            b_elementwise_op="Scale { inv_scale_w ? *inv_scale_w : 1.0f }"
+            if scale_w is not None
+            else "PassThrough {}",
             epilogue=f"Bilinear {{ {self.alpha}, {self.beta} }}"
             if Bias is not None
             else "PassThrough {}",

--- a/torch/_inductor/codegen/rocm/rocm_template.py
+++ b/torch/_inductor/codegen/rocm/rocm_template.py
@@ -160,9 +160,7 @@ class ROCmTemplate(KernelTemplate):
                 #endif
                 #endif
 
-                // using bfloat16 = __hip_bfloat16;
-                // using float8_e4m3fnuz = __hip_fp8_e4m3_fnuz;
-                // using float8_e5m2fnuz = __hip_fp8_e5m2_fnuz;
+                // as long as there is no custom arithmetic it's fine
                 using bfloat16 = uint16_t;
                 using float8_e4m3fnuz = uint8_t;
                 using float8_e5m2fnuz = uint8_t;

--- a/torch/_inductor/codegen/rocm/rocm_template.py
+++ b/torch/_inductor/codegen/rocm/rocm_template.py
@@ -160,9 +160,12 @@ class ROCmTemplate(KernelTemplate):
                 #endif
                 #endif
 
-                using bfloat16 = hip_bfloat16;
-                using float8_e4m3fnuz = __hip_fp8_e4m3_fnuz;
-                using float8_e5m2fnuz = __hip_fp8_e5m2_fnuz;
+                // using bfloat16 = __hip_bfloat16;
+                // using float8_e4m3fnuz = __hip_fp8_e4m3_fnuz;
+                // using float8_e5m2fnuz = __hip_fp8_e5m2_fnuz;
+                using bfloat16 = uint16_t;
+                using float8_e4m3fnuz = uint8_t;
+                using float8_e5m2fnuz = uint8_t;
             """
         )
         return res

--- a/torch/_inductor/codegen/rocm/rocm_template.py
+++ b/torch/_inductor/codegen/rocm/rocm_template.py
@@ -159,7 +159,10 @@ class ROCmTemplate(KernelTemplate):
                 #define PT_EXPORT
                 #endif
                 #endif
+
                 using bfloat16 = hip_bfloat16;
+                using float8_e4m3fnuz = __hip_fp8_e4m3_fnuz;
+                using float8_e5m2fnuz = __hip_fp8_e5m2_fnuz;
             """
         )
         return res


### PR DESCRIPTION
At the moment, lowering torch._scaled_mm with tensorwise scaling and rowwise scaling for both A and B

We probably also want to support either combination of tensorwise and rowwise for A and B, as well as bias support

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @zjing14 