### PR TITLE
register forBlobPrivateUse1 to construct tensor in privateuse1 device

### DIFF
--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -6,6 +6,9 @@
 #include <c10/core/Device.h>
 #include <c10/core/Storage.h>
 #include <c10/util/Exception.h>
+#include <c10/core/TensorOptions.h>
+#include <c10/core/TensorImpl.h>
+#include <c10/util/OptionalArrayRef.h>
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
 namespace at {
 
@@ -48,6 +51,13 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
         false,
         "You should register `PrivateUse1HooksInterface` for PrivateUse1 before call `resizePrivateUse1Bytes`.");
   }
+  virtual void forBlobPrivateUse1(Tensor&tensor, void* data, 
+  IntArrayRef sizes, 
+  at::OptionalIntArrayRef strides, 
+  c10::optional<int64_t> storage_offset,
+  at::TensorOptions options,
+  const c10::optional<Device> target_device) const {return;};
+
 };
 
 struct TORCH_API PrivateUse1HooksArgs {};

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -807,7 +807,12 @@ static PyObject* THPVariable_make_wrapper_subclass(
   // don't bother releasing GIL here, as we are not allocating any nontrivial
   // data
   Tensor tensor;
-
+  if(options.device().is_privateuseone())
+  {
+    at::GetPrivateUse1HooksInterface()->forBlobPrivateUse1(tensor, nullptr, r.intlist(1),
+    r.intlistOptional(2), r.toInt64Optional(3),options,options.device());
+  }
+  else
   {
     AutoDispatchBelowADInplaceOrView guard{}; // TODO: Remove.
     tracer::impl::NoTracerDispatchMode tracer_guard{};


### PR DESCRIPTION
Fixes #136344
Allow privateuse1 device to construct tensor by itself can fix the bug. In pytorch2.1, it uses for blob to construct tensor