### PR TITLE
[AMD] Skipping 0 byte send/recv for AMD GPU

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -558,7 +558,9 @@ constexpr auto count_max =
 // https://github.com/NVIDIA/nccl/issues/696. The issue of skipping send/recv
 // is that it can cause deadlock when a rank send and recv 0 bytes so it's
 // completely skipping the collective, causing mismatch across ranks
-#if defined(NCCL_MAJOR) && \
+// Note: on AMD GPU, we're running into hang w/ 0 byte send/recv, so we're
+// skipping this for ROCm for now
+#if !defined(USE_ROCM) && defined(NCCL_MAJOR) && \
     ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR > 13)))
 template <typename T>
 constexpr bool _nccl_should_send_recv(C10_UNUSED T _unused_) {


### PR DESCRIPTION
Summary: We found jobs getting stuck by send/recv zero bytes with RDMA on AMD GPUs. So just skipping them.

Reviewed By: danzimm

Differential Revision: D63075000
