### PR TITLE
[DSD] Fix loading uneven full tensor into sharded state dict

### DIFF
--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -9,10 +9,16 @@ from torch.distributed._state_dict_utils import (
     _check_state_dict_similarity,
     _copy_state_dict,
     _create_cpu_state_dict,
+    _distribute_tensors,
     _gather_state_dict,
     _offload_state_dict_to_cpu,
 )
-from torch.distributed._tensor import DTensor, Shard
+from torch.distributed._tensor import (
+    distribute_tensor,
+    DTensor,
+    init_device_mesh,
+    Shard,
+)
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -22,9 +28,12 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 class TestStateDictUtils(DTensorTestBase):
+    # @property
+    # def world_size(self):
+    #     return min(4, torch.cuda.device_count())
     @property
-    def world_size(self):
-        return min(4, torch.cuda.device_count())
+    def world_size(self) -> int:
+        return 2
 
     @with_comms
     @skip_if_lt_x_gpu(2)
@@ -169,6 +178,37 @@ class TestStateDictUtils(DTensorTestBase):
             state_dict, share_memory=True, pin_memory=True
         )
         _verify(cpu_state_dict)
+
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    def test_state_dict_util_distribute_tensors(self):
+        even_tensor = torch.randn(self.world_size, 2)
+        uneven_tensor = torch.randn(1, 2)
+
+        mesh = init_device_mesh("cuda", mesh_shape=(self.world_size,))
+        even_dtensor = distribute_tensor(
+            torch.randn(self.world_size, 2), mesh, [Shard(0)]
+        )
+        uneven_dtensor = distribute_tensor(torch.randn(1, 2), mesh, [Shard(0)])
+
+        # the dtensor and tensor are different before _distribute_tensors is called.
+        local_state_dict = {
+            "even": [even_dtensor, even_tensor],
+            "uneven": [uneven_dtensor, uneven_tensor],
+        }
+        ref_local_state_dict = copy.deepcopy(local_state_dict)
+        keys = ["even", "uneven"]
+
+        _distribute_tensors(local_state_dict, keys, self.device_type)
+        for local_v, ref_v in zip(
+            local_state_dict.values(), ref_local_state_dict.values()
+        ):
+            self.assertEqual(local_v.size(), ref_v[0].size())
+            self.assertEqual(local_v.stride(), ref_v[0].stride())
+            self.assertNotEqual(
+                local_v_full_tensor := local_v.full_tensor(), ref_v[0].full_tensor()
+            )
+            self.assertEqual(local_v_full_tensor, ref_v[1])
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_state_dict_utils.py
+++ b/test/distributed/checkpoint/test_state_dict_utils.py
@@ -28,12 +28,9 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 class TestStateDictUtils(DTensorTestBase):
-    # @property
-    # def world_size(self):
-    #     return min(4, torch.cuda.device_count())
     @property
-    def world_size(self) -> int:
-        return 2
+    def world_size(self):
+        return min(4, torch.cuda.device_count())
 
     @with_comms
     @skip_if_lt_x_gpu(2)

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -558,8 +558,14 @@ def _distribute_tensors(
         )
         slices = [slice(offset[i], shape[i] + offset[i]) for i in range(len(shape))]
         local_tensor = full_tensor[slices]
+        # TODO: currently, we cannot handle strided sharding if the dp dimension is not even. For example,
+        # one of the case that is not yet supported is when placements = (Shard(0), _StridedShard(0, sf=2)).
         local_state_dict[key] = DTensor.from_local(
-            local_tensor, local_state.device_mesh, local_state.placements
+            local_tensor,
+            local_state.device_mesh,
+            local_state.placements,
+            shape=local_state.shape,
+            stride=local_state.stride,
         )
 
 

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -565,7 +565,7 @@ def _distribute_tensors(
             local_state.device_mesh,
             local_state.placements,
             shape=local_state.shape,
-            stride=local_state.stride,
+            stride=local_state.stride(),
         )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136365

Fix #136228.

This is a follow up on https://github.com/pytorch/pytorch/pull/135725. We need to pass shape and stride from the original dtensor, since for uneven case, `from_local` would calculate shape and stride assuming the tensor is evenly-sharded based on the local tensor.  


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn