### PR TITLE
Fix `Vectorized<double>::next_after` SVE compilation

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_double.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_double.h
@@ -261,7 +261,7 @@ public:
   Vectorized<double> nextafter(const Vectorized<double> &b) const {
     USE_SLEEF(
       {
-        return Vectorized<double>(Sleef_nextafterfx_sve(values, b));
+        return Vectorized<double>(Sleef_nextafterdx_sve(values, b));
       },
       {
         __at_align__ double tmp[size()];


### PR DESCRIPTION
Should have called [`Sleef_nextafterdx_sve`](https://sleef.org/2-references/libm/aarch64#vectorized-double-precision-function-for-obtaining-the-next-representable-fp-value) rather than [`Sleef_nextafterfx_sve`](https://sleef.org/2-references/libm/aarch64#vectorized-single-precision-function-for-obtaining-the-next-representable-fp-value) to get vectorized `nextafter` for double precision rather than single precision values

This fixes a compilation issue introduced by https://github.com/pytorch/pytorch/pull/119571 and exposed by https://github.com/pytorch/pytorch/pull/133339

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10