### PR TITLE
[inductor] Log precompilation time

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1308,7 +1308,7 @@ class AlgorithmSelectorCache(PersistentCache):
                             "Exception %s for benchmark choice %s", e, futures[future]
                         )
                     else:
-                        log.info("Precompiling benchmark choice %s took %ss", futures[future], future.result())
+                        log.info("Precompiling benchmark choice %s took %.02fs", futures[future], future.result())
 
                 executor.shutdown(wait=True)
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1283,7 +1283,9 @@ class AlgorithmSelectorCache(PersistentCache):
 
             def precompile_with_captured_stdout(choice):
                 with restore_stdout_stderr(initial_stdout, initial_stderr):
-                    return choice.precompile()
+                    start_time = time.time()
+                    choice.precompile()
+                    return time.time() - start_time
 
             executor = ThreadPoolExecutor(max_workers=num_workers)
 
@@ -1305,6 +1307,8 @@ class AlgorithmSelectorCache(PersistentCache):
                         log.error(
                             "Exception %s for benchmark choice %s", e, futures[future]
                         )
+                    else:
+                        log.info("Precompiling benchmark choice %s took %ss", futures[future], future.result())
 
                 executor.shutdown(wait=True)
 

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1308,7 +1308,11 @@ class AlgorithmSelectorCache(PersistentCache):
                             "Exception %s for benchmark choice %s", e, futures[future]
                         )
                     else:
-                        log.info("Precompiling benchmark choice %s took %.02fs", futures[future], future.result())
+                        log.info(
+                            "Precompiling benchmark choice %s took %.02fs",
+                            futures[future],
+                            future.result(),
+                        )
 
                 executor.shutdown(wait=True)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136395

This has been useful for diagnosing the long compile time issues I've seen in the Triton CPU backend.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang