### PR TITLE
Backward pass ac

### DIFF
--- a/torch/_functorch/backward_pass_aware.py
+++ b/torch/_functorch/backward_pass_aware.py
@@ -197,7 +197,7 @@ class LongRecomputationChains:
             logger.error("Solver failed to find a solution: %s", LpStatus[status])
         else:
             print("Solver found a solution")
-        sol = [X[i].varValue for i in X.keys() if X[i].varValue > 0.9]
+
         saved_values = [i for i in X.keys() if X[i].varValue > 0.9]
         recomp_values = [i for i in X.keys() if X[i].varValue <= 0.9]
         return saved_values, recomp_values

--- a/torch/_functorch/backward_pass_aware.py
+++ b/torch/_functorch/backward_pass_aware.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+import functools
+from dataclasses import dataclass
+from typing import Dict, List, Set, Tuple
+
+import networkx as nx
+import torch.fx as fx
+import xpress as xp
+
+
+@dataclass
+class NodeInfo:
+    # Be careful about iterating over these explicitly, as their order may not
+    # be deterministic
+    inputs: List[fx.Node]
+    _required_fw_nodes: Set[fx.Node]
+    required_bw_nodes: Set[fx.Node]
+    unclaimed_nodes: Set[fx.Node]
+    fw_order: Dict[fx.Node, int]
+
+    @functools.cached_property
+    def required_fw_nodes(self) -> List[fx.Node]:
+        return sorted(
+            (n for n in self._required_fw_nodes), key=lambda n: self.fw_order[n]
+        )
+
+    def is_required_fw(self, n: fx.Node) -> bool:
+        return n in self._required_fw_nodes
+
+    def is_required_bw(self, n: fx.Node) -> bool:
+        return n in self.required_bw_nodes
+
+    def is_unclaimed(self, n: fx.Node) -> bool:
+        return n in self.unclaimed_nodes
+
+    def get_fw_order(self, n: fx.Node) -> int:
+        assert n in self._required_fw_nodes, f"Node {n} not in fw nodes!"
+        return self.fw_order[n]
+
+
+class LongRecomputationChains:
+    """
+    this class is intended to make AC backward pass aware. The code will be invoked after knapsack-based "foward-pass" AC (so it assumes that subset of nodes is already marked for recomputation).
+    The main idea is as follows.
+    The algorithm will decide to flip certain targeted nodes tagged as "recompute" and flip them to be "saved". Doing so will avoid rematerializing "long" or "memory-heavy" chains and thus avoid backward pass memory spikes.
+    """
+
+    def __init__(
+        self,
+        memory: List[float],
+        joint_graph: fx.Graph,
+        bw_memory_fraction_target: float,
+        node_info: NodeInfo,
+        all_recomputable_banned_nodes: List[fx.Node],
+    ) -> None:
+        """
+        data: a dictionary of node_id -> node_data
+        saved_nodes: a set of node_ids that are "saved" i.e. marked for recomputation by the knapsack solver
+        my_digraph: a networkx digraph object representing the computation graph
+        """
+        print("====== initializing LongRecomputationChains =======")
+        self.prob = xp.problem()
+        self.node_info = node_info
+
+        # print(node_info)
+        self.graph = self._compute_digraph(
+            node_info, joint_graph, all_recomputable_banned_nodes
+        )
+
+        # Discretization level
+        S = 100000
+        self.memory: Dict[fx.Node, int] = {
+            node: int(normalized_memory * S)
+            for node, normalized_memory in zip(all_recomputable_banned_nodes, memory)
+        }
+        print(
+            "=========GRAPH SIZE:{graphsize} nodes".format(
+                graphsize=len(self.graph.nodes)
+            )
+        )
+
+        self.all_nodes = list(joint_graph.nodes)
+        self.bw_mem_target = bw_memory_fraction_target
+
+        self.data = self._extract_node_info()
+
+        self.formulate_ILP(self.bw_mem_target)
+
+    def _compute_digraph(
+        self,
+        node_info: NodeInfo,
+        joint_graph: fx.Graph,
+        all_recomputable_banned_nodes: Set[fx.Node],
+    ) -> nx.DiGraph:
+        """
+        from the joint graph, we construct a subgraph corresponding to all the forward nodes that are recomputable.
+        """
+        nx_graph = nx.DiGraph()
+        for node in joint_graph.nodes:
+            if (
+                node in node_info.required_fw_nodes
+                and node in all_recomputable_banned_nodes
+            ):
+                for inp in node.all_input_nodes:
+                    nx_graph.add_edge(inp.name, node.name)
+        return nx_graph
+
+    def _extract_node_info(self) -> Dict[fx.Node, Dict[str, float]]:
+        data = {}
+        for i in self.graph.nodes:
+            data[i] = {}
+            if i in self.memory:
+                data[i]["mem"] = self.memory[
+                    i
+                ]  # for each node, store the normalized memory size of the node.
+            else:  # if node not found in memory dict, then it is because it is not recomputable?
+                data[i][
+                    "mem"
+                ] = 0.0  # setting a high weight will ensure that this module does not get selected
+        return data
+
+    def formulate_ILP(self, recomp_budget) -> None:
+        """
+        solve the ILP problem to find the set of nodes to save.
+        """
+        # solve ILP
+        print("---------formulating ILP problem---------")
+        prob = xp.problem()
+
+        # Variables 1: x_i i.e. whether node is saved (1) or recomputed (0)
+        X = {
+            (i): xp.var(vartype=xp.binary, name="X[{i}]".format(i=i))
+            for i in list(self.graph.nodes)
+        }
+        prob.addVariable(list(X.values()))
+
+        # Variables 2: z_i cumulative memory needed to compute node i
+        Z = {
+            (i): xp.var(vartype=xp.continuous, name="Z[{i}]".format(i=i))
+            for i in list(self.graph.nodes)
+        }
+        prob.addVariable(list(Z.values()))
+
+        # Variables 3: dummy variable y for the max
+        y = xp.var(vartype=xp.continuous, name="y")
+        prob.addVariable(y)
+
+        # Variables 4: q_i aux variables for linearizing cumulative memory constraints q_i = Z[i]*X[i]. (Z ---> x and X ---> d see https://msi-jp.com/xpress/learning/square/10-mipformref.pdf pg 8)
+        Q = {}
+        for i in self.graph.nodes:
+            prec = list(self.graph.predecessors(i))
+            if i not in prec:
+                prec += [i]
+            for j in prec:
+                Q[i, j] = xp.var(vartype=xp.continuous, name=f"Q[{i}, {j}]")
+                prob.addVariable(Q[i, j])
+
+        M = 20 * sum([self.data[i]["mem"] for i in self.graph.nodes])
+
+        for i in list(self.graph.nodes):
+            prec = list(self.graph.predecessors(i))
+            if i in prec:
+                prec.remove(i)
+            # Constraint 1: cumulative memory: z_i = sum_j in prec z_j*(1-x_j) + m_i*(1-x_i) for (j,i) in E
+            c1 = xp.constraint(
+                (
+                    Z[i]
+                    == -self.data[i]["mem"] * X[i]
+                    + xp.Sum(Z[t] - Q[t, t] for t in prec)
+                    + self.data[i]["mem"]
+                ),
+                name="cumulative_mem_constraint {i}".format(i=i),
+            )
+            prob.addConstraint(c1)
+            c2 = xp.constraint(
+                Z[i] <= y, name="peak mem constraint {i}".format(i=i)
+            )  # peak memory dummy consraint
+            prob.addConstraint(c2)
+            for t in prec:
+                c3 = xp.constraint(
+                    Q[t, t] <= M * X[t],
+                    name="linearization constraint 1 {i}{t}".format(i=i, t=t),
+                )  # linearization constraint
+                prob.addConstraint(c3)
+                c4 = xp.constraint(
+                    Q[t, t] >= 0,
+                    name="linearization constraint 2 {i}{t}".format(i=i, t=t),
+                )  # linearization constraint
+                prob.addConstraint(c4)
+                c5 = xp.constraint(
+                    Z[t] - Q[t, t] >= 0,
+                    name="linearization constraint 3 {i}{t}".format(i=i, t=t),
+                )  # linearization constraint
+                prob.addConstraint(c5)
+                c6 = xp.constraint(
+                    Z[i] - Q[t, t] <= M * (1 - X[t]),
+                    name="linearization constraint 4 {i}{t}".format(i=i, t=t),
+                )  # linearization constraint
+                prob.addConstraint(c6)
+        prob.addConstraint(
+            xp.Sum(self.data[i]["mem"] * X[i] for i in list(self.graph.nodes))
+            <= recomp_budget
+        )
+
+        prob.setObjective(y, sense=xp.minimize)  # objective is to minimize peak memory
+        print("---------ILP problem is ready to be solved----------")
+        self.prob = prob
+
+    def solve_ILP(self) -> Tuple[List[int], List[int]]:
+        self.prob.solve()
+        X = self.prob.getSolution()
+        saved_values = [
+            idx for idx, z in enumerate(X[: len(self.graph.nodes)]) if z > 0.9
+        ]
+        recomp_values = [
+            idx for idx, z in enumerate(X[: len(self.graph.nodes)]) if z <= 0.9
+        ]
+        return saved_values, recomp_values
+
+
+def get_saved_recomp_nodes_from_BWPA(
+    memory: List[float],
+    joint_graph: fx.Graph,
+    max_memory: float,
+    node_info: NodeInfo,
+    all_recomputable_banned_nodes: List[fx.Node],
+) -> Tuple[List[int], List[int]]:
+    lrc = LongRecomputationChains(
+        memory, joint_graph, max_memory, node_info, all_recomputable_banned_nodes
+    )
+    saved_node_idx, recomp_node_idx = lrc.solve_ILP()
+    return saved_node_idx, recomp_node_idx

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -30,6 +30,7 @@ from torch.utils.checkpoint import CheckpointPolicy
 from . import config
 from ._aot_autograd.logging_utils import get_aot_graph_name
 from ._aot_autograd.utils import is_with_effects
+from .backward_pass_aware import get_saved_recomp_nodes_from_BWPA
 from .compile_utils import fx_graph_cse, get_aten_target
 
 
@@ -1494,21 +1495,50 @@ def dp_knapsack(
     # The maximum runtime that can be achieved within the max_memory constraint
     max_runtime = dp[n][quantized_max_memory].item()
 
+    print("SAVED VALUES:")
+    print(saved_items)
+    print("RECOMP VALUES:")
+    print(recomputable_items)
     return max_runtime, saved_items, recomputable_items
 
 
 def _optimize_runtime_with_given_memory(
+    joint_graph: fx.Graph,
     memory: List[float],
     runtimes: List[float],
     max_memory: float,
+    node_info: NodeInfo,
+    all_recomputable_banned_nodes: List[fx.Node],
 ) -> Tuple[float, List[int], List[int]]:
     SOLVER = config.activation_memory_budget_solver
     if SOLVER == "greedy":
+        memory = list(memory.values())
         return greedy_knapsack(memory, runtimes, max_memory)
     elif SOLVER == "ilp":
+        memory = list(memory.values())
         return ilp_knapsack(memory, runtimes, max_memory)
     elif SOLVER == "dp":
+        memory = list(memory.values())
         return dp_knapsack(memory, runtimes, max_memory)
+    elif SOLVER == "backward_pass_aware":
+        try:
+            print("----- solving ILP based approach ----")
+            saved_node_idx, recomp_node_idx = get_saved_recomp_nodes_from_BWPA(
+                memory,
+                joint_graph,
+                max_memory,
+                node_info,
+                all_recomputable_banned_nodes,
+            )
+            return [0.0, saved_node_idx, recomp_node_idx]
+        except Exception as e:
+            print(f"ILP based approach failed with error: {e}")
+            print("----- solving DP based approach ----")
+            memory = list(memory.values())
+            return dp_knapsack(memory, runtimes, max_memory)
+        finally:
+            print("----- done ----")
+
     else:
         raise RuntimeError(f"Not aware of memory budget knapsack solver: {SOLVER}")
 
@@ -1672,18 +1702,32 @@ def choose_saved_values_set(
     ]
     from torch.utils._mode_utils import no_dispatch
 
-    def get_saved_values_knapsack(memory_budget):
+    def get_saved_values_knapsack(memory_budget, node_info, joint_graph):
         with no_dispatch():
             (
                 expected_runtime,
                 saved_node_idxs,
                 recomputable_node_idxs,
             ) = _optimize_runtime_with_given_memory(
-                memories_banned_nodes, runtimes_banned_nodes, max(memory_budget, 0)
+                (
+                    joint_graph,
+                    memories_banned_nodes,
+                    runtimes_banned_nodes,
+                    max(
+                        min(
+                            config.activation_memory_budget,
+                            config.activation_memory_bw_budget,
+                        ),
+                        0,
+                    ),
+                    node_info,
+                    all_recomputable_banned_nodes,
+                )
             )
         dont_ban = set()
         for idx in recomputable_node_idxs:
-            dont_ban.add(all_recomputable_banned_nodes[idx])
+            if idx in all_recomputable_banned_nodes:
+                dont_ban.add(all_recomputable_banned_nodes[idx])
         assert dont_ban.issubset(all_recomputable_banned_nodes)
 
         saved_values, _ = solve_min_cut(


### PR DESCRIPTION
This PR introduces changes to the portion of the partitioner responsible for activation checkpointing (AC). In past work, changes were introduced where by activations were determined for check-pointing based on a knapsack -optimization formulation, and these were solved by either ILP, or a greedy heuristic, or a dynamic programming approach.
We identified an opportunity to further improve upon these heuristics. The main insight has been that an AC policy that introduces "long" recomputation chains are likely to be inefficienct, and drive memory-peaks upward due to the costs involved with rematerialization. These can be avoided by "breaking" these chains via saving a small set of strategically chosen nodes. In this diff, we introduce an approach for doing so. The nodes to be saved can be determined by solving an Integer Linear Program (ILP).
![image](https://github.com/user-attachments/assets/ffd82ec8-ba0c-48c7-9904-4a683eb009d3)

 
In the above, x, a binary decision-variable corresponds to save vs recompute decisions. Z_i corresponds to the memory needed to compute node i. If any of node i's dependencies (say node j) is not saved, it will need to be rematerialized. Thus the memory cost of materializing node i is the sum of m_i (the memory cost of node i) and the rematerialization costs of all the dependencies. The decision variable y is the peak memory cost. One nuance worth noting is that the above formulation involves a product of decision variables, Z_jx_j, which is "non-linear". To address this, we have to use a "linearization" trick that is standard in the Integer Linear Programming literature. This involves introducing a new variable Qj = Z_jx_j, and some addition constraints on Qj.
The diff defines a new class called LongRecomputationChains. Within this class we formulate the ILP and the solve_ILP() method solves the same. We also have additional code that is needed to form the appropriate data objects that are needed. The output is used to modify the saved_values_set in order to reduce the memory usage during backward pass. Additionally, the config.py file has been updated to include a new parameter that controls the option to choose the backward-pass-aware option and also the aggressiveness of the backward pass-aware AC.
Test Plan
ran on PyTorch benchmark "BERT_pytorch"