### PR TITLE
[AILab] Add TryExcept when decoding healthcheck port

### DIFF
--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -219,9 +219,16 @@ class LocalElasticAgent(SimpleElasticAgent):
             else:
                 alive_callback = self._worker_watchdog.get_last_progress_time
 
+            try:
+                healthcheck_port_as_int = int(healthcheck_port)
+            except ValueError:
+                logger.info(
+                    f"Invalid healthcheck port value: {healthcheck_port}, expecting integer"
+                )
+
             self._health_check_server = create_healthcheck_server(
                 alive_callback=alive_callback,
-                port=int(healthcheck_port),
+                port=healthcheck_port_as_int,
                 timeout=60,
             )
             self._health_check_server.start()


### PR DESCRIPTION
Summary:
Error Message:
```
  File "/packages/aps_models.examples.dlrm.lite/dlrm_train_app-inplace#link-tree/torch/distributed/elastic/agent/server/local_elastic_agent.py", line 224, in _setup_healthcheck
    port=int(healthcheck_port),
ValueError: invalid literal for int() with base 10: \'%port.thrift%\'
```

Test Plan:
```
lab-cli launch ai_lab.APF.dlrm_remote_mp --secure-group mobilelab
```
https://www.internalfb.com/mlhub/pipelines/runs/fblearner/645059074

Reviewed By: lijia19

Differential Revision: D63157491


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o