### PR TITLE
Add cache logs + other minor caching cleanup

### DIFF
--- a/test/inductor/mock_cache.py
+++ b/test/inductor/mock_cache.py
@@ -126,7 +126,7 @@ class MockBackend(RemoteCacheBackend[Any]):
         return wrapper
 
     @override
-    def get(self, key: str) -> Optional[Any]:
+    def _get(self, key: str) -> Optional[Any]:
         stat = global_stats.get_stat(self._name)
         if key in stat.cache:
             stat += Stats(num_get_hit=1)
@@ -136,7 +136,7 @@ class MockBackend(RemoteCacheBackend[Any]):
             return None
 
     @override
-    def put(self, key: str, data: Any) -> None:
+    def _put(self, key: str, data: Any) -> None:
         stat = global_stats.get_stat(self._name)
         stat += Stats(num_put=1)
         stat.cache[key] = data

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -67,6 +67,7 @@ from torch._inductor.codegen.rocm.compile_command import (
 )
 from torch._utils_internal import log_cache_bypass
 
+from .remote_cache import create_cache
 from .utils import _align
 
 
@@ -1323,25 +1324,13 @@ class FxGraphCache:
         """
         Attempts to load the remote cache, returns None on error.
         """
-        remote_cache = None
         cache_id = "fx-graph-v1"
-        try:
-            if config.is_fbcode():
-                from torch._inductor.fb.remote_cache import FbRemoteFxGraphCache
-
-                remote_cache = FbRemoteFxGraphCache(cache_id)
-            else:
-                from torch._inductor.remote_cache import RemoteFxGraphCache
-
-                remote_cache = RemoteFxGraphCache(cache_id)
-        except ModuleNotFoundError as e:
-            # No need for a stack trace on this error
-            remote_cache = None
-            log.warning("Unable to create a remote cache: %s", e)
-        except Exception:
-            remote_cache = None
-            log.warning("Unable to create a remote cache", exc_info=True)
-        return remote_cache
+        return create_cache(
+            cache_id,
+            config.is_fbcode(),
+            "FbRemoteFxGraphCache",
+            "RemoteFxGraphCache",
+        )
 
     @staticmethod
     def load_with_key(

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -9,20 +9,21 @@ def is_fbcode() -> bool:
     return not hasattr(torch.version, "git_version")
 
 
-def fx_graph_remote_cache_default() -> Optional[bool]:
-    if os.environ.get("TORCHINDUCTOR_FX_GRAPH_REMOTE_CACHE") == "1":
+def _get_tristate_env(name: str) -> Optional[bool]:
+    value = os.environ.get(name)
+    if value == "1":
         return True
-    if os.environ.get("TORCHINDUCTOR_FX_GRAPH_REMOTE_CACHE") == "0":
+    if value == "0":
         return False
     return None
+
+
+def fx_graph_remote_cache_default() -> Optional[bool]:
+    return _get_tristate_env("TORCHINDUCTOR_FX_GRAPH_REMOTE_CACHE")
 
 
 def autotune_remote_cache_default() -> Optional[bool]:
-    if os.environ.get("TORCHINDUCTOR_AUTOTUNE_REMOTE_CACHE") == "1":
-        return True
-    if os.environ.get("TORCHINDUCTOR_AUTOTUNE_REMOTE_CACHE") == "0":
-        return False
-    return None
+    return _get_tristate_env("TORCHINDUCTOR_AUTOTUNE_REMOTE_CACHE")
 
 
 # Enable auto_functionalized_v2 (enabled by default)

--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import atexit
+import collections
+import dataclasses
 import json
+import logging
 import os
+import sys
 import typing
 from abc import abstractmethod
 from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union
@@ -14,6 +19,9 @@ try:
     import redis
 except ImportError:
     redis = None  # type: ignore[assignment]
+
+
+log = logging.getLogger(__name__)
 
 
 if config.is_fbcode():
@@ -36,13 +44,33 @@ class RemoteCacheBackend(Generic[_T]):
     works with bytes in/out.  For structured data use a RemoteCache.
     """
 
+    def __init__(self) -> None:
+        self._name = f"backend:{type(self).__name__}"
+
     @abstractmethod
-    def get(self, key: str) -> Optional[_T]:
+    def _get(self, key: str) -> Optional[_T]:
         pass
 
     @abstractmethod
-    def put(self, key: str, data: _T) -> None:
+    def _put(self, key: str, data: _T) -> None:
         pass
+
+    def get(self, key: str) -> Optional[_T]:
+        try:
+            value = self._get(key)
+            cache_stats.get(self._name, value)
+        except Exception:
+            cache_stats.exception(self._name)
+            raise
+        return value
+
+    def put(self, key: str, data: _T) -> None:
+        try:
+            self._put(key, data)
+            cache_stats.put(self._name)
+        except Exception:
+            cache_stats.exception(self._name)
+            raise
 
 
 # Serde that encodes from _T to _U and decodes from _U to _T.
@@ -77,48 +105,108 @@ class RemoteCachePassthroughSerde(RemoteCacheSerde[_T, _T]):
         return data
 
 
+# This class is the top of a RemoteCache. A RemoteCache is fundamentally made of
+# three parts:
+#
+# 1. The controller (this class).
+# 2. A serializer/deserializer (instance of RemoteCacheSerde).
+# 3. A backend (instance of RemoteCacheBackend).
+#
+# To write (`put`), the RemoteCache takes data, uses the RemoteCacheSerde to
+# convert it for the backend and passes it to the backend.
+#
+# Conversly when reading (`get`), the RemoteCache takes data from the backend,
+# uses the RemoteCacheSerde to convert it and returns it.
+#
+# The RemoteCacheBackend is generic on _U - which is the type of data the
+# backend can directly cache (usually `bytes`).
+#
+# The RemoteCacheSerde is responsible for converting between _T (the type of
+# data the RemoteCache accepts in `put` and returns in `get`) and _U.
+#
+# When instantiating a RemoteCache you should override, not directly create a
+# RemoteCache. The reason is that when logging cache use (`TORCH_LOGS=cache`) we
+# use the concrete type of the RemoteCache as the reported cache. See
+# RemoteFxGraphCache below as an example.
 class RemoteCache(Generic[_T]):
     backend_override_cls: Optional[Callable[[], RemoteCacheBackend[Any]]] = None
 
     def __init__(
         self, backend: RemoteCacheBackend[_U], serde: RemoteCacheSerde[_T, _U]
     ) -> None:
-        # Support for testing.
+        # Support for testing to mock out the backend on a class-by-class basis.
         if (override_cls := self.__class__.backend_override_cls) is not None:
             self.backend = override_cls()
         else:
             self.backend = backend
         self.serde = serde
 
+    # See if the cache contains `key`. Returns `None` if the value is not
+    # present in the cache.
     def get(self, key: str) -> Optional[_T]:
         sample = self._create_sample()
-        result = self._get(key, sample)
+        try:
+            result = self._get(key, sample)
+            cache_stats.get(type(self).__name__, result)
+        except Exception:
+            cache_stats.exception(type(self).__name__)
+            raise
         self._log_sample(sample)
         return result
 
+    # Add `value` to the cache with the key `key`. Note that `None` is not a
+    # valid value even if _T supports it (because you can't tell the difference
+    # between `None` and a missing cache entry).
     def put(self, key: str, value: _T) -> None:
+        assert value is not None
         sample = self._create_sample()
-        self._put(key, value, sample)
+        try:
+            self._put(key, value, sample)
+            cache_stats.put(type(self).__name__)
+        except Exception:
+            cache_stats.exception(type(self).__name__)
+            raise
         self._log_sample(sample)
 
+    # Used to convert data from the cache into structured data.
     def _decode(self, data: _U, sample: Optional[Sample]) -> _T:  # type: ignore[override]
         return self.serde.decode(data)  # type: ignore[arg-type]
 
-    def _encode(self, value: _T, sample: Optional[Sample]) -> Any:  # returns _U
+    # Used to convert structured data into data for the cache.
+    def _encode(self, value: _T, sample: Optional[Sample]) -> object:  # returns _U
         return self.serde.encode(value)
 
+    # Get structured data from the cache.
+    # Separate from `get` so that it can be overridden.
     def _get(self, key: str, sample: Optional[Sample]) -> Optional[_T]:
-        if data := self.backend.get(key):
+        if data := self._backend_get(key):
             return self._decode(data, sample)
         return None
 
+    # Get unstructured data from the cache.
+    # Separate from `get` so that it can be overridden.
+    # Returns _U - but we aren't actually generic on _U
+    def _backend_get(self, key: str) -> object:
+        return self.backend.get(key)
+
+    # Put structured data into the cache.
+    # Separate from `put` so that it can be overridden.
     def _put(self, key: str, value: _T, sample: Optional[Sample]) -> None:
         data = self._encode(value, sample)
+        self._backend_put(key, data)
+
+    # Put unstructured data into the cache.
+    # Separate from `put` so that it can be overridden.
+    # Takes data: _U - but we aren't actually generic on _U
+    def _backend_put(self, key: str, data: object) -> None:
         self.backend.put(key, data)
 
+    # Create a logging Sample - used with internal loggers to monitor cache
+    # effectiveness.
     def _create_sample(self) -> Optional[Sample]:
         return None
 
+    # Write the logging Sample to the logger.
     def _log_sample(self, sample: Optional[Sample]) -> None:
         pass
 
@@ -132,6 +220,7 @@ class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
     _redis: Optional[redis.Redis] = None
 
     def __init__(self, cache_id: str) -> None:
+        super().__init__()
         if not redis:
             # We had trouble importing redis - just skip init.
             return
@@ -146,7 +235,7 @@ class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
         return self._key_fmt.format(key=key)
 
     @override
-    def get(self, key: str) -> Optional[bytes]:
+    def _get(self, key: str) -> Optional[bytes]:
         if not self._redis:
             # Either redis wasn't found or we already had some trouble...
             return None
@@ -164,7 +253,7 @@ class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
         return value
 
     @override
-    def put(self, key: str, data: bytes) -> None:
+    def _put(self, key: str, data: bytes) -> None:
         if not self._redis:
             # Either redis wasn't found or we already had some trouble...
             return
@@ -196,3 +285,85 @@ class RemoteAutotuneCache(RedisRemoteCache):
 
 class RemoteFxGraphCache(RedisRemoteCache):
     pass
+
+
+def create_cache(
+    key: str,
+    is_fbcode: bool,
+    fb_cache_cls: str,
+    oss_cache_cls: str,
+) -> Optional[RemoteCache[JsonDataTy]]:
+    try:
+        if is_fbcode:
+            import torch._inductor.fb.remote_cache
+
+            cache_cls = getattr(torch._inductor.fb.remote_cache, fb_cache_cls)
+            return cache_cls(key)
+        else:
+            this_module = sys.modules[__name__]
+
+            cache_cls = getattr(this_module, oss_cache_cls)
+            return cache_cls(key)
+
+    except Exception:
+        log.warning("Unable to create a remote cache", exc_info=True)
+        return None
+
+
+# Some simple stat capture
+@dataclasses.dataclass
+class _CacheStat:
+    miss: int = 0
+    hit: int = 0
+    put: int = 0
+    exception: int = 0
+
+    def __str__(self) -> str:
+        return f"{{hit: {self.hit}, miss: {self.miss}, put: {self.put}, exception: {self.exception}}}"
+
+
+class _CacheStats:
+    _stats: Dict[str, _CacheStat]
+
+    def __init__(self) -> None:
+        self._stats = collections.defaultdict(_CacheStat)
+
+    def miss(self, name: str, count: int = 1) -> None:
+        self._stats[name].miss += count
+
+    def hit(self, name: str, count: int = 1) -> None:
+        self._stats[name].hit += count
+
+    def get(self, name: str, value: Optional[object]) -> None:
+        if value is None:
+            self.miss(name)
+        else:
+            self.hit(name)
+
+    def put(self, name: str, count: int = 1) -> None:
+        self._stats[name].put += count
+
+    def exception(self, name: str, count: int = 1) -> None:
+        self._stats[name].exception += count
+
+
+cache_stats = _CacheStats()
+
+
+@atexit.register
+def dump_cache_stats() -> None:
+    if not log.isEnabledFor(logging.INFO):
+        return
+
+    import io
+
+    out = io.StringIO()
+
+    if not cache_stats._stats:
+        print(" None", file=out)
+    else:
+        print(file=out)
+        for k, v in sorted(cache_stats._stats.items()):
+            print(f"  {k}: {v}", file=out)
+
+    log.info("Cache Metrics:%s", out.getvalue())

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -12,6 +12,7 @@ import torch
 from torch.utils._triton import has_triton_package
 
 from ..remote_cache import (
+    create_cache,
     JsonDataTy,
     RemoteCache,
     RemoteCacheBackend,
@@ -91,12 +92,24 @@ class AutotuneCache:
         if not _should_use_remote_autotune_cache(inductor_meta):
             return
 
-        remote_cache = _create_cache(
-            inductor_meta,
-            self.configs_hash,
+        if (backend_hash := inductor_meta.get("backend_hash", None)) is None:
+            log.debug(
+                "backend_hash is not passed on the inductor_meta, unable to use autotune remote cache"
+            )
+            return
+        assert isinstance(backend_hash, str)
+
+        is_fbcode = bool(inductor_meta.get("is_fbcode", False))
+
+        salt = "autotune-best-config-v2"
+        key = backend_hash + self.configs_hash + salt
+        key = hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+        remote_cache = create_cache(
+            key,
+            is_fbcode,
             "FbRemoteAutotuneCache",
             "RemoteAutotuneCache",
-            "autotune-best-config-v2",
         )
         if not remote_cache:
             return
@@ -131,7 +144,7 @@ class AutotuneCache:
             cache.put(key, data)
 
 
-def _should_use_remote_autotune_cache(inductor_meta: Dict[str, object]) -> bool:
+def _should_use_remote_autotune_cache(inductor_meta: _InductorMetaTy) -> bool:
     if (config := inductor_meta.get("autotune_remote_cache")) is not None:
         return bool(config)
     if not inductor_meta.get("is_fbcode"):
@@ -155,7 +168,7 @@ def _load_cached_autotuning(
     best_config: Dict[str, JsonDataTy],
     configs_hash: str,
     configs: List[Config],
-    inductor_meta: Dict[str, object],
+    inductor_meta: _InductorMetaTy,
 ) -> Optional[Config]:
     if best_config is None:
         return None
@@ -187,44 +200,9 @@ def _load_cached_autotuning(
     return matching_configs[0]
 
 
-def _create_cache(
-    inductor_meta: Dict[str, object],
-    configs_hash: str,
-    fb_cache_cls: str,
-    oss_cache_cls: str,
-    salt: str,
-) -> Optional[RemoteCache[JsonDataTy]]:
-    backend_hash = inductor_meta.get("backend_hash", None)
-    if backend_hash is None:
-        log.debug(
-            "backend_hash is not passed on the inductor_meta, unable to use autotune remote cache"
-        )
-        return None
-
-    assert isinstance(backend_hash, str)
-
-    key = backend_hash + configs_hash + salt
-    key = hashlib.sha256(key.encode("utf-8")).hexdigest()
-
-    try:
-        if inductor_meta.get("is_fbcode"):
-            import torch._inductor.fb.remote_cache
-
-            cache_cls = getattr(torch._inductor.fb.remote_cache, fb_cache_cls)
-            return cache_cls(key)
-        else:
-            import torch._inductor.remote_cache
-
-            cache_cls = getattr(torch._inductor.remote_cache, oss_cache_cls)
-            return cache_cls(key)
-    except Exception:
-        log.warning("Unable to create a remote cache", exc_info=True)
-        return None
-
-
 class _LocalAutotuneCacheBackend(RemoteCacheBackend[bytes]):
     @override
-    def get(self, key: str) -> Optional[bytes]:
+    def _get(self, key: str) -> Optional[bytes]:
         try:
             with open(key, "rb") as fd:
                 return fd.read()
@@ -232,7 +210,8 @@ class _LocalAutotuneCacheBackend(RemoteCacheBackend[bytes]):
             return None
 
     @override
-    def put(self, key: str, data: bytes) -> None:
+    def _put(self, key: str, data: bytes) -> None:
+        os.makedirs(os.path.dirname(key), exist_ok=True)
         with open(key, "wb") as fd:
             fd.write(data)
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1347,36 +1347,21 @@ def pointwise(
         triton_config, min_elem_per_thread=min_elem_per_thread
     )
 
+    configs = None
     if len(size_hints) == 1:
         if disable_pointwise_autotuning(inductor_meta) and not (
             inductor_meta.get("max_autotune")
             or inductor_meta.get("max_autotune_pointwise")
         ):
-            return cached_autotune(
-                size_hints,
-                [triton_config_with_settings(size_hints, bs)],
-                triton_meta=triton_meta,
-                inductor_meta=inductor_meta,
-                heuristic_type=HeuristicType.POINTWISE,
-                filename=filename,
-            )
+            configs = [triton_config_with_settings(size_hints, bs)]
         else:
-            return cached_autotune(
-                size_hints,
-                [
-                    triton_config_with_settings(
-                        size_hints, bs, num_elements_per_warp=256
-                    ),
-                    triton_config_with_settings(
-                        size_hints, bs // 2, num_elements_per_warp=64
-                    ),
-                    *hinted_configs,
-                ],
-                triton_meta=triton_meta,
-                inductor_meta=inductor_meta,
-                heuristic_type=HeuristicType.POINTWISE,
-                filename=filename,
-            )
+            configs = [
+                triton_config_with_settings(size_hints, bs, num_elements_per_warp=256),
+                triton_config_with_settings(
+                    size_hints, bs // 2, num_elements_per_warp=64
+                ),
+                *hinted_configs,
+            ]
     if len(size_hints) == 2:
         if (
             disable_pointwise_autotuning(inductor_meta) or tile_hint == TileHint.SQUARE
@@ -1384,17 +1369,9 @@ def pointwise(
             inductor_meta.get("max_autotune")
             or inductor_meta.get("max_autotune_pointwise")
         ):
-            return cached_autotune(
-                size_hints,
-                [triton_config_with_settings(size_hints, 32, 32)],
-                triton_meta=triton_meta,
-                inductor_meta=inductor_meta,
-                heuristic_type=HeuristicType.POINTWISE,
-                filename=filename,
-            )
-        return cached_autotune(
-            size_hints,
-            [
+            configs = [triton_config_with_settings(size_hints, 32, 32)]
+        else:
+            configs = [
                 triton_config_with_settings(size_hints, 32, 32),
                 triton_config_with_settings(size_hints, 64, 64),  # ~8% better for fp16
                 triton_config_with_settings(size_hints, 256, 16),
@@ -1402,25 +1379,12 @@ def pointwise(
                 triton_config_with_settings(size_hints, bs, 1),
                 triton_config_with_settings(size_hints, 1, bs),
                 *hinted_configs,
-            ],
-            triton_meta=triton_meta,
-            inductor_meta=inductor_meta,
-            filename=filename,
-            heuristic_type=HeuristicType.POINTWISE,
-        )
+            ]
     if len(size_hints) == 3:
         if disable_pointwise_autotuning(inductor_meta):
-            return cached_autotune(
-                size_hints,
-                [triton_config_with_settings(size_hints, 16, 16, 16)],
-                triton_meta=triton_meta,
-                inductor_meta=inductor_meta,
-                heuristic_type=HeuristicType.POINTWISE,
-                filename=filename,
-            )
-        return cached_autotune(
-            size_hints,
-            [
+            configs = [triton_config_with_settings(size_hints, 16, 16, 16)]
+        else:
+            configs = [
                 triton_config_with_settings(size_hints, 16, 16, 16),
                 triton_config_with_settings(size_hints, 64, 8, 8),
                 triton_config_with_settings(size_hints, 8, 64, 8),
@@ -1429,13 +1393,18 @@ def pointwise(
                 triton_config_with_settings(size_hints, 1, bs, 1),
                 triton_config_with_settings(size_hints, 1, 1, bs),
                 *hinted_configs,
-            ],
-            triton_meta=triton_meta,
-            inductor_meta=inductor_meta,
-            filename=filename,
-            heuristic_type=HeuristicType.POINTWISE,
-        )
-    raise NotImplementedError(f"size_hints: {size_hints}")
+            ]
+
+    if not configs:
+        raise NotImplementedError(f"size_hints: {size_hints}")
+    return cached_autotune(
+        size_hints,
+        configs,
+        triton_meta=triton_meta,
+        inductor_meta=inductor_meta,
+        heuristic_type=HeuristicType.POINTWISE,
+        filename=filename,
+    )
 
 
 def _reduction_configs(

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -13,6 +13,9 @@ DISTRIBUTED = [
     "torch.nn.parallel.distributed",
 ]
 
+register_log(
+    "cache", ("torch._inductor.remote_cache", "torch._inductor.fb.remote_cache")
+)
 register_log("dynamo", ["torch._dynamo", *DYNAMIC])
 register_log("fake_tensor", ["torch._subclasses.fake_tensor"])
 register_log("aot", ["torch._functorch.aot_autograd", "torch._functorch._aot_autograd"])


### PR DESCRIPTION
Summary:
- Added TORCH_LOGS=cache to dump cache stats on exit - supported by RemoteCache.
- Split REMOTE_CACHE_VERSION - it was used for both JKs fx_graph_memcache_version and autotune_memcache_version but they really should be separate (just in case we need to change one but not the other)
- Prepare `_ManifoldCache` for use with other subpath keys
- Move create_cache to be more public and use it in codecache
- Add _InductorMetaTy alias (still just a dict)
- Cleaned up some common cached_autotune calls in triton_heuristics

Test Plan: unit tests

Reviewed By: oulgen

Differential Revision: D62648249


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang