### PR TITLE
viable/strict update: log push to s3

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -11,15 +11,39 @@ concurrency:
 
 jobs:
   do_update_viablestrict:
+    permissions:
+      id-token: write
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-20.04
     environment: ${{ (github.event_name == 'schedule') && 'mergebot' || '' }}
     steps:
       - name: Update viable/strict
         uses: pytorch/test-infra/.github/actions/update-viablestrict@main
+        id: update_viablestrict
         with:
           repository: pytorch/pytorch
           stable-branch: viable/strict
           requires: '[\"pull\", \"trunk\", \"lint\", \"linux-binary\"]'
           secret-bot-token: ${{ secrets.MERGEBOT_TOKEN }}
           rockset-api-key: ${{ secrets.ROCKSET_API_KEY }}
+
+      - name: Authenticate to AWS with OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/upload_to_ossci_raw_job_status
+          aws-region: us-east-1
+
+      - name: Print sha
+        env:
+          LATEST_SHA: ${{ steps.update_viablestrict.outputs.latest_viable_sha }}
+          PUSH_RESULT: ${{ steps.update_viablestrict.outputs.push_result }}
+          TIME: ${{ steps.update_viablestrict.outputs.time }}
+        run: |
+          echo "${PUSH_RESULT}"
+          if [ "$PUSH_RESULT" = "Everything up-to-date" ]; then
+            echo "No update pushed"
+          else
+            echo "{\"sha\": \"${LATEST_SHA}\", \"repository\":\"pytorch/pytorch\", \"timestamp\": ${TIME}}" > "/tmp/${TIME}.json"
+            pip install awscli
+            aws s3 cp "/tmp/${TIME}.json" "s3://ossci-raw-job-status/stable_pushes/pytorch/pytorch/${TIME}.json"
+          fi

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -43,7 +43,7 @@ jobs:
           if [ "$PUSH_RESULT" = "Everything up-to-date" ]; then
             echo "No update pushed"
           else
-            echo "{\"sha\": \"${LATEST_SHA}\", \"repository\":\"pytorch/pytorch\", \"timestamp\": ${TIME}}" > "/tmp/${TIME}.json"
+            echo "{\"sha\": \"${LATEST_SHA}\", \"repository\":\"pytorch/pytorch\", \"timestamp\": ${TIME}}" > "/tmp/${LATEST_SHA}.json"
             pip install awscli==1.29.40
-            aws s3 cp "/tmp/${TIME}.json" "s3://ossci-raw-job-status/stable_pushes/pytorch/pytorch/${TIME}.json"
+            aws s3 cp "/tmp/${LATEST_SHA}.json" "s3://ossci-raw-job-status/stable_pushes/pytorch/pytorch/${LATEST_SHA}.json"
           fi

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -44,6 +44,6 @@ jobs:
             echo "No update pushed"
           else
             echo "{\"sha\": \"${LATEST_SHA}\", \"repository\":\"pytorch/pytorch\", \"timestamp\": ${TIME}}" > "/tmp/${TIME}.json"
-            pip install awscli
+            pip install awscli==1.29.40
             aws s3 cp "/tmp/${TIME}.json" "s3://ossci-raw-job-status/stable_pushes/pytorch/pytorch/${TIME}.json"
           fi


### PR DESCRIPTION
I cannot figure out a way to determine the push time from webhooks (other than when the webhook was sent, but that isn't super accurate either).  Instead, manually save a json file to s3 that contains information for the sha and date so that we can still get this information.

Relies on https://github.com/pytorch/test-infra/pull/5690

tested in https://github.com/pytorch/pytorch/pull/136387 (but I squashed so it's kinda hard to find now)