### PR TITLE
[NCCL][CUDA] Don't throw a device assert in Nan check

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -3186,6 +3186,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
   // Only check for NaN for send ops, for recv ops `tensor` can be a random
   // placeholder
   if (enableNanCheck_ && opType == OpType::SEND) {
+    at::cuda::CUDAStreamGuard ncclStreamGuard(ncclStream);
     bool nan = isnan(tensor)._is_any_true().item<bool>();
     if (nan) {
       throw std::runtime_error("NaN check failed in pointToPoint()");


### PR DESCRIPTION
One possible workaround for #136390

Uses the anomaly-detection approach which incurs a host-side sync but doesn't corrupt the CUDA context

CC @nWEIdia 

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o