### PR TITLE
[SymmetricMemory] add support for cuStreamWriteValue32

### DIFF
--- a/c10/cuda/driver_api.h
+++ b/c10/cuda/driver_api.h
@@ -29,6 +29,7 @@
   _(cuMemGetAllocationGranularity)  \
   _(cuMemExportToShareableHandle)   \
   _(cuMemImportFromShareableHandle) \
+  _(cuStreamWriteValue32)           \
   _(cuGetErrorString)
 
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 12030)

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -503,6 +503,7 @@ class SymmetricMemoryTest(MultiProcessTestCase):
         dist.destroy_process_group()
 
     @skipIfRocm
+    @skip_if_lt_x_gpu(2)
     def test_stream_write_value(self):
         self._init_process()
         group_name = dist.group.WORLD.group_name

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -523,7 +523,7 @@ class SymmetricMemoryTest(MultiProcessTestCase):
             symm_mem.stream_write_value32(
                 int(tensor.data_ptr()) + i * tensor.element_size(), 1
             )
-            self.assertTrue(torch.allclose(tensor, expect[i]))
+            torch.testing.assert_close(tensor, expect[i])
 
 
 if __name__ == "__main__":

--- a/torch/csrc/distributed/c10d/CUDASymmetricMemory-inl.h
+++ b/torch/csrc/distributed/c10d/CUDASymmetricMemory-inl.h
@@ -12,7 +12,7 @@ constexpr size_t max_num_threads_per_block = 1024;
 constexpr size_t max_num_blocks = 8;
 
 template <typename T>
-size_t get_alignment(T ptr_or_size) {
+__inline__ size_t get_alignment(T ptr_or_size) {
   auto val = reinterpret_cast<uintptr_t>(ptr_or_size);
   if (val % 16 == 0) {
     return 16;
@@ -28,7 +28,7 @@ size_t get_alignment(T ptr_or_size) {
 }
 
 template <>
-size_t get_alignment<size_t>(size_t size) {
+__inline__ size_t get_alignment<size_t>(size_t size) {
   return get_alignment(reinterpret_cast<void*>(size));
 }
 

--- a/torch/csrc/distributed/c10d/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/CUDASymmetricMemory.hpp
@@ -52,6 +52,8 @@ class CUDASymmetricMemory : public SymmetricMemory {
   int get_rank() override;
   int get_world_size() override;
 
+  void stream_write_value32(uintptr_t addr, uint32_t val) override;
+
  private:
   std::vector<HandleType> handles_;
   size_t block_size_;

--- a/torch/csrc/distributed/c10d/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/SymmetricMemory.hpp
@@ -66,6 +66,8 @@ class TORCH_API SymmetricMemory : public c10::intrusive_ptr_target {
 
   virtual int get_rank() = 0;
   virtual int get_world_size() = 0;
+
+  virtual void stream_write_value32(uintptr_t addr, uint32_t val) = 0;
 };
 
 class SymmetricMemoryAllocator : public c10::intrusive_ptr_target {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1080,7 +1080,12 @@ This class does not support ``__members__`` property.)");
           "wait_signal",
           &SymmetricMemory::wait_signal,
           py::arg("src_rank"),
-          py::arg("channel") = 0);
+          py::arg("channel") = 0)
+      .def(
+          "stream_write_value32",
+          &SymmetricMemory::stream_write_value32,
+          py::arg("addr"),
+          py::arg("val"));
 
   auto store =
       py::class_<::c10d::Store, c10::intrusive_ptr<::c10d::Store>, PythonStore>(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136488

cuStreamWriteValue efficiently combines the issuing of a system-level fence with the update of a single memory location. It is highly suitable for inter-stream progress sharing (e.g., all_gather_with_progress).

Exposing it via SymmetricMemory allows users to more easily implement efficient progress-aware matmuls in triton ([xformers example](https://github.com/facebookresearch/xformers/blob/main/xformers/ops/_triton/sequence_parallel_fused_kernels.py)).

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o