### PR TITLE
Constraint setuptools to 72.1.0 or older in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ psutil
 pyyaml
 requests
 # Setuptools>=74.0.0 stopped support for directly using private funcs(_msvccompiler)
-# and consolidated all compiler logic in distutils used in Pytorch build, so older 
+# and consolidated all compiler logic in distutils used in Pytorch build, so older
 # is required until pytorch build not refactored to work for latest setuptools.
 setuptools<=72.1.0
 types-dataclasses

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,10 @@ numpy
 psutil
 pyyaml
 requests
-setuptools==72.1.0
+# Setuptools>=74.0.0 stopped support for directly using private funcs(_msvccompiler)
+# and consolidated all compiler logic in distutils used in Pytorch build, so older 
+# is required until pytorch build not refactored to work for latest setuptools.
+setuptools<=72.1.0
 types-dataclasses
 typing-extensions>=4.8.0
 sympy==1.12.1 ; python_version == "3.8"
@@ -17,7 +20,5 @@ jinja2
 fsspec
 lintrunner
 ninja
-# setuptools was removed from default python install
-setuptools==72.1.0 ; python_version >= "3.12"
 packaging
 optree>=0.12.0 ; python_version <= "3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy
 psutil
 pyyaml
 requests
-setuptools
+setuptools==72.1.0
 types-dataclasses
 typing-extensions>=4.8.0
 sympy==1.12.1 ; python_version == "3.8"
@@ -18,6 +18,6 @@ fsspec
 lintrunner
 ninja
 # setuptools was removed from default python install
-setuptools ; python_version >= "3.12"
+setuptools==72.1.0 ; python_version >= "3.12"
 packaging
 optree>=0.12.0 ; python_version <= "3.12"


### PR DESCRIPTION
FIXES: https://github.com/pytorch/pytorch/issues/136541

Setuptools>=74.0.0 has deprecated support for some functions in distutils, and so the builds run into error such as ```AttributeError: module 'distutils' has no attribute '_msvccompiler'```. Also, the pytorch builds have setuptools pin to 72.1.0 according to these PRs: https://github.com/pytorch/builder/pull/1995 and https://github.com/pytorch/builder/commit/89d9a8cf6f4357d5d523b8d7c46351ac913e1309. So, until there is a fix to change the function usage in accordance with latest setuptools, the 72.1.0 version works fine. 

Also observed in CI jobs: https://github.com/pytorch/pytorch/actions/runs/10979326524