### PR TITLE
Move print_export_warning so lru_cache works

### DIFF
--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -69,6 +69,9 @@ def capture_pre_autograd_graph_warning():
     if config.is_fbcode():
         log.warning("For unittest, capture_pre_autograd_graph() will fallback to torch.export.export_for_training.")  # noqa: B950
 
+@lru_cache
+def print_export_warning():
+    log.warning("Using torch.export.export_for_training(...,strict=True)")
 
 @compatibility(is_backward_compatible=False)
 def capture_pre_autograd_graph(
@@ -126,9 +129,6 @@ def capture_pre_autograd_graph(
         kwargs = {}
 
     if capture_pre_autograd_graph_using_training_ir():
-        @lru_cache
-        def print_export_warning():
-            log.warning("Using torch.export.export_for_training(...,strict=True)")
         print_export_warning()
         module = torch.export.export_for_training(f, args, kwargs, dynamic_shapes=dynamic_shapes, strict=True).module()
     else:


### PR DESCRIPTION
Summary:
as title

move print_export_warning() out of the function so `lru_cache` actually works

Test Plan: CI

Differential Revision: D63297083
