### PR TITLE
[pipelining] fix py ref cycle in stage_backward

### DIFF
--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -320,6 +320,8 @@ def stage_backward(
         torch.autograd.backward(
             stage_output_tensors, grad_tensors=output_grad_tensors  # type: ignore[arg-type]
         )
+        del stage_output_tensors
+        del output_grad_tensors
 
         # Extract gradients wrt the input values
         grad_inputs = []

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -283,10 +283,16 @@ def stage_backward(
     try:
         # stage_output may be a composite datatype like dict. Extract all individual
         # tensor values here
-        stage_output_tensors = []
-        output_grad_tensors = []
+        stage_output_tensors: List[torch.Tensor] = []
+        output_grad_tensors: List[torch.Tensor] = []
 
-        def extract_tensors_with_grads(output_val, grad_val):
+        def extract_tensors_with_grads(
+            output_val,
+            grad_val,
+            stage_output_tensors,
+            output_grad_tensors,
+            extract_tensors_with_grads,
+        ):
             if isinstance(output_val, torch.Tensor):
                 if not output_val.requires_grad and output_val.grad_fn is None:
                     return
@@ -303,25 +309,49 @@ def stage_backward(
                 ), f"grad_value expected to have type {type(output_val)} but got {type(grad_val)}"
                 assert len(output_val) == len(grad_val)
                 for ov, gv in zip(output_val, grad_val):
-                    extract_tensors_with_grads(ov, gv)
+                    extract_tensors_with_grads(
+                        ov,
+                        gv,
+                        stage_output_tensors,
+                        output_grad_tensors,
+                        extract_tensors_with_grads,
+                    )
             elif isinstance(output_val, dict):
                 if grad_val is None:
                     return
                 assert isinstance(grad_val, dict)
                 assert set(output_val.keys()) == set(grad_val.keys())
                 for k in output_val.keys():
-                    extract_tensors_with_grads(output_val[k], grad_val[k])
+                    extract_tensors_with_grads(
+                        output_val[k],
+                        grad_val[k],
+                        stage_output_tensors,
+                        output_grad_tensors,
+                        extract_tensors_with_grads,
+                    )
             else:
                 # Output is a non-tensor type; just ignore it
                 pass
 
-        extract_tensors_with_grads(stage_output, output_grads)
+        # Note: break a ref cycle that would keep tensors alive until GC runs
+        # 1. extract_tensors_with_grads refers to a cell that holds refs to any vars defined in stage_backward
+        #    and used in extract_tensors_with_grads
+        # 2. extract_tensors_with_grads referred to both stage_output_tensors, output_grad_tensors,
+        #    and to itself (extract_tensors_with_grads) since it makes a recursive call
+        # 3. stage_output_tensors was kept alive by the above refcycle, and it holds activation tensors, which is bad
+        # -> explicitly pass in those lists, so the lists don't show up in the cell.
+        # -> also pass in the ref to the fn, so there is no gc cycle anymore
+        extract_tensors_with_grads(
+            stage_output,
+            output_grads,
+            stage_output_tensors,
+            output_grad_tensors,
+            extract_tensors_with_grads,
+        )
 
         torch.autograd.backward(
             stage_output_tensors, grad_tensors=output_grad_tensors  # type: ignore[arg-type]
         )
-        del stage_output_tensors
-        del output_grad_tensors
 
         # Extract gradients wrt the input values
         grad_inputs = []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136507

TLDR; found forward activation tensors were being kept alive "forever"
(or until GC ran), and tracked it down to a cycle involving
`stage_backward.<locals>.extract_tensors_with_grads`.

The reference cycle in question is below.  (constructed using gc.get_referrers after doing a gc.collect in gc debug mode)

tensor is kept alive by
`[(<class 'cell'>, '0x7f7360234400')]`

tuple of cell objects
`(<cell at 0x7f73602343d0: function object at 0x7f734fff0ee0>, <cell at 0x7f7360234400: list object at 0x7f734e4d9a80>, <cell at 0x7f73602a4190: list object at 0x7f734eff8b00>)`
is kept alive by
`[(<class 'function'>, '0x7f734fff0ee0')]`

`<function stage_backward.<locals>.extract_tensors_with_grads at 0x7f734fff0ee0>`
is kept alive by 
`[(<class 'cell'>, '0x7f73602343d0')]`

Put into more plain terms,

```

def stage_backward(...):
    ...
    stage_output_tensors = []

    # a cell object will exist that contains the variables defined in stage_backward and used by
    # both stage_backward and nested functions
    # in this case, the cell object contains 'stage_output_tensors' but 

    # this function object will hold a reference to a 'cell' that contains any vars from
    # the parent scope not explicitly passed into the function as args.
    def extract_tensors_with_grads(...):
        ...
            # extract_tensors_with_grads refers to stage_output_tensors, so stage_output_tensors
            # is in the cell
            stage_output_tensors.append(output_val)
        ...
            # but extract_tensors_with_grads ALSO refers to itself (extract_tensors_with_grads),
            # so `extract_tensors_with_grads` will be in the cell
            extract_tensors_with_grads(...)
```

More debug details:
https://docs.google.com/document/d/1QPH1Lz0tnieIFPM2tyHrjVB-bjlnHuDgjx1p2am3cmE/edit?usp=sharing

In pdb:
```
gc.collect()
g = gc.garbage
g[-1]
[rank0]:(Pdb) [rank0]:<function
stage_backward.<locals>.extract_tensors_with_grads at 0x7fee5c3392d0>
g[-2]
[rank0]:(Pdb) [rank0]:(<cell at 0x7fee7abbcf40: function object at
0x7fee5c3392d0>, <cell at 0x7fee7abbcf70: list object at
0x7fee7ab68940>, <cell at 0x7fee5c3210c0: list object at 0x7fee5e1
d6340>)
g[-3]
[rank0]:(Pdb) [rank0]:[tensor([[[-4.1127e-06, -3.3826e-06,  2.6226e-06,
...,  6.4969e-06,
[rank0]:          -4.4405e-06, -4.7684e-06],
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @d4l3k @c-p-i-o