### PR TITLE
[Distributed] [12/N] Fix clang-tidy warnings in torch/csrc/distributed/

### DIFF
--- a/torch/csrc/distributed/rpc/agent_utils.cpp
+++ b/torch/csrc/distributed/rpc/agent_utils.cpp
@@ -136,7 +136,7 @@ void removeCurrentName(
 
   // Remove the current name and rank
   std::string str_to_erase = fmt::format("{}-{},", selfName, selfId);
-  int start_position_to_erase = allWorkerInfos.find(str_to_erase);
+  auto start_position_to_erase = allWorkerInfos.find(str_to_erase);
   allWorkerInfos.erase(start_position_to_erase, str_to_erase.length());
 
   // Set the new data
@@ -178,7 +178,7 @@ int syncCallCount(
 
   // Add to keys which will record the number of processes and active calls
   store.add(activeCallCountKey, activeCalls);
-  int totalProcessCount = store.add(processCountKey, 1);
+  auto totalProcessCount = store.add(processCountKey, 1);
 
   // The last worker will need to set the ready key
   if (totalProcessCount == worldSize) {

--- a/torch/csrc/distributed/rpc/agent_utils.h
+++ b/torch/csrc/distributed/rpc/agent_utils.h
@@ -3,9 +3,7 @@
 #include <torch/csrc/distributed/c10d/PrefixStore.hpp>
 #include <torch/csrc/distributed/rpc/utils.h>
 
-namespace torch {
-namespace distributed {
-namespace rpc {
+namespace torch::distributed::rpc {
 
 // All RPC peers should call into this function at the same time. Each peer
 // provides its own id and name, and this function uses the given Store to
@@ -41,6 +39,4 @@ TORCH_API int syncCallCount(
     const int worldSize,
     int activeCalls = 0);
 
-} // namespace rpc
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::rpc

--- a/torch/csrc/distributed/rpc/script_call.cpp
+++ b/torch/csrc/distributed/rpc/script_call.cpp
@@ -9,15 +9,15 @@ const std::string ScriptCall::ATEN_PREFIX_("aten::");
 
 ScriptCall::ScriptCall(
     std::shared_ptr<Operator> op,
-    std::vector<at::IValue> stack)
-    : op_(std::move(op)), stack_(std::move(stack)), isAsyncExecution_(false) {}
+    std::vector<at::IValue>&& stack)
+    : op_(std::move(op)), stack_(stack), isAsyncExecution_(false) {}
 
 ScriptCall::ScriptCall(
     const c10::QualifiedName& qualifiedName,
-    std::vector<at::IValue> stack,
+    std::vector<at::IValue>&& stack,
     const bool isAsyncExecution)
     : qualifiedName_(qualifiedName),
-      stack_(std::move(stack)),
+      stack_(stack),
       isAsyncExecution_(isAsyncExecution) {}
 
 bool ScriptCall::hasOp() const {
@@ -86,10 +86,10 @@ std::unique_ptr<ScriptCall> ScriptCall::fromIValues(
       "At least 2 IValues are required to build a ScriptCall.");
 
   // Last element in the vector is always qualifiedName for both
-  // builitin operator and TorchScript function
+  // builtin operator and TorchScript function
   // If the qualifiedName is not a builtin operator name, then treat it
   // as TorchScript function name
-  const std::string& qualifiedName = ivalues.back().toStringRef();
+  std::string qualifiedName = ivalues.back().toStringRef();
 
   if (qualifiedName.rfind(BUILTIN_OP_NAMESPACE_) == 0) {
     ivalues.pop_back();

--- a/torch/csrc/distributed/rpc/script_call.cpp
+++ b/torch/csrc/distributed/rpc/script_call.cpp
@@ -9,15 +9,15 @@ const std::string ScriptCall::ATEN_PREFIX_("aten::");
 
 ScriptCall::ScriptCall(
     std::shared_ptr<Operator> op,
-    std::vector<at::IValue>&& stack)
-    : op_(std::move(op)), stack_(stack), isAsyncExecution_(false) {}
+    std::vector<at::IValue> stack)
+    : op_(std::move(op)), stack_(std::move(stack)), isAsyncExecution_(false) {}
 
 ScriptCall::ScriptCall(
     const c10::QualifiedName& qualifiedName,
-    std::vector<at::IValue>&& stack,
+    std::vector<at::IValue> stack,
     const bool isAsyncExecution)
     : qualifiedName_(qualifiedName),
-      stack_(stack),
+      stack_(std::move(stack)),
       isAsyncExecution_(isAsyncExecution) {}
 
 bool ScriptCall::hasOp() const {

--- a/torch/csrc/distributed/rpc/script_call.h
+++ b/torch/csrc/distributed/rpc/script_call.h
@@ -18,12 +18,12 @@ using torch::jit::Operator;
 // to the TorchScript function schema name and a list of arguments.
 class TORCH_API ScriptCall : public RpcCommandBase {
  public:
-  // Constructor for builitin operator call.
-  ScriptCall(std::shared_ptr<Operator> op, std::vector<at::IValue> stack);
+  // Constructor for builtin operator call.
+  ScriptCall(std::shared_ptr<Operator> op, std::vector<at::IValue>&& stack);
   // Constructor for TorchScript function call.
   ScriptCall(
       const c10::QualifiedName& qualifiedName,
-      std::vector<at::IValue> stack,
+      std::vector<at::IValue>&& stack,
       const bool isAsyncExecution = false);
 
   bool hasOp() const;

--- a/torch/csrc/distributed/rpc/script_call.h
+++ b/torch/csrc/distributed/rpc/script_call.h
@@ -7,9 +7,7 @@
 #include <optional>
 #include <vector>
 
-namespace torch {
-namespace distributed {
-namespace rpc {
+namespace torch::distributed::rpc {
 
 using torch::jit::Operator;
 
@@ -21,11 +19,11 @@ using torch::jit::Operator;
 class TORCH_API ScriptCall : public RpcCommandBase {
  public:
   // Constructor for builitin operator call.
-  ScriptCall(std::shared_ptr<Operator> op, std::vector<at::IValue>&& stack);
+  ScriptCall(std::shared_ptr<Operator> op, std::vector<at::IValue> stack);
   // Constructor for TorchScript function call.
   ScriptCall(
       const c10::QualifiedName& qualifiedName,
-      std::vector<at::IValue>&& stack,
+      std::vector<at::IValue> stack,
       const bool isAsyncExecution = false);
 
   bool hasOp() const;
@@ -66,6 +64,4 @@ class TORCH_API ScriptCall : public RpcCommandBase {
   const bool isAsyncExecution_;
 };
 
-} // namespace rpc
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::rpc

--- a/torch/csrc/distributed/rpc/script_remote_call.h
+++ b/torch/csrc/distributed/rpc/script_remote_call.h
@@ -16,7 +16,7 @@ using torch::jit::Operator;
 // contains the RRefId and the ForkId of the return value RRef.
 class TORCH_API ScriptRemoteCall final : public ScriptCall {
  public:
-  // Constructor for builitin operator call.
+  // Constructor for builtin operator call.
   ScriptRemoteCall(
       std::shared_ptr<Operator> op,
       std::vector<at::IValue>&& stack,

--- a/torch/csrc/distributed/rpc/torchscript_functions.cpp
+++ b/torch/csrc/distributed/rpc/torchscript_functions.cpp
@@ -47,7 +47,7 @@ c10::intrusive_ptr<JitFuture> rpcTorchscript(
       rpcTimeoutSeconds);
 
   // Get function return type to construct JitFuture.
-  auto returns = functionSchema.returns();
+  auto const& returns = functionSchema.returns();
   // Script call only allows single IValue returned.
   TORCH_INTERNAL_ASSERT(
       returns.size() == 1,
@@ -90,7 +90,7 @@ c10::intrusive_ptr<RRef> remoteTorchscript(
   auto& ctx = RRefContext::getInstance();
 
   // Get function return type to construct UserRRef.
-  auto returns = functionSchema.returns();
+  auto const& returns = functionSchema.returns();
   // Script call only allows single IValue returned.
   TORCH_INTERNAL_ASSERT(
       returns.size() == 1,

--- a/torch/csrc/distributed/rpc/types.cpp
+++ b/torch/csrc/distributed/rpc/types.cpp
@@ -103,7 +103,7 @@ SerializedPyObj SerializedPyObj::fromIValues(std::vector<at::IValue> values) {
   std::vector<at::Tensor> tensors;
   tensors.reserve(values.size());
   for (auto& value : values) {
-    tensors.emplace_back(value.toTensor());
+    tensors.emplace_back(std::move(value).toTensor());
   }
   return SerializedPyObj(std::move(payload), std::move(tensors));
 }


### PR DESCRIPTION
Follows #136439. A dangling reference to qualifiedName was found and fixed.


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o