### PR TITLE
[AOTAutogradCache] Log time taken_ns

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -11,7 +11,7 @@ import pickle
 import shutil
 import time
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
 from torch._dynamo.utils import counters, get_chromium_event_logger
@@ -39,7 +39,7 @@ from .runtime_wrappers import (
     RuntimeWrapper,
     SubclassMeta,
 )
-from .schemas import AOTConfig, ViewAndMutationMeta  # noqa: F401
+from .schemas import AOTAutogradCacheInfo, AOTConfig, ViewAndMutationMeta  # noqa: F401
 
 
 if TYPE_CHECKING:
@@ -343,6 +343,12 @@ class AOTAutogradCacheEntry:
     # Used by RuntimeWrapepr
     indices_of_inps_to_detach: List[int]
 
+    # Time taken to trace/compile the forward
+    # forward_time_taken includes AOTAutograd tracing time + inductor compilation time
+    # backward_time_taken is essentially just the time inductor took to compile
+    forward_time_taken_ns: int
+    backward_time_taken_ns: int
+
     # Turn cache entry into the original callable
     def wrap_post_compile(
         self,
@@ -489,6 +495,7 @@ class AOTAutogradCache:
         """
         gm = mod.gm if isinstance(mod, torch._dynamo.utils.GmWrapper) else mod
         compiled_fn = None
+        cache_info: Dict[str, Any] = {}
         cache_key = None
         debug_lines: List[str] = []
         cache_event_time = time.time_ns()
@@ -503,6 +510,15 @@ class AOTAutogradCache:
                 counters["aot_autograd"]["autograd_cache_hit"] += 1
                 cache_state = "hit"
                 cache_event_time = time.time_ns()
+                forward_time_saved = entry.forward_time_taken_ns // 1e6
+                backward_time_saved = entry.backward_time_taken_ns // 1e6
+                cache_info.update(
+                    {
+                        "forward_time_saved_ms": forward_time_saved,
+                        "backward_time_saved_ms": backward_time_saved,
+                        "time_saved_ms": forward_time_saved + backward_time_saved,
+                    }
+                )
             if compiled_fn is None:
                 log.info("AOTAutograd cache miss for key %s", cache_key)
                 counters["aot_autograd"]["autograd_cache_miss"] += 1
@@ -525,16 +541,19 @@ class AOTAutogradCache:
                 raise e
         if compiled_fn is None:
             # Set the cache key so we can save a cache result later
-            aot_config.cache_key = cache_key
+            if cache_key is not None:
+                aot_config.cache_info = AOTAutogradCacheInfo(cache_key, time.time_ns())
             compiled_fn = dispatch_and_compile()
-        cache_args = {
-            "key": cache_key,
-            "cache_state": cache_state,
-            "components": debug_lines,
-        }
+        cache_info.update(
+            {
+                "key": cache_key,
+                "cache_state": cache_state,
+                "components": debug_lines,
+            }
+        )
         chromium_log = get_chromium_event_logger()
         chromium_log.log_instant_event(
-            f"autograd_cache_{cache_state}", cache_event_time, metadata=cache_args
+            f"autograd_cache_{cache_state}", cache_event_time, metadata=cache_info
         )
         torch._logging.trace_structured(
             "artifact",
@@ -542,7 +561,7 @@ class AOTAutogradCache:
                 "name": "aotautograd_cache_hash",
                 "encoding": "json",
             },
-            payload_fn=lambda: json.dumps(cache_args),
+            payload_fn=lambda: json.dumps(cache_info),
         )
         return compiled_fn
 

--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -11,6 +11,7 @@ An aot_dispatch_* function:
 
 import itertools
 import logging
+import time
 import traceback
 from contextlib import nullcontext
 from typing import Any, Callable, List, Optional, Sequence, Tuple
@@ -193,9 +194,10 @@ def aot_dispatch_base(
     compiled_fw = functionalized_rng_wrapper.post_compile(
         compiled_fw, aot_config, runtime_metadata=fw_metadata
     )
-
-    if config.enable_autograd_cache and aot_config.cache_key:
+    cache_info = aot_config.cache_info
+    if config.enable_autograd_cache and cache_info:
         if fw_key := getattr(compiled_fw, "_fx_graph_cache_key", None):
+            time_taken_ns = time.time_ns() - cache_info.start_time_ns
             entry = AOTAutogradCacheEntry(
                 compiled_fw=CompiledForward(fw_key),
                 compiled_bw=None,
@@ -204,8 +206,10 @@ def aot_dispatch_base(
                 maybe_subclass_meta=maybe_subclass_meta,
                 num_fw_outs_saved_for_bw=None,
                 indices_of_inps_to_detach=[],
+                forward_time_taken_ns=time_taken_ns,
+                backward_time_taken_ns=0,
             )
-            AOTAutogradCache.save(aot_config.cache_key, entry)
+            AOTAutogradCache.save(cache_info.cache_key, entry)
 
     compiled_fw = fakified_out_wrapper.post_compile(
         compiled_fw,
@@ -731,12 +735,29 @@ def aot_dispatch_autograd(
     make_runtime_safe(fw_metadata, maybe_subclass_meta)
 
     try_save_cache_entry: Optional[Callable] = None
-    if config.enable_autograd_cache:
 
-        def try_save_cache_entry(compiled_bw_func, _fw_metadata):  # noqa: F811
+    if config.enable_autograd_cache:
+        cache_info = aot_config.cache_info
+        if cache_info is not None:
+            forward_time_taken_ns = time.time_ns() - cache_info.start_time_ns
+        else:
+            forward_time_taken_ns = None
+
+        def try_save_cache_entry(  # noqa: F811
+            compiled_bw_func, _fw_metadata, aot_config
+        ):
             fw_key = getattr(compiled_fw_func, "_fx_graph_cache_key", None)
             bw_key = getattr(compiled_bw_func, "_fx_graph_cache_key", None)
-            if aot_config.cache_key and fw_key and bw_key:
+            cache_info = aot_config.cache_info
+            if cache_info is not None and fw_key and bw_key:
+                assert forward_time_taken_ns is not None
+                # TODO: technically, AOTAutograd does a *little* bit of post processing work
+                # in the backward that isn't measured here. But it's small enough that it's not worth
+                # the complexity of threading a bunch of times through the code, so we
+                # use the compiled_bw_func's inductor compile time instead.
+                # It's possible this changes in the future, in which case we should
+                # update backward_time_taken_ns to be more inclusive
+                backward_time_taken_ns = getattr(compiled_bw_func, "_time_taken_ns", 0)
                 entry = AOTAutogradCacheEntry(
                     CompiledForward(fw_key),
                     CompiledBackward(
@@ -747,12 +768,14 @@ def aot_dispatch_autograd(
                     maybe_subclass_meta,
                     num_fw_outs_saved_for_bw,
                     _indices_of_inps_to_detach,
+                    forward_time_taken_ns,
+                    backward_time_taken_ns,
                 )
-                AOTAutogradCache.save(aot_config.cache_key, entry)
+                AOTAutogradCache.save(cache_info.cache_key, entry)
 
         if compiled_bw_func is not None:
             # If we already compiled it we can just run it right now without waiting
-            try_save_cache_entry(compiled_bw_func, fw_metadata)
+            try_save_cache_entry(compiled_bw_func, fw_metadata, aot_config)
             try_save_cache_entry = None
 
     compiled_fn = AOTDispatchAutograd.post_compile(

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1957,7 +1957,9 @@ To fix this, your tensor subclass must implement the dunder method __force_to_sa
                             # Maybe save cache entry
                             if try_save_cache_entry is not None:
                                 try_save_cache_entry(
-                                    CompiledFunction.compiled_bw, fw_metadata
+                                    CompiledFunction.compiled_bw,
+                                    fw_metadata,
+                                    aot_config,
                                 )
 
                     if (

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -797,6 +797,12 @@ class GraphSignature:
 
 
 @dataclass
+class AOTAutogradCacheInfo:
+    cache_key: str
+    start_time_ns: int
+
+
+@dataclass
 class AOTConfig:
     """
     Configuration for AOTDispatcher
@@ -818,9 +824,8 @@ class AOTConfig:
     enable_log: bool = True
     # this is always false outside of export.
     pre_dispatch: bool = False
-
     # Key to use for AOTAutogradCache
-    cache_key: Optional[str] = None
+    cache_info: Optional[AOTAutogradCacheInfo] = None
 
     def __post_init__(self):
         if self.pre_dispatch:

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1054,7 +1054,7 @@ def aot_module_simplified(
         static_input_indices=static_input_indices,
         is_export=False,
         no_tangents=False,
-        cache_key=None,
+        cache_info=None,
     )
     fake_mode, shape_env = construct_fake_mode(full_args, aot_config)
     fake_flat_args = process_inputs(full_args, aot_config, fake_mode, shape_env)


### PR DESCRIPTION
Summary:
This diff logs the time_taken_ns for the forward and backward graphs in AOTAutogradCache, saving it into the cache entry. 

This information is helpful later when I remotify the cache, and also is just useful to have in tlparse and chromium events.

Test Plan: Run benchmark, see that the times are in the chromium events.

Reviewed By: aorenste

Differential Revision: D62590077


