### PR TITLE
[inductor][memory] add signpost event for memory pass

### DIFF
--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -556,7 +556,6 @@ def reorder_for_peak_memory(
         except Exception as e:
             torch_log.error("Failed to reorder for %s: %s", method.__name__, e)
 
-    # logging to scuba table (fb internal)
     signpost_event(
         category="inductor",
         name="memory",

--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -536,7 +536,7 @@ def reorder_for_peak_memory(
     peak_memory_diff_methods.append(
         PeakMemoryResult(nodes, estimated_peak_memory, "baseline")
     )
-    torch_log.warning("Baseline peak memory: %d", estimated_peak_memory)
+    torch_log.info("Baseline peak memory: %d", estimated_peak_memory)
 
     # other methods
     for method in methods:
@@ -552,7 +552,7 @@ def reorder_for_peak_memory(
             peak_memory_diff_methods.append(
                 PeakMemoryResult(order, peak_memory, method.__name__)
             )
-            torch_log.warning("%s peak memory: %d", method.__name__, peak_memory)
+            torch_log.info("%s peak memory: %d", method.__name__, peak_memory)
         except Exception as e:
             torch_log.error("Failed to reorder for %s: %s", method.__name__, e)
 


### PR DESCRIPTION
Add logging to scuba table for internal models. 

For verification, I triggered a sample workflow internally and checked the scuba table logging to make sure the `Paramaters` column has the expected loggings, see [here](https://fburl.com/scuba/workflow_signpost/39h7qo9s). 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang