### PR TITLE
[mha] Disable native_mha(fast_path) in dynamo compilation

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1287,6 +1287,8 @@ class MultiheadAttention(Module):
                 why_not_fast_path = "some Tensor argument has_torch_function"
             elif _is_make_fx_tracing():
                 why_not_fast_path = "we are running make_fx tracing"
+            elif torch._dynamo.is_compiling():
+                why_not_fast_path = "we are running dynamo tracing"
             elif not all(_check_arg_device(x) for x in tensor_args):
                 why_not_fast_path = (
                     "some Tensor argument's device is neither one of "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136542

mha_fastpath has already check `has_torch_functions` which is False for AO subclasses during dynamo compilation.

As a result AO subclasses fail with NYI on native_mha_attention.

If this path is only supposed to be used in eager, lets disable it for compilation.
E.g. https://github.com/pytorch/ao/issues/898

```
python tutorials/quantize_vit/run_vit_b_quant.py
```
