### PR TITLE
Don't actually import module when checking if its valid

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import functools
 import hashlib
+import importlib.util
 import itertools
 import json
 import logging
@@ -13,7 +14,6 @@ import tempfile
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from importlib import __import__
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from weakref import WeakSet
 
@@ -724,11 +724,8 @@ def _parse_log_settings(settings):
 
 
 def _is_valid_module(qname):
-    try:
-        __import__(qname)
-        return True
-    except ImportError:
-        return False
+    spec = importlib.util.find_spec(qname)
+    return spec is not None
 
 
 def _update_log_state_from_env():


### PR DESCRIPTION
Summary: If you actually import the module, you might end up with some import cycle situation where a module is imported too early and accesses things that are not initialized yet.

Test Plan:
sandcastle and ossci

```
TORCH_LOGS=+torch._inductor.codecache buck run mode/opt caffe2/benchmarks/dynamo:torchbench
```

Differential Revision: D63330224
