### PR TITLE
Enable failing diffs on regression

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -401,7 +401,7 @@ pr_time_benchmarks() {
 
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
-  PYTHONPATH=$(pwd)/benchmarks/dynamo/pr_time_benchmarks source benchmarks/dynamo/pr_time_benchmarks/benchmark_runner.sh "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv" "benchmarks/dynamo/pr_time_benchmarks/benchmarks"
+  PR_TIME_BENCHMARKS_TEST=1 PYTHONPATH=$(pwd)/benchmarks/dynamo/pr_time_benchmarks source benchmarks/dynamo/pr_time_benchmarks/benchmark_runner.sh "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv" "benchmarks/dynamo/pr_time_benchmarks/benchmarks"
   echo "benchmark results on current PR: "
   cat  "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv"
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -404,7 +404,7 @@ pr_time_benchmarks() {
   PYTHONPATH=$(pwd)/benchmarks/dynamo/pr_time_benchmarks source benchmarks/dynamo/pr_time_benchmarks/benchmark_runner.sh "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv" "benchmarks/dynamo/pr_time_benchmarks/benchmarks"
   echo "benchmark results on current PR: "
   cat  "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv"
-  PYTHONPATH=$(pwd)/benchmarks/dynamo/pr_time_benchmarks python benchmarks/dynamo/pr_time_benchmarks/benchmark_runner/check_results.py "benchmarks/dynamo/pr_time_benchmarks/expected_results.csv" "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv"
+  PYTHONPATH=$(pwd)/benchmarks/dynamo/pr_time_benchmarks python benchmarks/dynamo/pr_time_benchmarks/check_results.py "benchmarks/dynamo/pr_time_benchmarks/expected_results.csv" "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv"
 }
 
 if [[ "${TEST_CONFIG}" == *pr_time_benchmarks* ]]; then

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -401,10 +401,10 @@ pr_time_benchmarks() {
 
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
-  PR_TIME_BENCHMARKS_TEST=1 PYTHONPATH=$(pwd)/benchmarks/dynamo/pr_time_benchmarks source benchmarks/dynamo/pr_time_benchmarks/benchmark_runner.sh "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv" "benchmarks/dynamo/pr_time_benchmarks/benchmarks"
+  PYTHONPATH=$(pwd)/benchmarks/dynamo/pr_time_benchmarks source benchmarks/dynamo/pr_time_benchmarks/benchmark_runner.sh "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv" "benchmarks/dynamo/pr_time_benchmarks/benchmarks"
   echo "benchmark results on current PR: "
   cat  "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv"
-
+  PYTHONPATH=$(pwd)/benchmarks/dynamo/pr_time_benchmarks python benchmarks/dynamo/pr_time_benchmarks/benchmark_runner/check_results.py "benchmarks/dynamo/pr_time_benchmarks/expected_results.csv" "$TEST_REPORTS_DIR/pr_time_benchmarks_results.csv"
 }
 
 if [[ "${TEST_CONFIG}" == *pr_time_benchmarks* ]]; then

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -118,7 +118,7 @@ class BenchmarkBase(ABC):
 
     def _verify_instruction_count(self, result):
         if not compare_results_with_expected:
-            return 
+            return
 
         def log(event_name):
             scribe.open_source_signpost(

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -61,18 +61,17 @@ compare_results_with_expected = os.environ.get("PR_TIME_BENCHMARKS_TEST", "1") =
 
 
 class BenchmarkBase(ABC):
-    # measure total number of instruction spent in _work.
-    # Garbage collection is NOT disabled during the work.
+    # Measure total number of instruction spent in _work.
+    # Garbage collection is NOT disabled during _work().
     _enable_instruction_count = False
 
-    # measure total number of instruction spent in convert_frame.compile_inner
-    # Garbage collection is disabled during the work function to avoid noise.
-    # TODO is there other parts we need to add ?
+    # Measure total number of instruction spent in convert_frame.compile_inner
+    # Garbage collection is disabled during _work() to avoid noise.
     _enable_compile_time_instruction_count = False
 
     # A pair of (expected, noise_margin) to compare with the actual instruction count.
-    # margin is a percentage that represent acceptable noise margin.
-    # for example(100, 0.1(10%)) means the actual instruction count should be between 90 and 110.
+    # Margin is a percentage that represent acceptable noise margin.
+    # For example(100, 0.1(10%)) means that the actual instruction count should be between 90 and 110.
 
     # The same variable is used for both instruction_count and compile_time_instruction_count
     # because we do not allow both of them to be enabled at the same time now since they both log to the same scuba field.

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -62,14 +62,6 @@ class BenchmarkBase(ABC):
     # Garbage collection is disabled during _work() to avoid noise.
     _enable_compile_time_instruction_count = False
 
-    # A pair of (expected, noise_margin) to compare with the actual instruction count.
-    # Margin is a percentage that represent acceptable noise margin.
-    # For example(100, 0.1(10%)) means that the actual instruction count should be between 90 and 110.
-
-    # The same variable is used for both instruction_count and compile_time_instruction_count
-    # because we do not allow both of them to be enabled at the same time now since they both log to the same scuba field.
-    _expected_instruction_count_result = None
-
     # number of iterations used to run when collecting instruction_count or compile_time_instruction_count.
     _num_iterations = 5
 
@@ -110,7 +102,6 @@ class BenchmarkBase(ABC):
             id = i_counter.start()
             self._work()
             count = i_counter.end(id)
-
             print(f"instruction count for iteration {i} is {count}")
             results.append(count)
         return min(results)
@@ -173,7 +164,6 @@ class BenchmarkBase(ABC):
                 name=self.name(),
                 instruction_count=r,
             )
-
         if self._enable_compile_time_instruction_count:
             r = self._count_compile_time_instructions()
 

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -57,7 +57,11 @@ struct TorchBenchmarkCompileTimeLogEntry {
 
 # This is enabled only for OSS runs, we always run on the same machine, when running locally
 # expected values are different so by default this is not enabled.
+<<<<<<< HEAD
 compare_results_with_expected = os.environ.get("PR_TIME_BENCHMARKS_TEST", "0") == "1"
+=======
+compare_results_with_expected = os.environ.get("PR_TIME_BENCHMARKS_TEST", "1") == "1"
+>>>>>>> 6e74d64ebac (enable failing diffs on regression)
 
 
 class BenchmarkBase(ABC):
@@ -147,7 +151,11 @@ if this is an expected regression, please update the expected instruction count 
         if result < low:
             print(
                 f"**WIN** benchmark {self.name()} failed, \
+<<<<<<< HEAD
 actual instruction count {result} is lower than expected {expected} with noise margin {noise_margin} \
+=======
+actual instruction count {result} is lower than expected {expected} with noise margin {noise_margin}\
+>>>>>>> 6e74d64ebac (enable failing diffs on regression)
 please update the expected instruction count in the benchmark",
             )
             # if the test is by passed

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -163,7 +163,6 @@ please update the expected instruction count in the benchmark",
             count = i_counter.end(id)
 
             print(f"instruction count for iteration {i} is {count}")
-            self._verify_instruction_count(count)
             results.append(count)
         return min(results)
 
@@ -189,7 +188,6 @@ please update the expected instruction count in the benchmark",
                     )
                 print(f"compile time instruction count for iteration {i} is {count}")
                 results.append(count)
-                self._verify_instruction_count(count)
 
             config.record_compile_time_instruction_count = False
             return min(results)
@@ -226,6 +224,8 @@ please update the expected instruction count in the benchmark",
                 name=self.name(),
                 instruction_count=r,
             )
+            self._verify_instruction_count(r)
+
         if self._enable_compile_time_instruction_count:
             r = self._count_compile_time_instructions()
 
@@ -241,4 +241,5 @@ please update the expected instruction count in the benchmark",
                 name=self.name(),
                 instruction_count=r,
             )
+            self._verify_instruction_count(r)
         return self

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -130,18 +130,20 @@ class BenchmarkBase(ABC):
 
         if result > high:
             print(
-                f"**REGRESSION** benchmark {self.name()} failed, actual instruction count {result} is higher than expected {expected} with noise margin {noise_margin}\n",
-                "if this is an expected regression, please update the expected instruction count in the benchmark"
+                f"**REGRESSION** benchmark {self.name()} failed, actual instruction count {result} is higher than expected \
+{expected} with noise margin {noise_margin} \
+if this is an expected regression, please update the expected instruction count in the benchmark.",
             )
-        
+
             log("instruction_count_test_fail_regression")
 
         if result < low:
             print(
-                f"**WIN** benchmark {self.name()} failed, actual instruction count {result} is lower than expected {expected} with noise margin {noise_margin}\n",
-                "please update the expected instruction count in the benchmark"
+                f"**WIN** benchmark {self.name()} failed, actual instruction count {result} is lower than expected {expected} \
+with noise margin {noise_margin} \
+please update the expected instruction count in the benchmark.",
             )
-            # if the test is by passed 
+            # if the test is by passed
             log("instruction_count_test_fail_win")
 
     def _count_instructions(self):
@@ -152,9 +154,8 @@ class BenchmarkBase(ABC):
             id = i_counter.start()
             self._work()
             count = i_counter.end(id)
-            
+
             print(f"instruction count for iteration {i} is {count}")
-            self._verify_instruction_count(count)
             results.append(count)
         return min(results)
 
@@ -180,7 +181,6 @@ class BenchmarkBase(ABC):
                     )
                 print(f"compile time instruction count for iteration {i} is {count}")
                 results.append(count)
-                self._verify_instruction_count(count)
 
             config.record_compile_time_instruction_count = False
             return min(results)
@@ -217,6 +217,7 @@ class BenchmarkBase(ABC):
                 name=self.name(),
                 instruction_count=r,
             )
+            self._verify_instruction_count(r)
         if self._enable_compile_time_instruction_count:
             r = self._count_compile_time_instructions()
 
@@ -232,4 +233,6 @@ class BenchmarkBase(ABC):
                 name=self.name(),
                 instruction_count=r,
             )
+            self._verify_instruction_count(r)
+
         return self

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -1,11 +1,13 @@
 import csv
 import gc
+import json
 from abc import ABC, abstractmethod
 
 from fbscribelogger import make_scribe_logger
 
 import torch._C._instruction_counter as i_counter
 import torch._dynamo.config as config
+import torch._logging.scribe as scribe
 from torch._dynamo.utils import CompileTimeInstructionCounter
 
 
@@ -55,11 +57,21 @@ struct TorchBenchmarkCompileTimeLogEntry {
 
 class BenchmarkBase(ABC):
     # measure total number of instruction spent in _work.
+    # Garbage collection is NOT disabled during the work.
     _enable_instruction_count = False
 
     # measure total number of instruction spent in convert_frame.compile_inner
+    # Garbage collection is disabled during the work function to avoid noise.
     # TODO is there other parts we need to add ?
     _enable_compile_time_instruction_count = False
+
+    # A pair of (expected, noise_margin) to compare with the actual instruction count.
+    # margin is a percentage that represent acceptable noise margin.
+    # for example(100, 0.1(10%)) means the actual instruction count should be between 90 and 110.
+
+    # The same variable is used for both instruction_count and compile_time_instruction_count
+    # because we do not allow both of them to be enabled at the same time now since they both log to the same scuba field.
+    _expected_instruction_count_result = None
 
     # number of iterations used to run when collecting instruction_count or compile_time_instruction_count.
     _num_iterations = 5
@@ -68,12 +80,19 @@ class BenchmarkBase(ABC):
         self._num_iterations = value
         return self
 
-    def enable_instruction_count(self):
+    def enable_instruction_count(self, expected=None, noise_margin=None):
         self._enable_instruction_count = True
+        if expected is not None:
+            assert noise_margin is not None
+            self._expected_instruction_count_result = (expected, noise_margin)
+
         return self
 
-    def enable_compile_time_instruction_count(self):
+    def enable_compile_time_instruction_count(self, expected=None, noise_margin=None):
         self._enable_compile_time_instruction_count = True
+        if expected is not None:
+            assert noise_margin is not None
+            self._expected_instruction_count_result = (expected, noise_margin)
         return self
 
     def name(self):
@@ -93,6 +112,38 @@ class BenchmarkBase(ABC):
     def _prepare_once(self):  # noqa: B027
         pass
 
+    def _verify_instruction_count(self, result):
+        def log(event_name):
+            scribe.open_source_signpost(
+                subsystem="pr_time_benchmarks",
+                name=event_name,
+                parameters=json.dumps(self.name()),
+            )
+
+        if self._expected_instruction_count_result is None:
+            log("instruction_count_disabled")
+            return
+
+        (expected, noise_margin) = self._expected_instruction_count_result
+        low = expected - expected * noise_margin
+        high = expected + expected * noise_margin
+
+        if result > high:
+            print(
+                f"**REGRESSION** benchmark {self.name()} failed, actual instruction count {result} is higher than expected {expected} with noise margin {noise_margin}\n",
+                "if this is an expected regression, please update the expected instruction count in the benchmark"
+            )
+        
+            log("instruction_count_test_fail_regression")
+
+        if result < low:
+            print(
+                f"**WIN** benchmark {self.name()} failed, actual instruction count {result} is lower than expected {expected} with noise margin {noise_margin}\n",
+                "please update the expected instruction count in the benchmark"
+            )
+            # if the test is by passed 
+            log("instruction_count_test_fail_win")
+
     def _count_instructions(self):
         print(f"collecting instruction count for {self.name()}")
         results = []
@@ -101,7 +152,9 @@ class BenchmarkBase(ABC):
             id = i_counter.start()
             self._work()
             count = i_counter.end(id)
+            
             print(f"instruction count for iteration {i} is {count}")
+            self._verify_instruction_count(count)
             results.append(count)
         return min(results)
 
@@ -127,6 +180,7 @@ class BenchmarkBase(ABC):
                     )
                 print(f"compile time instruction count for iteration {i} is {count}")
                 results.append(count)
+                self._verify_instruction_count(count)
 
             config.record_compile_time_instruction_count = False
             return min(results)

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -57,7 +57,7 @@ struct TorchBenchmarkCompileTimeLogEntry {
 
 # This is enabled only for OSS runs, we always run on the same machine, when running locally
 # expected values are different so by default this is not enabled.
-compare_results_with_expected = os.environ.get("PR_TIME_BENCHMARKS_TEST", "1") == "1"
+compare_results_with_expected = os.environ.get("PR_TIME_BENCHMARKS_TEST", "0") == "1"
 
 
 class BenchmarkBase(ABC):
@@ -118,7 +118,7 @@ class BenchmarkBase(ABC):
 
     def _verify_instruction_count(self, result):
         if not compare_results_with_expected:
-            return False
+            return 
 
         def log(event_name):
             scribe.open_source_signpost(
@@ -147,7 +147,7 @@ if this is an expected regression, please update the expected instruction count 
         if result < low:
             print(
                 f"**WIN** benchmark {self.name()} failed, \
-actual instruction count {result} is lower than expected {expected} with noise margin {noise_margin}\
+actual instruction count {result} is lower than expected {expected} with noise margin {noise_margin} \
 please update the expected instruction count in the benchmark",
             )
             # if the test is by passed

--- a/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmark_base.py
@@ -57,11 +57,7 @@ struct TorchBenchmarkCompileTimeLogEntry {
 
 # This is enabled only for OSS runs, we always run on the same machine, when running locally
 # expected values are different so by default this is not enabled.
-<<<<<<< HEAD
 compare_results_with_expected = os.environ.get("PR_TIME_BENCHMARKS_TEST", "0") == "1"
-=======
-compare_results_with_expected = os.environ.get("PR_TIME_BENCHMARKS_TEST", "1") == "1"
->>>>>>> 6e74d64ebac (enable failing diffs on regression)
 
 
 class BenchmarkBase(ABC):
@@ -151,11 +147,7 @@ if this is an expected regression, please update the expected instruction count 
         if result < low:
             print(
                 f"**WIN** benchmark {self.name()} failed, \
-<<<<<<< HEAD
 actual instruction count {result} is lower than expected {expected} with noise margin {noise_margin} \
-=======
-actual instruction count {result} is lower than expected {expected} with noise margin {noise_margin}\
->>>>>>> 6e74d64ebac (enable failing diffs on regression)
 please update the expected instruction count in the benchmark",
             )
             # if the test is by passed

--- a/benchmarks/dynamo/pr_time_benchmarks/check_results.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/check_results.py
@@ -42,8 +42,8 @@ def main():
         reader = csv.reader(f)
         for row in reader:
             entry = ExpectedFileEntry(
-                benchmark_name=row[0].strip(),
-                metric_name=row[1].strip(),
+                benchmark_name=row[0],
+                metric_name=row[1],
                 expected_value=int(row[2]),
                 noise_margin=float(row[3]),
             )
@@ -58,9 +58,7 @@ def main():
         reader = csv.reader(f)
         for row in reader:
             entry = ResultFileEntry(
-                benchmark_name=row[0].strip(),
-                metric_name=row[1].strip(),
-                actual_value=int(row[2]),
+                benchmark_name=row[0], metric_name=row[1], actual_value=int(row[2])
             )
 
             key = (entry.benchmark_name, entry.metric_name)

--- a/benchmarks/dynamo/pr_time_benchmarks/check_results.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/check_results.py
@@ -41,7 +41,6 @@ def main():
     with open(expected_file_path) as f:
         reader = csv.reader(f)
         for row in reader:
-            print(row)
             entry = ExpectedFileEntry(
                 benchmark_name=row[0],
                 metric_name=row[1],

--- a/benchmarks/dynamo/pr_time_benchmarks/check_results.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/check_results.py
@@ -42,8 +42,8 @@ def main():
         reader = csv.reader(f)
         for row in reader:
             entry = ExpectedFileEntry(
-                benchmark_name=row[0],
-                metric_name=row[1],
+                benchmark_name=row[0].strip(),
+                metric_name=row[1].strip(),
                 expected_value=int(row[2]),
                 noise_margin=float(row[3]),
             )
@@ -58,7 +58,9 @@ def main():
         reader = csv.reader(f)
         for row in reader:
             entry = ResultFileEntry(
-                benchmark_name=row[0], metric_name=row[1], actual_value=int(row[2])
+                benchmark_name=row[0].strip(),
+                metric_name=row[1].strip(),
+                actual_value=int(row[2]),
             )
 
             key = (entry.benchmark_name, entry.metric_name)

--- a/benchmarks/dynamo/pr_time_benchmarks/check_results.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/check_results.py
@@ -91,6 +91,7 @@ def main():
             )
 
         if result > high:
+            fail = True
             ratio = (float)(result - entry.expected_value) * 100 / entry.expected_value
             print(
                 f"REGRESSION: benchmark {key} failed, actual result {result} "
@@ -99,9 +100,9 @@ def main():
             )
 
             log("fail_regression")
-            fail = True
 
         if result < low:
+            fail = True
             ratio = (float)(entry.expected_value - result) * 100 / entry.expected_value
 
             print(

--- a/benchmarks/dynamo/pr_time_benchmarks/check_results.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/check_results.py
@@ -1,0 +1,139 @@
+import csv
+import json
+import sys
+from dataclasses import dataclass
+
+import torch._logging.scribe as scribe
+
+
+@dataclass
+class ExpectedFileEntry:
+    benchmark_name: str
+    metric_name: str
+    expected_value: int
+    noise_margin: float
+
+
+@dataclass
+class ResultFileEntry:
+    benchmark_name: str
+    metric_name: str
+    actual_value: int
+
+
+def main():
+    # Expected file is the file that have the results that we are comparing against.
+    # Expected has the following format:
+    # benchmark_name, metric name, expected value, noise margin (as percentage)
+    # Example:
+    # add_loop_eager,compile_time_instruction_count,283178305, 0.01 (1% noise margin)
+    expected_file_path = sys.argv[1]
+
+    # Result file is the file that have the results of the current run. It has the following format:
+    # benchmark_name, metric name, expected value, noise margin (as percentage)
+    # Example:
+    # add_loop_eager,compile_time_instruction_count,283178305
+    result_file_path = sys.argv[2]
+
+    # Read expected data file.
+    expected_data: dict[str, ExpectedFileEntry] = {}
+
+    with open(expected_file_path) as f:
+        reader = csv.reader(f)
+        for row in reader:
+            print(row)
+            entry = ExpectedFileEntry(
+                benchmark_name=row[0],
+                metric_name=row[1],
+                expected_value=int(row[2]),
+                noise_margin=float(row[3]),
+            )
+            key = (entry.benchmark_name, entry.metric_name)
+            assert key not in expected_data, f"Duplicate entry for {key}"
+            expected_data[key] = entry
+
+    # Read result data file.
+    result_data: dict[str, ResultFileEntry] = {}
+
+    with open(result_file_path) as f:
+        reader = csv.reader(f)
+        for row in reader:
+            entry = ResultFileEntry(
+                benchmark_name=row[0], metric_name=row[1], actual_value=int(row[2])
+            )
+
+            key = (entry.benchmark_name, entry.metric_name)
+            assert key not in result_data, f"Duplicate entry for {key}"
+            result_data[key] = entry
+
+    fail = False
+    for key, entry in expected_data.items():
+        if key not in result_data:
+            print(f"Missing entry for {key} in result file")
+            sys.exit(1)
+
+        low = entry.expected_value - entry.expected_value * entry.noise_margin
+        high = entry.expected_value + entry.expected_value * entry.noise_margin
+        result = result_data[key].actual_value
+
+        def log(event_name):
+            scribe.open_source_signpost(
+                subsystem="pr_time_benchmarks",
+                name=event_name,
+                parameters=json.dumps(
+                    {
+                        "benchmark_name": entry.benchmark_name,
+                        "metric_name": entry.metric_name,
+                        "actual_value": result,
+                        "expected_value": entry.expected_value,
+                        "noise_margin": entry.noise_margin,
+                    }
+                ),
+            )
+
+        if result > high:
+            ratio = (float)(result - entry.expected_value) * 100 / entry.expected_value
+            print(
+                f"REGRESSION: benchmark {key} failed, actual result {result} "
+                f"is {ratio:.2f}% higher than expected {entry.expected_value} ±{entry.noise_margin*100:.2f}% "
+                f"if this is an expected regression, please update the expected results."
+            )
+
+            log("fail_regression")
+            fail = True
+
+        if result < low:
+            ratio = (float)(entry.expected_value - result) * 100 / entry.expected_value
+
+            print(
+                f"WIN: benchmark {key} failed, actual result {result} is {ratio:.2f}% lower than "
+                f"expected {entry.expected_value} ±{entry.noise_margin*100:.2f}% "
+                f"please update the expected results."
+            )
+
+            log("fail_win")
+
+    # Log all benchmarks that do not have a regression test enabled for them.
+    for key, entry in result_data.items():
+        if key not in expected_data:
+            print(
+                f"MISSING REGRESSION TEST: benchmark {key} does not have a regression test enabled for it"
+            )
+            scribe.open_source_signpost(
+                subsystem="pr_time_benchmarks",
+                name="missing_regression_test",
+                parameters=json.dumps(
+                    {
+                        "benchmark_name": entry.benchmark_name,
+                        "metric_name": entry.metric_name,
+                    }
+                ),
+            )
+    if fail:
+        sys.exit(1)
+    else:
+        print("All benchmarks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/dynamo/pr_time_benchmarks/check_results.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/check_results.py
@@ -105,7 +105,7 @@ def main():
 
         if result < low:
             fail = True
-            ratio = (float)(entry.expected_value - result) * 100 / entry.expected_value
+            ratio = float(entry.expected_value - result) * 100 / entry.expected_value
 
             print(
                 f"WIN: benchmark {key} failed, actual result {result} is {ratio:.2f}% lower than "

--- a/benchmarks/dynamo/pr_time_benchmarks/check_results.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/check_results.py
@@ -94,7 +94,7 @@ def main():
 
         if result > high:
             fail = True
-            ratio = (float)(result - entry.expected_value) * 100 / entry.expected_value
+            ratio = float(result - entry.expected_value) * 100 / entry.expected_value
             print(
                 f"REGRESSION: benchmark {key} failed, actual result {result} "
                 f"is {ratio:.2f}% higher than expected {entry.expected_value} ±{entry.noise_margin*100:.2f}% "

--- a/benchmarks/dynamo/pr_time_benchmarks/test_check_result/expected_test.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/test_check_result/expected_test.csv
@@ -1,0 +1,3 @@
+a, instruction count, 110, 0.01
+b, memory, 100, 0.1
+c, something, 100, 0.1

--- a/benchmarks/dynamo/pr_time_benchmarks/test_check_result/result_test.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/test_check_result/result_test.csv
@@ -1,0 +1,4 @@
+a, instruction count, 90, 0.01
+b, memory, 200, 0.1
+c, something, 107, 0.1
+d, missing-test, 10

--- a/benchmarks/dynamo/pr_time_benchmarks/test_check_result/result_test.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/test_check_result/result_test.csv
@@ -1,4 +1,4 @@
 a, instruction count, 90
-b, memory, 200, 0.1
-c, something, 107, 0.1
+b, memory, 200
+c, something, 107
 d, missing-test, 10

--- a/benchmarks/dynamo/pr_time_benchmarks/test_check_result/result_test.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/test_check_result/result_test.csv
@@ -1,4 +1,4 @@
-a, instruction count, 90, 0.01
+a, instruction count, 90
 b, memory, 200, 0.1
 c, something, 107, 0.1
 d, missing-test, 10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136551
* #136383

1. example of failing diff
https://github.com/pytorch/pytorch/pull/136740

2. test this by running 
python check_results.py test_check_result/expected_test.csv   test_check_result/result_test.csv 

results
```
WIN: benchmark ('a', ' instruction count') failed, actual result 90 is 18.18% lower than expected 110 ±1.00% please update the expected results.
REGRESSION: benchmark ('b', ' memory') failed, actual result 200 is 100.00% higher than expected 100 ±10.00% if this is an expected regression, please update the expected results.
MISSING REGRESSION TEST: benchmark ('d', ' missing-test') does not have a regression test enabled for it
```
MISSING REGRESSION TEST does not fail but its logged. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec