### PR TITLE
[export] fix _get_non_persistent_buffers for duplicates

### DIFF
--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -827,7 +827,7 @@ def _get_non_persistent_buffers(mod: torch.nn.Module) -> Set[str]:
     Returns set of non-persistent buffers in a module and its submodules.
     """
     result = set()
-    for name, m in mod.named_modules():
+    for name, m in mod.named_modules(remove_duplicate=False):
         for b in m._non_persistent_buffers_set:
             result.add(f"{name}.{b}" if name else b)
     return result


### PR DESCRIPTION
Summary: Export's method _get_non_persistent_buffers doesn't check duplicate submodules, so we run into state_dict related issues if non-persistent buffers exist on shared submodules.

Test Plan: test_export

Differential Revision: D63332976


