### PR TITLE
[DTensor] Add shard method

### DIFF
--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -465,6 +465,46 @@ class DTensor(torch.Tensor):
             self, grad_placements
         )  # pyre-ignore[16]: autograd func
 
+    @staticmethod
+    def shard(
+        full_tensor: torch.Tensor,
+        placements: Sequence[Placement],
+        device_mesh: Optional[DeviceMesh] = None,
+    ) -> "DTensor":
+        """
+        Shards a full tensor based on indicated placements, and returns a
+        DTensor containing the shard.
+
+        Args:
+            full_tensor (torch.Tensor): the full tensor to be sharded.
+            placements (Sequence[:class:`Placement`]): the placements that
+                describes how to place the local tensor on DeviceMesh.
+            device_mesh (:class:`DeviceMesh`, optional): DeviceMesh to place the
+                DTensor.  Must have same dimension as the number of placements.
+                If not specified, would be retrieve from current context.
+
+        Returns:
+            A :class:`DTensor` object with the shard as its local tensor.
+
+        Examples:
+            >>> # xdoctest: +SKIP("need world_size and rank")
+            >>> device_mesh = dist.init_device_mesh("cuda", (world_size,))
+            >>> full_tensor = torch.arange(world_size, device=f"cuda:{rank}")
+            >>> placements = [Shard(1)]
+            >>> dtensor = DTensor.shard(full_tensor, placements, device_mesh)
+        """
+        device_mesh = device_mesh or _mesh_resources.get_current_mesh()
+
+        shape, offset = compute_local_shape_and_global_offset(
+            full_tensor.shape, device_mesh, placements
+        )
+        slices = [
+            slice(cur_offset, cur_offset + cur_shape)
+            for cur_shape, cur_offset in zip(shape, offset)
+        ]
+        local_tensor = full_tensor[slices]
+        return DTensor.from_local(local_tensor, device_mesh, placements)
+
     def redistribute(
         self,
         device_mesh: Optional[DeviceMesh] = None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136589

        Shards a full tensor based on indicated placements, and returns a
        DTensor containing the shard.

        Args:
            full_tensor (torch.Tensor): the full tensor to be sharded.
            placements (Sequence[:class:`Placement`]): the placements that
                describes how to place the local tensor on DeviceMesh.
            device_mesh (:class:`DeviceMesh`, optional): DeviceMesh to place the
                DTensor.  Must have same dimension as the number of placements.
                If not specified, would be retrieve from current context.

        Returns:
            A :class:`DTensor` object with the shard as its local tensor.

        Examples:
            >>> # xdoctest: +SKIP("need world_size and rank")
            >>> device_mesh = dist.init_device_mesh("cuda", (world_size,))
            >>> full_tensor = torch.arange(world_size, device=f"cuda:{rank}")
            >>> placements = [Shard(1)]
            >>> dtensor = DTensor.shard(full_tensor, placements, device_mesh)

### Use cases:

(i) Distributed state dict:
https://github.com/pytorch/pytorch/blob/9629835b1ccce8e72fc93bf95be13e3d53cb4871/torch/distributed/_state_dict_utils.py#L556-L569

(ii) torchchat:
Converting loaded checkpoint into DTensor:
https://github.com/pytorch/torchchat/blob/main/distributed/dtensor_utils.py#L31-L58

(iii) torchao:
Sharding quantized tensor:
https://github.com/pytorch/ao/pull/937

cc @XilunWu @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o