### PR TITLE
Fix bug in functional tensor decomp

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -450,7 +450,7 @@ def forward(self, x_1):
 
     def test_pre_dispatch_functionalization(self):
         def f(x):
-            a = FunctionalTensorMode(pre_dispatch=True)
+            a = FunctionalTensorMode(pre_dispatch=True, export=True)
             with a:
                 x_unwrapped = FunctionalTensor.to_functional(x)
                 y = torch.matmul(x_unwrapped, x_unwrapped)
@@ -475,7 +475,7 @@ def forward(self, x_1):
 
     def test_pre_dispatch_functionalization_view_op(self):
         def f(x):
-            a = FunctionalTensorMode(pre_dispatch=True)
+            a = FunctionalTensorMode(pre_dispatch=True, export=True)
             with a:
                 x_unwrapped = FunctionalTensor.to_functional(x)
                 y = torch.matmul(x_unwrapped, x_unwrapped)

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -418,16 +418,22 @@ class FunctionalTensorMode(TorchDispatchMode):
                 return True
 
             # If we are here, it means we are seeing functional composite op.
-            # For pre-dispatch IR or export inference IR, we wont' decompose them
-            if (self.export or self.pre_dispatch) and func._can_decompose():
-                if func.namespace not in ["aten", "prim"]:
-                    # TODO (tmanlaibaatar) check if the op is PT2 compliant
-                    warnings.warn(
-                        f"At pre-dispatch tracing, we assume that any custom op marked with "
-                        f"CompositeImplicitAutograd and have functional schema are safe to not decompose. "
-                        f"Found {func} to be one such op."
-                    )
-                return False
+            # For pre-dispatch IR, we don't want to decompose this op
+            # For post-dispatch IR, we do want to decompose this op. it is fine
+            # to decompose here even if you want to preserve a CIA in post-dispatch export
+            # because we already override decompose behaviour so it will do the
+            # right thing.
+            if self.export:
+                if self.pre_dispatch:
+                    # If it is CIA custom op, we warn that we are assuming this op is indeed functional.
+                    if func.namespace not in ["aten", "prim"] and func._can_decompose():
+                        warnings.warn(
+                            f"At pre-dispatch tracing, we assume that any custom op marked with "
+                            f"CompositeImplicitAutograd and have functional schema are safe to not decompose. "
+                            f"Found {func} to be one such op."
+                        )
+                    return False
+                return True
 
             # in normal torch.compile IR, we decompose functional composite ops
             return True


### PR DESCRIPTION
Summary: Previously we had a very bad bug where we don't allow any decomp on CIA. This never mattered before because we never had to actually push CIA decomp to Python key level in export.

Test Plan: CI

Differential Revision: D63363749
