### PR TITLE
[DeviceMesh] Remove set_device

### DIFF
--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -473,22 +473,6 @@ else:
                     f"Mesh should not be bigger than default world size {world_size}, but found {self.mesh.numel()} ranks!"
                 )
 
-            device_handle = _get_device_handle(self.device_type)
-            # TODO: if user want to pass pg_options, offer a way to do it
-            if not default_initialized and device_handle:
-                # automatically set the current cuda/cuda-like device base on num of gpu devices available in each host
-                # NOTE: This device selection would only work for homogeneous hardware.
-                num_devices_per_host = device_handle.device_count()
-                if (
-                    world_size > num_devices_per_host
-                    and world_size % num_devices_per_host != 0
-                ):
-                    raise RuntimeError(
-                        f"DeviceMesh only support homogeneous hardware, but found "
-                        f"{world_size} ranks and {num_devices_per_host} {self.device_type} devices!"
-                    )
-                device_handle.set_device(get_rank() % num_devices_per_host)
-
             return _get_default_group()
 
         def _init_process_groups(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #136615
* __->__ #136604

Setting device without user's awareness can lead to OOMs, hangs or data corruption. The setting being in library rather than user code can make debugging difficult.

I recommend not to provide such convenience. 

The convenience also should not come from guessing, i.e. `device_id = rank % num_devices_per_host`.

cc @XilunWu @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o