### PR TITLE
Fix comment posting permissions for check-labels.yml

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -30,6 +30,9 @@ concurrency:
 
 jobs:
   check-labels:
+    permissions:
+      contents: read
+      pull-requests: write
     name: Check labels
     if: github.repository_owner == 'pytorch'
     runs-on: linux.20_04.4x


### PR DESCRIPTION
Currently it fails with 

Error fetching https://api.github.com/repos/pytorch/pytorch/issues/136607/comments HTTP Error 403: Forbidden

(see https://github.com/pytorch/pytorch/actions/runs/11026434368/job/30622960113?pr=136607)
