### PR TITLE
[DeviceMesh] Respect user's device type in complimentary PG init

### DIFF
--- a/torch/_dynamo/variables/distributed.py
+++ b/torch/_dynamo/variables/distributed.py
@@ -237,7 +237,9 @@ class DeviceMeshVariable(DistributedVariable):
         if name == "get_group":
             return ConstantVariable.create(self.value.get_group())
         if name == "_get_or_create_default_group":
-            return ProcessGroupVariable(self.value._get_or_create_default_group())
+            return ProcessGroupVariable(
+                self.value._get_or_create_default_group(self.value.device_type)
+            )
         return super().call_method(tx, name, args, kwargs)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136615
* #136604

### Terminology
"Complimentary init" means:
`init_device_mesh` calls `init_process_group` on user's behalf, if user hasn't done so.

While a convenience feature (validity of which deserves more discussion), today's implementation is not "device neutral" -- in passing `"cuda:nccl,cpu:gloo"` to `init_process_group`. If the `device_type` passed to `init_device_mesh` is neither `cuda` nor `cpu`, then that setting become irrelevant.

### Changes
The PR did not remove the complimentary init fearing BC break. It tries to `init_process_group` with as much information as it can find:
(i) `device_type` provided by the user;
(ii) find a backend for the `device_type` from the `default_device_backend_map` in c10d. (If user registered a backend for a custom device, it would show up here too.)

If not enough info is found (e.g. we don't know what backend to use), it would frankly error out and ask user to call `init_process_group` explicitly.

cc @XilunWu @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec