### PR TITLE
Fix 136201-Compile with USE_CPP_CODE_COVERAGE=ON throw erros: use lld…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1161,6 +1161,8 @@ if(USE_CPP_CODE_COVERAGE)
     string(APPEND CMAKE_C_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
     string(APPEND CMAKE_CXX_FLAGS
            " -fprofile-instr-generate -fcoverage-mapping")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS
+          " -fuse-ld=lld")
   else()
     message(
       ERROR


### PR DESCRIPTION
I add linker options: " -fuse-ld=lld" to force clang using lld in the step of linking when USE_CPP_CODE_COVERAGE=ON with clang. 
Now I can compile it normally and use `tools/code_coverage/oss_coverage.py`

```
[----------] 7 tests from NNUtilsTest
[ RUN      ] NNUtilsTest.ClipGradNorm
[       OK ] NNUtilsTest.ClipGradNorm (5 ms)
[ RUN      ] NNUtilsTest.ClipGradNormErrorIfNonfinite
[       OK ] NNUtilsTest.ClipGradNormErrorIfNonfinite (574 ms)
[ RUN      ] NNUtilsTest.ClipGradValue
[       OK ] NNUtilsTest.ClipGradValue (0 ms)
[ RUN      ] NNUtilsTest.ConvertParameters
```

```
SUMMARY
covered: 135331
uncovered: 182242
percentage: 74.26%
```

Fixes #136201

