### PR TITLE
[export] fix lifted constants order for 0-input graphs

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6339,6 +6339,19 @@ def forward(self, x, b_t, y):
         ep = export(m, (inp,))
         self.assertEqual(ep.module()(torch.ones(4, 4)), m(torch.ones(4, 4)))
 
+    def test_double_lifted_constants(self):
+        class EmptyM(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self):
+                return (torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6]))
+
+        m = EmptyM()
+        ep = torch.export.export(m, ())
+        for out, real_out in zip(ep.module()(), m()):
+            self.assertTrue(torch.allclose(out, real_out))
+
     def test_trace_under_fake(self):
         class MyModule(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -146,7 +146,7 @@ def lift_constants_pass(
         tuple(node.meta["val"] for node in gm.graph.nodes if node.op == "placeholder")
     )
 
-    first_user_input_loc, first_user_input = 0, None
+    first_user_input_loc, first_user_input = 0, next(iter(gm.graph.nodes))
     for node in gm.graph.nodes:
         if node.op == "placeholder" and node.name in graph_signature.user_inputs:
             first_user_input = node


### PR DESCRIPTION
Summary:
With empty graphs, the `graph.inserting_before(first_user_input = None)` call turns into a `graph.inserting_after(root)` call, inverting the order of constant input nodes being inserted.

This fixes the issue by initializing to the first node in the graph (still valid if not a user input - only used for insertion).

Test Plan: test_export

Differential Revision: D63403514


