### PR TITLE
Do not XFAIL test_segfault in fbcode

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1508,7 +1508,7 @@ def xfailIfTorchDynamo(func):
 
 
 def xfailIfLinux(func):
-    return unittest.expectedFailure(func) if IS_LINUX and not TEST_WITH_ROCM else func
+    return unittest.expectedFailure(func) if IS_LINUX and not TEST_WITH_ROCM and not IS_FBCODE else func
 
 
 def skipIfTorchDynamo(msg="test doesn't currently work with dynamo"):


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/136252 silence the failure on OSS, but the test actually passed on fbcode [T202241133](https://www.internalfb.com/intern/tasks/?t=202241133)

cc @andrewkho @gokulavasan @SsnL @VitalyFedyunin @dzhulgakov