### PR TITLE
Update current maintainers

### DIFF
--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -34,8 +34,8 @@ NN APIs (torch.nn)
 ~~~~~~~~~~~~~~~~~~
 
 -  Mikayla Gawarecki (`mikaylagawarecki <https://github.com/mikaylagawarecki>`__)
--  Joel Schlosser (`jbschlosser <https://github.com/jbschlosser>`__)
 -  Alban Desmaison (`albanD <https://github.com/albanD>`__)
+-  Joel Schlosser (`jbschlosser <https://github.com/jbschlosser>`__)
 -  (emeritus) Greg Chanan (`gchanan <https://github.com/gchanan>`__)
 -  (emeritus) Soumith Chintala (`soumith <https://github.com/soumith>`__)
 -  (emeritus) Sam Gross (`colesbury <https://github.com/colesbury>`__)
@@ -54,17 +54,17 @@ Optimizers (torch.optim)
 Autograd (torch.autograd)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Edward Yang (`ezyang <https://github.com/ezyang>`__)
--  Alban Desmaison (`alband <https://github.com/alband>`__)
 -  Jeffrey Wan (`soulitzer <https://github.com/soulitzer>`__)
+-  Alban Desmaison (`alband <https://github.com/alband>`__)
+-  Edward Yang (`ezyang <https://github.com/ezyang>`__)
 -  (emeritus) Adam Paszke (`apaszke <https://github.com/apaszke>`__)
 
 TorchDynamo
 ~~~~~~~~~~~
 
+-  Animesh Jain (`anijain2305 <https://github.com/anijain2305>`__)
 -  Jason Ansel (`jansel <https://github.com/jansel>`__)
 -  Edward Yang (`ezyang <https://github.com/ezyang>`__)
--  Animesh Jain (`anijain2305 <https://github.com/anijain2305>`__)
 
 TorchInductor
 ~~~~~~~~~~~~~
@@ -82,8 +82,8 @@ Cudagraph Tree
 PT2 Dispatcher
 ~~~~~~~~~~~~~~
 
--  Richard Zou (`zou3519 <https://github.com/zou3519>`__)
 -  Brian Hirsh (`bdhirsh <https://github.com/bdhirsh>`__)
+-  Richard Zou (`zou3519 <https://github.com/zou3519>`__)
 -  Horace He (`Chillee <https://github.com/Chillee>`__)
 -  Edward Yang (`ezyang <https://github.com/ezyang>`__)
 
@@ -97,8 +97,8 @@ AOT Inductor (AOTI) & AOTI Runtime
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Bin Bao (`desertfire <https://github.com/desertfire>`__)
--  Yang Chen (`chenyang78 <https://github.com/chenyang78>`__)
 -  Angela Yi (`angelayi <https://github.com/angelayi>`__)
+-  Yang Chen (`chenyang78 <https://github.com/chenyang78>`__)
 
 Compilers (JIT / TorchScript / Package / Deploy)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -123,11 +123,11 @@ Distributions & RNG
 Distributed
 ~~~~~~~~~~~
 -  Will Constable (`wconstab <https://github.com/wconstab>`__)
+-  Howard Huang (`H-Huang <https://github.com/H-Huang>`__)
 -  Wanchao Liang (`wanchaol <https://github.com/wanchaol>`__)
--  Tristan Rice (`d4l3k <https://github.com/d4l3k>`__)
 -  Ke Wen (`kwen2501 <https://github.com/kwen2501>`__)
 -  Chien-Chin Huang (`fegin <https://github.com/fegin>`__)
--  Howard Huang (`H-Huang <https://github.com/H-Huang>`__)
+-  Tristan Rice (`d4l3k <https://github.com/d4l3k>`__)
 -  (emeritus) Shen Li (`mrshenli <https://github.com/mrshenli>`__)
 -  (emeritus) Pritam Damania (`pritamdamania87 <https://github.com/pritamdamania87>`__)
 -  (emeritus) Yanli Zhao (`zhaojuanmao <https://github.com/zhaojuanmao>`__)
@@ -167,11 +167,11 @@ Sparse (torch.sparse)
 NestedTensor (torch.nested)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Alban Desmaison (`albanD <https://github.com/albanD>`__)
+-  Joel Schlosser (`jbschlosser <https://github.com/jbschlosser>`__)
 -  Christian Puhrsch (`cpuhrsch <https://github.com/cpuhrsch>`__)
 -  Driss Guessous (`drisspg <https://github.com/drisspg>`__)
--  Joel Schlosser (`jbschlosser <https://github.com/jbschlosser>`__)
 -  Mikayla Gawarecki (`mikaylagawarecki <https://github.com/mikaylagawarecki>`__)
+-  Alban Desmaison (`albanD <https://github.com/albanD>`__)
 -  (emeritus) Natalia Gimelshein (`ngimel <https://github.com/ngimel>`__)
 
 MaskedTensor (torch.masked)
@@ -189,9 +189,9 @@ Fast Fourier Transform (torch.fft)
 MKLDNN
 ~~~~~~
 
+-  Xiaobing Zhang (`XiaobingSuper <https://github.com/XiaobingSuper>`__)
 -  Mingfei Ma (`mingfeima <https://github.com/mingfeima>`__)
 -  Jiong Gong (`jgong5 <https://github.com/jgong5>`__)
--  Xiaobing Zhang (`XiaobingSuper <https://github.com/XiaobingSuper>`__)
 -  (emeritus) Xiaoqiang Zheng (`zheng-xq <https://github.com/zheng-xq>`__)
 -  (emeritus) Sam Gross (`colesbury <https://github.com/colesbury>`__)
 -  (emeritus) Christian Puhrsch (`cpuhrsch <https://github.com/cpuhrsch>`__)
@@ -215,8 +215,8 @@ CUDA
 AMD/ROCm/HIP
 ~~~~~~~~~~~~
 
--  Jithun Nair (`jithunnair-amd <https://github.com/jithunnair-amd>`__)
 -  Jeff Daily (`jeffdaily <https://github.com/jeffdaily>`__)
+-  Jithun Nair (`jithunnair-amd <https://github.com/jithunnair-amd>`__)
 -  (emeritus) Junjie Bai (`bddppq <https://github.com/bddppq>`__)
 
 Build + CI
@@ -237,9 +237,6 @@ Build + CI
 Performance Tools
 ~~~~~~~~~~~~~~~~~
 
--  Shivam Raikundalia (`sraikund <https://github.com/sraikund>`__)
--  Adnan Aziz (`adnanaziz <https://github.com/adnanaziz>`__)
--  CK Luk (`ckluk <https://github.com/ckluk>`__)
 -  Taylor Robie (`robieta <https://github.com/robieta>`__)
 -  Xu Zhao (`xuzhao9 <https://github.com/xuzhao9>`__)
 -  (emeritus) Victor Bittorf (`bitfort <https://github.com/bitfort>`__)
@@ -290,7 +287,6 @@ Quantization (torch/ao)
 -  Mark Saroufim (`msaroufim <https://github.com/msaroufim>`__)
 -  Vasiliy Kuznetsov (`vkuzo <https://github.com/vkuzo>`__)
 -  Jerry Zhang (`jerryzh168 <https://github.com/jerryzh168>`__)
--  Supriya Rao (`supriyar <https://github.com/supriyar>`__)
 -  (emeritus) Zafar Takhirov (`z-a-f <https://github.com/z-a-f>`__)
 -  (emeritus) Raghuraman Krishnamoorthi (`raghuramank100 <https://github.com/raghuramank100>`__)
 
@@ -384,8 +380,8 @@ TorchAudio
 TorchRec
 ~~~~~~~~
 
--  Paul Zhang (`PaulZhang12 <https://github.com/PaulZhang12>`__)
 -  Colin Taylor (`colin2328 <https://github.com/colin2328>`__)
+-  Paul Zhang (`PaulZhang12 <https://github.com/PaulZhang12>`__)
 -  (emeritus) Dmytro Ivchenko (`divchenko <https://github.com/divchenko>`__)
 
 TorchX
@@ -410,16 +406,16 @@ ExecuTorch (Edge, Mobile)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Mergen Nachin (`mergennachin <https://github.com/mergennachin>`__)
--  Martin Yuan (`iseeyuan <https://github.com/iseeyuan>`__)
 -  Kimish Patel (`kimishpatel <https://github.com/kimishpatel>`__)
 -  Dave Bort (`dbort <https://github.com/dbort>`__)
+-  Martin Yuan (`iseeyuan <https://github.com/iseeyuan>`__)
 
 TorchTune
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+-  Kartikay Khandelwal (`kartikayk <https://github.com/kartikayk>`__)
 -  Evan Smothers (`ebsmothers <https://github.com/ebsmothers>`__)
 -  Joe Cummings (`joecummings <https://github.com/joecummings>`__)
--  Kartikay Khandelwal (`kartikayk <https://github.com/kartikayk>`__)
 
 TorchChat
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -432,5 +428,5 @@ TorchCodec
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Nicolas Hug (`nicolashug <https://github.com/nicolashug>`__)
--  Ahmad Sharif (`ahmads <https://github.com/ahmads>`__)
--  Scott Schneider (`scottas <https://github.com/scottas>`__)
+-  Ahmad Sharif (`ahmadsharif1 <https://github.com/ahmadsharif1>`__)
+-  Scott Schneider (`scotts <https://github.com/scotts>`__)

--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -33,19 +33,21 @@ Module-level maintainers
 NN APIs (torch.nn)
 ~~~~~~~~~~~~~~~~~~
 
--  Greg Chanan (`gchanan <https://github.com/gchanan>`__)
--  Soumith Chintala (`soumith <https://github.com/soumith>`__)
+-  Mikayla Gawarecki (`mikaylagawarecki <https://github.com/mikaylagawarecki>`__)
 -  Joel Schlosser (`jbschlosser <https://github.com/jbschlosser>`__)
 -  Alban Desmaison (`albanD <https://github.com/albanD>`__)
+-  (emeritus) Greg Chanan (`gchanan <https://github.com/gchanan>`__)
+-  (emeritus) Soumith Chintala (`soumith <https://github.com/soumith>`__)
 -  (emeritus) Sam Gross (`colesbury <https://github.com/colesbury>`__)
 -  (emeritus) Adam Paszke (`apaszke <https://github.com/apaszke>`__)
 
 Optimizers (torch.optim)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+-  Jane Xu (`janeyx99 <https://github.com/janeyx99>`__)
 -  Alban Desmaison (`albanD <https://github.com/albanD>`__)
 -  Joel Schlosser (`jbschlosser <https://github.com/jbschlosser>`__)
--  Soumith Chintala (`soumith <https://github.com/soumith>`__)
+-  (emeritus) Soumith Chintala (`soumith <https://github.com/soumith>`__)
 -  (emeritus) Ilqar Ramazanli (`iramazanli <https://github.com/iramazanli>`__)
 -  (emeritus) Vincent Quenneville-Belair (`vincentqb <https://github.com/vincentqb>`__)
 
@@ -57,15 +59,56 @@ Autograd (torch.autograd)
 -  Jeffrey Wan (`soulitzer <https://github.com/soulitzer>`__)
 -  (emeritus) Adam Paszke (`apaszke <https://github.com/apaszke>`__)
 
-Compilers (JIT / TorchScript / FX / TorchDynamo)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+TorchDynamo
+~~~~~~~~~~~
+
+-  Jason Ansel (`jansel <https://github.com/jansel>`__)
+-  Edward Yang (`ezyang <https://github.com/ezyang>`__)
+-  Animesh Jain (`anijain2305 <https://github.com/anijain2305>`__)
+
+TorchInductor
+~~~~~~~~~~~~~
 
 -  Elias Ellison (`eellison <https://github.com/eellison>`__)
--  Michael Suo (`suo <https://github.com/suo>`__)
--  Yanan Cao (`gmagogsfm <https://github.com/gmagogsfm>`__)
--  James Reed (`jamesr66a <https://github.com/jamesr66a>`__)
+-  Horace He (`Chillee <https://github.com/Chillee>`__)
+-  Shunting Zhang (`shunting314 <https://github.com/shunting314>`__)
 -  Jason Ansel (`jansel <https://github.com/jansel>`__)
--  Jiong Gong (`jgong5 <https://github.com/jgong5>`__)
+
+Cudagraph Tree
+~~~~~~~~~~~~~~
+
+-  Elias Ellison (`eellison <https://github.com/eellison>`__)
+
+PT2 Dispatcher
+~~~~~~~~~~~~~~
+
+-  Richard Zou (`zou3519 <https://github.com/zou3519>`__)
+-  Brian Hirsh (`bdhirsh <https://github.com/bdhirsh>`__)
+-  Horace He (`Chillee <https://github.com/Chillee>`__)
+-  Edward Yang (`ezyang <https://github.com/ezyang>`__)
+
+PT2 Export (torch.export)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Avik Chaudhuri (`avikchaudhuri <https://github.com/avikchaudhuri>`__)
+-  Yanan Cao (`gmagogsfm <https://github.com/gmagogsfm>`__)
+
+AOT Inductor (AOTI) & AOTI Runtime
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Bin Bao (`desertfire <https://github.com/desertfire>`__)
+-  Yang Chen (`chenyang78 <https://github.com/chenyang78>`__)
+-  Angela Yi (`angelayi <https://github.com/angelayi>`__)
+
+Compilers (JIT / TorchScript / Package / Deploy)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  (emeritus) Elias Ellison (`eellison <https://github.com/eellison>`__)
+-  (emeritus) Michael Suo (`suo <https://github.com/suo>`__)
+-  (emeritus) Yanan Cao (`gmagogsfm <https://github.com/gmagogsfm>`__)
+-  (emeritus) James Reed (`jamesr66a <https://github.com/jamesr66a>`__)
+-  (emeritus) Jason Ansel (`jansel <https://github.com/jansel>`__)
+-  (emeritus) Jiong Gong (`jgong5 <https://github.com/jgong5>`__)
 -  (emeritus) Zach Devito (`zdevito <https://github.com/zdevito>`__)
 
 
@@ -79,46 +122,47 @@ Distributions & RNG
 
 Distributed
 ~~~~~~~~~~~
-
--  Shen Li (`mrshenli <https://github.com/mrshenli>`__)
--  Pritam Damania (`pritamdamania87 <https://github.com/pritamdamania87>`__)
--  Yanli Zhao (`zhaojuanmao <https://github.com/zhaojuanmao>`__)
--  Rohan Varma (`rohan-varma <https://github.com/rohan-varma>`__)
+-  Will Constable (`wconstab <https://github.com/wconstab>`__)
 -  Wanchao Liang (`wanchaol <https://github.com/wanchaol>`__)
--  Junjie Wang (`fduwjj <https://github.com/fduwjj>`__)
--  Howard Huang (`H-Huang <https://github.com/H-Huang>`__)
 -  Tristan Rice (`d4l3k <https://github.com/d4l3k>`__)
--  Alisson Azzolini (`aazzolini <https://github.com/aazzolini>`__)
 -  Ke Wen (`kwen2501 <https://github.com/kwen2501>`__)
--  James Reed (`jamesr66a <https://github.com/jamesr66a>`__)
--  Kiuk Chung (`kiukchung <https://github.com/kiukchung>`__)
+-  Chien-Chin Huang (`fegin <https://github.com/fegin>`__)
+-  Howard Huang (`H-Huang <https://github.com/H-Huang>`__)
+-  (emeritus) Shen Li (`mrshenli <https://github.com/mrshenli>`__)
+-  (emeritus) Pritam Damania (`pritamdamania87 <https://github.com/pritamdamania87>`__)
+-  (emeritus) Yanli Zhao (`zhaojuanmao <https://github.com/zhaojuanmao>`__)
+-  (emeritus) Rohan Varma (`rohan-varma <https://github.com/rohan-varma>`__)
+-  (emeritus) Junjie Wang (`fduwjj <https://github.com/fduwjj>`__)
+-  (emeritus) Alisson Azzolini (`aazzolini <https://github.com/aazzolini>`__)
+-  (emeritus) James Reed (`jamesr66a <https://github.com/jamesr66a>`__)
+-  (emeritus) Kiuk Chung (`kiukchung <https://github.com/kiukchung>`__)
 -  (emeritus) Pieter Noordhuis (`pietern <https://github.com/pietern>`__)
 -  (emeritus) Mingzhe Li (`mingzhe09088 <https://github.com/mingzhe09088>`__)
 -  (emeritus) Omkar Salpekar (`osalpekar <https://github.com/osalpekar>`__)
 
-Multiprocessing and DataLoaders
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Multiprocessing
+~~~~~~~~~~~~~~~
 
--  Simon Wang (`SsnL <https://github.com/SsnL>`__)
+-  (emeritus) Simon Wang (`SsnL <https://github.com/SsnL>`__)
 -  (emeritus) Vitaly Fedyunin (`VitalyFedyunin <https://github.com/VitalyFedyunin>`__)
 -  (emeritus) Adam Paszke (`apaszke <https://github.com/apaszke>`__)
 
 Linear Algebra (torch.linalg)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Mike Ruberry (`mruberry <https://github.com/mruberry>`__)
 -  Mario Lezcano (`lezcano <https://github.com/lezcano>`__)
--  Ivan Yashchuk (`IvanYashchuk <https://github.com/IvanYashchuk>`__)
+-  (emeritus) Mike Ruberry (`mruberry <https://github.com/mruberry>`__)
+-  (emeritus) Ivan Yashchuk (`IvanYashchuk <https://github.com/IvanYashchuk>`__)
 -  (emeritus) Vishwak Srinivasan (`vishwakftw <https://github.com/vishwakftw>`__)
 
 Sparse (torch.sparse)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Pearu Peterson (`pearu <https://github.com/pearu>`__)
--  Nikita Vedeneev (`nikitaved <https://github.com/nikitaved>`__)
--  Ivan Yashchuk (`IvanYashchuk <https://github.com/IvanYashchuk>`__)
--  Christian Puhrsch (`cpuhrsch <https://github.com/cpuhrsch>`__)
--  Andrew James (`amjames <https://github.com/amjames>`__)
+-  (emeritus) Pearu Peterson (`pearu <https://github.com/pearu>`__)
+-  (emeritus) Nikita Vedeneev (`nikitaved <https://github.com/nikitaved>`__)
+-  (emeritus) Ivan Yashchuk (`IvanYashchuk <https://github.com/IvanYashchuk>`__)
+-  (emeritus) Christian Puhrsch (`cpuhrsch <https://github.com/cpuhrsch>`__)
+-  (emeritus) Andrew James (`amjames <https://github.com/amjames>`__)
 
 NestedTensor (torch.nested)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -128,7 +172,7 @@ NestedTensor (torch.nested)
 -  Driss Guessous (`drisspg <https://github.com/drisspg>`__)
 -  Joel Schlosser (`jbschlosser <https://github.com/jbschlosser>`__)
 -  Mikayla Gawarecki (`mikaylagawarecki <https://github.com/mikaylagawarecki>`__)
--  Natalia Gimelshein (`ngimel <https://github.com/ngimel>`__)
+-  (emeritus) Natalia Gimelshein (`ngimel <https://github.com/ngimel>`__)
 
 MaskedTensor (torch.masked)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -139,11 +183,11 @@ MaskedTensor (torch.masked)
 Fast Fourier Transform (torch.fft)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Mike Ruberry (`mruberry <https://github.com/mruberry>`__)
--  Peter Bell (`peterbell10 <https://github.com/peterbell10>`__)
+-  (emeritus) Mike Ruberry (`mruberry <https://github.com/mruberry>`__)
+-  (emeritus) Peter Bell (`peterbell10 <https://github.com/peterbell10>`__)
 
-CPU Performance (Torch Inductor / MKLDNN)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+MKLDNN
+~~~~~~
 
 -  Mingfei Ma (`mingfeima <https://github.com/mingfeima>`__)
 -  Jiong Gong (`jgong5 <https://github.com/jgong5>`__)
@@ -157,29 +201,20 @@ CPU Performance (Torch Inductor / MKLDNN)
 -  (emeritus) Vitaly Fedyunin (`VitalyFedyunin <https://github.com/VitalyFedyunin>`__)
 -  (emeritus) Jianhui Li (`Jianhui-Li <https://github.com/Jianhui-Li>`__)
 
-GPU Performance (Torch Inductor / Triton / CUDA)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+CUDA
+~~~~
 
 -  Natalia Gimelshein (`ngimel <https://github.com/ngimel>`__)
 -  Edward Yang (`ezyang <https://github.com/ezyang>`__)
 -  Piotr Bialecki (`ptrblck <https://github.com/ptrblck>`__)
 -  Christian Sarofeen (`csarofeen <https://github.com/csarofeen>`__)
--  Andrew Tulloch (`ajtulloch <https://github.com/ajtulloch>`__)
+-  (emeritus) Andrew Tulloch (`ajtulloch <https://github.com/ajtulloch>`__)
 -  (emeritus) Xiaoqiang Zheng (`zheng-xq <https://github.com/zheng-xq>`__)
-
-NVFuser
-~~~~~~~
-
--  Christian Sarofeen (`csarofeen <https://github.com/csarofeen>`__)
--  Alex Jann (`jjsjann123 <https://github.com/jjsjann123>`__)
--  Piotr Bialecki (`ptrblck <https://github.com/ptrblck>`__)
--  Natalia Gimelshein (`ngimel <https://github.com/ngimel>`__)
 
 
 AMD/ROCm/HIP
 ~~~~~~~~~~~~
 
--  Peng Sun (`sunway513 <https://github.com/sunway513>`__)
 -  Jithun Nair (`jithunnair-amd <https://github.com/jithunnair-amd>`__)
 -  Jeff Daily (`jeffdaily <https://github.com/jeffdaily>`__)
 -  (emeritus) Junjie Bai (`bddppq <https://github.com/bddppq>`__)
@@ -190,11 +225,11 @@ Build + CI
 -  Nikita Shulga (`malfet <https://github.com/malfet>`__)
 -  Eli Uriegas (`seemethere <https://github.com/seemethere>`__)
 -  Alban Desmaison (`alband <https://github.com/alband>`__)
--  Mikey Dagitses (`dagitses <https://github.com/dagitses>`__)
--  Omkar Salpekar (`osalpekar <https://github.com/osalpekar>`__)
--  Zain Rizvi (`ZainRizvi <https://github.com/ZainRizvi>`__)
--  Nirav Mehta (`mehtanirav <https://github.com/mehtanirav>`__)
 -  Andrey Talman (`atalman <https://github.com/atalman>`__)
+-  Zain Rizvi (`ZainRizvi <https://github.com/ZainRizvi>`__)
+-  (emeritys) Mikey Dagitses (`dagitses <https://github.com/dagitses>`__)
+-  (emeritys) Omkar Salpekar (`osalpekar <https://github.com/osalpekar>`__)
+-  (emeritys) Nirav Mehta (`mehtanirav <https://github.com/mehtanirav>`__)
 -  (emeritus) Zhuojie Zhou (`zhouzhuojie <https://github.com/zhouzhuojie>`__)
 -  (emeritus) Edward Yang (`ezyang <https://github.com/ezyang>`__)
 -  (emeritus) Karl Ostmo (`kostmo <https://github.com/kostmo>`__)
@@ -202,11 +237,11 @@ Build + CI
 Performance Tools
 ~~~~~~~~~~~~~~~~~
 
+-  Shivam Raikundalia (`sraikund <https://github.com/sraikund>`__)
 -  Adnan Aziz (`adnanaziz <https://github.com/adnanaziz>`__)
 -  CK Luk (`ckluk <https://github.com/ckluk>`__)
 -  Taylor Robie (`robieta <https://github.com/robieta>`__)
 -  Xu Zhao (`xuzhao9 <https://github.com/xuzhao9>`__)
--  Geeta Chauhan (`chauhang <https://github.com/chauhang>`__)
 -  (emeritus) Victor Bittorf (`bitfort <https://github.com/bitfort>`__)
 -  (emeritus) Gisle Dankel (`gdankel <https://github.com/gdankel>`__)
 -  (emeritus) Natalia Gimelshein (`ngimel <https://github.com/ngimel>`__)
@@ -215,7 +250,7 @@ Performance Tools
 C++ API
 ~~~~~~~
 
--  Joel Schlosser (`jbschlosser <https://github.com/jbschlosser>`__)
+-  (emeritus) Joel Schlosser (`jbschlosser <https://github.com/jbschlosser>`__)
 -  (emeritus) Will Feng (`yf225 <https://github.com/yf225>`__)
 
 C10 utils and operator dispatch
@@ -223,7 +258,7 @@ C10 utils and operator dispatch
 
 -  Brian Hirsh (`bdhirsh <https://github.com/bdhirsh>`__)
 -  Edward Yang (`ezyang <https://github.com/ezyang>`__)
--  Dmytro Dzhulgakov (`dzhulgakov <https://github.com/dzhulgakov>`__)
+-  (emeritus) Dmytro Dzhulgakov (`dzhulgakov <https://github.com/dzhulgakov>`__)
 -  (emeritus) Sebastian Messmer (`smessmer <https://github.com/smessmer>`__)
 
 ONNX exporter
@@ -241,16 +276,18 @@ ONNX exporter
 -  (emeritus) Negin Raoof (`neginraoof <https://github.com/neginraoof>`__)
 -  (emeritus) Spandan Tiwari (`spandantiwari <https://github.com/spandantiwari>`__)
 
-Mobile / Edge
-~~~~~~~~~~~~~
--  David Reiss (`dreiss <https://github.com/dreiss>`__)
--  Raziel Guevara (`raziel <https://github.com/raziel>`__)
--  Linbin Yu (`linbinyu <https://github.com/linbinyu>`__)
--  Ivan Kobzarev (`IvanKobzarev <https://github.com/IvanKobzarev>`__)
--  Tao Xu (`xta0 <https://github.com/xta0>`__)
+LiteInterpreter
+~~~~~~~~~~~~~~~
+-  (emeritus) David Reiss (`dreiss <https://github.com/dreiss>`__)
+-  (emeritus) Raziel Guevara (`raziel <https://github.com/raziel>`__)
+-  (emeritus) Linbin Yu (`linbinyu <https://github.com/linbinyu>`__)
+-  (emeritus) Ivan Kobzarev (`IvanKobzarev <https://github.com/IvanKobzarev>`__)
+-  (emeritus) Tao Xu (`xta0 <https://github.com/xta0>`__)
 
-Model Compression & Optimization
+Quantization (torch/ao)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Mark Saroufim (`msaroufim <https://github.com/msaroufim>`__)
 -  Vasiliy Kuznetsov (`vkuzo <https://github.com/vkuzo>`__)
 -  Jerry Zhang (`jerryzh168 <https://github.com/jerryzh168>`__)
 -  Supriya Rao (`supriyar <https://github.com/supriyar>`__)
@@ -265,13 +302,13 @@ Windows
 -  (emeritus) Teng Gao (`gaoteng-git <https://github.com/gaoteng-git>`__)
 -  (emeritus) Peter Johnson (`peterjc123 <https://github.com/peterjc123>`__)
 
-Apple M1/MPS
-~~~~~~~~~~~~
+Apple M1/MPS/Metal
+~~~~~~~~~~~~~~~~~~~~
 
+-  Kulin Seth (`kulinseth <https://github.com/kulinseth>`__)
 -  Alban Desmaison (`alband <https://github.com/alband>`__)
 -  Nikita Shulga (`malfet <https://github.com/malfet>`__)
--  Kulin Seth (`kulinseth <https://github.com/kulinseth>`__)
--  Ramin Azarmehr (`razarmehr <https://github.com/razarmehr>`__)
+-  (emeritus) Ramin Azarmehr (`razarmehr <https://github.com/razarmehr>`__)
 
 PowerPC
 ~~~~~~~
@@ -306,26 +343,29 @@ XLA
 TorchServe
 ~~~~~~~~~~
 
--  Geeta Chauhan (`chauhang <https://github.com/chauhang>`__)
--  Manoj Rao (`mycpuorg <https://github.com/mycpuorg>`__)
--  Vamshi Dantu (`vdantu <https://github.com/vdantu>`__)
--  Dhanasekar Karuppasamy (`dhanainme <https://github.com/dhanainme>`__)
+-  Li Ning (`lxning <https://github.com/lxning>`__)
+-  Ankith Gunapal (`agunapal <https://github.com/agunapal>`__)
+-  Hamid Shojanazeri (`HamidShojanazeri <https://github.com/HamidShojanazeri>`__)
+-  (emeritus) Mark Saroufim (`msaroufIm <https://github.com/msaroufIm>`__)
+-  (emeritus) Manoj Rao (`mycpuorg <https://github.com/mycpuorg>`__)
+-  (emeritus) Vamshi Dantu (`vdantu <https://github.com/vdantu>`__)
+-  (emeritus) Dhanasekar Karuppasamy (`dhanainme <https://github.com/dhanainme>`__)
 
 TorchVision
 ~~~~~~~~~~~
 
--  Francisco Massa (`fmassa <https://github.com/fmassa>`__)
--  Vasilis Vryniotis (`datumbox <https://github.com/datumbox>`__)
 -  Nicolas Hug (`NicolasHug <https://github.com/NicolasHug>`__)
--  Yosua Michael Maranatha (`YosuaMichael <https://github.com/YosuaMichael>`__)
--  Joao Gomes (`jdsgomes <https://github.com/jdsgomes>`__)
 -  Philip Meier (`pmeier <https://github.com/pmeier>`__)
 -  Victor Fomin (`vfdev-5 <https://github.com/vfdev-5>`__)
+-  (emeritus) Francisco Massa (`fmassa <https://github.com/fmassa>`__)
+-  (emeritus) Vasilis Vryniotis (`datumbox <https://github.com/datumbox>`__)
+-  (emeritus) Yosua Michael Maranatha (`YosuaMichael <https://github.com/YosuaMichael>`__)
+-  (emeritus) Joao Gomes (`jdsgomes <https://github.com/jdsgomes>`__)
 
 TorchText
 ~~~~~~~~~
 
--  Nayef Ahmed (`Nayef211 <https://github.com/Nayef211>`__)
+-  (emeritus) Nayef Ahmed (`Nayef211 <https://github.com/Nayef211>`__)
 -  (emeritus) Parmeet Singh Bhatia (`parmeet <https://github.com/parmeet>`__)
 -  (emeritus) Guanheng George Zhang (`zhangguanheng66 <https://github.com/zhangguanheng66>`__)
 -  (emeritus) Christian Puhrsch (`cpuhrsch <https://github.com/cpuhrsch>`__)
@@ -334,7 +374,7 @@ TorchAudio
 ~~~~~~~~~~
 
 -  Moto Hira (`mthrok <https://github.com/mthrok>`__)
--  Jeff Hwang (`hwangjeff <https://github.com/hwangjeff>`__)
+-  (emeritus) Jeff Hwang (`hwangjeff <https://github.com/hwangjeff>`__)
 -  (emeritus) Caroline Chen (`carolineechen <https://github.com/carolineechen>`__)
 -  (emeritus) Xiaohui Zhang (`xiaohui-zhang <https://github.com/xiaohui-zhang>`__)
 -  (emeritus) Zhaoheng Ni (`nateanl <https://github.com/nateanl>`__)
@@ -344,17 +384,53 @@ TorchAudio
 TorchRec
 ~~~~~~~~
 
--  Dmytro Ivchenko (`divchenko <https://github.com/divchenko>`__)
+-  Paul Zhang (`PaulZhang12 <https://github.com/PaulZhang12>`__)
 -  Colin Taylor (`colin2328 <https://github.com/colin2328>`__)
+-  (emeritus) Dmytro Ivchenko (`divchenko <https://github.com/divchenko>`__)
 
 TorchX
 ~~~~~~
 
--  Tristan Rice (`d4l3k <https://github.com/d4l3k>`__)
--  Kiuk Chung (`kiukchung <https://github.com/kiukchung>`__)
+-  (emeritus) Tristan Rice (`d4l3k <https://github.com/d4l3k>`__)
+-  (emeritus) Kiuk Chung (`kiukchung <https://github.com/kiukchung>`__)
 
-TorchData / TorchArrow
+TorchData
 ~~~~~~~~~~~~~~~~~~~~~~
 
--  Wenlei Xie (`wenleix <https://github.com/wenleix>`__)
+-  Andrew Ho (`andrewkho <https://github.com/andrewkho>`__)
+-  Divyansh Khanna (`divyanshk <https://github.com/divyanshk>`__)
+
+TorchArrow
+~~~~~~~~~~~~~~~~~~~~~~
+
+-  (emeritus) Wenlei Xie (`wenleix <https://github.com/wenleix>`__)
 -  (emeritus) Vitaly Fedyunin (`VitalyFedyunin <https://github.com/VitalyFedyunin>`__)
+
+ExecuTorch (Edge, Mobile)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Mergen Nachin (`mergennachin <https://github.com/mergennachin>`__)
+-  Martin Yuan (`iseeyuan <https://github.com/iseeyuan>`__)
+-  Kimish Patel (`kimishpatel <https://github.com/kimishpatel>`__)
+-  Dave Bort (`dbort <https://github.com/dbort>`__)
+
+TorchTune
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Evan Smothers (`ebsmothers <https://github.com/ebsmothers>`__)
+-  Joe Cummings (`joecummings <https://github.com/joecummings>`__)
+-  Kartikay Khandelwal (`kartikayk <https://github.com/kartikayk>`__)
+
+TorchChat
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Jack Khuu (Jack-Khuu)
+-  Jesse White (`byjlw <https://github.com/byjlw>`__)
+-  (emeritus) Michael Gschwind (`mikekgfb <https://github.com/mikekgfb>`__)
+
+TorchCodec
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Nicolas Hug (`nicolashug <https://github.com/nicolashug>`__)
+-  Ahmad Sharif (`ahmads <https://github.com/ahmads>`__)
+-  Scott Schneider (`scottas <https://github.com/scottas>`__)

--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -227,9 +227,9 @@ Build + CI
 -  Alban Desmaison (`alband <https://github.com/alband>`__)
 -  Andrey Talman (`atalman <https://github.com/atalman>`__)
 -  Zain Rizvi (`ZainRizvi <https://github.com/ZainRizvi>`__)
--  (emeritys) Mikey Dagitses (`dagitses <https://github.com/dagitses>`__)
--  (emeritys) Omkar Salpekar (`osalpekar <https://github.com/osalpekar>`__)
--  (emeritys) Nirav Mehta (`mehtanirav <https://github.com/mehtanirav>`__)
+-  (emeritus) Mikey Dagitses (`dagitses <https://github.com/dagitses>`__)
+-  (emeritus) Omkar Salpekar (`osalpekar <https://github.com/osalpekar>`__)
+-  (emeritus) Nirav Mehta (`mehtanirav <https://github.com/mehtanirav>`__)
 -  (emeritus) Zhuojie Zhou (`zhouzhuojie <https://github.com/zhouzhuojie>`__)
 -  (emeritus) Edward Yang (`ezyang <https://github.com/ezyang>`__)
 -  (emeritus) Karl Ostmo (`kostmo <https://github.com/kostmo>`__)
@@ -309,7 +309,7 @@ Apple M1/MPS/Metal
 PowerPC
 ~~~~~~~
 
--  Alfredo Mendoza (`avmgithub <https://github.com/avmgithub>`__)
+-  (emeritus) Alfredo Mendoza (`avmgithub <https://github.com/avmgithub>`__)
 
 AArch64 CPU
 ~~~~~~~~~~~~

--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -420,7 +420,7 @@ TorchTune
 TorchChat
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Jack Khuu (Jack-Khuu)
+-  Jack Khuu (`Jack-Khuu <https://github.com/Jack-Khuu>`__)
 -  Jesse White (`byjlw <https://github.com/byjlw>`__)
 -  (emeritus) Michael Gschwind (`mikekgfb <https://github.com/mikekgfb>`__)
 


### PR DESCRIPTION
This file didn't had an overall in a few years so long overdue. Most of the credit goes to @orionr for gathering all of this info.

The main rules we followed:
- No code contributor is removed, they're all placed as emeritus
- Breakdown too big categories to make this document useful to know who to ping
- No category where the code is still in the codebase is removed
- We did not rework the categories (for example to be closer to module: labels) and leave that for later
- All non-emeritus names are ordered by their number of comments on issues related to their topic