### PR TITLE
[FlexAttention] Reduce expensive test time by 10x

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1491,7 +1491,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     def test_aot_eager_gradcheck(self, score_mod):
         make_tensor = functools.partial(
             torch.randn,
-            (2, 2, 128, 4),
+            (2, 2, 11, 4),
             device="cuda",
             dtype=torch.float64,
             requires_grad=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136677
* #136673

Now that we support non 128 divisble sequence lengths; drops expensive tests by like 10x
Before
```Shell
46.32s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod1
45.61s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod2
44.45s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod3
43.61s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod0
```

After:
```Shell
4.25s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod5
4.20s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod4
4.19s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod1
4.04s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod2
3.99s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod0
3.98s call     test/inductor/test_flex_attention.py::TestFlexAttention::test_aot_eager_gradcheck_score_mod3
````

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang