### PR TITLE
[user triton] Make tl.constexpr specialization work for triton_op & capture_triton

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -1670,84 +1670,52 @@ def forward(self, x_1, output_1):
 
     @requires_gpu
     @parametrize("wrapped", [False, True])
-    def test_constexpr_dynamic_shapes(self, wrapped):
+    @parametrize("autotune", [False, True])
+    def test_constexpr_dynamic_shapes(self, wrapped, autotune):
         # https://github.com/pytorch/pytorch/issues/136504
         @triton.jit
-        def triton_(x_ptr, y_ptr, NUMEL: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+        def triton_(
+            x_ptr,
+            y_ptr,
+            NUMEL: tl.constexpr,
+            IS_ODD: tl.constexpr,
+            BLOCK_SIZE: tl.constexpr,
+        ):
             pid = tl.program_id(0)
             offsets = BLOCK_SIZE * pid + tl.arange(0, BLOCK_SIZE)
             mask = offsets < NUMEL
 
             data = tl.load(x_ptr + offsets, mask)
             result = data * data
+            if IS_ODD:
+                result = result + 1
 
             tl.store(y_ptr + offsets, result, mask)
 
-        def triton_kernel_impl(x: torch.Tensor) -> torch.Tensor:
-            y = torch.empty_like(x)
-            BLOCK_SIZE = 256
-            numel = x.numel()
-            grid = (triton.cdiv(numel, BLOCK_SIZE),)
-            if wrapped:
-                capture_triton(triton_)[grid](x, y, numel, BLOCK_SIZE)
-            else:
-                triton_[grid](x, y, numel, BLOCK_SIZE)
-            return y
-
-        if wrapped:
-            triton_kernel = torch._library.triton_op(
-                "constexpr_test::square", triton_kernel_impl, mutates_args={}
-            )
-        else:
-            triton_kernel = triton_kernel_impl
-
-        def fn(x):
-            return triton_kernel(x)
-
-        fn_c = torch.compile(fn, dynamic=True)
-
-        x = torch.randn(512 + 5, device=GPU_TYPE)
-        res = fn_c(x)
-        self.assertEqual(x * x, res)
-
-        x2 = torch.randn(1024 + 5, device=GPU_TYPE)
-        res2 = fn_c(x2)
-        self.assertEqual(x2 * x2, res2)
-
-    @requires_gpu
-    @parametrize("wrapped", [False, True])
-    def test_constexpr_autotune_dynamic_shapes(self, wrapped):
-        # https://github.com/pytorch/pytorch/issues/136504
-        @triton.autotune(
-            [
-                triton.Config(kwargs={"BLOCK_SIZE": 128}),
-                triton.Config(kwargs={"BLOCK_SIZE": 256}),
-            ],
-            key=[],
-        )
-        @triton.jit
-        def triton_(x_ptr, y_ptr, NUMEL: tl.constexpr, BLOCK_SIZE: tl.constexpr):
-            pid = tl.program_id(0)
-            offsets = BLOCK_SIZE * pid + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < NUMEL
-
-            data = tl.load(x_ptr + offsets, mask)
-            result = data * data
-
-            tl.store(y_ptr + offsets, result, mask)
+        if autotune:
+            triton_ = triton.autotune(
+                [
+                    triton.Config(kwargs={"BLOCK_SIZE": 128}),
+                    triton.Config(kwargs={"BLOCK_SIZE": 256}),
+                ],
+                key=[],
+            )(triton_)
 
         def triton_kernel_impl(x: torch.Tensor) -> torch.Tensor:
             y = torch.empty_like(x)
-            BLOCK_SIZE = 256
             numel = x.numel()
+
+            args = [x, y, numel, numel % 2 == 0]
+            if not autotune:
+                args.append(256)  # BLOCK_SIZE
 
             def grid(meta):
                 return (triton.cdiv(numel, meta["BLOCK_SIZE"]),)
 
             if wrapped:
-                capture_triton(triton_)[grid](x, y, numel)
+                capture_triton(triton_)[grid](*args)
             else:
-                triton_[grid](x, y, numel)
+                triton_[grid](*args)
             return y
 
         if wrapped:

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1148,7 +1148,7 @@ class TritonKernelVariable(VariableTracker):
         # Bail out to parent's implementation
         return super().call_method(tx, name, args, kwargs)
 
-    def try_specialize(self, arg: Any) -> Any:
+    def specialize_symbolic(self, arg: Any) -> Any:
         from .constant import ConstantVariable
         from .tensor import SymNodeVariable
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -1147,3 +1147,12 @@ class TritonKernelVariable(VariableTracker):
 
         # Bail out to parent's implementation
         return super().call_method(tx, name, args, kwargs)
+
+    def try_specialize(self, arg: Any) -> Any:
+        from .constant import ConstantVariable
+        from .tensor import SymNodeVariable
+
+        # See [Note: Specialize tl.constexpr args in user-defined triton kernels]
+        if isinstance(arg, SymNodeVariable):
+            return ConstantVariable.create(arg.evaluate_expr())
+        return arg

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -968,7 +968,6 @@ class TritonHOPifier:
             assert isinstance(variable.kernel, Autotuner)
             constexprs = variable.kernel.fn.constexprs
 
-        # breakpoint()
         for idx, arg_name in enumerate(variable.kernel.arg_names):
             if idx in constexprs:
                 if arg_name in combined_args_raw:
@@ -982,7 +981,7 @@ class TritonHOPifier:
                     #
                     # Depending on the type of `variable` we might expect different types for the symbolic args:
                     # either SymNodeVariables (for TritonKernelVariables) or SymInts (TracingTritonKernelWrapper)
-                    combined_args_raw[arg_name] = variable.try_specialize(
+                    combined_args_raw[arg_name] = variable.specialize_symbolic(
                         combined_args_raw[arg_name]
                     )
 
@@ -1073,7 +1072,7 @@ class TraceableTritonKernelWrapper:
             assert self.kernel is not None
             return self.kernel[self.grid](*args, **kwargs)
 
-    def try_specialize(self, arg: Any) -> Any:
+    def specialize_symbolic(self, arg: Any) -> Any:
         # See [Note: Specialize tl.constexpr args in user-defined triton kernels]
         if isinstance(arg, (torch.SymInt, torch.SymBool, torch.SymFloat)):
             return guard_scalar(arg)

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -887,9 +887,6 @@ class TritonHOPifier:
         from triton import JITFunction
         from triton.runtime.autotuner import autotune, Autotuner, Config
 
-        from torch._dynamo.variables.constant import ConstantVariable
-        from torch._dynamo.variables.tensor import SymNodeVariable
-
         if "num_ctas" in kwargs:
             self.raise_unsupported(
                 "Passing num_ctas directly to the Triton kernel is not supported. "
@@ -970,19 +967,19 @@ class TritonHOPifier:
             assert isinstance(variable.kernel, Autotuner)
             constexprs = variable.kernel.fn.constexprs
 
+        # breakpoint()
         for idx, arg_name in enumerate(variable.kernel.arg_names):
             if idx in constexprs:
-                if arg_name in combined_args_raw and isinstance(
-                    combined_args_raw[arg_name], SymNodeVariable
-                ):
+                if arg_name in combined_args_raw:
+                    # [Note: Specialize tl.constexpr args in user-defined triton kernels]
                     # This arg is marked as tl.constexpr. That means that triton will recompile every time
                     # this value changes.
                     # https://github.com/pytorch/pytorch/issues/136504
                     # One option is to correctly pass the symints in so that the symbolic expressions are defined
                     # when the triton code is being executed.
                     # But since triton will have to recompile either way, we instead just specialize on the value.
-                    combined_args_raw[arg_name] = ConstantVariable.create(
-                        combined_args_raw[arg_name].evaluate_expr()
+                    combined_args_raw[arg_name] = variable.try_specialize(
+                        combined_args_raw[arg_name]
                     )
 
         if len(set(pytree.tree_map(intify, grids))) == 1:
@@ -1071,3 +1068,9 @@ class TraceableTritonKernelWrapper:
         else:
             assert self.kernel is not None
             return self.kernel[self.grid](*args, **kwargs)
+
+    def try_specialize(self, arg: Any) -> Any:
+        # See [Note: Specialize tl.constexpr args in user-defined triton kernels]
+        if isinstance(arg, (torch.SymInt)):
+            return int(arg)
+        return arg


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136686

In #136512, we fixed handling for tl.constexpr and dynamic shapes: if a symint is passed to tl.constexpr, you should specialize on it, because tl.constexpr implies needing to know the concrete value at compile time.

However, when using triton_op, capture_triton, or non-strict export, the regression remains (and #136512 might technically regress some specific export scenarios) - see [Richard's comment](https://github.com/pytorch/pytorch/pull/136512/files#r1775999871).

This fixes these scenarios: implement the handling differently depending on whether we're expecting a SymNodeVariable or a SymInt(/SymBool/SymFloat)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @rec