### PR TITLE
Rewrite fake mode detector

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -882,7 +882,12 @@ def _detect_fake_mode_from_gm(
             fake_val = node.meta["val"]
             if fake_val is not None and isinstance(fake_val, torch.Tensor):
                 fake_inps.append(fake_val)
-        elif len(fake_inps) == 0 and (
+    
+    if len(fake_inps) > 0:
+        return detect_fake_mode(fake_inps)
+    
+    for node in gm.graph.nodes:
+        if (
             "example_value" in node.meta or "val" in node.meta
         ):
             fake_val = None
@@ -892,5 +897,5 @@ def _detect_fake_mode_from_gm(
                 fake_val = node.meta["val"]
             if fake_val is not None and isinstance(fake_val, torch.Tensor):
                 fake_vals.append(fake_val)
-
-    return detect_fake_mode(fake_inps + fake_vals)
+    
+    return detect_fake_mode(fake_vals)


### PR DESCRIPTION
Summary: If we pass in unlifted module where getattr nodes sometimes can go before placeholders, it will error. Because example_value from dynamo always has different fake mode and we extract that before we get to placeholder nodes.

Test Plan: CI

Differential Revision: D63421110
