### PR TITLE
[RELEASE-ONLY CHANGES] Don't push to https://ghcr.io/

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: nick-fields/retry@v3.0.0
         name: Push to https://https://ghcr.io/
         id: push-to-ghcr-io
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ 0 && github.event_name == 'push' }}
         env:
           ECR_DOCKER_IMAGE: ${{ steps.build-docker-image.outputs.docker-image }}
           GHCR_PAT: ${{ secrets.GHCR_PAT }}


### PR DESCRIPTION
Don't do push to https://ghcr.io/ on release branch: we don't need it and it fails with "unauthorized: unauthenticated: User cannot be authenticated with the token provided".
