### PR TITLE
Delete duplicate bindings in torch/csrc/autograd/python_torch_functions_manual.cpp

### DIFF
--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -737,13 +737,6 @@ void initTorchFunctions(PyObject* module) {
             dst.sym_sizes(),
             dst.sym_strides());
       });
-  py_module.def(
-      "_functionalize_mark_mutation_hidden_from_autograd",
-      [](const at::Tensor& t) {
-        TORCH_INTERNAL_ASSERT(
-            at::functionalization::impl::isFunctionalTensor(t));
-        at::functionalization::impl::mark_mutation_hidden_from_autograd(t);
-      });
   py_module.def("_is_functional_tensor", [](const at::Tensor& t) {
     return at::functionalization::impl::isFunctionalTensor(t);
   });


### PR DESCRIPTION
This change deletes the duplicate binding of `torch. _functionalize_mark_mutation_hidden_from_autograd()`, another defination is here:

https://github.com/pytorch/pytorch/blob/5c78c6b05abc1c19dabdb2b41755e8dbf9321e61/torch/csrc/autograd/python_torch_functions_manual.cpp#L630-L636
