### PR TITLE
[test] enable test_triton_wrapper again

### DIFF
--- a/test/inductor/test_triton_wrapper.py
+++ b/test/inductor/test_triton_wrapper.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 
+import os
 import subprocess
 import sys
 
@@ -39,11 +40,16 @@ class TestTritonWrapper(TestCase):
         y = torch.rand(N).to(device=GPU_TYPE)
         out = f(x, y)
         compiled_module = self.get_compiled_module()
-
+        # to make sure the subprocess runs on the exact same path as the parent process
+        # we augment the PYTHONPATH env var
+        augmented_pp = ":".join(sys.path)
+        if os.environ.get("PYTHONPATH"):
+            augmented_pp = f"{os.environ.get('PYTHONPATH')}:{augmented_pp}"
         # now run the compiled module in subprocess and check its output
         bench_out = subprocess.check_output(
             f"{sys.executable} {compiled_module.__file__}".split(),
             stderr=subprocess.STDOUT,
+            env={**os.environ, "PYTHONPATH": augmented_pp},
         ).decode()
 
         self.assertTrue(len(bench_out) > 0)


### PR DESCRIPTION
Summary:
Reenable the `test_triton_wrapper.py` test again

# Why

We want this to run internally

# What

- fix python path issue on the test
- reenable the test

# Background

It appears that the parent process does not pass the entire path down to the child process. Namely, if there is some setup that makes the sys.path effectively look different than, say, PYTHONPATH or something like this, the child will not inherit this setup. To avoid needing to keep track of specific setups, we pass the effective `sys.path` from the parent to the child through the PYTHONPATH env variable

Test Plan: buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/inductor:triton_wrapper

Differential Revision: D63438186


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang