### PR TITLE
[Quant] Check stride > 0 for QConv and QConvTranspose

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -343,6 +343,9 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsOnednn<
       "stride should contain ", kSpatialDim, " elements for ",
       kSpatialDim, "D convolution.");
   TORCH_CHECK(
+      std::all_of(stride.begin(), stride.end(), [](bool s) { return s > 0; }),
+      "quantized::conv_prepack: stride should be positive.");
+  TORCH_CHECK(
       padding.size() == kSpatialDim,
       "Specify front/top/left padding only. "
       "end/bottom/right padding assumed to be equal to front/top/left");


### PR DESCRIPTION
Fixes #136722
Fixes #136718

By default, it goes to onednn. So this PR adds a check to ensure stride > 0. Now program will quit with an error message if stride is 0.
FBGEMM and QNNPACK can create modules with stride=0 without error but program crashes when calling forward.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10