### PR TITLE
Fix overflow error when `torch.bincount()` handles a large tensor

### DIFF
--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -40,7 +40,7 @@ Tensor _bincount_cpu_template(
   if (max_val >= std::numeric_limits<int64_t>::max()) {
     AT_ERROR(
         "maximum value of input overflowed, it should be < ",
-        std::numeric_limits<input_t>::max(),
+        std::numeric_limits<int64_t>::max(),
         " but got ",
         max_val
     );

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -5,6 +5,8 @@
 #include <ATen/Dispatch.h>
 #include <c10/util/irange.h>
 
+#include <limits>
+
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
@@ -31,6 +33,9 @@ Tensor _bincount_cpu_template(
   }
   if (self.dim() != 1 || *self.min().data_ptr<input_t>() < 0) {
     AT_ERROR("bincount only supports 1-d non-negative integral inputs.");
+  }
+  if (*self.max().data_ptr<input_t>() >= std::numeric_limits<input_t>::max()) {
+    AT_ERROR("input overflowed, it should be < ", std::numeric_limits<input_t>::max());
   }
 
   bool has_weights = weights.defined();

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -34,8 +34,16 @@ Tensor _bincount_cpu_template(
   if (self.dim() != 1 || *self.min().data_ptr<input_t>() < 0) {
     AT_ERROR("bincount only supports 1-d non-negative integral inputs.");
   }
-  if (*self.max().data_ptr<input_t>() >= std::numeric_limits<input_t>::max()) {
-    AT_ERROR("input overflowed, it should be < ", std::numeric_limits<input_t>::max());
+
+  // Ensure max_val < 2 ^ 63 - 1 (9223372036854775807)
+  auto max_val = *self.max().data_ptr<input_t>();
+  if (max_val >= std::numeric_limits<int64_t>::max()) {
+    AT_ERROR(
+        "maximum value of input overflowed, it should be < ",
+        std::numeric_limits<input_t>::max(),
+        " but got ",
+        max_val
+    );
   }
 
   bool has_weights = weights.defined();
@@ -45,7 +53,7 @@ Tensor _bincount_cpu_template(
 
   Tensor output;
   int64_t self_size = self.size(0);
-  int64_t nbins = static_cast<int64_t>(*self.max().data_ptr<input_t>()) + 1L;
+  int64_t nbins = static_cast<int64_t>(max_val) + 1L;
   nbins = std::max(nbins, minlength); // at least minlength # of bins
 
   const input_t* self_p = self.const_data_ptr<input_t>();


### PR DESCRIPTION
Fixes #136720

the result in this case says:

```
Traceback (most recent call last):
  File "/Users/shenke/workspace/pytorch/mytest.py", line 9, in <module>
    result = torch.bincount(input)
             ^^^^^^^^^^^^^^^^^^^^^
RuntimeError: maximum value of input overflowed, it should be < 9223372036854775807 but got 9223372036854775807
```
