### PR TITLE
Implement `AcceleratorHooksInterface`'s virtual functions `deviceCount()` and `getCurrentDevice()` for CUDA and XPU

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -513,7 +513,7 @@ inline size_t getNumGPUs() {
         "to be CUDA (e.g., when you say CUDA, on a HIP build of ATen, this actually "
         "means HIP.  Rebuild PyTorch with one or the other disabled.");
   } else if (hasCUDA()) {
-    return detail::getCUDAHooks().getNumGPUs();
+    return detail::getCUDAHooks().deviceCount();
   } else if (hasHIP()) {
     return detail::getHIPHooks().getNumGPUs();
   } else {
@@ -550,7 +550,7 @@ inline void manual_seed(uint64_t seed) {
   }
   // NB: Sometimes we build with CUDA, but we don't have any GPUs
   // available. In that case, we must not seed CUDA; it will fail!
-  const auto cuda_num_gpus = detail::getCUDAHooks().getNumGPUs();
+  const auto cuda_num_gpus = detail::getCUDAHooks().deviceCount();
   if (hasCUDA() && cuda_num_gpus > 0) {
     for (const auto i : c10::irange(cuda_num_gpus)) {
       auto cuda_gen = globalContext().defaultGenerator(

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -562,7 +562,7 @@ inline void manual_seed(uint64_t seed) {
     }
   }
 
-  const auto xpu_num_gpus = detail::getXPUHooks().getNumGPUs();
+  const auto xpu_num_gpus = detail::getXPUHooks().deviceCount();
   if (hasXPU() && xpu_num_gpus) {
     for (const auto i : c10::irange(xpu_num_gpus)) {
       auto xpu_gen = globalContext().defaultGenerator(

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -106,8 +106,7 @@ class TORCH_API Context {
             opt_device_type.value())) { // passed device not an accelerator
       return false;
     }
-    return getAcceleratorHooksInterface(opt_device_type)
-        .isPinnedPtr(data);
+    return getAcceleratorHooksInterface(opt_device_type).isPinnedPtr(data);
   }
   Allocator* getPinnedMemoryAllocator(
       std::optional<c10::DeviceType> device_type = std::nullopt) {

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -106,7 +106,7 @@ class TORCH_API Context {
             opt_device_type.value())) { // passed device not an accelerator
       return false;
     }
-    return getAcceleratorHooksInterface(opt_device_type.value())
+    return getAcceleratorHooksInterface(opt_device_type)
         .isPinnedPtr(data);
   }
   Allocator* getPinnedMemoryAllocator(

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -241,6 +241,9 @@ DeviceIndex current_device() {
   return -1;
 }
 
+/**
+ * DEPRECATED: use getCurrentDevice() instead
+ */
 DeviceIndex CUDAHooks::current_device() const {
   return at::cuda::detail::current_device();
 }
@@ -445,6 +448,10 @@ int CUDAHooks::getNumGPUs() const {
 
 DeviceIndex CUDAHooks::deviceCount() const {
   return at::cuda::device_count();
+}
+
+DeviceIndex CUDAHooks::getCurrentDevice() const {
+  return at::cuda::detail::current_device();
 }
 
 #ifdef USE_ROCM

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -436,7 +436,14 @@ void CUDAHooks::cuFFTClearPlanCache(DeviceIndex device_index) const {
   at::native::detail::cufft_clear_plan_cache_impl(device_index);
 }
 
+/**
+ * DEPRECATED: use deviceCount() instead
+ */
 int CUDAHooks::getNumGPUs() const {
+  return at::cuda::device_count();
+}
+
+DeviceIndex CUDAHooks::deviceCount() const {
   return at::cuda::device_count();
 }
 

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -50,6 +50,7 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   void cuFFTClearPlanCache(DeviceIndex device_index) const override;
   int getNumGPUs() const override;
   DeviceIndex deviceCount() const override;
+  DeviceIndex getCurrentDevice() const override;
 
 #ifdef USE_ROCM
   bool isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const override;

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -49,6 +49,8 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   int64_t cuFFTGetPlanCacheSize(DeviceIndex device_index) const override;
   void cuFFTClearPlanCache(DeviceIndex device_index) const override;
   int getNumGPUs() const override;
+  DeviceIndex deviceCount() const override;
+
 #ifdef USE_ROCM
   bool isGPUArch(DeviceIndex device_index, const std::vector<std::string>& archs) const override;
 #endif

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -109,33 +109,33 @@ CuFFTParamsLRUCache &cufft_get_plan_cache(DeviceIndex device_index) {
 namespace detail {
 
 int64_t cufft_get_plan_cache_max_size_impl(DeviceIndex device_index) {
-  TORCH_CHECK(0 <= device_index && device_index < at::detail::getCUDAHooks().getNumGPUs(),
+  TORCH_CHECK(0 <= device_index && device_index < at::detail::getCUDAHooks().deviceCount(),
     "cufft_get_plan_cache_max_size: expected 0 <= device_index < ",
-    at::detail::getCUDAHooks().getNumGPUs(), "], but got device_index=",
+    at::detail::getCUDAHooks().deviceCount(), "], but got device_index=",
     device_index);
   return cufft_get_plan_cache(device_index).max_size();
 }
 
 void cufft_set_plan_cache_max_size_impl(DeviceIndex device_index, int64_t max_size) {
-  TORCH_CHECK(0 <= device_index && device_index < at::detail::getCUDAHooks().getNumGPUs(),
+  TORCH_CHECK(0 <= device_index && device_index < at::detail::getCUDAHooks().deviceCount(),
     "cufft_set_plan_cache_max_size: expected 0 <= device_index < ",
-    at::detail::getCUDAHooks().getNumGPUs(), "], but got device_index=",
+    at::detail::getCUDAHooks().deviceCount(), "], but got device_index=",
     device_index);
   return cufft_get_plan_cache(device_index).resize(max_size);
 }
 
 int64_t cufft_get_plan_cache_size_impl(DeviceIndex device_index) {
-  TORCH_CHECK(0 <= device_index && device_index < at::detail::getCUDAHooks().getNumGPUs(),
+  TORCH_CHECK(0 <= device_index && device_index < at::detail::getCUDAHooks().deviceCount(),
     "cufft_get_plan_cache_size: expected 0 <= device_index < ",
-    at::detail::getCUDAHooks().getNumGPUs(), "], but got device_index=",
+    at::detail::getCUDAHooks().deviceCount(), "], but got device_index=",
     device_index);
   return cufft_get_plan_cache(device_index).size();
 }
 
 void cufft_clear_plan_cache_impl(DeviceIndex device_index) {
-  TORCH_CHECK(0 <= device_index && device_index < at::detail::getCUDAHooks().getNumGPUs(),
+  TORCH_CHECK(0 <= device_index && device_index < at::detail::getCUDAHooks().deviceCount(),
     "cufft_clear_plan_cache: expected 0 <= device_index < ",
-    at::detail::getCUDAHooks().getNumGPUs(), "], but got device_index=",
+    at::detail::getCUDAHooks().deviceCount(), "], but got device_index=",
     device_index);
   return cufft_get_plan_cache(device_index).clear();
 }

--- a/aten/src/ATen/xpu/detail/XPUHooks.cpp
+++ b/aten/src/ATen/xpu/detail/XPUHooks.cpp
@@ -53,10 +53,16 @@ Device XPUHooks::getDeviceFromPtr(void* data) const {
 #endif
 }
 
+/**
+ * DEPRECATED: use deviceCount() instead
+ */
 c10::DeviceIndex XPUHooks::getNumGPUs() const {
   return at::xpu::device_count();
 }
 
+/**
+ * DEPRECATED: use getCurrentDevice() instead
+ */
 DeviceIndex XPUHooks::current_device() const {
   return c10::xpu::current_device();
 }
@@ -83,6 +89,14 @@ bool XPUHooks::isPinnedPtr(const void* data) const {
 bool XPUHooks::hasPrimaryContext(DeviceIndex device_index) const {
   // The default context is utilized for each device. So it always returns true.
   return true;
+}
+
+DeviceIndex XPUHooks::deviceCount() const {
+  return at::xpu::device_count();
+}
+
+DeviceIndex XPUHooks::getCurrentDevice() const {
+  return at::xpu::current_device();
 }
 
 REGISTER_XPU_HOOKS(XPUHooks);

--- a/aten/src/ATen/xpu/detail/XPUHooks.h
+++ b/aten/src/ATen/xpu/detail/XPUHooks.h
@@ -21,6 +21,8 @@ struct XPUHooks : public at::XPUHooksInterface {
   Allocator* getPinnedMemoryAllocator() const override;
   bool isPinnedPtr(const void* data) const override;
   bool hasPrimaryContext(DeviceIndex device_index) const override;
+  DeviceIndex deviceCount() const override;
+  DeviceIndex getCurrentDevice() const override;
 };
 
 } // namespace at::xpu::detail

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2120,7 +2120,7 @@ Call this whenever a new thread is created in order to propagate values from
     auto device_type = at::getAccelerator();
     if (device_type.has_value()) {
       return at::globalContext()
-          .getAcceleratorHooksInterface(device_type.value())
+          .getAcceleratorHooksInterface(device_type)
           .deviceCount();
     }
     return c10::DeviceIndex(-1);
@@ -2132,7 +2132,7 @@ Call this whenever a new thread is created in order to propagate values from
         auto device_type = at::getAccelerator();
         if (device_type.has_value()) {
           at::globalContext()
-              .getAcceleratorHooksInterface(device_type.value())
+              .getAcceleratorHooksInterface(device_type)
               .setCurrentDevice(device_index);
         }
       });
@@ -2141,7 +2141,7 @@ Call this whenever a new thread is created in order to propagate values from
     auto device_type = at::getAccelerator();
     if (device_type.has_value()) {
       return at::globalContext()
-          .getAcceleratorHooksInterface(device_type.value())
+          .getAcceleratorHooksInterface(device_type)
           .getCurrentDevice();
     }
     return c10::DeviceIndex(-1);
@@ -2152,7 +2152,7 @@ Call this whenever a new thread is created in order to propagate values from
         auto device_type = at::getAccelerator();
         if (device_type.has_value()) {
           return at::globalContext()
-              .getAcceleratorHooksInterface(device_type.value())
+              .getAcceleratorHooksInterface(device_type)
               .exchangeDevice(device_index);
         }
         return c10::DeviceIndex(-1);
@@ -2164,7 +2164,7 @@ Call this whenever a new thread is created in order to propagate values from
         auto device_type = at::getAccelerator();
         if (device_type.has_value()) {
           return at::globalContext()
-              .getAcceleratorHooksInterface(device_type.value())
+              .getAcceleratorHooksInterface(device_type)
               .maybeExchangeDevice(device_index);
         }
         return c10::DeviceIndex(-1);

--- a/torch/csrc/api/src/cuda.cpp
+++ b/torch/csrc/api/src/cuda.cpp
@@ -27,7 +27,7 @@ bool cudnn_is_available() {
 /// Sets the seed for the current GPU.
 void manual_seed(uint64_t seed) {
   if (is_available()) {
-    auto index = at::detail::getCUDAHooks().current_device();
+    auto index = at::detail::getCUDAHooks().getCurrentDevice();
     auto gen = at::detail::getCUDAHooks().getDefaultCUDAGenerator(index);
     {
       // See Note [Acquire lock when using random generators]

--- a/torch/csrc/api/src/cuda.cpp
+++ b/torch/csrc/api/src/cuda.cpp
@@ -9,7 +9,7 @@
 namespace torch::cuda {
 
 size_t device_count() {
-  return at::detail::getCUDAHooks().getNumGPUs();
+  return at::detail::getCUDAHooks().deviceCount();
 }
 
 bool is_available() {

--- a/torch/csrc/api/src/xpu.cpp
+++ b/torch/csrc/api/src/xpu.cpp
@@ -4,7 +4,7 @@
 namespace torch::xpu {
 
 size_t device_count() {
-  return at::detail::getXPUHooks().getNumGPUs();
+  return at::detail::getXPUHooks().deviceCount();
 }
 
 bool is_available() {
@@ -13,7 +13,7 @@ bool is_available() {
 
 void manual_seed(uint64_t seed) {
   if (is_available()) {
-    auto index = at::detail::getXPUHooks().current_device();
+    auto index = at::detail::getXPUHooks().getCurrentDevice();
     auto gen = at::detail::getXPUHooks().getDefaultXPUGenerator(index);
     {
       // See Note [Acquire lock when using random generators]

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -480,7 +480,7 @@ at::Tensor tensor_from_cuda_array_interface(PyObject* obj) {
     if (data_ptr != nullptr) {
       return {};
     } else {
-      const auto current_device = at::detail::getCUDAHooks().current_device();
+      const auto current_device = at::detail::getCUDAHooks().getCurrentDevice();
       return Device(
           kCUDA,
           static_cast<DeviceIndex>(current_device > -1 ? current_device : 0));


### PR DESCRIPTION
Fixes #136751
