### PR TITLE
[EZ][MPS] Extend `arange` to bfloat16

### DIFF
--- a/aten/src/ATen/native/mps/TensorFactory.h
+++ b/aten/src/ATen/native/mps/TensorFactory.h
@@ -5,6 +5,7 @@
       TYPE, NAME,                                                       \
       AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)              \
       AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)               \
+      AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)           \
       AT_DISPATCH_CASE(at::ScalarType::Long, __VA_ARGS__)               \
       AT_DISPATCH_CASE(at::ScalarType::Int, __VA_ARGS__)                \
       AT_DISPATCH_CASE(at::ScalarType::Short, __VA_ARGS__)              \

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7734,6 +7734,11 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(np.arange(7, 1, -1), torch.arange(7, 1, -1, device='mps'))
         self.assertEqual(np.arange(1, 2, .3, dtype=np.float32), torch.arange(1, 2, .3, device='mps'))
         self.assertEqual(np.arange(6.3, dtype=np.float32), torch.arange(6.3, device='mps'))
+        # To be removed
+        if product_version >= 14.0:
+            def do_arange(start=1.2, end=10.3, dtype=torch.bfloat16, device='cpu'):
+                return torch.arange(start, end, device=device, dtype=dtype)
+            self.assertEqual(do_arange(device='mps'), do_arange(device='cpu'))
 
     def test_arange_empty(self):
         out_mps = torch.tensor([], device="mps")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #136755
* __->__ #136754

RangeFactories class is the only one that uses `AT_DISPATCH_MPS_TYPES`

Fixes https://github.com/pytorch/pytorch/issues/136624