### PR TITLE
Fix for MSVC problem on Windows Arm64

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -297,8 +297,10 @@ public:
   }
   Vectorized<T> map(T (*const f)(T)) const {
     Vectorized<T> ret;
-    for (int64_t i = 0; i != size(); i++) {
+    for (int64_t i = 0; i < size(); i++) {
       ret[i] = f(values[i]);
+      if (++i < size())
+        ret[i] = f(values[i]);
     }
     return ret;
   }

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -295,6 +295,8 @@ public:
     }
     return false;
   }
+// TODO: Remove this once the issue with MSVC is fixed
+//       See https://developercommunity.visualstudio.com/t/MSVC-loop-unrolling-problem-194033813-/10720692
 #if defined(_WIN32) && defined(__aarch64__)
   Vectorized<T> map(T (*const f)(T)) const {
     Vectorized<T> ret;

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -295,6 +295,7 @@ public:
     }
     return false;
   }
+#if defined(_WIN32) && defined(__aarch64__)
   Vectorized<T> map(T (*const f)(T)) const {
     Vectorized<T> ret;
     for (int64_t i = 0; i < size(); i++) {
@@ -304,6 +305,15 @@ public:
     }
     return ret;
   }
+#else
+  Vectorized<T> map(T (*const f)(T)) const {
+    Vectorized<T> ret;
+    for (int64_t i = 0; i != size(); i++) {
+      ret[i] = f(values[i]);
+    }
+    return ret;
+  }
+#endif
   Vectorized<T> map(T (*const f)(const T &)) const {
     Vectorized<T> ret;
     for (int64_t i = 0; i != size(); i++) {


### PR DESCRIPTION
This PR proposes a workaround for an internal issue introduced in MSVC 14.37 for Windows Arm64 target. It is still an ongoing problem.
The fix will be released with the future versions of Visual Studio 2022 but until then the changes to cpu/vec/vec_base.h should be sufficient.  
We also opened a new ticket on Visual Studio Developer Community, it can be found here: https://developercommunity.visualstudio.com/t/MSVC-loop-unrolling-problem-194033813-/10720692

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10