### PR TITLE
[aoti][inplace] Support skipping model buffers

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -159,6 +159,15 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantFromFolded(
   CONVERT_EXCEPTION_TO_ERROR_CODE({ *from_folded = container->constant_from_folded(idx); })
 }
 
+AOTIRuntimeError AOTInductorModelContainerGetConstantType(
+    AOTInductorModelContainerHandle container_handle,
+    size_t idx,
+    int32_t* type) {
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(container_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({ *type = container->constant_type(idx); })
+}
+
 AOTIRuntimeError AOTInductorModelContainerGetConstantDtype(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -97,6 +97,7 @@ from .utils import (
     get_cloned_parameter_buffer_name,
     get_sympy_Expr_dtype,
     maybe_get_suppress_shape_guards_ctx,
+    normalize_name,
     should_assume_input_aligned,
 )
 from .virtualized import NullHandler, V
@@ -876,7 +877,7 @@ class GraphLowering(torch.fx.Interpreter):
         name = self.qualify_name(name)
         # We may generate a var name for each constant in the codegen.
         # Let's only keep sane characters.
-        prefix = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+        prefix = normalize_name(name)
         name = prefix
         cnt = 0
         while name in self.constants:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -14,6 +14,7 @@ import math
 import operator
 import os
 import platform
+import re
 import shutil
 import sys
 import tempfile
@@ -2076,3 +2077,7 @@ def should_use_remote_fx_graph_cache():
         jk_name = "pytorch/remote_cache:fx_graph_memcache_version_amd"
 
     return REMOTE_CACHE_VERSION >= torch._utils_internal.justknobs_getval_int(jk_name)
+
+
+def normalize_name(name: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_]", "_", name)

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -87,6 +87,14 @@ AOTIRuntimeError AOTInductorModelContainerGetConstantFromFolded(
     size_t idx,
     bool* from_folded);
 
+// Retrieves the inductor constant type.
+// idx is the index of the internal's constants.
+// Need idx < num_constants from AOTInductorModelContainerGetNumConstants
+AOTIRuntimeError AOTInductorModelContainerGetConstantType(
+    AOTInductorModelContainerHandle container_handle,
+    size_t idx,
+    int32_t* type);
+
 // Retrieves a constant's dtype.
 // idx is the index of the internal's constants.
 // Need idx < num_constants from AOTInductorModelContainerGetNumConstants

--- a/torch/csrc/inductor/aoti_runtime/model.h
+++ b/torch/csrc/inductor/aoti_runtime/model.h
@@ -56,6 +56,14 @@ CUDAPtr RAII_cudaMalloc(size_t num_bytes) {
 } // anonymous namespace
 
 namespace torch::aot_inductor {
+enum ConstantType : uint8_t {
+  Unknown = 0,
+  Parameter = 1,
+  Buffer = 2,
+  TensorConstant = 3,
+  FoldedConstant = 4,
+};
+
 using ConstantMap = std::unordered_map<std::string, RAIIAtenTensorHandle>;
 
 // valid device strs are: cpu, cuda, cuda:0, cuda:1, ...
@@ -395,6 +403,10 @@ class AOTInductorModelBase {
     return constants_info_.at(idx).from_folded;
   }
 
+  int32_t constant_type(int64_t idx) const {
+    return constants_info_.at(idx).type;
+  }
+
   const char* get_in_spec() const {
     return in_spec_.c_str();
   }
@@ -529,6 +541,7 @@ class AOTInductorModelBase {
     int64_t opaque_metadata_size{};
     const char* original_fqn = nullptr;
     bool from_folded{};
+    int32_t type{};
   };
 
   std::vector<ParamInfo> inputs_info_;

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -147,6 +147,14 @@ class AOTInductorModelContainer {
     return models_[0]->constant_from_folded(static_cast<int64_t>(idx));
   }
 
+  // retrieve type of constants_info_[idx]
+  int32_t constant_type(size_t idx) const {
+    if (this->num_models() == 0) {
+      throw std::runtime_error("No available models in container!");
+    }
+    return models_[0]->constant_type(static_cast<int64_t>(idx));
+  }
+
   // retrieve dtype of constants_info_[idx]
   int32_t constant_dtype(size_t idx) const {
     if (this->num_models() == 0) {
@@ -217,9 +225,11 @@ class AOTInductorModelContainer {
     pending_models_available_.notify_one();
   }
 
-  bool _is_tensor_constant(const std::string& constant_name) const {
-    return constant_name.rfind("_tensor_constant", 0) == 0;
+  bool _should_skip_update(const size_t idx) const {
+    auto constant_type = models_[0]->constant_type(idx);
+    return constant_type == ConstantType::TensorConstant;
   }
+
   // This function updates the buffer for storing constants.
   // It will update the buffer, the mapping and the array mapping.
   void update_constant_buffer(
@@ -241,7 +251,7 @@ class AOTInductorModelContainer {
             std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
         auto it = constants_map.find(constant_name);
         if (it == constants_map.end()) {
-          if (_is_tensor_constant(constant_name)) {
+          if (_should_skip_update(idx)) {
             // tracing sometimes creates tensors that are non-existent in
             // original graph. We could skip those and do a direct copy.
             std::cerr << "[WARNING] Found constant " << constant_name
@@ -263,13 +273,13 @@ class AOTInductorModelContainer {
           std::string(models_[0]->constant_name(static_cast<int64_t>(idx)));
       auto it = constants_map.find(constant_name);
       if (it == constants_map.end() &&
-          !(_is_tensor_constant(constant_name) && use_inactive)) {
+          !(_should_skip_update(idx) && use_inactive)) {
         continue;
       }
 
 #ifdef USE_CUDA
       AtenTensorHandle tensor;
-      if (_is_tensor_constant(constant_name) && use_inactive) {
+      if (_should_skip_update(idx) && use_inactive) {
         tensor = original_constants_map->find(constant_name)->second.get();
       } else {
         tensor = it->second;


### PR DESCRIPTION
Summary: Some AOTI tensor constants may be model buffers that never needs to be updated.

Differential Revision: D62777502


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang