### PR TITLE
[AOTI] Move calc_erfinv to generic_math.h

### DIFF
--- a/aten/src/ATen/core/PhiloxRNGEngine.h
+++ b/aten/src/ATen/core/PhiloxRNGEngine.h
@@ -13,8 +13,6 @@
 
 #include <ATen/core/Array.h>
 #include <c10/macros/Macros.h>
-#include <c10/util/Exception.h>
-#include <c10/util/Half.h>
 #include <cmath>
 #include <cstdint>
 

--- a/aten/src/ATen/cpu/vec/sve/vec_double.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_double.h
@@ -188,7 +188,7 @@ public:
     return USE_SLEEF(Vectorized<double>(Sleef_erfcdx_u15sve(values)),map(std::erfc));
   }
   Vectorized<double> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
   Vectorized<double> exp() const {
     return USE_SLEEF(Vectorized<double>(Sleef_expdx_u10sve(values)),map(std::exp));

--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -188,7 +188,7 @@ public:
     return USE_SLEEF(Vectorized<float>(Sleef_erfcfx_u15sve(values)),map(std::erfc));
   }
   Vectorized<float> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
   Vectorized<float> exp() const {
     return USE_SLEEF(Vectorized<float>(Sleef_expfx_u10sve(values)),map(std::exp));

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -396,8 +396,8 @@ public:
     _mm256_storeu_ps(reinterpret_cast<float*>(tmp1), lo);
     _mm256_storeu_ps(reinterpret_cast<float*>(tmp2), hi);
     for (int64_t i = 0; i < size() / 2; i++) {
-      tmp1[i] = calc_erfinv(tmp1[i]);
-      tmp2[i] = calc_erfinv(tmp2[i]);
+      tmp1[i] = c10::calc_erfinv(tmp1[i]);
+      tmp2[i] = c10::calc_erfinv(tmp2[i]);
     }
     auto o1 = _mm256_loadu_ps(tmp1);
     auto o2 = _mm256_loadu_ps(tmp2);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -166,7 +166,7 @@ public:
     return Vectorized<double>(Sleef_erfcd4_u15(values));
   }
   Vectorized<double> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
   Vectorized<double> exp() const {
     return Vectorized<double>(Sleef_expd4_u10(values));

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -203,7 +203,7 @@ public:
     return Vectorized<float>(Sleef_erfcf8_u15(values));
   }
   Vectorized<float> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
   Vectorized<float> exp() const {
     return Vectorized<float>(Sleef_expf8_u10(values));

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
@@ -417,7 +417,7 @@ public:
     );
   }
   Vectorized<float> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
   Vectorized<float> exp() const {
     return USE_SLEEF(

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
@@ -261,7 +261,7 @@ class Vectorized<double> {
   }
 
   Vectorized<double> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
 
   Vectorized<double> angle() const {

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_float_vsx.h
@@ -297,7 +297,7 @@ class Vectorized<float> {
   }
 
   Vectorized<float> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
 
   Vectorized<float> angle() const {

--- a/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
+++ b/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
@@ -1087,7 +1087,7 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented<T>()>> {
   }
 
   Vectorized<T> erfinv() const {
-    return mapOrdinary(calc_erfinv);
+    return mapOrdinary(c10::calc_erfinv);
   }
 
   Vectorized<T> digamma() const {

--- a/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
@@ -480,8 +480,8 @@ public:
     _mm512_storeu_ps(reinterpret_cast<float*>(tmp1), lo);
     _mm512_storeu_ps(reinterpret_cast<float*>(tmp2), hi);
     for (int64_t i = 0; i < size() / 2; i++) {
-      tmp1[i] = calc_erfinv(tmp1[i]);
-      tmp2[i] = calc_erfinv(tmp2[i]);
+      tmp1[i] = c10::calc_erfinv(tmp1[i]);
+      tmp2[i] = c10::calc_erfinv(tmp2[i]);
     }
     auto o1 = _mm512_loadu_ps(tmp1);
     auto o2 = _mm512_loadu_ps(tmp2);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_double.h
@@ -175,7 +175,7 @@ public:
     return Vectorized<double>(Sleef_erfcd8_u15(values));
   }
   Vectorized<double> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
   Vectorized<double> exp() const {
     return Vectorized<double>(Sleef_expd8_u10(values));

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float.h
@@ -223,7 +223,7 @@ public:
     return Vectorized<float>(Sleef_erfcf16_u15(values));
   }
   Vectorized<float> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
   Vectorized<float> exp() const {
     return Vectorized<float>(Sleef_expf16_u10(values));

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -431,7 +431,7 @@ public:
     return map(std::erfc);
   }
   Vectorized<T> erfinv() const {
-    return map(calc_erfinv);
+    return map(c10::calc_erfinv);
   }
   Vectorized<T> exp() const {
     return map(std::exp);

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -30,6 +30,7 @@
 #include <c10/util/BFloat16.h>
 #include <c10/util/BFloat16-math.h>
 #include <c10/util/copysign.h>
+#include <c10/util/generic_math.h>
 #include <ATen/native/cpu/zmath.h>
 #include <c10/util/TypeCast.h>
 #include <c10/macros/Macros.h>

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -5,7 +5,7 @@
 #include <ATen/jiterator_macros.h>
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
-#include <c10/util/MathConstants.h>
+#include <c10/util/generic_math.h>
 #include <cfloat>
 #include <cmath>
 #include <cstdint>
@@ -143,58 +143,6 @@ jiterator_also_stringify_as(jiterator_code(
   }),
   i0e_string); // i0e_string
 }
-
-#define CENTRAL_RANGE 0.7
-
-template <typename T>
-inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
-calc_erfinv(T y) {
-/* Function to calculate inverse error function.  Rational approximation
-is used to generate an initial approximation, which is then improved to
-full accuracy by two steps of Newton's method.  Code is a direct
-translation of the erfinv m file in matlab version 2.0.
-Author:  Gary L. Pavlis, Indiana University
-Date:  February 1996
-*/
-  T x, z, num, dem; /*working variables */
-  /* coefficients in rational expansion */
-  T a[4] = {  T(0.886226899), T(-1.645349621),  T(0.914624893), T(-0.140543331) };
-  T b[4] = { T(-2.118377725),  T(1.442710462), T(-0.329097515),  T(0.012229801) };
-  T c[4] = { T(-1.970840454), T(-1.624906493),  T(3.429567803),  T(1.641345311) };
-  T d[2] = {  T(3.543889200),  T(1.637067800) };
-  T y_abs = std::abs(y);
-  if(y_abs > 1.0) return std::numeric_limits<T>::quiet_NaN();
-#ifdef _WIN32
-  // error C2039: '_copysign': is not a member of 'std'
-  if(y_abs == 1.0) return copysign(std::numeric_limits<T>::infinity(), y);
-#else
-  if(y_abs == 1.0) return std::copysign(std::numeric_limits<T>::infinity(), y);
-#endif
-  if(y_abs <= static_cast<T>(CENTRAL_RANGE)) {
-    z = y * y;
-    num = (((a[3]*z + a[2])*z + a[1])*z + a[0]);
-    dem = ((((b[3]*z + b[2])*z + b[1])*z +b[0]) * z + static_cast<T>(1.0));
-    x = y * num / dem;
-  }
-  else{
-    z = std::sqrt(-std::log((static_cast<T>(1.0)-y_abs)/static_cast<T>(2.0)));
-    num = ((c[3]*z + c[2])*z + c[1]) * z + c[0];
-    dem = (d[1]*z + d[0])*z + static_cast<T>(1.0);
-#ifdef _WIN32
-    // error C2039: '_copysign': is not a member of 'std'
-    x = copysign(num, y) / dem;
-#else
-    x = std::copysign(num, y) / dem;
-#endif
-  }
-  /* Two steps of Newton-Raphson correction */
-  x = x - (std::erf(x) - y) / ((static_cast<T>(2.0)/static_cast<T>(std::sqrt(c10::pi<double>)))*std::exp(-x*x));
-  x = x - (std::erf(x) - y) / ((static_cast<T>(2.0)/static_cast<T>(std::sqrt(c10::pi<double>)))*std::exp(-x*x));
-
-  return(x);
-}
-
-#undef CENTRAL_RANGE
 
 /*
  * Note [3-Clause BSD License for the Cephes Math Library]

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -1170,8 +1170,6 @@ C10_UNUSED inline c10::Half calc_igammac<c10::Half>(c10::Half a, c10::Half x) {
   return calc_igammac<float>(float(a), float(x));
 }
 
-inline c10::BFloat16 calc_erfinv(c10::BFloat16 a) { return calc_erfinv(float(a)); }
-
 template <typename T>
 inline T abs_impl(T v) {
   return std::abs(v);

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -524,7 +524,7 @@ namespace {
         using vec = TypeParam;
         test_unary<vec>(
             NAME_INFO(erfinv),
-            RESOLVE_OVERLOAD(calc_erfinv),
+            RESOLVE_OVERLOAD(c10::calc_erfinv),
             [](const vec& v) { return v.erfinv(); },
             createDefaultUnaryTestCase<vec>(TestSeed(), false, true));
     }

--- a/c10/util/generic_math.h
+++ b/c10/util/generic_math.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/macros/Macros.h>
+#include <c10/util/MathConstants.h>
 #include <c10/util/TypeSafeSignMath.h>
 #include <cmath>
 
@@ -68,5 +69,67 @@ inline C10_HOST_DEVICE scalar_t div_floor_integer(scalar_t a, scalar_t b) {
   }
   return a / b;
 }
+
+#define CENTRAL_RANGE 0.7
+
+template <typename T>
+inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
+calc_erfinv(T y) {
+  /* Function to calculate inverse error function.  Rational approximation
+  is used to generate an initial approximation, which is then improved to
+  full accuracy by two steps of Newton's method.  Code is a direct
+  translation of the erfinv m file in matlab version 2.0.
+  Author:  Gary L. Pavlis, Indiana University
+  Date:  February 1996
+  */
+  T x, z, num, dem; /*working variables */
+  /* coefficients in rational expansion */
+  T a[4] = {T(0.886226899), T(-1.645349621), T(0.914624893), T(-0.140543331)};
+  T b[4] = {T(-2.118377725), T(1.442710462), T(-0.329097515), T(0.012229801)};
+  T c[4] = {T(-1.970840454), T(-1.624906493), T(3.429567803), T(1.641345311)};
+  T d[2] = {T(3.543889200), T(1.637067800)};
+  T y_abs = std::abs(y);
+  if (y_abs > 1.0)
+    return std::numeric_limits<T>::quiet_NaN();
+#ifdef _WIN32
+  // error C2039: '_copysign': is not a member of 'std'
+  if (y_abs == 1.0)
+    return copysign(std::numeric_limits<T>::infinity(), y);
+#else
+  if (y_abs == 1.0)
+    return std::copysign(std::numeric_limits<T>::infinity(), y);
+#endif
+  if (y_abs <= static_cast<T>(CENTRAL_RANGE)) {
+    z = y * y;
+    num = (((a[3] * z + a[2]) * z + a[1]) * z + a[0]);
+    dem =
+        ((((b[3] * z + b[2]) * z + b[1]) * z + b[0]) * z + static_cast<T>(1.0));
+    x = y * num / dem;
+  } else {
+    z = std::sqrt(
+        -std::log((static_cast<T>(1.0) - y_abs) / static_cast<T>(2.0)));
+    num = ((c[3] * z + c[2]) * z + c[1]) * z + c[0];
+    dem = (d[1] * z + d[0]) * z + static_cast<T>(1.0);
+#ifdef _WIN32
+    // error C2039: '_copysign': is not a member of 'std'
+    x = copysign(num, y) / dem;
+#else
+    x = std::copysign(num, y) / dem;
+#endif
+  }
+  /* Two steps of Newton-Raphson correction */
+  x = x -
+      (std::erf(x) - y) /
+          ((static_cast<T>(2.0) / static_cast<T>(std::sqrt(c10::pi<double>))) *
+           std::exp(-x * x));
+  x = x -
+      (std::erf(x) - y) /
+          ((static_cast<T>(2.0) / static_cast<T>(std::sqrt(c10::pi<double>))) *
+           std::exp(-x * x));
+
+  return (x);
+}
+
+#undef CENTRAL_RANGE
 
 } // namespace c10

--- a/c10/util/generic_math.h
+++ b/c10/util/generic_math.h
@@ -93,15 +93,18 @@ calc_erfinv(T y) {
       T(-1.970840454), T(-1.624906493), T(3.429567803), T(1.641345311)};
   std::array<T, 2> d = {T(3.543889200), T(1.637067800)};
   T y_abs = std::abs(y);
-  if (y_abs > 1.0)
+  if (y_abs > 1.0) {
     return std::numeric_limits<T>::quiet_NaN();
+  }
 #ifdef _WIN32
   // error C2039: '_copysign': is not a member of 'std'
-  if (y_abs == 1.0)
+  if (y_abs == 1.0) {
     return copysign(std::numeric_limits<T>::infinity(), y);
+  }
 #else
-  if (y_abs == 1.0)
+  if (y_abs == 1.0) {
     return std::copysign(std::numeric_limits<T>::infinity(), y);
+  }
 #endif
   if (y_abs <= static_cast<T>(CENTRAL_RANGE)) {
     z = y * y;

--- a/c10/util/generic_math.h
+++ b/c10/util/generic_math.h
@@ -3,6 +3,7 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/MathConstants.h>
 #include <c10/util/TypeSafeSignMath.h>
+#include <array>
 #include <cmath>
 
 #if defined(__CUDA_ARCH__)
@@ -84,10 +85,13 @@ calc_erfinv(T y) {
   */
   T x, z, num, dem; /*working variables */
   /* coefficients in rational expansion */
-  T a[4] = {T(0.886226899), T(-1.645349621), T(0.914624893), T(-0.140543331)};
-  T b[4] = {T(-2.118377725), T(1.442710462), T(-0.329097515), T(0.012229801)};
-  T c[4] = {T(-1.970840454), T(-1.624906493), T(3.429567803), T(1.641345311)};
-  T d[2] = {T(3.543889200), T(1.637067800)};
+  std::array<T, 4> a = {
+      T(0.886226899), T(-1.645349621), T(0.914624893), T(-0.140543331)};
+  std::array<T, 4> b = {
+      T(-2.118377725), T(1.442710462), T(-0.329097515), T(0.012229801)};
+  std::array<T, 4> c = {
+      T(-1.970840454), T(-1.624906493), T(3.429567803), T(1.641345311)};
+  std::array<T, 2> d = {T(3.543889200), T(1.637067800)};
   T y_abs = std::abs(y);
   if (y_abs > 1.0)
     return std::numeric_limits<T>::quiet_NaN();
@@ -131,5 +135,9 @@ calc_erfinv(T y) {
 }
 
 #undef CENTRAL_RANGE
+
+inline c10::BFloat16 calc_erfinv(c10::BFloat16 a) {
+  return calc_erfinv(float(a));
+}
 
 } // namespace c10

--- a/test/cpp/aoti_abi_check/test_math.cpp
+++ b/test/cpp/aoti_abi_check/test_math.cpp
@@ -12,6 +12,7 @@ TEST(TestMath, TestDivFloor) {
   EXPECT_DOUBLE_EQ(c10::div_floor_floating(5., -2.), -3.);
   EXPECT_EQ(c10::div_floor_integer(5, 2), 2);
   EXPECT_EQ(c10::div_floor_integer(5, -2), -3);
+  EXPECT_EQ(c10::calc_erfinv(0.5), 0.4769);
 }
 
 TEST(TestMath, TestNan) {

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -639,7 +639,7 @@ class CppOverrides(OpOverrides):
 
     @staticmethod
     def erfinv(x):
-        return f"calc_erfinv({x})"
+        return f"c10::calc_erfinv({x})"
 
     @staticmethod
     def sqrt(x):

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -36,9 +36,6 @@
 #if INDUCTOR_USE_VECTOR_TYPES()
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
-#else
-// For calc_erfinv
-#include <ATen/native/Math.h>
 #endif
 
 typedef at::Half half;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #136534
* __->__ #136776

Summary: When Inductor generates cpp kernels, cpp_prefix.h includes ATen/native/Math.h which transitively includes more header files. Some of those header files are not header-only and thus are not ABI-compatible.
Because  ATen/native/Math.h was only included to use calc_erfinv, we can move tcalc_erfinv to c10/util/generic_math.h which is implemented as header-only.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang

Differential Revision: [D63487088](https://our.internmc.facebook.com/intern/diff/D63487088)