### PR TITLE
override bool(), is_nonzero for real tensor tracing

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1917,6 +1917,13 @@ class FakeTensorMode(TorchDispatchMode):
                     if isinstance(t.node.expr, sympy.Symbol):
                         assert self.shape_env is not None
                         self.shape_env.set_unbacked_var_to_val(t.node.expr, real_t)
+                    elif (
+                        isinstance(s := t.node.expr, sympy.Eq)
+                        and isinstance(s.lhs, sympy.Symbol)
+                        and s.rhs == 1
+                    ):
+                        assert self.shape_env is not None
+                        self.shape_env.set_unbacked_var_to_val(s, int(real_t))
 
             if real_out is not nil:
                 if (

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -309,6 +309,9 @@ class FunctionalTensor(torch.Tensor):
     def layout(self):
         return self.elem.layout
 
+    def __bool__(self):
+        return bool(self.item())
+
 
 class FunctionalTensorMode(TorchDispatchMode):
     def __init__(self, pre_dispatch=False, export=False, _allow_token_discovery=False):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -801,6 +801,10 @@ def proxy_call(
             if r is not NotImplemented:
                 return r
 
+    if func is torch.ops.aten.is_nonzero.default:
+        with proxy_mode:
+            return (args[0] != 0).item()  # type: ignore[attr-defined]
+
     tracer = proxy_mode.tracer
     f_flat_args_kwargs = [
         (


### PR DESCRIPTION
Fixes bool() and is_nonzero() calls for real tensor tracing, non-strict export

Differential Revision: D63482693


