### PR TITLE
[CI] upload_metrics function to upload to s3 instead of dynamo

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1819,6 +1819,7 @@ def main():
     print_to_stderr(f"Running parallel tests on {NUM_PROCS} processes")
     print_to_stderr(test_batch)
     print_to_stderr(test_batch_exclude)
+    emit_metric("test_this_works", {"hello": "world"})
 
     if options.dry_run:
         return

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1819,7 +1819,6 @@ def main():
     print_to_stderr(f"Running parallel tests on {NUM_PROCS} processes")
     print_to_stderr(test_batch)
     print_to_stderr(test_batch_exclude)
-    emit_metric("test_this_works", {"hello": "world"})
 
     if options.dry_run:
         return

--- a/tools/stats/upload_metrics.py
+++ b/tools/stats/upload_metrics.py
@@ -141,15 +141,13 @@ def emit_metric(
         return
 
     # Prefix key with metric name and timestamp to derisk chance of a uuid1 name collision
-    default_metrics[
-        "dynamo_key"
-    ] = f"{metric_name}_{int(time.time())}_{uuid.uuid1().hex}"
+    s3_key = f"{metric_name}_{int(time.time())}_{uuid.uuid1().hex}"
 
     if EMIT_METRICS:
         try:
             upload_to_s3(
                 bucket_name="ossci-raw-job-status",
-                key=f"ossci_uploaded_metrics/{default_metrics['dynamo_key']}",
+                key=f"ossci_uploaded_metrics/{s3_key}",
                 docs=[{**default_metrics, "info": metrics}],
             )
         except Exception as e:

--- a/tools/stats/upload_metrics.py
+++ b/tools/stats/upload_metrics.py
@@ -158,9 +158,9 @@ def emit_metric(
     if EMIT_METRICS:
         try:
             upload_to_s3(
-                bucket_name="ossci-metrics",
-                key=f"metrics/{reserved_metrics['dynamo_key']}",
-                docs={**reserved_metrics, "info": metrics},
+                bucket_name="ossci-raw-job-status",
+                key=f"ossci_uploaded_metrics/{reserved_metrics['dynamo_key']}",
+                docs=[{**reserved_metrics, "info": metrics}],
             )
         except Exception as e:
             # We don't want to fail the job if we can't upload the metric.

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -222,12 +222,6 @@ class TestUploadStats(unittest.TestCase):
             f"Metrics should not include optional item 'pr_number' when it's envvar is set to '{default_val}'",
         )
 
-    def test_blocks_emission_if_reserved_keyword_used(self, mock_resource: Any) -> None:
-        metric = {"repo": "awesome/repo"}
-
-        with self.assertRaises(ValueError):
-            emit_metric("metric_name", metric)
-
     def test_no_metrics_emitted_if_required_env_var_not_set(
         self, mock_resource: Any
     ) -> None:

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-import decimal
+import gzip
 import inspect
 import json
 import sys
 import unittest
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from tools.stats.upload_metrics import add_global_metric, emit_metric
-from tools.stats.upload_stats_lib import BATCH_SIZE, remove_nan_inf, upload_to_rockset
+from tools.stats.upload_metrics import add_global_metric, emit_metric, global_metrics
+from tools.stats.upload_stats_lib import BATCH_SIZE, remove_nan_inf, get_s3_resource, upload_to_rockset
 
 
 sys.path.remove(str(REPO_ROOT))
@@ -33,9 +33,22 @@ JOB_ID = 234
 JOB_NAME = "some-job-name"
 
 
+@mock.patch("boto3.resource")
 class TestUploadStats(unittest.TestCase):
+    emitted_metric: Dict[str, Any] = {"did_not_emit": True}
+
+    def mock_put_item(self, **kwargs: Any) -> None:
+        # Utility for mocking putting items into s3.  THis will save the emitted
+        # metric so tests can check it
+        self.emitted_metric = json.loads(
+            gzip.decompress(kwargs["Body"]).decode("utf-8")
+        )
+
     # Before each test, set the env vars to their default values
     def setUp(self) -> None:
+        get_s3_resource.cache_clear()
+        global_metrics.clear()
+
         mock.patch.dict(
             "os.environ",
             {
@@ -54,7 +67,6 @@ class TestUploadStats(unittest.TestCase):
             clear=True,  # Don't read any preset env vars
         ).start()
 
-    @mock.patch("boto3.Session.resource")
     def test_emits_default_and_given_metrics(self, mock_resource: Any) -> None:
         metric = {
             "some_number": 123,
@@ -79,29 +91,20 @@ class TestUploadStats(unittest.TestCase):
             "run_id": RUN_ID,
             "run_number": RUN_NUMBER,
             "run_attempt": RUN_ATTEMPT,
-            "some_number": 123,
-            "float_number": decimal.Decimal(str(32.34)),
             "job_id": JOB_ID,
             "job_name": JOB_NAME,
+            "info": metric,
         }
 
-        # Preserve the metric emitted
-        emitted_metric: dict[str, Any] = {}
-
-        def mock_put_item(Item: dict[str, Any]) -> None:
-            nonlocal emitted_metric
-            emitted_metric = Item
-
-        mock_resource.return_value.Table.return_value.put_item = mock_put_item
+        mock_resource.return_value.Object.return_value.put = self.mock_put_item
 
         emit_metric("metric_name", metric)
 
         self.assertEqual(
-            emitted_metric,
-            {**emit_should_include, **emitted_metric},
+            self.emitted_metric,
+            {**self.emitted_metric, **emit_should_include},
         )
 
-    @mock.patch("boto3.Session.resource")
     def test_when_global_metric_specified_then_it_emits_it(
         self, mock_resource: Any
     ) -> None:
@@ -119,23 +122,15 @@ class TestUploadStats(unittest.TestCase):
             global_metric_name: global_metric_value,
         }
 
-        # Preserve the metric emitted
-        emitted_metric: dict[str, Any] = {}
-
-        def mock_put_item(Item: dict[str, Any]) -> None:
-            nonlocal emitted_metric
-            emitted_metric = Item
-
-        mock_resource.return_value.Table.return_value.put_item = mock_put_item
+        mock_resource.return_value.Object.return_value.put = self.mock_put_item
 
         emit_metric("metric_name", metric)
 
         self.assertEqual(
-            emitted_metric,
-            {**emitted_metric, **emit_should_include},
+            self.emitted_metric,
+            {**self.emitted_metric, "info": emit_should_include},
         )
 
-    @mock.patch("boto3.Session.resource")
     def test_when_local_and_global_metric_specified_then_global_is_overridden(
         self, mock_resource: Any
     ) -> None:
@@ -155,23 +150,15 @@ class TestUploadStats(unittest.TestCase):
             global_metric_name: local_override,
         }
 
-        # Preserve the metric emitted
-        emitted_metric: dict[str, Any] = {}
-
-        def mock_put_item(Item: dict[str, Any]) -> None:
-            nonlocal emitted_metric
-            emitted_metric = Item
-
-        mock_resource.return_value.Table.return_value.put_item = mock_put_item
+        mock_resource.return_value.Object.return_value.put = self.mock_put_item
 
         emit_metric("metric_name", metric)
 
         self.assertEqual(
-            emitted_metric,
-            {**emitted_metric, **emit_should_include},
+            self.emitted_metric,
+            {**self.emitted_metric, "info": emit_should_include},
         )
 
-    @mock.patch("boto3.Session.resource")
     def test_when_optional_envvar_set_to_actual_value_then_emit_vars_emits_it(
         self, mock_resource: Any
     ) -> None:
@@ -180,7 +167,7 @@ class TestUploadStats(unittest.TestCase):
         }
 
         emit_should_include = {
-            **metric,
+            "info": {**metric},
             "pr_number": PR_NUMBER,
         }
 
@@ -191,23 +178,15 @@ class TestUploadStats(unittest.TestCase):
             },
         ).start()
 
-        # Preserve the metric emitted
-        emitted_metric: dict[str, Any] = {}
-
-        def mock_put_item(Item: dict[str, Any]) -> None:
-            nonlocal emitted_metric
-            emitted_metric = Item
-
-        mock_resource.return_value.Table.return_value.put_item = mock_put_item
+        mock_resource.return_value.Object.return_value.put = self.mock_put_item
 
         emit_metric("metric_name", metric)
 
         self.assertEqual(
-            emitted_metric,
-            {**emit_should_include, **emitted_metric},
+            self.emitted_metric,
+            {**self.emitted_metric, **emit_should_include},
         )
 
-    @mock.patch("boto3.Session.resource")
     def test_when_optional_envvar_set_to_a_empty_str_then_emit_vars_ignores_it(
         self, mock_resource: Any
     ) -> None:
@@ -224,35 +203,26 @@ class TestUploadStats(unittest.TestCase):
             },
         ).start()
 
-        # Preserve the metric emitted
-        emitted_metric: dict[str, Any] = {}
-
-        def mock_put_item(Item: dict[str, Any]) -> None:
-            nonlocal emitted_metric
-            emitted_metric = Item
-
-        mock_resource.return_value.Table.return_value.put_item = mock_put_item
+        mock_resource.return_value.Object.return_value.put = self.mock_put_item
 
         emit_metric("metric_name", metric)
 
         self.assertEqual(
-            emitted_metric,
-            {**emit_should_include, **emitted_metric},
+            self.emitted_metric,
+            {**self.emitted_metric, "info": emit_should_include},
             f"Metrics should be emitted when an option parameter is set to '{default_val}'",
         )
         self.assertFalse(
-            emitted_metric.get("pr_number"),
+            self.emitted_metric.get("pr_number"),
             f"Metrics should not include optional item 'pr_number' when it's envvar is set to '{default_val}'",
         )
 
-    @mock.patch("boto3.Session.resource")
     def test_blocks_emission_if_reserved_keyword_used(self, mock_resource: Any) -> None:
         metric = {"repo": "awesome/repo"}
 
         with self.assertRaises(ValueError):
             emit_metric("metric_name", metric)
 
-    @mock.patch("boto3.Session.resource")
     def test_no_metrics_emitted_if_required_env_var_not_set(
         self, mock_resource: Any
     ) -> None:
@@ -267,19 +237,12 @@ class TestUploadStats(unittest.TestCase):
             clear=True,
         ).start()
 
-        put_item_invoked = False
-
-        def mock_put_item(Item: dict[str, Any]) -> None:
-            nonlocal put_item_invoked
-            put_item_invoked = True
-
-        mock_resource.return_value.Table.return_value.put_item = mock_put_item
+        mock_resource.return_value.Object.return_value.put = self.mock_put_item
 
         emit_metric("metric_name", metric)
 
-        self.assertFalse(put_item_invoked)
+        self.assertTrue(self.emitted_metric["did_not_emit"])
 
-    @mock.patch("boto3.Session.resource")
     def test_no_metrics_emitted_if_required_env_var_set_to_empty_string(
         self, mock_resource: Any
     ) -> None:
@@ -292,19 +255,13 @@ class TestUploadStats(unittest.TestCase):
             },
         ).start()
 
-        put_item_invoked = False
-
-        def mock_put_item(Item: dict[str, Any]) -> None:
-            nonlocal put_item_invoked
-            put_item_invoked = True
-
-        mock_resource.return_value.Table.return_value.put_item = mock_put_item
+        mock_resource.return_value.Object.return_value.put = self.mock_put_item
 
         emit_metric("metric_name", metric)
 
-        self.assertFalse(put_item_invoked)
+        self.assertTrue(self.emitted_metric["did_not_emit"])
 
-    def test_upload_to_rockset_batch_size(self) -> None:
+    def test_upload_to_rockset_batch_size(self, _mocked_resource: Any) -> None:
         cases = [
             {
                 "batch_size": BATCH_SIZE - 1,

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -298,7 +298,7 @@ class TestUploadStats(unittest.TestCase):
                 expected_number_of_requests,
             )
 
-    def test_remove_nan_inf(self) -> None:
+    def test_remove_nan_inf(self, _mocked_resource: Any) -> None:
         checks = [
             (float("inf"), '"inf"', "Infinity"),
             (float("nan"), '"nan"', "NaN"),

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -14,7 +14,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools.stats.upload_metrics import add_global_metric, emit_metric, global_metrics
-from tools.stats.upload_stats_lib import BATCH_SIZE, remove_nan_inf, get_s3_resource, upload_to_rockset
+from tools.stats.upload_stats_lib import (
+    BATCH_SIZE,
+    get_s3_resource,
+    remove_nan_inf,
+    upload_to_rockset,
+)
 
 
 sys.path.remove(str(REPO_ROOT))


### PR DESCRIPTION

* Upload_metrics function to upload to ossci-raw-job-status bucket instead of dynamo
* Moves all added metrics to a field called "info" so ingesting into database table with a strict schema is easier
* Removes the dynamo_key field since it is no longer needed
* Removes the concept of reserved metrics, since they cannot be overwritten by user added metrics anymore
* Moves s3 resource initialization behind a function so import is faster
---
Tested by emitting a metric during run_test and seeing that documents got added to s3