### PR TITLE
[export] add translations for SymInt/Bool deserialization; FloorDiv

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -301,6 +301,24 @@ class TestSerialize(TestCase):
             self.assertEqual(node.inputs[0].name, "self")
             self.assertEqual(node.inputs[1].name, "dim")
 
+    def test_serialize_floordiv_ranges(self):
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                return x.view(-1, x.shape[0] - 1)
+
+        ep = torch.export._trace._export(
+            Foo(),
+            (torch.randn(4, 6),),
+            dynamic_shapes={
+                "x": (Dim("dx"), Dim("dy")),
+            },
+            allow_complex_guards_as_runtime_asserts=True,
+        )
+        buffer = io.BytesIO()
+        save(ep, buffer)
+        buffer.seek(0)
+        load(buffer)
+
     def test_serialize_list_returns(self) -> None:
         class MyModule(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1415,6 +1415,35 @@ class ExportedProgramSerializer(metaclass=Final):
         )
 
 
+def _translate_deserialized_sym_expr(expr: sympy.Expr) -> sympy.Expr:
+    """
+    De-serialized symbolic expressions can differ from their original expressions in structure;
+    we serialize by dumping expressions containing custom torch sympy.Functions into strings,
+    then de-serialize with sympy.sympify(). This pattern matches and translates the de-serialized
+    expressions into their original form.
+    """
+    from torch.utils._sympy.functions import FloorDiv
+
+    def _match_floordiv(x):
+        # matches sympy.floor(Mul(*a, Pow(b, -1)))
+        return (
+            x.func == sympy.floor
+            and (_mul := x.args[0]).func == sympy.Mul
+            and (_pow := _mul.args[-1]).func == sympy.Pow
+            and _pow.args[1] == -1
+        )
+
+    def _translate_floordiv(x):
+        # converts sympy.floor(Mul(*a, Pow(b, -1))),
+        # into FloorDiv(a, b) or FloorDiv(Mul(*a), b).
+        *a, pow_b = x.args[0].args
+        return FloorDiv(sympy.Mul(*a) if len(a) > 1 else a[0], pow_b.args[0])
+
+    # add any translations here
+    expr = expr.replace(_match_floordiv, _translate_floordiv)
+    return expr
+
+
 @final
 class GraphModuleDeserializer(metaclass=Final):
     @dataclasses.dataclass
@@ -1499,6 +1528,7 @@ class GraphModuleDeserializer(metaclass=Final):
                     val.expr_str,
                     locals={**self.sympy_functions, **self.symbol_name_to_symbol},
                 )
+                sym = _translate_deserialized_sym_expr(sym)
                 # NOTE(avik): Assumptions on symbols are not explicitly serialized.
                 # This seems dangerous: it might cause unknown differences in shape env behavior
                 # on deserialization? Probably deserves a follow-up.


### PR DESCRIPTION
Summary:
fix for https://github.com/pytorch/pytorch/issues/136797

We have an issue with deserialization for symbolic expressions, where the original expression has a structure mismatch with the deserialized expression. This happens because we serialize the expressions into strings, and deserialize using sympy.sympify().

This seems to cause issues with custom torch sympy.Functions, in this case FloorDiv. In this case, the expression `FloorDiv(a, b)` turns into `sympy.floor(a, PowByNatural(b, -1))`, or `sympy.floor(sympy.Mul(*a), PowByNatural(b, -1))` if a is also a sympy.Mul. This seems to break downstream when we call torch.empty_strided() on this expression, and the PowByNatural has an invalid ValueRange (e.g. [0, -1]).

This fixes that by adding translations after deserialization, to pattern match and transform expressions into the original format. Other potential strategies are a) we could also serialize SymInts as sympy.Expr structures, but that seems a lot more involved and BC breaking, or b) we could modify sympy.sympify(?), but I don't know if this is possible.

Test Plan: test_export/test_serialize

Differential Revision: D63493615


