### PR TITLE
[hack/POC] get DTensor to work with compiled autograd

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_examples_compile.py
+++ b/test/distributed/tensor/parallel/test_tp_examples_compile.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
+
+import torch
+from torch.distributed._tensor import DeviceMesh, Shard
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    parallelize_module,
+    RowwiseParallel,
+)
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    MLPModule,
+    NUM_DEVICES,
+    with_comms,
+)
+import logging
+
+
+c10d_functional = torch.ops.c10d_functional
+
+
+# simplifed tests from test/distributed/tensor/parallel/test_tp_examples.py
+class DistTensorParallelExampleTest(DTensorTestBase):
+    @with_comms
+    def test_mlp_training(self, is_seq_parallel=False):
+        inp_size = [8, 10]
+        # Ensure all tp ranks have same input.
+        rng_seed = self.rank if is_seq_parallel else 0
+        torch.manual_seed(rng_seed)
+        inp = torch.rand(*inp_size, device=self.device_type)
+        model = MLPModule(self.device_type)
+        device_mesh = DeviceMesh(
+            self.device_type,
+            torch.arange(0, NUM_DEVICES),
+        )
+        parallelize_plan = {
+            "net1": ColwiseParallel(input_layouts=Shard(0))
+            if is_seq_parallel
+            else ColwiseParallel(),
+            "net2": RowwiseParallel(output_layouts=Shard(0))
+            if is_seq_parallel
+            else RowwiseParallel(),
+        }
+        model_tp = parallelize_module(model, device_mesh, parallelize_plan)
+        #model_tp = torch.compile(model_tp)
+        model_tp.compile()
+        output = model_tp(inp)
+        output.sum().backward()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -70,7 +70,9 @@ class AutogradCompilerInstance:
             shape_env=self.shape_env,
         )
         self.fx_tracer = PythonKeyTracer()
-        self.proxy_mode = ProxyTorchDispatchMode(self.fx_tracer, "symbolic")
+        self.proxy_mode = ProxyTorchDispatchMode(
+            self.fx_tracer, "symbolic", pre_dispatch=True
+        )
         self.hooks_proxy: Optional[Proxy] = None
         self.graph_placeholders = ["inputs", "sizes", "scalars", "hooks"]
 

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -461,7 +461,6 @@ def process_inputs(
                 return x
             if isinstance(x, FakeTensor):
                 assert x.fake_mode is fake_mode
-                return x
             if is_traceable_wrapper_subclass(x):
                 attrs, _ = x.__tensor_flatten__()
                 if all(isinstance(getattr(x, attr), FakeTensor) for attr in attrs):

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -312,11 +312,13 @@ class Redistribute(torch.autograd.Function):
             output = input._local_tensor
             target_spec = current_spec
 
-        return dtensor.DTensor(
-            output,
-            target_spec,
-            requires_grad=input.requires_grad,
-        )
+        dtensor_meta_dict = dtensor.dtensor_meta_dict()
+        meta_hash = hash(target_spec) + hash(input.requires_grad)
+        dtensor_meta_dict[meta_hash] = {
+            "spec": target_spec,
+            "requires_grad": input.requires_grad,
+        }
+        return torch.ops.dtensor.create_dtensor(output, meta_hash)
 
     @staticmethod
     def backward(ctx, grad_output: "dtensor.DTensor"):  # type: ignore[override]


### PR DESCRIPTION
Not for landing. Changes here are enough to get a simple function that uses compiled autograd + DTensor working (see the test in `test_dtensor_compile.py`)

There are a few changes in here that are worth landing, I'll move them into other PR's and land them separately as part of the "pre-dispatch backward graph" work.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136803



cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec