### PR TITLE
[Pytorch][AO] Update choose_qparams_per_token op to output correct shape for scales and zp

### DIFF
--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -771,7 +771,7 @@ def choose_qparams_per_token_meta(
     input: torch.Tensor,
     dtype: torch.dtype,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    size = (1, input.size(-1))
+    size = list(input.shape[:-1]) + [1]
     return torch.empty(size, dtype=torch.double, device=input.device), torch.empty(
         size, dtype=torch.int64, device=input.device
     )
@@ -827,7 +827,7 @@ def _choose_qparams_per_token_asymmetric_impl(
     )
     zero_point = torch.clamp(zero_point, qmin, qmax).round()
 
-    return scale.to(torch.float32), zero_point.to(torch.float32)
+    return scale.to(torch.float64), zero_point.to(torch.int64)
 
 
 quantized_decomposed_lib.define(
@@ -856,7 +856,7 @@ def choose_qparams_per_token_asymmetric_meta(
     input: torch.Tensor,
     dtype: torch.dtype,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    size = (1, input.size(-1))
+    size = list(input.shape[:-1]) + [1]
     return torch.empty(size, dtype=torch.double, device=input.device), torch.empty(
         size, dtype=torch.int64, device=input.device
     )
@@ -954,7 +954,7 @@ def dequantize_per_token(
 
     Args:
        input (torch.Tensor): quantized Tensor (uint8, int8 etc.)
-       scales (float32 torch.Tensor): quantization parameter for per token affine quantization
+       scales (float64 torch.Tensor): quantization parameter for per token affine quantization
        zero_points (int32 torch.Tensor): quantization parameter for per token affine quantization
        quant_min (int): minimum quantized value for input Tensor
        quant_max (int): maximum quantized value for input Tensor
@@ -965,8 +965,9 @@ def dequantize_per_token(
        dequantized Tensor with dtype `output_dtype`
     """
     input = input - zero_points
-    input = input.to(output_dtype) * scales
-    return input
+    input = input * scales
+    # Since scales are of float64 type, we need to cast it to output dtype requested
+    return input.to(output_dtype)
 
 
 @impl(quantized_decomposed_lib, "dequantize_per_token", "Meta")

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -955,7 +955,7 @@ def dequantize_per_token(
     Args:
        input (torch.Tensor): quantized Tensor (uint8, int8 etc.)
        scales (float64 torch.Tensor): quantization parameter for per token affine quantization
-       zero_points (int32 torch.Tensor): quantization parameter for per token affine quantization
+       zero_points (int64 torch.Tensor): quantization parameter for per token affine quantization
        quant_min (int): minimum quantized value for input Tensor
        quant_max (int): maximum quantized value for input Tensor
        dtype (torch.dtype): dtype (e.g. torch.uint8) for input Tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136807

- also makes scales and zp dtype reconcile with meta impl as well as other
quantized ops representation of scales and zero point
- make sure qunatize_per_token's output_dtype is respected

There are a few places where we need to reconcile on scale and zero point dtype
but that will come later. This fixes are mainly being done to enable quantized
kv cache though ET stack

Differential Revision: [D62301840](https://our.internmc.facebook.com/intern/diff/D62301840/)