### PR TITLE
[BE][MPS] Delete MacOS12 low-precision ops

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12055,6 +12055,7 @@ class TestConsistency(TestCaseMPS):
         'nn.functional.interpolate',
         'nn.functional.upsample_bilinear',
         'nn.functional.upsample_nearest',
+        'norm', 'masked.normalize',
     }
 
     FP32_LOW_PRECISION_LIST = {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -12055,14 +12055,6 @@ class TestConsistency(TestCaseMPS):
         'nn.functional.interpolate',
         'nn.functional.upsample_bilinear',
         'nn.functional.upsample_nearest',
-
-        # for macOS 12
-        'masked.normalize', 'masked.sum', 'masked.var',
-        'outer',
-        'sum_to_size', 'sum',
-        'mul',
-        'nansum', 'nanmean',
-        'norm',
     }
 
     FP32_LOW_PRECISION_LIST = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #136863
* #136822
* __->__ #136821
* #136755
* #136754

`norm` and `masked.normalize` still have to stay in the list