### PR TITLE
[cpu] Modify inductor opt flag --- ftree-loop-vectorize

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -855,11 +855,6 @@ class cpp:
         == "1"
     )
 
-    # Use ftree-loop-vectorize when compiling
-    enable_tree_loop_vec_opt_flag = (
-        os.environ.get("TORCHINDUCTOR_CPP_ENABLE_TREE_LOOP_VEC_OPT_FLAG", "0") == "1"
-    )
-
     # Disable the tiling select heuristic
     enable_tiling_heuristics = (
         os.environ.get("TORCHINDUCTOR_CPP_ENABLE_TILING_HEURISTIC", "1") == "1"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -855,6 +855,11 @@ class cpp:
         == "1"
     )
 
+    # Use ftree-loop-vectorize when compiling
+    enable_tree_loop_vec_opt_flag = (
+        os.environ.get("TORCHINDUCTOR_CPP_ENABLE_TREE_LOOP_VEC_OPT_FLAG", "0") == "1"
+    )
+
     # Disable the tiling select heuristic
     enable_tiling_heuristics = (
         os.environ.get("TORCHINDUCTOR_CPP_ENABLE_TILING_HEURISTIC", "1") == "1"

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -543,8 +543,7 @@ def _get_optimization_cflags() -> List[str]:
             cflags.append("fno-unsafe-math-optimizations")
         if not config.cpp.enable_floating_point_contract_flag:
             cflags.append("ffp-contract=off")
-        if not config.cpp.enable_tree_loop_vec_opt_flag:
-            cflags.append("fno-tree-loop-vectorize")
+        cflags.append("fno-tree-loop-vectorize")
 
         if sys.platform != "darwin":
             # https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -543,6 +543,8 @@ def _get_optimization_cflags() -> List[str]:
             cflags.append("fno-unsafe-math-optimizations")
         if not config.cpp.enable_floating_point_contract_flag:
             cflags.append("ffp-contract=off")
+        if not config.cpp.enable_tree_loop_vec_opt_flag:
+            cflags.append("fno-tree-loop-vectorize")
 
         if sys.platform != "darwin":
             # https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -543,10 +543,10 @@ def _get_optimization_cflags() -> List[str]:
             cflags.append("fno-unsafe-math-optimizations")
         if not config.cpp.enable_floating_point_contract_flag:
             cflags.append("ffp-contract=off")
-        if not config.cpp.enable_tree_loop_vec_opt_flag:
-            cflags.append("fno-tree-loop-vectorize")
 
         if sys.platform != "darwin":
+            # on macos, unknown argument: '-fno-tree-loop-vectorize'
+            cflags.append("fno-tree-loop-vectorize")
             # https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1
             # `-march=native` is unrecognized option on M1
             if not config.is_fbcode():

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -543,7 +543,8 @@ def _get_optimization_cflags() -> List[str]:
             cflags.append("fno-unsafe-math-optimizations")
         if not config.cpp.enable_floating_point_contract_flag:
             cflags.append("ffp-contract=off")
-        cflags.append("fno-tree-loop-vectorize")
+        if not config.cpp.enable_tree_loop_vec_opt_flag:
+            cflags.append("fno-tree-loop-vectorize")
 
         if sys.platform != "darwin":
             # https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -546,7 +546,8 @@ def _get_optimization_cflags() -> List[str]:
 
         if sys.platform != "darwin":
             # on macos, unknown argument: '-fno-tree-loop-vectorize'
-            cflags.append("fno-tree-loop-vectorize")
+            if is_gcc():
+                cflags.append("fno-tree-loop-vectorize")
             # https://stackoverflow.com/questions/65966969/why-does-march-native-not-work-on-apple-m1
             # `-march=native` is unrecognized option on M1
             if not config.is_fbcode():


### PR DESCRIPTION
Reopen https://github.com/pytorch/pytorch/pull/121782, as more optimizations have landed.

Fixes https://github.com/pytorch/pytorch/issues/115261, https://github.com/pytorch/pytorch/issues/113017.
For CPU inductor path, remove -ftree-loop-vectorize from optimization flags to fix functional issues.

### Validation on 3 benchmark suites

#### FP32
![image](https://github.com/user-attachments/assets/ec920928-fa36-467f-ba07-d2c05c51b92e)

Outlier models (speedup<0.8, single socket): None.

#### BF16
![image](https://github.com/user-attachments/assets/4a301e5e-147d-4b74-beb1-40290969ed80)

Outlier models (speedup<0.8, single socket multi threads):

- functorch_dp_cifar10 0.58
- opacus_cifar10 0.57

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov