### PR TITLE
Add option to disable operator profiling

### DIFF
--- a/test/edge/event_tracer_hooks.h
+++ b/test/edge/event_tracer_hooks.h
@@ -46,6 +46,22 @@ class EventTracerProfileScope final {
 };
 
 /**
+ * This class enables scope based profiling where needed using RAII.
+ * Profiling will be started when the object is created and will end
+ * when the object goes out of scope.
+ */
+class EventTracerProfileOpScope final {
+ public:
+  EventTracerProfileOpScope(EventTracer* event_tracer, const char* name) {};
+
+  ~EventTracerProfileOpScope() {};
+
+ private:
+  EventTracer* event_tracer_;
+  EventTracerEntry event_entry_;
+};
+
+/**
  * This class helps us set and then clear out the chain id and debug handle
  * values stored in the event tracer class using RAII. This is typically called
  * in the executor loop before entering the codegen layer to configure the chain

--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -503,7 +503,7 @@ Kernel(
         """
             + """
 
-        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_op_1");
+        internal::EventTracerProfileOpScope event_tracer_op_scope(context.internal_event_tracer(), "native_call_op_1");
         EXECUTORCH_SCOPE_PROF("native_call_op_1");
         bool result_ = at::native::default_kernel(context, );
         internal::event_tracer_log_evalue(context.internal_event_tracer(), *stack[0]);
@@ -590,7 +590,7 @@ Kernel(
         """
             + """
 
-        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_op_1");
+        internal::EventTracerProfileOpScope event_tracer_op_scope(context.internal_event_tracer(), "native_call_op_1");
         EXECUTORCH_SCOPE_PROF("native_call_op_1");
         bool result_ = at::native::default_kernel(context, );
         internal::event_tracer_log_evalue(context.internal_event_tracer(), *stack[0]);
@@ -626,7 +626,7 @@ Kernel(
         """
             + """
 
-        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_op_1");
+        internal::EventTracerProfileOpScope event_tracer_op_scope(context.internal_event_tracer(), "native_call_op_1");
         EXECUTORCH_SCOPE_PROF("native_call_op_1");
         bool result_ = at::native::default_kernel(context, );
         internal::event_tracer_log_evalue(context.internal_event_tracer(), *stack[0]);

--- a/torchgen/gen_executorch.py
+++ b/torchgen/gen_executorch.py
@@ -271,7 +271,7 @@ Kernel(
     []({contextArg.defn()}, EValue** stack) {{
         {code_connector.join(code_list)}
 
-        internal::EventTracerProfileScope event_tracer_scope(context.internal_event_tracer(), "native_call_{f.func.name}");
+        internal::EventTracerProfileOpScope event_tracer_op_scope(context.internal_event_tracer(), "native_call_{f.func.name}");
         EXECUTORCH_SCOPE_PROF("native_call_{f.func.name}");
         {ret_prefix}{kernel_call}(context, {args_str});
         {event_tracer_output_logging}


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/executorch/pull/5720

For smaller models the overhead of profiling ops might be prohibitively large (distorting the inference execution time significantly) so we provide users an option to disable op profiling and essentially only profile the important events such as inference execution time.

To disable operator profiling users need to do:
```
etdump_gen.set_event_tracer_profiling_level(executorch::runtime::EventTracerProfilingLevel::kNoOperatorProfiling);
```

Test Plan: Added test case.

Differential Revision: D61883224


