### PR TITLE
Turn some variables and functions into static

### DIFF
--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <c10/core/Allocator.h>
 
 #include <c10/util/ThreadLocalDebugInfo.h>
@@ -36,10 +37,8 @@ at::DataPtr InefficientStdFunctionContext::makeDataPtr(
       device};
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-C10_API at::Allocator* allocator_array[at::COMPILE_TIME_MAX_DEVICE_TYPES];
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
-C10_API uint8_t allocator_priority[at::COMPILE_TIME_MAX_DEVICE_TYPES] = {0};
+static std::array<at::Allocator*,at::COMPILE_TIME_MAX_DEVICE_TYPES> allocator_array{};
+static std::array<uint8_t, at::COMPILE_TIME_MAX_DEVICE_TYPES> allocator_priority{};
 
 void SetAllocator(at::DeviceType t, at::Allocator* alloc, uint8_t priority) {
   if (priority >= allocator_priority[static_cast<int>(t)]) {

--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -1,5 +1,5 @@
-#include <array>
 #include <c10/core/Allocator.h>
+#include <array>
 
 #include <c10/util/ThreadLocalDebugInfo.h>
 
@@ -37,8 +37,10 @@ at::DataPtr InefficientStdFunctionContext::makeDataPtr(
       device};
 }
 
-static std::array<at::Allocator*,at::COMPILE_TIME_MAX_DEVICE_TYPES> allocator_array{};
-static std::array<uint8_t, at::COMPILE_TIME_MAX_DEVICE_TYPES> allocator_priority{};
+static std::array<at::Allocator*, at::COMPILE_TIME_MAX_DEVICE_TYPES>
+    allocator_array{};
+static std::array<uint8_t, at::COMPILE_TIME_MAX_DEVICE_TYPES>
+    allocator_priority{};
 
 void SetAllocator(at::DeviceType t, at::Allocator* alloc, uint8_t priority) {
   if (priority >= allocator_priority[static_cast<int>(t)]) {

--- a/c10/core/StorageImpl.cpp
+++ b/c10/core/StorageImpl.cpp
@@ -4,11 +4,11 @@
 namespace c10 {
 
 // The array to save function pointer for custom storageImpl create.
-C10_API std::array<StorageImplCreateHelper, at::COMPILE_TIME_MAX_DEVICE_TYPES>
+static std::array<StorageImplCreateHelper, at::COMPILE_TIME_MAX_DEVICE_TYPES>
     StorageImplCreate;
 
 // A allowlist of device type, currently available is PrivateUse1
-inline ska::flat_hash_set<c10::DeviceType>& GetBackendMetaAllowlist() {
+static ska::flat_hash_set<c10::DeviceType>& GetBackendMetaAllowlist() {
   static ska::flat_hash_set<c10::DeviceType> DeviceTypeAllowList{
       DeviceType::PrivateUse1};
   return DeviceTypeAllowList;

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -126,7 +126,7 @@ constexpr size_t kMinLargeAlloc =
     10485760; // allocations between 1 and 10 MiB may use kLargeBuffer
 constexpr size_t kRoundLarge = 2097152; // round up large allocations to 2 MiB
 
-char SHAREABLE_HANDLE_VERSION = 1;
+static char SHAREABLE_HANDLE_VERSION = 1;
 enum ShareableHandleType : char {
   SHAREABLE_CUDA_MALLOC = 'c',
   SHAREABLE_CUDA_EXPANDABLE_SEGMENT = 'e'
@@ -3189,7 +3189,7 @@ static void uncached_delete(void* ptr) {
   C10_CUDA_CHECK(cudaFree(ptr));
 }
 
-void local_raw_delete(void* ptr);
+static void local_raw_delete(void* ptr);
 
 class NativeCachingAllocator : public CUDAAllocator {
  private:
@@ -3795,7 +3795,7 @@ class NativeCachingAllocator : public CUDAAllocator {
   }
 };
 
-NativeCachingAllocator allocator;
+static NativeCachingAllocator allocator;
 
 void local_raw_delete(void* ptr) {
   if (TORCH_SDT_IS_ENABLED(free)) {
@@ -3854,7 +3854,7 @@ struct BackendStaticInitializer {
 };
 
 std::atomic<CUDAAllocator*> allocator;
-BackendStaticInitializer backend_static_initializer;
+static BackendStaticInitializer backend_static_initializer;
 } // namespace cuda::CUDACachingAllocator
 } // namespace c10
 

--- a/c10/cuda/CUDAFunctions.cpp
+++ b/c10/cuda/CUDAFunctions.cpp
@@ -175,7 +175,7 @@ namespace _internal {
 bool dummyHasPrimaryContext([[maybe_unused]] DeviceIndex device_index) {
   TORCH_CHECK(false, "Should never been called");
 }
-bool (*hasPrimaryContext)(DeviceIndex) = dummyHasPrimaryContext;
+static bool (*hasPrimaryContext)(DeviceIndex) = dummyHasPrimaryContext;
 
 // Private api to be called from CUDAHooks.cpp
 C10_CUDA_API void setHasPrimaryContext(bool (*func)(DeviceIndex)) {
@@ -210,7 +210,7 @@ cudaError_t GetDeviceCount(int* dev_count) {
 // call y = torch.empty(1, device=“cuda”) # CUDA context is created on cuda:0
 // ```
 #if CUDA_VERSION >= 12000
-thread_local DeviceIndex targetDeviceIndex = -1;
+thread_local static DeviceIndex targetDeviceIndex = -1;
 
 cudaError_t GetDevice(DeviceIndex* device) {
   if (targetDeviceIndex >= 0) {

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -400,7 +400,7 @@ void mallocAsync(
 
 } // anonymous namespace
 
-void local_raw_delete(void* ptr);
+static void local_raw_delete(void* ptr);
 
 // Same pattern as CUDACachingAllocator.cpp.
 struct CudaMallocAsyncAllocator : public CUDAAllocator {
@@ -900,7 +900,7 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
   }
 };
 
-CudaMallocAsyncAllocator device_allocator;
+static CudaMallocAsyncAllocator device_allocator;
 
 void local_raw_delete(void* ptr) {
   freeAsync(ptr);
@@ -911,7 +911,7 @@ CUDAAllocator* allocator() {
 
 #else
 CUDAAllocator* allocator() {
-  TORCH_CHECK(false, "Cannot use cudaMallocAsyncAllocator with cuda < 11.4.");
+  TORCH_CHECK(false, "Cannot use CudaMallocAsyncAllocator with cuda < 11.4.");
   return nullptr;
 }
 

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -175,7 +175,7 @@ WarningHandler* get_warning_handler() noexcept(true) {
   return ThreadWarningHandler::get_handler();
 }
 
-bool warn_always = false;
+static bool warn_always = false;
 
 void set_warnAlways(bool setting) noexcept(true) {
   warn_always = setting;

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -209,10 +209,6 @@ void SetPyTorchDDPUsageLogger(
 
 static int64_t GLOBAL_RANK = -1;
 
-int64_t GetGlobalRank() {
-  return GLOBAL_RANK;
-}
-
 void SetGlobalRank(int64_t rank) {
   GLOBAL_RANK = rank;
 }

--- a/c10/util/ParallelGuard.cpp
+++ b/c10/util/ParallelGuard.cpp
@@ -2,7 +2,7 @@
 
 namespace c10 {
 
-thread_local bool in_at_parallel = false;
+thread_local static bool in_at_parallel = false;
 
 bool ParallelGuard::is_enabled() {
   return in_at_parallel;

--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -37,14 +37,18 @@ std::string ExcludeFileExtension(const std::string& file_name) {
 
 // Narrows the wstr argument and then passes it to _str.
 // Assumes that the input (wide) text is encoded as UTF-16.
-static std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString);
+static std::ostream& _strFromWide(
+    std::ostream& ss,
+    const std::wstring& wString);
 
 #ifndef _WIN32
 
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 // TODO (huydhn) https://en.cppreference.com/w/cpp/header/codecvt has been
 // deprecated in C++17 but there is no alternative yet, so I just ack it
-static std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString) {
+static std::ostream& _strFromWide(
+    std::ostream& ss,
+    const std::wstring& wString) {
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   return _str(ss, converter.to_bytes(wString));
 }
@@ -54,7 +58,9 @@ C10_DIAGNOSTIC_POP()
 // The WIN32 implementation of wstring_convert leaks memory; see
 // https://github.com/microsoft/STL/issues/443
 
-static std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString) {
+static std::ostream& _strFromWide(
+    std::ostream& ss,
+    const std::wstring& wString) {
   return _str(ss, u16u8(wString));
 }
 

--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -37,14 +37,14 @@ std::string ExcludeFileExtension(const std::string& file_name) {
 
 // Narrows the wstr argument and then passes it to _str.
 // Assumes that the input (wide) text is encoded as UTF-16.
-std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString);
+static std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString);
 
 #ifndef _WIN32
 
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
 // TODO (huydhn) https://en.cppreference.com/w/cpp/header/codecvt has been
 // deprecated in C++17 but there is no alternative yet, so I just ack it
-std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString) {
+static std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString) {
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   return _str(ss, converter.to_bytes(wString));
 }
@@ -54,7 +54,7 @@ C10_DIAGNOSTIC_POP()
 // The WIN32 implementation of wstring_convert leaks memory; see
 // https://github.com/microsoft/STL/issues/443
 
-std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString) {
+static std::ostream& _strFromWide(std::ostream& ss, const std::wstring& wString) {
   return _str(ss, u16u8(wString));
 }
 

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-PyObject* THPUpperModuleOfDevice = nullptr;
+static PyObject* THPUpperModuleOfDevice = nullptr;
 
 PyObject* THPDevice_New(const at::Device& device) {
   auto type = (PyTypeObject*)&THPDeviceType;
@@ -27,7 +27,7 @@ PyObject* THPDevice_New(const at::Device& device) {
   return self.release();
 }
 
-PyObject* THPDevice_repr(THPDevice* self) {
+static PyObject* THPDevice_repr(THPDevice* self) {
   std::ostringstream oss;
   oss << "device(type=\'" << self->device.type() << "\'";
   if (self->device.has_index()) {
@@ -40,13 +40,13 @@ PyObject* THPDevice_repr(THPDevice* self) {
   return THPUtils_packString(oss.str().c_str());
 }
 
-PyObject* THPDevice_str(THPDevice* self) {
+static PyObject* THPDevice_str(THPDevice* self) {
   std::ostringstream oss;
   oss << self->device;
   return THPUtils_packString(oss.str().c_str());
 }
 
-PyObject* THPDevice_pynew(
+static PyObject* THPDevice_pynew(
     PyTypeObject* type,
     PyObject* args,
     PyObject* kwargs) {
@@ -87,7 +87,7 @@ PyObject* THPDevice_pynew(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDevice_type(THPDevice* self, PyObject* noargs) {
+static PyObject* THPDevice_type(THPDevice* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   std::ostringstream oss;
   oss << self->device.type();
@@ -96,7 +96,7 @@ PyObject* THPDevice_type(THPDevice* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDevice_index(THPDevice* self, PyObject* noargs) {
+static PyObject* THPDevice_index(THPDevice* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   if (self->device.has_index()) {
     return THPUtils_packInt64(self->device.index());
@@ -114,7 +114,7 @@ static Py_ssize_t THPDevice_hash(THPDevice* self) {
   END_HANDLE_TH_ERRORS_RET(-1)
 }
 
-PyObject* THPDevice_rc(PyObject* a, PyObject* b, int op) {
+static PyObject* THPDevice_rc(PyObject* a, PyObject* b, int op) {
   HANDLE_TH_ERRORS
   if (!THPDevice_Check(a) || !THPDevice_Check(b)) {
     // Py_RETURN_NOTIMPLEMENTED not in python 2.
@@ -148,7 +148,7 @@ PyObject* THPDevice_rc(PyObject* a, PyObject* b, int op) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDevice_reduce(PyObject* _self, PyObject* noargs) {
+static PyObject* THPDevice_reduce(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   auto self = (THPDevice*)_self;
   auto ret = THPObjectPtr{PyTuple_New(2)};
@@ -176,7 +176,7 @@ PyObject* THPDevice_reduce(PyObject* _self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDevice_enter(PyObject* self, PyObject* noargs) {
+static PyObject* THPDevice_enter(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   py::object mode = py::module::import("torch.utils._device")
                         .attr("DeviceContext")(py::handle(self));
@@ -189,14 +189,22 @@ PyObject* THPDevice_enter(PyObject* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDevice_exit(PyObject* self, PyObject* unused) {
+static PyObject* THPDevice_exit(PyObject* self, PyObject* unused) {
   HANDLE_TH_ERRORS
   at::impl::PythonTorchFunctionTLS::pop_stack();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDevice_call(PyObject* self, PyObject* args, PyObject* kwargs) {
+/*
+// TODO: We're not sure if this is a good idea or not, because making
+// torch.device callable means that it will start returning true
+// for callable() queries, and that is unexpected.  We can always add
+// this later, so for now, don't actually implement this.
+static PyObject* THPDevice_call(
+    PyObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
   HANDLE_TH_ERRORS
   py::object deco =
       py::module::import("torch.utils._device").attr("device_decorator");
@@ -205,6 +213,7 @@ PyObject* THPDevice_call(PyObject* self, PyObject* args, PyObject* kwargs) {
       .ptr();
   END_HANDLE_TH_ERRORS
 }
+*/
 
 typedef PyObject* (*getter)(PyObject*, void*);
 

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -26,7 +26,7 @@ PyObject* THPDtype_New(at::ScalarType scalar_type, const std::string& name) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDtype_is_floating_point(THPDtype* self, PyObject* noargs) {
+static PyObject* THPDtype_is_floating_point(THPDtype* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   if (at::isFloatingType(self->scalar_type)) {
     Py_RETURN_TRUE;
@@ -36,14 +36,14 @@ PyObject* THPDtype_is_floating_point(THPDtype* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDtype_itemsize(THPDtype* self, PyObject* noargs) {
+static PyObject* THPDtype_itemsize(THPDtype* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   return THPUtils_packUInt64(
       scalarTypeToTypeMeta(self->scalar_type).itemsize());
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDtype_is_complex(THPDtype* self, PyObject* noargs) {
+static PyObject* THPDtype_is_complex(THPDtype* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   if (at::isComplexType(self->scalar_type)) {
     Py_RETURN_TRUE;
@@ -53,7 +53,7 @@ PyObject* THPDtype_is_complex(THPDtype* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDtype_is_signed(THPDtype* self, PyObject* noargs) {
+static PyObject* THPDtype_is_signed(THPDtype* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   if (at::isSignedType(self->scalar_type)) {
     Py_RETURN_TRUE;
@@ -63,7 +63,7 @@ PyObject* THPDtype_is_signed(THPDtype* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDtype_reduce(PyObject* _self, PyObject* noargs) {
+static PyObject* THPDtype_reduce(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   /*
    * For singletons, a string is returned. The string should be interpreted
@@ -74,7 +74,7 @@ PyObject* THPDtype_reduce(PyObject* _self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDtype_to_real(PyObject* _self, PyObject* noargs) {
+static PyObject* THPDtype_to_real(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   auto* self = (THPDtype*)_self;
   auto scalar_type = self->scalar_type;
@@ -85,7 +85,7 @@ PyObject* THPDtype_to_real(PyObject* _self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDtype_to_complex(PyObject* _self, PyObject* noargs) {
+static PyObject* THPDtype_to_complex(PyObject* _self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   auto* self = (THPDtype*)_self;
   auto scalar_type = self->scalar_type;
@@ -118,7 +118,7 @@ static PyMethodDef THPDtype_methods[] = {
     {nullptr} /* Sentinel */
 };
 
-PyObject* THPDtype_repr(THPDtype* self) {
+static PyObject* THPDtype_repr(THPDtype* self) {
   return THPUtils_packString(std::string("torch.") + self->name);
 }
 

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -118,7 +118,7 @@ could not be completed because the input matrix is singular.",
 
 namespace torch {
 
-void processErrorMsgInplace(std::string& str) {
+static void processErrorMsgInplace(std::string& str) {
   // Translate Aten types to their respective pytorch ones
   constexpr std::array<std::pair<c10::string_view, c10::string_view>, 64>
       changes{{
@@ -223,7 +223,7 @@ void translate_exception_to_python(const std::exception_ptr& e_ptr) {
         "called with invalid exception pointer");
     std::rethrow_exception(e_ptr);
   }
-  CATCH_ALL_ERRORS(return)
+  CATCH_ALL_ERRORS(return )
 }
 
 TypeError::TypeError(const char* format, ...) {
@@ -251,7 +251,7 @@ PyWarningHandler::PyWarningHandler() noexcept(true)
 }
 
 // Get the Python warning type for a warning
-PyObject* map_warning_to_python_type(const c10::Warning& warning) {
+static PyObject* map_warning_to_python_type(const c10::Warning& warning) {
   struct Visitor {
     PyObject* operator()(const c10::UserWarning&) const {
       return PyExc_UserWarning;

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -223,7 +223,7 @@ void translate_exception_to_python(const std::exception_ptr& e_ptr) {
         "called with invalid exception pointer");
     std::rethrow_exception(e_ptr);
   }
-  CATCH_ALL_ERRORS(return )
+  CATCH_ALL_ERRORS(return)
 }
 
 TypeError::TypeError(const char* format, ...) {

--- a/torch/csrc/Layout.cpp
+++ b/torch/csrc/Layout.cpp
@@ -22,7 +22,7 @@ PyObject* THPLayout_New(at::Layout layout, const std::string& name) {
   return self.release();
 }
 
-PyObject* THPLayout_repr(THPLayout* self) {
+static PyObject* THPLayout_repr(THPLayout* self) {
   return THPUtils_packString(self->name);
 }
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1631,15 +1631,14 @@ static PyMethodDef TorchMethods[] = { // NOLINT
      nullptr},
     {nullptr, nullptr, 0, nullptr}};
 
-static void THCPStream_init(PyObject* module);
-static void THCPEvent_init(PyObject* module);
-static void THCPGraph_init(PyObject* module);
-static void THCPMemPool_init(PyObject* module);
-
 #ifdef USE_CUDA
-static PyMethodDef* THCPModule_methods();
+void THCPStream_init(PyObject* module);
+void THCPEvent_init(PyObject* module);
+void THCPGraph_init(PyObject* module);
+void THCPMemPool_init(PyObject* module);
+PyMethodDef* THCPModule_methods();
 namespace torch::cuda {
-static void initModule(PyObject* module);
+void initModule(PyObject* module);
 } // namespace torch::cuda
 #endif
 
@@ -1654,7 +1653,7 @@ void initModule(PyObject* module);
 
 #ifdef USE_ITT
 namespace torch::profiler {
-static void initIttBindings(PyObject* module);
+void initIttBindings(PyObject* module);
 } // namespace torch::profiler
 #endif
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -346,7 +346,9 @@ static PyObject* THPModule_setNumInteropThreads(
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_setDefaultTensorType(PyObject* _unused, PyObject* type) {
+static PyObject* THPModule_setDefaultTensorType(
+    PyObject* _unused,
+    PyObject* type) {
   HANDLE_TH_ERRORS
   torch::tensors::py_set_default_tensor_type(type);
   Py_RETURN_NONE;
@@ -699,13 +701,17 @@ static PyObject* THPModule_setSDPUseFlash(PyObject* _unused, PyObject* arg) {
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-static PyObject* THPModule_userEnabledFlashSDP(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledFlashSDP(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().userEnabledFlashSDP())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
-static PyObject* THPModule_setSDPUseMemEfficient(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setSDPUseMemEfficient(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -716,7 +722,9 @@ static PyObject* THPModule_setSDPUseMemEfficient(PyObject* _unused, PyObject* ar
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-static PyObject* userEnabledMemEfficientSDP(PyObject* _unused, PyObject* noargs) {
+static PyObject* userEnabledMemEfficientSDP(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().userEnabledMemEfficientSDP())
     Py_RETURN_TRUE;
   else
@@ -733,7 +741,9 @@ static PyObject* THPModule_setSDPUseMath(PyObject* _unused, PyObject* arg) {
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-static PyObject* THPModule_userEnabledMathSDP(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledMathSDP(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().userEnabledMathSDP())
     Py_RETURN_TRUE;
   else
@@ -760,7 +770,9 @@ static PyObject* THPModule_allowFP16BF16ReductionMathSDP(
   else
     Py_RETURN_FALSE;
 }
-static PyObject* THPModule_setSDPUseOverrideable(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setSDPUseOverrideable(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -790,14 +802,18 @@ static PyObject* THPModule_setSDPUseCuDNN(PyObject* _unused, PyObject* arg) {
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-static PyObject* THPModule_userEnabledCuDNNSDP(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledCuDNNSDP(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().userEnabledCuDNNSDP())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-static PyObject* THPModule_setUserEnabledCuDNN(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setUserEnabledCuDNN(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -809,14 +825,18 @@ static PyObject* THPModule_setUserEnabledCuDNN(PyObject* _unused, PyObject* arg)
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_userEnabledCuDNN(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledCuDNN(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().userEnabledCuDNN())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-static PyObject* THPModule_setUserEnabledMkldnn(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setUserEnabledMkldnn(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -828,14 +848,18 @@ static PyObject* THPModule_setUserEnabledMkldnn(PyObject* _unused, PyObject* arg
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_userEnabledMkldnn(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledMkldnn(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().userEnabledMkldnn())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-static PyObject* THPModule_setDeterministicCuDNN(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setDeterministicCuDNN(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -847,14 +871,18 @@ static PyObject* THPModule_setDeterministicCuDNN(PyObject* _unused, PyObject* ar
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_deterministicCuDNN(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_deterministicCuDNN(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().deterministicCuDNN())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-static PyObject* THPModule_setDeterministicMkldnn(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setDeterministicMkldnn(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -866,7 +894,9 @@ static PyObject* THPModule_setDeterministicMkldnn(PyObject* _unused, PyObject* a
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_deterministicMkldnn(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_deterministicMkldnn(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().deterministicMkldnn())
     Py_RETURN_TRUE;
   else
@@ -927,7 +957,9 @@ static PyObject* THPModule_deterministicFillUninitializedMemory(
     Py_RETURN_FALSE;
 }
 
-static PyObject* THPModule_setUserEnabledNNPACK(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setUserEnabledNNPACK(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -939,7 +971,9 @@ static PyObject* THPModule_setUserEnabledNNPACK(PyObject* _unused, PyObject* arg
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_userEnabledNNPACK(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledNNPACK(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().userEnabledNNPACK())
     Py_RETURN_TRUE;
   else
@@ -974,7 +1008,9 @@ static PyObject* THPModule_warn(PyObject* _unused, PyObject* noargs) {
 }
 
 // Used only for testing C++ to Python warning translations.
-static PyObject* THPModule_warnDeprecation(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_warnDeprecation(
+    PyObject* _unused,
+    PyObject* noargs) {
   HANDLE_TH_ERRORS
   TORCH_WARN_DEPRECATION("Test message for TORCH_WARN_DEPRECATION");
   Py_RETURN_NONE;
@@ -1000,7 +1036,9 @@ static PyObject* THPModule_benchmarkCuDNN(PyObject* _unused, PyObject* noargs) {
   Py_RETURN_FALSE;
 }
 
-static PyObject* THPModule_setAllowTF32CuBLAS(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setAllowTF32CuBLAS(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -1012,7 +1050,9 @@ static PyObject* THPModule_setAllowTF32CuBLAS(PyObject* _unused, PyObject* arg) 
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_allowTF32CuBLAS(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_allowTF32CuBLAS(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().allowTF32CuBLAS()) {
     Py_RETURN_TRUE;
   }
@@ -1065,7 +1105,9 @@ static PyObject* THPModule_allowBF16ReductionCuBLAS(
   Py_RETURN_FALSE;
 }
 
-static PyObject* THPModule_setAllowFP16ReductionCPU(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setAllowFP16ReductionCPU(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -1077,7 +1119,9 @@ static PyObject* THPModule_setAllowFP16ReductionCPU(PyObject* _unused, PyObject*
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_allowFP16ReductionCPU(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_allowFP16ReductionCPU(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().allowFP16ReductionCPU()) {
     Py_RETURN_TRUE;
   }
@@ -1131,7 +1175,9 @@ static PyObject* THPModule_qEngine(PyObject* _unused, PyObject* noargs) {
       static_cast<int64_t>(at::globalContext().qEngine()));
 }
 
-static PyObject* THPModule_supportedQEngines(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_supportedQEngines(
+    PyObject* _unused,
+    PyObject* noargs) {
   auto qengines = at::globalContext().supportedQEngines();
   auto list =
       THPObjectPtr(PyList_New(static_cast<Py_ssize_t>(qengines.size())));
@@ -1146,7 +1192,9 @@ static PyObject* THPModule_supportedQEngines(PyObject* _unused, PyObject* noargs
   return list.release();
 }
 
-static PyObject* THPModule_isEnabledXNNPACK(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_isEnabledXNNPACK(
+    PyObject* _unused,
+    PyObject* noargs) {
   if (at::globalContext().isXNNPACKAvailable())
     Py_RETURN_TRUE;
   else
@@ -1176,7 +1224,9 @@ static PyObject* THPModule_checkSparseTensorInvariants(
     Py_RETURN_FALSE;
 }
 
-static PyObject* THPModule_willEngineExecuteNode(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_willEngineExecuteNode(
+    PyObject* _unused,
+    PyObject* arg) {
   HANDLE_TH_ERRORS
   bool isTHPFunction = THPFunction_Check(arg);
   bool isTHPCppFunction = torch::autograd::THPCppFunction_Check(arg);
@@ -1241,7 +1291,9 @@ static PyObject* THPModule_getCurrentGraphTaskExecutionOrder(
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THPModule_getCurrentGraphTaskId(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_getCurrentGraphTaskId(
+    PyObject* _unused,
+    PyObject* noargs) {
   HANDLE_TH_ERRORS
   return THPUtils_packInt64(torch::autograd::get_current_graph_task_id());
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -129,9 +129,9 @@
 
 namespace py = pybind11;
 
-PyObject* module;
+static PyObject* module;
 
-THPGenerator* THPDefaultCPUGenerator = nullptr;
+static THPGenerator* THPDefaultCPUGenerator = nullptr;
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -346,21 +346,21 @@ static PyObject* THPModule_setNumInteropThreads(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_setDefaultTensorType(PyObject* _unused, PyObject* type) {
+static PyObject* THPModule_setDefaultTensorType(PyObject* _unused, PyObject* type) {
   HANDLE_TH_ERRORS
   torch::tensors::py_set_default_tensor_type(type);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_setDefaultDtype(PyObject* _unused, PyObject* dtype) {
+static PyObject* THPModule_setDefaultDtype(PyObject* _unused, PyObject* dtype) {
   HANDLE_TH_ERRORS
   torch::tensors::py_set_default_dtype(dtype);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_swap_tensor_impl(PyObject* _unused, PyObject* args) {
+static PyObject* THPModule_swap_tensor_impl(PyObject* _unused, PyObject* args) {
   HANDLE_TH_ERRORS
   PyObject* a_ = nullptr;
   PyObject* b_ = nullptr;
@@ -414,7 +414,7 @@ PyObject* THPModule_swap_tensor_impl(PyObject* _unused, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_addDocStr(PyObject* _unused, PyObject* args) {
+static PyObject* THPModule_addDocStr(PyObject* _unused, PyObject* args) {
   // adds a __doc__ string to a function, similar to numpy's arr_add_docstring
   static std::vector<std::string> all_docs;
   PyObject* obj = nullptr;
@@ -475,7 +475,7 @@ PyObject* THPModule_addDocStr(PyObject* _unused, PyObject* args) {
   return obj;
 }
 
-PyObject* THPModule_inferSize(PyObject* _unused, PyObject* args) {
+static PyObject* THPModule_inferSize(PyObject* _unused, PyObject* args) {
   HANDLE_TH_ERRORS
   Py_ssize_t num_args = args ? (Py_ssize_t)PyTuple_Size(args) : 0;
   TORCH_CHECK(num_args == 2, "expected exactly 2 arguments");
@@ -537,7 +537,7 @@ static PyObject* THPModule_getBackcompatKeepdimWarn(
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_hasDistributed(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_hasDistributed(PyObject* _unused, PyObject* noargs) {
 #ifdef USE_DISTRIBUTED
   Py_RETURN_TRUE;
 #else
@@ -571,7 +571,7 @@ static PyObject* THPModule_getCpuCapability(
   END_HANDLE_TH_ERRORS
 }
 
-void DLPack_Capsule_Destructor(PyObject* data) {
+static void DLPack_Capsule_Destructor(PyObject* data) {
   if (C10_LIKELY(!PyCapsule_IsValid(data, "dltensor"))) {
     // early out, see DLPack spec: if a consuming library sets the capsule
     // name to something else, they own it and we don't need to do anything
@@ -591,7 +591,7 @@ void DLPack_Capsule_Destructor(PyObject* data) {
   END_HANDLE_TH_ERRORS_RET()
 }
 
-PyObject* THPModule_toDLPack(PyObject* _unused, PyObject* data) {
+static PyObject* THPModule_toDLPack(PyObject* _unused, PyObject* data) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(THPVariable_Check(data), "data must be a Tensor");
   DLManagedTensor* dlMTensor = at::toDLPack(THPVariable_Unpack(data));
@@ -599,7 +599,7 @@ PyObject* THPModule_toDLPack(PyObject* _unused, PyObject* data) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_fromDLPack(PyObject* _unused, PyObject* data) {
+static PyObject* THPModule_fromDLPack(PyObject* _unused, PyObject* data) {
   using namespace torch::autograd;
   HANDLE_TH_ERRORS
   auto tensor = torch::utils::tensor_fromDLPack(data);
@@ -607,7 +607,7 @@ PyObject* THPModule_fromDLPack(PyObject* _unused, PyObject* data) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THModule_getCppBacktrace(PyObject* _unused, PyObject* args) {
+static PyObject* THModule_getCppBacktrace(PyObject* _unused, PyObject* args) {
   HANDLE_TH_ERRORS
   size_t frames_to_skip = 0;
   size_t maximum_number_of_frames = 0;
@@ -642,7 +642,7 @@ static PyObject* THModule_get_privateuse1_backend_name(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_setAllowTF32CuDNN(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setAllowTF32CuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -654,14 +654,14 @@ PyObject* THPModule_setAllowTF32CuDNN(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_allowTF32CuDNN(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_allowTF32CuDNN(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().allowTF32CuDNN())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setFloat32MatmulPrecision(
+static PyObject* THPModule_setFloat32MatmulPrecision(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
@@ -676,7 +676,7 @@ PyObject* THPModule_setFloat32MatmulPrecision(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_float32MatmulPrecision(
+static PyObject* THPModule_float32MatmulPrecision(
     PyObject* _unused,
     PyObject* noargs) {
   std::string s = "highest";
@@ -688,7 +688,7 @@ PyObject* THPModule_float32MatmulPrecision(
   }
   return THPUtils_packString(s);
 }
-PyObject* THPModule_setSDPUseFlash(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setSDPUseFlash(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -699,13 +699,13 @@ PyObject* THPModule_setSDPUseFlash(PyObject* _unused, PyObject* arg) {
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-PyObject* THPModule_userEnabledFlashSDP(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledFlashSDP(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().userEnabledFlashSDP())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
-PyObject* THPModule_setSDPUseMemEfficient(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setSDPUseMemEfficient(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -716,13 +716,13 @@ PyObject* THPModule_setSDPUseMemEfficient(PyObject* _unused, PyObject* arg) {
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-PyObject* userEnabledMemEfficientSDP(PyObject* _unused, PyObject* noargs) {
+static PyObject* userEnabledMemEfficientSDP(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().userEnabledMemEfficientSDP())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
-PyObject* THPModule_setSDPUseMath(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setSDPUseMath(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -733,13 +733,13 @@ PyObject* THPModule_setSDPUseMath(PyObject* _unused, PyObject* arg) {
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-PyObject* THPModule_userEnabledMathSDP(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledMathSDP(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().userEnabledMathSDP())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
-PyObject* THPModule_setAllowFP16BF16ReductionMathSDP(
+static PyObject* THPModule_setAllowFP16BF16ReductionMathSDP(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
@@ -752,7 +752,7 @@ PyObject* THPModule_setAllowFP16BF16ReductionMathSDP(
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-PyObject* THPModule_allowFP16BF16ReductionMathSDP(
+static PyObject* THPModule_allowFP16BF16ReductionMathSDP(
     PyObject* _unused,
     PyObject* noargs) {
   if (at::globalContext().allowFP16BF16ReductionMathSDP())
@@ -760,7 +760,7 @@ PyObject* THPModule_allowFP16BF16ReductionMathSDP(
   else
     Py_RETURN_FALSE;
 }
-PyObject* THPModule_setSDPUseOverrideable(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setSDPUseOverrideable(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -771,7 +771,7 @@ PyObject* THPModule_setSDPUseOverrideable(PyObject* _unused, PyObject* arg) {
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-PyObject* THPModule_userEnabledOverrideableSDP(
+static PyObject* THPModule_userEnabledOverrideableSDP(
     PyObject* _unused,
     PyObject* noargs) {
   if (at::globalContext().userEnabledOverrideableSDP())
@@ -779,7 +779,7 @@ PyObject* THPModule_userEnabledOverrideableSDP(
   else
     Py_RETURN_FALSE;
 }
-PyObject* THPModule_setSDPUseCuDNN(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setSDPUseCuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -790,14 +790,14 @@ PyObject* THPModule_setSDPUseCuDNN(PyObject* _unused, PyObject* arg) {
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
-PyObject* THPModule_userEnabledCuDNNSDP(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledCuDNNSDP(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().userEnabledCuDNNSDP())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setUserEnabledCuDNN(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setUserEnabledCuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -809,14 +809,14 @@ PyObject* THPModule_setUserEnabledCuDNN(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_userEnabledCuDNN(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledCuDNN(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().userEnabledCuDNN())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setUserEnabledMkldnn(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setUserEnabledMkldnn(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -828,14 +828,14 @@ PyObject* THPModule_setUserEnabledMkldnn(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_userEnabledMkldnn(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledMkldnn(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().userEnabledMkldnn())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setDeterministicCuDNN(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setDeterministicCuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -847,14 +847,14 @@ PyObject* THPModule_setDeterministicCuDNN(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_deterministicCuDNN(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_deterministicCuDNN(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().deterministicCuDNN())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setDeterministicMkldnn(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setDeterministicMkldnn(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -866,14 +866,14 @@ PyObject* THPModule_setDeterministicMkldnn(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_deterministicMkldnn(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_deterministicMkldnn(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().deterministicMkldnn())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setDeterministicAlgorithms(
+static PyObject* THPModule_setDeterministicAlgorithms(
     PyObject* _unused,
     PyObject* args,
     PyObject* kwargs) {
@@ -889,7 +889,7 @@ PyObject* THPModule_setDeterministicAlgorithms(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_deterministicAlgorithms(
+static PyObject* THPModule_deterministicAlgorithms(
     PyObject* _unused,
     PyObject* noargs) {
   if (at::globalContext().deterministicAlgorithms()) {
@@ -898,7 +898,7 @@ PyObject* THPModule_deterministicAlgorithms(
   Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_deterministicAlgorithmsWarnOnly(
+static PyObject* THPModule_deterministicAlgorithmsWarnOnly(
     PyObject* _unused,
     PyObject* noargs) {
   if (at::globalContext().deterministicAlgorithmsWarnOnly()) {
@@ -907,7 +907,7 @@ PyObject* THPModule_deterministicAlgorithmsWarnOnly(
   Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setDeterministicFillUninitializedMemory(
+static PyObject* THPModule_setDeterministicFillUninitializedMemory(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
@@ -918,7 +918,7 @@ PyObject* THPModule_setDeterministicFillUninitializedMemory(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_deterministicFillUninitializedMemory(
+static PyObject* THPModule_deterministicFillUninitializedMemory(
     PyObject* _unused,
     PyObject* noargs) {
   if (at::globalContext().deterministicFillUninitializedMemory())
@@ -927,7 +927,7 @@ PyObject* THPModule_deterministicFillUninitializedMemory(
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setUserEnabledNNPACK(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setUserEnabledNNPACK(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -939,14 +939,14 @@ PyObject* THPModule_setUserEnabledNNPACK(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_userEnabledNNPACK(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_userEnabledNNPACK(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().userEnabledNNPACK())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setWarnAlways(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setWarnAlways(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -958,7 +958,7 @@ PyObject* THPModule_setWarnAlways(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_warnAlways(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_warnAlways(PyObject* _unused, PyObject* noargs) {
   if (c10::WarningUtils::get_warnAlways()) {
     Py_RETURN_TRUE;
   }
@@ -966,7 +966,7 @@ PyObject* THPModule_warnAlways(PyObject* _unused, PyObject* noargs) {
 }
 
 // Used only for testing C++ to Python warning translations.
-PyObject* THPModule_warn(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_warn(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
   TORCH_WARN("Test message for TORCH_WARN");
   Py_RETURN_NONE;
@@ -974,14 +974,14 @@ PyObject* THPModule_warn(PyObject* _unused, PyObject* noargs) {
 }
 
 // Used only for testing C++ to Python warning translations.
-PyObject* THPModule_warnDeprecation(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_warnDeprecation(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
   TORCH_WARN_DEPRECATION("Test message for TORCH_WARN_DEPRECATION");
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_setBenchmarkCuDNN(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setBenchmarkCuDNN(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -993,14 +993,14 @@ PyObject* THPModule_setBenchmarkCuDNN(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_benchmarkCuDNN(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_benchmarkCuDNN(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().benchmarkCuDNN()) {
     Py_RETURN_TRUE;
   }
   Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setAllowTF32CuBLAS(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setAllowTF32CuBLAS(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -1012,14 +1012,14 @@ PyObject* THPModule_setAllowTF32CuBLAS(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_allowTF32CuBLAS(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_allowTF32CuBLAS(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().allowTF32CuBLAS()) {
     Py_RETURN_TRUE;
   }
   Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setAllowFP16ReductionCuBLAS(
+static PyObject* THPModule_setAllowFP16ReductionCuBLAS(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
@@ -1033,7 +1033,7 @@ PyObject* THPModule_setAllowFP16ReductionCuBLAS(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_allowFP16ReductionCuBLAS(
+static PyObject* THPModule_allowFP16ReductionCuBLAS(
     PyObject* _unused,
     PyObject* noargs) {
   if (at::globalContext().allowFP16ReductionCuBLAS()) {
@@ -1042,7 +1042,7 @@ PyObject* THPModule_allowFP16ReductionCuBLAS(
   Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setAllowBF16ReductionCuBLAS(
+static PyObject* THPModule_setAllowBF16ReductionCuBLAS(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
@@ -1056,7 +1056,7 @@ PyObject* THPModule_setAllowBF16ReductionCuBLAS(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_allowBF16ReductionCuBLAS(
+static PyObject* THPModule_allowBF16ReductionCuBLAS(
     PyObject* _unused,
     PyObject* noargs) {
   if (at::globalContext().allowBF16ReductionCuBLAS()) {
@@ -1065,7 +1065,7 @@ PyObject* THPModule_allowBF16ReductionCuBLAS(
   Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setAllowFP16ReductionCPU(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setAllowFP16ReductionCPU(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -1077,14 +1077,14 @@ PyObject* THPModule_setAllowFP16ReductionCPU(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_allowFP16ReductionCPU(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_allowFP16ReductionCPU(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().allowFP16ReductionCPU()) {
     Py_RETURN_TRUE;
   }
   Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setFlushDenormal(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_setFlushDenormal(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyBool_Check(arg),
@@ -1098,14 +1098,14 @@ PyObject* THPModule_setFlushDenormal(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_getDefaultDtype(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_getDefaultDtype(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   auto scalar_type = torch::tensors::get_default_scalar_type();
   return Py_NewRef(torch::getTHPDtype(scalar_type));
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_getDefaultDevice(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_getDefaultDevice(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   return THPUtils_packString(c10::DeviceTypeName(
       dispatchKeyToDeviceType(torch::tensors::get_default_dispatch_key()),
@@ -1113,7 +1113,7 @@ PyObject* THPModule_getDefaultDevice(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_setQEngine(PyObject* /* unused */, PyObject* arg) {
+static PyObject* THPModule_setQEngine(PyObject* /* unused */, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       THPUtils_checkLong(arg),
@@ -1126,12 +1126,12 @@ PyObject* THPModule_setQEngine(PyObject* /* unused */, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_qEngine(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_qEngine(PyObject* _unused, PyObject* noargs) {
   return THPUtils_packInt64(
       static_cast<int64_t>(at::globalContext().qEngine()));
 }
 
-PyObject* THPModule_supportedQEngines(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_supportedQEngines(PyObject* _unused, PyObject* noargs) {
   auto qengines = at::globalContext().supportedQEngines();
   auto list =
       THPObjectPtr(PyList_New(static_cast<Py_ssize_t>(qengines.size())));
@@ -1146,14 +1146,14 @@ PyObject* THPModule_supportedQEngines(PyObject* _unused, PyObject* noargs) {
   return list.release();
 }
 
-PyObject* THPModule_isEnabledXNNPACK(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_isEnabledXNNPACK(PyObject* _unused, PyObject* noargs) {
   if (at::globalContext().isXNNPACKAvailable())
     Py_RETURN_TRUE;
   else
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_setCheckSparseTensorInvariants(
+static PyObject* THPModule_setCheckSparseTensorInvariants(
     PyObject* _unused,
     PyObject* arg) {
   HANDLE_TH_ERRORS
@@ -1167,7 +1167,7 @@ PyObject* THPModule_setCheckSparseTensorInvariants(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_checkSparseTensorInvariants(
+static PyObject* THPModule_checkSparseTensorInvariants(
     PyObject* _unused,
     PyObject* noargs) {
   if (at::globalContext().checkSparseTensorInvariants())
@@ -1176,7 +1176,7 @@ PyObject* THPModule_checkSparseTensorInvariants(
     Py_RETURN_FALSE;
 }
 
-PyObject* THPModule_willEngineExecuteNode(PyObject* _unused, PyObject* arg) {
+static PyObject* THPModule_willEngineExecuteNode(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   bool isTHPFunction = THPFunction_Check(arg);
   bool isTHPCppFunction = torch::autograd::THPCppFunction_Check(arg);
@@ -1219,7 +1219,7 @@ PyObject* THPModule_willEngineExecuteNode(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_getCurrentGraphTaskExecutionOrder(
+static PyObject* THPModule_getCurrentGraphTaskExecutionOrder(
     PyObject* _unused,
     PyObject* noargs) {
   HANDLE_TH_ERRORS
@@ -1241,20 +1241,20 @@ PyObject* THPModule_getCurrentGraphTaskExecutionOrder(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_getCurrentGraphTaskId(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_getCurrentGraphTaskId(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
   return THPUtils_packInt64(torch::autograd::get_current_graph_task_id());
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_getCurrentNode(PyObject* _unused, PyObject* noargs) {
+static PyObject* THPModule_getCurrentNode(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
   return torch::autograd::functionToPyObject(
       torch::autograd::get_current_node());
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_setDefaultMobileCPUAllocator(
+static PyObject* THPModule_setDefaultMobileCPUAllocator(
     PyObject* _unused,
     PyObject* noargs) {
   HANDLE_TH_ERRORS
@@ -1263,7 +1263,7 @@ PyObject* THPModule_setDefaultMobileCPUAllocator(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPModule_unsetDefaultMobileCPUAllocator(
+static PyObject* THPModule_unsetDefaultMobileCPUAllocator(
     PyObject* _unused,
     PyObject* noargs) {
   HANDLE_TH_ERRORS
@@ -1579,15 +1579,15 @@ static PyMethodDef TorchMethods[] = { // NOLINT
      nullptr},
     {nullptr, nullptr, 0, nullptr}};
 
-void THCPStream_init(PyObject* module);
-void THCPEvent_init(PyObject* module);
-void THCPGraph_init(PyObject* module);
-void THCPMemPool_init(PyObject* module);
+static void THCPStream_init(PyObject* module);
+static void THCPEvent_init(PyObject* module);
+static void THCPGraph_init(PyObject* module);
+static void THCPMemPool_init(PyObject* module);
 
 #ifdef USE_CUDA
-PyMethodDef* THCPModule_methods();
+static PyMethodDef* THCPModule_methods();
 namespace torch::cuda {
-void initModule(PyObject* module);
+static void initModule(PyObject* module);
 } // namespace torch::cuda
 #endif
 
@@ -1602,7 +1602,7 @@ void initModule(PyObject* module);
 
 #ifdef USE_ITT
 namespace torch::profiler {
-void initIttBindings(PyObject* module);
+static void initIttBindings(PyObject* module);
 } // namespace torch::profiler
 #endif
 
@@ -2399,7 +2399,7 @@ Call this whenever a new thread is created in order to propagate values from
 // Checks that the _C shared library isn't initialized multiple times. This
 // can happen if the same csrc files are compiled into multiple shared
 // libraries.
-inline void pytorch_duplicate_guard() {
+inline static void pytorch_duplicate_guard() {
   static int initialized = 0;
   if (initialized) {
     fmt::print(stderr, "pytorch: _C shared library re-initialized\n");

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -588,9 +588,12 @@ struct THPStorageMeta {
   PyHeapTypeObject base;
 };
 
-int THPStorageMetaType_init(PyObject* cls, PyObject* args, PyObject* kwargs);
+static int THPStorageMetaType_init(
+    PyObject* cls,
+    PyObject* args,
+    PyObject* kwargs);
 
-PyTypeObject THPStorageMetaType = {
+static PyTypeObject THPStorageMetaType = {
     PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
     "torch._C._StorageMeta", /* tp_name */
     sizeof(THPStorageMeta), /* tp_basicsize */
@@ -692,7 +695,7 @@ static PyObject* THPStorage_device(THPStorage* self, void* unused) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage_get_cdata(THPStorage* self, void* unused) {
+static PyObject* THPStorage_get_cdata(THPStorage* self, void* unused) {
   HANDLE_TH_ERRORS
   return PyLong_FromVoidPtr(THPStorage_Unpack(self).unsafeGetStorageImpl());
   END_HANDLE_TH_ERRORS

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -392,7 +392,7 @@ static PyObject* THPStorage_fromFile(
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage_writeFile(PyObject* self, PyObject* args) {
+static PyObject* THPStorage_writeFile(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   THPStorage_assertNotNull(self);
   const auto& storage = THPStorage_Unpack(self);
@@ -428,7 +428,7 @@ PyObject* THPStorage_writeFile(PyObject* self, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage_newWithFile(PyObject* _unused, PyObject* args) {
+static PyObject* THPStorage_newWithFile(PyObject* _unused, PyObject* args) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       PyTuple_Size(args) == 2, "_new_with_file takes exactly two arguments");
@@ -517,7 +517,7 @@ static PyObject* THPStorage_setFromFile(PyObject* self, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage__setCdata(PyObject* _self, PyObject* new_cdata) {
+static PyObject* THPStorage__setCdata(PyObject* _self, PyObject* new_cdata) {
   HANDLE_TH_ERRORS
   auto self = (THPStorage*)_self;
   TORCH_CHECK(
@@ -534,7 +534,7 @@ PyObject* THPStorage__setCdata(PyObject* _self, PyObject* new_cdata) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage_byteswap(PyObject* self, PyObject* args) {
+static PyObject* THPStorage_byteswap(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(PyTuple_GET_SIZE(args) == 1, "tuple of 1 item expected");
   PyObject* _elem_size = PyTuple_GET_ITEM(args, 0);

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -580,7 +580,7 @@ static PyObject* THPStorage_weakRef(PyObject* self, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage_newWithWeakPtr(PyObject* _unused, PyObject* arg) {
+static PyObject* THPStorage_newWithWeakPtr(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(
       THPUtils_checkLong(arg), "_new_with_weak_ptr(): arg must be an 'int'");
@@ -593,7 +593,7 @@ PyObject* THPStorage_newWithWeakPtr(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage_freeWeakRef(PyObject* _unused, PyObject* arg) {
+static PyObject* THPStorage_freeWeakRef(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   if (arg == Py_None) {
     Py_RETURN_NONE;
@@ -607,7 +607,7 @@ PyObject* THPStorage_freeWeakRef(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage_expired(PyObject* _unused, PyObject* arg) {
+static PyObject* THPStorage_expired(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(THPUtils_checkLong(arg), "_expired(): arg must be an 'int'");
   c10::StorageImpl* weak_storage = (c10::StorageImpl*)PyLong_AsVoidPtr(arg);
@@ -616,7 +616,7 @@ PyObject* THPStorage_expired(PyObject* _unused, PyObject* arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage_sharedFd(PyObject* self, PyObject* noargs) {
+static PyObject* THPStorage_sharedFd(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   THPStorage_assertNotNull(self);
   at::MapAllocator* ctx = nullptr;
@@ -630,7 +630,7 @@ PyObject* THPStorage_sharedFd(PyObject* self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPStorage_isShared(PyObject* self, PyObject* noargs) {
+static PyObject* THPStorage_isShared(PyObject* self, PyObject* noargs) {
   const auto& storage = THPStorage_Unpack(self);
   if (storage.device_type() == at::kCUDA) {
     Py_RETURN_TRUE;

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -331,7 +331,7 @@ static PyMethodDef THPStream_methods[] = {
     {"__eq__", (PyCFunction)THPStream_eq, METH_O, nullptr},
     {nullptr}};
 
-PyTypeObject THPStreamType = {
+static PyTypeObject THPStreamType = {
     PyVarObject_HEAD_INIT(nullptr, 0)
     "torch.Stream", /* tp_name */
     sizeof(THPStream), /* tp_basicsize */

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -17,7 +17,7 @@
 #include <limits>
 #include <sstream>
 
-PyObject* THPFInfo_New(const at::ScalarType& type) {
+static PyObject* THPFInfo_New(const at::ScalarType& type) {
   auto finfo = (PyTypeObject*)&THPFInfoType;
   auto self = THPObjectPtr{finfo->tp_alloc(finfo, 0)};
   if (!self)
@@ -27,7 +27,7 @@ PyObject* THPFInfo_New(const at::ScalarType& type) {
   return self.release();
 }
 
-PyObject* THPIInfo_New(const at::ScalarType& type) {
+static PyObject* THPIInfo_New(const at::ScalarType& type) {
   auto iinfo = (PyTypeObject*)&THPIInfoType;
   auto self = THPObjectPtr{iinfo->tp_alloc(iinfo, 0)};
   if (!self)
@@ -37,7 +37,10 @@ PyObject* THPIInfo_New(const at::ScalarType& type) {
   return self.release();
 }
 
-PyObject* THPFInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
+static PyObject* THPFInfo_pynew(
+    PyTypeObject* type,
+    PyObject* args,
+    PyObject* kwargs) {
   HANDLE_TH_ERRORS
   static torch::PythonArgParser parser({
       "finfo(ScalarType type)",
@@ -65,7 +68,10 @@ PyObject* THPFInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPIInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
+static PyObject* THPIInfo_pynew(
+    PyTypeObject* type,
+    PyObject* args,
+    PyObject* kwargs) {
   HANDLE_TH_ERRORS
   static torch::PythonArgParser parser({
       "iinfo(ScalarType type)",
@@ -90,7 +96,10 @@ PyObject* THPIInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPDTypeInfo_compare(THPDTypeInfo* a, THPDTypeInfo* b, int op) {
+static PyObject* THPDTypeInfo_compare(
+    THPDTypeInfo* a,
+    THPDTypeInfo* b,
+    int op) {
   switch (op) {
     case Py_EQ:
       if (a->type == b->type) {
@@ -234,7 +243,7 @@ static PyObject* THPFInfo_dtype(THPFInfo* self, void*) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject* THPFInfo_str(THPFInfo* self) {
+static PyObject* THPFInfo_str(THPFInfo* self) {
   std::ostringstream oss;
   const auto dtypeStr = THPFInfo_dtype(self, nullptr);
   oss << "finfo(resolution="
@@ -251,7 +260,7 @@ PyObject* THPFInfo_str(THPFInfo* self) {
   return !PyErr_Occurred() ? THPUtils_packString(oss.str().c_str()) : nullptr;
 }
 
-PyObject* THPIInfo_str(THPIInfo* self) {
+static PyObject* THPIInfo_str(THPIInfo* self) {
   std::ostringstream oss;
 
   const auto dtypeStr = THPIInfo_dtype(self, nullptr);

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -272,7 +272,7 @@ char* tensor_repr(const at::Tensor& tensor) {
   // observed that sometimes gdb passes the outer Tensor address exactly as is
   // into this function.
   // See https://github.com/pytorch/pytorch/issues/134762
-  pytensor = THPVariable_Wrap(tensor);
+  pytensor = THPVariable_Wrap(std::move(tensor));
   if (!pytensor)
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;


### PR DESCRIPTION
Re-check some files and mark variables and functions into static and fix other warnings.
