### PR TITLE
Enable clang-tidy on torch/csrc/lazy

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -246,7 +246,6 @@ exclude_patterns = [
     'torch/csrc/inductor/aoti_torch/c/shim.h',
     'torch/csrc/jit/**/*',
     'torch/csrc/jit/serialization/mobile_bytecode_generated.h',
-    'torch/csrc/lazy/**/*',
 ]
 init_command = [
     'python3',

--- a/torch/csrc/lazy/core/dynamic_ir.h
+++ b/torch/csrc/lazy/core/dynamic_ir.h
@@ -2,15 +2,6 @@
 
 #include <ATen/core/symbol.h>
 
-#include <functional>
-#include <memory>
-#include <set>
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
-#include <vector>
-
 #include <c10/core/ScalarType.h>
 #include <c10/util/Flags.h>
 #include <torch/csrc/lazy/core/hash.h>


### PR DESCRIPTION
Enable clang-tidy on  torch/csrc/lazy