### PR TITLE
[export] Draft of draft export

### DIFF
--- a/op.py
+++ b/op.py
@@ -1,0 +1,108 @@
+from collections import defaultdict
+
+import torch
+import torch.utils._pytree as pytree
+from torch.utils._python_dispatch import TorchDispatchMode
+
+
+#####################################################################
+# Custom op changes
+#####################################################################
+
+
+class OperatorProfiles:
+    def __init__(self):
+        self.data = defaultdict(list)
+
+    def record(self, op, real_args, real_kwargs, real_output):
+        metadata = pytree.tree_map_only(
+            torch.Tensor, TensorMetadata, (real_args, real_kwargs, real_output)
+        )
+        self.data[op].append(metadata)
+
+    def generic_fake_kernel(self, op, fake_mode, *args, **kwargs):
+        if op not in self.data:
+            raise RuntimeError(f"no meta {op}")
+        stuff = self.data[op]
+
+        def to_fake(metadata):
+            def fn():
+                result = fake_mode.shape_env.create_unbacked_symint()
+                torch.fx.experimental.symbolic_shapes._constrain_range_for_size(result)
+                return result
+
+            fake_shape = [fn() for _ in range(metadata.dim)]
+            with fake_mode:
+                return torch.empty(
+                    fake_shape, dtype=metadata.dtype, device=metadata.device
+                )
+
+        for s in stuff:
+            if not profile_matches(s, *args, **kwargs):
+                continue
+            output_metadata = s[-1]
+            result = pytree.tree_map_only(TensorMetadata, to_fake, output_metadata)
+            return result
+        raise RuntimeError(f"no meta {op}")
+
+
+class TensorMetadata:
+    def __init__(self, real_tensor):
+        self.shape = real_tensor.shape
+        self.strides = real_tensor.stride()
+        self.storage_offset = real_tensor.storage_offset()
+        self.is_contiguous = real_tensor.is_contiguous()
+        self.dtype = real_tensor.dtype
+        self.device = real_tensor.device
+        # self.key_set = torch._C._key_set(real_tensor)
+
+    @property
+    def dim(self):
+        return len(self.shape)
+
+
+# torch_dispatch mode to record metas for this...
+
+
+class OperatorProfilingMode(TorchDispatchMode):
+    def __init__(self):
+        self.profiles = OperatorProfiles()
+
+    def reports(self):
+        return self.profiles
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        out = func(*args, **kwargs)
+        if not torch._library.utils.is_builtin(
+            func
+        ) and not func.has_kernel_for_dispatch_key("Meta"):
+            self.profiles.record(func, args, kwargs, out)
+        # TODO: check that the op doesn't return a view.
+        # If it does, we may need to error.
+        # TODO: check that the op doesn't return any non-Tensors
+        # (we don't support that)
+        # TODO: block TorchBind (for now)
+        return out
+
+
+def profile_matches(profile, *fake_args, **fake_kwargs):
+    args_metadata, kwargs_metadata, _ = profile
+    # TODO: they're not zippable in general
+    assert not kwargs_metadata
+    assert not fake_kwargs
+    for metadata, fake_arg in zip(args_metadata, fake_args):
+        if isinstance(fake_arg, torch.Tensor):
+            if fake_arg.device != metadata.device:
+                return False
+            if fake_arg.dtype != metadata.dtype:
+                return False
+            if fake_arg.dim() != metadata.dim:
+                return False
+            if not fake_arg.is_contiguous:
+                return False
+        else:
+            if metadata != fake_arg:
+                return False
+    return True

--- a/test/export/test_draft_export.py
+++ b/test/export/test_draft_export.py
@@ -1,0 +1,88 @@
+# Owner(s): ["oncall: export"]
+
+import torch
+from torch.export import Dim
+from torch.export._draft_export import draft_export
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestDraftExport(TestCase):
+    def test_missing_meta_kernel(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define(
+                "mylib::foo",
+                "(Tensor a, Tensor b) -> Tensor",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl("mylib::foo", "cpu", lib=lib)
+            def foo_impl(a, b):
+                return a + b
+
+            # @torch.library.register_fake("mylib::foo")
+            # def mylib_foo_default_fake(*args, **kwargs):
+            #     ctx = torch.library.get_ctx()
+            #     fake_shape = [ctx.new_dynamic_size() for _ in range(2)]
+            #     return torch.empty(fake_shape, dtype=torch.float32, device="cpu")
+
+            class M(torch.nn.Module):
+                def forward(self, a, b):
+                    res = torch.ops.mylib.foo(a, b)
+                    return res
+
+            inp = (torch.ones(3, 3), torch.ones(3, 3))
+
+            ep, report = draft_export(
+                M(), inp, fake_tensor_propagate_real_tensors=False
+            )
+            print(ep)
+            print(report)
+
+    def test_data_dependent_failure(self):
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define(
+                "mylib::foo1",
+                "(Tensor a, Tensor b) -> Tensor",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl("mylib::foo1", "cpu", lib=lib)
+            def foo_impl(a, b):
+                return a + b
+
+            @torch.library.register_fake("mylib::foo1")
+            def mylib_foo_default_fake(*args, **kwargs):
+                ctx = torch.library.get_ctx()
+                fake_shape = [ctx.new_dynamic_size() for _ in range(2)]
+                return torch.empty(fake_shape, dtype=torch.float32, device="cpu")
+
+            class M(torch.nn.Module):
+                def forward(self, a, b, c):
+                    res = torch.ops.mylib.foo1(a, b)
+
+                    c_item = c.item()
+                    return res[:c_item]
+
+            inp = (torch.ones(3, 3), torch.ones(3, 3), torch.tensor(3))
+
+            ep, report = draft_export(M(), inp)
+            print(ep)
+            print(report)
+
+    def test_shape_failure(self):
+        class M(torch.nn.Module):
+            def forward(self, a):
+                assert a.shape[0] == 3
+                return a * a
+
+        inp = (torch.ones(3, 3),)
+
+        ep, report = draft_export(M(), inp, dynamic_shapes={"a": {0: Dim("a0")}})
+        print(ep)
+        print(report)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -221,6 +221,8 @@ same_two_models_use_fp64 = True
 # This requires dynamic_shapes to be True.
 capture_scalar_outputs = os.environ.get("TORCHDYNAMO_CAPTURE_SCALAR_OUTPUTS") == "1"
 
+custom_ops_profile = None
+
 # Not all backends support operators that have dynamic output shape (e.g.,
 # nonzero, unique).  When this flag is set to False, we introduce a graph
 # break instead of capturing.  This requires dynamic_shapes to be True.

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1993,6 +1993,11 @@ class FakeTensorMode(TorchDispatchMode):
                     func.prim_meta_impl(*args, **kwargs)
                 )
 
+        profiles = torch._dynamo.config.custom_ops_profile
+        if profiles is not None:
+            if func in profiles.data:
+                return profiles.generic_fake_kernel(func, self, *args, **kwargs)
+
         # Users can register FakeTensor rules for custom operators
         # Call them if they exist.
         maybe_fake_impl = torch._library.simple_registry.singleton.find(

--- a/torch/export/_draft_export.py
+++ b/torch/export/_draft_export.py
@@ -1,0 +1,177 @@
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from op import OperatorProfilingMode
+
+import torch
+from torch.export import ExportedProgram
+from torch.export.dynamic_shapes import refine_dynamic_shapes_from_suggested_fixes
+from torch.fx.experimental.symbolic_shapes import RealTensorLoggingMode
+
+
+class FailureType(Enum):
+    MISSING_FAKE_KERNEL = 1
+    DATA_DEPENDENT_ERROR = 2
+    INPUT_SHAPE_MISMATCH = 3
+
+    def __str__(self):
+        return self.name
+
+
+class FailureReport:
+    def __init__(self, failure_type, data, xfail=False):
+        self.failure_type = failure_type
+        self.data = data
+        self.xfail = xfail
+
+    def __str__(self):
+        if self.failure_type == FailureType.MISSING_FAKE_KERNEL:
+            op, profiles = self.data
+            example_output_metadata = profiles[0][-1]
+
+            return f"""Missing fake kernel.
+    torch.ops.{op} is missing a fake kernel implementation.
+
+    Here's a template for registering a fake kernel implementation. Please refer to https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit#heading=h.ahugy69p2jmz for more detailed instructions.
+
+    Here is an example of a fake kernel for your op, but it might not be correct for all use cases:
+    ```
+    @torch.library.register_fake("{op.name()}")
+    def {str(op).replace(".", "_")}_fake(*args, **kwargs):
+        ctx = torch.library.get_ctx()
+        fake_shape = [ctx.new_dynamic_size() for _ in range(2)]
+        return torch.empty(fake_shape, dtype={example_output_metadata.dtype}, device="{example_output_metadata.device}")
+    ```
+"""
+
+        elif self.failure_type == FailureType.INPUT_SHAPE_MISMATCH:
+            return f"""Input shape mismatch.
+    The specified input dynamic_shapes spec was found to be incorrect during tracing.
+    Instead, we have modified the dynamic shapes structure to be the following:
+    ```
+    dynamic_shapes = {self.data}
+    ```
+"""
+
+        elif self.failure_type == FailureType.DATA_DEPENDENT_ERROR:
+            return f"""Data dependent error.
+    When exporting, we were unable to figure out if the expression `{self.data["expr"]}` always holds.
+    This occurred on the following line: {self.data["stack"]}.
+    As a result, it was specialized to evaluate to `{self.data["result"]}`, and asserts were inserted into the graph.
+
+    Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
+    Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.
+"""
+
+        else:
+            raise ValueError(f"Unknown failure type: {self.failure_type}")
+
+
+class DraftExportReport:
+    def __init__(self, failures: List[FailureReport]):
+        self.failures: List[FailureReport] = failures
+
+    def __str__(self):
+        if len(self.failures) == 0:
+            return """
+##############################################################################################
+Congratuations: No issues are found during export, and it was able to soundly produce a graph.
+You can now change back to torch.export.export()
+##############################################################################################
+"""
+
+        error = f"""
+###################################################################################################
+WARNING: {len(self.failures)} issue(s) found during export, and it was not able to soundly produce a graph.
+Please follow the instructions to fix the errors.
+Issues are compiled in hive table: TODO
+###################################################################################################
+
+"""
+
+        for i, failure in enumerate(self.failures):
+            error += f"{i + 1}. {str(failure)}\n"
+
+        return error
+
+    def serialize(self):
+        pass
+
+    def apply_suggested_fixes(self):
+        pass
+
+
+def draft_export(
+    mod: torch.nn.Module,
+    args: Tuple[Any, ...],
+    kwargs: Optional[Dict[str, Any]] = None,
+    *,
+    dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any], List[Any]]] = None,
+    preserve_module_call_signature: Tuple[str, ...] = (),
+    fake_tensor_propagate_real_tensors: Optional[bool] = True,
+) -> ExportedProgram:
+    kwargs = kwargs or {}
+
+    with OperatorProfilingMode() as mode:
+        mod(*args, **kwargs)
+    custom_op_profile = mode.reports()
+
+    torch._dynamo.config.custom_ops_profile = custom_op_profile
+
+    with torch._functorch.config.patch(
+        fake_tensor_propagate_real_tensors=fake_tensor_propagate_real_tensors
+    ), RealTensorLoggingMode():
+        try:
+            new_shapes = None
+            ep = torch.export.export(
+                mod,
+                args,
+                kwargs,
+                dynamic_shapes=dynamic_shapes,
+                strict=False,
+                preserve_module_call_signature=preserve_module_call_signature,
+            )
+        except torch._dynamo.exc.UserError as exc:
+            new_shapes = refine_dynamic_shapes_from_suggested_fixes(
+                exc.msg, dynamic_shapes
+            )
+            ep = torch.export.export(
+                mod,
+                args,
+                kwargs,
+                dynamic_shapes=new_shapes,
+                strict=False,
+                preserve_module_call_signature=preserve_module_call_signature,
+            )
+
+        from torch.fx.experimental.symbolic_shapes import REAL_TENSOR_LOGGING
+
+        failures = []
+        for op, profiles in custom_op_profile.data.items():
+            failures.append(
+                FailureReport(
+                    FailureType.MISSING_FAKE_KERNEL,
+                    (op, profiles),
+                )
+            )
+
+        if new_shapes is not None:
+            failures.append(
+                FailureReport(
+                    FailureType.INPUT_SHAPE_MISMATCH,
+                    new_shapes,
+                )
+            )
+
+        for log in REAL_TENSOR_LOGGING:
+            failures.append(
+                FailureReport(
+                    FailureType.DATA_DEPENDENT_ERROR,
+                    log,
+                )
+            )
+
+        report = DraftExportReport(failures)
+    ep._report = report
+
+    return ep, report

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -709,6 +709,7 @@ class ExportedProgram:
         self._verifiers = verifiers
         # Validate should be always the last step of the constructor.
         self.validate()
+        self._report = None
 
     @property
     @compatibility(is_backward_compatible=False)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -122,6 +122,19 @@ def log_lru_cache_stats(wrapped_f):
     log.debug("lru_cache_stats %s: %s", wrapped_f.__name__, wrapped_f.cumulative_cache_info())
 
 
+REAL_TENSOR_LOGGING = None
+class RealTensorLoggingMode:
+    def __enter__(self):
+        global REAL_TENSOR_LOGGING
+        assert REAL_TENSOR_LOGGING is None
+        REAL_TENSOR_LOGGING = []
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        global REAL_TENSOR_LOGGING
+        REAL_TENSOR_LOGGING = None
+
+
 # Wrapper on lru_cache that reports statistics at process end
 def lru_cache(maxsize):
     def inner(f):
@@ -4788,6 +4801,7 @@ class ShapeEnv:
                             "stack": structured.from_traceback(CapturedTraceback.extract(skip=1).summary()),
                         },
                     )
+                    breakpoint()
                     self.defer_runtime_assert(
                         sympy.Eq(result_expr, unsound_expr),
                         f"propagate_real_tensors: {result_expr} == {unsound_expr}"
@@ -5365,6 +5379,14 @@ class ShapeEnv:
                                 "stack": structured.from_traceback(CapturedTraceback.extract(skip=1).summary()),
                             },
                         )
+                        REAL_TENSOR_LOGGING.append(
+                            {
+                                "expr": repr(orig_expr),
+                                "result": repr(unsound_result),
+                                "stack": format_frame(self._get_stack_summary(True)[0]),
+                            }
+                        )
+
                         transmute_into_runtime_assert = True
                         concrete_val = unsound_result
                     else:


### PR DESCRIPTION
###################################################################################################
WARNING: 1 issue(s) found during export, and it was not able to soundly produce a graph.
Please follow the instructions to fix the errors.
Issues are compiled in hive table: TODO
###################################################################################################

1. Missing fake kernel.
    torch.ops.mylib.foo.default is missing a fake kernel implementation.

    Here's a template for registering a fake kernel implementation. Please refer to https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit#heading=h.ahugy69p2jmz for more detailed instructions.

    Here is an example of a fake kernel for your op, but it might not be correct for all use cases:
    ```
    @torch.library.register_fake("mylib::foo")
    def mylib_foo_default_fake(*args, **kwargs):
        ctx = torch.library.get_ctx()
        fake_shape = [ctx.new_dynamic_size() for _ in range(2)]
        return torch.empty(fake_shape, dtype=torch.float32, device="cpu")
    ```

###################################################################################################
WARNING: 8 issue(s) found during export, and it was not able to soundly produce a graph.
Please follow the instructions to fix the errors.
Issues are compiled in hive table: TODO
###################################################################################################

1. Data dependent error.
    When exporting, we were unable to figure out if the expression `u2 < 0` always holds.
    This occurred on the following line: _decomp/decompositions.py:771 in slice_forward.
    As a result, it was specialized to evaluate to `False`, and asserts were inserted into the graph.

    Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
    Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.

2. Data dependent error.
    When exporting, we were unable to figure out if the expression `u2 > u0` always holds.
    This occurred on the following line: _decomp/decompositions.py:781 in slice_forward.
    As a result, it was specialized to evaluate to `False`, and asserts were inserted into the graph.

    Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
    Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.

3. Data dependent error.
    When exporting, we were unable to figure out if the expression `Eq(u2, 0)` always holds.
    This occurred on the following line: _subclasses/functional_tensor.py:140 in __new__.
    As a result, it was specialized to evaluate to `False`, and asserts were inserted into the graph.

    Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
    Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.

4. Data dependent error.
    When exporting, we were unable to figure out if the expression `u5 < 0` always holds.
    This occurred on the following line: _decomp/decompositions.py:771 in slice_forward.
    As a result, it was specialized to evaluate to `False`, and asserts were inserted into the graph.

    Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
    Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.

5. Data dependent error.
    When exporting, we were unable to figure out if the expression `u5 > u3` always holds.
    This occurred on the following line: _decomp/decompositions.py:781 in slice_forward.
    As a result, it was specialized to evaluate to `False`, and asserts were inserted into the graph.

    Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
    Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.

6. Data dependent error.
    When exporting, we were unable to figure out if the expression `Eq(u4*u5, 0)` always holds.
    This occurred on the following line: fx/passes/shape_prop.py:50 in _extract_tensor_metadata.
    As a result, it was specialized to evaluate to `False`, and asserts were inserted into the graph.

    Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
    Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.

7. Data dependent error.
    When exporting, we were unable to figure out if the expression `Ne(u5, 1)` always holds.
    This occurred on the following line: fx/passes/shape_prop.py:50 in _extract_tensor_metadata.
    As a result, it was specialized to evaluate to `True`, and asserts were inserted into the graph.

    Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
    Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.

8. Data dependent error.
    When exporting, we were unable to figure out if the expression `Eq(u5, 0)` always holds.
    This occurred on the following line: _subclasses/functional_tensor.py:140 in __new__.
    As a result, it was specialized to evaluate to `False`, and asserts were inserted into the graph.

    Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
    Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.


###################################################################################################
WARNING: 1 issue(s) found during export, and it was not able to soundly produce a graph.
Please follow the instructions to fix the errors.
Issues are compiled in hive table: TODO
###################################################################################################

1. Input shape mismatch.
    The specified input dynamic_shapes spec was found to be incorrect during tracing.
    Instead, we have modified the dynamic shapes structure to be the following:
    ```
    dynamic_shapes = {'a': {0: 3}}
    ```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames