### PR TITLE
upload test stats: remove nan/inf when uploading

### DIFF
--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gzip
 import io
 import json
+import math
 import os
 import time
 import zipfile
@@ -203,7 +204,7 @@ def remove_nan_inf(old: Any) -> Any:
     # Casta NaN, inf, -inf to string from float since json.dumps outputs invalid
     # json with them
     def _helper(o: Any) -> Any:
-        if isinstance(o, float) and (o == float("inf") or o == float("-inf") or o != o):
+        if isinstance(o, float) and (math.isinf(o) or math.isnan(o)):
             return str(o)
         if isinstance(o, list):
             return [_helper(v) for v in o]

--- a/tools/stats/upload_stats_lib.py
+++ b/tools/stats/upload_stats_lib.py
@@ -199,6 +199,23 @@ def read_from_s3(
     return [json.loads(result) for result in results if result]
 
 
+def remove_nan_inf(old: Any) -> Any:
+    # Casta NaN, inf, -inf to string from float since json.dumps outputs invalid
+    # json with them
+    def _helper(o: Any) -> Any:
+        if isinstance(o, float) and (o == float("inf") or o == float("-inf") or o != o):
+            return str(o)
+        if isinstance(o, list):
+            return [_helper(v) for v in o]
+        if isinstance(o, dict):
+            return {_helper(k): _helper(v) for k, v in o.items()}
+        if isinstance(o, tuple):
+            return tuple(_helper(v) for v in o)
+        return o
+
+    return _helper(old)
+
+
 def upload_workflow_stats_to_s3(
     workflow_run_id: int,
     workflow_run_attempt: int,

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -13,6 +13,7 @@ from tools.stats.test_dashboard import upload_additional_info
 from tools.stats.upload_stats_lib import (
     download_s3_artifacts,
     get_job_id,
+    remove_nan_inf,
     unzip,
     upload_workflow_stats_to_s3,
 )
@@ -266,7 +267,7 @@ if __name__ == "__main__":
         args.workflow_run_id,
         args.workflow_run_attempt,
         "test_run_summary",
-        test_case_summary,
+        remove_nan_inf(test_case_summary),
     )
 
     # Separate out the failed test cases.
@@ -281,13 +282,13 @@ if __name__ == "__main__":
         args.workflow_run_id,
         args.workflow_run_attempt,
         "failed_test_runs",
-        failed_tests_cases,
+        remove_nan_inf(failed_tests_cases),
     )
 
     if args.head_branch == "main" and args.head_repository == "pytorch/pytorch":
         # For jobs on main branch, upload everything.
         upload_workflow_stats_to_s3(
-            args.workflow_run_id, args.workflow_run_attempt, "test_run", test_cases
+            args.workflow_run_id, args.workflow_run_attempt, "test_run", remove_nan_inf(test_cases)
         )
 
     upload_additional_info(args.workflow_run_id, args.workflow_run_attempt, test_cases)

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -288,7 +288,10 @@ if __name__ == "__main__":
     if args.head_branch == "main" and args.head_repository == "pytorch/pytorch":
         # For jobs on main branch, upload everything.
         upload_workflow_stats_to_s3(
-            args.workflow_run_id, args.workflow_run_attempt, "test_run", remove_nan_inf(test_cases)
+            args.workflow_run_id,
+            args.workflow_run_attempt,
+            "test_run",
+            remove_nan_inf(test_cases),
         )
 
     upload_additional_info(args.workflow_run_id, args.workflow_run_attempt, test_cases)

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -341,7 +341,7 @@ class TestUploadStats(unittest.TestCase):
             (float("inf"), '"inf"', "Infinity"),
             (float("nan"), '"nan"', "NaN"),
             ({1: float("inf")}, '{"1": "inf"}', '{"1": Infinity}'),
-            ([float("nan")], '["nan"]', '[NaN]'),
+            ([float("nan")], '["nan"]', "[NaN]"),
             ({1: [float("nan")]}, '{"1": ["nan"]}', '{"1": [NaN]}'),
         ]
 
@@ -358,6 +358,7 @@ class TestUploadStats(unittest.TestCase):
                 unclean,
                 f"Expected {unclean} when input is {unclean}, got {unclean_output}",
             )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -180,7 +180,6 @@ class TestUploadStats(unittest.TestCase):
         }
 
         emit_should_include = {
-            "info": metric,
             "pr_number": PR_NUMBER,
         }
 

--- a/tools/test/test_upload_stats_lib.py
+++ b/tools/test/test_upload_stats_lib.py
@@ -180,6 +180,7 @@ class TestUploadStats(unittest.TestCase):
         }
 
         emit_should_include = {
+            **metric,
             "pr_number": PR_NUMBER,
         }
 


### PR DESCRIPTION
`json.dumps(float("inf"))` returns `Infinity`, which is technically invalid json

This is fine if you json.load, but ClickHouse cannot handle it

Solution here: cast inf and nan to string (which ClickHouse is able to cast back to float)