### PR TITLE
[dynamo] Properly prune dead cell local variables

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -4020,7 +4020,7 @@ class GraphModule(torch.nn.Module):
         set_inplace_requires_grad_allowed_1 = torch._C._functorch.set_inplace_requires_grad_allowed(False);  set_inplace_requires_grad_allowed_1 = None
 
         sin: "f32[3, 3, 3]" = diff_args.sin()
-        add: "f32[3, 3, 3]" = sin + y;  sin = None
+        add: "f32[3, 3, 3]" = sin + y;  sin = y = None
         output: "f32[]" = add.sum();  add = None
 
         _autograd_grad = torch._functorch.eager_transforms._autograd_grad((output,), [diff_args], create_graph = True);  diff_args = None
@@ -4032,7 +4032,7 @@ class GraphModule(torch.nn.Module):
 
         _grad_decrement_nesting = torch._C._functorch._grad_decrement_nesting();  _grad_decrement_nesting = None
         _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable();  _saved_tensors_hooks_enable = None
-        return (y, grad_input_1)
+        return (grad_input_1,)
 """,
         )
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11382,6 +11382,125 @@ fn
         self.assertEqual(expected, actual)
         self.assertGreater(po.call_count, 0)
 
+    class AssertNumOutputBackend:
+        """
+        A backend that checks the number of output for compiled graph, and
+        return the graph as is.
+        """
+
+        def __init__(self, test_case, expected_num_output: int):
+            self.test_case = test_case
+            self.expected_num_output = expected_num_output
+
+        def __call__(self, gm: torch.fx.GraphModule, example_inputs):
+            outputs = gm(*example_inputs)
+            self.test_case.assertEqual(self.expected_num_output, len(outputs))
+            return gm
+
+    def test_returning_nested_func_with_captured_tensor(self):
+        @torch.compile(backend=self.AssertNumOutputBackend(self, 2))
+        def test():
+            x = torch.rand(1)
+
+            def func():
+                return x + x
+
+            # Returning `func` forces dynamo to output `x` in the compiled
+            # graph, so that we can store it as `func`'s closure. The output of
+            # compiled graph would be `(x, x + x)`.
+            return func, func()
+
+        test()
+
+    def test_running_nested_func_with_captured_tensor(self):
+        @torch.compile(backend=self.AssertNumOutputBackend(self, 1))
+        def test():
+            x = torch.rand(1)
+
+            def func():
+                return x + x
+
+            # `x` is no longer needed after running the compiled graph, so we
+            # shouldn't return it. The output of compiled graph would be `(x +
+            # x,)`.
+            return func()
+
+        test()
+
+    def test_returning_func_with_captured_func_and_tensor(self):
+        @torch.compile(backend=self.AssertNumOutputBackend(self, 2))
+        def test():
+            x = torch.rand(1)
+
+            def nested():
+                return x + x
+
+            def func():
+                return nested()
+
+            # Returning `func` forces dynamo to output `x` in the compiled
+            # graph, so that we can store it as `func`'s closure. The output of
+            # compiled graph would be `(x, x + x)`.
+            return func, func()
+
+        test()
+
+    def test_running_func_with_captured_func_and_tensor(self):
+        @torch.compile(backend=self.AssertNumOutputBackend(self, 1))
+        def test():
+            x = torch.rand(1)
+
+            def nested():
+                return x + x
+
+            def func():
+                return nested()
+
+            # `x` is no longer needed after running the compiled graph, so we
+            # shouldn't return it. The output of compiled graph would be `(x)`.
+            return func()
+
+        test()
+
+    def test_escaping_closure_var_with_backward_hook(self):
+        @torch.compile(backend=self.AssertNumOutputBackend(self, 2))
+        def fn(x):
+            temp = x * x
+            captured_var = temp + 1
+
+            # This is where the lambda escapes the lifetime of `fn`, so
+            # dynamo must generate proper bytecode to update `captured_var`.
+            x.register_hook(lambda _: captured_var)
+
+            # The output of compiled graph would be `(x * x, x * x + 1)`.
+            return temp
+
+        ones = torch.ones(4, requires_grad=True)
+        fn(ones).sum().backward()
+
+    def test_escaping_closure_var_with_nonlocal_var(self):
+        nonlocal_fn = None
+
+        @torch.compile(backend=self.AssertNumOutputBackend(self, 2))
+        def fn(x):
+            temp = x * x
+            captured_var = x + 1
+
+            def inner():
+                return captured_var
+
+            # This is where `inner` escapes the lifetime of `fn`, so dynamo must
+            # generate proper bytecode to update `captured_var`.
+            nonlocal nonlocal_fn
+            nonlocal_fn = inner
+
+            # The output of compiled graph would be `(x * x, x * x + 1)`.
+            return temp
+
+        ones = torch.ones(4, requires_grad=True)
+        fn(ones)
+        nonlocal_fn()
+
 
 class TestTracer(JitTestCase):
     def test_jit_save(self):

--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -240,10 +240,8 @@ class TestPoitwiseOps(torch.nn.Module):
         inputs = torch.split(x.to(self.device), 500, dim=1)
         x_split = torch.split(inputs[0].to(self.device), 50, dim=1)
         y_split = torch.split(inputs[1].to(self.device), 50, dim=1)
-        tanh_1 = [torch.tanh(x_split[i]) for i in range(len(x_split))]
-        tanh_2 = [torch.tanh(y_split[i]) for i in range(len(y_split))]
-        sigmoid_1 = [torch.sigmoid(tanh_1[i]) for i in range(len(tanh_1))]
-        sigmoid_2 = [torch.sigmoid(tanh_2[i]) for i in range(len(tanh_2))]
+        sigmoid_1 = [torch.sigmoid(x_split[i]) for i in range(len(x_split))]
+        sigmoid_2 = [torch.sigmoid(y_split[i]) for i in range(len(y_split))]
         relu_1 = [torch.nn.functional.relu(sigmoid_1[i]) for i in range(len(sigmoid_1))]
         relu_2 = [torch.nn.functional.relu(sigmoid_2[i]) for i in range(len(sigmoid_2))]
         add = [torch.add(relu_1[i], relu_2[i]) for i in range(len(relu_1))]
@@ -344,7 +342,7 @@ class TestGroupBatchFusion(TestCase):
             )
             self.assertEqual(
                 counters["inductor"]["batch_aten_add"],
-                3,
+                0,
             )
             self.assertIn("GroupLinearFusion", optimus_scuba_log)
             counters.clear()
@@ -438,7 +436,6 @@ class TestGroupBatchFusion(TestCase):
         ref = module(*input)
         res = traced(*input)
         self.compare_pred(module, traced, input)
-        self.assertEqual(counters["inductor"]["batch_tanh"], 1)
         self.assertEqual(counters["inductor"]["batch_relu"], 1)
         self.assertEqual(counters["inductor"]["batch_sigmoid"], 1)
         self.assertEqual(counters["inductor"]["batch_aten_add"], 1)
@@ -472,7 +469,7 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(counters["inductor"]["batch_aten_tanh"], 1)
         self.assertEqual(counters["inductor"]["batch_aten_relu"], 1)
         self.assertEqual(counters["inductor"]["batch_aten_sigmoid"], 1)
-        self.assertEqual(counters["inductor"]["unbind_stack_aten_pass"], 2)
+        self.assertEqual(counters["inductor"]["unbind_stack_aten_pass"], 1)
         ref.sum().backward()
         res.sum().backward()
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -88,6 +88,7 @@ from .variables.functions import (
     UserMethodVariable,
 )
 from .variables.iter import MAX_ITERATOR_LIMIT
+from .variables.lazy import LazyVariableTracker
 from .variables.lists import (
     BaseListVariable,
     ListIteratorVariable,
@@ -797,16 +798,27 @@ class InstructionTranslatorBase(
                     return True
         return False
 
+    def cellvars(self):
+        if not hasattr(self, "_cellvars"):
+            self._cellvars = tuple(self.code_options["co_cellvars"] or [])
+            # An inlined function might depend on the cellvar of the parent
+            # function. So, recursively obtain parent cellvars.
+            if isinstance(self, InliningInstructionTranslator):
+                self._cellvars += self.parent.cellvars()
+        return self._cellvars
+
+    def freevars(self):
+        if not hasattr(self, "_freevars"):
+            self._freevars = tuple(self.code_options["co_freevars"] or [])
+            # An inlined function might depend on the freevar of the parent
+            # function. So, recursively obtain parent freevars.
+            if isinstance(self, InliningInstructionTranslator):
+                self._freevars += self.parent.freevars()
+        return self._freevars
+
     def cell_and_freevars(self):
         if not hasattr(self, "_cell_and_freevars"):
-            self._cell_and_freevars = tuple(
-                self.code_options["co_cellvars"] or []
-            ) + tuple(self.code_options["co_freevars"] or [])
-
-            # An inlined function might depend on the freevar of the parent
-            # function. So, recursively obtain parent cell and freevars.
-            if isinstance(self, InliningInstructionTranslator):
-                self._cell_and_freevars += self.parent.cell_and_freevars()
+            self._cell_and_freevars = self.cellvars() + self.freevars()
         return self._cell_and_freevars
 
     def prune_dead_locals(self):
@@ -814,11 +826,98 @@ class InstructionTranslatorBase(
         # implicit use by super()
         # reads = reads | {"__class__"}
         # output variables?
-        reads = reads | set(self.cell_and_freevars())
+        reads = reads | set(self.freevars())
+
+        # First we prune the non-cell local vars, this allows us to prune more
+        # cell local vars later on (e.g., if we manage to prune a
+        # `NestedUserFunctionVariable` that makes use of some cell locals).
+        cellvars = set(self.cellvars())
         self.symbolic_locals = {
-            k: v for k, v in self.symbolic_locals.items() if k in reads
+            k: v for k, v in self.symbolic_locals.items() if k in cellvars or k in reads
         }
+
+        # Then we prune the side effects, which might enable us to prune more
+        # cellvars afterwards.
         self.output.side_effects.prune_dead_object_new(self)
+
+        # Then we prune the cell locals.
+        #
+        # Note that we keep certain cell locals, because the current mechanism
+        # for codegen closure initialization for nested function creation is:
+        # 1. `NestedUserFunctionVariable` codegen assumes its closure has been
+        #    initialized properly by its creator, i.e., the tuple of cells will
+        #    be populated with correct content before the function is used.
+        # 2. `OutputGraph::compile_subgraph`, we populate the tuple of cells
+        #    _after_ emitting the `MAKE_FUNCTION` bytecode, via `STORE_DEREF`;
+        #    these `STORE_DEREF` are generated partly based on the current
+        #    `symbolic_locals`.
+        # As a result, we must be careful not to prune the cell locals that'll
+        # allow `OutputGraph` to generate the proper `STORE_DEREF`.
+        #
+        # On the other hand, we do want to prune away the truly dead ones, e.g.,
+        # say after we invoke a nested function, and the function is never used
+        # again. So here we do some conservative pruning, by tracing from a
+        # series of must-live root variables -- for any reachable cell, it must
+        # be kept alive.
+        #
+        # TODO(#137123) there are extra complexities due to side-effects (e.g.,
+        # the nested function leaking out into backward hook or globals). We
+        # could probably improve the variable tracing here to include the
+        # relevant variables in `output.side_effects`.
+        if self.output.side_effects.is_empty():
+            cellvars_that_must_live = set()
+            visited = set()
+
+            def visit(var: VariableTracker):
+                if var in visited:
+                    return
+                visited.add(var)
+
+                # Avoid realizing the lazy variable which could end up adding a
+                # graph input which isn't needed, this is sound because there's
+                # there doesn't seem to be a way to go from a
+                # `LazyVariableTracker` to `ClosureVariable`. TODO is this
+                # really true in general?
+                if isinstance(var, LazyVariableTracker):
+                    return
+
+                # We need to do this explicitly to walk the entire use chain,
+                # e.g., from a `ClosureVariable` to its underlying
+                # `NestedUserFunctionVariable`, rather than just stopping at the
+                # `ClosureVariable` with a name.
+                if isinstance(var, ClosureVariable):
+                    cellvars_that_must_live.add(var.name)
+
+                    # We only recur if the closure variable has been initialized.
+                    actual_var = self.symbolic_locals.get(var.name, None)
+                    if actual_var is not None:
+                        VariableTracker.visit(visit, actual_var)
+
+            # Populate `cellvars_that_must_live`
+            #
+            # NOTE: Don't trace from the cell locals which aren't explicitly
+            # read anymore; if they are indirectly used, they will be reached by
+            # other roots. These initially excluded cells are the ones that will
+            # hopefully be pruned.
+            local_roots = [
+                var
+                for name, var in self.symbolic_locals.items()
+                if name not in cellvars or name in reads
+            ]
+            VariableTracker.visit(
+                visit, (local_roots, self.stack, self.output.backward_state)
+            )
+            # Manually release the self-referential nested function, which
+            # captures `self.symbolic_locals` and affects parts of PT test/logic
+            # that are sensitive to when certain objects get released.
+            del visit
+
+            # Only keep locals that will be read, or are cellvars that must live.
+            self.symbolic_locals = {
+                k: v
+                for k, v in self.symbolic_locals.items()
+                if k in reads or k in cellvars_that_must_live
+            }
 
     def call_function(
         self,


### PR DESCRIPTION
This patch updates the `prune_dead_locals` logic to do slightly more aggressive pruning for cell local variables, in absence of side-effects, e.g., a cell variable can be pruned when its user function(s) will never be used again.

See added tests for examples; note that a few tests in `test/dynamo/test_higher_order_ops.py` also got updated because we are no longer returning the unnecessary graph output.

Fixes #127350, #124653

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @rec