### PR TITLE
Fix test for np.linalg.qr in numpy 2

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5234,7 +5234,9 @@ class TestLinalg(TestCase):
                 tau_shape = [*A_cpu.shape[:-2], A_cpu.shape[-1]]
                 tau = torch.empty(tau_shape, dtype=dtype).view(-1, A_cpu.shape[-1])
                 for A_i, reflectors_i, tau_i in zip(A_cpu.contiguous().view(*flattened_batch_shape), reflectors, tau):
-                    reflectors_tmp, tau_i[:] = map(torch.from_numpy, np.linalg.qr(A_i, mode='raw'))
+                    reflectors_tmp, tau_i[:] = (
+                        torch.from_numpy(x) if isinstance(x, np.ndarray) else x for x in np.linalg.qr(A_i, mode='raw')
+                    )
                     reflectors_i[:] = reflectors_tmp.T
                 reflectors = reflectors.view(*A_cpu.shape)
                 tau = tau.view(tau_shape)


### PR DESCRIPTION
Related to #107302.

When built and tested with NumPy 2 the following unit tests failed.

```
...
____________________________________________________________________________________ TestLinalgCPU.test_householder_product_cpu_float64 ____________________________________________________________________________________
Traceback (most recent call last):
  File "/usr/local/google/home/haifengj/git/pytorch_np2/test/test_linalg.py", line 5279, in test_householder_product
    run_test(shape)
  File "/usr/local/google/home/haifengj/git/pytorch_np2/test/test_linalg.py", line 5249, in run_test
    reflectors, tau = generate_reflectors_and_tau(A)
  File "/usr/local/google/home/haifengj/git/pytorch_np2/test/test_linalg.py", line 5237, in generate_reflectors_and_tau
    reflectors_tmp, tau_i[:] = map(torch.from_numpy, np.linalg.qr(A_i, mode='raw'))
TypeError: expected np.ndarray (got Tensor)

To execute this test, run the following from the base repo dir:
    python test/test_linalg.py TestLinalgCPU.test_householder_product_cpu_float64

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
================================================================================================= short test summary info ==================================================================================================
FAILED [0.0062s] test/test_linalg.py::TestLinalgCPU::test_householder_product_cpu_complex128 - TypeError: expected np.ndarray (got Tensor)
FAILED [0.0030s] test/test_linalg.py::TestLinalgCPU::test_householder_product_cpu_complex64 - TypeError: expected np.ndarray (got Tensor)
FAILED [0.0025s] test/test_linalg.py::TestLinalgCPU::test_householder_product_cpu_float32 - TypeError: expected np.ndarray (got Tensor)
FAILED [0.0037s] test/test_linalg.py::TestLinalgCPU::test_householder_product_cpu_float64 - TypeError: expected np.ndarray (got Tensor)
============================================================================================ 4 failed, 1174 deselected in 4.05s ============================================================================================

```

This PR fixes them. The test is now compatible with both NumPy 1 & 2.

The cause of the failure is when passing a `torch.Tensor` to `np.linalg.qr`, the return type in NumPy 1 is `(np.ndarray, np.ndarray)`, while it is `(torch.Tensor, torch.Tensor)` in NumPy 2.

cc: @kiukchung 