### PR TITLE
[Inductor] Switch cpp_wrapper tests to ABI-compatible

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -105,7 +105,7 @@ def make_test_case(
     assert callable(func), "not a callable"
     func = slowTest(func) if slow else func
 
-    @config.patch(cpp_wrapper=True, search_autotune_cache=False, abi_compatible=True)
+    @config.patch(cpp_wrapper=True, search_autotune_cache=False)
     def fn(self):
         tests.setUpClass()
         tests.setUp()
@@ -142,6 +142,7 @@ def make_test_case(
 
 
 if RUN_CPU:
+    config.abi_compatible = True
 
     class BaseTest(NamedTuple):
         name: str
@@ -167,16 +168,12 @@ if RUN_CPU:
             test_mkldnn_pattern_matcher.TestPatternMatcher(),
             condition=torch.backends.mkldnn.is_available(),
             func_inputs=[
-                (
-                    None
-                    if config.abi_compatible
-                    else ["op_mkldnn__convolution_pointwise_binary.call"]
-                ),
-                (
-                    None
-                    if config.abi_compatible
-                    else ["op_mkldnn__convolution_pointwise__binary.call"]
-                ),
+                None
+                if config.abi_compatible
+                else ["op_mkldnn__convolution_pointwise_binary.call"],
+                None
+                if config.abi_compatible
+                else ["op_mkldnn__convolution_pointwise__binary.call"],
             ],
         ),
         BaseTest(
@@ -185,16 +182,12 @@ if RUN_CPU:
             test_mkldnn_pattern_matcher.TestPatternMatcher(),
             condition=torch.backends.mkldnn.is_available(),
             func_inputs=[
-                (
-                    None
-                    if config.abi_compatible
-                    else ["op_mkldnn__convolution_pointwise__binary.call"]
-                ),
-                (
-                    None
-                    if config.abi_compatible
-                    else ["op_mkldnn__convolution_pointwise_binary.call"]
-                ),
+                None
+                if config.abi_compatible
+                else ["op_mkldnn__convolution_pointwise__binary.call"],
+                None
+                if config.abi_compatible
+                else ["op_mkldnn__convolution_pointwise_binary.call"],
             ],
         ),
         BaseTest(
@@ -293,15 +286,13 @@ if RUN_CPU:
             test_mkldnn_pattern_matcher.TestDynamicPatternMatcher(),
             condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
             func_inputs=[
-                (
-                    None
-                    if config.abi_compatible
-                    else [
-                        "op_onednn_qconv2d_pointwise_.call",
-                        "op_quantized_max_pool2d_.call",
-                        "op_onednn_qlinear_pointwise_tensor.call",
-                    ]
-                ),
+                None
+                if config.abi_compatible
+                else [
+                    "op_onednn_qconv2d_pointwise_.call",
+                    "op_quantized_max_pool2d_.call",
+                    "op_onednn_qlinear_pointwise_tensor.call",
+                ],
             ],
         ),
         BaseTest(

--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -105,7 +105,7 @@ def make_test_case(
     assert callable(func), "not a callable"
     func = slowTest(func) if slow else func
 
-    @config.patch(cpp_wrapper=True, search_autotune_cache=False)
+    @config.patch(cpp_wrapper=True, search_autotune_cache=False, abi_compatible=True)
     def fn(self):
         tests.setUpClass()
         tests.setUp()
@@ -167,12 +167,16 @@ if RUN_CPU:
             test_mkldnn_pattern_matcher.TestPatternMatcher(),
             condition=torch.backends.mkldnn.is_available(),
             func_inputs=[
-                None
-                if config.abi_compatible
-                else ["op_mkldnn__convolution_pointwise_binary.call"],
-                None
-                if config.abi_compatible
-                else ["op_mkldnn__convolution_pointwise__binary.call"],
+                (
+                    None
+                    if config.abi_compatible
+                    else ["op_mkldnn__convolution_pointwise_binary.call"]
+                ),
+                (
+                    None
+                    if config.abi_compatible
+                    else ["op_mkldnn__convolution_pointwise__binary.call"]
+                ),
             ],
         ),
         BaseTest(
@@ -181,12 +185,16 @@ if RUN_CPU:
             test_mkldnn_pattern_matcher.TestPatternMatcher(),
             condition=torch.backends.mkldnn.is_available(),
             func_inputs=[
-                None
-                if config.abi_compatible
-                else ["op_mkldnn__convolution_pointwise__binary.call"],
-                None
-                if config.abi_compatible
-                else ["op_mkldnn__convolution_pointwise_binary.call"],
+                (
+                    None
+                    if config.abi_compatible
+                    else ["op_mkldnn__convolution_pointwise__binary.call"]
+                ),
+                (
+                    None
+                    if config.abi_compatible
+                    else ["op_mkldnn__convolution_pointwise_binary.call"]
+                ),
             ],
         ),
         BaseTest(
@@ -285,13 +293,15 @@ if RUN_CPU:
             test_mkldnn_pattern_matcher.TestDynamicPatternMatcher(),
             condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
             func_inputs=[
-                None
-                if config.abi_compatible
-                else [
-                    "op_onednn_qconv2d_pointwise_.call",
-                    "op_quantized_max_pool2d_.call",
-                    "op_onednn_qlinear_pointwise_tensor.call",
-                ],
+                (
+                    None
+                    if config.abi_compatible
+                    else [
+                        "op_onednn_qconv2d_pointwise_.call",
+                        "op_quantized_max_pool2d_.call",
+                        "op_onednn_qlinear_pointwise_tensor.call",
+                    ]
+                ),
             ],
         ),
         BaseTest(

--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -81,7 +81,7 @@ def make_test_case(
     assert callable(func), "not a callable"
     func = slowTest(func) if slow else func
 
-    @config.patch(cpp_wrapper=True, search_autotune_cache=False)
+    @config.patch(cpp_wrapper=True, search_autotune_cache=False, abi_compatible=True)
     def fn(self):
         tests.setUpClass()
         tests.setUp()

--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -81,7 +81,7 @@ def make_test_case(
     assert callable(func), "not a callable"
     func = slowTest(func) if slow else func
 
-    @config.patch(cpp_wrapper=True, search_autotune_cache=False, abi_compatible=True)
+    @config.patch(cpp_wrapper=True, search_autotune_cache=False)
     def fn(self):
         tests.setUpClass()
         tests.setUp()
@@ -118,6 +118,7 @@ def make_test_case(
 
 
 if RUN_CUDA:
+    config.abi_compatible = True
 
     class BaseTest(NamedTuple):
         name: str

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -973,9 +973,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
     @cache_on_self
     def get_output_refs(self):
         return [
-            f"torch::tensor({x.codegen_reference(self.wrapper_call)})"
-            if isinstance(x, ir.ShapeAsConstantBuffer) and not config.abi_compatible
-            else x.codegen_reference(self.wrapper_call)
+            (
+                f"torch::tensor({x.codegen_reference(self.wrapper_call)})"
+                if isinstance(x, ir.ShapeAsConstantBuffer) and not config.abi_compatible
+                else x.codegen_reference(self.wrapper_call)
+            )
             for x in V.graph.graph_outputs
         ]
 
@@ -1179,9 +1181,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
             outputs_str = "output_tensors"
         else:
             outputs = [
-                f"output_tensors[{i}]"
-                if self.output_is_tensor[i]
-                else f"output_tensors[{i}].item()"
+                (
+                    f"output_tensors[{i}]"
+                    if self.output_is_tensor[i]
+                    else f"output_tensors[{i}].item()"
+                )
                 for i in range(len(V.graph.graph_outputs))
             ]
             outputs_str = f"[{', '.join(outputs)}]"
@@ -1336,9 +1340,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # TODO: consider remove "_out" and add missing inplace variants to fallback_ops.py
             cpp_kernel_name = cpp_kernel_name.replace("__", "_") + "_out"
             inputs_wrapped = [
-                f"convert_arrayref_tensor_to_tensor({x})"
-                if isinstance(x, str)
-                else str(x)
+                (
+                    f"convert_arrayref_tensor_to_tensor({x})"
+                    if isinstance(x, str)
+                    else str(x)
+                )
                 for x in inputs
             ]
             line = f"{cpp_kernel_name}(convert_arrayref_tensor_to_tensor({output}), {','.join(inputs_wrapped)}"
@@ -2212,6 +2218,9 @@ if (custom_op_wrapper.get() == NULL) {
                     )
             elif isinstance(raw_arg, torch.dtype):
                 # dtype
+                if sys.version_info < (3, 10):
+                    # Py_NewRef is only available since Python 3.10
+                    self.include_extra_header("torch/csrc/utils/pythoncapi_compat.h")
                 self.include_extra_header("torch/csrc/DynamicTypes.h")
                 return f"Py_NewRef(torch::getTHPDtype(static_cast<c10::ScalarType>({self.codegen_dtype(raw_arg)})))"
             else:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -973,11 +973,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
     @cache_on_self
     def get_output_refs(self):
         return [
-            (
-                f"torch::tensor({x.codegen_reference(self.wrapper_call)})"
-                if isinstance(x, ir.ShapeAsConstantBuffer) and not config.abi_compatible
-                else x.codegen_reference(self.wrapper_call)
-            )
+            f"torch::tensor({x.codegen_reference(self.wrapper_call)})"
+            if isinstance(x, ir.ShapeAsConstantBuffer) and not config.abi_compatible
+            else x.codegen_reference(self.wrapper_call)
             for x in V.graph.graph_outputs
         ]
 
@@ -1181,11 +1179,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
             outputs_str = "output_tensors"
         else:
             outputs = [
-                (
-                    f"output_tensors[{i}]"
-                    if self.output_is_tensor[i]
-                    else f"output_tensors[{i}].item()"
-                )
+                f"output_tensors[{i}]"
+                if self.output_is_tensor[i]
+                else f"output_tensors[{i}].item()"
                 for i in range(len(V.graph.graph_outputs))
             ]
             outputs_str = f"[{', '.join(outputs)}]"
@@ -1340,11 +1336,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # TODO: consider remove "_out" and add missing inplace variants to fallback_ops.py
             cpp_kernel_name = cpp_kernel_name.replace("__", "_") + "_out"
             inputs_wrapped = [
-                (
-                    f"convert_arrayref_tensor_to_tensor({x})"
-                    if isinstance(x, str)
-                    else str(x)
-                )
+                f"convert_arrayref_tensor_to_tensor({x})"
+                if isinstance(x, str)
+                else str(x)
                 for x in inputs
             ]
             line = f"{cpp_kernel_name}(convert_arrayref_tensor_to_tensor({output}), {','.join(inputs_wrapped)}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136904

Summary: Switch test_cpu_cpp_wrapper and test_cuda_cpp_wrapper to test the ABI-compatible mode only. Fixed a missing Py_NewRef issue for python 3.9.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang