### PR TITLE
[Elasitc][fix] Use the right env variable TORCH_ELASTIC_WORKER_IDENTICAL for unit test

### DIFF
--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -547,7 +547,7 @@ class SimpleElasticAgentTest(unittest.TestCase):
         )
 
     def test_assign_worker_ranks_indentical(self):
-        os.environ["TORCH_SKIP_STORE_BARRIER"] = "1"
+        os.environ["TORCH_ELASTIC_WORKER_IDENTICAL"] = "1"
         role_infos = [
             _RoleInstanceInfo("trainer", 0, 4),
             _RoleInstanceInfo("trainer", 1, 4),
@@ -597,7 +597,7 @@ class SimpleElasticAgentTest(unittest.TestCase):
                 ],
             ],
         )
-        os.environ["TORCH_SKIP_STORE_BARRIER"] = "0"
+        os.environ["TORCH_ELASTIC_WORKER_IDENTICAL"] = "0"
 
     def test_get_event(self):
         spec = self._get_worker_spec(max_restarts=1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

as title, this is an easy fix for unit test.

Differential Revision: [D63577774](https://our.internmc.facebook.com/intern/diff/D63577774/)

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @wz337 @wconstab @d4l3k @c-p-i-o