### PR TITLE
docs: clarify alias usage for `x` parameter in vector_norm function

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1441,6 +1441,7 @@ but it is faster in some cases.
 Args:
     x (Tensor): tensor, flattened by default, but this behavior can be
         controlled using :attr:`dim`.
+        Note: The parameter `input` can also be used as an alias for `x`
     ord (int, float, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `2`
     dim (int, Tuple[int], optional): dimensions over which to compute
         the norm. See above for the behavior when :attr:`dim`\ `= None`.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1440,8 +1440,8 @@ but it is faster in some cases.
 
 Args:
     x (Tensor): tensor, flattened by default, but this behavior can be
-        controlled using :attr:`dim`.
-        Note: The parameter `input` can also be used as an alias for `x`
+        controlled using :attr:`dim`.  (Note: the keyword argument
+        `input` can also be used as an alias for `x`.)
     ord (int, float, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `2`
     dim (int, Tuple[int], optional): dimensions over which to compute
         the norm. See above for the behavior when :attr:`dim`\ `= None`.


### PR DESCRIPTION
- Added a note in the documentation specifying that the `input` parameter can be used as an alias for `x`.

Fixes #136560
