### PR TITLE
Use inferred dimension in k,v states in MHA implementation to allow ONNX export with dynamic axes

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6172,7 +6172,7 @@ def multi_head_attention_forward(
     #
     q = q.view(tgt_len, bsz * num_heads, head_dim).transpose(0, 1)
     if static_k is None:
-        k = k.view(k.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+        k = k.view(-1, bsz * num_heads, head_dim).transpose(0, 1)
     else:
         # TODO finish disentangling control flow so we don't do in-projections when statics are passed
         assert (
@@ -6183,7 +6183,7 @@ def multi_head_attention_forward(
         ), f"expecting static_k.size(2) of {head_dim}, but got {static_k.size(2)}"
         k = static_k
     if static_v is None:
-        v = v.view(v.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+        v = v.view(-1, bsz * num_heads, head_dim).transpose(0, 1)
     else:
         # TODO finish disentangling control flow so we don't do in-projections when statics are passed
         assert (

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6172,7 +6172,8 @@ def multi_head_attention_forward(
     #
     q = q.view(tgt_len, bsz * num_heads, head_dim).transpose(0, 1)
     if static_k is None:
-        k = k.view(-1, bsz * num_heads, head_dim).transpose(0, 1)
+        # Use inferred dimension when possible for ONNX export tracing
+        k = k.view(-1 if k.numel() > 0 else k.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
     else:
         # TODO finish disentangling control flow so we don't do in-projections when statics are passed
         assert (
@@ -6183,7 +6184,8 @@ def multi_head_attention_forward(
         ), f"expecting static_k.size(2) of {head_dim}, but got {static_k.size(2)}"
         k = static_k
     if static_v is None:
-        v = v.view(-1, bsz * num_heads, head_dim).transpose(0, 1)
+        # Use inferred dimension when possible for ONNX export tracing
+        v = v.view(-1 if v.numel() > 0 else v.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
     else:
         # TODO finish disentangling control flow so we don't do in-projections when statics are passed
         assert (


### PR DESCRIPTION
Fixes #99701
Follow up on #111800

This changes relies on the fact that all other dimensions are explicitly specified in the reshape, so it's okay to use an inferred dimension on the sequence length. This forces the ONNX operator to treat it as a dynamic axis.

I have verified that this change works by deploying my Cronformer implementation at https://huggingface.co/openblitz/cronformer/blob/main/cronformer.onnx (code is [here](https://github.com/openblitz/cronformer))
