### PR TITLE
[distributed][test] Remove unused variable and fix doc typo

### DIFF
--- a/test/distributed/checkpoint/e2e/test_fine_tuning.py
+++ b/test/distributed/checkpoint/e2e/test_fine_tuning.py
@@ -106,7 +106,7 @@ class TestFineTuning(DTensorTestBase):
         # Save state_dict
         model_state_dict, optim_state_dict = get_state_dict(model, optimizers=optim)
         saved_state_dict = {"model": model_state_dict, "optim": optim_state_dict}
-        dist_cp.save_state_dict(
+        dist_cp.save(
             state_dict=saved_state_dict,
             storage_writer=dist_cp.FileSystemWriter(pretrain_dir),
         )
@@ -127,7 +127,7 @@ class TestFineTuning(DTensorTestBase):
                 submodules={model.pretrain},
                 options=StateDictOptions(keep_submodule_prefixes=False),
             )
-            dist_cp.load_state_dict(
+            dist_cp.load(
                 {"model": pretrain_state_dict},
                 storage_reader=dist_cp.FileSystemReader(pretrain_dir),
             )
@@ -175,7 +175,7 @@ class TestFineTuning(DTensorTestBase):
                 options=StateDictOptions(ignore_frozen_params=True),
             )
             saved_state_dict = {"model": model_state_dict, "optim": optim_state_dict}
-            dist_cp.save_state_dict(
+            dist_cp.save(
                 state_dict=saved_state_dict,
                 storage_writer=dist_cp.FileSystemWriter(finetune_dir),
             )

--- a/test/distributed/checkpoint/test_dtensor_checkpoint.py
+++ b/test/distributed/checkpoint/test_dtensor_checkpoint.py
@@ -172,7 +172,7 @@ class DTensorPlanner(DTensorTestBase):
             )
         """
 
-        dist_cp.save_state_dict(
+        dist_cp.save(
             state_dict=state_dict,
             storage_writer=dist_cp.FileSystemWriter(path=CHECKPOINT_DIR),
             planner=dist_cp.DefaultSavePlanner(),
@@ -224,7 +224,7 @@ class DTensorPlanner(DTensorTestBase):
             )
         """
 
-        dist_cp.load_state_dict(
+        dist_cp.load(
             state_dict=state_dict,
             storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
             planner=dist_cp.DefaultLoadPlanner(),

--- a/test/distributed/checkpoint/test_dtensor_resharding.py
+++ b/test/distributed/checkpoint/test_dtensor_resharding.py
@@ -255,7 +255,7 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
         dtensor = distribute_tensor(tensor, mesh, [Shard(0)])
         ref_state_dict = {"dtensor": dtensor}
 
-        dist_cp.save_state_dict(
+        dist_cp.save(
             state_dict=ref_state_dict,
             storage_writer=dist_cp.FileSystemWriter(path=self.temp_dir),
         )
@@ -264,7 +264,7 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
         mesh_2 = init_device_mesh(self.device_type, (2, self.world_size // 2))
         dtensor = distribute_tensor(tensor, mesh_2, [Shard(0), Shard(0)])
         state_dict = {"dtensor": dtensor}
-        dist_cp.load_state_dict(
+        dist_cp.load(
             state_dict=state_dict,
             storage_reader=dist_cp.FileSystemReader(self.temp_dir),
         )

--- a/test/distributed/checkpoint/test_dtensor_resharding.py
+++ b/test/distributed/checkpoint/test_dtensor_resharding.py
@@ -63,7 +63,7 @@ class TestDTensorReshardPlacementChange(DTensorTestBase):
             )
             state_dict_to_save = {"dtensor": dtensor}
 
-            dist_cp.save_state_dict(
+            dist_cp.save(
                 state_dict=state_dict_to_save,
                 storage_writer=dist_cp.FileSystemWriter(path=CHECKPOINT_DIR),
                 planner=dist_cp.DefaultSavePlanner(),
@@ -74,7 +74,7 @@ class TestDTensorReshardPlacementChange(DTensorTestBase):
             )
             state_dict_to_load = {"dtensor": zero_dtensor}
 
-            dist_cp.load_state_dict(
+            dist_cp.load(
                 state_dict=state_dict_to_load,
                 storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
                 planner=dist_cp.DefaultLoadPlanner(),
@@ -115,7 +115,7 @@ class TestDTensorReshardPlacementChange(DTensorTestBase):
             )
             state_dict_to_save = {"dtensor": dtensor}
 
-            dist_cp.save_state_dict(
+            dist_cp.save(
                 state_dict=state_dict_to_save,
                 storage_writer=dist_cp.FileSystemWriter(path=CHECKPOINT_DIR),
                 planner=dist_cp.DefaultSavePlanner(),
@@ -124,7 +124,7 @@ class TestDTensorReshardPlacementChange(DTensorTestBase):
             zero_dtensor = zeros([4, 4], device_mesh=mesh_2d, placements=new_placement)
             state_dict_to_load = {"dtensor": zero_dtensor}
 
-            dist_cp.load_state_dict(
+            dist_cp.load(
                 state_dict=state_dict_to_load,
                 storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
                 planner=dist_cp.DefaultLoadPlanner(),
@@ -165,7 +165,7 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
             )
             state_dict_to_save = {"dtensor": dtensor}
 
-            dist_cp.save_state_dict(
+            dist_cp.save(
                 state_dict=state_dict_to_save,
                 storage_writer=dist_cp.FileSystemWriter(path=CHECKPOINT_DIR),
                 planner=dist_cp.DefaultSavePlanner(),
@@ -180,7 +180,7 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
                 )
                 state_dict_to_load = {"dtensor": zero_dtensor}
 
-                dist_cp.load_state_dict(
+                dist_cp.load(
                     state_dict=state_dict_to_load,
                     storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
                     planner=dist_cp.DefaultLoadPlanner(),
@@ -211,7 +211,7 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
             )
             state_dict_to_save = {"dtensor": dtensor}
 
-            dist_cp.save_state_dict(
+            dist_cp.save(
                 state_dict=state_dict_to_save,
                 storage_writer=dist_cp.FileSystemWriter(path=CHECKPOINT_DIR),
                 planner=dist_cp.DefaultSavePlanner(),
@@ -226,7 +226,7 @@ class TestDTensorReshardMeshChange(DTensorTestBase):
                 )
                 state_dict_to_load = {"dtensor": zero_dtensor}
 
-                dist_cp.load_state_dict(
+                dist_cp.load(
                     state_dict=state_dict_to_load,
                     storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
                     planner=dist_cp.DefaultLoadPlanner(),

--- a/test/distributed/checkpoint/test_fsdp_tp_checkpoint_conversion.py
+++ b/test/distributed/checkpoint/test_fsdp_tp_checkpoint_conversion.py
@@ -79,7 +79,7 @@ class TestFsdpTpCheckpointConversion(DTensorTestBase):
                 ).to_local()
                 self.assertNotEqual(fsdp_redistributed, tp_redistributed)
 
-        dist_cp.load_state_dict(
+        dist_cp.load(
             state_dict=tp_state_dict,
             storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
         )

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -894,9 +894,6 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
         with _dynamo_dist_per_rank_init(self.rank, self.world_size):
             torch._dynamo.utils.clear_compilation_metrics()
 
-            # TODO: This should be possible to do inside the function, but
-            device = f"cuda:{self.rank}"
-
             @torch.compile()
             def f(x, y):
                 zx = x.shape
@@ -926,8 +923,6 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
     def test_compiler_collectives_graph_break_empty_graph_still_collective(self):
         with _dynamo_dist_per_rank_init(self.rank, self.world_size):
             torch._dynamo.utils.clear_compilation_metrics()
-
-            device = f"cuda:{self.rank}"
 
             @torch.compile()
             def f(x, y):

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -629,7 +629,7 @@ def distribute_tensor(
     Distribute a leaf ``torch.Tensor`` (i.e. nn.Parameter/buffers) to the ``device_mesh`` according
     to the ``placements`` specified. The rank of ``device_mesh`` and ``placements`` must be the
     same. The ``tensor`` to distribute is the logical or "global" tensor, and the API would use
-    the ``tensor`` from first rank of the DeviceMesh dimension as the source of truth to perserve
+    the ``tensor`` from first rank of the DeviceMesh dimension as the source of truth to preserve
     the single-device semantic. If you want to construct a DTensor in the middle of the Autograd
     computation, please use :meth:`DTensor.from_local` instead.
 

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -53,7 +53,7 @@ class Shard(Placement):
     DeviceMesh dimension only holds a shard/piece of the global Tensor. The
     ``Shard(dim)`` placement follows the ``torch.chunk(dim)`` semantic, where the
     last few shards on the DeviceMesh dimension might be empty when the tensor dimension
-    is not evenly divisble on the DeviceMesh dimension. The ``Shard`` placement can be
+    is not evenly divisible on the DeviceMesh dimension. The ``Shard`` placement can be
     used by all DTensor APIs (i.e. distribute_tensor, from_local, etc.)
 
     Args:


### PR DESCRIPTION
Refactor distributed test code:
- Fix TODO: Remove unused variable
- Fix doc typo
- Migrate deprecated method call `load_state_dict` and `save_state_dict`

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @LucasLLC @MeetVadakkanchery @mhorowitz @pradeepfn