### PR TITLE
[Inductor UT] Generalize newly introduced inductor UTs for intel GPU (Part 3)

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1,5 +1,4 @@
 # Owner(s): ["module: inductor"]
-import functools
 import os
 import pickle
 import unittest
@@ -35,10 +34,11 @@ from torch.testing._internal.inductor_utils import (
     HAS_CUDA,
     HAS_GPU,
     HAS_MULTIGPU,
+    HAS_TRITON,
     requires_gpu,
+    requires_triton,
 )
 from torch.testing._internal.triton_utils import requires_cuda
-from torch.utils._triton import has_triton
 
 
 try:
@@ -47,14 +47,10 @@ except ImportError:
     from mock_cache import global_stats, PatchCaches, Stats  # @manual
 
 
-HAS_TRITON = has_triton()
-
 if HAS_TRITON:
     import triton  # @manual
 
     from torch.testing._internal.triton_utils import add_kernel
-
-requires_triton = functools.partial(unittest.skipIf, not HAS_TRITON, "requires triton")
 
 torch._dynamo.config.fake_tensor_cache_enabled = True
 torch._dynamo.config.fake_tensor_cache_crosscheck_enabled = True

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -33,7 +33,6 @@ from torch.testing._internal.common_device_type import expectedFailureXPU, skipC
 from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
-    HAS_CUDA,
     HAS_GPU,
     IS_A100,
     IS_BIG_GPU,

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -30,7 +30,7 @@ from torch._inductor.virtualized import V
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_device_type import expectedFailureXPU, skipCUDAIf
-from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
+from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_GPU,
@@ -129,7 +129,7 @@ class TestPatternMatcher(TestCase):
             )  # also checks that dtype is correct
 
     @skipIfRocm
-    @expectedFailureXPU
+    @skipIfXpu
     @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(force_fuse_int_mm_with_mul=True)
     def test_fused_int_mm_mul(self):
@@ -164,7 +164,7 @@ class TestPatternMatcher(TestCase):
             self._test_fused_int_mm_mul_impl(fn2, args, True)
 
     @skipIfRocm
-    @expectedFailureXPU
+    @skipIfXpu
     @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(force_fuse_int_mm_with_mul=True)
     def test_fused_int_mm_mul_gating(self):

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -29,7 +29,7 @@ from torch._inductor.utils import run_and_get_code
 from torch._inductor.virtualized import V
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM80OrLater
-from torch.testing._internal.common_device_type import expectedFailureXPU
+from torch.testing._internal.common_device_type import expectedFailureXPU, skipCUDAIf
 from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
@@ -42,6 +42,8 @@ from torch.utils import _pytree as pytree
 
 
 class TestPatternMatcher(TestCase):
+    device_type = GPU_TYPE
+
     def common(
         self,
         fn,
@@ -129,7 +131,7 @@ class TestPatternMatcher(TestCase):
 
     @skipIfRocm
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(force_fuse_int_mm_with_mul=True)
     def test_fused_int_mm_mul(self):
         def fn1(a, b, c):
@@ -164,7 +166,7 @@ class TestPatternMatcher(TestCase):
 
     @skipIfRocm
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(force_fuse_int_mm_with_mul=True)
     def test_fused_int_mm_mul_gating(self):
         def fn1(a, b, c):
@@ -204,7 +206,7 @@ class TestPatternMatcher(TestCase):
         self.assertEqual("fallback_mixed_mm" in code, fallback_mixed_mm_expected)
 
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton")
     def test_mixed_mm(self):
         def fn(a, b):
@@ -233,7 +235,7 @@ class TestPatternMatcher(TestCase):
             self._test_mixed_impl(fn, args, True, False)
 
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton")
     def test_mixed_mm_exhaustive_dtypes(self):
         def fn(a, b):
@@ -258,7 +260,7 @@ class TestPatternMatcher(TestCase):
             )
 
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton")
     def test_mixed_mm_bad_cases(self):
         def fn(a, b):
@@ -284,7 +286,7 @@ class TestPatternMatcher(TestCase):
             self._test_mixed_impl(fn, args, True, True)
 
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton", max_autotune_gemm=True)
     def test_mixed_mm_epi_works(self):
         def fn(a, b, c, d):
@@ -315,9 +317,9 @@ class TestPatternMatcher(TestCase):
             self._test_mixed_impl(fn, args, True, False)
 
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
-    @unittest.skipIf(HAS_CUDA ^ bool(IS_A100), "heuristic only run on Linux A100")
-    @unittest.skipIf(HAS_CUDA ^ bool(IS_BIG_GPU), "tests fail on small GPU")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
+    @skipCUDAIf(not IS_A100, "heuristic only run on Linux A100")
+    @skipCUDAIf(not IS_BIG_GPU, "tests fail on small GPU")
     @inductor_config.patch(
         mixed_mm_choice="heuristic",
         autoheuristic_use="",
@@ -386,9 +388,9 @@ class TestPatternMatcher(TestCase):
             self._test_mixed_impl(fn, args, True, True)
 
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
-    @unittest.skipIf(HAS_CUDA ^ bool(IS_A100), "heuristic only run on Linux A100")
-    @unittest.skipIf(HAS_CUDA ^ bool(IS_BIG_GPU), "tests fail on small GPU")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
+    @skipCUDAIf(not IS_A100, "heuristic only run on Linux A100")
+    @skipCUDAIf(not IS_BIG_GPU, "tests fail on small GPU")
     @inductor_config.patch(
         mixed_mm_choice="heuristic",
         autoheuristic_use="",
@@ -451,7 +453,7 @@ class TestPatternMatcher(TestCase):
             self._test_mixed_impl(fn, args, True, False, rtol=0.01, atol=0.04)
 
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
     def test_mixed_mm_gating(self):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))
@@ -508,7 +510,7 @@ class TestPatternMatcher(TestCase):
         self._test_mixed_impl(fn, args, False, False)
 
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(use_mixed_mm=True)
     def test_uint4x2_mixed_mm(self):
         def fn(a, b):
@@ -561,7 +563,7 @@ class TestPatternMatcher(TestCase):
             check_uint4x2_mixed_mm(args, False)
 
     @expectedFailureXPU
-    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @skipCUDAIf(not SM80OrLater, "need sm_80")
     @inductor_config.patch(use_mixed_mm=True)
     def test_uint4x2_mixed_mm_epi(self):
         def fn(a, b, c, d):

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -29,8 +29,14 @@ from torch._inductor.utils import run_and_get_code
 from torch._inductor.virtualized import V
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM80OrLater
-from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
-from torch.testing._internal.inductor_utils import HAS_CUDA, IS_A100, IS_BIG_GPU
+from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm, xfailIfXpu
+from torch.testing._internal.inductor_utils import (
+    GPU_TYPE,
+    HAS_CUDA,
+    HAS_GPU,
+    IS_A100,
+    IS_BIG_GPU,
+)
 from torch.utils import _pytree as pytree
 
 
@@ -74,16 +80,16 @@ class TestPatternMatcher(TestCase):
         # when m1 == n1 and m2 == n2, mm_plus_mm can be matched to fused op
         fusible_args_list = [
             (
-                torch.randn(16, 16, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
+                torch.randn(16, 16, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
             ),
             (
-                torch.randn(1, 4, device="cuda"),
-                torch.randn(4, 2, device="cuda"),
-                torch.randn(1, 5, device="cuda"),
-                torch.randn(5, 2, device="cuda"),
+                torch.randn(1, 4, device=GPU_TYPE),
+                torch.randn(4, 2, device=GPU_TYPE),
+                torch.randn(1, 5, device=GPU_TYPE),
+                torch.randn(5, 2, device=GPU_TYPE),
             ),
         ]
         for args in fusible_args_list:
@@ -93,16 +99,16 @@ class TestPatternMatcher(TestCase):
         unfusible_args_list = [
             # https://github.com/pytorch/pytorch/issues/100670.
             (
-                torch.randn(1, 4, device="cuda"),
-                torch.randn(4, 2, device="cuda"),
-                torch.randn(1, 2, device="cuda"),
-                torch.randn(2, 1, device="cuda"),
+                torch.randn(1, 4, device=GPU_TYPE),
+                torch.randn(4, 2, device=GPU_TYPE),
+                torch.randn(1, 2, device=GPU_TYPE),
+                torch.randn(2, 1, device=GPU_TYPE),
             ),
             (
-                torch.randn(1, 2, device="cuda"),
-                torch.randn(2, 1, device="cuda"),
-                torch.randn(1, 4, device="cuda"),
-                torch.randn(4, 2, device="cuda"),
+                torch.randn(1, 2, device=GPU_TYPE),
+                torch.randn(2, 1, device=GPU_TYPE),
+                torch.randn(1, 4, device=GPU_TYPE),
+                torch.randn(4, 2, device=GPU_TYPE),
             ),
         ]
         for args in unfusible_args_list:
@@ -121,7 +127,8 @@ class TestPatternMatcher(TestCase):
             )  # also checks that dtype is correct
 
     @skipIfRocm
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(force_fuse_int_mm_with_mul=True)
     def test_fused_int_mm_mul(self):
         def fn1(a, b, c):
@@ -134,19 +141,19 @@ class TestPatternMatcher(TestCase):
 
         args_list = [
             (
-                torch.randint(-128, 127, (32, 32), dtype=torch.int8, device="cuda"),
-                torch.randint(-128, 127, (32, 8), dtype=torch.int8, device="cuda"),
-                torch.randn((32, 1), dtype=torch.float16, device="cuda") * 0 + 0.5,
+                torch.randint(-128, 127, (32, 32), dtype=torch.int8, device=GPU_TYPE),
+                torch.randint(-128, 127, (32, 8), dtype=torch.int8, device=GPU_TYPE),
+                torch.randn((32, 1), dtype=torch.float16, device=GPU_TYPE) * 0 + 0.5,
             ),
             (
-                torch.randint(-128, 127, (32, 32), dtype=torch.int8, device="cuda"),
-                torch.randint(-128, 127, (32, 8), dtype=torch.int8, device="cuda"),
-                torch.randn((1, 8), dtype=torch.bfloat16, device="cuda"),
+                torch.randint(-128, 127, (32, 32), dtype=torch.int8, device=GPU_TYPE),
+                torch.randint(-128, 127, (32, 8), dtype=torch.int8, device=GPU_TYPE),
+                torch.randn((1, 8), dtype=torch.bfloat16, device=GPU_TYPE),
             ),
             (
-                torch.randint(-128, 127, (32, 32), dtype=torch.int8, device="cuda"),
-                torch.randint(-128, 127, (32, 8), dtype=torch.int8, device="cuda"),
-                torch.randn((1, 8), dtype=torch.float32, device="cuda"),
+                torch.randint(-128, 127, (32, 32), dtype=torch.int8, device=GPU_TYPE),
+                torch.randint(-128, 127, (32, 8), dtype=torch.int8, device=GPU_TYPE),
+                torch.randn((1, 8), dtype=torch.float32, device=GPU_TYPE),
             ),
         ]
 
@@ -155,22 +162,23 @@ class TestPatternMatcher(TestCase):
             self._test_fused_int_mm_mul_impl(fn2, args, True)
 
     @skipIfRocm
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(force_fuse_int_mm_with_mul=True)
     def test_fused_int_mm_mul_gating(self):
         def fn1(a, b, c):
             return out_dtype(torch.ops.aten.mm.default, torch.int32, a, b) * c
 
         args1 = (
-            torch.randint(-128, 127, (32, 32), dtype=torch.int8, device="cuda"),
-            torch.randint(-128, 127, (32, 8), dtype=torch.int8, device="cuda"),
-            torch.randn((8), dtype=torch.float32, device="cuda"),
+            torch.randint(-128, 127, (32, 32), dtype=torch.int8, device=GPU_TYPE),
+            torch.randint(-128, 127, (32, 8), dtype=torch.int8, device=GPU_TYPE),
+            torch.randn((8), dtype=torch.float32, device=GPU_TYPE),
         )
 
         args2 = (
-            torch.randint(-128, 127, (32, 32), dtype=torch.int8, device="cuda"),
-            torch.randint(-128, 127, (32, 8), dtype=torch.int8, device="cuda"),
-            torch.randn((32, 1), dtype=torch.float16, device="cuda"),
+            torch.randint(-128, 127, (32, 32), dtype=torch.int8, device=GPU_TYPE),
+            torch.randint(-128, 127, (32, 8), dtype=torch.int8, device=GPU_TYPE),
+            torch.randn((32, 1), dtype=torch.float16, device=GPU_TYPE),
         )
         self._test_fused_int_mm_mul_impl(fn1, args1, False)
         self._test_fused_int_mm_mul_impl(fn1, [arg.cpu() for arg in args2], False)
@@ -194,7 +202,8 @@ class TestPatternMatcher(TestCase):
         self.assertEqual("mixed_mm" in code, mixed_mm_expected)
         self.assertEqual("fallback_mixed_mm" in code, fallback_mixed_mm_expected)
 
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton")
     def test_mixed_mm(self):
         def fn(a, b):
@@ -202,27 +211,28 @@ class TestPatternMatcher(TestCase):
 
         args_list = [
             (
-                torch.randn(8, 8, device="cuda"),
-                torch.randint(-128, 127, (8, 8), dtype=torch.int8, device="cuda"),
+                torch.randn(8, 8, device=GPU_TYPE),
+                torch.randint(-128, 127, (8, 8), dtype=torch.int8, device=GPU_TYPE),
             ),
             (
-                torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
-                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
+                torch.randn(8, 2, device=GPU_TYPE, dtype=torch.bfloat16),
+                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device=GPU_TYPE),
             ),
             (
-                torch.randn(8, 5, device="cuda", dtype=torch.float16),
-                torch.randint(0, 255, (5, 2), dtype=torch.uint8, device="cuda"),
+                torch.randn(8, 5, device=GPU_TYPE, dtype=torch.float16),
+                torch.randint(0, 255, (5, 2), dtype=torch.uint8, device=GPU_TYPE),
             ),
             (
-                torch.randn(8, 8, device="cuda", dtype=torch.float32),
-                torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
+                torch.randn(8, 8, device=GPU_TYPE, dtype=torch.float32),
+                torch.randn(8, 8, device=GPU_TYPE, dtype=torch.bfloat16),
             ),
         ]
 
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)
 
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton")
     def test_mixed_mm_exhaustive_dtypes(self):
         def fn(a, b):
@@ -234,8 +244,10 @@ class TestPatternMatcher(TestCase):
         for dtype_left, dtype_right in itertools.product(dtypes_left, dtypes_right):
             low, high = dtype_ranges[dtype_right]
             args = (
-                torch.randn(256, 256, dtype=dtype_left, device="cuda"),
-                torch.randint(low, high, (256, 256), dtype=dtype_right, device="cuda"),
+                torch.randn(256, 256, dtype=dtype_left, device=GPU_TYPE),
+                torch.randint(
+                    low, high, (256, 256), dtype=dtype_right, device=GPU_TYPE
+                ),
             )
             fallback_mixed_mm_expected = (
                 dtype_left == torch.bfloat16 and dtype_right == torch.uint8
@@ -244,7 +256,8 @@ class TestPatternMatcher(TestCase):
                 fn, args, True, fallback_mixed_mm_expected, rtol=0.16, atol=1e-4
             )
 
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton")
     def test_mixed_mm_bad_cases(self):
         def fn(a, b):
@@ -253,14 +266,14 @@ class TestPatternMatcher(TestCase):
         # when b is transposed and not contiguous, we skip triton and use fallback
         args_list = [
             (
-                torch.randn(8, 8, device="cuda", dtype=torch.float16),
-                torch.randint(-128, 127, (4, 8), dtype=torch.int8, device="cuda").t()[
+                torch.randn(8, 8, device=GPU_TYPE, dtype=torch.float16),
+                torch.randint(-128, 127, (4, 8), dtype=torch.int8, device=GPU_TYPE).t()[
                     :, ::2
                 ],
             ),
             (
-                torch.randn(8, 8, device="cuda", dtype=torch.bfloat16),
-                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device="cuda").t()[
+                torch.randn(8, 8, device=GPU_TYPE, dtype=torch.bfloat16),
+                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device=GPU_TYPE).t()[
                     :, ::2
                 ],
             ),
@@ -269,7 +282,8 @@ class TestPatternMatcher(TestCase):
         for args in args_list:
             self._test_mixed_impl(fn, args, True, True)
 
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton", max_autotune_gemm=True)
     def test_mixed_mm_epi_works(self):
         def fn(a, b, c, d):
@@ -277,31 +291,32 @@ class TestPatternMatcher(TestCase):
 
         args_list = [
             (
-                torch.randn(8, 8, device="cuda"),
-                torch.randint(-128, 127, (8, 8), dtype=torch.int8, device="cuda"),
-                torch.randn(8, device="cuda"),
-                torch.randn(8, device="cuda"),
+                torch.randn(8, 8, device=GPU_TYPE),
+                torch.randint(-128, 127, (8, 8), dtype=torch.int8, device=GPU_TYPE),
+                torch.randn(8, device=GPU_TYPE),
+                torch.randn(8, device=GPU_TYPE),
             ),
             (
-                torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
-                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
-                torch.randn(8, device="cuda", dtype=torch.bfloat16),
-                torch.randn(8, device="cuda", dtype=torch.bfloat16),
+                torch.randn(8, 2, device=GPU_TYPE, dtype=torch.bfloat16),
+                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device=GPU_TYPE),
+                torch.randn(8, device=GPU_TYPE, dtype=torch.bfloat16),
+                torch.randn(8, device=GPU_TYPE, dtype=torch.bfloat16),
             ),
             (
-                torch.randn(8, 5, device="cuda", dtype=torch.float16),
-                torch.randint(0, 255, (5, 2), dtype=torch.uint8, device="cuda"),
-                torch.randn(2, device="cuda", dtype=torch.float16),
-                torch.randn(2, device="cuda", dtype=torch.float16),
+                torch.randn(8, 5, device=GPU_TYPE, dtype=torch.float16),
+                torch.randint(0, 255, (5, 2), dtype=torch.uint8, device=GPU_TYPE),
+                torch.randn(2, device=GPU_TYPE, dtype=torch.float16),
+                torch.randn(2, device=GPU_TYPE, dtype=torch.float16),
             ),
         ]
 
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)
 
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
-    @unittest.skipIf(not IS_A100, "heuristic only run on Linux A100")
-    @unittest.skipIf(not IS_BIG_GPU, "tests fail on small GPU")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @unittest.skipIf(HAS_CUDA ^ bool(IS_A100), "heuristic only run on Linux A100")
+    @unittest.skipIf(HAS_CUDA ^ bool(IS_BIG_GPU), "tests fail on small GPU")
     @inductor_config.patch(
         mixed_mm_choice="heuristic",
         autoheuristic_use="",
@@ -315,53 +330,64 @@ class TestPatternMatcher(TestCase):
 
         # examples that should not be selected by handwritten heuristic
         mat1_dtype = torch.float16
-        dyn_tensor = torch.randn(4, 4096, dtype=mat1_dtype, device="cuda")
+        dyn_tensor = torch.randn(4, 4096, dtype=mat1_dtype, device=GPU_TYPE)
         torch._dynamo.mark_dynamic(dyn_tensor, 0)
         args_list = [
             (
-                torch.randn(1, 4097, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (4097, 4096), dtype=torch.int8, device="cuda"),
-            ),
-            (
-                torch.randn(1, 4096, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (4096, 4097), dtype=torch.int8, device="cuda"),
-            ),
-            (
-                torch.randn(8, 8, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (8, 8), dtype=torch.int8, device="cuda"),
-            ),
-            (
-                torch.randn(8, 2048, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (2048, 2048), dtype=torch.int8, device="cuda"),
-            ),
-            (
-                torch.randn(8, 2048, dtype=mat1_dtype, device="cuda"),
+                torch.randn(1, 4097, dtype=mat1_dtype, device=GPU_TYPE),
                 torch.randint(
-                    -128, 127, (2048, 2048), dtype=torch.int8, device="cuda"
+                    -128, 127, (4097, 4096), dtype=torch.int8, device=GPU_TYPE
+                ),
+            ),
+            (
+                torch.randn(1, 4096, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (4096, 4097), dtype=torch.int8, device=GPU_TYPE
+                ),
+            ),
+            (
+                torch.randn(8, 8, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(-128, 127, (8, 8), dtype=torch.int8, device=GPU_TYPE),
+            ),
+            (
+                torch.randn(8, 2048, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (2048, 2048), dtype=torch.int8, device=GPU_TYPE
+                ),
+            ),
+            (
+                torch.randn(8, 2048, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (2048, 2048), dtype=torch.int8, device=GPU_TYPE
                 ).t(),
             ),
             (
-                torch.randn(8, 4096, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (4096, 4096), dtype=torch.int8, device="cuda")[
-                    :, ::2
-                ],
+                torch.randn(8, 4096, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (4096, 4096), dtype=torch.int8, device=GPU_TYPE
+                )[:, ::2],
             ),
             (
-                torch.randn(1, 4096, dtype=torch.float32, device="cuda"),
-                torch.randint(-128, 127, (4096, 4096), dtype=torch.int8, device="cuda"),
+                torch.randn(1, 4096, dtype=torch.float32, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (4096, 4096), dtype=torch.int8, device=GPU_TYPE
+                ),
             ),
             (
                 dyn_tensor,
-                torch.randint(-128, 127, (4096, 4096), dtype=torch.int8, device="cuda"),
+                torch.randint(
+                    -128, 127, (4096, 4096), dtype=torch.int8, device=GPU_TYPE
+                ),
             ),
         ]
 
         for args in args_list:
             self._test_mixed_impl(fn, args, True, True)
 
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
-    @unittest.skipIf(not IS_A100, "heuristic only run on Linux A100")
-    @unittest.skipIf(not IS_BIG_GPU, "tests fail on small GPU")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
+    @unittest.skipIf(HAS_CUDA ^ bool(IS_A100), "heuristic only run on Linux A100")
+    @unittest.skipIf(HAS_CUDA ^ bool(IS_BIG_GPU), "tests fail on small GPU")
     @inductor_config.patch(
         mixed_mm_choice="heuristic",
         autoheuristic_use="",
@@ -377,50 +403,61 @@ class TestPatternMatcher(TestCase):
         # examples that should be selected by handwritten heuristic
         args_list = [
             (
-                torch.randn(1, 4096, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (4096, 4096), dtype=torch.int8, device="cuda"),
-            ),
-            (
-                torch.randn(4, 4096, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (4096, 4096), dtype=torch.int8, device="cuda"),
-            ),
-            (
-                torch.randn(8, 4096, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (4096, 4096), dtype=torch.int8, device="cuda"),
-            ),
-            (
-                torch.randn(8, 4096, dtype=mat1_dtype, device="cuda"),
+                torch.randn(1, 4096, dtype=mat1_dtype, device=GPU_TYPE),
                 torch.randint(
-                    -128, 127, (4096, 4096), dtype=torch.int8, device="cuda"
+                    -128, 127, (4096, 4096), dtype=torch.int8, device=GPU_TYPE
+                ),
+            ),
+            (
+                torch.randn(4, 4096, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (4096, 4096), dtype=torch.int8, device=GPU_TYPE
+                ),
+            ),
+            (
+                torch.randn(8, 4096, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (4096, 4096), dtype=torch.int8, device=GPU_TYPE
+                ),
+            ),
+            (
+                torch.randn(8, 4096, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (4096, 4096), dtype=torch.int8, device=GPU_TYPE
                 ).t(),
             ),
             (
-                torch.randn(16, 4096, dtype=mat1_dtype, device="cuda"),
+                torch.randn(16, 4096, dtype=mat1_dtype, device=GPU_TYPE),
                 torch.randint(
-                    -128, 127, (8192, 4096), dtype=torch.int8, device="cuda"
+                    -128, 127, (8192, 4096), dtype=torch.int8, device=GPU_TYPE
                 ).t(),
             ),
             (
-                torch.randn(32, 4096, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (4096, 8192), dtype=torch.int8, device="cuda"),
+                torch.randn(32, 4096, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (4096, 8192), dtype=torch.int8, device=GPU_TYPE
+                ),
             ),
             (
-                torch.randn(64, 4096, dtype=mat1_dtype, device="cuda"),
-                torch.randint(-128, 127, (4096, 4096), dtype=torch.int8, device="cuda"),
+                torch.randn(64, 4096, dtype=mat1_dtype, device=GPU_TYPE),
+                torch.randint(
+                    -128, 127, (4096, 4096), dtype=torch.int8, device=GPU_TYPE
+                ),
             ),
         ]
 
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False, rtol=0.01, atol=0.04)
 
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     def test_mixed_mm_gating(self):
         def fn(a, b):
             return torch.mm(a, b.to(a.dtype))
 
         args = (
-            torch.randn(8, 8, device="cuda"),
-            torch.randint(-128, 127, (8, 8), dtype=torch.int8, device="cuda"),
+            torch.randn(8, 8, device=GPU_TYPE),
+            torch.randint(-128, 127, (8, 8), dtype=torch.int8, device=GPU_TYPE),
         )
         # will ignore the mixed_mm code (including fallback)
         with inductor_config.patch(
@@ -469,7 +506,8 @@ class TestPatternMatcher(TestCase):
         )
         self._test_mixed_impl(fn, args, False, False)
 
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(use_mixed_mm=True)
     def test_uint4x2_mixed_mm(self):
         def fn(a, b):
@@ -491,12 +529,12 @@ class TestPatternMatcher(TestCase):
 
         args_expect_mixed_mm = [
             (
-                torch.randn(8, 8, device="cuda"),
-                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device="cuda"),
+                torch.randn(8, 8, device=GPU_TYPE),
+                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device=GPU_TYPE),
             ),
             (
-                torch.randn(8, 8, device="cuda", dtype=torch.float16),
-                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device="cuda")
+                torch.randn(8, 8, device=GPU_TYPE, dtype=torch.float16),
+                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device=GPU_TYPE)
                 .t()
                 .contiguous()
                 .t(),
@@ -509,19 +547,20 @@ class TestPatternMatcher(TestCase):
         # mixed mm is only enabled when casting from a lower-bitwidth dtype to a higher one
         args_expect_no_mixed_mm = [
             (
-                torch.randn(8, 8, device="cuda"),
-                torch.randint(0, 255, (4, 8), dtype=torch.int32, device="cuda"),
+                torch.randn(8, 8, device=GPU_TYPE),
+                torch.randint(0, 255, (4, 8), dtype=torch.int32, device=GPU_TYPE),
             ),
             (
-                torch.randn(8, 8, device="cuda"),
-                torch.randint(0, 255, (4, 8), dtype=torch.int64, device="cuda"),
+                torch.randn(8, 8, device=GPU_TYPE),
+                torch.randint(0, 255, (4, 8), dtype=torch.int64, device=GPU_TYPE),
             ),
         ]
 
         for args in args_expect_no_mixed_mm:
             check_uint4x2_mixed_mm(args, False)
 
-    @unittest.skipIf(not SM80OrLater, "need sm_80")
+    @xfailIfXpu
+    @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(use_mixed_mm=True)
     def test_uint4x2_mixed_mm_epi(self):
         def fn(a, b, c, d):
@@ -539,10 +578,10 @@ class TestPatternMatcher(TestCase):
 
         args_list = [
             (
-                torch.randn(8, 8, device="cuda"),
-                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device="cuda"),
-                torch.randn(8, device="cuda"),
-                torch.randn(8, device="cuda"),
+                torch.randn(8, 8, device=GPU_TYPE),
+                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device=GPU_TYPE),
+                torch.randn(8, device=GPU_TYPE),
+                torch.randn(8, device=GPU_TYPE),
             ),
         ]
 
@@ -572,8 +611,8 @@ class TestPatternMatcher(TestCase):
                 torch.randint(0, 255, (4, 8), dtype=torch.uint8),
             ),
             (  # int8
-                torch.randn(8, 8, device="cuda"),
-                torch.randint(-128, 127, (4, 8), dtype=torch.int8, device="cuda"),
+                torch.randn(8, 8, device=GPU_TYPE),
+                torch.randint(-128, 127, (4, 8), dtype=torch.int8, device=GPU_TYPE),
             ),  # we don't match for int8 since numerics
         ]  # for int8 bitshifts don't match between triton and pytorch
 
@@ -599,8 +638,8 @@ class TestPatternMatcher(TestCase):
 
         args_list = [
             (
-                torch.randn(8, 8, device="cuda"),
-                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device="cuda"),
+                torch.randn(8, 8, device=GPU_TYPE),
+                torch.randint(0, 255, (4, 8), dtype=torch.uint8, device=GPU_TYPE),
             ),
         ]
 
@@ -618,33 +657,33 @@ class TestPatternMatcher(TestCase):
 
         args_list = [
             (
-                torch.randn(16, 16, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
+                torch.randn(16, 16, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
                 True,
             ),
             (
-                torch.randn(8, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
-                torch.randn(16, 8, device="cuda"),
+                torch.randn(8, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
+                torch.randn(16, 8, device=GPU_TYPE),
                 True,
             ),
             (
-                torch.randn(16, 16, device="cuda"),
-                torch.randn(1, 16, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
+                torch.randn(16, 16, device=GPU_TYPE),
+                torch.randn(1, 16, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
                 False,
             ),
             (
-                torch.randn(1, 16, 16, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
+                torch.randn(1, 16, 16, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
                 False,
             ),
             (
                 4,
-                torch.randn(16, 16, device="cuda"),
-                torch.randn(16, 16, device="cuda"),
+                torch.randn(16, 16, device=GPU_TYPE),
+                torch.randn(16, 16, device=GPU_TYPE),
                 False,
             ),
         ]
@@ -665,8 +704,8 @@ class TestPatternMatcher(TestCase):
             bias = m1.size(0)
             return torch.add(bias, torch.mm(m1, m2)), torch.mm(m1, m2) + bias
 
-        m1 = torch.randn(16, 16, device="cuda")
-        m2 = torch.randn(16, 16, device="cuda")
+        m1 = torch.randn(16, 16, device=GPU_TYPE)
+        m2 = torch.randn(16, 16, device=GPU_TYPE)
 
         counters.clear()
         expect = fn(m1, m2)
@@ -679,16 +718,16 @@ class TestPatternMatcher(TestCase):
             def __init__(self) -> None:
                 super().__init__()
                 self.linear = torch.nn.functional.linear
-                self.linear_weight = torch.randn(4, 4).cuda()
-                self.bias = torch.randn(1, 4).cuda()
+                self.linear_weight = torch.randn(4, 4).to(GPU_TYPE)
+                self.bias = torch.randn(1, 4).to(GPU_TYPE)
 
             def forward(self, x):
                 x = self.linear(x, self.linear_weight, self.bias)
                 return x
 
-        input_tensor = torch.randn(1, 3, 4).cuda()
+        input_tensor = torch.randn(1, 3, 4).to(GPU_TYPE)
 
-        func = Model().cuda()
+        func = Model().to(GPU_TYPE)
 
         res1 = func(input_tensor)
         jit_func = torch.compile(func)
@@ -708,9 +747,9 @@ class TestPatternMatcher(TestCase):
             )
 
         args = [
-            torch.randn(16, 16, device="cuda"),
-            torch.randn(16, 16, device="cuda"),
-            torch.randn(16, 16, device="cuda"),
+            torch.randn(16, 16, device=GPU_TYPE),
+            torch.randn(16, 16, device=GPU_TYPE),
+            torch.randn(16, 16, device=GPU_TYPE),
         ]
         self.common(fn, args, 1, 4)
 
@@ -726,9 +765,9 @@ class TestPatternMatcher(TestCase):
             )
 
         args = [
-            torch.randn(16, 16, device="cuda"),
-            torch.randn(16, 16, device="cuda"),
-            torch.randn(16, 16, device="cuda"),
+            torch.randn(16, 16, device=GPU_TYPE),
+            torch.randn(16, 16, device=GPU_TYPE),
+            torch.randn(16, 16, device=GPU_TYPE),
         ]
         self.common(fn, args, 1, 4)
 
@@ -740,14 +779,14 @@ class TestPatternMatcher(TestCase):
             return torch.ops.aten.cat.default([cat_1, slice_2], 1)
 
         args = [
-            torch.randn(2, 32, device="cuda"),
-            torch.randn(2, 16, device="cuda"),
+            torch.randn(2, 32, device=GPU_TYPE),
+            torch.randn(2, 16, device=GPU_TYPE),
         ]
         self.common(fn, args, 1, 3)
 
         args = [
-            torch.randn(2, 8, device="cuda"),
-            torch.randn(2, 16, device="cuda"),
+            torch.randn(2, 8, device=GPU_TYPE),
+            torch.randn(2, 16, device=GPU_TYPE),
         ]
         torch._dynamo.reset()
         counters.clear()
@@ -767,8 +806,8 @@ class TestPatternMatcher(TestCase):
             return torch.ops.aten.cat.default([cat_1, slice_2], 1)
 
         args = [
-            torch.randn(2, 8, device="cuda"),
-            torch.randn(2, 16, device="cuda"),
+            torch.randn(2, 8, device=GPU_TYPE),
+            torch.randn(2, 16, device=GPU_TYPE),
         ]
         self.common(fn, args, 1, 3)
 
@@ -843,7 +882,7 @@ class TestPatternMatcher(TestCase):
             return cat**2
 
         args = [
-            torch.randn(2, 32, device="cuda"),
+            torch.randn(2, 32, device=GPU_TYPE),
         ]
         self.common(fn, args, 1, 4)
 
@@ -857,7 +896,7 @@ class TestPatternMatcher(TestCase):
             return cat**2 + getitem_2
 
         args = [
-            torch.randn(2, 32, device="cuda"),
+            torch.randn(2, 32, device=GPU_TYPE),
         ]
         self.common(fn, args, 0, 0)
 
@@ -870,7 +909,7 @@ class TestPatternMatcher(TestCase):
             return cat**2
 
         args = [
-            torch.randn(2, 32, device="cuda"),
+            torch.randn(2, 32, device=GPU_TYPE),
         ]
         self.common(fn, args, 0, 0)
 
@@ -881,7 +920,7 @@ class TestPatternMatcher(TestCase):
             return cat
 
         args = [
-            torch.randn(1, 8, device="cuda"),
+            torch.randn(1, 8, device=GPU_TYPE),
         ]
         self.common(fn, args, 0, 0)
 
@@ -895,9 +934,9 @@ class TestPatternMatcher(TestCase):
             return [s**2 for s in split_with_sizes]
 
         args = [
-            torch.randn(2, 2, device="cuda"),
-            torch.randn(2, 3, device="cuda"),
-            torch.randn(2, 5, device="cuda"),
+            torch.randn(2, 2, device=GPU_TYPE),
+            torch.randn(2, 3, device=GPU_TYPE),
+            torch.randn(2, 5, device=GPU_TYPE),
         ]
         self.common(fn, args, 1, 2)
 
@@ -910,9 +949,9 @@ class TestPatternMatcher(TestCase):
             return [s**2 for s in split_with_sizes] + [cat**3]
 
         args = [
-            torch.randn(2, 2, device="cuda"),
-            torch.randn(2, 3, device="cuda"),
-            torch.randn(2, 5, device="cuda"),
+            torch.randn(2, 2, device=GPU_TYPE),
+            torch.randn(2, 3, device=GPU_TYPE),
+            torch.randn(2, 5, device=GPU_TYPE),
         ]
         self.common(fn, args, 0, 0)
 
@@ -925,9 +964,9 @@ class TestPatternMatcher(TestCase):
             return [s**2 for s in split_with_sizes]
 
         args = [
-            torch.randn(10, 2, device="cuda"),
-            torch.randn(10, 3, device="cuda"),
-            torch.randn(10, 5, device="cuda"),
+            torch.randn(10, 2, device=GPU_TYPE),
+            torch.randn(10, 3, device=GPU_TYPE),
+            torch.randn(10, 5, device=GPU_TYPE),
         ]
         self.common(fn, args, 0, 0)
 
@@ -938,9 +977,9 @@ class TestPatternMatcher(TestCase):
             return [s**2 for s in split_with_sizes]
 
         args = [
-            torch.randn(2, 2, device="cuda"),
-            torch.randn(2, 3, device="cuda"),
-            torch.randn(2, 5, device="cuda"),
+            torch.randn(2, 2, device=GPU_TYPE),
+            torch.randn(2, 3, device=GPU_TYPE),
+            torch.randn(2, 5, device=GPU_TYPE),
         ]
         self.common(fn, args, 0, 0)
 
@@ -953,9 +992,9 @@ class TestPatternMatcher(TestCase):
             return [s**2 for s in split_with_sizes]
 
         args = [
-            torch.randn(2, 2, device="cuda"),
-            torch.randn(2, 3, device="cuda"),
-            torch.randn(2, 5, device="cuda"),
+            torch.randn(2, 2, device=GPU_TYPE),
+            torch.randn(2, 3, device=GPU_TYPE),
+            torch.randn(2, 5, device=GPU_TYPE),
         ]
         self.common(fn, args, 0, 0)
 
@@ -1064,7 +1103,7 @@ class TestPatternMatcher(TestCase):
 
         def fn3(x, y):
             a = torch.sin(x)
-            with torch.autocast("cuda"):
+            with torch.autocast(GPU_TYPE):
                 b = torch.add(x, a)
             return b
 
@@ -1081,8 +1120,8 @@ class TestPatternMatcher(TestCase):
             return b
 
         args = [
-            torch.randn(5, 5, device="cuda"),
-            torch.randn(5, 5, device="cuda"),
+            torch.randn(5, 5, device=GPU_TYPE),
+            torch.randn(5, 5, device=GPU_TYPE),
         ]
 
         with unittest.mock.patch(
@@ -1113,11 +1152,12 @@ class TestPatternMatcher(TestCase):
         self.assertIn("return (buf0, )", code[0])
         self.assertNotIn("async_compile.cpp", code[0])
 
+    @xfailIfXpu
     def test_unfuse_bias_addmm(self):
         args = [
-            torch.randn(20, device="cuda"),
-            torch.randn(10, 15, device="cuda"),
-            torch.randn(15, 20, device="cuda"),
+            torch.randn(20, device=GPU_TYPE),
+            torch.randn(10, 15, device=GPU_TYPE),
+            torch.randn(15, 20, device=GPU_TYPE),
         ]
 
         @torch.compile()
@@ -1194,9 +1234,9 @@ class TestPatternMatcher(TestCase):
         test_pass = PatternMatcherPass()
 
         args = [
-            torch.randn(20, device="cuda"),
-            torch.randn(10, 15, device="cuda"),
-            torch.randn(15, 20, device="cuda"),
+            torch.randn(20, device=GPU_TYPE),
+            torch.randn(10, 15, device=GPU_TYPE),
+            torch.randn(15, 20, device=GPU_TYPE),
         ]
 
         def f0(inp, a, b):
@@ -1251,9 +1291,9 @@ class TestPatternMatcher(TestCase):
         test_pass = PatternMatcherPass()
 
         args = [
-            torch.randn(20, device="cuda"),
-            torch.randn(10, 15, device="cuda"),
-            torch.randn(15, 20, device="cuda"),
+            torch.randn(20, device=GPU_TYPE),
+            torch.randn(10, 15, device=GPU_TYPE),
+            torch.randn(15, 20, device=GPU_TYPE),
         ]
 
         def f0(inp, a, b):
@@ -1297,9 +1337,9 @@ class TestPatternMatcher(TestCase):
         test_pass = PatternMatcherPass()
 
         args = [
-            torch.randn(20, device="cuda"),
-            torch.randn(10, 15, device="cuda"),
-            torch.randn(15, 20, device="cuda"),
+            torch.randn(20, device=GPU_TYPE),
+            torch.randn(10, 15, device=GPU_TYPE),
+            torch.randn(15, 20, device=GPU_TYPE),
         ]
 
         def f0(inp, a, b):
@@ -1425,7 +1465,7 @@ class TestPatternMatcher(TestCase):
         check(
             "call_function",
             torch.amp.autocast_mode._enter_autocast,
-            ("cuda", None, True, None),
+            (GPU_TYPE, None, True, None),
             {},
         )
         check("call_function", torch.amp.autocast_mode._exit_autocast, (None,), {})
@@ -1462,5 +1502,5 @@ class TestPatternMatcher(TestCase):
 
 
 if __name__ == "__main__":
-    if IS_LINUX and HAS_CUDA:
+    if IS_LINUX and HAS_GPU:
         run_tests()

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -29,7 +29,8 @@ from torch._inductor.utils import run_and_get_code
 from torch._inductor.virtualized import V
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import SM80OrLater
-from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm, xfailIfXpu
+from torch.testing._internal.common_device_type import expectedFailureXPU
+from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CUDA,
@@ -127,7 +128,7 @@ class TestPatternMatcher(TestCase):
             )  # also checks that dtype is correct
 
     @skipIfRocm
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(force_fuse_int_mm_with_mul=True)
     def test_fused_int_mm_mul(self):
@@ -162,7 +163,7 @@ class TestPatternMatcher(TestCase):
             self._test_fused_int_mm_mul_impl(fn2, args, True)
 
     @skipIfRocm
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(force_fuse_int_mm_with_mul=True)
     def test_fused_int_mm_mul_gating(self):
@@ -202,7 +203,7 @@ class TestPatternMatcher(TestCase):
         self.assertEqual("mixed_mm" in code, mixed_mm_expected)
         self.assertEqual("fallback_mixed_mm" in code, fallback_mixed_mm_expected)
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton")
     def test_mixed_mm(self):
@@ -231,7 +232,7 @@ class TestPatternMatcher(TestCase):
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton")
     def test_mixed_mm_exhaustive_dtypes(self):
@@ -256,7 +257,7 @@ class TestPatternMatcher(TestCase):
                 fn, args, True, fallback_mixed_mm_expected, rtol=0.16, atol=1e-4
             )
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton")
     def test_mixed_mm_bad_cases(self):
@@ -282,7 +283,7 @@ class TestPatternMatcher(TestCase):
         for args in args_list:
             self._test_mixed_impl(fn, args, True, True)
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(mixed_mm_choice="triton", max_autotune_gemm=True)
     def test_mixed_mm_epi_works(self):
@@ -313,7 +314,7 @@ class TestPatternMatcher(TestCase):
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False)
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @unittest.skipIf(HAS_CUDA ^ bool(IS_A100), "heuristic only run on Linux A100")
     @unittest.skipIf(HAS_CUDA ^ bool(IS_BIG_GPU), "tests fail on small GPU")
@@ -384,7 +385,7 @@ class TestPatternMatcher(TestCase):
         for args in args_list:
             self._test_mixed_impl(fn, args, True, True)
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @unittest.skipIf(HAS_CUDA ^ bool(IS_A100), "heuristic only run on Linux A100")
     @unittest.skipIf(HAS_CUDA ^ bool(IS_BIG_GPU), "tests fail on small GPU")
@@ -449,7 +450,7 @@ class TestPatternMatcher(TestCase):
         for args in args_list:
             self._test_mixed_impl(fn, args, True, False, rtol=0.01, atol=0.04)
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     def test_mixed_mm_gating(self):
         def fn(a, b):
@@ -506,7 +507,7 @@ class TestPatternMatcher(TestCase):
         )
         self._test_mixed_impl(fn, args, False, False)
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(use_mixed_mm=True)
     def test_uint4x2_mixed_mm(self):
@@ -559,7 +560,7 @@ class TestPatternMatcher(TestCase):
         for args in args_expect_no_mixed_mm:
             check_uint4x2_mixed_mm(args, False)
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @unittest.skipIf(HAS_CUDA ^ bool(SM80OrLater), "need sm_80")
     @inductor_config.patch(use_mixed_mm=True)
     def test_uint4x2_mixed_mm_epi(self):
@@ -1152,7 +1153,7 @@ class TestPatternMatcher(TestCase):
         self.assertIn("return (buf0, )", code[0])
         self.assertNotIn("async_compile.cpp", code[0])
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_unfuse_bias_addmm(self):
         args = [
             torch.randn(20, device=GPU_TYPE),

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -82,6 +82,8 @@ class TestCase(InductorTestCase):
 
 
 class UnsupportedTests(TestCase):
+    device = DEVICE
+
     def test_no_op(self):
         def f(a):
             return a
@@ -98,6 +100,9 @@ class UnsupportedTests(TestCase):
 
 
 class ComputeBoundedTests(TestCase):
+    device = DEVICE
+
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_conv1d(self):
         def f(x, y):
@@ -106,6 +111,7 @@ class ComputeBoundedTests(TestCase):
         inp = (T(33, 16, 30), T(20, 16, 5))
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_conv2d(self):
         def f(x, y):
@@ -114,6 +120,7 @@ class ComputeBoundedTests(TestCase):
         inp = (T(8, 4, 3, 3), T(1, 4, 5, 5))
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_conv2d_transpose(self):
         def f(x, y):
@@ -122,6 +129,7 @@ class ComputeBoundedTests(TestCase):
         inp = (T(8, 1, 1, 1), T(1, 4, 5, 5))
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_conv3d(self):
         def f(x, y):
@@ -130,6 +138,7 @@ class ComputeBoundedTests(TestCase):
         inp = (T(20, 16, 50, 10, 20), T(33, 16, 3, 3, 3))
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_mm(self):
         def f(a, b):
@@ -141,6 +150,7 @@ class ComputeBoundedTests(TestCase):
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_addmm(self):
         def f(a, b, c):
@@ -153,6 +163,7 @@ class ComputeBoundedTests(TestCase):
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_bmm(self):
         def f(a, b):
@@ -166,6 +177,9 @@ class ComputeBoundedTests(TestCase):
 
 
 class MemoryBoundedTests(TestCase):
+    device = DEVICE
+
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_relu(self):
         def f(a):
@@ -174,6 +188,7 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10, 10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_horizontal_reduction_pointwise(self):
         def f(a):
@@ -184,6 +199,7 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10, 10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_pointwise(self):
         def f(x):
@@ -192,6 +208,7 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     @torch._dynamo.config.patch(assume_static_by_default=False)
     def test_dynamic(self):
@@ -204,6 +221,8 @@ class MemoryBoundedTests(TestCase):
 
 @skipIf(not dist.is_available(), "requires distributed")
 class TestCommAnalysis(TestCase):
+    device = DEVICE
+
     WORLD_SIZE: int = 8
     RANKS = list(range(8))
 
@@ -235,6 +254,7 @@ class TestCommAnalysis(TestCase):
         finally:
             dist.destroy_process_group()
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_legacy_all_reduce(self):
         def fn(x):
@@ -244,6 +264,7 @@ class TestCommAnalysis(TestCase):
         inp = T(10, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_legacy_all_reduce_coalesced(self):
         def fn(x):
@@ -253,6 +274,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_legacy_all_gather_into_tensor_coalesced(self):
         def fn(x):
@@ -267,6 +289,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_all_reduce(self):
         def fn(x):
@@ -276,6 +299,7 @@ class TestCommAnalysis(TestCase):
         inp = T(10, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_all_reduce_coalesced(self):
         def fn(x):
@@ -285,6 +309,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_all_gather_into_tensor(self):
         def fn(x):
@@ -298,6 +323,7 @@ class TestCommAnalysis(TestCase):
         inp = T(10, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_all_gather_into_tensor_coalesced(self):
         def fn(x):
@@ -311,6 +337,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_reduce_scatter_tensor(self):
         def fn(x):
@@ -325,6 +352,7 @@ class TestCommAnalysis(TestCase):
         inp = T(self.WORLD_SIZE, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
+    # lack of profiler on XPU
     @expectedFailureXPU
     def test_reduce_scatter_tensor_coalesced(self):
         def fn(x):

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -235,6 +235,7 @@ class TestCommAnalysis(TestCase):
         finally:
             dist.destroy_process_group()
 
+    @xfailIfXpu
     def test_legacy_all_reduce(self):
         def fn(x):
             r = c10d.all_reduce(x, "sum", "", self.RANKS, self.WORLD_SIZE)
@@ -243,6 +244,7 @@ class TestCommAnalysis(TestCase):
         inp = T(10, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
+    @xfailIfXpu
     def test_legacy_all_reduce_coalesced(self):
         def fn(x):
             rs = c10d.all_reduce_coalesced(x, "sum", "", self.RANKS, self.WORLD_SIZE)
@@ -251,6 +253,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
+    @xfailIfXpu
     def test_legacy_all_gather_into_tensor_coalesced(self):
         def fn(x):
             rs = c10d.all_gather_into_tensor_coalesced(
@@ -264,6 +267,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
+    @xfailIfXpu
     def test_all_reduce(self):
         def fn(x):
             r = _c10d.all_reduce(x, "sum", "0")
@@ -272,6 +276,7 @@ class TestCommAnalysis(TestCase):
         inp = T(10, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
+    @xfailIfXpu
     def test_all_reduce_coalesced(self):
         def fn(x):
             rs = _c10d.all_reduce_coalesced(x, "sum", "0")
@@ -293,6 +298,7 @@ class TestCommAnalysis(TestCase):
         inp = T(10, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
+    @xfailIfXpu
     def test_all_gather_into_tensor_coalesced(self):
         def fn(x):
             rs = _c10d.all_gather_into_tensor_coalesced(
@@ -305,6 +311,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
+    @xfailIfXpu
     def test_reduce_scatter_tensor(self):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor(
@@ -318,6 +325,7 @@ class TestCommAnalysis(TestCase):
         inp = T(self.WORLD_SIZE, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
+    @xfailIfXpu
     def test_reduce_scatter_tensor_coalesced(self):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor_coalesced(

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -280,6 +280,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
+    @xfailIfXpu
     def test_all_gather_into_tensor(self):
         def fn(x):
             rs = _c10d.all_gather_into_tensor(

--- a/test/inductor/test_snode_runtime.py
+++ b/test/inductor/test_snode_runtime.py
@@ -10,7 +10,7 @@ from torch._inductor.comm_analysis import estimate_nccl_collective_runtime
 from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import is_collective
-from torch.testing._internal.common_utils import xfailIfXpu
+from torch.testing._internal.common_device_type import expectedFailureXPU
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
@@ -98,7 +98,7 @@ class UnsupportedTests(TestCase):
 
 
 class ComputeBoundedTests(TestCase):
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_conv1d(self):
         def f(x, y):
             return torch.nn.functional.conv1d(x, y)
@@ -106,7 +106,7 @@ class ComputeBoundedTests(TestCase):
         inp = (T(33, 16, 30), T(20, 16, 5))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_conv2d(self):
         def f(x, y):
             return torch.nn.functional.conv2d(x, y, padding=1)
@@ -114,7 +114,7 @@ class ComputeBoundedTests(TestCase):
         inp = (T(8, 4, 3, 3), T(1, 4, 5, 5))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_conv2d_transpose(self):
         def f(x, y):
             return torch.nn.functional.conv_transpose2d(x, y, padding=1)
@@ -122,7 +122,7 @@ class ComputeBoundedTests(TestCase):
         inp = (T(8, 1, 1, 1), T(1, 4, 5, 5))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_conv3d(self):
         def f(x, y):
             return torch.nn.functional.conv3d(x, y)
@@ -130,7 +130,7 @@ class ComputeBoundedTests(TestCase):
         inp = (T(20, 16, 50, 10, 20), T(33, 16, 3, 3, 3))
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_mm(self):
         def f(a, b):
             return torch.mm(a, b)
@@ -141,7 +141,7 @@ class ComputeBoundedTests(TestCase):
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_addmm(self):
         def f(a, b, c):
             return torch.addmm(a, b, c)
@@ -153,7 +153,7 @@ class ComputeBoundedTests(TestCase):
         )
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_bmm(self):
         def f(a, b):
             return torch.bmm(a, b)
@@ -166,7 +166,7 @@ class ComputeBoundedTests(TestCase):
 
 
 class MemoryBoundedTests(TestCase):
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_relu(self):
         def f(a):
             return torch.nn.functional.relu(a)
@@ -174,7 +174,7 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10, 10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_horizontal_reduction_pointwise(self):
         def f(a):
             b = a.sum(dim=1)
@@ -184,7 +184,7 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10, 10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_pointwise(self):
         def f(x):
             return x.cos()
@@ -192,7 +192,7 @@ class MemoryBoundedTests(TestCase):
         inp = (T(10),)
         self.assertNotZero(calculate_runtime(f, *inp))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @torch._dynamo.config.patch(assume_static_by_default=False)
     def test_dynamic(self):
         def f(x):
@@ -235,7 +235,7 @@ class TestCommAnalysis(TestCase):
         finally:
             dist.destroy_process_group()
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_legacy_all_reduce(self):
         def fn(x):
             r = c10d.all_reduce(x, "sum", "", self.RANKS, self.WORLD_SIZE)
@@ -244,7 +244,7 @@ class TestCommAnalysis(TestCase):
         inp = T(10, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_legacy_all_reduce_coalesced(self):
         def fn(x):
             rs = c10d.all_reduce_coalesced(x, "sum", "", self.RANKS, self.WORLD_SIZE)
@@ -253,7 +253,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_legacy_all_gather_into_tensor_coalesced(self):
         def fn(x):
             rs = c10d.all_gather_into_tensor_coalesced(
@@ -267,7 +267,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_all_reduce(self):
         def fn(x):
             r = _c10d.all_reduce(x, "sum", "0")
@@ -276,7 +276,7 @@ class TestCommAnalysis(TestCase):
         inp = T(10, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_all_reduce_coalesced(self):
         def fn(x):
             rs = _c10d.all_reduce_coalesced(x, "sum", "0")
@@ -285,7 +285,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_all_gather_into_tensor(self):
         def fn(x):
             rs = _c10d.all_gather_into_tensor(
@@ -298,7 +298,7 @@ class TestCommAnalysis(TestCase):
         inp = T(10, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_all_gather_into_tensor_coalesced(self):
         def fn(x):
             rs = _c10d.all_gather_into_tensor_coalesced(
@@ -311,7 +311,7 @@ class TestCommAnalysis(TestCase):
         inp = [T(10, 10), T(15, 15)]
         self._verify_runtime_estimation(fn, (inp,))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_reduce_scatter_tensor(self):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor(
@@ -325,7 +325,7 @@ class TestCommAnalysis(TestCase):
         inp = T(self.WORLD_SIZE, 10)
         self._verify_runtime_estimation(fn, (inp,))
 
-    @xfailIfXpu
+    @expectedFailureXPU
     def test_reduce_scatter_tensor_coalesced(self):
         def fn(x):
             rs = _c10d.reduce_scatter_tensor_coalesced(

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2694,6 +2694,8 @@ if HAS_GPU:
 class CustomOpTests(torch._inductor.test_case.TestCase):
     """Tests for custom ops wrapping triton kernels"""
 
+    device_type = GPU_TYPE
+
     @requires_gpu
     @common_utils.parametrize("autotuned", [False, True])
     @common_utils.parametrize("dynamic", [False, True])

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -969,10 +969,7 @@ def forward(self, x_1, output_1):
         self.assertEqual(compiled_out, eager_out)
 
         # Check that we're allocating the minimal # of buffers.
-        if GPU_TYPE == "xpu":
-            code_string = "empty_strided_xpu((10, ), (1, ), torch.float32)"
-        else:
-            code_string = "empty_strided_cuda((10, ), (1, ), torch.float32)"
+        code_string = f"empty_strided_{GPU_TYPE}((10, ), (1, ), torch.float32)"
 
         num_bufs_allocated = code.count(code_string)
         self.assertEqual(num_bufs_allocated, 2)

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -18,7 +18,6 @@ from torch._inductor.utils import run_and_get_code
 from torch._library import capture_triton
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
-from torch.testing._internal.common_device_type import expectedFailureXPU
 from torch.testing._internal.common_utils import (
     parametrize,
     skipIfRocm,
@@ -2691,8 +2690,6 @@ if HAS_GPU:
 class CustomOpTests(torch._inductor.test_case.TestCase):
     """Tests for custom ops wrapping triton kernels"""
 
-    device_type = GPU_TYPE
-
     @requires_gpu
     @common_utils.parametrize("autotuned", [False, True])
     @common_utils.parametrize("dynamic", [False, True])
@@ -2913,7 +2910,7 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
         gm = make_fx(f, tracing_mode=tracing_mode)(x, x)
         self.assertEqual(gm(x, x), x + x)
 
-    @expectedFailureXPU
+    @skipIfXpu
     @requires_gpu
     @patch.object(torch._inductor.config, "cpp_wrapper", True)
     @patch.object(torch._inductor.config, "triton.autotune_at_compile_time", True)

--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -18,12 +18,12 @@ from torch._inductor.utils import run_and_get_code
 from torch._library import capture_triton
 from torch.testing import FileCheck
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_device_type import expectedFailureXPU
 from torch.testing._internal.common_utils import (
     parametrize,
     skipIfRocm,
     skipIfXpu,
     TEST_WITH_ROCM,
-    xfailIfXpu,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CUDA, HAS_GPU, HAS_XPU
 from torch.testing._internal.logging_utils import logs_to_string
@@ -2914,7 +2914,7 @@ class CustomOpTests(torch._inductor.test_case.TestCase):
         gm = make_fx(f, tracing_mode=tracing_mode)(x, x)
         self.assertEqual(gm(x, x), x + x)
 
-    @xfailIfXpu
+    @expectedFailureXPU
     @requires_gpu
     @patch.object(torch._inductor.config, "cpp_wrapper", True)
     @patch.object(torch._inductor.config, "triton.autotune_at_compile_time", True)

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -9,16 +9,19 @@ from torch._inductor import config as inductor_config
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import is_big_gpu
 from torch.testing import make_tensor
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    skipCUDAIf,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import IS_LINUX, parametrize
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CUDA
+from torch.testing._internal.inductor_utils import (
+    GPU_TYPE,
+    HAS_CUDA,
+    HAS_GPU,
+    requires_gpu,
+    requires_triton,
+)
 
 
 class TestUnbackedSymints(InductorTestCase):
-    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @requires_triton()
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_expand(self, device):
         def fn(x, y):
@@ -39,7 +42,7 @@ class TestUnbackedSymints(InductorTestCase):
 
         torch.testing.assert_close(actual, expected)
 
-    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @requires_triton()
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_expand_ok_with_runtime_assert(self, device):
         def fn(x):
@@ -50,7 +53,7 @@ class TestUnbackedSymints(InductorTestCase):
         x = make_tensor(32, 4, device=device, dtype=torch.float32, exclude_zero=True)
         actual = torch.compile(fn, fullgraph=True)(x)
 
-    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @requires_triton()
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_broadcast_tensors(self, device):
         def fn(x):
@@ -64,7 +67,7 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(x)
         torch.testing.assert_close(actual, expected)
 
-    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @requires_triton()
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_autotuning(self, device):
         def fn(x, y):
@@ -88,7 +91,7 @@ class TestUnbackedSymints(InductorTestCase):
 
         torch.testing.assert_close(actual, expected)
 
-    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @requires_triton()
     @dynamo_config.patch({"capture_scalar_outputs": True})
     def test_split_with_sizes(self, device):
         def fn(x, y):
@@ -104,7 +107,7 @@ class TestUnbackedSymints(InductorTestCase):
 
         torch.testing.assert_close(actual, expected)
 
-    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @requires_triton()
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_view_of_slice(self, device):
         # Tests View.create(slice, size_with_unbacked_symint)
@@ -122,7 +125,7 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
-    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @requires_gpu()
     @dynamo_config.patch({"capture_scalar_outputs": True})
     @inductor_config.patch({"abi_compatible": True})
     def test_triton_kernel_grid(self, device):
@@ -145,7 +148,7 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
-    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @requires_triton()
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_nonzero_in_inference_mode(self, device):
         def fn(x):
@@ -191,14 +194,11 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
-    @skipCUDAIf(not HAS_CUDA, "requires cuda")
+    @requires_gpu()
     @dynamo_config.patch({"capture_scalar_outputs": True})
     def test_vertical_pointwise_reduction_fusion(self, device):
         # reset in case we run both cpu and cuda tests
         torch._inductor.metrics.reset()
-
-        if device == "cpu":
-            raise unittest.SkipTest("This test requires cuda")
 
         # Tests fusing a pointwise & reduction op with unbacked numel/rnumel.
         def fn(x, y, repeats):
@@ -213,9 +213,9 @@ class TestUnbackedSymints(InductorTestCase):
             return pointwise, reduction
 
         example_inputs = (
-            torch.randn(32, 16).cuda(),
-            torch.randn(1, 16).cuda(),
-            torch.tensor(32).cuda(),
+            torch.randn(32, 16).to(GPU_TYPE),
+            torch.randn(1, 16).to(GPU_TYPE),
+            torch.tensor(32).to(GPU_TYPE),
         )
 
         actual = torch.compile(fn, fullgraph=True)(*example_inputs)
@@ -279,12 +279,10 @@ class TestUnbackedSymints(InductorTestCase):
         torch.testing.assert_close(actual, expected)
 
 
-instantiate_device_type_tests(
-    TestUnbackedSymints, globals(), only_for=(GPU_TYPE, "cpu")
-)
+instantiate_device_type_tests(TestUnbackedSymints, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if IS_LINUX and HAS_CUDA and is_big_gpu(0):
+    if IS_LINUX and HAS_GPU and (not HAS_CUDA or is_big_gpu(0)):
         run_tests()

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -9,19 +9,21 @@ from torch._inductor import config as inductor_config
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import is_big_gpu
 from torch.testing import make_tensor
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    skipGPUIf,
+)
 from torch.testing._internal.common_utils import IS_LINUX, parametrize
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CUDA,
     HAS_GPU,
     requires_gpu,
-    requires_triton,
 )
 
 
 class TestUnbackedSymints(InductorTestCase):
-    @requires_triton()
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_expand(self, device):
         def fn(x, y):
@@ -42,7 +44,7 @@ class TestUnbackedSymints(InductorTestCase):
 
         torch.testing.assert_close(actual, expected)
 
-    @requires_triton()
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_expand_ok_with_runtime_assert(self, device):
         def fn(x):
@@ -53,7 +55,7 @@ class TestUnbackedSymints(InductorTestCase):
         x = make_tensor(32, 4, device=device, dtype=torch.float32, exclude_zero=True)
         actual = torch.compile(fn, fullgraph=True)(x)
 
-    @requires_triton()
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_broadcast_tensors(self, device):
         def fn(x):
@@ -67,7 +69,7 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(x)
         torch.testing.assert_close(actual, expected)
 
-    @requires_triton()
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_autotuning(self, device):
         def fn(x, y):
@@ -91,7 +93,7 @@ class TestUnbackedSymints(InductorTestCase):
 
         torch.testing.assert_close(actual, expected)
 
-    @requires_triton()
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_scalar_outputs": True})
     def test_split_with_sizes(self, device):
         def fn(x, y):
@@ -107,7 +109,7 @@ class TestUnbackedSymints(InductorTestCase):
 
         torch.testing.assert_close(actual, expected)
 
-    @requires_triton()
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_view_of_slice(self, device):
         # Tests View.create(slice, size_with_unbacked_symint)
@@ -148,7 +150,7 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
-    @requires_triton()
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_nonzero_in_inference_mode(self, device):
         def fn(x):

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1823,7 +1823,7 @@ def get_cloned_parameter_buffer_name(name: str):
 
 def is_gpu(device: str):
     assert isinstance(device, str) or device is None, device
-    return device in ["cuda", "xpu"]
+    return device in GPU_TYPES
 
 
 def device_need_guard(device: str):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -11,10 +11,21 @@ import unittest
 from collections import namedtuple
 from enum import Enum
 from functools import partial, wraps
-from typing import Any, ClassVar, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import torch
-from torch._inductor.utils import is_gpu
+from torch._inductor.utils import GPU_TYPES
 from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
     _get_torch_rocm_version,
@@ -1206,8 +1217,8 @@ class skipIf:
                 self.device_type is None
                 or self.device_type == slf.device_type
                 or (
-                    self.device_type == "gpu"
-                    and is_gpu(slf.device_type)
+                    isinstance(self.device_type, Iterable)
+                    and slf.device_type in self.device_type
                 )
             ):
                 if (isinstance(self.dep, str) and getattr(slf, self.dep, True)) or (
@@ -1241,7 +1252,7 @@ class skipXPUIf(skipIf):
 # Skips a test on XPU or CUDA if the condition is true.
 class skipGPUIf(skipIf):
     def __init__(self, dep, reason):
-        super().__init__(dep, reason, device_type="gpu")
+        super().__init__(dep, reason, device_type=GPU_TYPES)
 
 
 # Skips a test on Lazy if the condition is true.

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -14,6 +14,7 @@ from functools import partial, wraps
 from typing import Any, ClassVar, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import torch
+from torch._inductor.utils import is_gpu
 from torch.testing._internal.common_cuda import (
     _get_torch_cuda_version,
     _get_torch_rocm_version,
@@ -1205,8 +1206,8 @@ class skipIf:
                 self.device_type is None
                 or self.device_type == slf.device_type
                 or (
-                    isinstance(self.device_type, tuple)
-                    and slf.device_type in self.device_type
+                    self.device_type == "gpu"
+                    and is_gpu(slf.device_type)
                 )
             ):
                 if (isinstance(self.dep, str) and getattr(slf, self.dep, True)) or (
@@ -1240,7 +1241,7 @@ class skipXPUIf(skipIf):
 # Skips a test on XPU or CUDA if the condition is true.
 class skipGPUIf(skipIf):
     def __init__(self, dep, reason):
-        super().__init__(dep, reason, device_type=("xpu", "cuda"))
+        super().__init__(dep, reason, device_type="gpu")
 
 
 # Skips a test on Lazy if the condition is true.

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1201,7 +1201,14 @@ class skipIf:
     def __call__(self, fn):
         @wraps(fn)
         def dep_fn(slf, *args, **kwargs):
-            if self.device_type is None or self.device_type == slf.device_type:
+            if (
+                self.device_type is None
+                or self.device_type == slf.device_type
+                or (
+                    isinstance(self.device_type, tuple)
+                    and slf.device_type in self.device_type
+                )
+            ):
                 if (isinstance(self.dep, str) and getattr(slf, self.dep, True)) or (
                     isinstance(self.dep, bool) and self.dep
                 ):
@@ -1228,6 +1235,12 @@ class skipCUDAIf(skipIf):
 class skipXPUIf(skipIf):
     def __init__(self, dep, reason):
         super().__init__(dep, reason, device_type="xpu")
+
+
+# Skips a test on XPU or CUDA if the condition is true.
+class skipGPUIf(skipIf):
+    def __init__(self, dep, reason):
+        super().__init__(dep, reason, device_type=("xpu", "cuda"))
 
 
 # Skips a test on Lazy if the condition is true.

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1795,11 +1795,6 @@ def skipIfXpu(func=None, *, msg="test doesn't currently work on the XPU stack"):
         return dec_fn(func)
     return dec_fn
 
-def xfailIfXpu(func):
-    if TEST_XPU:
-        func.__unittest_expecting_failure__ = True
-    return func
-
 def skipIfMps(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1795,6 +1795,11 @@ def skipIfXpu(func=None, *, msg="test doesn't currently work on the XPU stack"):
         return dec_fn(func)
     return dec_fn
 
+def xfailIfXpu(func):
+    if TEST_XPU:
+        func.__unittest_expecting_failure__ = True
+    return func
+
 def skipIfMps(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -39,9 +39,11 @@ def test_cpu():
 
 HAS_CPU = LazyVal(test_cpu)
 
-HAS_CUDA = torch.cuda.is_available() and has_triton()
+HAS_TRITON = has_triton()
 
-HAS_XPU = torch.xpu.is_available() and has_triton()
+HAS_CUDA = torch.cuda.is_available() and HAS_TRITON
+
+HAS_XPU = torch.xpu.is_available() and HAS_TRITON
 
 HAS_GPU = HAS_CUDA or HAS_XPU
 
@@ -102,6 +104,7 @@ def skip_windows_ci(name: str, file: str) -> None:
         raise unittest.SkipTest("requires sympy/functorch/filelock")
 
 requires_gpu = functools.partial(unittest.skipIf, not HAS_GPU, "requires gpu")
+requires_triton = functools.partial(unittest.skipIf, not HAS_TRITON, "requires triton")
 
 skipCUDAIf = functools.partial(skipDeviceIf, device="cuda")
 skipXPUIf = functools.partial(skipDeviceIf, device="xpu")


### PR DESCRIPTION
[Inductor UT] Generalize Newly introduced inductor UTs for intel GPU
reuse `test/inductor/test_pattern_matcher.py`
reuse `test/inductor/test_snode_runtime.py`
reuse `test/inductor/test_unbacked_symints.py`
fix `test/inductor/test_triton_kernels.py`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang