### PR TITLE
Deprecate `skip_code_recursive_on_cache_limit_hit` config flag

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -55,7 +55,7 @@ recompile_limit = 8
 # [@compile_ignored: runtime_behaviour] safeguarding to prevent horrible recomps
 accumulated_recompile_limit = 256
 
-# [@compile_ignored: runtime_behaviour] skip tracing recursively if cache limit is hit
+# [@compile_ignored: runtime_behaviour] skip tracing recursively if cache limit is hit (deprecated: does not do anything)
 skip_code_recursive_on_recompile_limit_hit = True
 
 # raise a hard error if cache limit is hit.  If you are on a model where you
@@ -69,6 +69,8 @@ cache_size_limit: int = Config(alias="torch._dynamo.config.recompile_limit")
 accumulated_cache_size_limit: int = Config(
     alias="torch._dynamo.config.accumulated_recompile_limit"
 )
+
+# (deprecated: does not do anything)
 skip_code_recursive_on_cache_limit_hit: bool = Config(
     alias="torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit"
 )

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -953,7 +953,7 @@ def _compile(
                     "recompilations, enable TORCH_LOGS=recompiles. If recompilations are expected, consider "
                     "increasing torch._dynamo.config.cache_size_limit to an appropriate value."
                 )
-            elif config.skip_code_recursive_on_recompile_limit_hit and justknobs_check(
+            elif justknobs_check(
                 "pytorch/compiler:skip_code_recursive_on_recompile_limit_hit"
             ):
                 raise RecompileLimitExceeded(f"{limit_type} reached")


### PR DESCRIPTION
Fixes one of #136862

Make `skip_code_recursive_on_cache_limit_hit` flag deprecated.

Affected logic is in here:
https://github.com/pytorch/pytorch/blob/6931c1644afdba53e63ce5671455e4e1b7265dd9/torch/_dynamo/convert_frame.py#L866-L876

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec @ezyang 