### PR TITLE
[MPS] Fix Gamma for bfloat16 dtypes

### DIFF
--- a/aten/src/ATen/native/mps/operations/Gamma.mm
+++ b/aten/src/ATen/native/mps/operations/Gamma.mm
@@ -333,7 +333,7 @@ kernel void lgamma(device {0} *input [[buffer(0)]],
                    device {1} *output [[buffer(1)]],
                    uint id [[thread_position_in_grid]])
 {{
-    output[id] = LogGamma(static_cast<float>(input[id]));
+    output[id] = static_cast<{1}>(LogGamma(static_cast<float>(input[id])));
 }}
 
 
@@ -346,24 +346,21 @@ kernel void digamma (device {0} *input [[buffer(0)]],
         if (x == trunc(x)) {{
             // As per C++ standard for gamma related functions and SciPy,
             // If the argument is a negative integer, NaN is returned
-            output[id] = NAN;
-        }}
-        else {{
+            output[id] = static_cast<{1}>(NAN);
+        }} else {{
             // Extracts the fractional part of x as r, since tan(pi * r) is more numerically
             // accurate than tan(pi * x). While these operations are mathematically equivalent
             // since both x and r are in radians and tan() has a periodicity of pi, in practice
             // the computation of pi * x is a source of error (when |x| > 1).
             float r = fract(x);
-            output[id] = calc_digamma_positive_domain(1.0f - x) - PI / tan(PI * r);
+            output[id] = static_cast<{1}>(calc_digamma_positive_domain(1.0f - x) - PI / tan(PI * r));
         }}
-    }}
-    else if (x == 0.0f) {{
+    }} else if (x == 0.0f) {{
         // As per C++ standard for gamma related functions and SciPy,
         // If the argument is ±0, ±∞ is returned
-        output[id] = copysign(INFINITY, -x);
-    }}
-    else {{
-        output[id] = calc_digamma_positive_domain(x);
+        output[id] = static_cast<{1}>(copysign(INFINITY, -x));
+    }} else {{
+        output[id] = static_cast<{1}>(calc_digamma_positive_domain(x));
     }}
 }}
 
@@ -373,7 +370,7 @@ kernel void trigamma(device {0} *input [[buffer(0)]],
                      uint id [[thread_position_in_grid]])
 {{
     float x = input[id];
-    output[id] = calc_trigamma(x);
+    output[id] = static_cast<{1}>(calc_trigamma(x));
 }}
 
 
@@ -385,7 +382,7 @@ kernel void polygamma(device {0} *input [[buffer(0)]],
   float x = input[id];
   float n = order;
   float sgn = ((order % 2) ? 1 : -1);
-  output[id] = sgn * Gamma(n + 1) * calc_zeta(n + 1, x);
+  output[id] = static_cast<{1}>(sgn * Gamma(n + 1) * calc_zeta(n + 1, x));
 }}
 
 )METAL",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #136987
* #137004
* #137003
* #136986
* #136985
* #136984
* #136983
* #136982
* __->__ #136981

Before this change, test failed with unable to compile errors, as `bfloat16` requires explicit cast. 
Tested in https://github.com/pytorch/pytorch/pull/136987