### PR TITLE
[MPS] Enable `torch.linalg.cross` for bfloat16

### DIFF
--- a/aten/src/ATen/native/mps/operations/CrossKernel.mm
+++ b/aten/src/ATen/native/mps/operations/CrossKernel.mm
@@ -33,6 +33,9 @@ REGISTER_CROSS_FUNC(short);
 REGISTER_CROSS_FUNC(char);
 REGISTER_CROSS_FUNC(uchar);
 REGISTER_CROSS_FUNC(bool);
+#if __METAL_VERSION__ >= 310
+REGISTER_CROSS_FUNC(bfloat);
+#endif
 
 template<typename T, typename U>
 kernel void cross(constant void     * input_        [[buffer(0)]],
@@ -77,6 +80,9 @@ REGISTER_CROSS_OP(short);
 REGISTER_CROSS_OP(char);
 REGISTER_CROSS_OP(uchar);
 REGISTER_CROSS_OP(bool);
+#if __METAL_VERSION__ >= 310
+REGISTER_CROSS_OP(bfloat);
+#endif
 
 )CROSS_METAL");
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #136987
* #137004
* #137003
* #136986
* #136985
* __->__ #136984
* #136983
* #136982
* #136981

By adding explicit instantiation. Tested in https://github.com/pytorch/pytorch/pull/136987