### PR TITLE
[MPS] Enable Renorm for bfloat16

### DIFF
--- a/aten/src/ATen/native/mps/operations/RenormKernel.mm
+++ b/aten/src/ATen/native/mps/operations/RenormKernel.mm
@@ -27,9 +27,9 @@ kernel void renorm(constant T* norm [[buffer(0)]],
                    device T* factor [[buffer(1)]],
                    constant float& maxnorm [[buffer(2)]],
                    uint index [[thread_position_in_grid]]) {
-  constexpr T eps = 1e-7;
+  constexpr auto eps = static_cast<T>(1e-7);
   constexpr T one = 1;
-  factor[index] = norm[index] > maxnorm ? maxnorm / (norm[index] + eps) : one;
+  factor[index] = norm[index] > maxnorm ? static_cast<T>(maxnorm / (norm[index] + eps)) : one;
 }
 
 #define REGISTER_RENORM_OP(DTYPE)                                  \
@@ -42,6 +42,9 @@ kernel void renorm<DTYPE>(constant DTYPE* norm [[buffer(0)]],      \
 
 REGISTER_RENORM_OP(float);
 REGISTER_RENORM_OP(half);
+#if __METAL_VERSION__ >= 310
+REGISTER_RENORM_OP(bfloat);
+#endif
 
 )RENORM_METAL");
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #136987
* #137004
* #137003
* #136986
* __->__ #136985
* #136984
* #136983
* #136982
* #136981

