### PR TITLE
Openreg: Support stream

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_aten_impl.py
@@ -32,6 +32,11 @@ _register_same_name("free", True)
 _register_same_name("isPinnedPtr", True)
 _register_same_name("hostMalloc", True)
 _register_same_name("hostFree", True)
+_register_same_name("getNewStream")
+_register_same_name("queryStream")
+_register_same_name("getStream")
+_register_same_name("exchangeStream")
+_register_same_name("synchronizeStream")
 
 
 # TODO: replace it with implementing torch.openreg.device

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/_device_daemon.py
@@ -90,12 +90,14 @@ class Driver:
 
         # State of our driver
         self.curr_device_idx = 0
-        self.curr_stream = 0
-        # Constant properties of our device
-        self.num_devices = 2
+        self.curr_streams = {}
+
         # Allocated memory belongs to which device
         self.memory_belong = {}
         self.host_allocator = Allocator()
+
+        # Constant properties of our device
+        self.num_devices = 2
         self.devices = []
 
         for i in range(self.num_devices):
@@ -128,8 +130,9 @@ class Driver:
 
     def run_on_executor(self, device_idx, cmd, *args):
         req_queue, ans_queue, _ = self.devices[device_idx]
+        stream = self.getStream(device_idx)
         validate_send_queue_args(cmd, args)
-        req_queue.put((cmd,) + args)
+        req_queue.put((stream, cmd) + args)
         return ans_queue.get()
 
     registry = {}
@@ -180,16 +183,42 @@ class Driver:
     def hostFree(self, ptr):
         return self.host_allocator.free(ptr)
 
+    @register(registry)
+    def getNewStream(self, device_idx, priority):
+        return self.run_on_executor(device_idx, "getNewStream", priority)
+
+    @register(registry)
+    def queryStream(self, stream):
+        return self.run_on_executor(
+            stream.device_index, "queryStream", stream.stream_id
+        )
+
+    @register(registry)
+    def getStream(self, device_idx):
+        return self.curr_streams.get(device_idx, 0)
+
+    @register(registry)
+    def exchangeStream(self, stream):
+        stream_id = self.curr_streams.get(stream.device_index, 0)
+        self.curr_streams[stream.device_index] = stream.stream_id
+        return stream_id
+
+    @register(registry)
+    def synchronizeStream(self, stream):
+        self.run_on_executor(stream.device_index, "synchronizeStream", stream.stream_id)
+
 
 class _Executor:
     def __init__(self, id):
         self.id = id
         self.allocator = Allocator()
+        self.stream = 0
 
     def run_forever(self, req_queue, ans_queue):
         # Serve all requests
         while True:
-            cmd, *args = req_queue.get()
+            # Ignore stream since cpu backend doesn't support asynchronous execution
+            _, cmd, *args = req_queue.get()
             log.info("Worker executing: %s", cmd)
             if cmd in _Executor.registry:
                 res = _Executor.registry[cmd](self, *args)
@@ -232,6 +261,20 @@ class _Executor:
     def recv_data(self, host_tensor, dev_mem):
         dev_tensor = OpenRegTensorData.from_meta(self.allocator, dev_mem)
         dev_tensor.copy_(host_tensor)
+
+    @register(registry)
+    def getNewStream(self, priority):
+        self.stream += 1
+        return self.stream
+
+    @register(registry)
+    def queryStream(self, stream):
+        return True
+
+    @register(registry)
+    def synchronizeStream(self, stream):
+        # no-op
+        pass
 
 
 driver = Driver()

--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegHooks.cpp
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegHooks.cpp
@@ -138,7 +138,8 @@ struct OpenRegGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   c10::Stream getStream(c10::Device d) const noexcept override {
     py::gil_scoped_acquire acquire;
-    return get_method("getStream")(d.index()).cast<c10::Stream>();
+    auto stream_id = get_method("getStream")(d.index()).cast<c10::StreamId>();
+    return c10::Stream(c10::Stream::UNSAFE, d, stream_id);
   }
 
   /**
@@ -164,7 +165,8 @@ struct OpenRegGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   c10::Stream getNewStream(c10::Device d, int priority = 0) const override {
     py::gil_scoped_acquire acquire;
-    return get_method("getNewStream")(d.index(), priority).cast<c10::Stream>();
+    auto stream_id = get_method("getNewStream")(d.index(), priority).cast<c10::StreamId>();
+    return c10::Stream(c10::Stream::UNSAFE, d, stream_id);
   }
 
   /**
@@ -174,7 +176,8 @@ struct OpenRegGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    */
   c10::Stream exchangeStream(c10::Stream s) const noexcept override {
     py::gil_scoped_acquire acquire;
-    return get_method("exchangeStream")(s).cast<c10::Stream>();
+    auto stream_id = get_method("exchangeStream")(s).cast<c10::StreamId>();
+    return c10::Stream(c10::Stream::UNSAFE, s.device(), stream_id);
   }
 
   /**

--- a/test/cpp_extensions/open_registration_extension/test/test_openreg.py
+++ b/test/cpp_extensions/open_registration_extension/test/test_openreg.py
@@ -75,6 +75,11 @@ class TestOpenReg(TestCase):
         slice_a = pinned_a[2:5]
         self.assertTrue(slice_a.is_pinned())
 
+    def test_stream_synchronize(self):
+        stream = torch.Stream(device="openreg:1")
+        stream.synchronize()
+        self.assertEqual(True, stream.query())
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Support stream. When the driver communicates with the executor, it will send the stream id corresponding to the execution command; when the executor receives the command with the stream id, it will ignore the stream id because cpu backend doesn't support asynchronous execution.

cc @albanD @FFFrog
