### PR TITLE
[AOTI] Update sam_fast from timeout to fail_to_run

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_inductor_torchbench_inference.csv
@@ -282,7 +282,7 @@ sam,fail_to_run,0
 
 
 
-sam_fast,timeout,0
+sam_fast,fail_to_run,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
@@ -210,10 +210,6 @@ mobilenet_v3_large,pass,0
 
 
 
-moco,model_fail_to_load,0
-
-
-
 moondream,pass,0
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_aot_inductor_amp_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_aot_inductor_amp_freezing_torchbench_inference.csv
@@ -162,11 +162,11 @@ maml_omniglot,pass,0
 
 
 
-mobilenet_v2,pass,0
-
-
-
 mnasnet1_0,pass,0
+
+
+
+mobilenet_v2,pass,0
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
@@ -194,10 +194,6 @@ mobilenet_v3_large,pass,0
 
 
 
-moco,model_fail_to_load,0
-
-
-
 moondream,pass,0
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #136996

Summary: sam_fast changes from timeout to fail_to_run after https://github.com/pytorch/pytorch/pull/136591, which "regressed" in a good way. Update the expected result file and continue investigating.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec