### PR TITLE
[triton] Try to use triton.language.extra.libdevice when possible

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -36,10 +36,16 @@ if HAS_GPU:
 
     if not TEST_WITH_ROCM:
         if HAS_CUDA:
-            from triton.language.extra.cuda.libdevice import (  # @manual
-                fast_dividef,
-                fast_dividef as my_fast_dividef,
-            )
+            try:
+                from triton.language.extra.libdevice import (  # @manual
+                    fast_dividef,
+                    fast_dividef as my_fast_dividef,
+                )
+            except ImportError:
+                from triton.language.extra.cuda.libdevice import (  # @manual
+                    fast_dividef,
+                    fast_dividef as my_fast_dividef,
+                )
         elif HAS_XPU:
             from triton.language.extra.intel.libdevice import (  # @manual
                 fast_dividef,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/generative-recommenders/pull/90

In view of https://github.com/triton-lang/triton/pull/3825 we should try to use `triton.language.extra.libdevice` instead of `triton.language.extra.cuda.libdevice`.

Test Plan: CI

Reviewed By: bertmaher, karthik-man

Differential Revision: D63583965


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang