### PR TITLE
[export] hook up mark_dynamic to export Dims

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7757,6 +7757,81 @@ def forward(self, x, y):
             }
             _load_dynamic_shapes(spec, from_dict=True)
 
+    def test_dim_dynamic(self):
+        dynamic = Dim.DYNAMIC
+
+        # dynamic should infer equalities and relations
+        class Relations(torch.nn.Module):
+            def forward(self, u, w, x, y, z):
+                a = u[1:] + w + x  # s0 == s1 + 1 == s2 + 1
+                b = y.flatten() + z  # s2*s3 == s4
+                return a, b
+
+        inputs = (
+            torch.randn(5),
+            torch.randn(4),
+            torch.randn(4),
+            torch.randn(4, 4),
+            torch.randn(16),
+        )
+        ep = export(
+            Relations(),
+            inputs,
+            dynamic_shapes={
+                "u": (dynamic,),
+                "w": (dynamic,),
+                "x": (dynamic,),
+                "y": (dynamic, dynamic),
+                "z": (dynamic,),
+            },
+        )
+        ep.module()(
+            torch.randn(6),
+            torch.randn(5),
+            torch.randn(5),
+            torch.randn(7, 8),
+            torch.randn(56),
+        )
+
+        # dynamic should complain when force specialized
+        class Specialize(torch.nn.Module):
+            def forward(self, x):
+                torch._check(x.shape[0] == 4)
+                return x + 2
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.UserError,
+            r"Not all values of RelaxedUnspecConstraint.* are valid because .* was inferred to be a constant",
+        ):
+            ep = export(
+                Specialize(),
+                (torch.randn(4, 8),),
+                dynamic_shapes={
+                    "x": (dynamic, dynamic),
+                },
+            )
+
+        # dynamic should handle complex guards in the same way as auto
+        class ModConstraint(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.view(x.shape[0] - 1, -1)
+
+        ep = export(
+            ModConstraint(),
+            (torch.randn(3, 4),),
+            dynamic_shapes={
+                "x": (dynamic, dynamic),
+            },
+        )
+        ep.module()(torch.randn(5, 8))
+        num_asserts = [
+            node.target == torch.ops.aten._assert_scalar.default
+            for node in ep.graph.nodes
+        ].count(True)
+        self.assertEqual(num_asserts, 1)
+        with self.assertRaises(RuntimeError):
+            ep.module()(torch.randn(4, 2))
+
     @testing.expectedFailureNonStrict
     @testing.expectedFailureTrainingIRToRunDecompNonStrict  # unbacked symint not tracked?
     @testing.expectedFailureSerDer  # T195866111

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7757,6 +7757,7 @@ def forward(self, x, y):
             }
             _load_dynamic_shapes(spec, from_dict=True)
 
+    @testing.expectedFailureSerDer  # TODO(pianpwk): PowByNatural valuerange deserialization
     def test_dim_dynamic(self):
         dynamic = Dim.DYNAMIC
 

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -2244,7 +2244,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
             + re.escape(
                 "specified at `dynamic_shapes[0]['k']['k'][0]` "
                 "(expected either a list/tuple of dimensions, or a dict mapping indices to dimensions,"
-                " where each dimension is an int, a Dim, Dim.AUTO, or Dim.STATIC)"
+                " where each dimension is an int, a Dim, Dim.AUTO, Dim.STATIC, or Dim.DYNAMIC)"
             ),
         ):
             export(M(), inputs, dynamic_shapes=dynamic_shapes)
@@ -2321,7 +2321,7 @@ def forward(self, p_linear_weight, p_linear_bias, b_buffer, x):
         with self.assertRaisesRegex(
             torch._dynamo.exc.UserError,
             re.escape(
-                "Specifying both `Dim.AUTO` and `Dim` or `DerivedDim` in `dynamic_shapes` is not well supported at the moment, "
+                "Specifying both `Dim.AUTO/Dim.DYNAMIC` and `Dim/DerivedDim` in `dynamic_shapes` is not well supported at the moment, "
                 "and can easily lead to constraint violation errors or obscure errors in torch.export."
             ),
         ):

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -93,12 +93,15 @@ def fakify(
     if not isinstance(t, torch.Tensor):
         raise ValueError(f"Unsupported input type {type(t)}")
     n_dims = len(t.shape)
-    dynamic_sizes = [
-        DimDynamic.DYNAMIC
-        if i in getattr(t, "_dynamo_weak_dynamic_indices", {})
-        else DimDynamic.STATIC
-        for i in range(n_dims)
-    ]
+    dynamic_sizes = []
+    for i in range(n_dims):
+        if (
+            i in getattr(t, "_dynamo_weak_dynamic_indices", {})
+            or i in getattr(t, "_dynamo_dynamic_indices", {})
+        ):
+            dynamic_sizes.append(DimDynamic.DYNAMIC)
+        else:
+            dynamic_sizes.append(DimDynamic.STATIC)
     symbolic_context = StatelessSymbolicContext(
         dynamic_sizes=dynamic_sizes,
         constraint_sizes=[None] * n_dims,

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -104,12 +104,12 @@ def fakify(
             # where a RelaxedUnspecConstraint is created for Dim.DYNAMIC, so constraint violations
             # are raised when specializing.
             dynamic_sizes.append(DimDynamic.DYNAMIC)
-            constraint_sizes[i] = RelaxedUnspecConstraint(warn_only=False)
+            constraint_sizes[i] = RelaxedUnspecConstraint(warn_only=False)  # type: ignore[call-overload]
         else:
             dynamic_sizes.append(DimDynamic.STATIC)
     symbolic_context = StatelessSymbolicContext(
         dynamic_sizes=dynamic_sizes,
-        constraint_sizes=constraint_sizes,
+        constraint_sizes=constraint_sizes,  # type: ignore[arg-type]
     )
     t_id = id(t)
     assert mode.shape_env is not None

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -95,9 +95,8 @@ def fakify(
     n_dims = len(t.shape)
     dynamic_sizes = []
     for i in range(n_dims):
-        if (
-            i in getattr(t, "_dynamo_weak_dynamic_indices", {})
-            or i in getattr(t, "_dynamo_dynamic_indices", {})
+        if i in getattr(t, "_dynamo_weak_dynamic_indices", {}) or i in getattr(
+            t, "_dynamo_dynamic_indices", {}
         ):
             dynamic_sizes.append(DimDynamic.DYNAMIC)
         else:

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -45,10 +45,12 @@ class _DimHint(Enum):
     Enum for dynamic shape hints.
     - AUTO means automatic inference of shape (static or dynamic).
     - STATIC means static shape (always specialized).
+    - DYNAMIC means dynamic, will error out if specialized.
     """
 
     AUTO = auto()
     STATIC = auto()
+    DYNAMIC = auto()
 
 
 class _Dim(type):
@@ -235,6 +237,7 @@ def Dim(name: str, *, min: Optional[int] = None, max: Optional[int] = None):
 
 Dim.AUTO = _DimHint.AUTO  # type: ignore[attr-defined]
 Dim.STATIC = _DimHint.STATIC  # type: ignore[attr-defined]
+Dim.DYNAMIC = _DimHint.DYNAMIC  # type: ignore[attr-defined]
 
 
 def dims(*names: str, min: Optional[int] = None, max: Optional[int] = None):
@@ -694,7 +697,8 @@ def _check_dynamic_shapes(
                         UserErrorType.INVALID_INPUT,
                         f"Unexpected dimension mapped to index {i} in input tensor shape {shape} "
                         f"specified at `dynamic_shapes{keystr(path)}` "
-                        f"(expected None, an int, a Dim, Dim.AUTO, or Dim.STATIC, but got {dim} instead)",
+                        f"(expected None, an int, a Dim, Dim.AUTO, Dim.STATIC, or Dim.DYNAMIC, "
+                        f" but got {dim} instead)",
                         case_name="dynamic_shapes_validation",
                     )
         elif isinstance(shape, (tuple, list)):
@@ -708,7 +712,8 @@ def _check_dynamic_shapes(
                         UserErrorType.INVALID_INPUT,
                         f"Unexpected dimension #{i} in input tensor shape {shape} "
                         f"specified at `dynamic_shapes{keystr(path)}` "
-                        f"(expected None, an int, a Dim, Dim.AUTO, or Dim.STATIC, but got {dim} instead)",
+                        f"(expected None, an int, a Dim, Dim.AUTO, Dim.STATIC, or Dim.DYNAMIC, "
+                        f"but got {dim} instead)",
                         case_name="dynamic_shapes_validation",
                     )
         elif shape is not None:
@@ -716,7 +721,7 @@ def _check_dynamic_shapes(
                 UserErrorType.INVALID_INPUT,
                 f"Unexpected input tensor shape {shape} specified at `dynamic_shapes{keystr(path)}` "
                 f"(expected either a list/tuple of dimensions, or a dict mapping indices to dimensions,"
-                f" where each dimension is an int, a Dim, Dim.AUTO, or Dim.STATIC)",
+                f" where each dimension is an int, a Dim, Dim.AUTO, Dim.STATIC, or Dim.DYNAMIC)",
                 case_name="dynamic_shapes_validation",
             )
 
@@ -771,12 +776,13 @@ def _check_dynamic_shapes(
     ):
         raise UserError(
             UserErrorType.INVALID_INPUT,
-            "Specifying both `Dim.AUTO` and `Dim` or `DerivedDim` in `dynamic_shapes` is not well supported at the moment, "
-            "and can easily lead to constraint violation errors or obscure errors in torch.export. Dim/DerivedDims "
-            "expect all equal or related dimensions to be specified, and does not yet compose well with `Dim.AUTO`. "
-            "We suggest using `Dim.AUTO` mixed with `None` for auto-dynamic + static shapes, plus torch._check(dim >= min), "
-            "torch._check(dim <= max) calls in your program to specify min/max ranges, or `Dim`/`DerivedDim` mixed with `None` "
-            "if you want to assert on the exact specification of your program's dynamic shapes behavior.",
+            "Specifying both `Dim.AUTO/Dim.DYNAMIC` and `Dim/DerivedDim` in `dynamic_shapes` is not "
+            "well supported at the moment, and can easily lead to constraint violation errors or obscure errors in torch.export. "
+            "Dim/DerivedDims expect all equal or related dimensions to be specified, and does not yet compose well with `Dim.AUTO`. "
+            "We suggest using `Dim.AUTO/Dim.DYNAMIC` mixed with `Dim.STATIC` for auto-dynamic + static shapes, "
+            "plus torch._check(dim >= min), torch._check(dim <= max) calls in your program to specify min/max ranges, "
+            "or `Dim`/`DerivedDim` mixed with `Dim.STATIC` if you want to assert on the exact specification of your program's "
+            "dynamic shapes behavior.",
             case_name="dynamic_shapes_validation",
         )
 
@@ -891,6 +897,7 @@ def _process_dynamic_shapes(
         # clean out decorators from user side, or previous export call
         tensor._dynamo_weak_dynamic_indices = set()
         tensor._dynamo_dynamic_indices = set()
+        tensor._dynamo_dynamic_range = set()
         tensor._dynamo_static_indices = set()
         tensor._dynamo_unbacked_indices = set()
 
@@ -906,6 +913,8 @@ def _process_dynamic_shapes(
                         torch._dynamo.maybe_mark_dynamic(tensor, i)
                     elif dim == _DimHint.STATIC:
                         torch._dynamo.mark_static(tensor, i)
+                    elif dim == _DimHint.DYNAMIC:
+                        torch._dynamo.mark_dynamic(tensor, i)
                 elif dim is None:
                     torch._dynamo.mark_static(tensor, i)
         elif isinstance(shape, (tuple, list)):
@@ -920,6 +929,8 @@ def _process_dynamic_shapes(
                         torch._dynamo.maybe_mark_dynamic(tensor, i)
                     elif dim == _DimHint.STATIC:
                         torch._dynamo.mark_static(tensor, i)
+                    elif dim == _DimHint.DYNAMIC:
+                        torch._dynamo.mark_dynamic(tensor, i)
                 elif dim is None:
                     torch._dynamo.mark_static(tensor, i)
         elif shape is None:

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -777,12 +777,12 @@ def _check_dynamic_shapes(
         raise UserError(
             UserErrorType.INVALID_INPUT,
             "Specifying both `Dim.AUTO/Dim.DYNAMIC` and `Dim/DerivedDim` in `dynamic_shapes` is not "
-            "well supported at the moment, and can easily lead to constraint violation errors or obscure errors in torch.export. "
-            "Dim/DerivedDims expect all equal or related dimensions to be specified, and does not yet compose well with `Dim.AUTO`. "
-            "We suggest using `Dim.AUTO/Dim.DYNAMIC` mixed with `Dim.STATIC` for auto-dynamic + static shapes, "
-            "plus torch._check(dim >= min), torch._check(dim <= max) calls in your program to specify min/max ranges, "
-            "or `Dim`/`DerivedDim` mixed with `Dim.STATIC` if you want to assert on the exact specification of your program's "
-            "dynamic shapes behavior.",
+            "well supported at the moment, and can easily lead to constraint violation errors or obscure errors "
+            "in torch.export. Dim/DerivedDims expect all equal or related dimensions to be specified, "
+            "and do not yet compose well with `Dim.AUTO`. We suggest using `Dim.AUTO/Dim.DYNAMIC` mixed with "
+            "`Dim.STATIC` for auto-dynamic + static shapes, plus torch._check(dim >= min), torch._check(dim <= max) "
+            "calls in your program to specify min/max ranges, or `Dim`/`DerivedDim` mixed with `Dim.STATIC` "
+            "if you want to assert on the exact specification of your program's dynamic shapes behavior.",
             case_name="dynamic_shapes_validation",
         )
 
@@ -813,7 +813,7 @@ def _process_dynamic_shapes(
     def to_constraint(dim, tensor, i):
         import sympy
 
-        from torch.fx.experimental.symbolic_shapes import RelaxedUnspecConstraint, StrictMinMaxConstraint
+        from torch.fx.experimental.symbolic_shapes import StrictMinMaxConstraint
         from torch.utils._sympy.solve import try_solve
         from torch.utils._sympy.value_ranges import ValueRanges
 


### PR DESCRIPTION
Adds Dim.DYNAMIC which calls torch._dynamo.mark_dynamic() in the backend. Similar to Dim.AUTO in that it does automatic inference for ranges & relations, but errors out for specializations.