### PR TITLE
Update FlexAttention benchmarks

### DIFF
--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -704,11 +704,11 @@ def generate_block_mask(attn_type: str, shape: Tuple[int]):
         new_mask_mod = mask_mod
 
     mask_shape = (1, 1, M, N) if attn_type != "document_mask" else (1, 1, M * B, N * B)
-
+    compiled_block_mask = torch.compile(create_block_mask)
     if new_mask_mod:
-        block_mask = create_block_mask(new_mask_mod, *mask_shape, "cuda")
+        block_mask = compiled_block_mask(new_mask_mod, *mask_shape, "cuda")
     else:
-        block_mask = create_block_mask(noop_mask, *mask_shape, "cuda")
+        block_mask = compiled_block_mask(noop_mask, *mask_shape, "cuda")
 
     return block_mask, mask_mod_kwargs
 

--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -227,65 +227,67 @@ def run_single_backend_sdpa(
                 config.attn_type, config.shape, config.dtype, block_mask
             )
 
-    if config.attn_type == "document_mask":
-        if backend in ["og-eager"]:
-            print(f"Backend {backend} not supported for document mask")
-        else:  # sdpa
-            q_eager, k_eager, v_eager = generate_jagged_inputs(
-                query, key, value, **mask_kwargs
-            )
-            q_eager = q_eager.transpose(1, 2).requires_grad_(query.requires_grad)
-            k_eager = k_eager.transpose(1, 2).requires_grad_(key.requires_grad)
-            v_eager = v_eager.transpose(1, 2).requires_grad_(value.requires_grad)
-    else:
-        q_eager, k_eager, v_eager = query_key_value_clones(query, key, value)
+        if config.attn_type == "document_mask":
+            if backend in ["og-eager"]:
+                print(f"Backend {backend} not supported for document mask")
+            else:  # sdpa
+                q_eager, k_eager, v_eager = generate_jagged_inputs(
+                    query, key, value, **mask_kwargs
+                )
+                q_eager = q_eager.transpose(1, 2).requires_grad_(query.requires_grad)
+                k_eager = k_eager.transpose(1, 2).requires_grad_(key.requires_grad)
+                v_eager = v_eager.transpose(1, 2).requires_grad_(value.requires_grad)
+        else:
+            q_eager, k_eager, v_eager = query_key_value_clones(query, key, value)
 
-    if eager_sdpa:
-        try:
-            out_eager = eager_sdpa(query=q_eager, key=k_eager, value=v_eager)
-        except RuntimeError as e:
-            print(f"Error: {e}")
-            return ExperimentResults(fwd_time=float("nan"), bwd_time=float("nan"))
-        if config.attn_type in ["document_mask"]:
-            flatten_o_eager = torch.cat(torch.unbind(out_eager.transpose(1, 2)))
-            flatten_o_compile = out_compile.transpose(1, 2).flatten(
-                start_dim=0, end_dim=1
-            )
-            torch.testing.assert_close(
-                flatten_o_eager, flatten_o_compile, atol=1e-2, rtol=1e-2
-            )
-        elif not (
-            config.attn_type in ["rel", "alibi"]
-            and config.dtype in [torch.float16, torch.bfloat16]
-        ):  # rel has accuracy issue with 16bit floats
-            torch.testing.assert_close(out_eager, out_compile, atol=1e-2, rtol=1e-2)
+        if eager_sdpa:
+            try:
+                out_eager = eager_sdpa(query=q_eager, key=k_eager, value=v_eager)
+            except RuntimeError as e:
+                print(
+                    f"Backend: {backend} failed on shape {config.shape} with error: {e} "
+                )
+                return ExperimentResults(fwd_time=float("nan"), bwd_time=float("nan"))
+            if config.attn_type in ["document_mask"]:
+                flatten_o_eager = torch.cat(torch.unbind(out_eager.transpose(1, 2)))
+                flatten_o_compile = out_compile.transpose(1, 2).flatten(
+                    start_dim=0, end_dim=1
+                )
+                torch.testing.assert_close(
+                    flatten_o_eager, flatten_o_compile, atol=1e-2, rtol=1e-2
+                )
+            elif not (
+                config.attn_type in ["rel", "alibi"]
+                and config.dtype in [torch.float16, torch.bfloat16]
+            ):  # rel has accuracy issue with 16bit floats
+                torch.testing.assert_close(out_eager, out_compile, atol=1e-2, rtol=1e-2)
 
-    if eager_sdpa:
-        forward_eager_time = benchmark_torch_function_in_microseconds(
-            eager_sdpa, query=q_eager, key=k_eager, value=v_eager
-        )
-    else:
-        forward_eager_time = float("nan")
-
-    if config.calculate_bwd_time:
-        # TODO: debug backward pass for njt
-        if eager_sdpa and not config.attn_type == "document_mask":
-            dOut = torch.randn_like(out_eager.transpose(1, 2)).transpose(1, 2)
-            backward_eager_time = benchmark_torch_function_in_microseconds(
-                out_eager.backward, dOut, retain_graph=True
+        if eager_sdpa:
+            forward_eager_time = benchmark_torch_function_in_microseconds(
+                eager_sdpa, query=q_eager, key=k_eager, value=v_eager
             )
         else:
-            backward_eager_time = float("nan")
+            forward_eager_time = float("nan")
 
-        return ExperimentResults(
-            fwd_time=forward_eager_time,
-            bwd_time=backward_eager_time,
-        )
-    else:
-        return ExperimentResults(
-            fwd_time=forward_eager_time,
-            bwd_time=None,
-        )
+        if config.calculate_bwd_time:
+            # TODO: debug backward pass for njt
+            if eager_sdpa and not config.attn_type == "document_mask":
+                dOut = torch.randn_like(out_eager.transpose(1, 2)).transpose(1, 2)
+                backward_eager_time = benchmark_torch_function_in_microseconds(
+                    out_eager.backward, dOut, retain_graph=True
+                )
+            else:
+                backward_eager_time = float("nan")
+
+            return ExperimentResults(
+                fwd_time=forward_eager_time,
+                bwd_time=backward_eager_time,
+            )
+        else:
+            return ExperimentResults(
+                fwd_time=forward_eager_time,
+                bwd_time=None,
+            )
 
 
 def run_single_backend_FA(
@@ -323,7 +325,7 @@ def run_single_backend_FA(
         else:
             out_FA_updated = out_FA
         torch.testing.assert_close(
-            out_FA_updated, out_compile.transpose(1, 2), atol=1e-2, rtol=1e-2
+            out_FA_updated, out_compile.transpose(1, 2), atol=1e-1, rtol=1e-1
         )
 
     if FA:
@@ -563,6 +565,8 @@ def print_results(results: List[Experiment], save_path: Optional[str] = None):
     print(tabulate(table_data, headers="keys", tablefmt="github", floatfmt=".3f"))
 
     for backend in results[0].config.backends:
+        if np.isnan(table_data[f"fwd_{backend}_speedup"]).all():
+            continue
         print("\n")
         print(f"FWD Speedups vs. {backend}".center(125, "="))
         print("\n")
@@ -613,7 +617,7 @@ def generate_score_mod(attn_type: str, shape: Tuple[int]) -> Callable | None:
         "alibi": generate_alibi_bias(Hq),
         "sliding_window": None,
         "document_mask": None,
-        "prefix_ml": None,
+        "prefix_lm": None,
         "softcap": generate_tanh_softcap(softcap_value, approx=True),
         "transfusion": generate_tanh_softcap(softcap_value, approx=True),
     }
@@ -923,7 +927,7 @@ def generate_eager_sdpa(
 ) -> Callable | None:
     B, Hq, M, Hkv, N, D = shape
     is_decoding = M == 1
-    if attn_type == "sliding_window" or attn_type == "prefix_ml":
+    if attn_type == "sliding_window" or attn_type == "prefix_lm":
         attn_mask = create_mask(block_mask.mask_mod, 1, 1, M, N, device="cuda")
     elif attn_type == "rel":
         m = torch.arange(M, dtype=int, device="cuda")
@@ -1127,7 +1131,7 @@ if __name__ == "__main__":
         "-mods",
         type=str,
         nargs="+",
-        help="score mods: noop, causal, rel, head_bias, alibi, sliding_window, document_mask, prefix_ml, softcap",
+        help="score mods: noop, causal, rel, head_bias, alibi, sliding_window, document_mask, prefix_lm, softcap",
         default=["noop", "causal", "rel", "head_bias"],
     )
     parser.add_argument(

--- a/benchmarks/transformer/score_mod.py
+++ b/benchmarks/transformer/score_mod.py
@@ -911,7 +911,7 @@ def generate_FD_callable(
         ),
         "document_mask": None,
         "prefix_lm": None,
-        "softcap": None,
+        "softcap": partial(flash_attn_with_kvcache_renamed, softcap=softcap_value),
         "transfusion": None,
     }
 

--- a/benchmarks/transformer/score_mod_helper.py
+++ b/benchmarks/transformer/score_mod_helper.py
@@ -1,0 +1,111 @@
+import math
+from functools import partial
+from typing import Tuple
+
+import torch
+from torch.nn.attention.flex_attention import BlockMask, create_mask
+
+
+def scaled_dot_product_attention_debug(
+    query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
+) -> torch.Tensor:
+    B, H, L, S = query.size(0), query.size(1), query.size(-2), key.size(-2)
+    scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
+    attn_bias = torch.zeros(B, H, L, S, dtype=query.dtype, device=query.device)
+    if is_causal:
+        assert attn_mask is None
+        temp_mask = torch.ones(B, H, L, S, dtype=torch.bool, device=query.device).tril(
+            diagonal=0
+        )
+        attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf"))
+        attn_bias.to(query.dtype)
+
+    if attn_mask is not None:
+        if attn_mask.dtype == torch.bool:
+            attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
+        else:
+            attn_bias += attn_mask
+    attn_weight = query @ key.transpose(-2, -1) * scale_factor
+    print("scores", attn_weight[0, 0])
+    print("attn_bias", attn_bias[0, 0])
+    attn_weight += attn_bias
+    print("post weight attn", attn_weight[0, 0])
+    attn_weight = torch.softmax(attn_weight, dim=-1)
+    attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
+    return attn_weight @ value
+
+
+def generate_OG_pytorch(
+    attn_type: str, shape: Tuple[int], dtype: torch.dtype, block_mask: BlockMask
+):
+    B, Hq, M, Hkv, N, D = shape
+    ## From T5x
+
+    ## From transfusion-pytorch
+    def transfusion_attn(
+        query,
+        key,
+        value,
+        attn_mask,
+        softcap_value,
+        causal=True,
+        dropout_p=0.0,
+        scale=D**-0.5,
+    ):
+        import einx
+
+        from einops import einsum
+
+        def softclamp(t, value=50.0):
+            return (t / value).tanh() * value
+
+        q = query * scale
+        k = key
+        v = value
+
+        sim = einsum(q, k, "b h i d, b h j d -> b h i j")
+
+        sim = softclamp(sim, softcap_value)
+
+        mask_value = -torch.finfo(sim.dtype).max
+        mask_value = float("-inf")
+
+        sim = einx.where("b i j, b h i j, -> b h i j", attn_mask, sim, mask_value)
+
+        attn = sim.softmax(dim=-1)
+
+        dropout = torch.nn.Dropout(dropout_p)
+        attn = dropout(attn)
+
+        out = einsum(attn, v, "b h i j, b h j d -> b h i d")
+
+        return out
+
+    if attn_type == "transfusion":
+        attn_mask = create_mask(block_mask.mask_mod, B, 1, M, N, device="cuda").squeeze(
+            1
+        )
+
+    from score_mod import dropout_p, softcap_value
+
+    function_dict = {
+        "noop": None,
+        "causal": None,
+        "offset": None,
+        "rel": None,
+        "head_bias": None,
+        "alibi": None,
+        "sliding_window": None,
+        "document_mask": None,
+        "prefix_ml": None,
+        "transfusion": partial(
+            transfusion_attn,
+            softcap_value=softcap_value,
+            dropout_p=dropout_p,
+            attn_mask=attn_mask,
+        )
+        if Hq == Hkv
+        else None,
+    }
+
+    return function_dict[attn_type]

--- a/torch/_inductor/kernel/flex_decoding.py
+++ b/torch/_inductor/kernel/flex_decoding.py
@@ -290,12 +290,11 @@ flex_decoding_template = TritonTemplate(
 )
 
 
-def get_split_k(B: int, H: int, Mk: int, SM: int = 128) -> int:
-    """Heuristic for the number of splits from xformer"""
+def get_split_k(B: int, H: int, Mk: int) -> int:
+    num_SM = torch.cuda.get_device_properties("cuda").multi_processor_count
     bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
-    split_k = SM // bh  # Each SM should at least get one block.
+    split_k = num_SM // bh * 2  # Each SM should at least get one block.
     split_k = max(split_k, 1)
-
     return split_k
 
 


### PR DESCRIPTION
This PR adds more attention variants and builtin FlashAttention support for FlexAttention benchmark. 

Example command: 
```
# training
python benchmarks/transformer/score_mod.py -b 2 -d 64 -mods sliding_window -dtype float16 --calculate-bwd --flash-attn
# inference
python benchmarks/transformer/score_mod.py --kv-cache-size 128  -d 64 -mods causal -dtype float16 --flash-attn --decoding
```
Supported mods: `noop, causal, rel, head_bias, alibi, sliding_window, document_mask, prefix_ml, softcap`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov