### PR TITLE
[PyTorch] Classify Unsupported mutated Dynamic Shapes as User Error

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -144,6 +144,7 @@ class UserErrorType(Enum):
     DYNAMIC_DIM = auto()
     INVALID_INPUT = auto()
     INVALID_OUTPUT = auto()
+    UNSUPPORTED_ALIASED_MUTATED_DYNAMIC_INPUTS = auto()
 
 
 class UserError(Unsupported):


### PR DESCRIPTION
Summary: We don't need an assert on for unsupported dyn shape inputs, removing the assert and raising a user exception instead.

Differential Revision: D63661569


cc @ezyang @albanD @gqchen @pearu @nikitaved @soulitzer @Varal7 @xmfan @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec