### PR TITLE
Load cuda deps more aggressively

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -292,7 +292,7 @@ def _get_cuda_dep_paths(path: str, lib_folder: str, lib_name: str) -> list[str]:
     return nvidia_lib_paths + lib_paths
 
 
-def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
+def _preload_cuda_dep(lib_folder: str, lib_name: str) -> None:
     """Preloads cuda deps if they could not be found otherwise."""
     # Should only be called on Linux if default path resolution have failed
     assert platform.system() == "Linux", "Should only be called on Linux"
@@ -306,6 +306,40 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
     if not lib_path:
         raise ValueError(f"{lib_name} not found in the system path {sys.path}")
     ctypes.CDLL(lib_path)
+
+
+def _preload_cuda_deps(err: _Union[ImportError, OSError]) -> builtins.bool:
+    """Preloads cuda deps if they could not be found otherwise."""
+    # Can only happen for wheel with cuda libs as PYPI deps
+    # As PyTorch is not purelib, but nvidia-*-cu12 is
+    from torch.version import cuda as cuda_version
+
+    cuda_libs: dict[str, str] = {
+        "nvjitlink": "libnvJitLink.so.*[0-9]",
+        "cublas": "libcublas.so.*[0-9]",
+        "cudnn": "libcudnn.so.*[0-9]",
+        "cuda_nvrtc": "libnvrtc.so.*[0-9]",
+        "cuda_runtime": "libcudart.so.*[0-9]",
+        "cuda_cupti": "libcupti.so.*[0-9]",
+        "cufft": "libcufft.so.*[0-9]",
+        "curand": "libcurand.so.*[0-9]",
+        "cusparse": "libcusparse.so.*[0-9]",
+        "cusparselt": "libcusparseLt.so.*[0-9]",
+        "cusolver": "libcusolver.so.*[0-9]",
+        "nccl": "libnccl.so.*[0-9]",
+        "nvtx": "libnvToolsExt.so.*[0-9]",
+        "nvshmem": "libnvshmem_host.so.*[0-9]",
+        "cufile": "libcufile.so.*[0-9]",
+    }
+
+    is_cuda_lib_err = [
+        lib for lib in cuda_libs.values() if lib.split(".")[0] in err.args[0]
+    ]
+    if not is_cuda_lib_err and "cannot open shared object file:" not in err.args[0]:
+        return False
+    for lib_folder, lib_name in cuda_libs.items():
+        _preload_cuda_dep(lib_folder, lib_name)
+    return True
 
 
 # See Note [Global dependencies]
@@ -335,41 +369,14 @@ def _load_global_deps() -> None:
                 return
             # If all above-mentioned conditions are met, preload nvrtc and nvjitlink
             # Please note that order are important for CUDA-11.8 , as nvjitlink does not exist there
-            _preload_cuda_deps("cuda_nvrtc", "libnvrtc.so.*[0-9]")
-            _preload_cuda_deps("nvjitlink", "libnvJitLink.so.*[0-9]")
+            _preload_cuda_dep("cuda_nvrtc", "libnvrtc.so.*[0-9]")
+            _preload_cuda_dep("nvjitlink", "libnvJitLink.so.*[0-9]")
         except Exception:
             pass
 
     except OSError as err:
-        # Can only happen for wheel with cuda libs as PYPI deps
-        # As PyTorch is not purelib, but nvidia-*-cu12 is
-        from torch.version import cuda as cuda_version
-
-        cuda_libs: dict[str, str] = {
-            "cublas": "libcublas.so.*[0-9]",
-            "cudnn": "libcudnn.so.*[0-9]",
-            "cuda_nvrtc": "libnvrtc.so.*[0-9]",
-            "cuda_runtime": "libcudart.so.*[0-9]",
-            "cuda_cupti": "libcupti.so.*[0-9]",
-            "cufft": "libcufft.so.*[0-9]",
-            "curand": "libcurand.so.*[0-9]",
-            "nvjitlink": "libnvJitLink.so.*[0-9]",
-            "cusparse": "libcusparse.so.*[0-9]",
-            "cusparselt": "libcusparseLt.so.*[0-9]",
-            "cusolver": "libcusolver.so.*[0-9]",
-            "nccl": "libnccl.so.*[0-9]",
-            "nvtx": "libnvToolsExt.so.*[0-9]",
-            "nvshmem": "libnvshmem_host.so.*[0-9]",
-            "cufile": "libcufile.so.*[0-9]",
-        }
-
-        is_cuda_lib_err = [
-            lib for lib in cuda_libs.values() if lib.split(".")[0] in err.args[0]
-        ]
-        if not is_cuda_lib_err:
+        if not _preload_cuda_deps(err):
             raise err
-        for lib_folder, lib_name in cuda_libs.items():
-            _preload_cuda_deps(lib_folder, lib_name)
         ctypes.CDLL(global_deps_lib_path, mode=ctypes.RTLD_GLOBAL)
 
 
@@ -412,7 +419,14 @@ else:
     # See Note [Global dependencies]
     if USE_GLOBAL_DEPS:
         _load_global_deps()
-    from torch._C import *  # noqa: F403
+
+    try:
+        from torch._C import *  # noqa: F403
+    except ImportError as err:
+        if not _preload_cuda_deps(err):
+            raise err
+
+        from torch._C import *  # noqa: F403
 
 
 class SymInt:


### PR DESCRIPTION
Previously cuda deps were only loaded if loading the globals library
failed with a cuda shared lib related error. It's possible the globals
library to load successfully, but then for the torch native libraries to
fail with a cuda error. This now handles both of these cases.

Fixes https://github.com/pytorch/pytorch/issues/117350


cc @malfet @seemethere @ptrblck @msaroufim @eqy @jerryzh168