### PR TITLE
[MPS] Fix bfloat to complex casts

### DIFF
--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -733,6 +733,10 @@ static std::string genScatterGatherCvtFunc(const std::string& dtypeSrc, const st
   const bool srcComplex = dtypeSrc[dtypeSrc.size() - 1] == '2';
   const bool dstComplex = dtypeDst[dtypeDst.size() - 1] == '2';
   if (dstComplex) {
+    // TODO: Document why explicit cast is needed only for bfloat types
+    if (dtypeSrc == "bfloat") {
+        return dtypeDst + "(float(x), 0.0)";
+    }
     return dtypeDst + (srcComplex ? needsConj ? "(x.x, -x.y)" : "(x.x, x.y)" : "(x,  0.0)");
   }
   if (srcComplex) {
@@ -746,7 +750,7 @@ static std::string genScatterGatherCvtFunc(const std::string& dtypeSrc, const st
   if (dtypeDst == "bfloat") {
     return "bfloat(x)";
   }
-  return "(x)";
+  return dtypeSrc == "bfloat" ? dtypeDst + "(x)" :  "(x)";
 }
 
 static MetalShaderLibrary scatterLib(SCATTER_OPS_TEMPLATE, 3);

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -735,7 +735,7 @@ static std::string genScatterGatherCvtFunc(const std::string& dtypeSrc, const st
   if (dstComplex) {
     // TODO: Document why explicit cast is needed only for bfloat types
     if (dtypeSrc == "bfloat") {
-        return dtypeDst + "(float(x), 0.0)";
+      return dtypeDst + "(float(x), 0.0)";
     }
     return dtypeDst + (srcComplex ? needsConj ? "(x.x, -x.y)" : "(x.x, x.y)" : "(x,  0.0)");
   }
@@ -750,7 +750,7 @@ static std::string genScatterGatherCvtFunc(const std::string& dtypeSrc, const st
   if (dtypeDst == "bfloat") {
     return "bfloat(x)";
   }
-  return dtypeSrc == "bfloat" ? dtypeDst + "(x)" :  "(x)";
+  return dtypeSrc == "bfloat" ? dtypeDst + "(x)" : "(x)";
 }
 
 static MetalShaderLibrary scatterLib(SCATTER_OPS_TEMPLATE, 3);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #136987
* __->__ #137070


For Metal cast ops to comple, one need to explicitly cast to/from `bfloat` unlike for other dtypes

Tested in https://github.com/pytorch/pytorch/pull/136987