### PR TITLE
fix build error with gcc 12+

### DIFF
--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -44,7 +44,6 @@ set(TORCH_API_TEST_SOURCES
   ${TORCH_API_TEST_DIR}/operations.cpp
   ${TORCH_API_TEST_DIR}/nested_int.cpp
 )
-include(CheckCXXCompilerFlag)
 if(USE_CUDA OR USE_ROCM)
   list(APPEND TORCH_API_TEST_SOURCES ${TORCH_API_TEST_DIR}/parallel.cpp)
 endif()
@@ -66,13 +65,10 @@ if(NOT MSVC)
   target_compile_options_if_supported(test_api "-Wno-maybe-uninitialized")
   # gcc gives nonsensical warnings about variadic.h
   target_compile_options_if_supported(test_api "-Wno-unused-but-set-parameter")
-  
+
   # Add -Wno-error=nonnull for GCC 12+
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
-    check_cxx_compiler_flag("-Wno-error=nonnull" HAS_WNO_ERROR_NONNULL)
-    if(HAS_WNO_ERROR_NONNULL)
-      target_compile_options(test_api PRIVATE "-Wno-error=nonnull")
-    endif()
+    target_compile_options_if_supported(test_api "-Wno-error=nonnull")
   endif()
 endif()
 

--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -44,6 +44,7 @@ set(TORCH_API_TEST_SOURCES
   ${TORCH_API_TEST_DIR}/operations.cpp
   ${TORCH_API_TEST_DIR}/nested_int.cpp
 )
+include(CheckCXXCompilerFlag)
 if(USE_CUDA OR USE_ROCM)
   list(APPEND TORCH_API_TEST_SOURCES ${TORCH_API_TEST_DIR}/parallel.cpp)
 endif()
@@ -65,6 +66,14 @@ if(NOT MSVC)
   target_compile_options_if_supported(test_api "-Wno-maybe-uninitialized")
   # gcc gives nonsensical warnings about variadic.h
   target_compile_options_if_supported(test_api "-Wno-unused-but-set-parameter")
+  
+  # Add -Wno-error=nonnull for GCC 12+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
+    check_cxx_compiler_flag("-Wno-error=nonnull" HAS_WNO_ERROR_NONNULL)
+    if(HAS_WNO_ERROR_NONNULL)
+      target_compile_options(test_api PRIVATE "-Wno-error=nonnull")
+    endif()
+  endif()
 endif()
 
 if(INSTALL_TEST)


### PR DESCRIPTION
Fixes #127920 

This commit addresses a build failure occurring with GCC 12 and above due to the -Werror=nonnull flag. The error manifests in the test_api target.

**Issue:**
When building with GCC 12+, the following error occurs:
```
error: argument 1 null where non-null expected [-Werror=nonnull]
  431 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This change ensures that:
1. The flag is only added for GCC 12 or higher
2. The flag is only added if it's supported by the compiler
3. The flag is added specifically to the test_api target, not globally

By disabling this specific error, we allow the build to proceed while maintaining other compiler warnings.

**Test Plan:**
- Verified successful build with GCC 12 and above
- Ensured no regression in builds with earlier GCC versions and other compilers


cc @malfet @seemethere 