### PR TITLE
improve get_schedule_class()

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -62,7 +62,9 @@ class ScheduleTest(TestCase):
         # List of all expected schedule names
         schedule_names = [
             "1F1B",
+            "1f1b",
             "Interleaved1F1B",
+            "INTERLEAVED1F1B",
             "GPipe",
             "FlexibleInterleaved1F1B",
             "LoopedBFS",
@@ -81,6 +83,12 @@ class ScheduleTest(TestCase):
                     issubclass(schedule_class, _PipelineSchedule),
                     f"{name} should be a subclass of _PipelineSchedule",
                 )
+
+        error_case = ["ScheduleThatDoesNotExist"]
+        for name in error_case:
+            # Test that the original name is included in the error message
+            with self.assertRaisesRegex(ValueError, f"{name}"):
+                get_schedule_class(name)
 
 
 class TestSchedulePlan(TestCase):

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -2160,7 +2160,7 @@ class ScheduleInterleavedZeroBubble(ScheduleFlexibleInterleaved1F1B):
 
 def get_schedule_class(schedule_name: str):
     """
-    Maps a schedule name to its corresponding class object.
+    Maps a schedule name (case insensitive) to its corresponding class object.
 
     Args:
         schedule_name (str): The name of the schedule.
@@ -2175,6 +2175,10 @@ def get_schedule_class(schedule_name: str):
         "PipelineScheduleSingle": PipelineScheduleSingle,
         "PipelineScheduleMulti": PipelineScheduleMulti,
     }
-    if schedule_name not in schedule_map:
-        raise ValueError(f"Unknown schedule name: {schedule_name}")
-    return schedule_map[schedule_name]
+    lowercase_keys = {k.lower(): k for k in schedule_map.keys()}
+    lowercase_schedule_name = schedule_name.lower()
+    if lowercase_schedule_name not in lowercase_keys:
+        raise ValueError(
+            f"Unknown schedule name '{schedule_name}'. The valid options are {list(schedule_map.keys())}"
+        )
+    return schedule_map[lowercase_keys[lowercase_schedule_name]]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137103

Small change to make `get_schedule_class()` take case insensitive schedule names

cc @XilunWu @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o