### PR TITLE
[BE] [NEON] Use `vshlq_n_u32` instead of `vshlq_u32`

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -306,11 +306,10 @@ struct VecConvert<float, 1, BFloat16, 1> {
       const VectorizedN<BFloat16, 1>& src) {
     VectorizedN<float, 1> result;
     uint16x8_t u16_8 = vld1q_u16(reinterpret_cast<const uint16_t*>(&src[0]));
-    int32x4_t shift = vdupq_n_s32(16);
     auto u16_low1 = vget_low_u16(u16_8);
     auto u16_high1 = vget_high_u16(u16_8);
-    float32x4_t f32x4_0 = vreinterpretq_f32_u32(vshlq_u32(vmovl_u16(u16_low1), shift));
-    float32x4_t f32x4_1 = vreinterpretq_f32_u32(vshlq_u32(vmovl_u16(u16_high1), shift));
+    float32x4_t f32x4_0 = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(u16_low1), 16));
+    float32x4_t f32x4_1 = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(u16_high1), 16));
     result[0] = {f32x4_0, f32x4_1};
     return result;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137131
* __->__ #137122

As compiler optimizes it away anyway

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10