### PR TITLE
Fix to() on non-contiguous NJTs

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7019,6 +7019,62 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
         self.assertIsNone(nt._values.grad_fn)
 
     @dtypes(torch.float64, torch.float32, torch.half)
+    @parametrize(
+        "contiguity",
+        ["noncontig_transposed", "noncontig_with_holes"],
+        name_fn=lambda c: c,
+    )
+    def test_noncontiguous_to(self, device, dtype, contiguity):
+        # Dense tensors preserve non-contiguity through to() calls (i.e. strides are
+        # preserved). Test for the analogous behavior for NJTs:
+        # 1. non-contiguous transposed
+        # 2. non-contiguous with holes
+        if contiguity == "noncontig_transposed":
+            nt = random_nt_from_dims(
+                [3, None, 5, 2],
+                device=device,
+                dtype=dtype,
+                layout=torch.jagged,
+            ).transpose(-3, -2)
+        elif contiguity == "noncontig_with_holes":
+            nt = torch.nested.nested_tensor_from_jagged(
+                values=torch.randn(10, 3, device=device, dtype=dtype),
+                offsets=torch.tensor([0, 3, 7, 10], device=device, dtype=torch.int64),
+                # these lengths specify holes
+                lengths=torch.tensor([1, 2, 3], device=device, dtype=torch.int64),
+            )
+        else:
+            raise ValueError("invalid contiguity specified for test_noncontiguous_to()")
+
+        # test dtype conversion
+        dtype_conversions = {
+            torch.float32: torch.half,
+            torch.float64: torch.float32,
+            torch.half: torch.float32,
+        }
+        other_dtype = dtype_conversions[dtype]
+        nt2 = nt.to(dtype=other_dtype)
+        self.assertEqual(nt2.dtype, other_dtype)
+        self.assertEqual(nt.is_contiguous(), nt2.is_contiguous())
+        self.assertEqual(nt._values.is_contiguous(), nt2._values.is_contiguous())
+        self.assertEqual(nt.shape, nt2.shape)
+        # expect no change for offsets / lengths
+        self.assertEqual(nt._offsets, nt2._offsets)
+        self.assertEqual(nt._lengths, nt2._lengths)
+
+        # test device conversion
+        other_device = "cuda:0" if device == "cpu" else "cpu"
+        nt3 = nt.to(device=other_device)
+        self.assertEqual(nt3.device, torch.device(other_device))
+        self.assertEqual(nt.is_contiguous(), nt3.is_contiguous())
+        self.assertEqual(nt._values.is_contiguous(), nt3._values.is_contiguous())
+        self.assertEqual(nt.shape, nt3.shape)
+        # expect device change for offsets / lengths
+        self.assertEqual(nt3._offsets.device, torch.device(other_device))
+        if nt._lengths is not None:
+            self.assertEqual(nt3._lengths.device, torch.device(other_device))
+
+    @dtypes(torch.float64, torch.float32, torch.half)
     def test_jagged_padded_dense_conversion_kernels(self, device, dtype):
         values = torch.randn(10, 5, device=device, dtype=dtype)
         offsets = torch.tensor([0, 1, 3, 8, 10], device=device, dtype=torch.int64)
@@ -7625,6 +7681,15 @@ COMPILE_FORWARD_FAILURES = {
     # clone() on non-contiguous with holes NJTs currently use unbind(), leading to
     # data-dependent error in torch.compile
     "clone",
+    # to(device) allocates a new nested int in compile only.
+    # AssertionError: The values for attribute 'shape' do not match:
+    # torch.Size([7, j2]) != torch.Size([7, j1]).
+    "to",
+}
+
+COMPILE_BACKWARD_FAILURES = {
+    *COMPILE_FORWARD_FAILURES,
+    *BACKWARD_FAILURES,
 }
 
 COMPARE_TENSOR_COMPONENT_EQUALITY = {
@@ -7715,7 +7780,7 @@ class TestNestedTensorOpInfo(NestedTensorTestCase):
             else:
                 self.assertEqual(out_compile, out_ref)
 
-    @withXFails(BACKWARD_FAILURES)
+    @withXFails(COMPILE_BACKWARD_FAILURES)
     @ops(
         [op for op in njt_op_db if op.supports_njt and op.supports_autograd],
         allowed_dtypes=(torch.float32,),

--- a/torch/testing/_internal/opinfo/definitions/nested.py
+++ b/torch/testing/_internal/opinfo/definitions/nested.py
@@ -315,6 +315,25 @@ def sample_inputs_special_polygamma_n(n):
     return partial(sample_inputs_elementwise_njt_unary, op_kwargs={"n": n})
 
 
+def sample_inputs_to(op_info, device, dtype, requires_grad, op_kwargs=None, **kwargs):
+    for njt in _sample_njts(
+        device=device,
+        dtype=dtype,
+        requires_grad=requires_grad,
+        dims=[2, 3, 4],
+    ):
+        other_dtypes = (
+            d for d in (torch.float32, torch.half, torch.double) if d is not dtype
+        )
+        for other_dtype in other_dtypes:
+            sample_name = f"{njt.dim()}D: {dtype} -> {other_dtype}"
+            yield SampleInput(njt.clone().detach(), kwargs={"dtype": dtype}, name=sample_name)
+
+        other_device = "cuda" if device == "cpu" else "cpu"
+        sample_name = f"{njt.dim()}D: {device} -> {other_device}"
+        yield SampleInput(njt.clone().detach(), kwargs={"device": other_device}, name=sample_name)
+
+
 def sample_inputs_masked_select(
     op_info, device, dtype, requires_grad, op_kwargs=None, **kwargs
 ):
@@ -463,6 +482,7 @@ njt_sample_inputs = {
     "nn.functional.threshold": sample_inputs_nn_functional_threshold,
     **{f"polygamma.polygamma_n_{n}": sample_inputs_polygamma_n(n=n) for n in range(5)},
     "special.polygamma.special_polygamma_n_0": sample_inputs_special_polygamma_n(n=0),
+    "to": sample_inputs_to,
     "masked_select": sample_inputs_masked_select,
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137126
* #137125
* #137099
* __->__ #137124
* #137031
* #137030

Called out via torchrec integration: `lengths` is not handled properly.

Future work (not related to non-contiguous NJTs): #137275