### PR TITLE
Allow opt-einsum to be a real dependency now as v3.4 is numpy-free

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -134,7 +134,7 @@ numba==0.55.2 ; python_version == "3.10"
 #Pinned versions: 1.9.0
 #test that import:
 
-opt-einsum==3.3
+opt-einsum>=3.4
 #Description: Python library to optimize tensor contraction order, used in einsum
 #Pinned versions: 3.3
 #test that import: test_linalg.py

--- a/.github/actions/linux-test/action.yml
+++ b/.github/actions/linux-test/action.yml
@@ -251,7 +251,7 @@ runs:
         # Propagate download.pytorch.org IP to container
         grep download.pytorch.org /etc/hosts | docker exec -i "${container_name}" sudo bash -c "/bin/cat >> /etc/hosts"
         echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
-        docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
+        docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl) && ${TEST_COMMAND}"
 
     - name: Upload pytest cache if tests failed
       uses: ./.github/actions/pytest-cache-upload

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -8,7 +8,7 @@ networkx==2.8.7
 # Use numba-0.49.1 or older on Intel Macs, but 0.56.0 on M1 machines, as older numba is not available
 numba==0.56.0; platform_machine == "arm64"
 numba<=0.49.1; platform_machine != "arm64"
-opt-einsum>=3.3
+opt-einsum>=3.4
 psutil==5.9.1
 nvidia-ml-py==11.525.84
 packaging==23.1

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -177,7 +177,7 @@ jobs:
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
-          docker exec -t "${container_name}" bash -c "sudo chown -R jenkins . && pip install $(echo dist/*.whl)[opt-einsum] && ./.ci/pytorch/${DOCS_TYPE}_doc_push_script.sh"
+          docker exec -t "${container_name}" bash -c "sudo chown -R jenkins . && pip install $(echo dist/*.whl) && ./.ci/pytorch/${DOCS_TYPE}_doc_push_script.sh"
 
       - name: Chown workspace
         uses: ./.github/actions/chown-workspace

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -290,7 +290,7 @@ jobs:
           # Propagate download.pytorch.org IP to container
           grep download.pytorch.org /etc/hosts | docker exec -i "${container_name}" sudo bash -c "/bin/cat >> /etc/hosts"
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
-          docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
+          docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl) && ${TEST_COMMAND}"
 
       - name: Upload pytest cache if tests failed
         uses: ./.github/actions/pytest-cache-upload

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           pushd "${PYTORCH_FINAL_PACKAGE_DIR}"
           # shellcheck disable=SC2046,SC2102
-          python3 -mpip install $(echo *.whl)[opt-einsum,optree] optree==0.12.1
+          python3 -mpip install $(echo *.whl)[optree] optree==0.12.1
           popd
 
           .ci/pytorch/win-test.sh

--- a/setup.py
+++ b/setup.py
@@ -1148,6 +1148,7 @@ def main():
         "networkx",
         "jinja2",
         "fsspec",
+        "opt-einsum>=3.4",
     ]
 
     if BUILD_PYTHON_ONLY:
@@ -1204,7 +1205,6 @@ def main():
 
     extras_require = {
         "optree": ["optree>=0.12.0"],
-        "opt-einsum": ["opt-einsum>=3.3"],
     }
 
     # Read in README.md for our long_description


### PR DESCRIPTION
Partially addresses #127109 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137138

