### PR TITLE
Fix test_out when run on CPU with CUDA available

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -18,7 +18,10 @@ import torch
 import torch._prims as prims
 import torch.utils._pytree as pytree
 from torch._prims.context import TorchRefsMode
-from torch._prims_common.wrappers import _maybe_remove_out_wrapper
+from torch._prims_common.wrappers import (
+    _maybe_remove_out_wrapper,
+    is_cpu_scalar,
+)
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._subclasses.fake_utils import outputs_alias_inputs
 from torch.testing import make_tensor
@@ -1100,6 +1103,8 @@ class TestCommon(TestCase):
                 out = _apply_out_transform(_case_three_transform, expected)
 
                 if op.is_factory_function and sample.kwargs.get("device", None) is None:
+                    op_out(out=out)
+                elif is_cpu_scalar(sample.input):
                     op_out(out=out)
                 else:
                     msg_fail = (

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1084,12 +1084,13 @@ class TestCommon(TestCase):
             # Case 3: out= with correct shape and dtype, but wrong device.
             #   Expected behavior: throws an error.
             #   This case is ignored on CPU to allow some scalar operations to succeed.
+            factory_fn_msg = (
+                "\n\nNOTE: If your op is a factory function (i.e., it accepts TensorOptions) you should mark its "
+                "OpInfo with `is_factory_function=True`."
+            )
+
             if torch.device(device).type != "cpu":
                 wrong_device = "cpu"
-                factory_fn_msg = (
-                    "\n\nNOTE: If your op is a factory function (i.e., it accepts TensorOptions) you should mark its "
-                    "OpInfo with `is_factory_function=True`."
-                )
 
                 def _case_three_transform(t):
                     return make_tensor(t.shape, dtype=t.dtype, device=wrong_device)


### PR DESCRIPTION
Ever since #135140, this test will fail if run with CPU parameterization (e.g. test_out__refs_logical_or_cpu_float32) and CUDA available - as far as I can tell, the PyTorch CI isn't currently checking for this.


cc @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov