### PR TITLE
[inductor mkldnn test][BE] Use parametrize to shorten test run time

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -295,42 +295,16 @@ if RUN_CPU:
                 ],
             ],
         ),
-        BaseTest(
-            "test_qlinear",
-            "cpu",
-            test_mkldnn_pattern_matcher.TestPatternMatcher(),
-            condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
-        ),
-        BaseTest(
-            "test_qlinear_relu",
-            "cpu",
-            test_mkldnn_pattern_matcher.TestPatternMatcher(),
-            condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
-        ),
-        BaseTest(
-            "test_qlinear_gelu",
-            "cpu",
-            test_mkldnn_pattern_matcher.TestPatternMatcher(),
-            condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
-        ),
-        BaseTest(
-            "test_qlinear_add",
-            "cpu",
-            test_mkldnn_pattern_matcher.TestPatternMatcher(),
-            condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
-        ),
-        BaseTest(
-            "test_qlinear_add_relu",
-            "cpu",
-            test_mkldnn_pattern_matcher.TestPatternMatcher(),
-            condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
-        ),
-        BaseTest(
-            "test_qlinear_dequant_promotion",
-            "cpu",
-            test_mkldnn_pattern_matcher.TestPatternMatcher(),
-            condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
-        ),
+        *[
+            BaseTest(
+                func,
+                "",
+                test_mkldnn_pattern_matcher.TestPatternMatcher(),
+                condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
+            )
+            for func in dir(test_mkldnn_pattern_matcher.TestPatternMatcher())
+            if func.startswith("test_qlinear")
+        ],
         BaseTest(
             "test_dynamic_qlinear",
             "cpu",

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -19,7 +19,13 @@ from torch.testing._internal.common_quantization import (
     skipIfNoONEDNN,
     skipIfNoONEDNNBF16,
 )
-from torch.testing._internal.common_utils import IS_LINUX, skipIfRocm, TEST_MKL
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    IS_LINUX,
+    parametrize,
+    skipIfRocm,
+    TEST_MKL,
+)
 from torch.testing._internal.inductor_utils import _check_has_dynamic_shape, HAS_CPU
 
 
@@ -1681,7 +1687,9 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 (torch.randn((2, 4)),), gelu, int8_mixed_bf16=True
             )
 
-    def _qlinear_add_cpu_test_helper(self, use_relu=False, int8_mixed_bf16=False):
+    def _qlinear_add_cpu_test_helper(
+        self, use_relu=False, int8_mixed_bf16=False, is_qat=True, is_dynamic=True
+    ):
         r"""
         This testcase will quantize two consecutive Linear->Add(->relu) patterns as:
                  X
@@ -1783,72 +1791,70 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     (4 if is_dynamic else 5) + 2 * use_relu + to_bf16_after_binary,
                 )
 
-            is_qat_list = [False, True]
-            is_dynamic_list = [False, True]
-            cases = itertools.product(is_qat_list, is_dynamic_list)
-            for is_qat, is_dynamic in cases:
-                self._test_common(
+            self._test_common(
+                mod,
+                (v,),
+                check_quantization=True,
+                check_autocast=torch.bfloat16 if int8_mixed_bf16 else torch.float,
+                matcher_check_fn=matcher_check_fn,
+                is_qat=is_qat,
+                is_dynamic=is_dynamic,
+            )
+            if torch._inductor.config.cpp_wrapper:
+                # For CPP wrapper
+                self._test_code_common(
                     mod,
                     (v,),
+                    [
+                        "torch.ops.onednn.qlinear_pointwise.tensor",
+                        "torch.ops.onednn.qlinear_pointwise.binary",
+                    ]
+                    if config.abi_compatible
+                    else [
+                        "op_onednn_qlinear_pointwise_tensor.call",
+                        "op_onednn_qlinear_pointwise_binary_tensor.call",
+                    ],
+                    [],
                     check_quantization=True,
-                    check_autocast=torch.bfloat16 if int8_mixed_bf16 else torch.float,
-                    matcher_check_fn=matcher_check_fn,
-                    is_qat=is_qat,
-                    is_dynamic=is_dynamic,
+                    num_include_ops=[4, 4] if config.abi_compatible else [2, 2],
                 )
-                if torch._inductor.config.cpp_wrapper:
-                    # For CPP wrapper
-                    self._test_code_common(
-                        mod,
-                        (v,),
-                        [
-                            "torch.ops.onednn.qlinear_pointwise.tensor",
-                            "torch.ops.onednn.qlinear_pointwise.binary",
-                        ]
-                        if config.abi_compatible
-                        else [
-                            "op_onednn_qlinear_pointwise_tensor.call",
-                            "op_onednn_qlinear_pointwise_binary_tensor.call",
-                        ],
-                        [],
-                        check_quantization=True,
-                        num_include_ops=[4, 4] if config.abi_compatible else [2, 2],
-                    )
-                else:
-                    # For python wrapper
-                    self._test_code_common(
-                        mod,
-                        (v,),
-                        [
-                            "torch.ops.onednn.qlinear_pointwise.tensor",
-                            "torch.ops.onednn.qlinear_pointwise.binary",
-                        ],
-                        [],
-                        check_quantization=True,
-                        num_include_ops=[2, 2],
-                    )
+            else:
+                # For python wrapper
+                self._test_code_common(
+                    mod,
+                    (v,),
+                    [
+                        "torch.ops.onednn.qlinear_pointwise.tensor",
+                        "torch.ops.onednn.qlinear_pointwise.binary",
+                    ],
+                    [],
+                    check_quantization=True,
+                    num_include_ops=[2, 2],
+                )
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
-    def test_qlinear_add_cpu(self):
-        self._qlinear_add_cpu_test_helper()
+    @parametrize("use_relu", [True, False])
+    @parametrize("is_qat", [True, False])
+    @parametrize("is_dynamic", [True, False])
+    def test_qlinear_add_cpu(self, use_relu, is_qat, is_dynamic):
+        self._qlinear_add_cpu_test_helper(
+            use_relu=use_relu, is_qat=is_qat, is_dynamic=is_dynamic
+        )
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNNBF16
     @skipIfNoONEDNN
-    def test_qlinear_add_int8_mixed_bf16(self):
-        self._qlinear_add_cpu_test_helper(int8_mixed_bf16=True)
-
-    @skipIfNoDynamoSupport
-    @skipIfNoONEDNN
-    def test_qlinear_add_relu_cpu(self):
-        self._qlinear_add_cpu_test_helper(use_relu=True)
-
-    @skipIfNoDynamoSupport
-    @skipIfNoONEDNNBF16
-    @skipIfNoONEDNN
-    def test_qlinear_add_relu_int8_mixed_bf16(self):
-        self._qlinear_add_cpu_test_helper(use_relu=True, int8_mixed_bf16=True)
+    @parametrize("use_relu", [True, False])
+    @parametrize("is_qat", [True, False])
+    @parametrize("is_dynamic", [True, False])
+    def test_qlinear_add_int8_mixed_bf16(self, use_relu, is_qat, is_dynamic):
+        self._qlinear_add_cpu_test_helper(
+            int8_mixed_bf16=True,
+            use_relu=use_relu,
+            is_qat=is_qat,
+            is_dynamic=is_dynamic,
+        )
 
     def _qlinear_dequant_promotion_cpu_test_helper(
         self,
@@ -2852,6 +2858,8 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 quantizer=quantizer,
             )
 
+
+instantiate_parametrized_tests(TestPatternMatcher)
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_CPU and torch.backends.mkldnn.is_available():


### PR DESCRIPTION
Summary:
Tests in test_mkldnn_pattern_matcher.py can take too long to finish. Splitting them into smaller tests, using `parametrize`.

I guess this means this test file has some refactoring opportunities as well. Next time would be the parametrize the add functions.

Differential Revision: D63723925


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang