### PR TITLE
Fix unlift to unblock training IR + run_decomp on aliasing constants

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -7067,7 +7067,7 @@ def forward(self, x, y):
         m2 = M2()
         m1 = M1(m2, m2.foo)
         inps = (torch.ones(3, 3),)
-        ep = torch.export.export(m1, inps, strict=False)
+        ep = export(m1, inps, strict=False)
         # check both constants appear in list
         self.assertEqual(sorted(list(ep.constants)), ["foo", "m2.foo"])
         # check only one input spec exists

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 import torch.utils._pytree as pytree
 from torch._export.utils import _check_input_constraints_for_graph
-from torch.export.unflatten import _assign_attr, _AttrKind, _recursive_getattr
+from torch.export.unflatten import _assign_attr, _AttrKind
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 
 from ._remove_effect_tokens_pass import _remove_effect_tokens
@@ -297,7 +297,7 @@ def _create_stateful_graph_module(
             )
             buffer = buffer.detach()
         *prefix, field = constant_fqn.rsplit(".")
-        submod = _recursive_getattr(stateful_gm, prefix)
+        submod = torch.fx.graph_module._get_attr_via_attr_list(stateful_gm, prefix)
         delattr(submod, field)
         _assign_attr(buffer, stateful_gm, constant_fqn, attr_kind=_AttrKind.CONSTANT)
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -28,6 +28,7 @@ __all__ = [
 
 _USER_PRESERVED_ATTRIBUTES_KEY = "_user_preserved_attributes"
 
+
 # Normal exec loses the source code, however we can work with
 # the linecache module to recover it.
 # Using _exec_with_source will add it to our local cache
@@ -113,7 +114,9 @@ def _format_import_statement(name: str, obj: Any, importer: Importer) -> str:
 
 
 def _format_import_block(globals: Dict[str, Any], importer: Importer):
-    import_strs: Set[str] = {_format_import_statement(name, obj, importer) for name, obj in globals.items()}
+    import_strs: Set[str] = {
+        _format_import_statement(name, obj, importer) for name, obj in globals.items()
+    }
     # Sort the imports so we have a stable import block that allows us to
     # hash the graph module and get a consistent key for use in a cache.
     return "\n".join(sorted(import_strs))
@@ -157,7 +160,9 @@ class _CodeOnlyModule(torch.nn.Module):
         self.__dict__ = body
 
 
-def _deserialize_graph_module(forward, body: Dict[Any, Any], graph_module_cls=None) -> torch.nn.Module:
+def _deserialize_graph_module(
+    forward, body: Dict[Any, Any], graph_module_cls=None
+) -> torch.nn.Module:
     """
     Deserialize a GraphModule given the dictionary of the original module,
     using the code to reconstruct the graph. We delete the actual graph before
@@ -195,7 +200,10 @@ def _deserialize_graph_module(forward, body: Dict[Any, Any], graph_module_cls=No
     # referencing the private local subclass KeepModules.
     graph._tracer_cls = tracer_cls
     from ._lazy_graph_module import _make_graph_module
-    gm = _make_graph_module(com, graph, class_name=graphmodule_cls_name, graph_module_cls=graph_module_cls)
+
+    gm = _make_graph_module(
+        com, graph, class_name=graphmodule_cls_name, graph_module_cls=graph_module_cls
+    )
 
     # The GraphModule constructor only retains attributes referenced by the graph.
     # In this case, our goal is return a GraphModule as close to identical as the one
@@ -257,6 +265,28 @@ def _assign_attr(from_obj: Any, to_module: torch.nn.Module, target: str):
         setattr(to_module, field, from_obj)
 
 
+# Recursively look up target from a graph module.
+def _get_attr(model: torch.nn.Module, attr_name: str):
+    *prefix, field = attr_name.split(".")
+    t = model
+    for item in prefix:
+        t = getattr(t, item, None)  # type: ignore[assignment]
+        assert t is not None
+
+    return getattr(t, field)
+
+
+def _has_attr(model: torch.nn.Module, attr_name: str):
+    *prefix, field = attr_name.split(".")
+    t = model
+    for item in prefix:
+        t = hasattr(t, item)  # type: ignore[assignment]
+        if t is False:
+            return False
+
+    return hasattr(t, field)
+
+
 def _print_readable(
     module,
     module_name,
@@ -266,7 +296,9 @@ def _print_readable(
     colored=False,
 ):
     graph = module.graph
-    assert graph is not None and isinstance(graph, torch.fx.Graph), "print_readable must be used on a module with a graph"
+    assert graph is not None and isinstance(
+        graph, torch.fx.Graph
+    ), "print_readable must be used on a module with a graph"
 
     verbose_python_code = graph.python_code(
         root_module="self",
@@ -348,9 +380,11 @@ class _WrappedCall:
                 return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
         except Exception as e:
             assert e.__traceback__
-            topmost_framesummary: traceback.FrameSummary = (
-                traceback.StackSummary.extract(traceback.walk_tb(e.__traceback__))[-1]
-            )  # type: ignore[arg-type]
+            topmost_framesummary: (
+                traceback.FrameSummary
+            ) = traceback.StackSummary.extract(traceback.walk_tb(e.__traceback__))[
+                -1
+            ]  # type: ignore[arg-type]
             if "eval_with_key" in topmost_framesummary.filename:
                 print(
                     _WrappedCall._generate_error_message(topmost_framesummary),
@@ -359,6 +393,7 @@ class _WrappedCall:
                 raise e.with_traceback(None)  # noqa: B904
             else:
                 raise e
+
 
 @compatibility(is_backward_compatible=True)
 class GraphModule(torch.nn.Module):
@@ -568,7 +603,9 @@ class {module_name}(torch.nn.Module):
                 blobified_modules.append(module_name)
                 module_repr = module.__repr__().replace("\r", " ").replace("\n", " ")
                 # weights_only=False as this is legacy code that saves the model
-                module_str = f"torch.load(r'{module_file}', weights_only=False) # {module_repr}"
+                module_str = (
+                    f"torch.load(r'{module_file}', weights_only=False) # {module_repr}"
+                )
             model_str += f"{tab*2}self.{module_name} = {module_str}\n"
 
         for buffer_name, buffer in self._buffers.items():
@@ -849,7 +886,7 @@ class {module_name}(torch.nn.Module):
             "_load_state_dict_post_hooks",
             "_replace_hook",
             "_create_node_hooks",
-            "_erase_node_hooks"
+            "_erase_node_hooks",
         ]
         for attr in extra_preserved_attrs:
             if attr in self.__dict__:
@@ -862,12 +899,19 @@ class {module_name}(torch.nn.Module):
 
     def __copy__(self):
         from ._lazy_graph_module import _make_graph_module
+
         res = _make_graph_module(self, self.graph)
         res.meta = getattr(self, "meta", {})
         return res
 
     @compatibility(is_backward_compatible=False)
-    def print_readable(self, print_output=True, include_stride=False, include_device=False, colored=False):
+    def print_readable(
+        self,
+        print_output=True,
+        include_stride=False,
+        include_device=False,
+        colored=False,
+    ):
         """
         Return the Python code generated for current GraphModule and its children GraphModules
         """
@@ -938,6 +982,7 @@ class {module_name}(torch.nn.Module):
         """
         assert callable(f), "erase_node hook must be a callable."
         self._erase_node_hooks.remove(f)
+
 
 # workarounds for issues in __torch_function__
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -271,6 +271,8 @@ def _get_attr(model: torch.nn.Module, attr_name: str):
 
 
 def _get_attr_via_attr_list(model: torch.nn.Module, attr_list: List[str]):
+    if len(attr_list) == 0:
+        return model
     *prefix, field = attr_list
     t = model
     for item in prefix:

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -267,7 +267,11 @@ def _assign_attr(from_obj: Any, to_module: torch.nn.Module, target: str):
 
 # Recursively look up target from a graph module.
 def _get_attr(model: torch.nn.Module, attr_name: str):
-    *prefix, field = attr_name.split(".")
+    return _get_attr_via_attr_list(model, attr_name.split("."))
+
+
+def _get_attr_via_attr_list(model: torch.nn.Module, attr_list: List[str]):
+    *prefix, field = attr_list
     t = model
     for item in prefix:
         t = getattr(t, item, None)  # type: ignore[assignment]

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -1,24 +1,23 @@
 # mypy: allow-untyped-defs
-from dataclasses import dataclass, field
-from collections import defaultdict
 import copy
-import torch
-from torch.fx import (
-    Node,
-    Graph,
-)
-from torch.fx._compatibility import compatibility
-from typing import Dict, List, Set, Any, Union, Tuple
 import logging
 import os
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Set, Tuple, Union
 
-__all__ = ['SubgraphMatcher', 'InternalMatch']
+import torch
+from torch.fx import Graph, Node
+from torch.fx._compatibility import compatibility
+
+__all__ = ["SubgraphMatcher", "InternalMatch"]
+
 
 # Set`PYTORCH_MATCHER_LOGLEVEL=INFO` to see debug logs
 def _init_logger():
     logger = logging.getLogger(__name__)
 
-    level = os.environ.get('PYTORCH_MATCHER_LOGLEVEL', 'WARNING').upper()
+    level = os.environ.get("PYTORCH_MATCHER_LOGLEVEL", "WARNING").upper()
     logger.setLevel(level)
     console = logging.StreamHandler()
     formatter = logging.Formatter("%(filename)s > %(message)s")
@@ -29,7 +28,9 @@ def _init_logger():
     logger.propagate = False
     return logger
 
+
 logger = _init_logger()
+
 
 @compatibility(is_backward_compatible=False)
 @dataclass
@@ -50,17 +51,24 @@ class InternalMatch:
     name_node_map: Dict[str, Node] = field(default_factory=dict)
 
     def __copy__(self):
-        return InternalMatch(anchors=self.anchors, nodes_map=self.nodes_map.copy(),
-                             placeholder_nodes=self.placeholder_nodes.copy(),
-                             returning_nodes=self.returning_nodes.copy())
+        return InternalMatch(
+            anchors=self.anchors,
+            nodes_map=self.nodes_map.copy(),
+            placeholder_nodes=self.placeholder_nodes.copy(),
+            returning_nodes=self.returning_nodes.copy(),
+        )
+
 
 @compatibility(is_backward_compatible=False)
 class SubgraphMatcher:
-    def __init__(self, pattern: Graph,
-                 match_output: bool = False,
-                 match_placeholder: bool = False,
-                 remove_overlapping_matches: bool = True,
-                 ignore_literals: bool = False) -> None:
+    def __init__(
+        self,
+        pattern: Graph,
+        match_output: bool = False,
+        match_placeholder: bool = False,
+        remove_overlapping_matches: bool = True,
+        ignore_literals: bool = False,
+    ) -> None:
         """
         Args:
             pattern: the targeted matching pattern, represented in fx.Graph.
@@ -81,16 +89,21 @@ class SubgraphMatcher:
         self.ignore_literals = ignore_literals
 
         if len(pattern.nodes) == 0:
-            raise ValueError("SubgraphMatcher cannot be initialized with an empty pattern")
+            raise ValueError(
+                "SubgraphMatcher cannot be initialized with an empty pattern"
+            )
 
         for node in pattern.nodes:
             if node.op != "output":
-                assert len(node.users) > 0, \
-                       "SubgraphMatcher cannot be initialized with an pattern with dead code"
+                assert (
+                    len(node.users) > 0
+                ), "SubgraphMatcher cannot be initialized with an pattern with dead code"
 
         # TODO: assert pattern is a connected graph
 
-        self.pattern_placeholder_nodes = [n for n in pattern.nodes if n.op == "placeholder"]
+        self.pattern_placeholder_nodes = [
+            n for n in pattern.nodes if n.op == "placeholder"
+        ]
         output_node = next(iter(reversed(pattern.nodes)))
         # nodes returned by outputs
         self.pattern_returning_nodes: List[Node] = output_node.all_input_nodes
@@ -101,25 +114,17 @@ class SubgraphMatcher:
         else:
             # If a node has output_node as the ONLY user, then this node is a graph sink,
             # and should be matched against as an anchor
-            self.pattern_anchors = [n for n in output_node.all_input_nodes if len(n.users) == 1]
+            self.pattern_anchors = [
+                n for n in output_node.all_input_nodes if len(n.users) == 1
+            ]
 
     def _match_attributes(self, pn: Node, gn: Node) -> bool:
         # Attributes matching is complicated. Right now we only support matching constant tensor
         assert isinstance(pn.target, str), f"pn.target {pn.target} must be a string."
         assert isinstance(gn.target, str), f"gn.target {gn.target} must be a string."
 
-        # TODO(tmanlaibaatar) should probably make this actual API
-        def _getattr(model: torch.fx.GraphModule, attr_name: str):
-            *prefix, field = attr_name.split(".")
-            t = model
-            for item in prefix:
-                t = getattr(t, item, None)  # type: ignore[assignment]
-                assert t is not None
-
-            return getattr(t, field)
-
-        pn_value = _getattr(pn.graph.owning_module, pn.target)
-        gn_value = _getattr(gn.graph.owning_module, gn.target)
+        pn_value = torch.fx.graph_module._get_attr(pn.graph.owning_module, pn.target)
+        gn_value = torch.fx.graph_module._get_attr(gn.graph.owning_module, gn.target)
 
         if type(pn_value) != type(gn_value):
             return False
@@ -149,7 +154,9 @@ class SubgraphMatcher:
         # that are part of `pattern`
 
         # Placeholders can be used by other nodes in the graphs
-        lookup: Dict[Node, Node] = {gn : pn for pn, gn in nodes_map.items() if pn.op != "placeholder"}
+        lookup: Dict[Node, Node] = {
+            gn: pn for pn, gn in nodes_map.items() if pn.op != "placeholder"
+        }
 
         for gn, pn in lookup.items():
             # nodes returned by output are allowed to be used in other areas of the graph
@@ -163,7 +170,9 @@ class SubgraphMatcher:
                     return False
         return True
 
-    def _remove_overlapping_matches(self, matches: List[InternalMatch]) -> List[InternalMatch]:
+    def _remove_overlapping_matches(
+        self, matches: List[InternalMatch]
+    ) -> List[InternalMatch]:
         non_overlapping_matches: List[InternalMatch] = []
         nodes_matched: Set[Node] = set()
 
@@ -182,7 +191,9 @@ class SubgraphMatcher:
         return non_overlapping_matches
 
     def _match_literals(self, pn: Any, gn: Any, match: InternalMatch) -> bool:
-        assert not (isinstance(pn, Node) and isinstance(gn, Node)), "pn and gn cannot both be Node"
+        assert not (
+            isinstance(pn, Node) and isinstance(gn, Node)
+        ), "pn and gn cannot both be Node"
 
         if isinstance(pn, Node) and not isinstance(gn, Node):
             if pn.op == "placeholder":
@@ -203,7 +214,9 @@ class SubgraphMatcher:
     def _match_nodes(self, pn: Node, gn: Node, match: InternalMatch) -> bool:
         logger.info("  matching %s to %s", pn, gn)
 
-        assert isinstance(pn, Node) and isinstance(gn, Node), str(f"pn and gn must be Node, pn: {pn}, gn: {gn}")
+        assert isinstance(pn, Node) and isinstance(gn, Node), str(
+            f"pn and gn must be Node, pn: {pn}, gn: {gn}"
+        )
 
         # Check if we've already matched these nodes in the current
         # traversal
@@ -240,7 +253,9 @@ class SubgraphMatcher:
                 elif isinstance(a1, (list, tuple)) and isinstance(a2, (list, tuple)):
                     matched = _match_args(a1, a2)
                 else:
-                    matched = self._match_literals(a1, a2, match) or self.ignore_literals
+                    matched = (
+                        self._match_literals(a1, a2, match) or self.ignore_literals
+                    )
 
                 if not matched:
                     return False
@@ -250,9 +265,12 @@ class SubgraphMatcher:
         # Flatten all args/kwargs into 1 list of args
         pn_args, gn_args = None, None
         if (
-            (len(pn.args) != len(gn.args) or list(pn.kwargs.keys()) != list(gn.kwargs.keys())) and
-            pn.op == "call_function" and
-            isinstance(pn.target, torch._ops.OpOverload)
+            (
+                len(pn.args) != len(gn.args)
+                or list(pn.kwargs.keys()) != list(gn.kwargs.keys())
+            )
+            and pn.op == "call_function"
+            and isinstance(pn.target, torch._ops.OpOverload)
         ):
             args_schema = pn.target._schema.arguments
 
@@ -270,7 +288,9 @@ class SubgraphMatcher:
             pn_args = get_all_arguments(pn.args, pn.kwargs)
             gn_args = get_all_arguments(gn.args, gn.kwargs)
 
-        elif len(pn.args) == len(gn.args) and list(pn.kwargs.keys()) == list(gn.kwargs.keys()):
+        elif len(pn.args) == len(gn.args) and list(pn.kwargs.keys()) == list(
+            gn.kwargs.keys()
+        ):
             pn_args = list(pn.args)
             gn_args = list(gn.args)
             pn_args.extend(list(pn.kwargs.values()))
@@ -279,10 +299,10 @@ class SubgraphMatcher:
             match_found = False
 
         match_found = (
-            match_found and
-            pn_args is not None and
-            gn_args is not None and
-            _match_args(pn_args, gn_args)
+            match_found
+            and pn_args is not None
+            and gn_args is not None
+            and _match_args(pn_args, gn_args)
         )
 
         if not match_found:
@@ -344,8 +364,12 @@ class SubgraphMatcher:
 
         def backtracking(anchor_index, match):
             if anchor_index == len(match_candidates_list):
-                match.placeholder_nodes = [match.nodes_map[pn] for pn in self.pattern_placeholder_nodes]
-                match.returning_nodes = [match.nodes_map[pn] for pn in self.pattern_returning_nodes]
+                match.placeholder_nodes = [
+                    match.nodes_map[pn] for pn in self.pattern_placeholder_nodes
+                ]
+                match.returning_nodes = [
+                    match.nodes_map[pn] for pn in self.pattern_returning_nodes
+                ]
                 matches.append(match)
 
                 logger.info("Found a match: %s\n", match)
@@ -362,7 +386,9 @@ class SubgraphMatcher:
                     # match next anchor
                     backtracking(anchor_index + 1, match)
                 else:
-                    logger.info("Failed to match anchor %s to %s\n", pattern_anchor, node)
+                    logger.info(
+                        "Failed to match anchor %s to %s\n", pattern_anchor, node
+                    )
 
                 # revert to saved_match before matching with current anchor
                 match = copy.copy(saved_match)
@@ -376,25 +402,37 @@ class SubgraphMatcher:
         matches = [match for match in matches if self._is_contained(match.nodes_map)]
         after = len(matches)
         if before != after:
-            logger.info("Filtered out %s matches because they are not fully contained", before - after)
+            logger.info(
+                "Filtered out %s matches because they are not fully contained",
+                before - after,
+            )
 
         # filter out the matches that form a cycle if the subgraph is fused
         valid_matches = []
         for match in matches:
-            matched_compute_nodes = \
-                [gn for pn, gn in match.nodes_map.items() if pn.op not in {"placeholder", "output"}]
+            matched_compute_nodes = [
+                gn
+                for pn, gn in match.nodes_map.items()
+                if pn.op not in {"placeholder", "output"}
+            ]
             if validate_partition(matched_compute_nodes):
                 valid_matches.append(match)
         if len(valid_matches) != len(matches):
-            logger.info("Filtered out %s matches because \
-                          matched subgraph would form a cycle if fused", len(matches) - len(valid_matches))
+            logger.info(
+                "Filtered out %s matches because \
+                          matched subgraph would form a cycle if fused",
+                len(matches) - len(valid_matches),
+            )
 
         if self.remove_overlapping_matches:
             before = len(valid_matches)
             matches = self._remove_overlapping_matches(valid_matches)
             after = len(matches)
             if before != after:
-                logger.info("Filtered out %s matches because matched subgraphs are overlapping", before - after)
+                logger.info(
+                    "Filtered out %s matches because matched subgraphs are overlapping",
+                    before - after,
+                )
 
         logger.info("Matches returned: %s", matches)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137162

When we populate unlifted graph module, we actually only "unlift" constant tensor inputs which is problematic because export de-duplicates aliasing constants. As a result, we only register one constant instead of two constants. This PR fixes that by querying ep.constants table instead of ep.graph_signature.lifted_tensor_constants. 

Differential Revision: [D63743111](https://our.internmc.facebook.com/intern/diff/D63743111)