### PR TITLE
[BE] [CI] Skip clean gha workspace if CI is running in a container for checkout-pytorch

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Check if in a container runner
       shell: bash
       id: check_container_runner
-      run: echo "IN_CONTAINER_RUNNER=$([ -f /.inarc -o -f /.incontainer ] && echo true || echo false)" >> $GITHUB_OUTPUT
+      run: echo "IN_CONTAINER_RUNNER=$(if [ -f /.inarc ] || [ -f /.incontainer ]; then echo true ; else echo false; fi)" >> "$GITHUB_OUTPUT"
 
     - name: Clean workspace
       shell: bash

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -18,8 +18,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check if in a container runner
+      shell: bash
+      id: check_container_runner
+      run: echo "IN_CONTAINER_RUNNER=$([ -f /.inarc -o -f /.incontainer ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
     - name: Clean workspace
       shell: bash
+      if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
       env:
         NO_SUDO: ${{ inputs.no-sudo }}
       run: |


### PR DESCRIPTION
For the reusable action checkout-pytorch, skips cleaning workspace when running from a container environment.

The motivation for this change is twofold:
* There is no need for cleanup when running in ephemeral containers, as any changes will be discarded when the docker container is terminated;
* In the specific case of GITHUB_WORKSPACE, to enable sharing this between multiple containers, it need to be mounted with `-v`. This prevents the possibility of running `rm -r` and deleting this mount path; 

