### PR TITLE
Enable  clang-tidy on torch/csrc/distributed/autograd/*

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -216,6 +216,8 @@ include_patterns = [
     'torch/csrc/*.cpp',
     'torch/csrc/**/*.h',
     'torch/csrc/**/*.cpp',
+    'torch/csrc/distributed/autograd/*.cpp',
+    'torch/csrc/distributed/autograd/*.h',
     'torch/csrc/jit/serialization/*.h',
     'torch/csrc/jit/serialization/*.cpp',
 ]

--- a/torch/csrc/distributed/autograd/context/container.cpp
+++ b/torch/csrc/distributed/autograd/context/container.cpp
@@ -51,7 +51,7 @@ DistAutogradContainer& DistAutogradContainer::init(int64_t worker_id) {
     return container;
   }
 
-  container.worker_id_ = worker_id;
+  container.worker_id_ = static_cast<int16_t>(worker_id);
   container.next_context_id_ = static_cast<int64_t>(worker_id)
       << kAutoIncrementBits;
   container.next_autograd_message_id_ = static_cast<int64_t>(worker_id)

--- a/torch/csrc/distributed/autograd/context/container.h
+++ b/torch/csrc/distributed/autograd/context/container.h
@@ -5,9 +5,7 @@
 
 #include <torch/csrc/distributed/autograd/context/context.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Singleton class per worker which is responsible for storing the distributed
 // autograd context for each autograd pass and also cleans up data for an
@@ -92,6 +90,8 @@ class TORCH_API DistAutogradContainer {
   // Returns the current thread local context id for this thread.
   static int64_t currentContextId();
 
+  DistAutogradContainer() = delete;
+  ~DistAutogradContainer() = default;
   DistAutogradContainer(const DistAutogradContainer&) = delete;
   DistAutogradContainer& operator=(const DistAutogradContainer&) = delete;
   DistAutogradContainer(DistAutogradContainer&&) = delete;
@@ -117,8 +117,6 @@ class TORCH_API DistAutogradContainer {
     std::unordered_map<int64_t, ContextPtr> contexts;
   };
 
-  DistAutogradContainer() = delete;
-  ~DistAutogradContainer() = default;
 
   static DistAutogradContainer& getInstanceInternal();
 
@@ -162,6 +160,4 @@ class TORCH_API DistAutogradContainer {
   int64_t max_id_;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/context/container.h
+++ b/torch/csrc/distributed/autograd/context/container.h
@@ -117,7 +117,6 @@ class TORCH_API DistAutogradContainer {
     std::unordered_map<int64_t, ContextPtr> contexts;
   };
 
-
   static DistAutogradContainer& getInstanceInternal();
 
   // Retrieve the shard for given context_id.

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -9,9 +9,7 @@
 #include <torch/csrc/distributed/autograd/functions/sendrpc_backward.h>
 #include <torch/csrc/distributed/rpc/rpc_agent.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 class RecvRpcBackward;
 
@@ -169,6 +167,4 @@ class TORCH_API ThreadLocalDistAutogradContext {
   ContextPtr prev_context_ptr_;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/engine/dist_engine.h
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.h
@@ -8,9 +8,7 @@
 #include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/distributed/autograd/context/context.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Forward declaration.
 class BackwardPassCleanupGuard;
@@ -171,6 +169,4 @@ class BackwardPassCleanupGuard {
   ContextPtr autogradContext_;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/functions/recvrpc_backward.h
+++ b/torch/csrc/distributed/autograd/functions/recvrpc_backward.h
@@ -5,9 +5,7 @@
 #include <torch/csrc/distributed/autograd/rpc_messages/autograd_metadata.h>
 #include <torch/csrc/distributed/rpc/rpc_agent.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Forward declarations.
 class DistAutogradContext;
@@ -44,6 +42,4 @@ class TORCH_API RecvRpcBackward : public torch::autograd::Node {
   const rpc::DeviceMap deviceMap_;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/functions/sendrpc_backward.h
+++ b/torch/csrc/distributed/autograd/functions/sendrpc_backward.h
@@ -2,9 +2,7 @@
 
 #include <torch/csrc/autograd/function.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // As part of our distributed autograd implementation, whenever we send an RPC
 // from one node to another, we add a 'SendRpcBackward' autograd function to the
@@ -32,6 +30,4 @@ struct TORCH_API SendRpcBackward : public torch::autograd::Node {
   torch::autograd::variable_list grads_;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/autograd_metadata.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/autograd_metadata.h
@@ -3,9 +3,7 @@
 #include <torch/csrc/Export.h>
 #include <cstdint>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // This structure represents autograd metadata that we need to pass across
 // different nodes when we call an RPC which needs autograd computation.
@@ -20,6 +18,4 @@ struct TORCH_API AutogradMetadata {
   int64_t autogradMessageId;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.h
@@ -4,9 +4,7 @@
 #include <torch/csrc/distributed/rpc/message.h>
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Used to request other workers to clean up their autograd context.
 class TORCH_API CleanupAutogradContextReq : public rpc::RpcCommandBase {
@@ -24,6 +22,4 @@ class TORCH_API CleanupAutogradContextReq : public rpc::RpcCommandBase {
   int64_t context_id_;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.h
@@ -3,9 +3,7 @@
 #include <torch/csrc/distributed/rpc/message.h>
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Empty response for CleanupAutogradContextReq. Send to acknowledge receipt of
 // a CleanupAutogradContextReq.
@@ -18,6 +16,4 @@ class TORCH_API CleanupAutogradContextResp : public rpc::RpcCommandBase {
       const rpc::Message& message);
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.h
@@ -5,9 +5,7 @@
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 #include <vector>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Used to propagate gradients from one node to another during a distributed
 // backwards pass. This RPC call is invoked when we hit a `recv` autograd
@@ -37,6 +35,4 @@ class TORCH_API PropagateGradientsReq : public rpc::RpcCommandBase {
   bool retainGraph_;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.h
@@ -3,9 +3,7 @@
 #include <torch/csrc/distributed/rpc/message.h>
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Response for the PropagateGradients call. Currently, this class is mostly
 // just a placeholder and sends an empty message over the wire. The purpose of
@@ -19,6 +17,4 @@ class TORCH_API PropagateGradientsResp : public rpc::RpcCommandBase {
       const rpc::Message& message);
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.h
@@ -4,9 +4,7 @@
 #include <torch/csrc/distributed/rpc/rpc_agent.h>
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Represents an RPC that includes autograd information. This class basically
 // wraps another `RpcCommandBase` object which represents the actual RPC and has
@@ -93,6 +91,4 @@ class TORCH_API RpcWithAutograd final : public rpc::RpcCommandBase {
   rpc::DeviceMap deviceMap_;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.h
@@ -6,9 +6,7 @@
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 #include <torch/csrc/distributed/rpc/types.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 class TORCH_API RpcWithProfilingReq : public rpc::RpcCommandBase {
  public:
@@ -48,15 +46,16 @@ class TORCH_API RpcWithProfilingReq : public rpc::RpcCommandBase {
 
  private:
   // message type
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const rpc::MessageType messageType_;
   // wrapped message
   c10::intrusive_ptr<rpc::Message> wrappedMessage_;
   std::unique_ptr<RpcCommandBase> wrappedRpc_;
   rpc::MessageType wrappedMessageType_;
   std::vector<torch::Tensor> tensors_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const torch::autograd::profiler::ProfilerConfig profilerConfig_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const rpc::ProfilingId profilingKeyId_;
 };
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.h
@@ -6,9 +6,7 @@
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 #include <torch/csrc/distributed/rpc/types.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 class TORCH_API RpcWithProfilingResp : public rpc::RpcCommandBase {
  public:
   // For sending RPCs over the wire
@@ -45,15 +43,16 @@ class TORCH_API RpcWithProfilingResp : public rpc::RpcCommandBase {
 
  private:
   // message type
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const rpc::MessageType messageType_;
   // wrapped message
   c10::intrusive_ptr<rpc::Message> wrappedMessage_;
   std::unique_ptr<RpcCommandBase> wrappedRpc_;
   rpc::MessageType wrappedMessageType_;
   std::vector<torch::Tensor> tensors_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const std::vector<torch::autograd::profiler::LegacyEvent> profiledEvents_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const rpc::ProfilingId profilingId_;
 };
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.h
@@ -4,9 +4,7 @@
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 #include <torch/csrc/distributed/rpc/types.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Internal system RPC to invoke distributed backward pass on remote nodes when
 // 'rref.backward()' is invoked.
@@ -29,11 +27,12 @@ class TORCH_API RRefBackwardReq : public rpc::RpcCommandBase {
       const rpc::Message& message);
 
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const rpc::RRefId rrefId_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const int64_t autogradContextId_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const bool retainGraph_;
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_resp.h
@@ -3,9 +3,7 @@
 #include <torch/csrc/distributed/rpc/message.h>
 #include <torch/csrc/distributed/rpc/rpc_command_base.h>
 
-namespace torch {
-namespace distributed {
-namespace autograd {
+namespace torch::distributed::autograd {
 
 // Response for the RRefBackwardReq.
 class TORCH_API RRefBackwardResp : public rpc::RpcCommandBase {
@@ -16,6 +14,4 @@ class TORCH_API RRefBackwardResp : public rpc::RpcCommandBase {
       const rpc::Message& message);
 };
 
-} // namespace autograd
-} // namespace distributed
-} // namespace torch
+} // namespace torch::distributed::autograd


### PR DESCRIPTION
Enable clang-tidy on `torch/csrc/distributed/autograd/*` directory.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o