### PR TITLE
Relax mutation to aten.to in export

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -65,6 +65,14 @@ void FunctionalTensorWrapper::freeze_storage() const {
   functional_storage_impl()->freeze();
 }
 
+void FunctionalTensorWrapper::partial_freeze_storage() const {
+  functional_storage_impl()->partial_freeze();
+}
+
+bool FunctionalTensorWrapper::partial_frozen_mutated() const {
+  return functional_storage_impl()->partial_frozen_mutated();
+}
+
 // Note [Functionalization: Alias Removal]
 // When someone calls a view() op during the functionalization pass, e.g. 'b = a.view(...)',
 // we link `b` and `a` to a shared Alias object to preserve the aliasing relationship.
@@ -756,6 +764,18 @@ void freeze_functional_tensor(const Tensor& tensor) {
   TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(tensor));
   auto functional_base_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
   functional_base_impl->freeze_storage();
+}
+
+void partial_freeze_functional_tensor(const Tensor& tensor) {
+  TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(tensor));
+  auto functional_base_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
+  functional_base_impl->partial_freeze_storage();
+}
+
+bool partial_frozen_mutated(const Tensor& tensor) {
+  TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(tensor));
+  auto functional_base_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
+  return functional_base_impl->partial_frozen_mutated();
 }
 
 Tensor create_functional_tensor_with_view_meta(const at::Tensor& view_to_wrap, const at::Tensor& base, functionalization::ViewMeta meta, int64_t out_idx) {

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -139,6 +139,8 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   bool is_up_to_date() const;
   // Freezes the storage of this tensor, preventing subsequent mutations
   void freeze_storage() const;
+  void partial_freeze_storage() const;
+  bool partial_frozen_mutated() const;
   // Every FunctionalTensorWrapper contains a vector<ViewMeta> objects
   // describing the series of view ops that ran to generate the current tensor
   // from the base tensor. This method is used by inplace-view ops like
@@ -312,6 +314,8 @@ TORCH_API c10::List<std::optional<Tensor>> to_functional_tensor(
 TORCH_API std::vector<Tensor> to_functional_tensor(ITensorListRef t_list);
 
 TORCH_API void freeze_functional_tensor(const Tensor& tensor);
+TORCH_API void partial_freeze_functional_tensor(const Tensor& tensor);
+TORCH_API bool partial_frozen_mutated(const Tensor& tensor);
 
 TORCH_API Tensor
 from_functional_tensor(const Tensor& tensor, bool assert_functional = true);

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -628,6 +628,7 @@ def _create_aot_dispatcher_function(
                         keep_input_mutations=aot_config.keep_inference_input_mutations,
                         is_train=needs_autograd,
                         pre_dispatch=aot_config.pre_dispatch,
+                        is_export=aot_config.is_export,
                     )(*_dup_fake_script_obj(fake_flat_args))
 
                 req_subclass_dispatch = requires_subclass_dispatch(

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -748,6 +748,12 @@ void initTorchFunctions(PyObject* module) {
   py_module.def("_freeze_functional_tensor", [](const at::Tensor& t) {
     at::functionalization::impl::freeze_functional_tensor(t);
   });
+  py_module.def("_partial_freeze_functional_tensor", [](const at::Tensor& t) {
+    at::functionalization::impl::partial_freeze_functional_tensor(t);
+  });
+  py_module.def("_partial_frozen_mutated", [](const at::Tensor& t) {
+    return at::functionalization::impl::partial_frozen_mutated(t);
+  });
   py_module.def(
       "_enable_functionalization",
       [](bool reapply_views = false) {


### PR DESCRIPTION
Summary:
Today, we force aten.to to always copy under the hood and ban the mutation on the output of aten.to to address silent behavior divergence from eager mode. But in some cases, this is too strict because we only want to ban mutation if the output has an alias to it.

Here we relax it to: you can mutate the result of aten.to, but you cannot use it for any computation further.

You can:
```
    def forward(self, x):
        y = x + 1
        z = y.to("cpu")
        z.add_(5)
        return x
```

You can't:

```
    def forward(self, x):
        y = x + 1
        z = y.to("cpu")
        z.add_(5)
        return z
```


Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export  -- -r  test_device_to_mutation
```

Differential Revision: D63672868
