### PR TITLE
[PT2][Inductor][Reliability] Add back unit test for pad_mm with BF16

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -9,10 +9,12 @@ from torch._inductor.fx_passes.pad_mm import (
     get_pad_cache,
     get_padded_length,
     should_pad_common,
+    should_pad_mm_bf16,
 )
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_inductor_cache, is_big_gpu, run_and_get_code
 from torch.testing import FileCheck
+from torch.testing._internal.common_utils import skipIfRocm
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
 
@@ -448,6 +450,44 @@ class PadMMTest(TestCase):
         FileCheck().check_count("exclude_pad:False", 3, exactly=True).run(
             repr(get_pad_cache().get_local_cache())
         )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability() >= (9, 0),
+        "No perf regression on H100+ with BF16",
+    )
+    @skipIfRocm
+    @fresh_inductor_cache()
+    @inductor_config.patch(
+        post_grad_fusion_options={"pad_aten_mm_pass": {"k_threshold_to_pad": 8388608}}
+    )
+    def test_pad_mm_bf16(self):
+        m = 2
+        n = 13
+        k = 15691904
+        mat1 = torch.ones((m, k), device="cuda", dtype=torch.bfloat16)
+        mat2 = torch.ones((k, n), device="cuda", dtype=torch.bfloat16)
+        expected_alignment = get_alignment_size(mat1)
+
+        assert expected_alignment == 8, "Alignment for bfloat16 should be 8"
+        assert should_pad_common(
+            mat1, mat2
+        ), "This should pass the common padding criteria"
+        assert should_pad_mm_bf16(
+            mat1.dtype, m, n, k
+        ), "This should pass the should_pad_mm_bf16 padding criteria"
+
+        @torch.compile()
+        def mm(mat1, mat2):
+            return torch.mm(mat1, mat2)
+
+        res2, (code,) = run_and_get_code(mm, mat1, mat2)
+        mm_expected_result = torch.mm(mat1, mat2)
+        # in call code, expect to see a single pad per input, and then we should see padded allocation for output
+        FileCheck().check("del async_compile").check_count(
+            ".run(", 2, exactly=True
+        ).check("empty_strided_cuda((8, 16)").run(code)
+
+        assert torch.allclose(res2, mm_expected_result), "MM results are not identical"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: We added the unit test for recent added pad_mm pattern in customized optimus D63040455, where it will resolve the long computation kernel issue for BF16 on A100.

Test Plan:
```
buck2 test mode/opt //caffe2/test/inductor:pad_mm -- test_pad_mm_bf16
```

Buck UI: https://www.internalfb.com/buck2/4dd4c90c-4a2a-4859-923c-a4008f78a1cd
Test UI: https://www.internalfb.com/intern/testinfra/testrun/9851624237127136
Network: Up: 100KiB  Down: 4.3GiB  (reSessionID-87f11454-d920-47af-9af5-39ca0572b7c6)
Jobs completed: 7079. Time elapsed: 3:34.3s.
Cache hits: 99%. Commands: 7061 (cached: 7024, remote: 19, local: 18)
Tests finished: Pass 2. Fail 0. Fatal 0. Skip 0. Build failure 0

Differential Revision: D63794727




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang