### PR TITLE
[CUDA] Update heuristic deciding embedding backward dispatch

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -259,7 +259,9 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
   auto grad = grad_.contiguous().view({num_indices, grad_.size(-1)});
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  if (num_indices <= 3072 && !scale_grad_by_freq) {
+  static int num_indices_native_kernel = at::cuda::getCurrentDeviceProperties()->major >= 9 ? 4096 : 3072;
+
+  if (num_indices <= num_indices_native_kernel && !scale_grad_by_freq) {
     auto indices_contig = indices.contiguous();
     auto grad_weight = at::zeros({num_weights, grad_.size(-1)}, grad_.options());
     int64_t stride = grad_weight.stride(0);


### PR DESCRIPTION
Follow-up of https://github.com/pytorch/pytorch/pull/49913 for newer hardware

(only the num_tokens == 4096 cases should be affected), benchmarked on power-limited H100
before:
```
bprop num_tokens   512, num_features    64, time 0.000072
bprop num_tokens   512, num_features   256, time 0.000081
bprop num_tokens   512, num_features  1024, time 0.000090
bprop num_tokens   512, num_features  2048, time 0.000134
bprop num_tokens   512, num_features  4096, time 0.000214
bprop num_tokens   512, num_features  8192, time 0.000384
bprop num_tokens  1024, num_features    64, time 0.000068
bprop num_tokens  1024, num_features   256, time 0.000089
bprop num_tokens  1024, num_features  1024, time 0.000113
bprop num_tokens  1024, num_features  2048, time 0.000157
bprop num_tokens  1024, num_features  4096, time 0.000241
bprop num_tokens  1024, num_features  8192, time 0.000416
bprop num_tokens  2048, num_features    64, time 0.000069
bprop num_tokens  2048, num_features   256, time 0.000102
bprop num_tokens  2048, num_features  1024, time 0.000164
bprop num_tokens  2048, num_features  2048, time 0.000204
bprop num_tokens  2048, num_features  4096, time 0.000296
bprop num_tokens  2048, num_features  8192, time 0.000484
bprop num_tokens  4096, num_features    64, time 0.000214
bprop num_tokens  4096, num_features   256, time 0.000222
bprop num_tokens  4096, num_features  1024, time 0.000256
bprop num_tokens  4096, num_features  2048, time 0.000362
bprop num_tokens  4096, num_features  4096, time 0.000570
bprop num_tokens  4096, num_features  8192, time 0.000960
bprop num_tokens  5120, num_features    64, time 0.000211
bprop num_tokens  5120, num_features   256, time 0.000232
bprop num_tokens  5120, num_features  1024, time 0.000269
bprop num_tokens  5120, num_features  2048, time 0.000389
bprop num_tokens  5120, num_features  4096, time 0.000621
bprop num_tokens  5120, num_features  8192, time 0.001066
bprop num_tokens  6144, num_features    64, time 0.000214
bprop num_tokens  6144, num_features   256, time 0.000221
bprop num_tokens  6144, num_features  1024, time 0.000287
bprop num_tokens  6144, num_features  2048, time 0.000422
bprop num_tokens  6144, num_features  4096, time 0.000684
bprop num_tokens  6144, num_features  8192, time 0.001181
bprop num_tokens  8192, num_features    64, time 0.000212
bprop num_tokens  8192, num_features   256, time 0.000218
bprop num_tokens  8192, num_features  1024, time 0.000321
bprop num_tokens  8192, num_features  2048, time 0.000487
bprop num_tokens  8192, num_features  4096, time 0.000805
bprop num_tokens  8192, num_features  8192, time 0.001410
bprop num_tokens 16384, num_features    64, time 0.000210
bprop num_tokens 16384, num_features   256, time 0.000223
bprop num_tokens 16384, num_features  1024, time 0.000436
bprop num_tokens 16384, num_features  2048, time 0.000709
bprop num_tokens 16384, num_features  4096, time 0.001232
bprop num_tokens 16384, num_features  8192, time 0.002228
bprop num_tokens 32768, num_features    64, time 0.000233
bprop num_tokens 32768, num_features   256, time 0.000282
bprop num_tokens 32768, num_features  1024, time 0.000624
bprop num_tokens 32768, num_features  2048, time 0.001070
bprop num_tokens 32768, num_features  4096, time 0.001920
bprop num_tokens 32768, num_features  8192, time 0.003550
bprop num_tokens 65536, num_features    64, time 0.000211
bprop num_tokens 65536, num_features   256, time 0.000301
bprop num_tokens 65536, num_features  1024, time 0.000757
bprop num_tokens 65536, num_features  2048, time 0.001317
bprop num_tokens 65536, num_features  4096, time 0.002399
bprop num_tokens 65536, num_features  8192, time 0.004460
```
after
```
bprop num_tokens   512, num_features    64, time 0.000090
bprop num_tokens   512, num_features   256, time 0.000070
bprop num_tokens   512, num_features  1024, time 0.000091
bprop num_tokens   512, num_features  2048, time 0.000136
bprop num_tokens   512, num_features  4096, time 0.000213
bprop num_tokens   512, num_features  8192, time 0.000382
bprop num_tokens  1024, num_features    64, time 0.000079
bprop num_tokens  1024, num_features   256, time 0.000090
bprop num_tokens  1024, num_features  1024, time 0.000112
bprop num_tokens  1024, num_features  2048, time 0.000154
bprop num_tokens  1024, num_features  4096, time 0.000240
bprop num_tokens  1024, num_features  8192, time 0.000421
bprop num_tokens  2048, num_features    64, time 0.000077
bprop num_tokens  2048, num_features   256, time 0.000109
bprop num_tokens  2048, num_features  1024, time 0.000159
bprop num_tokens  2048, num_features  2048, time 0.000204
bprop num_tokens  2048, num_features  4096, time 0.000295
bprop num_tokens  2048, num_features  8192, time 0.000482
bprop num_tokens  4096, num_features    64, time 0.000122
bprop num_tokens  4096, num_features   256, time 0.000174
bprop num_tokens  4096, num_features  1024, time 0.000257
bprop num_tokens  4096, num_features  2048, time 0.000306
bprop num_tokens  4096, num_features  4096, time 0.000405
bprop num_tokens  4096, num_features  8192, time 0.000602
bprop num_tokens  5120, num_features    64, time 0.000212
bprop num_tokens  5120, num_features   256, time 0.000221
bprop num_tokens  5120, num_features  1024, time 0.000271
bprop num_tokens  5120, num_features  2048, time 0.000394
bprop num_tokens  5120, num_features  4096, time 0.000621
bprop num_tokens  5120, num_features  8192, time 0.001070
bprop num_tokens  6144, num_features    64, time 0.000208
bprop num_tokens  6144, num_features   256, time 0.000218
bprop num_tokens  6144, num_features  1024, time 0.000286
bprop num_tokens  6144, num_features  2048, time 0.000424
bprop num_tokens  6144, num_features  4096, time 0.000686
bprop num_tokens  6144, num_features  8192, time 0.001185
bprop num_tokens  8192, num_features    64, time 0.000218
bprop num_tokens  8192, num_features   256, time 0.000211
bprop num_tokens  8192, num_features  1024, time 0.000479
bprop num_tokens  8192, num_features  2048, time 0.000489
bprop num_tokens  8192, num_features  4096, time 0.000806
bprop num_tokens  8192, num_features  8192, time 0.001407
bprop num_tokens 16384, num_features    64, time 0.000221
bprop num_tokens 16384, num_features   256, time 0.000219
bprop num_tokens 16384, num_features  1024, time 0.000438
bprop num_tokens 16384, num_features  2048, time 0.000709
bprop num_tokens 16384, num_features  4096, time 0.001233
bprop num_tokens 16384, num_features  8192, time 0.002231
bprop num_tokens 32768, num_features    64, time 0.000216
bprop num_tokens 32768, num_features   256, time 0.000275
bprop num_tokens 32768, num_features  1024, time 0.000622
bprop num_tokens 32768, num_features  2048, time 0.001066
bprop num_tokens 32768, num_features  4096, time 0.001922
bprop num_tokens 32768, num_features  8192, time 0.003547
bprop num_tokens 65536, num_features    64, time 0.000217
bprop num_tokens 65536, num_features   256, time 0.000301
bprop num_tokens 65536, num_features  1024, time 0.000755
bprop num_tokens 65536, num_features  2048, time 0.001314
bprop num_tokens 65536, num_features  4096, time 0.002399
bprop num_tokens 65536, num_features  8192, time 0.004468
```


cc @ptrblck @msaroufim