### PR TITLE
handle state tensors in training ir path

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -791,8 +791,8 @@ graph():
                 # z = 4
                 return x + y + z + w2
 
-        ep = torch.export.export(M(), (torch.randn(2, 3),), strict=False)
-        self.assertEqual(ep.graph_signature.buffers_to_mutate, {"add_2": "buf"})
+        ep = export(M(), (torch.randn(2, 3),), strict=False)
+        self.assertEqual(list(ep.graph_signature.buffers_to_mutate.values()), ["buf"])
         self.assertTrue(
             torch.allclose(ep.module()(torch.ones(2, 3) + 1), torch.ones(2, 3) * 12)
         )
@@ -815,7 +815,7 @@ graph():
             ValueError,
             "The tensor attribute self.buf was assigned during export",
         ):
-            torch.export.export(M(), (torch.randn(2, 3),), strict=False)
+            export(M(), (torch.randn(2, 3),), strict=False)
 
         class M(torch.nn.Module):  # complex with register buffer
             def __init__(self) -> None:
@@ -840,9 +840,9 @@ graph():
                 # z = 3 + 3
                 return x + y + z
 
-        ep = torch.export.export(M(), (torch.randn(2, 3),), strict=False)
+        ep = export(M(), (torch.randn(2, 3),), strict=False)
         self.assertEqual(
-            ep.graph_signature.buffers_to_mutate, {"add_1": "buf_0", "add_2": "buf_1"}
+            list(ep.graph_signature.buffers_to_mutate.values()), ["buf_0", "buf_1"]
         )
         self.assertTrue(
             torch.allclose(ep.module()(torch.ones(2, 3) + 1), torch.ones(2, 3) * 10)
@@ -873,7 +873,7 @@ graph():
             ValueError,
             "The tensor attributes self.tensors\\[0\\], self.tensors\\[1\\] were assigned during export",
         ):
-            torch.export.export(M(), (torch.randn(2, 3),), strict=False)
+            export(M(), (torch.randn(2, 3),), strict=False)
 
     def test_state_primitives(self):
         class M(torch.nn.Module):

--- a/torch/_functorch/_aot_autograd/dispatch_and_compile_graph.py
+++ b/torch/_functorch/_aot_autograd/dispatch_and_compile_graph.py
@@ -5,7 +5,7 @@ pathways, taking into account the AOTConfig and the collected ViewAndMutationMet
 """
 
 import dataclasses
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.utils._pytree as pytree
@@ -16,7 +16,6 @@ from torch._dynamo.utils import lazy_format_graph_code
 from torch._logging import getArtifactLogger, trace_structured
 from torch._subclasses.functional_tensor import FunctionalTensorMode
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.utils._python_dispatch import _detect_infra_mode
 
 from .. import config
 from .functional_utils import (
@@ -34,6 +33,7 @@ from .traced_function_transforms import (
 )
 from .utils import (
     copy_fwd_metadata_to_bw_nodes,
+    register_buffer_assignment_hook,
     root_module_when_exporting_non_strict,
     unlift_tokens,
 )
@@ -124,28 +124,9 @@ def aot_dispatch_base_graph(
     if aot_config.is_export and mod_when_exporting_non_strict is not None:
         # For any buffer that is assigned, we want to associate it to the final proxy node
         # that it is assigned to. This node can then be added as a buffer mutation output.
-        assigned_buffers = {}
-
-        def _map_assigned_buffer_to_proxy(_mod, name, buffer):
-            # We intercept buffer assignments on the root module through this hook.
-            if _mod._buffers is mod_when_exporting_non_strict._buffers:
-                # The value assigned to a buffer is a functional tensor, which wraps a fake tensor.
-                assert isinstance(
-                    buffer, torch._subclasses.functional_tensor.FunctionalTensor
-                )
-                fake = buffer.from_functional()
-                # The fake tensor in turn is associated with a proxy node.
-                proxy_mode = _detect_infra_mode(torch._C._TorchDispatchModeKey.PROXY)
-                assert proxy_mode is not None
-                proxy = torch.fx.experimental.proxy_tensor.get_proxy_slot(
-                    fake, proxy_mode.tracer
-                ).proxy.node
-                # We map the assigned buffer to this proxy node.
-                assigned_buffers[name] = proxy.name
-            return buffer
-
-        handle = torch.nn.modules.module.register_module_buffer_registration_hook(
-            _map_assigned_buffer_to_proxy
+        assigned_buffers: Dict[str, str] = {}
+        hook = register_buffer_assignment_hook(
+            mod_when_exporting_non_strict, assigned_buffers
         )
 
     saved_updated_flat_args_subclasses_desugared = pytree.tree_map_only(
@@ -170,7 +151,6 @@ def aot_dispatch_base_graph(
 
         # We add nodes corresponding to buffer assignments as output nodes in the graph.
         add_nodes = []
-        output_node = None
         output_node = list(fw_module.graph.nodes)[-1]
         for name in assigned_buffers.values():  # type: ignore[possibly-undefined]
             for node in fw_module.graph.nodes:
@@ -179,7 +159,7 @@ def aot_dispatch_base_graph(
                     node.users[output_node] = None
         output_node.args = ((*add_nodes, *output_node.args[0]),)
 
-        handle.remove()  # type: ignore[possibly-undefined]
+        hook.remove()  # type: ignore[possibly-undefined]
 
     # As long as we opted to remove input mutations, then
     # there should be *NO* mutating ops in the graph at this point.

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -54,8 +54,14 @@ from torch._functorch._aot_autograd.input_output_analysis import (
 from torch._functorch._aot_autograd.traced_function_transforms import (
     create_functional_call,
 )
-from torch._functorch._aot_autograd.utils import create_tree_flattened_fn
-from torch._functorch.aot_autograd import aot_export_module
+from torch._functorch._aot_autograd.utils import (
+    create_tree_flattened_fn,
+    register_buffer_assignment_hook,
+)
+from torch._functorch.aot_autograd import (
+    _detect_attribute_assignment,
+    aot_export_module,
+)
 from torch._guards import detect_fake_mode
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
@@ -1424,11 +1430,46 @@ def _export_to_aten_ir_make_fx(
             return tuple(flat_fn(*args))
 
         with enable_python_dispatcher():
-            gm = make_fx(
-                wrapped_fn,
-                record_module_stack=True,
-                pre_dispatch=True,
-            )(*flat_args)
+            ctx = nullcontext()
+            non_strict_root = getattr(mod, "_export_root", None)
+            if non_strict_root is not None:
+                ctx = _detect_attribute_assignment(non_strict_root)  # type: ignore[assignment]
+
+                # For any buffer that is assigned, we want to associate it to the final proxy node
+                # that it is assigned to. This node can then be copied into the buffer.
+                assigned_buffers: Dict[str, str] = {}
+                hook = register_buffer_assignment_hook(
+                    non_strict_root, assigned_buffers
+                )
+
+            with ctx:
+                gm = make_fx(
+                    wrapped_fn,
+                    record_module_stack=True,
+                    pre_dispatch=True,
+                )(*flat_args)
+
+            if non_strict_root is not None:
+                input_names = _graph_input_names(gm)
+                buffer_input_names = {
+                    buf: input_names[param_len + i]
+                    for i, buf in enumerate(non_strict_root._buffers)
+                }
+                output_node = list(gm.graph.nodes)[-1]
+                # We copy nodes corresponding to buffer assignments to buffers in the graph.
+                for buf, name in assigned_buffers.items():  # type: ignore[possibly-undefined]
+                    buf_node = _find_node(gm, buffer_input_names[buf])
+                    name_node = _find_node(gm, name)
+                    with gm.graph.inserting_before(output_node):
+                        new_node = gm.graph.create_node(
+                            "call_function",
+                            torch.ops.aten.copy_.default,
+                            args=(buf_node, name_node),
+                        )
+                        new_node.meta = name_node.meta
+
+                hook.remove()  # type: ignore[possibly-undefined]
+
             gm.graph.eliminate_dead_code()
 
         # create graph signature
@@ -1547,6 +1588,10 @@ def _export_to_aten_ir_make_fx(
         export_graph_signature,
         constants,
     )
+
+
+def _find_node(gm: torch.fx.GraphModule, name: str) -> torch.fx.Node:
+    return next(iter(node for node in gm.graph.nodes if node.name == name))
 
 
 def _non_strict_export(


### PR DESCRIPTION
Summary: We had attribute assignment detection and handling of registered buffer assignments when using `aot_autograd`, but not when using just `make_fx`. Fixed.

Test Plan: expanded coverage of `test_state_tensors` to use `export` instead of `torch.export.export`

Differential Revision: D63802576
