### PR TITLE
Correcting cholesky_backward

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1943,10 +1943,10 @@ Tensor cholesky_backward(const Tensor& gL, bool upper, const Tensor& L) {
   // dL = L\pi(L^{-1}dA(L^-H))
   //
   // Let gL be the projection into the lower-triangular gradient wrt L. Taking
-  // adjoints we have gA_asym = L^{-H}\pi(L^H gL)L^{-1} where \pi as seen in cholesky_jvp
-  // but since A is symmetric, we have to use gA = gA_asym + gA_asym^H - diag(gA_asym)
+  // adjoints we have gA_asym = L^{-H}\pi(L^H gL)L^{-1} where \pi as seen in 
+  // cholesky_jvp but since A is symmetric, we have to use:
+  // gA = gA_asym + gA_asym^H - diag(gA_asym)
   // See Murray, Iain. "Differentiation of the Cholesky decomposition."
-  //                        arXiv preprint arXiv:1602.07527 (2016).
   // Note that the gradient is symmetric and not triangular.
   auto L_ = upper ? L.mH() : L;
   auto gL_ = upper ? gL.mH() : gL;

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1924,7 +1924,7 @@ Tensor cholesky_jvp(const Tensor& dA, const Tensor& L, bool upper) {
   //               = sym(L^{-1}dL)
   // where sym(X) = X + X^H
   // A short computation gives that the inverse of sym is given by
-  // \pi(X) = X.tril() - 0.5*diag(X) when X is lower triangular,
+  // \pi(X) = X.tril() - 0.5*diag(X)
   // so
   // dL = L\pi(L^{-1}dA(L^{-H}))
 

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1924,7 +1924,7 @@ Tensor cholesky_jvp(const Tensor& dA, const Tensor& L, bool upper) {
   //               = sym(L^{-1}dL)
   // where sym(X) = X + X^H
   // A short computation gives that the inverse of sym is given by
-  // \pi(X) = X.tril() - 0.5*diag(X)
+  // \pi(X) = X.tril() - 0.5*diag(X) when X is lower triangular,
   // so
   // dL = L\pi(L^{-1}dA(L^{-H}))
 
@@ -1943,25 +1943,21 @@ Tensor cholesky_backward(const Tensor& gL, bool upper, const Tensor& L) {
   // dL = L\pi(L^{-1}dA(L^-H))
   //
   // Let gL be the projection into the lower-triangular gradient wrt L. Taking
-  // adjoints we have gA = L^{-H}\pi^*((L^HgL).tril())L^{-1} where \pi^*(X) =
-  // 0.5 * (X + X^H - diag(X)) The only non-standard point of this derivation is
-  // noting that the adjoint to multiplying on the left by a lower triangular
-  // matrix L is multiplying by L^H and then projecting back to the lower
-  // triangular matrices (hence the .tril() projection) Note that the gradient
-  // is symmetric and not triangular.
+  // adjoints we have gA_asym = L^{-H}\pi(L^H gL)L^{-1} where \pi as seen in cholesky_jvp
+  // but since A is symmetric, we have to use gA = gA_asym + gA_asym^H - diag(gA_asym)
+  // See Murray, Iain. "Differentiation of the Cholesky decomposition."
+  //                        arXiv preprint arXiv:1602.07527 (2016).
+  // Note that the gradient is symmetric and not triangular.
   auto L_ = upper ? L.mH() : L;
   auto gL_ = upper ? gL.mH() : gL;
 
-  // Nb. We don't need to compute gL_ = gL.tril() as
-  // tril(L^H gL) = tril(L^H (triu(gL, 1) + tril(gL)))
-  //              = tril(L^H tril(gL)) + tril(L^H triu(gL, 1))
-  //              = tril(L^H tril(gL))
-  // since tril(L^H triu(gL, 1)) = 0, as L^H triu(gL, 1) is upper triangular
-  auto gA = L_.mH().matmul(gL_).tril();
-  // Equivalent to 0.5 * (gA + gA^H - diag(gA))
-  gA = 0.5 * (gA + gA.tril(-1).mH());
+  auto gA = L_.mH().matmul(gL_);
+
+  gA = gA.tril() - gA.diagonal(0, -2, -1).mul(0.5).diag_embed();
   gA = at::linalg_solve_triangular(L_.mH(), gA, /*upper=*/true, /*left=*/true);
   gA = at::linalg_solve_triangular(L_, gA, /*upper=*/false, /*left=*/false);
+  // Apply to (gA + gA^H - diag(gA))
+  gA = (gA + gA.mH() - gA.diagonal(0, -2, -1).diag_embed());
   return gA;
 }
 


### PR DESCRIPTION
incorrect cholesky_backward due to halving the non-diagonal elements when making the backward sensitivities symmetric.

Fixes #137284 
