### PR TITLE
Extend preservable op list to custom ops

### DIFF
--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -369,7 +369,7 @@ You can also go from this IR to an inference IR via :func:`run_decompositions` w
 ::
 
     # Lower to core aten inference IR, but keep conv2d
-    decomp_table = torch.export.core_aten_decompositions()
+    decomp_table = torch.export.default_decompositions()
     del decomp_table[torch.ops.aten.conv2d.default]
     ep_for_inference = ep_for_training.run_decompositions(decomp_table)
 
@@ -418,7 +418,7 @@ You can do even more customizations by directly registering custom decomp behavi
 ::
 
     # Lower to core aten inference IR, but customize conv2d
-    decomp_table = torch.export.core_aten_decompositions()
+    decomp_table = torch.export.default_decompositions()
 
     def my_awesome_custom_conv2d_function(x, weight, bias, stride=[1, 1], padding=[0, 0], dilation=[1, 1], groups=1):
         return 2 * torch.ops.aten.convolution(x, weight, bias, stride, padding, dilation, False, [0, 0], groups)
@@ -849,7 +849,7 @@ API Reference
 .. autofunction:: load
 .. autofunction:: register_dataclass
 .. autofunction:: torch.export.dynamic_shapes.Dim
-.. autofunction:: torch.export.exported_program.core_aten_decompositions
+.. autofunction:: torch.export.exported_program.default_decompositions
 .. autofunction:: dims
 .. autoclass:: torch.export.dynamic_shapes.ShapesCollection
 

--- a/test/export/test_export_training_ir_to_run_decomp.py
+++ b/test/export/test_export_training_ir_to_run_decomp.py
@@ -1,6 +1,5 @@
 # Owner(s): ["oncall: export"]
 import torch
-from torch.testing._internal.common_utils import IS_FBCODE
 
 
 try:
@@ -16,10 +15,6 @@ test_classes = {}
 
 def mocked_training_ir_to_run_decomp_export_strict(*args, **kwargs):
     ep = torch.export.export_for_training(*args, **kwargs)
-    if IS_FBCODE:
-        return ep.run_decompositions(
-            {}, _preserve_ops=testing._COMPOSITE_OPS_THAT_CAN_BE_PRESERVED_TESTING_ONLY
-        )
     return ep.run_decompositions({})
 
 
@@ -29,10 +24,6 @@ def mocked_training_ir_to_run_decomp_export_non_strict(*args, **kwargs):
     else:
         ep = torch.export.export_for_training(*args, **kwargs, strict=False)
 
-    if IS_FBCODE:
-        return ep.run_decompositions(
-            {}, _preserve_ops=testing._COMPOSITE_OPS_THAT_CAN_BE_PRESERVED_TESTING_ONLY
-        )
     return ep.run_decompositions({})
 
 

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -10,7 +10,7 @@ from functools import partial
 import torch._inductor.decomposition
 import torch.autograd
 from torch import Tensor
-from torch._decomp import _is_cia_op, core_aten_decompositions, decomposition_table
+from torch._decomp import core_aten_decompositions, decomposition_table
 from torch._dispatch.python import enable_python_dispatcher
 from torch._ops import DispatchKey
 from torch.testing import make_tensor
@@ -62,7 +62,7 @@ decomposition_names = {
 core_decomposition_names = {
     overload_to_aten_name(k)
     for k in core_aten_decompositions()
-    if isinstance(k, torch._ops.OpOverload) and not _is_cia_op(k)
+    if isinstance(k, torch._ops.OpOverload)
 }
 _decomp_test_ops = [
     op

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import inspect
 from collections import defaultdict
-from functools import lru_cache, partial, wraps
+from functools import wraps
 from itertools import chain
 from typing import (
     Callable,
@@ -20,7 +20,6 @@ import torch
 import torch.library
 from torch._ops import HigherOrderOperator, OperatorBase, OpOverload, OpOverloadPacket
 from torch._prims_common import CustomOutParamAnnotation
-from torch._subclasses.functional_tensor import FunctionalTensor
 from torch.utils import _pytree as pytree
 
 
@@ -31,8 +30,6 @@ __all__ = [
     "register_decomposition",
     "get_decompositions",
     "core_aten_decompositions",
-    "_decomp_table_to_post_autograd_aten",
-    "_special_op_to_preserve_cia",
 ]
 
 _T = TypeVar("_T")
@@ -207,9 +204,19 @@ def register_decomposition(
     return decomposition_decorator
 
 
+def _is_cia_op(op: "OperatorBase") -> bool:
+    return (
+        torch._C._dispatch_has_kernel_for_dispatch_key(
+            op.name(), torch._C.DispatchKey.CompositeImplicitAutograd
+        )
+        or torch._C.DispatchKey.CompositeImplicitAutograd in op.py_kernels
+    )
+
+
 def get_decompositions(
     aten_ops: Sequence[Union[torch._ops.OperatorBase, OpOverloadPacket]],
     type: str = "post_autograd",
+    ignore_cia: bool = False,
 ) -> Dict[torch._ops.OperatorBase, Callable]:
     """
     Retrieve a dictionary of decompositions corresponding to the list of
@@ -233,9 +240,15 @@ def get_decompositions(
     for op in aten_ops:
         if isinstance(op, OpOverloadPacket) and op in packets_to_overloads:
             for op_overload in packets_to_overloads[op]:
-                decompositions[op_overload] = registry[op_overload]
+                if ignore_cia and _is_cia_op(op_overload):
+                    continue
+                else:
+                    decompositions[op_overload] = registry[op_overload]
         elif isinstance(op, (torch._ops.OperatorBase)) and op in registry:
-            decompositions[op] = registry[op]
+            if ignore_cia and _is_cia_op(op):
+                continue
+            else:
+                decompositions[op] = registry[op]
     return decompositions
 
 
@@ -263,192 +276,15 @@ import torch._decomp.decompositions
 import torch._refs
 
 
-# Our strategy for deciding if we can preserve a op is following:
-# 1. The op should be known statically that it is functional
-# 2. If it is maybe aliasing, we decompose because we must know if an op
-#    is mutating or aliasing.
-# TODO (tmanlaibaatar) make this utility function and share it with functional_tensor
-# decomp part. (https://github.com/pytorch/pytorch/issues/129431)
-def _check_valid_to_preserve(op_overload: "OperatorBase"):
-    if op_overload in FunctionalTensor.maybe_aliasing_or_mutating_ops:
-        return False
-    if op_overload in FunctionalTensor.metadata_fns:
-        return False
-
-    if not hasattr(op_overload, "_schema"):
-        return False
-
-    alias_info = len(
-        [i for i in op_overload._schema.arguments if i.alias_info is not None]
-    )
-
-    is_mutating_or_aliasing = alias_info != 0 or op_overload._schema.is_mutable
-
-    if is_mutating_or_aliasing:
-        return False
-
-    if not torch._C._dispatch_has_kernel(op_overload.name()):
-        return False
-
-    return True
-
-
-def _is_cia_op(op: "OperatorBase") -> bool:
-    return (
-        torch._C._dispatch_has_kernel_for_dispatch_key(
-            op.name(), torch._C.DispatchKey.CompositeImplicitAutograd
-        )
-        or torch._C.DispatchKey.CompositeImplicitAutograd in op.py_kernels
-    )
-
-
-def _is_preservable_cia_op(op: "OperatorBase") -> bool:
-    return _check_valid_to_preserve(op) and _is_cia_op(op)
-
-
-@lru_cache(maxsize=1)
-def _collect_all_valid_cia_ops() -> Set["OperatorBase"]:
-    """
-    This is an util function that gets the all CIA functional ops.
-
-    The algorithm is in 2 steps:
-      1. We first query C++ dispatcher to get the list of CIA ops
-         and then we call getattr on torch.ops.aten to lazily populate
-         them.
-
-      2. Sometimes, handful of ops have CIA registered in python dispatcher
-         but not on the C++ side, these can't be caught at the first step.
-         So we walk again to get the final list.
-
-    Note that the output of this function should never be modified
-    """
-    # First step to lazily populate torch.ops.aten
-    cia_ops = torch._C._dispatch_get_registrations_for_dispatch_key(
-        "CompositeImplicitAutograd"
-    )
-    # Ignore quantized namespace ops
-    cia_ops = [name[6:] for name in cia_ops if name.startswith("aten::")]
-    # Materialize all CIA ops first
-    for op in cia_ops:
-        split_list = op.split(".")
-        # Sometime overload could be missing
-        assert len(split_list) == 1 or len(split_list) == 2
-        op_name = split_list[0]
-        op_overload_name = "default"
-        if len(split_list) == 2:
-            op_overload_name = split_list[1]
-
-        _ = getattr(getattr(torch.ops.aten, op_name), op_overload_name)
-
-    # Second step to finally compile the list of all valid ops
-    cia_ops = set()
-    for op in torch.ops.aten:
-        op_packet = getattr(torch.ops.aten, op)
-        for overload in op_packet.overloads():
-            op_overload = getattr(op_packet, overload)
-            if _is_preservable_cia_op(op_overload):
-                cia_ops.add(op_overload)
-    return cia_ops
-
-
-def _get_decomp_for_cia(op):
-    # [NOTE] Seperating out func.decompose
-    # Ideally we should be able to just register func.decompose but
-    # we can't as this decomp is gonna be registered to the py_impl.
-    # As a result it will infinitely recurse. So we first check if the op
-    # has py_impl entry for CIA and if it is we use that first. If not,
-    # we register C++ query to py_impl.
-    dk = torch._C.DispatchKey.CompositeImplicitAutograd
-    if dk in op.py_kernels and not isinstance(op.py_kernels[dk], torch._C.DispatchKey):
-        return op.py_kernels[dk]
-
-    def _special_op_to_decompose_cia(*args, **kwargs):
-        kernel = kwargs["kernel"]
-        del kwargs["kernel"]
-        # Can't call kernel.decompose due to infinite recursion as
-        # we register this kernel to py_impl directly
-        dk = torch._C.DispatchKey.CompositeImplicitAutograd
-        if torch._C._dispatch_has_kernel_for_dispatch_key(
-            kernel.name(), torch._C.DispatchKey.CompositeImplicitAutograd
-        ):
-            return kernel._op_dk(dk, *args, **kwargs)
-        else:
-            raise AssertionError(
-                f"Expected {kernel} to have CompositeImplicitAutograd kernel"
-            )
-
-    return partial(_special_op_to_decompose_cia, kernel=op)
-
-
 # See NOTE [Core ATen Ops]
 #
 # list was copied from torch/_inductor/decomposition.py
 # excluding decompositions that results in prim ops
 # Resulting opset of decomposition is core aten ops
 def core_aten_decompositions() -> Dict[torch._ops.OperatorBase, Callable]:
-    decomp_table = _core_aten_decompositions_post_autograd()
-
-    # If it is fbcode change, we return the old decomposition list
-    from torch._inductor import config
-
-    if config.is_fbcode():
-        return decomp_table
-
     aten = torch.ops.aten
 
-    # We are deleting custom decomp in core_aten_decomp
-    # for CIA ops but it should be fine technically
-    # because this table is only meant to be used in export context
-    # in which we really carefully control the decomp behaviour
-    # In any case, C++ decomps should be preferred
-    cia_ops_that_should_be_removed = [
-        aten.all.dimname,
-        aten.index_add.dimname,
-        aten.index_copy.dimname,
-        aten.index_fill.Dimname_Scalar,
-        aten.index_fill.Dimname_Tensor,
-        aten.norm.names_ScalarOpt_dim_dtype,
-        aten.norm.names_ScalarOpt_dim,
-        aten.silu_backward.default,
-        aten.std.default,
-        aten.std.dim,
-        aten.std.names_dim,
-        aten.std.correction_names,
-        aten.std_mean.default,
-        aten.std_mean.dim,
-        aten.std_mean.names_dim,
-        aten.std_mean.correction_names,
-        aten.upsample_bilinear2d.vec,
-        aten.upsample_trilinear3d.vec,
-    ]
-
-    for k in list(decomp_table.keys()):
-        if k in cia_ops_that_should_be_removed:
-            del decomp_table[k]
-
-    for op in _collect_all_valid_cia_ops():
-        decomp_table[op] = _get_decomp_for_cia(op)
-    return decomp_table
-
-
-# This table is a stop-gap table which replicates
-# the old behaviour of post-dispatch IR.
-# This table contains all functional CIA ops mapping
-# to their default decomp. In old export, this will
-# be decomposed implicitly.
-def _decomp_table_to_post_autograd_aten():
-    decomp_table = {}
-    for k in _collect_all_valid_cia_ops():
-        decomp_table[k] = _get_decomp_for_cia(k)
-    return decomp_table
-
-
-def _core_aten_decompositions_post_autograd() -> (
-    Dict[torch._ops.OperatorBase, Callable]
-):
-    aten = torch.ops.aten
-    # TODO Delete all mutating or CIA ops from this list
-    return get_decompositions(
+    decomp_table = get_decompositions(
         [
             aten.addcdiv,
             aten.addcdiv_,
@@ -675,5 +511,8 @@ def _core_aten_decompositions_post_autograd() -> (
             aten.zeros_like,
             aten._chunk_cat,
             aten._weight_norm_interface,
-        ]
+        ],
+        ignore_cia=True,
     )
+
+    return decomp_table

--- a/torch/export/__init__.py
+++ b/torch/export/__init__.py
@@ -50,7 +50,7 @@ __all__ = [
     "ExportedProgram",
     "ModuleCallEntry",
     "ModuleCallSignature",
-    "core_aten_decompositions",
+    "default_decompositions",
     "dims",
     "export",
     "export_for_training",
@@ -66,7 +66,7 @@ __all__ = [
 
 from .dynamic_shapes import Constraint, Dim, dims, ShapesCollection
 from .exported_program import (
-    core_aten_decompositions,
+    default_decompositions,
     ExportedProgram,
     ModuleCallEntry,
     ModuleCallSignature,

--- a/torch/onnx/_internal/exporter/_decomp.py
+++ b/torch/onnx/_internal/exporter/_decomp.py
@@ -58,7 +58,7 @@ def create_onnx_friendly_decomposition_table(
     decomposition_table: dict[torch._ops.OperatorBase, Callable] = {}
 
     for op_overload, decomp_fn in itertools.chain(
-        torch._decomp._decomp_table_to_post_autograd_aten().items(),  # type: ignore[attr-defined]
+        torch.export.exported_program._decomp_table_to_post_autograd_aten().items(),  # type: ignore[attr-defined]
         torch._decomp.decomposition_table.items(),  # type: ignore[attr-defined]
     ):
         # Skip decomposition for op_overload as long as that op_overload has a corresponding ONNX


### PR DESCRIPTION
Summary:
User can preserve custom ops as well. We do so by extending current logic to also query CIA ops from all possible op namespaces.


imported-using-ghimport

Test Plan: Imported from OSS

Differential Revision: D63846603

Pulled By: tugsbayasgalan


