### PR TITLE
[BE] Use helper functions in mps_extension

### DIFF
--- a/test/cpp_extensions/mps_extension.mm
+++ b/test/cpp_extensions/mps_extension.mm
@@ -3,7 +3,7 @@
 
 // this sample custom kernel is taken from:
 // https://developer.apple.com/documentation/metal/performing_calculations_on_a_gpu
-static const char* CUSTOM_KERNEL = R"MPS_ADD_ARRAYS(
+static at::native::mps::MetalShaderLibrary lib(R"MPS_ADD_ARRAYS(
 #include <metal_stdlib>
 using namespace metal;
 kernel void add_arrays(device const float* inA,
@@ -13,7 +13,7 @@ kernel void add_arrays(device const float* inA,
 {
     result[index] = inA[index] + inB[index];
 }
-)MPS_ADD_ARRAYS";
+)MPS_ADD_ARRAYS");
 
 at::Tensor get_cpu_add_output(at::Tensor & cpu_input1, at::Tensor & cpu_input2) {
   return cpu_input1 + cpu_input2;
@@ -30,20 +30,8 @@ at::Tensor get_mps_add_output(at::Tensor & mps_input1, at::Tensor & mps_input2) 
   at::Tensor mps_output = at::empty_like(mps_input1);
 
   @autoreleasepool {
-    id<MTLDevice> device = MPSDevice::getInstance()->device();
-    NSError *error = nil;
     size_t numThreads = mps_output.numel();
-    id<MTLLibrary> customKernelLibrary = [device newLibraryWithSource: [NSString stringWithUTF8String:CUSTOM_KERNEL]
-                                                              options: nil
-                                                                error: &error];
-    TORCH_CHECK(customKernelLibrary, "Failed to to create custom kernel library, error: ", error.localizedDescription.UTF8String);
-
-    id<MTLFunction> customFunction = [customKernelLibrary newFunctionWithName: @"add_arrays"];
-    TORCH_CHECK(customFunction, "Failed to create function state object for the kernel");
-
-    id<MTLComputePipelineState> kernelPSO = [device newComputePipelineStateWithFunction: customFunction error: &error];
-    TORCH_CHECK(kernelPSO, error.localizedDescription.UTF8String);
-
+    auto kernelPSO = lib.getPipelineStateForFunc("add_arrays");
     MPSStream* mpsStream = getCurrentMPSStream();
 
     dispatch_sync(mpsStream->queue(), ^() {
@@ -53,18 +41,10 @@ at::Tensor get_mps_add_output(at::Tensor & mps_input1, at::Tensor & mps_input2) 
 
       // Encode the pipeline state object and its parameters.
       [computeEncoder setComputePipelineState: kernelPSO];
-      [computeEncoder setBuffer: getMTLBufferStorage(mps_input1) offset:0 atIndex:0];
-      [computeEncoder setBuffer: getMTLBufferStorage(mps_input2) offset:0 atIndex:1];
-      [computeEncoder setBuffer: getMTLBufferStorage(mps_output) offset:0 atIndex:2];
-      MTLSize gridSize = MTLSizeMake(numThreads, 1, 1);
-
-      // Calculate a thread group size.
-      NSUInteger threadsPerGroupSize = std::min(kernelPSO.maxTotalThreadsPerThreadgroup, numThreads);
-      MTLSize threadGroupSize = MTLSizeMake(threadsPerGroupSize, 1, 1);
-
-      // Encode the compute command.
-      [computeEncoder dispatchThreads: gridSize threadsPerThreadgroup: threadGroupSize];
-
+      mtl_setBuffer(computeEncoder, mps_input1, 0);
+      mtl_setBuffer(computeEncoder, mps_input2, 1);
+      mtl_setBuffer(computeEncoder, mps_output, 2);
+      mtl_dispatch1DJob(computeEncoder, kernelPSO, numThreads);
     });
   }
   return mps_output;


### PR DESCRIPTION
This should be a no-op change, i.e. it runs the same code, but replaces verbose ObjectiveC invocation with helper function from OperationUtils.h, which this example already depends on