### PR TITLE
Fixed invalid param type for issue #136697

### DIFF
--- a/torch/_functorch/benchmark_utils.py
+++ b/torch/_functorch/benchmark_utils.py
@@ -222,7 +222,7 @@ def benchmark_utilization(
         optimize_ctx,
         [ProfilerActivity.CUDA],
         num_runs=num_runs,
-        devices="cuda",
+        devices=["cuda"], #invalid param, changed from string type to array
     )
     utilization, mm_conv_utilization = compute_utilization(
         chrome_trace_file_name, total_length


### PR DESCRIPTION
Fixes #136697

Fixed an invalid parameter type in dump_chrome_trace().
Changed the string "cuda" to an array list type ["cuda"] in the benchmark_utilization function found in pytorch/torch/_functorch/benchmark_utils.py which was leading to unexpected behavior.

Original Code:
![1](https://github.com/user-attachments/assets/7876bcc1-e2f9-4001-8c62-f5bf527a8e2c)

Edited Changes:
![image](https://github.com/user-attachments/assets/52c6cbee-8b57-4ab0-a0e1-d655797ddfab)
