### PR TITLE
[AOTI][Tooling][10/n] Add scalar and symbolic type input debug printing support

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -3531,6 +3531,44 @@ class AOTInductorTestsTemplate:
                     count,
                 ).run(code)
 
+    def test_aoti_debug_printer_sym_inputs(self):
+        if self.device != "cuda":
+            raise unittest.SkipTest("requires CUDA")
+
+        from torch.testing._internal.triton_utils import add_kernel
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                maxlen = max(x.item(), 512)
+                a = torch.ones(maxlen, device="cuda")
+                b = torch.ones(maxlen, device="cuda")
+                out = torch.zeros_like(a)
+                # unbacked symint in grid
+                add_kernel[(1, 1, maxlen)](a, b, out, maxlen, 32)
+                return out
+
+        example_inputs = (torch.randint(high=1024, size=(1,), device=self.device),)
+
+        expected_scalar_args = [
+            "triton_poi_fused_zeros_like_0_xnumel",
+            "triton_poi_fused_ones_1_xnumel",
+            "std::max(static_cast<int64_t>(512L), static_cast<int64_t>(u0))",
+        ]
+
+        with config.patch({"aot_inductor.debug_intermediate_value_printer": "2"}):
+            result, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            self.assertEqual("aoti_torch_print_tensor_handle" in code, True)
+            for scalar in expected_scalar_args:
+                FileCheck().check_count(
+                    f"{scalar}",
+                    2,
+                ).run(code)
+
     def test_size_from_multi_output(self):
         class Model(torch.nn.Module):
             def __init__(self):
@@ -3767,6 +3805,7 @@ CUDA_TEST_FAILURES = {
     "test_aoti_debug_printer_user_defined_triton_kernel": fail_non_abi_compatible_cuda(
         is_skip=True
     ),
+    "test_aoti_debug_printer_sym_inputs": fail_non_abi_compatible_cuda(is_skip=True),
 }
 
 
@@ -3830,6 +3869,7 @@ if not IS_FBCODE:
             "test_aoti_debug_printer_user_defined_triton_kernel": fail_cuda(
                 is_skip=True
             ),
+            "test_aoti_debug_printer_sym_inputs": fail_cuda(is_skip=True),
         }
     )
 

--- a/torch/_inductor/codegen/debug_utils.py
+++ b/torch/_inductor/codegen/debug_utils.py
@@ -7,6 +7,7 @@ import os
 from enum import Enum
 from typing import List, Optional
 
+import torch
 from torch import dtype as torch_dtype
 
 from .. import config
@@ -56,6 +57,7 @@ class DebugPrinterManager:
         kernel_name: str = "",
         kernel=None,
         arg_signatures: Optional[List[type]] = None,
+        kernel_type=None,
     ):
         self.debug_printer_level = IntermediateValueDebuggingLevel(debug_printer_level)
         if args_to_print_or_save is None:
@@ -65,6 +67,7 @@ class DebugPrinterManager:
         self.arg_signatures: Optional[List[type]] = None
         self.kernel = kernel
         self.filtered_kernel_names_to_print = self._get_debug_filtered_kernel_names()
+        self.kernel_type = None
 
     def __enter__(self):
         self._perform_debug_print_or_save_helper(
@@ -142,6 +145,7 @@ class DebugPrinterManager:
             )
             self.debug_printer_level = IntermediateValueDebuggingLevel.OFF
 
+        self.kernel_type = kernel_type
         # Note: if the kernel type is an extern kernel (or cpp kernel), we do a special handling to
         # get the list of args_to_print_or_save
         # TODO: Find a more reliable way to detect kernel args types to print for extern kernel calls
@@ -229,25 +233,46 @@ class DebugPrinterManager:
                     V.graph.wrapper_code.writeline('printf("\\n");')
             return
 
+        if self.debug_printer_level != IntermediateValueDebuggingLevel.PRINT_ONLY:
+            return
         for i, arg in enumerate(args_to_print):
-            if arg_signatures is not None and not isinstance(
-                arg_signatures[i], torch_dtype
+            # when debug printing is enabled i.e. IntermediateValueDebuggingLevel.PRINT_ONLY,
+            # check if filtered kernel name list is provided
+            if (
+                len(self.filtered_kernel_names_to_print) > 0
+                and kernel_name.lower() not in self.filtered_kernel_names_to_print
             ):
-                # infer from the arg data type (has torch.dtype) to see if it is a tensor type
                 continue
-            if self.debug_printer_level == IntermediateValueDebuggingLevel.PRINT_ONLY:
-                # when debug printing is enabled i.e. IntermediateValueDebuggingLevel.PRINT_ONLY,
-                # check if filtered kernel name list is provided
-                if (
-                    len(self.filtered_kernel_names_to_print) > 0
-                    and kernel_name.lower() not in self.filtered_kernel_names_to_print
-                ):
-                    continue
-
+            if V.graph.cpp_wrapper:
                 if config.abi_compatible:
-                    V.graph.wrapper_code.writeline(
-                        f'aoti_torch_print_tensor_handle({arg}, "{launch_prefix} - {kernel_name} - {arg}");'
-                    )
+                    if arg_signatures is not None and isinstance(
+                        arg_signatures[i], (torch_dtype)
+                    ):
+                        # infer from the arg data type (has torch.dtype) to see if it is a tensor type
+                        V.graph.wrapper_code.writeline(
+                            f'aoti_torch_print_tensor_handle({arg}, "{launch_prefix} - {kernel_name} - {arg}");'
+                        )
+                    elif arg_signatures is not None and isinstance(
+                        arg_signatures[i],
+                        (
+                            type(torch._inductor.codegen.wrapper.SymbolicCallArg),
+                            type(int),
+                            type(float),
+                            type(bool),
+                        ),
+                    ):
+                        V.graph.wrapper_code.writeline(
+                            f'printf("[  {launch_prefix} - {kernel_name} - {arg}: %ld  ]", {arg}); printf("\\n");'
+                        )
+                    else:
+                        if (
+                            arg_signatures is None
+                            and self.kernel_type == "cpp"
+                            or "extern"
+                        ):
+                            V.graph.wrapper_code.writeline(
+                                f'aoti_torch_print_tensor_handle({arg}, "{launch_prefix} - {kernel_name} - {arg}");'
+                            )
                 else:
                     # TODO: add non-abi compatible mode debug printing info
                     pass


### PR DESCRIPTION
Summary:
- Further added more types for debug value dumping.

- Add a test case for symint inputs for debug printer. in real prod model use cases,  "unbacked symints" (those 'u0', 's0', etc.) can be helpful if we can examine their value.

Test Plan:
```
AOT_INDUCTOR_DEBUG_INTERMEDIATE_VALUE_PRINTER=2  TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 TORCHINDUCTOR_ABI_COMPATIBLE=1 TORCH_COMPILE_DEBUG=1 TORCH_LOGS="+graph, inductor, +schedule, output_code" buck2 run -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=h100 @//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor -- -r test_aoti_debug_printer_sym_inputs_abi_compatible_cuda
```

Differential Revision: D63864708




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang