### PR TITLE
Fixed developer setup issue in open_registration_extension

### DIFF
--- a/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegHooks.cpp
+++ b/test/cpp_extensions/open_registration_extension/pytorch_openreg/csrc/OpenRegHooks.cpp
@@ -195,7 +195,7 @@ struct OpenRegGuardImpl final : public c10::impl::DeviceGuardImplInterface {
    * Wait (by blocking the calling thread) until all the work previously
    * enqueued on the stream has completed running on the device.
    */
-  virtual void synchronizeStream(const c10::Stream& stream) const {
+  virtual void synchronizeStream(const c10::Stream& stream) const override {
     py::gil_scoped_acquire acquire;
     get_method("synchronizeStream")(stream);
   }


### PR DESCRIPTION
This PR fixes an issue where when running `python setup.py develop`, the `open_registration_extension` self contained example will not build due to the following:

```
error: 'synchronizeStream' overrides a member function but is not marked 'override'
```
