### PR TITLE
Fix triton_reshape to properly expand `Min` keyword in triton codegen

### DIFF
--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -497,6 +497,27 @@ class TritonBlockPointerTest(InductorTestCase):
                 else:
                     self.assertNotIn(tile_name, program)
 
+    def test_complex_reshape_block_ptr(self):
+        def func(x, y):
+            add_ = x + y
+            reshape_0 = add_.reshape([8, 16, 128])
+            permute_0 = reshape_0.permute([0, 2, 1])
+            reshape_1 = permute_0.reshape([1024, 16])
+            clone_0 = reshape_1.clone(memory_format=torch.contiguous_format)
+            permute_1 = clone_0.permute([1, 0])
+            clone_1 = permute_1.clone(memory_format=torch.contiguous_format)
+
+            return clone_0, clone_1
+
+        inps = (torch.rand((8, 2048), device=GPU_TYPE, dtype=torch.float32),) * 2
+        result, code = self.run_and_compare(
+            func,
+            *inps,
+            expected_num_triton_kernels=2,
+            expected_num_block_pointers=4,
+        )
+        self.assertTrue("Min" not in code[0])
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -448,12 +448,8 @@ def triton_reshape(
     """Workaround https://github.com/openai/triton/issues/2836"""
     assert isinstance(old_shape, list) and isinstance(new_shape, list)
 
-    def shape_to_str(shape: List[sympy.Expr]) -> List[str]:
-        return [str(dim) for dim in shape]
-
-    old_shape_str, new_shape_str = tuple(
-        shape_to_str(shape) for shape in (old_shape, new_shape)
-    )
+    old_shape_str = [V.kernel.index_to_str(shape) for shape in old_shape]
+    new_shape_str = [V.kernel.index_to_str(shape) for shape in new_shape]
 
     if old_shape_str == new_shape_str:
         return value


### PR DESCRIPTION
Summary: Previously triton_reshape will generate code with `Min` keyword in it, which is incorrect. This diff updates the triton_reshape function to properly expand `Min` keyword to `<`.

Test Plan:
```
buck2 run @//mode/{opt,mtia,inplace} //glow/fb/fx/fba/tests:test_fba_inductor -- -r test_Min_keyword_in_block_shape
```

Differential Revision: D63850158




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang