### PR TITLE
Remove unused enforce_cond_guard_match Dynamo feature flag.

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -252,10 +252,6 @@ allow_complex_guards_as_runtime_asserts = False
 # compile this code; however, this can be useful for export.
 force_unspec_int_unbacked_size_like_on_torchrec_kjt = False
 
-# Should almost always be true in prod. This relaxes the requirement that cond's true_fn and
-# false_fn produces code with identical guards.
-enforce_cond_guards_match = True
-
 # Specify how to optimize a compiled DDP module. The flag accepts a boolean
 # value or a string. There are 4 modes.
 # 1. "ddp_optimizer" (or True): with "ddp_ptimizer", Dynamo will automatically


### PR DESCRIPTION
The flag is currently unused in `pytorch/pytorch`: https://github.com/search?q=repo%3Apytorch%2Fpytorch+enforce_cond_guards_match&type=code

Scanning the overall GitHub search results, the only instances are old forks of `pytorch` and `torchdynamo`: https://github.com/search?q=enforce_cond_guards_match&type=code&p=1

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137379



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec

Differential Revision: [D63924843](https://our.internmc.facebook.com/intern/diff/D63924843)