### PR TITLE
Enable channels_last format for FSDP

### DIFF
--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -13,7 +13,12 @@ from torch.distributed.fsdp._flat_param import (
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    TEST_WITH_DEV_DBG_ASAN,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
 
 
 if not dist.is_available():
@@ -335,6 +340,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["0.weight"],
                 param_shapes=[(10, 10)],
+                param_strides=[(10, 1)],
                 param_numels=[100],
                 param_offsets=[(0, 0)],
             ),
@@ -346,6 +352,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["0.weight"],
                 param_shapes=[(10, 10)],
+                param_strides=[(10, 1)],
                 param_numels=[100],
                 param_offsets=[(0, 50)],
             ),
@@ -357,6 +364,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["0.weight"],
                 param_shapes=[(10, 10)],
+                param_strides=[(10, 1)],
                 param_numels=[100],
                 param_offsets=[(0, 99)],
             ),
@@ -368,6 +376,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
+                param_strides=[(10, 1), (10, 1)],
                 param_numels=[100, 100],
                 param_offsets=[(50, 99), (0, 49)],
             ),
@@ -379,6 +388,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
+                param_strides=[(10, 1), (10, 1)],
                 param_numels=[100, 100],
                 param_offsets=[(50, 99), (0, 99)],
             ),
@@ -390,6 +400,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
+                param_strides=[(10, 1), (10, 1)],
                 param_numels=[100, 100],
                 param_offsets=[(99, 99), (0, 99)],
             ),
@@ -401,6 +412,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["2.weight"],
                 param_shapes=[(10, 10)],
+                param_strides=[(10, 1)],
                 param_numels=[100],
                 param_offsets=[(0, 99)],
             ),
@@ -412,6 +424,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["2.weight", "4.weight"],
                 param_shapes=[(10, 10), (10, 10)],
+                param_strides=[(10, 1), (10, 1)],
                 param_numels=[100, 100],
                 param_offsets=[(0, 99), (0, 99)],
             ),
@@ -423,6 +436,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["2.weight", "4.weight"],
                 param_shapes=[(10, 10), (10, 10)],
+                param_strides=[(10, 1), (10, 1)],
                 param_numels=[100, 100],
                 param_offsets=[(0, 99), (0, 99)],
             ),
@@ -434,6 +448,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["4.weight"],
                 param_shapes=[(10, 10)],
+                param_strides=[(10, 1)],
                 param_numels=[100],
                 param_offsets=[(99, 99)],
             ),
@@ -469,6 +484,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["0.weight", "1.weight"],
                 param_shapes=[(7, 3), (5, 7)],
+                param_strides=[(3, 1), (7, 1)],
                 param_numels=[21, 35],
                 # 21 + (3) + 19 = 43
                 param_offsets=[(0, 20), (0, 18)],
@@ -482,6 +498,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["1.weight", "2.weight"],
                 param_shapes=[(5, 7), (5, 5)],
+                param_strides=[(7, 1), (5, 1)],
                 param_numels=[35, 25],
                 # 16 + (1) + 25 = 42
                 param_offsets=[(19, 34), (0, 24)],
@@ -519,6 +536,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["0.weight", "1.weight"],
                 param_shapes=[(5, 2), (5, 5)],
+                param_strides=[(2, 1), (5, 1)],
                 param_numels=[10, 25],
                 # 10 + (6) + 16 = 32
                 param_offsets=[(0, 9), (0, 15)],
@@ -532,6 +550,7 @@ class TestFlattenParams(FSDPTest):
             expected=FlatParamShardMetadata(
                 param_names=["1.weight", "2.weight"],
                 param_shapes=[(5, 5), (3, 5)],
+                param_strides=[(5, 1), (5, 1)],
                 param_numels=[25, 15],
                 # 9 + (7) + 15 = 31
                 param_offsets=[(16, 24), (0, 14)],
@@ -565,6 +584,54 @@ class TestFlattenParams(FSDPTest):
             msg=f"{handle.shard_metadata()}, {expected}",
         )
 
+    @parametrize("memory_format", [torch.contiguous_format, torch.channels_last])
+    def test_flat_param_shard_metadata_with_memory_format(self, memory_format):
+        """
+        Tests that ``FlatParameter`` shard metadata are computed as expected
+        with alignment padding and parameter full precision.
+        """
+        module = torch.nn.Sequential(
+            torch.nn.Conv2d(10, 20, 3, bias=False),  # 0.weight, 1800 params
+            torch.nn.Conv2d(20, 10, 5, bias=False),  # 1.weight, 5000 params
+            torch.nn.Conv2d(10, 10, 1, bias=False),  # 2.weight, 100 params
+        ).to(memory_format=memory_format)
+        params_to_flatten = list(module.parameters())
+        handle_kwargs = self._get_default_config()
+        handle_kwargs["use_orig_params"] = True
+        handle = FlatParamHandle(params_to_flatten, module, **handle_kwargs)
+        self._test_flat_param_shard_metadata(
+            handle,
+            # Emulate rank 0 of 2 ranks
+            start=0,
+            end=2999,
+            expected=FlatParamShardMetadata(
+                param_names=["0.weight", "1.weight"],
+                param_shapes=[(20, 10, 3, 3), (10, 20, 5, 5)],
+                param_strides=[(90, 9, 3, 1), (500, 25, 5, 1)]
+                if memory_format == torch.contiguous_format
+                else [(90, 1, 30, 10), (500, 1, 100, 20)],
+                param_numels=[1800, 5000],
+                param_offsets=[(0, 1799), (0, 1199)],
+            ),
+        )
+        self._test_flat_param_shard_metadata(
+            handle,
+            # Emulate rank 1 of 2 ranks
+            start=3000,
+            end=6899,
+            expected=FlatParamShardMetadata(
+                param_names=["1.weight", "2.weight"],
+                param_shapes=[(10, 20, 5, 5), (10, 10, 1, 1)],
+                param_strides=[(500, 25, 5, 1), (10, 1, 1, 1)]
+                if memory_format == torch.contiguous_format
+                else [(500, 1, 100, 20), (10, 1, 10, 10)],
+                param_numels=[5000, 100],
+                param_offsets=[(1200, 4999), (0, 99)],
+            ),
+        )
+
+
+instantiate_parametrized_tests(TestFlattenParams)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -14,10 +14,10 @@ from torch.distributed.fsdp._flat_param import (
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
-    TEST_WITH_DEV_DBG_ASAN,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
 )
 
 
@@ -341,6 +341,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["0.weight"],
                 param_shapes=[(10, 10)],
                 param_strides=[(10, 1)],
+                param_contiguities=[True],
                 param_numels=[100],
                 param_offsets=[(0, 0)],
             ),
@@ -353,6 +354,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["0.weight"],
                 param_shapes=[(10, 10)],
                 param_strides=[(10, 1)],
+                param_contiguities=[True],
                 param_numels=[100],
                 param_offsets=[(0, 50)],
             ),
@@ -365,6 +367,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["0.weight"],
                 param_shapes=[(10, 10)],
                 param_strides=[(10, 1)],
+                param_contiguities=[True],
                 param_numels=[100],
                 param_offsets=[(0, 99)],
             ),
@@ -377,6 +380,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_strides=[(10, 1), (10, 1)],
+                param_contiguities=[True, True],
                 param_numels=[100, 100],
                 param_offsets=[(50, 99), (0, 49)],
             ),
@@ -389,6 +393,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_strides=[(10, 1), (10, 1)],
+                param_contiguities=[True, True],
                 param_numels=[100, 100],
                 param_offsets=[(50, 99), (0, 99)],
             ),
@@ -401,6 +406,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_strides=[(10, 1), (10, 1)],
+                param_contiguities=[True, True],
                 param_numels=[100, 100],
                 param_offsets=[(99, 99), (0, 99)],
             ),
@@ -413,6 +419,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["2.weight"],
                 param_shapes=[(10, 10)],
                 param_strides=[(10, 1)],
+                param_contiguities=[True],
                 param_numels=[100],
                 param_offsets=[(0, 99)],
             ),
@@ -425,6 +432,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["2.weight", "4.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_strides=[(10, 1), (10, 1)],
+                param_contiguities=[True, True],
                 param_numels=[100, 100],
                 param_offsets=[(0, 99), (0, 99)],
             ),
@@ -437,6 +445,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["2.weight", "4.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_strides=[(10, 1), (10, 1)],
+                param_contiguities=[True, True],
                 param_numels=[100, 100],
                 param_offsets=[(0, 99), (0, 99)],
             ),
@@ -449,6 +458,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["4.weight"],
                 param_shapes=[(10, 10)],
                 param_strides=[(10, 1)],
+                param_contiguities=[True],
                 param_numels=[100],
                 param_offsets=[(99, 99)],
             ),
@@ -485,6 +495,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["0.weight", "1.weight"],
                 param_shapes=[(7, 3), (5, 7)],
                 param_strides=[(3, 1), (7, 1)],
+                param_contiguities=[True, True],
                 param_numels=[21, 35],
                 # 21 + (3) + 19 = 43
                 param_offsets=[(0, 20), (0, 18)],
@@ -499,6 +510,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["1.weight", "2.weight"],
                 param_shapes=[(5, 7), (5, 5)],
                 param_strides=[(7, 1), (5, 1)],
+                param_contiguities=[True, True],
                 param_numels=[35, 25],
                 # 16 + (1) + 25 = 42
                 param_offsets=[(19, 34), (0, 24)],
@@ -537,6 +549,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["0.weight", "1.weight"],
                 param_shapes=[(5, 2), (5, 5)],
                 param_strides=[(2, 1), (5, 1)],
+                param_contiguities=[True, True],
                 param_numels=[10, 25],
                 # 10 + (6) + 16 = 32
                 param_offsets=[(0, 9), (0, 15)],
@@ -551,6 +564,7 @@ class TestFlattenParams(FSDPTest):
                 param_names=["1.weight", "2.weight"],
                 param_shapes=[(5, 5), (3, 5)],
                 param_strides=[(5, 1), (5, 1)],
+                param_contiguities=[True, True],
                 param_numels=[25, 15],
                 # 9 + (7) + 15 = 31
                 param_offsets=[(16, 24), (0, 14)],
@@ -599,6 +613,7 @@ class TestFlattenParams(FSDPTest):
         handle_kwargs = self._get_default_config()
         handle_kwargs["use_orig_params"] = True
         handle = FlatParamHandle(params_to_flatten, module, **handle_kwargs)
+        contiguous_tensors = memory_format == torch.contiguous_format
         self._test_flat_param_shard_metadata(
             handle,
             # Emulate rank 0 of 2 ranks
@@ -608,8 +623,9 @@ class TestFlattenParams(FSDPTest):
                 param_names=["0.weight", "1.weight"],
                 param_shapes=[(20, 10, 3, 3), (10, 20, 5, 5)],
                 param_strides=[(90, 9, 3, 1), (500, 25, 5, 1)]
-                if memory_format == torch.contiguous_format
+                if contiguous_tensors
                 else [(90, 1, 30, 10), (500, 1, 100, 20)],
+                param_contiguities=[contiguous_tensors, contiguous_tensors],
                 param_numels=[1800, 5000],
                 param_offsets=[(0, 1799), (0, 1199)],
             ),
@@ -623,8 +639,9 @@ class TestFlattenParams(FSDPTest):
                 param_names=["1.weight", "2.weight"],
                 param_shapes=[(10, 20, 5, 5), (10, 10, 1, 1)],
                 param_strides=[(500, 25, 5, 1), (10, 1, 1, 1)]
-                if memory_format == torch.contiguous_format
+                if contiguous_tensors
                 else [(500, 1, 100, 20), (10, 1, 10, 10)],
+                param_contiguities=[contiguous_tensors, contiguous_tensors],
                 param_numels=[5000, 100],
                 param_offsets=[(1200, 4999), (0, 99)],
             ),


### PR DESCRIPTION
Enable FSDP to deal with channels_last memory formatted tensors. Preserving channels_last memory format makes FSDP compatible with the best kernels CUDNN offers.

Summary of changes:
1) Store strides information along with shapes
2) Replace calls to flatten() with as_strided(size=(param.numel(),), stride=(1,)) for flattening
3) Replace calls to view() with as_strided with the stored sizes and strides for unflattening

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o