### PR TITLE
Fix gumbel softmax

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2201,6 +2201,7 @@ def gumbel_softmax(
         .exponential_()
         .log()
     )  # ~Gumbel(0,1)
+    logits = logits.log_softmax(dim)
     gumbels = (logits + gumbels) / tau  # ~Gumbel(logits,tau)
     y_soft = gumbels.softmax(dim)
 


### PR DESCRIPTION
Reference #77053 

The inputs of the `gumbel_softmax` should be normalized, otherwise it will lead to incorrect results. However, the documentation said it is unormalized. I normalize it inside the function.
