### PR TITLE
[1/N] Fix extra warnings brought by clang-tidy-17

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3658,9 +3658,7 @@ class NativeCachingAllocator : public CUDAAllocator {
         c10::DeviceIndex device,
         std::string& handle,
         const DeviceCachingAllocator& allocator)
-        : device_(device),
-          expandable_segment_(nullptr),
-          cuda_ipc_ptr_(nullptr) {
+        : device_(device) {
       int type = SHAREABLE_CUDA_MALLOC;
       std::istringstream ss(handle);
       if (handle.size() != CUDA_IPC_HANDLE_SIZE) {
@@ -3710,8 +3708,8 @@ class NativeCachingAllocator : public CUDAAllocator {
       }
     }
     c10::DeviceIndex device_;
-    ExpandableSegment* expandable_segment_;
-    void* cuda_ipc_ptr_; // nullptr if expandable_segment_ is not null
+    ExpandableSegment* expandable_segment_{nullptr};
+    void* cuda_ipc_ptr_{nullptr}; // nullptr if expandable_segment_ is not null
     std::weak_ptr<void> wp_;
   };
 

--- a/c10/test/core/CompileTimeFunctionPointer_test.cpp
+++ b/c10/test/core/CompileTimeFunctionPointer_test.cpp
@@ -14,14 +14,14 @@ void dummy() {}
 using dummy_ptr = TORCH_FN_TYPE(dummy);
 static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value);
 static_assert(dummy_ptr::func_ptr() == &dummy);
-static_assert(std::is_same<void(), dummy_ptr::FuncType>::value);
+static_assert(std::is_same_v<void(), dummy_ptr::FuncType>);
 } // namespace test_access_through_type
 
 namespace test_access_through_value {
 void dummy() {}
 constexpr auto dummy_ptr = TORCH_FN(dummy);
 static_assert(dummy_ptr.func_ptr() == &dummy);
-static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value);
+static_assert(std::is_same_v<void(), decltype(dummy_ptr)::FuncType>);
 } // namespace test_access_through_value
 
 namespace test_access_through_type_also_works_if_specified_as_pointer {
@@ -29,14 +29,14 @@ void dummy() {}
 using dummy_ptr = TORCH_FN_TYPE(&dummy);
 static_assert(c10::is_compile_time_function_pointer<dummy_ptr>::value);
 static_assert(dummy_ptr::func_ptr() == &dummy);
-static_assert(std::is_same<void(), dummy_ptr::FuncType>::value);
+static_assert(std::is_same_v<void(), dummy_ptr::FuncType>);
 } // namespace test_access_through_type_also_works_if_specified_as_pointer
 
 namespace test_access_through_value_also_works_if_specified_as_pointer {
 void dummy() {}
 constexpr auto dummy_ptr = TORCH_FN(&dummy);
 static_assert(dummy_ptr.func_ptr() == &dummy);
-static_assert(std::is_same<void(), decltype(dummy_ptr)::FuncType>::value);
+static_assert(std::is_same_v<void(), decltype(dummy_ptr)::FuncType>);
 } // namespace test_access_through_value_also_works_if_specified_as_pointer
 
 namespace test_run_through_type {

--- a/c10/test/util/LeftRight_test.cpp
+++ b/c10/test/util/LeftRight_test.cpp
@@ -34,7 +34,7 @@ TEST(LeftRightTest, givenVector_whenWritingReturnsValue_thenValueIsReturned) {
   LeftRight<vector<int>> obj;
 
   auto a = obj.write([](vector<int>&) -> int { return 5; });
-  static_assert(std::is_same<int, decltype(a)>::value);
+  static_assert(std::is_same_v<int, decltype(a)>);
   EXPECT_EQ(5, a);
 }
 

--- a/c10/test/util/Metaprogramming_test.cpp
+++ b/c10/test/util/Metaprogramming_test.cpp
@@ -88,10 +88,10 @@ using is_my_movable_only_class =
     std::is_same<MovableOnly, std::remove_cv_t<std::remove_reference_t<T>>>;
 
 struct CopyCounting {
-  int move_count;
-  int copy_count;
+  int move_count{0};
+  int copy_count{0};
 
-  CopyCounting() : move_count(0), copy_count(0) {}
+  CopyCounting() {}
   CopyCounting(const CopyCounting& rhs)
       : move_count(rhs.move_count), copy_count(rhs.copy_count + 1) {}
   CopyCounting(CopyCounting&& rhs) noexcept

--- a/c10/test/util/ThreadLocal_test.cpp
+++ b/c10/test/util/ThreadLocal_test.cpp
@@ -149,7 +149,7 @@ TEST(ThreadLocalTest, TestObjectsAreReleased) {
   static std::atomic<int> ctors{0};
   static std::atomic<int> dtors{0};
   struct A {
-    A() : i() {
+    A() {
       ++ctors;
     }
 
@@ -160,7 +160,7 @@ TEST(ThreadLocalTest, TestObjectsAreReleased) {
     A(const A&) = delete;
     A& operator=(const A&) = delete;
 
-    int i;
+    int i{};
   };
 
   C10_DEFINE_TLS_static(A, a);
@@ -184,7 +184,7 @@ TEST(ThreadLocalTest, TestObjectsAreReleasedByNonstaticThreadLocal) {
   static std::atomic<int> ctors(0);
   static std::atomic<int> dtors(0);
   struct A {
-    A() : i() {
+    A() {
       ++ctors;
     }
 
@@ -195,7 +195,7 @@ TEST(ThreadLocalTest, TestObjectsAreReleasedByNonstaticThreadLocal) {
     A(const A&) = delete;
     A& operator=(const A&) = delete;
 
-    int i;
+    int i{};
   };
 
   std::atomic_bool b(false);

--- a/c10/test/util/TypeIndex_test.cpp
+++ b/c10/test/util/TypeIndex_test.cpp
@@ -148,7 +148,7 @@ static_assert(
 static_assert(
     string_view::npos ==
         get_fully_qualified_type_name<
-            typename std::remove_pointer<typename Type<int>::type>::type>()
+            std::remove_pointer_t<typename Type<int>::type>>()
             .find("*"),
     "");
 #endif

--- a/c10/test/util/TypeList_test.cpp
+++ b/c10/test/util/TypeList_test.cpp
@@ -14,79 +14,73 @@ static_assert(3 == size<typelist<int, float&, const MyClass&&>>::value, "");
 namespace test_from_tuple {
 class MyClass {};
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int, float&, const MyClass&&>,
-        from_tuple_t<std::tuple<int, float&, const MyClass&&>>>::value,
+        from_tuple_t<std::tuple<int, float&, const MyClass&&>>>,
     "");
-static_assert(std::is_same<typelist<>, from_tuple_t<std::tuple<>>>::value, "");
+static_assert(std::is_same_v<typelist<>, from_tuple_t<std::tuple<>>>, "");
 } // namespace test_from_tuple
 
 namespace test_to_tuple {
 class MyClass {};
 static_assert(
-    std::is_same<
+    std::is_same_v<
         std::tuple<int, float&, const MyClass&&>,
-        to_tuple_t<typelist<int, float&, const MyClass&&>>>::value,
+        to_tuple_t<typelist<int, float&, const MyClass&&>>>,
     "");
-static_assert(std::is_same<std::tuple<>, to_tuple_t<typelist<>>>::value, "");
+static_assert(std::is_same_v<std::tuple<>, to_tuple_t<typelist<>>>, "");
 } // namespace test_to_tuple
 
 namespace test_concat {
 class MyClass {};
-static_assert(std::is_same<typelist<>, concat_t<>>::value, "");
-static_assert(std::is_same<typelist<>, concat_t<typelist<>>>::value, "");
+static_assert(std::is_same_v<typelist<>, concat_t<>>, "");
+static_assert(std::is_same_v<typelist<>, concat_t<typelist<>>>, "");
+static_assert(std::is_same_v<typelist<>, concat_t<typelist<>, typelist<>>>, "");
+static_assert(std::is_same_v<typelist<int>, concat_t<typelist<int>>>, "");
 static_assert(
-    std::is_same<typelist<>, concat_t<typelist<>, typelist<>>>::value,
-    "");
-static_assert(std::is_same<typelist<int>, concat_t<typelist<int>>>::value, "");
-static_assert(
-    std::is_same<typelist<int>, concat_t<typelist<int>, typelist<>>>::value,
+    std::is_same_v<typelist<int>, concat_t<typelist<int>, typelist<>>>,
     "");
 static_assert(
-    std::is_same<typelist<int>, concat_t<typelist<>, typelist<int>>>::value,
+    std::is_same_v<typelist<int>, concat_t<typelist<>, typelist<int>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int>,
-        concat_t<typelist<>, typelist<int>, typelist<>>>::value,
+        concat_t<typelist<>, typelist<int>, typelist<>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int, float&>,
-        concat_t<typelist<int>, typelist<float&>>>::value,
+        concat_t<typelist<int>, typelist<float&>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int, float&>,
-        concat_t<typelist<>, typelist<int, float&>, typelist<>>>::value,
+        concat_t<typelist<>, typelist<int, float&>, typelist<>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int, float&, const MyClass&&>,
-        concat_t<
-            typelist<>,
-            typelist<int, float&>,
-            typelist<const MyClass&&>>>::value,
+        concat_t<typelist<>, typelist<int, float&>, typelist<const MyClass&&>>>,
     "");
 } // namespace test_concat
 
 namespace test_filter {
 class MyClass {};
 static_assert(
-    std::is_same<typelist<>, filter_t<std::is_reference, typelist<>>>::value,
+    std::is_same_v<typelist<>, filter_t<std::is_reference, typelist<>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<>,
-        filter_t<std::is_reference, typelist<int, float, double, MyClass>>>::
-        value,
+        filter_t<std::is_reference, typelist<int, float, double, MyClass>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<float&, const MyClass&&>,
         filter_t<
             std::is_reference,
-            typelist<int, float&, double, const MyClass&&>>>::value,
+            typelist<int, float&, double, const MyClass&&>>>,
     "");
 } // namespace test_filter
 
@@ -140,67 +134,63 @@ static_assert(!true_for_any_type<std::is_reference, typelist<>>::value, "");
 namespace test_map {
 class MyClass {};
 static_assert(
-    std::is_same<typelist<>, map_t<std::add_lvalue_reference_t, typelist<>>>::
-        value,
+    std::is_same_v<typelist<>, map_t<std::add_lvalue_reference_t, typelist<>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int&>,
-        map_t<std::add_lvalue_reference_t, typelist<int>>>::value,
+        map_t<std::add_lvalue_reference_t, typelist<int>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int&, double&, const MyClass&>,
         map_t<
             std::add_lvalue_reference_t,
-            typelist<int, double, const MyClass>>>::value,
+            typelist<int, double, const MyClass>>>,
     "");
 } // namespace test_map
 
 namespace test_head {
 class MyClass {};
-static_assert(std::is_same<int, head_t<typelist<int, double>>>::value, "");
+static_assert(std::is_same_v<int, head_t<typelist<int, double>>>, "");
 static_assert(
-    std::is_same<const MyClass&, head_t<typelist<const MyClass&, double>>>::
-        value,
+    std::is_same_v<const MyClass&, head_t<typelist<const MyClass&, double>>>,
     "");
 static_assert(
-    std::is_same<MyClass&&, head_t<typelist<MyClass&&, MyClass>>>::value,
+    std::is_same_v<MyClass&&, head_t<typelist<MyClass&&, MyClass>>>,
     "");
-static_assert(std::is_same<bool, head_t<typelist<bool>>>::value, "");
+static_assert(std::is_same_v<bool, head_t<typelist<bool>>>, "");
 } // namespace test_head
 
 namespace test_head_with_default {
 class MyClass {};
 static_assert(
-    std::is_same<int, head_with_default_t<bool, typelist<int, double>>>::value,
+    std::is_same_v<int, head_with_default_t<bool, typelist<int, double>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         const MyClass&,
-        head_with_default_t<bool, typelist<const MyClass&, double>>>::value,
+        head_with_default_t<bool, typelist<const MyClass&, double>>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         MyClass&&,
-        head_with_default_t<bool, typelist<MyClass&&, MyClass>>>::value,
+        head_with_default_t<bool, typelist<MyClass&&, MyClass>>>,
     "");
 static_assert(
-    std::is_same<int, head_with_default_t<bool, typelist<int>>>::value,
+    std::is_same_v<int, head_with_default_t<bool, typelist<int>>>,
     "");
-static_assert(
-    std::is_same<bool, head_with_default_t<bool, typelist<>>>::value,
-    "");
+static_assert(std::is_same_v<bool, head_with_default_t<bool, typelist<>>>, "");
 } // namespace test_head_with_default
 
 namespace test_reverse {
 class MyClass {};
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int, double, MyClass*, const MyClass&&>,
-        reverse_t<typelist<const MyClass&&, MyClass*, double, int>>>::value,
+        reverse_t<typelist<const MyClass&&, MyClass*, double, int>>>,
     "");
-static_assert(std::is_same<typelist<>, reverse_t<typelist<>>>::value, "");
+static_assert(std::is_same_v<typelist<>, reverse_t<typelist<>>>, "");
 } // namespace test_reverse
 
 namespace test_map_types_to_values {
@@ -215,7 +205,7 @@ TEST(TypeListTest, MapTypesToValues_sametype) {
   auto sizes =
       map_types_to_values<typelist<int64_t, bool, uint32_t>>(map_to_size());
   std::tuple<size_t, size_t, size_t> expected(8, 1, 4);
-  static_assert(std::is_same<decltype(expected), decltype(sizes)>::value, "");
+  static_assert(std::is_same_v<decltype(expected), decltype(sizes)>, "");
   EXPECT_EQ(expected, sizes);
 }
 
@@ -230,9 +220,9 @@ TEST(TypeListTest, MapTypesToValues_differenttypes) {
   auto shared_ptrs =
       map_types_to_values<typelist<int, double>>(map_make_shared());
   static_assert(
-      std::is_same<
+      std::is_same_v<
           std::tuple<std::shared_ptr<int>, std::shared_ptr<double>>,
-          decltype(shared_ptrs)>::value,
+          decltype(shared_ptrs)>,
       "");
 }
 
@@ -258,7 +248,7 @@ TEST(TypeListTest, MapTypesToValues_members) {
   auto result =
       map_types_to_values<typelist<Class1, Class2>>(mapper_call_func());
   std::tuple<int, double> expected(3, 2.0);
-  static_assert(std::is_same<decltype(expected), decltype(result)>::value, "");
+  static_assert(std::is_same_v<decltype(expected), decltype(result)>, "");
   EXPECT_EQ(expected, result);
 }
 
@@ -273,7 +263,7 @@ TEST(TypeListTest, MapTypesToValues_empty) {
   auto result =
       map_types_to_values<typelist<>>(mapper_call_nonexistent_function());
   std::tuple<> expected;
-  static_assert(std::is_same<decltype(expected), decltype(result)>::value, "");
+  static_assert(std::is_same_v<decltype(expected), decltype(result)>, "");
   EXPECT_EQ(expected, result);
 }
 } // namespace test_map_types_to_values
@@ -299,82 +289,75 @@ static_assert(!contains<typelist<>, double>::value, "");
 } // namespace test_contains
 
 namespace test_take {
-static_assert(std::is_same<typelist<>, take_t<typelist<>, 0>>::value, "");
+static_assert(std::is_same_v<typelist<>, take_t<typelist<>, 0>>, "");
+static_assert(std::is_same_v<typelist<>, take_t<typelist<int64_t>, 0>>, "");
 static_assert(
-    std::is_same<typelist<>, take_t<typelist<int64_t>, 0>>::value,
+    std::is_same_v<typelist<int64_t>, take_t<typelist<int64_t>, 1>>,
     "");
 static_assert(
-    std::is_same<typelist<int64_t>, take_t<typelist<int64_t>, 1>>::value,
+    std::is_same_v<typelist<>, take_t<typelist<int64_t, int32_t>, 0>>,
     "");
 static_assert(
-    std::is_same<typelist<>, take_t<typelist<int64_t, int32_t>, 0>>::value,
+    std::is_same_v<typelist<int64_t>, take_t<typelist<int64_t, int32_t>, 1>>,
     "");
 static_assert(
-    std::is_same<typelist<int64_t>, take_t<typelist<int64_t, int32_t>, 1>>::
-        value,
-    "");
-static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int64_t, int32_t>,
-        take_t<typelist<int64_t, int32_t>, 2>>::value,
+        take_t<typelist<int64_t, int32_t>, 2>>,
     "");
 } // namespace test_take
 
 namespace test_drop {
-static_assert(std::is_same<typelist<>, drop_t<typelist<>, 0>>::value, "");
+static_assert(std::is_same_v<typelist<>, drop_t<typelist<>, 0>>, "");
 static_assert(
-    std::is_same<typelist<int64_t>, drop_t<typelist<int64_t>, 0>>::value,
+    std::is_same_v<typelist<int64_t>, drop_t<typelist<int64_t>, 0>>,
     "");
+static_assert(std::is_same_v<typelist<>, drop_t<typelist<int64_t>, 1>>, "");
 static_assert(
-    std::is_same<typelist<>, drop_t<typelist<int64_t>, 1>>::value,
-    "");
-static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int64_t, int32_t>,
-        drop_t<typelist<int64_t, int32_t>, 0>>::value,
+        drop_t<typelist<int64_t, int32_t>, 0>>,
     "");
 static_assert(
-    std::is_same<typelist<int32_t>, drop_t<typelist<int64_t, int32_t>, 1>>::
-        value,
+    std::is_same_v<typelist<int32_t>, drop_t<typelist<int64_t, int32_t>, 1>>,
     "");
 static_assert(
-    std::is_same<typelist<>, drop_t<typelist<int64_t, int32_t>, 2>>::value,
+    std::is_same_v<typelist<>, drop_t<typelist<int64_t, int32_t>, 2>>,
     "");
 } // namespace test_drop
 
 namespace test_drop_if_nonempty {
 static_assert(
-    std::is_same<typelist<>, drop_if_nonempty_t<typelist<>, 0>>::value,
+    std::is_same_v<typelist<>, drop_if_nonempty_t<typelist<>, 0>>,
     "");
 static_assert(
-    std::is_same<typelist<int64_t>, drop_if_nonempty_t<typelist<int64_t>, 0>>::
-        value,
+    std::is_same_v<typelist<int64_t>, drop_if_nonempty_t<typelist<int64_t>, 0>>,
     "");
 static_assert(
-    std::is_same<typelist<>, drop_if_nonempty_t<typelist<int64_t>, 1>>::value,
+    std::is_same_v<typelist<>, drop_if_nonempty_t<typelist<int64_t>, 1>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int64_t, int32_t>,
-        drop_if_nonempty_t<typelist<int64_t, int32_t>, 0>>::value,
+        drop_if_nonempty_t<typelist<int64_t, int32_t>, 0>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<int32_t>,
-        drop_if_nonempty_t<typelist<int64_t, int32_t>, 1>>::value,
+        drop_if_nonempty_t<typelist<int64_t, int32_t>, 1>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<>,
-        drop_if_nonempty_t<typelist<int64_t, int32_t>, 2>>::value,
+        drop_if_nonempty_t<typelist<int64_t, int32_t>, 2>>,
     "");
 static_assert(
-    std::is_same<typelist<>, drop_if_nonempty_t<typelist<>, 1>>::value,
+    std::is_same_v<typelist<>, drop_if_nonempty_t<typelist<>, 1>>,
     "");
 static_assert(
-    std::is_same<
+    std::is_same_v<
         typelist<>,
-        drop_if_nonempty_t<typelist<int64_t, int32_t>, 3>>::value,
+        drop_if_nonempty_t<typelist<int64_t, int32_t>, 3>>,
     "");
 } // namespace test_drop_if_nonempty
 // NOLINTEND(modernize-unary-static-assert)

--- a/c10/test/util/flags_test.cpp
+++ b/c10/test/util/flags_test.cpp
@@ -15,8 +15,7 @@ TEST(FlagsTest, TestGflagsCorrectness) {
   FLAGS_c10_flags_test_only_flag = true;
   EXPECT_EQ(FLAGS_c10_flags_test_only_flag, true);
 #else // C10_USE_GFLAGS
-  std::cout << "Caffe2 is not built with gflags. Nothing to test here."
-            << std::endl;
+  std::cout << "Caffe2 is not built with gflags. Nothing to test here." << '\n';
 #endif
 }
 

--- a/c10/test/util/small_vector_test.cpp
+++ b/c10/test/util/small_vector_test.cpp
@@ -888,8 +888,8 @@ TEST(SmallVectorCustomTest, NoAssignTest) {
 }
 
 struct MovedFrom {
-  bool hasValue;
-  MovedFrom() : hasValue(true) {}
+  bool hasValue{true};
+  MovedFrom() = default;
   MovedFrom(MovedFrom&& m) noexcept : hasValue(m.hasValue) {
     m.hasValue = false;
   }
@@ -1107,7 +1107,7 @@ class SmallVectorReferenceInvalidationTest : public SmallVectorTestBase {
 
   template <class T>
   static bool isValueType() {
-    return std::is_same<T, typename VectorT::value_type>::value;
+    return std::is_same_v<T, typename VectorT::value_type>;
   }
 
   void SetUp() override {

--- a/c10/test/util/ssize_test.cpp
+++ b/c10/test/util/ssize_test.cpp
@@ -30,7 +30,7 @@ TEST(ssizeTest, size_t) {
 
 TEST(ssizeTest, size_t_overflow) {
 #if defined(NDEBUG)
-  GTEST_SKIP() << "Only valid if assert is enabled." << std::endl;
+  GTEST_SKIP() << "Only valid if assert is enabled." << '\n';
 #endif
 
   constexpr auto ptrdiff_t_max =
@@ -47,7 +47,7 @@ TEST(ssizeTest, small_container_promotes_to_ptrdiff_t) {
 
 TEST(ssizeTest, promotes_to_64_bit_on_32_bit_platform) {
   if (sizeof(std::intptr_t) != 4) {
-    GTEST_SKIP() << "Only valid in 64-bits." << std::endl;
+    GTEST_SKIP() << "Only valid in 64-bits." << '\n';
   }
 
   auto signed_size = ssize(Container(std::uint64_t{3}));

--- a/c10/test/util/typeid_test.cpp
+++ b/c10/test/util/typeid_test.cpp
@@ -72,18 +72,18 @@ TEST(TypeMetaTest, TypeMeta) {
 
 class ClassAllowAssignment {
  public:
-  ClassAllowAssignment() : x(42) {}
+  ClassAllowAssignment() = default;
   ClassAllowAssignment(const ClassAllowAssignment& src) = default;
   ClassAllowAssignment& operator=(const ClassAllowAssignment& src) = default;
-  int x;
+  int x{42};
 };
 
 class ClassNoAssignment {
  public:
-  ClassNoAssignment() : x(42) {}
+  ClassNoAssignment() = default;
   ClassNoAssignment(const ClassNoAssignment& src) = delete;
   ClassNoAssignment& operator=(const ClassNoAssignment& src) = delete;
-  int x;
+  int x{42};
 };
 } // namespace
 

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -128,7 +128,7 @@ bool IsAPIUsageDebugMode() {
 
 void APIUsageDebug(const string& event) {
   // use stderr to avoid messing with glog
-  std::cerr << "PYTORCH_API_USAGE " << event << std::endl;
+  std::cerr << "PYTORCH_API_USAGE " << event << '\n';
 }
 
 APIUsageLoggerType* GetAPIUsageLogger() {
@@ -393,12 +393,12 @@ bool InitCaffeLogging(int* argc, char** argv) {
     std::cerr << "InitCaffeLogging() has to be called after "
                  "c10::ParseCommandLineFlags. Modify your program to make sure "
                  "of this."
-              << std::endl;
+              << '\n';
     return false;
   }
   if (FLAGS_caffe2_log_level > GLOG_FATAL) {
     std::cerr << "The log level of Caffe2 has to be no larger than GLOG_FATAL("
-              << GLOG_FATAL << "). Capping it to GLOG_FATAL." << std::endl;
+              << GLOG_FATAL << "). Capping it to GLOG_FATAL." << '\n';
     FLAGS_caffe2_log_level = GLOG_FATAL;
   }
   return true;
@@ -542,7 +542,7 @@ void setLogLevelFlagFromEnv() {
       << "`TORCH_CPP_LOG_LEVEL` environment variable cannot be parsed. Valid values are "
          "`INFO`, `WARNING`, `ERROR`, and `FATAL` or their numerical equivalents `0`, `1`, "
          "`2`, and `3`."
-      << std::endl;
+      << '\n';
 }
 
 } // namespace

--- a/c10/util/flags_use_no_gflags.cpp
+++ b/c10/util/flags_use_no_gflags.cpp
@@ -40,7 +40,7 @@ C10_EXPORT bool ParseCommandLineFlags(int* pargc, char*** pargv) {
     return true;
   char** argv = *pargv;
   bool success = true;
-  GlobalInitStream() << "Parsing commandline arguments for c10." << std::endl;
+  GlobalInitStream() << "Parsing commandline arguments for c10." << '\n';
   // write_head is the location we write the unused arguments to.
   int write_head = 1;
   for (int i = 1; i < *pargc; ++i) {
@@ -48,11 +48,11 @@ C10_EXPORT bool ParseCommandLineFlags(int* pargc, char*** pargv) {
 
     if (arg.find("--help") != string::npos) {
       // Print the help message, and quit.
-      std::cout << UsageMessage() << std::endl;
-      std::cout << "Arguments: " << std::endl;
+      std::cout << UsageMessage() << '\n';
+      std::cout << "Arguments: " << '\n';
       for (const auto& help_msg : C10FlagsRegistry()->HelpMessage()) {
         std::cout << "    " << help_msg.first << ": " << help_msg.second
-                  << std::endl;
+                  << '\n';
       }
       exit(0);
     }
@@ -61,7 +61,7 @@ C10_EXPORT bool ParseCommandLineFlags(int* pargc, char*** pargv) {
       GlobalInitStream()
           << "C10 flag: commandline argument does not match --name=var "
              "or --name format: "
-          << arg << ". Ignoring this argument." << std::endl;
+          << arg << ". Ignoring this argument." << '\n';
       argv[write_head++] = argv[i];
       continue;
     }
@@ -92,14 +92,14 @@ C10_EXPORT bool ParseCommandLineFlags(int* pargc, char*** pargv) {
     // If the flag is not registered, we will ignore it.
     if (!C10FlagsRegistry()->Has(key)) {
       GlobalInitStream() << "C10 flag: unrecognized commandline argument: "
-                         << arg << std::endl;
+                         << arg << '\n';
       success = false;
       break;
     }
     std::unique_ptr<C10FlagParser> parser(
         C10FlagsRegistry()->Create(key, value));
     if (!parser->success()) {
-      GlobalInitStream() << "C10 flag: illegal argument: " << arg << std::endl;
+      GlobalInitStream() << "C10 flag: illegal argument: " << arg << '\n';
       success = false;
       break;
     }
@@ -138,7 +138,7 @@ C10_EXPORT bool C10FlagParser::Parse<int>(const string& content, int* value) {
     return true;
   } catch (...) {
     GlobalInitStream() << "C10 flag error: Cannot convert argument to int: "
-                       << content << std::endl;
+                       << content << '\n';
     return false;
   }
 }
@@ -158,7 +158,7 @@ C10_EXPORT bool C10FlagParser::Parse<int64_t>(
     return true;
   } catch (...) {
     GlobalInitStream() << "C10 flag error: Cannot convert argument to int: "
-                       << content << std::endl;
+                       << content << '\n';
     return false;
   }
 }
@@ -172,7 +172,7 @@ C10_EXPORT bool C10FlagParser::Parse<double>(
     return true;
   } catch (...) {
     GlobalInitStream() << "C10 flag error: Cannot convert argument to double: "
-                       << content << std::endl;
+                       << content << '\n';
     return false;
   }
 }
@@ -191,12 +191,12 @@ C10_EXPORT bool C10FlagParser::Parse<bool>(const string& content, bool* value) {
   } else {
     GlobalInitStream()
         << "C10 flag error: Cannot convert argument to bool: " << content
-        << std::endl
+        << '\n'
         << "Note that if you are passing in a bool flag, you need to "
            "explicitly specify it, like --arg=True or --arg True. Otherwise, "
            "the next argument may be inadvertently used as the argument, "
            "causing the above error."
-        << std::endl;
+        << '\n';
     return false;
   }
 }

--- a/c10/util/signal_handler.cpp
+++ b/c10/util/signal_handler.cpp
@@ -175,7 +175,7 @@ void FatalSignalHandler::stacktraceSignalHandler(bool needsLock) {
       ::getpid(),
       tid,
       c10::get_backtrace());
-  std::cerr << backtrace << std::endl;
+  std::cerr << backtrace << '\n';
   if (needsLock) {
     ul.unlock();
     writingCond.notify_all();
@@ -229,7 +229,7 @@ void FatalSignalHandler::fatalSignalHandler(int signum) {
         if (std::cv_status::timeout == writingCond.wait_until(ul, now + 2s)) {
           if (!signalReceived) {
             std::cerr << "signal lost waiting for stacktrace " << pid << ":"
-                      << tid << std::endl;
+                      << tid << '\n';
             break;
           }
         }

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -338,7 +338,8 @@ namespace detail {
 struct noop_gil_scoped_release {
   // user-defined constructor (i.e. not defaulted) to avoid
   // unused-variable warnings at usage sites of this class
-  noop_gil_scoped_release() = default;
+  // NOLINTNEXTLINE(modernize-use-equals-default)
+  noop_gil_scoped_release(){};
 };
 
 template <bool release_gil>

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -338,7 +338,7 @@ namespace detail {
 struct noop_gil_scoped_release {
   // user-defined constructor (i.e. not defaulted) to avoid
   // unused-variable warnings at usage sites of this class
-  noop_gil_scoped_release() {}
+  noop_gil_scoped_release() = default;
 };
 
 template <bool release_gil>

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -178,11 +178,11 @@ static PyObject* THPModule_initExtension(
       if (torch::get_symbolize_mode() == torch::unwind::Mode::addr2line) {
         LOG(WARNING)
             << "symbolizing C++ stack trace for exception; if this hangs, rerun with TORCH_DISABLE_ADDR2LINE=1..."
-            << std::endl;
+            << '\n';
       }
       auto s_tbs = torch::symbolize({tb.get()});
       std::stringstream oss;
-      oss << "C++ CapturedTraceback:" << std::endl;
+      oss << "C++ CapturedTraceback:" << '\n';
       const auto& s_tb = s_tbs.tracebacks.at(0);
       for (auto idx : c10::irange(s_tb.size())) {
         // Skip the first few frames:
@@ -195,7 +195,7 @@ static PyObject* THPModule_initExtension(
         auto frame_id = s_tb[idx];
         const auto& frame = s_tbs.all_frames.at(frame_id);
         oss << "#" << idx << " " << frame.funcname << " from " << frame.filename
-            << ":" << frame.lineno << std::endl;
+            << ":" << frame.lineno << '\n';
       }
       return oss.str();
     });

--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -202,7 +202,7 @@ static PyObject* THPStream_record_event(
     PyObject* kwargs) {
   HANDLE_TH_ERRORS
   auto self = (THPStream*)_self;
-  PyObject* _new_event;
+  PyObject* _new_event = nullptr;
   PyObject* _event = Py_None;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
@@ -274,7 +274,7 @@ static PyObject* THPStream_richcompare(
     PyObject* self,
     PyObject* other,
     int op) {
-  PyObject* result = NULL;
+  PyObject* result = nullptr;
   if (other == Py_None) {
     result = Py_False;
   } else {

--- a/torch/csrc/cpu/Module.h
+++ b/torch/csrc/cpu/Module.h
@@ -1,10 +1,8 @@
 #pragma once
 #include <torch/csrc/python_headers.h>
 
-namespace torch {
-namespace cpu {
+namespace torch::cpu {
 
 void initModule(PyObject* module);
 
-} // namespace cpu
-} // namespace torch
+} // namespace torch::cpu

--- a/torch/csrc/functorch/init.cpp
+++ b/torch/csrc/functorch/init.cpp
@@ -392,13 +392,13 @@ static void _set_dynamic_layer_keys_included(bool value) {
 }
 
 static void dump_dls() {
-  std::cout << getDynamicLayerStack() << std::endl;
+  std::cout << getDynamicLayerStack() << '\n';
 }
 
 static void dump_local_tls() {
   auto tls = c10::impl::tls_local_dispatch_key_set();
-  std::cout << "[Local Include] " << tls.included_ << std::endl;
-  std::cout << "[Local Exclude] " << tls.excluded_ << std::endl;
+  std::cout << "[Local Include] " << tls.included_ << '\n';
+  std::cout << "[Local Exclude] " << tls.excluded_ << '\n';
 }
 
 namespace {

--- a/torch/csrc/monitor/counters.cpp
+++ b/torch/csrc/monitor/counters.cpp
@@ -2,8 +2,7 @@
 
 #include <unordered_set>
 
-namespace torch {
-namespace monitor {
+namespace torch::monitor {
 
 const char* aggregationName(Aggregation agg) {
   switch (agg) {
@@ -64,5 +63,4 @@ void unregisterStat(Stat<int64_t>* stat) {
 }
 } // namespace detail
 
-} // namespace monitor
-} // namespace torch
+} // namespace torch::monitor

--- a/torch/csrc/monitor/counters.h
+++ b/torch/csrc/monitor/counters.h
@@ -10,8 +10,7 @@
 
 #include <torch/csrc/monitor/events.h>
 
-namespace torch {
-namespace monitor {
+namespace torch::monitor {
 
 constexpr int NUM_AGGREGATIONS = 7;
 
@@ -275,5 +274,4 @@ class Stat {
   const std::chrono::milliseconds windowSize_;
   const int64_t maxSamples_;
 };
-} // namespace monitor
-} // namespace torch
+} // namespace torch::monitor

--- a/torch/csrc/monitor/events.cpp
+++ b/torch/csrc/monitor/events.cpp
@@ -4,8 +4,7 @@
 #include <mutex>
 #include <vector>
 
-namespace torch {
-namespace monitor {
+namespace torch::monitor {
 
 namespace {
 class EventHandlers {
@@ -55,5 +54,4 @@ void unregisterEventHandler(const std::shared_ptr<EventHandler>& p) {
   EventHandlers::get().unregisterEventHandler(p);
 }
 
-} // namespace monitor
-} // namespace torch
+} // namespace torch::monitor

--- a/torch/csrc/monitor/events.h
+++ b/torch/csrc/monitor/events.h
@@ -8,8 +8,7 @@
 #include <c10/macros/Macros.h>
 #include <variant>
 
-namespace torch {
-namespace monitor {
+namespace torch::monitor {
 
 // data_value_t is the type for Event data values.
 using data_value_t = std::variant<std::string, double, int64_t, bool>;
@@ -69,5 +68,4 @@ TORCH_API void registerEventHandler(std::shared_ptr<EventHandler> p);
 // shared_ptr.
 TORCH_API void unregisterEventHandler(const std::shared_ptr<EventHandler>& p);
 
-} // namespace monitor
-} // namespace torch
+} // namespace torch::monitor

--- a/torch/csrc/monitor/python_init.cpp
+++ b/torch/csrc/monitor/python_init.cpp
@@ -15,8 +15,7 @@
 #include <torch/csrc/monitor/counters.h>
 #include <torch/csrc/monitor/events.h>
 
-namespace pybind11 {
-namespace detail {
+namespace pybind11::detail {
 template <>
 struct type_caster<torch::monitor::data_value_t> {
  public:
@@ -61,11 +60,9 @@ struct type_caster<torch::monitor::data_value_t> {
     throw std::runtime_error("unknown data_value_t type");
   }
 };
-} // namespace detail
-} // namespace pybind11
+} // namespace pybind11::detail
 
-namespace torch {
-namespace monitor {
+namespace torch::monitor {
 
 namespace {
 class PythonEventHandler : public EventHandler {
@@ -341,5 +338,4 @@ void initMonitorBindings(PyObject* module) {
           )DOC");
 }
 
-} // namespace monitor
-} // namespace torch
+} // namespace torch::monitor

--- a/torch/csrc/monitor/python_init.h
+++ b/torch/csrc/monitor/python_init.h
@@ -2,10 +2,8 @@
 
 #include <torch/csrc/utils/pybind.h>
 
-namespace torch {
-namespace monitor {
+namespace torch::monitor {
 
 void initMonitorBindings(PyObject* module);
 
 }
-} // namespace torch

--- a/torch/csrc/mtia/Module.cpp
+++ b/torch/csrc/mtia/Module.cpp
@@ -11,8 +11,7 @@
 #include <pthread.h>
 #endif
 
-namespace torch {
-namespace mtia {
+namespace torch::mtia {
 
 static bool in_bad_fork = false; // True for children forked after mtia init
 
@@ -88,5 +87,4 @@ void initModule(PyObject* module) {
   });
 }
 
-} // namespace mtia
-} // namespace torch
+} // namespace torch::mtia

--- a/torch/csrc/mtia/Module.h
+++ b/torch/csrc/mtia/Module.h
@@ -2,11 +2,9 @@
 
 #include <torch/csrc/python_headers.h>
 
-namespace torch {
-namespace mtia {
+namespace torch::mtia {
 
 // PyMethodDef* python_functions();
 void initModule(PyObject* module);
 
-} // namespace mtia
-} // namespace torch
+} // namespace torch::mtia

--- a/torch/csrc/onnx/init.cpp
+++ b/torch/csrc/onnx/init.cpp
@@ -218,7 +218,7 @@ void initONNXBindings(PyObject* module) {
                   &std::cerr, [](std::ostream*) {});
             } else {
               std::cerr << "ERROR: only `stdout` and `stderr`"
-                        << "are supported as `stream_name`" << std::endl;
+                        << "are supported as `stream_name`" << '\n';
             }
             ::torch::jit::onnx::set_log_output_stream(out);
           },
@@ -231,7 +231,7 @@ void initONNXBindings(PyObject* module) {
               for (auto arg : args) {
                 out << ::c10::str(arg);
               }
-              out << std::endl;
+              out << '\n';
             }
           },
           "Write `args` to the previously specified ONNX log stream.")

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -4,9 +4,7 @@
 
 #include <utility>
 
-namespace torch {
-namespace profiler {
-namespace impl {
+namespace torch::profiler::impl {
 
 using GlobalManager = GlobalStateManager<ProfilerStateBase>;
 
@@ -182,6 +180,4 @@ torch::profiler::impl::ProfilerConfig getProfilerConfig() {
   return state_ptr->config();
 }
 
-} // namespace impl
-} // namespace profiler
-} // namespace torch
+} // namespace torch::profiler::impl

--- a/torch/csrc/profiler/orchestration/observer.h
+++ b/torch/csrc/profiler/orchestration/observer.h
@@ -5,9 +5,7 @@
 
 #include <utility>
 
-namespace torch {
-namespace profiler {
-namespace impl {
+namespace torch::profiler::impl {
 
 // ----------------------------------------------------------------------------
 // -- Profiler Config ---------------------------------------------------------
@@ -161,6 +159,4 @@ TORCH_API bool profilerEnabled();
 TORCH_API ActiveProfilerType profilerType();
 TORCH_API ProfilerConfig getProfilerConfig();
 
-} // namespace impl
-} // namespace profiler
-} // namespace torch
+} // namespace torch::profiler::impl

--- a/torch/csrc/profiler/orchestration/python_tracer.cpp
+++ b/torch/csrc/profiler/orchestration/python_tracer.cpp
@@ -1,9 +1,6 @@
 #include <torch/csrc/profiler/orchestration/python_tracer.h>
 
-namespace torch {
-namespace profiler {
-namespace impl {
-namespace python_tracer {
+namespace torch::profiler::impl::python_tracer {
 namespace {
 MakeFn make_fn;
 
@@ -32,7 +29,4 @@ std::unique_ptr<PythonTracerBase> PythonTracerBase::make(RecordQueue* queue) {
   }
   return make_fn(queue);
 }
-} // namespace python_tracer
-} // namespace impl
-} // namespace profiler
-} // namespace torch
+} // namespace torch::profiler::impl::python_tracer

--- a/torch/csrc/profiler/orchestration/python_tracer.h
+++ b/torch/csrc/profiler/orchestration/python_tracer.h
@@ -11,9 +11,7 @@
 #include <torch/csrc/profiler/kineto_shim.h>
 #include <torch/csrc/profiler/util.h>
 
-namespace torch {
-namespace profiler {
-namespace impl {
+namespace torch::profiler::impl {
 
 class RecordQueue;
 struct Result;
@@ -59,6 +57,4 @@ struct TORCH_API PythonTracerBase {
 using MakeFn = std::unique_ptr<PythonTracerBase> (*)(RecordQueue*);
 TORCH_API void registerTracer(MakeFn make_tracer);
 } // namespace python_tracer
-} // namespace impl
-} // namespace profiler
-} // namespace torch
+} // namespace torch::profiler::impl

--- a/torch/csrc/profiler/orchestration/vulkan.cpp
+++ b/torch/csrc/profiler/orchestration/vulkan.cpp
@@ -2,10 +2,7 @@
 
 #include <utility>
 
-namespace torch {
-namespace profiler {
-namespace impl {
-namespace vulkan {
+namespace torch::profiler::impl::vulkan {
 namespace {
 
 GetShaderNameAndDurationNsFn get_shader_name_and_duration_ns_fn;
@@ -41,7 +38,4 @@ std::tuple<std::string, uint64_t> getShaderNameAndDurationNs(
   return get_shader_name_and_duration_ns_fn(vulkan_id.value_of());
 }
 
-} // namespace vulkan
-} // namespace impl
-} // namespace profiler
-} // namespace torch
+} // namespace torch::profiler::impl::vulkan

--- a/torch/csrc/profiler/orchestration/vulkan.h
+++ b/torch/csrc/profiler/orchestration/vulkan.h
@@ -4,10 +4,7 @@
 #include <torch/csrc/profiler/util.h>
 #include <cstdint>
 
-namespace torch {
-namespace profiler {
-namespace impl {
-namespace vulkan {
+namespace torch::profiler::impl::vulkan {
 
 // Using function pointer i.e. [std::tuple<std::string, uint64_t> (*)(int64_t)]
 // doesn't work because we need to capture the QueryPool in the lambda context
@@ -22,7 +19,4 @@ TORCH_API void deregisterGetShaderNameAndDurationNs();
 std::tuple<std::string, uint64_t> getShaderNameAndDurationNs(
     const vulkan_id_t& vulkan_id);
 
-} // namespace vulkan
-} // namespace impl
-} // namespace profiler
-} // namespace torch
+} // namespace torch::profiler::impl::vulkan

--- a/torch/csrc/profiler/stubs/base.cpp
+++ b/torch/csrc/profiler/stubs/base.cpp
@@ -2,9 +2,7 @@
 
 #include <c10/util/Exception.h>
 
-namespace torch {
-namespace profiler {
-namespace impl {
+namespace torch::profiler::impl {
 
 ProfilerStubs::~ProfilerStubs() = default;
 
@@ -78,6 +76,4 @@ REGISTER_DEFAULT(itt, ITT)
 REGISTER_DEFAULT(privateuse1, PrivateUse1)
 #undef REGISTER_DEFAULT
 
-} // namespace impl
-} // namespace profiler
-} // namespace torch
+} // namespace torch::profiler::impl

--- a/torch/csrc/profiler/stubs/base.h
+++ b/torch/csrc/profiler/stubs/base.h
@@ -9,9 +9,7 @@
 
 struct CUevent_st;
 
-namespace torch {
-namespace profiler {
-namespace impl {
+namespace torch::profiler::impl {
 
 // ----------------------------------------------------------------------------
 // -- Annotation --------------------------------------------------------------
@@ -52,6 +50,4 @@ using vulkan_id_t = strong::type<
     strong::convertible_to<int64_t>,
     strong::hashable>;
 
-} // namespace impl
-} // namespace profiler
-} // namespace torch
+} // namespace torch::profiler::impl

--- a/torch/csrc/profiler/stubs/cuda.cpp
+++ b/torch/csrc/profiler/stubs/cuda.cpp
@@ -12,9 +12,7 @@
 #include <torch/csrc/profiler/stubs/base.h>
 #include <torch/csrc/profiler/util.h>
 
-namespace torch {
-namespace profiler {
-namespace impl {
+namespace torch::profiler::impl {
 namespace {
 
 static inline void cudaCheck(cudaError_t result, const char* file, int line) {
@@ -111,6 +109,4 @@ struct RegisterCUDAMethods {
 RegisterCUDAMethods reg;
 
 } // namespace
-} // namespace impl
-} // namespace profiler
-} // namespace torch
+} // namespace torch::profiler::impl

--- a/torch/csrc/profiler/unwind/action.h
+++ b/torch/csrc/profiler/unwind/action.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <stdint.h>
+#include <cstdint>
 #include <ostream>
 
 namespace torch::unwind {

--- a/torch/csrc/profiler/unwind/eh_frame_hdr.h
+++ b/torch/csrc/profiler/unwind/eh_frame_hdr.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <stdint.h>
+#include <cstdint>
 #include <ostream>
 
 #include <torch/csrc/profiler/unwind/lexer.h>

--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -9,8 +9,7 @@ namespace at {
 class Tensor;
 } // namespace at
 
-namespace torch {
-namespace tensors {
+namespace torch::tensors {
 
 // Initializes the Python tensor type objects: torch.FloatTensor,
 // torch.DoubleTensor, etc. and binds them in their containing modules.
@@ -32,5 +31,4 @@ at::Device get_default_device();
 
 // Gets the ScalarType for the default tensor type.
 at::ScalarType get_default_scalar_type();
-} // namespace tensors
-} // namespace torch
+} // namespace torch::tensors

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -274,7 +274,7 @@ char* tensor_repr(at::Tensor tensor) {
   // observed that sometimes gdb passes the outer Tensor address exactly as is
   // into this function.
   // See https://github.com/pytorch/pytorch/issues/134762
-  pytensor = THPVariable_Wrap(tensor);
+  pytensor = THPVariable_Wrap(std::move(tensor));
   if (!pytensor)
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -16,8 +16,6 @@
 #include <iterator>
 #include <sstream>
 #include <string>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 int THPUtils_getCallable(PyObject* arg, PyObject** result) {
@@ -274,7 +272,8 @@ char* tensor_repr(at::Tensor tensor) {
   // observed that sometimes gdb passes the outer Tensor address exactly as is
   // into this function.
   // See https://github.com/pytorch/pytorch/issues/134762
-  pytensor = THPVariable_Wrap(std::move(tensor));
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
+  pytensor = THPVariable_Wrap(tensor);
   if (!pytensor)
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     goto error;


### PR DESCRIPTION
 Before we can use clang-tidy-17