### PR TITLE
cannot fuse - no shared data

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -845,6 +845,13 @@ class Reduction(Loops):
         reduction_numel_hint = V.graph.sizevars.symbolic_hint(reduction_numel)
         numel_hint = V.graph.sizevars.symbolic_hint(sympy_product(ranges))
 
+        print("reduction_numel_hint", reduction_numel_hint)
+        print("numel_hint", numel_hint)
+        
+        import traceback
+
+        traceback.print_stack()
+
         should_split = (
             not V.graph.has_feature(device, BackendFeature.REDUCE_TO_SINGLE_ELEMENT)
             and reduction_type
@@ -857,6 +864,11 @@ class Reduction(Loops):
             and _is_static(reduction_numel_hint)
             and _is_static(numel_hint)
         )
+
+        # TODO: add a config option to skip reducton split
+        # Defer the reduction splitting, will split in the scheduler
+        should_split = False
+
         if not should_split:
             return ReductionHint.DEFAULT, 1
 


### PR DESCRIPTION
Just for testing


Test code:
```
import torch
from torch._inductor.utils import do_bench_using_profiling
from triton.testing import do_bench

torch._inductor.config.force_disable_caches = True
# torch._inductor.config.aggressive_fusion = True

import os


def test(x):
    y = torch.sum(x)
    z = x / 10.0
    z_t = z.t().contiguous().t()
    return y, z, z_t

test = torch.compile(test)

x = torch.randn(4096, 2048, device="cuda")

y, z, z_t = test(x)

print(y.shape, z.shape, z_t.shape)
```


`
TORCHINDUCTOR_LOOP_ORDERING_AFTER_FUSION=1 TORCHINDUCTOR_PROFILE=1 TORCHINDUCTOR_PROFILE_WITH_DO_BENCH_USING_PROFILING=1 TORCHINDUCTOR_PROFILE_OUTPUT=/tmp/profile.txt INDUCTOR_ORIG_FX_SVG=1 INDUCTOR_POST_FUSION_SVG=1 TORCHINDUCTOR_COMPILE_THREADS=1 TORCH_LOGS="fusion, +inductor,+schedule,output_code" TORCH_COMPILE_DEBUG=1 python test1.py  2>&1 | tee log4.txt
`


With Loop o enabled, `z` and `z_t` are fused into one op. However, (after I temporarily disabled reduction split), when checking the fusion between `x.sum` (`node1`) and `fused z_t` (`node2`), they can not fuse because "no shared data".

```
node1 SchedulerNode(name='op0')
node1.read_writes.reads 1 OrderedSet([MemoryDep('arg0_1', 2048*d0 + d1, {d0: 4096, d1: 2048}, None)])
node1.read_writes.writes 1 OrderedSet([MemoryDep('buf0', 0, {}, None)])

node2 FusedSchedulerNode(nodes=op1_op2)
node2.read_writes.reads 1 OrderedSet([MemoryDep('arg0_1', d0 + 2048*d1, {d0: 2048, d1: 4096}, None)])
node2.read_writes.writes 2 OrderedSet([MemoryDep('buf1', d0 + 2048*d1, {d0: 2048, d1: 4096}, None), MemoryDep('buf2', 4096*d0 + d1, {d0: 2048, d1: 4096}, None)])
```

Although `node1` and `node2` both read the same `arg0_1`, they seem to have different index/range??
```
MemoryDep('arg0_1', 2048*d0 + d1, {d0: 4096, d1: 2048}
MemoryDep('arg0_1', d0 + 2048*d1, {d0: 2048, d1: 4096}
```