### PR TITLE
Make collect env work in an env without pip

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -401,6 +401,8 @@ def get_pip_packages(run_lambda, patterns=None):
     # But here it is invoked as `python -mpip`
     def run_with_pip(pip):
         out = run_and_read_all(run_lambda, pip + ["list", "--format=freeze"])
+        if out is None:
+            return ""
         return "\n".join(
             line
             for line in out.splitlines()


### PR DESCRIPTION
Summary: If `pip` is not available, `run_and_read_all` returns `None`, and it fails.

Test Plan: manual testing

Differential Revision: D63985323


