### PR TITLE
forward-fix D63916220 breaking test_cutlass_backend in FBCode

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -6,7 +6,11 @@ import unittest
 from typing import Callable, List, Optional
 from unittest import mock
 
-from test_aot_inductor_utils import AOTIRunnerUtil
+
+try:
+    from test_aot_inductor_utils import AOTIRunnerUtil
+except ImportError:
+    from .test_aot_inductor_utils import AOTIRunnerUtil
 
 import torch
 from torch._dynamo.utils import counters


### PR DESCRIPTION
Summary: It seems like the import path is different from FBCode & OSS. Wondering how to consolidate them.

Test Plan:
```
buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/inductor:cutlass_backend

Tests finished: Pass 2. Fail 0. Fatal 0. Skip 33. Build failure 0
```

Differential Revision: D63991961


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @amjames @desertfire @chauhang