### PR TITLE
Remove dependency on numpy for serialization for XLA/open registration devices without numpy

### DIFF
--- a/test/test_cpp_extensions_open_device_registration.py
+++ b/test/test_cpp_extensions_open_device_registration.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: cpp-extensions"]
 
 import _codecs
+import io
 import os
 import tempfile
 import types
@@ -529,35 +530,112 @@ class TestCppExtensionOpenRgistration(common.TestCase):
         # call _fused_adamw_ with undefined tensor.
         self.module.fallback_with_undefined_tensor()
 
+    @unittest.skipIf(
+        np.__version__ < "1.25",
+        "versions < 1.25 represent dtypes differently from the string",
+    )
     def test_open_device_numpy_serialization(self):
+        """
+        This tests the legacy _rebuild_device_tensor_from_numpy serialization path
+        """
         torch.utils.rename_privateuse1_backend("foo")
         device = self.module.custom_device()
         default_protocol = torch.serialization.DEFAULT_PROTOCOL
-        # This is a hack to test serialization through numpy
+
+        # Legacy data saved with _rebuild_device_tensor_from_numpy via
+        # with patch.object(torch._C, "_has_storage", return_value=False):
+        #     x = torch.tensor([[1, 2, 3], [4, 5, 6]], device=device)
+        #     x_foo = x.to(device)
+        #     sd = {"x": x_foo}
+        #     rebuild_func = x_foo._reduce_ex_internal(default_protocol)[0]
+        #     self.assertTrue(
+        #         rebuild_func is torch._utils._rebuild_device_tensor_from_numpy
+        #     )
+        #     # Test map_location
+        #     with open("foo.pt", "wb") as f:
+        #         torch.save(sd, f)
+
+        data_legacy_numpy = (
+            b"PK\x03\x04\x00\x00\x08\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x10\x00\x12\x00archive/data.pklFB\x0e\x00ZZZZZZZZZ"
+            b"ZZZZZ\x80\x02}q\x00X\x01\x00\x00\x00xq\x01ctorch._utils\n_rebuild_device_ten"
+            b"sor_from_numpy\nq\x02(cnumpy.core.multiarray\n_reconstruct\nq\x03cnumpy\nnda"
+            b"rray\nq\x04K\x00\x85q\x05c_codecs\nencode\nq\x06X\x01\x00\x00\x00bq\x07X\x06"
+            b"\x00\x00\x00latin1q\x08\x86q\tRq\n\x87q\x0bRq\x0c(K\x01K\x02K\x03\x86q\rcnum"
+            b"py\ndtype\nq\x0eX\x02\x00\x00\x00i8q\x0f\x89\x88\x87q\x10Rq\x11(K\x03X\x01"
+            b"\x00\x00\x00<q\x12NNNJ\xff\xff\xff\xffJ\xff\xff\xff\xffK\x00tq\x13b\x89h\x06X0"
+            b"\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00"
+            b"\x03\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00"
+            b"\x00\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00q\x14h\x08\x86q\x15Rq\x16tq"
+            b"\x17bctorch\nint64\nq\x18X\x05\x00\x00\x00foo:0q\x19\x89tq\x1aRq\x1bs.PK\x07"
+            b"\x08l+\xb4\x80a\x01\x00\x00a\x01\x00\x00PK\x03\x04\x00\x00\x08\x08\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x00 \x00archi"
+            b"ve/byteorderFB\x1c\x00ZZZZZZZZZZZZZZZZZZZZZZZZZZZZlittlePK\x07\x08\x85=\xe3"
+            b"\x19\x06\x00\x00\x00\x06\x00\x00\x00PK\x03\x04\x00\x00\x08\x08\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0f\x00=\x00archive/v"
+            b"ersionFB9\x00ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ3\nPK"
+            b"\x07\x08\xd1\x9egU\x02\x00\x00\x00\x02\x00\x00\x00PK\x03\x04\x00\x00\x08\x08\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1e\x002"
+            b"\x00archive/.data/serialization_idFB.\x00ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+            b"ZZZZZZZZZZ0636457737946401051300000020022438324384PK\x07\x08\x01\x05Tt(\x00\x00"
+            b"\x00(\x00\x00\x00PK\x01\x02\x00\x00\x00\x00\x08\x08\x00\x00\x00\x00\x00\x00l+"
+            b"\xb4\x80a\x01\x00\x00a\x01\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00archive/data.pklPK\x01\x02\x00\x00\x00\x00\x08\x08"
+            b"\x00\x00\x00\x00\x00\x00\x85=\xe3\x19\x06\x00\x00\x00\x06\x00\x00\x00\x11\x00"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xb1\x01\x00\x00archive/byteord"
+            b"erPK\x01\x02\x00\x00\x00\x00\x08\x08\x00\x00\x00\x00\x00\x00\xd1\x9egU\x02\x00"
+            b"\x00\x00\x02\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x16\x02\x00\x00archive/versionPK\x01\x02\x00\x00\x00\x00\x08\x08\x00\x00\x00"
+            b"\x00\x00\x00\x01\x05Tt(\x00\x00\x00(\x00\x00\x00\x1e\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00\x00\x00\x00\x00\x92\x02\x00\x00archive/.data/serialization_idPK\x06"
+            b"\x06,\x00\x00\x00\x00\x00\x00\x00\x1e\x03-\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x04\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x06\x01\x00\x00"
+            b"\x00\x00\x00\x008\x03\x00\x00\x00\x00\x00\x00PK\x06\x07\x00\x00\x00\x00>\x04\x00"
+            b"\x00\x00\x00\x00\x00\x01\x00\x00\x00PK\x05\x06\x00\x00\x00\x00\x04\x00\x04\x00"
+            b"\x06\x01\x00\x008\x03\x00\x00\x00\x00"
+        )
+        buf_data_legacy_numpy = io.BytesIO(data_legacy_numpy)
+
+        with safe_globals(
+            [
+                np.core.multiarray._reconstruct,
+                np.ndarray,
+                np.dtype,
+                _codecs.encode,
+                np.dtypes.Float32DType,
+            ]
+        ):
+            sd_loaded = torch.load(buf_data_legacy_numpy)
+            buf_data_legacy_numpy.seek(0)
+            # Test map_location
+            sd_loaded_cpu = torch.load(buf_data_legacy_numpy, map_location="cpu")
+        expected = torch.tensor([[1, 2, 3], [4, 5, 6]], device=device)
+        self.assertEqual(sd_loaded["x"].cpu(), expected.cpu())
+        self.assertFalse(sd_loaded["x"].is_cpu)
+        self.assertTrue(sd_loaded_cpu["x"].is_cpu)
+
+    def test_open_device_cpu_serialization(self):
+        torch.utils.rename_privateuse1_backend("foo")
+        device = self.module.custom_device()
+        default_protocol = torch.serialization.DEFAULT_PROTOCOL
+
         with patch.object(torch._C, "_has_storage", return_value=False):
             x = torch.randn(2, 3)
             x_foo = x.to(device)
             sd = {"x": x_foo}
             rebuild_func = x_foo._reduce_ex_internal(default_protocol)[0]
             self.assertTrue(
-                rebuild_func is torch._utils._rebuild_device_tensor_from_numpy
+                rebuild_func is torch._utils._rebuild_device_tensor_from_cpu_tensor
             )
             # Test map_location
             with TemporaryFileName() as f:
                 torch.save(sd, f)
-                with safe_globals(
-                    [
-                        np.core.multiarray._reconstruct,
-                        np.ndarray,
-                        np.dtype,
-                        _codecs.encode,
-                        type(np.dtype(np.float32))
-                        if np.__version__ < "1.25.0"
-                        else np.dtypes.Float32DType,
-                    ]
-                ):
-                    sd_loaded = torch.load(f, map_location="cpu")
-                self.assertTrue(sd_loaded["x"].is_cpu)
+                sd_loaded = torch.load(f)
+                # Test map_location
+                sd_loaded_cpu = torch.load(f, map_location="cpu")
+            self.assertFalse(sd_loaded["x"].is_cpu)
+            self.assertEqual(sd_loaded["x"].cpu(), x)
+            self.assertTrue(sd_loaded_cpu["x"].is_cpu)
 
             # Test metadata_only
             with TemporaryFileName() as f:

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -300,6 +300,20 @@ class Tensor(torch._C.TensorBase):
             torch.serialization._serialization_tls.materialize_fake_tensors
         )
 
+        if self.device.type == "xla" or (
+            not torch._C._has_storage(self)
+            and self.device.type == torch._C._get_privateuse1_backend_name()
+        ):
+            if skip_data:
+                raise RuntimeError(
+                    "Cannot serialize tensors on backends with no storage under skip_data context manager"
+                )
+            cpu_tensor = self.cpu()
+            return (
+                torch._utils._rebuild_device_tensor_from_cpu_tensor,
+                (cpu_tensor, self.dtype, str(self.device), self.requires_grad),
+            )
+        # Legacy comment that does not hold anymore.
         # Note: Numpy array is chosen to be the rebuild component for XLA, MTIA, MAIA Tensors.
         # We considered a few options:
         # 1. CPU tensor can't be used here.
@@ -310,10 +324,7 @@ class Tensor(torch._C.TensorBase):
         # 2. Python list is not a good fit due to performance reason.
         #    `tolist()` converts every single element in the tensor into python objects
         #    and serialize them one by one.
-        if self.device.type in ["xla", "mtia", "maia"] or (
-            not torch._C._has_storage(self)
-            and self.device.type == torch._C._get_privateuse1_backend_name()
-        ):
+        if self.device.type in ["mtia", "maia"]:
             # Convert BFloat16 tesors to Float32 before conversion to numpy, as numpy doesn't
             # support BFloat16. The rebuild tensor from numpy takes in the original self.dtype,
             # this would reconstruct the BFloat16 tensor from numpy.

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -330,6 +330,13 @@ def _rebuild_nested_tensor(buffer, sizes, strides, storage_offsets):
     return torch._nested_view_from_buffer(buffer, sizes, strides, storage_offsets)
 
 
+def _rebuild_device_tensor_from_cpu_tensor(data, dtype, device, requires_grad):
+    device = _get_restore_location(device)
+    tensor = data.to(dtype=dtype, device=device)
+    tensor.requires_grad = requires_grad
+    return tensor
+
+
 def _rebuild_device_tensor_from_numpy(data, dtype, device, requires_grad):
     device = _get_restore_location(device)
     tensor = torch.from_numpy(data).to(dtype=dtype, device=device)


### PR DESCRIPTION
## Motivation

With the move to `weights_only` by default, we are making an explicit decision not to allowlist GLOBALs required to deserialize `numpy` tensors  by default. The implication is that backends relying on numpy for serialization will fail loudly when `torch.load` flips `weights_only`.

However, we make the observation that this dependency on numpy was legacy and is not actually needed before. So we can remove it, which aligns with our weights_only strategy.

## Why is this ok?

The following comment on why numpy is necessary for serialization is legacy

https://github.com/pytorch/pytorch/blob/c87c9f0a01f4840bd19ac5058960c9766dd15ef8/torch/_tensor.py#L303-L312

We no longer do the following, though it was the case 5 years ago in the PR that added this 
> CPU storage is reconstructed with randomly iinitialized data, moved onto backend device, and then storage is updated to the serialized content

Old behavior (`legacy_load`): https://github.com/ailzhang/pytorch/blob/67adda891a839691790a0dcd99062430050eff3b/torch/serialization.py#L620

Instead what now happens is that CPU storage is constructed with data from the file **and then** moved onto backend device.



Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137439

