### PR TITLE
Update mutation checking in pattern matcher

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -1460,6 +1460,18 @@ class TestPatternMatcher(TestCase):
             expect=False,
         )
 
+        @torch.library.custom_op("vllm::fused_rms_norm_quant_static", mutates_args=[])
+        def fused_rms_norm_quant_static(out: torch.Tensor, input: torch.Tensor) -> None:
+            pass
+
+        check(
+            "call_function",
+            torch.ops.vllm.fused_rms_norm_quant_static,
+            (t, t),
+            {},
+            expect=False,
+        )
+
 
 if __name__ == "__main__":
     if IS_LINUX and HAS_CUDA:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -39,7 +39,7 @@ verbose_progress = False
 
 # use fx aot graph codegen cache
 fx_graph_cache = (
-    os.environ.get("TORCHINDUCTOR_FX_GRAPH_CACHE", "0" if is_fbcode() else "1") == "1"
+    os.environ.get("TORCHINDUCTOR_FX_GRAPH_CACHE", "0" if is_fbcode() else "0") == "1"
 )
 
 # use remote fx aot graph codegen cache

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -39,7 +39,7 @@ verbose_progress = False
 
 # use fx aot graph codegen cache
 fx_graph_cache = (
-    os.environ.get("TORCHINDUCTOR_FX_GRAPH_CACHE", "0" if is_fbcode() else "0") == "1"
+    os.environ.get("TORCHINDUCTOR_FX_GRAPH_CACHE", "0" if is_fbcode() else "1") == "1"
 )
 
 # use remote fx aot graph codegen cache

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1616,7 +1616,7 @@ def is_start_of_fx_graph(graph: torch.fx.Graph, node: torch.fx.Node) -> bool:
 _mutation_op_re = re.compile(r"(?<!_)(_$|_[.]|(\b|_)(set|enter|exit|seed)(\b|_))(?!_)")
 
 
-def incorrect_inductor_schema_op(op: torch._ops.OpOverload):
+def incorrect_inductor_schema_op(op: torch._ops.OpOverload) -> bool:
     if op.namespace != "inductor":
         return False
 

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -1616,11 +1616,12 @@ def is_start_of_fx_graph(graph: torch.fx.Graph, node: torch.fx.Node) -> bool:
 _mutation_op_re = re.compile(r"(?<!_)(_$|_[.]|(\b|_)(set|enter|exit|seed)(\b|_))(?!_)")
 
 
-def incorrect_inductor_schema_op(op: torch._ops.OpOverload) -> bool:
+def fixme_incorrect_inductor_schema_op(op: torch._ops.OpOverload) -> bool:
     if op.namespace != "inductor":
         return False
 
     # TODO - fix schema
+    # Dont add any more !
     return op in (
         torch.ops.inductor.accumulate_grad_.default,
         torch.ops.inductor.resize_storage_bytes_.default,
@@ -1630,7 +1631,7 @@ def incorrect_inductor_schema_op(op: torch._ops.OpOverload) -> bool:
 def is_mutation_op(node: torch.fx.Node) -> bool:
     if isinstance(
         node.target, torch._ops.OpOverload
-    ) and not incorrect_inductor_schema_op(node.target):
+    ) and not fixme_incorrect_inductor_schema_op(node.target):
         return node.target._schema.is_mutable
     elif isinstance(
         node.target, torch._higher_order_ops.auto_functionalize.AutoFunctionalized


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137449
* __->__ #137448

Fix for https://github.com/pytorch/pytorch/issues/137229

The current mutation checking is complicated because it works for pre grad IR. When pre grad ir has been traced to OpOverloads checking is much easier. I am also special casing auto functional hop although I discussed with @zou3519 it would be nice to have a way of querying HOPs that mimic schemas.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang