### PR TITLE
fix unroll in successive unflatten

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6020,6 +6020,62 @@ graph():
 
         self.assertEqual(gm_flat_non_strict(*inp), gm_flat_strict(*inp))
 
+    def test_unflatten_no_unroll(self):
+        inp = (torch.ones(1),)
+
+        class N(torch.nn.Module):
+            def forward(self, x, b):
+                if b:
+                    return x + 1
+                else:
+                    return x + 2
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.n = N()
+
+            def forward(self, x):
+                x0 = x + 3
+                x1 = self.n(x0, True)
+                x2 = self.n(x0, False)
+                return x1 + x2
+
+        m = M()
+        eager_result = m(*inp)
+
+        if not is_retracebility_test(self._testMethodName):
+            ep = export(M(), inp, preserve_module_call_signature=("n",))
+            with self.assertRaisesRegex(
+                ValueError,
+                "Cannot unflatten multiple calls to module n while preserving its signature",
+            ):
+                torch.export.unflatten(ep)
+
+        ep = export(M(), inp)
+        print(ep)
+        epm = ep.module()
+        ufm = torch.export.unflatten(ep)
+
+        exported_result = epm(*inp)
+        self.assertTrue(torch.allclose(exported_result, eager_result))
+
+        unflattened_result = ufm(*inp)
+        self.assertTrue(torch.allclose(unflattened_result, eager_result))
+
+        class _N(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        class _N_1(torch.nn.Module):
+            def forward(self, x):
+                return x + 2
+
+        ufm.set_submodule("n", _N())
+        ufm.set_submodule("n@1", _N_1())
+        unflattened_result = ufm(*inp)
+        self.assertTrue(torch.allclose(unflattened_result, eager_result))
+
     def test_preserve_module_call_signature_unflatten_specialization(self):
         class N(torch.nn.Module):
             def forward(self, x, b):

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1813,8 +1813,10 @@ class TestFX(JitTestCase):
         gm = torch.fx.symbolic_trace(m)
 
         mod_stack = {}
-        expected_stack = [('sub_mod', ('sub_mod', type(m.sub_mod))),
-                          ('sub_mod.conv_mod', ('sub_mod.conv_mod', type(m.sub_mod.conv_mod)))]
+        expected_stack = [
+            ('sub_mod', ('sub_mod', type(m.sub_mod), 0)),
+            ('sub_mod.conv_mod', ('sub_mod.conv_mod', type(m.sub_mod.conv_mod), 0)),
+        ]
         for node in gm.graph.nodes:
             mod_stack = node.meta.get('nn_module_stack', {})
             if mod_stack:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2618,6 +2618,7 @@ class InstructionTranslatorBase(
         # The first field of tuple is the fully qualified name of current module
         # in original hierarchy.  The second field is the type of current nn.module
         self.nn_module_stack: Dict[str, Tuple[str, Type[Any]]] = {}
+        self.num_calls: Dict[str, int] = {}
         # Flag to indicate whether tracing is used for export.
         self.export = export
         self.one_graph = False

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -82,8 +82,14 @@ def initialize_lazy_module(tx: "InstructionTranslator", mod, args, kwargs):
 @contextmanager
 def record_nn_module_stack(module_key: str, source, tx, mod: torch.nn.Module):
     fully_qualified_name = source.name()
+    num_calls = tx.num_calls.get(fully_qualified_name, 0)
     try:
-        tx.nn_module_stack[module_key] = (fully_qualified_name, mod.__class__)
+        tx.nn_module_stack[module_key] = (
+            fully_qualified_name,
+            mod.__class__,
+            num_calls,
+        )
+        tx.num_calls[fully_qualified_name] = num_calls + 1
         yield
     finally:
         del tx.nn_module_stack[module_key]

--- a/torch/_export/passes/_node_metadata_hook.py
+++ b/torch/_export/passes/_node_metadata_hook.py
@@ -50,6 +50,7 @@ def _node_metadata_hook(node: torch.fx.Node, stack_trace: str) -> None:
             _EMPTY_NN_MODULE_STACK_KEY: (
                 _EMPTY_NN_MODULE_STACK_KEY,
                 _EMPTY_NN_MODULE_STACK_KEY,
+                0,
             )
         },
     )

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -584,13 +584,14 @@ class GraphModuleSerializer(metaclass=Final):
         if nn_module_stack := node.meta.get("nn_module_stack"):
 
             def export_nn_module_stack(val):
-                assert isinstance(val, tuple) and len(val) == 2
-                path, ty = val
+                assert isinstance(val, tuple) and len(val) == 3
+                path, ty, num_calls = val
 
                 assert isinstance(path, str)
                 assert isinstance(ty, str)
+                assert isinstance(num_calls, int)
 
-                return path + "," + ty
+                return f"{path},{ty},{num_calls}"
 
             # Serialize to "key,orig_path,type_str"
             nn_module_list = [
@@ -2199,8 +2200,8 @@ class GraphModuleDeserializer(metaclass=Final):
 
         if nn_module_stack_str := metadata.get("nn_module_stack"):
             # Originally serialized to "key,orig_path,type_str"
-            def import_nn_module_stack(key, path, ty):
-                return key, (path, ty)
+            def import_nn_module_stack(key, path, ty, num_calls="0"):
+                return key, (path, ty, int(num_calls))
 
             # Helper function that splits strings by commas except for those
             # encapsulated by parens, which are valid traces.

--- a/torch/ao/quantization/quantizer/utils.py
+++ b/torch/ao/quantization/quantizer/utils.py
@@ -77,7 +77,7 @@ def _get_module_name_filter(module_name: str):
                 prefix = len("L['self'].")
             return n[prefix:]
 
-        names = [_normalize_path(n) for n, _ in nn_module_stack.values()]
+        names = [_normalize_path(n) for n, _, _ in nn_module_stack.values()]
         return module_name in names
 
     return module_name_filter

--- a/torch/ao/quantization/quantizer/xnnpack_quantizer.py
+++ b/torch/ao/quantization/quantizer/xnnpack_quantizer.py
@@ -212,7 +212,7 @@ def _get_module_type_filter(tp: Callable):
         # }
         nn_module_stack = n.meta.get("nn_module_stack", {})
         types = []
-        for _, t in nn_module_stack.values():
+        for _, t, _ in nn_module_stack.values():
             # export() returns str, but older APIs (e.g. capture_pre_autograd_graph)
             # return type. Handle both cases.
             if isinstance(t, type):

--- a/torch/distributed/pipelining/_unflatten.py
+++ b/torch/distributed/pipelining/_unflatten.py
@@ -18,7 +18,7 @@ def _outline_submodules(orig_graph: torch.fx.Graph):
         seen_nodes,
         seen_modules,
         None,
-        [""],
+        [("", 0)],
         "",
         {},
         module=new_module,

--- a/torch/export/_swap.py
+++ b/torch/export/_swap.py
@@ -262,7 +262,7 @@ def _swap_module_helper(
     # TODO: Handle the duplicate module case
     for node in gm.graph.nodes:
         if nn_module_stack := node.meta.get("nn_module_stack"):
-            for path, _ in nn_module_stack.values():
+            for path, _, _ in nn_module_stack.values():
                 if path in modules_to_swap:
                     partitions[path].append(node)
                     break

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -308,6 +308,7 @@ class Tracer(TracerBase):
         self.scope = Scope("", None)
         # Records the module call stack
         self.module_stack = collections.OrderedDict()
+        self.num_calls: Dict[str, int] = {}
         # Mapping of node name to module scope
         self.node_name_to_scope: Dict[str, Tuple[str, type]] = {}
 
@@ -514,7 +515,9 @@ class Tracer(TracerBase):
         with ScopeContextManager(self.scope, Scope(module_qualified_name, type(m))) as _scope:
             # module_stack is an ordered dict so writing then deleting the
             # entry is equivalent to push/pop on a list
-            self.module_stack[_scope.module_path] = (module_qualified_name, _scope.module_type)
+            num_calls = self.num_calls.get(module_qualified_name, 0)
+            self.module_stack[_scope.module_path] = (module_qualified_name, _scope.module_type, num_calls)
+            self.num_calls[module_qualified_name] = num_calls + 1
             if not self.is_leaf_module(m, module_qualified_name):
                 ret_val = forward(*args, **kwargs)
             else:

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1759,11 +1759,12 @@ class _ModuleStackTracer(PythonKeyTracer):
             if "nn_module_stack" not in node.meta:
                 node.meta["nn_module_stack"] = self.module_stack
             # convert nn_module_stack from Dict[key, (FQN, class)] -> Dict[str, Tuple[str, str]]
-            for key, (fqn, mod_cls) in node.meta["nn_module_stack"].items():
+            for key, (fqn, mod_cls, num_calls) in node.meta["nn_module_stack"].items():
                 if isinstance(mod_cls, type):
                     node.meta["nn_module_stack"][key] = (
                         fqn,
                         mod_cls.__module__ + "." + mod_cls.__qualname__,
+                        num_calls,
                     )
 
         # torch_fn

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -126,7 +126,7 @@ class TracerBase:
     scope : Scope
 
     # Records the module call stack
-    module_stack: OrderedDict[str, Tuple[str, Any]]
+    module_stack: OrderedDict[str, Tuple[str, Any, int]]
 
     # Mapping of node name to module scope
     node_name_to_scope: Dict[str, Tuple[str, type]]

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -264,7 +264,7 @@ def _get_node_namespace(node: torch.fx.Node) -> tuple[str, list[str], list[str]]
     namespaces = []
     class_hierarchy = []
     name_scopes = []
-    for name, nn_module in nn_module_stack.values():
+    for name, nn_module, _ in nn_module_stack.values():
         name_scopes.append(name)
         nn_module_name = _get_qualified_module_name(nn_module)
         class_hierarchy.append(nn_module_name)

--- a/torch/onnx/_internal/fx/passes/modularization.py
+++ b/torch/onnx/_internal/fx/passes/modularization.py
@@ -18,7 +18,7 @@ _FX_TRACER_NN_MODULE_META_TYPE = Tuple[str, type]
 _FX_TRACER_NN_MODULE_STACK_META_TYPE = collections.OrderedDict
 """Legacy type of `node.meta["nn_module_stack"]` produced by FX symbolic tracer."""
 
-_DYNAMO_NN_MODULE_META_TYPE = Tuple[str, Tuple[str, type]]
+_DYNAMO_NN_MODULE_META_TYPE = Tuple[str, Tuple[str, type, int]]
 """Type of item from `node.meta["nn_module_stack"].items()` produced by FX dynamo tracer."""
 _DYNAMO_NN_MODULE_STACK_META_TYPE = Dict[str, _DYNAMO_NN_MODULE_META_TYPE]
 """Type of `node.meta["nn_module_stack"]` produced by FX dynamo tracer."""
@@ -139,7 +139,7 @@ class _ModuleMeta:
         cls, raw_meta: _DYNAMO_NN_MODULE_META_TYPE
     ) -> _ModuleMeta:
         """Create a module meta from raw meta produced by FX dynamo tracer."""
-        module_name, (qualified_name, module_class) = raw_meta
+        module_name, (qualified_name, module_class, _) = raw_meta
         return _ModuleMeta(module_name, module_class, raw_meta)
 
     @classmethod


### PR DESCRIPTION
We use `nn_module_stack` in `unflatten` to recognize when module calls begin and end. However the current format is not sufficient to detect module call boundaries when we have successive calls to the same module, because the successive instructions (end of one call, begin of next call) have the same `nn_module_stack`. This causes us to effectively "unroll" successive calls to a single call. This can cause problems when preserving module call signatures because the outputs of the successive calls might be concatenated in the single call.

Previously we introduced the concept of a "call index" to generate multiple graphs when unflattening, one per call. This PR pushes this concept into `nn_module_stack` itself. Thus entries in `nn_module_stack` go from `(fqn, type)` to `(fqn, type, call_index)`.

Note that we still do not have the ability to preserve module call signatures for multiple calls to the same module. But now instead of randomly crashing we give a proper error. OTOH when not preserving module call signatures we simply generate multiple calls, each with its own graph, possibly deduplicated, matching what we would do for non-successive calls.

Differential Revision: D64014936


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec