### PR TITLE
[Inductor] Update AttrsDescriptor instantiation for Triton changes

### DIFF
--- a/docs/source/torch.compiler_get_started.rst
+++ b/docs/source/torch.compiler_get_started.rst
@@ -57,7 +57,7 @@ the following:
 
 .. code-block:: python
 
-   @pointwise(size_hints=[16384], filename=__file__, triton_meta={'signature': {'in_ptr0': '*fp32', 'out_ptr0': '*fp32', 'xnumel': 'i32'}, 'device': 0, 'constants': {}, 'mutated_arg_names': [], 'configs': [instance_descriptor(divisible_by_16=(0, 1, 2), equal_to_1=())]})
+   @pointwise(size_hints=[16384], filename=__file__, triton_meta={'signature': {'in_ptr0': '*fp32', 'out_ptr0': '*fp32', 'xnumel': 'i32'}, 'device': 0, 'constants': {}, 'mutated_arg_names': [], 'configs': [AttrsDescriptor(divisible_by_16=(0, 1, 2), equal_to_1=())]})
    @triton.jit
    def triton_(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr):
       xnumel = 10000

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -417,7 +417,7 @@ class CudaReproTests(TestCase):
         https://github.com/pytorch/torchdynamo/issues/1670
         """
         from torch._C import _cuda_getCurrentRawStream as get_cuda_stream
-        from torch._inductor.runtime.hints import HeuristicType, instance_descriptor
+        from torch._inductor.runtime.hints import AttrsDescriptorWrapper, HeuristicType
         from torch._inductor.runtime.triton_heuristics import CachingAutotuner, grid
 
         def autotune(configs, meta):
@@ -447,7 +447,9 @@ class CudaReproTests(TestCase):
                     "xnumel": "i32",
                 },
                 "device": DeviceProperties.create(torch.device("cuda")),
-                "configs": [instance_descriptor(divisible_by_16=(0, 1), equal_to_1=())],
+                "configs": [
+                    AttrsDescriptorWrapper(divisible_by_16=(0, 1), equal_to_1=())
+                ],
                 "constants": {},
             },
         )

--- a/test/inductor/test_metrics.py
+++ b/test/inductor/test_metrics.py
@@ -18,7 +18,7 @@ example_kernel = """
         'device': 0,
         'device_type': 'GPU_TYPE',
         'constants': {},
-        'configs': [AttrsDescriptor(divisible_by_16=(0, 1, 2, 3), equal_to_1=(), ids_of_folded_args=(), divisible_by_8=(2, 3))]},
+        'configs': [AttrsDescriptor(divisible_by_16=(0, 1, 2, 3), equal_to_1=())]},
     inductor_meta={
         'autotune_hints': set(),
         'kernel_name': 'triton_red_fused_add_sum_2',

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -125,7 +125,7 @@ def gen_common_triton_imports():
         """
         from torch._inductor.runtime import triton_helpers, triton_heuristics
         from torch._inductor.runtime.triton_helpers import libdevice, math as tl_math
-        from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, instance_descriptor, DeviceProperties
+        from torch._inductor.runtime.hints import AutotuneHint, ReductionHint, TileHint, DeviceProperties
         """
     )
     return imports.getvalue()

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -160,11 +160,6 @@ def config_of(
         )
     else:
         divisible_by_16 = ()
-    divisible_by_8 = tuple(
-        i
-        for i, arg in zip(indices, args)
-        if is_aligned(arg, alignment=8, include_tensor=False)
-    )
 
     equal_to_1 = tuple(
         i
@@ -173,10 +168,5 @@ def config_of(
         and isinstance(arg.expr, (int, sympy.Integer))
         and V.graph.sizevars.statically_known_equals(arg.expr, 1)  # type: ignore[arg-type]
     )
-    # ids_of_folded_args is set from equal_to_1
-    # and None args by the Triton compiler
-    ids_of_folded_args = tuple(equal_to_1)
 
-    return instance_descriptor(
-        divisible_by_16, equal_to_1, ids_of_folded_args, divisible_by_8
-    )
+    return instance_descriptor(divisible_by_16, equal_to_1)

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -6,7 +6,7 @@ import sympy
 import torch
 
 from .. import config
-from ..runtime.hints import instance_descriptor
+from ..runtime.hints import AttrsDescriptorWrapper
 from ..utils import _type_of, expr_fits_within_32bit
 from ..virtualized import V
 from .common import KernelArgType, SizeArg, TensorArg, WorkspaceArg
@@ -169,4 +169,4 @@ def config_of(
         and V.graph.sizevars.statically_known_equals(arg.expr, 1)  # type: ignore[arg-type]
     )
 
-    return instance_descriptor(divisible_by_16, equal_to_1)
+    return AttrsDescriptorWrapper(divisible_by_16, equal_to_1)

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -52,7 +52,7 @@ if attrs_descriptor_available:
 
 else:
     # Define a namedtuple as a fallback when AttrsDescriptor is not available
-    AttrsDescriptorWrapper = collections.namedtuple(  # type: ignore[no-redef]
+    AttrsDescriptorWrapper = collections.namedtuple(  # type: ignore[no-redef, name-match]
         "AttrsDescriptor",
         ["divisible_by_16", "equal_to_1"],
         defaults=[(), ()],

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 import collections
 import typing
-from dataclasses import fields
 from enum import auto, Enum
 from typing import Dict, List, Optional, Union
 
@@ -32,10 +31,6 @@ try:
     from triton.compiler.compiler import AttrsDescriptor
 
     attrs_descriptor_available = True
-    # Determine if 'ids_of_folded_args' is a valid field for AttrsDescriptor
-    attr_desc_fields = {f.name for f in fields(AttrsDescriptor)}
-    ids_of_folded_args_available = "ids_of_folded_args" in attr_desc_fields
-    divisible_by_8_available = "divisible_by_8" in attr_desc_fields
 except ImportError:
     attrs_descriptor_available = False
 
@@ -45,20 +40,12 @@ if attrs_descriptor_available:
     def instance_descriptor(
         divisible_by_16=None,
         equal_to_1=None,
-        ids_of_folded_args=None,
-        divisible_by_8=None,
     ):
         # Prepare the arguments for AttrsDescriptor
         kwargs = {
             "divisible_by_16": divisible_by_16,
             "equal_to_1": equal_to_1,
         }
-
-        # Conditionally add 'ids_of_folded_args' if it's available in AttrsDescriptor
-        if ids_of_folded_args_available:
-            kwargs["ids_of_folded_args"] = ids_of_folded_args
-        if divisible_by_8_available:
-            kwargs["divisible_by_8"] = divisible_by_8
 
         # Instantiate AttrsDescriptor with the prepared arguments
         return AttrsDescriptor(**kwargs)
@@ -67,8 +54,8 @@ else:
     # Define a namedtuple as a fallback when AttrsDescriptor is not available
     instance_descriptor = collections.namedtuple(  # type: ignore[no-redef]
         "instance_descriptor",
-        ["divisible_by_16", "equal_to_1", "ids_of_folded_args", "divisible_by_8"],
-        defaults=[(), (), (), ()],
+        ["divisible_by_16", "equal_to_1"],
+        defaults=[(), ()],
     )
 
 

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -34,10 +34,10 @@ try:
 except ImportError:
     attrs_descriptor_available = False
 
-# Define `instance_descriptor` function with clear conditional handling
+# Define `AttrsDescriptorWrapper` function with clear conditional handling
 if attrs_descriptor_available:
 
-    def instance_descriptor(
+    def AttrsDescriptorWrapper(
         divisible_by_16=None,
         equal_to_1=None,
     ):
@@ -52,8 +52,8 @@ if attrs_descriptor_available:
 
 else:
     # Define a namedtuple as a fallback when AttrsDescriptor is not available
-    instance_descriptor = collections.namedtuple(  # type: ignore[no-redef]
-        "instance_descriptor",
+    AttrsDescriptorWrapper = collections.namedtuple(  # type: ignore[no-redef]
+        "AttrsDescriptor",
         ["divisible_by_16", "equal_to_1"],
         defaults=[(), ()],
     )


### PR DESCRIPTION
The `AttrsDescriptor` class has been present in Triton for almost a year now (introduced [here](https://github.com/triton-lang/triton/commit/72c983392749d31fef953beae5d983db9d778b41)), so we should be able to rely on it existing. I am in the process of supporting the new `AttrsDescriptor` class and @jansel suggested I split changes to the existing class out separately to make sure nothing breaks removing the legacy attribute descriptor attributes. 

Initially I attempted to remove the branching around detecting whether `AttrsDescriptor` exists but that breaks because PyTorch must build without Triton. So, I went back and updated for the naming introduced in the commit linked above, and also removed two unused attributes `divisible_by_8` and `ids_to_fold` which were removed in Feb 2024 (https://github.com/triton-lang/triton/pull/3122 and https://github.com/triton-lang/triton/pull/3080 respectively).

With these changes only the internal workings of the `AttrsDescriptor` class will differ between supported Triton versions, but the data stored will remain consistent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang