### PR TITLE
Intel GPU: Correct the decoration of symbol visibility for XPU backend in ATen codegen

### DIFF
--- a/torchgen/dest/native_functions.py
+++ b/torchgen/dest/native_functions.py
@@ -4,7 +4,7 @@ import torchgen.api.meta as meta
 import torchgen.api.structured as structured
 from torchgen.api.types import kernel_signature
 from torchgen.context import with_native_function_and_index
-from torchgen.model import BackendIndex, NativeFunction, NativeFunctionsGroup
+from torchgen.model import BackendIndex, NativeFunction, NativeFunctionsGroup,DispatchKey
 from torchgen.utils import mapMaybe
 
 
@@ -29,6 +29,8 @@ def gen_structured(g: NativeFunctionsGroup, backend_index: BackendIndex) -> list
     if metadata is None:
         return []
     prefix = "" if backend_index.external else "TORCH_API "
+    if backend_index.dispatch_key == DispatchKey.XPU:
+        prefix = "TORCH_XPU_API "
     return [
         f"""\
 struct {prefix}structured_{metadata.kernel} : public at::meta::structured_{meta_name} {{


### PR DESCRIPTION
Compilation on windows is affected after enabling aligned ATen code-gen in torch-xpu-ops.
The XPU ops object is packed into libtorch-xpu.so.  The compilation of xpu object is within third_party/torch-xpu-ops , which is controlled by building variable TORCH_XPU_BUILD_MAIN_LIB, where it affects symbol visibility via TORCH_XPU_API. 

cc @frank-wei @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @EikanWang @fengyuan14 @guangyey