### PR TITLE
Add type check for `ord` in `torch.linalg.vector_norm()` and `torch.linalg.matrix_norm()`

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2893,6 +2893,7 @@ Tensor linalg_matrix_norm(
     bool keepdim,
     std::optional<ScalarType> opt_dtype) {
   // Check ord first as it will be used in the dtype check of A
+  TORCH_CHECK(!at::isComplexType(scalar_ord.type()), "linalg.matrix_norm: Expected a non-complex scalar as the order of norm.");
   auto ord = scalar_ord.toDouble();
   auto abs_ord = std::abs(ord);
   TORCH_CHECK(abs_ord == 2. || abs_ord == 1. || abs_ord == INFINITY, "linalg.matrix_norm: Order ", ord, " not supported.");

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -207,6 +207,7 @@ TORCH_META_FUNC(mm)(const Tensor & self, const Tensor & mat2) {
 
 TORCH_META_FUNC(linalg_vector_norm)(const Tensor& self, const Scalar& scalar_ord, OptionalIntArrayRef opt_dim, bool keepdim, std::optional<ScalarType> opt_dtype) {
   at::native::checkFloatingOrComplex(self, "linalg.vector_norm");
+  TORCH_CHECK(!at::isComplexType(scalar_ord.type()), "linalg.vector_norm: Expected a non-complex scalar as the order of norm.");
 
   auto dim = opt_dim.value_or(IntArrayRef{});
   // Casting a large integer to a double will just introduce an error for

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1392,6 +1392,10 @@ class TestLinalg(TestCase):
         make_arg = partial(make_tensor, dtype=dtype, device=device)
 
         def run_test_case(input, ord, dim, keepdim):
+            if isinstance(ord, complex):
+                error_msg = "Expected a non-complex scalar"
+                with self.assertRaisesRegex(RuntimeError, error_msg):
+                    torch.linalg.matrix_norm(input, ord, dim, keepdim)
             msg = f'input.size()={input.size()}, ord={ord}, dim={dim}, keepdim={keepdim}, dtype={dtype}'
             result = torch.linalg.norm(input, ord, dim, keepdim)
             input_numpy = input.cpu().numpy()
@@ -1403,7 +1407,7 @@ class TestLinalg(TestCase):
                 result = torch.linalg.matrix_norm(input, ord, dim, keepdim)
                 self.assertEqual(result, result_numpy, msg=msg)
 
-        ord_matrix = [1, -1, 2, -2, inf, -inf, 'nuc', 'fro']
+        ord_matrix = [1, -1, 2, -2, inf, -inf, 'nuc', 'fro', 1 + 2j]
         S = 10
         test_cases = [
             # input size, dim

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1275,7 +1275,7 @@ class TestLinalg(TestCase):
             return result
 
         def run_test_case(input, ord, dim, keepdim, norm_dtype):
-            if ord.dtype.is_complex:
+            if isinstance(ord, complex):
                 error_msg = "Expected a non-complex scalar"
                 with self.assertRaisesRegex(RuntimeError, error_msg):
                     torch.linalg.vector_norm(input, ord, dim=dim, keepdim=keepdim, dtype=norm_dtype)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1280,8 +1280,8 @@ class TestLinalg(TestCase):
                 with self.assertRaisesRegex(RuntimeError, error_msg):
                     torch.linalg.vector_norm(input, ord, dim=dim, keepdim=keepdim, dtype=norm_dtype)
             elif (input.numel() == 0 and
-                (ord < 0. or ord == inf) and
-               (dim is None or input.shape[dim] == 0)):
+                  (ord < 0. or ord == inf) and
+                  (dim is None or input.shape[dim] == 0)):
                 # The operation does not have an identity.
                 error_msg = "linalg.vector_norm cannot compute"
                 with self.assertRaisesRegex(RuntimeError, error_msg):

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1396,16 +1396,17 @@ class TestLinalg(TestCase):
                 error_msg = "Expected a non-complex scalar"
                 with self.assertRaisesRegex(RuntimeError, error_msg):
                     torch.linalg.matrix_norm(input, ord, dim, keepdim)
-            msg = f'input.size()={input.size()}, ord={ord}, dim={dim}, keepdim={keepdim}, dtype={dtype}'
-            result = torch.linalg.norm(input, ord, dim, keepdim)
-            input_numpy = input.cpu().numpy()
-            result_numpy = np.linalg.norm(input_numpy, ord, dim, keepdim)
+            else:
+                msg = f'input.size()={input.size()}, ord={ord}, dim={dim}, keepdim={keepdim}, dtype={dtype}'
+                result = torch.linalg.norm(input, ord, dim, keepdim)
+                input_numpy = input.cpu().numpy()
+                result_numpy = np.linalg.norm(input_numpy, ord, dim, keepdim)
 
-            result = torch.linalg.norm(input, ord, dim, keepdim)
-            self.assertEqual(result, result_numpy, msg=msg)
-            if ord is not None and dim is not None:
-                result = torch.linalg.matrix_norm(input, ord, dim, keepdim)
+                result = torch.linalg.norm(input, ord, dim, keepdim)
                 self.assertEqual(result, result_numpy, msg=msg)
+                if ord is not None and dim is not None:
+                    result = torch.linalg.matrix_norm(input, ord, dim, keepdim)
+                    self.assertEqual(result, result_numpy, msg=msg)
 
         ord_matrix = [1, -1, 2, -2, inf, -inf, 'nuc', 'fro', 1 + 2j]
         S = 10

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1251,7 +1251,7 @@ class TestLinalg(TestCase):
         # have to use torch.randn(...).to(bfloat16) instead of
         # This test compares torch.linalg.vector_norm's output with
         # torch.linalg.norm given a flattened tensor
-        ord_vector = [0, 0.9, 1, 2, 3, inf, -0.5, -1, -2, -3, -inf]
+        ord_vector = [0, 0.9, 1, 2, 3, inf, -0.5, -1, -2, -3, -inf, 1 + 2j]
         input_sizes = [
             (1, ),
             (10, ),
@@ -1275,7 +1275,11 @@ class TestLinalg(TestCase):
             return result
 
         def run_test_case(input, ord, dim, keepdim, norm_dtype):
-            if (input.numel() == 0 and
+            if ord.dtype.is_complex:
+                error_msg = "Expected a non-complex scalar"
+                with self.assertRaisesRegex(RuntimeError, error_msg):
+                    torch.linalg.vector_norm(input, ord, dim=dim, keepdim=keepdim, dtype=norm_dtype)
+            elif (input.numel() == 0 and
                 (ord < 0. or ord == inf) and
                (dim is None or input.shape[dim] == 0)):
                 # The operation does not have an identity.


### PR DESCRIPTION
fixes #137424, fixes #137460 