### PR TITLE
Add device agnostic API for accelerator hooks

### DIFF
--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -37,17 +37,14 @@ struct TORCH_API AcceleratorHooksInterface {
 
   virtual DeviceIndex getCurrentDevice() const {
     TORCH_CHECK(false, "Backend doesn't support getCurrentDevice()");
-    return -1;
   }
 
   virtual DeviceIndex exchangeDevice(DeviceIndex device) const {
     TORCH_CHECK(false, "Backend doesn't support exchangeDevice()");
-    return -1;
   }
 
   virtual DeviceIndex maybeExchangeDevice(DeviceIndex device) const {
     TORCH_CHECK(false, "Backend doesn't support maybeExchangeDevice()");
-    return -1;
   }
 
   virtual bool isPinnedPtr(const void* data) const {
@@ -56,7 +53,14 @@ struct TORCH_API AcceleratorHooksInterface {
 
   virtual Allocator* getPinnedMemoryAllocator() const {
     TORCH_CHECK(false, "Backend doesn't support getPinnedMemoryAllocator()");
-    return nullptr;
+  }
+
+  virtual std::string showConfig() const {
+    TORCH_CHECK(false, "Backend doesn't support showConfig()");
+  }
+
+  virtual void deviceSynchronize(DeviceIndex device) const {
+    TORCH_CHECK(false, "Backend doesn't support deviceSynchronize()");
   }
 
   virtual const Generator& getDefaultGenerator(

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -158,7 +158,7 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
     TORCH_CHECK(false, "Cannot query CUDART version without ATen_cuda library. ", CUDA_HELP);
   }
 
-  virtual std::string showConfig() const {
+  std::string showConfig() const override {
     TORCH_CHECK(false, "Cannot query detailed CUDA version without ATen_cuda library. ", CUDA_HELP);
   }
 
@@ -193,7 +193,7 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
   }
 #endif
 
-  virtual void deviceSynchronize(DeviceIndex /*device_index*/) const {
+  void deviceSynchronize(DeviceIndex /*device_index*/) const override {
     TORCH_CHECK(false, "Cannot synchronize CUDA device without ATen_cuda library. ", CUDA_HELP);
   }
 };

--- a/aten/src/ATen/detail/MAIAHooksInterface.h
+++ b/aten/src/ATen/detail/MAIAHooksInterface.h
@@ -22,7 +22,7 @@ struct TORCH_API MAIAHooksInterface : AcceleratorHooksInterface {
     return false;
   }
 
-  virtual std::string showConfig() const {
+  std::string showConfig() const override {
     TORCH_CHECK(false, "Cannot query detailed MAIA version information.");
   }
 };

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -38,7 +38,7 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
   virtual Allocator* getMPSDeviceAllocator() const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual void deviceSynchronize() const {
+  void deviceSynchronize(C10_UNUSED DeviceIndex device_index = -1) const override {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
   virtual void commitStream() const {

--- a/aten/src/ATen/detail/MTIAHooksInterface.h
+++ b/aten/src/ATen/detail/MTIAHooksInterface.h
@@ -46,11 +46,11 @@ struct TORCH_API MTIAHooksInterface : AcceleratorHooksInterface {
     return 0;
   }
 
-  virtual void deviceSynchronize(c10::DeviceIndex device_index) const {
+  void deviceSynchronize(c10::DeviceIndex device_index) const override {
     FAIL_MTIAHOOKS_FUNC(__func__);
   }
 
-  virtual std::string showConfig() const {
+  std::string showConfig() const override {
     FAIL_MTIAHOOKS_FUNC(__func__);
   }
 

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -21,7 +21,7 @@ struct TORCH_API XPUHooksInterface : AcceleratorHooksInterface{
     return false;
   }
 
-  virtual std::string showConfig() const {
+  std::string showConfig() const override {
     TORCH_CHECK(
         false,
         "Cannot query detailed XPU version without ATen_xpu library.");
@@ -54,7 +54,7 @@ struct TORCH_API XPUHooksInterface : AcceleratorHooksInterface{
     TORCH_CHECK(false, "Cannot get device of pointer on XPU without ATen_xpu library.");
   }
 
-  virtual void deviceSynchronize(DeviceIndex /*device_index*/) const {
+  void deviceSynchronize(DeviceIndex /*device_index*/) const override {
     TORCH_CHECK(false, "Cannot synchronize XPU device without ATen_xpu library.");
   }
 

--- a/aten/src/ATen/mps/MPSHooks.h
+++ b/aten/src/ATen/mps/MPSHooks.h
@@ -23,7 +23,7 @@ struct MPSHooks : public at::MPSHooksInterface {
       DeviceIndex device_index = -1) const override;
 
   // MPSStream interface
-  void deviceSynchronize() const override;
+  void deviceSynchronize(DeviceIndex device_index = -1) const override;
   void commitStream() const override;
   void* getCommandBuffer() const override;
   void* getDispatchQueue() const override;

--- a/aten/src/ATen/mps/MPSHooks.mm
+++ b/aten/src/ATen/mps/MPSHooks.mm
@@ -63,7 +63,7 @@ const Generator& MPSHooks::getDefaultGenerator([[maybe_unused]] DeviceIndex devi
   return at::mps::detail::getDefaultMPSGenerator();
 }
 
-void MPSHooks::deviceSynchronize() const {
+void MPSHooks::deviceSynchronize([[maybe_unused]] DeviceIndex device_index) const {
   at::mps::getDefaultMPSStream()->synchronize(SyncType::COMMIT_AND_WAIT);
 }
 


### PR DESCRIPTION
Make `AcceleratorHooksInterface` consistent for multiple accelerators
- Add `showConfig` and `deviceSynchronize` method declaration in `AcceleratorHooksInterface`
- Remove unreachable lines of code

cc @egienvalue @ezyang @albanD @FFFrog 