### PR TITLE
Add torch.squeeze parameter description to declare allowed type

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10378,7 +10378,7 @@ Example::
 add_docstr(
     torch.squeeze,
     r"""
-squeeze(input, dim=None) -> Tensor
+squeeze(input: Tensor, dim: Optional[Union[int, List[int]]]) -> Tensor
 
 Returns a tensor with all specified dimensions of :attr:`input` of size `1` removed.
 


### PR DESCRIPTION
Fixes #137422 

Add parameter type definition in API docs to clarify allowed value type, eliminate users pass `None`  as `dim` value directly.

```python
>>> import torch
>>> x = torch.randn(3,1,2)
>>> x.squeeze(dim=None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Please look up dimensions by name, got: name = None.
```

cc @albanD 

