### PR TITLE
[not ready yet] predispatch backward prototype

### DIFF
--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2023,7 +2023,7 @@ To fix this, your tensor subclass must implement the dunder method __force_to_sa
                                 "%s",
                                 lazy_format_graph_code(
                                     "Backward graph (retraced with runtime tangents)",
-                                    bw_module,
+                                    bw_module_retraced,
                                     CompiledFunction._aot_id,
                                     include_stride=True,
                                     include_device=True,

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -27,6 +27,7 @@ debug_assert = False
 
 debug_partitioner = os.environ.get("AOT_PARTITIONER_DEBUG", "0") != "0"
 
+# If we do this, should likely be a JK
 predispatch_backward = False
 
 # Today, if you are in a situation where there is "false aliasing"

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -27,6 +27,8 @@ debug_assert = False
 
 debug_partitioner = os.environ.get("AOT_PARTITIONER_DEBUG", "0") != "0"
 
+predispatch_backward = False
+
 # Today, if you are in a situation where there is "false aliasing"
 # (e.g. you have a bunch of model parameters that all alias the same underlying buffer),
 # our checks for this situation are very slow if these inputs have dynamic shapes.

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -259,10 +259,8 @@ def _has_tag_must_be_in_backward(node: fx.Node) -> bool:
 
 
 def _must_be_in_backward(node: fx.Node) -> bool:
-    return (
-        node.target is torch.ops.subclass_utils.wrap_subclass.default
-        or _has_tag_must_be_in_backward(node)
-        or (_has_tag_is_backward(node) and is_with_effects(node))
+    return _has_tag_must_be_in_backward(node) or (
+        _has_tag_is_backward(node) and is_with_effects(node)
     )
 
 
@@ -1163,8 +1161,8 @@ def solve_min_cut(
                         heapq.heappush(fusible, (node_info.get_fw_order(user), user))
 
     try:
-        visualize_min_cut_graph(nx_graph)
         cut_value, partition = nx.minimum_cut(nx_graph, "source", "sink")
+        print("\n".join(nx.readwrite.edgelist.generate_edgelist(nx_graph)))
     except Exception:
         print("Failed to compute min-cut on following graph:")
         print("\n".join(nx.readwrite.edgelist.generate_edgelist(nx_graph)))
@@ -1205,7 +1203,7 @@ def visualize_min_cut_graph(nx_graph):
         if weight == float("inf"):
             edge.set_color("red")
     print("Visualizing the failed graph to min_cut_failed.svg")
-    dot_graph.write_svg("min_cut_bad2.svg")
+    dot_graph.write_svg("min_cut_failed.svg")
 
 
 def get_default_op_list() -> OpTypes:
@@ -1285,7 +1283,6 @@ def get_default_op_list() -> OpTypes:
         aten.unsqueeze,
         aten.rsub,
         aten._to_copy,
-        torch.ops.subclass_utils.wrap_subclass.default,
     ]  # noqa: E501,B950
     recomputable_view_ops = [aten.squeeze, aten.unsqueeze, aten.alias]
     recomputable_view_ops += [
@@ -1297,7 +1294,7 @@ def get_default_op_list() -> OpTypes:
         aten.as_strided,
         aten.permute,
         aten.select,
-        torch.ops.subclass_utils.wrap_subclass.default,
+        torch.ops.subclass_utils.wrap_subclass,
     ]
     view_ops = recomputable_view_ops
     default_recomputable_ops += [


### PR DESCRIPTION
prototype. I have a simple example working, shown below. Other than hardening, the main thing I still need to look into is to fix up the joint graph pattern matcher.

example test:
```
    @torch._functorch.config.patch({"predispatch_backward": True})
    def test_aot_dispatch_intermediate_activations_and_subclass_tangents(self):
        # a is a subclass, b is not
        def f(a):
            return a.sin().sin().sin()
        
        a1_ref = torch.ones(3, 3, requires_grad=True)
        a2_ref = torch.ones(3, 3, requires_grad=True)
        a = TwoTensor(a1_ref, a2_ref)

        compiled_f = aot_function(
            f,
            fw_compiler=nop,
            bw_compiler=nop,
            partition_fn=min_cut_rematerialization_partition,
        )
        out = compiled_f(a)
        out.sum().backward()
```

Running it with `TORCH_LOGS="aot"` gives the following. A few things to note:

(1) there are new `wrap_subclass()` ops in the joint graph
(2) after partitioning, `wrap_subclass()` ops only show up in the backward graph. They are called on all the activations to wrap them into subclasses, before any compute happens on them with tangents
(3) there is a new "Backward graph (retraced)" log, showing the backward graph that we get after retracing the pre-dispatch backward graph.
```
INFO: TRACED GRAPH
 ===== Joint graph 0 =====
 <eval_with_key>.1 from /home/hirsheybar/local/b/pytorch/torch/fx/experimental/proxy_tensor.py:1258 in wrapped class joint_fn(torch.nn.Module):
    def forward(self, primals, tangents):
        primals_1: "f32[3, 3][3, 1]cpu"; primals_2: "f32[3, 3][3, 1]cpu"; tangents_1: "f32[3, 3][3, 1]cpu";

        primals_1, primals_2, tangents_1, = fx_pytree.tree_flatten_spec([primals, tangents], self._in_spec)
        # No stacktrace found for following nodes
        sin: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(primals_1)
        sin_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(primals_2)
        sin_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin)
        sin_3: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin_1)
        sin_4: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin_2)
        sin_5: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin_3)
        cos: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin_2);  sin_2 = None
        cos_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin_3);  sin_3 = None
        wrap_subclass: "f32[3, 3][3, 1]cpu" = torch.ops.subclass_utils.wrap_subclass.default([cos, cos_1], inner_tensor_names = ['a', 'b'], outer_size = (3, 3), outer_stride = (3, 1), subclass_module_name = 'torch.testing._internal.two_tensor', subclass_name = 'TwoTensor', metadata_hash = 477042);  cos = cos_1 = None
        mul: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(tangents_1, wrap_subclass);  tangents_1 = wrap_subclass = None
        cos_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin);  sin = None
        cos_3: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin_1);  sin_1 = None
        wrap_subclass_1: "f32[3, 3][3, 1]cpu" = torch.ops.subclass_utils.wrap_subclass.default([cos_2, cos_3], inner_tensor_names = ['a', 'b'], outer_size = (3, 3), outer_stride = (3, 1), subclass_module_name = 'torch.testing._internal.two_tensor', subclass_name = 'TwoTensor', metadata_hash = 477042);  cos_2 = cos_3 = None
        mul_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(mul, wrap_subclass_1);  mul = wrap_subclass_1 = None
        cos_4: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(primals_1);  primals_1 = None
        cos_5: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(primals_2);  primals_2 = None
        wrap_subclass_2: "f32[3, 3][3, 1]cpu" = torch.ops.subclass_utils.wrap_subclass.default([cos_4, cos_5], inner_tensor_names = ['a', 'b'], outer_size = (3, 3), outer_stride = (3, 1), subclass_module_name = 'torch.testing._internal.two_tensor', subclass_name = 'TwoTensor', metadata_hash = 477042);  cos_4 = cos_5 = None
        mul_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(mul_1, wrap_subclass_2);  mul_1 = wrap_subclass_2 = None
        return pytree.tree_unflatten([sin_4, sin_5, mul_2], self._out_spec)

INFO: TRACED GRAPH
 ===== Forward graph 0 =====
 <eval_with_key>.4 class GraphModule(torch.nn.Module):
    def forward(self, primals_1: "f32[3, 3][3, 1]cpu", primals_2: "f32[3, 3][3, 1]cpu"):
        # No stacktrace found for following nodes
        sin: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(primals_1)
        sin_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(primals_2)
        sin_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin);  sin = None
        sin_3: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin_1);  sin_1 = None
        sin_4: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin_2);  sin_2 = None
        sin_5: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin_3);  sin_3 = None
        return (sin_4, sin_5, primals_1, primals_2)


INFO: TRACED GRAPH
 ===== Backward graph 0 =====
 <eval_with_key>.6 class GraphModule(torch.nn.Module):
    def forward(self, primals_1: "f32[3, 3][3, 1]cpu", primals_2: "f32[3, 3][3, 1]cpu", tangents_1: "f32[3, 3][3, 1]cpu"):
        # No stacktrace found for following nodes
        sin: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(primals_1)
        sin_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(primals_2)
        sin_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin)
        sin_3: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin_1)
        cos: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin_2);  sin_2 = None
        cos_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin_3);  sin_3 = None
        wrap_subclass: "f32[3, 3][3, 1]cpu" = torch.ops.subclass_utils.wrap_subclass.default([cos, cos_1], inner_tensor_names = ['a', 'b'], outer_size = (3, 3), outer_stride = (3, 1), subclass_module_name = 'torch.testing._internal.two_tensor', subclass_name = 'TwoTensor', metadata_hash = 477042);  cos = cos_1 = None
        mul: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(tangents_1, wrap_subclass);  tangents_1 = wrap_subclass = None
        cos_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin);  sin = None
        cos_3: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin_1);  sin_1 = None
        wrap_subclass_1: "f32[3, 3][3, 1]cpu" = torch.ops.subclass_utils.wrap_subclass.default([cos_2, cos_3], inner_tensor_names = ['a', 'b'], outer_size = (3, 3), outer_stride = (3, 1), subclass_module_name = 'torch.testing._internal.two_tensor', subclass_name = 'TwoTensor', metadata_hash = 477042);  cos_2 = cos_3 = None
        mul_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(mul, wrap_subclass_1);  mul = wrap_subclass_1 = None
        cos_4: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(primals_1);  primals_1 = None
        cos_5: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(primals_2);  primals_2 = None
        wrap_subclass_2: "f32[3, 3][3, 1]cpu" = torch.ops.subclass_utils.wrap_subclass.default([cos_4, cos_5], inner_tensor_names = ['a', 'b'], outer_size = (3, 3), outer_stride = (3, 1), subclass_module_name = 'torch.testing._internal.two_tensor', subclass_name = 'TwoTensor', metadata_hash = 477042);  cos_4 = cos_5 = None
        mul_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(mul_1, wrap_subclass_2);  mul_1 = wrap_subclass_2 = None
        return (mul_2,)


INFO: TRACED GRAPH
 ===== Backward graph (retraced with runtime tangents) 0 =====
 <eval_with_key>.7 from /home/hirsheybar/local/b/pytorch/torch/fx/experimental/proxy_tensor.py:1258 in wrapped class <lambda>(torch.nn.Module):
    def forward(self, arg0_1: "f32[3, 3][3, 1]cpu", arg1_1: "f32[3, 3][3, 1]cpu", arg2_1: "f32[3, 3][0, 0]cpu", arg3_1: "f32[3, 3][0, 0]cpu"):
        # No stacktrace found for following nodes
        sin: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(arg0_1)
        sin_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(arg1_1)
        sin_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin)
        sin_3: "f32[3, 3][3, 1]cpu" = torch.ops.aten.sin.default(sin_1)
        cos: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin_2);  sin_2 = None
        cos_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin_3);  sin_3 = None
        mul: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(arg2_1, cos);  arg2_1 = cos = None
        mul_1: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(arg3_1, cos_1);  arg3_1 = cos_1 = None
        cos_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin);  sin = None
        cos_3: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(sin_1);  sin_1 = None
        mul_2: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(mul, cos_2);  mul = cos_2 = None
        mul_3: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(mul_1, cos_3);  mul_1 = cos_3 = None
        cos_4: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(arg0_1);  arg0_1 = None
        cos_5: "f32[3, 3][3, 1]cpu" = torch.ops.aten.cos.default(arg1_1);  arg1_1 = None
        mul_4: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(mul_2, cos_4);  mul_2 = cos_4 = None
        mul_5: "f32[3, 3][3, 1]cpu" = torch.ops.aten.mul.Tensor(mul_3, cos_5);  mul_3 = cos_5 = None
        return [mul_4, mul_5]
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137498

