### PR TITLE
[export] add min/max ranges to _DimHints

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -8219,7 +8219,7 @@ def forward(self, x):
                     0: Dim.Auto(min=4, max=16),
                     1: Dim.Auto(min=4, max=16),
                 },
-            }
+            },
         )
         x, y = [node for node in ep.graph.nodes if node.op == "placeholder"]
         s0 = x.meta["val"].shape[0]
@@ -8240,7 +8240,7 @@ def forward(self, x):
         with self.assertRaisesRegex(
             torch._dynamo.exc.UserError,
             r".*user-specified range of 512 \<\= inputs.* \<\= int_oo, "
-            r"but tracing produced valid range of \[128, 256\]"
+            r"but tracing produced valid range of \[128, 256\]",
         ):
             export(
                 Baz(),
@@ -8252,7 +8252,7 @@ def forward(self, x):
         with self.assertRaisesRegex(
             torch._dynamo.exc.UserError,
             r".*user-specified range of 0 \<\= inputs.* \<\= 64, "
-            r"but tracing produced valid range of \[128, 256\]"
+            r"but tracing produced valid range of \[128, 256\]",
         ):
             export(
                 Baz(),

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -40,15 +40,15 @@ from torch.fx.experimental.symbolic_shapes import (
     RelaxedUnspecConstraint,
     ShapeEnv,
     StatelessSymbolicContext,
-    ValueRanges,
     ValueRangeError,
+    ValueRanges,
 )
 from torch.utils._pytree import (
     GetAttrKey,
     KeyPath,
+    keystr,
     MappingKey,
     SequenceKey,
-    keystr,
     tree_flatten_with_path,
     tree_map_with_path,
 )
@@ -249,7 +249,9 @@ def _flatten_dynamic_shapes(
         nonlocal flat_shapes
         flat_shapes.append(shape)
 
-    _tree_map_with_path(_tree_map_helper, combined_args, dynamic_shapes, tree_name="inputs")
+    _tree_map_with_path(
+        _tree_map_helper, combined_args, dynamic_shapes, tree_name="inputs"
+    )
     return flat_shapes
 
 
@@ -400,7 +402,9 @@ def make_constraints(
                         _min = dim.min or 0
                         _max = dim.max or int_oo
                         try:
-                            range_constraints[d.node.expr] &= ValueRanges(lower=_min, upper=_max)
+                            range_constraints[d.node.expr] &= ValueRanges(
+                                lower=_min, upper=_max
+                            )
                         except ValueRangeError as exc:
                             vr = range_constraints[d.node.expr]
                             raise UserError(

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -41,12 +41,15 @@ from torch.fx.experimental.symbolic_shapes import (
     ShapeEnv,
     StatelessSymbolicContext,
     ValueRanges,
+    ValueRangeError,
 )
 from torch.utils._pytree import (
     GetAttrKey,
     KeyPath,
     MappingKey,
     SequenceKey,
+    keystr,
+    tree_flatten_with_path,
     tree_map_with_path,
 )
 
@@ -246,7 +249,7 @@ def _flatten_dynamic_shapes(
         nonlocal flat_shapes
         flat_shapes.append(shape)
 
-    _tree_map_with_path(_tree_map_helper, combined_args, dynamic_shapes)
+    _tree_map_with_path(_tree_map_helper, combined_args, dynamic_shapes, tree_name="inputs")
     return flat_shapes
 
 
@@ -342,6 +345,8 @@ def make_constraints(
         num_lifted_inputs: the number of non-user-input placeholder nodes in the graph
         (used only to enumerate the user-input nodes)
     """
+    from torch._dynamo.exc import UserError, UserErrorType
+    from torch.utils._sympy.numbers import int_oo
 
     shape_env = fake_mode.shape_env
     assert shape_env is not None
@@ -362,6 +367,7 @@ def make_constraints(
         assert isinstance(dynamic_shapes, (tuple, list))
         combined_args = type(dynamic_shapes)(combined_args.values())  # type: ignore[assignment, misc]
     flat_dynamic_shapes = _flatten_dynamic_shapes(combined_args, dynamic_shapes)
+    flat_paths = tree_flatten_with_path(combined_args)[0]
 
     # check number of shapes vs. number of inputs
     num_placeholders = [node.op == "placeholder" for node in gm.graph.nodes].count(True)
@@ -377,6 +383,7 @@ def make_constraints(
         ):
             continue
         shape_spec = flat_dynamic_shapes[input_index - num_lifted_inputs]
+        keypath, _ = flat_paths[input_index - num_lifted_inputs]
         for i, d in enumerate(node.meta["val"].shape):
             if isinstance(d, torch.SymInt) and not d.node.expr.is_number:
                 # Look up the range constraint for the symbol corresponding to this shape dimension
@@ -389,6 +396,19 @@ def make_constraints(
                     range_constraints[d.node.expr] = shape_env.var_to_range[
                         d.node._expr
                     ]
+                    if isinstance(dim, _DimHint):
+                        _min = dim.min or 0
+                        _max = dim.max or int_oo
+                        try:
+                            range_constraints[d.node.expr] &= ValueRanges(lower=_min, upper=_max)
+                        except ValueRangeError as exc:
+                            vr = range_constraints[d.node.expr]
+                            raise UserError(
+                                UserErrorType.INVALID_INPUT,
+                                "`dynamic_shapes` input contains user-specified range of "
+                                f"{_min} <= inputs{keystr(keypath)}.shape[{i}] <= {_max}, "
+                                f"but tracing produced valid range of [{vr.lower}, {vr.upper}]",
+                            ) from exc
                 else:
                     range_constraints[d.node.expr] = ValueRanges(
                         lower=dim.min, upper=dim.max

--- a/torch/_export/serde/dynamic_shapes.py
+++ b/torch/_export/serde/dynamic_shapes.py
@@ -158,7 +158,7 @@ def _dump_dynamic_shapes(
         if val is None or isinstance(val, int):  # non-tensor input or static
             return val
         if isinstance(val, _DimHint):  # store enum as string
-            return val.__class__.__name__ + "." + val.name
+            return val.__class__.__name__ + "." + val.type.name
 
         assert isinstance(val, _Dim)
 
@@ -301,9 +301,11 @@ def _load_dynamic_shapes(
         if val is None or isinstance(val, int):
             return val
         elif val == "_DimHint.AUTO":
-            return _DimHint.AUTO
+            return Dim.AUTO  # type: ignore[attr-defined]
         elif val == "_DimHint.STATIC":
-            return _DimHint.STATIC
+            return Dim.STATIC  # type: ignore[attr-defined]
+        elif val == "_DimHint.DYNAMIC":
+            return Dim.DYNAMIC  # type: ignore[attr-defined]
         if not isinstance(val, str):
             raise UserError(
                 UserErrorType.INVALID_INPUT,

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -66,7 +66,10 @@ from torch._guards import detect_fake_mode
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._utils_internal import log_export_usage
-from torch.export.dynamic_shapes import _check_dynamic_shapes, _combine_args
+from torch.export.dynamic_shapes import (
+    _check_dynamic_shapes,
+    _combine_args,
+)
 from torch.export.exported_program import OutputKind
 from torch.fx._utils import first_call_function_nn_module_stack
 from torch.fx.experimental.proxy_tensor import make_fx

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -66,10 +66,7 @@ from torch._guards import detect_fake_mode
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._utils_internal import log_export_usage
-from torch.export.dynamic_shapes import (
-    _check_dynamic_shapes,
-    _combine_args,
-)
+from torch.export.dynamic_shapes import _check_dynamic_shapes, _combine_args
 from torch.export.exported_program import OutputKind
 from torch.fx._utils import first_call_function_nn_module_stack
 from torch.fx.experimental.proxy_tensor import make_fx


### PR DESCRIPTION
This adds min/max range versions of `Dim.AUTO` and `Dim.DYNAMIC`: `Dim.Auto(min=a, max=b) & Dim.Dynamic(min=a, max=b)`. This is nice for users who want the existing benefits of `Dim.AUTO/DYNAMIC`, but would like to encode properties like a maximum batch size into their program.

The intended behavior is for each placeholder symbol's range to be the **intersection** of the user-specified range, and the range from model tracing. If the latter range is more strict, then the user-specified range is effectively no-op, and a UserError is raised if there is no range overlap.

Example:
```
class Foo(torch.nn.Module):
    def forward(self, x, y):
        torch._check(x.shape[0] >= 4)
        torch._check(y.shape[0] <= 10)
        return x[2:] + y

inputs = (torch.randn(6), torch.randn(4))
shapes = {
    "x": {0: Dim.Dynamic(max=8)},
    "y": {0: Dim.AUTO(min=2)},
}
print(export(Foo(), inputs, dynamic_shapes=shapes))

ExportedProgram:
    class GraphModule(torch.nn.Module):
        def forward(self, x: "f32[s1 + 2]", y: "f32[s1]"):
            ...
            return (add_2,)
Range constraints: {s1 + 2: VR[4, 8], s1: VR[2, 10]}
```

Implementation wise things are a bit sad because we have to support both strict + non-strict: we do a `ValueRanges.__and__` call in `_make_constraints`, which happens after produce_guards & the runtime asserts insertion pass. If we were to support non-strict only, we could refine these ranges with `torch._check` calls as part of a forward pre-hook to the original model. This would mean the min/max ranges are treated simply as additional relational guards, and go through the produce_guards process. This has benefits such as 1) eliminating any runtime assertions that become trivial, 2) better inference of ranges from relations & expressions, 3) having produce_guards + the Export solver as a single system for error handling. Unfortunately I couldn't figure out `torch._check` insertion for strict, and decided on this implementation to unify code paths.

Future follow ups:
- Figure out error messages & suggested fixes (?)
- Dynamic shapes serialization for these objects
