### PR TITLE
[SymmetricMemoryOps] use float32 as the accumulator type when accumulating bfloat16 with multimem.ld_reduce

### DIFF
--- a/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu
+++ b/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu
@@ -490,6 +490,13 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
       torch::dispatch(c10::DispatchKey::CUDA, ::multimem_all_reduce_),
       {at::Tag::pt2_compliant_tag});
 
+  // NOTE: [multimem_one_shot_all_reduce]
+  // multimem.ld_reduce does not guarantee a fixed accumulation order. This
+  // means that while multimem_one_shot_all_reduce is faster and has higher
+  // numerical accuracy than one_shot_all_reduce, it doesn't guarantee
+  // identical results across ranks. There may be use cases that can take
+  // advantage of this property, but it should not be used without
+  // understanding the caveats.
   m.def(
       "multimem_one_shot_all_reduce(Tensor input, str reduce_op, str group_name) -> Tensor",
       torch::dispatch(c10::DispatchKey::CUDA, ::multimem_one_shot_all_reduce),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137643
* #137530
* __->__ #137529
* #137475
* #137474
* #137473
* #137472
* #137471

This provides better accuracy without additional cost.

Also added documentation to `multimem_one_shot_all_reduce` to note the numerical caveats.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o