### PR TITLE
Fix dtype test for NumPy 2

### DIFF
--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -412,7 +412,7 @@ class TestNumPyInterop(TestCase):
             self.assertEqual(asarray.dtype, dtype)
             # Only concrete class can be given where "Type[number[_64Bit]]" is expected
             if np.dtype(dtype).kind == "u":  # type: ignore[misc]
-                wrapped_x = np.array([1, -2, 3, -4], dtype=dtype)
+                wrapped_x = np.array([1, -2, 3, -4]).astype(dtype)
                 for i in range(len(x)):
                     self.assertEqual(asarray[i], wrapped_x[i])
             else:


### PR DESCRIPTION
Related to #107302

The following test fails with NumPy 2.

```
_________ TestNumPyInteropCPU.test_numpy_array_interface_cpu __________
Traceback (most recent call last):
  File "/usr/local/google/home/haifengj/git/pytorch_np2/test/test_numpy_interop.py", line 415, in test_numpy_array_interface
    wrapped_x = np.array([1, -2, 3, -4], dtype=dtype)
OverflowError: Python integer -2 out of bounds for uint8

To execute this test, run the following from the base repo dir:
    python test/test_numpy_interop.py TestNumPyInteropCPU.test_numpy_array_interface_cpu

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
```

According to the official warning from NumPy 1, the assigning negative value to a `uint8` is deprecated.
The recommended way is to `np.array([1, -2, 3, -4]).astype(np.uint8)`
See the following for details.
```
>>> np.array([1, -2, 3, -4], dtype=np.uint8)
<stdin>:1: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -2 to uint8 will fail in the future.
For the old behavior, usually:
    np.array(value).astype(dtype)
will give the desired result (the cast overflows).
<stdin>:1: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -4 to uint8 will fail in the future.
For the old behavior, usually:
    np.array(value).astype(dtype)
will give the desired result (the cast overflows).
array([  1, 254,   3, 252], dtype=uint8)
```

This PR fixes the test failure.

cc @kiukchung 