### PR TITLE
Removes confusing note, addresses #38006

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -982,10 +982,6 @@ class Optimizer:
         Args:
             closure (Callable): A closure that reevaluates the model and
                 returns the loss. Optional for most optimizers.
-
-        .. note::
-            Unless otherwise specified, this function should not modify the
-            ``.grad`` field of the parameters.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
Fixes #38006 

The note was originally added in https://github.com/pytorch/pytorch/pull/30257, which tried to ensure that the gradient wasn't modified in the optimizer. This note creates more confusion than is helpful, so removing it is better than leaving it in, especially because most uses of closure that I know _does_ modify the grads.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137535

