### PR TITLE
Warn users of mkldnn device usage

### DIFF
--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -37,9 +37,9 @@ DeviceType parse_type(const std::string& device_string) {
           {"privateuseone", DeviceType::PrivateUse1},
       }};
   if (device_string == "mkldnn") {
-    TORCH_WARN(
-        "torch.device('mkldnn') is deprecated and will be removed in the future."
-        "Please use torch.device('cpu') instead.");
+    TORCH_WARN_ONCE(
+        "'mkldnn' is no longer used as device type. So torch.device('mkldnn') will be "
+        "deprecated and removed in the future. Please use other valid device types instead.");
   }
   auto device = std::find_if(
       types.begin(),

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -37,8 +37,9 @@ DeviceType parse_type(const std::string& device_string) {
           {"privateuseone", DeviceType::PrivateUse1},
       }};
   if (device_string == "mkldnn") {
-    TORCH_WARN("torch.device('mkldnn') is deprecated and will be removed in the future."
-               "Please use torch.device('cpu') instead.");
+    TORCH_WARN(
+        "torch.device('mkldnn') is deprecated and will be removed in the future."
+        "Please use torch.device('cpu') instead.");
   }
   auto device = std::find_if(
       types.begin(),

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -36,6 +36,10 @@ DeviceType parse_type(const std::string& device_string) {
           {"mtia", DeviceType::MTIA},
           {"privateuseone", DeviceType::PrivateUse1},
       }};
+  if (device_string == "mkldnn") {
+    TORCH_WARN("torch.device('mkldnn') is deprecated and will be removed in the future."
+               "Please use torch.device('cpu') instead.");
+  }
   auto device = std::find_if(
       types.begin(),
       types.end(),


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/issues/136831, user will use mkldnn device to generate tensor, while mkldnn device is no longer used as device type, and only mkldnn layout is used.

We plan to remove mkldnn device related code in the future release. This PR is to warn users not to use mkldnn device.


cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @Guobing-Chen @Xia-Weiwen @snadampal