### PR TITLE
Add document for exist torch attribute pi and e

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13975,6 +13975,30 @@ are freshly created instead of aliasing the input.
 """,
 )
 
+add_docstr(
+    torch.pi,
+    r"""
+A constant representing the mathematical constant π (Pi), which is the ratio of a circle's circumference to its diameter. 
+
+Example::
+
+    >>> torch.pi
+    3.141592653589793
+""",
+)
+
+add_docstr(
+    torch.e,
+    r"""
+A constant representing Euler's number (e), the base of the natural logarithm.
+
+Example::
+
+    >>> torch.e
+    2.718281828459045
+""",
+)
+
 for unary_base_func_name in (
     "exp",
     "sqrt",


### PR DESCRIPTION
Fixes #134964 

Add description for `torch.pi` and `torch.e`

```bash
>>> import torch
>>> torch.pi
3.141592653589793
>>> torch.e
2.718281828459045
```
