### PR TITLE
[PGNCCL] Limit access to ncclComm_

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -68,6 +68,7 @@ void NCCLComm::waitUntilInitialized(int timeoutSecs) {
   }
 }
 
+// TODO: why do we have `!defined(FBCODE_CAFFE2)` here?
 #if defined(NCCL_HAS_COMM_SPLIT) && !defined(FBCODE_CAFFE2)
 // last argument to split() API is not used to support
 // multiple implementations
@@ -78,9 +79,10 @@ std::shared_ptr<NCCLComm> NCCLComm::split(
     ncclConfig_t& config,
     std::vector<uint64_t>& ranks_ull) {
   auto comm = std::make_shared<NCCLComm>();
+  // This call will block until the source communicator is initialized
+  auto sourceComm = source->getNcclComm();
   C10D_NCCL_CHECK(
-      ncclCommSplit(
-          source->ncclComm_, color_id, rank, &(comm->ncclComm_), &config),
+      ncclCommSplit(sourceComm, color_id, rank, &(comm->ncclComm_), &config),
       std::nullopt);
   ++source->ncclCommSplitCounter_;
   comm->rank_ = rank;

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1180,7 +1180,7 @@ void ProcessGroupNCCL::abortCommsFromMap(
       gpuGuard.set_index(deviceIndex);
     }
     LOG(INFO) << logPrefix() << "ProcessGroupNCCL destroying ncclComm_ "
-              << ncclComm->ncclComm_ << " on CUDA device: " << devName;
+              << ncclComm->repr() << " on CUDA device: " << devName;
     ncclComm->ncclCommAbort(abortReason);
     // Note that we don't remove the aborted communicators from the
     // cache. The reason is that if we do remove the communicator
@@ -2301,7 +2301,7 @@ std::shared_ptr<NCCLComm> ProcessGroupNCCL::getNCCLComm(
       size_); // worldSize
 
   LOG(INFO) << logPrefix() << "ProcessGroupNCCL created ncclComm_ "
-            << ncclComm->ncclComm_
+            << ncclComm->repr()
             << " on CUDA device: " << static_cast<int>(deviceIndex);
 
   // At this point NCCL should have been initialized, hence we can accurately


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137544
* __->__ #137573
* #137572

When non-blocking mode is enabled, we need to make sure `ncclComm_` is ready before calling NCCL APIs on it. 
`NCCLComm::getNcclComm` help us do that (thanks to a wait function inside), thus is preferred than directly using `ncclComm_`.

To prevent `ncclComm_` from being directly used outside, e.g. in `ProcessGroupNCCL`, we also move it as a private member of `NCCLComm` class -- the external-facing wrapper.

cc @XilunWu @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o