### PR TITLE
[ONNX] Implement patch for jit.isinstance

### DIFF
--- a/test/onnx/exporter/test_capture_strategies.py
+++ b/test/onnx/exporter/test_capture_strategies.py
@@ -13,9 +13,9 @@ class ExportStrategiesTest(common_utils.TestCase):
     @common_utils.parametrize(
         "strategy_cls",
         [
-            (_capture_strategies.TorchExportStrategy),
-            (_capture_strategies.TorchExportNonStrictStrategy),
-            _capture_strategies.JitTraceConvertStrategy
+            _capture_strategies.TorchExportStrategy,
+            _capture_strategies.TorchExportNonStrictStrategy,
+            _capture_strategies.JitTraceConvertStrategy,
         ],
     )
     def test_jit_isinstance(self, strategy_cls):
@@ -29,9 +29,7 @@ class ExportStrategiesTest(common_utils.TestCase):
         a = torch.tensor(0.0)
         b = torch.tensor(1.0)
 
-        result = strategy_cls()(
-            model, (a, b), kwargs=None, dynamic_shapes=None
-        )
+        result = strategy_cls()(model, (a, b), kwargs=None, dynamic_shapes=None)
         ep = result.exported_program
         assert ep is not None
         torch.testing.assert_close(ep.module()(a, b), model(a, b))

--- a/test/onnx/exporter/test_capture_strategies.py
+++ b/test/onnx/exporter/test_capture_strategies.py
@@ -17,6 +17,7 @@ class ExportStrategiesTest(common_utils.TestCase):
             _capture_strategies.TorchExportNonStrictStrategy,
             _capture_strategies.JitTraceConvertStrategy,
         ],
+        name_fn=lambda strategy_cls: strategy_cls.__name__,
     )
     def test_jit_isinstance(self, strategy_cls):
         class Model(torch.nn.Module):

--- a/test/onnx/exporter/test_capture_strategies.py
+++ b/test/onnx/exporter/test_capture_strategies.py
@@ -1,0 +1,41 @@
+# Owner(s): ["module: onnx"]
+"""Unit tests for the _capture_strategies module."""
+
+from __future__ import annotations
+
+import torch
+from torch.onnx._internal.exporter import _capture_strategies
+from torch.testing._internal import common_utils
+
+
+@common_utils.instantiate_parametrized_tests
+class ExportStrategiesTest(common_utils.TestCase):
+    @common_utils.parametrize(
+        "strategy_cls",
+        [
+            (_capture_strategies.TorchExportStrategy),
+            (_capture_strategies.TorchExportNonStrictStrategy),
+            _capture_strategies.JitTraceConvertStrategy
+        ],
+    )
+    def test_jit_isinstance(self, strategy_cls):
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                if torch.jit.isinstance(a, torch.Tensor):
+                    return a.cos()
+                return b.sin()
+
+        model = Model()
+        a = torch.tensor(0.0)
+        b = torch.tensor(1.0)
+
+        result = strategy_cls()(
+            model, (a, b), kwargs=None, dynamic_shapes=None
+        )
+        ep = result.exported_program
+        assert ep is not None
+        torch.testing.assert_close(ep.module()(a, b), model(a, b))
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -183,11 +183,7 @@ class TorchExportNonStrictStrategy(CaptureStrategy):
     ) -> torch.export.ExportedProgram:
         try:
             return torch.export.export(
-                model,
-                args,
-                kwargs=kwargs,
-                dynamic_shapes=dynamic_shapes,
-                strict=False,
+                model, args, kwargs=kwargs, dynamic_shapes=dynamic_shapes, strict=False
             )
         except torch._dynamo.exc.UserError as exc:
             # Refine the dynamic shapes based on the suggested fixes.

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -39,7 +39,7 @@ def _take_first_line(text: str) -> str:
 
 
 @contextlib.contextmanager
-def _patch_dynamo_unsupported_functions() -> None:
+def _patch_dynamo_unsupported_functions():
     """Patch PyTorch to bypass some functions torch.export.export does not support."""
     # TODO: Remove the patches once dynamo supports these functions.
     import torch.jit

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -39,8 +39,9 @@ def _take_first_line(text: str) -> str:
 
 
 @contextlib.contextmanager
-def _patch_dynamo_unsupported_functions():
+def _patch_dynamo_unsupported_functions() -> None:
     """Patch PyTorch to bypass some functions torch.export.export does not support."""
+    # TODO: Remove the patches once dynamo supports these functions.
     import torch.jit
 
     # Replace torch.jit.isinstance with isinstance

--- a/torch/onnx/_internal/exporter/_capture_strategies.py
+++ b/torch/onnx/_internal/exporter/_capture_strategies.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import abc
+import contextlib
 import dataclasses
 import datetime
+import logging
 import pathlib
 from typing import Any, Callable, TYPE_CHECKING
 
@@ -15,6 +17,9 @@ from torch.utils import _pytree
 
 if TYPE_CHECKING:
     import os
+
+
+logger = logging.getLogger(__name__)
 
 
 def _verbose_printer(verbose: bool | None) -> Callable[..., None]:
@@ -31,6 +36,21 @@ def _take_first_line(text: str) -> str:
     if len(lines) > 1:
         first_line += "[...]"
     return first_line
+
+
+@contextlib.contextmanager
+def _patch_dynamo_unsupported_functions():
+    """Patch PyTorch to bypass some functions torch.export.export does not support."""
+    import torch.jit
+
+    # Replace torch.jit.isinstance with isinstance
+    jit_isinstance = torch.jit.isinstance
+    torch.jit.isinstance = isinstance
+    logger.info("Replaced torch.jit.isinstance with isinstance to allow dynamo tracing")
+    try:
+        yield
+    finally:
+        torch.jit.isinstance = jit_isinstance
 
 
 @dataclasses.dataclass
@@ -119,22 +139,23 @@ class TorchExportStrategy(CaptureStrategy):
     def _capture(
         self, model, args, kwargs, dynamic_shapes
     ) -> torch.export.ExportedProgram:
-        try:
-            return torch.export.export(
-                model, args, kwargs=kwargs, dynamic_shapes=dynamic_shapes
-            )
-        except torch._dynamo.exc.UserError as exc:
-            # Refine the dynamic shapes based on the suggested fixes.
+        with _patch_dynamo_unsupported_functions():
             try:
-                new_shapes = torch.export.dynamic_shapes.refine_dynamic_shapes_from_suggested_fixes(
-                    exc.msg, dynamic_shapes
+                return torch.export.export(
+                    model, args, kwargs=kwargs, dynamic_shapes=dynamic_shapes
                 )
-            except Exception:
-                # If the dynamic shapes cannot be refined, re-raise the exception.
-                raise exc from None
-            return torch.export.export(
-                model, args, kwargs=kwargs, dynamic_shapes=new_shapes
-            )
+            except torch._dynamo.exc.UserError as exc:
+                # Refine the dynamic shapes based on the suggested fixes.
+                try:
+                    new_shapes = torch.export.dynamic_shapes.refine_dynamic_shapes_from_suggested_fixes(
+                        exc.msg, dynamic_shapes
+                    )
+                except Exception:
+                    # If the dynamic shapes cannot be refined, re-raise the exception.
+                    raise exc from None
+                return torch.export.export(
+                    model, args, kwargs=kwargs, dynamic_shapes=new_shapes
+                )
 
     def _enter(self, model) -> None:
         model_repr = _take_first_line(repr(model))
@@ -162,7 +183,11 @@ class TorchExportNonStrictStrategy(CaptureStrategy):
     ) -> torch.export.ExportedProgram:
         try:
             return torch.export.export(
-                model, args, kwargs=kwargs, dynamic_shapes=dynamic_shapes, strict=False
+                model,
+                args,
+                kwargs=kwargs,
+                dynamic_shapes=dynamic_shapes,
+                strict=False,
             )
         except torch._dynamo.exc.UserError as exc:
             # Refine the dynamic shapes based on the suggested fixes.


### PR DESCRIPTION
Patch torch.jit.isinstance for users for models to be dynamo exportable. Replaces https://github.com/pytorch/pytorch/pull/137487.