### PR TITLE
Fix torch.compile correctness bug on aarch64+sve due to gcc bug

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -209,8 +209,12 @@ public:
     }
     return vector;
   }
-  static Vectorized<T> blendv(const Vectorized<T>& a, const Vectorized<T>& b,
-                          const Vectorized<T>& mask) {
+#if __GNUC__ <= 12 && defined(__ARM_FEATURE_SVE)
+  static Vectorized<T>  __attribute__ ((optimize("-fno-tree-loop-vectorize"))) blendv(const Vectorized<T>& a,
+#else
+  static Vectorized<T> blendv(const Vectorized<T>& a,
+#endif
+    const Vectorized<T>& b, const Vectorized<T>& mask) {
     Vectorized vector;
     int_same_size_t<T> buffer[size()];
     mask.store(buffer);

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -209,6 +209,7 @@ public:
     }
     return vector;
   }
+// Workaround for https: //gcc.gnu.org/bugzilla/show_bug.cgi?id=117001
 #if __GNUC__ <= 12 && defined(__ARM_FEATURE_SVE)
   static Vectorized<T>  __attribute__ ((optimize("-fno-tree-loop-vectorize"))) blendv(const Vectorized<T>& a,
 #else


### PR DESCRIPTION
Some unit tests were failing relating to argmin_vec/argmax_vec due to a bug in GCC affecting versions <= 12 on aarch64 platforms with SVE

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117001

Fixes #137597


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10