### PR TITLE
make it clearer (in docs) one can double decorate with torch.library.impl_* APIs

### DIFF
--- a/torch/library.py
+++ b/torch/library.py
@@ -555,18 +555,16 @@ def impl(qualname, types, func=None, *, lib=None):
         >>> import numpy as np
         >>> # Example 1: Register function.
         >>> # Define the operator
-        >>> torch.library.define("mylib::sin", "(Tensor x) -> Tensor")
+        >>> torch.library.define("mylib::mysin", "(Tensor x) -> Tensor")
         >>>
-        >>> # Add implementations for the operator
-        >>> @torch.library.impl("mylib::sin", "cpu")
+        >>> # Add implementations for the cpu device
+        >>> @torch.library.impl("mylib::mysin", "cpu")
         >>> def f(x):
         >>>     return torch.from_numpy(np.sin(x.numpy()))
         >>>
-        >>> # Call the new operator from torch.ops.
         >>> x = torch.randn(3)
-        >>> y1 = torch.ops.mylib.sin(x)
-        >>> y2 = torch.sin(x)
-        >>> assert torch.allclose(y1, y2)
+        >>> y = torch.ops.mylib.mysin(x)
+        >>> assert torch.allclose(y, x.sin())
         >>>
         >>> # Example 2: Register function with decorator.
         >>> def sin_decorator(func):
@@ -576,11 +574,8 @@ def impl(qualname, types, func=None, *, lib=None):
         >>>     return wrapper
         >>>
         >>> # Define the operator
-        >>> torch.library.define("mylibrary::sin", "(Tensor x) -> Tensor")
         >>> torch.library.define("mylib::decorated_sin", "(Tensor x) -> Tensor")
         >>>
-        >>> # Add implementations for the cpu device
-        >>> @torch.library.impl("mylibrary::sin", "cpu")
         >>> # Add implementations for the operator
         >>> @torch.library.impl("mylib::decorated_sin", "cpu")
         >>> @sin_decorator
@@ -589,8 +584,6 @@ def impl(qualname, types, func=None, *, lib=None):
         >>>
         >>> # Call the new operator from torch.ops.
         >>> x = torch.randn(3)
-        >>> y = torch.ops.mylibrary.sin(x)
-        >>> assert torch.allclose(y, x.sin())
         >>>
         >>> # This function call will print "sin_decorator called."
         >>> y1 = torch.ops.mylib.sin(x)

--- a/torch/library.py
+++ b/torch/library.py
@@ -567,27 +567,25 @@ def impl(qualname, types, func=None, *, lib=None):
         >>> assert torch.allclose(y, x.sin())
         >>>
         >>> # Example 2: Register function with decorator.
-        >>> def sin_decorator(func):
+        >>> def custom_decorator(func):
         >>>     def wrapper(*args, **kwargs):
-        >>>         print("sin_decorator called.")
-        >>>         return func(*args, **kwargs)
+        >>>         return func(*args, **kwargs) + 1
         >>>     return wrapper
         >>>
         >>> # Define the operator
-        >>> torch.library.define("mylib::decorated_sin", "(Tensor x) -> Tensor")
+        >>> torch.library.define("mylib::sin_plus_one", "(Tensor x) -> Tensor")
         >>>
         >>> # Add implementations for the operator
-        >>> @torch.library.impl("mylib::decorated_sin", "cpu")
-        >>> @sin_decorator
+        >>> @torch.library.impl("mylib::sin_plus_one", "cpu")
+        >>> @custom_decorator
         >>> def f(x):
         >>>     return torch.from_numpy(np.sin(x.numpy()))
         >>>
         >>> # Call the new operator from torch.ops.
         >>> x = torch.randn(3)
         >>>
-        >>> # This function call will print "sin_decorator called."
-        >>> y1 = torch.ops.mylib.sin(x)
-        >>> y2 = torch.sin(x)
+        >>> y1 = torch.ops.mylib.sin_plus_one(x)
+        >>> y2 = torch.sin(x) + 1
         >>> assert torch.allclose(y1, y2)
     """
     return _impl(qualname, types, func, lib=lib, disable_dynamo=False)

--- a/torch/library.py
+++ b/torch/library.py
@@ -553,6 +553,8 @@ def impl(qualname, types, func=None, *, lib=None):
             will be tied to the lifetime of the Library object.
 
     Examples:
+        >>> import torch
+        >>> import numpy as np
         >>> # Example 1: Register function.
         >>> # Define the operator
         >>> torch.library.define("mylib::sin", "(Tensor x) -> Tensor")

--- a/torch/library.py
+++ b/torch/library.py
@@ -543,7 +543,6 @@ def impl(qualname, types, func=None, *, lib=None):
     this API (see Example 2). Decorators placed outside this API will
     not be applied because this API does not return a function.
 
-
     Some valid types are: "cpu", "cuda", "xla", "mps", "ipu", "xpu".
 
     Args:

--- a/torch/library.py
+++ b/torch/library.py
@@ -540,8 +540,7 @@ def impl(qualname, types, func=None, *, lib=None):
 
     This API may be used as a decorator. You can use nested decorators
     with this API provided they return a function and are placed inside
-    this API (see Example 2). Decorators placed outside this API will
-    not be applied because this API does not return a function.
+    this API (see Example 2).
 
     Some valid types are: "cpu", "cuda", "xla", "mps", "ipu", "xpu".
 

--- a/torch/library.py
+++ b/torch/library.py
@@ -538,6 +538,12 @@ def impl(qualname, types, func=None, *, lib=None):
     Please only use this if the implementation truly supports all device types;
     for example, this is true if it is a composition of built-in PyTorch operators.
 
+    This API may be used as a decorator. You can use nested decorators
+    with this API provided they return a function and are placed inside
+    this API (see Example 2). Decorators placed outside this API will
+    not be applied because this API does not return a function.
+
+
     Some valid types are: "cpu", "cuda", "xla", "mps", "ipu", "xpu".
 
     Args:
@@ -547,20 +553,49 @@ def impl(qualname, types, func=None, *, lib=None):
             will be tied to the lifetime of the Library object.
 
     Examples:
-        >>> import torch
-        >>> import numpy as np
-        >>>
+        >>> # Example 1: Register function.
         >>> # Define the operator
-        >>> torch.library.define("mylib::mysin", "(Tensor x) -> Tensor")
+        >>> torch.library.define("mylib::sin", "(Tensor x) -> Tensor")
         >>>
-        >>> # Add implementations for the cpu device
-        >>> @torch.library.impl("mylib::mysin", "cpu")
+        >>> # Add implementations for the operator
+        >>> @torch.library.impl("mylib::sin", "cpu")
         >>> def f(x):
         >>>     return torch.from_numpy(np.sin(x.numpy()))
         >>>
+        >>> # Call the new operator from torch.ops.
         >>> x = torch.randn(3)
-        >>> y = torch.ops.mylib.mysin(x)
+        >>> y1 = torch.ops.mylib.sin(x)
+        >>> y2 = torch.sin(x)
+        >>> assert torch.allclose(y1, y2)
+        >>>
+        >>> # Example 2: Register function with decorator.
+        >>> def sin_decorator(func):
+        >>>     def wrapper(*args, **kwargs):
+        >>>         print("sin_decorator called.")
+        >>>         return func(*args, **kwargs)
+        >>>     return wrapper
+        >>>
+        >>> # Define the operator
+        >>> torch.library.define("mylibrary::sin", "(Tensor x) -> Tensor")
+        >>> torch.library.define("mylib::decorated_sin", "(Tensor x) -> Tensor")
+        >>>
+        >>> # Add implementations for the cpu device
+        >>> @torch.library.impl("mylibrary::sin", "cpu")
+        >>> # Add implementations for the operator
+        >>> @torch.library.impl("mylib::decorated_sin", "cpu")
+        >>> @sin_decorator
+        >>> def f(x):
+        >>>     return torch.from_numpy(np.sin(x.numpy()))
+        >>>
+        >>> # Call the new operator from torch.ops.
+        >>> x = torch.randn(3)
+        >>> y = torch.ops.mylibrary.sin(x)
         >>> assert torch.allclose(y, x.sin())
+        >>>
+        >>> # This function call will print "sin_decorator called."
+        >>> y1 = torch.ops.mylib.sin(x)
+        >>> y2 = torch.sin(x)
+        >>> assert torch.allclose(y1, y2)
     """
     return _impl(qualname, types, func, lib=lib, disable_dynamo=False)
 


### PR DESCRIPTION
Fixes #120503. Fix originally attempt by @soxand16 with PR: https://github.com/pytorch/pytorch/pull/121469. PR was almost ready to merge, but then went stale (over 6 months old). This PR implements original fix with refactoring for clarity. 

CC: @zou3519