### PR TITLE
Have Triton custom extension test use privateuseone device

### DIFF
--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -48,8 +48,7 @@ run_and_get_cpp_code = test_torchinductor.run_and_get_cpp_code
 TestCase = test_torchinductor.TestCase
 
 
-@unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
-class ExtensionBackendTests(TestCase):
+class BaseExtensionBackendTests(TestCase):
     module = None
 
     @classmethod
@@ -95,6 +94,9 @@ class ExtensionBackendTests(TestCase):
         # return the working directory (see setUp)
         os.chdir(self.old_working_dir)
 
+
+@unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
+class ExtensionBackendTests(BaseExtensionBackendTests):
     def test_open_device_registration(self):
         torch.utils.rename_privateuse1_backend("extension_device")
         torch._register_device_module("extension_device", self.module)

--- a/test/inductor/test_triton_extension_backend.py
+++ b/test/inductor/test_triton_extension_backend.py
@@ -36,8 +36,13 @@ from torch._inductor.codegen.common import (
     register_device_op_overrides,
 )
 from torch._inductor.utils import get_triton_code
-from torch.testing._internal.common_utils import IS_MACOS
+from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS
 
+
+try:
+    from .test_extension_backend import BaseExtensionBackendTests
+except ImportError:
+    from test_extension_backend import BaseExtensionBackendTests
 
 try:
     try:
@@ -59,42 +64,31 @@ def mock_triton_hash_with_backend(*args, **kwargs):
     return "".join(random.choices(string.ascii_uppercase + string.digits, k=64))
 
 
-class TritonExtensionBackendTests(TestCase):
+@unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
+class TritonExtensionBackendTests(BaseExtensionBackendTests):
     """
     Test creating a backend for inductor with Triton scheduling.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls._stack.close()
-        super().tearDownClass()
-
-    def setUp(self):
-        torch._dynamo.reset()
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-        torch._dynamo.reset()
-
     def test_open_device_registration(self):
-        register_backend_for_device("cpu", ExtensionScheduling, ExtensionWrapperCodegen)
-        register_device_op_overrides("cpu", CPUDeviceOpOverrides())
-        device_interface.register_interface_for_device("cpu", DeviceInterface)
-
-        self.assertTrue(get_scheduling_for_device("cpu") == ExtensionScheduling)
-        self.assertTrue(
-            get_wrapper_codegen_for_device("cpu") == ExtensionWrapperCodegen
+        torch._register_device_module("privateuseone", self.module)
+        register_backend_for_device(
+            "privateuseone", ExtensionScheduling, ExtensionWrapperCodegen
         )
-        self.assertTrue(
-            device_interface.get_interface_for_device("cpu") == DeviceInterface
+        register_device_op_overrides("privateuseone", CPUDeviceOpOverrides())
+        device_interface.register_interface_for_device("privateuseone", DeviceInterface)
+
+        self.assertEqual(
+            get_scheduling_for_device("privateuseone"), ExtensionScheduling
+        )
+        self.assertEqual(
+            get_wrapper_codegen_for_device("privateuseone"), ExtensionWrapperCodegen
+        )
+        self.assertEqual(
+            device_interface.get_interface_for_device("privateuseone"), DeviceInterface
         )
 
-        device = torch.device("cpu")
+        device = torch.device("privateuseone")
         x = torch.empty(2, 16).fill_(1).to(device)
 
         def foo(x):
@@ -113,7 +107,7 @@ class TritonExtensionBackendTests(TestCase):
 
         FileCheck().check("import triton").check("@triton.jit").check(
             "tl_math.sin"
-        ).check("device_str='cpu'").run(code)
+        ).check("device_str='privateuseone'").run(code)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -346,13 +346,13 @@ def register_interface_for_device(
     device: Union[str, torch.device], device_interface: Type[DeviceInterface]
 ):
     if isinstance(device, torch.device):
-        device = str(device)
+        device = device.type
     device_interfaces[device] = device_interface
 
 
 def get_interface_for_device(device: Union[str, torch.device]) -> Type[DeviceInterface]:
     if isinstance(device, torch.device):
-        device = str(device)
+        device = device.type
     if not _device_initialized:
         init_device_reg()
     if device in device_interfaces:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137611

The original PR #122396 used the CPU device since at that point in time
there was no actual Triton CPU backend. After #133408, this is no longer
the case, so we now have multiple backends getting registered for the
CPU. The test still works in OSS but fails internally due to different
test runners initializing the backends in a different order.

This PR doesn't actually end up fixing the test internally because
cpp_extension -- needed to implement the privateuseone device -- isn't
supported there, so we simply skip it instead. However, it still makes the
OSS test independent of initialization order, which is good.

Differential Revision: [D63838169](https://our.internmc.facebook.com/intern/diff/D63838169/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @rec