### PR TITLE
[CI] Adds support for selecting experiments for workflows on runner determinator

### DIFF
--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -365,7 +365,7 @@ def get_runner_prefix(
     rollout_state: str,
     workflow_requestors: Iterable[str],
     branch: str,
-    check_experiments: FrozenSet[str] = frozenset(),
+    eligible_experiments: FrozenSet[str] = frozenset(),
     is_canary: bool = False,
 ) -> str:
     settings = parse_settings(rollout_state)
@@ -381,11 +381,11 @@ def get_runner_prefix(
             )
             continue
 
-        if check_experiments:
-            if experiment_name not in check_experiments:
-                exp_list = ", ".join(check_experiments)
+        if eligible_experiments:
+            if experiment_name not in eligible_experiments:
+                exp_list = ", ".join(eligible_experiments)
                 log.info(
-                    f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}"
+                    f"Skipping experiment '{experiment_name}', as it is not in the eligible_experiments list: {exp_list}"
                 )
                 continue
         elif not experiment_settings.default:
@@ -476,7 +476,7 @@ def main() -> None:
             rollout_state,
             (args.github_issue_owner, username),
             args.github_branch,
-            args.check_experiments,
+            args.eligible_experiments,
             is_canary,
         )
 

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -374,7 +374,6 @@ def get_runner_prefix(
     fleet_prefix = ""
     prefixes = []
     for experiment_name, experiment_settings in settings.experiments.items():
-
         if not experiment_settings.all_branches and is_exception_branch(branch):
             log.info(
                 f"Branch {branch} is an exception branch. Not enabling experiment {experiment_name}."

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -145,7 +145,7 @@ def set_github_output(key: str, value: str) -> None:
 
 
 def _str_comma_separated_to_set(value: str) -> Set[str]:
-    return value.strip(" \n\t").split(",").map(str.strip).filter(lambda itm: itm != "").set()
+    return map(str.strip, value.strip(" \n\t").split(",")).filter(lambda itm: itm != "").set()
 
 
 def parse_args() -> Any:

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -145,7 +145,7 @@ def set_github_output(key: str, value: str) -> None:
 
 
 def _str_comma_separated_to_set(value: str) -> Set[str]:
-    return map(str.strip, value.strip(" \n\t").split(",")).filter(lambda itm: itm != "").set()
+    return filter(lambda itm: itm != "", map(str.strip, value.strip(" \n\t").split(","))).set()
 
 
 def parse_args() -> Any:

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -183,7 +183,7 @@ def parse_args() -> Any:
         help="Current GitHub ref type, branch or tag",
     )
     parser.add_argument(
-        "--check-experiments",
+        "--eligible-experiments",
         type=_str_comma_separated_to_set,
         required=False,
         default="",
@@ -388,10 +388,16 @@ def get_runner_prefix(
         ]
 
         if opted_in_users:
-            log.info(
-                f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}."
-            )
-            enabled = True
+            log.info(f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}.")
+
+            if check_experiments:
+                if experiment_name in check_experiments:
+                    enabled = True
+                else:
+                    log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list")
+            else:
+                enabled = True
+
         elif experiment_settings.rollout_perc:
             do_check = True
             if check_experiments:

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -374,7 +374,8 @@ def get_runner_prefix(
     for experiment_name, experiment_settings in settings.experiments.items():
         if check_experiments:
             if experiment_name not in check_experiments:
-                log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {", ".join(check_experiments)}")
+                exp_list = ", ".join(check_experiments)
+                log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}")
                 continue
         elif not experiment_settings.default:
             log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -363,7 +363,7 @@ def get_runner_prefix(
     rollout_state: str,
     workflow_requestors: Iterable[str],
     branch: str,
-    check_experiments: Set[str] = Set(),
+    check_experiments: Set[str] = set(),
     is_canary: bool = False,
 ) -> str:
     settings = parse_settings(rollout_state)

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -387,28 +387,21 @@ def get_runner_prefix(
             if is_user_opted_in(requestor, user_optins, experiment_name)
         ]
 
-        if opted_in_users:
-            log.info(f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}.")
+        do_check = True
+        if check_experiments:
+            if experiment_name not in check_experiments:
+                exp_list = ", ".join(check_experiments)
+                log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}")
+                do_check = False
+        elif not experiment_settings.default:
+            log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")
+            do_check = False
 
-            if check_experiments:
-                if experiment_name in check_experiments:
-                    enabled = True
-                else:
-                    log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list")
-            else:
-                enabled = True
+        if opted_in_users and do_check:
+            log.info(f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}.")
+            enabled = True
 
         elif experiment_settings.rollout_perc:
-            do_check = True
-            if check_experiments:
-                if experiment_name not in check_experiments:
-                    exp_list = ", ".join(check_experiments)
-                    log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}")
-                    do_check = False
-            elif not experiment_settings.default:
-                log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")
-                do_check = False
-
             # If no user is opted in, then we randomly enable the experiment based on the rollout percentage
             if do_check and random.uniform(0, 100) <= experiment_settings.rollout_perc:
                 log.info(

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -372,7 +372,7 @@ def get_runner_prefix(
     fleet_prefix = ""
     prefixes = []
     for experiment_name, experiment_settings in settings.experiments.items():
-        if check_experiments
+        if check_experiments:
             if experiment_name not in check_experiments:
                 log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {", ".join(check_experiments)}")
                 continue

--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -145,7 +145,7 @@ def set_github_output(key: str, value: str) -> None:
 
 
 def _str_comma_separated_to_set(value: str) -> Set[str]:
-    return filter(lambda itm: itm != "", map(str.strip, value.strip(" \n\t").split(","))).set()
+    return set(filter(lambda itm: itm != "", map(str.strip, value.strip(" \n\t").split(","))))
 
 
 def parse_args() -> Any:

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -211,7 +211,9 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH, {"lf", "otherExp"})
+        prefix = rd.get_runner_prefix(
+            settings_text, ["User2"], USER_BRANCH, {"lf", "otherExp"}
+        )
         self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for User2")
 
     def test_opted_in_user_two_experiments_default_exp_2(self) -> None:
@@ -230,7 +232,9 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         """
         prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH, {"otherExp"})
-        self.assertEqual("otherExp.", prefix, "Runner prefix not correct for User2")
+        self.assertEqual(
+            "otherExp.", prefix, "Runner prefix not correct for User2"
+        )
 
     @patch("random.uniform", return_value=50)
     def test_opted_out_user(self, mock_uniform: Mock) -> None:
@@ -271,7 +275,9 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for user")
 
     @patch("random.uniform", return_value=10)
-    def test_opted_out_user_was_pulled_in_by_rollout_excl_nondefault(self, mock_uniform: Mock) -> None:
+    def test_opted_out_user_was_pulled_in_by_rollout_excl_nondefault(
+        self, mock_uniform: Mock
+    ) -> None:
         settings_text = """
         experiments:
             lf:
@@ -292,7 +298,9 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         self.assertEqual("lf.", prefix, "Runner prefix not correct for user")
 
     @patch("random.uniform", return_value=10)
-    def test_opted_out_user_was_pulled_in_by_rollout_filter_exp(self, mock_uniform: Mock) -> None:
+    def test_opted_out_user_was_pulled_in_by_rollout_filter_exp(
+        self, mock_uniform: Mock
+    ) -> None:
         settings_text = """
         experiments:
             lf:
@@ -309,11 +317,15 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         """
 
         # User3 is opted out, but is pulled into default experiments by the 10% rollout
-        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH, check_experiments={"otherExp"})
+        prefix = rd.get_runner_prefix(
+            settings_text, ["User3"], USER_BRANCH, check_experiments={"otherExp"}
+        )
         self.assertEqual("otherExp.", prefix, "Runner prefix not correct for user")
 
     @patch("random.uniform", return_value=25)
-    def test_opted_out_user_was_pulled_out_by_rollout_filter_exp(self, mock_uniform: Mock) -> None:
+    def test_opted_out_user_was_pulled_out_by_rollout_filter_exp(
+        self, mock_uniform: Mock
+    ) -> None:
         settings_text = """
         experiments:
             lf:

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -212,7 +212,7 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         """
         prefix = rd.get_runner_prefix(
-            settings_text, ["User2"], USER_BRANCH, {"lf", "otherExp"}
+            settings_text, ["User2"], USER_BRANCH, frozenset(["lf", "otherExp"])
         )
         self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for User2")
 
@@ -231,10 +231,10 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         @User2,lf,otherExp
 
         """
-        prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH, {"otherExp"})
-        self.assertEqual(
-            "otherExp.", prefix, "Runner prefix not correct for User2"
+        prefix = rd.get_runner_prefix(
+            settings_text, ["User2"], USER_BRANCH, frozenset(["otherExp"])
         )
+        self.assertEqual("otherExp.", prefix, "Runner prefix not correct for User2")
 
     @patch("random.uniform", return_value=50)
     def test_opted_out_user(self, mock_uniform: Mock) -> None:
@@ -318,7 +318,7 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         # User3 is opted out, but is pulled into default experiments by the 10% rollout
         prefix = rd.get_runner_prefix(
-            settings_text, ["User3"], USER_BRANCH, eligible_experiments={"otherExp"}
+            settings_text, ["User3"], USER_BRANCH, frozenset(["otherExp"])
         )
         self.assertEqual("otherExp.", prefix, "Runner prefix not correct for user")
 

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -318,7 +318,7 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         # User3 is opted out, but is pulled into default experiments by the 10% rollout
         prefix = rd.get_runner_prefix(
-            settings_text, ["User3"], USER_BRANCH, check_experiments={"otherExp"}
+            settings_text, ["User3"], USER_BRANCH, eligible_experiments={"otherExp"}
         )
         self.assertEqual("otherExp.", prefix, "Runner prefix not correct for user")
 

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -168,7 +168,6 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
                 rollout_perc: 0
             otherExp:
                 rollout_perc: 0
-                default: false
         ---
 
         Users:
@@ -178,6 +177,60 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         """
         prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
         self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for User2")
+
+    def test_opted_in_user_two_experiments_default(self) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+            otherExp:
+                rollout_perc: 0
+                default: false
+        ---
+
+        Users:
+        @User1,lf
+        @User2,lf,otherExp
+
+        """
+        prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH)
+        self.assertEqual("lf.", prefix, "Runner prefix not correct for User2")
+
+    def test_opted_in_user_two_experiments_default_exp(self) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+            otherExp:
+                rollout_perc: 0
+                default: false
+        ---
+
+        Users:
+        @User1,lf
+        @User2,lf,otherExp
+
+        """
+        prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH, {"lf", "otherExp"})
+        self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for User2")
+
+    def test_opted_in_user_two_experiments_default_exp_2(self) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+            otherExp:
+                rollout_perc: 0
+                default: false
+        ---
+
+        Users:
+        @User1,lf
+        @User2,lf,otherExp
+
+        """
+        prefix = rd.get_runner_prefix(settings_text, ["User2"], USER_BRANCH, {"otherExp"})
+        self.assertEqual("otherExp.", prefix, "Runner prefix not correct for User2")
 
     @patch("random.uniform", return_value=50)
     def test_opted_out_user(self, mock_uniform: Mock) -> None:

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -277,7 +277,7 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         """
 
         # User3 is opted out, but is pulled into default experiments by the 10% rollout
-        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH, check_experiments={"otherExp"})
+        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
         self.assertEqual("", prefix, "Runner prefix not correct for user")
 
     def test_lf_prefix_always_comes_first(self) -> None:

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -16,6 +16,7 @@ class TestRunnerDeterminatorIssueParser(TestCase):
                 rollout_perc: 25
             otherExp:
                 rollout_perc: 0
+                default: false
         ---
 
         Users:
@@ -32,7 +33,7 @@ class TestRunnerDeterminatorIssueParser(TestCase):
             "lf settings not parsed correctly",
         )
         self.assertTupleEqual(
-            rd.Experiment(rollout_perc=0),
+            rd.Experiment(rollout_perc=0, default=False),
             settings.experiments["otherExp"],
             "otherExp settings not parsed correctly",
         )
@@ -46,7 +47,7 @@ class TestRunnerDeterminatorIssueParser(TestCase):
                 rollout_perc: 25
             otherExp:
                 rollout_perc: 0
-
+                default: false
         ```
 
         ---
@@ -65,7 +66,7 @@ class TestRunnerDeterminatorIssueParser(TestCase):
             "lf settings not parsed correctly",
         )
         self.assertTupleEqual(
-            rd.Experiment(rollout_perc=0),
+            rd.Experiment(rollout_perc=0, default=False),
             settings.experiments["otherExp"],
             "otherExp settings not parsed correctly",
         )
@@ -167,6 +168,7 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
                 rollout_perc: 0
             otherExp:
                 rollout_perc: 0
+                default: false
         ---
 
         Users:
@@ -214,6 +216,69 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
         # User3 is opted out, but is pulled into both experiments by the 10% rollout
         prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
         self.assertEqual("lf.otherExp.", prefix, "Runner prefix not correct for user")
+
+    @patch("random.uniform", return_value=10)
+    def test_opted_out_user_was_pulled_in_by_rollout_excl_nondefault(self, mock_uniform: Mock) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 25
+            otherExp:
+                rollout_perc: 25
+                default: false
+        ---
+
+        Users:
+        @User1,lf
+        @User2,lf,otherExp
+
+        """
+
+        # User3 is opted out, but is pulled into default experiments by the 10% rollout
+        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH)
+        self.assertEqual("lf.", prefix, "Runner prefix not correct for user")
+
+    @patch("random.uniform", return_value=10)
+    def test_opted_out_user_was_pulled_in_by_rollout_filter_exp(self, mock_uniform: Mock) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 25
+            otherExp:
+                rollout_perc: 25
+                default: false
+        ---
+
+        Users:
+        @User1,lf
+        @User2,lf,otherExp
+
+        """
+
+        # User3 is opted out, but is pulled into default experiments by the 10% rollout
+        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH, check_experiments={"otherExp"})
+        self.assertEqual("otherExp.", prefix, "Runner prefix not correct for user")
+
+    @patch("random.uniform", return_value=25)
+    def test_opted_out_user_was_pulled_out_by_rollout_filter_exp(self, mock_uniform: Mock) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 10
+            otherExp:
+                rollout_perc: 50
+                default: false
+        ---
+
+        Users:
+        @User1,lf
+        @User2,lf,otherExp
+
+        """
+
+        # User3 is opted out, but is pulled into default experiments by the 10% rollout
+        prefix = rd.get_runner_prefix(settings_text, ["User3"], USER_BRANCH, check_experiments={"otherExp"})
+        self.assertEqual("", prefix, "Runner prefix not correct for user")
 
     def test_lf_prefix_always_comes_first(self) -> None:
         settings_text = """

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -439,7 +439,6 @@ jobs:
               fleet_prefix = ""
               prefixes = []
               for experiment_name, experiment_settings in settings.experiments.items():
-
                   if not experiment_settings.all_branches and is_exception_branch(branch):
                       log.info(
                           f"Branch {branch} is an exception branch. Not enabling experiment {experiment_name}."

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -123,7 +123,7 @@ jobs:
           import random
           from argparse import ArgumentParser
           from logging import LogRecord
-          from typing import Any, Dict, Iterable, List, NamedTuple, Tuple, Set
+          from typing import Any, Dict, FrozenSet, Iterable, List, NamedTuple, Tuple
 
           import yaml
           from github import Auth, Github
@@ -209,8 +209,10 @@ jobs:
                   f.write(f"{key}={value}\n")
 
 
-          def _str_comma_separated_to_set(value: str) -> Set[str]:
-              return set(filter(lambda itm: itm != "", map(str.strip, value.strip(" \n\t").split(","))))
+          def _str_comma_separated_to_set(value: str) -> FrozenSet[str]:
+              return frozenset(
+                  filter(lambda itm: itm != "", map(str.strip, value.strip(" \n\t").split(",")))
+              )
 
 
           def parse_args() -> Any:
@@ -252,7 +254,7 @@ jobs:
                   type=_str_comma_separated_to_set,
                   required=False,
                   default="",
-                  help="comma separated list of experiments to check, if omitted all experiments marked with default=True are checked"
+                  help="comma separated list of experiments to check, if omitted all experiments marked with default=True are checked",
               )
 
               return parser.parse_args()
@@ -428,7 +430,7 @@ jobs:
               rollout_state: str,
               workflow_requestors: Iterable[str],
               branch: str,
-              check_experiments: Set[str] = set(),
+              check_experiments: FrozenSet[str] = frozenset(),
               is_canary: bool = False,
           ) -> str:
               settings = parse_settings(rollout_state)
@@ -456,14 +458,20 @@ jobs:
                   if check_experiments:
                       if experiment_name not in check_experiments:
                           exp_list = ", ".join(check_experiments)
-                          log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}")
+                          log.info(
+                              f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}"
+                          )
                           do_check = False
                   elif not experiment_settings.default:
-                      log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")
+                      log.info(
+                          f"Skipping experiment '{experiment_name}', as it is not a default experiment"
+                      )
                       do_check = False
 
                   if opted_in_users and do_check:
-                      log.info(f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}.")
+                      log.info(
+                          f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}."
+                      )
                       enabled = True
 
                   elif experiment_settings.rollout_perc:

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -430,7 +430,7 @@ jobs:
               rollout_state: str,
               workflow_requestors: Iterable[str],
               branch: str,
-              check_experiments: FrozenSet[str] = frozenset(),
+              eligible_experiments: FrozenSet[str] = frozenset(),
               is_canary: bool = False,
           ) -> str:
               settings = parse_settings(rollout_state)
@@ -446,11 +446,11 @@ jobs:
                       )
                       continue
 
-                  if check_experiments:
-                      if experiment_name not in check_experiments:
-                          exp_list = ", ".join(check_experiments)
+                  if eligible_experiments:
+                      if experiment_name not in eligible_experiments:
+                          exp_list = ", ".join(eligible_experiments)
                           log.info(
-                              f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}"
+                              f"Skipping experiment '{experiment_name}', as it is not in the eligible_experiments list: {exp_list}"
                           )
                           continue
                   elif not experiment_settings.default:
@@ -541,7 +541,7 @@ jobs:
                       rollout_state,
                       (args.github_issue_owner, username),
                       args.github_branch,
-                      args.check_experiments,
+                      args.eligible_experiments,
                       is_canary,
                   )
 

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -439,11 +439,23 @@ jobs:
               fleet_prefix = ""
               prefixes = []
               for experiment_name, experiment_settings in settings.experiments.items():
-                  enabled = False
 
                   if not experiment_settings.all_branches and is_exception_branch(branch):
                       log.info(
                           f"Branch {branch} is an exception branch. Not enabling experiment {experiment_name}."
+                      )
+                      continue
+
+                  if check_experiments:
+                      if experiment_name not in check_experiments:
+                          exp_list = ", ".join(check_experiments)
+                          log.info(
+                              f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}"
+                          )
+                          continue
+                  elif not experiment_settings.default:
+                      log.info(
+                          f"Skipping experiment '{experiment_name}', as it is not a default experiment"
                       )
                       continue
 
@@ -454,21 +466,8 @@ jobs:
                       if is_user_opted_in(requestor, user_optins, experiment_name)
                   ]
 
-                  do_check = True
-                  if check_experiments:
-                      if experiment_name not in check_experiments:
-                          exp_list = ", ".join(check_experiments)
-                          log.info(
-                              f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}"
-                          )
-                          do_check = False
-                  elif not experiment_settings.default:
-                      log.info(
-                          f"Skipping experiment '{experiment_name}', as it is not a default experiment"
-                      )
-                      do_check = False
-
-                  if opted_in_users and do_check:
+                  enabled = False
+                  if opted_in_users:
                       log.info(
                           f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}."
                       )
@@ -476,7 +475,7 @@ jobs:
 
                   elif experiment_settings.rollout_perc:
                       # If no user is opted in, then we randomly enable the experiment based on the rollout percentage
-                      if do_check and random.uniform(0, 100) <= experiment_settings.rollout_perc:
+                      if random.uniform(0, 100) <= experiment_settings.rollout_perc:
                           log.info(
                               f"Based on rollout percentage of {experiment_settings.rollout_perc}%, enabling experiment {experiment_name}."
                           )

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -437,7 +437,7 @@ jobs:
               fleet_prefix = ""
               prefixes = []
               for experiment_name, experiment_settings in settings.experiments.items():
-                  if check_experiments
+                  if check_experiments:
                       if experiment_name not in check_experiments:
                           log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {", ".join(check_experiments)}")
                           continue

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -428,7 +428,7 @@ jobs:
               rollout_state: str,
               workflow_requestors: Iterable[str],
               branch: str,
-              check_experiments: Set[str],
+              check_experiments: Set[str] = Set(),
               is_canary: bool = False,
           ) -> str:
               settings = parse_settings(rollout_state)
@@ -437,15 +437,6 @@ jobs:
               fleet_prefix = ""
               prefixes = []
               for experiment_name, experiment_settings in settings.experiments.items():
-                  if check_experiments:
-                      if experiment_name not in check_experiments:
-                          exp_list = ", ".join(check_experiments)
-                          log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}")
-                          continue
-                  elif not experiment_settings.default:
-                      log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")
-                      continue
-
                   enabled = False
 
                   if not experiment_settings.all_branches and is_exception_branch(branch):
@@ -467,8 +458,18 @@ jobs:
                       )
                       enabled = True
                   elif experiment_settings.rollout_perc:
+                      do_check = True
+                      if check_experiments:
+                          if experiment_name not in check_experiments:
+                              exp_list = ", ".join(check_experiments)
+                              log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}")
+                              do_check = False
+                      elif not experiment_settings.default:
+                          log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")
+                          do_check = False
+
                       # If no user is opted in, then we randomly enable the experiment based on the rollout percentage
-                      if random.uniform(0, 100) <= experiment_settings.rollout_perc:
+                      if do_check and random.uniform(0, 100) <= experiment_settings.rollout_perc:
                           log.info(
                               f"Based on rollout percentage of {experiment_settings.rollout_perc}%, enabling experiment {experiment_name}."
                           )

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -3,6 +3,11 @@ name: Check whether the workflow owner can use ARC runners
 on:
   workflow_call:
     inputs:
+      check_experiments:
+        required: false
+        type: string
+        description: |
+          List of experiments for this workfow. If not defined, all default experiments are included.
       triggering_actor:
         required: true
         type: string
@@ -538,4 +543,5 @@ jobs:
             --github-actor "$TRIGGERING_ACTOR" \
             --github-issue-owner "$ISSUE_OWNER" \
             --github-ref-type "$curr_ref_type" \
-            --github-repo "$GITHUB_REPOSITORY"
+            --github-repo "$GITHUB_REPOSITORY" \
+            --check-experiments "$" \

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -210,7 +210,7 @@ jobs:
 
 
           def _str_comma_separated_to_set(value: str) -> Set[str]:
-              return value.strip(" \n\t").split(",").map(str.strip).filter(lambda itm: itm != "").set()
+              return map(str.strip, value.strip(" \n\t").split(",")).filter(lambda itm: itm != "").set()
 
 
           def parse_args() -> Any:

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -210,7 +210,7 @@ jobs:
 
 
           def _str_comma_separated_to_set(value: str) -> Set[str]:
-              return filter(lambda itm: itm != "", map(str.strip, value.strip(" \n\t").split(","))).set()
+              return set(filter(lambda itm: itm != "", map(str.strip, value.strip(" \n\t").split(","))))
 
 
           def parse_args() -> Any:

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -248,7 +248,7 @@ jobs:
                   help="Current GitHub ref type, branch or tag",
               )
               parser.add_argument(
-                  "--check-experiments",
+                  "--eligible-experiments",
                   type=_str_comma_separated_to_set,
                   required=False,
                   default="",
@@ -453,10 +453,16 @@ jobs:
                   ]
 
                   if opted_in_users:
-                      log.info(
-                          f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}."
-                      )
-                      enabled = True
+                      log.info(f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}.")
+
+                      if check_experiments:
+                          if experiment_name in check_experiments:
+                              enabled = True
+                          else:
+                              log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list")
+                      else:
+                          enabled = True
+
                   elif experiment_settings.rollout_perc:
                       do_check = True
                       if check_experiments:
@@ -572,4 +578,4 @@ jobs:
             --github-issue-owner "$ISSUE_OWNER" \
             --github-ref-type "$curr_ref_type" \
             --github-repo "$GITHUB_REPOSITORY" \
-            --check-experiments "$CHECK_EXPERIMENTS" \
+            --eligible-experiments "$CHECK_EXPERIMENTS" \

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -439,7 +439,8 @@ jobs:
               for experiment_name, experiment_settings in settings.experiments.items():
                   if check_experiments:
                       if experiment_name not in check_experiments:
-                          log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {", ".join(check_experiments)}")
+                          exp_list = ", ".join(check_experiments)
+                          log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}")
                           continue
                   elif not experiment_settings.default:
                       log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -48,6 +48,7 @@ jobs:
       ISSUE_NUMBER: ${{ inputs.issue_number }}
       TRIGGERING_ACTOR: ${{ inputs.triggering_actor }}
       ISSUE_OWNER: ${{ inputs.issue_owner }}
+      CHECK_EXPERIMENTS: ${{ inputs.check_experiments }}
     steps:
       # - name: Checkout PyTorch
       #   uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -544,4 +545,4 @@ jobs:
             --github-issue-owner "$ISSUE_OWNER" \
             --github-ref-type "$curr_ref_type" \
             --github-repo "$GITHUB_REPOSITORY" \
-            --check-experiments "$" \
+            --check-experiments "$CHECK_EXPERIMENTS" \

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -428,7 +428,7 @@ jobs:
               rollout_state: str,
               workflow_requestors: Iterable[str],
               branch: str,
-              check_experiments: Set[str] = Set(),
+              check_experiments: Set[str] = set(),
               is_canary: bool = False,
           ) -> str:
               settings = parse_settings(rollout_state)

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -104,7 +104,8 @@ jobs:
               experiments:
                 lf:
                   rollout_percent: 25
-
+                  all_branches: false
+                  default: true
               ---
 
               # Opt-ins:
@@ -122,7 +123,7 @@ jobs:
           import random
           from argparse import ArgumentParser
           from logging import LogRecord
-          from typing import Any, Dict, Iterable, List, NamedTuple, Tuple
+          from typing import Any, Dict, Iterable, List, NamedTuple, Tuple, Set
 
           import yaml
           from github import Auth, Github
@@ -150,6 +151,9 @@ jobs:
               )
               all_branches: bool = (
                   False  # If True, the experiment is also enabled on the exception branches
+              )
+              default: bool = (
+                  True  # If True, the experiment is enabled by default for all queries
               )
 
               # Add more fields as needed
@@ -205,6 +209,10 @@ jobs:
                   f.write(f"{key}={value}\n")
 
 
+          def _str_comma_separated_to_set(value: str) -> Set[str]:
+              return value.strip(" \n\t").split(",").map(str.strip).filter(lambda itm: itm != "").set()
+
+
           def parse_args() -> Any:
               parser = ArgumentParser("Get dynamic rollout settings")
               parser.add_argument("--github-token", type=str, required=True, help="GitHub token")
@@ -238,6 +246,13 @@ jobs:
                   type=str,
                   required=True,
                   help="Current GitHub ref type, branch or tag",
+              )
+              parser.add_argument(
+                  "--check-experiments",
+                  type=_str_comma_separated_to_set,
+                  required=False,
+                  default="",
+                  help="comma separated list of experiments to check, if omitted all experiments marked with default=True are checked"
               )
 
               return parser.parse_args()
@@ -413,6 +428,7 @@ jobs:
               rollout_state: str,
               workflow_requestors: Iterable[str],
               branch: str,
+              check_experiments: Set[str],
               is_canary: bool = False,
           ) -> str:
               settings = parse_settings(rollout_state)
@@ -421,6 +437,14 @@ jobs:
               fleet_prefix = ""
               prefixes = []
               for experiment_name, experiment_settings in settings.experiments.items():
+                  if check_experiments
+                      if experiment_name not in check_experiments:
+                          log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {", ".join(check_experiments)}")
+                          continue
+                  elif not experiment_settings.default:
+                      log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")
+                      continue
+
                   enabled = False
 
                   if not experiment_settings.all_branches and is_exception_branch(branch):
@@ -509,6 +533,7 @@ jobs:
                       rollout_state,
                       (args.github_issue_owner, username),
                       args.github_branch,
+                      args.check_experiments,
                       is_canary,
                   )
 

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -210,7 +210,7 @@ jobs:
 
 
           def _str_comma_separated_to_set(value: str) -> Set[str]:
-              return map(str.strip, value.strip(" \n\t").split(",")).filter(lambda itm: itm != "").set()
+              return filter(lambda itm: itm != "", map(str.strip, value.strip(" \n\t").split(","))).set()
 
 
           def parse_args() -> Any:

--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -452,28 +452,21 @@ jobs:
                       if is_user_opted_in(requestor, user_optins, experiment_name)
                   ]
 
-                  if opted_in_users:
-                      log.info(f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}.")
+                  do_check = True
+                  if check_experiments:
+                      if experiment_name not in check_experiments:
+                          exp_list = ", ".join(check_experiments)
+                          log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}")
+                          do_check = False
+                  elif not experiment_settings.default:
+                      log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")
+                      do_check = False
 
-                      if check_experiments:
-                          if experiment_name in check_experiments:
-                              enabled = True
-                          else:
-                              log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list")
-                      else:
-                          enabled = True
+                  if opted_in_users and do_check:
+                      log.info(f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}.")
+                      enabled = True
 
                   elif experiment_settings.rollout_perc:
-                      do_check = True
-                      if check_experiments:
-                          if experiment_name not in check_experiments:
-                              exp_list = ", ".join(check_experiments)
-                              log.info(f"Skipping experiment '{experiment_name}', as it is not in the check_experiments list: {exp_list}")
-                              do_check = False
-                      elif not experiment_settings.default:
-                          log.info(f"Skipping experiment '{experiment_name}', as it is not a default experiment")
-                          do_check = False
-
                       # If no user is opted in, then we randomly enable the experiment based on the rollout percentage
                       if do_check and random.uniform(0, 100) <= experiment_settings.rollout_perc:
                           log.info(

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -13,39 +13,27 @@ concurrency:
 permissions: read-all
 
 jobs:
-  get-build-label-type:
-    name: get-build-label-type
+  get-label-type:
+    name: get-label-type
     uses: ./.github/workflows/_runner-determinator.yml
     with:
       triggering_actor: ${{ github.triggering_actor }}
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
-
-  get-test-label-type:
-    name: get-test-label-type
-    uses: ./.github/workflows/_runner-determinator.yml
-    with:
-      triggering_actor: ${{ github.triggering_actor }}
-      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
-      curr_branch: ${{ github.head_ref || github.ref_name }}
-      curr_ref_type: ${{ github.ref_type }}
-      check_experiments: "awsa100"
 
   linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
     name: cuda12.1-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-build.yml
-    needs:
-      - get-build-label-type
-      - get-test-label-type
+    needs: get-label-type
     with:
-      runner_prefix: "${{ needs.get-build-label-type.outputs.label-type }}"
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
       docker-image-name: pytorch-linux-focal-cuda12.1-cudnn9-py3-gcc9-inductor-benchmarks
       cuda-arch-list: '8.0'
       test-matrix: |
         { include: [
-          { config: "inductor_huggingface_perf_compare", shard: 1, num_shards: 1, runner: "${{ needs.get-test-label-type.outputs.label-type }}linux.gcp.a100" },
+          { config: "inductor_huggingface_perf_compare", shard: 1, num_shards: 1, runner: "linux.gcp.a100" },
           { config: "inductor_timm_perf_compare", shard: 1, num_shards: 2, runner: "linux.gcp.a100" },
           { config: "inductor_timm_perf_compare", shard: 2, num_shards: 2, runner: "linux.gcp.a100" },
           { config: "inductor_torchbench_perf_compare", shard: 1, num_shards: 1, runner: "linux.gcp.a100" },

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -13,8 +13,8 @@ concurrency:
 permissions: read-all
 
 jobs:
-  get-label-type:
-    name: get-label-type
+  get-build-label-type:
+    name: get-build-label-type
     uses: ./.github/workflows/_runner-determinator.yml
     with:
       triggering_actor: ${{ github.triggering_actor }}
@@ -22,18 +22,30 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
+  get-test-label-type:
+    name: get-test-label-type
+    uses: ./.github/workflows/_runner-determinator.yml
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      check_experiments: "awsa100"
+
   linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
     name: cuda12.1-py3.10-gcc9-sm80
     uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
+    needs:
+      - get-build-label-type
+      - get-test-label-type
     with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner_prefix: "${{ needs.get-build-label-type.outputs.label-type }}"
       build-environment: linux-focal-cuda12.1-py3.10-gcc9-sm80
       docker-image-name: pytorch-linux-focal-cuda12.1-cudnn9-py3-gcc9-inductor-benchmarks
       cuda-arch-list: '8.0'
       test-matrix: |
         { include: [
-          { config: "inductor_huggingface_perf_compare", shard: 1, num_shards: 1, runner: "linux.gcp.a100" },
+          { config: "inductor_huggingface_perf_compare", shard: 1, num_shards: 1, runner: "${{ needs.get-test-label-type.outputs.label-type }}linux.gcp.a100" },
           { config: "inductor_timm_perf_compare", shard: 1, num_shards: 2, runner: "linux.gcp.a100" },
           { config: "inductor_timm_perf_compare", shard: 2, num_shards: 2, runner: "linux.gcp.a100" },
           { config: "inductor_torchbench_perf_compare", shard: 1, num_shards: 1, runner: "linux.gcp.a100" },


### PR DESCRIPTION
adds a `default` tag to experiment configurations, allowing to remove some experiments by default on the random draw:

```
        experiments:
            lf:
                rollout_perc: 25
            otherExp:
                rollout_perc: 25
                default: false
        ---
```

and includes the configuration to filter what experiments are of interest for a particular workflow (comma separated):

```
  get-test-label-type:
    name: get-test-label-type
    uses: ./.github/workflows/_runner-determinator.yml
    with:
      ...
      check_experiments: "awsa100"
```

The end goal, is to enable us to run multiple experiments, that are independent from one another. For example, while we still runs the LF infra experiment, we want to migrate other runners leveraging the current solution. A immediate UC is for the A100 instances, where we want to migrate to AWS. 

Those new instances will during the migration period be labeled both `awsa100.linux.gcp.a100` and `linux.aws.a100`. Once the experiment ends, we will remove the first confusing one.

```
jobs:
  get-build-label-type:
    name: get-build-label-type
    uses: ./.github/workflows/_runner-determinator.yml
    with:
      ...

  get-test-label-type:
    name: get-test-label-type
    uses: ./.github/workflows/_runner-determinator.yml
    with:
      ...
      check_experiments: "awsa100"
      
  linux-focal-cuda12_1-py3_10-gcc9-inductor-build:
    name: cuda12.1-py3.10-gcc9-sm80
    uses: ./.github/workflows/_linux-build.yml
    needs:
      - get-build-label-type
      - get-test-label-type
    with:
      runner_prefix: "${{ needs.get-build-label-type.outputs.label-type }}"
      ...
      test-matrix: |
        { include: [
          { config: "inductor_huggingface_perf_compare", shard: 1, num_shards: 1, runner: "${{ needs.get-test-label-type.outputs.label-type }}linux.gcp.a100" },
          ...
        ]}
      ...
```

```
experiments:
    lf:
        rollout_perc: 50
    awsa100:
        rollout_perc: 50
         default: false
```