### PR TITLE
[POC] torch.cond support size mismatch in output

### DIFF
--- a/ca.py
+++ b/ca.py
@@ -1,0 +1,17 @@
+import torch
+
+torch._dynamo.config.capture_scalar_outputs = True
+
+def true_fn():
+    return torch.randn(10)
+
+def false_fn():
+    return torch.randn(5)
+
+@torch.compile(backend="eager", fullgraph=True)
+def f(x):
+    u0, u1 = x.tolist()
+
+    return torch.cond(u0 == 20, true_fn, false_fn, ()) * 2
+
+f(torch.tensor([20, 21]))

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6525,8 +6525,8 @@ class Conditional(ExternKernel):
         # make sure true and false outputs are structurally equivalent
         assert len(true_outputs) == len(false_outputs), (true_outputs, false_outputs)
         for i, (to, fo) in enumerate(zip(true_outputs, false_outputs)):
-            assert to.get_size() == fo.get_size(), (i, to, fo)
-            assert to.get_stride() == fo.get_stride(), (i, to, fo)
+            #assert to.get_size() == fo.get_size(), (i, to, fo)
+            #assert to.get_stride() == fo.get_stride(), (i, to, fo)
             assert to.get_device() == fo.get_device(), (i, to, fo)
             assert to.get_dtype() == fo.get_dtype(), (i, to, fo)
             assert to.get_layout().offset == fo.get_layout().offset, (i, to, fo)
@@ -6561,8 +6561,7 @@ class Conditional(ExternKernel):
                 conditional,
                 [(list, i)],
             )
-            # as the true and false outputs are equivalent,
-            # we can use either of them here as a "template"
+            # TODO: read this out of the fake tensor
             for i, output in enumerate(true_outputs)
         ]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137615
* #137605

Fixes https://github.com/pytorch/pytorch/issues/137520

This POC PR shows that it is possible to have torch.cond support mismatching shapes on the true/false branches, by allocating an unbacked SymInt on the fly when this occurs. This supports tracing through eager/AOTAutograd; Inductor compilation doesn't work and needs similar treatment (in particular, I assume because torch.cond has special codegen, we need to add special codegen to make sure we bind the unbacked SymInt so it can be used downstream of it).

I'll add some commentary in the PR about other things that would need to be finished.

Internal xref: https://fb.workplace.com/groups/6829516587176185/permalink/8109696255824872/

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @rec

Differential Revision: [D65282013](https://our.internmc.facebook.com/intern/diff/D65282013)