### PR TITLE
ATen | Fix header namespace pollution.

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNConvOp.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNConvOp.h
@@ -14,11 +14,10 @@ API_AVAILABLE(ios(11.0), macos(10.13))
 
 @end
 
-using namespace at::native::metal;
 API_AVAILABLE(ios(11.0), macos(10.13))
 @interface MPSCNNConvOp : NSObject<MPSCNNOp>
-+ (MPSCNNConvOp*)conv2d:(const Conv2DParams&)params
++ (MPSCNNConvOp*)conv2d:(const at::native::metal::Conv2DParams&)params
                 weights:(float*)w
                    bias:(float*)b
-           neuronFilter:(NeuronType)t;
+           neuronFilter:(at::native::metal::NeuronType)t;
 @end

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNConvOp.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNConvOp.mm
@@ -68,10 +68,10 @@
 
 @synthesize kernel = _kernel;
 
-+ (MPSCNNConvOp*)conv2d:(const Conv2DParams&)params
++ (MPSCNNConvOp*)conv2d:(const at::native::metal::Conv2DParams&)params
                 weights:(float*)w
                    bias:(float*)b
-           neuronFilter:(NeuronType)t API_AVAILABLE(ios(11.0), macos(10.13)) {
+           neuronFilter:(at::native::metal::NeuronType)t API_AVAILABLE(ios(11.0), macos(10.13)) {
   using namespace at::native::metal::mpscnn;
   TORCH_CHECK(
       params.DX == params.DY == 1, "Dilated convolution is not supported yet.");

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.h
@@ -5,8 +5,8 @@
 
 API_AVAILABLE(ios(11.0), macos(10.13))
 @interface MPSCNNFullyConnectedOp : NSObject<MPSCNNOp>
-+ (MPSCNNFullyConnectedOp*)linear:(const Conv2DParams&)params
++ (MPSCNNFullyConnectedOp*)linear:(const at::native::metal::Conv2DParams&)params
                           weights:(float*)w
                              bias:(float*)b
-                     neuronFilter:(NeuronType)t;
+                     neuronFilter:(at::native::metal::NeuronType)t;
 @end

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.mm
@@ -6,10 +6,10 @@
 
 @synthesize kernel = _kernel;
 
-+ (MPSCNNFullyConnectedOp*)linear:(const Conv2DParams&)params
++ (MPSCNNFullyConnectedOp*)linear:(const at::native::metal::Conv2DParams&)params
                           weights:(float*)w
                              bias:(float*)b
-                     neuronFilter:(NeuronType)t
+                     neuronFilter:(at::native::metal::NeuronType)t
     API_AVAILABLE(ios(11.0), macos(10.13)) {
   MPSCNNNeuron* neuron = at::native::metal::neuron(t);
   MPSCNNConvolutionDescriptor* desc = [MPSCNNConvolutionDescriptor


### PR DESCRIPTION
Summary: Fixing a warning, so we can enable it globally.

Test Plan: Sandcastle-only, no runtime changes.

Differential Revision: D64122115


