### PR TITLE
Add support for remainder in tensorify_python_scalars fx pass

### DIFF
--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -70,6 +70,7 @@ SUPPORTED_OPS = {
     torch.ops.aten.div.Tensor,
     torch.ops.aten.pow.Tensor,
     torch.ops.aten.floor_divide.Tensor,
+    torch.ops.aten.remainder.Tensor,
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137628
* __->__ #137627
* #137625
* #137624
* #137623
* #137622
* #137620
* #137588
* #136674

