### PR TITLE
[rfc] should we support all the following ops in tensorify_python_scalars fx pass

### DIFF
--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -71,6 +71,12 @@ SUPPORTED_OPS = {
     torch.ops.aten.pow.Tensor,
     torch.ops.aten.floor_divide.Tensor,
     torch.ops.aten.remainder.Tensor,
+    # torch.ops.aten.fmod.Tensor
+    # torch.ops.aten.eq.Tensor
+    # torch.ops.aten.lt.Tensor
+    # torch.ops.aten.le.Tensor
+    # torch.ops.aten.gt.Tensor
+    # torch.ops.aten.ge.Tensor
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137628
* #137627
* #137625
* #137624
* #137623
* #137622
* #137620
* #137588
* #136674



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec