### PR TITLE
Setting wrong values to num_layers of nn.RNN() gets indirect error messages

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -132,7 +132,7 @@ class RNNBase(Module):
                 f"hidden_size should be of type int, got: {type(hidden_size).__name__}"
             )
 
-        if not isinstance(num_layers, int):
+        if not isinstance(num_layers, int) or isinstance(num_layers, bool):
             raise TypeError(
                 f"num_layers should be of type int, got: {type(num_layers).__name__}"
             )

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -131,6 +131,12 @@ class RNNBase(Module):
             raise TypeError(
                 f"hidden_size should be of type int, got: {type(hidden_size).__name__}"
             )
+
+        if not isinstance(num_layers, int):
+            raise TypeError(
+                f"num_layers should be of type int, got: {type(num_layers).__name__}"
+            )
+
         if hidden_size <= 0:
             raise ValueError("hidden_size must be greater than zero")
         if num_layers <= 0:


### PR DESCRIPTION
Fixes #136938. Added a type check for num_layers. Implemented similarly to the type check for hidden_size. 
