### PR TITLE
NotImplementedError: Operator aten.unbind.int does not have a sharding

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -303,6 +303,7 @@ class TestFullyShard1DTrainingCore(FSDPTest):
 
         shard_placement_fn = _shard_placement_fn if use_shard_placement_fn else None
         fully_shard(model, shard_placement_fn=shard_placement_fn)
+        print([name for name, param in model.parameters()])
         optim = torch.optim.Adam(model.parameters(), lr=1e-2)
         torch.manual_seed(42 + self.rank + 1)
         inp = (torch.randn((4, lin_shapes[0][0]), device="cuda"),)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137649
* #137496
* #137593

`pytest -s test/distributed/_composable/fsdp/test_fully_shard_training.py -k test_train_parity_single_group_shard_largest_dim`

```
File "/data/users/weif/pytorch/test/distributed/_composable/fsdp/test_fully_shard_training.py", line 306, in <listcomp>
    print([name for name, param in model.parameters()])
  File "/data/users/weif/pytorch/torch/_tensor.py", line 1151, in __iter__
    return iter(self.unbind(0))
  File "/data/users/weif/pytorch/torch/_compile.py", line 32, in inner
    return disable_fn(*args, **kwargs)
  File "/data/users/weif/pytorch/torch/_dynamo/eval_frame.py", line 629, in _fn
    return fn(*args, **kwargs)
  File "/data/users/weif/pytorch/torch/distributed/tensor/_api.py", line 340, in __torch_dispatch__
    return DTensor._op_dispatcher.dispatch(
  File "/data/users/weif/pytorch/torch/distributed/tensor/_dispatch.py", line 169, in dispatch
    self.sharding_propagator.propagate(op_info)
  File "/data/users/weif/pytorch/torch/distributed/tensor/_sharding_prop.py", line 206, in propagate
    OutputSharding, self.propagate_op_sharding(op_info.schema)
  File "/data/users/weif/pytorch/torch/distributed/tensor/_sharding_prop.py", line 46, in __call__
    return self.cache(*args, **kwargs)
  File "/data/users/weif/pytorch/torch/distributed/tensor/_sharding_prop.py", line 455, in propagate_op_sharding_non_cached
    raise NotImplementedError(
NotImplementedError: Operator aten.unbind.int does not have a sharding strategy registered.
```

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o