### PR TITLE
[dynamo, 3.13] fix typo in remove_fused_load_store

### DIFF
--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -1037,7 +1037,7 @@ def remove_fused_load_store(instructions: List[Instruction]) -> None:
                 create_instruction(inst0, argval=argval0),
                 create_instruction(inst1, argval=argval1),
             ]
-            new_insts.append(overwrite_instruction(inst, replace_insts))
+            new_insts.extend(overwrite_instruction(inst, replace_insts))
         else:
             new_insts.append(inst)
     instructions[:] = new_insts


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137656
* __->__ #137652

Whoops!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec