### PR TITLE
Fix custom op bug of clearing dir

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1047,7 +1047,7 @@ graph():
             warnings.simplefilter("error")
             torch.export.export(Foo(), (x,))
 
-        ops_registered_before = set(op for op in torch.ops.mylib)
+        ops_registered_before = set(torch.ops.mylib)
 
         # Assert warning for CompositeImplictAutograd op
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
@@ -1065,7 +1065,7 @@ graph():
                     warnings.simplefilter("always")
                     torch.export.export(Bar(), (x,))
 
-        ops_registered_after = set(op for op in torch.ops.mylib)
+        ops_registered_after = set(torch.ops.mylib)
         self.assertEqual(ops_registered_after, ops_registered_before)
 
     def test_export_preserve_linear_at_aot_level(self):

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1064,10 +1064,10 @@ graph():
                 with warnings.catch_warnings():
                     warnings.simplefilter("always")
                     torch.export.export(Bar(), (x,))
-        
+
         ops_registered_after = set(op for op in torch.ops.mylib)
         self.assertEqual(ops_registered_after, ops_registered_before)
-        
+
     def test_export_preserve_linear_at_aot_level(self):
         class Foo(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1047,6 +1047,8 @@ graph():
             warnings.simplefilter("error")
             torch.export.export(Foo(), (x,))
 
+        ops_registered_before = set(op for op in torch.ops.mylib)
+
         # Assert warning for CompositeImplictAutograd op
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
             lib.define("foo123(Tensor x) -> Tensor")
@@ -1062,7 +1064,9 @@ graph():
                 with warnings.catch_warnings():
                     warnings.simplefilter("always")
                     torch.export.export(Bar(), (x,))
-
+        
+        ops_registered_after = set(op for op in torch.ops.mylib)
+        self.assertEqual(ops_registered_after, ops_registered_before)
     def test_export_preserve_linear_at_aot_level(self):
         class Foo(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -1067,6 +1067,7 @@ graph():
         
         ops_registered_after = set(op for op in torch.ops.mylib)
         self.assertEqual(ops_registered_after, ops_registered_before)
+        
     def test_export_preserve_linear_at_aot_level(self):
         class Foo(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/library.py
+++ b/torch/library.py
@@ -1,4 +1,4 @@
-caf# mypy: allow-untyped-defs
+# mypy: allow-untyped-defs
 import contextlib
 import functools
 import inspect

--- a/torch/library.py
+++ b/torch/library.py
@@ -1,4 +1,4 @@
-# mypy: allow-untyped-defs
+caf# mypy: allow-untyped-defs
 import contextlib
 import functools
 import inspect
@@ -424,6 +424,7 @@ class Library:
             if not hasattr(namespace, name):
                 continue
             delattr(namespace, name)
+            namespace._dir.remove(name)
 
 
 def _del_library(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137655
Previously when we delete a custom op out of context manager, we weren't clearing the dir field of the op namespace. As a result, it was polluting other tests. 

Differential Revision: [D64141465](https://our.internmc.facebook.com/intern/diff/D64141465/)