### PR TITLE
Add Android.bp for ExecuTorch AOSP use

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,9 @@
+filegroup {
+    name: "torchgen_native_functions",
+    srcs: ["aten/src/ATen/native/native_functions.yaml"],
+}
+
+filegroup {
+    name: "torchgen_tags",
+    srcs: ["aten/src/ATen/native/tags.yaml"],
+}

--- a/torchgen/Android.bp
+++ b/torchgen/Android.bp
@@ -1,0 +1,18 @@
+python_library_host {
+    name: "torchgen_library",
+    srcs: [
+        "**/*.py"
+    ],
+    pkg_path: "torchgen",
+    libs: [
+        "pyyaml",
+        "typing_extensions",
+    ],
+}
+
+python_binary_host {
+    name: "torchgen_executorch",
+    main: "gen_executorch.py",
+    srcs: ["gen_executorch.py"],
+    libs: ["torchgen_library"],
+}


### PR DESCRIPTION
ExecuTorch on AOSP needs torchgen from pytorch/pytorch to generate op lib tempalte.

Repo steps:

1. Download/init AOSP repo. See https://source.android.com/docs/setup/download

2. Go to the AOSP tree.

3. Clone repo
```
mkdir external/pytorch
cd external/pytorch
git clone https://github.com/pytorch/pytorch.git -b aosp-android-bp
git clone https://github.com/pytorch/executorch.git -b aosp-test
cd ../..
```
4. Build
```
source build/envsetup.sh
lunch aosp_arm64-trunk_staging-userdebug
m executor_runner
```
5. Run on device
```
adb push out/target/product/generic_arm64/system/bin/executor_runner /data/local/tmp
adb shell chmod +x /data/local/tmp/executor_runner
adb shell /data/local/tmp/executor_runner --model_path <MODEL.PTE>
```
6. Run on host
```
out/host/linux-x86/bin/executor_runner --model_path <MODEL.PTE>
```