### PR TITLE
Masked select decomposition

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -450,7 +450,6 @@ def _core_aten_decompositions_post_autograd() -> (
     # TODO Delete all mutating or CIA ops from this list
     return get_decompositions(
         [
-            aten.masked_select,
             aten.addcdiv,
             aten.addcdiv_,
             aten.addcmul,

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -450,6 +450,7 @@ def _core_aten_decompositions_post_autograd() -> (
     # TODO Delete all mutating or CIA ops from this list
     return get_decompositions(
         [
+            aten.masked_select,
             aten.addcdiv,
             aten.addcdiv_,
             aten.addcmul,
@@ -548,6 +549,7 @@ def _core_aten_decompositions_post_autograd() -> (
             aten.logsumexp.default,
             aten.masked_fill,
             aten.masked_fill_,
+            aten.masked_select,
             aten.max_unpool2d,
             aten.max_unpool3d,
             aten.mish,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -459,7 +459,7 @@ def masked_select(input: Tensor, mask: Tensor) -> torch.Tensor:
     if not has_free_symbols(input.numel()):
         num_elements = int(input.numel())
     else:
-        prod_node = math.prod(input.shape).node
+        prod_node = math.prod(input.shape).node  # type: ignore
         prod_range = bound_sympy(prod_node.expr, prod_node.shape_env.var_to_range)
         if isinstance(prod_range.upper, IntInfinity):
             num_elements = sys.maxsize - 1
@@ -468,7 +468,7 @@ def masked_select(input: Tensor, mask: Tensor) -> torch.Tensor:
     if num_elements > 2:
         maxval = num_elements
 
-    _constrain_range_for_size(res.size(0), max=maxval)
+    _constrain_range_for_size(res.size(0), max=maxval)  # type: ignore
     return res
 
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -431,8 +431,15 @@ def safe_softmax(self, dim, dtype=None):
 
 
 @register_decomposition(aten.masked_select)
-def masked_select(self, mask: Tensor) -> torch.Tensor:
-    return torch.ops.aten.index(input, [torch.ops.aten.copy(torch.ops.aten.empty(input.shape, dtype=torch.bool), mask)])
+def masked_select(input: Tensor, mask: Tensor) -> torch.Tensor:
+    return torch.ops.aten.index(
+        input,
+        [
+            torch.ops.aten.copy(
+                torch.ops.aten.empty(input.shape, dtype=torch.bool), mask
+            )
+        ],
+    )
 
 
 @register_decomposition(aten.smooth_l1_loss)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -430,6 +430,11 @@ def safe_softmax(self, dim, dtype=None):
     return torch.where(masked_rows, zeros, out)
 
 
+@register_decomposition(aten.masked_select)
+def masked_select(self, mask: Tensor) -> torch.Tensor:
+    return torch.ops.aten.index(input, [torch.ops.aten.copy(torch.ops.aten.empty(input.shape, dtype=torch.bool), mask)])
+
+
 @register_decomposition(aten.smooth_l1_loss)
 @out_wrapper()
 @pw_cast_for_opmath

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -445,27 +445,27 @@ def masked_select(input: Tensor, mask: Tensor) -> torch.Tensor:
         ],
     )
 
-    # Avoid importing sympy at a module level
-    from torch.fx.experimental.symbolic_shapes import (
-        _constrain_range_for_size,
-        has_free_symbols,
-    )
-    from torch.utils._sympy.numbers import IntInfinity
-    from torch.utils._sympy.value_ranges import bound_sympy
+    # # Avoid importing sympy at a module level
+    # from torch.fx.experimental.symbolic_shapes import (
+    #     _constrain_range_for_size,
+    #     has_free_symbols,
+    # )
+    # from torch.utils._sympy.numbers import IntInfinity
+    # from torch.utils._sympy.value_ranges import bound_sympy
 
-    # If num elements is expressed symbolically, calculate
-    # the concrete value based on upper bounds. Otherwise,
-    # we can set max val directly.
-    maxval = sys.maxsize - 1
-    if not has_free_symbols(input.numel()):
-        num_elements = int(input.numel())
-    else:
-        prod_node = math.prod(input.shape).node  # type: ignore[attr-defined]
-        prod_range = bound_sympy(prod_node.expr, prod_node.shape_env.var_to_range)
-        if not isinstance(prod_range.upper, IntInfinity) and prod_range.upper > 2:
-            num_elements = prod_range.upper
+    # # If num elements is expressed symbolically, calculate
+    # # the concrete value based on upper bounds. Otherwise,
+    # # we can set max val directly.
+    # maxval = sys.maxsize - 1
+    # if not has_free_symbols(input.numel()):
+    #     num_elements = int(input.numel())
+    # else:
+    #     prod_node = math.prod(input.shape).node  # type: ignore[attr-defined]
+    #     prod_range = bound_sympy(prod_node.expr, prod_node.shape_env.var_to_range)
+    #     if not isinstance(prod_range.upper, IntInfinity) and prod_range.upper > 2:
+    #         num_elements = prod_range.upper
 
-    _constrain_range_for_size(res.size(0), max=maxval)
+    # _constrain_range_for_size(res.size(0), max=maxval)
     return res
 
 


### PR DESCRIPTION
Needed since ExecuTorch has no portable kernel for `aten.masked_select`.