### PR TITLE
[BC] Add check for core ATen opset schema BC

### DIFF
--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -435,7 +435,7 @@ if __name__ == "__main__":
         sys.exit(1)
     # TODO in case there is FC breaking changes,
     # we just warn for now until there is a policy.
-    check_fc(non_core_aten_schema_list)
+    check_fc(slist)
 
     if not check_bc(non_core_aten_schema_list):
         sys.exit(1)

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -314,7 +314,7 @@ def check_core_aten_ops_bc(existing_schemas):
     broken_ops = []
 
     for existing_schema in existing_schemas:
-        logging.info(
+        logging.debug(
             "processing existing core ATen op: %s::%s ",
             existing_schema.name,
             existing_schema.overload_name,

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -26,8 +26,9 @@ logging.basicConfig(level=logging.INFO, format=FORMAT)
 #    `python test/forward_backward_compatibility/check_forward_backward_compatibility.py --existing-schemas nightly_schemas.txt`
 
 # The date specifies how long the allowlist exclusion should apply to. Note that core ATen opset
-# (https://pytorch.org/docs/stable/torch.compiler_ir.html#core-aten-ir) is guaranteed to be BC and hence the allowlist
-# does not apply (or the date is always arbitrarily far for core ATen ops).
+# (https://pytorch.org/docs/stable/torch.compiler_ir.html#core-aten-ir) is guaranteed to be BC, based on this policy
+# (https://dev-discuss.pytorch.org/t/core-aten-opset-backward-forward-compatibility-policy/1772) and hence the
+# allowlist does not apply (or the date is always arbitrarily far for core ATen ops).
 #
 #   - If we NEVER give BC guarantee for an operator, you can put the
 #     date arbitrarily far in the future.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137664

Summary: Based on core ATen opset BC policy: https://dev-discuss.pytorch.org/t/core-aten-opset-backward-forward-compatibility-policy/1772

Encorcing this policy in `check_forward_backward_compatibility.py`.
Basically the script will error out if any BC breaking schema changes
occurs to core ATen operators.

Test Plan:

Run `python test/forward_backward_compatibility/dump_all_function_schemas.py --filename nightly_schemas.txt`

Manually added a argument to `nightly_schemas.txt`, `convolution`
schema, see the following error:

```
[WARNING 2024-10-09 15:54:36,224 check_forward_backward_compatibility.py:329] Can NOT find backward compatible schemas after changes for schema aten::convolution(Tensor input, Tensor weight, Tensor? bias, SymInt[] stride, SymInt[] padding, SymInt[] dilation, bool transposed, SymInt[] output_padding, SymInt groups, SymInt new_arg) -> Tensor from the following candidates:
[
        aten::convolution(Tensor input, Tensor weight, Tensor? bias, SymInt[] stride, SymInt[] padding, SymInt[] dilation, bool transposed, SymInt[] output_padding, SymInt groups) -> Tensor
	aten::convolution.out(Tensor input, Tensor weight, Tensor? bias, SymInt[] stride, SymInt[] padding, SymInt[] dilation, bool transposed, SymInt[] output_padding, SymInt groups, *, Tensor(a!) out) -> Tensor(a!)
]. Please contact PyTorch team to confirm if this BC breaking change is safe or not.
...
[WARNING 2024-10-09 15:54:36,224 check_forward_backward_compatibility.py:342] The PR is introducing backward incompatible changes to core ATen operators. Please contact PyTorch team to confirm whether this change is wanted or not.

Broken ops: [
	aten::convolution(Tensor input, Tensor weight, Tensor? bias, SymInt[] stride, SymInt[] padding, SymInt[] dilation, bool transposed, SymInt[] output_padding, SymInt groups, SymInt new_arg) -> Tensor
]
```
Reviewers:

Subscribers:

Tasks:

Tags: