### PR TITLE
Use device-agnostic runtime API in distributed DDP/FSDP instead of `cuda` device specific.

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -922,11 +922,7 @@ def _functionalize_sync(t):
 
 
 @functools.lru_cache(2)
-def _get_device_module(device_type: Optional[str] = None):
-    # If no device type is specified as an argument,
-    # the detected underlying accelerator device type will be used.
-    if device_type is None:
-        device_type = torch._C._get_accelerator().type
+def _get_device_module(device_type: str):
     device_module = getattr(torch, device_type, None)
     if device_module is None:
         raise RuntimeError(

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -922,7 +922,9 @@ def _functionalize_sync(t):
 
 
 @functools.lru_cache(2)
-def _get_device_module(device_type: str):
+def _get_device_module(device_type: str = None):
+    if device_type is None:
+        device_type = torch._C._get_accelerator().type
     device_module = getattr(torch, device_type, None)
     if device_module is None:
         raise RuntimeError(

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -922,7 +922,7 @@ def _functionalize_sync(t):
 
 
 @functools.lru_cache(2)
-def _get_device_module(device_type: str = None):
+def _get_device_module(device_type: Optional[str] = None):
     if device_type is None:
         device_type = torch._C._get_accelerator().type
     device_module = getattr(torch, device_type, None)

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -923,6 +923,8 @@ def _functionalize_sync(t):
 
 @functools.lru_cache(2)
 def _get_device_module(device_type: Optional[str] = None):
+    # If no device type is specified as an argument,
+    # the detected underlying accelerator device type will be used.
     if device_type is None:
         device_type = torch._C._get_accelerator().type
     device_module = getattr(torch, device_type, None)

--- a/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
@@ -5,7 +5,6 @@ import torch
 import torch.distributed as dist
 from torch.autograd import Variable
 from torch.distributed.utils import _free_storage
-from torch._utils import _get_device_module
 
 
 @dataclass

--- a/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
@@ -47,7 +47,7 @@ def _reducer_allreduce_and_upcast_hook(
     fut = reducer._run_allreduce_hook(bucket)
     ret_fut = torch.futures.Future()
     stream = hook_state.upcast_stream
-    with _get_device_module().stream(stream):
+    with torch.get_device_module().stream(stream):
         fut.wait()
         bucket.buffer().div_(process_group.size())
         ret_fut.set_result(bucket.buffer())

--- a/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
@@ -62,7 +62,7 @@ def _reducer_allreduce_and_upcast_hook(
 
     # enqueue a callback to wait for this stream at end of backward
     def wait_for_stream_cb():
-        _get_device_module().current_stream().wait_stream(stream)
+        torch.acc.current_stream().wait_stream(stream)
         # Remove post-backward hooks since they are re-installed in next
         # iteration, similar to FSDP.
         # Parameters that don't require grad still needed to be casted since

--- a/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
@@ -62,7 +62,7 @@ def _reducer_allreduce_and_upcast_hook(
 
     # enqueue a callback to wait for this stream at end of backward
     def wait_for_stream_cb():
-        torch.acc.current_stream().wait_stream(stream)
+        torch.accelerator.current_stream().wait_stream(stream)
         # Remove post-backward hooks since they are re-installed in next
         # iteration, similar to FSDP.
         # Parameters that don't require grad still needed to be casted since

--- a/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, List, no_type_check
 import torch
 import torch.distributed as dist
 from torch.autograd import Variable
-from torch._utils import _get_device_module
+
 
 __all__: List[str] = []
 

--- a/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
@@ -72,7 +72,7 @@ def _apply_optim_in_backward_hook(
         reducer, process_group = ddp_inst.reducer, ddp_inst.process_group
         fut = reducer._run_allreduce_hook(bucket)
         optimizer_stream = optim_stream_state.optim_stream
-        with _get_device_module().stream(optimizer_stream):
+        with torch.get_device_module().stream(optimizer_stream):
             fut.wait()
             # Apply gradient division since C++ side only allreduces and does
             # not average. TODO: (rohan-varma) the div factor may be different

--- a/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
@@ -99,7 +99,9 @@ def _apply_optim_in_backward_hook(
         # enqueue a callback to wait for this optimizer stream at the end of
         # backward and set all DDP managed grads to None.
         def wait_for_optim_stream_callback():
-            torch.accelerator.current_stream().wait_stream(optim_stream_state.optim_stream)
+            torch.accelerator.current_stream().wait_stream(
+                optim_stream_state.optim_stream
+            )
             # Set DDP managed grads to None
             for param in ddp_inst._get_data_parallel_params(ddp_inst.module):
                 if hasattr(param, "_in_backward_optimizers"):

--- a/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, List, no_type_check
 import torch
 import torch.distributed as dist
 from torch.autograd import Variable
-
+from torch._utils import _get_device_module
 
 __all__: List[str] = []
 
@@ -41,7 +41,7 @@ class _OptimizerHookState:
 
 @dataclass
 class _OptimInBackwardHookState:
-    optim_stream: torch.cuda.Stream
+    optim_stream: torch.Stream
     wait_for_optim_stream_enqueued: bool
 
 
@@ -57,7 +57,7 @@ def _apply_optim_in_backward_hook(
     step for parameters after gradient communication has taken place.
     """
     optim_in_bwd_state = _OptimInBackwardHookState(
-        optim_stream=torch.cuda.Stream(),
+        optim_stream=_get_device_module().Stream(),
         wait_for_optim_stream_enqueued=False,
     )
 
@@ -72,7 +72,7 @@ def _apply_optim_in_backward_hook(
         reducer, process_group = ddp_inst.reducer, ddp_inst.process_group
         fut = reducer._run_allreduce_hook(bucket)
         optimizer_stream = optim_stream_state.optim_stream
-        with torch.cuda.stream(optimizer_stream):
+        with _get_device_module().stream(optimizer_stream):
             fut.wait()
             # Apply gradient division since C++ side only allreduces and does
             # not average. TODO: (rohan-varma) the div factor may be different
@@ -99,7 +99,7 @@ def _apply_optim_in_backward_hook(
         # enqueue a callback to wait for this optimizer stream at the end of
         # backward and set all DDP managed grads to None.
         def wait_for_optim_stream_callback():
-            torch.cuda.current_stream().wait_stream(optim_stream_state.optim_stream)
+            _get_device_module().current_stream().wait_stream(optim_stream_state.optim_stream)
             # Set DDP managed grads to None
             for param in ddp_inst._get_data_parallel_params(ddp_inst.module):
                 if hasattr(param, "_in_backward_optimizers"):

--- a/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
@@ -99,7 +99,7 @@ def _apply_optim_in_backward_hook(
         # enqueue a callback to wait for this optimizer stream at the end of
         # backward and set all DDP managed grads to None.
         def wait_for_optim_stream_callback():
-            torch.acc.current_stream().wait_stream(optim_stream_state.optim_stream)
+            torch.accelerator.current_stream().wait_stream(optim_stream_state.optim_stream)
             # Set DDP managed grads to None
             for param in ddp_inst._get_data_parallel_params(ddp_inst.module):
                 if hasattr(param, "_in_backward_optimizers"):

--- a/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
@@ -57,7 +57,7 @@ def _apply_optim_in_backward_hook(
     step for parameters after gradient communication has taken place.
     """
     optim_in_bwd_state = _OptimInBackwardHookState(
-        optim_stream=_get_device_module().Stream(),
+        optim_stream=torch.Stream(),
         wait_for_optim_stream_enqueued=False,
     )
 
@@ -99,7 +99,7 @@ def _apply_optim_in_backward_hook(
         # enqueue a callback to wait for this optimizer stream at the end of
         # backward and set all DDP managed grads to None.
         def wait_for_optim_stream_callback():
-            _get_device_module().current_stream().wait_stream(optim_stream_state.optim_stream)
+            torch.acc.current_stream().wait_stream(optim_stream_state.optim_stream)
             # Set DDP managed grads to None
             for param in ddp_inst._get_data_parallel_params(ddp_inst.module):
                 if hasattr(param, "_in_backward_optimizers"):

--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -40,8 +40,7 @@ def average_parameters(
     flat_params = torch.cat([p.data.reshape(-1) for p in params_it1])
     flat_params /= dist.get_world_size(group_to_use)
     # Make sure the allreduce will not conflict with any other ongoing process group.
-    params_device_type = flat_params.device.type
-    if params_device_type in ["cuda", "xpu"]:
+    if torch.acc.is_available():
         torch.acc.synchronize()
     dist.all_reduce(flat_params, group=group_to_use)
 

--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -42,6 +42,8 @@ def average_parameters(
     # Make sure the allreduce will not conflict with any other ongoing process group.
     if torch.cuda.is_available():
         torch.cuda.synchronize()
+    elif torch.xpu.is_available():
+        torch.xpu.synchronize()
     dist.all_reduce(flat_params, group=group_to_use)
 
     offset = 0

--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -40,8 +40,8 @@ def average_parameters(
     flat_params = torch.cat([p.data.reshape(-1) for p in params_it1])
     flat_params /= dist.get_world_size(group_to_use)
     # Make sure the allreduce will not conflict with any other ongoing process group.
-    if torch.acc.is_available():
-        torch.acc.synchronize()
+    if torch.accelerator.is_available():
+        torch.accelerator.synchronize()
     dist.all_reduce(flat_params, group=group_to_use)
 
     offset = 0

--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -5,7 +5,6 @@ from typing import Dict, Iterable, Iterator, Union
 
 import torch
 import torch.distributed as dist
-from torch._utils import _get_device_module
 
 # The two imports below are not always available depending on the
 # USE_DISTRIBUTED compile flag. Make sure they raise import error
@@ -43,7 +42,7 @@ def average_parameters(
     # Make sure the allreduce will not conflict with any other ongoing process group.
     params_device_type = flat_params.device.type
     if params_device_type in ["cuda", "xpu"]:
-        _get_device_module(params_device_type).synchronize()
+        torch.acc.synchronize()
     dist.all_reduce(flat_params, group=group_to_use)
 
     offset = 0

--- a/torch/distributed/algorithms/model_averaging/utils.py
+++ b/torch/distributed/algorithms/model_averaging/utils.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable, Iterator, Union
 
 import torch
 import torch.distributed as dist
+from torch._utils import _get_device_module
 
 # The two imports below are not always available depending on the
 # USE_DISTRIBUTED compile flag. Make sure they raise import error
@@ -40,10 +41,9 @@ def average_parameters(
     flat_params = torch.cat([p.data.reshape(-1) for p in params_it1])
     flat_params /= dist.get_world_size(group_to_use)
     # Make sure the allreduce will not conflict with any other ongoing process group.
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
-    elif torch.xpu.is_available():
-        torch.xpu.synchronize()
+    params_device_type = flat_params.device.type
+    if params_device_type in ["cuda", "xpu"]:
+        _get_device_module(params_device_type).synchronize()
     dist.all_reduce(flat_params, group=group_to_use)
 
     offset = 0

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -92,8 +92,6 @@ class _FSDPDeviceHandle:
         Just return torch.cuda if the device is cuda to make attribute-access faster.
         Custom backend must first register a module with the same name with {device.type} on torch.
         """
-        if device.type == "xpu":
-            return cast(_FSDPDeviceHandle, torch.xpu)
         if device.type == "cuda":
             return cast(_FSDPDeviceHandle, torch.cuda)
         elif device.type == "mtia":

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -92,6 +92,8 @@ class _FSDPDeviceHandle:
         Just return torch.cuda if the device is cuda to make attribute-access faster.
         Custom backend must first register a module with the same name with {device.type} on torch.
         """
+        if device.type == "xpu":
+            return cast(_FSDPDeviceHandle, torch.xpu)
         if device.type == "cuda":
             return cast(_FSDPDeviceHandle, torch.cuda)
         elif device.type == "mtia":
@@ -535,10 +537,11 @@ def _override_module_mixed_precision(
 
 
 def _no_dispatch_record_stream(tensor: torch.Tensor, stream: torch.Stream) -> None:
-    # FIXME record_stream doesn't work with non-cuda/mtia tensors
+    # FIXME record_stream doesn't work with non-cuda/mtia/xpu tensors
     if tensor.device.type not in [
         "cuda",
         "mtia",
+        "xpu",
         torch._C._get_privateuse1_backend_name(),
     ]:
         return

--- a/torch/distributed/fsdp/sharded_grad_scaler.py
+++ b/torch/distributed/fsdp/sharded_grad_scaler.py
@@ -22,6 +22,7 @@ def _is_supported_device(tensor: torch.Tensor) -> bool:
         "cpu",
         "hpu",
         "mtia",
+        "xpu",
         torch._C._get_privateuse1_backend_name(),
     )
 


### PR DESCRIPTION
# Motivation
This PR targets to use device-agnostic runtime API in distributed DDP/FSDP instead of `cuda` device specific.

cc cc [@jgong5](https://github.com/jgong5) [@gujinghui](https://github.com/gujinghui) [@EikanWang](https://github.com/EikanWang) [@fengyuan14](https://github.com/fengyuan14) [@guangyey](https://github.com/guangyey) 

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o