### PR TITLE
[benchmark] mimic new copy-out kernels with out_views

### DIFF
--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -1,5 +1,5 @@
 # mypy: allow-untyped-defs
-from typing import Any
+from typing import Any, List
 
 import torch
 from torch.utils._contextlib import (
@@ -395,3 +395,38 @@ class _unsafe_preserve_version_counter(_DecoratorContextManager):
 
     def __exit__(self, *args) -> None:
         torch._C._autograd._unsafe_set_version_counter(self.tensor, self.prev_version)
+
+
+class _unsafe_preserve_version_counters(_DecoratorContextManager):
+    r"""DO NOT USE THIS UNLESS YOU KNOW EXACTLY WHAT YOU'RE DOING.
+
+    This context manager can lead to arbitrary silent-correctness issues in any other part of your code
+    (even the ones not touched directly by the context manager)!
+
+    Ordinarily, autograd will track mutations to tensors by incrementing it's `._version` attribute.
+    This is generally important for correctness, as for example, mutating a tensor that autograd has saved
+    for the backwards pass can result in incorrect gradients, and autograd uses the version counter to detect
+    and error out in this situation.
+
+    However, there are rare instances where it might be useful to hide mutations from autograd. For example:
+    if a tensor is very large, and you'd like to free its memory by storing it elsewhere, and re-populate
+    the tensor right before it is needed by autograd.
+
+    Args:
+        tensor (torch.Tensor): the tensor in question, that you would like to preserve the version counter of.
+
+    .. note::
+        This API does not apply to :ref:`forward-mode AD <forward-mode-ad>`.
+
+    """
+
+    def __init__(self, tensors: List[torch.Tensor]) -> None:
+        self.tensors = tensors
+        self.prev_versions = [tensor._version for tensor in tensors]
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(self, *args) -> None:
+        for tensor, prev_version in zip(self.tensors, self.prev_versions):
+            torch._C._autograd._unsafe_set_version_counter(tensor, prev_version)

--- a/torch/distributed/_composable/fsdp/_fsdp_param.py
+++ b/torch/distributed/_composable/fsdp/_fsdp_param.py
@@ -352,6 +352,7 @@ class FSDPParam:
                 f"Shard dim {shard_dim} is invalid for {param_data.ndim}D tensor: {param.shape}"
             )
         self._orig_size = param_data.size()
+        self._orig_numel = param_data.numel()
         self._contiguous_orig_stride = make_contiguous_strides_for(self._orig_size)
         shard_rank = self.mesh_info.shard_mesh_rank
         shard_world_size = self.mesh_info.shard_mesh_size


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137683
* #137496
* #137593

cmd: `pytest -s test/distributed/_composable/fsdp/test_fully_shard_training.py -k test_train_parity_shard_placement_fn_shard_largest_dim`

test on llama: `CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_llama_train.sh --experimental.fsdp_sharding_on_largest_dim`

for dim-1, use out_views trick to avoid extra gpu copies, at the cost of cpu overhead with many torch.narrow


gpu copy time are indeed similar
* 1st picture is out_views trick
* 2nd picture is dim0 sharding
<img width="1003" alt="Screenshot 2024-10-09 at 10 56 06 PM" src="https://github.com/user-attachments/assets/35048fc9-6282-4d10-ad46-5166265f8c0d">

<img width="1220" alt="Screenshot 2024-10-09 at 10 55 54 PM" src="https://github.com/user-attachments/assets/5a59ffbd-43c1-465d-a875-6dce6ebe0341">

cpu cost is crazy (6144 `aten.narrow`) that the workload becomes cpu bound. looks like we have to rely on data pointers manipulation at cpp layer

```
[rank0]:FSDPParam(fqn=layers.1..attention.wk.weight, orig_size=torch.Size([1024, 4096]))
[rank0]:FSDPParam(fqn=layers.1..attention.wv.weight, orig_size=torch.Size([1024, 4096]))
[rank0]:FSDPParam(fqn=layers.1..feed_forward.w2.weight, orig_size=torch.Size([4096, 14336]))
```
<img width="728" alt="Screenshot 2024-10-09 at 11 00 41 PM" src="https://github.com/user-attachments/assets/45a60dc5-d113-4810-a843-0d35d7f68165">




cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o