### PR TITLE
Save graph prints as lazy strings instead of eager

### DIFF
--- a/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py
@@ -373,12 +373,12 @@ def aot_dispatch_autograd(
                 colored=True,
             ),
         )
-        joint_graph_str = fx_g.print_readable(
+        joint_graph_str_fn = lambda: fx_g.print_readable(
             print_output=False, include_stride=True, include_device=True
         )
         trace_structured(
             "aot_joint_graph",
-            payload_fn=lambda: joint_graph_str,
+            payload_fn=joint_graph_str_fn,
         )
 
     with torch.no_grad():
@@ -572,19 +572,19 @@ def aot_dispatch_autograd(
                     colored=True,
                 ),
             )
-            fw_module_str = fw_module.print_readable(
+            fw_module_str_fn = lambda: fw_module.print_readable(
                 print_output=False, include_stride=True, include_device=True
             )
-            bw_module_str = bw_module.print_readable(
+            bw_module_str_fn = lambda: bw_module.print_readable(
                 print_output=False, include_stride=True, include_device=True
             )
             trace_structured(
                 "aot_forward_graph",
-                payload_fn=lambda: fw_module_str,
+                payload_fn=fw_module_str_fn,
             )
             trace_structured(
                 "aot_backward_graph",
-                payload_fn=lambda: bw_module_str,
+                payload_fn=bw_module_str_fn,
             )
 
         with track_graph_compiling(aot_config, "forward"):
@@ -787,9 +787,9 @@ def aot_dispatch_autograd(
                 # update backward_time_taken_ns to be more inclusive
                 backward_time_taken_ns = getattr(compiled_bw_func, "_time_taken_ns", 0)
 
-                aot_forward_graph_str: Optional[str] = fw_module_str
-                aot_backward_graph_str: Optional[str] = bw_module_str
-                aot_joint_graph_str: Optional[str] = joint_graph_str
+                aot_forward_graph_str: Optional[str] = fw_module_str_fn()
+                aot_backward_graph_str: Optional[str] = bw_module_str_fn()
+                aot_joint_graph_str: Optional[str] = joint_graph_str_fn()
                 entry = AOTAutogradCacheEntry(
                     CompiledForward(fw_key),
                     CompiledBackward(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137700

My previous PR made these eager instead of lazy, making it regress some small pr time benchmarks that don't use structured trace. Making them lazy again by putting them under a function call fixes the issue. Production jobs should not be affected by the change either way, because structured logs are turned on and evaluated there. 


Without this diff:
```
collecting compile time instruction count for aotdispatcher_inference_nosubclass_cpu
compile time instruction count for iteration 0 is 10241330219
compile time instruction count for iteration 1 is 1970239415
compile time instruction count for iteration 2 is 1955721527
compile time instruction count for iteration 3 is 1949317363
compile time instruction count for iteration 4 is 1947567621
collecting compile time instruction count for aotdispatcher_training_nosubclass_cpu
compile time instruction count for iteration 0 is 4203676200
compile time instruction count for iteration 1 is 3739626299
compile time instruction count for iteration 2 is 3736479815
compile time instruction count for iteration 3 is 3734131630
compile time instruction count for iteration 4 is 3733066773
collecting compile time instruction count for aotdispatcher_inference_subclass_cpu
compile time instruction count for iteration 0 is 5621749132
compile time instruction count for iteration 1 is 5621658470
compile time instruction count for iteration 2 is 5620004680
compile time instruction count for iteration 3 is 5617585817
compile time instruction count for iteration 4 is 5618850646
collecting compile time instruction count for aotdispatcher_training_subclass_cpu
compile time instruction count for iteration 0 is 10005741891
compile time instruction count for iteration 1 is 10003433898
compile time instruction count for iteration 2 is 10002792031
compile time instruction count for iteration 3 is 10000217081
compile time instruction count for iteration 4 is 10000992803
```


With this diff: 
```
collecting compile time instruction count for aotdispatcher_inference_nosubclass_cpu
compile time instruction count for iteration 0 is 10128746827
compile time instruction count for iteration 1 is 1965846584
compile time instruction count for iteration 2 is 1952468717
compile time instruction count for iteration 3 is 1946109980
compile time instruction count for iteration 4 is 1944459203
collecting compile time instruction count for aotdispatcher_training_nosubclass_cpu
compile time instruction count for iteration 0 is 4052066041
compile time instruction count for iteration 1 is 3589558675
compile time instruction count for iteration 2 is 3585668104
compile time instruction count for iteration 3 is 3584020963
compile time instruction count for iteration 4 is 3583162039
collecting compile time instruction count for aotdispatcher_inference_subclass_cpu
compile time instruction count for iteration 0 is 5617038583
compile time instruction count for iteration 1 is 5617303182
compile time instruction count for iteration 2 is 5613289422
compile time instruction count for iteration 3 is 5612847744
compile time instruction count for iteration 4 is 5612093362
collecting compile time instruction count for aotdispatcher_training_subclass_cpu
compile time instruction count for iteration 0 is 9705752209
compile time instruction count for iteration 1 is 9704758787
compile time instruction count for iteration 2 is 9703760884
compile time instruction count for iteration 3 is 9704687557
compile time instruction count for iteration 4 is 9704824140
```

Specifically, aotdispatcher_training_nosubclass_cpu and aotdispatcher_training_subclass_cpu look better

