### PR TITLE
[FSDP] set_device during device handle init

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -93,7 +93,9 @@ class _FSDPDeviceHandle:
         Custom backend must first register a module with the same name with {device.type} on torch.
         """
         if device.type == "cuda":
-            return cast(_FSDPDeviceHandle, torch.cuda)
+            handle = cast(_FSDPDeviceHandle, torch.cuda)
+            handle.set_device(device)
+            return handle
         elif device.type == "mtia":
             return cast(_FSDPDeviceHandle, torch.mtia)
         return cls(device)

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -94,7 +94,8 @@ class _FSDPDeviceHandle:
         """
         if device.type == "cuda":
             handle = cast(_FSDPDeviceHandle, torch.cuda)
-            handle.set_device(device)
+            if device.index is not None:
+                handle.set_device(device)
             return handle
         elif device.type == "mtia":
             return cast(_FSDPDeviceHandle, torch.mtia)


### PR DESCRIPTION
A torchrun application using FSDP and utilizing 1 GPU per local rank may use code like the following:

```python
_local_rank = int(os.environ.get("LOCAL_RANK"))
torch_device = torch.device(f"cuda:{_local_rank}")
# work-around: FSDP device rank is lost during init, set it now
torch.cuda.set_device(device)
fsdp_model = FullyShardedDataParallel(model, device_id=device)
```

The above work-around is needed to avoid GPU 0 being set as the FSDP compute stream via torch.cuda.current_stream() during initialization across all GPUs.  This PR sets the current device during handle initialization to avoid this situation.

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o