### PR TITLE
[PyTorch] Move NEON VecConvert specialization from vec256_convert to vec128_convert

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128.h
@@ -3,6 +3,8 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 
+#include <ATen/cpu/vec/vec128/vec128_convert.h>
+
 #if !defined(CPU_CAPABILITY_SVE)
 #include <ATen/cpu/vec/vec128/vec128_float_neon.h>
 #include <ATen/cpu/vec/vec128/vec128_half_neon.h>

--- a/aten/src/ATen/cpu/vec/vec128/vec128_convert.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_convert.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <ATen/cpu/vec/vec_base.h>
+#include <ATen/cpu/vec/vec_convert.h>
+
+namespace at::vec {
+inline namespace CPU_CAPABILITY {
+#if (defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256))
+template <typename src_t>
+struct VecConvert<
+    float,
+    1,
+    src_t,
+    1,
+    typename std::enable_if_t<is_8bit_integer_v<src_t>,
+        void>> {
+  static inline VectorizedN<float, 1> apply(const VectorizedN<src_t, 1>& src) {
+    return convert_int8_half_register_to_float(src[0]);
+  }
+};
+template <typename src_t>
+struct VecConvert<
+    float,
+    2,
+    src_t,
+    1,
+    typename std::enable_if_t<is_8bit_integer_v<src_t>,
+        void>> {
+  static inline VectorizedN<float, 2> apply(const VectorizedN<src_t, 1>& src) {
+    const auto [v0, v1] = convert_int8_to_float(src[0]);
+    return VectorizedN<float, 2>(v0, v1);
+  }
+};
+
+template <>
+struct VecConvert<float, 2, BFloat16, 1> {
+  static inline VectorizedN<float, 2> apply(
+      const VectorizedN<BFloat16, 1>& src) {
+    VectorizedN<float, 2> result;
+    uint16x8_t u16_8 = vld1q_u16(reinterpret_cast<const uint16_t*>(&src[0]));
+    auto u16_low1 = vget_low_u16(u16_8);
+    auto u16_high1 = vget_high_u16(u16_8);
+    float32x4_t f32x4_0 = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(u16_low1), 16));
+    float32x4_t f32x4_1 = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(u16_high1), 16));
+    result[0] = f32x4_0;
+    result[1] = f32x4_1;
+    return result;
+  }
+};
+// Half register to full register.
+template <>
+struct VecConvert<float, 1, BFloat16, 1> {
+  static inline VectorizedN<float, 1> apply(
+      const VectorizedN<BFloat16, 1>& src) {
+    VectorizedN<float, 1> result;
+    uint16x4_t u16_8 = vld1_u16(reinterpret_cast<const uint16_t*>(&src[0]));
+    float32x4_t f32x4_0 = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(u16_8), 16));
+    result[0] = f32x4_0;
+    return result;
+  }
+};
+#endif
+} // namespace CPU_CAPABILITY
+} // namespace at::vec

--- a/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_convert.h
@@ -298,63 +298,6 @@ struct VecConvert<
   }
 };
 #endif
-#if (defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256))
-template <typename src_t>
-struct VecConvert<
-    float,
-    1,
-    src_t,
-    1,
-    typename std::enable_if_t<is_8bit_integer_v<src_t>,
-        void>> {
-  static inline VectorizedN<float, 1> apply(const VectorizedN<src_t, 1>& src) {
-    return convert_int8_half_register_to_float(src[0]);
-  }
-};
-template <typename src_t>
-struct VecConvert<
-    float,
-    2,
-    src_t,
-    1,
-    typename std::enable_if_t<is_8bit_integer_v<src_t>,
-        void>> {
-  static inline VectorizedN<float, 2> apply(const VectorizedN<src_t, 1>& src) {
-    const auto [v0, v1] = convert_int8_to_float(src[0]);
-    return VectorizedN<float, 2>(v0, v1);
-  }
-};
-#endif
-
-#if (defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE256))
-template <>
-struct VecConvert<float, 2, BFloat16, 1> {
-  static inline VectorizedN<float, 2> apply(
-      const VectorizedN<BFloat16, 1>& src) {
-    VectorizedN<float, 2> result;
-    uint16x8_t u16_8 = vld1q_u16(reinterpret_cast<const uint16_t*>(&src[0]));
-    auto u16_low1 = vget_low_u16(u16_8);
-    auto u16_high1 = vget_high_u16(u16_8);
-    float32x4_t f32x4_0 = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(u16_low1), 16));
-    float32x4_t f32x4_1 = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(u16_high1), 16));
-    result[0] = f32x4_0;
-    result[1] = f32x4_1;
-    return result;
-  }
-};
-// Half register to full register.
-template <>
-struct VecConvert<float, 1, BFloat16, 1> {
-  static inline VectorizedN<float, 1> apply(
-      const VectorizedN<BFloat16, 1>& src) {
-    VectorizedN<float, 1> result;
-    uint16x4_t u16_8 = vld1_u16(reinterpret_cast<const uint16_t*>(&src[0]));
-    float32x4_t f32x4_0 = vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(u16_8), 16));
-    result[0] = f32x4_0;
-    return result;
-  }
-};
-#endif
 
 template <typename src_t>
 struct VecConvert<


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137731
* __->__ #137730
* #137729
* #137728
* #137727

NEON vectors are 128-bit and don't belong with 256 stuff.

Differential Revision: [D64143615](https://our.internmc.facebook.com/intern/diff/D64143615/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10