### PR TITLE
[ONNX] Implement compatible behavior for `optimize()`

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -286,8 +286,8 @@ def export(
             Only one parameter `dynamic_axes` or `dynamic_shapes` should be set
             at the same time.
         report: Whether to generate a markdown report for the export process.
-        optimize: Whether to optimize the exported model. When ``f`` is specified (backward compatible usage),
-            optimization is performed by default. When ``f`` is not specified (recommended),
+        optimize: Whether to optimize the exported model. By default when unspecified, when ``f`` is provided (backward compatible usage),
+            optimization is performed by default. When ``f`` is ``None`` (recommended),
             the resulting :class:`torch.onnx.ONNXProgram` will contain the un-optimized model.
             You may run ``onnx_program.optimize()`` to optimize the model.
         verify: Whether to verify the exported model using ONNX Runtime.

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -154,7 +154,7 @@ def export(
     external_data: bool = True,
     dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None = None,
     report: bool = False,
-    optimize: bool = False,
+    optimize: bool | None = None,
     verify: bool = False,
     profile: bool = False,
     dump_exported_program: bool = False,
@@ -286,7 +286,10 @@ def export(
             Only one parameter `dynamic_axes` or `dynamic_shapes` should be set
             at the same time.
         report: Whether to generate a markdown report for the export process.
-        optimize: Whether to optimize the exported model.
+        optimize: Whether to optimize the exported model. When ``f`` is specified (backward compatible usage),
+            optimization is performed by default. When ``f`` is not specified (recommended),
+            the resulting :class:`torch.onnx.ONNXProgram` will contain the un-optimized model.
+            You may run ``onnx_program.optimize()`` to optimize the model.
         verify: Whether to verify the exported model using ONNX Runtime.
         profile: Whether to profile the export process.
         dump_exported_program: Whether to dump the :class:`torch.export.ExportedProgram` to a file.

--- a/torch/onnx/_internal/exporter/_compat.py
+++ b/torch/onnx/_internal/exporter/_compat.py
@@ -132,7 +132,7 @@ def export_compat(
     keep_initializers_as_inputs: bool = False,
     external_data: bool = True,
     report: bool = False,
-    optimize: bool = False,
+    optimize: bool | None = None,
     verify: bool = False,
     profile: bool = False,
     dump_exported_program: bool = False,
@@ -204,7 +204,7 @@ def export_compat(
     onnx_program.model = onnxscript_apis.convert_version(
         onnx_program.model, opset_version
     )
-    if optimize:
+    if optimize or (optimize is None and f is not None):
         onnx_program.optimize()
 
     if f is not None:


### PR DESCRIPTION
When ``f`` is specified (backward compatible usage),
optimization is performed by default. When ``f`` is not specified (recommended),
the resulting :class:`torch.onnx.ONNXProgram` will contain the un-optimized model.
Users may run ``onnx_program.optimize()`` to optimize the model.
