### PR TITLE
[Inductor]: Support updated Triton `AttrsDescriptor`

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -18,6 +18,7 @@ except ImportError:
 
 from torch._inductor import config
 from torch._inductor.runtime.hints import (
+    AttrsDescriptorWrapper,
     AutotuneHint,
     DeviceProperties,
     HeuristicType,
@@ -93,8 +94,6 @@ class TestTritonHeuristics(TestCase):
         self._test_artificial_zgrid()
 
     def _get_cos_kernel_caching_autotuner_args(self):
-        from triton.compiler.compiler import AttrsDescriptor  # @manual
-
         @triton.jit
         def triton_(in_ptr0, out_ptr0, xnumel, XBLOCK: tl.constexpr):
             xnumel = 16
@@ -110,7 +109,9 @@ class TestTritonHeuristics(TestCase):
             "signature": {"in_ptr0": "*fp32", "out_ptr0": "*fp32", "xnumel": "i32"},
             "device": DeviceProperties.create(torch.device("cuda")),
             "constants": {},
-            "configs": [AttrsDescriptor(divisible_by_16=(0, 1, 2), equal_to_1=())],
+            "configs": [
+                AttrsDescriptorWrapper(divisible_by_16=(0, 1, 2), equal_to_1=())
+            ],
         }
 
         configs = [

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -104,6 +104,8 @@ def gen_attr_descriptor_import():
 
     import triton.compiler.compiler
 
+    # Note: this works because triton.compiler.compiler imports AttrsDescriptor from triton.backends.compiler
+    # When support for the legacy AttrsDescriptor is removed then this import path should be changed.
     if hasattr(triton.compiler.compiler, "AttrsDescriptor"):
         return "from triton.compiler.compiler import AttrsDescriptor"
     else:

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -51,7 +51,10 @@ if _is_triton_available():
             }
 
             # Instantiate AttrsDescriptor with the prepared arguments
-            return AttrsDescriptor.from_dict(kwargs)
+            res = AttrsDescriptor.from_dict(kwargs)
+            assert res.property_values["tt.divisibility"] == 16
+            assert res.property_values["tt.equal_to"] == 1
+            return res
 
     except ImportError:
         from triton.compiler.compiler import AttrsDescriptor

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -26,29 +26,48 @@ class TileHint(Enum):
     DEFAULT = 1
 
 
-# Attempt to import AttrsDescriptor from Triton
-try:
-    from triton.compiler.compiler import AttrsDescriptor
+def _is_triton_available():
+    try:
+        import triton  # noqa: F401
 
-    attrs_descriptor_available = True
-except ImportError:
-    attrs_descriptor_available = False
+        return True
+    except ImportError:
+        return False
+
 
 # Define `AttrsDescriptorWrapper` function with clear conditional handling
-if attrs_descriptor_available:
+if _is_triton_available():
+    try:
+        from triton.backends.compiler import AttrsDescriptor
 
-    def AttrsDescriptorWrapper(
-        divisible_by_16=None,
-        equal_to_1=None,
-    ):
-        # Prepare the arguments for AttrsDescriptor
-        kwargs = {
-            "divisible_by_16": divisible_by_16,
-            "equal_to_1": equal_to_1,
-        }
+        def AttrsDescriptorWrapper(
+            divisible_by_16=None,
+            equal_to_1=None,
+        ):
+            # Prepare the arguments for AttrsDescriptor
+            kwargs = {
+                "tt.divisibility": divisible_by_16,
+                "tt.equal_to": equal_to_1,
+            }
 
-        # Instantiate AttrsDescriptor with the prepared arguments
-        return AttrsDescriptor(**kwargs)
+            # Instantiate AttrsDescriptor with the prepared arguments
+            return AttrsDescriptor.from_dict(kwargs)
+
+    except ImportError:
+        from triton.compiler.compiler import AttrsDescriptor
+
+        def AttrsDescriptorWrapper(
+            divisible_by_16=None,
+            equal_to_1=None,
+        ):
+            # Prepare the arguments for AttrsDescriptor
+            kwargs = {
+                "divisible_by_16": divisible_by_16,
+                "equal_to_1": equal_to_1,
+            }
+
+            # Instantiate AttrsDescriptor with the prepared arguments
+            return AttrsDescriptor(**kwargs)
 
 else:
     # Define a namedtuple as a fallback when AttrsDescriptor is not available


### PR DESCRIPTION
The Triton `AttrsDescriptor` object was refactored in https://github.com/triton-lang/triton/pull/4734. These changes add support for the new `AttrsDescriptor` while maintaining backwards compatibility with the existing version. The main changes are different names for the initialized of the descriptor parameters, and a creation via a static method instead of the class constructor. 

Depends on #137458 which removes some unused logic around the old descriptor. Those changes make this PR cleaner, but if for some reason that old logic is still used I can make adjustments. 

Use of the new `AttrsDescriptor` depends on https://github.com/triton-lang/triton/pull/4888

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang