### PR TITLE
[Pipelining] Refactor Interleaved1F1B and ZeroBubble

### DIFF
--- a/docs/source/distributed.pipelining.rst
+++ b/docs/source/distributed.pipelining.rst
@@ -483,8 +483,6 @@ Pipeline Schedules
 
 .. autoclass:: Schedule1F1B
 
-.. autoclass:: ScheduleFlexibleInterleaved1F1B
-
 .. autoclass:: ScheduleInterleaved1F1B
 
 .. autoclass:: ScheduleLoopedBFS

--- a/docs/source/distributed.pipelining.rst
+++ b/docs/source/distributed.pipelining.rst
@@ -414,7 +414,7 @@ You can implement your own pipeline schedule by extending one of the following t
 ``PipelineScheduleMulti`` is for schedules that assigns multiple stages per rank.
 
 For example, ``ScheduleGPipe`` and ``Schedule1F1B`` are subclasses of ``PipelineScheduleSingle``.
-Whereas, ``ScheduleFlexibleInterleaved1F1B``, ``ScheduleInterleaved1F1B`` and ``ScheduleLoopedBFS``
+Whereas, ``ScheduleInterleaved1F1B``, ``ScheduleLoopedBFS``, and ``ScheduleInterleavedZeroBubble``
 are subclasses of ``PipelineScheduleMulti``.
 
 

--- a/test/distributed/_composable/test_composability/test_pp_composability.py
+++ b/test/distributed/_composable/test_composability/test_pp_composability.py
@@ -14,7 +14,6 @@ from torch.distributed.pipelining import PipelineStage
 from torch.distributed.pipelining.schedules import (
     PipelineScheduleSingle,
     Schedule1F1B,
-    ScheduleFlexibleInterleaved1F1B,
     ScheduleGPipe,
     ScheduleInterleaved1F1B,
     ScheduleInterleavedZeroBubble,
@@ -86,7 +85,6 @@ class ComposabilityTest(MultiProcessTestCase):
             Schedule1F1B,
             ScheduleInterleaved1F1B,
             ScheduleLoopedBFS,
-            ScheduleFlexibleInterleaved1F1B,
             ScheduleInterleavedZeroBubble,
         ],
     )

--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -4,11 +4,7 @@ import logging
 from typing import List
 
 import torch
-from torch.distributed.pipelining import (
-    ScheduleFlexibleInterleaved1F1B,
-    ScheduleInterleaved1F1B,
-    ScheduleLoopedBFS,
-)
+from torch.distributed.pipelining import ScheduleInterleaved1F1B, ScheduleLoopedBFS
 from torch.distributed.pipelining.schedules import (
     _Action,
     _add_send_recv,
@@ -164,7 +160,7 @@ class TestSchedulePlan(TestCase):
 
     @parametrize(
         "ScheduleClass",
-        [ScheduleFlexibleInterleaved1F1B],
+        [ScheduleInterleaved1F1B],
     )
     def test_pipeline_order_flex_and_zero_bubble(self, ScheduleClass):
         for num_local_stages, num_microbatches, group_size in self.test_cases:

--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -4,7 +4,11 @@ import logging
 from typing import List
 
 import torch
-from torch.distributed.pipelining import ScheduleInterleaved1F1B, ScheduleLoopedBFS
+from torch.distributed.pipelining import (
+    ScheduleInterleaved1F1B,
+    ScheduleInterleavedZeroBubble,
+    ScheduleLoopedBFS,
+)
 from torch.distributed.pipelining.schedules import (
     _Action,
     _add_send_recv,
@@ -62,7 +66,6 @@ class ScheduleTest(TestCase):
             "Interleaved1F1B",
             "INTERLEAVED1F1B",
             "GPipe",
-            "FlexibleInterleaved1F1B",
             "LoopedBFS",
             "PipelineScheduleSingle",
             "PipelineScheduleMulti",
@@ -160,7 +163,7 @@ class TestSchedulePlan(TestCase):
 
     @parametrize(
         "ScheduleClass",
-        [ScheduleInterleaved1F1B],
+        [ScheduleInterleaved1F1B, ScheduleInterleavedZeroBubble],
     )
     def test_pipeline_order_flex_and_zero_bubble(self, ScheduleClass):
         for num_local_stages, num_microbatches, group_size in self.test_cases:
@@ -175,25 +178,22 @@ class TestSchedulePlan(TestCase):
                 warmup_ops = warmups_ops_last_stage + 2 * (group_size - 1)
                 warmup_ops = min(warmup_ops, num_microbatches * num_local_stages)
 
-                for i in range(2):
-                    num_stages = num_local_stages * group_size
-                    stages = [
-                        MockPipelineStage(group_size=group_size, num_stages=num_stages)
-                        for i in range(num_local_stages)
-                    ]
-                    schedule = ScheduleClass(
-                        stages, num_microbatches, enable_zero_bubble=(i == 0)
-                    )
-                    formatted_pipeline_order = _format_pipeline_order(
-                        schedule.pipeline_order
-                    )
-                    # print(formatted_pipeline_order)
-                    _validate_pipeline_order(
-                        schedule.pipeline_order,
-                        num_microbatches,
-                        num_stages,
-                        enable_zero_bubble=(i == 0),
-                    )
+                num_stages = num_local_stages * group_size
+                stages = [
+                    MockPipelineStage(group_size=group_size, num_stages=num_stages)
+                    for i in range(num_local_stages)
+                ]
+                schedule = ScheduleClass(stages, num_microbatches)
+                formatted_pipeline_order = _format_pipeline_order(
+                    schedule.pipeline_order
+                )
+                # print(formatted_pipeline_order)
+                _validate_pipeline_order(
+                    schedule.pipeline_order,
+                    num_microbatches,
+                    num_stages,
+                    enable_zero_bubble=(ScheduleClass is ScheduleInterleavedZeroBubble),
+                )
 
 
 instantiate_parametrized_tests(TestSchedulePlan)

--- a/torch/distributed/pipelining/__init__.py
+++ b/torch/distributed/pipelining/__init__.py
@@ -3,7 +3,6 @@ from ._IR import Pipe, pipe_split, pipeline, SplitPoint
 from .schedules import (
     _ScheduleForwardOnly,
     Schedule1F1B,
-    ScheduleFlexibleInterleaved1F1B,
     ScheduleGPipe,
     ScheduleInterleaved1F1B,
     ScheduleInterleavedZeroBubble,
@@ -20,7 +19,6 @@ __all__ = [
     "PipelineStage",
     "build_stage",
     "Schedule1F1B",
-    "ScheduleFlexibleInterleaved1F1B",
     "ScheduleGPipe",
     "ScheduleInterleaved1F1B",
     "ScheduleLoopedBFS",

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -38,7 +38,6 @@ __all__ = [
     "PipelineScheduleSingle",
     "PipelineScheduleMulti",
     "Schedule1F1B",
-    "ScheduleFlexibleInterleaved1F1B",
     "ScheduleGPipe",
     "ScheduleInterleaved1F1B",
     "ScheduleLoopedBFS",
@@ -1828,114 +1827,14 @@ class ScheduleInterleaved1F1B(PipelineScheduleMulti):
     state and supports multiple stages per rank. When microbatches are ready for
     multiple local stages, Interleaved 1F1B prioritizes the earlier microbatch
     (also called "depth first").
-    """
 
-    def __init__(
-        self,
-        stages: List[_PipelineStageBase],
-        n_microbatches: int,
-        loss_fn: Optional[Callable] = None,
-        args_chunk_spec: Optional[Tuple[TensorChunkSpec, ...]] = None,
-        kwargs_chunk_spec: Optional[Dict[str, TensorChunkSpec]] = None,
-        output_merge_spec: Optional[Union[Dict[str, Any], Tuple[Any]]] = None,
-    ):
-        self.pp_group_size = stages[0].group_size
-        # TODO: is this limitation a must?
-        if n_microbatches % self.pp_group_size != 0:
-            raise ValueError(
-                f"Interleaved 1F1B schedule requires the number of microbatches ({n_microbatches}) \
-                to be a multiple of the number of pipeline ranks ({self.pp_group_size})."
-            )
-
-        super().__init__(
-            stages=stages,
-            n_microbatches=n_microbatches,
-            loss_fn=loss_fn,
-            args_chunk_spec=args_chunk_spec,
-            kwargs_chunk_spec=kwargs_chunk_spec,
-            output_merge_spec=output_merge_spec,
-        )
-
-        self.n_local_stages = len(stages)
-        self.rank = stages[0].group_rank
-        self.group = stages[0].group
-
-        # 1. Create the pipeline_order (all ranks do this calculation)
-        # This will be used to keep track of the current state of the entire pipeline
-        # pipeline_order[rank] = [Action(computation_type, microbatch_index, stage_index), ...]
-        self.pipeline_order: Dict[int, List[Optional[_Action]]] = {}
-
-        for rank in range(self.pp_group_size):
-            rank_ops = self._calculate_single_rank_operations(rank)
-            self.pipeline_order[rank] = rank_ops
-
-    def _calculate_single_rank_operations(self, rank) -> List[Optional[_Action]]:
-        def get_rank_warmup_ops(rank):
-            # Warms up operations for last stage
-            warmups_ops_last_stage = (self.n_local_stages - 1) * self.pp_group_size
-            # Increment warmup operations by 2 for each hop away from the last stage
-            warmup_ops = warmups_ops_last_stage + 2 * ((self.pp_group_size - 1) - rank)
-            # We cannot have more warmup operations than there are number of microbatches, so cap it there
-            return min(warmup_ops, self._n_microbatches * self.n_local_stages)
-
-        warmup_ops = get_rank_warmup_ops(rank)
-        microbatch_ops = self.n_local_stages * self._n_microbatches
-        # fwd_bwd_ops should encompass the remaining forwards
-        fwd_bwd_ops = microbatch_ops - warmup_ops
-        # cooldown_ops should encompass the remaining backwards
-        cooldown_ops = microbatch_ops - fwd_bwd_ops
-        # total ops encompass both forward and backward ops
-        total_ops = warmup_ops + fwd_bwd_ops + cooldown_ops
-        # warmup_ops + fwd_bwd_ops * 2 + cooldown_ops == microbatch_ops * 2
-
-        logger.debug(
-            "rank %s, warmup_ops %s, 1f1b %s, cooldown_ops %s total_ops %s",
-            rank,
-            warmup_ops,
-            fwd_bwd_ops,
-            cooldown_ops,
-            total_ops,
-        )
-
-        # Calculates the stage index based on step and pp_group_size
-        def forward_stage_index(step):
-            # Get the local index from 0 to n_local_stages-1
-            local_index = (step // self.pp_group_size) % self.n_local_stages
-            return (local_index * self.pp_group_size) + rank
-
-        def backward_stage_index(step):
-            local_index = (
-                self.n_local_stages
-                - 1
-                - ((step - warmup_ops) // self.pp_group_size) % self.n_local_stages
-            )
-            return (local_index * self.pp_group_size) + rank
-
-        return _get_1f1b_rank_ops(
-            self.n_local_stages,
-            self.pp_group_size,
-            warmup_ops,
-            fwd_bwd_ops,
-            cooldown_ops,
-            rank,
-            forward_stage_index,
-            backward_stage_index,
-        )
-
-
-class ScheduleFlexibleInterleaved1F1B(PipelineScheduleMulti):
-    """
-    The Flexible Interleaved 1F1B schedule.
-
-    This schedule is mostly similar to the interleaved 1F1B schedule.
+    This schedule is mostly similar to the original paper.
     It differs by being relaxing the requirement of num_microbatch % pp_size == 0.
     Using the flex_pp schedule, we will have num_rounds = max(1, n_microbatches // pp_group_size) and
     it works as long as n_microbatches % num_rounds is 0. As a few examples, support
 
     1. pp_group_size = 4, n_microbatches = 10. We will have num_rounds = 2 and n_microbatches % 2 is 0.
     2. pp_group_size = 4, n_microbatches = 3. We will have num_rounds = 1 and n_microbatches % 1 is 0.
-
-    When enable_zero_bubble is True, we will use the ZB1P schedule in https://openreview.net/pdf?id=tuzTN0eIO5
     """
 
     def __init__(
@@ -1965,7 +1864,7 @@ class ScheduleFlexibleInterleaved1F1B(PipelineScheduleMulti):
         self.enable_zero_bubble = enable_zero_bubble
         if n_microbatches % self.number_of_rounds != 0:
             raise ValueError(
-                "Flexible Interleaved 1F1B requires the number of microbatches to be a "
+                "Interleaved 1F1B requires the number of microbatches to be a "
                 f"multiple of the number of rounds ({self.number_of_rounds}), "
                 f"but got {n_microbatches}."
             )
@@ -1976,13 +1875,6 @@ class ScheduleFlexibleInterleaved1F1B(PipelineScheduleMulti):
         for rank in range(self.pp_group_size):
             rank_ops = self._calculate_single_rank_operations(rank)
             self.pipeline_order[rank] = rank_ops
-
-        # This function add bubbles to the generated schedule based on dependencies of actions
-        # Note that the ZB1P schedule will not require bubbles to be manually added and it is
-        # only useful when n_microbatches <= microbatches_per_round
-        self.pipeline_order = self._add_bubbles_to_actions(
-            self.n_local_stages * self.pp_group_size,
-        )
 
     def _calculate_single_rank_operations(self, rank) -> List[Optional[_Action]]:
         def get_rank_warmup_ops(rank):
@@ -2033,22 +1925,6 @@ class ScheduleFlexibleInterleaved1F1B(PipelineScheduleMulti):
             )
             return (local_index * self.pp_group_size) + rank
 
-        if self.enable_zero_bubble:
-            num_1f1b_microbatches = rank
-
-            return _get_1f1b_rank_ops(
-                self.n_local_stages,
-                self.pp_group_size,
-                warmup_ops,
-                fwd_bwd_ops,
-                cooldown_ops,
-                rank,
-                forward_stage_index,
-                backward_stage_index,
-                num_1f1b_microbatches,
-                enable_zero_bubble=True,
-            )
-
         return _get_1f1b_rank_ops(
             self.n_local_stages,
             self.pp_group_size,
@@ -2060,10 +1936,128 @@ class ScheduleFlexibleInterleaved1F1B(PipelineScheduleMulti):
             backward_stage_index,
         )
 
+
+class ScheduleInterleavedZeroBubble(PipelineScheduleMulti):
+    """
+    The Interleaved Zero Bubble schedule.
+    See https://arxiv.org/pdf/2401.10241 for details.
+    Will perform one forward and one backward on inputs for the microbatches in steady
+    state and supports multiple stages per rank. Uses the backward for weights to fill in
+    the pipeline bubble.
+
+    In particular this is implementing the ZB1P schedule in the paper.
+    """
+
+    def __init__(
+        self,
+        stages: List[_PipelineStageBase],
+        n_microbatches: int,
+        loss_fn: Optional[Callable] = None,
+        args_chunk_spec: Optional[Tuple[TensorChunkSpec, ...]] = None,
+        kwargs_chunk_spec: Optional[Dict[str, TensorChunkSpec]] = None,
+        output_merge_spec: Optional[Union[Dict[str, Any], Tuple[Any]]] = None,
+    ):
+        self.pp_group_size = stages[0].group_size
+        super().__init__(
+            stages=stages,
+            n_microbatches=n_microbatches,
+            loss_fn=loss_fn,
+            args_chunk_spec=args_chunk_spec,
+            kwargs_chunk_spec=kwargs_chunk_spec,
+            output_merge_spec=output_merge_spec,
+            use_full_backward=False,
+        )
+        self.n_local_stages = len(stages)
+        self.rank = stages[0].group_rank
+        self.number_of_rounds = max(1, n_microbatches // self.pp_group_size)
+        self.microbatches_per_round = n_microbatches // self.number_of_rounds
+        if n_microbatches % self.number_of_rounds != 0:
+            raise ValueError(
+                "Zero bubble requires the number of microbatches to be a "
+                f"multiple of the number of rounds ({self.number_of_rounds}), "
+                f"but got {n_microbatches}."
+            )
+        # 1. Create the pipeline_order (all ranks do this calculation)
+        # This will be used to keep track of the current state of the entire pipeline
+        # pipeline_order[rank] = [Action(computation_type, microbatch_index, stage_index), ...]
+        self.pipeline_order: Dict[int, List[Optional[_Action]]] = {}
+        for rank in range(self.pp_group_size):
+            rank_ops = self._calculate_single_rank_operations(rank)
+            self.pipeline_order[rank] = rank_ops
+
+        # This function add bubbles to the generated schedule based on dependencies of actions
+        # Note that the ZB1P schedule will not require bubbles to be manually added and it is
+        # only useful when n_microbatches <= microbatches_per_round
+        self.pipeline_order = self._add_bubbles_to_actions(
+            self.n_local_stages * self.pp_group_size,
+        )
+
+    def _calculate_single_rank_operations(self, rank) -> List[Optional[_Action]]:
+        def get_rank_warmup_ops(rank):
+            # Warms up operations for last stage
+            warmups_ops_last_stage = (
+                self.n_local_stages - 1
+            ) * self.microbatches_per_round
+            # Increment warmup operations by 2 for each hop away from the last stage
+            multiply_factor = 1
+            warmup_ops = warmups_ops_last_stage + multiply_factor * (
+                (self.pp_group_size - 1) - rank
+            )
+
+            # We cannot have more warmup operations than there are number of microbatches, so cap it there
+            return min(warmup_ops, self._n_microbatches * self.n_local_stages)
+
+        warmup_ops = get_rank_warmup_ops(rank)
+        microbatch_ops = self.n_local_stages * self._n_microbatches
+        # fwd_bwd_ops should encompass the remaining forwards
+        fwd_bwd_ops = microbatch_ops - warmup_ops
+        # cooldown_ops should encompass the remaining backwards
+        cooldown_ops = microbatch_ops - fwd_bwd_ops
+        # total ops encompass both forward and backward ops
+        total_ops = warmup_ops + fwd_bwd_ops + cooldown_ops
+        # warmup_ops + fwd_bwd_ops * 2 + cooldown_ops == microbatch_ops * 2
+        logger.debug(
+            "rank %s, warmup_ops %s, 1f1b %s, cooldown_ops %s total_ops %s",
+            rank,
+            warmup_ops,
+            fwd_bwd_ops,
+            cooldown_ops,
+            total_ops,
+        )
+
+        # Calculates the stage index based on step and pp_group_size
+
+        def forward_stage_index(step):
+            # Get the local index from 0 to n_local_stages-1
+            local_index = (step // self.microbatches_per_round) % self.n_local_stages
+            return (local_index * self.pp_group_size) + rank
+
+        def backward_stage_index(step):
+            local_index = (
+                self.n_local_stages
+                - 1
+                - ((step - warmup_ops) // self.microbatches_per_round)
+                % self.n_local_stages
+            )
+            return (local_index * self.pp_group_size) + rank
+
+        num_1f1b_microbatches = rank
+
+        return _get_1f1b_rank_ops(
+            self.n_local_stages,
+            self.pp_group_size,
+            warmup_ops,
+            fwd_bwd_ops,
+            cooldown_ops,
+            rank,
+            forward_stage_index,
+            backward_stage_index,
+            num_1f1b_microbatches,
+            enable_zero_bubble=True,
+        )
+
     def _add_bubbles_to_actions(self, num_stages_global):
         actions = self.pipeline_order
-        if not self.enable_zero_bubble:
-            return actions
 
         def need_bubble(stage, op, microbatch, num_stages_global, seen_ops):
             if op == _ComputationType.FORWARD:
@@ -2129,35 +2123,6 @@ class ScheduleFlexibleInterleaved1F1B(PipelineScheduleMulti):
         return result
 
 
-class ScheduleInterleavedZeroBubble(ScheduleFlexibleInterleaved1F1B):
-    """
-    The Interleaved Zero Bubble schedule.
-    See https://arxiv.org/pdf/2401.10241 for details.
-    Will perform one forward and one backward on inputs for the microbatches in steady
-    state and supports multiple stages per rank. Uses the backward for weights to fill in
-    the pipeline bubble.
-    """
-
-    def __init__(
-        self,
-        stages: List[_PipelineStageBase],
-        n_microbatches: int,
-        loss_fn: Optional[Callable] = None,
-        args_chunk_spec: Optional[Tuple[TensorChunkSpec, ...]] = None,
-        kwargs_chunk_spec: Optional[Dict[str, TensorChunkSpec]] = None,
-        output_merge_spec: Optional[Union[Dict[str, Any], Tuple[Any]]] = None,
-    ):
-        super().__init__(
-            stages=stages,
-            n_microbatches=n_microbatches,
-            loss_fn=loss_fn,
-            args_chunk_spec=args_chunk_spec,
-            kwargs_chunk_spec=kwargs_chunk_spec,
-            output_merge_spec=output_merge_spec,
-            enable_zero_bubble=True,
-        )
-
-
 def get_schedule_class(schedule_name: str):
     """
     Maps a schedule name (case insensitive) to its corresponding class object.
@@ -2169,7 +2134,6 @@ def get_schedule_class(schedule_name: str):
         "1F1B": Schedule1F1B,
         "Interleaved1F1B": ScheduleInterleaved1F1B,
         "GPipe": ScheduleGPipe,
-        "FlexibleInterleaved1F1B": ScheduleFlexibleInterleaved1F1B,
         "LoopedBFS": ScheduleLoopedBFS,
         "InterleavedZeroBubble": ScheduleInterleavedZeroBubble,
         "PipelineScheduleSingle": PipelineScheduleSingle,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137783

NOTE: this PR removes `ScheduleFlexibleInterleaved1F1B`, let me know if theres any concerns.

`ScheduleFlexibleInterleaved1F1B` is a superset of `Interleaved1F1B` and uses most of the same implementation, but relaxes the condition that `n_microbatches % pp_size == 0`. This is refactors the implementation into `Interleaved1F1B` and then removes it since it is confusing to have both schedules with similar names. This also refactors the zero bubble logic to belong in the `ZeroBubble` schedule class. 

cc @XilunWu @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o