### PR TITLE
Add check to see if hidden_size is bool

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -127,7 +127,7 @@ class RNNBase(Module):
                 f"num_layers={num_layers}"
             )
 
-        if not isinstance(hidden_size, int):
+        if not isinstance(hidden_size, int) or isinstance(hidden_size, bool):
             raise TypeError(
                 f"hidden_size should be of type int, got: {type(hidden_size).__name__}"
             )


### PR DESCRIPTION
Fixes #136937. As bool is a subclass of integer in Python, this caused an incorrect error message when a bool value was provided to hidden_size. A similar check is already implemented to see if the dropout parameter is a bool. 