### PR TITLE
Fix for gcc10 torch.compile compiler error when march=aarch64+sve

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -1,4 +1,8 @@
 #pragma once
+#if defined(__GNUC__) && __GNUC__ == 10 && __GNUC_MINOR__ <= 2 && defined(__ARM_FEATURE_SVE)
+// Workaround for https: //gcc.gnu.org/bugzilla/show_bug.cgi?id=117161
+#pragma GCC optimize("no-tree-vectorize")
+#endif
 
 // DO NOT DEFINE STATIC DATA IN THIS HEADER!
 // See Note [Do not compile initializers with AVX]


### PR DESCRIPTION
Disable tree vectorize in vec_convert.h for gcc10 and aarch64+sve which causes compiler error to occur.

```
/tmp/tmpuqk7lj9j/zx/czx2eyturb6j6m727xhvknkjbdu3y5nqqk66wgxcjkwnxuzvpm5r.cpp:3:18: internal compiler error: in vect_get_vector_types_for_stmt, at tree-vect-stmts.c:12252
    3 | extern "C"  void kernel(const float* in_ptr0,
```
Fixes #137775

I've not linked a gcc bug report yet as they require a minimal reproducer to be made.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10