### PR TITLE
[DRAFT] call sympy.Max(a, b, evaluate=False) instead of torch.utils._sympy.functions .Max

### DIFF
--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -808,8 +808,12 @@ def _sympy_min(a, b):
 
 def _sympy_max(a, b):
     from torch.utils._sympy.functions import Max
-
-    return Max(a, b)
+    # return Max(a, b)
+    # print(f"Max({a}, {b})")
+    # x= Max(a, b)
+    # # print(f"result  is {x}")
+    import sympy
+    return sympy.Max(a, b, evaluate=False)
 
 
 def _sympy_ite(a, t, f):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1063,6 +1063,13 @@ def statically_known_true(x: Union[bool, SymBool]) -> bool:
     if isinstance(x, SymBool):
         expr = x.node.expr
         shape_env = x.node.shape_env
+        # This can be expensive, BUT it is a really a trade of between construction time simplication and here 
+        # and its all program depends. 
+        try:
+            if expr.simplify():
+                return True
+        except Exception:
+            pass
         try:
             simplified = shape_env._maybe_evaluate_static(expr)
             if simplified is not None:


### PR DESCRIPTION
Summary:
I was looking at this profile with @bobrenjc93 

```
TORCH_COMPILE_STROBELIGHT=1 COMPILE_STROBELIGHT_MAX_STACK_LENGTH= 500 buck2 run @fbcode//mode/opt fbcode//torchrec/distributed/tests:pt2_compile_benchmark -- --num-features=200
```



strobelight profile link: https://fburl.com/scuba/pyperf_experimental/on_demand/lrh6erxx
<img width="1393" alt="Screenshot 2024-10-11 at 11 46 52 AM" src="https://github.com/user-attachments/assets/f256fc79-9be4-499a-a330-ebaf493df9b3">
<img width="629" alt="Screenshot 2024-10-11 at 11 47 08 AM" src="https://github.com/user-attachments/assets/beb72871-42b6-453c-87ca-343bac1d1da9">

Most of the time is spent in constructing the max() node. if we pass evaluate=False we no longer have the exponential cost!?

paste that show what we construct when we call max https://www.internalfb.com/phabricator/paste/view/P1644273374
there is a clear repetition across calls, and simplification is not doing much other than flattening inputs of max.


This is just draft to make sure all test pass in OSS, wonder if avoid simplification at construction can make other 
programs slower? if so maybe we can add this under a flag?

alternatively we can also define our own max function and customize automatic simplifications inside 
https://docs.sympy.org/latest/explanation/best-practices.html#avoid-too-much-automatic-evaluation

--num-features=200
compile.compile_inner                
16.5991s vs   120.824s

--num-features=400 (compile.compile_inner )
40s vs 918.024s


 num_features=100
```
rank: 0, world_size: 2, num_features: 100, batch_size: 10, time: 20.05s
va
rank: 0, world_size: 2, num_features: 100, batch_size: 10, time: 40.24s
```


 num_features=200
```
rank: 0, world_size: 2, num_features: 200, batch_size: 10, time: 20.66s
rank: 0, world_size: 2, num_features: 200, batch_size: 10, time: 125.05s
```

Differential Revision: D64252491


