### PR TITLE
Run lint-autoformat only on PRs to main

### DIFF
--- a/.github/workflows/lint-autoformat.yml
+++ b/.github/workflows/lint-autoformat.yml
@@ -4,6 +4,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
+    branches: [main]
 
 jobs:
   lintrunner-autoformat:


### PR DESCRIPTION
This is mostly to prevent showing up on ghstack PRs, with which code suggestions are not compatible.
