### PR TITLE
Default to use training IR

### DIFF
--- a/torch/ao/quantization/pt2e/utils.py
+++ b/torch/ao/quantization/pt2e/utils.py
@@ -363,8 +363,7 @@ def _get_aten_graph_module_for_pattern(
     pattern: Callable,
     example_inputs: Tuple[Any, ...],
     is_cuda: bool = False,
-    *,
-    using_training_ir: bool,
+    using_training_ir: bool = True,
     **kwargs,
 ) -> GraphModule:
     """


### PR DESCRIPTION
Summary: Since capture_pre_autograd_graph is deprecated and will be deleted soon, we default this option to true.

Test Plan: CI

Reviewed By: tugsbayasgalan

Differential Revision: D64254236


