### PR TITLE
Fix torch_np/test_basic for NumPy 2

### DIFF
--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -561,14 +561,19 @@ class TestDefaultDtype(TestCase):
 @skip(_np.__version__ <= "1.23", reason="from_dlpack is new in NumPy 1.23")
 class TestExport(TestCase):
     def test_exported_objects(self):
-        exported_fns = (
+        exported_fns = {
             x
             for x in dir(w)
             if inspect.isfunction(getattr(w, x))
             and not x.startswith("_")
             and x != "set_default_dtype"
-        )
-        diff = set(exported_fns).difference(set(dir(_np)))
+        }
+        if _np.__version__ > "2":
+            # The following methods are removed in NumPy 2.
+            # See https://numpy.org/devdocs/numpy_2_0_migration_guide.html#main-namespace
+            exported_fns -= {"product", "round_", "sometrue", "cumproduct", "alltrue"}
+
+        diff = exported_fns.difference(set(dir(_np)))
         assert len(diff) == 0, str(diff)
 
 


### PR DESCRIPTION
Related to #107302 

`TestExport.test_exported_objects` in `test/torch_np/test_basic.py` is failing with NumPy 2.
The test is checking if all methods under `torch._numpy` exist in `numpy`.
However, some of them are removed in NumPy 2.

This PR fixes the issue by not checking the removed methods when running with NumPy 2.

cc @kiukchung 