### PR TITLE
Fix masked tensor test_stack memory leak

### DIFF
--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -226,6 +226,11 @@ class TestBasics(TestCase):
         for mt, t in zip(masked_tensors, data_tensors):
             _compare_mt_t(mt.grad, t.grad, atol=1e-06)
 
+        # Free up the masked tensors manually to avoid memory leak
+        for mt in masked_tensors:
+            del mt._masked_mask
+            del mt._masked_data
+
     def test_to_sparse(self, device):
         for sample in _generate_sample_data(device=device):
             data = sample.input

--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -78,6 +78,9 @@ def _compare_forward_backward(data, mask, fn):
     _compare_mt_t(masked_res, tensor_res)
     _compare_mt_t(mt.grad, t.grad, atol=1e-06)
 
+    # Free up the masked tensors manually to avoid memory leak
+    del mt._masked_mask
+    del mt._masked_data
 
 def _create_random_mask(shape, device):
     return make_tensor(shape, device=device, dtype=torch.bool)


### PR DESCRIPTION
This test is currently failing in trunk when memory leak check is enabled, for example https://github.com/pytorch/pytorch/actions/runs/11296206361/job/31422348823#step:22:1970.  When testing locally, calling `backward` on a masked tensor always causes memory leak until I clean up the data and the mask manually.  This is probably related to this warning from masked tensor `UserWarning: It is not recommended to create a MaskedTensor with a tensor that requires_grad. To avoid this, you can use data.clone().detach()`, but I don't know much about the internal details here to go further.  So, let's just fix the test first/

### Testing

```
PYTORCH_TEST_CUDA_MEM_LEAK_CHECK=1 python test/test_maskedtensor.py TestBasicsCUDA.test_stack_cuda
```

passes and doesn't warn about memory leak anymore.

The test itself came from https://github.com/pytorch/pytorch/pull/125262#issuecomment-2344068012