### PR TITLE
Always use aten.constant_pad_nd for mm padding

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -5,5 +5,5 @@ add_loop_inductor_dynamic_gpu, compile_time_instruction_count, 40992578178, 0.02
 add_loop_inductor_gpu,         compile_time_instruction_count, 22822864522, 0.015
 basic_modules_ListOfLinears_eager,                         compile_time_instruction_count, 1034818091,     0.015
 basic_modules_ListOfLinears_inductor,                      compile_time_instruction_count, 18830023930,    0.015
-basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,  compile_time_instruction_count, 16470006841,    0.015
+basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,  compile_time_instruction_count, 15806042948,    0.015
 basic_modules_ListOfLinears_inductor_gpu,                  compile_time_instruction_count, 16403080126,    0.20

--- a/torch/_inductor/fx_passes/pad_mm.py
+++ b/torch/_inductor/fx_passes/pad_mm.py
@@ -706,35 +706,25 @@ def should_pad_mm(match: Match) -> bool:
 
 
 def pad_mat1(mat1, *, m_padded_length, k_padded_length, is_bmm=False):
-    if m_padded_length == 0 and k_padded_length == 0:
-        return mat1
-    elif k_padded_length != 0 and m_padded_length != 0:
+    if k_padded_length != 0 or m_padded_length != 0:
         # dim order is reversed for constant_pad_nd, for every dim we specify right and left padding
         pad_arg = [0, k_padded_length, 0, m_padded_length]
         if is_bmm:
             pad_arg.extend((0, 0))
         return aten.constant_pad_nd(mat1, pad_arg)
-    elif m_padded_length != 0:
-        return pad_dim(mat1, m_padded_length, 0 if not is_bmm else 1)
     else:
-        assert k_padded_length != 0
-        return pad_dim(mat1, k_padded_length, 1 if not is_bmm else 2)
+        return mat1
 
 
 def pad_mat2(mat2, *, k_padded_length, n_padded_length, is_bmm=False):
-    if k_padded_length == 0 and n_padded_length == 0:
-        return mat2
-    elif k_padded_length != 0 and n_padded_length != 0:
+    if k_padded_length != 0 or n_padded_length != 0:
         # dim order is reversed for constant_pad_nd, for every dim we specify right and left padding
         pad_arg = [0, n_padded_length, 0, k_padded_length]
         if is_bmm:
             pad_arg.extend((0, 0))
         return aten.constant_pad_nd(mat2, pad_arg)
-    elif k_padded_length != 0:
-        return pad_dim(mat2, k_padded_length, 0 if not is_bmm else 1)
     else:
-        assert n_padded_length != 0
-        return pad_dim(mat2, n_padded_length, 1 if not is_bmm else 2)
+        return mat2
 
 
 def pad_mm(


### PR DESCRIPTION
Summary: From experiment, it seems like aten.constant_pad_nd has better QPS compared to torch.cat. The qps gain for ig ctr is ~10%, and ~5% for oc.

Test Plan:
```
buck2 run mode/opt -c fbcode.nvcc_arch=a100 //caffe2/torch/fb/model_transform/experimental/benchmark:mts_gpu_benchmark -- --model-path=manifold://ads_storage_fblearner/tree/user/facebook/fblearner/predictor/585279927/480/gpu_lowering/input.predictor.disagg.gpu.merge --lower-backend=AOT_INDUCTOR
```
```
buck2 run mode/opt //caffe2/torch/fb/model_transform/experimental/benchmark:mts_gpu_benchmark -- --model-path=manifold://ads_storage_fblearner/tree/user/facebook/fblearner/predictor/588102397/1500/gpu_lowering/input.predictor.disagg.gpu.merge --lower-backend=AOT_INDUCTOR
```

Differential Revision: D64271583




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @rec