### PR TITLE
[Dynamo] Disable Torch Function Subclasses with eager backend, they should've been traced

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -562,6 +562,36 @@ class SubclassTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(cnt.frame_count, 2)
 
+    def test_torch_function_disabled_eager_backend(self):
+        @compile_full_eager
+        def fn(x):
+            return torch.add(x, 1.0)
+
+        class TestSubclass(torch.Tensor):
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                if kwargs is None:
+                    kwargs = {}
+
+                if func == torch.add:
+                    return super().__torch_function__(
+                        lambda x, y: torch.add(x, y) + 2, types, args, kwargs
+                    )
+
+                return super().__torch_function__(func, types, args, kwargs)
+
+        x = torch.ones(2, 2)
+        x = x.as_subclass(TestSubclass)
+
+        with torch._dynamo.config.patch("traceable_tensor_subclasses", {TestSubclass}):
+            result = fn(x)
+
+        print(result)
+        self.assertEqual(result, torch.ones(2, 2) + 3)
+
+        # create a subclass which rewrites a source op
+        # to the same source op w/ a different operand
+
     def test_return_subclass(self):
         @torch.compile(backend="eager", fullgraph=True)
         def fn(x):

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -26,10 +26,17 @@ This file contains TorchDynamo backends intended for debugging uses.
 
 @register_backend
 def eager(gm, fake_tensor_inputs, **kwargs):
-    with torch._C.DisableTorchFunctionSubclass():
-        if kwargs:
-            log.warning("eager backend ignoring extra kwargs %s", kwargs)
-        return gm.forward
+    if kwargs:
+        log.warning("eager backend ignoring extra kwargs %s", kwargs)
+
+    forward = gm.forward
+
+    def fn(*args, **kwargs):
+        # Modes are already disabled when entering dynamo
+        with torch._C.DisableTorchFunctionSubclass():
+            return forward(*args, **kwargs)
+
+    return fn
 
 
 def make_eager_backend_with_torch_function_mode(mode):
@@ -43,13 +50,14 @@ def make_eager_backend_with_torch_function_modes(modes):
     from contextlib import ExitStack
 
     def fn(gm, fake_tensor_inputs, **kwargs):
-        stack = ExitStack()
-        for mode in modes:
-            stack.enter_context(mode)
+        with torch._C.DisableTorchFunctionSubclass():
+            stack = ExitStack()
+            for mode in modes:
+                stack.enter_context(mode)
 
-        result = gm.forward
-        stack.close()
-        return result
+            result = gm.forward
+            stack.close()
+            return result
 
     return fn
 
@@ -62,12 +70,13 @@ def eager_noexcept(gm, fake_tensor_inputs, **kwargs):
     # This backend is intended to check that dynamo-generated GraphModules
     # do not cause errors.
     def inner(*args):
-        try:
-            return gm(*args)
-        except Exception as e:
-            raise torch._dynamo.exc.TorchDynamoException(
-                "Unexpected exception when running generated GraphModule"
-            ) from e
+        with torch._C.DisableTorchFunctionSubclass():
+            try:
+                return gm(*args)
+            except Exception as e:
+                raise torch._dynamo.exc.TorchDynamoException(
+                    "Unexpected exception when running generated GraphModule"
+                ) from e
 
     return inner
 

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -26,9 +26,10 @@ This file contains TorchDynamo backends intended for debugging uses.
 
 @register_backend
 def eager(gm, fake_tensor_inputs, **kwargs):
-    if kwargs:
-        log.warning("eager backend ignoring extra kwargs %s", kwargs)
-    return gm.forward
+    with torch._C.DisableTorchFunctionSubclass():
+        if kwargs:
+            log.warning("eager backend ignoring extra kwargs %s", kwargs)
+        return gm.forward
 
 
 def make_eager_backend_with_torch_function_mode(mode):


### PR DESCRIPTION
Today Dynamo traces torch function into the graph, so when running the eager backend, we should not enable torch_function, as it will not be correct. (we will run torch function twice)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec