### PR TITLE
JustKnobsConfig: Make this work with install_config_module

### DIFF
--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -30,7 +30,7 @@ class TestInductorConfig(TestCase):
     def test_set(self):
         config.max_fusion_size = 13337
         self.assertEqual(config.max_fusion_size, 13337)
-        self.assertEqual(config.shallow_copy_dict()["max_fusion_size"], 13337)
+        self.assertEqual(config.get_config_copy()["max_fusion_size"], 13337)
         config.max_fusion_size = 32
         self.assertEqual(config.max_fusion_size, 32)
 
@@ -38,7 +38,7 @@ class TestInductorConfig(TestCase):
         prior = config.triton.cudagraphs
         config.triton.cudagraphs = not prior
         self.assertEqual(config.triton.cudagraphs, not prior)
-        self.assertEqual(config.shallow_copy_dict()["triton.cudagraphs"], not prior)
+        self.assertEqual(config.get_config_copy()["triton.cudagraphs"], not prior)
 
     def test_save_load(self):
         config.max_fusion_size = 123

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -1,0 +1,268 @@
+# Owner(s): ["module: unknown"]
+import pickle
+
+from torch.testing._internal import fake_config_module as config
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestConfigModule(TestCase):
+    def test_base_value_loading(self):
+        self.assertTrue(config.e_bool)
+        self.assertTrue(config.nested.e_bool)
+        self.assertEqual(config.e_int, 1)
+        self.assertEqual(config.e_float, 1.0)
+        self.assertEqual(config.e_string, "string")
+        self.assertEqual(config.e_list, [1])
+        self.assertEqual(config.e_set, {1})
+        self.assertEqual(config.e_tuple, (1,))
+        self.assertEqual(config.e_dict, {1: 2})
+        self.assertEqual(config.e_none, None)
+        with self.assertRaises(
+            AttributeError, msg="fake_config_module.does_not_exist does not exist"
+        ):
+            config.does_not_exist
+
+    def test_overrides(self):
+        config.e_bool = False
+        self.assertFalse(config.e_bool)
+        config.nested.e_bool = False
+        self.assertFalse(config.nested.e_bool)
+        config.e_int = 2
+        self.assertEqual(config.e_int, 2)
+        config.e_float = 2.0
+        self.assertEqual(config.e_float, 2.0)
+        config.e_string = "string2"
+        self.assertEqual(config.e_string, "string2")
+        config.e_list = [2]
+        self.assertEqual(config.e_list, [2])
+        config.e_set = {2}
+        self.assertEqual(config.e_set, {2})
+        config.e_tuple = (2,)
+        self.assertEqual(config.e_tuple, (2,))
+        config.e_dict = {2: 3}
+        self.assertEqual(config.e_dict, {2: 3})
+        config.e_none = "not none"
+        self.assertEqual(config.e_none, "not none")
+        config.e_none = None
+        self.assertEqual(config.e_none, None)
+        with self.assertRaises(
+            AttributeError, msg="fake_config_module.does_not_exist does not exist"
+        ):
+            config.does_not_exist = 0
+        # Config changes get persisted between test cases
+        config.e_bool = True
+        config.nested.e_bool = True
+        config.e_int = 1
+        config.e_float = 1.0
+        config.e_string = "string"
+        config.e_list = [1]
+        config.e_set = {1}
+        config.e_tuple = (1,)
+        config.e_dict = {1: 2}
+        config.e_none = None
+
+    def test_delete(self):
+        self.assertTrue(config.e_bool)
+        del config.e_bool
+        with self.assertRaises(
+            AttributeError, msg="fake_config_module.e_bool does not exist"
+        ):
+            print(config.e_bool)
+        # Config changes get persisted between test cases
+        config.e_bool = True
+
+    def test_save_config(self):
+        p = config.save_config()
+        self.assertEqual(
+            pickle.loads(p),
+            {
+                "_cache_config_ignore_prefix": ["magic_cache_config"],
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "_e_ignored": True,
+                "e_compile_ignored": True,
+                "magic_cache_config_ignored": True,
+                "_save_config_ignore": ["e_ignored"],
+            },
+        )
+        config.e_bool = False
+        config.e_ignored = False
+        config.load_config(p)
+        self.assertTrue(config.e_bool)
+        self.assertFalse(config.e_ignored)
+        # Config changes get persisted between test cases
+        config.e_ignored = True
+
+    def test_save_config_portable(self):
+        p = config.save_config_portable()
+        self.assertEqual(
+            p,
+            {
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "e_ignored": True,
+                "e_compile_ignored": True,
+            },
+        )
+        config.e_bool = False
+        config._e_ignored = False
+        config.load_config(p)
+        self.assertTrue(config.e_bool)
+        self.assertFalse(config._e_ignored)
+        # Config changes get persisted between test cases
+        config._e_ignored = True
+
+    def test_codegen_config(self):
+        config.e_bool = False
+        config.e_ignored = False
+        code = config.codegen_config()
+        self.assertEqual(
+            code, "torch.testing._internal.fake_config_module.e_bool = False"
+        )
+        # Config changes get persisted between test cases
+        config.e_bool = True
+        config.e_ignored = True
+
+    def test_get_hash(self):
+        self.assertEqual(
+            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        # Test cached value
+        self.assertEqual(
+            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        self.assertEqual(
+            config._hash_digest, b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        config._hash_digest = "fake"
+        self.assertEqual(config.get_hash(), "fake")
+
+        # BUG
+        config.e_bool = False
+        # self.assertEqual(config.get_hash(), b'\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6')
+        # Hack around bug
+        config._is_dirty = True
+        self.assertNotEqual(
+            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        config.e_bool = True
+
+        # Test ignored values
+        config.e_compile_ignored = False
+        config._is_dirty = True
+        self.assertEqual(
+            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        config.e_compile_ignored = True
+
+    def test_dict_copy_semantics(self):
+        p = config.shallow_copy_dict()
+        self.assertEqual(
+            p,
+            {
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "e_ignored": True,
+                "_e_ignored": True,
+                "e_compile_ignored": True,
+                "_cache_config_ignore_prefix": ["magic_cache_config"],
+                "_save_config_ignore": ["e_ignored"],
+                "magic_cache_config_ignored": True,
+            },
+        )
+        p2 = config.to_dict()
+        self.assertEqual(
+            p2,
+            {
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "e_ignored": True,
+                "_e_ignored": True,
+                "e_compile_ignored": True,
+                "_cache_config_ignore_prefix": ["magic_cache_config"],
+                "_save_config_ignore": ["e_ignored"],
+                "magic_cache_config_ignored": True,
+            },
+        )
+        p3 = config.get_config_copy()
+        self.assertEqual(
+            p3,
+            {
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "e_ignored": True,
+                "_e_ignored": True,
+                "e_compile_ignored": True,
+                "_cache_config_ignore_prefix": ["magic_cache_config"],
+                "_save_config_ignore": ["e_ignored"],
+                "magic_cache_config_ignored": True,
+            },
+        )
+
+        # Shallow + deep copy semantics
+        config.e_dict[2] = 3
+        self.assertEqual(p["e_dict"], {1: 2, 2: 3})
+        self.assertEqual(p2["e_dict"], {1: 2, 2: 3})
+        self.assertEqual(p3["e_dict"], {1: 2})
+        config.e_dict = {1: 2}
+
+    def test_patch(self):
+        with config.patch("e_bool", False):
+            self.assertFalse(config.e_bool)
+        self.assertTrue(config.e_bool)
+        with config.patch(e_bool=False):
+            self.assertFalse(config.e_bool)
+        self.assertTrue(config.e_bool)
+        with self.assertRaises(AssertionError):
+            with config.patch("does_not_exist"):
+                pass
+
+    def test_make_closur_patcher(self):
+        revert = config._make_closure_patcher(e_bool=False)()
+        self.assertFalse(config.e_bool)
+        revert()
+        self.assertTrue(config.e_bool)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -241,8 +241,8 @@ class TestConfigModule(TestCase):
 
         # Shallow + deep copy semantics
         config.e_dict[2] = 3
-        self.assertEqual(p["e_dict"], {1: 2, 2: 3})
-        self.assertEqual(p2["e_dict"], {1: 2, 2: 3})
+        self.assertEqual(p["e_dict"], {1: 2})
+        self.assertEqual(p2["e_dict"], {1: 2})
         self.assertEqual(p3["e_dict"], {1: 2})
         config.e_dict = {1: 2}
 

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -155,9 +155,6 @@ class TestConfigModule(TestCase):
 
         # BUG
         config.e_bool = False
-        # self.assertEqual(config.get_hash(), b'\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6')
-        # Hack around bug
-        config._is_dirty = True
         self.assertNotEqual(
             config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
         )
@@ -165,7 +162,6 @@ class TestConfigModule(TestCase):
 
         # Test ignored values
         config.e_compile_ignored = False
-        config._is_dirty = True
         self.assertEqual(
             config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
         )

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -89,6 +89,8 @@ class TestConfigModule(TestCase):
                 "e_compile_ignored": True,
                 "magic_cache_config_ignored": True,
                 "_save_config_ignore": ["e_ignored"],
+                "e_jk": True,
+                "e_jk_false": False,
             },
         )
         config.e_bool = False
@@ -116,6 +118,8 @@ class TestConfigModule(TestCase):
                 "nested.e_bool": True,
                 "e_ignored": True,
                 "e_compile_ignored": True,
+                "e_jk": True,
+                "e_jk_false": False,
             },
         )
         config.e_bool = False
@@ -139,14 +143,14 @@ class TestConfigModule(TestCase):
 
     def test_get_hash(self):
         self.assertEqual(
-            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+            config.get_hash(), b"&\xac\xb0\xd7\xa7c\x85\xa5\x9ek\xb0\xcbz\x1c\xe7I"
         )
         # Test cached value
         self.assertEqual(
-            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+            config.get_hash(), b"&\xac\xb0\xd7\xa7c\x85\xa5\x9ek\xb0\xcbz\x1c\xe7I"
         )
         self.assertEqual(
-            config._hash_digest, b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+            config.get_hash(), b"&\xac\xb0\xd7\xa7c\x85\xa5\x9ek\xb0\xcbz\x1c\xe7I"
         )
         config._hash_digest = "fake"
         self.assertEqual(config.get_hash(), "fake")
@@ -154,14 +158,14 @@ class TestConfigModule(TestCase):
         # BUG
         config.e_bool = False
         self.assertNotEqual(
-            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+            config.get_hash(), b"&\xac\xb0\xd7\xa7c\x85\xa5\x9ek\xb0\xcbz\x1c\xe7I"
         )
         config.e_bool = True
 
         # Test ignored values
         config.e_compile_ignored = False
         self.assertEqual(
-            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+            config.get_hash(), b"&\xac\xb0\xd7\xa7c\x85\xa5\x9ek\xb0\xcbz\x1c\xe7I"
         )
         del config.e_compile_ignored
 
@@ -186,6 +190,8 @@ class TestConfigModule(TestCase):
                 "_cache_config_ignore_prefix": ["magic_cache_config"],
                 "_save_config_ignore": ["e_ignored"],
                 "magic_cache_config_ignored": True,
+                "e_jk": True,
+                "e_jk_false": False,
             },
         )
         p2 = config.to_dict()
@@ -208,6 +214,8 @@ class TestConfigModule(TestCase):
                 "_cache_config_ignore_prefix": ["magic_cache_config"],
                 "_save_config_ignore": ["e_ignored"],
                 "magic_cache_config_ignored": True,
+                "e_jk": True,
+                "e_jk_false": False,
             },
         )
         p3 = config.get_config_copy()
@@ -230,6 +238,8 @@ class TestConfigModule(TestCase):
                 "_cache_config_ignore_prefix": ["magic_cache_config"],
                 "_save_config_ignore": ["e_ignored"],
                 "magic_cache_config_ignored": True,
+                "e_jk": True,
+                "e_jk_false": False,
             },
         )
 

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -50,26 +50,24 @@ class TestConfigModule(TestCase):
         ):
             config.does_not_exist = 0
         # Config changes get persisted between test cases
-        config.e_bool = True
-        config.nested.e_bool = True
-        config.e_int = 1
-        config.e_float = 1.0
-        config.e_string = "string"
-        config.e_list = [1]
-        config.e_set = {1}
-        config.e_tuple = (1,)
-        config.e_dict = {1: 2}
-        config.e_none = None
+        del config.e_bool
+        del config.nested.e_bool
+        del config.e_int
+        del config.e_float
+        del config.e_string
+        del config.e_list
+        del config.e_set
+        del config.e_tuple
+        del config.e_dict
+        del config.e_none
 
     def test_delete(self):
         self.assertTrue(config.e_bool)
         del config.e_bool
-        with self.assertRaises(
-            AttributeError, msg="fake_config_module.e_bool does not exist"
-        ):
-            print(config.e_bool)
-        # Config changes get persisted between test cases
-        config.e_bool = True
+        self.assertTrue(config.e_bool)
+        config.e_bool = False
+        del config.e_bool
+        self.assertTrue(config.e_bool)
 
     def test_save_config(self):
         p = config.save_config()
@@ -99,7 +97,7 @@ class TestConfigModule(TestCase):
         self.assertTrue(config.e_bool)
         self.assertFalse(config.e_ignored)
         # Config changes get persisted between test cases
-        config.e_ignored = True
+        del config.e_ignored
 
     def test_save_config_portable(self):
         p = config.save_config_portable()
@@ -126,7 +124,7 @@ class TestConfigModule(TestCase):
         self.assertTrue(config.e_bool)
         self.assertFalse(config._e_ignored)
         # Config changes get persisted between test cases
-        config._e_ignored = True
+        del config._e_ignored
 
     def test_codegen_config(self):
         config.e_bool = False
@@ -136,8 +134,8 @@ class TestConfigModule(TestCase):
             code, "torch.testing._internal.fake_config_module.e_bool = False"
         )
         # Config changes get persisted between test cases
-        config.e_bool = True
-        config.e_ignored = True
+        del config.e_bool
+        del config.e_ignored
 
     def test_get_hash(self):
         self.assertEqual(
@@ -165,7 +163,7 @@ class TestConfigModule(TestCase):
         self.assertEqual(
             config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
         )
-        config.e_compile_ignored = True
+        del config.e_compile_ignored
 
     def test_dict_copy_semantics(self):
         p = config.shallow_copy_dict()
@@ -240,7 +238,7 @@ class TestConfigModule(TestCase):
         self.assertEqual(p["e_dict"], {1: 2})
         self.assertEqual(p2["e_dict"], {1: 2})
         self.assertEqual(p3["e_dict"], {1: 2})
-        config.e_dict = {1: 2}
+        del config.e_dict
 
     def test_patch(self):
         with config.patch("e_bool", False):

--- a/test/test_utils_internal.py
+++ b/test/test_utils_internal.py
@@ -2,7 +2,7 @@
 
 import os
 
-from torch._utils_internal import justknobs_feature, JustKnobsConfig
+from torch._utils_internal import justknobs_feature
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     load_tests,
 )
@@ -16,35 +16,6 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 
 class TestJustKnob(TestCase):
-    def test_justknob_config(self):
-        with self.subTest("Returns True"):
-            a = JustKnobsConfig()
-            self.assertTrue(a.get())
-        with self.subTest("Returns False"):
-            a = JustKnobsConfig(name="fake_name", default=False)
-            self.assertFalse(a.get())
-        with self.subTest("Returns True via config"):
-            a = JustKnobsConfig(name="fake_name", default=False)
-            a.set(True)
-            self.assertTrue(a.get())
-        with self.subTest("Returns True via env"):
-            os.environ["FAKE_FEATURE"] = "1"
-            a = JustKnobsConfig(
-                name="fake_name", env_name="FAKE_FEATURE", default=False
-            )
-            self.assertTrue(a.get())
-        with self.subTest("Returns same value consistently"):
-            a = JustKnobsConfig(name="fake_name", default=False)
-            a.set(True)
-            self.assertTrue(a.get())
-            a.set(False)
-            self.assertTrue(a.get())
-        with self.subTest("Checks __bool__"):
-            a = JustKnobsConfig(name="fake_name", default=False)
-            if a:
-                raise RuntimeError("Should not be true")
-            self.assertFalse(a)
-
     def test_justknob_feature(self):
         with self.subTest("OSS is True"):
             self.assertTrue(justknobs_feature("testname"))

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2227,7 +2227,7 @@ class _TorchCompileInductorWrapper:
 
         from torch._inductor import config
 
-        current_config: _Dict[str, _Any] = config.shallow_copy_dict()
+        current_config: _Dict[str, _Any] = config.get_config_copy()
 
         for key, val in options.items():
             attr_name = key.replace("-", "_")

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1086,7 +1086,7 @@ def _compile(
                     for key, value in d.items()
                 }
 
-            config_dict = handle_sets(config.shallow_copy_dict())
+            config_dict = handle_sets(config.get_config_copy())
             metrics = CompilationMetrics(
                 str(compile_id),
                 frame_key,

--- a/torch/_dynamo/test_minifier_common.py
+++ b/torch/_dynamo/test_minifier_common.py
@@ -100,8 +100,8 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
 
             # NB: Can't use save_config because that will omit some fields,
             # but we must save and reset ALL fields
-            dynamo_config = torch._dynamo.config.shallow_copy_dict()
-            inductor_config = torch._inductor.config.shallow_copy_dict()
+            dynamo_config = torch._dynamo.config.get_config_copy()
+            inductor_config = torch._inductor.config.get_config_copy()
             try:
                 stderr = io.StringIO()
                 log_handler = logging.StreamHandler(stderr)

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -258,7 +258,7 @@ def list_options() -> List[str]:
 
     from torch._inductor import config
 
-    current_config: Dict[str, Any] = config.shallow_copy_dict()
+    current_config: Dict[str, Any] = config.get_config_copy()
 
     return list(current_config.keys())
 

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import tempfile
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import torch
@@ -163,55 +164,30 @@ def capture_pre_autograd_graph_using_training_ir() -> bool:
     return False
 
 
+@dataclass
 class JustKnobsConfig:
-    """Represents a lazily loaded config
+    """Represents a lazily loaded justknob config
 
     This is designed to be used to specify a value in a config.
 
-    i.e. foo.bar = JustknobsConfig(name="//foo:bar", env_name="FORCE_FOO_BAR")
+    i.e.
+    foo = JustknobsConfig(name="//foo:bar")
+    install_config_module(...)
 
-    Call .get() in order to access the value
-    i.e. if foo.bar.get():
+    This configs must be installed with install_config_module to be used
 
-    Note that the value is fetched once, and then not allowed to change. This
-    means less suprises, at the downside that you may have to restart a job
-    to pick up an update.
+    Arguments:
+        name is the name of the feature / JK. In OSS this is unused.
+        defaults is the value to default this knob to in OSS.
 
-    It can also be set explicitly via set - i.e.
-    foo.bar = JustknobsConfig(name="//foo:bar")
-    foo.bar.set(True)
+    The semantics of this knob, are if no one has manually set it, it will resolve once to the underlying JK value.
+    It will not change the JK value at runtime. If the knob has been manually set, it will ignore JK and use the manually set value.
+    Similarly, if this is a OSS run, there is no JK, and it'll return the default value
 
-    Note that this does allow for no JK name (so that you can use this to replace old configurations).
     """
 
-    def __init__(
-        self, *, name: Optional[str] = None, env_name=None, default: bool = True
-    ):
-        self.name = name
-        self.env_name = env_name
-        self.default = default
-        self.value: Optional[bool] = None
-        self.executed_value = None
-
-    def set(self, value: bool):
-        self.value = value
-
-    def get(self):
-        if self.executed_value is None:
-            self.executed_value = justknobs_feature(
-                self.name,
-                config_value=self.value,
-                env_name=self.env_name,
-                default=self.default,
-            )
-        return self.executed_value
-
-    def __str__(self):
-        v = bool(self)
-        return f"JustknobsConfig(name={self.name}, env_name={self.env_name}, default={self.default} - evals_to={v})"
-
-    def __bool__(self):
-        return self.get()
+    name: Optional[str] = None
+    default: bool = True
 
 
 def justknobs_feature(
@@ -272,7 +248,7 @@ def justknobs_feature(
     return justknobs_check(name)
 
 
-def justknobs_check(name: str) -> bool:
+def justknobs_check(name: str, default=True) -> bool:
     """
     This function can be used to killswitch functionality in FB prod,
     where you can toggle this value to False in JK without having to
@@ -295,7 +271,7 @@ def justknobs_check(name: str) -> bool:
     fork safe and you will break anyone who forks the process and then
     hits JK again.
     """
-    return True
+    return default
 
 
 def justknobs_getval_int(name: str) -> int:

--- a/torch/testing/_internal/fake_config_module.py
+++ b/torch/testing/_internal/fake_config_module.py
@@ -1,0 +1,30 @@
+import sys
+
+from torch.utils._config_module import install_config_module
+from typing import Optional
+
+
+e_bool = True
+e_int = 1
+e_float = 1.0
+e_string = "string"
+e_list = [1]
+e_set = {1}
+e_tuple = (1,)
+e_dict = {1: 2}
+e_none: Optional[bool] = None
+e_ignored = True
+_e_ignored = True
+magic_cache_config_ignored = True
+# [@compile_ignored: debug]
+e_compile_ignored = True
+
+
+class nested:
+    e_bool = True
+
+
+_cache_config_ignore_prefix = ["magic_cache_config"]
+_save_config_ignore = ["e_ignored"]
+
+install_config_module(sys.modules[__name__])

--- a/torch/testing/_internal/fake_config_module.py
+++ b/torch/testing/_internal/fake_config_module.py
@@ -1,7 +1,8 @@
 import sys
-
-from torch.utils._config_module import install_config_module
 from typing import Optional
+
+from torch._utils_internal import JustKnobsConfig
+from torch.utils._config_module import install_config_module
 
 
 e_bool = True
@@ -18,6 +19,8 @@ _e_ignored = True
 magic_cache_config_ignored = True
 # [@compile_ignored: debug]
 e_compile_ignored = True
+e_jk = JustKnobsConfig("does_not_exist")
+e_jk_false = JustKnobsConfig("does_not_exist", default=False)
 
 
 class nested:

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -144,6 +144,7 @@ class ConfigModule(ModuleType):
             raise AttributeError(f"{self.__name__}.{name} does not exist")
         else:
             self._config[name] = value
+            self._is_dirty = True
 
     def __getattr__(self, name: str) -> Any:
         try:
@@ -153,6 +154,7 @@ class ConfigModule(ModuleType):
             raise AttributeError(f"{self.__name__}.{name} does not exist") from e
 
     def __delattr__(self, name: str) -> None:
+        self._is_dirty = True
         # must support delete because unittest.mock.patch deletes
         # then recreate things
         del self._config[name]

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -207,15 +207,22 @@ class ConfigModule(ModuleType):
         return self._hash_digest
 
     @deprecated(
-        "`config.to_dict()` has been deprecated. It may no longer change the underlying config."
-        " use `config.shallow_copy_dict()` or `config.get_config_copy()` instead",
+        "`config.to_dict()` has been deprecated. It no longer changes the underlying config."
+        " use `config.get_config_copy()` instead if you just want a copy of the config, or "
+        "config.load_config if you need mutable access",
         category=FutureWarning,
     )
     def to_dict(self) -> Dict[str, Any]:
-        return self.shallow_copy_dict()
+        return self.get_config_copy()
 
+    @deprecated(
+        "`config.shallow_copy_dict()` has been deprecated. It no longer changes the underlying config."
+        " use `config.get_config_copy()` instead if you just want a copy of the config, or "
+        "config.load_config if you need mutable access",
+        category=FutureWarning,
+    )
     def shallow_copy_dict(self) -> Dict[str, Any]:
-        return {**self._config}
+        return self.get_config_copy()
 
     def load_config(self, maybe_pickled_config: Union[bytes, Dict[str, Any]]) -> None:
         """Restore from a prior call to save_config() or shallow_copy_dict()"""

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -284,23 +284,19 @@ class ConfigModule(ModuleType):
         assert isinstance(changes, dict), f"expected `dict` got {type(changes)}"
         prior: Dict[str, Any] = {}
         config = self
-        dirty = False
 
         class ConfigPatch(ContextDecorator):
             def __enter__(self) -> None:
                 assert not prior
-                nonlocal dirty
                 for key in changes.keys():
                     # KeyError on invalid entry
-                    prior[key] = config._config[key]
-                    dirty = key not in config._compile_ignored_keys
-                config._config.update(changes)
-                config._is_dirty = dirty
+                    prior[key] = config.__getattr__(key)
+                for k, v in changes.items():
+                    config.__setattr__(k, v)
 
             def __exit__(self, exc_type, exc_val, exc_tb):  # type: ignore[no-untyped-def]
-                nonlocal dirty
-                config._config.update(prior)
-                config._is_dirty = dirty
+                for k, v in prior.items():
+                    config.__setattr__(k, v)
                 prior.clear()
 
         return ConfigPatch()

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -8,7 +8,7 @@ import tokenize
 import unittest
 import warnings
 from types import FunctionType, ModuleType
-from typing import Any, Callable, Dict, NoReturn, Optional, Set, Union
+from typing import Any, Callable, Dict, List, NoReturn, Optional, Set, Union
 from typing_extensions import deprecated
 from unittest import mock
 
@@ -159,25 +159,40 @@ class ConfigModule(ModuleType):
         # then recreate things
         del self._config[name]
 
+    def _get_dict(
+        self,
+        ignored_keys: Optional[List[str]] = None,
+        ignored_prefixes: Optional[List[str]] = None,
+        skip_default: bool = False,
+    ) -> Dict[str, Any]:
+        config: Dict[str, Any] = {}
+        for key in self._config:
+            if ignored_keys and key in ignored_keys:
+                if skip_default and self._config[key] != self._default[key]:
+                    warnings.warn(
+                        f"Skipping serialization of {key} value {self._config[key]}"
+                    )
+                continue
+            if ignored_prefixes:
+                if any(key.startswith(prefix) for prefix in ignored_prefixes):
+                    continue
+            if skip_default and self._config[key] == self._default[key]:
+                continue
+            config[key] = copy.deepcopy(self._config[key])
+        return config
+
     def save_config(self) -> bytes:
         """Convert config to a pickled blob"""
-        config = dict(self._config)
-        for key in config.get("_save_config_ignore", ()):
-            config.pop(key)
-        return pickle.dumps(config, protocol=2)
+        return pickle.dumps(
+            self._get_dict(ignored_keys=self._config.get("_save_config_ignore", ())),
+            protocol=2,
+        )
 
     def save_config_portable(self) -> Dict[str, Any]:
         """Convert config to portable format"""
-        config: Dict[str, Any] = {}
-        for key in sorted(self._config):
-            if key.startswith("_"):
-                continue
-            if any(
-                key.startswith(e) for e in self._config["_cache_config_ignore_prefix"]
-            ):
-                continue
-            config[key] = self._config[key]
-        return config
+        prefixes = ["_"]
+        prefixes.extend(self._config["_cache_config_ignore_prefix"])
+        return self._get_dict(ignored_prefixes=prefixes)
 
     def codegen_config(self) -> str:
         """Convert config to Python statements that replicate current config.
@@ -185,24 +200,16 @@ class ConfigModule(ModuleType):
         """
         lines = []
         mod = self.__name__
-        for k, v in self._config.items():
-            if k in self._config.get("_save_config_ignore", ()):
-                if v != self._default[k]:
-                    warnings.warn(f"Skipping serialization of {k} value {v}")
-                continue
-            if v == self._default[k]:
-                continue
+        for k, v in self._get_dict(
+            ignored_keys=self._config.get("_save_config_ignore"), skip_default=True
+        ).items():
             lines.append(f"{mod}.{k} = {v!r}")
         return "\n".join(lines)
 
     def get_hash(self) -> bytes:
         """Hashes the configs that are not compile_ignored"""
         if self._is_dirty or self._hash_digest is None:
-            dict_to_hash = {
-                k: v
-                for k, v in self._config.items()
-                if k not in self._compile_ignored_keys
-            }
+            dict_to_hash = self._get_dict(ignored_keys=list(self._compile_ignored_keys))
             string_to_hash = repr(sorted(dict_to_hash.items()))
             self._hash_digest = hashlib.md5(string_to_hash.encode("utf-8")).digest()
             self._is_dirty = False
@@ -235,7 +242,7 @@ class ConfigModule(ModuleType):
         self._config.update(config)
 
     def get_config_copy(self) -> Dict[str, Any]:
-        return copy.deepcopy(self._config)
+        return self._get_dict()
 
     def patch(
         self,

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -7,6 +7,7 @@ import pickle
 import tokenize
 import unittest
 import warnings
+from dataclasses import dataclass
 from types import FunctionType, ModuleType
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Set, Union
 from typing_extensions import deprecated
@@ -43,8 +44,7 @@ def install_config_module(module: ModuleType) -> None:
 
             name = f"{prefix}{key}"
             if isinstance(value, CONFIG_TYPES):
-                config[name] = value
-                default[name] = value
+                config[name] = _ConfigEntry(default=value)
                 if dest is module:
                     delattr(module, key)
             elif isinstance(value, type):
@@ -59,15 +59,12 @@ def install_config_module(module: ModuleType) -> None:
             else:
                 raise AssertionError(f"Unhandled config {key}={value} ({type(value)})")
 
-    config: Dict[str, Any] = {}
-    default: Dict[str, Any] = {}
+    config: Dict[str, _ConfigEntry] = {}
 
     compile_ignored_keys = get_assignments_with_compile_ignored_comments(module)
 
     visit(module, module, "")
     module._config = config  # type: ignore[attr-defined]
-    module._default = default  # type: ignore[attr-defined]
-    module._allowed_keys = set(config.keys())  # type: ignore[attr-defined]
     module._compile_ignored_keys = compile_ignored_keys  # type: ignore[attr-defined]
     module.__class__ = ConfigModuleInstance
     module._is_dirty = True  # type: ignore[attr-defined]
@@ -116,17 +113,21 @@ def get_assignments_with_compile_ignored_comments(module: ModuleType) -> Set[str
     return assignments
 
 
+@dataclass
+class _ConfigEntry:
+    # The default value specified in the configuration
+    default: Any
+    # The value specified by the user when they overrode the configuration
+    user_override: Any = None
+
+
 class ConfigModule(ModuleType):
     # NOTE: This should be kept in sync with _config_typing.pyi.
 
-    # The default values of the configuration settings.  This can be used to
-    # determine if the config has been changed or not.
-    _default: Dict[str, Any]
     # The actual configuration settings.  E.g., torch._dynamo.config.debug
     # would live as "debug" in the key, and torch._inductor.config.triton.cudagraphs
-    # maps as "triton.cudagraphs"
-    _config: Dict[str, Any]
-    _allowed_keys: Set[str]
+    # maps as "triton.cudagraphs". See discussion on the class for meaning of various sub items
+    _config: Dict[str, _ConfigEntry]
     _bypass_keys: Set[str]
     _compile_ignored_keys: Set[str]
     _is_dirty: bool
@@ -140,15 +141,18 @@ class ConfigModule(ModuleType):
     def __setattr__(self, name: str, value: object) -> None:
         if name in self._bypass_keys:
             super().__setattr__(name, value)
-        elif name not in self._allowed_keys:
+        elif name not in self._config:
             raise AttributeError(f"{self.__name__}.{name} does not exist")
         else:
-            self._config[name] = value
+            self._config[name].user_override = value
             self._is_dirty = True
 
     def __getattr__(self, name: str) -> Any:
         try:
-            return self._config[name]
+            config = self._config[name]
+            if config.user_override is not None:
+                return copy.deepcopy(config.user_override)
+            return copy.deepcopy(config.default)
         except KeyError as e:
             # make hasattr() work properly
             raise AttributeError(f"{self.__name__}.{name} does not exist") from e
@@ -157,7 +161,13 @@ class ConfigModule(ModuleType):
         self._is_dirty = True
         # must support delete because unittest.mock.patch deletes
         # then recreate things
-        del self._config[name]
+        self._config[name].user_override = None
+
+    def _is_default(self, name: str) -> bool:
+        return (
+            self._config[name].user_override is None
+            or self._config[name].user_override == self._config[name].default
+        )
 
     def _get_dict(
         self,
@@ -168,7 +178,7 @@ class ConfigModule(ModuleType):
         config: Dict[str, Any] = {}
         for key in self._config:
             if ignored_keys and key in ignored_keys:
-                if skip_default and self._config[key] != self._default[key]:
+                if skip_default and not self._is_default(key):
                     warnings.warn(
                         f"Skipping serialization of {key} value {self._config[key]}"
                     )
@@ -176,22 +186,27 @@ class ConfigModule(ModuleType):
             if ignored_prefixes:
                 if any(key.startswith(prefix) for prefix in ignored_prefixes):
                     continue
-            if skip_default and self._config[key] == self._default[key]:
+            if skip_default and self._is_default(key):
                 continue
-            config[key] = copy.deepcopy(self._config[key])
+            config[key] = self.__getattr__(key)
         return config
 
     def save_config(self) -> bytes:
         """Convert config to a pickled blob"""
+        ignore = []
+        if "_save_config_ignore" in self._config:
+            ignore = self._save_config_ignore
+        assert isinstance(ignore, list)
+
         return pickle.dumps(
-            self._get_dict(ignored_keys=self._config.get("_save_config_ignore", ())),
+            self._get_dict(ignored_keys=ignore),
             protocol=2,
         )
 
     def save_config_portable(self) -> Dict[str, Any]:
         """Convert config to portable format"""
         prefixes = ["_"]
-        prefixes.extend(self._config["_cache_config_ignore_prefix"])
+        prefixes.extend(self._cache_config_ignore_prefix)
         return self._get_dict(ignored_prefixes=prefixes)
 
     def codegen_config(self) -> str:
@@ -201,7 +216,7 @@ class ConfigModule(ModuleType):
         lines = []
         mod = self.__name__
         for k, v in self._get_dict(
-            ignored_keys=self._config.get("_save_config_ignore"), skip_default=True
+            ignored_keys=self._save_config_ignore, skip_default=True
         ).items():
             lines.append(f"{mod}.{k} = {v!r}")
         return "\n".join(lines)
@@ -239,7 +254,13 @@ class ConfigModule(ModuleType):
             config = pickle.loads(maybe_pickled_config)
         else:
             config = maybe_pickled_config
-        self._config.update(config)
+        for k, v in config.items():
+            if k in self._config:
+                self.__setattr__(k, v)
+            else:
+                warnings.warn(
+                    f"key {k} with value {v} is not understood by this config"
+                )
 
     def get_config_copy(self) -> Dict[str, Any]:
         return self._get_dict()
@@ -322,11 +343,13 @@ class ConfigModule(ModuleType):
         config = self._config
 
         def change() -> Callable[[], None]:
-            prior = {k: config[k] for k in changes}
-            config.update(changes)
+            prior = {k: config[k].user_override for k in changes}
+            for k, v in changes.items():
+                self._config[k].user_override = v
 
             def revert() -> None:
-                config.update(prior)
+                for k, v in prior.items():
+                    self._config[k].user_override = v
 
             return revert
 


### PR DESCRIPTION
The goal of this PR is to make JustKnobsConfig usable with install_config_module. in support of this, there are 3 major parts to this PR.

- The first is that this is based upon https://github.com/pytorch/pytorch/pull/138377, which was broken out into a seperate PR, since it's mostly unrelated to JK changes.
- The second is rewrite install_config_modules to use a layered approach. Explicitly keeping user_overrides and default values seperate. This allows easy insertion of JK default values as a layer in between (and in the future other values if desired, i.e. env variables).
- The last one is convert JustKnobsConfig to be a pure dataclass, and do all resolution within the existing install_config_module resolution system.

There are a couple design decisions that should be mentioned.
1) I flipped everything to a single map, storing _ConfigEntries. We could use multiple maps but this seemed simpler.
2) When saving config we convert everything (including JKs) into user overrides when the configuration is loaded back in. We could do more complex pickling, but that seemed unlikely to have a lot of use.

let me know how this looks.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @rec