### PR TITLE
[NCCL][CUDA] Set `PYTORCH_C10_DRIVER_API_SUPPORTED` in `ProcessGroupNCCL.cpp` compilation

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -562,6 +562,7 @@ if(USE_CUDA)
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/intra_node_comm.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/CudaDMAConnectivity.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/CUDASymmetricMemory.cu
+        ${TORCH_SRC_DIR}/csrc/distributed/c10d/ProcessGroupNCCL.cpp
         PROPERTIES COMPILE_FLAGS "-DPYTORCH_C10_DRIVER_API_SUPPORTED=1"
       )
     endif()


### PR DESCRIPTION
Otherwise `expandable_segments()` is hardcoded to false in `CUDAAllocatorConfig.h`

cc @malfet @seemethere @ptrblck @msaroufim