### PR TITLE
Inductor cpp wrapper: clean-up hard-coded schema for conv OPs

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -300,16 +300,17 @@ Tensor mkldnn_convolution_pointwise(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding,
-    IntArrayRef stride,
-    IntArrayRef dilation,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation,
     int64_t groups,
-    c10::string_view attr,
-    torch::List<std::optional<at::Scalar>> scalars,
-    std::optional<c10::string_view> algorithm) {
+    std::string attr,
+    std::vector<std::optional<at::Scalar>> scalars,
+    std::optional<std::string> algorithm) {
   c10::impl::ExcludeDispatchKeyGuard edkg(c10::autograd_dispatch_keyset);
   bool use_channels_last =
       weight_t.is_mkldnn() || mkldnn_conv_use_channels_last(input_t, weight_t);
+  c10::List<std::optional<at::Scalar>> scalars_list(scalars);
   return _mkldnn_convolution(
       input_t,
       weight_t,
@@ -320,7 +321,7 @@ Tensor mkldnn_convolution_pointwise(
       groups,
       use_channels_last,
       attr,
-      scalars,
+      scalars_list,
       algorithm);
 }
 

--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -339,15 +339,15 @@ Tensor mkldnn_convolution_pointwise_binary(
     const Tensor& other_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding,
-    IntArrayRef stride,
-    IntArrayRef dilation,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation,
     int64_t groups,
-    c10::string_view binary_attr,
+    std::string binary_attr,
     std::optional<at::Scalar> alpha,
-    std::optional<c10::string_view> unary_attr,
-    torch::List<std::optional<at::Scalar>> unary_scalars,
-    std::optional<c10::string_view> unary_algorithm) {
+    std::optional<std::string> unary_attr,
+    std::vector<std::optional<at::Scalar>> unary_scalars,
+    std::optional<std::string> unary_algorithm) {
   TORCH_CHECK(
       input_t.ndimension() == 4 || input_t.ndimension() == 5,
       "mkldnn_convolution_pointwise_binary: currently only support 2d and 3d")
@@ -503,15 +503,15 @@ Tensor& mkldnn_convolution_pointwise_binary_(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding,
-    IntArrayRef stride,
-    IntArrayRef dilation,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation,
     int64_t groups,
-    c10::string_view binary_attr,
+    std::string binary_attr,
     std::optional<at::Scalar> alpha,
-    std::optional<c10::string_view> unary_attr,
-    torch::List<std::optional<at::Scalar>> unary_scalars,
-    std::optional<c10::string_view> unary_algorithm) {
+    std::optional<std::string> unary_attr,
+    std::vector<std::optional<at::Scalar>> unary_scalars,
+    std::optional<std::string> unary_algorithm) {
   // other_t += convolution(...), other_t = unary(other_t)
   TORCH_CHECK(
       input_t.ndimension() == 4 || input_t.ndimension() == 5,
@@ -718,14 +718,14 @@ Tensor mkldnn_convolution_transpose_pointwise_meta(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding,
-    IntArrayRef output_padding,
-    IntArrayRef stride,
-    IntArrayRef dilation,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> output_padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation,
     int64_t groups,
-    c10::string_view attr,
-    torch::List<std::optional<at::Scalar>> scalars,
-    std::optional<c10::string_view> algorithm) {
+    std::string attr,
+    std::vector<std::optional<at::Scalar>> scalars,
+    std::optional<std::string> algorithm) {
 
   std::vector<int64_t> weight_IOHW_sizes = _original_deconv_weight_size(weight_t, groups);
   int64_t dim = input_t.ndimension() - 2;
@@ -865,17 +865,18 @@ Tensor mkldnn_convolution_transpose_pointwise(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding,
-    IntArrayRef output_padding,
-    IntArrayRef stride,
-    IntArrayRef dilation,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> output_padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation,
     int64_t groups,
-    c10::string_view attr,
-    torch::List<std::optional<at::Scalar>> scalars,
-    std::optional<c10::string_view> algorithm) {
+    std::string attr,
+    std::vector<std::optional<at::Scalar>> scalars,
+    std::optional<std::string> algorithm) {
   c10::impl::ExcludeDispatchKeyGuard edkg(c10::autograd_dispatch_keyset);
   bool use_channels_last =
       weight_t.is_mkldnn() || mkldnn_conv_use_channels_last(input_t, weight_t);
+  c10::List<std::optional<at::Scalar>> scalars_list(scalars);
   return _mkldnn_convolution_transpose(
       input_t,
       weight_t,
@@ -887,7 +888,7 @@ Tensor mkldnn_convolution_transpose_pointwise(
       groups,
       use_channels_last,
       attr,
-      scalars,
+      scalars_list,
       algorithm
   );
 }

--- a/aten/src/ATen/native/mkldnn/Conv.h
+++ b/aten/src/ATen/native/mkldnn/Conv.h
@@ -24,43 +24,43 @@ C10_API Tensor mkldnn_convolution_pointwise_binary(
     const Tensor& other_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding,
-    IntArrayRef stride,
-    IntArrayRef dilation,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation,
     int64_t groups,
-    c10::string_view binary_attr,
+    std::string binary_attr,
     std::optional<at::Scalar> alpha,
-    std::optional<c10::string_view> unary_attr,
-    torch::List<std::optional<at::Scalar>> unary_scalars,
-    std::optional<c10::string_view> unary_algorithm);
+    std::optional<std::string> unary_attr,
+    std::vector<std::optional<at::Scalar>> unary_scalars,
+    std::optional<std::string> unary_algorithm);
 
 C10_API Tensor& mkldnn_convolution_pointwise_binary_(
     Tensor& other_t,
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding,
-    IntArrayRef stride,
-    IntArrayRef dilation,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation,
     int64_t groups,
-    c10::string_view binary_attr,
+    std::string binary_attr,
     std::optional<at::Scalar> alpha,
-    std::optional<c10::string_view> unary_attr,
-    torch::List<std::optional<at::Scalar>> unary_scalars,
-    std::optional<c10::string_view> unary_algorithm);
+    std::optional<std::string> unary_attr,
+    std::vector<std::optional<at::Scalar>> unary_scalars,
+    std::optional<std::string> unary_algorithm);
 
 Tensor mkldnn_convolution_transpose_pointwise(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding,
-    IntArrayRef output_padding,
-    IntArrayRef stride,
-    IntArrayRef dilation,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> output_padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation,
     int64_t groups,
-    c10::string_view attr,
-    torch::List<std::optional<at::Scalar>> scalars,
-    std::optional<c10::string_view> algorithm);
+    std::string attr,
+    std::vector<std::optional<at::Scalar>> scalars,
+    std::optional<std::string> algorithm);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/mkldnn/Conv.h
+++ b/aten/src/ATen/native/mkldnn/Conv.h
@@ -11,13 +11,13 @@ C10_API Tensor mkldnn_convolution_pointwise(
     const Tensor& input_t,
     const Tensor& weight_t,
     const std::optional<Tensor>& bias_opt,
-    IntArrayRef padding,
-    IntArrayRef stride,
-    IntArrayRef dilation,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> dilation,
     int64_t groups,
-    c10::string_view attr,
-    torch::List<std::optional<at::Scalar>> scalars,
-    std::optional<c10::string_view> algorithm);
+    std::string attr,
+    std::vector<std::optional<at::Scalar>> scalars,
+    std::optional<std::string> algorithm);
 
 C10_API Tensor mkldnn_convolution_pointwise_binary(
     const Tensor& input_t,

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -327,21 +327,6 @@ class ConvolutionBinary(ExternKernelAlloc):
             if config.abi_compatible
             else None,
         )
-        self.cpp_op_schema = """
-            at::Tensor(
-                const at::Tensor& input_t,
-                const at::Tensor& other_t,
-                const at::Tensor& weight_t,
-                const std::optional<at::Tensor>& bias_opt,
-                at::IntArrayRef padding,
-                at::IntArrayRef stride,
-                at::IntArrayRef dilation,
-                int64_t groups,
-                c10::string_view binary_attr,
-                std::optional<at::Scalar> alpha,
-                std::optional<c10::string_view> unary_attr,
-                torch::List<std::optional<at::Scalar>> unary_scalars,
-                std::optional<c10::string_view> unary_algorithm)"""
         self.cpp_constant_args = cpp_constant_args
 
     def codegen(self, wrapper):
@@ -427,22 +412,6 @@ class ConvolutionBinaryInplace(ExternKernelAlloc):
             if config.abi_compatible
             else None,
         )
-        # TODO: op.call: input[0] should be at::Tensor&
-        self.cpp_op_schema = """
-            at::Tensor&(
-                at::Tensor& other_t,
-                const at::Tensor& input_t,
-                const at::Tensor& weight_t,
-                const std::optional<at::Tensor>& bias_opt,
-                at::IntArrayRef padding,
-                at::IntArrayRef stride,
-                at::IntArrayRef dilation,
-                int64_t groups,
-                c10::string_view binary_attr,
-                std::optional<at::Scalar> alpha,
-                std::optional<c10::string_view> unary_attr,
-                torch::List<std::optional<at::Scalar>> unary_scalars,
-                std::optional<c10::string_view> unary_algorithm)"""
 
         self.mutation_outputs = [
             MutationOutput(NoneLayout(inputs[0].get_device()), inputs[0], self),
@@ -533,19 +502,6 @@ class ConvolutionTransposeUnary(ExternKernelAlloc):
             if config.abi_compatible
             else None,
         )
-        self.cpp_op_schema = """
-            at::Tensor(
-                const at::Tensor& input_t,
-                const at::Tensor& weight_t,
-                const std::optional<at::Tensor>& bias_opt,
-                at::IntArrayRef padding,
-                at::IntArrayRef output_padding,
-                at::IntArrayRef stride,
-                at::IntArrayRef dilation,
-                int64_t groups,
-                c10::string_view attr,
-                torch::List<std::optional<at::Scalar>> scalars,
-                std::optional<c10::string_view> algorithm)"""
 
     def codegen(self, wrapper):
         if config.abi_compatible:

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -258,18 +258,6 @@ class ConvolutionUnary(ExternKernelAlloc):
             if config.abi_compatible
             else None,
         )
-        self.cpp_op_schema = """
-            at::Tensor(
-                const at::Tensor& input_t,
-                const at::Tensor& weight_t,
-                const std::optional<at::Tensor>& bias_opt,
-                at::IntArrayRef padding,
-                at::IntArrayRef stride,
-                at::IntArrayRef dilation,
-                int64_t groups,
-                c10::string_view attr,
-                torch::List<std::optional<at::Scalar>> scalars,
-                std::optional<c10::string_view> algorithm)"""
 
     def codegen(self, wrapper):
         if config.abi_compatible:

--- a/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
@@ -34,7 +34,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary(
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> unary_scalars_list;
+    std::vector<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
     for (int64_t i = 0; i < unary_scalars_len_; i++) {
       unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
@@ -50,9 +50,9 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary(
         groups,
         binary_attr,
         pointer_to_optional<c10::Scalar>(alpha),
-        pointer_to_optional<c10::string_view>(unary_attr),
+        pointer_to_optional<std::string>(unary_attr),
         unary_scalars_list,
-        pointer_to_optional<c10::string_view>(unary_algorithm));
+        pointer_to_optional<std::string>(unary_algorithm));
     *ret0 = new_tensor_handle(std::move(tmp_result));
   });
 }
@@ -77,7 +77,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary_(
     const char** unary_algorithm,
     AtenTensorHandle* ret0) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> unary_scalars_list;
+    std::vector<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
     for (int64_t i = 0; i < unary_scalars_len_; i++) {
       unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
@@ -93,9 +93,9 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary_(
         groups,
         binary_attr,
         pointer_to_optional<c10::Scalar>(alpha),
-        pointer_to_optional<c10::string_view>(unary_attr),
+        pointer_to_optional<std::string>(unary_attr),
         unary_scalars_list,
-        pointer_to_optional<c10::string_view>(unary_algorithm));
+        pointer_to_optional<std::string>(unary_algorithm));
     *ret0 = new_tensor_handle(std::move(tmp_result));
   });
 }
@@ -157,7 +157,7 @@ aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
     const char** algorithm,
     AtenTensorHandle* ret0) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> scalars_list;
+    std::vector<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(scalars_len_);
     for (int64_t i = 0; i < scalars_len_; i++) {
       scalars_list.emplace_back(pointer_to_optional(scalars[i]));
@@ -173,7 +173,7 @@ aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
         groups,
         attr,
         scalars_list,
-        pointer_to_optional<c10::string_view>(algorithm));
+        pointer_to_optional<std::string>(algorithm));
     *ret0 = new_tensor_handle(std::move(tmp_result));
   });
 }

--- a/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
@@ -117,7 +117,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise(
     const char** algorithm,
     AtenTensorHandle* ret0) {
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
-    c10::List<std::optional<c10::Scalar>> scalars_list;
+    std::vector<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(scalars_len_);
     for (int64_t i = 0; i < scalars_len_; i++) {
       scalars_list.emplace_back(pointer_to_optional(scalars[i]));
@@ -132,7 +132,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise(
         groups,
         attr,
         scalars_list,
-        pointer_to_optional<c10::string_view>(algorithm));
+        pointer_to_optional<std::string>(algorithm));
     *ret0 = new_tensor_handle(std::move(tmp_result));
   });
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137833
* __->__ #137829
* #137685

Clean-up for:
- ConvolutionUnary
- ConvolutionBinary
- ConvolutionBinaryInplace
- ConvolutionTransposeUnary

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang