### PR TITLE
[ScaledMM] More Large shape tuning

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -381,13 +381,11 @@ void dispatch_fp8_rowwise_kernel_on_cluster_size_and_transpose(
     std::optional<at::Tensor> bias,
     at::Tensor out) {
   int M = XQ.size(0);
-  int K = XQ.size(1);
   int N = WQ.size(1);
 
   // All the tiles we use have sizes which are multiples of 64, hence any
   // non-multiple of 64 will get padded anyways. Let's round up to simplify.
   M = round_up_to_nearest_multiple(M, 64);
-  K = round_up_to_nearest_multiple(K, 64);
   N = round_up_to_nearest_multiple(N, 64);
 
   // Small/skinny shapes with odd multiples of 64.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137832


Fixes buggy in previous PR with check, and also after some more performance tuning at very large sizes found that when N > M it is valuable to transpose otherwise performance is better untransposed:

If you look at the absolute Tflops I think we still have some room for improvement!
### Perf

Here are some TFLOP deltas at larger sizes where green is the positive gain in TFLops at different values of K


![large_shape_old_vs_update_m_greater_n_FP8Kernel_SCALED_MM_K32768_tflops_delta_heatmap](https://github.com/user-attachments/assets/dcd009a5-1e4f-449c-b852-a92bb7db66e3)

<details>
<summary>### Different Values of K</summary>
![large_shape_old_vs_update_m_greater_n_FP8Kernel_SCALED_MM_K24576_tflops_delta_heatmap](https://github.com/user-attachments/assets/8c043f6c-b8aa-48a9-bd5d-3ec6f39818cd)
![large_shape_old_vs_update_m_greater_n_FP8Kernel_SCALED_MM_K16384_tflops_delta_heatmap](https://github.com/user-attachments/assets/41a4b9f4-2749-4a84-b9c7-bddc2c2334c0)
![large_shape_old_vs_update_m_greater_n_FP8Kernel_SCALED_MM_K12288_tflops_delta_heatmap](https://github.com/user-attachments/assets/68d42421-cfa9-4a0a-a5a5-9f6db80bf609)
![large_shape_old_vs_update_m_greater_n_FP8Kernel_SCALED_MM_K8192_tflops_delta_heatmap](https://github.com/user-attachments/assets/c03906a0-5de7-463e-96a8-85f1774b3af6)
![large_shape_old_vs_update_m_greater_n_FP8Kernel_SCALED_MM_K6144_tflops_delta_heatmap](https://github.com/user-attachments/assets/d697b2d0-efc9-4ea8-9002-d517f3abaf50)
![large_shape_old_vs_update_m_greater_n_FP8Kernel_SCALED_MM_K4096_tflops_delta_heatmap](https://github.com/user-attachments/assets/06f8ef5c-277f-45ca-a44f-ed2e54d4133a)
</details>


<details>
<summary>### Absolute Tflops</summary>

## Old
![large_shape_old_FP8Kernel_SCALED_MM_K32768_tflops_heatmap](https://github.com/user-attachments/assets/8872506b-0ff1-400e-8d11-71eff6d8d59a)

## New
![update_m_greater_n_FP8Kernel_SCALED_MM_K32768_tflops_heatmap](https://github.com/user-attachments/assets/9fc9ec24-ff1a-4b47-8934-72d181677d14)

</details>
