### PR TITLE
Fix test_matmul_offline_tunableop by writing its output files to a temp dir

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4575,6 +4575,7 @@ class TestLinalg(TestCase):
 
     @onlyCUDA
     @dtypes(torch.half)
+    @serialTest()
     def test_matmul_offline_tunableop(self, device, dtype):
         import os
         os.putenv('PYTORCH_TUNABLEOP_ROTATING_BUFFER_SIZE', '0')

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4613,13 +4613,6 @@ class TestLinalg(TestCase):
         result_filename = f"tunableop_results{ordinal}.csv"
         assert os.path.exists(result_filename)
 
-        # remove the files created above to avoid error 'Build left local git repository checkout dirty', ignore errors
-        for filename in [untuned_filename, result_filename]:
-            try:
-                os.remove(filename)
-            except PermissionError:
-                pass
-
         # disables TunableOp, no file will be written, restore to default values
         torch.cuda.tunable.enable(False)
         torch.cuda.tunable.record_untuned_enable(False)
@@ -4627,6 +4620,14 @@ class TestLinalg(TestCase):
         torch.cuda.tunable.set_max_tuning_iterations(100)
         assert torch.cuda.tunable.is_enabled() is False, "TunableOp should be off after resetting"
         assert torch.cuda.tunable.get_max_tuning_iterations() == 100
+
+        # remove the files created above to avoid error 'Build left local git repository checkout dirty', ignore errors
+        for filename in [untuned_filename, result_filename]:
+            try:
+                os.remove(filename)
+            # NB: The file is locked on Windows, so do this last
+            except (FileNotFoundError, PermissionError):
+                pass
 
     @onlyCUDA
     @skipCUDAIfNotRocm

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4617,7 +4617,7 @@ class TestLinalg(TestCase):
         for filename in [untuned_filename, result_filename]:
             try:
                 os.remove(filename)
-            finally:
+            except PermissionError:
                 pass
 
         # disables TunableOp, no file will be written, restore to default values


### PR DESCRIPTION
The test is failing (flakily?) on periodic Windows CUDA jobs with the following error:

```
__________ TestLinalgCUDA.test_matmul_offline_tunableop_cuda_float16 __________
Traceback (most recent call last):
  File "C:\actions-runner\_work\pytorch\pytorch\test\test_linalg.py", line 4618, in test_matmul_offline_tunableop
    os.remove(filename)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'tunableop_untuned0.csv'
```

For example, https://github.com/pytorch/pytorch/actions/runs/11292745299/job/31410578167#step:15:15097

The test tried to catch and ignore this, but this is Windows.  So, the fix is to:

1. Ignore if these files couldn't be removed
2. Write them to a temp directory instead, otherwise, [assert_git_not_dirty](https://github.com/pytorch/pytorch/blob/main/.ci/pytorch/test.sh#L286) won't be happy


