### PR TITLE
Improve the scheduling of _pipelined_produce_and_all2all

### DIFF
--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -303,12 +303,10 @@ def _pipelined_produce_and_all2all(
         remote_rank = (rank - step) % group_size
         if step % 2 == 0:
             stream = torch.cuda.current_stream()
-            other_stream = backend_stream
             p2p_buf = local_p2p_buf_1
             remote_p2p_buf = get_p2p_buf(remote_rank, 1)
         else:
             stream = backend_stream
-            other_stream = torch.cuda.current_stream()
             p2p_buf = local_p2p_buf_0
             remote_p2p_buf = get_p2p_buf(remote_rank, 0)
         with torch.cuda.stream(stream):

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -356,7 +356,7 @@ def _pipelined_produce_and_all2all(
             # will almost guarantee that the chunk_producer on stream 1 gets
             # scheduled first. Once the first chunk_producer is scheduled in
             # the correct order, there's very little room for the scheduling
-            # order of subsequent kernels to change.
+            # order of subsequent kernels to be inconsistent across ranks.
             if step == 2:
                 torch.cuda._sleep(100)
             chunk_producer((rank + step) % group_size, p2p_buf)

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -343,7 +343,7 @@ def _pipelined_produce_and_all2all(
             # stream 0: [  chunk_producer  ][b        ][ cp ][  chunk_producer ][b       ][ cp ]
             # stream 1:         [  chunk_producer  ][b]      [ cp ][  chunk_producer  ][b]      [ cp ]
             #
-            # <rank 1>
+            # [rank 1]
             # stream 0:         [  chunk_producer  ][b]      [ cp ][  chunk_producer  ][b]      [ cp ]
             # stream 1: [  chunk_producer  ][b        ][ cp ][  chunk_producer  ][b      ][ cp ]
             #

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -312,12 +312,57 @@ def _pipelined_produce_and_all2all(
             p2p_buf = local_p2p_buf_0
             remote_p2p_buf = get_p2p_buf(remote_rank, 0)
         with torch.cuda.stream(stream):
+            # Our parallelization strategy issues independent compute ->
+            # barrier -> p2p copy sequences on two streams. This strategy not
+            # only allows computation and p2p copy from different streams to
+            # overlap, it also allows computations in different streams to
+            # overlap, greatly reducing quantization inefficiency.
+            #
+            # Ideally, stream activities would look like this ("b" for
+            # barriers, "cp" for p2p copies):
+            #
+            # [rank 0]
+            # stream 0:         [  chunk_producer  ][b][ cp ][  chunk_producer ][b][ cp ]
+            # stream 1: [  chunk_producer  ][b][ cp ][  chunk_producer  ][b][ cp ]
+            #
+            # [rank 1]
+            # stream 0:         [  chunk_producer  ][b][ cp ][  chunk_producer ][b][ cp ]
+            # stream 1: [  chunk_producer  ][b][ cp ][  chunk_producer  ][b][ cp ]
+            #
+            # NOTE: the barriers synchronize streams with the same ID across
+            # ranks. They don't synchronize streams on the same rank.
+            #
+            # Since the work on both streams is independent, there's no
+            # guarantee that the chunk_producer from stream 0 or stream 1 will
+            # be scheduled first. If there is a scheduling mismatch across
+            # ranks, the barrier forces all ranks to wait for the slowest.
+            #
+            # When scheduling mismatches occur among ranks, the stream
+            # activities might look like this (note that p2p copies from
+            # different streams cannot overlap with each other):
+            #
+            # [rank 0]
+            # stream 0: [  chunk_producer  ][b        ][ cp ][  chunk_producer ][b       ][ cp ]
+            # stream 1:         [  chunk_producer  ][b]      [ cp ][  chunk_producer  ][b]      [ cp ]
+            #
+            # <rank 1>
+            # stream 0:         [  chunk_producer  ][b]      [ cp ][  chunk_producer  ][b]      [ cp ]
+            # stream 1: [  chunk_producer  ][b        ][ cp ][  chunk_producer  ][b      ][ cp ]
+            #
+            # To prevent this, we need to ensure that the chunk_producer on
+            # stream 1 runs first on every rank. Without access to the
+            # underlying kernels, CUDA offers no API to control the scheduling
+            # order of two independent, overlapping kernels. Our solution is to
+            # issue a small sleep kernel in stream 0. The sleep duration is
+            # insignificant. The sleep task itself will drastically increase
+            # the chance that the chunk_producer on stream 1 gets scheduled
+            # first. As long as the first chunk_producer is scheduled in the
+            # correct order, the likelihood of inconsistent scheduling orders
+            # for subsequent kernels across ranks will be minimal.
+            if step == 2:
+                torch.cuda._sleep(100)
             chunk_producer((rank + step) % group_size, p2p_buf)
             symm_mem.barrier(channel=step % 2)
-            # Make the other stream to wait for the barrier on the current
-            # stream to finish before chunk_producer to avoid the compute
-            # delaying the barrier.
-            other_stream.wait_stream(stream)
             out_chunks[remote_rank].copy_(remote_p2p_buf)
 
     chunk_producer(rank, out_chunks[rank])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137850
* __->__ #137836
* #137805
* #137738
* #137643

```
Parallelization strategy: every rank issues independent compute
-> barrier -> p2p copy sequences on two streams. In addition to
computation/communication overlapping, the strategy allows for
computation/computation overlapping, greatly reducing
quantization inefficiency.

Ideally, stream activities would look like this ("b" for
barriers, "cp" for p2p copies):

[rank 0]
stream 0:         [  chunk_producer  ][b][ cp ][  chunk_producer ][b][ cp ]
stream 1: [  chunk_producer  ][b][ cp ][  chunk_producer  ][b][ cp ]

[rank 1]
stream 0:         [  chunk_producer  ][b][ cp ][  chunk_producer ][b][ cp ]
stream 1: [  chunk_producer  ][b][ cp ][  chunk_producer  ][b][ cp ]

Note that the barriers synchronize streams with the same ID
across ranks. They don't synchronize streams on the same rank.

Since the work on both streams is independent, there's no
guarantee that the chunk_producer from stream 0 or stream 1 will
be scheduled first. If there is a scheduling mismatch across
ranks, the barrier forces all ranks to wait for the slowest.

When scheduling mismatches occur among ranks, the stream
activities might look like this (note that p2p copies from
different streams cannot overlap with each other):

[rank 0]
stream 0: [  chunk_producer  ][b        ][ cp ][  chunk_producer ][b       ][ cp ]
stream 1:         [  chunk_producer  ][b]      [ cp ][  chunk_producer  ][b]      [ cp ]

[rank 1]
stream 0:         [  chunk_producer  ][b]      [ cp ][  chunk_producer  ][b]      [ cp ]
stream 1: [  chunk_producer  ][b        ][ cp ][  chunk_producer  ][b      ][ cp ]

To prevent this, we need to ensure that the chunk_producer on
stream 1 gets scheduled first on every rank. Without access to
the underlying kernels, CUDA offers no API to control the
scheduling order of two independent, overlapping kernels. Our
solution is to issue a small sleep kernel in stream 0. The sleep
duration is insignificant, but having an extra task in stream 0
will almost guarantee that the chunk_producer on stream 1 gets
scheduled first. Once the first chunk_producer is scheduled in
the correct order, there's very little room for the scheduling
order of subsequent kernels to be inconsistent across ranks.
```

Currently, we perform stream synchronization to ensure scheduling order. The stream synchronization has no bearing on correctness, but prevents inconsistent scheduling orders across ranks.

Without the stream synchronization, ranks may have inconsistent scheduling order, and the barriers cause all ranks to wait for the slowest rank:
<img width="379" alt="image" src="https://github.com/user-attachments/assets/ffb97e76-7e19-4449-b121-83c32ec3e91d">

With stream synchronization, the inconsistent scheduling order issue is addressed, but we lose compute/compute overlapping (this is the state before this PR):
<img width="378" alt="image" src="https://github.com/user-attachments/assets/4cb76246-625f-4fc1-b49a-823ae46d3f23">

With this PR, we get both consistent scheduling order across ranks and compute/compute overlap:
<img width="327" alt="image" src="https://github.com/user-attachments/assets/51ab1bdc-4f60-46e0-b53c-6d208e2d4888">


cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o