### PR TITLE
XFAIL test_open_device_registration on ROCm

### DIFF
--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -30,7 +30,7 @@ from torch._inductor.codegen.common import (
     get_wrapper_codegen_for_device,
     register_backend_for_device,
 )
-from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS
+from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS, xfailIfRocm
 
 
 try:
@@ -97,6 +97,7 @@ class BaseExtensionBackendTests(TestCase):
 
 @unittest.skipIf(IS_FBCODE, "cpp_extension doesn't work in fbcode right now")
 class ExtensionBackendTests(BaseExtensionBackendTests):
+    @xfailIfRocm
     def test_open_device_registration(self):
         torch.utils.rename_privateuse1_backend("extension_device")
         torch._register_device_module("extension_device", self.module)

--- a/test/inductor/test_triton_extension_backend.py
+++ b/test/inductor/test_triton_extension_backend.py
@@ -36,7 +36,7 @@ from torch._inductor.codegen.common import (
     register_device_op_overrides,
 )
 from torch._inductor.utils import get_triton_code
-from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS
+from torch.testing._internal.common_utils import IS_FBCODE, IS_MACOS, xfailIfRocm
 
 
 try:
@@ -70,6 +70,7 @@ class TritonExtensionBackendTests(BaseExtensionBackendTests):
     Test creating a backend for inductor with Triton scheduling.
     """
 
+    @xfailIfRocm
     def test_open_device_registration(self):
         torch._register_device_module("privateuseone", self.module)
         register_backend_for_device(

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1511,6 +1511,10 @@ def xfailIfLinux(func):
     return unittest.expectedFailure(func) if IS_LINUX and not TEST_WITH_ROCM and not IS_FBCODE else func
 
 
+def xfailIfRocm(func):
+    return unittest.expectedFailure(func) if TEST_WITH_ROCM else func
+
+
 def skipIfTorchDynamo(msg="test doesn't currently work with dynamo"):
     """
     Usage:


### PR DESCRIPTION
Coming from https://github.com/pytorch/pytorch/pull/137611#issuecomment-2408376411.  We might not need this PR if the test can be forward fixed.  Otherwise, XFAIL it on ROCm will be nicer than trying to disable it on those existing issues:

* https://github.com/pytorch/pytorch/issues/136125
* https://github.com/pytorch/pytorch/issues/137026


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang