### PR TITLE
Prevent tuple instances from being weak-referenced.

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -2086,8 +2086,9 @@ class GuardBuilder(GuardBuilderBase):
         obj_ref = None
         # Not necessary to have weakref for Enum type, but there is a bug that
         # makes hasattr(guarded_object.__class__, "__weakref__") return True.
+        # See D64140537 for why we are checking for tuple.
         if hasattr(guarded_object.__class__, "__weakref__") and not isinstance(
-            guarded_object, enum.Enum
+            guarded_object, (enum.Enum, tuple)
         ):
             obj_ref = weakref.ref(guarded_object)
 


### PR DESCRIPTION
Summary:
Currently, https://fburl.com/code/uka25j1i checks whether the guarded object supports weakref by looking at its `__class__`
```
if hasattr(guarded_object.__class__, "__weakref__") and not isinstance(
    guarded_object, enum.Enum
):
    obj_ref = weakref.ref(guarded_object)
```

However, we have reason to modify this slightly because we use classes that "pretend" to be some other classes (e.g. nn.Parameter). Example https://fburl.com/code/8bcktgoh :
```
class QuantizedWeights:
    # TODO: Ugly trick so torch allows us to replace parameters
    # with our custom weights. Do this properly.
    property
    def __class__(self) -> Type[nn.parameter.Parameter]:
        return nn.Parameter

    property
    def grad_fn(self) -> None:
        return None
```

For example, Fp8RowwiseWeights which inherit from the base class above and also from namedtuple, actually does not have `__weakref__` attribute, but its "class" will say it does.

I think the easiest change is to use instance-level checking rather than class-level
```
if hasattr(guarded_object, "__weakref__") ...
```

But I'm wondering if this will harm any of the existing behaviors.

I'd appreciate reviews from the experts

(I just added all recommended reviewers since I'm not sure who is the best person to consult...)

Test Plan: CI?

Reviewed By: YJYJLee

Differential Revision: D64140537




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec