### PR TITLE
unwind: Fix undefined reference to `unwind_c` in `unwind_entry` while…

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -498,7 +498,7 @@ Stats stats() {
 
 } // namespace torch::unwind
 
-extern "C" void unwind_c(std::vector<void*>* result, int64_t rsp, int64_t rbp) {
+extern "C" __attribute__((used, visibility("default"))) void unwind_c(std::vector<void*>* result, int64_t rsp, int64_t rbp) {
   std::shared_lock lock(torch::unwind::cache_mutex_);
   torch::unwind::UnwindState state{};
   // NOLINTNEXTLINE(performance-no-int-to-ptr)


### PR DESCRIPTION
… LTO is enabled

With LTO enabled, some compiler will optimize it and it will be striped, which breaks building. Add attribute to avoid this bad situation.

