### PR TITLE
Add type check for `dilation` in `torch.quantized_max_pool3d()`

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/Pooling.cpp
+++ b/aten/src/ATen/native/quantized/cpu/Pooling.cpp
@@ -490,6 +490,8 @@ void check_maxpool3d_params(
               "Expected no strides or 3d strides, got", stride.size());
   TORCH_CHECK(padding.size() == 3, "Expected 3d padding, got ", padding.size());
   TORCH_CHECK(dilation.size() == 3, "Expected 1d or 3d dilation, got ", dilation.size());
+  TORCH_CHECK(dilation.allMatch([](const auto& ele) { return ele >= 1L; }),
+              "Expected dilation >= 1");
 }
 
 #ifdef USE_PYTORCH_QNNPACK

--- a/aten/src/ATen/native/quantized/cpu/Pooling.cpp
+++ b/aten/src/ATen/native/quantized/cpu/Pooling.cpp
@@ -478,6 +478,8 @@ void check_maxpool2d_params(
               "Expected 1d or 2d padding, got ", padding.size());
   TORCH_CHECK(dilation.size() == 1 || dilation.size() == 2,
               "Expected 1d or 2d dilation, got ", dilation.size());
+  TORCH_CHECK(dilation.allMatch([](const auto& ele) { return ele >= 1L; }),
+              "Expected dilation >= 1");
 }
 
 void check_maxpool3d_params(

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -162,6 +162,11 @@ class ArrayRef final {
     return reverse_iterator(begin());
   }
 
+  /// Check if all element in the array satisfies the given lambda expression
+  constexpr bool allMatch(const std::function<bool(const T&)>& pred) const {
+    return std::all_of(cbegin(), cend(), pred);
+  }
+
   /// empty - Check if the array is empty.
   constexpr bool empty() const {
     return Length == 0;

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -162,7 +162,7 @@ class ArrayRef final {
     return reverse_iterator(begin());
   }
 
-  /// Check if all element in the array satisfies the given lambda expression
+  /// Check if all elements in the array satisfy the given expression
   constexpr bool allMatch(const std::function<bool(const T&)>& pred) const {
     return std::all_of(cbegin(), cend(), pred);
   }

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -492,6 +492,14 @@ class TestPoolingNN(NNTestCase):
         with self.assertRaises(RuntimeError):
             torch.quantized_max_pool1d(temp_tensor, [])
 
+    def test_quantized_max_pool3d(self):
+        # This used to segfault when called with a negative dilation
+        # see https://github.com/pytorch/pytorch/issues/136716
+        input = torch.randn([1, 1, 1, 1, 1])
+        input = torch.quantize_per_tensor(input, -0.1, -10, torch.qint32)
+        with self.assertRaisesRegex(RuntimeError, "Expected dilation >= 1"):
+            torch.quantized_max_pool3d(input, (1, 1, 1), (1, 1, 1), (0, 0, 0), (-3, 1, 1))
+
 
 class TestPoolingNNDeviceType(NNTestCase):
     @onlyNativeDeviceTypes

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -498,7 +498,9 @@ class TestPoolingNN(NNTestCase):
         input = torch.randn([1, 1, 1, 1, 1])
         input = torch.quantize_per_tensor(input, -0.1, -10, torch.qint32)
         with self.assertRaisesRegex(RuntimeError, "Expected dilation >= 1"):
-            torch.quantized_max_pool3d(input, (1, 1, 1), (1, 1, 1), (0, 0, 0), (-3, 1, 1))
+            torch.quantized_max_pool3d(
+                input, (1, 1, 1), (1, 1, 1), (0, 0, 0), (-3, 1, 1)
+            )
 
 
 class TestPoolingNNDeviceType(NNTestCase):


### PR DESCRIPTION
Fixes #136716

repro:

```python
import torch
                                                                                                    
input = torch.randn([1, 1, 1, 1, 1])
input = torch.quantize_per_tensor(input, 0.1, 10, torch.qint32)
torch.quantized_max_pool3d(input, (1, 1, 1), (1, 1, 1), (0, 0, 0), (-3, 1, 1)) # crash
                                                                                                    
input = torch.randn([1, 1, 1, 1, 1])
input = torch.quantize_per_tensor(input, 0.1, 10, torch.qint32)
result = torch.nn.functional.max_pool3d(input, (1, 1, 1), (1, 1, 1), (0, 0, 0), (-3, 1, 1))  # crash
```

result:

```
RuntimeError: Expected dilation >= 1
```


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10