### PR TITLE
Add Intel GPU info collection to the collect env script

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -281,7 +281,7 @@ def get_pkg_version(run_lambda, pkg):
                 cmd = f"{mgr_name} -l | grep {pkg_name}"
             if cmd != "":
                 ret = run_and_read_all(run_lambda, cmd)
-    lst = []
+    lst: list[str] = []
     if ret:
         lst += re.sub(" +", " ", ret).split(" ")
     if len(lst) > index and index != -1:
@@ -292,7 +292,7 @@ def get_pkg_version(run_lambda, pkg):
 
 
 def get_intel_gpu_driver_version(run_lambda):
-    lst = []
+    lst: list[str] = []
     platform = get_platform()
     if platform == "linux":
         for pkg in ["intel_opencl", "level_zero"]:
@@ -320,7 +320,7 @@ def get_intel_gpu_driver_version(run_lambda):
 
 
 def get_intel_gpu_onboard(run_lambda):
-    lst = []
+    lst: list[str] = []
     platform = get_platform()
     if platform == "linux":
         txt = run_and_read_all(run_lambda, "xpu-smi discovery -j")
@@ -456,7 +456,7 @@ def get_cpu_info(run_lambda):
             | ConvertTo-Json"'
         )
         if rc == 0:
-            lst = []
+            lst: list[str] = []
             try:
                 obj = json.loads(out)
                 if type(obj) is list:

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -319,7 +319,7 @@ def get_intel_gpu_driver_version(run_lambda):
     lst = []
     platform = get_platform()
     if platform == "linux":
-            pkgs = {
+        pkgs = {
             "dpkg": {
                 "intel-opencl-icd",
                 "libze1",
@@ -333,8 +333,8 @@ def get_intel_gpu_driver_version(run_lambda):
                 "level-zero",
             },
             "zypper": {
-             "intel-opencl",
-             "level-zero",
+                "intel-opencl",
+                "level-zero",
             },
         }.get(detect_linux_pkg_manager(), {})
         for pkg in pkgs:

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -24,6 +24,7 @@ SystemEnv = namedtuple('SystemEnv', [
     'torch_version',
     'is_debug_build',
     'cuda_compiled_version',
+    'xpu_compiled_version',
     'gcc_version',
     'clang_version',
     'cmake_version',
@@ -37,6 +38,10 @@ SystemEnv = namedtuple('SystemEnv', [
     'nvidia_driver_version',
     'nvidia_gpu_models',
     'cudnn_version',
+    'is_xpu_available',
+    'intel_gpu_driver_version',
+    'intel_gpu_onboard',
+    'intel_gpu_detected',
     'pip_version',  # 'pip' or 'pip3'
     'pip_packages',
     'conda_packages',
@@ -165,6 +170,10 @@ def get_nvidia_driver_version(run_lambda):
 
 
 def get_gpu_info(run_lambda):
+    return get_nvidia_gpu_info(run_lambda)
+
+
+def get_nvidia_gpu_info(run_lambda):
     if get_platform() == 'darwin' or (TORCH_AVAILABLE and hasattr(torch.version, 'hip') and torch.version.hip is not None):
         if TORCH_AVAILABLE and torch.cuda.is_available():
             if torch.version.hip is not None:
@@ -241,6 +250,127 @@ def get_nvidia_smi():
                 smi = '"{}"'.format(candidate_smi)
                 break
     return smi
+
+
+def get_pkg_version(run_lambda, pkg):
+    ret = ""
+    index = -1
+    if get_platform() == "linux":
+        mgr_name = ""
+        for mgr_name in ["dpkg", "dnf", "yum", "zypper", ""]:
+            if mgr_name == "":
+                continue
+            rc, _, _ = run(f"which {mgr_name}")
+            if rc == 0:
+                break
+        if mgr_name != "":
+            cmd = ""
+            # 0: centos/suse
+            # 1: ubuntu
+            pkg_names = {0: {"intel_opencl": "intel-opencl",
+                             "level_zero": "level-zero"},
+                         1: {"intel_opencl": "intel-opencl-icd",
+                             "level_zero": "libze1"}}
+            if mgr_name in ["dnf", "yum", "zypper"]:
+                pkg_name = pkg_names[0][pkg]
+                if mgr_name in ["dnf", "yum"]:
+                    index = 1
+                    cmd = f"{mgr_name} list | grep {pkg_name}"
+                if mgr_name in ["zypper"]:
+                    index = 2
+                    cmd = f"{mgr_name} info {pkg_name} | grep Version"
+            if mgr_name == "dpkg":
+                index = 2
+                pkg_name = pkg_names[1][pkg]
+                cmd = f"{mgr_name} -l | grep {pkg_name}"
+            if cmd != "":
+                ret = run_and_read_all(run_lambda, cmd)
+    lst = []
+    if ret:
+        lst += re.sub(" +", " ", ret).split(" ")
+    if len(lst) > index and index != -1:
+        ret = lst[index]
+    else:
+        ret = "N/A"
+    return ret
+
+
+def get_intel_gpu_driver_version(run_lambda):
+    lst = []
+    platform = get_platform()
+    if platform == "linux":
+        for pkg in ["intel_opencl", "level_zero"]:
+            lst.append(f"* {pkg}:\t{get_pkg_version(run_lambda, pkg)}")
+    if platform == "win32" or platform == "cygwin":
+        txt = run_and_read_all(
+            run_lambda,
+            'powershell.exe "gwmi -Class Win32_PnpSignedDriver | where{$_.DeviceClass -eq \\"DISPLAY\\"\
+            -and $_.Manufacturer -match \\"Intel\\"} | Select-Object -Property DeviceName,DriverVersion,DriverDate\
+            | ConvertTo-Json"',
+        )
+        try:
+            obj = json.loads(txt)
+            if type(obj) is list:
+                for o in obj:
+                    lst.append(
+                        f'* {o["DeviceName"]}: {o["DriverVersion"]} ({o["DriverDate"]})'
+                    )
+            else:
+                lst.append(f'* {obj["DriverVersion"]} ({obj["DriverDate"]})')
+        except ValueError as e:
+            lst.append(txt)
+            lst.append(str(e))
+    return "\n".join(lst)
+
+
+def get_intel_gpu_onboard(run_lambda):
+    lst = []
+    platform = get_platform()
+    if platform == "linux":
+        txt = run_and_read_all(run_lambda, "xpu-smi discovery -j")
+        if txt:
+            try:
+                obj = json.loads(txt)
+                if type(obj["device_list"]) is list:
+                    for o in obj["device_list"]:
+                        lst.append(f'* {o["device_name"]}')
+                else:
+                    lst.append("N/A")
+            except (ValueError, TypeError) as e:
+                lst.append(str(e))
+        else:
+            lst.append("N/A")
+    if platform == "win32" or platform == "cygwin":
+        txt = run_and_read_all(
+            run_lambda,
+            'powershell.exe "gwmi -Class Win32_PnpSignedDriver | where{$_.DeviceClass -eq \\"DISPLAY\\"\
+            -and $_.Manufacturer -match \\"Intel\\"} | Select-Object -Property DeviceName | ConvertTo-Json"',
+        )
+        try:
+            obj = json.loads(txt)
+            if type(obj) is list:
+                for o in obj:
+                    lst.append(f'* {o["DeviceName"]}')
+            else:
+                lst.append(f'* {obj["DeviceName"]}')
+        except ValueError as e:
+            lst.append(txt)
+            lst.append(str(e))
+    return "\n".join(lst)
+
+
+def get_intel_gpu_detected(run_lambda):
+    if TORCH_AVAILABLE:
+        devices = [
+            f"* [{i}] {torch.xpu.get_device_properties(i)}"
+            for i in range(torch.xpu.device_count())
+        ]
+        if len(devices) > 0:
+            return "\n".join(devices)
+        else:
+            return "N/A"
+    else:
+        return "N/A"
 
 
 # example outputs of CPU infos
@@ -504,6 +634,10 @@ def get_env_info():
         debug_mode_str = str(torch.version.debug)
         cuda_available_str = str(torch.cuda.is_available())
         cuda_version_str = torch.version.cuda
+        xpu_available_str = str(torch.xpu.is_available())
+        xpu_version_str = 'N/A'
+        if torch.xpu.is_available():
+            xpu_version_str = torch.version.xpu
         if not hasattr(torch.version, 'hip') or torch.version.hip is None:  # cuda version
             hip_compiled_version = hip_runtime_version = miopen_runtime_version = 'N/A'
         else:  # HIP version
@@ -515,9 +649,10 @@ def get_env_info():
             hip_runtime_version = get_version_or_na(cfg, 'HIP Runtime')
             miopen_runtime_version = get_version_or_na(cfg, 'MIOpen')
             cuda_version_str = 'N/A'
+            xpu_version_str = 'N/A'
             hip_compiled_version = torch.version.hip
     else:
-        version_str = debug_mode_str = cuda_available_str = cuda_version_str = 'N/A'
+        version_str = debug_mode_str = cuda_available_str = cuda_version_str = xpu_available_str = xpu_version_str = 'N/A'
         hip_compiled_version = hip_runtime_version = miopen_runtime_version = 'N/A'
 
     sys_version = sys.version.replace("\n", " ")
@@ -533,9 +668,14 @@ def get_env_info():
         cuda_compiled_version=cuda_version_str,
         cuda_runtime_version=get_running_cuda_version(run_lambda),
         cuda_module_loading=get_cuda_module_loading_config(),
-        nvidia_gpu_models=get_gpu_info(run_lambda),
+        nvidia_gpu_models=get_nvidia_gpu_info(run_lambda),
         nvidia_driver_version=get_nvidia_driver_version(run_lambda),
         cudnn_version=get_cudnn_version(run_lambda),
+        is_xpu_available=xpu_available_str,
+        xpu_compiled_version=xpu_version_str,
+        intel_gpu_driver_version='\n{}'.format(get_intel_gpu_driver_version(run_lambda)),
+        intel_gpu_onboard='\n{}'.format(get_intel_gpu_onboard(run_lambda)),
+        intel_gpu_detected='\n{}'.format(get_intel_gpu_detected(run_lambda)),
         hip_compiled_version=hip_compiled_version,
         hip_runtime_version=hip_runtime_version,
         miopen_runtime_version=miopen_runtime_version,
@@ -557,6 +697,7 @@ PyTorch version: {torch_version}
 Is debug build: {is_debug_build}
 CUDA used to build PyTorch: {cuda_compiled_version}
 ROCM used to build PyTorch: {hip_compiled_version}
+XPU  used to build PyTorch: {xpu_compiled_version}
 
 OS: {os}
 GCC version: {gcc_version}
@@ -572,6 +713,10 @@ CUDA_MODULE_LOADING set to: {cuda_module_loading}
 GPU models and configuration: {nvidia_gpu_models}
 Nvidia driver version: {nvidia_driver_version}
 cuDNN version: {cudnn_version}
+Is XPU available: {is_xpu_available}
+Intel GPU driver version: {intel_gpu_driver_version}
+Intel GPU models onboard: {intel_gpu_onboard}
+Intel GPU models detected: {intel_gpu_detected}
 HIP runtime version: {hip_runtime_version}
 MIOpen runtime version: {miopen_runtime_version}
 Is XNNPACK available: {is_xnnpack_available}

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -269,7 +269,7 @@ def get_nvidia_smi():
     return smi
 
 
-def detect_linux_pkg_manager():
+def _detect_linux_pkg_manager():
     if get_platform() != "linux":
         return "N/A"
     for mgr_name in ["dpkg", "dnf", "yum", "zypper"]:
@@ -280,7 +280,7 @@ def detect_linux_pkg_manager():
 
 
 def get_linux_pkg_version(run_lambda, pkg_name):
-    pkg_mgr = detect_linux_pkg_manager()
+    pkg_mgr = _detect_linux_pkg_manager()
     if pkg_mgr == "N/A":
         return "N/A"
 
@@ -319,7 +319,7 @@ def get_intel_gpu_driver_version(run_lambda):
     lst = []
     platform = get_platform()
     if platform == "linux":
-        pkgs = {
+        pkgs = {. # type: ignore[var-annotated]
             "dpkg": {
                 "intel-opencl-icd",
                 "libze1",
@@ -336,7 +336,7 @@ def get_intel_gpu_driver_version(run_lambda):
                 "intel-opencl",
                 "level-zero",
             },
-        }.get(detect_linux_pkg_manager(), {})
+        }.get(_detect_linux_pkg_manager(), {})
         for pkg in pkgs:
             lst.append(f"* {pkg}:\t{get_linux_pkg_version(run_lambda, pkg)}")
     if platform in ["win32", "cygwin"]:

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -24,7 +24,6 @@ SystemEnv = namedtuple('SystemEnv', [
     'torch_version',
     'is_debug_build',
     'cuda_compiled_version',
-    'xpu_compiled_version',
     'gcc_version',
     'clang_version',
     'cmake_version',
@@ -39,9 +38,6 @@ SystemEnv = namedtuple('SystemEnv', [
     'nvidia_gpu_models',
     'cudnn_version',
     'is_xpu_available',
-    'intel_gpu_driver_version',
-    'intel_gpu_onboard',
-    'intel_gpu_detected',
     'pip_version',  # 'pip' or 'pip3'
     'pip_packages',
     'conda_packages',
@@ -636,9 +632,12 @@ def get_env_info():
         cuda_available_str = str(torch.cuda.is_available())
         cuda_version_str = torch.version.cuda
         xpu_available_str = str(torch.xpu.is_available())
-        xpu_version_str = 'N/A'
         if torch.xpu.is_available():
-            xpu_version_str = torch.version.xpu
+            xpu_available_str = f'{xpu_available_str}\n' + \
+                                f'XPU used to build PyTorch: {torch.version.xpu}\n' + \
+                                f'Intel GPU driver version:\n{get_intel_gpu_driver_version(run_lambda)}\n' + \
+                                f'Intel GPU models onboard:\n{get_intel_gpu_onboard(run_lambda)}\n' + \
+                                f'Intel GPU models detected:\n{get_intel_gpu_detected(run_lambda)}'
         if not hasattr(torch.version, 'hip') or torch.version.hip is None:  # cuda version
             hip_compiled_version = hip_runtime_version = miopen_runtime_version = 'N/A'
         else:  # HIP version
@@ -650,10 +649,9 @@ def get_env_info():
             hip_runtime_version = get_version_or_na(cfg, 'HIP Runtime')
             miopen_runtime_version = get_version_or_na(cfg, 'MIOpen')
             cuda_version_str = 'N/A'
-            xpu_version_str = 'N/A'
             hip_compiled_version = torch.version.hip
     else:
-        version_str = debug_mode_str = cuda_available_str = cuda_version_str = xpu_available_str = xpu_version_str = 'N/A'
+        version_str = debug_mode_str = cuda_available_str = cuda_version_str = xpu_available_str = 'N/A'
         hip_compiled_version = hip_runtime_version = miopen_runtime_version = 'N/A'
 
     sys_version = sys.version.replace("\n", " ")
@@ -673,10 +671,6 @@ def get_env_info():
         nvidia_driver_version=get_nvidia_driver_version(run_lambda),
         cudnn_version=get_cudnn_version(run_lambda),
         is_xpu_available=xpu_available_str,
-        xpu_compiled_version=xpu_version_str,
-        intel_gpu_driver_version='\n{}'.format(get_intel_gpu_driver_version(run_lambda)),
-        intel_gpu_onboard='\n{}'.format(get_intel_gpu_onboard(run_lambda)),
-        intel_gpu_detected='\n{}'.format(get_intel_gpu_detected(run_lambda)),
         hip_compiled_version=hip_compiled_version,
         hip_runtime_version=hip_runtime_version,
         miopen_runtime_version=miopen_runtime_version,
@@ -698,7 +692,6 @@ PyTorch version: {torch_version}
 Is debug build: {is_debug_build}
 CUDA used to build PyTorch: {cuda_compiled_version}
 ROCM used to build PyTorch: {hip_compiled_version}
-XPU  used to build PyTorch: {xpu_compiled_version}
 
 OS: {os}
 GCC version: {gcc_version}
@@ -715,9 +708,6 @@ GPU models and configuration: {nvidia_gpu_models}
 Nvidia driver version: {nvidia_driver_version}
 cuDNN version: {cudnn_version}
 Is XPU available: {is_xpu_available}
-Intel GPU driver version: {intel_gpu_driver_version}
-Intel GPU models onboard: {intel_gpu_onboard}
-Intel GPU models detected: {intel_gpu_detected}
 HIP runtime version: {hip_runtime_version}
 MIOpen runtime version: {miopen_runtime_version}
 Is XNNPACK available: {is_xnnpack_available}

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -307,7 +307,7 @@ def get_linux_pkg_version(run_lambda, pkg_name):
     cmd: str = str(grep_version[pkg_mgr]["command"])
     cmd = cmd.format(pkg_name)
     ret = run_and_read_all(run_lambda, cmd)
-    if ret == "":
+    if ret is None or ret == "":
         return "N/A"
     lst = re.sub(" +", " ", ret).split(" ")
     if len(lst) <= field_index:
@@ -323,6 +323,7 @@ def get_intel_gpu_driver_version(run_lambda):
             "dpkg": {
                 "intel-opencl-icd",
                 "libze1",
+                "level-zero",
             },
             "dnf": {
                 "intel-opencl",
@@ -338,7 +339,9 @@ def get_intel_gpu_driver_version(run_lambda):
             },
         }.get(_detect_linux_pkg_manager(), {})
         for pkg in pkgs:
-            lst.append(f"* {pkg}:\t{get_linux_pkg_version(run_lambda, pkg)}")
+            ver = get_linux_pkg_version(run_lambda, pkg)
+            if ver != "N/A":
+                lst.append(f"* {pkg}:\t{ver}")
     if platform in ["win32", "cygwin"]:
         txt = run_and_read_all(
             run_lambda,

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -272,21 +272,16 @@ def get_nvidia_smi():
 def _detect_linux_pkg_manager():
     if get_platform() != "linux":
         return "N/A"
-    mgr_name = ""
-    for mgr_name in ["dpkg", "dnf", "yum", "zypper", ""]:
-        if mgr_name == "":
-            continue
+    for mgr_name in ["dpkg", "dnf", "yum", "zypper"]:
         rc, _, _ = run(f"which {mgr_name}")
         if rc == 0:
-            break
-    return mgr_name
+            return mgr_name
+    return "N/A"
 
 
 def get_linux_pkg_version(run_lambda, pkg):
-    if get_platform() != "linux":
-        return "N/A"
     pkg_mgr = _detect_linux_pkg_manager()
-    if pkg_mgr in ["", "N/A"]:
+    if pkg_mgr == "N/A":
         return "N/A"
 
     pkgs = {

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -319,7 +319,7 @@ def get_intel_gpu_driver_version(run_lambda):
     lst = []
     platform = get_platform()
     if platform == "linux":
-        pkgs = {. # type: ignore[var-annotated]
+        pkgs = {  # type: ignore[var-annotated]
             "dpkg": {
                 "intel-opencl-icd",
                 "libze1",


### PR DESCRIPTION
As title, add Intel GPU info collection to the collect env script

Output examples:
1. CPU on Windows
```
C:\Users\user\miniforge3\envs\py310\lib\site-packages\torch\_subclasses\functional_tensor.py:279: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at C:\actions-runner\_work\pytorch\pytorch\pytorch\torch\csrc\utils\tensor_numpy.cpp:81.)
  cpu = _conversion_method_template(device=torch.device("cpu"))
Collecting environment information...
PyTorch version: 2.8.0.dev20250528+cpu
Is debug build: False
CUDA used to build PyTorch: None
ROCM used to build PyTorch: N/A

OS: Microsoft Windows 11 Enterprise (10.0.22631 64-bit)
GCC version: Could not collect
Clang version: Could not collect
CMake version: Could not collect
Libc version: N/A

Python version: 3.10.17 | packaged by conda-forge | (main, Apr 10 2025, 22:06:35) [MSC v.1943 64 bit (AMD64)] (64-bit runtime)
Python platform: Windows-10-10.0.22631-SP0
Is CUDA available: False
CUDA runtime version: No CUDA
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: No CUDA
Nvidia driver version: No CUDA
cuDNN version: No CUDA
Is XPU available: False
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True

CPU:
Name: 12th Gen Intel(R) Core(TM) i7-1270P
Manufacturer: GenuineIntel
Family: 198
Architecture: 9
ProcessorType: 3
DeviceID: CPU0
CurrentClockSpeed: 1711
MaxClockSpeed: 2200
L2CacheSize: 9216
L2CacheSpeed: None
Revision: None

Versions of relevant libraries:
[pip3] torch==2.8.0.dev20250528+cpu
[conda] torch                     2.8.0.dev20250528+cpu          pypi_0    pypi
```

2. XPU on Windows
```
Collecting environment information...
PyTorch version: 2.8.0a0+gitef6306e
Is debug build: False
CUDA used to build PyTorch: None
ROCM used to build PyTorch: N/A

OS: Microsoft Windows 10 Pro (10.0.19045 64-bit)
GCC version: (GCC) 13.1.0
Clang version: Could not collect
CMake version: version 3.29.3
Libc version: N/A

Python version: 3.10.17 | packaged by conda-forge | (main, Apr 10 2025, 22:06:35) [MSC v.1943 64 bit (AMD64)] (64-bit runtime)
Python platform: Windows-10-10.0.19045-SP0
Is CUDA available: False
CUDA runtime version: No CUDA
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: No CUDA
Nvidia driver version: No CUDA
cuDNN version: No CUDA
Is XPU available: True
XPU used to build PyTorch: 20250101
Intel GPU driver version:
* 32.0.101.6795 (20250520000000.******+***)
Intel GPU models onboard:
* Intel(R) Arc(TM) A770 Graphics
Intel GPU models detected:
* [0] _XpuDeviceProperties(name='Intel(R) Arc(TM) A770 Graphics', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.33184', total_memory=15915MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=64, max_work_group_size=1024, max_num_sub_groups=128, sub_group_sizes=[8 16 32], has_fp16=1, has_fp64=0, has_atomic64=1)
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True

CPU:
----------------------
Name: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
Manufacturer: GenuineIntel
Family: 179
Architecture: 9
ProcessorType: 3
DeviceID: CPU0
CurrentClockSpeed: 2401
MaxClockSpeed: 2401
L2CacheSize: 24576
L2CacheSpeed: None
Revision: 21767
----------------------
Name: Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz
Manufacturer: GenuineIntel
Family: 179
Architecture: 9
ProcessorType: 3
DeviceID: CPU1
CurrentClockSpeed: 2200
MaxClockSpeed: 2401
L2CacheSize: 24576
L2CacheSpeed: None
Revision: 21767

Versions of relevant libraries:
[pip3] intel_extension_for_pytorch==2.8.10+gitb3ea3a1
[pip3] numpy==2.1.2
[pip3] optree==0.13.1
[pip3] pytorch-triton-xpu==3.3.1+gitb0e26b73
[pip3] torch==2.8.0a0+gitef6306e
[conda] intel-extension-for-pytorch 2.8.10+gitb3ea3a1          pypi_0    pypi
[conda] mkl                       2025.1.0                 pypi_0    pypi
[conda] mkl-dpcpp                 2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-blas          2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-datafitting   2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-dft           2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-lapack        2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-rng           2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-sparse        2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-stats         2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-vm            2025.1.0                 pypi_0    pypi
[conda] pytorch-triton-xpu        3.3.1+gitb0e26b73          pypi_0    pypi
[conda] torch                     2.8.0a0+gitef6306e          pypi_0    pypi
```

3. CPU on Linux
```
/opt/python/cp312-cp312/lib/python3.12/site-packages/torch/_subclasses/functional_tensor.py:279: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:81.)
  cpu = _conversion_method_template(device=torch.device("cpu"))
Collecting environment information...
PyTorch version: 2.8.0.dev20250528+cpu
Is debug build: False
CUDA used to build PyTorch: None
ROCM used to build PyTorch: N/A

OS: AlmaLinux 8.10 (Cerulean Leopard) (x86_64)
GCC version: (GCC) 14.2.1 20250110 (Red Hat 14.2.1-7)
Clang version: Could not collect
CMake version: version 4.0.0
Libc version: glibc-2.28                                                                                                                                                                                                                                                                                                Python version: 3.12.10 (main, Apr 19 2025, 05:03:56) [GCC 14.2.1 20250110 (Red Hat 14.2.1-7)] (64-bit runtime)                                             Python platform: Linux-6.8.0-40-generic-x86_64-with-glibc2.28
Is CUDA available: False
CUDA runtime version: No CUDA
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: No CUDA
Nvidia driver version: No CUDA
cuDNN version: No CUDA
Is XPU available: False
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True

CPU:
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              88
On-line CPU(s) list: 0-87
Thread(s) per core:  2
Core(s) per socket:  22
Socket(s):           2
NUMA node(s):        2
Vendor ID:           GenuineIntel
CPU family:          6
Model:               85
Model name:          Intel(R) Xeon(R) Gold 6238M CPU @ 2.10GHz
Stepping:            7
CPU MHz:             1000.000
CPU max MHz:         3700.0000
CPU min MHz:         1000.0000
BogoMIPS:            4200.00
Virtualization:      VT-x
L1d cache:           32K
L1i cache:           32K
L2 cache:            1024K
L3 cache:            30976K
NUMA node0 CPU(s):   0-21,44-65
NUMA node1 CPU(s):   22-43,66-87
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 intel_ppin ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts vnmi pku ospke avx512_vnni md_clear flush_l1d arch_capabilities

Versions of relevant libraries:
[pip3] torch==2.8.0.dev20250528+cpu
[conda] Could not collect
```

5. XPU on Linux
```
Collecting environment information...
PyTorch version: 2.8.0.dev20250516+xpu
Is debug build: False
CUDA used to build PyTorch: None
ROCM used to build PyTorch: N/A

OS: Ubuntu 22.04.4 LTS (x86_64)
GCC version: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Clang version: Could not collect
CMake version: version 3.31.6
Libc version: glibc-2.35

Python version: 3.10.17 | packaged by conda-forge | (main, Apr 10 2025, 22:19:12) [GCC 13.3.0] (64-bit runtime)
Python platform: Linux-5.15.50-051550-generic-x86_64-with-glibc2.35
Is CUDA available: False
CUDA runtime version: No CUDA
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: No CUDA
Nvidia driver version: No CUDA
cuDNN version: No CUDA
Is XPU available: True
XPU used to build PyTorch: 20250101
Intel GPU driver version:
* intel_opencl: 24.39.31294.21-1032~22.04
* level_zero:   1.17.44.0-1022~22.04
Intel GPU models onboard:
* Intel(R) Data Center GPU Max 1550
* Intel(R) Data Center GPU Max 1550
* Intel(R) Data Center GPU Max 1550
* Intel(R) Data Center GPU Max 1550
Intel GPU models detected:
* [0] _XpuDeviceProperties(name='Intel(R) Data Center GPU Max 1550', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.31294+21', total_memory=65536MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=64, max_work_group_size=1024, max_num_sub_groups=64, sub_group_sizes=[16 32], has_fp16=1, has_fp64=1, has_atomic64=1)
* [1] _XpuDeviceProperties(name='Intel(R) Data Center GPU Max 1550', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.31294+21', total_memory=65536MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=64, max_work_group_size=1024, max_num_sub_groups=64, sub_group_sizes=[16 32], has_fp16=1, has_fp64=1, has_atomic64=1)
* [2] _XpuDeviceProperties(name='Intel(R) Data Center GPU Max 1550', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.31294+21', total_memory=65536MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=64, max_work_group_size=1024, max_num_sub_groups=64, sub_group_sizes=[16 32], has_fp16=1, has_fp64=1, has_atomic64=1)
* [3] _XpuDeviceProperties(name='Intel(R) Data Center GPU Max 1550', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.31294+21', total_memory=65536MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=64, max_work_group_size=1024, max_num_sub_groups=64, sub_group_sizes=[16 32], has_fp16=1, has_fp64=1, has_atomic64=1)
* [4] _XpuDeviceProperties(name='Intel(R) Data Center GPU Max 1550', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.31294+21', total_memory=65536MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=64, max_work_group_size=1024, max_num_sub_groups=64, sub_group_sizes=[16 32], has_fp16=1, has_fp64=1, has_atomic64=1)
* [5] _XpuDeviceProperties(name='Intel(R) Data Center GPU Max 1550', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.31294+21', total_memory=65536MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=64, max_work_group_size=1024, max_num_sub_groups=64, sub_group_sizes=[16 32], has_fp16=1, has_fp64=1, has_atomic64=1)
* [6] _XpuDeviceProperties(name='Intel(R) Data Center GPU Max 1550', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.31294+21', total_memory=65536MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=64, max_work_group_size=1024, max_num_sub_groups=64, sub_group_sizes=[16 32], has_fp16=1, has_fp64=1, has_atomic64=1)
* [7] _XpuDeviceProperties(name='Intel(R) Data Center GPU Max 1550', platform_name='Intel(R) oneAPI Unified Runtime over Level-Zero', type='gpu', driver_version='1.6.31294+21', total_memory=65536MB, max_compute_units=512, gpu_eu_count=512, gpu_subslice_count=64, max_work_group_size=1024, max_num_sub_groups=64, sub_group_sizes=[16 32], has_fp16=1, has_fp64=1, has_atomic64=1)
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True

CPU:
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Address sizes:                   52 bits physical, 57 bits virtual
Byte Order:                      Little Endian
CPU(s):                          224
On-line CPU(s) list:             0-223
Vendor ID:                       GenuineIntel
Model name:                      Intel(R) Xeon(R) Platinum 8480+
CPU family:                      6
Model:                           143
Thread(s) per core:              2
Core(s) per socket:              56
Socket(s):                       2
Stepping:                        6
CPU max MHz:                     3800.0000
CPU min MHz:                     800.0000
BogoMIPS:                        4000.00
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cat_l2 cdp_l3 invpcid_single intel_ppin cdp_l2 ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local split_lock_detect avx_vnni avx512_bf16 wbnoinvd dtherm ida arat pln pts hwp hwp_act_window hwp_epp hwp_pkg_req avx512vbmi umip pku ospke waitpkg avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg tme avx512_vpopcntdq la57 rdpid bus_lock_detect cldemote movdiri movdir64b enqcmd fsrm md_clear serialize tsxldtrk pconfig arch_lbr avx512_fp16 flush_l1d arch_capabilities
Virtualization:                  VT-x
L1d cache:                       5.3 MiB (112 instances)
L1i cache:                       3.5 MiB (112 instances)
L2 cache:                        224 MiB (112 instances)
L3 cache:                        210 MiB (2 instances)
NUMA node(s):                    2
NUMA node0 CPU(s):               0-55,112-167
NUMA node1 CPU(s):               56-111,168-223
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Mmio stale data:   Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Enhanced IBRS, IBPB conditional, RSB filling
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected

Versions of relevant libraries:
[pip3] numpy==2.2.5
[pip3] pytorch-triton-xpu==3.3.0+git0bcc8265
[pip3] torch==2.8.0.dev20250516+xpu
[conda] mkl                       2025.1.0                 pypi_0    pypi
[conda] numpy                     2.2.5                    pypi_0    pypi
[conda] onemkl-sycl-blas          2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-dft           2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-lapack        2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-rng           2025.1.0                 pypi_0    pypi
[conda] onemkl-sycl-sparse        2025.1.0                 pypi_0    pypi
[conda] pytorch-triton-xpu        3.3.0+git0bcc8265          pypi_0    pypi
[conda] torch                     2.8.0.dev20250516+xpu          pypi_0    pypi
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @kadeng @muchulee8 @amjames @chauhang @aakhundov @yf225 @ColinPeppler @desertfire