### PR TITLE
profiler: Fix undefined reference to `unwind_c` in `unwind_entry` while LTO is enabled

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -1,3 +1,4 @@
+#include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/profiler/unwind/unwind.h>
 #include <torch/csrc/utils/cpp_stacktraces.h>
@@ -498,10 +499,8 @@ Stats stats() {
 
 } // namespace torch::unwind
 
-extern "C" C10_USED void unwind_c(
-    std::vector<void*>* result,
-    int64_t rsp,
-    int64_t rbp) {
+extern "C" C10_USED void unwind_c(std::vector<void*>* result, int64_t rsp, 
+  int64_t rbp) {
   std::shared_lock lock(torch::unwind::cache_mutex_);
   torch::unwind::UnwindState state{};
   // NOLINTNEXTLINE(performance-no-int-to-ptr)

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -498,7 +498,7 @@ Stats stats() {
 
 } // namespace torch::unwind
 
-extern "C" __attribute__((used, visibility("default"))) void unwind_c(
+extern "C" C10_USED void unwind_c(
     std::vector<void*>* result,
     int64_t rsp,
     int64_t rbp) {

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -499,8 +499,10 @@ Stats stats() {
 
 } // namespace torch::unwind
 
-extern "C" C10_USED void unwind_c(std::vector<void*>* result, int64_t rsp, 
-  int64_t rbp) {
+extern "C" C10_USED void unwind_c(
+    std::vector<void*>* result,
+    int64_t rsp,
+    int64_t rbp) {
   std::shared_lock lock(torch::unwind::cache_mutex_);
   torch::unwind::UnwindState state{};
   // NOLINTNEXTLINE(performance-no-int-to-ptr)

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -498,7 +498,10 @@ Stats stats() {
 
 } // namespace torch::unwind
 
-extern "C" void unwind_c(std::vector<void*>* result, int64_t rsp, int64_t rbp) {
+extern "C" __attribute__((used, visibility("default"))) void unwind_c(
+    std::vector<void*>* result,
+    int64_t rsp,
+    int64_t rbp) {
   std::shared_lock lock(torch::unwind::cache_mutex_);
   torch::unwind::UnwindState state{};
   // NOLINTNEXTLINE(performance-no-int-to-ptr)


### PR DESCRIPTION
With LTO(Link Time Optimization) enabled in CFLAGS, some compiler will optimize and strip the unwind_c function, which is caused by compiler that couldn’t resolve reference correctly, thus breaking the build with undefined reference in unwind_entry. Add an attribute to avoid this bad situation.

Fixes #121282


cc @jbschlosser