### PR TITLE
Revert "Add support for add in tensorify_python_scalars fx pass (#137620)"

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -959,19 +959,6 @@ class TestInductorDynamic(TestCase):
         self.assertEqual(fn(x, 3.0), fn_opt(x, 3.0))
         self.assertEqual(cnt.frame_count, 1)
 
-    @torch._dynamo.config.patch(specialize_float=False, capture_scalar_outputs=True)
-    def test_unspecialized_float_add(self):
-        def fn(x, y):
-            return x + y
-
-        cnt = CompileCounterWithBackend("inductor")
-        fn_opt = torch._dynamo.optimize(cnt)(fn)
-
-        x = torch.arange(3)
-        self.assertEqual(fn(x, 2.0), fn_opt(x, 2.0))
-        self.assertEqual(fn(x, 3.0), fn_opt(x, 3.0))
-        self.assertEqual(cnt.frame_count, 1)
-
     def test_sort_dynamic_shape_with_check(self, device):
         if TEST_WITH_ROCM or torch.device(device).type != GPU_TYPE:
 

--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -68,6 +68,7 @@ SUPPORTED_OPS = {
     torch.ops.aten.add.Tensor,
 }
 
+
 @torch.fx._compatibility.compatibility(is_backward_compatible=False)
 def tensorify_python_scalars(
     gm: GraphModule, shape_env: ShapeEnv, fake_mode: fake_tensor.FakeTensorMode


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This reverts commit 0430e72e755d2c1953917ffb78f00c516eb4bbd5.

Reverted https://github.com/pytorch/pytorch/pull/137620 on behalf of https://github.com/huydhn due to Sorry for reverting your change, but it seems to cause test_torchbind_inductor to fail in trunk https://hud.pytorch.org/pytorch/pytorch/commit/0430e72e755d2c1953917ffb78f00c516eb4bbd5 ([comment](https://github.com/pytorch/pytorch/pull/137620#issuecomment-2408784170))

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang