### PR TITLE
Fix memory leak on masked Tensor

### DIFF
--- a/test/test_maskedtensor.py
+++ b/test/test_maskedtensor.py
@@ -78,10 +78,6 @@ def _compare_forward_backward(data, mask, fn):
     _compare_mt_t(masked_res, tensor_res)
     _compare_mt_t(mt.grad, t.grad, atol=1e-06)
 
-    # Free up the masked tensors manually to avoid memory leak
-    del mt._masked_mask
-    del mt._masked_data
-
 def _create_random_mask(shape, device):
     return make_tensor(shape, device=device, dtype=torch.bool)
 
@@ -228,11 +224,6 @@ class TestBasics(TestCase):
         _compare_mt_t(masked_res, tensor_res)
         for mt, t in zip(masked_tensors, data_tensors):
             _compare_mt_t(mt.grad, t.grad, atol=1e-06)
-
-        # Free up the masked tensors manually to avoid memory leak
-        for mt in masked_tensors:
-            del mt._masked_mask
-            del mt._masked_data
 
     def test_to_sparse(self, device):
         for sample in _generate_sample_data(device=device):

--- a/torch/masked/maskedtensor/core.py
+++ b/torch/masked/maskedtensor/core.py
@@ -334,7 +334,7 @@ class MaskedTensor(torch.Tensor):
         class GetData(torch.autograd.Function):
             @staticmethod
             def forward(ctx, self):
-                return self._masked_data
+                return self._masked_data.detach()
 
             @staticmethod
             def backward(ctx, grad_output):


### PR DESCRIPTION
Note that this reverts the change from https://github.com/pytorch/pytorch/pull/137815 as well which is not needed anymore!

Without this, you create an unbeakable reference cycle. It is unbreakable because part of the cycle is through the autograd graph which we cannot traverse.