### PR TITLE
Revert "[Dynamo][autograd.Function] Trace fwd graph under no_grad mode (#134872)"

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -439,29 +439,6 @@ class AutogradFunctionTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(result, Foo.apply(x))
         self.assertEqual(cnt.frame_count, 1)
 
-    def test_fwd_no_grad(self):
-        # autograd.Function.forward should be traced and called under no_grad mode.
-        # torch.exp with out=... arguments don't support automatic differentiation,
-        # so can't be traced/called under grad mode (throwing RuntimeError),
-        # therefore this unit test ensures fwd is under no_grad mode.
-        class Foo(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, inputs):
-                torch.exp(inputs, out=inputs)
-                return inputs
-
-            @staticmethod
-            def backward(ctx, grad_output):
-                return None
-
-        @torch.compile(backend="eager", fullgraph=True)
-        def f(x):
-            return Foo.apply(x)
-
-        x1 = torch.randn(2, 3, requires_grad=True)
-        x2 = x1.clone()
-        self.assertEqual(f(x1), Foo.apply(x2))
-
     def test_amp_custom_fwd_bwd(self):
         torch._dynamo.utils.counters.clear()
         cnt = torch._dynamo.testing.CompileCounter()
@@ -570,13 +547,9 @@ class GraphModule(torch.nn.Module):
 
     class fwd_body_0(torch.nn.Module):
         def forward(self, ctx, x: "f32[]", z: "f32[]", l_weird_b: "f32[]", l_weird_c: "f32[]"):
-            _set_grad_enabled = torch._C._set_grad_enabled(False);  _set_grad_enabled = None
-
             mul: "f32[]" = l_weird_b * l_weird_c
             clone: "f32[]" = x.clone();  x = None
             mul_1: "f32[]" = mul * clone;  mul = clone = None
-
-            _set_grad_enabled_1 = torch._C._set_grad_enabled(True);  _set_grad_enabled_1 = None
             return (mul_1, [l_weird_b, l_weird_c])
 
     class bwd_body_0(torch.nn.Module):
@@ -1140,13 +1113,9 @@ class GraphModule(torch.nn.Module):
 
     class fwd_body_0(torch.nn.Module):
         def forward(self, ctx, x: "f32[]", y: "f32[]"):
-            _set_grad_enabled = torch._C._set_grad_enabled(False);  _set_grad_enabled = None
-
             out1: "f32[]" = x.sin();  x = None
 
             out2: "f32[]" = y * 2;  y = None
-
-            _set_grad_enabled_1 = torch._C._set_grad_enabled(True);  _set_grad_enabled_1 = None
             return ((out1, out2), [])
 
     class bwd_body_0(torch.nn.Module):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2217,7 +2217,6 @@ class AutogradFunctionApplyVariable(VariableTracker):
             fwd_args,
             kwargs,
             "autograd.Function",
-            enable_grad=False,
             set_subgraph_inputs="semi_automatic",
             restore_side_effects=False,
             tracer=fwd_tracer,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137891

This reverts commit e688b78791d01bd91614a61e57726c32beb46ee4.

We're reverting this because:
1) The original PR (#134872) fixed a bug but caused another one. The
   assessment is that the bug it caused is worse than the bug it fixed.
2) it was reverted on the release 2.5 branch, so we want to prevent
   divergence
3) The original author is out-of-office for a while so we don't want the
   divergence to wait until they're back

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec