### PR TITLE
Update inductor benchmark time to avoid flakiness

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -4,6 +4,6 @@ add_loop_inductor,             compile_time_instruction_count, 23155396049, 0.01
 add_loop_inductor_dynamic_gpu, compile_time_instruction_count, 39410000000, 0.025
 add_loop_inductor_gpu,         compile_time_instruction_count, 21929517491, 0.015
 basic_modules_ListOfLinears_eager,                         compile_time_instruction_count, 1034818091,     0.015
-basic_modules_ListOfLinears_inductor,                      compile_time_instruction_count, 19080000000,    0.015
+basic_modules_ListOfLinears_inductor,                      compile_time_instruction_count, 18830023930,    0.015
 basic_modules_ListOfLinears_inductor_gpu_force_shape_pad,  compile_time_instruction_count, 16470006841,    0.015
 basic_modules_ListOfLinears_inductor_gpu,                  compile_time_instruction_count, 16403080126,    0.20


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #137900



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec