### PR TITLE
[dynamo] Don't codegen temporary cells for pre-existing cells

### DIFF
--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -427,16 +427,15 @@ class SideEffects:
 
     def codegen_save_tempvars(self, cg: PyCodegen):
         for var in self._get_modified_vars():
-            if isinstance(
-                var.mutable_local, (AttributeMutationExisting, AttributeMutationNew)
-            ) and isinstance(var, variables.NewCellVariable):
+            if isinstance(var.mutable_local, AttributeMutationNew) and isinstance(
+                var, variables.NewCellVariable
+            ):
                 cg.add_push_null(
                     lambda: cg.load_import_from(utils.__name__, "make_cell")
                 )
                 cg.extend_output(create_call_function(0, False))
                 cg.add_cache(var)
-                if isinstance(var.mutable_local, AttributeMutationNew):
-                    var.mutable_local.source = LocalSource(cg.tempvars[var])  # type: ignore[attr-defined]
+                var.mutable_local.source = LocalSource(cg.tempvars[var])  # type: ignore[attr-defined]
             elif isinstance(var.mutable_local, AttributeMutationNew):
                 if isinstance(var, variables.AutogradFunctionContextVariable):
                     unimplemented("AutogradFunctionContextVariable escaped")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137906
* #137905
* __->__ #137907

This patch removes tempvar codegen for the `NewCellVariable` that has
`AttributeMutationExisting`, because these tempvar will never get used.
Note that tempvar codegen for other objects also follow this pattern,
i.e., it only fires on `AttributeMutationNew`.

To visualize, in the following program, we'll see the modified bytecode
contains redundant `make_cell` calls, and stores the result to a local
`tmp_2` which is never used again.

```python
import torch

def test_write_cell():
    count = torch.ones(1)
    def inc():
        nonlocal count
        count = count + 1

    torch.compile()
    def fn():
        inc()

    fn()

test_write_cell()
```

```
$ TORCH_LOGS="bytecode" TORCH_LOGS_FORMAT="short" python test.py

......
    0 COPY_FREE_VARS           1
    2 RESUME                   0
    4 LOAD_GLOBAL              9 (NULL + __compiled_fn_2)
   14 LOAD_DEREF               3 (inc)
   16 LOAD_ATTR                6 (__closure__)
   36 LOAD_CONST               1 (0)
   38 BINARY_SUBSCR
   42 LOAD_ATTR                4 (cell_contents)
   62 CALL                     1
   70 STORE_FAST               0 (graph_out_0)
   72 LOAD_GLOBAL              0 (__import_torch_dot__dynamo_dot_utils)
   82 LOAD_ATTR                3 (NULL|self + make_cell)
  102 CALL                     0
  110 STORE_FAST               2 (tmp_2)
  112 LOAD_FAST                0 (graph_out_0)
  114 LOAD_CONST               1 (0)
  116 BINARY_SUBSCR
  120 LOAD_DEREF               3 (inc)
  122 LOAD_ATTR                6 (__closure__)
  142 LOAD_CONST               1 (0)
  144 BINARY_SUBSCR
  148 STORE_ATTR               2 (cell_contents)
  158 DELETE_FAST              0 (graph_out_0)
  160 RETURN_CONST             0 (None)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec