### PR TITLE
[fuzzing result][fuzz_torch_jit_lite_interpreter] read-heap-buffer-overflow (size 4) in c10::IValue::IValue()

### DIFF
--- a/aten/src/ATen/core/stack.h
+++ b/aten/src/ATen/core/stack.h
@@ -103,6 +103,9 @@ inline void drop(Stack* stack, size_t n) {
   drop(*stack, n);
 }
 inline IValue pop(Stack& stack) {
+  if (stack.empty()) {
+    throw std::runtime_error("pop() called on empty stack");
+  }
   auto r = std::move(stack.back());
   stack.pop_back();
   return r;


### PR DESCRIPTION
Summary: Calling `pop()` on empty stack

Test Plan: CI

Differential Revision: D64332420
