### PR TITLE
Use filelock to build extension_device backend one at a time

### DIFF
--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -54,9 +54,7 @@ class BaseExtensionBackendTests(TestCase):
     module = None
 
     # Use a lock file so that only one test can build this extension at a time
-    lock_file = os.path.join(
-        torch.utils.cpp_extension.get_default_build_root(), "extension_device.lock"
-    )
+    lock_file = "extension_device.lock"
     lock = FileLock(lock_file)
 
     @classmethod
@@ -90,6 +88,9 @@ class BaseExtensionBackendTests(TestCase):
         super().tearDownClass()
 
         torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
+
+        if os.path.exists(cls.lock_file):
+            os.remove(cls.lock_file)
         cls.lock.release()
 
     def setUp(self):

--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 import os
 import sys
+import tempfile
 import unittest
 
 import torch
@@ -50,6 +51,9 @@ TestCase = test_torchinductor.TestCase
 
 class BaseExtensionBackendTests(TestCase):
     module = None
+    # Use a temp dir as build root as there might be multiple tests trying to
+    # build the same extension at the same time
+    build_directory = tempfile.mkdtemp()
 
     @classmethod
     def setUpClass(cls):
@@ -67,6 +71,7 @@ class BaseExtensionBackendTests(TestCase):
                 str(source_file),
             ],
             extra_cflags=["-g"],
+            build_directory=cls.build_directory,
             verbose=True,
         )
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/136125
Fixes https://github.com/pytorch/pytorch/issues/137026
Fixes https://github.com/pytorch/pytorch/issues/137027

The compilation fails during `setUpClass`, so disabling the test doesn't do nothing.  The theory I have for this flaky issue is that `test_open_device_registration` from both `TritonExtensionBackendTests` and `ExtensionBackendTests` are run in parallel and cleaned up while the other is still in fly, causing flaky failure.

Here is an example failure https://github.com/pytorch/pytorch/actions/runs/11331105492/job/31512603585#step:22:1710

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang