### PR TITLE
Make masked_scatter core aten

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8015,6 +8015,7 @@
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: masked_scatter
+  tags: core
 
 - func: masked_scatter_backward(Tensor grad_output, Tensor mask, SymInt[] sizes) -> Tensor
   dispatch:


### PR DESCRIPTION
Summary: Making `masked_scatter` core aten since it is hard to decompose and we now have a portable kernel for it

Test Plan: N/A

Differential Revision: D64368725


