### PR TITLE
[AMD] Do not skip 0-byte send/recv

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -557,9 +557,7 @@ constexpr auto count_max =
 // https://github.com/NVIDIA/nccl/issues/696. The issue of skipping send/recv
 // is that it can cause deadlock when a rank send and recv 0 bytes so it's
 // completely skipping the collective, causing mismatch across ranks
-// Note: on AMD GPU, we're running into hang w/ 0 byte send/recv, so we're
-// skipping this for ROCm for now
-#if !defined(USE_ROCM) && defined(NCCL_MAJOR) && \
+#if defined(NCCL_MAJOR) && \
     ((NCCL_MAJOR > 2) || ((NCCL_MAJOR == 2) && (NCCL_MINOR > 13)))
 template <typename T>
 constexpr bool _nccl_should_send_recv(C10_UNUSED T _unused_) {


### PR DESCRIPTION
Summary: With https://github.com/ROCm/rccl/pull/1376, we can remove this hack now and we have verified that we no longer run into hang

Test Plan: https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-xdwang-900def406a?job_attempt=0&version=1&env=PRODUCTION

Differential Revision: D64370817


