### PR TITLE
Revert D64266727: Multisect successfully blamed "D64266727: [ONNX] Remove ExportTypes (#137789)" for one test failure

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "symbolic_opset19",
     "symbolic_opset20",
     # Enums
+    "ExportTypes",
     "OperatorExportTypes",
     "TrainingMode",
     "TensorProtoDataType",
@@ -55,6 +56,7 @@ from torch import _C
 from torch._C import _onnx as _C_onnx
 from torch._C._onnx import OperatorExportTypes, TensorProtoDataType, TrainingMode
 
+from ._exporter_states import ExportTypes
 from ._internal.exporter._onnx_program import ONNXProgram
 from ._internal.onnxruntime import (
     is_onnxrt_backend_supported,
@@ -111,6 +113,7 @@ if TYPE_CHECKING:
 # Set namespace for exposed private names
 DiagnosticOptions.__module__ = "torch.onnx"
 ExportOptions.__module__ = "torch.onnx"
+ExportTypes.__module__ = "torch.onnx"
 JitScalarType.__module__ = "torch.onnx"
 ONNXProgram.__module__ = "torch.onnx"
 ONNXRuntimeOptions.__module__ = "torch.onnx"

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -26,7 +26,7 @@ import numpy.typing as npt
 import torch
 import torch._C._onnx as _C_onnx
 from torch import _C
-from torch.onnx import _constants, _experimental, utils
+from torch.onnx import _constants, _experimental, _exporter_states, utils
 from torch.onnx._globals import GLOBALS
 from torch.onnx._internal import onnx_proto_utils
 from torch.types import Number
@@ -893,7 +893,8 @@ def verify_aten_graph(
         graph, export_options, onnx_params_dict
     )
     model_f: str | io.BytesIO = io.BytesIO()
-    onnx_proto_utils._export_file(proto, model_f, export_map)
+    export_type = _exporter_states.ExportTypes.PROTOBUF_FILE
+    onnx_proto_utils._export_file(proto, model_f, export_type, export_map)
 
     # NOTE: Verification is unstable. Try catch to emit information for debugging.
     try:


### PR DESCRIPTION
Summary:
This diff reverts D64266727
D64266727: [ONNX] Remove ExportTypes (#137789) by generatedunixname499836121 causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_witflow_test#main](https://www.internalfb.com/intern/test/281475020844955/)

Here's the Multisect link:
https://www.internalfb.com/multisect/12123947
Here are the tasks that are relevant to this breakage:
T191381482: 500+ CI signals unhealthy for assistant_studio

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Test Plan: NA

Reviewed By: lcpoletto

Differential Revision: D64288022


