### PR TITLE
Add getDeviceAllocator device agnostic API in accelerator hooks

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -97,7 +97,8 @@ class TORCH_API Context {
     } else if (device.is_meta()) {
       allocator = GetAllocator(kMeta);
     } else {
-      allocator = getAcceleratorHooksInterface(device.type()).getDeviceAllocator();
+      allocator =
+          getAcceleratorHooksInterface(device.type()).getDeviceAllocator();
     }
     return allocator;
   }

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -90,6 +90,18 @@ class TORCH_API Context {
     }
   }
 
+  at::Allocator* getDeviceAllocator(Device device) {
+    at::Allocator* allocator = nullptr;
+    if (device.is_cpu()) {
+      allocator = GetAllocator(kCPU);
+    } else if (device.is_meta()) {
+      allocator = GetAllocator(kMeta);
+    } else {
+      allocator = getAcceleratorHooksInterface(device.type()).getDeviceAllocator();
+    }
+    return allocator;
+  }
+
   bool isPinnedPtr(
       const void* data,
       std::optional<c10::DeviceType> device_type = std::nullopt) {

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -72,6 +72,10 @@ struct TORCH_API AcceleratorHooksInterface {
       [[maybe_unused]] DeviceIndex device_index = -1) const {
     TORCH_CHECK(false, "Backend doesn`t support getNewGenerator()");
   }
+
+  virtual Allocator* getDeviceAllocator() const {
+    TORCH_CHECK(false, "Backend doesn`t support getDeviceAllocator()");
+  }
 };
 
 } // namespace at

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -134,6 +134,7 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
     TORCH_CHECK(false, "Pinned memory requires CUDA. ", CUDA_HELP);
   }
 
+  // deprecated use device-agnostic API getDeviceAllocator()
   virtual Allocator* getCUDADeviceAllocator() const {
     TORCH_CHECK(false, "CUDADeviceAllocator requires CUDA. ", CUDA_HELP);
   }

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -138,6 +138,10 @@ struct TORCH_API CUDAHooksInterface : AcceleratorHooksInterface {
     TORCH_CHECK(false, "CUDADeviceAllocator requires CUDA. ", CUDA_HELP);
   }
 
+  Allocator* getDeviceAllocator() const override {
+    return getCUDADeviceAllocator();
+  }
+
   virtual bool compiledWithCuDNN() const {
     return false;
   }

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -42,6 +42,9 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
   virtual Allocator* getMPSDeviceAllocator() const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
+  Allocator* getDeviceAllocator() const override {
+    FAIL_MPSHOOKS_FUNC(__func__);
+  }
   virtual void deviceSynchronize() const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -39,6 +39,7 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
       [[maybe_unused]] DeviceIndex device_index) const override {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
+  // deprecated use device-agnostic API getDeviceAllocator()
   virtual Allocator* getMPSDeviceAllocator() const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -60,6 +60,10 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
     FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
   }
 
+  Allocator* getDeviceAllocator() const override {
+    return GetAllocator(kPrivateUse1);
+  }
+
 #undef FAIL_PRIVATEUSE1HOOKS_FUNC
 };
 

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -11,7 +11,6 @@
 #include <ATen/quantized/Quantizer.h>
 #include <c10/core/CPUAllocator.h>
 #include <c10/util/accumulate.h>
-#include <ATen/Context.h>
 
 #include <cmath>
 #include <utility>

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -11,6 +11,7 @@
 #include <ATen/quantized/Quantizer.h>
 #include <c10/core/CPUAllocator.h>
 #include <c10/util/accumulate.h>
+#include <ATen/Context.h>
 
 #include <cmath>
 #include <utility>
@@ -111,19 +112,7 @@ inline Tensor new_qtensor(
     QuantizerPtr quantizer) {
   auto memory_format = options.memory_format_opt().value_or(MemoryFormat::Contiguous);
   auto device = options.device();
-  at::Allocator* allocator = nullptr;
-  // TODO: why isn't this just using GetAllocator
-  if (device.is_cuda()) {
-    allocator = at::detail::getCUDAHooks().getCUDADeviceAllocator();
-  } else if (device.is_cpu()) {
-    allocator = at::getCPUAllocator();
-  } else if (device.is_meta()) {
-    allocator = GetAllocator(kMeta);
-  } else if (device.is_privateuseone()) {
-    allocator = GetAllocator(kPrivateUse1);
-  } else {
-    TORCH_INTERNAL_ASSERT(0, "unrecognized device for new_qtensor: ", device);
-  }
+  Allocator* allocator = globalContext().getDeviceAllocator(device);
 
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK) {


### PR DESCRIPTION
Make `AcceleratorHooksInterface` consistent for multiple accelerators
- Add `getDeviceAllocator` method declaration in `AcceleratorHooksInterface` for device extension
- Add `getDeviceAllocator` in `Context.h` to avoid expose device relative logic to other modules
- Remove `virtual` to fix lint errors

cc @albanD @ezyang @FFFrog 