### PR TITLE
Fix layout for SetSourceTensorKernel

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -639,6 +639,66 @@ class CPUReproTests(TestCase):
             change_input_sizes=True,
         )
 
+    def test_set_source_Tensor(self):
+        class MaskedConv2d(torch.nn.Conv2d):
+            def __init__(
+                self,
+                *,
+                in_channels: int,
+                out_channels: int,
+                kernel_size: int,
+                padding: int = 0,
+            ) -> None:
+                super().__init__(
+                    in_channels, out_channels, kernel_size, padding=padding
+                )
+                mask = torch.zeros_like(self.weight)
+
+                mask[:, :, : kernel_size // 2, :] = 1
+                mask[:, :, kernel_size // 2, : kernel_size // 2] = 1
+                self.register_buffer("mask", mask)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                with torch.no_grad():
+                    self.weight.data *= self.mask
+                return super().forward(x)
+
+        class M(torch.nn.Module):
+            def __init__(
+                self, num_channels: int, num_colors: int, H: int, W: int
+            ) -> None:
+                super().__init__()
+                self.num_channels = num_channels
+                self.num_colors = num_colors
+                self.H = H
+                self.W = W
+                kernel_size = 7
+                padding = (kernel_size - 1) // 2
+                # 1 7x7 Mask
+                layers = [
+                    MaskedConv2d(
+                        in_channels=self.num_channels,
+                        out_channels=64,
+                        kernel_size=kernel_size,
+                        padding=padding,
+                    ),
+                ]
+                self.model = nn.Sequential(*layers)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                x = x.permute(0, 3, 1, 2)
+                return self.model(x)
+
+        model = M(H=32, W=32, num_channels=4, num_colors=2)
+        fn_opt = torch._dynamo.optimize("inductor")(model)
+        v = (torch.rand(10, 32, 32, 4) > 0.5).to(torch.float32)
+        inps = [
+            v.clone(),
+        ]
+        result, code = run_and_get_cpp_code(fn_opt, *inps)
+        self.assertTrue("aten.set_.source_Tensor" in code)
+        self.assertEqual(model(*inps), result)
+
     @torch._dynamo.config.patch(dynamic_shapes=True)
     @torch._dynamo.config.patch(assume_static_by_default=False)
     @torch._dynamo.config.patch(allow_rnn=True)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5720,9 +5720,9 @@ class ResizeStorageBytes(MutatingFirstArgExternKernel):
 
 class SetSourceTensorKernel(ExternKernelAlloc):
     def __init__(self, self_tensor, storage_tensor):
-        self_tensor.freeze_layout()
+        storage_tensor.freeze_layout()
         super().__init__(
-            self_tensor.get_layout(),
+            storage_tensor.get_layout(),
             [self_tensor, storage_tensor],
             python_kernel_name="torch.ops.aten.set_.source_Tensor",
             op_overload=torch.ops.aten.set_.source_Tensor,


### PR DESCRIPTION
Fixes #136837.
`aten.set_.source_Tensor` will make the size and stride of the first input and output follow that of the second input: https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/TensorShape.cpp#L440. If the layouts of the two inputs are different, the following `assert_size_stride` will fail.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov