### PR TITLE
skip lintrunner install on Windows.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ filelock
 networkx
 jinja2
 fsspec
-lintrunner ; platform_system != "Windows"
+lintrunner ; platform_system != "Windows" or (platform_system == "Windows" and platform_machine == "x86")
 ninja
 packaging
 optree>=0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ filelock
 networkx
 jinja2
 fsspec
-lintrunner
+lintrunner ; platform_system != "Windows"
 ninja
 packaging
 optree>=0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ filelock
 networkx
 jinja2
 fsspec
-lintrunner ; platform_system != "Windows" or (platform_system == "Windows" and platform_machine == "x86")
+lintrunner ; platform_system != "Windows"
 ninja
 packaging
 optree>=0.13.0


### PR DESCRIPTION
`lintrunner` is not support Windows x64. Ref: https://pypi.org/project/lintrunner/#files 

When we install python dependency by `pip install -r requirements.txt` on Windows x64, it will failed on `lintrunner`.
<img width="887" alt="image" src="https://github.com/user-attachments/assets/e3815177-e893-41ae-96af-8b39d12f74a7">

Solution: skip install `lintrunner` on Windows.
Reference doc: https://peps.python.org/pep-0508/#environment-markers 

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @iremyux @Blackhex @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10