### PR TITLE
[pytorch_operator_stats] log if using torchscript runtime

### DIFF
--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -115,6 +115,10 @@ struct TLSCurrentInterpreterGuard {
   InterpreterStateImpl* prev_state_;
 };
 
+bool in_torchscript_runtime() {
+  return tls_int_state_ptr_ != nullptr;
+}
+
 // InterpreterState state that and used to compute a Code
 struct InterpreterStateImpl : c10::intrusive_ptr_target {
   InterpreterStateImpl(const Code& code, TaskLauncher taskLauncher)

--- a/torch/csrc/jit/runtime/interpreter.h
+++ b/torch/csrc/jit/runtime/interpreter.h
@@ -40,6 +40,8 @@ using Stack = std::vector<c10::IValue>;
 using c10::ivalue::Future;
 using TaskLauncher = std::function<void(std::function<void()>)>;
 
+bool TORCH_API in_torchscript_runtime();
+
 struct TORCH_API Code {
   Code() = default;
   explicit Code(interpreter::CodeImpl* pImpl);


### PR DESCRIPTION
Summary: logs if an operator is run with the TorchScript runtime, using a thread_local variable set in `InterpreterState.run()`

Test Plan: buck2 run mode/dev-nosan caffe2/torch/fb/observers:scuba_observer_runner

Reviewed By: zou3519

Differential Revision: D64200781


