### PR TITLE
fixup! Remove unused Python variables in torch/[_-a]*

### DIFF
--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -274,6 +274,7 @@ def _create_runtime_wrapper(
     if config.unlift_effect_tokens:
         assert len(runtime_metadata.tokens) == 0
 
+    replay_views = config.view_replay_for_aliased_outputs
     if runtime_metadata.num_outputs_aliased > 0:
         output_handlers = tuple(
             make_output_handler(info, runtime_metadata, trace_joint)
@@ -1061,6 +1062,11 @@ class AOTSyntheticBaseWrapper(CompilerWrapper):
         self.aliased_arg_idx_with_metadata_mutations = (
             aliased_arg_idx_with_metadata_mutations
         )
+
+        num_aliased_args_with_metadata_mutations = len(
+            aliased_arg_idx_with_metadata_mutations
+        )
+
         replay_views = config.view_replay_for_aliased_outputs
 
         def _unpack_synthetic_bases(primals: Tuple[Any, ...]) -> List[Any]:
@@ -1849,7 +1855,7 @@ To fix this, your tensor subclass must implement the dunder method __force_to_sa
                                 )
 
                     # Get the number of tangents after unwrapping
-                    len_tangents = len(  # noqa: F841
+                    len_tangents = len(
                         unwrap_tensor_subclasses(
                             tangents,
                             is_joint_structure=False,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

