### PR TITLE
Use sha256 rather than md5 to compute log digest

### DIFF
--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -1185,7 +1185,7 @@ def trace_structured(
                 else:
                     # force newlines so we are unlikely to overflow line limit
                     payload = json.dumps(payload, indent=0)
-            h = hashlib.md5()
+            h = hashlib.sha256()
             h.update(payload.encode("utf-8"))
             record["has_payload"] = h.hexdigest()
         trace_log.debug(


### PR DESCRIPTION
`md5` is just too weak, isn't it? Though may be md5 is fine here if we want to spend minimal amount of time computing the signature
