### PR TITLE
[BE] Move numpy installation logic to `requirements-ci.txt`

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -66,15 +66,8 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   if [[ $(uname -m) == "aarch64" ]]; then
     CONDA_COMMON_DEPS="astunparse pyyaml setuptools openblas==0.3.25=*openmp* ninja==1.11.1 scons==4.5.2"
-    NUMPY_VERSION=1.26.2
   else
     CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
-
-    if [ "$ANACONDA_PYTHON_VERSION" = "3.11" ] || [ "$ANACONDA_PYTHON_VERSION" = "3.12" ] || [ "$ANACONDA_PYTHON_VERSION" = "3.13" ]; then
-      NUMPY_VERSION=1.26.0
-    else
-      NUMPY_VERSION=1.21.2
-    fi
   fi
   conda_install ${CONDA_COMMON_DEPS}
 
@@ -98,7 +91,6 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
 
   # Install some other packages, including those needed for Python test reporting
   pip_install -r /opt/conda/requirements-ci.txt
-  pip_install numpy=="$NUMPY_VERSION"
   pip_install -U scikit-learn
 
   if [ -n "$DOCS" ]; then

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -128,6 +128,8 @@ numba==0.55.2 ; python_version == "3.10"
 #test_nn.py, test_namedtensor.py, test_linalg.py, test_jit_cuda_fuser.py,
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
+numpy==1.26.2; python_version < 3.13
+numpy==2.1.2; python_version == 3.13
 
 #onnxruntime
 #Description: scoring engine for Open Neural Network Exchange (ONNX) models

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -128,7 +128,8 @@ numba==0.55.2 ; python_version == "3.10"
 #test_nn.py, test_namedtensor.py, test_linalg.py, test_jit_cuda_fuser.py,
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
-numpy==1.26.2; python_version < "3.13"
+numpy==1.21.2; python_version < "3.11" and platform_machine == "x86_64"
+numpy==1.26.2; (python_version >= "3.11" and python_version < "3.13") or platform_machine != "x86_64"
 numpy==2.1.2; python_version >= "3.13"
 
 #onnxruntime

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -129,7 +129,7 @@ numba==0.55.2 ; python_version == "3.10"
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
 numpy==1.21.2; python_version < "3.11" and platform_machine == "x86_64"
-numpy==1.26.2; (python_version >= "3.11" and python_version < "3.13") or platform_machine != "x86_64"
+numpy==1.26.2; (python_version >= "3.11" or platform_machine != "x86_64") and python_version < "3.13"
 numpy==2.1.2; python_version >= "3.13"
 
 #onnxruntime

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -128,9 +128,9 @@ numba==0.55.2 ; python_version == "3.10"
 #test_nn.py, test_namedtensor.py, test_linalg.py, test_jit_cuda_fuser.py,
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
-numpy==1.21.2; python_version == "3.9" and platform_machine == "x86_64"
-numpy==1.22.4; python_version == "3.10" and platform_machine == "x86_64"
-numpy==1.26.2; (python_version >= "3.11" or platform_machine != "x86_64") and python_version < "3.13"
+numpy==1.21.2; python_version == "3.9"
+numpy==1.22.4; python_version == "3.10"
+numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
 numpy==2.1.2; python_version >= "3.13"
 
 #onnxruntime

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -118,7 +118,7 @@ numba==0.55.2 ; python_version == "3.10"
 
 #numpy
 #Description: Provides N-dimensional arrays and linear algebra
-#Pinned versions: 1.20
+#Pinned versions: 1.26.2
 #test that import: test_view_ops.py, test_unary_ufuncs.py, test_type_promotion.py,
 #test_type_info.py, test_torch.py, test_tensorexpr_pybind.py, test_tensorexpr.py,
 #test_tensorboard.py, test_tensor_creation_ops.py, test_static_runtime.py,
@@ -128,8 +128,8 @@ numba==0.55.2 ; python_version == "3.10"
 #test_nn.py, test_namedtensor.py, test_linalg.py, test_jit_cuda_fuser.py,
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
-numpy==1.26.2; python_version < 3.13
-numpy==2.1.2; python_version == 3.13
+numpy==1.26.2; python_version < "3.13"
+numpy==2.1.2; python_version >= "3.13"
 
 #onnxruntime
 #Description: scoring engine for Open Neural Network Exchange (ONNX) models
@@ -344,7 +344,6 @@ parameterized==0.8.1
 #Pinned versions:
 #test that import:
 
-numpy>=1.22.4 ; python_version >= "3.8"
 #Description: required for testing torch/distributed/_tools/sac_estimator.py
 #Pinned versions: 1.24.0
 #test that import: test_sac_estimator.py

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -128,7 +128,8 @@ numba==0.55.2 ; python_version == "3.10"
 #test_nn.py, test_namedtensor.py, test_linalg.py, test_jit_cuda_fuser.py,
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
-numpy==1.21.2; python_version < "3.11" and platform_machine == "x86_64"
+numpy==1.21.2; python_version == "3.9" and platform_machine == "x86_64"
+numpy==1.22.4; python_version == "3.10" and platform_machine == "x86_64"
 numpy==1.26.2; (python_version >= "3.11" or platform_machine != "x86_64") and python_version < "3.13"
 numpy==2.1.2; python_version >= "3.13"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #137995
* #138024
* #138023
* __->__ #137992

And slightly adjust versioning logic, as current one seems to exist to hide version conflicts:
 - 1.21.2 for Python-3.9
 - 1.24.2 for Python-3.10 (to resolve conflict with numba-0.55.2)
 - 1.26.2 for Python-3.11 or 3.12
 - 2.1.2 for Python-3.13
