### PR TITLE
preserve module signature with multiple calls

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6168,11 +6168,16 @@ graph():
         inp = (torch.ones(1),)
 
         class N(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.const = torch.ones(1) * 4
+                self.buf = torch.nn.Buffer(torch.ones(1) * 4)
+
             def forward(self, x, b):
                 if b:
-                    return x + 1
+                    return x + self.const + 1
                 else:
-                    return x + 2
+                    return x + 2 * (self.buf + 1) - self.const
 
         class M(torch.nn.Module):
             def __init__(self):
@@ -6188,37 +6193,39 @@ graph():
         m = M()
         eager_result = m(*inp)
 
+        def test(ep, swap):
+            epm = ep.module()
+            ufm = torch.export.unflatten(ep)
+
+            exported_result = epm(*inp)
+            self.assertTrue(torch.allclose(exported_result, eager_result))
+
+            unflattened_result = ufm(*inp)
+            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+
+            for fqn, mod in swap.items():
+                ufm.set_submodule(fqn, mod)
+            unflattened_result = ufm(*inp)
+            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+
         if not is_retracebility_test(self._testMethodName):
-            ep = export(M(), inp, preserve_module_call_signature=("n",))
-            with self.assertRaisesRegex(
-                ValueError,
-                "Cannot unflatten multiple calls to module n while preserving its signature",
-            ):
-                torch.export.unflatten(ep)
-
-        ep = export(M(), inp)
-        print(ep)
-        epm = ep.module()
-        ufm = torch.export.unflatten(ep)
-
-        exported_result = epm(*inp)
-        self.assertTrue(torch.allclose(exported_result, eager_result))
-
-        unflattened_result = ufm(*inp)
-        self.assertTrue(torch.allclose(unflattened_result, eager_result))
+            test(
+                export(M(), inp, preserve_module_call_signature=("n",)),
+                swap={"n": N(), "n@1": N()},
+            )
 
         class _N(torch.nn.Module):
             def forward(self, x):
-                return x + 1
+                return x + 5
 
         class _N_1(torch.nn.Module):
             def forward(self, x):
-                return x + 2
+                return x + 6
 
-        ufm.set_submodule("n", _N())
-        ufm.set_submodule("n@1", _N_1())
-        unflattened_result = ufm(*inp)
-        self.assertTrue(torch.allclose(unflattened_result, eager_result))
+        test(
+            export(M(), inp),
+            swap={"n": _N(), "n@1": _N_1()},
+        )
 
     def test_preserve_module_call_signature_unflatten_specialization(self):
         class N(torch.nn.Module):
@@ -6257,7 +6264,7 @@ graph():
             unflattened_result = ufm(*inp)
             self.assertTrue(torch.allclose(unflattened_result, eager_result))
 
-    def test_unflatten_multiple_graphs_preserve_signature_error(self):
+    def test_unflatten_multiple_graphs_preserve_signature_no_error(self):
         class N(torch.nn.Module):
             def forward(self, x, b):
                 if b:
@@ -6271,33 +6278,31 @@ graph():
                 self.n = N()
 
             def forward(self, x):
+                x = x + 3
                 x = self.n(x, True)
-                x = x + 1
+                x = x + 4
                 x = self.n(x, False)
-                x = x + 1
+                x = x + 5
                 return x
 
         inp = (torch.ones(1),)
         m = M()
         eager_result = m(*inp)
 
+        def test(ep):
+            epm = ep.module()
+            ufm = torch.export.unflatten(ep)
+
+            exported_result = epm(*inp)
+            self.assertTrue(torch.allclose(exported_result, eager_result))
+
+            unflattened_result = ufm(*inp)
+            self.assertTrue(torch.allclose(unflattened_result, eager_result))
+
         if not is_retracebility_test(self._testMethodName):
-            ep = export(M(), inp, preserve_module_call_signature=("n",))
-            with self.assertRaisesRegex(
-                ValueError,
-                "Cannot unflatten multiple calls to module n while preserving its signature",
-            ):
-                torch.export.unflatten(ep)
+            test(export(M(), inp, preserve_module_call_signature=("n",)))
 
-        ep = export(M(), inp)
-        epm = ep.module()
-        ufm = torch.export.unflatten(ep)
-
-        exported_result = epm(*inp)
-        self.assertTrue(torch.allclose(exported_result, eager_result))
-
-        unflattened_result = ufm(*inp)
-        self.assertTrue(torch.allclose(unflattened_result, eager_result))
+        test(export(M(), inp))
 
     def test_unflatten_multiple_graphs_state(self):
         class N(torch.nn.Module):
@@ -6330,6 +6335,16 @@ graph():
         inp = (torch.ones(1),)
         m = M()
         eager_result = m(*inp)
+
+        if not is_retracebility_test(self._testMethodName):
+            with self.assertRaisesRegex(
+                ValueError,
+                r"Found multiple calls of module n that mutate buffer n.buf",
+            ):
+                # Unflattening while preserving signatures is NYI for this case.
+                torch.export.unflatten(
+                    export(M(), inp, preserve_module_call_signature=("n",))
+                )
 
         ep = export(M(), inp)
         epm = ep.module()

--- a/torch/_export/passes/collect_tracepoints_pass.py
+++ b/torch/_export/passes/collect_tracepoints_pass.py
@@ -66,6 +66,18 @@ class CollectTracepointsPass(PassBase):
                     node.meta["nn_module_stack"].popitem()
                 else:
                     nn_module_stack = None
+
+        def copy_sig(sig):
+            from torch.export.exported_program import ModuleCallSignature
+
+            return ModuleCallSignature(
+                inputs=[],
+                outputs=[],
+                in_spec=sig.in_spec,
+                out_spec=sig.out_spec,
+                forward_arg_names=None,
+            )
+
         for module in gm.modules():
             if not isinstance(module, torch.fx.GraphModule):
                 continue
@@ -73,16 +85,19 @@ class CollectTracepointsPass(PassBase):
                 if node.op != "call_function":
                     continue
                 if node.target == torch.ops.higher_order._export_tracepoint:
+                    path = node.kwargs["path"]
+                    module_key = next(reversed(node.meta["nn_module_stack"]))
+                    if "@" in module_key:
+                        call_path = f"{path}@{module_key.split('@')[-1]}"
+                        if call_path not in self.specs:
+                            self.specs[call_path] = copy_sig(self.specs[path])
+                        path = call_path
+                    kind = node.kwargs["kind"]
                     for i, arg in enumerate(node.args):
-                        kind = node.kwargs["kind"]
                         if kind == "module_call_inputs":
-                            self.specs[node.kwargs["path"]].inputs.append(
-                                get_arg_spec(arg)
-                            )
+                            self.specs[path].inputs.append(get_arg_spec(arg))
                         elif kind == "module_call_outputs":
-                            self.specs[node.kwargs["path"]].outputs.append(
-                                get_arg_spec(arg)
-                            )
+                            self.specs[path].outputs.append(get_arg_spec(arg))
                         else:
                             raise AssertionError(f"Unknown tracepoint kind: {kind}")
                         if isinstance(arg, torch.fx.Node):

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -505,25 +505,29 @@ def _get_module_hierarchy(mod: torch.nn.Module) -> Dict[str, str]:
 
 
 def _make_module_call_graph(
-    module_hierarchy: Dict[str, str],
     in_spec: TreeSpec,
     out_spec: TreeSpec,
     module_call_signatures: Dict[str, ModuleCallSignature],
     forward_arg_names: Optional[List[str]] = None,
 ) -> List[ModuleCallEntry]:
-    ret = [
+    original = [
         ModuleCallEntry(fqn=fqn, signature=module_call_signatures.get(fqn))
-        for fqn in module_hierarchy
+        for fqn in _EXPORT_MODULE_HIERARCHY  # type: ignore[union-attr]
     ]
-    assert ret[0].fqn == ""
-    ret[0].signature = ModuleCallSignature(
+    assert original[0].fqn == ""
+    original[0].signature = ModuleCallSignature(
         inputs=[],
         outputs=[],
         in_spec=in_spec,
         out_spec=out_spec,
         forward_arg_names=forward_arg_names,
     )
-    return ret
+    additional = [
+        ModuleCallEntry(fqn=fqn, signature=signature)
+        for fqn, signature in module_call_signatures.items()
+        if fqn not in _EXPORT_MODULE_HIERARCHY  # type: ignore[operator]
+    ]
+    return [*original, *additional]
 
 
 def _export_to_torch_ir(
@@ -1103,7 +1107,6 @@ def _get_module_call_graph(
 
     assert _EXPORT_MODULE_HIERARCHY is not None
     module_call_graph = _make_module_call_graph(
-        _EXPORT_MODULE_HIERARCHY,
         original_in_spec,
         out_spec,
         module_call_signatures,


### PR DESCRIPTION
Previously we would error when trying to preserve the call signature for a module when it was called multiple times. This PR can now do this without erroring. The fix is to propagate call indices in a few more places.

Note that while this works in the presence of params, buffers, and tensor constants, preserving call signatures for multiple calls to a module when buffers are mutated is not supported yet. This is future work. The main problem is that we do not have enough metadata to `copy_` mutated buffers at the end of each call to a module, so the next call can read those buffers at the beginning. Making this work will likely need some explicit tracking of intermediate values of mutated buffers when collecting metadata during functionalization in export.

Note also that we stop short of creating a single graph out of multiple graphs: that is still future work. So the unflattened module will still have different targets `n`, `n@1`, `n@2`, etc. for each call when we ask the module call signature of `n` to be preserved. However it is way easier to swap all of these targets with a replacement that behaves similar to the original, because all of these calls will respect the original module call signature. (In particular, any constant inputs will be carried by the calls.)


Differential Revision: D64406945
