### PR TITLE
Increase default COMPILE_STROBELIGHT_MAX_STACK_LENGTH to 500

### DIFF
--- a/torch/_strobelight/compile_time_profiler.py
+++ b/torch/_strobelight/compile_time_profiler.py
@@ -93,7 +93,7 @@ class StrobelightCompileTimeProfiler:
     profiler: Optional[Any] = None
 
     max_stack_length: int = int(
-        os.environ.get("COMPILE_STROBELIGHT_MAX_STACK_LENGTH", 127)
+        os.environ.get("COMPILE_STROBELIGHT_MAX_STACK_LENGTH", 500)
     )
     max_profile_time: int = int(
         os.environ.get("COMPILE_STROBELIGHT_MAX_PROFILE_TIME", 60 * 30)


### PR DESCRIPTION
Summary: pt2 call stacks are long, this reduces truncated stack
<img width="1363" alt="Screenshot 2024-10-15 at 11 35 11 AM" src="https://github.com/user-attachments/assets/d09a8fb5-eafc-4440-ab58-464889dc6df8">
<img width="1373" alt="Screenshot 2024-10-15 at 11 35 26 AM" src="https://github.com/user-attachments/assets/c4c9c245-54d1-4e35-b16f-029ece335e03">

Differential Revision: D64414746


