### PR TITLE
aten | Fix set but unused variables warning in release builds.

### DIFF
--- a/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
@@ -37,7 +37,10 @@ void cpu_max_unpool(
 
   // treat batch size and channels as one dimension
   // and the feature map as another dimension
-  [[maybe_unused]] int64_t channels, output_depth, output_height, output_width;
+  int64_t channels = 0;
+  [[maybe_unused]] int64_t output_depth = 0;
+  [[maybe_unused]] int64_t output_height = 0;
+  [[maybe_unused]] int64_t output_width = 0;
   if constexpr (is_3d) {
     TORCH_CHECK(ndim == 4 || ndim == 5, "MaxUnpool3d: expect input to be 4d or 5d tensor.");
     channels = ndim == 4 ? input.size(0) : input.size(0) * input.size(1);
@@ -174,7 +177,10 @@ void cpu_max_unpool_backward(
 
   // treat batch size and channels as one dimension
   // and the feature map as another dimension
-  int64_t channels, output_depth, output_height, output_width;
+  int64_t channels = 0;
+  [[maybe_unused]] int64_t output_depth = 0;
+  [[maybe_unused]] int64_t output_height = 0;
+  [[maybe_unused]] int64_t output_width = 0;
   if (is_3d) {
     TORCH_CHECK(ndim == 4 || ndim == 5, "MaxUnpool3d_backward: expect grad_output to be 4d or 5d tensor.");
     channels = ndim == 4 ? grad_output.size(0) : grad_output.size(0) * grad_output.size(1);


### PR DESCRIPTION
Summary: Fixing a warning that happens only in release builds.

Test Plan: Sandcastle + dependent diffs

Reviewed By: boguscoder

Differential Revision: D64415854




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10