### PR TITLE
[PyTorch] Don't hardcode 4 * Vec::size() in vectorized_reduction

### DIFF
--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -97,7 +97,8 @@ inline void vectorized_outer_reduction(char** data, int64_t inner_stride, int64_
   VEC_LOOP_HEADER(func_t, data)
 
   // reduce down each column of 4 * Vec::size() elements.
-  int64_t outer_stride[2] = { 4 * Vec::size(), 4 * Vec::size() };
+  const int64_t vector_stride = 4 * Vec::size() * sizeof(scalar_t);
+  int64_t outer_stride[2] = { stride, stride };
   UNARY_OUTER_LOOP(data, outer_stride, size1 / (4 * Vec::size()), [&] {
     vectorized_reduction(data, size0, inner_stride, op, vop, /*reduce=*/false);
   });

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -81,7 +81,7 @@ inline void UNARY_OUTER_LOOP(char* data[2], const int64_t strides[2], int64_t n,
 template <typename func_t, typename vec_func_t>
 inline void vectorized_inner_reduction(char** data, int64_t n, func_t op, vec_func_t vop) {
   VEC_LOOP_HEADER(func_t, data)
-  int64_t vector_stride = 4 * Vec::size() * sizeof(scalar_t);
+  constexpr int64_t vector_stride = 4 * Vec::size() * sizeof(scalar_t);
   int64_t count = n / (4 * Vec::size());
   if (count > 0) {
     vectorized_reduction(data, count, vector_stride, op, vop, /*reduce=*/true);
@@ -97,8 +97,8 @@ inline void vectorized_outer_reduction(char** data, int64_t inner_stride, int64_
   VEC_LOOP_HEADER(func_t, data)
 
   // reduce down each column of 4 * Vec::size() elements.
-  const int64_t vector_stride = 4 * Vec::size() * sizeof(scalar_t);
-  int64_t outer_stride[2] = { stride, stride };
+  constexpr int64_t vector_stride = 4 * Vec::size() * sizeof(scalar_t);
+  int64_t outer_stride[2] = { vector_stride, vector_stride };
   UNARY_OUTER_LOOP(data, outer_stride, size1 / (4 * Vec::size()), [&] {
     vectorized_reduction(data, size0, inner_stride, op, vop, /*reduce=*/false);
   });

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -96,12 +96,8 @@ template <typename func_t, typename vec_func_t>
 inline void vectorized_outer_reduction(char** data, int64_t inner_stride, int64_t size0, int64_t size1, func_t op, vec_func_t vop) {
   VEC_LOOP_HEADER(func_t, data)
 
-  // reduce down each column of 4 * Vec::size() elements (128 or 256 bytes)
-#if defined(CPU_CAPABILITY_AVX512)
-  int64_t outer_stride[2] = { 256, 256 };
-#else
-  int64_t outer_stride[2] = { 128, 128 };
-#endif
+  // reduce down each column of 4 * Vec::size() elements.
+  int64_t outer_stride[2] = { 4 * Vec::size(), 4 * Vec::size() };
   UNARY_OUTER_LOOP(data, outer_stride, size1 / (4 * Vec::size()), [&] {
     vectorized_reduction(data, size0, inner_stride, op, vop, /*reduce=*/false);
   });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138022
* __->__ #138014
* #137722

This will break once we support 128-bit vectors, and there's no reason to do it.

Differential Revision: [D64421982](https://our.internmc.facebook.com/intern/diff/D64421982/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10