### PR TITLE
Add option to use pinned memory for D2H in torch.save

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4337,6 +4337,17 @@ class TestSerialization(TestCase, SerializationMixin):
                 with zipfile.ZipFile(f) as zip_file:
                     zip_file.extractall(path=temp_dir)
 
+    def test_save_use_pin_memory_options(self):
+        sd = torch.nn.ModuleList([torch.nn.Linear(3, 5, device='cuda') for i in range(10)]).state_dict()
+        with TemporaryFileName() as f:
+            try:
+                torch.serialization.set_save_d2h_pin_memory_options(True)
+                torch.save(sd, f)
+                sd_loaded = torch.load(f, weights_only=True)
+                self.assertEqual(sd_loaded, sd)
+            finally:
+                torch.serialization.set_save_d2h_pin_memory_options(False)
+
     def run(self, *args, **kwargs):
         with serialization_method(use_zip=True):
             return super().run(*args, **kwargs)

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -273,9 +273,7 @@ class _StorageBase:
             storage = storage.clone()
         return storage
 
-    def to(
-        self, *, device: Union[str, torch.device], non_blocking: _bool = False
-    ) -> Union[_StorageBase, TypedStorage]:
+    def to(self, *, device: Union[str, torch.device], non_blocking: _bool = False):
         if isinstance(device, str):
             device = torch.device(device)
         return _to(self, device, non_blocking)


### PR DESCRIPTION
D2H to pinned memory significantly increases D2H bandwidth as compared to D2H to pageable (On my A100 ~1.4GB/s for `Memcpy DtoH (Device -> Pageable)` vs  ~12.6GB/s `Memcpy DtoH (Device -> Pinned)`.

However for the latter, if the `cudaHostAllocator` is not warmed up you do have to pay the cost for `cudaHostAlloc` within `torch.save`.

For a llama-style models, such as that in the script below I see ~14s without using pinned memory and ~11.3s using pinned memory https://gist.github.com/mikaylagawarecki/2f624656fef264ce2016d1dbe9034e0c on my A100

No pinned memory (default) -- see D2H bandwidth
<img width="1595" alt="Screenshot 2024-10-15 at 6 18 57 PM" src="https://github.com/user-attachments/assets/a2e25749-99de-4346-8e7c-a0f9bce0e5e0">

With pinned memory -- see D2H bandwidth
<img width="1594" alt="Screenshot 2024-10-15 at 6 18 25 PM" src="https://github.com/user-attachments/assets/f2f562c9-1425-40c3-a09f-d598d266035b">




Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138018
* #138011
* #137735

