### PR TITLE
[Record Function] Add Kwargs only USER_SCOPE Macro

### DIFF
--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -302,6 +302,31 @@ struct TORCH_API RecordFunction {
   template <typename F>
   void before(
       F fn,
+      c10::ArrayRef<const c10::IValue> args,
+      const std::unordered_map<std::string, IValue>* kwargs,
+      int64_t current_sequence_nr = -1) {
+    if (!isActive()) {
+      return;
+    }
+    kwinputs_ = *kwargs;
+    before(std::move(fn), args, current_sequence_nr);
+  }
+
+  template <typename F>
+  void before(
+      F fn,
+      const std::unordered_map<std::string, IValue>* kwargs,
+      int64_t current_sequence_nr = -1) {
+    if (!isActive()) {
+      return;
+    }
+    kwinputs_ = *kwargs;
+    before(fn, current_sequence_nr);
+  }
+
+  template <typename F>
+  void before(
+      F fn,
       const std::vector<IValue>* args,
       int64_t current_sequence_nr = -1) {
     before(
@@ -628,6 +653,13 @@ void record_function_with_scope_and_debug_handle(
 // RECORD_USER_SCOPE with inputs
 #define RECORD_USER_SCOPE_WITH_INPUTS(fn, inputs) \
   RECORD_FUNCTION_WITH_SCOPE(at::RecordScope::USER_SCOPE, fn, inputs)
+
+#define RECORD_USER_SCOPE_WITH_KWARGS_ONLY(fn, kwargs) \
+  RECORD_FUNCTION_WITH_SCOPE(                          \
+      at::RecordScope::USER_SCOPE,                     \
+      fn,                                              \
+      c10::ArrayRef<const c10::IValue>{},              \
+      kwargs)
 
 // Helper macro to pass in debug handle that is used to
 // post process events


### PR DESCRIPTION
Summary: Add a macro such that users can easily add a USER annotation with kwargs only

Test Plan: Will use D63801503 to test this E2E. Added unit test as well that makes sure that the kwargs get recorded correctly

Differential Revision: D64420328


