### PR TITLE
Added zb1p and zb-v schedules

### DIFF
--- a/docs/source/distributed.pipelining.rst
+++ b/docs/source/distributed.pipelining.rst
@@ -491,6 +491,8 @@ Pipeline Schedules
 
 .. autoclass:: ScheduleInterleavedZeroBubble
 
+.. autoclass:: ZeroBubbleAlgorithm
+
 .. autoclass:: PipelineScheduleSingle
   :members:
 

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -6,11 +6,11 @@ import os
 import sys
 import tempfile
 
-from model_registry import ModelWithKwargs, MultiMLP, MultiMLPWithDw
-from schedule_registry import ScheduleUnbalanced, ScheduleVShaped, ScheduleWithW
-
 import torch
 import torch.distributed as dist
+
+from model_registry import ModelWithKwargs, MultiMLP, MultiMLPWithDw
+from schedule_registry import ScheduleUnbalanced, ScheduleVShaped, ScheduleWithW
 from torch.distributed.pipelining import (
     _ScheduleForwardOnly,
     pipeline,
@@ -21,6 +21,7 @@ from torch.distributed.pipelining import (
     ScheduleInterleaved1F1B,
     ScheduleInterleavedZeroBubble,
     ScheduleLoopedBFS,
+    ZeroBubbleAlgorithm,
 )
 from torch.distributed.pipelining.schedules import _PipelineScheduleRuntime
 from torch.testing._internal.common_cuda import TEST_MULTIGPU
@@ -772,7 +773,10 @@ class ScheduleTest(MultiProcContinousTest):
 
         # Attach to a schedule
         schedule = ScheduleClass(
-            stages, chunks, loss_fn=full_loss_fn, enable_zero_bubble=True
+            stages,
+            chunks,
+            loss_fn=full_loss_fn,
+            zero_bubble_algorithm=ZeroBubbleAlgorithm.ZB2P,
         )
 
         for _ in range(2):

--- a/torch/distributed/pipelining/__init__.py
+++ b/torch/distributed/pipelining/__init__.py
@@ -8,6 +8,7 @@ from .schedules import (
     ScheduleInterleaved1F1B,
     ScheduleInterleavedZeroBubble,
     ScheduleLoopedBFS,
+    ZeroBubbleAlgorithm,
 )
 from .stage import build_stage, PipelineStage
 
@@ -25,4 +26,5 @@ __all__ = [
     "ScheduleInterleaved1F1B",
     "ScheduleLoopedBFS",
     "ScheduleInterleavedZeroBubble",
+    "ZeroBubbleAlgorithm",
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138034

Adds the ZB1P schedule in https://arxiv.org/pdf/2401.10241.

The ZB2P schedule might not be zero bubble when pp_group_size > 4. Proof:

![image](https://github.com/pytorch/pytorch/assets/13212964/fac4a738-c323-47c7-bcaa-c6cdd1cf20d7)

Since ZB2P generates longer schedules for some cases, and we might need a collective for fault tolerance all reduce at the end of every iteration for llama 4, so holding off to implement a more fancier ZBV schedule for now unless it would be useful.

Rebased/squashed from original PRs https://github.com/pytorch/pytorch/pull/130210, https://github.com/pytorch/pytorch/pull/132623

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @d4l3k @c-p-i-o