### PR TITLE
Add AOTI test

### DIFF
--- a/test/inductor/test_cuda_cpp_wrapper.py
+++ b/test/inductor/test_cuda_cpp_wrapper.py
@@ -177,6 +177,7 @@ if RUN_CUDA:
             BaseTest(f"test_unspec_inputs_{str(dtype)[6:]}")
             for dtype in test_torchinductor.test_dtypes
         ],
+        BaseTest("test_consecutive_split_cumprod"),
         BaseTest("test_pointwise_hermite_polynomial_he"),
         BaseTest("test_pointwise_hermite_polynomial_h"),
         BaseTest(


### PR DESCRIPTION
Summary:
add back the test that's removed in D63916320.

It should work now as D64361273 added back the workspace change.

Test Plan: CI

Differential Revision: D64442054




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang