### PR TITLE
[AOTI] Remove the non-ABI-compatible mode (part 2)

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -78,9 +78,6 @@ triton_kernel_default_layout_constraint = "flexible_layout"
 # use cpp wrapper instead of python wrapper
 cpp_wrapper = os.environ.get("TORCHINDUCTOR_CPP_WRAPPER", "0") == "1"
 
-# codegen cpp wrapper code in an ABI compatible mode
-abi_compatible = os.environ.get("TORCHINDUCTOR_ABI_COMPATIBLE", "1") == "1"
-
 c_shim_version = os.environ.get("TORCHINDUCTOR_C_SHIM_VERSION", "2")
 
 # dead code elimination

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -779,11 +779,6 @@ def _get_torch_related_args(
     if _IS_WINDOWS:
         libraries.append("sleef")
 
-    # Unconditionally import c10 for non-abi-compatible mode to use TORCH_CHECK - See PyTorch #108690
-    if not config.abi_compatible:
-        libraries.append("c10")
-        libraries_dirs.append(TORCH_LIB_PATH)
-
     return include_dirs, libraries_dirs, libraries
 
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4547,11 +4547,7 @@ class ExternKernel(InputsKernel):
 
     def get_kernel_name(self):
         return (
-            (
-                V.graph.wrapper_code.get_c_shim_func_name(self.cpp_kernel_name)  # type: ignore[attr-defined]
-                if config.abi_compatible
-                else self.cpp_kernel_name
-            )
+            V.graph.wrapper_code.get_c_shim_func_name(self.cpp_kernel_name)  # type: ignore[attr-defined]
             if V.graph.cpp_wrapper
             else self.python_kernel_name
         )
@@ -5151,11 +5147,7 @@ class ExternKernelOut(ExternKernel):
             and self.cpp_kernel_name == "torch::inductor::_mm_plus_mm"
         ):
             # For https://github.com/pytorch/pytorch/issues/128474
-            kernel_name = (
-                "aoti_torch__mm_plus_mm_out"
-                if config.abi_compatible
-                else "torch::inductor::_mm_plus_mm_out"
-            )
+            kernel_name = "aoti_torch__mm_plus_mm_out"
         else:
             kernel_name = self.get_kernel_name()
         wrapper.generate_extern_kernel_out(
@@ -5211,9 +5203,7 @@ class RandomSeeds(ExternKernelOut):
             # FIXME: Ideally we should only use at::_ops::randint_low_out::call here,
             # but the signature is different from is at::randint_out. Again,
             # we can simplify the code when only keeping an ABI-compatible version.
-            cpp_kernel_name="at::_ops::randint_low_out::call"
-            if config.abi_compatible
-            else "at::randint_out",
+            cpp_kernel_name="at::_ops::randint_low_out::call",
             op_overload=aten.randint.low_out,
         )
 
@@ -5395,7 +5385,7 @@ class InplaceBernoulliFallback(ExternKernel):
     def codegen(self, wrapper):
         (x,) = (t.codegen_reference() for t in self.inputs)
 
-        if V.graph.cpp_wrapper and config.abi_compatible:
+        if V.graph.cpp_wrapper:
             # Inductor doesn't really support aten Generator, so the Generator kwarg is always NULL here,
             # which needs to be explicitly generated for cpp wrapper
             wrapper.writeline(
@@ -5426,9 +5416,6 @@ class InplaceBernoulliFallback(ExternKernel):
         V.graph.mark_buffer_mutated(x.get_name())
         self.name = V.graph.register_buffer(self)
         V.graph.register_operation(self)
-        if not config.abi_compatible:
-            # TODO: this should be simplified once we switch to ABI-compatible only
-            self.cpp_kernel_name = "at::native::bernoulli_"
 
 
 # Used to deal with torch.complex types
@@ -5462,9 +5449,7 @@ class InplaceCopyFallback(ExternKernel):
             inputs,
             constant_args,
             python_kernel_name="aten.copy_",
-            cpp_kernel_name=(
-                "aoti_torch_copy_" if config.abi_compatible else "at::_ops::copy_::call"
-            ),
+            cpp_kernel_name="aoti_torch_copy_",
         )
         V.graph.mark_buffer_mutated(inputs[0].get_name())
         self.name = V.graph.register_buffer(self)
@@ -5655,9 +5640,7 @@ class IndexPutFallback(ExternKernel):
         self.indices = indices
         valid_indices = [i for i in indices if i is not None]
         tensors = [self.realize_input(x) for x in [x, values, *valid_indices]]
-        cpp_kernel_name = (
-            "aoti_torch_index_put_out" if config.abi_compatible else "at::index_put_out"
-        )
+        cpp_kernel_name = "aoti_torch_index_put_out"
         super().__init__(
             None,
             NoneLayout(x.get_device()),  # type: ignore[arg-type]
@@ -5784,26 +5767,6 @@ class AssertScalar(ExternKernel):
 class ExternKernelNode:
     name: str
     node: export_schema.Node
-
-
-has_c_shim = OrderedSet(
-    [
-        aten._embedding_bag.default,
-        aten._fft_c2c.default,
-        aten._scaled_dot_product_efficient_attention.default,
-        aten._scaled_dot_product_flash_attention.default,
-        aten._scaled_dot_product_cudnn_attention.default,
-        aten._scaled_mm.default,
-        aten.addmm.out,
-        aten.bmm.out,
-        aten.copy_.default,
-        aten.mm.out,
-        aten.repeat_interleave.Tensor,
-        aten.nonzero.default,
-        aten.view.dtype,
-        aten.view_as_real.default,
-    ]
-)
 
 
 class FallbackKernel(ExternKernelAlloc):
@@ -5972,7 +5935,7 @@ class FallbackKernel(ExternKernelAlloc):
                     raise AssertionError(f"unrecognized keypath {keypath}")
 
             def go_outer():
-                if V.graph.cpp_wrapper and config.abi_compatible:
+                if V.graph.cpp_wrapper:
                     # Special handling for the top level buffer access,
                     # because self.get_name() is actually never bound; the
                     # individual output arguments are bound by
@@ -6143,7 +6106,7 @@ class FallbackKernel(ExternKernelAlloc):
             if V.graph.cpp_wrapper:
                 from torchgen.aoti.fallback_ops import inductor_fallback_ops
 
-                if config.abi_compatible and str(kernel) not in inductor_fallback_ops:
+                if str(kernel) not in inductor_fallback_ops:
                     # C shim v2 is torchgen-ed, which should cover all aten ops.
                     # If you do hit a missed op, please update fallback_ops.py.
                     log.warning(
@@ -6154,9 +6117,6 @@ class FallbackKernel(ExternKernelAlloc):
         elif kernel.namespace == "_quantized":  # type: ignore[union-attr]
             # Internal Quantized Fallback Ops
             assert isinstance(kernel, torch._ops.OpOverload)
-            if V.graph.cpp_wrapper:
-                if not config.abi_compatible:
-                    self.use_runtime_dispatch = True
         else:
             # For non-aten OpOverload, i.e. custom ops
             if V.graph.cpp_wrapper:
@@ -6167,10 +6127,7 @@ class FallbackKernel(ExternKernelAlloc):
 
             exported_args = None
             args = None
-            if config.abi_compatible:
-                exported_args = self.export_extern_kernel_node()
-            else:
-                args = [*self.codegen_args(), *self.codegen_kwargs()]
+            exported_args = self.export_extern_kernel_node()
 
             wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
                 self.get_name(),

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -7,7 +7,6 @@ import torch
 from torch._prims_common import make_channels_last_strides_for
 from torch.utils._ordered_set import OrderedSet
 
-from . import config
 from .ir import (
     ExternKernelAlloc,
     FixedLayout,
@@ -228,9 +227,6 @@ def _prepare_linear_fusion_create(
 
 
 def _create_output_node(packed):
-    if not config.abi_compatible:
-        return packed
-
     output_ir = MultiOutput(
         packed.get_layout(),
         packed,
@@ -254,9 +250,7 @@ class ConvolutionUnary(ExternKernelAlloc):
             constant_args,
             None,
             op_overload=torch.ops.mkldnn._convolution_pointwise.default,
-            cpp_kernel_name="aoti_torch_cpu_mkldnn__convolution_pointwise"
-            if config.abi_compatible
-            else None,
+            cpp_kernel_name="aoti_torch_cpu_mkldnn__convolution_pointwise",
         )
         self.cpp_op_schema = """
             at::Tensor(
@@ -272,24 +266,8 @@ class ConvolutionUnary(ExternKernelAlloc):
                 std::optional<c10::string_view> algorithm)"""
 
     def codegen(self, wrapper):
-        if config.abi_compatible:
-            wrapper.include_extra_header(
-                "torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h"
-            )
-            super().codegen(wrapper)
-        else:
-            wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
-                self.get_name(),
-                self.python_kernel_name,
-                self.cpp_kernel_name,
-                self.codegen_args(),
-                self.cpp_op_schema,
-                self.cpp_kernel_key,
-                op_overload=self.op_overload,
-                raw_args=[*self.inputs, *self.constant_args],
-            )
-            if isinstance(self.layout, Layout):
-                self.codegen_size_asserts(wrapper)
+        wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
+        super().codegen(wrapper)
 
     @classmethod
     def create(
@@ -335,9 +313,7 @@ class ConvolutionBinary(ExternKernelAlloc):
             constant_args,
             None,
             op_overload=torch.ops.mkldnn._convolution_pointwise.binary,
-            cpp_kernel_name="aoti_torch_cpu_mkldnn__convolution_pointwise_binary"
-            if config.abi_compatible
-            else None,
+            cpp_kernel_name="aoti_torch_cpu_mkldnn__convolution_pointwise_binary",
         )
         self.cpp_op_schema = """
             at::Tensor(
@@ -357,25 +333,8 @@ class ConvolutionBinary(ExternKernelAlloc):
         self.cpp_constant_args = cpp_constant_args
 
     def codegen(self, wrapper):
-        if config.abi_compatible:
-            wrapper.include_extra_header(
-                "torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h"
-            )
-            super().codegen(wrapper)
-        else:
-            wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
-                self.get_name(),
-                self.python_kernel_name,
-                self.cpp_kernel_name,
-                self.codegen_args(),
-                self.cpp_op_schema,
-                self.cpp_kernel_key,
-                self.cpp_kernel_overload_name,
-                self.op_overload,
-                [*self.inputs, *self.constant_args],
-            )
-            if isinstance(self.layout, Layout):
-                self.codegen_size_asserts(wrapper)
+        wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
+        super().codegen(wrapper)
 
     @classmethod
     def create(
@@ -435,9 +394,7 @@ class ConvolutionBinaryInplace(ExternKernelAlloc):
             constant_args,
             None,
             op_overload=torch.ops.mkldnn._convolution_pointwise_.binary,
-            cpp_kernel_name="aoti_torch_cpu_mkldnn__convolution_pointwise_binary_"
-            if config.abi_compatible
-            else None,
+            cpp_kernel_name="aoti_torch_cpu_mkldnn__convolution_pointwise_binary_",
         )
         # TODO: op.call: input[0] should be at::Tensor&
         self.cpp_op_schema = """
@@ -462,23 +419,8 @@ class ConvolutionBinaryInplace(ExternKernelAlloc):
         ]
 
     def codegen(self, wrapper):
-        if config.abi_compatible:
-            wrapper.include_extra_header(
-                "torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h"
-            )
-            super().codegen(wrapper)
-        else:
-            wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
-                self.get_name(),
-                self.python_kernel_name,
-                self.cpp_kernel_name,
-                self.codegen_args(),
-                self.cpp_op_schema,
-                self.cpp_kernel_key,
-                self.cpp_kernel_overload_name,
-                self.op_overload,
-                [*self.inputs, *self.constant_args],
-            )
+        wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
+        super().codegen(wrapper)
 
     def get_unbacked_symbol_defs(self) -> OrderedSet[sympy.Symbol]:
         return OrderedSet()
@@ -541,9 +483,7 @@ class ConvolutionTransposeUnary(ExternKernelAlloc):
             constant_args,
             None,
             op_overload=torch.ops.mkldnn._convolution_transpose_pointwise.default,
-            cpp_kernel_name="aoti_torch_cpu_mkldnn__convolution_transpose_pointwise"
-            if config.abi_compatible
-            else None,
+            cpp_kernel_name="aoti_torch_cpu_mkldnn__convolution_transpose_pointwise",
         )
         self.cpp_op_schema = """
             at::Tensor(
@@ -560,20 +500,8 @@ class ConvolutionTransposeUnary(ExternKernelAlloc):
                 std::optional<c10::string_view> algorithm)"""
 
     def codegen(self, wrapper):
-        if config.abi_compatible:
-            wrapper.include_extra_header(
-                "torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h"
-            )
-            super().codegen(wrapper)
-        else:
-            wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
-                self.get_name(),
-                self.python_kernel_name,
-                self.cpp_kernel_name,
-                self.codegen_args(),
-                self.cpp_op_schema,
-                self.cpp_kernel_key,
-            )
+        wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
+        super().codegen(wrapper)
 
     @classmethod
     def create(
@@ -1215,9 +1143,7 @@ class LinearUnary(ExternKernelAlloc):
             constant_args,
             None,
             op_overload=torch.ops.mkldnn._linear_pointwise.default,
-            cpp_kernel_name="aoti_torch_cpu__linear_pointwise"
-            if config.abi_compatible
-            else None,
+            cpp_kernel_name="aoti_torch_cpu__linear_pointwise",
         )
         self.cpp_kernel_key = "linear_pointwise"
         self.cpp_op_schema = """
@@ -1230,23 +1156,8 @@ class LinearUnary(ExternKernelAlloc):
                 std::optional<c10::string_view> algorithm)"""
 
     def codegen(self, wrapper):
-        if config.abi_compatible:
-            wrapper.include_extra_header(
-                "torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h"
-            )
-            super().codegen(wrapper)
-        else:
-            wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
-                self.get_name(),
-                self.python_kernel_name,
-                self.cpp_kernel_name,
-                self.codegen_args(),
-                self.cpp_op_schema,
-                self.cpp_kernel_key,
-                op_overload=self.op_overload,
-                raw_args=[*self.inputs, *self.constant_args],
-                outputs=self.outputs,
-            )
+        wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
+        super().codegen(wrapper)
 
     @classmethod
     def create(cls, x, w, B, attr, scalars, algorithm):
@@ -1295,9 +1206,7 @@ class LinearBinary(ExternKernelAlloc):
             constant_args,
             None,
             op_overload=torch.ops.mkldnn._linear_pointwise.binary,
-            cpp_kernel_name="aoti_torch_cpu__linear_pointwise_binary"
-            if config.abi_compatible
-            else None,
+            cpp_kernel_name="aoti_torch_cpu__linear_pointwise_binary",
         )
         self.cpp_op_schema = """
             at::Tensor(
@@ -1309,24 +1218,8 @@ class LinearBinary(ExternKernelAlloc):
         """
 
     def codegen(self, wrapper):
-        if config.abi_compatible:
-            wrapper.include_extra_header(
-                "torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h"
-            )
-            super().codegen(wrapper)
-        else:
-            wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
-                self.get_name(),
-                self.python_kernel_name,
-                self.cpp_kernel_name,
-                self.codegen_args(),
-                self.cpp_op_schema,
-                self.cpp_kernel_key,
-                self.cpp_kernel_overload_name,
-                op_overload=self.op_overload,
-                raw_args=[*self.inputs, *self.constant_args],
-                outputs=self.outputs,
-            )
+        wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
+        super().codegen(wrapper)
 
     @classmethod
     def create(cls, x, y, w, B, attr):
@@ -1387,9 +1280,11 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
             inputs,
             constant_args,
             None,
-            op_overload=torch.ops.onednn.qlinear_pointwise.tensor
-            if x_scale_zp_are_tensors
-            else torch.ops.onednn.qlinear_pointwise.default,
+            op_overload=(
+                torch.ops.onednn.qlinear_pointwise.tensor
+                if x_scale_zp_are_tensors
+                else torch.ops.onednn.qlinear_pointwise.default
+            ),
         )
         x_scale_type_str, x_zp_type_str = (
             ("at::Tensor", "at::Tensor")
@@ -1600,9 +1495,11 @@ class QLinearPointwiseBinaryPT2E(ExternKernelAlloc):
             inputs,
             constant_args,
             None,
-            op_overload=torch.ops.onednn.qlinear_pointwise.binary_tensor
-            if x_scale_zp_are_tensors
-            else torch.ops.onednn.qlinear_pointwise.binary,
+            op_overload=(
+                torch.ops.onednn.qlinear_pointwise.binary_tensor
+                if x_scale_zp_are_tensors
+                else torch.ops.onednn.qlinear_pointwise.binary
+            ),
         )
         x_scale_type_str, x_zp_type_str = (
             ("at::Tensor", "at::Tensor")

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -987,7 +987,7 @@ class ExternKernelCaller(ChoiceCaller):
         )
 
     def output_node(self):
-        if config.abi_compatible and self.choice.use_fallback_kernel:
+        if self.choice.use_fallback_kernel:
             assert (
                 self.choice.op_overload is not None
             ), "Please provide an op_overload to use ir.FallbackKernel"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138047
* #138009
* #138016
* #137982

Summary: Continue to clean up non-ABI-compatible mode related code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @chauhang

Differential Revision: [D64444327](https://our.internmc.facebook.com/intern/diff/D64444327)