### PR TITLE
[POC] automatic_dynamic_local_pgo

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -483,6 +483,33 @@ compiled_autograd_kwargs_override: Dict[str, Any] = {}
 # NCCL timeout.
 enable_compiler_collectives = os.environ.get("TORCH_COMPILER_COLLECTIVES", "0") == "1"
 
+# Enables a local, filesystem "profile" which can be used for automatic
+# dynamic decisions, analogous to profile-guided optimization.  The idea is
+# that if we observe that a particular input is dynamic over multiple
+# iterations on one run, we can save a profile with this information so the
+# next time we run we can just make it dynamic the first time around, skipping
+# an unnecessary static compilation.  The profile can be soundly stale, if it
+# is wrong, it just means we may make more things dynamic than was actually
+# necessary (NB: this /can/ cause a failure if making something dynamic causes
+# the compiler to stop working because you tickled a latent bug.)
+#
+# The profile is ONLY guaranteed to work if the user source code is 100%
+# unchanged.  Applying the profile if there are user code changes is only
+# best effort otherwise.  In particular, we identify particular code objects
+# by filename, line number and name of their function, so adding/removing newlines
+# will typically cause cache misses.  Once a profile is created, it will
+# never be subsequently updated, even if we discover on a subsequent run that
+# more inputs are dynamic (TODO: add some way of manually clearing the
+# profile in a convenient way; TODO: add a way of not doing this behavior).
+#
+# Enabling this option can potentially change the automatic dynamic behavior
+# of your program, even when there is no profile.  Specifically, we uniquely
+# identify a code object by its filename/line number/name.  This means if you
+# have multiple distinct code objects that have identical filename/line
+# number, we will share automatic dynamic information across them (TODO:
+# change default automatic dynamic behavior so it also crosstalks in this way)
+automatic_dynamic_local_pgo = False
+
 # HACK: this is for testing custom ops profiling only
 _custom_ops_profile: Optional[Any] = None
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -49,9 +49,9 @@ from .exc import (
     unimplemented,
     unimplemented_with_warning,
 )
-from .pgo import put_automatic_dynamic_frame_state
 from .guards import GuardBuilder, install_guard
 from .mutation_guard import is_dynamic_nn_module
+from .pgo import put_automatic_dynamic_frame_state
 from .side_effects import AttributeMutationExisting, SideEffects
 from .source import (
     AttrSource,

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -49,6 +49,7 @@ from .exc import (
     unimplemented,
     unimplemented_with_warning,
 )
+from .pgo import put_automatic_dynamic_frame_state
 from .guards import GuardBuilder, install_guard
 from .mutation_guard import is_dynamic_nn_module
 from .side_effects import AttributeMutationExisting, SideEffects
@@ -1269,6 +1270,9 @@ class OutputGraph:
             )
 
     def run_compiler_collective(self, tx):
+        # TODO: maybe we need to rename this function
+        put_automatic_dynamic_frame_state(tx, self.frame_state)
+
         if (ds := tx.distributed_state) is not None and ds.all_states is None:
             compile_pg = ds.compile_pg
             log.info("compiler_collective %s", ds.local_state)

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -1,0 +1,77 @@
+# Profile-guided optimization for Dynamo
+
+from __future__ import annotations
+
+import os
+import os.path
+from typing import TYPE_CHECKING
+import functools
+import pickle
+import logging
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from torch._dynamo.variables.builder import FrameStateSizeEntry
+
+# TODO: an individual cache file per code object may not be optimal from an IO
+# perspective
+
+@functools.lru_cache(None)
+def _get_code_object_cache_path(filename, firstlineno, name):
+    # TODO: fix inductor layering problem
+    from torch._inductor.runtime.runtime_utils import cache_dir
+    from torch._inductor.codecache import sha256_hash
+
+    # TODO: pickle is too heavy a hammer, do not actually need it
+    # TODO: this scheme makes manual inspection of cache entries difficult,
+    # consider adding some breadcrumbs in the name for ease of use
+    r = os.path.join(cache_dir(), "dynamo", sha256_hash(pickle.dumps((filename, firstlineno, name))))
+
+    log.debug("get_code_object_cache_path %s %s %s = %s", filename, firstlineno, name, r)
+    return r
+
+def get_code_object_cache_path(tx):
+    return _get_code_object_cache_path(tx.f_code.co_filename, tx.f_code.co_firstlineno, tx.f_code.co_name)
+
+# NB: this INTENTIONALLY does not get updated when you write same process, we
+# want to KEEP writing from the same process
+@functools.lru_cache(None)
+def _get_code_object_cache(filename, firstlineno, name):
+    # TODO: this try-catch seems to have scope that's too long
+    path = _get_code_object_cache_path(filename, firstlineno, name)
+    try:
+        with open(path, 'rb') as f:
+            try:
+                r = pickle.load(f)
+            except Exception:
+                log.warning("get_code_object_cache failed while reading %s", path)
+                raise
+            log.info("get_code_object_cache hit len(frame_state)=%s", len(r))
+            log.debug("get_code_object_cache %s", r)
+            return r
+    except OSError:
+        return None
+
+def get_code_object_cache(tx):
+    return _get_code_object_cache(tx.f_code.co_filename, tx.f_code.co_firstlineno, tx.f_code.co_name)
+
+def get_automatic_dynamic_initial_frame_state(tx, name: str) -> FrameStateSizeEntry:
+    if frame_state := get_code_object_cache(tx):
+        r = frame_state.get(name)
+        if r is not None:
+            log.debug("get_automatic_dynamic_initial_frame_state %s = %s", name, r)
+        return r
+    return None
+
+def put_automatic_dynamic_frame_state(tx, frame_state: object) -> None:
+    # Do nothing if profile already exists (policy decision!)
+    if get_code_object_cache(tx) is not None:
+        return
+
+    path = get_code_object_cache_path(tx)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'wb') as f:
+        log.info("put_code_object_cache len(frame_state)=%s", len(frame_state))
+        log.debug("put_code_object_cache %s", frame_state)
+        pickle.dump(frame_state, f)

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -2,46 +2,60 @@
 
 from __future__ import annotations
 
+import functools
+import logging
 import os
 import os.path
-from typing import TYPE_CHECKING
-import functools
 import pickle
-import logging
+from typing import Dict, Optional, TYPE_CHECKING
+
 
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from torch._dynamo.symbolic_convert import InstructionTranslator
     from torch._dynamo.variables.builder import FrameStateSizeEntry
 
 # TODO: an individual cache file per code object may not be optimal from an IO
 # perspective
 
+
 @functools.lru_cache(None)
-def _get_code_object_cache_path(filename, firstlineno, name):
+def _get_code_object_cache_path(filename: str, firstlineno: int, name: str) -> str:
     # TODO: fix inductor layering problem
-    from torch._inductor.runtime.runtime_utils import cache_dir
     from torch._inductor.codecache import sha256_hash
+    from torch._inductor.runtime.runtime_utils import cache_dir
 
     # TODO: pickle is too heavy a hammer, do not actually need it
     # TODO: this scheme makes manual inspection of cache entries difficult,
     # consider adding some breadcrumbs in the name for ease of use
-    r = os.path.join(cache_dir(), "dynamo", sha256_hash(pickle.dumps((filename, firstlineno, name))))
+    r = os.path.join(
+        cache_dir(), "dynamo", sha256_hash(pickle.dumps((filename, firstlineno, name)))
+    )
 
-    log.debug("get_code_object_cache_path %s %s %s = %s", filename, firstlineno, name, r)
+    log.debug(
+        "get_code_object_cache_path %s %s %s = %s", filename, firstlineno, name, r
+    )
     return r
 
-def get_code_object_cache_path(tx):
-    return _get_code_object_cache_path(tx.f_code.co_filename, tx.f_code.co_firstlineno, tx.f_code.co_name)
+
+def get_code_object_cache_path(tx: InstructionTranslator) -> str:
+    return _get_code_object_cache_path(
+        tx.f_code.co_filename, tx.f_code.co_firstlineno, tx.f_code.co_name
+    )
+
 
 # NB: this INTENTIONALLY does not get updated when you write same process, we
-# want to KEEP writing from the same process
+# want to KEEP updating the file from the same process as we learn more
+# dynamic information
 @functools.lru_cache(None)
-def _get_code_object_cache(filename, firstlineno, name):
+def _get_code_object_cache(
+    filename: str, firstlineno: int, name: str
+) -> Optional[Dict[str, FrameStateSizeEntry]]:
     # TODO: this try-catch seems to have scope that's too long
     path = _get_code_object_cache_path(filename, firstlineno, name)
     try:
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             try:
                 r = pickle.load(f)
             except Exception:
@@ -53,10 +67,18 @@ def _get_code_object_cache(filename, firstlineno, name):
     except OSError:
         return None
 
-def get_code_object_cache(tx):
-    return _get_code_object_cache(tx.f_code.co_filename, tx.f_code.co_firstlineno, tx.f_code.co_name)
 
-def get_automatic_dynamic_initial_frame_state(tx, name: str) -> FrameStateSizeEntry:
+def get_code_object_cache(
+    tx: InstructionTranslator,
+) -> Optional[Dict[str, FrameStateSizeEntry]]:
+    return _get_code_object_cache(
+        tx.f_code.co_filename, tx.f_code.co_firstlineno, tx.f_code.co_name
+    )
+
+
+def get_automatic_dynamic_initial_frame_state(
+    tx: InstructionTranslator, name: str
+) -> Optional[FrameStateSizeEntry]:
     if frame_state := get_code_object_cache(tx):
         r = frame_state.get(name)
         if r is not None:
@@ -64,14 +86,21 @@ def get_automatic_dynamic_initial_frame_state(tx, name: str) -> FrameStateSizeEn
         return r
     return None
 
-def put_automatic_dynamic_frame_state(tx, frame_state: object) -> None:
+
+def put_automatic_dynamic_frame_state(
+    tx: InstructionTranslator, frame_state: Dict[str, FrameStateSizeEntry]
+) -> None:
     # Do nothing if profile already exists (policy decision!)
+    # TODO: if a process crashes midway through compilation while profiling, the profile
+    # may be irreparably "corrupted" (i.e., unable to force automatic dynamic
+    # as appropriate).  This is a downside of not continuously updating the
+    # profiles... not sure if it is worth or not.
     if get_code_object_cache(tx) is not None:
         return
 
     path = get_code_object_cache_path(tx)
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, 'wb') as f:
+    with open(path, "wb") as f:
         log.info("put_code_object_cache len(frame_state)=%s", len(frame_state))
         log.debug("put_code_object_cache %s", frame_state)
         pickle.dump(frame_state, f)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -57,8 +57,8 @@ from .. import config, mutation_guard, replay_record, trace_rules
 from ..device_interface import get_registered_device_interfaces
 from ..exc import InternalTorchDynamoError, unimplemented
 from ..guards import GuardBuilder, install_guard, make_dupe_guard
-from ..side_effects import SideEffects
 from ..pgo import get_automatic_dynamic_initial_frame_state
+from ..side_effects import SideEffects
 from ..source import (
     AttrProxySource,
     AttrSource,
@@ -1744,7 +1744,9 @@ class VariableBuilder:
             name = self.source.name()
 
             def update_frame_state(value):
-                frame_state_entry = tx.output.frame_state.get(name, get_automatic_dynamic_initial_frame_state(tx, name))
+                frame_state_entry = self.tx.output.frame_state.get(
+                    name, get_automatic_dynamic_initial_frame_state(self.tx, name)
+                )
                 if frame_state_entry is None:
                     # Note - this essentially means that if this name gets reused as a tensor,
                     # it will start fully dynamic. That should always be a safe option, and not awfully inefficient.
@@ -2448,7 +2450,9 @@ def _automatic_dynamic(
         # Intentionally shadow e from parent scope so it is not accidentally
         # called
         e = None
-        frame_state_entry = tx.output.frame_state.get(name, get_automatic_dynamic_initial_frame_state(tx, name))
+        frame_state_entry = tx.output.frame_state.get(
+            name, get_automatic_dynamic_initial_frame_state(tx, name)
+        )
         if frame_state_entry is None:
             # If there is no entry for this source, add the tensor to frame state with its current static size.
             # E.g., {} -> {"x": [2, 4]}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138052

The important comment:

```
# Enables a local, filesystem "profile" which can be used for automatic
# dynamic decisions, analogous to profile-guided optimization.  The idea is
# that if we observe that a particular input is dynamic over multiple
# iterations on one run, we can save a profile with this information so the
# next time we run we can just make it dynamic the first time around, skipping
# an unnecessary static compilation.  The profile can be soundly stale, if it
# is wrong, it just means we may make more things dynamic than was actually
# necessary (NB: this /can/ cause a failure if making something dynamic causes
# the compiler to stop working because you tickled a latent bug.)
#
# The profile is ONLY guaranteed to work if the user source code is 100%
# unchanged.  Applying the profile if there are user code changes is only
# best effort otherwise.  In particular, we identify particular code objects
# by filename, line number and name of their function, so adding/removing newlines
# will typically cause cache misses.  Once a profile is created, it will
# never be subsequently updated, even if we discover on a subsequent run that
# more inputs are dynamic (TODO: add some way of manually clearing the
# profile in a convenient way; TODO: add a way of not doing this behavior).
#
# Enabling this option can potentially change the automatic dynamic behavior
# of your program, even when there is no profile.  Specifically, we uniquely
# identify a code object by its filename/line number/name.  This means if you
# have multiple distinct code objects that have identical filename/line
# number, we will share automatic dynamic information across them (TODO:
# change default automatic dynamic behavior so it also crosstalks in this way)
automatic_dynamic_local_pgo = False
```

This is the dumbest, simplest thing I could manage to code in 1.5hrs.  Here's how I tested it:

```
(/home/ezyang/local/c/pytorch-env) [ezyang@devgpu005.nha1 ~/local/c/pytorch (9b2e453e)]$ cat a.py
import torch

@torch.compile(backend="eager")
def f(x, y):
    return x + y

f(torch.randn(3), torch.randn(3))
f(torch.randn(4), torch.randn(4))

(/home/ezyang/local/c/pytorch-env) [ezyang@devgpu005.nha1 ~/local/c/pytorch (9b2e453e)]$ TORCH_LOGS=+torch._dynamo.pgo python a.py
V1015 20:19:06.171000 1676841 torch/_dynamo/pgo.py:31] [0/0] get_code_object_cache_path /data/users/ezyang/c/pytorch/a.py 3 f = /tmp/torchinductor_ezyang/dynamo/mr4g5czsmyoe3dhkfs6xyxlvavkokjqpdqe3q23ogz7wd546l6e
I1015 20:19:06.176000 1676841 torch/_dynamo/pgo.py:73] [0/0] put_code_object_cache len(frame_state)=3
V1015 20:19:06.177000 1676841 torch/_dynamo/pgo.py:74] [0/0] put_code_object_cache {'_id': 0, "L['x']": FrameStateSizeEntry(scalar=None, size=[3], stride=[1]), "L['y']": FrameStateSizeEntry(scalar=None, size=[3], stride=[1])}
I1015 20:19:06.249000 1676841 torch/_dynamo/pgo.py:73] [0/1] put_code_object_cache len(frame_state)=3
V1015 20:19:06.250000 1676841 torch/_dynamo/pgo.py:74] [0/1] put_code_object_cache {'_id': 0, "L['x']": FrameStateSizeEntry(scalar=None, size=[None], stride=[1]), "L['y']": FrameStateSizeEntry(scalar=None, size=[None], stride=[1])}
(/home/ezyang/local/c/pytorch-env) [ezyang@devgpu005.nha1 ~/local/c/pytorch (9b2e453e)]$ TORCH_LOGS=+torch._dynamo.pgo python a.py
V1015 20:19:56.495000 1697047 torch/_dynamo/pgo.py:31] [0/0] get_code_object_cache_path /data/users/ezyang/c/pytorch/a.py 3 f = /tmp/torchinductor_ezyang/dynamo/mr4g5czsmyoe3dhkfs6xyxlvavkokjqpdqe3q23ogz7wd546l6e
I1015 20:19:56.496000 1697047 torch/_dynamo/pgo.py:50] [0/0] get_code_object_cache hit len(frame_state)=3
V1015 20:19:56.496000 1697047 torch/_dynamo/pgo.py:51] [0/0] get_code_object_cache {'_id': 0, "L['x']": FrameStateSizeEntry(scalar=None, size=[None], stride=[1]), "L['y']": FrameStateSizeEntry(scalar=None, size=[None], stride=[1])}
V1015 20:19:56.496000 1697047 torch/_dynamo/pgo.py:63] [0/0] get_automatic_dynamic_initial_frame_state L['x'] = FrameStateSizeEntry(scalar=None, size=[None], stride=[1])
V1015 20:19:56.541000 1697047 torch/_dynamo/pgo.py:63] [0/0] get_automatic_dynamic_initial_frame_state L['y'] = FrameStateSizeEntry(scalar=None, size=[None], stride=[1])
```

You can see on the second run it only compiles once, and cache hits.

There is a lot of extra polish needed, hopefully mostly all noted in TODOs. One big gap is how exactly to invalidate this cache. The config might want to be some sort of epoch number you can bump up to invalidate old caches. Won't polish until we agree this is a good approach.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec