### PR TITLE
include bw_compiler in strobelight profile

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -72,6 +72,7 @@ from torch._inductor.utils import (
 )
 from torch._logging import trace_structured
 from torch._ops import OpOverload
+from torch._utils_internal import compile_time_strobelight_meta
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymExprPrinter
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 from torch.monitor import _WaitCounter
@@ -1526,6 +1527,7 @@ def compile_fx(
                 gm, joint_inputs, **kwargs, compiler="inductor"
             )
 
+        @compile_time_strobelight_meta(phase_name="backward")
         def bw_compiler(
             model: torch.fx.GraphModule, example_inputs: List[torch.Tensor]
         ):


### PR DESCRIPTION
Summary: title + tlparse will have the phase name.

Test Plan: {F1933087525}

Differential Revision: D64450315




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang