### PR TITLE
Use std::move on stringstream to prevent unnecessary copy.

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -37,7 +37,7 @@ std::ostream& operator<<(std::ostream & out, const Scalar& s) {
 std::string toString(const Scalar& s) {
   std::stringstream out;
   out << s;
-  return out.str();
+  return std::move(out).str();
 }
 }
 namespace at {

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -124,7 +124,7 @@ inline std::string Join(const std::string& delimiter, const Container& v) {
   for (auto i = v.begin(); i != v.end(); ++i, --cnt) {
     s << (*i) << (cnt ? delimiter : "");
   }
-  return s.str();
+  return std::move(s).str();
 }
 
 // Replace all occurrences of "from" substring to "to" string.

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -638,7 +638,7 @@ void initDispatchBindings(PyObject* module) {
       if (!op.overload_name.empty()) {
         ss << "." << op.overload_name;
       }
-      names.emplace_back(ss.str());
+      names.emplace_back(std::move(ss).str());
     }
 
     return names;


### PR DESCRIPTION
- Takes advantage of C++20's improved handling of move semantics for std::basic_stringbuf.
- Reduces unnecessary copying and improves memory efficiency, especially for long formatted strings.

Benchmark(proof of concept): https://quick-bench.com/q/qohAu0ARH3vSDyKVsoKEfXOO6BI
