### PR TITLE
Add TORCH_CHECK_INDEX in convert_indices_from_coo_to_csr_cpu

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -1529,6 +1529,8 @@ void convert_indices_from_coo_to_csr_cpu(
         for (const auto i : c10::irange(start, end)) {
           next_value = data_in[i + 1];
           for (; curr_value < next_value; curr_value++)
+            TORCH_CHECK_INDEX(curr_value + 1 < size,
+                              "Row index ", (curr_value + 1 ), " is out of bounds.");
             data_out[curr_value + 1] = static_cast<output_t>(i + 1);
         }
       });


### PR DESCRIPTION
The `to_sparse_csr` CPU implementation `convert_indices_from_coo_to_csr_cpu`  doesn't validate the COO indices, which may lead to illegal memory access.

This PR fixes that by adding checks on the index before accessing the data.

```Python
# repro
num_nonzeros = 2048

#row,col
dense_size = (1024, 256)


row_indices = torch.randint(0, dense_size[0], (num_nonzeros,))
col_indices = torch.randint(0, dense_size[1], (num_nonzeros,))
coo_indices = torch.stack((row_indices, col_indices))

# this should work
sparse_coo = torch.sparse_coo_tensor(
    coo_indices,
    torch.ones(coo_indices.size(1), dtype=bool),
    dense_size,
)
dst_node_indices = sparse_coo.to_sparse_csr()
print(f"Works well {dst_node_indices}")


# altering row_indices, now it's expected to fail

row_indices[-1] = dense_size[0] + 42

coo_indices = torch.stack((row_indices, col_indices))

# this should not work
sparse_coo = torch.sparse_coo_tensor(
    coo_indices,
    torch.ones(coo_indices.size(1), dtype=bool),
    dense_size,
)
dst_node_indices = sparse_coo.to_sparse_csr()
print("Should never reach here")
```