### PR TITLE
Autocast re-tracibility

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -6794,8 +6794,6 @@ def forward(self, x, b_t, y):
             gm.code,
         )
 
-    # T203671967
-    @testing.expectedFailureRetraceability  # autocast nodes not created after re-tracing
     def test_export_with_autocast(self):
         class Model(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
Summary:
Support autocast re-tracing by giving it the same treatment as set_grad.

In re-tracing, when dynamo encounters an autocast HOP, we want it to trace through `with torch.autocast()` again, and replace the HOP with the traced subgraph.

Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export  -- -r  test_export_with_autocast
```

Differential Revision: D63856081


cc @mcarilli @ptrblck @leslie-fang-intel @jgong5 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec