### PR TITLE
Remove an unused variable in _subclasses.fake_impls

### DIFF
--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -630,7 +630,7 @@ def multi_device_op_default(fake_mode, func, *args, **kwargs):
 @register_op_impl(aten.slice_scatter.out)
 def multi_device_op_out(fake_mode, func, *args, **kwargs):
     with in_kernel_invocation_manager(fake_mode):
-        out = func(*args, **kwargs)
+        func(*args, **kwargs)
 
     _, new_kwargs = normalize_function(
         func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True


### PR DESCRIPTION
* Extracted from https://github.com/pytorch/pytorch/pull/133492

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #13808

