### PR TITLE
[Pipelining] fix extra memory usage in zero bubble

### DIFF
--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -201,6 +201,10 @@ def stage_backward_input(
                 inp.grad = dinputs[i]
             else:
                 inp.grad += dinputs[i]
+
+        for t in stage_outputs:
+            t.detach_()
+
     else:
         dinputs = None
     return dinputs, param_groups

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -202,13 +202,13 @@ def stage_backward_input(
             else:
                 inp.grad += dinputs[i]
 
+        # stage_outputs are not used in backwards after this point, so we can safely remove it from the autograd graph
+        # this allows autograd to clear up the graph dedicated for this output and free up significant memory
+        for t in stage_outputs:
+            t.detach_()
+
     else:
         dinputs = None
-
-    # stage_outputs are not used in backwards after this point, so we can safely remove it from the autograd graph
-    # this allows autograd to clear up the graph dedicated for this output and free up significant memory
-    for t in stage_outputs:
-        t.detach_()
 
     return dinputs, param_groups
 

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -202,11 +202,14 @@ def stage_backward_input(
             else:
                 inp.grad += dinputs[i]
 
-        for t in stage_outputs:
-            t.detach_()
-
     else:
         dinputs = None
+
+    # stage_outputs are not used in backwards after this point, so we can safely remove it from the autograd graph
+    # this allows autograd to clear up the graph dedicated for this output and free up significant memory
+    for t in stage_outputs:
+        t.detach_()
+
     return dinputs, param_groups
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138720
* #138735
* #138504
* __->__ #138119

Full debugging details in here: https://docs.google.com/document/d/1Pe_E0KWAfsJ6MCvKZ5aR28rTXX-rYLg13XxwXd6AALw/edit?usp=sharing

In zero bubble, we have two methods `stage_backward_input` and `stage_backward_weight`. During `stage_backward_input` we compute the gradients of the input with respect to the stage outputs and also retain the graph of the autograd graph (different than 1F1B where `retain_graph=False`). The output / loss was still being retained across the next schedule step() because we return the loss to the user and use the output to the next step. To allow autograd to free the variables in the graph we need to detach the output/loss after we don't need to use it autograd anymore.

Pre-fix:
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/6c8bf469-32b1-4dac-85ff-b97991f9f0e3">

Post-fix:
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/a1875038-e80b-4dd4-84f2-38727d7792dc">

without AC (7B model on titan):
10% memory improvement

with AC (7B model on titan)
50% memory improvement


cc @XilunWu @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o