### PR TITLE
Naive impls for NJT matmul

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7692,9 +7692,6 @@ COMPILE_FORWARD_FAILURES = {
     # clone() on non-contiguous with holes NJTs currently use unbind(), leading to
     # data-dependent error in torch.compile
     "clone",
-    # data-dependent error due to use of unbind(); should go away when we back this
-    # with proper kernels
-    "matmul",
     # to(device) allocates a new nested int in compile only.
     # AssertionError: The values for attribute 'shape' do not match:
     # torch.Size([7, j2]) != torch.Size([7, j1]).

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7692,6 +7692,9 @@ COMPILE_FORWARD_FAILURES = {
     # clone() on non-contiguous with holes NJTs currently use unbind(), leading to
     # data-dependent error in torch.compile
     "clone",
+    # data-dependent error due to use of unbind(); should go away when we back this
+    # with proper kernels
+    "matmul",
     # to(device) allocates a new nested int in compile only.
     # AssertionError: The values for attribute 'shape' do not match:
     # torch.Size([7, j2]) != torch.Size([7, j1]).

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -1063,6 +1063,23 @@ def matmul_default(func, *args, **kwargs):
     )
 
 
+@register_jagged_func(torch.ops.aten.bmm.default, "self: jt_all, mat2: any")
+def bmm_default(func, *args, **kwargs):
+    _, new_kwargs = normalize_function(  # type: ignore[misc]
+        func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
+    )
+
+    inp = new_kwargs.pop("input")
+    other = new_kwargs.pop("mat2")
+
+    if inp.dim() != 3:
+        raise ValueError("bmm(): input must be 3D")
+    if other.dim() != 3:
+        raise ValueError("bmm(): mat2 must be 3D")
+
+    return matmul_default(torch.ops.aten.matmul.default, inp, other)
+
+
 @register_jagged_func(
     torch.ops.aten.expand.default, "self: jt, size: any, implicit: any?"
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138121

Our matmul support is abysmal - let's at least get this working and do it performantly later.

Bonus: implements `bmm` as well.

jagged <-> padded dense conversions are utilized when possible, and an unbind-based fallback otherwise (the former works with torch.compile and the latter doesn't). Some testing is missing because we don't have factory function support yet :(