### PR TITLE
[Docs] Fix description in `torch.save` docs to show default for pickle_protocol instead of variable name

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -806,7 +806,7 @@ def save(
     # documentation. We need it so that Sphinx doesn't leak `pickle`s path from
     # the build environment (e.g. `<module 'pickle' from '/leaked/path').
 
-    """save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True)
+    """save(obj, f, pickle_module=pickle, pickle_protocol=2, _use_new_zipfile_serialization=True)
 
     Saves an object to a disk file.
 


### PR DESCRIPTION
Fixes #138013

Replace `DEFAULT_PROTOCOL` with actual default value `2` in `torch.save` method document

Before
![image](https://github.com/user-attachments/assets/cdd77d14-c009-4848-8538-9256bf22c32a)

After
![image](https://github.com/user-attachments/assets/f6b1063d-c955-478a-8d42-702b988426aa)
