### PR TITLE
[Dynamo] Allow `torch.cond()` to handle emply arguments

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3261,15 +3261,16 @@ def forward(self, x):
         def false_fn(x):
             return x.sin()
 
-        def f(x):
+        def fn(x):
             return cond(x.shape[0] > 10, true_fn, false_fn)
 
         example_inputs = (torch.rand(5),)
-        with self.assertRaisesRegex(
-            TypeError,
-            r"cond\(\) missing 1 required positional argument: 'operands'",
-        ):
-            f(*example_inputs)
+
+        try:
+            # Now we allow torch.cond to handle empty args
+            fn(*example_inputs)
+        except TypeError as e:
+            self.fail(f"Unexpected TypeError raised with empty args: {e}")
 
     def test_cond_raise_user_error_on_unsupported_pred(self):
         def f_unsupported_pred(x):

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3254,7 +3254,7 @@ def forward(self, x):
         self.assertEqual(gm(*true_inp), f(*true_inp))
         self.assertEqual(gm(*false_inp), f(*false_inp))
 
-    def test_cond_raise_user_error_on_missing_args(self):
+    def test_cond_no_raise_user_error_on_missing_args(self):
         def true_fn(x):
             return x.cos()
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3268,7 +3268,7 @@ def forward(self, x):
         example_inputs = (torch.rand(5),)
         with self.assertRaisesRegex(
             TypeError,
-            r".*false_fn\(\) missing 1 required positional argument: 'x'",
+            r"false_fn\(\) missing 1 required positional argument: 'x'",
         ):
             f(*example_inputs)
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3268,7 +3268,7 @@ def forward(self, x):
         example_inputs = (torch.rand(5),)
         with self.assertRaisesRegex(
             TypeError,
-            r"false_fn() missing 1 required positional argument: 'x'",
+            r".*false_fn\(\) missing 1 required positional argument: 'x'",
         ):
             f(*example_inputs)
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3254,23 +3254,23 @@ def forward(self, x):
         self.assertEqual(gm(*true_inp), f(*true_inp))
         self.assertEqual(gm(*false_inp), f(*false_inp))
 
-    def test_cond_no_raise_user_error_on_missing_args(self):
+    def test_cond_raise_user_error_on_missing_args(self):
         def true_fn(x):
             return x.cos()
 
         def false_fn(x):
             return x.sin()
 
-        def fn(x):
+        def f(x):
             return cond(x.shape[0] > 10, true_fn, false_fn)
 
+        # Now we allow torch.cond to handle empty args
         example_inputs = (torch.rand(5),)
-
-        try:
-            # Now we allow torch.cond to handle empty args
-            fn(*example_inputs)
-        except TypeError as e:
-            self.fail(f"Unexpected TypeError raised with empty args: {e}")
+        with self.assertRaisesRegex(
+            TypeError,
+            r"false_fn() missing 1 required positional argument: 'x'",
+        ):
+            f(*example_inputs)
 
     def test_cond_raise_user_error_on_unsupported_pred(self):
         def f_unsupported_pred(x):

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -2584,7 +2584,7 @@ def forward(self, L_pred_ : torch.Tensor, L_pytree_in_0_ : torch.Tensor, L_pytre
 
             return torch.cond(x, f, g)
 
-        zeros = torch.true(1)
+        zeros = torch.zeros(1)
         ones = torch.ones(1)
         self.assertEqual(fn(zeros, ones, ones), torch.tensor([2.]))
         self.assertEqual(fn(ones, ones, ones), torch.tensor([3.]))

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -2573,6 +2573,22 @@ def forward(self, L_pred_ : torch.Tensor, L_pytree_in_0_ : torch.Tensor, L_pytre
             ):
                 torch.compile(fn, backend="eager")(pred, pytree_in)
 
+    def test_cond_with_empty_operands(self):
+        @torch.compile(fullgraph=True)
+        def fn(x, y, z):
+            def f():
+                return y + 2
+
+            def g():
+                return z + 1
+
+            return torch.cond(x, f, g)
+
+        zeros = torch.true(1)
+        ones = torch.ones(1)
+        self.assertEqual(fn(zeros, ones, ones), torch.tensor([2.]))
+        self.assertEqual(fn(ones, ones, ones), torch.tensor([3.]))
+
     def test_hints_wrapper(self):
         def ref_fn(x, y):
             x = x + y

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -2576,18 +2576,18 @@ def forward(self, L_pred_ : torch.Tensor, L_pytree_in_0_ : torch.Tensor, L_pytre
     def test_cond_with_empty_operands(self):
         @torch.compile(fullgraph=True)
         def fn(x, y, z):
-            def f():
+            def true_fn():
                 return y + 2
 
-            def g():
+            def false_fn():
                 return z + 1
 
-            return torch.cond(x, f, g)
+            return torch.cond(x, true_fn, false_fn)
 
         zeros = torch.zeros(1)
         ones = torch.ones(1)
-        self.assertEqual(fn(zeros, ones, ones), torch.tensor([2.]))
-        self.assertEqual(fn(ones, ones, ones), torch.tensor([3.]))
+        self.assertEqual(fn(zeros, ones, ones), torch.tensor([2.0]))
+        self.assertEqual(fn(ones, ones, ones), torch.tensor([3.0]))
 
     def test_hints_wrapper(self):
         def ref_fn(x, y):

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -62,7 +62,7 @@ cond_op = CondOp()
 
 
 @exposed_in("torch")
-def cond(pred, true_fn, false_fn, operands=()):
+def cond(pred: Union[bool, torch.Tensor], true_fn: Callable, false_fn: Callable, operands: Tuple = ()):
     r"""
     Conditionally applies `true_fn` or `false_fn`.
 
@@ -95,7 +95,8 @@ def cond(pred, true_fn, false_fn, operands=()):
           have consistent input and outputs, meaning the inputs have to be
           the same, and the outputs have to be the same type and shape.
 
-        operands (Tuple of possibly nested dict/list/tuple of torch.Tensor): A tuple of inputs to the true/false functions.
+        operands (Tuple of possibly nested dict/list/tuple of torch.Tensor): A tuple of inputs to the
+          true/false functions. It can be empty if true_fn/false_fn doesn't require input. Defaults to ().
 
     Example::
 

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import logging
+from typing import Callable, Tuple, Union
 
 import torch
 import torch._subclasses.functional_tensor
@@ -62,7 +63,12 @@ cond_op = CondOp()
 
 
 @exposed_in("torch")
-def cond(pred: Union[bool, torch.Tensor], true_fn: Callable, false_fn: Callable, operands: Tuple = ()):
+def cond(
+    pred: Union[bool, torch.Tensor],
+    true_fn: Callable,
+    false_fn: Callable,
+    operands: Tuple = (),
+):
     r"""
     Conditionally applies `true_fn` or `false_fn`.
 

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -62,7 +62,7 @@ cond_op = CondOp()
 
 
 @exposed_in("torch")
-def cond(pred, true_fn, false_fn, operands):
+def cond(pred, true_fn, false_fn, operands=()):
     r"""
     Conditionally applies `true_fn` or `false_fn`.
 
@@ -156,7 +156,7 @@ def cond(pred, true_fn, false_fn, operands):
             )
 
         if not callable(true_fn) or not callable(false_fn):
-            raise RuntimeError("Expect both branches to be callbale.")
+            raise RuntimeError("Expect both branches to be callable.")
 
         if not isinstance(operands, (tuple, list)) or pytree.tree_any(
             lambda t: not isinstance(t, torch.Tensor), operands

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import logging
-from typing import Callable, List, Tuple, Union
+from typing import Any, Callable, List, Tuple, Union
 
 import torch
 import torch._subclasses.functional_tensor
@@ -62,13 +62,13 @@ class CondOp(HigherOrderOperator):
 cond_op = CondOp()
 
 
-@exposed_in("torch")
+@exposed_in("torch")  # type: ignore[misc]
 def cond(
     pred: Union[bool, int, float, torch.Tensor],
     true_fn: Callable,
     false_fn: Callable,
     operands: Union[Tuple, List] = (),
-):
+) -> Any:
     r"""
     Conditionally applies `true_fn` or `false_fn`.
 

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import logging
-from typing import Callable, Tuple, Union
+from typing import Callable, List, Tuple, Union
 
 import torch
 import torch._subclasses.functional_tensor
@@ -64,10 +64,10 @@ cond_op = CondOp()
 
 @exposed_in("torch")
 def cond(
-    pred: Union[bool, torch.Tensor],
+    pred: Union[bool, int, float, torch.Tensor],
     true_fn: Callable,
     false_fn: Callable,
-    operands: Tuple = (),
+    operands: Union[Tuple, List] = (),
 ):
     r"""
     Conditionally applies `true_fn` or `false_fn`.

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -1,3 +1,4 @@
+# mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import contextlib
 import logging
@@ -62,7 +63,7 @@ class CondOp(HigherOrderOperator):
 cond_op = CondOp()
 
 
-@exposed_in("torch")  # type: ignore[misc]
+@exposed_in("torch")
 def cond(
     pred: Union[bool, int, float, torch.Tensor],
     true_fn: Callable,

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -129,7 +129,7 @@ def while_loop(cond_fn, body_fn, carried_inputs):
 
     def _validate_input(cond_fn, body_fn, carried_inputs):
         if not callable(cond_fn) or not callable(body_fn):
-            raise RuntimeError("Expect cond_fn and body_fn to be callbale.")
+            raise RuntimeError("Expect cond_fn and body_fn to be callable.")
 
         if not isinstance(carried_inputs, (tuple, list)) or pytree.tree_any(
             lambda t: not isinstance(t, torch.Tensor), carried_inputs

--- a/torch/utils/_exposed_in.py
+++ b/torch/utils/_exposed_in.py
@@ -7,15 +7,8 @@
 # may not be very robust because it's not clear what __module__ is used for.
 # However, both numpy and jax overwrite the __module__ attribute of their APIs
 # without problem, so it seems fine.
-
-from typing import Any, Callable, TypeVar
-
-
-_F = TypeVar("_F", bound=Callable[..., Any])
-
-
-def exposed_in(module: str) -> Callable[[_F], _F]:
-    def wrapper(fn: _F) -> _F:
+def exposed_in(module):
+    def wrapper(fn):
         fn.__module__ = module
         return fn
 

--- a/torch/utils/_exposed_in.py
+++ b/torch/utils/_exposed_in.py
@@ -7,8 +7,15 @@
 # may not be very robust because it's not clear what __module__ is used for.
 # However, both numpy and jax overwrite the __module__ attribute of their APIs
 # without problem, so it seems fine.
-def exposed_in(module):
-    def wrapper(fn):
+
+from typing import Any, Callable, TypeVar
+
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def exposed_in(module: str) -> Callable[[_F], _F]:
+    def wrapper(fn: _F) -> _F:
         fn.__module__ = module
         return fn
 


### PR DESCRIPTION
Fixes #138150

```python
import torch


@torch.compile(fullgraph=True)
def foo(x, y, z):
    def f():
        return y + 2
                                                        
    def g():
        return z + 1
                                                        
    return torch.cond(x, f, g)
                                                        
                                                        
print(foo(torch.zeros(1), torch.ones(1), torch.ones(1))) # tensor([2.])
print(foo(torch.ones(1), torch.ones(1), torch.ones(1))) # tensor([3.])
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec