### PR TITLE
Update LSTM doc.py

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -799,10 +799,10 @@ class LSTM(RNNBase):
 
     .. math::
         \begin{array}{ll} \\
-            i_t = \sigma(W_{ii} x_t + b_{ii} + W_{hi} h_{t-1} + b_{hi}) \\
-            f_t = \sigma(W_{if} x_t + b_{if} + W_{hf} h_{t-1} + b_{hf}) \\
-            g_t = \tanh(W_{ig} x_t + b_{ig} + W_{hg} h_{t-1} + b_{hg}) \\
-            o_t = \sigma(W_{io} x_t + b_{io} + W_{ho} h_{t-1} + b_{ho}) \\
+            i_t = \sigma(x_t W_{ii}^T + b_{ii} + h_{t-1} W_{hi}^T+ b_{hi}) \\
+            f_t = \sigma(x_t W_{if}^T + b_{if} + h_{t-1} W_{hf}^T + b_{hf}) \\
+            g_t = \tanh(x_t W_{ig}^T + b_{ig} + h_{t-1} W_{hg}^T + b_{hg}) \\
+            o_t = \sigma(x_t W_{io}^T + b_{io} + h_{t-1} W_{ho}^T+ b_{ho}) \\
             c_t = f_t \odot c_{t-1} + i_t \odot g_t \\
             h_t = o_t \odot \tanh(c_t) \\
         \end{array}


### PR DESCRIPTION
In this pull request, I have corrected the matrix multiplication for the LSTM weight matrices $W_{hi}$, $W_{hf}$, $W_{hg}$, and $W_{ho}$. Previously, there was an attempt to multiply a 3x3 matrix with a 1x3 matrix, which is dimensionally incorrect. To fix this, I have updated the documentation and equations to reflect that these weight matrices must be multiplied from the right with their transposed forms (i.e., $W_{hi}^T$, $W_{hf}^T$, $W_{hg}^T$, and $W_{ho}^T$). This ensures that the matrix dimensions align properly during computation.

Additionally, to improve clarity and readability, I changed the notation for the input weights. The weights $W_{ii}$, $W_{if}$, $W_{ig}$, and $W_{io}$ have been updated for consistency with the new convention. This change enhances the overall readability and makes the equations more intuitive for users.

This is alligned with nn.RNN documentation.

Fixes #ISSUE_NUMBER


cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki