### PR TITLE
Fix cuda sanitizer and as_subclass calls

### DIFF
--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -9,6 +9,7 @@ import torch
 import torch.cuda._sanitizer as csan
 from torch.cuda._sanitizer import DataPtr, EventId, StreamId
 from torch.testing._internal.common_utils import NoTest, run_tests, TEST_CUDA, TestCase
+from torch.testing._internal.two_tensor import TwoTensor
 
 
 if not TEST_CUDA:
@@ -490,6 +491,20 @@ class TestMessages(TestCase):
                 """
             ),
         )
+
+    def test_subclass(self):
+        class MyT(torch.Tensor):
+            def __new__(cls, data):
+                new_data = data.clone()
+                return new_data.as_subclass(cls)
+
+        try:
+            csan.enable_cuda_sanitizer()
+            t = TwoTensor(torch.rand(2), torch.rand(2))
+
+            t = MyT(torch.rand(2))
+        finally:
+            csan.cuda_sanitizer.disable()
 
 
 if __name__ == "__main__":

--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -500,8 +500,10 @@ class TestMessages(TestCase):
 
         try:
             csan.enable_cuda_sanitizer()
-            t = TwoTensor(torch.rand(2), torch.rand(2))
 
+            # These two tests ensure that subclass creation
+            # happens smoothly under the mode used by csan
+            t = TwoTensor(torch.rand(2), torch.rand(2))
             t = MyT(torch.rand(2))
         finally:
             csan.cuda_sanitizer.disable()

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -683,9 +683,13 @@ static PyObject* THPVariable_as_subclass(
       "cls must be a type (got ",
       Py_TYPE(cls)->tp_name,
       ")");
+  // guard completely turns off torch dispatch modes, doesn't just pop off the
+  // stack
+  torch_dispatch_mode::StashTorchDispatchStackGuard td_g;
+  c10::impl::DisablePythonDispatcher dpd_g;
   return THPVariable_NewWithVar(
       (PyTypeObject*)cls,
-      self.alias(),
+      self.detach(),
       c10::impl::PyInterpreterStatus::DEFINITELY_UNINITIALIZED);
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -689,7 +689,7 @@ static PyObject* THPVariable_as_subclass(
   c10::impl::DisablePythonDispatcher dpd_g;
   return THPVariable_NewWithVar(
       (PyTypeObject*)cls,
-      self.detach(),
+      self.alias(),
       c10::impl::PyInterpreterStatus::DEFINITELY_UNINITIALIZED);
   END_HANDLE_TH_ERRORS
 }

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -608,13 +608,13 @@ class CUDASanitizer:
 
     def __del__(self):
         # Since this object lifetime is linked to the `torch.cuda._sanitizer` python
-        # module, it often gets deleted as part of the overal `torch` module cleanup
+        # module, it often gets deleted as part of the overall `torch` module cleanup
         # At that time, depending on CPython version, the torch.* module might be in
-        # different state of already cleaned up.
+        # different states of being already cleaned up.
         # Similarly other imports might already have been cleaned up so `sys` might
         # be already gone as well.
         # Skip exiting the mode if it outlived the runtime.
-        if (sys is not None) and (not sys.is_finalizing) and self.enabled:
+        if (sys is not None) and (not sys.is_finalizing()) and self.enabled:
             self.disable()
 
 

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -602,9 +602,20 @@ class CUDASanitizer:
         self.dispatch.__enter__()
         self.enabled = True
 
+    def disable(self):
+        self.dispatch.__exit__(None, None, None)
+        self.enabled = False
+
     def __del__(self):
-        if self.enabled:
-            self.dispatch.__exit__(None, None, None)
+        # Since this object lifetime is linked to the `torch.cuda._sanitizer` python
+        # module, it often gets deleted as part of the overal `torch` module cleanup
+        # At that time, depending on CPython version, the torch.* module might be in
+        # different state of already cleaned up.
+        # Similarly other imports might already have been cleaned up so `sys` might
+        # be already gone as well.
+        # Skip exiting the mode if it outlived the runtime.
+        if (sys is not None) and (not sys.is_finalizing) and self.enabled:
+            self.disable()
 
 
 def enable_cuda_sanitizer():


### PR DESCRIPTION
This fixes 4 main issues:
- The way the cuda sanitizer handle it's state is weird. In particular, because the lifetime of the Mode is linked to the submodule, then this might outlive the python runtime and other modules loaded. On my current version, this even outlives the "sys" module. Given that I'm not sure the impact of changing this lifetime handling, I'm making the exit handler a no-op when python is already dying and thus no point cleaning up.
- Adds a "disable" method to be able to test after the mode is enabled.
- Fix `Tensor.as_sublass()` to properly disable modes when creating the new Tensor object just like we already do in `make_subclass` and `make_wrapper_subclass`. The change here is just to apply the exact same treatment to it.
- ~Fix `Tensor.as_subclass()` not to propagate autograd as there is no valid backward associated here.~ We have test that check that this behavior happen so I guess this is not an obvious bugfix and expected behavior. Reverted that change.