### PR TITLE
c10 | Silence 'deprecated-dynamic-exception-spec' warning when importing cxxabi.

### DIFF
--- a/c10/util/Backtrace.cpp
+++ b/c10/util/Backtrace.cpp
@@ -1,3 +1,4 @@
+#include <c10/macros/Macros.h>
 #include <c10/util/Backtrace.h>
 #include <c10/util/Type.h>
 #include <c10/util/irange.h>
@@ -16,7 +17,10 @@
 #endif
 
 #if SUPPORTS_BACKTRACE
+C10_CLANG_DIAGNOSTIC_PUSH()
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wdeprecated-dynamic-exception-spec")
 #include <cxxabi.h>
+C10_CLANG_DIAGNOSTIC_POP()
 #ifdef C10_ANDROID
 #include <dlfcn.h>
 #include <unwind.h>


### PR DESCRIPTION
Summary: cxxabi header specifically from llvm violates this, ignore the warning when including it.

Test Plan: No runtime behavior change, sandcastle only

Differential Revision: D64540217


