### PR TITLE
Delay mul/pow expansion for `_SympyT` to enable more folding

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -1,5 +1,5 @@
 add_loop_eager,                compile_time_instruction_count, 3004749893,  0.015
-add_loop_eager_dynamic,        compile_time_instruction_count, 5726573328,  0.025
+add_loop_eager_dynamic,        compile_time_instruction_count, 5563298740,  0.025
 add_loop_inductor,             compile_time_instruction_count, 24064639114, 0.015
 add_loop_inductor_dynamic_gpu, compile_time_instruction_count, 40992578178, 0.025
 add_loop_inductor_gpu,         compile_time_instruction_count, 22822864522, 0.015

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -1055,7 +1055,6 @@ def _make_node_magic(method, func):
             get_proxy_mode,
             handle_sym_dispatch,
         )
-        from torch.fx.experimental.symbolic_shapes import safe_expand
 
         op = method_to_operator(method)
 
@@ -1095,7 +1094,6 @@ def _make_node_magic(method, func):
         except Exception:
             log.warning("failed to eval %s(%s, %s)", method, self.expr, other.expr)
             raise
-        out = safe_expand(out)
         sym_node_log.debug("%s %s %s -> %s", method, self.expr, other.expr, out)
         pytype: Type
         # This is not strictly correct. In Python, a**b may return complex when
@@ -1133,7 +1131,6 @@ def _make_node_magic(method, func):
             get_proxy_mode,
             handle_sym_dispatch,
         )
-        from torch.fx.experimental.symbolic_shapes import safe_expand
 
         op = method_to_operator(method)
         if get_proxy_mode():
@@ -1152,7 +1149,6 @@ def _make_node_magic(method, func):
         out_hint = None
         if self.hint is not None:
             out_hint = op(self.hint)
-        out = safe_expand(out)
         pytype: Type
         if method in always_int_magic_methods:
             pytype = int
@@ -1175,7 +1171,6 @@ def _make_node_magic(method, func):
                 get_proxy_mode,
                 handle_sym_dispatch,
             )
-            from torch.fx.experimental.symbolic_shapes import safe_expand
 
             out_hint = then_node.hint if pred_node.hint else else_node.hint
             if get_proxy_mode():
@@ -1204,7 +1199,6 @@ def _make_node_magic(method, func):
                 )
                 raise
 
-            out = safe_expand(out)
             fx_node, _ = pred_node.shape_env._create_fx_call_function(
                 sym_ite, (pred_node.fx_node, then_node.fx_node, else_node.fx_node)
             )
@@ -1220,7 +1214,6 @@ def _make_node_magic(method, func):
                 get_proxy_mode,
                 handle_sym_dispatch,
             )
-            from torch.fx.experimental.symbolic_shapes import safe_expand
 
             op = builtins.round
             if get_proxy_mode():
@@ -1234,8 +1227,6 @@ def _make_node_magic(method, func):
             except Exception:
                 log.warning("failed to eval %s(%s, ndigits=%s)", method, expr, ndigits)
                 raise
-
-            out = safe_expand(out)
 
             if ndigits is None:
                 pytype = int


### PR DESCRIPTION
Instead of calling `safe_expand` right after symbolic expression construction, we invoke it in `ShapeEnv.simplify`. This enables more simplification with product form, e.g.,
```
(a + b)^2 / (a + b) --> (a + b)
```
which won't happen if we expand eagerly during product construction:
```
(a^2 + 2ab + b^2) / (a + b) --> no change
```

Fixes #136044.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec