### PR TITLE
Add proper handling for view and factory function for csan

### DIFF
--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -37,7 +37,9 @@ class TestArgumentHandler(TestCase):
         c = torch.rand(2, 7, 5, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(cat_func._schema, ([a, b, c], 1), {}, is_factory=False)
+        argument_handler.parse_inputs(
+            cat_func._schema, ([a, b, c], 1), {}, is_factory=False
+        )
         d = torch.cat((a, b, c), dim=1)
         argument_handler.parse_outputs(cat_func._schema, d, is_factory=False)
 
@@ -65,7 +67,9 @@ class TestArgumentHandler(TestCase):
         a = torch.rand(4, 2, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(add_inplace_func._schema, (a, 5), {}, is_factory=False)
+        argument_handler.parse_inputs(
+            add_inplace_func._schema, (a, 5), {}, is_factory=False
+        )
         a.add_(5)
         argument_handler.parse_outputs(add_inplace_func._schema, a, is_factory=False)
 
@@ -78,7 +82,9 @@ class TestArgumentHandler(TestCase):
         b = torch.empty(8, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(mul_out_func._schema, (a, 3), {"out": b}, is_factory=False)
+        argument_handler.parse_inputs(
+            mul_out_func._schema, (a, 3), {"out": b}, is_factory=False
+        )
         torch.mul(a, 3, out=b)
         argument_handler.parse_outputs(mul_out_func._schema, b, is_factory=False)
 
@@ -90,7 +96,9 @@ class TestArgumentHandler(TestCase):
         a = torch.ones(5, 3, 2, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(nonzero_func._schema, (a,), {"as_tuple": True}, is_factory=False)
+        argument_handler.parse_inputs(
+            nonzero_func._schema, (a,), {"as_tuple": True}, is_factory=False
+        )
         out = torch.nonzero(a, as_tuple=True)
         argument_handler.parse_outputs(nonzero_func._schema, out, is_factory=False)
 
@@ -104,7 +112,9 @@ class TestArgumentHandler(TestCase):
         M = torch.zeros(3, 3, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(addr_func._schema, (M, vec, vec), {}, is_factory=False)
+        argument_handler.parse_inputs(
+            addr_func._schema, (M, vec, vec), {}, is_factory=False
+        )
         out = torch.addr(M, vec, vec)
         argument_handler.parse_outputs(addr_func._schema, out, is_factory=False)
 

--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -23,9 +23,9 @@ class TestArgumentHandler(TestCase):
         b = torch.randn(5, 3, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(add_func._schema, (a, b), {})
+        argument_handler.parse_inputs(add_func._schema, (a, b), {}, is_factory=False)
         c = torch.add(a, b)
-        argument_handler.parse_outputs(c)
+        argument_handler.parse_outputs(add_func._schema, c, is_factory=False)
 
         self.assertEqual({a.data_ptr(), b.data_ptr()}, argument_handler.dataptrs_read)
         self.assertEqual({c.data_ptr()}, argument_handler.dataptrs_written)
@@ -37,9 +37,9 @@ class TestArgumentHandler(TestCase):
         c = torch.rand(2, 7, 5, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(cat_func._schema, ([a, b, c], 1), {})
+        argument_handler.parse_inputs(cat_func._schema, ([a, b, c], 1), {}, is_factory=False)
         d = torch.cat((a, b, c), dim=1)
-        argument_handler.parse_outputs(d)
+        argument_handler.parse_outputs(cat_func._schema, d, is_factory=False)
 
         self.assertEqual(
             {a.data_ptr(), b.data_ptr(), c.data_ptr()}, argument_handler.dataptrs_read
@@ -51,22 +51,23 @@ class TestArgumentHandler(TestCase):
         a = torch.arange(10, device="cuda").reshape(5, 2)
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(split_func._schema, (a, 2), {})
+        argument_handler.parse_inputs(split_func._schema, (a, 2), {}, is_factory=False)
         out = torch.split(a, 2)
-        argument_handler.parse_outputs(out)
+        argument_handler.parse_outputs(split_func._schema, out, is_factory=False)
 
         outputs = {out[0].data_ptr(), out[1].data_ptr(), out[2].data_ptr()}
-        self.assertEqual({a.data_ptr()}, argument_handler.dataptrs_read)
-        self.assertEqual(outputs, argument_handler.dataptrs_written)
+        # Split is a view op, no data is read or written!
+        self.assertEqual(len(argument_handler.dataptrs_read), 0)
+        self.assertEqual(len(argument_handler.dataptrs_written), 0)
 
     def test_inplace(self):
         add_inplace_func = torch.ops.aten.add_.Tensor
         a = torch.rand(4, 2, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(add_inplace_func._schema, (a, 5), {})
+        argument_handler.parse_inputs(add_inplace_func._schema, (a, 5), {}, is_factory=False)
         a.add_(5)
-        argument_handler.parse_outputs(a)
+        argument_handler.parse_outputs(add_inplace_func._schema, a, is_factory=False)
 
         self.assertEqual(set(), argument_handler.dataptrs_read)
         self.assertEqual({a.data_ptr()}, argument_handler.dataptrs_written)
@@ -77,9 +78,9 @@ class TestArgumentHandler(TestCase):
         b = torch.empty(8, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(mul_out_func._schema, (a, 3), {"out": b})
+        argument_handler.parse_inputs(mul_out_func._schema, (a, 3), {"out": b}, is_factory=False)
         torch.mul(a, 3, out=b)
-        argument_handler.parse_outputs(b)
+        argument_handler.parse_outputs(mul_out_func._schema, b, is_factory=False)
 
         self.assertEqual({a.data_ptr()}, argument_handler.dataptrs_read)
         self.assertEqual({b.data_ptr()}, argument_handler.dataptrs_written)
@@ -89,9 +90,9 @@ class TestArgumentHandler(TestCase):
         a = torch.ones(5, 3, 2, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(nonzero_func._schema, (a,), {"as_tuple": True})
+        argument_handler.parse_inputs(nonzero_func._schema, (a,), {"as_tuple": True}, is_factory=False)
         out = torch.nonzero(a, as_tuple=True)
-        argument_handler.parse_outputs(out)
+        argument_handler.parse_outputs(nonzero_func._schema, out, is_factory=False)
 
         outputs = {out[0].data_ptr(), out[1].data_ptr(), out[2].data_ptr()}
         self.assertEqual({a.data_ptr()}, argument_handler.dataptrs_read)
@@ -103,9 +104,9 @@ class TestArgumentHandler(TestCase):
         M = torch.zeros(3, 3, device="cuda")
 
         argument_handler = csan.ArgumentHandler()
-        argument_handler.parse_inputs(addr_func._schema, (M, vec, vec), {})
+        argument_handler.parse_inputs(addr_func._schema, (M, vec, vec), {}, is_factory=False)
         out = torch.addr(M, vec, vec)
-        argument_handler.parse_outputs(out)
+        argument_handler.parse_outputs(addr_func._schema, out, is_factory=False)
 
         self.assertEqual(
             argument_handler.tensor_aliases,


### PR DESCRIPTION
In particular, properly handle that some functions only read/write metadata on the Tensor and thus should not be detected as read/write by csan.