### PR TITLE
[BE][MPS] Compile without warnings on MacOS15

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -38,7 +38,7 @@ id<MTLLibrary> MPSDevice::getMetalIndexingLibrary() {
     } else {
       C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
       [options setFastMathEnabled:YES];
-      C10_DIAGNOSTIC_POP
+      C10_DIAGNOSTIC_POP()
     }
     _mtl_indexing_library = [_mtl_device newLibraryWithSource:[NSString stringWithCString:mps::indexing_metal_shaders
                                                                                  encoding:NSASCIIStringEncoding]

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -36,7 +36,9 @@ id<MTLLibrary> MPSDevice::getMetalIndexingLibrary() {
     if (isMacOS13Plus(MacOSVersion::MACOS_VER_15_0_PLUS)) {
       options.mathMode = MTLMathModeFast;
     } else {
+      C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
       [options setFastMathEnabled:YES];
+      C10_DIAGNOSTIC_POP
     }
     _mtl_indexing_library = [_mtl_device newLibraryWithSource:[NSString stringWithCString:mps::indexing_metal_shaders
                                                                                  encoding:NSASCIIStringEncoding]

--- a/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
+++ b/aten/src/ATen/native/mps/MPSGraphSequoiaOps.h
@@ -31,8 +31,15 @@ typedef NS_ENUM(NSInteger, MTLMathMode)
     MTLMathModeFast = 2,
 };
 
+typedef NS_ENUM(NSInteger, MTLMathFloatingPointFunctions)
+{
+    MTLMathFloatingPointFunctionsFast = 0,
+    MTLMathFloatingPointFunctionsPrecise = 1,
+};
+
 @interface MTLCompileOptions()
 @property (readwrite, nonatomic) MTLMathMode mathMode;
+@property (readwrite, nonatomic) MTLMathFloatingPointFunctions mathFloatingPointFunctions;
 @end
 
 #endif

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -856,7 +856,13 @@ id<MTLLibrary> MetalShaderLibrary::compileLibrary(const std::string& src) {
     // Need 3.0 for atomic oprations, 3.1 introduces bfloat support
     [options setLanguageVersion:is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) ? MTLLanguageVersion3_1
                                                                                         : MTLLanguageVersion3_0];
-    [options setFastMathEnabled:(!fast_math || std::stoi(fast_math) == 0) ? NO : YES];
+    if (isMacOS13Plus(MacOSVersion::MACOS_VER_15_0_PLUS)) {
+      options.mathMode = !fast_math || std::stoi(fast_math) == 0) ? MTLMathModeSafe : MTLMathModeFast;
+    } else {
+      C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
+      [options setFastMathEnabled:(!fast_math || std::stoi(fast_math) == 0) ? NO : YES];
+      C10_DIAGNOSTIC_POP()
+    }
   }
 
   const auto str = [NSString stringWithCString:src.c_str() encoding:NSASCIIStringEncoding];

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -857,7 +857,7 @@ id<MTLLibrary> MetalShaderLibrary::compileLibrary(const std::string& src) {
     [options setLanguageVersion:is_macos_13_or_newer(MacOSVersion::MACOS_VER_14_0_PLUS) ? MTLLanguageVersion3_1
                                                                                         : MTLLanguageVersion3_0];
     if (isMacOS13Plus(MacOSVersion::MACOS_VER_15_0_PLUS)) {
-      options.mathMode = !fast_math || std::stoi(fast_math) == 0) ? MTLMathModeSafe : MTLMathModeFast;
+      options.mathMode = (!fast_math || std::stoi(fast_math) == 0) ? MTLMathModeSafe : MTLMathModeFast;
     } else {
       C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wdeprecated-declarations")
       [options setFastMathEnabled:(!fast_math || std::stoi(fast_math) == 0) ? NO : YES];


### PR DESCRIPTION
By guarding the calls to `-[MTLCompileOptions setFastMathEnabled]` with `C10_DIAGNOSTIC_PUSH` and `POP`
and using `-[MTLCompileOptions setMathMode:]` and `-[MTLCompileOptions setMathFloatingPointFunctions:]` on MacOS15