### PR TITLE
Consolidate Triton cache into Inductor cache

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 import os
 import pickle
+import shutil
 import tempfile
 import unittest
 from typing import List, Optional, Union
@@ -125,7 +126,8 @@ class TestFxGraphCache(TestCase):
     @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     @parametrize("dynamic", (False, True))
-    def test_cache_load_function(self, device, dtype, dynamic):
+    @parametrize("bundle_triton", (False, True))
+    def test_cache_load_function(self, device, dtype, dynamic, bundle_triton):
         """
         Verify that we can populate and load functions from the cache.
         """
@@ -140,30 +142,46 @@ class TestFxGraphCache(TestCase):
         a = torch.rand(25, dtype=dtype, device=device)
         b = torch.rand(5, 5, dtype=dtype, device=device)
 
-        compiled_fn = torch.compile(fn, dynamic=dynamic)
+        with config.patch(bundle_triton_into_fx_graph_cache=bundle_triton):
+            compiled_fn = torch.compile(fn, dynamic=dynamic)
 
-        # A first call should miss in the cache.
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
-        self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 0)
+            # A first call should miss in the cache.
+            self.assertEqual(fn(a, b), compiled_fn(a, b))
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 0)
 
-        # A second call should hit. (First reset so in-memory guards
-        # don't prevent compilation).
-        for m in torch._inductor.codecache.PyCodeCache.cache.values():
-            os.remove(m.__file__)
-        self.reset()
-        self.assertEqual(fn(a, b), compiled_fn(a, b))
-        self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-        self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
+            if bundle_triton and device != "cpu":
+                self.assertEqual(counters["inductor"]["triton_bundler_save_kernel"], 7)
+                self.assertEqual(
+                    counters["inductor"]["triton_bundler_read_and_emit_kernel"], 0
+                )
+
+            # A second call should hit. (First reset so in-memory guards
+            # don't prevent compilation).
+            for m in torch._inductor.codecache.PyCodeCache.cache.values():
+                os.remove(m.__file__)
+            # Clean triton kernels
+            shutil.rmtree(os.path.join(cache_dir(), "triton"), ignore_errors=True)
+            self.reset()
+            self.assertEqual(fn(a, b), compiled_fn(a, b))
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+            self.assertEqual(counters["inductor"]["fxgraph_lookup_write_file"], 1)
+
+            if bundle_triton and device != "cpu":
+                self.assertEqual(counters["inductor"]["triton_bundler_save_kernel"], 7)
+                self.assertEqual(
+                    counters["inductor"]["triton_bundler_read_and_emit_kernel"], 7
+                )
 
     @requires_triton()
     @config.patch({"fx_graph_remote_cache": True})
     @parametrize("device", (GPU_TYPE, "cpu"))
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     @parametrize("dynamic", (False, True))
-    def test_remote_cache_load_function(self, device, dtype, dynamic):
+    @parametrize("bundle_triton", (False, True))
+    def test_remote_cache_load_function(self, device, dtype, dynamic, bundle_triton):
         from unittest.mock import patch
 
         if device == GPU_TYPE and not HAS_GPU:
@@ -180,6 +198,7 @@ class TestFxGraphCache(TestCase):
         with config.patch(
             {
                 "fx_graph_remote_cache": True,
+                "bundle_triton_into_fx_graph_cache": bundle_triton,
             }
         ), patch.dict(os.environ), PatchCaches():
             os.environ.pop("TRITON_CACHE_MANAGER", None)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -71,6 +71,7 @@ from torch._utils_internal import log_cache_bypass
 from .remote_cache import create_cache
 from .runtime import autotune_cache
 from .runtime.autotune_cache import AutotuneCacheBundler
+from .triton_bundler import TritonBundler, TritonKernelArtifacts
 from .utils import _align
 
 
@@ -1030,7 +1031,7 @@ class FxGraphCache:
         example_inputs: Sequence[InputType],
         local: bool,
         remote_cache: Optional[RemoteCache[JsonDataTy]],
-    ) -> Optional[CompiledFxGraph]:
+    ) -> Tuple[Optional[CompiledFxGraph], Dict[str, Any]]:
         """
         Lookup a compiled graph in the cache by key. On a hit, return the
         deserialized CompiledFxGraph object. On a miss, return None.
@@ -1071,6 +1072,7 @@ class FxGraphCache:
         # Iterate over any entries in the subdir for this key and evaluate
         # their guards to determine whether there's a hit.
         graph = None
+        cache_info: Dict[str, Any] = dict()
 
         for candidate in iterate_over_candidates():
             if not candidate.guards_expr:
@@ -1097,7 +1099,7 @@ class FxGraphCache:
                 break
 
         if graph is None:
-            return None
+            return None, cache_info
 
         # See _save_graph(); we don't store the callable in the cache entry so
         # recreate it here from the PyCodeCache disk cache.
@@ -1118,6 +1120,14 @@ class FxGraphCache:
 
             write_atomic(artifact_path, code, make_dirs=True)
 
+        if bundle := graph._triton_bundle:
+            triton_bundler_meta = TritonBundler.read_and_emit(bundle)
+            if (meta := triton_bundler_meta) is not None:
+                cache_info["triton_bundler_meta"] = str(meta)
+                get_chromium_event_logger().add_event_data(
+                    "inductor_compile", cached_kernel_names=meta.cached_kernel_names
+                )
+
         inductor_meta = autotune_cache.inductor_meta_from_config()
         AutotuneCacheBundler.begin_compile(inductor_meta, code=code)
 
@@ -1132,7 +1142,7 @@ class FxGraphCache:
             # Not expected, but in case the PyCodeCache entry is removed from
             # underneath us, treat it as a cache miss and recompile.
             log.error("Failed to load cached artifact: %s", artifact_path)
-            return None
+            return None, cache_info
 
         # Now re-evaluate with the symints to add any guards to the current env.
         if graph.guards_expr:
@@ -1161,7 +1171,7 @@ class FxGraphCache:
             lambda: {"filename": artifact_path},
             payload_fn=lambda: code,
         )
-        return graph
+        return graph, cache_info
 
     @staticmethod
     def post_compile(
@@ -1383,10 +1393,11 @@ class FxGraphCache:
         Doesn't do any logging on its own, because AOTAutograd handles a cache miss
         differently from FXGraphCache.
         """
-        compiled_graph = FxGraphCache._lookup_graph(
+        compiled_graph, cache_info = FxGraphCache._lookup_graph(
             key, example_inputs, local, remote_cache
         )
         cache_info = {
+            **cache_info,
             "key": key,
             "components": debug_lines,
             "cache_event_time": time_ns(),
@@ -1463,6 +1474,9 @@ class FxGraphCache:
             compiled_graph._time_taken_ns = time_ns() - start_time
             cache_key = key_info[0]
             compiled_graph._fx_graph_cache_key = cache_key
+            compiled_graph._triton_bundle, triton_bundler_meta = TritonBundler.collect()
+            if triton_bundler_meta is not None:
+                cache_info["triton_bundler_meta"] = str(triton_bundler_meta)
             cache_info["time_taken_ns"] = compiled_graph._time_taken_ns
             FxGraphCache._save_graph(
                 cache_key,
@@ -1569,6 +1583,7 @@ class CompiledFxGraph:
     _time_taken_ns: Optional[int] = None
     _boxed_call: Optional[bool] = None
     _fx_graph_cache_key: Optional[str] = None
+    _triton_bundle: Optional[List[TritonKernelArtifacts]] = None
 
     def __init__(
         self,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -28,6 +28,10 @@ def bundled_autotune_remote_cache_default() -> Optional[bool]:
     return _get_tristate_env("TORCHINDUCTOR_BUNDLED_AUTOTUNE_REMOTE_CACHE")
 
 
+def bundle_triton_into_fx_graph_cache_default() -> Optional[bool]:
+    return _get_tristate_env("TORCHINDUCTOR_BUNDLE_TRITON_INTO_FX_GRAPH_CACHE")
+
+
 # Enable auto_functionalized_v2 (enabled by default)
 enable_auto_functionalized_v2 = (
     os.environ.get("TORCHDYNAMO_AUTO_FUNCTIONALIZED_V2", "1") == "1"
@@ -52,6 +56,11 @@ fx_graph_cache = (
 # True: Enables the cache
 # None: Not set -- Off for OSS, JustKnobs based for internal
 fx_graph_remote_cache: Optional[bool] = fx_graph_remote_cache_default()
+
+# should we bundle triton caching into fx graph cache
+bundle_triton_into_fx_graph_cache: Optional[
+    bool
+] = bundle_triton_into_fx_graph_cache_default()
 
 # Enable autotune local cache.
 #

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -97,6 +97,7 @@ from .runtime import autotune_cache
 from .runtime.autotune_cache import AutotuneCacheBundler
 from .scheduler import BaseSchedulerNode
 from .sizevars import SizeVarAllocator
+from .triton_bundler import TritonBundler
 from .utils import (
     convert_shape_to_inductor,
     gather_origins,
@@ -1961,6 +1962,7 @@ class GraphLowering(torch.fx.Interpreter):
 
         inductor_meta = autotune_cache.inductor_meta_from_config()
         AutotuneCacheBundler.begin_compile(inductor_meta, code=code)
+        TritonBundler.begin_compile()
 
         try:
             linemap = [(line_no, node.stack_trace) for line_no, node in linemap]  # type: ignore[misc]

--- a/torch/_inductor/runtime/cache_dir_utils.py
+++ b/torch/_inductor/runtime/cache_dir_utils.py
@@ -21,3 +21,13 @@ def default_cache_dir() -> str:
         tempfile.gettempdir(),
         "torchinductor_" + sanitized_username,
     )
+
+
+def triton_cache_dir(device: int) -> str:
+    if (directory := os.getenv("TRITON_CACHE_DIR")) is not None:
+        return directory
+    return os.path.join(
+        cache_dir(),
+        "triton",
+        str(device),
+    )

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -9,6 +9,7 @@ import torch
 from torch._inductor.runtime.cache_dir_utils import (  # noqa: F401
     cache_dir,
     default_cache_dir,
+    triton_cache_dir,
 )
 
 

--- a/torch/_inductor/triton_bundler.py
+++ b/torch/_inductor/triton_bundler.py
@@ -1,0 +1,234 @@
+import dataclasses
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from torch._dynamo.utils import counters, dynamo_timed
+from torch._utils_internal import justknobs_check
+
+from .runtime.runtime_utils import triton_cache_dir
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class TritonBundleEntry:
+    """
+    When we have compiled a triton kernel, we take note of that kernel by
+    its triton generated hash, its device, and where this kernel is located.
+    This is the minimum information we can use to later retrieve this kernel
+    from file system.
+    """
+
+    kernel_hash: str
+    device: int
+    directory: str
+
+
+@dataclasses.dataclass(frozen=True)
+class TritonKernelArtifact:
+    """
+    Artifact for an individual kernel converted to bytes.
+    Bytes could be a cubin, json, ttir, or ttgir.
+    """
+
+    filename: str
+    payload: bytes = dataclasses.field(repr=False)  # Do not display binary
+
+
+@dataclasses.dataclass(frozen=True)
+class TritonKernelArtifacts:
+    """
+    Collection of artifacts for a particular kernel.
+    """
+
+    kernel_hash: str
+    device: int
+    artifacts: List[TritonKernelArtifact]
+
+
+@dataclasses.dataclass(frozen=True)
+class TritonBundlerMetadata:
+    """
+    Metadata used for instrumentation
+    """
+
+    cached_kernel_names: List[str]
+
+
+class TritonBundler:
+    """
+    Lightweight Triton Kernel bundler that notes each time we compile a triton
+    kernel. When collect is called, converts all the previously noted kernels and
+    their artifacts into a structured bytes blob, and later when write is called
+    it writes this structured blob back to file system.
+
+    Intended Life cycle:
+    - TritonBundler.begin_compile is called when we start compiling in Inductor
+    - TritonBundler.put is called each time a Triton Kernel is compiled
+    - TritonBundler.collect is called when a cache entry is being generated
+    - TritonBundler.read_and_emit is called when a cache entry is read
+    """
+
+    _entries: Optional[List[TritonBundleEntry]] = None
+
+    # __grp__kernel_name.json contains metadata with source code paths
+    # we use this as sentinal value for search and replace
+    _REPLACE_BYTES: bytes = b"[REPLACE]"
+
+    @staticmethod
+    def is_enabled() -> bool:
+        from torch._inductor import config
+
+        if config.force_disable_caches:
+            return False
+
+        if (b := config.bundle_triton_into_fx_graph_cache) is not None:
+            return b
+
+        if not config.is_fbcode():
+            return False
+
+        return justknobs_check("pytorch/remote_cache:bundle_triton_into_fx_graph_cache")
+
+    @classmethod
+    def begin_compile(cls) -> None:
+        """
+        Initializes the TritonBundler.
+        The current TritonBundler bundle is finalized by TritonBundler.collect.
+        """
+        if not TritonBundler.is_enabled():
+            return
+        assert cls._entries is None
+        cls._entries = []
+
+    @classmethod
+    def put(cls, kernel_hash: str, device: int) -> None:
+        """
+        Lazily observes that we have seen a Triton kernel compilation. Remembers
+        it for when collect is later called.
+        """
+        if (entries := cls._entries) is not None:
+            entries.append(
+                TritonBundleEntry(kernel_hash, device, triton_cache_dir(device))
+            )
+
+    @classmethod
+    def collect(
+        cls,
+    ) -> Tuple[List[TritonKernelArtifacts], Optional[TritonBundlerMetadata]]:
+        """
+        This is the main function called when a cache write happens. This function
+        converts all the previously remembered kernels into bundled format so that
+        it can be written into a cache entry.
+        This function also finalizes the current bundle.
+        """
+        if not TritonBundler.is_enabled():
+            cls._entries = None
+            return [], None
+
+        with dynamo_timed(key="TritonBundler.collect", fwd_only=False):
+            entries = cls._entries
+            if entries is not None:
+                result: List[TritonKernelArtifacts] = []
+                kernel_names: List[str] = []
+                for entry in entries:
+                    artifacts: List[TritonKernelArtifact] = []
+                    path = os.path.join(entry.directory, entry.kernel_hash)
+                    if not os.path.exists(path):
+                        continue
+                    for filename in os.listdir(path):
+                        filepath = os.path.join(path, filename)
+                        try:
+                            assert os.path.isfile(filepath)
+                            with open(filepath, "rb") as file:
+                                payload = file.read()
+                                if filepath.endswith(".json"):
+                                    # Remove the path from payload
+                                    payload = payload.replace(
+                                        str.encode(path), TritonBundler._REPLACE_BYTES
+                                    )
+                                artifacts.append(
+                                    TritonKernelArtifact(filename, payload)
+                                )
+                            counters["inductor"]["triton_bundler_save_kernel"] += 1
+                        except Exception:
+                            log.debug("failed to collect triton kernel", exc_info=True)
+                        if filename.endswith(".cubin"):
+                            # Each kernel has bunch of files like .cubin, .json, .ttir
+                            # Just append one of them without the extension
+                            kernel_names.append(Path(filename).stem)
+                    if artifacts:
+                        result.append(
+                            TritonKernelArtifacts(
+                                entry.kernel_hash,
+                                entry.device,
+                                artifacts,
+                            )
+                        )
+                cls._entries = None
+                return result, TritonBundlerMetadata(kernel_names)
+            return [], None
+
+    @staticmethod
+    def read_and_emit(
+        bundle: List[TritonKernelArtifacts],
+    ) -> Optional[TritonBundlerMetadata]:
+        """
+        This is the main function called when a cache read happens. This function
+        converts the bundled format back into individual files and writes them
+        to the filesystem.
+
+        NOTE: When we are writing to the filesystem, we assume exclusive access
+        to the target directory.
+        This means that if the target folder already exists and is non-empty,
+        we bail out.
+        Exclusive access means that no other process should be writing to
+        or reading from the target directory.
+        """
+        if not TritonBundler.is_enabled():
+            return None
+
+        with dynamo_timed(key="TritonBundler.read_and_emit", fwd_only=False):
+            kernel_names: List[str] = []
+
+            for artifacts in bundle:
+                basedir = triton_cache_dir(artifacts.device)
+                directory = os.path.join(basedir, artifacts.kernel_hash)
+
+                if os.path.exists(directory) and len(os.listdir(directory)) != 0:
+                    # If directory already exists, we bail out and leave
+                    # local disk to take care of caching
+                    log.debug(
+                        "Bailing out TritonBundler.read_and_emit, %s is non empty",
+                        directory,
+                    )
+                    continue
+
+                Path(directory).mkdir(parents=True, exist_ok=True)
+
+                # Random ID to avoid any collisions
+                rnd_id = str(uuid.uuid4())
+                tmp_dir = os.path.join(basedir, f"tmp.{rnd_id}")
+                os.makedirs(tmp_dir)
+
+                for artifact in artifacts.artifacts:
+                    filepath = os.path.join(tmp_dir, artifact.filename)
+                    with open(filepath, "wb") as file:
+                        payload = artifact.payload
+                        if artifact.filename.endswith(".json"):
+                            payload = payload.replace(
+                                TritonBundler._REPLACE_BYTES, str.encode(directory)
+                            )
+                        file.write(payload)
+                    counters["inductor"]["triton_bundler_read_and_emit_kernel"] += 1
+                    if artifact.filename.endswith(".cubin"):
+                        # Each kernel has bunch of files like .cubin, .json, .ttir
+                        # Just append one of them without the extension
+                        kernel_names.append(Path(artifact.filename).stem)
+                # Atomic on POSIX systems
+                os.replace(tmp_dir, directory)
+            return TritonBundlerMetadata(kernel_names)


### PR DESCRIPTION
Summary:
This diff/PR attempts to consolidate Triton caching into the Inductor caching so that there can be just one cache that unifies them both, reducing network requests and increasing success rate.

Implementation details can be found via reading the code or the post: https://fb.workplace.com/groups/1553867532149891/posts/1605037517032892

I did not use the Autotune bundler code at all since I want to simplify that and merge it into this on the next diff/PR.

In terms of instrumentation
1) Dynamo compile: `triton_bundler_time_saved_s` this is sum of all triton.compile calls. We dont have to use the specific number, can use this as a binary value.
2) Events table: I used dynamo_timed to measure how much time we spend on bundler collect and write functions which is all the work we do in this diff
3) TLParse: I emitted number of kernels and triton_bundler_time_saved_s into tlparse as well

Test Plan: Updated unit tests

Adhoc running
```
TORCHINDUCTOR_BUNDLE_TRITON_INTO_FX_GRAPH_CACHE=1 buck2 run @mode/opt //scripts/oulgen:runner
```
gives
https://interncache-all.fbcdn.net/manifold/tlparse_reports/tree/logs/.tmpmTZt6b/0_0_0/fx_graph_cache_hit_4.json
<img width="771" alt="image" src="https://github.com/user-attachments/assets/478782a2-ee47-40cb-b723-fcac2bf9dd93">




Differential Revision: D64504909




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @rec