### PR TITLE
Use fresh cache directory in test_cudacodecache

### DIFF
--- a/test/inductor/test_cudacodecache.py
+++ b/test/inductor/test_cudacodecache.py
@@ -10,6 +10,7 @@ from torch._inductor.codecache import CUDACodeCache
 from torch._inductor.codegen.cuda.cuda_env import nvcc_exist
 from torch._inductor.exc import CUDACompileError
 from torch._inductor.test_case import TestCase as InductorTestCase
+from torch._inductor.utils import fresh_inductor_cache
 
 
 _SOURCE_CODE = r"""
@@ -39,51 +40,56 @@ int saxpy(int n, float a, float *x, float *y) {
 @unittest.skipIf(config.is_fbcode(), "fbcode requires different CUDA_HOME setup")
 class TestCUDACodeCache(InductorTestCase):
     def test_cuda_load(self):
-        # Test both .o and .so compilation.
-        object_file_path, object_hash_key, source_code_path0 = CUDACodeCache.compile(
-            _SOURCE_CODE, "o"
-        )
-        dll_wrapper, so_hash_key, source_code_path1 = CUDACodeCache.load(
-            _SOURCE_CODE, "so"
-        )
-        self.assertNotEqual(source_code_path0, source_code_path1)
-        self.assertNotEqual(object_hash_key, so_hash_key)
+        with fresh_inductor_cache():
+            # Test both .o and .so compilation.
+            (
+                object_file_path,
+                object_hash_key,
+                source_code_path0,
+            ) = CUDACodeCache.compile(_SOURCE_CODE, "o")
+            dll_wrapper, so_hash_key, source_code_path1 = CUDACodeCache.load(
+                _SOURCE_CODE, "so"
+            )
+            self.assertNotEqual(source_code_path0, source_code_path1)
+            self.assertNotEqual(object_hash_key, so_hash_key)
 
-        # Test load and call functions in .so.
-        x = torch.rand(10).float().cuda()
-        y = torch.rand(10).float().cuda()
-        a = 5.0
-        expected_y = a * x + y
-        res = dll_wrapper.saxpy(
-            ctypes.c_int(10),
-            ctypes.c_float(a),
-            ctypes.c_void_p(x.data_ptr()),
-            ctypes.c_void_p(y.data_ptr()),
-        )
-        torch.testing.assert_close(y, expected_y)
+            # Test load and call functions in .so.
+            x = torch.rand(10).float().cuda()
+            y = torch.rand(10).float().cuda()
+            a = 5.0
+            expected_y = a * x + y
+            res = dll_wrapper.saxpy(
+                ctypes.c_int(10),
+                ctypes.c_float(a),
+                ctypes.c_void_p(x.data_ptr()),
+                ctypes.c_void_p(y.data_ptr()),
+            )
+            torch.testing.assert_close(y, expected_y)
 
     def test_compilation_error(self):
-        error_source_code = _SOURCE_CODE.replace("saxpy_device", "saxpy_wrong", 1)
-        with self.assertRaises(CUDACompileError):
-            CUDACodeCache.compile(error_source_code, "o")
+        with fresh_inductor_cache():
+            error_source_code = _SOURCE_CODE.replace("saxpy_device", "saxpy_wrong", 1)
+            with self.assertRaises(CUDACompileError):
+                CUDACodeCache.compile(error_source_code, "o")
 
     def test_async_compile(self):
-        async_compile = AsyncCompile()
-        compiled_res = async_compile.cuda(_SOURCE_CODE, "so")
-        async_compile.wait(globals())
+        with fresh_inductor_cache():
+            async_compile = AsyncCompile()
+            compiled_res = async_compile.cuda(_SOURCE_CODE, "so")
+            async_compile.wait(globals())
 
-        # Test load and call functions in .so.
-        x = torch.rand(5).float().cuda()
-        y = torch.rand(5).float().cuda()
-        a = 2.0
-        expected_y = a * x + y
-        res = compiled_res.result().saxpy(
-            ctypes.c_int(5),
-            ctypes.c_float(a),
-            ctypes.c_void_p(x.data_ptr()),
-            ctypes.c_void_p(y.data_ptr()),
-        )
-        torch.testing.assert_close(y, expected_y)
+            # Test load and call functions in .so.
+            x = torch.rand(5).float().cuda()
+            y = torch.rand(5).float().cuda()
+            a = 2.0
+            expected_y = a * x + y
+            res = compiled_res.result().saxpy(
+                ctypes.c_int(5),
+                ctypes.c_float(a),
+                ctypes.c_void_p(x.data_ptr()),
+                ctypes.c_void_p(y.data_ptr()),
+            )
+            torch.testing.assert_close(y, expected_y)
 
 
 if __name__ == "__main__":

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -248,7 +248,6 @@ CI_SERIAL_LIST = [
     "inductor/test_max_autotune",
     "inductor/test_cutlass_backend",  # slow due to many nvcc compilation steps,
     "inductor/test_flex_attention",  # OOM
-    "inductor/test_cudacodecache",  # The test times out flakily
 ]
 # A subset of onnx tests that cannot run in parallel due to high memory usage.
 ONNX_SERIAL_LIST = [

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -248,6 +248,7 @@ CI_SERIAL_LIST = [
     "inductor/test_max_autotune",
     "inductor/test_cutlass_backend",  # slow due to many nvcc compilation steps,
     "inductor/test_flex_attention",  # OOM
+    "inductor/test_cudacodecache",  # The test times out flakily
 ]
 # A subset of onnx tests that cannot run in parallel due to high memory usage.
 ONNX_SERIAL_LIST = [


### PR DESCRIPTION
This test frequently times out flakily, for example, https://github.com/pytorch/pytorch/actions/runs/11377972115/job/31654107609#step:22:2376.  I still couldn't reproduce this behavior locally running this multiple times and in parallel.  ~~So, I suspect that the error only shows up when other tests are run in paralel.~~

~~I attempt to run this serially in this PR, once land, I can monitor trunk to see if this helps.~~

Running serially still ends up with a timing out https://github.com/pytorch/pytorch/actions/runs/11391445912/job/31697603438, another try with fresh cache.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov