### PR TITLE
Use CUDA 12.1 in Windows CI jobs

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -188,14 +188,14 @@ jobs:
 #      docker-image: ${{ needs.linux-focal-cuda11_8-py3_10-gcc9-debug-build.outputs.docker-image }}
 #      test-matrix: ${{ needs.linux-focal-cuda11_8-py3_10-gcc9-debug-build.outputs.test-matrix }}
 #
-  win-vs2019-cuda11_8-py3-build:
-    name: win-vs2019-cuda11.8-py3
+  win-vs2019-cuda12_4-py3-build:
+    name: win-vs2019-cuda12.4-py3
     uses: ./.github/workflows/_win-build.yml
     needs: get-label-type
     with:
       runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
-      build-environment: win-vs2019-cuda11.8-py3
-      cuda-version: "11.8"
+      build-environment: win-vs2019-cuda12.4-py3
+      cuda-version: "12.4"
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 4, runner: "windows.g5.4xlarge.nvidia.gpu" },
@@ -205,16 +205,16 @@ jobs:
           { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge.nonephemeral" },
         ]}
 
-  win-vs2019-cuda11_8-py3-test:
-    name: win-vs2019-cuda11.8-py3
+  win-vs2019-cuda12_4-py3-test:
+    name: win-vs2019-cuda12.4-py3
     uses: ./.github/workflows/_win-test.yml
     needs:
-      - win-vs2019-cuda11_8-py3-build
+      - win-vs2019-cuda12_4-py3-build
       - target-determination
     with:
-      build-environment: win-vs2019-cuda11.8-py3
-      cuda-version: "11.8"
-      test-matrix: ${{ needs.win-vs2019-cuda11_8-py3-build.outputs.test-matrix }}
+      build-environment: win-vs2019-cuda12.4-py3
+      cuda-version: "12.4"
+      test-matrix: ${{ needs.win-vs2019-cuda12_4-py3-build.outputs.test-matrix }}
 #
 #  # TODO: Figure out how to migrate this job to M1 runner
 #  ios-build-test:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -47,147 +47,147 @@ jobs:
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
 
-  linux-focal-cuda12_1-py3_10-gcc9-build:
-    name: linux-focal-cuda12.1-py3.10-gcc9
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9
-      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn9-py3-gcc9
-      test-matrix: |
-        { include: [
-          { config: "nogpu_AVX512", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "nogpu_AVX512", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "nogpu_NO_AVX2", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "nogpu_NO_AVX2", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "jit_legacy", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-        ]}
-  linux-focal-cuda12_1-py3_10-gcc9-test:
-    name: linux-focal-cuda12.1-py3.10-gcc9
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - linux-focal-cuda12_1-py3_10-gcc9-build
-      - target-determination
-    with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-build.outputs.test-matrix }}
-
-  linux-focal-cuda12_4-py3_10-gcc9-build:
-    name: linux-focal-cuda12.4-py3.10-gcc9
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-focal-cuda12.4-py3.10-gcc9
-      docker-image-name: pytorch-linux-focal-cuda12.4-cudnn9-py3-gcc9
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 2, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 3, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 4, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-          { config: "nogpu_AVX512", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "nogpu_AVX512", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "nogpu_NO_AVX2", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "nogpu_NO_AVX2", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "jit_legacy", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-        ]}
-
-  linux-focal-cuda12_4-py3_10-gcc9-test:
-    name: linux-focal-cuda12.4-py3.10-gcc9
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - linux-focal-cuda12_4-py3_10-gcc9-build
-      - target-determination
-    with:
-      timeout-minutes: 360
-      build-environment: linux-focal-cuda12.4-py3.10-gcc9
-      docker-image: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-build.outputs.test-matrix }}
-
-  parallelnative-linux-jammy-py3_9-gcc11-build:
-    name: parallelnative-linux-jammy-py3.9-gcc11
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: parallelnative-linux-jammy-py3.9-gcc11
-      docker-image-name: pytorch-linux-jammy-py3.9-gcc11
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
-          { config: "default", shard: 2, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
-          { config: "default", shard: 3, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
-          { config: "default", shard: 4, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
-        ]}
-
-  parallelnative-linux-jammy-py3_9-gcc11-test:
-    name: parallelnative-linux-jammy-py3.9-gcc11
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - parallelnative-linux-jammy-py3_9-gcc11-build
-      - target-determination
-    with:
-      build-environment: parallelnative-linux-jammy-py3.9-gcc11
-      docker-image: ${{ needs.parallelnative-linux-jammy-py3_9-gcc11-build.outputs.docker-image }}
-      test-matrix: ${{ needs.parallelnative-linux-jammy-py3_9-gcc11-build.outputs.test-matrix }}
-
-  linux-focal-cuda11_8-py3_9-gcc9-build:
-    name: linux-focal-cuda11.8-py3.9-gcc9
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-focal-cuda11.8-py3.9-gcc9
-      docker-image-name: pytorch-linux-focal-cuda11.8-cudnn9-py3-gcc9
-      cuda-arch-list: 8.6
-      test-matrix: |
-        { include: [
-          { config: "multigpu", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu" },
-        ]}
-      build-with-debug: false
-
-  linux-focal-cuda11_8-py3_9-gcc9-test:
-    name: linux-focal-cuda11.8-py3.9-gcc9
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-cuda11_8-py3_9-gcc9-build
-    with:
-      build-environment: linux-focal-cuda11.8-py3.9-gcc9
-      docker-image: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-build.outputs.test-matrix }}
-
-  linux-focal-cuda11_8-py3_10-gcc9-debug-build:
-    name: linux-focal-cuda11.8-py3.10-gcc9-debug
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-focal-cuda11.8-py3.10-gcc9-debug
-      docker-image-name: pytorch-linux-focal-cuda11.8-cudnn9-py3-gcc9
-      build-with-debug: true
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 2, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 3, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 4, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-        ]}
-
-  linux-focal-cuda11_8-py3_10-gcc9-debug-test:
-    name: linux-focal-cuda11.8-py3.10-gcc9-debug
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - linux-focal-cuda11_8-py3_10-gcc9-debug-build
-      - target-determination
-    with:
-      build-environment: linux-focal-cuda11.8-py3.10-gcc9-debug
-      docker-image: ${{ needs.linux-focal-cuda11_8-py3_10-gcc9-debug-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda11_8-py3_10-gcc9-debug-build.outputs.test-matrix }}
-
+#  linux-focal-cuda12_1-py3_10-gcc9-build:
+#    name: linux-focal-cuda12.1-py3.10-gcc9
+#    uses: ./.github/workflows/_linux-build.yml
+#    needs: get-label-type
+#    with:
+#      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+#      build-environment: linux-focal-cuda12.1-py3.10-gcc9
+#      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn9-py3-gcc9
+#      test-matrix: |
+#        { include: [
+#          { config: "nogpu_AVX512", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "nogpu_AVX512", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "nogpu_NO_AVX2", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "nogpu_NO_AVX2", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "jit_legacy", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#        ]}
+#  linux-focal-cuda12_1-py3_10-gcc9-test:
+#    name: linux-focal-cuda12.1-py3.10-gcc9
+#    uses: ./.github/workflows/_linux-test.yml
+#    needs:
+#      - linux-focal-cuda12_1-py3_10-gcc9-build
+#      - target-determination
+#    with:
+#      build-environment: linux-focal-cuda12.1-py3.10-gcc9
+#      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-build.outputs.docker-image }}
+#      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-build.outputs.test-matrix }}
+#
+#  linux-focal-cuda12_4-py3_10-gcc9-build:
+#    name: linux-focal-cuda12.4-py3.10-gcc9
+#    uses: ./.github/workflows/_linux-build.yml
+#    needs: get-label-type
+#    with:
+#      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+#      build-environment: linux-focal-cuda12.4-py3.10-gcc9
+#      docker-image-name: pytorch-linux-focal-cuda12.4-cudnn9-py3-gcc9
+#      test-matrix: |
+#        { include: [
+#          { config: "default", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#          { config: "default", shard: 2, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#          { config: "default", shard: 3, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#          { config: "default", shard: 4, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#          { config: "default", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#          { config: "nogpu_AVX512", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "nogpu_AVX512", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "nogpu_NO_AVX2", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "nogpu_NO_AVX2", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "jit_legacy", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#        ]}
+#
+#  linux-focal-cuda12_4-py3_10-gcc9-test:
+#    name: linux-focal-cuda12.4-py3.10-gcc9
+#    uses: ./.github/workflows/_linux-test.yml
+#    needs:
+#      - linux-focal-cuda12_4-py3_10-gcc9-build
+#      - target-determination
+#    with:
+#      timeout-minutes: 360
+#      build-environment: linux-focal-cuda12.4-py3.10-gcc9
+#      docker-image: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-build.outputs.docker-image }}
+#      test-matrix: ${{ needs.linux-focal-cuda12_4-py3_10-gcc9-build.outputs.test-matrix }}
+#
+#  parallelnative-linux-jammy-py3_9-gcc11-build:
+#    name: parallelnative-linux-jammy-py3.9-gcc11
+#    uses: ./.github/workflows/_linux-build.yml
+#    needs: get-label-type
+#    with:
+#      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+#      build-environment: parallelnative-linux-jammy-py3.9-gcc11
+#      docker-image-name: pytorch-linux-jammy-py3.9-gcc11
+#      test-matrix: |
+#        { include: [
+#          { config: "default", shard: 1, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+#          { config: "default", shard: 2, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+#          { config: "default", shard: 3, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+#          { config: "default", shard: 4, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+#        ]}
+#
+#  parallelnative-linux-jammy-py3_9-gcc11-test:
+#    name: parallelnative-linux-jammy-py3.9-gcc11
+#    uses: ./.github/workflows/_linux-test.yml
+#    needs:
+#      - parallelnative-linux-jammy-py3_9-gcc11-build
+#      - target-determination
+#    with:
+#      build-environment: parallelnative-linux-jammy-py3.9-gcc11
+#      docker-image: ${{ needs.parallelnative-linux-jammy-py3_9-gcc11-build.outputs.docker-image }}
+#      test-matrix: ${{ needs.parallelnative-linux-jammy-py3_9-gcc11-build.outputs.test-matrix }}
+#
+#  linux-focal-cuda11_8-py3_9-gcc9-build:
+#    name: linux-focal-cuda11.8-py3.9-gcc9
+#    uses: ./.github/workflows/_linux-build.yml
+#    needs: get-label-type
+#    with:
+#      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+#      build-environment: linux-focal-cuda11.8-py3.9-gcc9
+#      docker-image-name: pytorch-linux-focal-cuda11.8-cudnn9-py3-gcc9
+#      cuda-arch-list: 8.6
+#      test-matrix: |
+#        { include: [
+#          { config: "multigpu", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu" },
+#        ]}
+#      build-with-debug: false
+#
+#  linux-focal-cuda11_8-py3_9-gcc9-test:
+#    name: linux-focal-cuda11.8-py3.9-gcc9
+#    uses: ./.github/workflows/_linux-test.yml
+#    needs: linux-focal-cuda11_8-py3_9-gcc9-build
+#    with:
+#      build-environment: linux-focal-cuda11.8-py3.9-gcc9
+#      docker-image: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-build.outputs.docker-image }}
+#      test-matrix: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-build.outputs.test-matrix }}
+#
+#  linux-focal-cuda11_8-py3_10-gcc9-debug-build:
+#    name: linux-focal-cuda11.8-py3.10-gcc9-debug
+#    uses: ./.github/workflows/_linux-build.yml
+#    needs: get-label-type
+#    with:
+#      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+#      build-environment: linux-focal-cuda11.8-py3.10-gcc9-debug
+#      docker-image-name: pytorch-linux-focal-cuda11.8-cudnn9-py3-gcc9
+#      build-with-debug: true
+#      test-matrix: |
+#        { include: [
+#          { config: "default", shard: 1, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#          { config: "default", shard: 2, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#          { config: "default", shard: 3, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#          { config: "default", shard: 4, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#          { config: "default", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#        ]}
+#
+#  linux-focal-cuda11_8-py3_10-gcc9-debug-test:
+#    name: linux-focal-cuda11.8-py3.10-gcc9-debug
+#    uses: ./.github/workflows/_linux-test.yml
+#    needs:
+#      - linux-focal-cuda11_8-py3_10-gcc9-debug-build
+#      - target-determination
+#    with:
+#      build-environment: linux-focal-cuda11.8-py3.10-gcc9-debug
+#      docker-image: ${{ needs.linux-focal-cuda11_8-py3_10-gcc9-debug-build.outputs.docker-image }}
+#      test-matrix: ${{ needs.linux-focal-cuda11_8-py3_10-gcc9-debug-build.outputs.test-matrix }}
+#
   win-vs2019-cuda11_8-py3-build:
     name: win-vs2019-cuda11.8-py3
     uses: ./.github/workflows/_win-build.yml
@@ -215,173 +215,173 @@ jobs:
       build-environment: win-vs2019-cuda11.8-py3
       cuda-version: "11.8"
       test-matrix: ${{ needs.win-vs2019-cuda11_8-py3-build.outputs.test-matrix }}
-
-  # TODO: Figure out how to migrate this job to M1 runner
-  ios-build-test:
-    name: ios-build-test
-    # Has been broken for a while, see https://github.com/pytorch/pytorch/issues/136284
-    # if: github.event_name != 'schedule' || github.event.schedule == '45 0,8,16 * * 1-5' || github.event.schedule == '45 4 * * 0,6' || github.event.schedule == '29 8 * * *'
-    if: false
-    uses: ./.github/workflows/_ios-build-test.yml
-    with:
-      trigger-event: ${{ github.event_name }}
-      build-environment: ios-build-test
-      sync-tag: ios-build-test
-      test-matrix: |
-        { include: [
-          { config: "default",
-            shard: 1,
-            num_shards: 1,
-            runner: "macos-14-xlarge",
-            ios_platform: "SIMULATOR",
-            ios_arch: "arm64",
-            use_lite_interpreter: 1,
-            use_metal: 0,
-            use_coreml: 1,
-            use_custom_op_list: ""
-          },
-          { config: "default",
-            shard: 1,
-            num_shards: 1,
-            runner: "macos-14-xlarge",
-            ios_platform: "OS",
-            ios_arch: "arm64",
-            use_lite_interpreter: 1,
-            use_metal: 1,
-            use_coreml: 1,
-            use_custom_op_list: "mobilenetv2.yaml"
-          }
-        ]}
-
-  buck-build-test:
-    name: buck-build-test
-    uses: ./.github/workflows/_buck-build-test.yml
-    with:
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
-        ]}
-
-  android-emulator-build-test:
-    name: android-emulator-build-test
-    uses: ./.github/workflows/_run_android_tests.yml
-    with:
-      test-matrix: |
-        { include: [
-          { config: 'default',
-            shard: 1,
-            num_shards: 1,
-            runner: 'ubuntu-20.04-16x',
-            use_lite_interpreter: 1,
-            # Just set x86 for testing here
-            support_abi: 'x86',
-          },
-        ]}
-
-  linux-vulkan-focal-py3_11-clang10-build:
-    name: linux-vulkan-focal-py3.11-clang10
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-vulkan-focal-py3.11-clang10
-      docker-image-name: pytorch-linux-focal-py3.11-clang10
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
-        ]}
-
-  linux-vulkan-focal-py3_11-clang10-test:
-    name: linux-vulkan-focal-py3.11-clang10
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-vulkan-focal-py3_11-clang10-build
-    with:
-      build-environment: linux-vulkan-focal-py3.11-clang10
-      docker-image: ${{ needs.linux-vulkan-focal-py3_11-clang10-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-vulkan-focal-py3_11-clang10-build.outputs.test-matrix }}
-
-  linux-focal-rocm6_2-py3_10-build:
-    name: linux-focal-rocm6.2-py3.10
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-focal-rocm6.2-py3.10
-      docker-image-name: pytorch-linux-focal-rocm-n-py3
-      test-matrix: |
-        { include: [
-          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
-        ]}
-
-  linux-focal-rocm6_2-py3_10-test:
-    permissions:
-      id-token: write
-      contents: read
-    name: linux-focal-rocm6.2-py3.10
-    uses: ./.github/workflows/_rocm-test.yml
-    needs:
-      - linux-focal-rocm6_2-py3_10-build
-      - target-determination
-    with:
-      build-environment: linux-focal-rocm6.2-py3.10
-      docker-image: ${{ needs.linux-focal-rocm6_2-py3_10-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-rocm6_2-py3_10-build.outputs.test-matrix }}
-
-  linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build:
-    name: linux-focal-cuda12.1-py3.10-gcc9-experimental-split-build
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      use_split_build: true
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9
-      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn9-py3-gcc9
-      test-matrix: |
-        { include: [
-          { config: "nogpu_AVX512", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "nogpu_AVX512", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "nogpu_NO_AVX2", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "nogpu_NO_AVX2", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
-          { config: "jit_legacy", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
-        ]}
-
-  linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build-test:
-    name: linux-focal-cuda12.1-py3.10-gcc9-experimental-split-build
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build
-      - target-determination
-    with:
-      build-environment: linux-focal-cuda12.1-py3.10-gcc9-experimental-split-build
-      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build.outputs.test-matrix }}
-
-
-  linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build:
-    name: linux-focal-cuda11.8-py3.9-gcc9-experimental-split-build
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      use_split_build: true
-      build-environment: linux-focal-cuda11.8-py3.9-gcc9
-      docker-image-name: pytorch-linux-focal-cuda11.8-cudnn9-py3-gcc9
-      cuda-arch-list: 8.6
-      test-matrix: |
-        { include: [
-          { config: "multigpu", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu" },
-        ]}
-      build-with-debug: false
-
-  linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build-test:
-    name: linux-focal-cuda11.8-py3.9-gcc9-experimental-split-build-test
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build
-      - target-determination
-    with:
-      build-environment: linux-focal-cuda11.8-py3.9-gcc9-experimental-split-build
-      docker-image: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build.outputs.test-matrix }}
+#
+#  # TODO: Figure out how to migrate this job to M1 runner
+#  ios-build-test:
+#    name: ios-build-test
+#    # Has been broken for a while, see https://github.com/pytorch/pytorch/issues/136284
+#    # if: github.event_name != 'schedule' || github.event.schedule == '45 0,8,16 * * 1-5' || github.event.schedule == '45 4 * * 0,6' || github.event.schedule == '29 8 * * *'
+#    if: false
+#    uses: ./.github/workflows/_ios-build-test.yml
+#    with:
+#      trigger-event: ${{ github.event_name }}
+#      build-environment: ios-build-test
+#      sync-tag: ios-build-test
+#      test-matrix: |
+#        { include: [
+#          { config: "default",
+#            shard: 1,
+#            num_shards: 1,
+#            runner: "macos-14-xlarge",
+#            ios_platform: "SIMULATOR",
+#            ios_arch: "arm64",
+#            use_lite_interpreter: 1,
+#            use_metal: 0,
+#            use_coreml: 1,
+#            use_custom_op_list: ""
+#          },
+#          { config: "default",
+#            shard: 1,
+#            num_shards: 1,
+#            runner: "macos-14-xlarge",
+#            ios_platform: "OS",
+#            ios_arch: "arm64",
+#            use_lite_interpreter: 1,
+#            use_metal: 1,
+#            use_coreml: 1,
+#            use_custom_op_list: "mobilenetv2.yaml"
+#          }
+#        ]}
+#
+#  buck-build-test:
+#    name: buck-build-test
+#    uses: ./.github/workflows/_buck-build-test.yml
+#    with:
+#      test-matrix: |
+#        { include: [
+#          { config: "default", shard: 1, num_shards: 1, runner: "ubuntu-latest" },
+#        ]}
+#
+#  android-emulator-build-test:
+#    name: android-emulator-build-test
+#    uses: ./.github/workflows/_run_android_tests.yml
+#    with:
+#      test-matrix: |
+#        { include: [
+#          { config: 'default',
+#            shard: 1,
+#            num_shards: 1,
+#            runner: 'ubuntu-20.04-16x',
+#            use_lite_interpreter: 1,
+#            # Just set x86 for testing here
+#            support_abi: 'x86',
+#          },
+#        ]}
+#
+#  linux-vulkan-focal-py3_11-clang10-build:
+#    name: linux-vulkan-focal-py3.11-clang10
+#    uses: ./.github/workflows/_linux-build.yml
+#    needs: get-label-type
+#    with:
+#      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+#      build-environment: linux-vulkan-focal-py3.11-clang10
+#      docker-image-name: pytorch-linux-focal-py3.11-clang10
+#      test-matrix: |
+#        { include: [
+#          { config: "default", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+#        ]}
+#
+#  linux-vulkan-focal-py3_11-clang10-test:
+#    name: linux-vulkan-focal-py3.11-clang10
+#    uses: ./.github/workflows/_linux-test.yml
+#    needs: linux-vulkan-focal-py3_11-clang10-build
+#    with:
+#      build-environment: linux-vulkan-focal-py3.11-clang10
+#      docker-image: ${{ needs.linux-vulkan-focal-py3_11-clang10-build.outputs.docker-image }}
+#      test-matrix: ${{ needs.linux-vulkan-focal-py3_11-clang10-build.outputs.test-matrix }}
+#
+#  linux-focal-rocm6_2-py3_10-build:
+#    name: linux-focal-rocm6.2-py3.10
+#    uses: ./.github/workflows/_linux-build.yml
+#    needs: get-label-type
+#    with:
+#      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+#      build-environment: linux-focal-rocm6.2-py3.10
+#      docker-image-name: pytorch-linux-focal-rocm-n-py3
+#      test-matrix: |
+#        { include: [
+#          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
+#          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
+#          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
+#        ]}
+#
+#  linux-focal-rocm6_2-py3_10-test:
+#    permissions:
+#      id-token: write
+#      contents: read
+#    name: linux-focal-rocm6.2-py3.10
+#    uses: ./.github/workflows/_rocm-test.yml
+#    needs:
+#      - linux-focal-rocm6_2-py3_10-build
+#      - target-determination
+#    with:
+#      build-environment: linux-focal-rocm6.2-py3.10
+#      docker-image: ${{ needs.linux-focal-rocm6_2-py3_10-build.outputs.docker-image }}
+#      test-matrix: ${{ needs.linux-focal-rocm6_2-py3_10-build.outputs.test-matrix }}
+#
+#  linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build:
+#    name: linux-focal-cuda12.1-py3.10-gcc9-experimental-split-build
+#    uses: ./.github/workflows/_linux-build.yml
+#    needs: get-label-type
+#    with:
+#      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+#      use_split_build: true
+#      build-environment: linux-focal-cuda12.1-py3.10-gcc9
+#      docker-image-name: pytorch-linux-focal-cuda12.1-cudnn9-py3-gcc9
+#      test-matrix: |
+#        { include: [
+#          { config: "nogpu_AVX512", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "nogpu_AVX512", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "nogpu_NO_AVX2", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "nogpu_NO_AVX2", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+#          { config: "jit_legacy", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge.nvidia.gpu" },
+#        ]}
+#
+#  linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build-test:
+#    name: linux-focal-cuda12.1-py3.10-gcc9-experimental-split-build
+#    uses: ./.github/workflows/_linux-test.yml
+#    needs:
+#      - linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build
+#      - target-determination
+#    with:
+#      build-environment: linux-focal-cuda12.1-py3.10-gcc9-experimental-split-build
+#      docker-image: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build.outputs.docker-image }}
+#      test-matrix: ${{ needs.linux-focal-cuda12_1-py3_10-gcc9-experimental-split-build.outputs.test-matrix }}
+#
+#
+#  linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build:
+#    name: linux-focal-cuda11.8-py3.9-gcc9-experimental-split-build
+#    uses: ./.github/workflows/_linux-build.yml
+#    needs: get-label-type
+#    with:
+#      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+#      use_split_build: true
+#      build-environment: linux-focal-cuda11.8-py3.9-gcc9
+#      docker-image-name: pytorch-linux-focal-cuda11.8-cudnn9-py3-gcc9
+#      cuda-arch-list: 8.6
+#      test-matrix: |
+#        { include: [
+#          { config: "multigpu", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu" },
+#        ]}
+#      build-with-debug: false
+#
+#  linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build-test:
+#    name: linux-focal-cuda11.8-py3.9-gcc9-experimental-split-build-test
+#    uses: ./.github/workflows/_linux-test.yml
+#    needs:
+#      - linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build
+#      - target-determination
+#    with:
+#      build-environment: linux-focal-cuda11.8-py3.9-gcc9-experimental-split-build
+#      docker-image: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build.outputs.docker-image }}
+#      test-matrix: ${{ needs.linux-focal-cuda11_8-py3_9-gcc9-experimental-split-build.outputs.test-matrix }}

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -198,11 +198,11 @@ jobs:
       cuda-version: "11.8"
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 2, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 3, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}windows.g5.4xlarge.nvidia.gpu" },
-          { config: "default", shard: 4, num_shards: 4, runner: "${{ needs.get-label-type.outputs.label-type }}windows.g5.4xlarge.nvidia.gpu" },
-          { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 1, num_shards: 4, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 2, num_shards: 4, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 3, num_shards: 4, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "default", shard: 4, num_shards: 4, runner: "windows.g5.4xlarge.nvidia.gpu" },
+          { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge.nonephemeral" },
         ]}
 
   win-vs2019-cuda11_8-py3-test:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -188,14 +188,14 @@ jobs:
 #      docker-image: ${{ needs.linux-focal-cuda11_8-py3_10-gcc9-debug-build.outputs.docker-image }}
 #      test-matrix: ${{ needs.linux-focal-cuda11_8-py3_10-gcc9-debug-build.outputs.test-matrix }}
 #
-  win-vs2019-cuda12_4-py3-build:
-    name: win-vs2019-cuda12.4-py3
+  win-vs2019-cuda12_1-py3-build:
+    name: win-vs2019-cuda12.1-py3
     uses: ./.github/workflows/_win-build.yml
     needs: get-label-type
     with:
       runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
-      build-environment: win-vs2019-cuda12.4-py3
-      cuda-version: "12.4"
+      build-environment: win-vs2019-cuda12.1-py3
+      cuda-version: "12.1"
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 4, runner: "windows.g5.4xlarge.nvidia.gpu" },
@@ -205,16 +205,16 @@ jobs:
           { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge.nonephemeral" },
         ]}
 
-  win-vs2019-cuda12_4-py3-test:
-    name: win-vs2019-cuda12.4-py3
+  win-vs2019-cuda12_1-py3-test:
+    name: win-vs2019-cuda12.1-py3
     uses: ./.github/workflows/_win-test.yml
     needs:
-      - win-vs2019-cuda12_4-py3-build
+      - win-vs2019-cuda12_1-py3-build
       - target-determination
     with:
-      build-environment: win-vs2019-cuda12.4-py3
-      cuda-version: "12.4"
-      test-matrix: ${{ needs.win-vs2019-cuda12_4-py3-build.outputs.test-matrix }}
+      build-environment: win-vs2019-cuda12.1-py3
+      cuda-version: "12.1"
+      test-matrix: ${{ needs.win-vs2019-cuda12_1-py3-build.outputs.test-matrix }}
 #
 #  # TODO: Figure out how to migrate this job to M1 runner
 #  ios-build-test:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,9 +1,6 @@
 name: pull
 
 on:
-  pull_request:
-    branches-ignore:
-      - nightly
   push:
     branches:
       - main

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -214,13 +214,13 @@ jobs:
       cuda-version: cpu
       test-matrix: ${{ needs.win-vs2019-cpu-py3-build.outputs.test-matrix }}
 
-  win-vs2019-cuda12_4-py3-build:
-    name: win-vs2019-cuda12.4-py3
+  win-vs2019-cuda12_1py3-build:
+    name: win-vs2019-cuda12.1-py3
     uses: ./.github/workflows/_win-build.yml
     needs: get-label-type
     with:
-      build-environment: win-vs2019-cuda12.4-py3
-      cuda-version: "12.4"
+      build-environment: win-vs2019-cuda12.1-py3
+      cuda-version: "12.1"
       runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
 
   linux-focal-rocm6_2-py3_10-build:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -214,13 +214,13 @@ jobs:
       cuda-version: cpu
       test-matrix: ${{ needs.win-vs2019-cpu-py3-build.outputs.test-matrix }}
 
-  win-vs2019-cuda12_1-py3-build:
-    name: win-vs2019-cuda12.1-py3
+  win-vs2019-cuda12_4-py3-build:
+    name: win-vs2019-cuda12.4-py3
     uses: ./.github/workflows/_win-build.yml
     needs: get-label-type
     with:
-      build-environment: win-vs2019-cuda12.1-py3
-      cuda-version: "12.1"
+      build-environment: win-vs2019-cuda12.4-py3
+      cuda-version: "12.4"
       runner: "${{ needs.get-label-type.outputs.label-type }}windows.4xlarge.nonephemeral"
 
   linux-focal-rocm6_2-py3_10-build:


### PR DESCRIPTION
Windows GPU jobs are failing in trunk with the following failure https://github.com/pytorch/pytorch/actions/runs/11392803302/job/31701664460 coming from `test_autoload`:

```
building 'torch_test_cpp_extension.torch_library' extension
"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\bin\nvcc" -c torch_library.cu -o build\temp.win-amd64-cpython-39\Release\torch_library.obj -IC:\actions-runner\_work\pytorch\pytorch\build\win_tmp\build\torch\include -IC:\actions-runner\_work\pytorch\pytorch\build\win_tmp\build\torch\include\torch\csrc\api\include -IC:\actions-runner\_work\pytorch\pytorch\build\win_tmp\build\torch\include\TH -IC:\actions-runner\_work\pytorch\pytorch\build\win_tmp\build\torch\include\THC "-IC:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\include" -Iself_compiler_include_dirs_test -IC:\Jenkins\Miniconda3\include -IC:\Jenkins\Miniconda3\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\winrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\cppwinrt" -Xcudafe --diag_suppress=dll_interface_conflict_dllexport_assumed -Xcudafe --diag_suppress=dll_interface_conflict_none_assumed -Xcudafe --diag_suppress=field_without_dll_interface -Xcudafe --diag_suppress=base_class_has_different_dll_interface -Xcompiler /EHsc -Xcompiler /wd4068 -Xcompiler /wd4067 -Xcompiler /wd4624 -Xcompiler /wd4190 -Xcompiler /wd4018 -Xcompiler /wd4275 -Xcompiler /wd4267 -Xcompiler /wd4244 -Xcompiler /wd4251 -Xcompiler /wd4819 -Xcompiler /MD -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr -O2 -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=torch_library -D_GLIBCXX_USE_CXX11_ABI=0 -gencode=arch=compute_86,code=sm_86 -std=c++17 --use-local-env
torch_library.cu
nvcc error   : 'cudafe++' died with status 0xC0000005 (ACCESS_VIOLATION)
```

I'm still not sure why it starts to occurs now, but the fix seems to be to upgrade to a newer CUDA version.  As we have 11.8, 12.1, and 12.4 there

The attempt to use CUDA 12.4 fails because we need to upgrade NVIDIA driver on the AMI first https://github.com/pytorch/pytorch/actions/runs/11394450626/job/31707635601#step:15:13221

```
RuntimeError: The NVIDIA driver on your system is too old (found version 11040). Please update your GPU driver by downloading and installing a new version from the URL: http://www.nvidia.com/Download/index.aspx Alternatively, go to: https://pytorch.org/ to install a PyTorch version that has been compiled with your version of the CUDA driver.
```

So, 12.1 can be used for now till the AMI is updated.