### PR TITLE
Bugfix for passing None args to user defined Triton kernel

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1108,12 +1108,12 @@ class TritonHOPifier:
                 self.raise_unsupported("Grid can have at most rank 3")
 
         assert len(grids) != 0
-
         if isinstance(variable.kernel, JITFunction):
             constexprs = variable.kernel.constexprs
         else:
             assert isinstance(variable.kernel, Autotuner)
             constexprs = variable.kernel.fn.constexprs
+
 
         for idx, arg_name in enumerate(variable.kernel.arg_names):
             if idx in constexprs:
@@ -1131,7 +1131,6 @@ class TritonHOPifier:
                     combined_args_raw[arg_name] = variable.specialize_symbolic(
                         combined_args_raw[arg_name]
                     )
-
         return self.call_HOP(variable, grids, combined_args_raw, tx)
 
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1302,6 +1302,8 @@ class PythonWrapperCodegen(CodeGen):
             arg = kwargs[key]
             if idx in kernel.constexprs:
                 constants[key] = arg
+            elif kwargs[key] is None:
+                constants[key] = None
             else:
                 non_constant_indices.append(idx)
                 if isinstance(arg, ir.Buffer):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -5320,6 +5320,9 @@ class UserDefinedTritonKernel(ExternKernel):
 
         # Call to kernel
         self.codegen_comment(wrapper)
+
+        raw_args = list(filter(lambda x: not x is None, raw_args))
+
         wrapper.generate_user_defined_triton_kernel(
             new_name, raw_args, self.grid, configs, triton_meta, constexpr_indices
         )
@@ -5359,6 +5362,7 @@ class UserDefinedTritonKernel(ExternKernel):
         self.grid = grid
 
         kernel, configs = self.get_kernel_and_configs()
+
         # If we are autotuning, not all arguments will be passed
         self.ordered_kwargs_for_cpp_kernel = [
             arg for arg in kernel.arg_names if arg in kernel_args

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -478,12 +478,15 @@ class CachingAutotuner(KernelInterface):
                 raise
             binary._init_handles()
 
+
+        arg_names = [name for name in compile_meta["signature"].keys()]
+
         call_args = [
             arg
-            for i, arg in enumerate(self.fn.arg_names)
+            for i, arg in enumerate(arg_names)
             if i not in self.fn.constexprs
         ]
-        def_args = [name for name in self.fn.arg_names if name not in cfg.kwargs]
+        def_args = [name for name in arg_names if name not in cfg.kwargs]
 
         binary_shared = (
             binary.shared if hasattr(binary, "shared") else binary.metadata.shared
@@ -1714,7 +1717,6 @@ def user_autotune(
             )
             for c in configs
         ]
-
     return cached_autotune(
         None,
         configs,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

potential working bugfix

small nits

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang