### PR TITLE
[ROCm] index_put performance improvement

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -124,6 +124,55 @@ __global__ void indexing_backward_kernel(
   }
 }
 
+#ifdef USE_ROCM
+template <typename scalar_t, bool accumulate>
+__global__ void indexing_backward_kernel_rocm(
+  const int64_t* sorted_indices, const int64_t* indices, const scalar_t* grad_output, scalar_t* grad_weight,
+  int64_t numel, int64_t stride, int64_t stride_before, int64_t outer_dim) {
+
+  // This implementation is adopted from indexing_backward_kernel above.
+  using opmath_t = at::opmath_type<scalar_t>;
+  for (int64_t z = blockIdx.z; z < outer_dim; z += gridDim.z){
+    int64_t idx = blockIdx.x * blockDim.y + threadIdx.y;
+    if (idx < numel && (idx == 0 || sorted_indices[idx] != sorted_indices[idx - 1])){
+      do {
+        // if not accumulate, we only keep the last duplicate index so skip those before it
+        if constexpr (!accumulate) {
+          if ((idx < numel - 1) && sorted_indices[idx] == sorted_indices[idx + 1]) {
+            idx++;
+            continue;
+          }
+        }
+        const int64_t weight_row = ((int64_t) sorted_indices[idx]) * stride + z * stride_before;
+        const int64_t grad_row = ((int64_t) indices[idx]) * stride + z * numel * stride;
+
+        opmath_t gradient;
+        opmath_t weight;
+
+        int64_t feature_dim = threadIdx.x + blockIdx.y * blockDim.x;
+        while (feature_dim < stride) {
+          gradient = static_cast<opmath_t>(grad_output[grad_row + feature_dim]);
+          if constexpr (accumulate) {
+            weight = static_cast<opmath_t>(grad_weight[weight_row + feature_dim]);
+          }
+
+          if constexpr (accumulate) {
+            weight += gradient;
+          } else {
+            weight = gradient;
+          }
+
+          grad_weight[weight_row + feature_dim] = static_cast<scalar_t>(weight);
+          feature_dim += gridDim.y * blockDim.x;
+        }
+
+        idx++;
+      } while (idx < numel && sorted_indices[idx] == sorted_indices[idx - 1]);
+    }
+  }
+}
+#endif
+
 template <typename scalar_t>
 __global__ void indexing_backward_kernel_stride_1(
   const int64_t* sorted_indices, const int64_t* indices, const scalar_t* grad_output, scalar_t* grad_weight,
@@ -491,7 +540,11 @@ void index_put_with_sort_kernel(Tensor & self, const c10::List<std::optional<Ten
           linearIndex.numel()*sliceSize*nElemBefore == expandedValue.numel(),
           "number of flattened indices did not match number of elements in the value tensor: ",
           linearIndex.numel()*sliceSize*nElemBefore, " vs ", expandedValue.numel());
+#ifdef USE_ROCM
+      const int UNROLL = 1;
+#else
       const int UNROLL = 4;
+#endif
       const int indices_per_block = 4;
       const int warp_size = at::cuda::warp_size();
       dim3 grid(ceil_div(num_indices, (int64_t) indices_per_block),
@@ -549,6 +602,54 @@ void index_put_with_sort_kernel(Tensor & self, const c10::List<std::optional<Ten
             kHalf,
             kBool,
             kBFloat16);
+#ifdef USE_ROCM
+        } else if (UNROLL == 1) {
+          if (accumulate) {
+            AT_DISPATCH_V2(
+              expandedValue.scalar_type(),
+              "indexing_backward",
+              AT_WRAP([&] {
+                indexing_backward_kernel_rocm<scalar_t, true><<<grid, block, 0, stream>>>(
+                  sorted_indices.const_data_ptr<int64_t>(),
+                  orig_indices.const_data_ptr<int64_t>(),
+                  expandedValue.const_data_ptr<scalar_t>(),
+                  src_.mutable_data_ptr<scalar_t>(),
+                  num_indices,
+                  sliceSize,
+                  strideBefore,
+                  nElemBefore);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+              }),
+              AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
+              AT_EXPAND(AT_FLOAT8_TYPES),
+              kComplexHalf,
+              kHalf,
+              kBool,
+              kBFloat16);
+          } else {
+            AT_DISPATCH_V2(
+              expandedValue.scalar_type(),
+              "indexing_backward",
+              AT_WRAP([&] {
+                indexing_backward_kernel_rocm<scalar_t, false><<<grid, block, 0, stream>>>(
+                  sorted_indices.const_data_ptr<int64_t>(),
+                  orig_indices.const_data_ptr<int64_t>(),
+                  expandedValue.const_data_ptr<scalar_t>(),
+                  src_.mutable_data_ptr<scalar_t>(),
+                  num_indices,
+                  sliceSize,
+                  strideBefore,
+                  nElemBefore);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+              }),
+              AT_EXPAND(AT_ALL_TYPES_AND_COMPLEX),
+              AT_EXPAND(AT_FLOAT8_TYPES),
+              kComplexHalf,
+              kHalf,
+              kBool,
+              kBFloat16);
+          }
+#endif
         } else {
           AT_DISPATCH_V2(
             expandedValue.scalar_type(),
@@ -572,8 +673,8 @@ void index_put_with_sort_kernel(Tensor & self, const c10::List<std::optional<Ten
             kHalf,
             kBool,
             kBFloat16);
-          }
         }
+      }
 
       if (permuted) {
         self.copy_(src_.permute(inversePerm));

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -981,6 +981,35 @@ class TestIndexing(TestCase):
         self.assertEqual(out_cuda.cpu(), out_cpu)
 
     @onlyCUDA
+    def test_index_put_large_indices(self, device):
+        def generate_indices(num_indices: int, index_range: int):
+            indices = []
+            for _ in range(num_indices):
+                x = random.randint(0, index_range - 1)
+                indices.append(x)
+            return torch.tensor(indices)
+
+        num_indices = 401988
+        max_index_range = 2000
+        results = []
+        target_index_range = [16, 256, 2000]
+        for generated_index_range in target_index_range:
+            # create CPU tensors
+            a_tensor_size = tuple([max_index_range, 256])
+            a = torch.randn(a_tensor_size, dtype=torch.bfloat16)
+            b = generate_indices(num_indices=num_indices, index_range=generated_index_range)
+            c_tensor_size = tuple([num_indices, 256])
+            c = torch.randn(c_tensor_size, dtype=torch.bfloat16)
+            # create GPU copies
+            a_dev = a.to(device)
+            b_dev = b.to(device)
+            c_dev = c.to(device)
+            # run
+            a.index_put_(indices=[b], values=c, accumulate=True)
+            a_dev.index_put_(indices=[b_dev], values=c_dev, accumulate=True)
+            self.assertEqual(a_dev.cpu(), a)
+
+    @onlyCUDA
     def test_index_put_accumulate_non_contiguous(self, device):
         t = torch.zeros((5, 2, 2))
         t_dev = t.to(device)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -995,10 +995,12 @@ class TestIndexing(TestCase):
         target_index_range = [16, 256, 2000]
         for generated_index_range in target_index_range:
             # create CPU tensors
-            a_tensor_size = tuple([max_index_range, 256])
+            a_tensor_size = tuple(max_index_range, 256)
             a = torch.randn(a_tensor_size, dtype=torch.bfloat16)
-            b = generate_indices(num_indices=num_indices, index_range=generated_index_range)
-            c_tensor_size = tuple([num_indices, 256])
+            b = generate_indices(
+                num_indices=num_indices, index_range=generated_index_range
+            )
+            c_tensor_size = tuple(num_indices, 256)
             c = torch.randn(c_tensor_size, dtype=torch.bfloat16)
             # create GPU copies
             a_dev = a.to(device)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -995,12 +995,12 @@ class TestIndexing(TestCase):
         target_index_range = [16, 256, 2000]
         for generated_index_range in target_index_range:
             # create CPU tensors
-            a_tensor_size = tuple(max_index_range, 256)
+            a_tensor_size = tuple([max_index_range, 256])
             a = torch.randn(a_tensor_size, dtype=torch.bfloat16)
             b = generate_indices(
                 num_indices=num_indices, index_range=generated_index_range
             )
-            c_tensor_size = tuple(num_indices, 256)
+            c_tensor_size = tuple([num_indices, 256])
             c = torch.randn(c_tensor_size, dtype=torch.bfloat16)
             # create GPU copies
             a_dev = a.to(device)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -995,12 +995,12 @@ class TestIndexing(TestCase):
         target_index_range = [16, 256, 2000]
         for generated_index_range in target_index_range:
             # create CPU tensors
-            a_tensor_size = tuple([max_index_range, 256])
+            a_tensor_size = (max_index_range, 256)
             a = torch.randn(a_tensor_size, dtype=torch.bfloat16)
             b = generate_indices(
                 num_indices=num_indices, index_range=generated_index_range
             )
-            c_tensor_size = tuple([num_indices, 256])
+            c_tensor_size = (num_indices, 256)
             c = torch.randn(c_tensor_size, dtype=torch.bfloat16)
             # create GPU copies
             a_dev = a.to(device)


### PR DESCRIPTION
On ROCm, using a non-vectorized index_put kernel provides ~2x perf improvement over the hipified CUDA kernel.  None of the existing unit tests were exercising the large index case so a new unit test was added.

It was also noted that the scale value in the original kernel was hard-coded to 1.0 which would be a no-op, so it was removed from the simplified rocm kernel.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd