### PR TITLE
Add documentation for torch.default_generator

### DIFF
--- a/docs/source/default_generator.rst
+++ b/docs/source/default_generator.rst
@@ -1,0 +1,25 @@
+default_generator
+==================
+
+.. py:data:: torch.default_generator
+
+    The default random number generator used by PyTorch. This is an instance of :class:`torch.Generator` for the CPU device.
+
+    All functions in the :mod:`torch.random` module and many other random functions in PyTorch use this generator by default. 
+    You can manipulate this generator to control the randomness in your program.
+
+    **Example**::
+
+        import torch
+
+        # Get the current state of the default generator
+        state = torch.get_rng_state()
+
+        # Set a manual seed for the default generator
+        torch.manual_seed(12345)
+
+        # Generate random numbers
+        random_tensor = torch.rand(3)
+
+        # Restore the original state
+        torch.set_rng_state(state)

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -184,7 +184,7 @@ Random sampling
     initial_seed
     get_rng_state
     set_rng_state
-    default_generator
+    default_generator_func
     bernoulli
     multinomial
     normal

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -173,11 +173,6 @@ Generators
 
 :doc:`default_generator`
 
-.. toctree::
-    :maxdepth: 1
-
-    default_generator
-
 .. _random-sampling:
 
 Random sampling

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -171,13 +171,6 @@ Generators
 
     Generator
 
-:data:`torch.default_generator` returns the default CPU :class:`Generator`.
-
-Example::
-
-    >>> torch.default_generator.device
-    device(type='cpu')
-
 .. _random-sampling:
 
 Random sampling
@@ -191,6 +184,7 @@ Random sampling
     initial_seed
     get_rng_state
     set_rng_state
+    default_generator
     bernoulli
     multinomial
     normal

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -171,6 +171,11 @@ Generators
 
     Generator
 
+.. toctree::
+    :maxdepth: 1
+
+    default_generator
+
 .. _random-sampling:
 
 Random sampling
@@ -184,7 +189,6 @@ Random sampling
     initial_seed
     get_rng_state
     set_rng_state
-    default_generator
     bernoulli
     multinomial
     normal

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -184,7 +184,7 @@ Random sampling
     initial_seed
     get_rng_state
     set_rng_state
-    default_generator_func
+    default_generator
     bernoulli
     multinomial
     normal

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -171,6 +171,8 @@ Generators
 
     Generator
 
+:doc:`default_generator`
+
 .. toctree::
     :maxdepth: 1
 

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -171,6 +171,13 @@ Generators
 
     Generator
 
+:data:`torch.default_generator` returns the default CPU :class:`Generator`.
+
+Example::
+
+    >>> torch.default_generator.device
+    device(type='cpu')
+
 .. _random-sampling:
 
 Random sampling
@@ -184,20 +191,6 @@ Random sampling
     initial_seed
     get_rng_state
     set_rng_state
-
-.. autoattribute:: torch.default_generator
-   :annotation:  Returns the default CPU torch.Generator
-
-.. The following doesn't actually seem to exist.
-   https://github.com/pytorch/pytorch/issues/27780
-   .. autoattribute:: torch.cuda.default_generators
-      :annotation:  If cuda is available, returns a tuple of default CUDA torch.Generator-s.
-                    The number of CUDA torch.Generator-s returned is equal to the number of
-                    GPUs available in the system.
-.. autosummary::
-    :toctree: generated
-    :nosignatures:
-
     bernoulli
     multinomial
     normal

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1353,42 +1353,6 @@ Example::
 )
 
 add_docstr(
-    torch.default_generator,
-    r"""
-
-default_generator
-
-The default random number generator (RNG) used for generating random numbers in various operations.
-
-This generator is used in functions that rely on randomness, such as initializing tensors with random values, and can be modified or seeded for reproducibility.
-
-You can control randomness globally in PyTorch by manipulating `torch.default_generator`. For example, you can set a seed using `torch.manual_seed()` to ensure consistent results across runs.
-
-Example::
-
-    >>> # Setting a random seed for reproducibility using torch.default_generator
-    >>> torch.manual_seed(42)
-    >>> torch.rand(2, 2)
-    tensor([[0.3745, 0.9507],
-            [0.7319, 0.5987]])
-
-    >>> # Using torch.default_generator directly for generating random numbers
-    >>> generator = torch.default_generator
-    >>> generator.initial_seed()  # Get the seed used by the default generator
-    42
-    >>> torch.rand(2, 2, generator=generator)
-    tensor([[0.1560, 0.1559],
-            [0.0581, 0.8661]])
-
-    >>> # Manually creating and using a separate generator
-    >>> my_generator = torch.Generator().manual_seed(1234)
-    >>> torch.rand(2, 2, generator=my_generator)
-    tensor([[0.8274, 0.7944],
-            [0.2046, 0.4760]])
-""".format(**common_args),
-)
-
-add_docstr(
     torch.bernoulli,
     r"""
 bernoulli(input: Tensor, *, generator: Optional[Generator], out: Optional[Tensor]) -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1353,6 +1353,42 @@ Example::
 )
 
 add_docstr(
+    torch.default_generator,
+    r"""
+
+default_generator
+
+The default random number generator (RNG) used for generating random numbers in various operations.
+
+This generator is used in functions that rely on randomness, such as initializing tensors with random values, and can be modified or seeded for reproducibility.
+
+You can control randomness globally in PyTorch by manipulating `torch.default_generator`. For example, you can set a seed using `torch.manual_seed()` to ensure consistent results across runs.
+
+Example::
+
+    >>> # Setting a random seed for reproducibility using torch.default_generator
+    >>> torch.manual_seed(42)
+    >>> torch.rand(2, 2)
+    tensor([[0.3745, 0.9507],
+            [0.7319, 0.5987]])
+
+    >>> # Using torch.default_generator directly for generating random numbers
+    >>> generator = torch.default_generator
+    >>> generator.initial_seed()  # Get the seed used by the default generator
+    42
+    >>> torch.rand(2, 2, generator=generator)
+    tensor([[0.1560, 0.1559],
+            [0.0581, 0.8661]])
+
+    >>> # Manually creating and using a separate generator
+    >>> my_generator = torch.Generator().manual_seed(1234)
+    >>> torch.rand(2, 2, generator=my_generator)
+    tensor([[0.8274, 0.7944],
+            [0.2046, 0.4760]])
+""".format(**common_args),
+)
+
+add_docstr(
     torch.bernoulli,
     r"""
 bernoulli(input: Tensor, *, generator: Optional[Generator], out: Optional[Tensor]) -> Tensor

--- a/torch/random.py
+++ b/torch/random.py
@@ -210,7 +210,6 @@ def default_generator_func() -> torch.Generator:
 
     Returns:
         torch.Generator: The default generator for CPU.
-    
     Example:
         >>> gen = torch.random.default_generator_func()
         >>> torch.manual_seed(42, generator=gen)

--- a/torch/random.py
+++ b/torch/random.py
@@ -6,6 +6,13 @@ from typing import Generator
 import torch
 from torch._C import default_generator
 
+default_generator = torch.Generator()
+"""
+The default CPU generator used for random number generation in PyTorch.
+
+This generator is used by PyTorch for CPU-based random number generation when 
+no specific generator is provided in functions that require random numbers.
+"""
 
 def set_rng_state(new_state: torch.Tensor) -> None:
     r"""Sets the random number generator state.
@@ -201,17 +208,3 @@ def fork_rng(
         torch.set_rng_state(cpu_rng_state)
         for device, device_rng_state in zip(devices, device_rng_states):
             device_mod.set_rng_state(device_rng_state, device)
-
-def default_generator_func() -> torch.Generator:
-    r"""Returns the default random number generator.
-
-    The default generator is used by all random number generating functions unless a
-    specific generator is explicitly provided.
-
-    Returns:
-        torch.Generator: The default generator for CPU.
-    Example:
-        >>> gen = torch.random.default_generator_func()
-        >>> torch.manual_seed(42, generator=gen)
-    """
-    return default_generator

--- a/torch/random.py
+++ b/torch/random.py
@@ -201,3 +201,18 @@ def fork_rng(
         torch.set_rng_state(cpu_rng_state)
         for device, device_rng_state in zip(devices, device_rng_states):
             device_mod.set_rng_state(device_rng_state, device)
+
+def default_generator_func() -> torch.Generator:
+    r"""Returns the default random number generator.
+
+    The default generator is used by all random number generating functions unless a
+    specific generator is explicitly provided.
+
+    Returns:
+        torch.Generator: The default generator for CPU.
+    
+    Example:
+        >>> gen = torch.random.default_generator_func()
+        >>> torch.manual_seed(42, generator=gen)
+    """
+    return default_generator

--- a/torch/random.py
+++ b/torch/random.py
@@ -6,14 +6,6 @@ from typing import Generator
 import torch
 from torch._C import default_generator
 
-default_generator = torch.Generator()
-"""
-The default CPU generator used for random number generation in PyTorch.
-
-This generator is used by PyTorch for CPU-based random number generation when 
-no specific generator is provided in functions that require random numbers.
-"""
-
 def set_rng_state(new_state: torch.Tensor) -> None:
     r"""Sets the random number generator state.
 


### PR DESCRIPTION
These changes add documentation for `torch.default_generator`, addressing the need raised in an issue by @ssnl  (Issue [#9886](https://github.com/pytorch/pytorch/issues/9886)).

- [x] torch.default_generator