### PR TITLE
[Dynamo] Allow `filter()` to handle infinite iterator

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2378,13 +2378,14 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         input2 = torch.arange(2, dtype=torch.bfloat16)
         inputs = [input1, input2]
 
-        opt_fn = torch.compile()(fn)  # will graph break
+        opt_fn = torch.compile()(fn)
         self.assertEqual(opt_fn(inputs), fn(inputs))
 
         torch._dynamo.reset()
 
-        opt_fn = torch.compile()(fn)  # will graph break
-        self.assertEqual(opt_fn(inputs), fn(inputs))
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            opt_fn = torch.compile(fullgraph=True)(fn)
+            opt_fn(inputs)
 
     def test_filter_infinite_iterator(self):
         def fn(x):

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2390,11 +2390,15 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     def test_filter_infinite_iterator(self):
         def fn(x):
             x = x + 1
-            return zip(range(3), filter(lambda x: x < 10, itertools.count()))
+            return (
+                x,
+                list(zip(range(3), filter(lambda y: y < 10, itertools.count()))),
+                list(zip(range(10, 12), filter(lambda y: y > 10, itertools.count()))),
+            )
 
         inputs = torch.ones(1)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
-        self.assertListEqual(list(opt_fn(inputs)), list(fn(inputs)))
+        self.assertTupleEqual(opt_fn(inputs), fn(inputs))
 
     def test_filter_return_type(self):
         @torch.compile(backend="eager", fullgraph=True)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2383,9 +2383,8 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         torch._dynamo.reset()
 
-        with self.assertRaises(torch._dynamo.exc.Unsupported):
-            opt_fn = torch.compile(fullgraph=True)(fn)
-            opt_fn(inputs)
+        opt_fn = torch.compile(fullgraph=True)(fn)
+        self.assertEqual(opt_fn(inputs), fn(inputs))
 
     def test_pow_int(self):
         def fn(a, b):

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -2378,12 +2378,12 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         input2 = torch.arange(2, dtype=torch.bfloat16)
         inputs = [input1, input2]
 
-        opt_fn = torch.compile()(fn)
+        opt_fn = torch.compile()(fn)  # will graph break
         self.assertEqual(opt_fn(inputs), fn(inputs))
 
         torch._dynamo.reset()
 
-        opt_fn = torch.compile(fullgraph=True)(fn)
+        opt_fn = torch.compile()(fn)  # will graph break
         self.assertEqual(opt_fn(inputs), fn(inputs))
 
     def test_filter_infinite_iterator(self):

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -186,7 +186,7 @@ def addcmul_inplace(self, tensor1, tensor2, value):
     return self.add_(tensor1 * tensor2 * value)
 
 
-def predicate(obj):
+def predicate(obj: Any) -> bool:
     # This will cause the rest of dynamo to handle the if statement correctly, so we don't have to rewrite it here.
     # We can't just use bool() here since we can't trace into that in general.
     if obj:

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -187,7 +187,8 @@ def addcmul_inplace(self, tensor1, tensor2, value):
 
 
 def filter_is_true(obj):
-    # Checks if the Python constant represented by the VariableTracker object is true
+    # This will cause the rest of dynamo to handle the if statement correctly, so we don't have to rewrite it here.
+    # We can't just use bool() here since we can't trace into that in general.
     if obj:
         return True
     return False

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -184,3 +184,7 @@ def foreach_pow_scalar(scalar, exps):
 
 def addcmul_inplace(self, tensor1, tensor2, value):
     return self.add_(tensor1 * tensor2 * value)
+
+
+def filter_is_true(res):
+    return res.is_python_constant() and res.as_python_constant()

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -186,6 +186,8 @@ def addcmul_inplace(self, tensor1, tensor2, value):
     return self.add_(tensor1 * tensor2 * value)
 
 
-def filter_is_true(res):
+def filter_is_true(obj):
     # Checks if the Python constant represented by the VariableTracker object is true
-    return res.is_python_constant() and res.as_python_constant()
+    if obj:
+        return True
+    return False

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -187,4 +187,5 @@ def addcmul_inplace(self, tensor1, tensor2, value):
 
 
 def filter_is_true(res):
+    # Checks if the Python constant represented by the VariableTracker object is true
     return res.is_python_constant() and res.as_python_constant()

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -186,7 +186,7 @@ def addcmul_inplace(self, tensor1, tensor2, value):
     return self.add_(tensor1 * tensor2 * value)
 
 
-def filter_is_true(obj):
+def predicate(obj):
     # This will cause the rest of dynamo to handle the if statement correctly, so we don't have to rewrite it here.
     # We can't just use bool() here since we can't trace into that in general.
     if obj:

--- a/torch/_dynamo/polyfills/builtins.py
+++ b/torch/_dynamo/polyfills/builtins.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import builtins
 import functools
 import operator
-from typing import Callable, Iterable, TypeVar
+from typing import Iterable, TypeVar
 
 from ..decorators import substitute_in_graph
 
@@ -16,7 +16,6 @@ __all__ = [
     "all",
     "any",
     "enumerate",
-    # "filter",
     "sum",
 ]
 
@@ -55,15 +54,3 @@ def enumerate(iterable: Iterable[_T], start: int = 0) -> Iterable[tuple[int, _T]
 @substitute_in_graph(builtins.sum, can_constant_fold_through=True)  # type: ignore[arg-type]
 def sum(iterable: Iterable[_T], /, start: _T = 0) -> _T:  # type: ignore[assignment]
     return functools.reduce(operator.add, iterable, start)
-
-
-# TODO: infinite iterators
-# Reference: https://docs.python.org/3/library/functions.html#filter
-# @substitute_in_graph(builtins.filter, is_embedded_type=True)  # type: ignore[arg-type]
-def filter(function: Callable[[_T], bool], iterable: Iterable[_T]) -> _T:  # type: ignore[assignment]
-    if function is None:
-        function = bool
-
-    for x in iterable:
-        if function(x):
-            yield x

--- a/torch/_dynamo/polyfills/builtins.py
+++ b/torch/_dynamo/polyfills/builtins.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import builtins
 import functools
 import operator
-from typing import Iterable, TypeVar
+from typing import Callable, Iterable, TypeVar
 
 from ..decorators import substitute_in_graph
 
@@ -16,6 +16,7 @@ __all__ = [
     "all",
     "any",
     "enumerate",
+    # "filter",
     "sum",
 ]
 
@@ -54,3 +55,15 @@ def enumerate(iterable: Iterable[_T], start: int = 0) -> Iterable[tuple[int, _T]
 @substitute_in_graph(builtins.sum, can_constant_fold_through=True)  # type: ignore[arg-type]
 def sum(iterable: Iterable[_T], /, start: _T = 0) -> _T:  # type: ignore[assignment]
     return functools.reduce(operator.add, iterable, start)
+
+
+# TODO: infinite iterators
+# Reference: https://docs.python.org/3/library/functions.html#filter
+# @substitute_in_graph(builtins.filter, is_embedded_type=True)  # type: ignore[arg-type]
+def filter(function: Callable[[_T], bool], iterable: Iterable[_T]) -> _T:  # type: ignore[assignment]
+    if function is None:
+        function = bool
+
+    for x in iterable:
+        if function(x):
+            yield x

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -47,6 +47,7 @@ from .higher_order_ops import (
 from .iter import (
     CountIteratorVariable,
     CycleIteratorVariable,
+    FilterVariable,
     IteratorVariable,
     ItertoolsVariable,
     MapVariable,

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1614,18 +1614,8 @@ class BuiltinVariable(VariableTracker):
         return variables.MapVariable(fn, seqs, mutation_type=ValueMutationNew())
 
     def call_filter(self, tx: "InstructionTranslator", fn, seq):
-        if seq.has_unpack_var_sequence(tx):
-            seq_unpacked = seq.unpack_var_sequence(tx)
-            try:
-                items = list(
-                    filter(
-                        lambda x: fn.call_function(tx, [x], {}).as_python_constant(),
-                        seq_unpacked,
-                    )
-                )
-                return variables.TupleVariable(items)
-            except NotImplementedError:
-                return
+        seq = seq.unpack_var_sequence(tx) if seq.has_unpack_var_sequence(tx) else seq
+        return variables.FilterVariable(fn, seq, mutable_local=MutableLocal())
 
     def call_getattr(
         self,

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1615,7 +1615,7 @@ class BuiltinVariable(VariableTracker):
 
     def call_filter(self, tx: "InstructionTranslator", fn, seq):
         seq = seq.unpack_var_sequence(tx) if seq.has_unpack_var_sequence(tx) else seq
-        return variables.FilterVariable(fn, seq, mutable_local=MutableLocal())
+        return variables.FilterVariable(fn, seq, mutation_type=ValueMutationNew())
 
     def call_getattr(
         self,

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -491,12 +491,18 @@ class FilterVariable(MapVariable):
     """
 
     def __init__(
-            self,
-            fn: VariableTracker,
-            iterable: Union[List[VariableTracker], VariableTracker],
-            **kwargs,
+        self,
+        fn: VariableTracker,
+        iterable: Union[List[VariableTracker], VariableTracker],
+        **kwargs,
     ) -> None:
-        super().__init__(fn, [iterable, ], **kwargs)
+        super().__init__(
+            fn,
+            [
+                iterable,
+            ],
+            **kwargs,
+        )
         self.fn = fn
 
     def python_type(self):
@@ -504,7 +510,8 @@ class FilterVariable(MapVariable):
 
     def reconstruct(self, codegen):
         codegen.add_push_null(
-            lambda: codegen.load_import_from("builtins", "filter"), call_function_ex=True
+            lambda: codegen.load_import_from("builtins", "filter"),
+            call_function_ex=True,
         )
         codegen(self.fn)
         self.reconstruct_items(codegen)

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -539,7 +539,9 @@ class FilterVariable(IteratorVariable):
             item = _next()
             self.index += 1
             res = self.fn.call_function(tx, [item], {})
-            if polyfills.filter_is_true(res):
+            if variables.UserFunctionVariable(polyfills.filter_is_true).call_function(
+                tx, [res], {}
+            ):
                 return item
 
     def reconstruct_items(self, codegen):
@@ -553,10 +555,7 @@ class FilterVariable(IteratorVariable):
             codegen(self.iterable)
 
     def reconstruct(self, codegen):
-        codegen.add_push_null(
-            lambda: codegen.load_import_from("builtins", "filter"),
-            call_function_ex=True,
-        )
+        codegen.add_push_null(lambda: codegen.load_import_from("builtins", "filter"))
         codegen(self.fn)
         self.reconstruct_items(codegen)
         codegen.extend_output(create_call_function(2, False))

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -483,3 +483,34 @@ class MapVariable(ZipVariable):
                 create_instruction("CALL_FUNCTION_EX", arg=0),
             ]
         )
+
+
+class FilterVariable(MapVariable):
+    """
+    Represents filter(fn, iterable)
+    """
+
+    def __init__(
+            self,
+            fn: VariableTracker,
+            iterable: Union[List[VariableTracker], VariableTracker],
+            **kwargs,
+    ) -> None:
+        super().__init__(fn, [iterable, ], **kwargs)
+        self.fn = fn
+
+    def python_type(self):
+        return filter
+
+    def reconstruct(self, codegen):
+        codegen.add_push_null(
+            lambda: codegen.load_import_from("builtins", "filter"), call_function_ex=True
+        )
+        codegen(self.fn)
+        self.reconstruct_items(codegen)
+        codegen.extend_output(
+            [
+                create_instruction("BUILD_TUPLE", arg=len(self.iterables) + 1),
+                create_instruction("CALL_FUNCTION_EX", arg=0),
+            ]
+        )

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -560,9 +560,4 @@ class FilterVariable(IteratorVariable):
         )
         codegen(self.fn)
         self.reconstruct_items(codegen)
-        codegen.extend_output(
-            [
-                create_instruction("BUILD_TUPLE", arg=2),
-                create_instruction("CALL_FUNCTION_EX", arg=0),
-            ]
-        )
+        codegen.extend_output(create_call_function(2, False))

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -539,9 +539,10 @@ class FilterVariable(IteratorVariable):
             item = _next()
             self.index += 1
             res = self.fn.call_function(tx, [item], {})
-            if variables.UserFunctionVariable(polyfills.predicate).call_function(
-                tx, [res], {}
-            ):
+            pred_res = variables.UserFunctionVariable(
+                polyfills.predicate
+            ).call_function(tx, [res], {})
+            if pred_res.as_python_constant():
                 return item
 
     def reconstruct_items(self, codegen):

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -3,7 +3,7 @@
 import itertools
 import operator
 import sys
-from typing import Dict, List, Optional, TYPE_CHECKING, Union, Iterable
+from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
 from .. import polyfills, variables
 from ..bytecode_transformation import create_call_function, create_instruction

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -539,7 +539,7 @@ class FilterVariable(IteratorVariable):
             item = _next()
             self.index += 1
             res = self.fn.call_function(tx, [item], {})
-            if variables.UserFunctionVariable(polyfills.filter_is_true).call_function(
+            if variables.UserFunctionVariable(polyfills.predicate).call_function(
                 tx, [res], {}
             ):
                 return item


### PR DESCRIPTION
Fixes #137380

```python
import torch


def filt(x):
    return x < 10
                                                    
                                                    
@torch.compile(backend="eager", fullgraph=True)
def f(x):
    x = x + 1
    return zip(range(3), filter(filt, itertools.count()))
                                                    
                                                    
print(list(f(torch.ones(3)))) # [(0, 0), (1, 1), (2, 2)]
                                                    
                                                    
@torch.compile(backend="eager")
def g(x):
    x = x + 1
    return filter(filt, [1, 2, 3])
                                                    
                                                    
res = g(torch.ones(3))
assert isinstance(res, filter)
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec