### PR TITLE
Add operator.neg for serialize

### DIFF
--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -193,6 +193,7 @@ _SYM_BOOL_OPS = {
     operator.ge,
     operator.lt,
     operator.gt,
+    operator.neg,
     torch.sym_not,
 }
 

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -194,6 +194,7 @@ _SYM_BOOL_OPS = {
     operator.lt,
     operator.gt,
     operator.neg,
+    operator.pos,
     torch.sym_not,
 }
 


### PR DESCRIPTION
Fixes #129690

Add `operator.neg` and `oepartor.pos` into `_SYM_BOOL_OPS`. 

Provide simple unit test under `export/test_serialize.py` that can reproduce the issue.