### PR TITLE
Add missing operator and corresponding unittest

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -650,16 +650,16 @@ class TestDeserialize(TestCase):
 
             self.check_graph(M(), (torch.randn(3), torch.randn(3), torch.randn(3)))
 
-    def test_sym_bool(self) -> None:
+    def test_sym_bool_dynamic_shapes(self) -> None:
         class MyModule(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
 
             def forward(self, x, y):
-                z = x[:,-y.shape[0]:,:]
+                z = x[:, -y.shape[0] :, :]
                 return z
 
-        inputs = (torch.ones(4, 5 ,10), torch.ones(3))
+        inputs = (torch.ones(4, 5, 10), torch.ones(3))
         dynamic_shapes = {"x": {}, "y": {0: Dim("seqlen", max=4)}}
         # Compile with dynamic_shapes set to get operator.neg involved
         self.check_graph(MyModule(), inputs, dynamic_shapes=dynamic_shapes)

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -322,6 +322,29 @@ def forward(self, x):
             self.assertEqual(node.inputs[0].name, "self")
             self.assertEqual(node.inputs[1].name, "dim")
 
+    def test_serialize_sym_bool(self) -> None:
+        class MyModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(self, x, y):
+                z = x[:,-y.shape[0]:,:]
+                return z
+
+        inputs = (torch.ones(4, 5 ,10), torch.ones(3))
+        # Compile with dynamic_shapes set to get operator.neg involved
+        exported_module = export(
+            MyModule(), inputs, dynamic_shapes={"x": {}, "y": {0: Dim("seqlen", max=4)}}
+
+        )
+        serialized = ExportedProgramSerializer().serialize(exported_module)
+        sym_nodes = [
+            node
+            for node in serialized.exported_program.graph_module.graph.nodes
+            if node.target == '_operator.neg'
+        ]
+        self.assertNotEqual(len(sym_nodes), 0)
+
     def test_serialize_list_returns(self) -> None:
         class MyModule(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -650,6 +650,20 @@ class TestDeserialize(TestCase):
 
             self.check_graph(M(), (torch.randn(3), torch.randn(3), torch.randn(3)))
 
+    def test_sym_bool(self) -> None:
+        class MyModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(self, x, y):
+                z = x[:,-y.shape[0]:,:]
+                return z
+
+        inputs = (torch.ones(4, 5 ,10), torch.ones(3))
+        dynamic_shapes = {"x": {}, "y": {0: Dim("seqlen", max=4)}}
+        # Compile with dynamic_shapes set to get operator.neg involved
+        self.check_graph(MyModule(), inputs, dynamic_shapes=dynamic_shapes)
+
     def test_auto_functionalize(self):
         with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
             torch.library.define(
@@ -920,21 +934,6 @@ class TestDeserialize(TestCase):
 
         dynamic_shapes = {"x": {0: Dim("dim0"), 1: Dim("dim1")}}
         self.check_graph(Foo(), (torch.ones(4, 5),), dynamic_shapes=dynamic_shapes)
-
-    def test_serialize_sym_bool(self) -> None:
-        class MyModule(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-
-            def forward(self, x, y):
-                z = x[:,-y.shape[0]:,:]
-                return z
-
-        inputs = (torch.ones(4, 5 ,10), torch.ones(3))
-        dynamic_shapes = {"x": {}, "y": {0: Dim("seqlen", max=4)}}
-        # Compile with dynamic_shapes set to get operator.neg involved
-        self.check_graph(MyModule(), inputs, dynamic_shapes=dynamic_shapes)
-
 
     def test_multiple_getitem(self):
         class M(torch.nn.Module):

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -193,6 +193,8 @@ _SYM_BOOL_OPS = {
     operator.ge,
     operator.lt,
     operator.gt,
+    operator.neg,
+    operator.pos,
     torch.sym_not,
 }
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/129690

Add operator.neg and oepartor.pos into _SYM_BOOL_OPS.

Provide simple unit test under export/test_serialize.py that can reproduce the issue.