### PR TITLE
Skip test_circular_dependencies on ROCm

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -19,7 +19,7 @@ import torch
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import \
     (IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
-     parametrize, subtest, instantiate_parametrized_tests, dtype_name, TEST_WITH_ROCM, decorateIf)
+     parametrize, subtest, instantiate_parametrized_tests, dtype_name, TEST_WITH_ROCM, decorateIf, skipIfRocm)
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
      get_device_type_test_bases, instantiate_device_type_tests, onlyCPU, onlyCUDA, onlyNativeDeviceTypes,
@@ -2221,6 +2221,9 @@ class TestImports(TestCase):
             # fail, so just set CWD to this script's directory
             cwd=os.path.dirname(os.path.realpath(__file__)),).decode("utf-8")
 
+    # The test is flaky on ROCm and has been open and close multiple times
+    # https://github.com/pytorch/pytorch/issues/110040
+    @skipIfRocm
     def test_circular_dependencies(self) -> None:
         """ Checks that all modules inside torch can be imported
         Prevents regression reported in https://github.com/pytorch/pytorch/issues/77441 """


### PR DESCRIPTION
The test is flaky on ROCm and has been disabled for quite a while https://github.com/pytorch/pytorch/issues/110040.  The disabled issue was opened and then closed several times, so it's better to close that issue and skip the test here.

(Not really fix the issue, I just want the test to be skipped on PR instead of being disabled, then close the issue)
Fixes https://github.com/pytorch/pytorch/issues/110040

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd