### PR TITLE
[MPS] Fix sliced cast

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -541,7 +541,7 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor,
     MPSShape* mpsShape = getMPSShape(_tensor);
     MPSShape* mpsStrides = getMPSShape(_tensor.strides());
 
-    auto flattenedShaped = [srcBuf length] / src.element_size();;
+    auto flattenedShaped = [srcBuf length] / src.element_size();
     MPSShape* mpsBaseShape = @[ @(flattenedShaped) ];
     MPSNDArrayDescriptor* srcTensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:dataType shape:mpsBaseShape];
     srcTensorDesc.preferPackedRows = YES;

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -541,16 +541,7 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor,
     MPSShape* mpsShape = getMPSShape(_tensor);
     MPSShape* mpsStrides = getMPSShape(_tensor.strides());
 
-    IntArrayRef baseShape;
-    if (src.is_view()) {
-      baseShape = src._base().sizes();
-    } else {
-      baseShape = getIMPSAllocator()->getBufferShape(src.storage().data());
-    }
-    int flattenedShaped = 1;
-    for (const auto i : c10::irange(baseShape.size())) {
-      flattenedShaped *= baseShape[i];
-    }
+    auto flattenedShaped = [srcBuf length] / src.element_size();;
     MPSShape* mpsBaseShape = @[ @(flattenedShaped) ];
     MPSNDArrayDescriptor* srcTensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:dataType shape:mpsBaseShape];
     srcTensorDesc.preferPackedRows = YES;

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -541,9 +541,9 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor,
     MPSShape* mpsShape = getMPSShape(_tensor);
     MPSShape* mpsStrides = getMPSShape(_tensor.strides());
 
-    auto flattenedShaped = [srcBuf length] / src.element_size();
-    MPSShape* mpsBaseShape = @[ @(flattenedShaped) ];
-    MPSNDArrayDescriptor* srcTensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:dataType shape:mpsBaseShape];
+    auto storage_numel = src.storage().nbytes() / src.element_size();
+    MPSNDArrayDescriptor* srcTensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:dataType
+                                                                                 shape:@[ @(storage_numel) ]];
     srcTensorDesc.preferPackedRows = YES;
     MPSNDArray* srcNDArray = [[[MPSNDArray alloc] initWithBuffer:srcBuf
                                                           offset:src.storage_offset() * src.element_size()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11000,6 +11000,13 @@ class TestAdvancedIndexing(TestCaseMPS):
         t1.start()
         t2.start()
 
+    def test_sliced_view_cast(self):
+        # This used to crash on MacOS Sequoia
+        # See https://github.com/pytorch/pytorch/issues/137800
+        x = torch.rand(16, 16, device='mps', dtype=torch.float16)
+        y = x[:,0:2].view(torch.float32) + 1
+
+
     def test_masked_select(self):
         x = torch.randn(3, 4)
         x_mps = x.to("mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11006,7 +11006,6 @@ class TestAdvancedIndexing(TestCaseMPS):
         x = torch.rand(16, 16, device='mps', dtype=torch.float16)
         y = x[:,0:2].view(torch.float32) + 1
 
-
     def test_masked_select(self):
         x = torch.randn(3, 4)
         x_mps = x.to("mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11004,7 +11004,7 @@ class TestAdvancedIndexing(TestCaseMPS):
         # This used to crash on MacOS Sequoia
         # See https://github.com/pytorch/pytorch/issues/137800
         x = torch.rand(16, 16, device='mps', dtype=torch.float16)
-        y = x[:,0:2].view(torch.float32) + 1
+        y = x[:, 0:2].view(torch.float32) + 1
 
     def test_masked_select(self):
         x = torch.randn(3, 4)


### PR DESCRIPTION
This fixes internal crash due to the invalid bufer size computation if sliced API is used

Not sure what was the purpose of
```c++
IntArrayRef baseShape;
if (src.is_view()) {
  baseShape = src._base().sizes();
} else {
  baseShape = getIMPSAllocator()->getBufferShape(src.storage().data());
}
int flattenedShaped = 1;
for (const auto i : c10::irange(baseShape.size())) {
  flattenedShaped *= baseShape[i];
}
```
As flattenShaped could be much easier computed as `[srcBuf
lengh]/src.element_size()`, and even if `srcBuf` is padded it's a safe thing to do.

When someone allocated buffer to hold say uint8 and that view-casted it
to float16, attempt to compute `baseShape` returned sizes of original
tensor in its data type, rather than size in new dtypes

Fixes https://github.com/pytorch/pytorch/issues/137800