### PR TITLE
Update sympy version constraint to 1.13.3

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -326,7 +326,7 @@ lxml==5.0.0
 
 PyGithub==2.3.0
 
-sympy==1.13.1 ; python_version >= "3.9"
+sympy>=1.13.1,!=1.13.2 ; python_version >= "3.9"
 #Description: Required by coremltools, also pinned in .github/requirements/pip-requirements-macOS.txt
 #Pinned versions:
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -326,7 +326,7 @@ lxml==5.0.0
 
 PyGithub==2.3.0
 
-sympy>=1.13.1,!=1.13.2 ; python_version >= "3.9"
+sympy+=1.13.3 ; python_version >= "3.9"
 #Description: Required by coremltools, also pinned in .github/requirements/pip-requirements-macOS.txt
 #Pinned versions:
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -326,7 +326,7 @@ lxml==5.0.0
 
 PyGithub==2.3.0
 
-sympy+=1.13.3 ; python_version >= "3.9"
+sympy==1.13.3 ; python_version >= "3.9"
 #Description: Required by coremltools, also pinned in .github/requirements/pip-requirements-macOS.txt
 #Pinned versions:
 #test that import:

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -19,7 +19,7 @@ pytest-rerunfailures==10.3
 pytest-flakefinder==1.1.0
 scipy==1.10.1
 sympy==1.12.1 ; python_version == "3.8"
-sympy==1.13.1 ; python_version >= "3.9"
+sympy>=1.13.1,!=1.13.2 ; python_version >= "3.9"
 unittest-xml-reporting<=3.2.0,>=2.0.0
 xdoctest==1.1.0
 filelock==3.6.0

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -19,7 +19,7 @@ pytest-rerunfailures==10.3
 pytest-flakefinder==1.1.0
 scipy==1.10.1
 sympy==1.12.1 ; python_version == "3.8"
-sympy>=1.13.1,!=1.13.2 ; python_version >= "3.9"
+sympy==1.13.3 ; python_version >= "3.9"
 unittest-xml-reporting<=3.2.0,>=2.0.0
 xdoctest==1.1.0
 filelock==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ requests
 setuptools<=72.1.0
 types-dataclasses
 typing-extensions>=4.8.0
-sympy==1.13.1 ; python_version >= "3.9"
+sympy>=1.13.1,!=1.13.2 ; python_version >= "3.9"
 filelock
 networkx
 jinja2

--- a/setup.py
+++ b/setup.py
@@ -1147,7 +1147,7 @@ def main():
         "filelock",
         "typing-extensions>=4.8.0",
         'setuptools ; python_version >= "3.12"',
-        'sympy==1.13.1 ; python_version >= "3.9"',
+        'sympy>=1.13.1,!=1.13.2 ; python_version >= "3.9"',
         "networkx",
         "jinja2",
         "fsspec",

--- a/setup.py
+++ b/setup.py
@@ -1147,7 +1147,7 @@ def main():
         "filelock",
         "typing-extensions>=4.8.0",
         'setuptools ; python_version >= "3.12"',
-        'sympy>=1.13.1,!=1.13.2 ; python_version >= "3.9"',
+        'sympy>=1.13.3 ; python_version >= "3.9"',
         "networkx",
         "jinja2",
         "fsspec",


### PR DESCRIPTION
`simpy` was pinned to version 1.13.1 due to test failures with version 1.13.2 on Windows and mac, as reported in https://github.com/pytorch/pytorch/pull/133235. Now that a newer version, 1.13.3, has been released, this PR aims to verify if the test failure has been resolved and also allow building with newer versions for packaging purposes (e.g., https://github.com/conda-forge/pytorch-cpu-feedstock/pull/277#discussion_r1806721862).