### PR TITLE
[AOTI] Update FXSplitter base to include node names in the supported/unsupported logs

### DIFF
--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -490,22 +490,22 @@ class _SplitterBase:
 
             if self.operator_support.is_node_supported(submodules, node):
                 supported_nodes.append(node)
-                supported_node_types[target].add((arg_dtypes_tuple, kwarg_dtypes_tuple))
+                supported_node_types[target].add((arg_dtypes_tuple, kwarg_dtypes_tuple, node.name))
             else:
-                unsupported_node_types[target].add((arg_dtypes_tuple, kwarg_dtypes_tuple))
+                unsupported_node_types[target].add((arg_dtypes_tuple, kwarg_dtypes_tuple, node.name))
 
         if dump_graph:
             self._draw_graph_based_on_node_support(self.module, supported_nodes)
 
         reports = "\nSupported node types in the model:\n"
         for t, dtypes in supported_node_types.items():
-            for arg_dtypes_tuple, kwarg_dtypes_tuple in dtypes:
-                reports += f"{t}: ({arg_dtypes_tuple}, {dict(kwarg_dtypes_tuple)})\n"
+            for arg_dtypes_tuple, kwarg_dtypes_tuple, node_name in dtypes:
+                reports += f"{t}: ({arg_dtypes_tuple}, {dict(kwarg_dtypes_tuple)}) for node {node_name}\n"
 
         reports += "\nUnsupported node types in the model:\n"
         for t, dtypes in unsupported_node_types.items():
-            for arg_dtypes_tuple, kwarg_dtypes_tuple in dtypes:
-                reports += f"{t}: ({arg_dtypes_tuple}, {dict(kwarg_dtypes_tuple)})\n"
+            for arg_dtypes_tuple, kwarg_dtypes_tuple, node_name in dtypes:
+                reports += f"{t}: ({arg_dtypes_tuple}, {dict(kwarg_dtypes_tuple)}) for node {node_name}\n"
 
         print(reports)
 


### PR DESCRIPTION
Summary:
This basically helps with debugging/investigation for CPULowering and AOTISplitter in general.

If I want to use these logs and map to the graph it maybe difficult as if we look in CPULowering case there could be a node that we support/unsupport for the same operator and need some more info to trace back

Logs will look like this with for node included

```
Supported node types in the model:
_operator.getitem: ((), {}) for node getitem_1
_operator.getitem: ((), {}) for node getitem_7
_operator.getitem: ((), {}) for node getitem_5
_operator.getitem: ((), {}) for node getitem_10
_operator.getitem: ((torch.int64,), {}) for node getitem_3
_operator.getitem: ((), {}) for node getitem_8
_operator.getitem: ((), {}) for node getitem_9
_operator.getitem: ((), {}) for node getitem_6
_operator.getitem: ((), {}) for node getitem_11
torch.ops.fb.offsets_to_ranges: ((torch.int64, torch.int64), {}) for node offsets_to_ranges
torch.ops.fb.clip_ranges: ((torch.int32,), {}) for node clip_ranges
torch.ops.fb.gather_ranges: ((torch.int64, torch.int32), {}) for node gather_ranges
torch.ops.fb.sigrid_hash: ((torch.int64,), {}) for node sigrid_hash
<torch_package_5>.dper3.modules.low_level_modules.single_operators._slice_helper: ((torch.float32,), {}) for node _slice_helper_1
<torch_package_5>.dper3.modules.low_level_modules.single_operators._slice_helper: ((torch.float32,), {}) for node _slice_helper
torch.logit: ((torch.float32,), {}) for node logit
to: ((torch.int64,), {}) for node to_1
clamp_: ((torch.float32,), {}) for node clamp_
torch.pow: ((torch.float32,), {}) for node pow_1
torch.cat: ((), {}) for node cat_2
torch.cat: ((), {}) for node cat_1
torch.ops.quantized.linear_relu_dynamic_fp16: ((torch.float32,), {}) for node linear_relu_dynamic_fp16_2
torch.ops.quantized.linear_relu_dynamic_fp16: ((torch.float32,), {}) for node linear_relu_dynamic_fp16
torch.ops.quantized.linear_relu_dynamic_fp16: ((torch.float32,), {}) for node linear_relu_dynamic_fp16_1
torch.ops.quantized.linear_dynamic_fp16: ((torch.float32,), {}) for node linear_dynamic_fp16
torch.ops.quantized.linear_dynamic_fp16: ((torch.float32,), {}) for node linear_dynamic_fp16_2
torch.ops.quantized.linear_dynamic_fp16: ((torch.float32,), {}) for node linear_dynamic_fp16_1
torch.sigmoid: ((torch.float32,), {}) for node sigmoid
<torch_package_5>.dper3.modules.low_level_modules.single_operators.ElementwiseOp: ((torch.float32, torch.float32), {}) for node main_module_impl_impl_shared_arch_user_arch_entity_module_dense_arch_dense_projection_arch_gating_archs_0_mul_module
torch.ops.fb.lengths_to_offsets: ((torch.int32,), {}) for node lengths_to_offsets
torch.nn.modules.sparse.EmbeddingBag: ((), {'input': torch.int64, 'offsets': torch.int32}) for node main_module_impl_impl_shared_arch_user_arch_entity_module_sparse_arch_grouped_embedding_grouped_generic_embedding_grouped_embedding_bags_sparse_user_country_bucket
torch.ops.fb.equally_split: ((torch.float32,), {}) for node equally_split
torch.ops.fb.equally_split: ((torch.float32,), {}) for node equally_split_1
torch.stack: ((), {}) for node stack_1
torch.stack: ((), {}) for node stack
getattr: ((torch.float32,), {}) for node getattr_1
<torch_package_5>.dper3.modules.low_level_modules.single_operators._transpose_helper: ((torch.float32,), {}) for node _transpose_helper
_operator.mul: ((), {}) for node mul
reshape: ((torch.float32,), {}) for node reshape
torch.add: ((torch.float32, torch.float32), {}) for node add
```

Test Plan: Sandcastle

Reviewed By: hl475, FulinHuang

Differential Revision: D64612496


