### PR TITLE
[cuDNN][SDPA] Match `query`'s memory layout ordering for `output` in cuDNN SDPA

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -348,7 +348,7 @@ bool same_strides(const Tensor& t1, const Tensor& t2) {
   const auto t1strides = t1.strides();
   const auto t2strides = t2.strides();
   const int dim = t1strides.size();
-  if (dim != t2strides.size()) {
+  if (dim != (int) t2strides.size()) {
     return false;
   }
   const auto t1sizes = t1.sizes();

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -294,7 +294,7 @@ auto fixSizeOneDimStrideSDPA(
 }
 
 void alloc_with_matching_layout(
-    const Tensor& q, 
+    const Tensor& q,
     Tensor& output,
     const std::vector<int64_t>& shape) {
   TORCH_CHECK(
@@ -311,8 +311,8 @@ void alloc_with_matching_layout(
   const auto q_strides = q.strides();
   std::stable_sort(
       fill_order.begin(), fill_order.end(), [&q_strides](int idx1, int idx2) {
-        return q_strides[idx1] < q_strides[idx2]
-      ;});
+        return q_strides[idx1] < q_strides[idx2];
+      });
   std::vector<int64_t> ordered_strides(shape.size());
   int64_t current_stride = 1;
   for (const int dim_idx : fill_order) {

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -741,7 +741,6 @@ void run_cudnn_SDP_bprop(
     TORCH_WARN_ONCE("output: ", o.strides(), " grad_output: ", dO_.strides());
     permute_to_matching_layout(o, dO_);
   }
-  TORCH_WARN("output: ", o.strides(), " grad_output: ", dO_.strides());
   TORCH_INTERNAL_ASSERT(
       same_strides(o, dO_),
       "cuDNN SDPA expected grad_output.strides() == output.strides(), "

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -297,12 +297,13 @@ void alloc_with_matching_layout(
     const Tensor& q,
     Tensor& output,
     const std::vector<int64_t>& shape) {
-  TORCH_CHECK(
+  TORCH_INTERNAL_ASSERT(
       shape.size() == q.sizes().size(),
       "cuDNN SDPA alloc_with_matching_layout got requested shape ndim != q ndim");
 
   if (std::equal(q.sizes().begin(), q.sizes().end(), shape.begin())) {
     output = at::empty_like(q);
+    return;
   }
 
   // get the "fill order," which is just an argsort on the strides

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -345,14 +345,22 @@ void permute_to_matching_layout(const Tensor& output, Tensor& grad_output)
 bool same_strides(const Tensor& t1, const Tensor& t2) {
   std::vector<int> t1_strides_no_ones;
   std::vector<int> t2_strides_no_ones;
-  std::copy_if(t1.strides().begin(), t1.strides().end(),
-               std::back_inserter(t1_strides_no_ones), [](int i) {
-                 return i > 1;
-               });
-  std::copy_if(t2.strides().begin(), t2.strides().end(),
-               std::back_inserter(t2_strides_no_ones), [](int i) {
-                 return i > 1;
-               });
+  const auto t1strides = t1.strides();
+  const auto t2strides = t2.strides();
+  if (t1strides.size() != t2strides.size()) {
+    return false;
+  }
+  const auto t1sizes = t1.sizes();
+  const auto t2sizes = t2.sizes();
+  // we are going through strides backward here, but if both are backward it's comparable
+  for (int i = 0; i < t1strides.size(); i++) {
+    if (t1sizes[i] > 1) {
+      t1_strides_no_ones.push_back(t1strides[i]);
+    }
+    if (t2sizes[i] > 1) {
+      t2_strides_no_ones.push_back(t2strides[i]);
+    }
+  }
   return std::equal(t1_strides_no_ones.begin(), t1_strides_no_ones.end(), t2_strides_no_ones.begin(), t2_strides_no_ones.end());
 }
 } // namespace

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -297,7 +297,7 @@ void alloc_with_matching_layout(const Tensor& q, Tensor& output, const std::vect
   TORCH_CHECK(shape.size() == q.sizes().size(), "cuDNN SDPA alloc_with_matching_layout got requested shape ndim != q ndim");
   // get the "fill order," which is just an argsort on the strides
   std::vector<int> fill_order(shape.size());
-  std::iota(fill_order.begin(), fill_order.end(), 0);   
+  std::iota(fill_order.begin(), fill_order.end(), 0);
   std::stable_sort(fill_order.begin(), fill_order.end(), [&q](int idx1, int idx2) {return q.strides()[idx1] < q.strides()[idx2];});
   std::vector<int64_t> ordered_strides(shape.size());
   int64_t current_stride = 1;

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -300,6 +300,11 @@ void alloc_with_matching_layout(
   TORCH_CHECK(
       shape.size() == q.sizes().size(),
       "cuDNN SDPA alloc_with_matching_layout got requested shape ndim != q ndim");
+
+  if (std::equal(q.sizes().begin(), q.sizes().end(), shape.begin())) {
+    output = at::empty_like(q);
+  }
+
   // get the "fill order," which is just an argsort on the strides
   std::vector<int> fill_order(shape.size());
   std::iota(fill_order.begin(), fill_order.end(), 0);

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -293,19 +293,30 @@ auto fixSizeOneDimStrideSDPA(
   return strides;
 }
 
-void alloc_with_matching_layout(const Tensor& q, Tensor& output, const std::vector<int64_t>& shape) {
-  TORCH_CHECK(shape.size() == q.sizes().size(), "cuDNN SDPA alloc_with_matching_layout got requested shape ndim != q ndim");
+void alloc_with_matching_layout(
+    const Tensor& q, 
+    Tensor& output,
+    const std::vector<int64_t>& shape) {
+  TORCH_CHECK(
+      shape.size() == q.sizes().size(),
+      "cuDNN SDPA alloc_with_matching_layout got requested shape ndim != q ndim");
   // get the "fill order," which is just an argsort on the strides
   std::vector<int> fill_order(shape.size());
   std::iota(fill_order.begin(), fill_order.end(), 0);
-  std::stable_sort(fill_order.begin(), fill_order.end(), [&q](int idx1, int idx2) {return q.strides()[idx1] < q.strides()[idx2];});
+  const auto q_strides = q.strides();
+  std::stable_sort(
+      fill_order.begin(), fill_order.end(), [&q_strides](int idx1, int idx2) {
+        return q_strides[idx1] < q_strides[idx2]
+      ;});
   std::vector<int64_t> ordered_strides(shape.size());
   int64_t current_stride = 1;
   for (const int dim_idx : fill_order) {
     ordered_strides[dim_idx] = current_stride;
     current_stride *= shape[dim_idx];
   }
-  output = at::empty(at::IntArrayRef(shape), q.options()).as_strided(at::IntArrayRef(shape), at::IntArrayRef(ordered_strides), 0);
+  output = at::empty(at::IntArrayRef(shape), q.options())
+               .as_strided(
+                   at::IntArrayRef(shape), at::IntArrayRef(ordered_strides), 0);
 }
 } // namespace
 

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -553,7 +553,12 @@ void run_cudnn_SDP_fprop(
     Tensor& dropoutoffset) {
   cudnnHandle_t handle = getCudnnHandle();
   if (!o.defined()) {
-    o = at::empty({b, h, s_q, d_v}, q.options());
+    // q is passed to us in BHSD dim order
+    if (q.is_contiguous()) {
+      o = at::empty({b, h, s_q, d_v}, q.options());
+    } else {
+      o = at::empty({b, s_q, h, d_v}, q.options()).transpose(1, 2);
+    }
   }
 
   if (return_softmaxstats && !softmaxstats.defined()) {

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -347,13 +347,15 @@ bool same_strides(const Tensor& t1, const Tensor& t2) {
   std::vector<int> t2_strides_no_ones;
   const auto t1strides = t1.strides();
   const auto t2strides = t2.strides();
-  if (t1strides.size() != t2strides.size()) {
+  const int dim = t1strides.size();
+  if (dim != t2strides.size()) {
     return false;
   }
   const auto t1sizes = t1.sizes();
   const auto t2sizes = t2.sizes();
+  
   // we are going through strides backward here, but if both are backward it's comparable
-  for (int i = 0; i < t1strides.size(); i++) {
+  for (int i = 0; i < dim; i++) {
     if (t1sizes[i] > 1) {
       t1_strides_no_ones.push_back(t1strides[i]);
     }

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -55,7 +55,7 @@ namespace {
 
 // TODO(eqy): more benchmarking to determine whether this should include sm86/89
 // Needs to be kept in-sync with test_fused_chocie in test_transformers.py
-bool check_prefer_cudnn_attention(sdp_params const& params) {
+bool check_prefer_cudnn_attention() {
   // TODO(eqy): Re-enable by default after upgrading to a release later than 9.5.0
   // see context: https://github.com/pytorch/pytorch/issues/138340
   // return false;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -61,12 +61,9 @@ bool check_prefer_cudnn_attention(sdp_params const& params) {
   // return false;
 #if defined(CUDNN_VERSION)
 
-#if CUDNN_VERSION > 90500
+#if CUDNN_VERSION > 90000
   auto dprops = at::cuda::getCurrentDeviceProperties();
   return dprops->major >= 9;
-#elif CUDNN_VERSION >= 90000
-  auto dprops = at::cuda::getCurrentDeviceProperties();
-  return params.query.is_contiguous() && dprops->major >= 9;
 #else
   return false;
 #endif

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -56,6 +56,9 @@ namespace {
 // TODO(eqy): more benchmarking to determine whether this should include sm86/89
 // Needs to be kept in-sync with test_fused_chocie in test_transformers.py
 bool check_prefer_cudnn_attention() {
+  // TODO(eqy): Re-enable by default after upgrading to a release later than 9.5.0
+  // see context: https://github.com/pytorch/pytorch/issues/138340
+  return false;
 #if defined(CUDNN_VERSION) && CUDNN_VERSION >= 90000
   auto dprops = at::cuda::getCurrentDeviceProperties();
   return dprops->major >= 9;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -55,13 +55,22 @@ namespace {
 
 // TODO(eqy): more benchmarking to determine whether this should include sm86/89
 // Needs to be kept in-sync with test_fused_chocie in test_transformers.py
-bool check_prefer_cudnn_attention() {
+bool check_prefer_cudnn_attention(sdp_params const& params) {
   // TODO(eqy): Re-enable by default after upgrading to a release later than 9.5.0
   // see context: https://github.com/pytorch/pytorch/issues/138340
-  return false;
-#if defined(CUDNN_VERSION) && CUDNN_VERSION >= 90000
+  // return false;
+#if defined(CUDNN_VERSION)
+
+#if CUDNN_VERSION > 90500
   auto dprops = at::cuda::getCurrentDeviceProperties();
   return dprops->major >= 9;
+#elif CUDNN_VERSION >= 90000
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  return params.query.is_contiguous() && dprops->major >= 9;
+#else
+  return false;
+#endif
+
 #else
   return false;
 #endif

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2576,7 +2576,7 @@ class TestSDPACudaOnly(NNTestCase):
 
         class CausalSelfAttention(nn.Module):
 
-            def __init__(self, config):
+            def __init__(self, config, test):
                 super().__init__()
                 assert config.n_embd % config.n_head == 0
                 # key, query, value projections for all heads, but in a batch
@@ -2585,6 +2585,7 @@ class TestSDPACudaOnly(NNTestCase):
                 self.c_proj = nn.Linear(config.n_embd, config.n_embd, bias=config.bias)
                 self.n_head = config.n_head
                 self.n_embd = config.n_embd
+                self.test = test
 
             def forward(self, x):
                 B, T, C = x.size() # batch size, sequence length, embedding dimensionality (n_embd)
@@ -2595,15 +2596,15 @@ class TestSDPACudaOnly(NNTestCase):
 
                 y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
 
-                # HERE, WE NEED THIS CONTIGUOUS TO BE A NO-OP
                 # y = y.transpose(1, 2).contiguous().view(B, T, C)
+                self.test.assertTrue(y.transpose(1, 2).is_contiguous())
                 y = y.transpose(1, 2).view(B, T, C)
                 y = self.c_proj(y)
                 return y
 
         def test_attention(backend: SDPBackend):
             config = Config()
-            Attention = CausalSelfAttention(config).to("cuda", dtype=torch.float16)
+            Attention = CausalSelfAttention(config, self).to("cuda", dtype=torch.float16)
             sample_input = torch.randn(1, 2048, config.n_embd, device="cuda", dtype = torch.float16)
             with sdpa_kernel(backend):
               out = Attention(sample_input)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2589,7 +2589,7 @@ class TestSDPACudaOnly(NNTestCase):
 
             def forward(self, x):
                 B, T, C = x.size()  # batch size, sequence length, embedding dimensionality (n_embd)
-                q, k, v  = self.c_attn(x).split(self.n_embd, dim=2)
+                q, k, v = self.c_attn(x).split(self.n_embd, dim=2)
                 k = k.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)  # (B, nh, T, hs)
                 q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)  # (B, nh, T, hs)
                 v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)  # (B, nh, T, hs)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2575,9 +2575,9 @@ class TestSDPACudaOnly(NNTestCase):
             shape_q = [BHSqD[idx] for idx in permute_order]
             shape_kv = [BHSkvD[idx] for idx in permute_order]
             reverse = [permute_order.index(idx) for idx in range(4)]
-            q = torch.randn(*shape_q, dtype=torch.bfloat16, device='cuda').permute(reverse)
-            k = torch.randn(*shape_kv, dtype=torch.bfloat16, device='cuda').permute(reverse)
-            v = torch.randn(*shape_kv, dtype=torch.bfloat16, device='cuda').permute(reverse)
+            q = torch.randn(*shape_q, dtype=torch.bfloat16, device='cuda', requires_grad=True).permute(reverse)
+            k = torch.randn(*shape_kv, dtype=torch.bfloat16, device='cuda', requires_grad=True).permute(reverse)
+            v = torch.randn(*shape_kv, dtype=torch.bfloat16, device='cuda', requires_grad=True).permute(reverse)
             self.assertEqual(q.shape, BHSqD)
             self.assertEqual(k.shape, BHSkvD)
             self.assertEqual(v.shape, BHSkvD)
@@ -2585,6 +2585,7 @@ class TestSDPACudaOnly(NNTestCase):
             with sdpa_kernel(backend):
                 out = F.scaled_dot_product_attention(q, k, v)
                 self.assertTrue(out.permute(permute_order).is_contiguous())
+                out.sum().backward()
 
         permute_orders = list()
         permutable = [0, 1, 2]

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2564,6 +2564,53 @@ class TestSDPACudaOnly(NNTestCase):
         torch.testing.assert_close(k.grad, k_cpu.grad.cuda(), atol=3e-3, rtol=2e-3)
         torch.testing.assert_close(v.grad, v_cpu.grad.cuda(), atol=3e-3, rtol=2e-3)
 
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cudnn Attention is not supported on this system")
+    def test_cudnn_attention_preserves_query_layout(self, device):
+        class Config:
+            n_embd: int = 512
+            n_head: int = 8
+            n_layer: int = 6
+            n_ctx: int = 2048
+            bias: bool = False
+
+        class CausalSelfAttention(nn.Module):
+
+            def __init__(self, config):
+                super().__init__()
+                assert config.n_embd % config.n_head == 0
+                # key, query, value projections for all heads, but in a batch
+                self.c_attn = nn.Linear(config.n_embd, 3 * config.n_embd, bias=config.bias)
+                # output projection
+                self.c_proj = nn.Linear(config.n_embd, config.n_embd, bias=config.bias)
+                self.n_head = config.n_head
+                self.n_embd = config.n_embd
+
+            def forward(self, x):
+                B, T, C = x.size() # batch size, sequence length, embedding dimensionality (n_embd)
+                q, k, v  = self.c_attn(x).split(self.n_embd, dim=2)
+                k = k.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
+                q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
+                v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
+
+                y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
+
+                # HERE, WE NEED THIS CONTIGUOUS TO BE A NO-OP
+                # y = y.transpose(1, 2).contiguous().view(B, T, C)
+                y = y.transpose(1, 2).view(B, T, C)
+                y = self.c_proj(y)
+                return y
+
+        def test_attention(backend: SDPBackend):
+            config = Config()
+            Attention = CausalSelfAttention(config).to("cuda", dtype=torch.float16)
+            sample_input = torch.randn(1, 2048, config.n_embd, device="cuda", dtype = torch.float16)
+            with sdpa_kernel(backend):
+              out = Attention(sample_input)
+
+        width = 100
+        test_attention(SDPBackend.CUDNN_ATTENTION)
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION, "Fused SDPA was not built for this system")
     @parametrize("mask_dim", [1, 2, 3, 4])
     def test_mem_efficient_attention_mask_variants(self, device, mask_dim: List[int]):

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2588,15 +2588,13 @@ class TestSDPACudaOnly(NNTestCase):
                 self.test = test
 
             def forward(self, x):
-                B, T, C = x.size() # batch size, sequence length, embedding dimensionality (n_embd)
+                B, T, C = x.size()  # batch size, sequence length, embedding dimensionality (n_embd)
                 q, k, v  = self.c_attn(x).split(self.n_embd, dim=2)
-                k = k.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
-                q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
-                v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
+                k = k.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)  # (B, nh, T, hs)
+                q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)  # (B, nh, T, hs)
+                v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)  # (B, nh, T, hs)
 
                 y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
-
-                # y = y.transpose(1, 2).contiguous().view(B, T, C)
                 self.test.assertTrue(y.transpose(1, 2).is_contiguous())
                 y = y.transpose(1, 2).view(B, T, C)
                 y = self.c_proj(y)
@@ -2605,9 +2603,9 @@ class TestSDPACudaOnly(NNTestCase):
         def test_attention(backend: SDPBackend):
             config = Config()
             Attention = CausalSelfAttention(config, self).to("cuda", dtype=torch.float16)
-            sample_input = torch.randn(1, 2048, config.n_embd, device="cuda", dtype = torch.float16)
+            sample_input = torch.randn(1, 2048, config.n_embd, device="cuda", dtype=torch.float16)
             with sdpa_kernel(backend):
-              out = Attention(sample_input)
+                out = Attention(sample_input)
 
         width = 100
         test_attention(SDPBackend.CUDNN_ATTENTION)


### PR DESCRIPTION
For #138340

~~We might consider more sophisticated logic here but the corresponding logic in other backends doesn't seem to do anything fancy for non BSHD/BHSD cases https://github.com/pytorch/pytorch/blob/ea8ea2f33fc65b33dc562f4b0430f8c79eb81d8d/aten/src/ATen/native/transformers/cuda/attention.cu#L1145~~

ended up going with a more general approach to much more or less arbitrary layouts




cc @csarofeen @ptrblck @xwang233 @msaroufim @drisspg @mikaylagawarecki