### PR TITLE
[RELEASE-ONLY CHANGE] Don't try to load cufile

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -308,7 +308,6 @@ def _load_global_deps() -> None:
             "cuda_runtime": "libcudart.so.*[0-9]",
             "cuda_cupti": "libcupti.so.*[0-9]",
             "cufft": "libcufft.so.*[0-9]",
-            "cufile": "libcufile.so.*[0-9]",
             "curand": "libcurand.so.*[0-9]",
             "nvjitlink": "libnvJitLink.so.*[0-9]",
             "cusparse": "libcusparse.so.*[0-9]",


### PR DESCRIPTION
cufile is not available in AlmaLinux/AmazonLinux default configuration. cufile is not actually used currently by default - https://github.com/pytorch/pytorch/pull/133489