### PR TITLE
config: simplify most of the config handling and fix some bugs

### DIFF
--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -30,7 +30,7 @@ class TestInductorConfig(TestCase):
     def test_set(self):
         config.max_fusion_size = 13337
         self.assertEqual(config.max_fusion_size, 13337)
-        self.assertEqual(config.shallow_copy_dict()["max_fusion_size"], 13337)
+        self.assertEqual(config.get_config_copy()["max_fusion_size"], 13337)
         config.max_fusion_size = 32
         self.assertEqual(config.max_fusion_size, 32)
 
@@ -38,7 +38,7 @@ class TestInductorConfig(TestCase):
         prior = config.triton.cudagraphs
         config.triton.cudagraphs = not prior
         self.assertEqual(config.triton.cudagraphs, not prior)
-        self.assertEqual(config.shallow_copy_dict()["triton.cudagraphs"], not prior)
+        self.assertEqual(config.get_config_copy()["triton.cudagraphs"], not prior)
 
     def test_save_load(self):
         config.max_fusion_size = 123

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -1,0 +1,268 @@
+# Owner(s): ["module: unknown"]
+import pickle
+
+from torch.testing._internal import fake_config_module as config
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestConfigModule(TestCase):
+    def test_base_value_loading(self):
+        self.assertTrue(config.e_bool)
+        self.assertTrue(config.nested.e_bool)
+        self.assertEqual(config.e_int, 1)
+        self.assertEqual(config.e_float, 1.0)
+        self.assertEqual(config.e_string, "string")
+        self.assertEqual(config.e_list, [1])
+        self.assertEqual(config.e_set, {1})
+        self.assertEqual(config.e_tuple, (1,))
+        self.assertEqual(config.e_dict, {1: 2})
+        self.assertEqual(config.e_none, None)
+        with self.assertRaises(
+            AttributeError, msg="fake_config_module.does_not_exist does not exist"
+        ):
+            config.does_not_exist
+
+    def test_overrides(self):
+        config.e_bool = False
+        self.assertFalse(config.e_bool)
+        config.nested.e_bool = False
+        self.assertFalse(config.nested.e_bool)
+        config.e_int = 2
+        self.assertEqual(config.e_int, 2)
+        config.e_float = 2.0
+        self.assertEqual(config.e_float, 2.0)
+        config.e_string = "string2"
+        self.assertEqual(config.e_string, "string2")
+        config.e_list = [2]
+        self.assertEqual(config.e_list, [2])
+        config.e_set = {2}
+        self.assertEqual(config.e_set, {2})
+        config.e_tuple = (2,)
+        self.assertEqual(config.e_tuple, (2,))
+        config.e_dict = {2: 3}
+        self.assertEqual(config.e_dict, {2: 3})
+        config.e_none = "not none"
+        self.assertEqual(config.e_none, "not none")
+        config.e_none = None
+        self.assertEqual(config.e_none, None)
+        with self.assertRaises(
+            AttributeError, msg="fake_config_module.does_not_exist does not exist"
+        ):
+            config.does_not_exist = 0
+        # Config changes get persisted between test cases
+        config.e_bool = True
+        config.nested.e_bool = True
+        config.e_int = 1
+        config.e_float = 1.0
+        config.e_string = "string"
+        config.e_list = [1]
+        config.e_set = {1}
+        config.e_tuple = (1,)
+        config.e_dict = {1: 2}
+        config.e_none = None
+
+    def test_delete(self):
+        self.assertTrue(config.e_bool)
+        del config.e_bool
+        with self.assertRaises(
+            AttributeError, msg="fake_config_module.e_bool does not exist"
+        ):
+            print(config.e_bool)
+        # Config changes get persisted between test cases
+        config.e_bool = True
+
+    def test_save_config(self):
+        p = config.save_config()
+        self.assertEqual(
+            pickle.loads(p),
+            {
+                "_cache_config_ignore_prefix": ["magic_cache_config"],
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "_e_ignored": True,
+                "e_compile_ignored": True,
+                "magic_cache_config_ignored": True,
+                "_save_config_ignore": ["e_ignored"],
+            },
+        )
+        config.e_bool = False
+        config.e_ignored = False
+        config.load_config(p)
+        self.assertTrue(config.e_bool)
+        self.assertFalse(config.e_ignored)
+        # Config changes get persisted between test cases
+        config.e_ignored = True
+
+    def test_save_config_portable(self):
+        p = config.save_config_portable()
+        self.assertEqual(
+            p,
+            {
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "e_ignored": True,
+                "e_compile_ignored": True,
+            },
+        )
+        config.e_bool = False
+        config._e_ignored = False
+        config.load_config(p)
+        self.assertTrue(config.e_bool)
+        self.assertFalse(config._e_ignored)
+        # Config changes get persisted between test cases
+        config._e_ignored = True
+
+    def test_codegen_config(self):
+        config.e_bool = False
+        config.e_ignored = False
+        code = config.codegen_config()
+        self.assertEqual(
+            code, "torch.testing._internal.fake_config_module.e_bool = False"
+        )
+        # Config changes get persisted between test cases
+        config.e_bool = True
+        config.e_ignored = True
+
+    def test_get_hash(self):
+        self.assertEqual(
+            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        # Test cached value
+        self.assertEqual(
+            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        self.assertEqual(
+            config._hash_digest, b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        config._hash_digest = "fake"
+        self.assertEqual(config.get_hash(), "fake")
+
+        # BUG
+        config.e_bool = False
+        # self.assertEqual(config.get_hash(), b'\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6')
+        # Hack around bug
+        config._is_dirty = True
+        self.assertNotEqual(
+            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        config.e_bool = True
+
+        # Test ignored values
+        config.e_compile_ignored = False
+        config._is_dirty = True
+        self.assertEqual(
+            config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
+        )
+        config.e_compile_ignored = True
+
+    def test_dict_copy_semantics(self):
+        p = config.shallow_copy_dict()
+        self.assertEqual(
+            p,
+            {
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "e_ignored": True,
+                "_e_ignored": True,
+                "e_compile_ignored": True,
+                "_cache_config_ignore_prefix": ["magic_cache_config"],
+                "_save_config_ignore": ["e_ignored"],
+                "magic_cache_config_ignored": True,
+            },
+        )
+        p2 = config.to_dict()
+        self.assertEqual(
+            p2,
+            {
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "e_ignored": True,
+                "_e_ignored": True,
+                "e_compile_ignored": True,
+                "_cache_config_ignore_prefix": ["magic_cache_config"],
+                "_save_config_ignore": ["e_ignored"],
+                "magic_cache_config_ignored": True,
+            },
+        )
+        p3 = config.get_config_copy()
+        self.assertEqual(
+            p3,
+            {
+                "e_bool": True,
+                "e_dict": {1: 2},
+                "e_float": 1.0,
+                "e_int": 1,
+                "e_list": [1],
+                "e_none": None,
+                "e_set": {1},
+                "e_string": "string",
+                "e_tuple": (1,),
+                "nested.e_bool": True,
+                "e_ignored": True,
+                "_e_ignored": True,
+                "e_compile_ignored": True,
+                "_cache_config_ignore_prefix": ["magic_cache_config"],
+                "_save_config_ignore": ["e_ignored"],
+                "magic_cache_config_ignored": True,
+            },
+        )
+
+        # Shallow + deep copy semantics
+        config.e_dict[2] = 3
+        self.assertEqual(p["e_dict"], {1: 2, 2: 3})
+        self.assertEqual(p2["e_dict"], {1: 2, 2: 3})
+        self.assertEqual(p3["e_dict"], {1: 2})
+        config.e_dict = {1: 2}
+
+    def test_patch(self):
+        with config.patch("e_bool", False):
+            self.assertFalse(config.e_bool)
+        self.assertTrue(config.e_bool)
+        with config.patch(e_bool=False):
+            self.assertFalse(config.e_bool)
+        self.assertTrue(config.e_bool)
+        with self.assertRaises(AssertionError):
+            with config.patch("does_not_exist"):
+                pass
+
+    def test_make_closur_patcher(self):
+        revert = config._make_closure_patcher(e_bool=False)()
+        self.assertFalse(config.e_bool)
+        revert()
+        self.assertTrue(config.e_bool)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -241,8 +241,8 @@ class TestConfigModule(TestCase):
 
         # Shallow + deep copy semantics
         config.e_dict[2] = 3
-        self.assertEqual(p["e_dict"], {1: 2, 2: 3})
-        self.assertEqual(p2["e_dict"], {1: 2, 2: 3})
+        self.assertEqual(p["e_dict"], {1: 2})
+        self.assertEqual(p2["e_dict"], {1: 2})
         self.assertEqual(p3["e_dict"], {1: 2})
         config.e_dict = {1: 2}
 

--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -155,9 +155,6 @@ class TestConfigModule(TestCase):
 
         # BUG
         config.e_bool = False
-        # self.assertEqual(config.get_hash(), b'\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6')
-        # Hack around bug
-        config._is_dirty = True
         self.assertNotEqual(
             config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
         )
@@ -165,7 +162,6 @@ class TestConfigModule(TestCase):
 
         # Test ignored values
         config.e_compile_ignored = False
-        config._is_dirty = True
         self.assertEqual(
             config.get_hash(), b"\xcd\x96\x93\xf5(\xf8(\xa5\x1c+O\n\xd3_\x0b\xa6"
         )

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2227,7 +2227,7 @@ class _TorchCompileInductorWrapper:
 
         from torch._inductor import config
 
-        current_config: _Dict[str, _Any] = config.shallow_copy_dict()
+        current_config: _Dict[str, _Any] = config.get_config_copy()
 
         for key, val in options.items():
             attr_name = key.replace("-", "_")

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1086,7 +1086,7 @@ def _compile(
                     for key, value in d.items()
                 }
 
-            config_dict = handle_sets(config.shallow_copy_dict())
+            config_dict = handle_sets(config.get_config_copy())
             metrics = CompilationMetrics(
                 str(compile_id),
                 frame_key,

--- a/torch/_dynamo/test_minifier_common.py
+++ b/torch/_dynamo/test_minifier_common.py
@@ -100,8 +100,8 @@ torch._inductor.config.{"cpp" if device == "cpu" else "triton"}.inject_relu_bug_
 
             # NB: Can't use save_config because that will omit some fields,
             # but we must save and reset ALL fields
-            dynamo_config = torch._dynamo.config.shallow_copy_dict()
-            inductor_config = torch._inductor.config.shallow_copy_dict()
+            dynamo_config = torch._dynamo.config.get_config_copy()
+            inductor_config = torch._inductor.config.get_config_copy()
             try:
                 stderr = io.StringIO()
                 log_handler = logging.StreamHandler(stderr)

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -263,7 +263,7 @@ def list_options() -> List[str]:
 
     from torch._inductor import config
 
-    current_config: Dict[str, Any] = config.shallow_copy_dict()
+    current_config: Dict[str, Any] = config.get_config_copy()
 
     return list(current_config.keys())
 

--- a/torch/testing/_internal/fake_config_module.py
+++ b/torch/testing/_internal/fake_config_module.py
@@ -1,0 +1,30 @@
+import sys
+from typing import Optional
+
+from torch.utils._config_module import install_config_module
+
+
+e_bool = True
+e_int = 1
+e_float = 1.0
+e_string = "string"
+e_list = [1]
+e_set = {1}
+e_tuple = (1,)
+e_dict = {1: 2}
+e_none: Optional[bool] = None
+e_ignored = True
+_e_ignored = True
+magic_cache_config_ignored = True
+# [@compile_ignored: debug]
+e_compile_ignored = True
+
+
+class nested:
+    e_bool = True
+
+
+_cache_config_ignore_prefix = ["magic_cache_config"]
+_save_config_ignore = ["e_ignored"]
+
+install_config_module(sys.modules[__name__])

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -144,6 +144,7 @@ class ConfigModule(ModuleType):
             raise AttributeError(f"{self.__name__}.{name} does not exist")
         else:
             self._config[name] = value
+            self._is_dirty = True
 
     def __getattr__(self, name: str) -> Any:
         try:
@@ -153,6 +154,7 @@ class ConfigModule(ModuleType):
             raise AttributeError(f"{self.__name__}.{name} does not exist") from e
 
     def __delattr__(self, name: str) -> None:
+        self._is_dirty = True
         # must support delete because unittest.mock.patch deletes
         # then recreate things
         del self._config[name]

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -207,15 +207,22 @@ class ConfigModule(ModuleType):
         return self._hash_digest
 
     @deprecated(
-        "`config.to_dict()` has been deprecated. It may no longer change the underlying config."
-        " use `config.shallow_copy_dict()` or `config.get_config_copy()` instead",
+        "`config.to_dict()` has been deprecated. It no longer changes the underlying config."
+        " use `config.get_config_copy()` instead if you just want a copy of the config, or "
+        "config.load_config if you need mutable access",
         category=FutureWarning,
     )
     def to_dict(self) -> Dict[str, Any]:
-        return self.shallow_copy_dict()
+        return self.get_config_copy()
 
+    @deprecated(
+        "`config.shallow_copy_dict()` has been deprecated. It no longer changes the underlying config."
+        " use `config.get_config_copy()` instead if you just want a copy of the config, or "
+        "config.load_config if you need mutable access",
+        category=FutureWarning,
+    )
     def shallow_copy_dict(self) -> Dict[str, Any]:
-        return {**self._config}
+        return self.get_config_copy()
 
     def load_config(self, maybe_pickled_config: Union[bytes, Dict[str, Any]]) -> None:
         """Restore from a prior call to save_config() or shallow_copy_dict()"""

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -8,7 +8,7 @@ import tokenize
 import unittest
 import warnings
 from types import FunctionType, ModuleType
-from typing import Any, Callable, Dict, NoReturn, Optional, Set, Union
+from typing import Any, Callable, Dict, List, NoReturn, Optional, Set, Union
 from typing_extensions import deprecated
 from unittest import mock
 
@@ -159,25 +159,56 @@ class ConfigModule(ModuleType):
         # then recreate things
         del self._config[name]
 
+    def _get_dict(
+        self,
+        ignored_keys: Optional[List[str]] = None,
+        ignored_prefixes: Optional[List[str]] = None,
+        skip_default: bool = False,
+    ) -> Dict[str, Any]:
+        """Export a dictionary of current configuration keys and values.
+
+        This function is design to provide a single point which handles
+        accessing config options and exporting them into a dictionary.
+        This is used by a number of different user facing export methods
+        which all have slightly different semantics re: how and what to
+        skip.
+
+        Arguments:
+            ignored_keys are keys that should not be exported.
+            ignored_prefixes are prefixes that if a key matches should
+                not be exported
+            skip_default does two things. One if a key has not been modified
+                it skips it. The other is it modified the logging behaviour
+                to match what codegen already did for modified skipped keys
+        """
+        config: Dict[str, Any] = {}
+        for key in self._config:
+            if ignored_keys and key in ignored_keys:
+                if skip_default and self._config[key] != self._default[key]:
+                    warnings.warn(
+                        f"Skipping serialization of {key} value {self._config[key]}"
+                    )
+                continue
+            if ignored_prefixes:
+                if any(key.startswith(prefix) for prefix in ignored_prefixes):
+                    continue
+            if skip_default and self._config[key] == self._default[key]:
+                continue
+            config[key] = copy.deepcopy(self._config[key])
+        return config
+
     def save_config(self) -> bytes:
         """Convert config to a pickled blob"""
-        config = dict(self._config)
-        for key in config.get("_save_config_ignore", ()):
-            config.pop(key)
-        return pickle.dumps(config, protocol=2)
+        return pickle.dumps(
+            self._get_dict(ignored_keys=self._config.get("_save_config_ignore", ())),
+            protocol=2,
+        )
 
     def save_config_portable(self) -> Dict[str, Any]:
         """Convert config to portable format"""
-        config: Dict[str, Any] = {}
-        for key in sorted(self._config):
-            if key.startswith("_"):
-                continue
-            if any(
-                key.startswith(e) for e in self._config["_cache_config_ignore_prefix"]
-            ):
-                continue
-            config[key] = self._config[key]
-        return config
+        prefixes = ["_"]
+        prefixes.extend(self._config["_cache_config_ignore_prefix"])
+        return self._get_dict(ignored_prefixes=prefixes)
 
     def codegen_config(self) -> str:
         """Convert config to Python statements that replicate current config.
@@ -185,24 +216,16 @@ class ConfigModule(ModuleType):
         """
         lines = []
         mod = self.__name__
-        for k, v in self._config.items():
-            if k in self._config.get("_save_config_ignore", ()):
-                if v != self._default[k]:
-                    warnings.warn(f"Skipping serialization of {k} value {v}")
-                continue
-            if v == self._default[k]:
-                continue
+        for k, v in self._get_dict(
+            ignored_keys=self._config.get("_save_config_ignore"), skip_default=True
+        ).items():
             lines.append(f"{mod}.{k} = {v!r}")
         return "\n".join(lines)
 
     def get_hash(self) -> bytes:
         """Hashes the configs that are not compile_ignored"""
         if self._is_dirty or self._hash_digest is None:
-            dict_to_hash = {
-                k: v
-                for k, v in self._config.items()
-                if k not in self._compile_ignored_keys
-            }
+            dict_to_hash = self._get_dict(ignored_keys=list(self._compile_ignored_keys))
             string_to_hash = repr(sorted(dict_to_hash.items()))
             self._hash_digest = hashlib.md5(string_to_hash.encode("utf-8")).digest()
             self._is_dirty = False
@@ -235,7 +258,7 @@ class ConfigModule(ModuleType):
         self._config.update(config)
 
     def get_config_copy(self) -> Dict[str, Any]:
-        return copy.deepcopy(self._config)
+        return self._get_dict()
 
     def patch(
         self,


### PR DESCRIPTION
This PR combines a number of cleanups in one PR. If any of the specific cleanups don't seem to make sense, let me know and I can remove them.

Cleanups

- This PR adds a set of test suites for the config module code, which handles basically all the APIs and ways it is used. Please let me know if you see anything critical that is not tested that I missed. This test suite is primarily used as the regression test suite for later changes in this diff. Note that there is some dynamo specific testing of the config module, but it isn't as verbose.
- I removed all internal usage of shallow_copy_dict. Those usages could all use the deep copy, and did not depend on the reference behavior of certain config values that shallow_copy_dict allows.
- I removed shallow copy semantics for configuration with a deprecation warning. I think this requires a release note, so hopefully I did that correctly. Let me know if we want to continue to expose shallow copy value semantics, but I just can't find a case where I expect anyone would want it. It also complicated later internal changes to the API (i.e. breaking apart various layers of the config changes).
- I fixed what I believe is a bug in how hashes are calculated on configs. In particular, if you got the hash, then made a config change, and then got the hash again, it would not update the hash. @oulgen, please let me know if I'm misunderstanding this behavior and it is desired.
- I switched our multiple implementations of iterating through the dictionary to a single one. This is primarily to make later changes easier, but it also makes it clear how inconsistent our various config ignoring options are. Let me know if people would be interested in me unifying the various options for ignoring config values.
- I updated the test patcher (not the performance critical one, just the normal one), to use __setattr__ and __getattr__ to remove direct API access to the underlying config fetcher.

For release notes, Not sure exactly how to communicate this, but something like
"ConfigModule.to_dict, and ConfigModule.shallow_copy_dict no longer retain their shallow copy semantics, which allowed reference values objects to be modified. If you wish to modify the config object, call load_config explicitly".

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @rec