### PR TITLE
[pt2] Log is_forward field to dynamo_compile scuba table

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1121,6 +1121,7 @@ def _compile(
                 config.inline_inbuilt_nn_modules,
                 config.specialize_float,
                 json.dumps(config_dict),
+                True,
             )
             record_compilation_metrics(metrics)
             torch._dynamo.callback_handler.run_end_callbacks()

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -356,6 +356,7 @@ def dynamo_timed(
                                 fail_reason,
                                 remote_cache_time_saved,
                                 structured_logging_overhead_s,
+                                False,
                             )
                             record_compilation_metrics(metrics)
 
@@ -800,6 +801,7 @@ class CompilationMetrics:
     config_inline_inbuilt_nn_modules: Optional[bool]
     specialize_float: Optional[bool]
     dynamo_config: Optional[str]
+    is_forward: Optional[bool]
 
 
 @dataclasses.dataclass
@@ -811,6 +813,7 @@ class BwdCompilationMetrics:
     fail_reason: Optional[str]
     remote_cache_time_saved_s: Optional[float]
     structured_logging_overhead_s: Optional[float]
+    is_forward: Optional[bool]
 
 
 DEFAULT_COMPILATION_METRICS_LIMIT = 64


### PR DESCRIPTION
Summary: Redo of D64438144, which got reverted. I guess test failures because I tried to get too fancy with the definition of the field

Test Plan:
`buck2 run mode/opt scripts/slarsen/torch_compile_model:run`

```
(pytorch-3.10_4) devvm2296:~/fbcode  $ scuba -e="select time,co_filename,is_forward from \`dynamo_compile/sandbox\` where user_secure_group='slarsen' and time > now() - 120"
+------------+---------------------------------------------------------------------------------------------------------------------------+------------+
|    time    |                                                        co_filename                                                        | is_forward |
+------------+---------------------------------------------------------------------------------------------------------------------------+------------+
| 1729297313 | null                                                                                                                      |          0 |
| 1729297311 | /mnt/xarfuse/uid-9411/c61058ab-seed-nspid4026531836_cgpid2664473-ns-4026531841/scripts/slarsen/torch_compile_model/run.py |          1 |
+------------+---------------------------------------------------------------------------------------------------------------------------+------------+
```

Differential Revision: D64636398




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec