### PR TITLE
[PGNCCL] Ensure comm is ready before all accesses

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -557,8 +557,6 @@ class NCCLComm {
 
  private:
   ncclComm_t ncclComm_{nullptr};
-  // a helper function to wait until the communicator is initialized;
-  void waitUntilInitialized();
 };
 
 // Helper that automatically cleans up premul sums.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138644
* #138527
* __->__ #138384
* #138374
* #138488
* #137855

Previously we only wait for comm to become ready after its initialization. 
That's not enough. There are other NCCL APIs that can cause the comm to be InProgress, e.g. P2P calls, commSplit, commFinalize, etc.
Therefore, we just ensure comm is ready every "next time" we need to access ncclComm. 
The place to add such gate keeper is `getNcclComm`.

cc @XilunWu @H-Huang @awgu @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o