### PR TITLE
Log all failing test repros to scuba

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5328,9 +5328,6 @@ class ShapeEnv:
         s0 happens to be 3 this run, compute_hint will subsitute s0 with 3.
         """
 
-        # Purposely break things so we log failing repros...
-        return expr
-
         # axioms with compute hint NYE
         assert not compute_hint or not axioms
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5328,6 +5328,9 @@ class ShapeEnv:
         s0 happens to be 3 this run, compute_hint will subsitute s0 with 3.
         """
 
+        # Purposely break things so we log failing repros...
+        return expr
+
         # axioms with compute hint NYE
         assert not compute_hint or not axioms
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2874,6 +2874,7 @@ class TestCase(expecttest.TestCase):
                     test_run_cmd = f"python {test_filename} {class_name}.{method_name}"
                     env_var_prefix = TestEnvironment.repro_env_var_prefix()
                     repro_parts = [env_var_prefix, test_run_cmd]
+                    # TODO log to scribe here
                     self.wrap_with_policy(
                         method_name,
                         lambda repro_parts=repro_parts: print_repro_on_failure(repro_parts))

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2886,7 +2886,6 @@ class TestCase(expecttest.TestCase):
                     test_run_cmd = f"python {test_filename} {class_name}.{method_name}"
                     env_var_prefix = TestEnvironment.repro_env_var_prefix()
                     repro_parts = [env_var_prefix, test_run_cmd]
-
                     self.wrap_with_policy(
                         method_name,
                         lambda repro_parts=repro_parts: print_repro_on_failure(repro_parts))

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2895,7 +2895,7 @@ class TestCase(expecttest.TestCase):
                     test_run_cmd = f"python {test_filename} {class_name}.{method_name}"
                     env_var_prefix = TestEnvironment.repro_env_var_prefix()
                     repro_parts = [env_var_prefix, test_run_cmd]
-                    # TODO log to scribe here
+
                     self.wrap_with_policy(
                         method_name,
                         lambda repro_parts=repro_parts: print_repro_on_failure(repro_parts))

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2411,6 +2411,7 @@ def print_repro_on_failure(repro_parts):
             parameters=json.dumps(
                 {
                     'pull_request_url': pull_request_url,
+                    'commit_hash': os.getenv('GITHUB_SHA'),
                     "repro": " ".join(filter(None, (sample_isolation_prefix, *repro_parts))),
                 }
             ),

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -74,6 +74,7 @@ from torch import Tensor
 from torch._C import ScriptDict, ScriptList  # type: ignore[attr-defined]
 from torch._dynamo.trace_rules import _as_posix_path
 from torch._utils_internal import get_writable_path
+from torch._logging.scribe import open_source_signpost
 from torch.nn import (
     ModuleDict,
     ModuleList,
@@ -2396,6 +2397,25 @@ def print_repro_on_failure(repro_parts):
             sample_isolation_prefix = f"PYTORCH_OPINFO_SAMPLE_INPUT_INDEX={tracked_input.index}"
 
         repro_str = " ".join(filter(None, (sample_isolation_prefix, *repro_parts)))
+
+        event_path = os.getenv('GITHUB_EVENT_PATH')
+        pull_request_url = None
+        if event_path and os.path.exists(event_path):
+            with open(event_path) as event_file:
+                event_data = json.load(event_file)
+                pull_request_url = event_data.get('pull_request', {}).get('html_url')
+
+        open_source_signpost(
+            subsystem="test_repros",
+            name="test_failure",
+            parameters=json.dumps(
+                {
+                    'pull_request_url': pull_request_url,
+                    "repro": " ".join(filter(None, (sample_isolation_prefix, *repro_parts))),
+                }
+            ),
+        )
+
         repro_msg = f"""
 To execute this test, run the following from the base repo dir:
     {repro_str}

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2398,20 +2398,11 @@ def print_repro_on_failure(repro_parts):
 
         repro_str = " ".join(filter(None, (sample_isolation_prefix, *repro_parts)))
 
-        event_path = os.getenv('GITHUB_EVENT_PATH')
-        pull_request_url = None
-        if event_path and os.path.exists(event_path):
-            with open(event_path) as event_file:
-                event_data = json.load(event_file)
-                pull_request_url = event_data.get('pull_request', {}).get('html_url')
-
         open_source_signpost(
             subsystem="test_repros",
             name="test_failure",
             parameters=json.dumps(
                 {
-                    'pull_request_url': pull_request_url,
-                    'commit_hash': os.getenv('GITHUB_SHA'),
                     "repro": " ".join(filter(None, (sample_isolation_prefix, *repro_parts))),
                 }
             ),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138394

This has the benefit that

1) It's much easier to aggregate test failure repros into say a CSV or shell script from scuba
2) We can do analysis (eg. set different two sets of tests across two PRs)
3) We can get results faster at the test-level granularity instead of job-level granularity we see in the HUD/GH.

I tested this by introducing a breaking change, adding ci-scribe label and then verifying that the failed tests were logged to scuba: https://fburl.com/scuba/torch_open_source_signpost/w6qt7qr9

I then reverted the breaking change and published this PR.