### PR TITLE
[c10d] try fix the unstableness of test_get_future_result

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2685,7 +2685,11 @@ class NcclErrorHandlingTest(MultiProcessTestCase):
             work = process_group.allreduce(torch.rand(10).cuda(self.rank))
             work.wait()
             result = work.get_future_result().wait()
-            self.assertEqual(WorkResult(result), WorkResult.COMM_ERROR)
+            self.assertEqual(WorkResult(result), WorkResult.TIMEOUT)
+        else:
+            # other ranks not exiting before rank 0 timeout, this is to avoid
+            # nccl error happening before rank 0 timeouts
+            time.sleep(4)
 
         if prev_nccl_async_error_handling is not None:
             os.environ[


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138415

Summary:
Seems depends on the platform, nccl error or timeout would be raised
first on rank 0. Now we try to force the timeout by not exiting other
ranks
Test Plan:
Tests pass locally

Tags:

Fixes https://github.com/pytorch/pytorch/issues/138397

cc @XilunWu @H-Huang @awgu @kwen2501 @wanchaol @fegin @fduwjj @wz337 @wconstab @d4l3k @c-p-i-o