### PR TITLE
Correct mps supported_dtype check

### DIFF
--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -323,7 +323,7 @@ class autocast:
                     "Current CUDA Device does not support bfloat16. Please switch dtype to float16."
                 )
         elif self.device == "mps":
-            supported_dtype = [torch.float16]
+            supported_dtype = [torch.bfloat16]
             if self.fast_dtype not in supported_dtype:
                 error_message = "In MPS autocast, but the target dtype is not supported. Disabling autocast.\n"
                 error_message += (


### PR DESCRIPTION
The error message states it only supports bfloat16, but the check is actually float16. This corrects it to bfloat16 so folks can correctly autocast.



cc @mcarilli @ptrblck @leslie-fang-intel @jgong5