### PR TITLE
[AMD] Fix torch ck backend build with 6.2.1

### DIFF
--- a/aten/src/ATen/native/cuda/KernelUtils.cuh
+++ b/aten/src/ATen/native/cuda/KernelUtils.cuh
@@ -8,6 +8,7 @@
 // ROCm 6.3 is planned to have these functions, but until then here they are.
 #if defined(USE_ROCM) && ROCM_VERSION >= 60201
 #include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
 
 __device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(__hip_bfloat162* address, __hip_bfloat162 value) {
 #if (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)) && \


### PR DESCRIPTION
Summary: It's complaining about missing __hip_bfloat162 definition w/o this header.

Differential Revision: D64673284


