### PR TITLE
[AOTI] add C shim for QLinearPointwise

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/quantized/cpu/XnnpackUtils.h>
 #include <ATen/native/quantized/cpu/OnednnUtils.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
+#include <ATen/native/quantized/cpu/qlinear.h>
 #include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/library.h>
@@ -1103,6 +1104,42 @@ static at::Tensor linear_int8_with_onednn_weight(
 
 namespace at {
 namespace native {
+
+  Tensor QLinearOnednn::run_pointwise_tensor(
+      Tensor act, // int8 CPU tensor, not QTensor
+      Tensor act_scale,
+      Tensor act_zero_point,
+      Tensor onednn_weight, // int8 tensor from MkldnnCPU
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      std::optional<Tensor> bias,
+      double output_scale,
+      int64_t output_zero_point,
+      std::optional<c10::ScalarType> output_dtype,
+      c10::string_view post_op_name,
+      torch::List<std::optional<at::Scalar>> post_op_args,
+      c10::string_view post_op_algorithm) {
+#if AT_MKLDNN_ENABLED()
+    printf("act_scale numel: %ld\n", act_scale.numel());
+    printf("act_zero_point numel: %ld\n", act_zero_point.numel());
+    TORCH_CHECK(act_scale.numel() == 1 && act_zero_point.numel() == 1,
+        "onednn int8 linear: act scale/zp size should be 1");
+    static std::optional<at::Tensor> other = std::nullopt;
+    static const c10::string_view binary_post_op = "none";
+    return linear_int8_with_onednn_weight(
+        act, act_scale.item().toDouble(), act_zero_point.item().toLong(),
+        onednn_weight, weight_scales, weight_zero_points,
+        bias, output_scale, output_zero_point, output_dtype,
+        other, /*other scale*/1.0, /*other zp*/0,
+        binary_post_op, /*binary alpha*/1.0,
+        post_op_name, post_op_args, post_op_algorithm
+    );
+#endif
+    TORCH_CHECK(false, "Unimplemented (int8 linear with packed weight and bias)");
+  }
+
+
+
 namespace {
 
 template <bool ReluFused>
@@ -1220,37 +1257,6 @@ class QLinearOnednn final {
     TORCH_CHECK(false, "Unimplemented (int8 linear with packed weight and bias)");
   }
 
-  static Tensor run_pointwise_tensor(
-      Tensor act, // int8 CPU tensor, not QTensor
-      Tensor act_scale,
-      Tensor act_zero_point,
-      Tensor onednn_weight, // int8 tensor from MkldnnCPU
-      Tensor weight_scales,
-      Tensor weight_zero_points,
-      std::optional<Tensor> bias,
-      double output_scale,
-      int64_t output_zero_point,
-      std::optional<c10::ScalarType> output_dtype,
-      c10::string_view post_op_name,
-      torch::List<std::optional<at::Scalar>> post_op_args,
-      c10::string_view post_op_algorithm) {
-#if AT_MKLDNN_ENABLED()
-    TORCH_CHECK(act_scale.numel() == 1 && act_zero_point.numel() == 1,
-        "onednn int8 linear: act scale/zp size should be 1");
-    static std::optional<at::Tensor> other = std::nullopt;
-    static const c10::string_view binary_post_op = "none";
-    return linear_int8_with_onednn_weight(
-        act, act_scale.item().toDouble(), act_zero_point.item().toLong(),
-        onednn_weight, weight_scales, weight_zero_points,
-        bias, output_scale, output_zero_point, output_dtype,
-        other, /*other scale*/1.0, /*other zp*/0,
-        binary_post_op, /*binary alpha*/1.0,
-        post_op_name, post_op_args, post_op_algorithm
-    );
-#endif
-    TORCH_CHECK(false, "Unimplemented (int8 linear with packed weight and bias)");
-  }
-
   static Tensor run_pointwise_binary(
       Tensor act, // int8 CPU tensor, not QTensor
       double act_scale,
@@ -1340,7 +1346,7 @@ TORCH_LIBRARY_IMPL(onednn, MkldnnCPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("onednn::qlinear_pointwise"),
       TORCH_FN(QLinearOnednn::run_pointwise));
   m.impl(TORCH_SELECTIVE_NAME("onednn::qlinear_pointwise.tensor"),
-      TORCH_FN(QLinearOnednn::run_pointwise_tensor));
+      TORCH_FN(at::native::QLinearOnednn::run_pointwise_tensor));
   m.impl(TORCH_SELECTIVE_NAME("onednn::qlinear_pointwise.binary"),
       TORCH_FN(QLinearOnednn::run_pointwise_binary));
   m.impl(TORCH_SELECTIVE_NAME("onednn::qlinear_pointwise.binary_tensor"),

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1138,8 +1138,6 @@ namespace native {
     TORCH_CHECK(false, "Unimplemented (int8 linear with packed weight and bias)");
   }
 
-
-
 namespace {
 
 template <bool ReluFused>

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1120,8 +1120,6 @@ namespace native {
       torch::List<std::optional<at::Scalar>> post_op_args,
       c10::string_view post_op_algorithm) {
 #if AT_MKLDNN_ENABLED()
-    printf("act_scale numel: %ld\n", act_scale.numel());
-    printf("act_zero_point numel: %ld\n", act_zero_point.numel());
     TORCH_CHECK(act_scale.numel() == 1 && act_zero_point.numel() == 1,
         "onednn int8 linear: act scale/zp size should be 1");
     static std::optional<at::Tensor> other = std::nullopt;

--- a/aten/src/ATen/native/quantized/cpu/qlinear.h
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.h
@@ -21,6 +21,26 @@ class QLinearOnednn final {
       c10::string_view post_op_name,
       torch::List<std::optional<at::Scalar>> post_op_args,
       c10::string_view post_op_algorithm);
+
+C10_API static Tensor run_pointwise_binary_tensor(
+      Tensor act, // int8 CPU tensor, not QTensor
+      Tensor act_scale,
+      Tensor act_zero_point,
+      Tensor onednn_weight, // int8 tensor from MkldnnCPU
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      std::optional<at::Tensor> other, // extra input for binary post-op
+      std::optional<Tensor> bias,
+      double output_scale,
+      int64_t output_zero_point,
+      std::optional<c10::ScalarType> output_dtype,
+      double other_scale,
+      int64_t other_zero_point,
+      c10::string_view binary_post_op, // e.g. "none", "sum", "add"
+      double binary_alpha,
+      c10::string_view unary_post_op, // e.g. "none", "relu"
+      torch::List<std::optional<at::Scalar>> unary_post_op_args,
+      c10::string_view unary_post_op_algorithm);
 };
 
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/qlinear.h
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <ATen/Tensor.h>
+#include <ATen/Config.h>
+
+namespace at {
+namespace native {
+
+class QLinearOnednn final {
+ public:
+  C10_API static Tensor run_pointwise_tensor(
+      Tensor act, // int8 CPU tensor, not QTensor
+      Tensor act_scale,
+      Tensor act_zero_point,
+      Tensor onednn_weight, // int8 tensor from MkldnnCPU
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      std::optional<Tensor> bias,
+      double output_scale,
+      int64_t output_zero_point,
+      std::optional<c10::ScalarType> output_dtype,
+      c10::string_view post_op_name,
+      torch::List<std::optional<at::Scalar>> post_op_args,
+      c10::string_view post_op_algorithm);
+};
+
+} // namespace native
+} // namespace at

--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -285,7 +285,11 @@ if RUN_CPU:
             test_mkldnn_pattern_matcher.TestDynamicPatternMatcher(),
             condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
             func_inputs=[
-                None,
+                [
+                    "torch.ops.onednn.qconv2d_pointwise",
+                    "torch.ops.quantized.max_pool2d",
+                    "aoti_torch_cpu__qlinear_pointwise_tensor",
+                ]
             ],
         ),
         *[

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -1813,7 +1813,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     ],
                     [],
                     check_quantization=True,
-                    num_include_ops=[2, 1],  # TODO: check the 1 here
+                    num_include_ops=[2, 2],
                 )
             else:
                 # For python wrapper
@@ -1826,7 +1826,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     ],
                     [],
                     check_quantization=True,
-                    num_include_ops=[2, 1],  # TODO: check the 1 here
+                    num_include_ops=[2, 2],
                 )
 
     @skipIfNoDynamoSupport

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -1809,11 +1809,11 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     (v,),
                     [
                         "aoti_torch_cpu__qlinear_pointwise_tensor",
-                        "torch.ops.onednn.qlinear_pointwise.binary",
+                        "aoti_torch_cpu__qlinear_pointwise_binary_tensor",
                     ],
                     [],
                     check_quantization=True,
-                    num_include_ops=[2, 4],
+                    num_include_ops=[2, 1],
                 )
             else:
                 # For python wrapper

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -1813,7 +1813,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     ],
                     [],
                     check_quantization=True,
-                    num_include_ops=[2, 1],
+                    num_include_ops=[2, 1], # TODO: check the 1 here
                 )
             else:
                 # For python wrapper
@@ -1826,7 +1826,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     ],
                     [],
                     check_quantization=True,
-                    num_include_ops=[2, 2],
+                    num_include_ops=[2, 1], # TODO: check the 1 here
                 )
 
     @skipIfNoDynamoSupport

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -1808,12 +1808,12 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     mod,
                     (v,),
                     [
-                        "torch.ops.onednn.qlinear_pointwise.tensor",
+                        "aoti_torch_cpu__qlinear_pointwise_tensor",
                         "torch.ops.onednn.qlinear_pointwise.binary",
                     ],
                     [],
                     check_quantization=True,
-                    num_include_ops=[4, 4],
+                    num_include_ops=[2, 4],
                 )
             else:
                 # For python wrapper

--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -1813,7 +1813,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     ],
                     [],
                     check_quantization=True,
-                    num_include_ops=[2, 1], # TODO: check the 1 here
+                    num_include_ops=[2, 1],  # TODO: check the 1 here
                 )
             else:
                 # For python wrapper
@@ -1826,7 +1826,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                     ],
                     [],
                     check_quantization=True,
-                    num_include_ops=[2, 1], # TODO: check the 1 here
+                    num_include_ops=[2, 1],  # TODO: check the 1 here
                 )
 
     @skipIfNoDynamoSupport

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -188,6 +188,8 @@ def _prepare_linear_fusion_create(
     weight: "TensorBox",
     bias: "TensorBox",
     quantize_args: Optional[List["TensorBox"]] = None,
+    other: Optional["TensorBox"] = None,
+    binary_sum: bool = False,
 ):
     """
     This function is a helper function to prepare inputs, layout and constant args
@@ -212,18 +214,17 @@ def _prepare_linear_fusion_create(
     inputs = [x]
 
     if quantize_args is not None:
-        x_scale, x_zero_point = quantize_args[:2]
+        x_scale, x_zero_point, w_scale, w_zero_point = quantize_args
         x_scale.realize()
         x_zero_point.realize()
-        inputs = inputs + [x_scale, x_zero_point]
-
-    inputs = inputs + [weight]
-
-    if quantize_args is not None:
-        w_scale, w_zero_point = quantize_args[2:]
         w_scale.realize()
         w_zero_point.realize()
-        inputs = inputs + [w_scale, w_zero_point]
+        inputs = inputs + [x_scale, x_zero_point] + [weight] + [w_scale, w_zero_point]
+
+    if other is not None:
+        if binary_sum:
+            other = cls.require_stride_order(other, req_stride_order)
+        inputs = inputs + [other]
 
     output_stride = FlexibleLayout.contiguous_strides(output_size)
     kernel_layout = FixedLayout(
@@ -1367,36 +1368,28 @@ class QLinearPointwiseBinaryPT2E(ExternKernelAlloc):
         inputs,
         constant_args=(),
         has_bias=True,
-        x_scale_zp_are_tensors=False,
     ) -> None:
         """
         if bias is not None
-            - inputs = [x, w, b, weight_scale, weight_zp, x2]
-            - const_args is: [x_scale, x_zp, o_scale, o_zp,
+            - inputs = [x, w, x_scale, x_zp, weight_scale, weight_zp, x2, bias]
+            - const_args is: [o_scale, o_zp,
               fp32_output, binary_attr, aplha, unary_attr, unary_scalars, unary_algorithm]
         else
-            - inputs = [x, w, weight_scale, weight_zp, x2]
-            - const_args is: [bias, x_scale, x_zp, o_scale, o_zp,
+            - inputs = [x, w, x_scale, x_zp, weight_scale, weight_zp, x2]
+            - const_args is: [bias, o_scale, o_zp,
               fp32_output, binary_attr, aplha, unary_attr, unary_scalars, unary_algorithm]
         """
         self.has_bias = has_bias
-        self.x_scale_zp_are_tensors = x_scale_zp_are_tensors
+        self.idx_for_inplace_sum = 6
         super().__init__(
             layout,
             inputs,
             constant_args,
             None,
-            op_overload=(
-                torch.ops.onednn.qlinear_pointwise.binary_tensor
-                if x_scale_zp_are_tensors
-                else torch.ops.onednn.qlinear_pointwise.binary
-            ),
+            op_overload=(torch.ops.onednn.qlinear_pointwise.binary_tensor),
+            cpp_kernel_name="aoti_torch_cpu__qlinear_pointwise_binary_tensor",
         )
-        x_scale_type_str, x_zp_type_str = (
-            ("at::Tensor", "at::Tensor")
-            if x_scale_zp_are_tensors
-            else ("double", "int64_t")
-        )
+        x_scale_type_str, x_zp_type_str = ("at::Tensor", "at::Tensor")
         self.cpp_op_schema = f"""
             at::Tensor(
                 at::Tensor act,
@@ -1419,134 +1412,8 @@ class QLinearPointwiseBinaryPT2E(ExternKernelAlloc):
                 c10::string_view unary_post_op_algorithm)"""
 
     def codegen(self, wrapper):
-        # Parser the inputs and constant
-        # The raw_args setup can be skipped if there is a C shim implementation
-        args = [x.codegen_reference() for x in self.inputs]
-        const_args = []
-        const_args.extend(self.codegen_const_args())
-
-        x = args[0]
-        x_raw = self.inputs[0]
-        packed_weight = args[1]
-        packed_weight_raw = self.inputs[1]
-        bias = args[2] if self.has_bias else const_args[0]
-        bias_raw = self.inputs[2] if self.has_bias else self.constant_args[0]
-        w_scale, w_zp, other = args[-3], args[-2], args[-1]
-        w_scale_raw, w_zp_raw, other_raw = (
-            self.inputs[-3],
-            self.inputs[-2],
-            self.inputs[-1],
-        )
-        if self.x_scale_zp_are_tensors:
-            assert len(args) >= 5
-            x_scale, x_zp = args[-5], args[-4]
-            x_scale_raw, x_zp_raw = self.inputs[-5], self.inputs[-4]
-            (
-                o_scale,
-                o_zp,
-                output_dtype,
-                other_scale,
-                other_zp,
-                binary_attr,
-                alpha,
-                unary_attr,
-                unary_scalars,
-                unary_algorithm,
-            ) = const_args[-10:]
-            (
-                o_scale_raw,
-                o_zp_raw,
-                output_dtype_raw,
-                other_scale_raw,
-                other_zp_raw,
-                binary_attr_raw,
-                alpha_raw,
-                unary_attr_raw,
-                unary_scalars_raw,
-                unary_algorithm_raw,
-            ) = self.constant_args[-10:]
-        else:
-            assert len(const_args) >= 8
-            (
-                x_scale,
-                x_zp,
-                o_scale,
-                o_zp,
-                output_dtype,
-                other_scale,
-                other_zp,
-                binary_attr,
-                alpha,
-                unary_attr,
-                unary_scalars,
-                unary_algorithm,
-            ) = const_args[-12:]
-            (
-                x_scale_raw,
-                x_zp_raw,
-                o_scale_raw,
-                o_zp_raw,
-                output_dtype_raw,
-                other_scale_raw,
-                other_zp_raw,
-                binary_attr_raw,
-                alpha_raw,
-                unary_attr_raw,
-                unary_scalars_raw,
-                unary_algorithm_raw,
-            ) = self.constant_args[-12:]
-
-        codegen_args = (
-            x,
-            x_scale,
-            x_zp,
-            packed_weight,
-            w_scale,
-            w_zp,
-            other,
-            bias,
-            o_scale,
-            o_zp,
-            output_dtype,
-            other_scale,
-            other_zp,
-            binary_attr,
-            alpha,
-            unary_attr,
-            unary_scalars,
-            unary_algorithm,
-        )
-        raw_args = (
-            x_raw,
-            x_scale_raw,
-            x_zp_raw,
-            packed_weight_raw,
-            w_scale_raw,
-            w_zp_raw,
-            other_raw,
-            bias_raw,
-            o_scale_raw,
-            o_zp_raw,
-            output_dtype_raw,
-            other_scale_raw,
-            other_zp_raw,
-            binary_attr_raw,
-            alpha_raw,
-            unary_attr_raw,
-            unary_scalars_raw,
-            unary_algorithm_raw,
-        )
-        wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
-            self.get_name(),
-            self.python_kernel_name,
-            self.cpp_kernel_name,
-            codegen_args,
-            self.cpp_op_schema,
-            self.cpp_kernel_key,
-            self.cpp_kernel_overload_name,
-            self.op_overload,
-            raw_args,
-        )
+        wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
+        super().codegen(wrapper)
         if isinstance(self.layout, Layout):
             self.codegen_size_asserts(wrapper)
 
@@ -1561,8 +1428,8 @@ class QLinearPointwiseBinaryPT2E(ExternKernelAlloc):
     def create(
         cls,
         qx: "TensorBox",
-        x_scale: float,
-        x_zero_point: int,
+        x_scale: "TensorBox",
+        x_zero_point: "TensorBox",
         qw: "TensorBox",  # packed_weight
         w_scale: "TensorBox",
         w_zero_point: "TensorBox",
@@ -1589,23 +1456,11 @@ class QLinearPointwiseBinaryPT2E(ExternKernelAlloc):
             qx,
             qw,
             bias,
+            [x_scale, x_zero_point, w_scale, w_zero_point],
+            other,
+            binary_post_op == "sum",
         )
 
-        if isinstance(x_scale, TensorBox) and isinstance(x_zero_point, TensorBox):
-            x_scale.realize()
-            x_zero_point.realize()
-            inputs = inputs + [x_scale, x_zero_point]
-            x_scale_zp_are_tensors = True
-        else:
-            assert isinstance(x_scale, float) and isinstance(x_zero_point, int)
-            constant_args = constant_args + [x_scale, x_zero_point]
-            x_scale_zp_are_tensors = False
-        w_scale.realize()
-        w_zero_point.realize()
-        inputs = inputs + [w_scale, w_zero_point]
-        if binary_post_op == "sum":
-            other = cls.require_stride_order(other, req_stride_order)
-        inputs.append(other)
         constant_args = constant_args + [
             output_scale,
             output_zero_point,
@@ -1626,10 +1481,9 @@ class QLinearPointwiseBinaryPT2E(ExternKernelAlloc):
                 inputs=inputs,
                 constant_args=constant_args,
                 has_bias=(bias is not None),
-                x_scale_zp_are_tensors=x_scale_zp_are_tensors,
             )
             # Return other since it has been inplace changed.
-            return packed.inputs[-1]
+            return packed.inputs[packed.idx_for_inplace_sum]
 
         assert output_dtype is not None
         if output_dtype in [torch.float32, torch.bfloat16]:
@@ -1642,7 +1496,6 @@ class QLinearPointwiseBinaryPT2E(ExternKernelAlloc):
             inputs=inputs,
             constant_args=constant_args,
             has_bias=(bias is not None),
-            x_scale_zp_are_tensors=x_scale_zp_are_tensors,
         )
 
 

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -187,6 +187,7 @@ def _prepare_linear_fusion_create(
     x: "TensorBox",
     weight: "TensorBox",
     bias: "TensorBox",
+    quantize_args: Optional[List["TensorBox"]] = None,
 ):
     """
     This function is a helper function to prepare inputs, layout and constant args
@@ -208,7 +209,21 @@ def _prepare_linear_fusion_create(
 
     x = cls.require_stride_order(x, req_stride_order)
     assert x.get_device().type == "cpu" and weight.get_device().type == "cpu"
-    inputs = [x, weight]
+    inputs = [x]
+
+    if quantize_args is not None:
+        x_scale, x_zero_point = quantize_args[:2]
+        x_scale.realize()
+        x_zero_point.realize()
+        inputs = inputs + [x_scale, x_zero_point]
+
+    inputs = inputs + [weight]
+
+    if quantize_args is not None:
+        w_scale, w_zero_point = quantize_args[2:]
+        w_scale.realize()
+        w_zero_point.realize()
+        inputs = inputs + [w_scale, w_zero_point]
 
     output_stride = FlexibleLayout.contiguous_strides(output_size)
     kernel_layout = FixedLayout(
@@ -1253,7 +1268,6 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
         inputs,
         constant_args=(),
         has_bias=True,
-        x_scale_zp_are_tensors=False,
     ) -> None:
         """
         if bias is not None
@@ -1266,23 +1280,15 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
               fp32_output, unary_attr, unary_scalars, unary_algorithm]
         """
         self.has_bias = has_bias
-        self.x_scale_zp_are_tensors = x_scale_zp_are_tensors
         super().__init__(
             layout,
             inputs,
             constant_args,
             None,
-            op_overload=(
-                torch.ops.onednn.qlinear_pointwise.tensor
-                if x_scale_zp_are_tensors
-                else torch.ops.onednn.qlinear_pointwise.default
-            ),
+            op_overload=(torch.ops.onednn.qlinear_pointwise.tensor),
+            cpp_kernel_name=("aoti_torch_cpu__qlinear_pointwise_tensor"),
         )
-        x_scale_type_str, x_zp_type_str = (
-            ("at::Tensor", "at::Tensor")
-            if x_scale_zp_are_tensors
-            else ("double", "int64_t")
-        )
+        x_scale_type_str, x_zp_type_str = ("at::Tensor", "at::Tensor")
         self.cpp_op_schema = f"""
             at::Tensor(
                 at::Tensor act,
@@ -1300,104 +1306,9 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
                 c10::string_view post_op_algorithm)"""
 
     def codegen(self, wrapper):
-        # Parser the inputs and constant
-        # The raw_args setup can be skipped if there is a C shim implementation
-        args = [x.codegen_reference() for x in self.inputs]
-        const_args = []
-        const_args.extend(self.codegen_const_args())
+        wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h")
+        super().codegen(wrapper)
 
-        x = args[0]
-        x_raw = self.inputs[0]
-        packed_weight = args[1]
-        packed_weight_raw = self.inputs[1]
-        bias = args[2] if self.has_bias else const_args[0]
-        bias_raw = self.inputs[2] if self.has_bias else self.constant_args[0]
-        w_scale, w_zp = args[-2], args[-1]
-        w_scale_raw, w_zp_raw = self.inputs[-2], self.inputs[-1]
-        if self.x_scale_zp_are_tensors:
-            assert len(args) >= 4
-            x_scale, x_zp = args[-4], args[-3]
-            x_scale_raw, x_zp_raw = self.inputs[-4], self.inputs[-3]
-            (
-                o_scale,
-                o_zp,
-                output_dtype,
-                unary_attr,
-                unary_scalars,
-                unary_algorithm,
-            ) = const_args[-6:]
-            (
-                o_scale_raw,
-                o_zp_raw,
-                output_dtype_raw,
-                unary_attr_raw,
-                unary_scalars_raw,
-                unary_algorithm_raw,
-            ) = self.constant_args[-6:]
-        else:
-            assert len(const_args) >= 8
-            (
-                x_scale,
-                x_zp,
-                o_scale,
-                o_zp,
-                output_dtype,
-                unary_attr,
-                unary_scalars,
-                unary_algorithm,
-            ) = const_args[-8:]
-            (
-                x_scale_raw,
-                x_zp_raw,
-                o_scale_raw,
-                o_zp_raw,
-                output_dtype_raw,
-                unary_attr_raw,
-                unary_scalars_raw,
-                unary_algorithm_raw,
-            ) = self.constant_args[-8:]
-
-        codegen_args = (
-            x,
-            x_scale,
-            x_zp,
-            packed_weight,
-            w_scale,
-            w_zp,
-            bias,
-            o_scale,
-            o_zp,
-            output_dtype,
-            unary_attr,
-            unary_scalars,
-            unary_algorithm,
-        )
-        raw_args = (
-            x_raw,
-            x_scale_raw,
-            x_zp_raw,
-            packed_weight_raw,
-            w_scale_raw,
-            w_zp_raw,
-            bias_raw,
-            o_scale_raw,
-            o_zp_raw,
-            output_dtype_raw,
-            unary_attr_raw,
-            unary_scalars_raw,
-            unary_algorithm_raw,
-        )
-        wrapper.generate_extern_kernel_alloc_and_find_schema_if_needed(
-            self.get_name(),
-            self.python_kernel_name,
-            self.cpp_kernel_name,
-            codegen_args,
-            self.cpp_op_schema,
-            self.cpp_kernel_key,
-            self.cpp_kernel_overload_name,
-            self.op_overload,
-            raw_args,
-        )
         if isinstance(self.layout, Layout):
             self.codegen_size_asserts(wrapper)
 
@@ -1405,8 +1316,8 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
     def create(
         cls,
         qx: "TensorBox",
-        x_scale: float,
-        x_zero_point: int,
+        x_scale: "TensorBox",
+        x_zero_point: "TensorBox",
         qw: "TensorBox",  # packed_weight
         w_scale: "TensorBox",
         w_zero_point: "TensorBox",
@@ -1423,20 +1334,9 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
             qx,
             qw,
             bias,
+            [x_scale, x_zero_point, w_scale, w_zero_point],
         )
 
-        if isinstance(x_scale, TensorBox) and isinstance(x_zero_point, TensorBox):
-            x_scale.realize()
-            x_zero_point.realize()
-            inputs = inputs + [x_scale, x_zero_point]
-            x_scale_zp_are_tensors = True
-        else:
-            assert isinstance(x_scale, float) and isinstance(x_zero_point, int)
-            constant_args = constant_args + [x_scale, x_zero_point]
-            x_scale_zp_are_tensors = False
-        w_scale.realize()
-        w_zero_point.realize()
-        inputs = inputs + [w_scale, w_zero_point]
         constant_args = constant_args + [
             output_scale,
             output_zero_point,
@@ -1457,7 +1357,6 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
             inputs=inputs,
             constant_args=constant_args,
             has_bias=(bias is not None),
-            x_scale_zp_are_tensors=x_scale_zp_are_tensors,
         )
 
 

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -241,7 +241,7 @@ def _prepare_linear_fusion_create(
         inputs.append(bias)
     else:
         constant_args.insert(0, bias)
-    return inputs, constant_args, kernel_layout, req_stride_order
+    return inputs, constant_args, kernel_layout, req_stride_order, other
 
 
 def _create_output_node(packed):
@@ -1332,7 +1332,7 @@ class QLinearPointwisePT2E(ExternKernelAlloc):
         post_op_args,
         post_op_algorithm,
     ):
-        (inputs, constant_args, kernel_layout, _) = _prepare_linear_fusion_create(
+        (inputs, constant_args, kernel_layout, _, _) = _prepare_linear_fusion_create(
             cls,
             qx,
             qw,
@@ -1422,7 +1422,7 @@ class QLinearPointwiseBinaryPT2E(ExternKernelAlloc):
     def get_mutation_names(self):
         binary_post_op = self.constant_args[-5]
         if binary_post_op == "sum":
-            return [self.inputs[-1].get_name()]
+            return [self.inputs[self.idx_for_inplace_sum].get_name()]
         else:
             return []
 
@@ -1453,6 +1453,7 @@ class QLinearPointwiseBinaryPT2E(ExternKernelAlloc):
             constant_args,
             kernel_layout,
             req_stride_order,
+            other,
         ) = _prepare_linear_fusion_create(
             cls,
             qx,

--- a/torch/_inductor/mkldnn_ir.py
+++ b/torch/_inductor/mkldnn_ir.py
@@ -220,6 +220,8 @@ def _prepare_linear_fusion_create(
         w_scale.realize()
         w_zero_point.realize()
         inputs = inputs + [x_scale, x_zero_point] + [weight] + [w_scale, w_zero_point]
+    else:
+        inputs += [weight]
 
     if other is not None:
         if binary_sum:

--- a/torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h
@@ -129,6 +129,23 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
     const char* attr,
     AtenTensorHandle* ret0);
 
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
+    AtenTensorHandle X,
+    AtenTensorHandle act_scale,
+    AtenTensorHandle act_zero_point,
+    AtenTensorHandle onednn_weight,
+    AtenTensorHandle weight_scales,
+    AtenTensorHandle weight_zero_points,
+    AtenTensorHandle* B,
+    double output_scale,
+    int64_t output_zero_point,
+    const int32_t* output_dtype,
+    const char* post_op_name,
+    const double** post_op_args,
+    int64_t post_op_args_len_,
+    const char* post_op_algorithm,
+    AtenTensorHandle* ret0);
+
 #if AT_MKL_ENABLED()
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__mkl_linear(

--- a/torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim_mkldnn.h
@@ -146,6 +146,29 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
     const char* post_op_algorithm,
     AtenTensorHandle* ret0);
 
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cpu__qlinear_pointwise_binary_tensor(
+    AtenTensorHandle X,
+    AtenTensorHandle act_scale,
+    AtenTensorHandle act_zero_point,
+    AtenTensorHandle onednn_weight,
+    AtenTensorHandle weight_scales,
+    AtenTensorHandle weight_zero_points,
+    AtenTensorHandle* other,
+    AtenTensorHandle* B,
+    double output_scale,
+    int64_t output_zero_point,
+    const int32_t* output_dtype,
+    double other_scale,
+    int64_t other_zero_point,
+    const char* binary_post_op,
+    double binary_alpha,
+    const char* unary_post_op,
+    const double** unary_post_op_args,
+    int64_t unary_post_op_args_len_,
+    const char* unary_post_op_algorithm,
+    AtenTensorHandle* ret0);
+
 #if AT_MKL_ENABLED()
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__mkl_linear(

--- a/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
@@ -9,6 +9,7 @@
 #endif
 #include <ATen/native/mkldnn/Conv.h>
 #include <ATen/native/mkldnn/Linear.h>
+#include <ATen/native/quantized/cpu/qlinear.h>
 
 using namespace torch::aot_inductor;
 
@@ -265,6 +266,47 @@ AOTITorchError aoti_torch_cpu__linear_pointwise_binary(
         *tensor_handle_to_tensor_pointer(W),
         pointer_to_optional<at::Tensor>(B),
         attr);
+    *ret0 = new_tensor_handle(std::move(tmp_result));
+  });
+}
+
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
+    AtenTensorHandle X,
+    AtenTensorHandle act_scale,
+    AtenTensorHandle act_zero_point,
+    AtenTensorHandle onednn_weight,
+    AtenTensorHandle weight_scales,
+    AtenTensorHandle weight_zero_points,
+    AtenTensorHandle* B,
+    double output_scale,
+    int64_t output_zero_point,
+    const int32_t* output_dtype,
+    const char* post_op_name,
+    const double** post_op_args,
+    int64_t post_op_args_len_,
+    const char* post_op_algorithm,
+    AtenTensorHandle* ret0) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    c10::List<std::optional<c10::Scalar>> scalars_list;
+    scalars_list.reserve(post_op_args_len_);
+    for (int64_t i = 0; i < post_op_args_len_; i++) {
+      scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
+    }
+
+    auto tmp_result = at::native::QLinearOnednn::run_pointwise_tensor(
+        *tensor_handle_to_tensor_pointer(X),
+        *tensor_handle_to_tensor_pointer(act_scale),
+        *tensor_handle_to_tensor_pointer(act_zero_point),
+        *tensor_handle_to_tensor_pointer(onednn_weight),
+        *tensor_handle_to_tensor_pointer(weight_scales),
+        *tensor_handle_to_tensor_pointer(weight_zero_points),
+        pointer_to_optional<at::Tensor>(B),
+        output_scale,
+        output_zero_point,
+        pointer_to_optional<at::ScalarType>(output_dtype),
+        post_op_name,
+        scalars_list,
+        post_op_algorithm);
     *ret0 = new_tensor_handle(std::move(tmp_result));
   });
 }

--- a/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_mkldnn.cpp
@@ -311,6 +311,58 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
   });
 }
 
+AOTI_TORCH_EXPORT AOTITorchError
+aoti_torch_cpu__qlinear_pointwise_binary_tensor(
+    AtenTensorHandle X,
+    AtenTensorHandle act_scale,
+    AtenTensorHandle act_zero_point,
+    AtenTensorHandle onednn_weight,
+    AtenTensorHandle weight_scales,
+    AtenTensorHandle weight_zero_points,
+    AtenTensorHandle* other,
+    AtenTensorHandle* B,
+    double output_scale,
+    int64_t output_zero_point,
+    const int32_t* output_dtype,
+    double other_scale,
+    int64_t other_zero_point,
+    const char* binary_post_op,
+    double binary_alpha,
+    const char* unary_post_op,
+    const double** unary_post_op_args,
+    int64_t unary_post_op_args_len_,
+    const char* unary_post_op_algorithm,
+    AtenTensorHandle* ret0) {
+  AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
+    c10::List<std::optional<c10::Scalar>> scalars_list;
+    scalars_list.reserve(unary_post_op_args_len_);
+    for (int64_t i = 0; i < unary_post_op_args_len_; i++) {
+      scalars_list.emplace_back(pointer_to_optional(unary_post_op_args[i]));
+    }
+
+    auto tmp_result = at::native::QLinearOnednn::run_pointwise_binary_tensor(
+        *tensor_handle_to_tensor_pointer(X),
+        *tensor_handle_to_tensor_pointer(act_scale),
+        *tensor_handle_to_tensor_pointer(act_zero_point),
+        *tensor_handle_to_tensor_pointer(onednn_weight),
+        *tensor_handle_to_tensor_pointer(weight_scales),
+        *tensor_handle_to_tensor_pointer(weight_zero_points),
+        pointer_to_optional<at::Tensor>(other),
+        pointer_to_optional<at::Tensor>(B),
+        output_scale,
+        output_zero_point,
+        pointer_to_optional<at::ScalarType>(output_dtype),
+        other_scale,
+        other_zero_point,
+        binary_post_op,
+        binary_alpha,
+        unary_post_op,
+        scalars_list,
+        unary_post_op_algorithm);
+    *ret0 = new_tensor_handle(std::move(tmp_result));
+  });
+}
+
 #if AT_MKL_ENABLED()
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_cpu__mkl_linear(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138806
* #138691
* #138540
* __->__ #138439

This PR adds C shim for `QLinearPointwisePT2E` and `QLinearPointwiseBinaryPT2E`.

The below changes are needed:
- We moved the qlinear API out of the anonymous namespace since we need to call it in the shim layer.

- We fixed the code which generated the `inputs` and `constant_args` so that we can directly leverage the `codegen` of the parent class.

- `x_scale` and `x_zp` are ensured to be tensor during the lowering stage, thus we can remove the code which handles whether they're tensor or not.
  https://github.com/pytorch/pytorch/blob/fb0da323773e47bc9df5cf3a0628c9a9d7baea73/torch/_inductor/mkldnn_lowerings.py#L492-L496
  
  https://github.com/pytorch/pytorch/blob/fb0da323773e47bc9df5cf3a0628c9a9d7baea73/torch/_inductor/mkldnn_lowerings.py#L499-L503

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov