### PR TITLE
Revert "Bugfix for passing None args to user defined Triton kernel"

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2118,51 +2118,6 @@ def forward(self, arg0_1, arg1_1):
         res2 = fn_c(x2)
         self.assertEqual(x2 * x2, res2)
 
-    @requires_gpu
-    def test_triton_kernel_none_args(self):
-        # https://github.com/pytorch/pytorch/issues/115344
-        @triton.autotune(
-            configs=[
-                triton.Config({"BLOCK_SIZE": 32}, num_stages=5, num_warps=2),
-                triton.Config({"BLOCK_SIZE": 64}, num_stages=4, num_warps=4),
-            ],
-            key=["n_elements"],
-        )
-        @triton.jit
-        def sin_kernel(
-            in_ptr0,
-            out_ptr,
-            n_elements,
-            BLOCK_SIZE: "tl.constexpr",
-        ):
-            pid = tl.program_id(axis=0)
-            block_start = pid * BLOCK_SIZE
-            offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < n_elements
-            if in_ptr0 is not None:
-                x = tl.load(in_ptr0 + offsets, mask=mask)
-            else:
-                x = 0.0
-            output = tl.sin(x)
-            tl.store(out_ptr + offsets, output, mask=mask)
-
-        def sin_triton(x, out):
-            n_elements = out.numel()
-            sin_kernel[(n_elements,)](x, out, n_elements)
-
-        x = torch.randn(65, device="cuda")
-        out = torch.empty_like(x)
-        out_compiled = torch.empty_like(x)
-        sin_triton_compiled = torch.compile(fullgraph=True)(sin_triton)
-
-        sin_triton(x, out)
-        sin_triton_compiled(x, out_compiled)
-        self.assertEqual(out, out_compiled)
-
-        sin_triton(None, out)
-        sin_triton_compiled(None, out_compiled)
-        self.assertEqual(out, out_compiled)
-
 
 def make_mutation_test(fn):
     @requires_gpu

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1108,6 +1108,7 @@ class TritonHOPifier:
                 self.raise_unsupported("Grid can have at most rank 3")
 
         assert len(grids) != 0
+
         if isinstance(variable.kernel, JITFunction):
             constexprs = variable.kernel.constexprs
         else:
@@ -1130,6 +1131,7 @@ class TritonHOPifier:
                     combined_args_raw[arg_name] = variable.specialize_symbolic(
                         combined_args_raw[arg_name]
                     )
+
         return self.call_HOP(variable, grids, combined_args_raw, tx)
 
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1304,8 +1304,6 @@ class PythonWrapperCodegen(CodeGen):
             arg = kwargs[key]
             if idx in kernel.constexprs:
                 constants[key] = arg
-            elif kwargs[key] is None:
-                constants[key] = None
             else:
                 non_constant_indices.append(idx)
                 if isinstance(arg, ir.TMADescriptor):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4831,13 +4831,11 @@ class ExternKernel(InputsKernel):
                         x,
                         freeze=True,
                         want_contiguous=False,
-                        stride_order=(
-                            get_stride_order(
-                                V.graph.sizevars.size_hints(x.get_layout().stride)
-                            )
-                            if is_stride_order_storage_and_layout(x, order)
-                            else order
-                        ),
+                        stride_order=get_stride_order(
+                            V.graph.sizevars.size_hints(x.get_layout().stride)
+                        )
+                        if is_stride_order_storage_and_layout(x, order)
+                        else order,
                         allow_padding=allow_padding,
                     )
                     return x
@@ -5405,25 +5403,9 @@ class UserDefinedTritonKernel(ExternKernel):
         for idx, kwarg in enumerate(self.ordered_kwargs_for_cpp_kernel):
             if kernel.arg_names.index(kwarg) in kernel.constexprs:
                 constexpr_indices.append(idx)
-        """
-        Filter out None args.
-
-        see https://github.com/pytorch/pytorch/issues/115344
-
-        Two cases for a None arg:
-        1. The arg is already tl.constexpr, so leave it in
-        2. The arg is not tl.constexpr so we have to remove it
-        """
-        constexpr_indices_set = set(constexpr_indices)
-        raw_args = [
-            arg
-            for idx, arg in enumerate(raw_args)
-            if (arg is not None) or (arg is None and idx in constexpr_indices_set)
-        ]
 
         # Call to kernel
         self.codegen_comment(wrapper)
-
         wrapper.generate_user_defined_triton_kernel(
             new_name, raw_args, self.grid, configs, triton_meta, constexpr_indices
         )
@@ -5465,7 +5447,6 @@ class UserDefinedTritonKernel(ExternKernel):
         self.grid = grid
 
         kernel, configs = self.get_kernel_and_configs()
-
         # If we are autotuning, not all arguments will be passed
         self.ordered_kwargs_for_cpp_kernel = [
             arg for arg in kernel.arg_names if arg in kernel_args

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -128,9 +128,9 @@ def autotune_hints_to_configs(
                     triton_config(
                         size_hints,
                         *xyz,
-                        num_elements_per_warp=(
-                            device_props.warp_size if device_props.warp_size else 32
-                        ),
+                        num_elements_per_warp=device_props.warp_size
+                        if device_props.warp_size
+                        else 32,
                     )
                 )
 
@@ -481,38 +481,13 @@ class CachingAutotuner(KernelInterface):
                 raise
             binary._init_handles()
 
-        """
-        https://github.com/pytorch/pytorch/issues/115344
-
-        self.fn.constexprs doesn't properly deal with None args, so when we filter out
-        an arg in UserDefinedTritonKernel.codegen, we need to filter it here as well.
-        We also don't want to modify self.fn.
-
-        We know that we removed something from the signature if:
-            1. It's in compile_meta["constants"]
-            2. It isn't a constant we already know about
-                Note: The value of interest has already been added to compile_meta['constants'],
-                    so we use self.fn.constexprs instead.
-            3. It isn't in the compile_meta signature
-        """
-        none_args = set(compile_meta["constants"].keys())
-        known_constants = {
-            arg for i, arg in enumerate(self.fn.arg_names) if i in self.fn.constexprs
-        }
-        none_args = none_args.difference(known_constants)
-        none_args = none_args.difference(set(compile_meta["signature"].keys()))
-
         call_args = [
             arg
             for i, arg in enumerate(self.fn.arg_names)
-            if i not in self.fn.constexprs and arg not in none_args
+            if i not in self.fn.constexprs
         ]
+        def_args = [name for name in self.fn.arg_names if name not in cfg.kwargs]
 
-        def_args = [
-            name
-            for name in self.fn.arg_names
-            if name not in cfg.kwargs and name not in none_args
-        ]
         binary_shared = (
             binary.shared if hasattr(binary, "shared") else binary.metadata.shared
         )
@@ -522,11 +497,9 @@ class CachingAutotuner(KernelInterface):
             "bin": binary,
             "launch_enter_hook": CompiledKernel.launch_enter_hook,
             "launch_exit_hook": CompiledKernel.launch_exit_hook,
-            "metadata": (
-                binary.packed_metadata
-                if hasattr(binary, "packed_metadata")
-                else binary.metadata
-            ),
+            "metadata": binary.packed_metadata
+            if hasattr(binary, "packed_metadata")
+            else binary.metadata,
             "shared": binary_shared,
         }
 
@@ -857,11 +830,9 @@ class CachingAutotuner(KernelInterface):
         key = self.inductor_meta.get("kernel_name", None)  # unique kernel name
         assert key is not None, "kernel_name can not be None"
         params = {
-            "mangled_name": (
-                launcher.bin.metadata.name
-                if hasattr(launcher.bin.metadata, "name")
-                else launcher.bin.metadata["name"]
-            ),
+            "mangled_name": launcher.bin.metadata.name
+            if hasattr(launcher.bin.metadata, "name")
+            else launcher.bin.metadata["name"],
             "grid_x": grid_x,
             "grid_y": grid_y,
             "grid_z": grid_z,
@@ -869,16 +840,12 @@ class CachingAutotuner(KernelInterface):
             "y_block": launcher.config.kwargs.get("YBLOCK", None),
             "z_block": launcher.config.kwargs.get("ZBLOCK", None),
             "r_block": launcher.config.kwargs.get("RBLOCK", None),
-            "num_warps": (
-                launcher.bin.num_warps
-                if hasattr(launcher.bin, "num_warps")
-                else launcher.bin.metadata.num_warps
-            ),
-            "shared_mem": (
-                launcher.bin.shared
-                if hasattr(launcher.bin, "shared")
-                else launcher.bin.metadata.shared
-            ),
+            "num_warps": launcher.bin.num_warps
+            if hasattr(launcher.bin, "num_warps")
+            else launcher.bin.metadata.num_warps,
+            "shared_mem": launcher.bin.shared
+            if hasattr(launcher.bin, "shared")
+            else launcher.bin.metadata.shared,
             "stream": stream,
             # User defined triton kernels will have arbitrary kwarg names
             "meta": launcher.config.kwargs,
@@ -1750,6 +1717,7 @@ def user_autotune(
             )
             for c in configs
         ]
+
     return cached_autotune(
         None,
         configs,


### PR DESCRIPTION
Reverts pytorch/pytorch#138260

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov