### PR TITLE
DLPack: add support to PyTorch/XLA

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -2,7 +2,6 @@
 import copyreg
 import enum
 import functools
-import os
 import warnings
 from collections import OrderedDict
 from copy import deepcopy
@@ -1619,8 +1618,15 @@ class Tensor(torch._C.TensorBase):
                     event = torch.cuda.Event()
                     event.record(sync_stream)
                     stream.wait_event(event)
-        if self.device.type == 'xla' and os.environ.get('PJRT_DEVICE', '').lower() == 'cuda':
+        if self.device.type == 'xla':
+            import torch_xla
             import torch_xla.utils.dlpack as xla_dlpack
+
+            if (
+                len(torch_xla.real_devices()) <= 0
+                or "cuda" not in torch_xla.real_devices()[0].lower()
+            ):
+                RuntimeError("Can't export XLA tensors not on CUDA.")
             return xla_dlpack.to_dlpack(self)
         return torch.to_dlpack(self)
 
@@ -1645,7 +1651,14 @@ class Tensor(torch._C.TensorBase):
             device_type = DLDeviceType.kDLOneAPI
         elif self.device.type == "privateuse1":
             device_type = DLDeviceType.kDLExtDev
-        elif torch_device_type == 'xla' and os.environ.get('PJRT_DEVICE', '').lower() == 'cuda':
+        elif torch_device_type == 'xla':
+            import torch_xla
+
+            if (
+                len(torch_xla.real_devices()) <= 0
+                or "cuda" not in torch_xla.real_devices()[0].lower()
+            ):
+                raise ValueError(f"Unknown device type {torch_device_type} for Dlpack")
             device_type = DLDeviceType.kDLGPU
         else:
             raise ValueError(f"Unknown device type {torch_device_type} for Dlpack")

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1618,7 +1618,7 @@ class Tensor(torch._C.TensorBase):
                     event = torch.cuda.Event()
                     event.record(sync_stream)
                     stream.wait_event(event)
-        if self.device.type == 'xla':
+        if self.device.type == "xla":
             import torch_xla
             import torch_xla.utils.dlpack as xla_dlpack
 
@@ -1626,7 +1626,9 @@ class Tensor(torch._C.TensorBase):
                 len(torch_xla.real_devices()) <= 0
                 or "cuda" not in torch_xla.real_devices()[0].lower()
             ):
-                raise RuntimeError("Can't export to dlpack an XLA tensor that is not on CUDA.")
+                raise RuntimeError(
+                    "Can't export to dlpack an XLA tensor that is not on CUDA."
+                )
             return xla_dlpack.to_dlpack(self)
         return torch.to_dlpack(self)
 
@@ -1651,7 +1653,7 @@ class Tensor(torch._C.TensorBase):
             device_type = DLDeviceType.kDLOneAPI
         elif self.device.type == "privateuse1":
             device_type = DLDeviceType.kDLExtDev
-        elif torch_device_type == 'xla':
+        elif torch_device_type == "xla":
             import torch_xla
 
             if (

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -2,6 +2,7 @@
 import copyreg
 import enum
 import functools
+import os
 import warnings
 from collections import OrderedDict
 from copy import deepcopy
@@ -1618,6 +1619,9 @@ class Tensor(torch._C.TensorBase):
                     event = torch.cuda.Event()
                     event.record(sync_stream)
                     stream.wait_event(event)
+        if self.device.type == 'xla' and os.environ.get('PJRT_DEVICE', '').lower() == 'cuda':
+            import torch_xla.utils.dlpack as xla_dlpack
+            return xla_dlpack.to_dlpack(self)
         return torch.to_dlpack(self)
 
     def __dlpack_device__(self) -> Tuple[enum.IntEnum, int]:
@@ -1637,10 +1641,12 @@ class Tensor(torch._C.TensorBase):
             device_type = DLDeviceType.kDLGPU
         elif torch_device_type == "cpu":
             device_type = DLDeviceType.kDLCPU
-        elif self.device.type == "xpu":
+        elif torch_device_type == "xpu":
             device_type = DLDeviceType.kDLOneAPI
         elif self.device.type == "privateuse1":
             device_type = DLDeviceType.kDLExtDev
+        elif torch_device_type == 'xla' and os.environ.get('PJRT_DEVICE', '').lower() == 'cuda':
+            device_type = DLDeviceType.kDLGPU
         else:
             raise ValueError(f"Unknown device type {torch_device_type} for Dlpack")
         return (device_type, idx)

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1626,7 +1626,7 @@ class Tensor(torch._C.TensorBase):
                 len(torch_xla.real_devices()) <= 0
                 or "cuda" not in torch_xla.real_devices()[0].lower()
             ):
-                raise RuntimeError("Can't export XLA tensors not on CUDA.")
+                raise RuntimeError("Can't export to dlpack an XLA tensor that is not on CUDA.")
             return xla_dlpack.to_dlpack(self)
         return torch.to_dlpack(self)
 
@@ -1659,6 +1659,7 @@ class Tensor(torch._C.TensorBase):
                 or "cuda" not in torch_xla.real_devices()[0].lower()
             ):
                 raise ValueError(f"Unknown device type {torch_device_type} for Dlpack")
+
             device_type = DLDeviceType.kDLGPU
         else:
             raise ValueError(f"Unknown device type {torch_device_type} for Dlpack")

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1626,7 +1626,7 @@ class Tensor(torch._C.TensorBase):
                 len(torch_xla.real_devices()) <= 0
                 or "cuda" not in torch_xla.real_devices()[0].lower()
             ):
-                RuntimeError("Can't export XLA tensors not on CUDA.")
+                raise RuntimeError("Can't export XLA tensors not on CUDA.")
             return xla_dlpack.to_dlpack(self)
         return torch.to_dlpack(self)
 


### PR DESCRIPTION
Taking over: #128176.

In summary, this PR:

- `__dlpack__`: Calls PyTorch/XLA `to_dlpack` function, if the tensor lives in an XLA:CUDA device
- `__dlpack_device__`: Correctly maps PyTorch/XLA tensors to `kDLGPU`, if XLA:CUDA is being used

The tests are introduced in https://github.com/pytorch/xla/pull/7213.