### PR TITLE
Add support for adding extra metadata to chromium events, log to separate columns

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -910,11 +910,9 @@ class ChromiumEventLogger:
             return self.tls.stack
 
     def get_event_data(self) -> Dict[str, Any]:
-        if hasattr(self.tls, "event_data"):
-            return self.tls.event_data
-        else:
+        if not hasattr(self.tls, "event_data"):
             self.tls.event_data = {}
-            return self.tls.event_data
+        return self.tls.event_data
 
     def __init__(self):
         self.tls = threading.local()

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -826,7 +826,7 @@ def add_compilation_metrics_to_chromium(c: CompilationMetrics):
     # The following compilation metrics are related to
     # dynamo, so go with the "entire frame compile" event
     event_logger.add_event_data(
-        event_name="entire_frame_compile",
+        event_name="dynamo",
         frame_key=c.frame_key,
         co_name=c.co_name,
         co_filename=c.co_filename,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -821,6 +821,37 @@ _compilation_metrics: Deque[
 ] = collections.deque(maxlen=DEFAULT_COMPILATION_METRICS_LIMIT)
 
 
+def add_compilation_metrics_to_chromium(c: CompilationMetrics):
+    event_logger = get_chromium_event_logger()
+    # The following compilation metrics are related to
+    # dynamo, so go with the "entire frame compile" event
+    event_logger.add_event_data(
+        event_name="entire_frame_compile",
+        frame_key=c.frame_key,
+        co_name=c.co_name,
+        co_filename=c.co_filename,
+        co_firstlineno=c.co_firstlineno,
+        cache_size=c.cache_size,
+        accumulated_cache_size=c.accumulated_cache_size,
+        guard_count=c.guard_count,
+        shape_env_guard_count=c.shape_env_guard_count,
+        graph_op_count=c.graph_op_count,
+        graph_node_count=c.graph_node_count,
+        graph_input_count=c.graph_input_count,
+        fail_type=c.fail_type,
+        fail_reason=c.fail_reason,
+        fail_user_frame_filename=c.fail_user_frame_filename,
+        fail_user_frame_lineno=c.fail_user_frame_lineno,
+        # Sets aren't JSON serializable
+        non_compliant_ops=list(c.non_compliant_ops),
+        compliant_custom_ops=list(c.compliant_custom_ops),
+        restart_reasons=list(c.restart_reasons),
+        dynamo_time_before_restart_s=c.dynamo_time_before_restart_s,
+        has_guarded_code=c.has_guarded_code,
+        dynamo_config=c.dynamo_config,
+    )
+
+
 def record_compilation_metrics(
     compilation_metrics: Union[CompilationMetrics, BwdCompilationMetrics]
 ):
@@ -828,6 +859,7 @@ def record_compilation_metrics(
     _compilation_metrics.append(compilation_metrics)
     if isinstance(compilation_metrics, CompilationMetrics):
         name = "compilation_metrics"
+        add_compilation_metrics_to_chromium(compilation_metrics)
     else:
         name = "bwd_compilation_metrics"
     torch._logging.trace_structured(
@@ -877,6 +909,13 @@ class ChromiumEventLogger:
             self.tls.stack = ["__start__"]
             return self.tls.stack
 
+    def get_event_data(self) -> Dict[str, Any]:
+        if hasattr(self.tls, "event_data"):
+            return self.tls.event_data
+        else:
+            self.tls.event_data = {}
+            return self.tls.event_data
+
     def __init__(self):
         self.tls = threading.local()
         # Generate a unique id for this logger, which we can use in scuba to filter down
@@ -885,6 +924,25 @@ class ChromiumEventLogger:
 
         # TODO: log to init/id tlparse after I add support for it
         log.info("ChromiumEventLogger initialized with id %s", self.id_)
+
+    def add_event_data(
+        self,
+        event_name: str,
+        **kwargs,
+    ) -> None:
+        """
+        Adds additional metadata info to an in-progress event
+        This metadata is recorded in the END event
+        """
+        if event_name not in self.get_stack():
+            raise RuntimeError(
+                "Cannot add metadata to events that aren't in progress."
+                "Please make sure the event has started and hasn't ended."
+            )
+        event_data = self.get_event_data()
+        if event_name not in event_data:
+            event_data[event_name] = {}
+        event_data[event_name].update(kwargs)
 
     def log_event_start(
         self,
@@ -898,7 +956,6 @@ class ChromiumEventLogger:
         :param time_ns Timestamp in nanoseconds
         :param metadata: Any extra metadata associated with this event
         """
-
         compile_id = str(torch._guards.CompileContext.current_compile_id())
         metadata["compile_id"] = compile_id
         self._log_timed_event(
@@ -915,6 +972,8 @@ class ChromiumEventLogger:
         stack = self.get_stack()
         stack.clear()
         stack.append("__start__")
+        event_data = self.get_event_data()
+        event_data.clear()
 
     def log_event_end(
         self,
@@ -932,11 +991,22 @@ class ChromiumEventLogger:
         """
         compile_id = str(torch._guards.CompileContext.current_compile_id())
         metadata["compile_id"] = compile_id
+
+        # Grab metadata collected during event span
+        all_event_data = self.get_event_data()
+        if event_name in all_event_data:
+            event_metadata = all_event_data[event_name]
+            del all_event_data[event_name]
+        else:
+            event_metadata = {}
+        # Add the passed in metadata
+        event_metadata.update(metadata)
+
         event = self._log_timed_event(
             event_name,
             time_ns,
             "E",
-            metadata,
+            event_metadata,
         )
 
         # These stack health checks currently never happen,
@@ -958,7 +1028,7 @@ class ChromiumEventLogger:
             )
             stack.pop()
 
-        log_chromium_event_internal(event, stack, compile_id, self.id_, start_time_ns)
+        log_chromium_event_internal(event, stack, self.id_, start_time_ns)
         # Finally pop the actual event off the stack
         stack.pop()
 
@@ -1025,9 +1095,7 @@ class ChromiumEventLogger:
             expect_trace_id=True,
         )
         # Log an instant event with the same start and end time
-        log_chromium_event_internal(
-            event, self.get_stack(), compile_id, self.id_, time_ns
-        )
+        log_chromium_event_internal(event, self.get_stack(), self.id_, time_ns)
 
 
 CHROMIUM_EVENT_LOG: Optional[ChromiumEventLogger] = None

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -359,7 +359,6 @@ def maybe_upload_prof_stats_to_manifold(profile_path: str) -> Optional[str]:
 def log_chromium_event_internal(
     event: Dict[str, Any],
     stack: List[str],
-    compile_id: Optional[str],
     logger_uuid: str,
     start_time_ns: int,
 ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138604
* #138603
* __->__ #138477

This diff does a few things:

## Add metadata to events in progress
Adds the ability to add extra metadata to Chromium Events via `add_event_data`. 
Metadata can only be added to chromium events that have started, but not ended (so, in progress events)
- When you add the data, the metadata is appended to the metadata when you call log_event_end(). 
- The metadata appears in chromium events in tlparse. It also gets logged to scuba. 


## New `dynamo` chromium event
We add a new `dynamo` chromium event to the top of the stack, where we collect various metadata found in dynamo_compile. So the new order of events goes:

```
__start__
-> dynamo (dynamo compile metrics)
-> entire_frame_compile (compile.inner)
-> backend_compile (i.e. aotdispatch)
-> create_aot_dispatch_function
-> inductor_compile 
-> ...
```

BackwardCompilationMetrics doesn't have any dynamo specific information (as it's mostly inductor timings). So we don't include that here. 


*FAQ: Why can't we use `entire_frame_compile` as the event?*
This is mostly due to backward compatibility with `dynamo_compile`. `dynamo_compile` collects CompilationMetrics outside of `compile.compile_inner`, and uses `dynamo_timed` to grab timings from phases of the compiler, including `entire_frame_compile`. So we don't have a CompilationMetric object until after an `entire_frame_compile` event ends! Separately, `dynamo` as a name for all of dynamo compile is more descriptive than `entire_frame_compile`, imo. 


## Log metadata as separate columns
(Meta only): Separately, this also changes the `metadata` column in PT2 Compile Events. Instead of logging a single metadata column in JSON, it separates the JSON into separate columns. This is much better for data analysis. Now that this table is more mature, I think logging keys to separate columns is a better system.Differential Revision: [D64696287](https://our.internmc.facebook.com/intern/diff/D64696287/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D64696287/)!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec