### PR TITLE
[PyTorch] Fix inductor CPU masked() body codegen when result dtype is bool and operator is where

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -4358,6 +4358,15 @@ class CPUReproTests(TestCase):
             ):
                 check_use_full_bits(func, shapes, dtype, mixed, check_vecn)
 
+    @config.patch("cpp.simdlen", 256)
+    @requires_vectorization
+    def test_avx2_bool_constant_pad_nd(self):
+        # NOTE: I tried using (0, 12, 12) and removing the cpp.simdlen=256 override, but
+        # that didn't repro the issue.
+        result = torch.testing.make_tensor((0, 6, 6), dtype=torch.bool, device=torch.device('cpu'))
+        def fn(arg):
+            return torch.constant_pad_nd(arg, (1, 1, 1, 1, 1, 1))
+        self.common(fn, (result,))
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -4363,10 +4363,15 @@ class CPUReproTests(TestCase):
     def test_avx2_bool_constant_pad_nd(self):
         # NOTE: I tried using (0, 12, 12) and removing the cpp.simdlen=256 override, but
         # that didn't repro the issue.
-        result = torch.testing.make_tensor((0, 6, 6), dtype=torch.bool, device=torch.device('cpu'))
+        result = torch.testing.make_tensor(
+            (0, 6, 6), dtype=torch.bool, device=torch.device("cpu")
+        )
+
         def fn(arg):
             return torch.constant_pad_nd(arg, (1, 1, 1, 1, 1, 1))
+
         self.common(fn, (result,))
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1487,11 +1487,12 @@ class CppVecOverrides(CppOverrides):
 
         dtype = result.dtype
         body_code = f"{var}()"
-        body_code_vec = (
-            body_code
-            if result.is_vec
-            else f"{V.kernel._get_vec_type(dtype)}({body_code})"
-        )
+        if result.is_vec:
+            body_code_vec = body_code
+        else:
+            body_code_vec = f"{V.kernel._get_vec_type(dtype)}({body_code})"
+            if dtype == torch.bool:
+                body_code_vec = f"{V.kernel._get_mask_type()}::from({body_code_vec})"
         other_code = value_to_cpp(other, DTYPE_TO_CPP[dtype])
         # loading bool as VecMask<float, N>
         other_code_vec = (

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1487,12 +1487,14 @@ class CppVecOverrides(CppOverrides):
 
         dtype = result.dtype
         body_code = f"{var}()"
+
         def maskify_or_vecify(code):
             return (
                 f"{V.kernel._get_mask_type()}::from({code})"
                 if dtype == torch.bool
                 else f"{V.kernel._get_vec_type(dtype)}({code})"
             )
+
         if result.is_vec:
             body_code_vec = body_code
         else:

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1487,19 +1487,19 @@ class CppVecOverrides(CppOverrides):
 
         dtype = result.dtype
         body_code = f"{var}()"
+        def maskify_or_vecify(code):
+            return (
+                f"{V.kernel._get_mask_type()}::from({code})"
+                if dtype == torch.bool
+                else f"{V.kernel._get_vec_type(dtype)}({code})"
+            )
         if result.is_vec:
             body_code_vec = body_code
         else:
-            body_code_vec = f"{V.kernel._get_vec_type(dtype)}({body_code})"
-            if dtype == torch.bool:
-                body_code_vec = f"{V.kernel._get_mask_type()}::from({body_code_vec})"
+            body_code_vec = maskify_or_vecify(body_code)
         other_code = value_to_cpp(other, DTYPE_TO_CPP[dtype])
         # loading bool as VecMask<float, N>
-        other_code_vec = (
-            f"{V.kernel._get_mask_type()}::from({other_code})"
-            if dtype == torch.bool
-            else f"{V.kernel._get_vec_type(dtype)}({other_code})"
-        )
+        other_code_vec = maskify_or_vecify(other_code)
         assert isinstance(new_mask, CppCSEVariable), new_mask
         if new_mask.is_vec:
             code = BracesBuffer()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #138275
* #138005
* #137918
* #137917
* #137916
* #137915
* #137914
* #137913
* #137912
* #137911
* #137661
* #137426
* #138744
* #138716
* #138655
* #138542
* __->__ #138486

In this case, it looks like we expect the body to be a VecMask (unify_mask_base_type is called by where()), but we didn't make it a VecMask. Now we do.

Differential Revision: [D64702918](https://our.internmc.facebook.com/intern/diff/D64702918/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov