### PR TITLE
FlopCounterMode: Decompose ops for inference mode

### DIFF
--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -725,21 +725,21 @@ class FlopCounterMode(TorchDispatchMode):
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         kwargs = kwargs if kwargs else {}
 
-        # Skip non-decomposoable ops from non-standard dispatch_sizes_strides_policy such as NJT
-        if func in [torch.ops.aten.is_contiguous.default,
-            torch.ops.aten.is_contiguous.memory_format,
-            torch.ops.aten.is_strides_like_format.default,
-            torch.ops.aten.is_non_overlapping_and_dense.default,
-            torch.ops.aten.size.default,
-            torch.ops.aten.sym_size.default,
-            torch.ops.aten.stride.default,
-            torch.ops.aten.sym_stride.default,
-            torch.ops.aten.storage_offset.default,
-            torch.ops.aten.sym_storage_offset.default,
-            torch.ops.aten.numel.default,
-            torch.ops.aten.sym_numel.default,
-            torch.ops.aten.dim.default, 
-            torch.ops.prim.layout.default]:
+        # Skip ops from non-standard dispatch_sizes_strides_policy such as NJT
+        if func in {torch.ops.aten.is_contiguous.default,
+                    torch.ops.aten.is_contiguous.memory_format,
+                    torch.ops.aten.is_strides_like_format.default,
+                    torch.ops.aten.is_non_overlapping_and_dense.default,
+                    torch.ops.aten.size.default,
+                    torch.ops.aten.sym_size.default,
+                    torch.ops.aten.stride.default,
+                    torch.ops.aten.sym_stride.default,
+                    torch.ops.aten.storage_offset.default,
+                    torch.ops.aten.sym_storage_offset.default,
+                    torch.ops.aten.numel.default,
+                    torch.ops.aten.sym_numel.default,
+                    torch.ops.aten.dim.default,
+                    torch.ops.prim.layout.default}:
 
             return NotImplemented
 

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -761,7 +761,7 @@ class _FlopCounterMode(TorchDispatchMode):
             return NotImplemented
 
         # If we don't have func in flop_registry, see if it can decompose
-        if func not in self.counter.flop_registry:
+        if func not in self.counter.flop_registry and func is not torch.ops.prim.device.default:
             with self:
                 r = func.decompose(*args, **kwargs)
                 if r is not NotImplemented:

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -623,7 +623,7 @@ class FlopCounterMode:
         self.flop_counts: Dict[str, Dict[Any, int]] = defaultdict(lambda: defaultdict(int))
         self.depth = depth
         self.display = display
-        self.mode = None
+        self.mode: Optional[_FlopCounterMode] = None
         if custom_mapping is None:
             custom_mapping = {}
         if mods is not None:
@@ -718,6 +718,7 @@ class FlopCounterMode:
         return self
 
     def __exit__(self, *args):
+        assert self.mode is not None
         b = self.mode.__exit__(*args)
         self.mode = None  # break cycles
         self.mod_tracker.__exit__()


### PR DESCRIPTION
Fixes #126268

I've basically followed @ezyang suggestion (I think) to use `func.decompose(...)`. Since `__torch_dispatch__` won't be called a second time for the same op, I've added a second `TorchDispatchMode` (`_DecomposedCounterMode`) that simpy dispatches to the parent flop counter. Using `self` as the inner context manager is not possible, since the second call to `__enter__` would re-initialize the counter's tracking state.

Let me know if there's something wrong with this implementation, since I'm quite unsure how the decomposition thing actually works :D
