### PR TITLE
[AOTInductor] Add relu_nan_to_num option for pre-grad passes

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1069,6 +1069,9 @@ class aot_inductor:
         os.environ.get("AOTINDUCTOR_RAISE_ERROR_ON_IGNORED_OPTIMIZATION", "1") == "1"
     )
 
+    # Dictionary of presets that can be passed in
+    presets: Dict[str, Any] = {}
+
 
 class cuda:
     # CUDA arch to use for CUDA template kernel compilation.

--- a/torch/_inductor/fx_passes/pre_grad.py
+++ b/torch/_inductor/fx_passes/pre_grad.py
@@ -104,6 +104,10 @@ def merge_concats_pass(graph):
     return None
 
 
+def relu_nan_to_num(graph):
+    return None
+
+
 @init_once_fakemode
 def lazy_init():
     from . import efficient_conv_bn_eval, split_cat  # noqa: F401  # noqa: F401
@@ -161,6 +165,12 @@ def pre_grad_passes(
                 gm,
                 example_inputs,
                 "[Pre grad(predispatch IR)]Apply remove_noop pass",
+            )
+            pass_execution_and_save(
+                relu_nan_to_num,
+                gm,
+                example_inputs,
+                "[Pre grad(predispatch IR)]Apply relu_nan_to_num pass",
             )
             pass_execution_and_save(
                 fuse_chunk_reshape_concat_pass,


### PR DESCRIPTION
Summary: Add a relu_nan_to_num in pre-grad pass.

Test Plan: Included in commit

Differential Revision: D64724780




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @ColinPeppler @amjames @desertfire @chauhang @aakhundov