### PR TITLE
TEST with out export = self.export

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/benchmarks/symint_sum.py
+++ b/benchmarks/dynamo/pr_time_benchmarks/benchmarks/symint_sum.py
@@ -1,0 +1,44 @@
+import sys
+
+from benchmark_base import BenchmarkBase
+
+import torch
+
+
+class Benchmark(BenchmarkBase):
+    N = 200
+
+    def name(self):
+        return "symint_sum"
+
+    def description(self):
+        return "see https://docs.google.com/document/d/11xJXl1etSmefUxPiVyk885e0Dl-4o7QwxYcPiMIo2iY/edit"
+
+    def _prepare_once(self):
+        torch._dynamo.config.capture_scalar_outputs = True
+        torch.manual_seed(0)
+
+        self.splits = torch.randint(10, (self.N,))
+
+    def _prepare(self):
+        torch._dynamo.reset()
+
+    def _work(self):
+        @torch.compile(fullgraph=True)
+        def f(a):
+            xs = a.tolist()
+            y = sum(xs)
+            return torch.tensor(y)
+
+        f(self.splits)
+
+
+def main():
+    result_path = sys.argv[1]
+    Benchmark().enable_compile_time_instruction_count().collect_all().append_results(
+        result_path
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -731,6 +731,7 @@ Symbolic Numbers
     sym_min
     sym_not
     sym_ite
+    sym_sum
 
 Export Path
 -------------

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -253,6 +253,20 @@ class TestInductorDynamic(TestCase):
         opt_r = opt_f()
         self.assertEqual(r, opt_r)
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_sym_sum_unbacked(self, device):
+        def f(a):
+            xs = a.tolist()
+            y = sum(xs)
+            return torch.tensor(y)
+
+        splits = torch.randint(10, (100,), device=device)
+
+        opt_f = torch.compile(f, fullgraph=True)
+        r = f(splits)
+        opt_r = opt_f(splits)
+        self.assertEqual(r, opt_r)
+
     @torch._dynamo.config.patch(capture_dynamic_output_shape_ops=True)
     def test_nonzero_size_factory_nobreak(self, device):
         def f(x, b):

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -451,6 +451,15 @@ class TestPySymInt(TestCase):
         self.assertEqual(guard_int(a0), 2)
         self.assertExpectedInline(str(shape_env.guards[0][0]), """Eq(s0, 2)""")
 
+    def test_sym_sum(self):
+        shape_env = ShapeEnv()
+        s0 = create_symint(shape_env, 2)
+        s1 = create_symint(shape_env, 3)
+        s2 = create_symint(shape_env, 4)
+        self.assertEqual(
+            (s0 + s1 + s2).node.expr, torch.sym_sum([s0, s1, s2]).node.expr
+        )
+
     def test_prefer_deferred_runtime_assertions_over_guards(self):
         shape_env = ShapeEnv(prefer_deferred_runtime_asserts_over_guards=True)
         s0 = create_symint(shape_env, 2)

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -691,7 +691,10 @@ def generate_tensor_like_override_tests(cls):
                     f"Unsupported argument type {arg_type} for {arg_name} of function {func}"
                 )
 
-        if func in annotated_args:
+        # Special case; this doesn't have a schema but takes a list
+        if func is torch.sym_sum:
+            func_args.append([TensorLike(), TensorLike()])
+        elif func in annotated_args:
             for arg in annotated_args[func]:
                 # Guess valid input to aten function based on type of argument
                 t = arg["simple_type"]

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -133,6 +133,7 @@ __all__ = [
     "sym_max",
     "sym_min",
     "sym_not",
+    "sym_sum",
     "typename",
     "unravel_index",
     "use_deterministic_algorithms",
@@ -844,6 +845,28 @@ def sym_min(a, b):
         return builtins.float(builtins.min(a, b))
     else:
         return builtins.min(a, b)
+
+
+def sym_sum(args):
+    """
+    N-ary add which is faster to compute for long lists than iterated binary
+    addition.  Only does something special for integers.
+    """
+    if overrides.has_torch_function(args):
+        return overrides.handle_torch_function(sym_sum, args, args)
+
+    found = None
+    for a in args:
+        if not isinstance(a, (SymInt, builtins.int)):
+            return builtins.sum(args)
+        if isinstance(a, SymInt):
+            found = a.node
+    if found is None:
+        return builtins.sum(args)
+
+    from torch.fx.experimental.sym_node import to_node, wrap_node
+
+    return wrap_node(found.sym_sum(tuple(to_node(found, a) for a in args)))
 
 
 # Drop in replacement for math.sqrt, math.sin, math.cos etc

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -321,9 +321,9 @@ class OutputGraph:
         # We use this map to interpret (i.e., check for violations of) constraints,
         # specifically equality constraints, which have shared tensor ids in them.
         # This map should also be generally useful, e.g., for (de)serialization.
-        self.tracked_fakes_id_to_source: Dict[int, List[Source]] = (
-            collections.defaultdict(list)
-        )
+        self.tracked_fakes_id_to_source: Dict[
+            int, List[Source]
+        ] = collections.defaultdict(list)
         # Stores the full fqn of a param or buffer to the relevant source.
         self.param_name_to_source: Optional[Dict[str, Source]] = {}
         self.side_effects = SideEffects(self)
@@ -1336,9 +1336,9 @@ class OutputGraph:
                 register_finalizer(gm)
 
             gm.compile_subgraph_reason = self.compile_subgraph_reason
-            gm.meta["dynamo_flat_name_to_original_fqn"] = (
-                self.dynamo_flat_name_to_original_fqn.copy()
-            )
+            gm.meta[
+                "dynamo_flat_name_to_original_fqn"
+            ] = self.dynamo_flat_name_to_original_fqn.copy()
 
             graph_code_log.debug(
                 "%s",

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -321,9 +321,9 @@ class OutputGraph:
         # We use this map to interpret (i.e., check for violations of) constraints,
         # specifically equality constraints, which have shared tensor ids in them.
         # This map should also be generally useful, e.g., for (de)serialization.
-        self.tracked_fakes_id_to_source: Dict[
-            int, List[Source]
-        ] = collections.defaultdict(list)
+        self.tracked_fakes_id_to_source: Dict[int, List[Source]] = (
+            collections.defaultdict(list)
+        )
         # Stores the full fqn of a param or buffer to the relevant source.
         self.param_name_to_source: Optional[Dict[str, Source]] = {}
         self.side_effects = SideEffects(self)
@@ -1319,6 +1319,8 @@ class OutputGraph:
                     fx.GraphModule(root, self.graph),
                     self.shape_env,
                     name,
+                    # Passing this fails some internal tests.
+                    # export=self.export,
                 )
             # NB: deferred runtime asserts can keep graphargs live, so make sure
             # those are inserted before pruning
@@ -1334,9 +1336,9 @@ class OutputGraph:
                 register_finalizer(gm)
 
             gm.compile_subgraph_reason = self.compile_subgraph_reason
-            gm.meta[
-                "dynamo_flat_name_to_original_fqn"
-            ] = self.dynamo_flat_name_to_original_fqn.copy()
+            gm.meta["dynamo_flat_name_to_original_fqn"] = (
+                self.dynamo_flat_name_to_original_fqn.copy()
+            )
 
             graph_code_log.debug(
                 "%s",

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -183,6 +183,7 @@ _SYM_INT_OPS = {
     torch.sym_max,
     torch.sym_min,
     torch.sym_sqrt,
+    torch.sym_sum,
 }
 
 

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -20,6 +20,7 @@ from torch.fx import GraphModule
 if TYPE_CHECKING:
     from torch.export.exported_program import ExportedProgram
 
+
 class SpecViolationError(Exception):
     pass
 
@@ -41,9 +42,13 @@ def _check_val(node: torch.fx.Node) -> None:
             return True
         elif isinstance(val, (int, bool, str, float)):
             return True
-        elif isinstance(val, (torch.memory_format, torch.dtype, torch.device, torch.layout)):
+        elif isinstance(
+            val, (torch.memory_format, torch.dtype, torch.device, torch.layout)
+        ):
             return True
-        elif isinstance(val, (FakeTensor, torch.Tensor)):  # TODO(zhxchen17) Remove Tensor.
+        elif isinstance(
+            val, (FakeTensor, torch.Tensor)
+        ):  # TODO(zhxchen17) Remove Tensor.
             return True
         elif isinstance(val, (SymInt, SymFloat, SymBool)):
             return True
@@ -71,16 +76,21 @@ def _check_val(node: torch.fx.Node) -> None:
 def _check_torch_fn(node: torch.fx.Node) -> None:
     torch_fn = node.meta.get("torch_fn")
     if torch_fn is None:
-        raise SpecViolationError(f"Unable to find torch_fn metadata for node {node.name}")
+        raise SpecViolationError(
+            f"Unable to find torch_fn metadata for node {node.name}"
+        )
     if (
-        not isinstance(torch_fn, tuple) and
-        isinstance(torch_fn[0], str) and
-        isinstance(torch_fn[1], str)
+        not isinstance(torch_fn, tuple)
+        and isinstance(torch_fn[0], str)
+        and isinstance(torch_fn[1], str)
     ):
-        raise SpecViolationError(f"Node.meta {node.name} has invalid torch_fn field {torch_fn}")
+        raise SpecViolationError(
+            f"Node.meta {node.name} has invalid torch_fn field {torch_fn}"
+        )
+
 
 class _VerifierMeta(type):
-    _registry: Dict[str, Type['Verifier']] = {}
+    _registry: Dict[str, Type["Verifier"]] = {}
 
     def __new__(metacls, name, bases, attrs):
         if bases:
@@ -97,12 +107,15 @@ class _VerifierMeta(type):
         metacls._registry[attrs["dialect"]] = ret  # type: ignore[assignment]
         return ret
 
+
 def getattr_recursive(obj: Any, target: str) -> Any:
-    target_atoms = target.split('.')
+    target_atoms = target.split(".")
     attr_itr = obj
     for i, atom in enumerate(target_atoms):
         if not hasattr(attr_itr, atom):
-            raise RuntimeError(f"Node referenced nonexistent target {'.'.join(target_atoms[:i])}")
+            raise RuntimeError(
+                f"Node referenced nonexistent target {'.'.join(target_atoms[:i])}"
+            )
         attr_itr = getattr(attr_itr, atom)
     return attr_itr
 
@@ -181,6 +194,7 @@ class Verifier(metaclass=_VerifierMeta):
                 torch.sym_float,
                 torch.sym_ite,
                 torch.sym_max,
+                torch.sum_sum,
                 torch.sym_min,
                 torch.sym_not,
                 torch.sym_sqrt,
@@ -193,7 +207,10 @@ class Verifier(metaclass=_VerifierMeta):
             )
 
             if not isinstance(op, _allowed_op_types()):
-                if op not in _allowed_builtin_ops() and op not in _allowed_torch_functions:
+                if (
+                    op not in _allowed_builtin_ops()
+                    and op not in _allowed_torch_functions
+                ):
                     raise SpecViolationError(
                         f"Operator '{op}' is not an allowed operator type: {_allowed_op_types()}\n"
                         f"Valid builtin ops: {_allowed_builtin_ops()}"
@@ -204,9 +221,7 @@ class Verifier(metaclass=_VerifierMeta):
                 # All ops functional
                 # TODO (tmanlaibaatar) more proper way is needed here
                 if self.dialect != "TRAINING" and not is_functional(op):
-                    raise SpecViolationError(
-                        f"operator '{op}' is not functional"
-                    )
+                    raise SpecViolationError(f"operator '{op}' is not functional")
             self.check_valid_op(op)
 
         for mod in gm.modules():
@@ -234,13 +249,17 @@ class Verifier(metaclass=_VerifierMeta):
 
                     attr = getattr_recursive(mod, node.target)
                     if isinstance(attr, torch.nn.Module):
+
                         def _is_type(name, ty):
                             return isinstance(getattr(attr, name, None), ty)
+
                         if type(attr).__name__ == "LoweredBackendModule":
-                            if _is_type("backend_id", str) \
-                                    and _is_type("processed_bytes", bytes) \
-                                    and _is_type("compile_specs", list) \
-                                    and hasattr(attr, "original_module"):
+                            if (
+                                _is_type("backend_id", str)
+                                and _is_type("processed_bytes", bytes)
+                                and _is_type("compile_specs", list)
+                                and hasattr(attr, "original_module")
+                            ):
                                 continue
                             else:
                                 backend_id = getattr(attr, "backend_id", None)
@@ -260,7 +279,6 @@ class Verifier(metaclass=_VerifierMeta):
                             f"Valid get_attr types: {_allowed_getattr_types()}"
                         )
 
-
                 elif node.op == "placeholder":
                     _check_val(node)
                 # TODO(zhxchen17)
@@ -276,9 +294,7 @@ class TrainingIRVerifier(Verifier):
 
 def _verify_exported_program_module_call_graph(exported_program) -> None:
     module_call_graph = exported_program.module_call_graph
-    nodes = {
-        node.name for node in exported_program.graph.nodes
-    }
+    nodes = {node.name for node in exported_program.graph.nodes}
     for entry in module_call_graph:
         if entry.signature is not None:
             for arg in entry.signature.inputs:
@@ -298,7 +314,9 @@ def _verify_exported_program_signature(exported_program) -> None:
     gs = exported_program.graph_signature
 
     # Check every node in the signature exists in the graph
-    input_node_names = [node.name for node in exported_program.graph.nodes if node.op == "placeholder"]
+    input_node_names = [
+        node.name for node in exported_program.graph.nodes if node.op == "placeholder"
+    ]
 
     if len(input_node_names) != len(gs.input_specs):
         raise SpecViolationError(
@@ -328,9 +346,7 @@ def _verify_exported_program_signature(exported_program) -> None:
 
             param = input_spec.target
             if param not in exported_program.state_dict:
-                raise SpecViolationError(
-                    f"Parameter {param} is not in the state dict."
-                )
+                raise SpecViolationError(f"Parameter {param} is not in the state dict.")
 
             if not isinstance(exported_program.state_dict[param], torch.nn.Parameter):
                 raise SpecViolationError(
@@ -353,10 +369,11 @@ def _verify_exported_program_signature(exported_program) -> None:
                     f"Buffer {buffer} is missing a persistence flag"
                 )
 
-            if input_spec.persistent is True and buffer not in exported_program.state_dict:
-                raise SpecViolationError(
-                    f"Buffer {buffer} is not in the state dict."
-                )
+            if (
+                input_spec.persistent is True
+                and buffer not in exported_program.state_dict
+            ):
+                raise SpecViolationError(f"Buffer {buffer} is not in the state dict.")
 
             if input_spec.persistent is False and buffer in exported_program.state_dict:
                 raise SpecViolationError(
@@ -398,9 +415,7 @@ def _verify_exported_program_signature(exported_program) -> None:
                     f"Constant tensor {input_spec.name} is not a tensor argument. Found {input_spec.arg} instead."
                 )
         else:
-            raise SpecViolationError(
-                f"Unknown InputKind {input_spec.kind}."
-            )
+            raise SpecViolationError(f"Unknown InputKind {input_spec.kind}.")
 
     # Check outputs
     output_node = list(exported_program.graph.nodes)[-1]
@@ -421,7 +436,7 @@ def _verify_exported_program_signature(exported_program) -> None:
     num_tokens = len(gs.output_tokens)
     end = len(gs.buffers_to_mutate) + len(gs.user_inputs_to_mutate) + num_tokens
     mutate_nodes: List[str] = output_nodes[num_tokens:end]
-    user_output_nodes = output_nodes[end:end + len(gs.user_outputs)]
+    user_output_nodes = output_nodes[end : end + len(gs.user_outputs)]
 
     for mutation_node in mutate_nodes:
         if mutation_node in gs.buffers_to_mutate:
@@ -436,7 +451,8 @@ def _verify_exported_program_signature(exported_program) -> None:
                 raise SpecViolationError(
                     f"User input output {mutation_node} does not point to a user input that exists. \n"
                     f"Dict of user inputs that are mutated, in order: {gs.user_inputs_to_mutate} \n"
-                    f"User input nodes available: {gs.user_inputs} \n")
+                    f"User input nodes available: {gs.user_inputs} \n"
+                )
         else:
             raise SpecViolationError(
                 f"Mutation node {mutation_node} is neither a buffer nor a user input. "

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -194,7 +194,7 @@ class Verifier(metaclass=_VerifierMeta):
                 torch.sym_float,
                 torch.sym_ite,
                 torch.sym_max,
-                torch.sum_sum,
+                torch.sym_sum,
                 torch.sym_min,
                 torch.sym_not,
                 torch.sym_sqrt,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6207,6 +6207,11 @@ for method, func in magic_methods.items():
     register_lowering(method_to_operator(method))(func)
 
 
+@register_lowering(torch.sym_sum)
+def sym_sum(args):
+    return sympy.Add(*args)
+
+
 @register_lowering(aten._foobar)
 def foobar(self, *args, **kwargs):
     raise NotImplementedError("Helpful for debugging")

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -720,6 +720,12 @@ def sym_constrain_range_for_size(size, min=None, max=None):
 
     if isinstance(size, (SymFloat, SymBool)):
         raise ValueError("Constraining SymFloat or Symbool is nyi")
+    if type(size) is int:
+        if min is not None:
+            torch._check(size >= min)
+        if max is not None:
+            torch._check(size <= max)
+        return
     _constrain_range_for_size(size, min=min, max=max)
 
 

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1356,12 +1356,24 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
     def _compute_proxy(
         self, func: OpOverload, args: Tuple[object, ...], out: PySymType
     ) -> Proxy:
-        n_args = tuple(
-            get_proxy_slot(a, self.tracer).force().node
-            if isinstance(a, py_sym_types)
-            else a
-            for a in args
-        )
+        # Handle torch.sym_sum
+        n_args: Tuple[object, ...]
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            n_args = (
+                tuple(
+                    get_proxy_slot(a, self.tracer).force().node
+                    if isinstance(a, py_sym_types)
+                    else a
+                    for a in args[0]
+                ),
+            )
+        else:
+            n_args = tuple(
+                get_proxy_slot(a, self.tracer).force().node
+                if isinstance(a, py_sym_types)
+                else a
+                for a in args
+            )
 
         # func doesn't have a __torch_function__ that Proxy can interpose, so
         # we gotta do it manually

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -422,6 +422,47 @@ class SymNode:
     def int_(self):
         return self.guard_int("", 0)  # NB: uses Python backtrace
 
+    # This one is currently done by hand, but if we add other variadic
+    # functions consider factoring it out to be metaprogrammed too.  Note that
+    # some load bearing logic is directly in torch.sym_sum
+
+    def sym_sum(self, args) -> "SymNode":
+        import sympy
+
+        # Inner impl
+        from torch.fx.experimental.proxy_tensor import (
+            get_proxy_mode,
+            handle_sym_dispatch,
+        )
+
+        if get_proxy_mode():
+            return to_node(
+                self,
+                handle_sym_dispatch(
+                    torch.sym_sum,
+                    (tuple(wrap_node(a) for a in args),),
+                    {},
+                ),
+            )
+        exprs = [a.expr for a in args]
+        out = sympy.Add(*exprs)
+
+        size_hints = []
+        out_hint = None
+        for a in args:
+            if a.hint is None:
+                break
+            size_hints.append(a.hint)
+        else:
+            out_hint = sum(size_hints)
+
+        fx_node, _ = self.shape_env._create_fx_call_function(
+            torch.sym_sum, (tuple(a.fx_node for a in args),)
+        )
+
+        # NB: Only for integers!
+        return SymNode(out, self.shape_env, int, out_hint, fx_node=fx_node)
+
     # You can manually trigger a guard with this function
     def guard_int(self, file, line):
         # TODO: use the file/line for some useful diagnostic on why a

--- a/torch/fx/passes/runtime_assert.py
+++ b/torch/fx/passes/runtime_assert.py
@@ -105,12 +105,16 @@ def insert_deferred_runtime_asserts(
         resolve_unbacked_bindings,
     )
     from torch.utils._sympy.numbers import int_oo
-    from torch.utils._sympy.reference import PythonReferenceAnalysis
+    from torch.utils._sympy.reference import (
+        OptimizedPythonReferenceAnalysis,
+        PythonReferenceAnalysis,
+    )
     from torch.utils._sympy.value_ranges import ValueRanges
 
     # TODO: Request simplification on runtime asserts before emitting them
     ras_by_symbol = shape_env.deferred_runtime_asserts.copy()
     graph = gm.graph
+    tracer = fx.proxy.GraphAppendingTracer(graph)
     graph_code_log.debug(
         "%s",
         lazy_format_graph_code(
@@ -161,10 +165,12 @@ def insert_deferred_runtime_asserts(
         stack_trace: Optional[str] = None,
         nn_module_stack: Optional[Dict[str, Any]] = None,
     ) -> None:
-        fake_args = [
-            _get_example_value(arg) if isinstance(arg, torch.fx.Node) else arg
-            for arg in node.args
-        ]
+        fake_args = pytree.tree_map(
+            lambda arg: _get_example_value(arg)
+            if isinstance(arg, torch.fx.Node)
+            else arg,
+            node.args,
+        )
         try:
             node.meta[val_key] = node.target(*fake_args)  # type: ignore[operator]
         except NotImplementedError:
@@ -181,6 +187,8 @@ def insert_deferred_runtime_asserts(
     added_asserts: Set[sympy.Expr] = set()
     constrained_unbacked_symbols: Set[sympy.Symbol] = set()
 
+    Analysis = PythonReferenceAnalysis if export else OptimizedPythonReferenceAnalysis
+
     def _sympy_interp(expr_to_proxy, expr):
         # sympy_interp() with hash consing
         from sympy import Integer, Number, Symbol
@@ -193,11 +201,11 @@ def insert_deferred_runtime_asserts(
             return expr_to_proxy[expr]
         # base cases, don't cache
         if isinstance(expr, (Integer, Number, Symbol, BooleanAtom)):
-            return sympy_interp(PythonReferenceAnalysis, expr_to_proxy, expr)
+            return sympy_interp(Analysis, expr_to_proxy, expr)
 
         # hash cons on arguments, run expr handler
         expr_to_proxy[expr] = _run_sympy_handler(
-            PythonReferenceAnalysis,
+            Analysis,
             [_sympy_interp(expr_to_proxy, arg) for arg in expr.args],
             expr,
         )
@@ -281,7 +289,7 @@ def insert_deferred_runtime_asserts(
                         and s not in expr_to_proxy
                     ):
                         with _set_node_metadata_hook(gm, _node_metadata_hook):
-                            expr_to_proxy[s] = fx.Proxy(cb())
+                            expr_to_proxy[s] = fx.Proxy(cb(), tracer=tracer)
                         log.debug("expr_to_proxy[%s] = %s", s, expr_to_proxy[s])
 
                 match_symbol(example_value, lambda: node)
@@ -387,7 +395,7 @@ def insert_deferred_runtime_asserts(
                 elif sym_expr not in expr_to_proxy and not isinstance(
                     sym_expr, (sympy.Number, sympy.logic.boolalg.BooleanAtom)
                 ):  # don't hash cons primitives
-                    expr_to_proxy[sym_expr] = fx.Proxy(node)  # type: ignore[arg-type]
+                    expr_to_proxy[sym_expr] = fx.Proxy(node, tracer=tracer)  # type: ignore[arg-type]
 
             # We add sym_constrain_range calls for symbols later in any case if they're size-like or range-constrained,
             # so calls before that are redundant.
@@ -480,7 +488,9 @@ def insert_deferred_runtime_asserts(
 
                     if s not in expr_to_proxy:
                         with _set_node_metadata_hook(gm, _node_metadata_hook):
-                            expr_to_proxy[s] = fx.Proxy(go(node, keypath))
+                            expr_to_proxy[s] = fx.Proxy(
+                                go(node, keypath), tracer=tracer
+                            )
                         log.debug("expr_to_proxy[%s] = %s", s, expr_to_proxy[s])
 
             for i0 in defs:

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1139,6 +1139,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.sym_min: lambda a, b: -1,
         torch.sym_not: lambda input: -1,
         torch.sym_ite: lambda a, b, c: -1,
+        torch.sym_sum: lambda args: -1,
         torch._sym_sqrt: lambda input: -1,
         torch._sym_cos: lambda input: -1,
         torch._sym_cosh: lambda input: -1,

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -138,6 +138,12 @@ def _run_sympy_handler(analysis, args, expr, index_dtype=torch.int64):
     if (handler_name := INDEX_DTYPE_HANDLERS.get(expr.func)) is not None:
         return getattr(analysis, handler_name)(*args, index_dtype)
 
+    # Fastpath for n-ary integral addition
+    if expr.func is sympy.Add and expr.is_integer and hasattr(analysis, "sym_sum"):
+        r = analysis.sym_sum(args)
+        log.debug("sym_sum(%s) -> %s", args, r)
+        return r
+
     if hasattr(expr.func, "_torch_handler_name"):
         handler_name = expr.func._torch_handler_name
     else:

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -142,6 +142,10 @@ class ReferenceAnalysis:
     def add(a, b):
         return _keep_float(operator.add)(a, b)
 
+    @classmethod
+    def sym_sum(cls, args):
+        return sympy.Add(*args)
+
     @staticmethod
     def mul(a, b):
         return _keep_float(operator.mul)(a, b)
@@ -205,6 +209,17 @@ class PythonReferenceAnalysis(ReferenceAnalysis):
     @staticmethod
     def not_(a):
         return torch.sym_not(a)
+
+    @classmethod
+    def sym_sum(cls, args):
+        if len(args) == 0:
+            return 0
+        if len(args) == 1:
+            return args[0]
+        acc = cls.add(args[0], args[1])
+        for i in range(2, len(args)):
+            acc = cls.add(acc, args[i])
+        return acc
 
     @staticmethod
     def floordiv(a, b):
@@ -282,6 +297,14 @@ class PythonReferenceAnalysis(ReferenceAnalysis):
     @staticmethod
     def round_decimal(a, b):
         return round(a, ndigits=b)
+
+
+# Like PythonReferenceAnalysis, but some export-unfriendly choices of
+# operators to make things faster
+class OptimizedPythonReferenceAnalysis(PythonReferenceAnalysis):
+    @staticmethod
+    def sym_sum(args):
+        return torch.sym_sum(args)
 
 
 def _to_dtype(x: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138549

Partially addresses https://github.com/pytorch/pytorch/issues/128150

When you have big sums of values, we end up computing long chains of
binary addition in our FX graph representation.  Not only is this ugly,
it also is quadratic, as the sympy.Add constructor is O(N) in number
of arguments.  Instead, ensure that we maintain the summation as a
single FX node so we can do the entire addition all in one go.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov @rec