### PR TITLE
Fix dot reference checks 

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6244,7 +6244,7 @@ def dot(self, other):
             return torch.vdot(other.conj(), self)
 
     _dot_check(self, other)
-    return (self * other).sum()
+    return torch.sum(self * other, dtype=self.dtype)
 
 
 @register_decomposition(aten.vdot)
@@ -6263,7 +6263,7 @@ def vdot(self, other):
 
     _dot_check(self, other)
     # The decomposition fails if you do self.conj()... not sure why
-    return (self.conj_physical() * other).sum()
+    return torch.sum(self.conj_physical() * other, dtype=self.dtype)
 
 
 @register_decomposition(aten.select_scatter)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6244,7 +6244,11 @@ def dot(self, other):
             return torch.vdot(other.conj(), self)
 
     _dot_check(self, other)
-    return torch.sum(self * other, dtype=self.dtype)
+
+    return elementwise_type_promotion_wrapper(
+        type_promoting_args=("self", "other"),
+        type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    )(lambda self, other: (self * other).sum())(self, other)
 
 
 @register_decomposition(aten.vdot)
@@ -6262,8 +6266,12 @@ def vdot(self, other):
         return torch.dot(self, other.conj()).conj()
 
     _dot_check(self, other)
+
     # The decomposition fails if you do self.conj()... not sure why
-    return torch.sum(self.conj_physical() * other, dtype=self.dtype)
+    return elementwise_type_promotion_wrapper(
+        type_promoting_args=("self", "other"),
+        type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    )(lambda self, other: (self.conj_physical() * other).sum())(self, other)
 
 
 @register_decomposition(aten.select_scatter)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4033,7 +4033,10 @@ def _index_fill(
         )  # type: ignore[arg-type]
     else:
         value = torch.scalar_tensor(
-            value, dtype=x.dtype, layout=x.layout, device=x.device  # type: ignore[arg-type]
+            value,
+            dtype=x.dtype,
+            layout=x.layout,
+            device=x.device,  # type: ignore[arg-type]
         )
 
     # index_copy has some unnecessary preconditions when x is a scalar. We do this to work through them
@@ -4070,7 +4073,10 @@ def index_add(
 ):
     # index_add always returns a new contiguous tensor
     return x.clone(memory_format=torch.contiguous_format).index_add_(
-        dim, index, tensor, alpha=alpha  # type: ignore[arg-type]
+        dim,
+        index,
+        tensor,
+        alpha=alpha,  # type: ignore[arg-type]
     )
 
 
@@ -6210,6 +6216,12 @@ def _dot_check(self, other):
         lambda: f"1D tensors expected, but got {self.dim()}D and {other.dim()}D tensors",
     )
 
+    torch._check(
+        self.dtype == other.dtype,
+        lambda: "dot : expected both vectors to have same dtype, but found "
+        f"{self.dtype} and {other.dtype}",
+    )
+
     def numel_error():
         return (
             f"inconsistent tensor size, expected tensor [{self.numel()}] and src [{other.numel()}] to have the"
@@ -6221,10 +6233,6 @@ def _dot_check(self, other):
 
 @register_decomposition(aten.dot)
 @out_wrapper()
-@elementwise_type_promotion_wrapper(
-    type_promoting_args=("self", "other"),
-    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
-)
 def dot(self, other):
     if self.is_complex():
         if self.is_conj():
@@ -6241,10 +6249,6 @@ def dot(self, other):
 
 @register_decomposition(aten.vdot)
 @out_wrapper()
-@elementwise_type_promotion_wrapper(
-    type_promoting_args=("self", "other"),
-    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
-)
 def vdot(self, other):
     if not self.is_complex():
         return torch.dot(self, other)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1254,9 +1254,8 @@ def sample_inputs_dot_vdot(self, device, dtype, requires_grad, **kwargs):
 def error_inputs_dot_vdot(op_info, device, is_ref=False, **kwargs):
     make_input = partial(make_tensor, device=device, dtype=torch.float32)
 
-    if not is_ref:
-        yield ErrorInput(SampleInput(make_input(1), args=(make_input(3, dtype=torch.float16),)),
-                         error_regex='dot : expected both vectors to have same dtype')
+    yield ErrorInput(SampleInput(make_input(1), args=(make_input(3, dtype=torch.float16),)),
+                     error_regex='dot : expected both vectors to have same dtype')
     yield ErrorInput(SampleInput(make_input(1, 1), args=(make_input(3),)),
                      error_regex='1D tensors expected')
     yield ErrorInput(SampleInput(make_input(9), args=(make_input(3),)),


### PR DESCRIPTION
dot reference implementation should be consistent with the cpu / cuda implementations since it may be used for meta dispatch

i.e. 
```python
import torch 
x = torch.tensor([1,2,3], dtype=torch.float32)
y = torch.tensor([4,5,6], dtype=torch.float16)
x.dot(y)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: dot : expected both vectors to have same dtype, but found Float and Half
```

However the below does not raise an exception
```python
x.to("meta").dot(y.to("meta"))
```
Fixes #ISSUE_NUMBER
