### PR TITLE
Have as_tensor always return a float64 tensor in dynamo

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -601,7 +601,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         compl_fn = torch.compile(fn, dynamic=True, backend="eager")
         self.assertEqual(compl_fn(inputs), fn(inputs))
 
-    @torch._dynamo.config.patch(specialize_float=False, capture_scalar_outputs=True)
+    @torch._dynamo.config.patch(specialize_float=False)
     def test_unspec_roundtrip_float_input(self):
         def f(x, y):
             if y == 5.0:

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -601,6 +601,20 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         compl_fn = torch.compile(fn, dynamic=True, backend="eager")
         self.assertEqual(compl_fn(inputs), fn(inputs))
 
+    @torch._dynamo.config.patch(specialize_float=False, capture_scalar_outputs=True)
+    def test_unspec_roundtrip_float_input(self):
+        def f(x, y):
+            if y == 5.0:
+                return x + 2
+            else:
+                return x + y
+            return (x, y)
+
+        cf = torch.compile(backend="eager", fullgraph=True)(f)
+        x = 1.1234567891234568
+        y = 1.1234567891234569
+        self.assertAlmostEqual(f(x, y), cf(x, y))
+
     @torch._dynamo.config.patch(specialize_float=False, assume_static_by_default=True)
     def test_unspec_float_input(self):
         cnts = torch._dynamo.testing.CompileCounter()

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -185,7 +185,9 @@ class PyCodegen:
             # NB: It works to add_graph_output on a computed expression
             # as_tensor here, because we memoize as_tensor calls on
             # SymNodeVariable!
-            graph_outputs_key = self.add_graph_output(value.as_tensor(self.tx))
+            graph_outputs_key = self.add_graph_output(
+                value.as_tensor(self.tx, torch.float64)
+            )
 
             def gen_fn():
                 self.load_graph_output(graph_outputs[graph_outputs_key].index)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1150,7 +1150,9 @@ class SymNodeVariable(VariableTracker):
         if self._tensor_var is None:
             self._tensor_var = VariableTracker.build(
                 tx, torch.scalar_tensor
-            ).call_function(tx, [self], {})
+            ).call_function(
+                tx, [self], {"dtype": VariableTracker.build(tx, torch.float64)}
+            )
         return self._tensor_var
 
     def evaluate_expr(self, output_graph=None):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1146,18 +1146,11 @@ class SymNodeVariable(VariableTracker):
     def as_proxy(self):
         return self.proxy
 
-    def as_tensor(self, tx):
+    def as_tensor(self, tx, dtype):
         if self._tensor_var is None:
-            if isinstance(self.sym_num, torch.SymFloat):
-                self._tensor_var = VariableTracker.build(
-                    tx, torch.scalar_tensor
-                ).call_function(
-                    tx, [self], {"dtype": VariableTracker.build(tx, torch.float64)}
-                )
-            else:
-                self._tensor_var = VariableTracker.build(
-                    tx, torch.scalar_tensor
-                ).call_function(tx, [self], {})
+            self._tensor_var = VariableTracker.build(
+                tx, torch.scalar_tensor
+            ).call_function(tx, [self], {"dtype": VariableTracker.build(tx, dtype)})
         return self._tensor_var
 
     def evaluate_expr(self, output_graph=None):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1148,11 +1148,16 @@ class SymNodeVariable(VariableTracker):
 
     def as_tensor(self, tx):
         if self._tensor_var is None:
-            self._tensor_var = VariableTracker.build(
-                tx, torch.scalar_tensor
-            ).call_function(
-                tx, [self], {"dtype": VariableTracker.build(tx, torch.float64)}
-            )
+            if isinstance(self.sym_num, torch.SymFloat):
+                self._tensor_var = VariableTracker.build(
+                    tx, torch.scalar_tensor
+                ).call_function(
+                    tx, [self], {"dtype": VariableTracker.build(tx, torch.float64)}
+                )
+            else:
+                self._tensor_var = VariableTracker.build(
+                    tx, torch.scalar_tensor
+                ).call_function(tx, [self], {})
         return self._tensor_var
 
     def evaluate_expr(self, output_graph=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138598
* #138595

As discussed with @ezyang, this set of diffs are extracting fixes to problems discovered to flipping `specialize_float=False` in https://github.com/pytorch/pytorch/pull/137782. Since these codepaths are exercised in existing tests, I'm going to bias towards shipping speed and put these up with the primary test plan as the global CI. These code paths are all tested via existing tests when `specialize_float=False` and it feels a bit wonky to add more gated tests that only test behavior when this flag is True, especially since these code paths are already covered. That being said, I'm happy to add individual tests if reviewers insist or have a different POV.  

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chenyang78 @kadeng @chauhang @amjames @rec