### PR TITLE
Improve input validation for NJT pointwise ops

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3888,6 +3888,21 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
 
         gradcheck(grad_test_func, inputs=(a, b, c), check_batched_grad=False)
 
+    def test_binary_pointwise_with_nested_int_second_arg(self, device):
+        # See https://github.com/pytorch/pytorch/issues/138496
+        nt = random_nt_from_dims(
+            [3, None, 5],
+            device=device,
+            dtype=torch.float32,
+            layout=torch.jagged,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "expected 2 tensor args but found 1"):
+            nt * nt.size(1)
+
+        with self.assertRaisesRegex(RuntimeError, "expected 2 tensor args but found 1"):
+            nt + nt.size(1)
+
     def test_split(self, device):
         a = torch.randn(2, 3, requires_grad=True, dtype=torch.float64, device=device)
         b = torch.randn(3, 3, requires_grad=True, dtype=torch.float64, device=device)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -3897,10 +3897,10 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
             layout=torch.jagged,
         )
 
-        with self.assertRaisesRegex(RuntimeError, "expected 2 tensor args but found 1"):
+        with self.assertRaisesRegex(RuntimeError, "invalid argument"):
             nt * nt.size(1)
 
-        with self.assertRaisesRegex(RuntimeError, "expected 2 tensor args but found 1"):
+        with self.assertRaisesRegex(RuntimeError, "invalid argument"):
             nt + nt.size(1)
 
     def test_split(self, device):

--- a/torch/nested/_internal/ops.py
+++ b/torch/nested/_internal/ops.py
@@ -209,6 +209,14 @@ def lookup_jagged(func, *args, **kwargs) -> Optional[Callable]:
     if torch.Tag.pointwise in func.tags:
         # Assume there aren't additional tensors that aren't the "unary/binary" args
         num_tensor_args = sum(isinstance(x, torch.Tensor) for x in args)
+        num_schema_tensor_args = sum(
+            isinstance(a.type, torch.TensorType) for a in func._schema.arguments
+        )
+        if num_tensor_args != num_schema_tensor_args:
+            raise RuntimeError(
+                f"{func}: expected {num_schema_tensor_args} tensor args but found {num_tensor_args}"
+            )
+
         if num_tensor_args == 1:
             # Build up the check schema string. The first tensor arg is assumed to be
             # an NJT and other args are sent through as-is.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #138602

Before this PR, NJT would dispatch e.g. `NJT * nested_int` to `mul.Tensor`, wrongly interpreting the SymInt as a tensor and outputting garbage. This PR verifies that there are no nested ints in the list of args before dispatching for pointwise ops.

I originally tried checking that `the number of passed tensor args == the number of func schema tensor args`, but this wrongly disallows `nt * 2`, which (non-intuitively to me at least at first) dispatches via the `mul.Tensor` overload.