### PR TITLE
Relax mutation to aten.to in export

### DIFF
--- a/aten/src/ATen/FunctionalStorageImpl.h
+++ b/aten/src/ATen/FunctionalStorageImpl.h
@@ -156,6 +156,10 @@ struct TORCH_API FunctionalStorageImpl : public c10::StorageImpl {
     return inductor_storage_resized_;
   }
 
+  uint64_t mutation_counter() const {
+    return mutation_counter_;
+  }
+
  private:
   // NB: base_ should always point to a tensor BELOW the current
   // functionalization layer. This is mainly to avoid reference cycles. e.g.

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -65,6 +65,10 @@ void FunctionalTensorWrapper::freeze_storage() const {
   functional_storage_impl()->freeze();
 }
 
+uint64_t FunctionalTensorWrapper::mutation_counter() const {
+  return functional_storage_impl()->mutation_counter();
+}
+
 // Note [Functionalization: Alias Removal]
 // When someone calls a view() op during the functionalization pass, e.g. 'b = a.view(...)',
 // we link `b` and `a` to a shared Alias object to preserve the aliasing relationship.
@@ -756,6 +760,12 @@ void freeze_functional_tensor(const Tensor& tensor) {
   TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(tensor));
   auto functional_base_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
   functional_base_impl->freeze_storage();
+}
+
+uint64_t mutation_counter(const Tensor& tensor) {
+  TORCH_INTERNAL_ASSERT(at::functionalization::impl::isFunctionalTensor(tensor));
+  auto functional_base_impl = at::functionalization::impl::unsafeGetFunctionalWrapper(tensor);
+  return functional_base_impl->mutation_counter();
 }
 
 Tensor create_functional_tensor_with_view_meta(const at::Tensor& view_to_wrap, const at::Tensor& base, functionalization::ViewMeta meta, int64_t out_idx) {

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -139,6 +139,7 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   bool is_up_to_date() const;
   // Freezes the storage of this tensor, preventing subsequent mutations
   void freeze_storage() const;
+  uint64_t mutation_counter() const;
   // Every FunctionalTensorWrapper contains a vector<ViewMeta> objects
   // describing the series of view ops that ran to generate the current tensor
   // from the base tensor. This method is used by inplace-view ops like
@@ -312,6 +313,7 @@ TORCH_API c10::List<std::optional<Tensor>> to_functional_tensor(
 TORCH_API std::vector<Tensor> to_functional_tensor(ITensorListRef t_list);
 
 TORCH_API void freeze_functional_tensor(const Tensor& tensor);
+TORCH_API uint64_t mutation_counter(const Tensor& tensor);
 
 TORCH_API Tensor
 from_functional_tensor(const Tensor& tensor, bool assert_functional = true);

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -748,6 +748,9 @@ void initTorchFunctions(PyObject* module) {
   py_module.def("_freeze_functional_tensor", [](const at::Tensor& t) {
     at::functionalization::impl::freeze_functional_tensor(t);
   });
+  py_module.def("_mutation_counter", [](const at::Tensor& t) {
+    return at::functionalization::impl::mutation_counter(t);
+  });
   py_module.def(
       "_enable_functionalization",
       [](bool reapply_views = false) {


### PR DESCRIPTION
Summary:
Today, we force aten.to to always copy under the hood and ban the mutation on the output of aten.to to address silent behavior divergence from eager mode. But in some cases, this is too strict because we only want to ban mutation if the output has an alias to it.

Here we relax it to: you can mutate the result of aten.to, but you cannot use it for any computation further.

Under export, aten.to() should always return a FunctionalTensor that aliases its input storage

If a tensor X with the above storage (S) is mutated, we need to flip a bit so that we can error IF:
- Any aliases of X are used in any operation (or if they are returned as graph outputs)
- If X is not a graph input, but its storage is part of a graph input





You can:
```
    def forward(self, x):
        y = x + 1
        z = y.to("cpu")
        z.add_(5)
        return x
```


You can't:

```
    def forward(self, x):
        y = x + 1
        z = y.to("cpu")
        z.add_(5)
        return z
```

Test Plan:
```
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export  -- -r  test_device_to
buck2 run 'fbcode//mode/dev-nosan' //caffe2/test/functorch:test_aotdispatch -- -r test_aot_export_ban_dropout_mut_pre_dispatch
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:torch -- -r test_to$
buck2 run 'fbcode//mode/dev-nosan' fbcode//caffe2/test:test_export  -- -r  test_solver_unsupported_sympy_function$
```

Differential Revision: D64768928


