### PR TITLE
DOC - fix typo in ``torch.linspace``

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5814,7 +5814,7 @@ add_docstr(
 linspace(start, end, steps, *, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor
 
 Creates a one-dimensional tensor of size :attr:`steps` whose values are evenly
-spaced from :attr:`start` to :attr:`end`, inclusive. That is, the value are:
+spaced from :attr:`start` to :attr:`end`, inclusive. That is, the values are:
 
 .. math::
     (\text{start},


### PR DESCRIPTION
Spotted a missing s in [``torch.linspace``](https://pytorch.org/docs/stable/generated/torch.linspace.html#torch.linspace) documentation.
