### PR TITLE
Refactor DynamicCounter to Use Factory-Based Backend Registration

### DIFF
--- a/c10/util/DynamicCounter.cpp
+++ b/c10/util/DynamicCounter.cpp
@@ -1,5 +1,4 @@
 #include <c10/util/DynamicCounter.h>
-
 #include <c10/util/Synchronized.h>
 
 #include <stdexcept>
@@ -10,11 +9,11 @@
 namespace c10::monitor {
 
 namespace {
-using DynamicCounterBackends =
-    std::vector<std::shared_ptr<detail::DynamicCounterBackendIf>>;
+using DynamicCounterBackendFactories =
+    std::vector<std::shared_ptr<detail::DynamicCounterBackendFactoryIf>>;
 
-Synchronized<DynamicCounterBackends>& dynamicCounterBackends() {
-  static auto instance = new Synchronized<DynamicCounterBackends>();
+Synchronized<DynamicCounterBackendFactories>& dynamicCounterBackendFactories() {
+  static auto instance = new Synchronized<DynamicCounterBackendFactories>();
   return *instance;
 }
 
@@ -26,18 +25,16 @@ Synchronized<std::unordered_set<std::string>>& registeredCounters() {
 
 namespace detail {
 void registerDynamicCounterBackend(
-    std::unique_ptr<DynamicCounterBackendIf> backend) {
-  dynamicCounterBackends().withLock(
-      [&](auto& backends) { backends.push_back(std::move(backend)); });
+    std::unique_ptr<DynamicCounterBackendFactoryIf> factory) {
+  dynamicCounterBackendFactories().withLock(
+      [&](auto& factories) { factories.push_back(std::move(factory)); });
 }
 } // namespace detail
 
 struct DynamicCounter::Guard {
   Guard(std::string_view key, Callback&& getCounterCallback)
-      : key_{key},
-        getCounterCallback_(std::move(getCounterCallback)),
-        backends_{dynamicCounterBackends().withLock(
-            [](auto& backends) { return backends; })} {
+      : key_{key}, getCounterCallback_(std::move(getCounterCallback)) {
+    // Ensure that the counter with this key is not already registered
     registeredCounters().withLock([&](auto& registeredCounters) {
       if (!registeredCounters.insert(std::string(key)).second) {
         throw std::logic_error(
@@ -45,18 +42,28 @@ struct DynamicCounter::Guard {
       }
     });
 
-    for (const auto& backend : backends_) {
-      // Avoid copying the user-provided callback to avoid unexpected behavior
-      // changes when more than one backend is registered.
-      backend->registerCounter(key, [&]() { return getCounterCallback_(); });
-    }
+    // Create backends for this dynamic counter using the factory
+    dynamicCounterBackendFactories().withLock([&](auto& factories) {
+      for (const auto& factory : factories) {
+        auto backend = factory->create(key);
+        if (backend) {
+          // Avoid copying the user-provided callback to avoid unexpected
+          // behavior changes when more than one backend is registered.
+          backend->registerCounter(
+              key_, [&]() { return getCounterCallback_(); });
+          backends_.push_back(std::move(backend));
+        }
+      }
+    });
   }
 
   ~Guard() {
+    // Unregister the counter from all backends
     for (const auto& backend : backends_) {
       backend->unregisterCounter(key_);
     }
 
+    // Remove the counter from the registered counters set
     registeredCounters().withLock(
         [&](auto& registeredCounters) { registeredCounters.erase(key_); });
   }
@@ -64,7 +71,8 @@ struct DynamicCounter::Guard {
  private:
   std::string key_;
   Callback getCounterCallback_;
-  DynamicCounterBackends backends_;
+  std::vector<std::unique_ptr<detail::DynamicCounterBackendIf>>
+      backends_; // Store backends created by the factory
 };
 
 DynamicCounter::DynamicCounter(

--- a/c10/util/DynamicCounter.h
+++ b/c10/util/DynamicCounter.h
@@ -43,7 +43,15 @@ class DynamicCounterBackendIf {
   virtual void unregisterCounter(std::string_view key) = 0;
 };
 
-void C10_API
-    registerDynamicCounterBackend(std::unique_ptr<DynamicCounterBackendIf>);
+class DynamicCounterBackendFactoryIf {
+ public:
+  virtual ~DynamicCounterBackendFactoryIf() = default;
+
+  virtual std::unique_ptr<DynamicCounterBackendIf> create(
+      std::string_view key) = 0;
+};
+
+void C10_API registerDynamicCounterBackend(
+    std::unique_ptr<DynamicCounterBackendFactoryIf>);
 } // namespace detail
 } // namespace c10::monitor


### PR DESCRIPTION
Summary:
refactors the `DynamicCounter` implementation to adopt a factory-based approach for backend registration, similar to how gauges and wait counters are handled. This enhances flexibility and opens up the opportunities for other backends to take advantage of obtaining the information from the `key`

- Introduced `DynamicCounterBackendFactoryIf` to create backends via a factory pattern.
- Replaced direct registration and management of `DynamicCounterBackendIf` with a factory-based approach.
- Updated the `registerDynamicCounterBackend` function to accept backend factories instead of individual backends.
- Simplified backend handling for future extensibility, ensuring that additional backends can be easily integrated.

Test Plan:
sandcastle + existing unit test for pytorch's dynamic counter

No functionality change introduced

Differential Revision: D64728815


