### PR TITLE
Enable inductor-rocm workflow for all trunk commits AND inductor-related PRs

### DIFF
--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -32,7 +32,7 @@ on:
       - 'torch/csrc/inductor/**'
       - 'test/cpp/aoti_abi_check/**'
       - 'test/cpp/aoti_inference/**'
-      # from "module: inductor" in .github/labeler.yml 
+      # from "module: inductor" in .github/labeler.yml
       - 'test/inductor/**'
   push:
     branches:

--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -3,7 +3,7 @@ name: inductor-rocm
 on:
   pull_request:
     paths:
-      # from "ciflow/inductor" in .github/labeler.yml 
+      # from "ciflow/inductor" in .github/labeler.yml
       - 'torch/_decomp/**'
       - 'torch/_dynamo/**'
       - 'torch/_export/**'

--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -1,15 +1,42 @@
 name: inductor-rocm
 
 on:
-  schedule:
-    # We have several schedules so jobs can check github.event.schedule to activate only for a fraction of the runs.
-    # Also run less frequently on weekends.
-    - cron: 45 0,4,8,12,16,20 * * 1-5
-    - cron: 45 4,12 * * 0,6
-    - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
+  pull_request:
+    paths:
+      # from "ciflow/inductor" in .github/labeler.yml 
+      - 'torch/_decomp/**'
+      - 'torch/_dynamo/**'
+      - 'torch/_export/**'
+      - 'torch/_inductor/**'
+      - 'benchmarks/dynamo/**'
+      - 'torch/_subclasses/fake_tensor.py'
+      - 'torch/_subclasses/fake_utils.py'
+      - 'torch/_subclasses/meta_utils.py'
+      - 'test/distributed/test_dynamo_distributed.py'
+      - 'test/distributed/test_inductor_collectives.py'
+      - 'torch/_functorch/_aot_autograd/**'
+      - 'torch/_functorch/aot_autograd.py'
+      - 'torch/_functorch/partitioners.py'
+      - '.ci/docker/ci_commit_pins/**'
+      - '.github/ci_commit_pins/**'
+      - 'c10/core/Sym*'
+      - 'torch/fx/experimental/symbolic_shapes.py'
+      - 'torch/fx/experimental/recording.py'
+      - 'torch/fx/experimental/sym_node.py'
+      - 'torch/fx/experimental/validator.py'
+      - 'torch/fx/experimental/proxy_tensor.py'
+      - 'test/distributed/_tensor/test_dtensor_compile.py'
+      - 'test/distributed/tensor/parallel/test_fsdp_2d_parallel.py'
+      - 'torch/distributed/_tensor/**'
+      - 'torch/distributed/fsdp/**'
+      - 'torch/csrc/inductor/**'
+      - 'test/cpp/aoti_abi_check/**'
+      - 'test/cpp/aoti_inference/**'
+      # from "module: inductor" in .github/labeler.yml 
+      - 'test/inductor/**'
   push:
     branches:
-#     - main
+      - main
       - release/*
     tags:
       - ciflow/inductor-rocm/*

--- a/.github/workflows/inductor-rocm.yml
+++ b/.github/workflows/inductor-rocm.yml
@@ -43,7 +43,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}-${{ github.event.schedule }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}-${{ github.event.schedule }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/test/inductor/minifier_smoke.py
+++ b/test/inductor/minifier_smoke.py
@@ -5,6 +5,7 @@
 import os
 
 
+
 os.environ["TORCHDYNAMO_REPRO_AFTER"] = "dynamo"
 import torch
 import torch._dynamo as torchdynamo

--- a/test/inductor/minifier_smoke.py
+++ b/test/inductor/minifier_smoke.py
@@ -5,7 +5,6 @@
 import os
 
 
-
 os.environ["TORCHDYNAMO_REPRO_AFTER"] = "dynamo"
 import torch
 import torch._dynamo as torchdynamo


### PR DESCRIPTION
It should help with triaging ROCm-inductor-related breakages and surfacing them in the PRs itself.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang @naromero77amd @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @yf225 @chenyang78 @kadeng @muchulee8 @ColinPeppler @amjames @desertfire @chauhang @aakhundov